### PR TITLE
Configure Letta server to use PostgreSQL

### DIFF
--- a/letta_config.env
+++ b/letta_config.env
@@ -1,15 +1,12 @@
 # Letta Server Configuration for NEXUS
-# Uses the existing PostgreSQL database with a dedicated schema
+# Configures Letta to use the existing PostgreSQL database
 
 # PostgreSQL Configuration
-PG_HOST=localhost
-PG_PORT=5432
-PG_USER=pythagor
-PG_DB=NEXUS
-# No password needed for local authentication
-
-# This will create tables in the 'letta' schema within the NEXUS database
-# Letta will handle schema creation automatically
+LETTA_PG_HOST=localhost
+LETTA_PG_PORT=5432
+LETTA_PG_USER=pythagor
+LETTA_PG_DB=NEXUS
+LETTA_PG_PASSWORD=
 
 # Server Configuration
 LETTA_SERVER_PORT=8283
@@ -18,9 +15,14 @@ LETTA_SERVER_HOST=0.0.0.0
 # Disable cloud features
 LETTA_TELEMETRY=false
 
-# Use local models (we'll override in code)
+# Default model handles (override in code as needed)
 DEFAULT_LLM_HANDLE=openai/gpt-4o-mini
 DEFAULT_EMBEDDING_HANDLE=openai/text-embedding-3-small
 
 # Debug mode
 DEBUG=false
+
+# Optional: specify a custom schema by providing LETTA_PG_URI
+# Example:
+# LETTA_PG_URI=postgresql+pg8000://pythagor:@localhost:5432/NEXUS?options=-csearch_path%3Dletta
+

--- a/start_letta_server.sh
+++ b/start_letta_server.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Start Letta server using PostgreSQL backend
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="$SCRIPT_DIR/letta_config.env"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "Configuration file $CONFIG_FILE not found" >&2
+  exit 1
+fi
+
+# Load environment variables
+set -a
+source "$CONFIG_FILE"
+set +a
+
+echo "Starting Letta server on ${LETTA_SERVER_HOST}:${LETTA_SERVER_PORT}"
+echo "Connecting to PostgreSQL ${LETTA_PG_DB} at ${LETTA_PG_HOST}:${LETTA_PG_PORT} as ${LETTA_PG_USER}"
+if [ -n "${LETTA_PG_URI:-}" ]; then
+  echo "Using custom PG URI: ${LETTA_PG_URI}"
+fi
+
+exec letta server --port "${LETTA_SERVER_PORT}" --host "${LETTA_SERVER_HOST}"
+

--- a/test_letta_connection.py
+++ b/test_letta_connection.py
@@ -1,0 +1,73 @@
+'''Basic connectivity test for Letta server configured with PostgreSQL.'''
+import json
+import sys
+
+BASE_URL = "http://localhost:8283"
+
+
+def main() -> None:
+    try:
+        import requests
+    except Exception as e:  # pragma: no cover - missing dependency
+        print("requests library not available", e)
+        sys.exit(1)
+
+    try:
+        import letta_client
+        from letta_client import Letta, CreateBlock
+    except Exception as e:  # pragma: no cover - missing dependency
+        print("letta_client not available", e)
+        return
+
+    # Check server health
+    try:
+        resp = requests.get(f"{BASE_URL}/health", timeout=5)
+        resp.raise_for_status()
+    except Exception as e:
+        print("Letta server not reachable", e)
+        return
+
+    client = Letta(base_url=BASE_URL)
+
+    agent = client.agents.create(
+        name="letta_test_agent",
+        memory_blocks=[
+            CreateBlock(label="human", value="Test User"),
+            CreateBlock(label="persona", value="Test Persona"),
+        ],
+        model="openai/gpt-4o-mini",
+        embedding="openai/text-embedding-3-small",
+    )
+
+    # Update and verify memory
+    client.agents.blocks.update(
+        agent_id=agent.id,
+        block_id="human",
+        value="Updated User",
+    )
+    refreshed = client.agents.retrieve(agent_id=agent.id)
+    success = any(b.label == "human" and b.value == "Updated User" for b in refreshed.memory.blocks)
+    print("Memory write/read successful:", success)
+
+    # Confirm PostgreSQL tables
+    try:
+        import psycopg
+        with psycopg.connect("host=localhost port=5432 dbname=NEXUS user=pythagor") as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname='public' AND tablename='agents');"
+                )
+                exists = cur.fetchone()[0]
+                print("Agents table present:", exists)
+                cur.execute("DELETE FROM agents WHERE name='letta_test_agent';")
+                conn.commit()
+    except Exception as e:
+        print("PostgreSQL check failed", e)
+
+    client.agents.delete(agent_id=agent.id)
+    print("Cleanup complete")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- configure `letta_config.env` with `LETTA_` PostgreSQL settings and add optional schema URI example
- add `start_letta_server.sh` to launch the server with PostgreSQL configuration
- include `test_letta_connection.py` to verify server connectivity and database tables

## Testing
- `PYENV_VERSION=3.11.12 python test_letta_connection.py` *(fails: No module named 'requests')*
- `PYENV_VERSION=3.11.12 pip install requests letta_client psycopg --quiet` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bb65a5bc8323adc3d01716a05efb