### PR TITLE
Add custom two-pass memory system for LORE

### DIFF
--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -35,3 +35,4 @@ class TurnContext:
     apex_response: Optional[str] = None
     error_log: List[str] = field(default_factory=list)
     token_counts: Dict[str, int] = field(default_factory=dict)
+    memory_state: Dict[str, Any] = field(default_factory=dict)

--- a/nexus/memory/__init__.py
+++ b/nexus/memory/__init__.py
@@ -1,0 +1,5 @@
+"""Custom memory system for LORE."""
+
+from .manager import ContextMemoryManager
+
+__all__ = ["ContextMemoryManager"]

--- a/nexus/memory/context_state.py
+++ b/nexus/memory/context_state.py
@@ -1,0 +1,194 @@
+"""State tracking for LORE's two-pass memory system."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+
+
+@dataclass
+class ContextPackage:
+    """Represents the combined state of Pass 1 and Pass 2 context."""
+
+    baseline_chunks: Set[int] = field(default_factory=set)
+    baseline_entities: Dict[str, Any] = field(default_factory=dict)
+    baseline_themes: List[str] = field(default_factory=list)
+    token_usage: Dict[str, int] = field(default_factory=dict)
+
+    divergence_detected: bool = False
+    divergence_confidence: float = 0.0
+    additional_chunks: Set[int] = field(default_factory=set)
+    gap_analysis: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class PassTransition:
+    """Holds information needed to bridge Storyteller and user passes."""
+
+    storyteller_output: str
+    expected_user_themes: List[str]
+    assembled_context: Dict[str, Any]
+    remaining_budget: int
+
+
+class ContextStateManager:
+    """Maintains Pass 1 baseline and Pass 2 incremental state."""
+
+    def __init__(self) -> None:
+        self._current_package: Optional[ContextPackage] = None
+        self._transition: Optional[PassTransition] = None
+        self._baseline_warm_slice: List[Dict[str, Any]] = []
+        self._baseline_retrievals: List[Dict[str, Any]] = []
+        self._incremental_chunks: List[Dict[str, Any]] = []
+        self._warm_expansions: List[Dict[str, Any]] = []
+        self._analysis: Dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Pass 1 lifecycle
+    # ------------------------------------------------------------------
+    def initialize_pass1(
+        self,
+        package: ContextPackage,
+        transition: PassTransition,
+        warm_slice: Optional[List[Dict[str, Any]]],
+        retrieved_passages: Optional[List[Dict[str, Any]]],
+        analysis: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Store the baseline context generated during Pass 1."""
+
+        self._current_package = package
+        self._transition = transition
+        self._baseline_warm_slice = list(warm_slice or [])
+        self._baseline_retrievals = list(retrieved_passages or [])
+        self._incremental_chunks = []
+        self._warm_expansions = []
+        self._analysis = analysis or {}
+
+    def reset(self) -> None:
+        """Completely clear all state (used when Storyteller fails)."""
+
+        self._current_package = None
+        self._transition = None
+        self._baseline_warm_slice = []
+        self._baseline_retrievals = []
+        self._incremental_chunks = []
+        self._warm_expansions = []
+        self._analysis = {}
+
+    # ------------------------------------------------------------------
+    # Pass 2 updates
+    # ------------------------------------------------------------------
+    def update_divergence(self, detected: bool, confidence: float) -> None:
+        if not self._current_package:
+            return
+        self._current_package.divergence_detected = detected
+        self._current_package.divergence_confidence = confidence
+
+    def update_gap_analysis(self, analysis: Dict[str, str]) -> None:
+        if not self._current_package:
+            return
+        self._current_package.gap_analysis = analysis
+
+    def register_additional_chunks(
+        self,
+        chunks: List[Dict[str, Any]],
+        *,
+        component: str,
+        token_usage: int = 0,
+        as_warm_slice: bool = False,
+    ) -> None:
+        """Track newly retrieved chunks from Pass 2."""
+
+        if not self._current_package or not chunks:
+            return
+
+        for chunk in chunks:
+            chunk_id = chunk.get("id")
+            if not chunk_id:
+                continue
+            if chunk_id in self._current_package.baseline_chunks:
+                continue
+            if chunk_id in self._current_package.additional_chunks:
+                continue
+
+            self._current_package.additional_chunks.add(chunk_id)
+            if as_warm_slice:
+                self._warm_expansions.append(chunk)
+            else:
+                self._incremental_chunks.append(chunk)
+
+        if token_usage:
+            current = self._current_package.token_usage.get(component, 0)
+            self._current_package.token_usage[component] = current + token_usage
+            total = self._current_package.token_usage.get("pass2", 0)
+            self._current_package.token_usage["pass2"] = total + token_usage
+
+    def consume_budget(self, amount: int) -> int:
+        """Decrease the remaining Pass 2 token budget."""
+
+        if not self._transition or amount <= 0:
+            return 0
+
+        remaining = max(self._transition.remaining_budget, 0)
+        consumed = min(amount, remaining)
+        self._transition.remaining_budget = remaining - consumed
+        return consumed
+
+    # ------------------------------------------------------------------
+    # Accessors
+    # ------------------------------------------------------------------
+    @property
+    def current_package(self) -> Optional[ContextPackage]:
+        return self._current_package
+
+    @property
+    def transition(self) -> Optional[PassTransition]:
+        return self._transition
+
+    @property
+    def baseline_analysis(self) -> Dict[str, Any]:
+        return self._analysis
+
+    def get_baseline_context(self) -> Optional[ContextPackage]:
+        return self._current_package
+
+    def get_transition_state(self) -> Optional[PassTransition]:
+        return self._transition
+
+    def get_warm_slice(self) -> List[Dict[str, Any]]:
+        return list(self._baseline_warm_slice) + list(self._warm_expansions)
+
+    def get_incremental_chunks(self) -> List[Dict[str, Any]]:
+        return list(self._incremental_chunks)
+
+    def get_all_chunks(self) -> List[Dict[str, Any]]:
+        return self.get_warm_slice() + list(self._baseline_retrievals) + list(self._incremental_chunks)
+
+    def get_complete_context(self) -> Dict[str, Any]:
+        if not self._current_package:
+            return {}
+
+        return {
+            "baseline_warm_slice": list(self._baseline_warm_slice),
+            "baseline_retrievals": list(self._baseline_retrievals),
+            "warm_expansions": list(self._warm_expansions),
+            "incremental_chunks": list(self._incremental_chunks),
+            "package": self._current_package,
+            "transition": self._transition,
+            "analysis": self._analysis,
+        }
+
+    def get_memory_summary(self) -> Dict[str, Any]:
+        if not self._current_package:
+            return {}
+
+        summary = {
+            "baseline_chunks": len(self._current_package.baseline_chunks),
+            "additional_chunks": len(self._current_package.additional_chunks),
+            "divergence_detected": self._current_package.divergence_detected,
+            "divergence_confidence": round(self._current_package.divergence_confidence, 3),
+            "remaining_budget": self._transition.remaining_budget if self._transition else 0,
+        }
+        if self._current_package.gap_analysis:
+            summary["gap_analysis"] = self._current_package.gap_analysis
+        return summary

