### PR TITLE
Configure Letta server to use PostgreSQL backend

### DIFF
--- a/letta_config.env
+++ b/letta_config.env
@@ -1,15 +1,15 @@
 # Letta Server Configuration for NEXUS
-# Uses the existing PostgreSQL database with a dedicated schema
+# Connects Letta to the existing PostgreSQL database
 
 # PostgreSQL Configuration
-PG_HOST=localhost
-PG_PORT=5432
-PG_USER=pythagor
-PG_DB=NEXUS
+LETTA_PG_HOST=localhost
+LETTA_PG_PORT=5432
+LETTA_PG_USER=pythagor
+LETTA_PG_DB=NEXUS
 # No password needed for local authentication
-
-# This will create tables in the 'letta' schema within the NEXUS database
-# Letta will handle schema creation automatically
+LETTA_PG_PASSWORD=
+# NOTE: Letta does not currently support selecting a custom PostgreSQL schema;
+# tables will be created in the default schema of the NEXUS database.
 
 # Server Configuration
 LETTA_SERVER_PORT=8283
@@ -18,7 +18,7 @@ LETTA_SERVER_HOST=0.0.0.0
 # Disable cloud features
 LETTA_TELEMETRY=false
 
-# Use local models (we'll override in code)
+# Use local models (overridden in code as needed)
 DEFAULT_LLM_HANDLE=openai/gpt-4o-mini
 DEFAULT_EMBEDDING_HANDLE=openai/text-embedding-3-small
 

--- a/start_letta_server.sh
+++ b/start_letta_server.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+# Load environment variables from letta_config.env
+CONFIG_FILE="$(dirname "$0")/letta_config.env"
+if [ -f "$CONFIG_FILE" ]; then
+  echo "Loading configuration from $CONFIG_FILE"
+  set -a
+  # shellcheck source=/dev/null
+  source "$CONFIG_FILE"
+  set +a
+else
+  echo "Configuration file not found: $CONFIG_FILE" >&2
+  exit 1
+fi
+
+echo "Starting Letta server..."
+echo "Using PostgreSQL at ${LETTA_PG_HOST}:${LETTA_PG_PORT}/${LETTA_PG_DB}"  
+
+exec letta server --port "${LETTA_SERVER_PORT:-8283}" --host "${LETTA_SERVER_HOST:-0.0.0.0}"

--- a/test_letta_connection.py
+++ b/test_letta_connection.py
@@ -1,0 +1,57 @@
+"""Simple connectivity test for the Letta server.
+
+This script verifies that the Letta server is reachable, can create
+an agent, store and retrieve a memory, and that the underlying
+PostgreSQL tables are created in the NEXUS database.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import requests
+import psycopg2
+
+BASE_URL = "http://localhost:8283/v1"
+PG_CONN_INFO = dict(host="localhost", port=5432, user="pythagor", dbname="NEXUS")
+
+
+def main() -> None:
+    # Create a test agent
+    agent_name = f"test-agent-{uuid.uuid4().hex[:8]}"
+    resp = requests.post(f"{BASE_URL}/agents", json={"name": agent_name})
+    resp.raise_for_status()
+    agent_id = resp.json()["id"]
+
+    try:
+        # Send a message that should be stored in memory
+        message_payload = {"messages": [{"role": "user", "content": "remember me"}]}
+        msg_resp = requests.post(f"{BASE_URL}/agents/{agent_id}/messages", json=message_payload)
+        msg_resp.raise_for_status()
+
+        # Retrieve messages to confirm storage
+        history_resp = requests.get(f"{BASE_URL}/agents/{agent_id}/messages")
+        history_resp.raise_for_status()
+        messages = history_resp.json().get("messages", [])
+        assert any(m.get("content") == "remember me" for m in messages), "Memory retrieval failed"
+        print("Memory storage and retrieval succeeded.")
+
+        # Verify PostgreSQL tables exist and contain the agent
+        with psycopg2.connect(**PG_CONN_INFO) as conn:
+            with conn.cursor() as cur:
+                # Ensure agents table exists
+                cur.execute("SELECT to_regclass('public.agents')")
+                if cur.fetchone()[0] is None:
+                    raise RuntimeError("Agents table not found in PostgreSQL")
+                # Check that our agent was persisted
+                cur.execute("SELECT id FROM agents WHERE id = %s", (agent_id,))
+                assert cur.fetchone() is not None, "Agent not found in database"
+        print("PostgreSQL table verification succeeded.")
+    finally:
+        # Clean up the test agent
+        requests.delete(f"{BASE_URL}/agents/{agent_id}")
+        print("Test agent cleaned up.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Configure Letta environment to point at local PostgreSQL instance
- Add startup script to launch Letta server using that config
- Provide test script for verifying Letta ↔ PostgreSQL connectivity

## Testing
- `PYENV_VERSION=3.11.12 python -m py_compile test_letta_connection.py`
- `PYENV_VERSION=3.11.12 python test_letta_connection.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `PYENV_VERSION=3.11.12 pip install requests psycopg2-binary` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bb65a5bc8323adc3d01716a05efb