### PR TITLE
Configure Letta server for PostgreSQL backend

### DIFF
--- a/letta_config.env
+++ b/letta_config.env
@@ -1,15 +1,12 @@
 # Letta Server Configuration for NEXUS
-# Uses the existing PostgreSQL database with a dedicated schema
+# Configure Letta to use the existing PostgreSQL database.
 
 # PostgreSQL Configuration
-PG_HOST=localhost
-PG_PORT=5432
-PG_USER=pythagor
-PG_DB=NEXUS
-# No password needed for local authentication
-
-# This will create tables in the 'letta' schema within the NEXUS database
-# Letta will handle schema creation automatically
+LETTA_PG_HOST=localhost
+LETTA_PG_PORT=5432
+LETTA_PG_USER=pythagor
+LETTA_PG_DB=NEXUS
+LETTA_PG_PASSWORD=
 
 # Server Configuration
 LETTA_SERVER_PORT=8283
@@ -18,9 +15,6 @@ LETTA_SERVER_HOST=0.0.0.0
 # Disable cloud features
 LETTA_TELEMETRY=false
 
-# Use local models (we'll override in code)
-DEFAULT_LLM_HANDLE=openai/gpt-4o-mini
-DEFAULT_EMBEDDING_HANDLE=openai/text-embedding-3-small
+# Letta does not currently support selecting a custom PostgreSQL schema.
+# Tables will be created in the default schema of the NEXUS database.
 
-# Debug mode
-DEBUG=false

--- a/start_letta_server.sh
+++ b/start_letta_server.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Start the Letta server configured for the NEXUS PostgreSQL database.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/letta_config.env"
+
+echo "Using PostgreSQL database '$LETTA_PG_DB' on $LETTA_PG_HOST:$LETTA_PG_PORT as user '$LETTA_PG_USER'"
+
+letta server --port "${LETTA_SERVER_PORT:-8283}" --host "${LETTA_SERVER_HOST:-0.0.0.0}"
+

--- a/test_letta_connection.py
+++ b/test_letta_connection.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Simple connectivity test for the Letta server and PostgreSQL backend."""
+import os
+
+from letta_client import CreateBlock, Letta as LettaSDKClient
+from letta_client.types import AgentState
+import psycopg2
+
+SERVER_URL = os.getenv("LETTA_SERVER_URL", "http://localhost:8283")
+
+
+def main() -> None:
+    client = LettaSDKClient(base_url=SERVER_URL, token=None)
+
+    # Create an agent with a test memory block
+    agent: AgentState = client.agents.create(
+        memory_blocks=[CreateBlock(label="test", value="remember this")],
+        model="openai/gpt-4o-mini",
+        embedding="openai/text-embedding-3-small",
+    )
+
+    # Retrieve the agent to verify the memory block was stored
+    fetched = client.agents.get(agent.id)
+    assert any(block.value == "remember this" for block in fetched.memory_blocks)
+
+    # Clean up
+    client.agents.delete(agent.id)
+
+    # Verify PostgreSQL tables exist
+    conn = psycopg2.connect(host="localhost", port=5432, user="pythagor", dbname="NEXUS")
+    cur = conn.cursor()
+    cur.execute("SELECT table_name FROM information_schema.tables WHERE table_name='agents';")
+    assert cur.fetchone(), "Letta tables not found in PostgreSQL"
+    cur.close()
+    conn.close()
+
+    print("Letta connection test completed successfully.")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- configure `letta_config.env` with `LETTA_PG_*` variables for the NEXUS PostgreSQL instance
- add `start_letta_server.sh` to source the config and launch the Letta server
- include `test_letta_connection.py` to verify connectivity and data persistence

## Testing
- `python3 test_letta_connection.py` *(fails: ModuleNotFoundError: No module named 'letta_client')*

------
https://chatgpt.com/codex/tasks/task_e_68b9bb65a5bc8323adc3d01716a05efb