--- a/nexus/memory/divergence.py
+++ b/nexus/memory/divergence.py
@@ -1,0 +1,212 @@
+"""Divergence detection heuristics for LORE's Pass 2."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+from .context_state import ContextPackage, PassTransition
+
+logger = logging.getLogger("nexus.memory.divergence")
+
+_STOPWORDS = {
+    "the",
+    "and",
+    "with",
+    "that",
+    "this",
+    "from",
+    "into",
+    "your",
+    "have",
+    "what",
+    "when",
+    "where",
+    "who",
+    "about",
+    "just",
+    "like",
+    "into",
+    "then",
+    "them",
+    "they",
+    "their",
+    "been",
+    "were",
+    "will",
+    "would",
+    "could",
+    "should",
+    "might",
+    "again",
+    "still",
+    "even",
+}
+
+
+@dataclass
+class DivergenceResult:
+    """Structured result describing divergence detection outcome."""
+
+    detected: bool
+    confidence: float
+    gap_terms: List[str] = field(default_factory=list)
+    missing_entities: Set[str] = field(default_factory=set)
+    missing_themes: Set[str] = field(default_factory=set)
+    gap_analysis: Dict[str, str] = field(default_factory=dict)
+
+
+class DivergenceDetector:
+    """Simple heuristic-based divergence detector."""
+
+    def __init__(self, threshold: float = 0.7) -> None:
+        self.threshold = threshold
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def detect(
+        self,
+        user_input: str,
+        baseline: Optional[ContextPackage],
+        transition: Optional[PassTransition],
+    ) -> DivergenceResult:
+        """Compare user input against Pass 1 baseline context."""
+
+        if not user_input or not baseline:
+            return DivergenceResult(False, 0.0)
+
+        normalized_entities = {
+            self._normalize(name): name for name in baseline.baseline_entities.keys()
+        }
+        baseline_themes = {self._normalize(theme) for theme in baseline.baseline_themes}
+        expected = {
+            self._normalize(theme)
+            for theme in (transition.expected_user_themes if transition else [])
+            if theme
+        }
+
+        entity_tokens = self._extract_named_tokens(user_input)
+        keyword_tokens = self._extract_keywords(user_input)
+
+        missing_entities, entity_gap_terms = self._compute_missing_tokens(
+            entity_tokens, normalized_entities, baseline_themes, expected
+        )
+        missing_themes, theme_gap_terms = self._compute_missing_tokens(
+            keyword_tokens, None, baseline_themes, expected
+        )
+
+        gap_terms = sorted({*entity_gap_terms, *theme_gap_terms})
+
+        gap_analysis = {}
+        for term in gap_terms:
+            if term in entity_gap_terms:
+                gap_analysis[term] = (
+                    "Entity or reference not present in Pass 1 baseline context"
+                )
+            else:
+                gap_analysis[term] = (
+                    "Theme or topic absent from Pass 1 baseline context"
+                )
+
+        confidence = self._calculate_confidence(
+            entity_tokens,
+            keyword_tokens,
+            missing_entities,
+            missing_themes,
+        )
+        detected = bool(gap_terms) and confidence >= self.threshold
+
+        logger.debug(
+            "Divergence detection completed: detected=%s confidence=%.2f gaps=%s",
+            detected,
+            confidence,
+            gap_terms,
+        )
+
+        return DivergenceResult(
+            detected=detected,
+            confidence=confidence,
+            gap_terms=gap_terms,
+            missing_entities=missing_entities,
+            missing_themes=missing_themes,
+            gap_analysis=gap_analysis,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize(text: str) -> str:
+        return re.sub(r"\s+", " ", text.strip().lower()) if text else ""
+
+    def _extract_named_tokens(self, text: str) -> Dict[str, str]:
+        """Return capitalized entities and quoted strings."""
+
+        tokens: Dict[str, str] = {}
+        for match in re.finditer(r"([A-Z][\w']+(?:\s+[A-Z][\w']+)*)", text):
+            original = match.group(1).strip()
+            normalized = self._normalize(original)
+            if normalized and normalized not in tokens:
+                tokens[normalized] = original
+
+        # Capture quoted terms (for things like "Pete's Silo")
+        for match in re.finditer(r"['\"]([^'\"]{2,})['\"]", text):
+            original = match.group(1).strip()
+            normalized = self._normalize(original)
+            if normalized and normalized not in tokens:
+                tokens[normalized] = original
+
+        return tokens
+
+    def _extract_keywords(self, text: str) -> Dict[str, str]:
+        tokens: Dict[str, str] = {}
+        for raw in re.findall(r"\b[\w'][\w'-]{3,}\b", text):
+            normalized = self._normalize(raw)
+            if (
+                normalized
+                and normalized not in _STOPWORDS
+                and not normalized.isdigit()
+            ):
+                tokens.setdefault(normalized, raw)
+        return tokens
+
+    def _compute_missing_tokens(
+        self,
+        tokens: Dict[str, str],
+        baseline_entities: Optional[Dict[str, str]],
+        baseline_themes: Set[str],
+        expected: Set[str],
+    ) -> Tuple[Set[str], Set[str]]:
+        missing: Set[str] = set()
+        gap_terms: Set[str] = set()
+
+        for normalized, original in tokens.items():
+            if normalized in expected:
+                continue
+            if baseline_entities is not None and normalized in baseline_entities:
+                continue
+            if normalized in baseline_themes:
+                continue
+            missing.add(original)
+            gap_terms.add(original)
+        return missing, gap_terms
+
+    def _calculate_confidence(
+        self,
+        entity_tokens: Dict[str, str],
+        keyword_tokens: Dict[str, str],
+        missing_entities: Iterable[str],
+        missing_themes: Iterable[str],
+    ) -> float:
+        entity_count = len(entity_tokens)
+        keyword_count = len(keyword_tokens)
+
+        max_score = entity_count * 1.0 + keyword_count * 0.5
+        if max_score <= 0:
+            return 0.0
+
+        score = len(set(missing_entities)) * 1.0 + len(set(missing_themes)) * 0.5
+        return min(1.0, score / max_score)

--- a/nexus/memory/incremental.py
+++ b/nexus/memory/incremental.py
@@ -1,0 +1,190 @@
+"""Incremental context retrieval for LORE's Pass 2."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from nexus.agents.lore.utils.chunk_operations import calculate_chunk_tokens
+
+from .context_state import ContextStateManager
+from .divergence import DivergenceResult
+from .query_memory import QueryMemory
+
+logger = logging.getLogger("nexus.memory.incremental")
+
+
+class IncrementalRetriever:
+    """Handles Pass 2 augmentation without duplicating baseline chunks."""
+
+    def __init__(
+        self,
+        *,
+        memnon: Optional[Any],
+        query_memory: QueryMemory,
+        warm_slice_default: bool = True,
+    ) -> None:
+        self.memnon = memnon
+        self.query_memory = query_memory
+        self.warm_slice_default = warm_slice_default
+
+    # ------------------------------------------------------------------
+    # Divergence handling
+    # ------------------------------------------------------------------
+    def retrieve_for_divergence(
+        self,
+        divergence: DivergenceResult,
+        state: ContextStateManager,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """Retrieve context for detected divergence."""
+
+        if not divergence.detected or not self.memnon:
+            return [], 0
+
+        additions: List[Dict[str, Any]] = []
+        tokens_used = 0
+
+        gap_terms = divergence.gap_terms
+        if not gap_terms:
+            return [], 0
+
+        for term in gap_terms:
+            if self.query_memory.remaining_iterations(2) <= 0:
+                logger.debug("Query budget exhausted for Pass 2; stopping retrieval")
+                break
+            if self.query_memory.was_executed(term):
+                logger.debug("Skipping duplicate query term: %s", term)
+                continue
+
+            self.query_memory.record_queries(2, [term])
+
+            try:
+                results = self.memnon.query_memory(query=term, k=5, use_hybrid=True)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Pass 2 retrieval failed for '%s': %s", term, exc)
+                continue
+
+            for chunk in results.get("results", []):
+                chunk_id = chunk.get("id")
+                if not chunk_id:
+                    continue
+                package = state.current_package
+                if not package:
+                    break
+                if chunk_id in package.baseline_chunks:
+                    continue
+                if chunk_id in package.additional_chunks:
+                    continue
+
+                chunk_tokens = self._estimate_tokens(chunk)
+                if chunk_tokens <= 0:
+                    continue
+
+                if state.transition and state.transition.remaining_budget < chunk_tokens:
+                    logger.debug(
+                        "Budget exhausted before adding chunk %s (tokens=%s)",
+                        chunk_id,
+                        chunk_tokens,
+                    )
+                    continue
+
+                additions.append(chunk)
+                tokens_used += chunk_tokens
+                state.consume_budget(chunk_tokens)
+
+                logger.debug(
+                    "Pass 2 added chunk %s (term='%s', tokens=%s)",
+                    chunk_id,
+                    term,
+                    chunk_tokens,
+                )
+
+                if state.transition and state.transition.remaining_budget <= 0:
+                    logger.debug("Remaining Pass 2 budget depleted after chunk %s", chunk_id)
+                    break
+
+            if state.transition and state.transition.remaining_budget <= 0:
+                break
+
+        return additions, tokens_used
+
+    # ------------------------------------------------------------------
+    # Warm slice expansion
+    # ------------------------------------------------------------------
+    def expand_warm_slice(
+        self,
+        state: ContextStateManager,
+        desired: int = 3,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """Fill remaining budget with recent warm slice chunks."""
+
+        if not self.memnon or not self.warm_slice_default:
+            return [], 0
+
+        package = state.current_package
+        if not package:
+            return [], 0
+
+        existing_ids = set(package.baseline_chunks) | set(package.additional_chunks)
+
+        try:
+            recent = self.memnon.get_recent_chunks(limit=desired * 3)
+            candidates = recent.get("results", [])
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to expand warm slice: %s", exc)
+            return [], 0
+
+        additions: List[Dict[str, Any]] = []
+        tokens_used = 0
+
+        for chunk in candidates:
+            chunk_id = chunk.get("id")
+            if not chunk_id or chunk_id in existing_ids:
+                continue
+
+            chunk_tokens = self._estimate_tokens(chunk)
+            if chunk_tokens <= 0:
+                continue
+
+            if state.transition and state.transition.remaining_budget < chunk_tokens:
+                logger.debug(
+                    "Skipping warm addition %s due to budget (%s tokens)",
+                    chunk_id,
+                    chunk_tokens,
+                )
+                continue
+
+            additions.append(chunk)
+            tokens_used += chunk_tokens
+            existing_ids.add(chunk_id)
+            state.consume_budget(chunk_tokens)
+
+            logger.debug(
+                "Warm slice expansion added chunk %s (tokens=%s)",
+                chunk_id,
+                chunk_tokens,
+            )
+
+            if len(additions) >= desired:
+                break
+            if state.transition and state.transition.remaining_budget <= 0:
+                break
+
+        return additions, tokens_used
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+    def _estimate_tokens(self, chunk: Dict[str, Any]) -> int:
+        text = (
+            chunk.get("full_text")
+            or chunk.get("raw_text")
+            or chunk.get("text")
+            or ""
+        )
+        if not text:
+            return 0
+        try:
+            return calculate_chunk_tokens(text)
+        except Exception:  # pragma: no cover - fallback to length heuristic
+            return max(1, len(text) // 4)

--- a/nexus/memory/manager.py
+++ b/nexus/memory/manager.py
@@ -1,0 +1,338 @@
+"""Public interface for LORE's custom two-pass memory system."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from nexus.agents.lore.utils.chunk_operations import calculate_chunk_tokens
+
+from .context_state import ContextPackage, ContextStateManager, PassTransition
+from .divergence import DivergenceDetector
+from .incremental import IncrementalRetriever
+from .query_memory import QueryMemory
+
+logger = logging.getLogger("nexus.memory.manager")
+
+
+class ContextMemoryManager:
+    """Coordinates Pass 1 baseline storage and Pass 2 augmentation."""
+
+    def __init__(
+        self,
+        settings: Optional[Dict[str, Any]] = None,
+        *,
+        memnon: Optional[Any] = None,
+        token_manager: Optional[Any] = None,
+        llm_manager: Optional[Any] = None,
+    ) -> None:
+        self.settings = settings or {}
+        memory_cfg = self.settings.get("memory", {})
+
+        self.pass2_reserve = float(memory_cfg.get("pass2_budget_reserve", 0.25))
+        self.divergence_threshold = float(memory_cfg.get("divergence_threshold", 0.7))
+        self.warm_slice_default = bool(memory_cfg.get("warm_slice_default", True))
+        self.max_sql_iterations = int(memory_cfg.get("max_sql_iterations", 5))
+
+        self.memnon = memnon
+        self.token_manager = token_manager
+        self.llm_manager = llm_manager
+
+        self.state = ContextStateManager()
+        self.query_memory = QueryMemory(self.max_sql_iterations)
+        self.divergence_detector = DivergenceDetector(self.divergence_threshold)
+        self.incremental = IncrementalRetriever(
+            memnon=self.memnon,
+            query_memory=self.query_memory,
+            warm_slice_default=self.warm_slice_default,
+        )
+
+    # ------------------------------------------------------------------
+    # Dependency updates
+    # ------------------------------------------------------------------
+    def refresh_memnon(self, memnon: Any) -> None:
+        self.memnon = memnon
+        self.incremental.memnon = memnon
+
+    # ------------------------------------------------------------------
+    # Pass 1 handling
+    # ------------------------------------------------------------------
+    def handle_storyteller_response(self, storyteller_output: str, turn_context: Any) -> None:
+        """Store Pass 1 baseline context after Storyteller completes."""
+
+        if not storyteller_output:
+            logger.debug("No storyteller output provided; skipping baseline storage")
+            self.state.reset()
+            return
+
+        warm_slice = getattr(turn_context, "warm_slice", []) or []
+        retrieved_passages = getattr(turn_context, "retrieved_passages", []) or []
+        entity_data = getattr(turn_context, "entity_data", {}) or {}
+        phase_states = getattr(turn_context, "phase_states", {}) or {}
+        analysis = phase_states.get("warm_analysis", {}).get("analysis", {})
+        token_counts = getattr(turn_context, "token_counts", {}) or {}
+        context_payload = getattr(turn_context, "context_payload", {}) or {}
+
+        baseline_entities = self._extract_entities(entity_data, analysis)
+        baseline_themes = self._extract_themes(analysis, storyteller_output)
+        baseline_chunks = self._collect_chunk_ids(warm_slice, retrieved_passages)
+        token_usage = self._estimate_token_usage(warm_slice, retrieved_passages, storyteller_output)
+        expected_themes = self._derive_expected_themes(
+            analysis,
+            storyteller_output,
+            baseline_entities,
+            baseline_themes,
+        )
+        remaining_budget = self._calculate_remaining_budget(token_counts, token_usage)
+
+        package = ContextPackage(
+            baseline_chunks=baseline_chunks,
+            baseline_entities=baseline_entities,
+            baseline_themes=baseline_themes,
+            token_usage={**token_usage, "remaining_budget": remaining_budget},
+        )
+        transition = PassTransition(
+            storyteller_output=storyteller_output,
+            expected_user_themes=expected_themes,
+            assembled_context=context_payload,
+            remaining_budget=remaining_budget,
+        )
+
+        self.state.initialize_pass1(package, transition, warm_slice, retrieved_passages, analysis)
+        self.query_memory.reset_pass(2)
+
+        logger.debug(
+            "Stored baseline context: %s baseline chunks, reserve=%s",
+            len(baseline_chunks),
+            remaining_budget,
+        )
+
+    # ------------------------------------------------------------------
+    # Pass 2 handling
+    # ------------------------------------------------------------------
+    def handle_user_input(self, turn_context: Any) -> Dict[str, Any]:
+        """Evaluate user input for divergence and retrieve incremental context."""
+
+        baseline = self.state.get_baseline_context()
+        summary: Dict[str, Any] = {}
+
+        if not baseline:
+            logger.debug("No Pass 1 baseline available; using default warm slice workflow")
+            return summary
+
+        divergence = self.divergence_detector.detect(
+            turn_context.user_input,
+            baseline,
+            self.state.get_transition_state(),
+        )
+        self.state.update_divergence(divergence.detected, divergence.confidence)
+        self.state.update_gap_analysis(divergence.gap_analysis)
+
+        additions: List[Dict[str, Any]] = []
+        warm_additions: List[Dict[str, Any]] = []
+        aug_tokens = 0
+        warm_tokens = 0
+
+        if divergence.detected:
+            additions, aug_tokens = self.incremental.retrieve_for_divergence(divergence, self.state)
+            self.state.register_additional_chunks(
+                additions,
+                component="augmentation",
+                token_usage=aug_tokens,
+                as_warm_slice=False,
+            )
+        elif self.warm_slice_default:
+            warm_additions, warm_tokens = self.incremental.expand_warm_slice(self.state)
+            self.state.register_additional_chunks(
+                warm_additions,
+                component="warm_slice",
+                token_usage=warm_tokens,
+                as_warm_slice=True,
+            )
+
+        # Update turn context state
+        combined_warm = self.state.get_warm_slice()
+        turn_context.warm_slice = combined_warm
+        turn_context.memory_state = self.state.get_memory_summary()
+
+        if aug_tokens:
+            turn_context.token_counts["augmentation"] = (
+                turn_context.token_counts.get("augmentation", 0) + aug_tokens
+            )
+        if warm_tokens:
+            turn_context.token_counts["warm_slice"] = (
+                turn_context.token_counts.get("warm_slice", 0) + warm_tokens
+            )
+        if self.state.transition:
+            turn_context.token_counts["remaining_pass2_budget"] = self.state.transition.remaining_budget
+
+        summary.update(
+            {
+                "divergence_detected": divergence.detected,
+                "confidence": divergence.confidence,
+                "gap_analysis": divergence.gap_analysis,
+                "added_chunk_ids": [chunk.get("id") for chunk in additions],
+                "warm_slice_added": [chunk.get("id") for chunk in warm_additions],
+                "remaining_budget": self.state.transition.remaining_budget if self.state.transition else 0,
+            }
+        )
+
+        logger.debug(
+            "Pass 2 summary: detected=%s confidence=%.2f additions=%s warm_additions=%s",
+            divergence.detected,
+            divergence.confidence,
+            summary["added_chunk_ids"],
+            summary["warm_slice_added"],
+        )
+
+        return summary
+
+    def merge_incremental_results(self, turn_context: Any) -> None:
+        """Inject divergence retrievals into the aggregated retrieval set."""
+
+        incremental_chunks = self.state.get_incremental_chunks()
+        if not incremental_chunks:
+            return
+
+        existing_ids = {chunk.get("id") for chunk in turn_context.retrieved_passages}
+        merged = list(turn_context.retrieved_passages)
+
+        for chunk in incremental_chunks:
+            chunk_id = chunk.get("id")
+            if not chunk_id or chunk_id in existing_ids:
+                continue
+            merged.append(chunk)
+            existing_ids.add(chunk_id)
+
+        turn_context.retrieved_passages = merged
+
+    # ------------------------------------------------------------------
+    # Query tracking utilities
+    # ------------------------------------------------------------------
+    def record_queries(self, pass_id: int, queries: Sequence[str], *, replace: bool = False) -> None:
+        self.query_memory.record_queries(pass_id, list(queries), replace=replace)
+
+    def get_memory_summary(self) -> Dict[str, Any]:
+        return self.state.get_memory_summary()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _extract_entities(
+        self,
+        entity_data: Dict[str, Any],
+        analysis: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        entities: Dict[str, Any] = {}
+        for character in entity_data.get("characters", []):
+            name = character.get("name")
+            if name:
+                entities[name] = character
+        for location in entity_data.get("locations", []):
+            name = location.get("name")
+            if name:
+                enriched = dict(location)
+                enriched.setdefault("type", "location")
+                entities[name] = enriched
+
+        if analysis:
+            for name in analysis.get("characters", []) or []:
+                if name and name not in entities:
+                    entities[name] = {"name": name, "type": "character"}
+            for name in analysis.get("locations", []) or []:
+                if name and name not in entities:
+                    entities[name] = {"name": name, "type": "location"}
+            for name in analysis.get("entities_for_retrieval", []) or []:
+                if name and name not in entities:
+                    entities[name] = {"name": name, "type": "entity"}
+
+        return entities
+
+    def _extract_themes(
+        self,
+        analysis: Optional[Dict[str, Any]],
+        storyteller_output: str,
+    ) -> List[str]:
+        themes: List[str] = []
+        if analysis:
+            themes.extend(analysis.get("entities_for_retrieval", []) or [])
+            if analysis.get("context_type"):
+                themes.append(str(analysis.get("context_type")))
+            themes.extend(analysis.get("locations", []) or [])
+        keywords = list(self.divergence_detector._extract_keywords(storyteller_output).values())
+        for keyword in keywords:
+            if keyword not in themes:
+                themes.append(keyword)
+        return themes[:20]
+
+    def _derive_expected_themes(
+        self,
+        analysis: Optional[Dict[str, Any]],
+        storyteller_output: str,
+        entities: Dict[str, Any],
+        baseline_themes: Iterable[str],
+    ) -> List[str]:
+        expected: List[str] = []
+        if analysis:
+            expected.extend(analysis.get("entities_for_retrieval", []) or [])
+            if analysis.get("context_type"):
+                expected.append(str(analysis.get("context_type")))
+        expected.extend(list(entities.keys()))
+        expected.extend(list(baseline_themes))
+        keywords = list(self.divergence_detector._extract_keywords(storyteller_output).values())
+        for keyword in keywords[:8]:
+            if keyword not in expected:
+                expected.append(keyword)
+        return expected[:25]
+
+    def _collect_chunk_ids(
+        self,
+        warm_slice: List[Dict[str, Any]],
+        retrieved: List[Dict[str, Any]],
+    ) -> set:
+        chunk_ids = {chunk.get("id") for chunk in warm_slice if chunk.get("id")}
+        chunk_ids.update({chunk.get("id") for chunk in retrieved if chunk.get("id")})
+        return chunk_ids
+
+    def _estimate_token_usage(
+        self,
+        warm_slice: List[Dict[str, Any]],
+        retrieved: List[Dict[str, Any]],
+        storyteller_output: str,
+    ) -> Dict[str, int]:
+        warm_tokens = sum(self._estimate_tokens_from_text(self._chunk_text(chunk)) for chunk in warm_slice)
+        retrieval_tokens = sum(self._estimate_tokens_from_text(self._chunk_text(chunk)) for chunk in retrieved)
+        storyteller_tokens = self._estimate_tokens_from_text(storyteller_output)
+        return {
+            "warm_slice": warm_tokens,
+            "retrieval": retrieval_tokens,
+            "storyteller_output": storyteller_tokens,
+            "baseline_total": warm_tokens + retrieval_tokens,
+        }
+
+    def _chunk_text(self, chunk: Dict[str, Any]) -> str:
+        return (
+            chunk.get("full_text")
+            or chunk.get("raw_text")
+            or chunk.get("text")
+            or ""
+        )
+
+    def _estimate_tokens_from_text(self, text: str) -> int:
+        if not text:
+            return 0
+        try:
+            return calculate_chunk_tokens(text)
+        except Exception:  # pragma: no cover - fallback
+            return max(1, len(text) // 4)
+
+    def _calculate_remaining_budget(
+        self,
+        token_counts: Dict[str, int],
+        token_usage: Dict[str, int],
+    ) -> int:
+        total_available = int(token_counts.get("total_available", 0))
+        baseline_used = token_usage.get("baseline_total", 0)
+        remaining = max(0, total_available - baseline_used)
+        reserve = int(total_available * self.pass2_reserve)
+        return min(total_available, max(reserve, remaining))

--- a/nexus/memory/query_memory.py
+++ b/nexus/memory/query_memory.py
@@ -1,0 +1,66 @@
+"""Pass-aware query tracking for the custom memory system."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List
+
+logger = logging.getLogger("nexus.memory.query_memory")
+
+
+class QueryMemory:
+    """Tracks executed queries across Pass 1 and Pass 2."""
+
+    def __init__(self, max_iterations: int = 5) -> None:
+        self.max_iterations = max_iterations
+        self._queries: Dict[int, List[str]] = {1: [], 2: []}
+
+    # ------------------------------------------------------------------
+    # Recording and deduplication
+    # ------------------------------------------------------------------
+    def record_queries(self, pass_id: int, queries: List[str], replace: bool = False) -> None:
+        if pass_id not in self._queries or not queries:
+            return
+
+        normalized = [self._normalize(q) for q in queries if q]
+        if replace:
+            self._queries[pass_id] = []
+
+        for query in normalized:
+            if not query:
+                continue
+            if query in self._queries[pass_id]:
+                continue
+            if len(self._queries[pass_id]) >= self.max_iterations:
+                logger.debug(
+                    "Query budget reached for pass %s; skipping '%s'", pass_id, query
+                )
+                break
+            self._queries[pass_id].append(query)
+
+    def was_executed(self, query: str) -> bool:
+        normalized = self._normalize(query)
+        return any(normalized in queries for queries in self._queries.values())
+
+    def remaining_iterations(self, pass_id: int) -> int:
+        if pass_id not in self._queries:
+            return 0
+        used = len(self._queries[pass_id])
+        return max(0, self.max_iterations - used)
+
+    # ------------------------------------------------------------------
+    # State management
+    # ------------------------------------------------------------------
+    def reset_pass(self, pass_id: int) -> None:
+        if pass_id in self._queries:
+            self._queries[pass_id] = []
+
+    def get_queries(self, pass_id: int) -> List[str]:
+        return list(self._queries.get(pass_id, []))
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize(query: str) -> str:
+        return " ".join(query.lower().split()) if query else ""

--- a/settings.json
+++ b/settings.json
@@ -435,5 +435,11 @@
             "batch": 1,
             "rate_limit": 300
         }
+    },
+    "memory": {
+        "pass2_budget_reserve": 0.25,
+        "divergence_threshold": 0.7,
+        "warm_slice_default": true,
+        "max_sql_iterations": 5
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `nexus.memory` package with context state tracking, divergence detection, incremental retrieval, query bookkeeping, and a top-level manager to coordinate LORE's two-pass workflow
- integrate the new memory manager throughout LORE's turn cycle to run divergence checks before warm analysis, merge incremental context, and persist storyteller output while exposing memory status via `get_status`
- extend `settings.json` with configurable memory thresholds and budgets for pass-two behaviour

## Testing
- `python3 -m compileall nexus/memory`
- `python3 -m compileall nexus/agents/lore`


------
https://chatgpt.com/codex/tasks/task_e_68c981c3e1b48323baafd53d2bb42999