### PR TITLE
Add custom two-pass memory system for LORE

### DIFF
--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -35,3 +35,4 @@ class TurnContext:
     apex_response: Optional[str] = None
     error_log: List[str] = field(default_factory=list)
     token_counts: Dict[str, int] = field(default_factory=dict)
+    memory_state: Dict[str, Any] = field(default_factory=dict)

--- a/nexus/memory/__init__.py
+++ b/nexus/memory/__init__.py
@@ -1,0 +1,18 @@
+"""Custom memory system for the LORE agent."""
+
+from .context_state import ContextPackage, PassTransition, ContextStateManager
+from .divergence import DivergenceDetector, DivergenceResult
+from .incremental import IncrementalRetriever
+from .manager import ContextMemoryManager
+from .query_memory import QueryMemory
+
+__all__ = [
+    "ContextPackage",
+    "PassTransition",
+    "ContextStateManager",
+    "DivergenceDetector",
+    "DivergenceResult",
+    "IncrementalRetriever",
+    "ContextMemoryManager",
+    "QueryMemory",
+]

--- a/nexus/memory/context_state.py
+++ b/nexus/memory/context_state.py
@@ -1,0 +1,312 @@
+"""Context state management for LORE's custom memory system."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+logger = logging.getLogger("nexus.memory.context_state")
+
+
+@dataclass
+class ContextPackage:
+    """Represents the combined context state across both passes."""
+
+    baseline_chunks: Set[int] = field(default_factory=set)
+    baseline_entities: Dict[str, Any] = field(default_factory=dict)
+    baseline_themes: List[str] = field(default_factory=list)
+    token_usage: Dict[str, int] = field(default_factory=dict)
+    divergence_detected: bool = False
+    divergence_confidence: float = 0.0
+    additional_chunks: Set[int] = field(default_factory=set)
+    gap_analysis: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class PassTransition:
+    """Stores information that flows from Pass 1 to Pass 2."""
+
+    storyteller_output: str = ""
+    expected_user_themes: List[str] = field(default_factory=list)
+    assembled_context: Dict[str, Any] = field(default_factory=dict)
+    remaining_budget: int = 0
+
+
+class ContextStateManager:
+    """Tracks baseline and incremental context for the two-pass system."""
+
+    def __init__(self) -> None:
+        self.context = ContextPackage()
+        self.transition: Optional[PassTransition] = None
+        self.chunk_store: Dict[int, Dict[str, Any]] = {}
+        self.baseline_chunk_order: List[int] = []
+        self.additional_chunk_order: List[int] = []
+        self.last_user_input: Optional[str] = None
+        self.last_analysis: Dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Baseline (Pass 1) state
+    # ------------------------------------------------------------------
+    def reset(self) -> None:
+        """Reset all context state."""
+
+        logger.debug("Resetting context state manager")
+        self.context = ContextPackage()
+        self.transition = None
+        self.chunk_store.clear()
+        self.baseline_chunk_order.clear()
+        self.additional_chunk_order.clear()
+        self.last_user_input = None
+        self.last_analysis = {}
+
+    def reset_incremental_state(self) -> None:
+        """Clear Pass 2 additions while keeping baseline context intact."""
+
+        logger.debug("Resetting incremental context state")
+        self.context.divergence_detected = False
+        self.context.divergence_confidence = 0.0
+        self.context.additional_chunks.clear()
+        self.context.gap_analysis.clear()
+        self.additional_chunk_order.clear()
+
+    def store_pass_transition(self, transition: PassTransition) -> None:
+        """Persist PassTransition information."""
+
+        logger.debug(
+            "Storing pass transition: remaining_budget=%s, themes=%s",
+            transition.remaining_budget,
+            transition.expected_user_themes,
+        )
+        self.transition = transition
+
+    def update_remaining_budget(self, remaining_budget: int) -> None:
+        """Update the remaining token budget available for Pass 2."""
+
+        if not self.transition:
+            self.transition = PassTransition()
+        logger.debug("Updating remaining budget to %s", remaining_budget)
+        self.transition.remaining_budget = max(0, int(remaining_budget))
+
+    def store_baseline_context(
+        self,
+        chunk_ids: Iterable[int],
+        entities: Dict[str, Any],
+        themes: Iterable[str],
+        token_usage: Dict[str, int],
+        chunk_details: Iterable[Dict[str, Any]],
+        storyteller_output: str,
+        expected_user_themes: Iterable[str],
+        assembled_context: Dict[str, Any],
+        remaining_budget: int,
+        analysis: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Store baseline context for Pass 1."""
+
+        self.reset_incremental_state()
+
+        normalized_ids = {self._normalize_chunk_id(cid) for cid in chunk_ids if cid is not None}
+        normalized_ids.discard(None)
+        self.context.baseline_chunks = normalized_ids
+        self.context.baseline_entities = entities or {}
+        self.context.baseline_themes = list(themes or [])
+        self.context.token_usage = token_usage or {}
+        self.last_analysis = analysis or {}
+
+        logger.debug(
+            "Stored baseline context with %d chunk(s) and %d entity entries",
+            len(self.context.baseline_chunks),
+            len(self.context.baseline_entities),
+        )
+
+        # Store chunk data for baseline access
+        self.baseline_chunk_order = []
+        for chunk in chunk_details or []:
+            chunk_id = self._extract_chunk_id(chunk)
+            if chunk_id is None:
+                continue
+            if chunk_id not in self.context.baseline_chunks:
+                self.context.baseline_chunks.add(chunk_id)
+            if chunk_id not in self.baseline_chunk_order:
+                self.baseline_chunk_order.append(chunk_id)
+            self.chunk_store[chunk_id] = chunk
+
+        # Persist pass transition details
+        transition = PassTransition(
+            storyteller_output=storyteller_output or "",
+            expected_user_themes=list(expected_user_themes or []),
+            assembled_context=assembled_context or {},
+            remaining_budget=int(remaining_budget),
+        )
+        self.store_pass_transition(transition)
+
+    # ------------------------------------------------------------------
+    # Incremental (Pass 2) state
+    # ------------------------------------------------------------------
+    def mark_divergence(
+        self,
+        detected: bool,
+        confidence: float,
+        gap_analysis: Dict[str, str],
+    ) -> None:
+        """Record divergence information detected in Pass 2."""
+
+        self.context.divergence_detected = bool(detected)
+        self.context.divergence_confidence = max(0.0, min(1.0, confidence))
+        self.context.gap_analysis = gap_analysis or {}
+        logger.debug(
+            "Marked divergence detected=%s confidence=%.3f gaps=%s",
+            detected,
+            confidence,
+            list(gap_analysis.keys()),
+        )
+
+    def register_additional_chunk(self, chunk: Dict[str, Any]) -> Optional[int]:
+        """Register a chunk retrieved during Pass 2."""
+
+        chunk_id = self._extract_chunk_id(chunk)
+        if chunk_id is None:
+            return None
+
+        if chunk_id in self.context.baseline_chunks or chunk_id in self.context.additional_chunks:
+            return None
+
+        self.chunk_store[chunk_id] = chunk
+        self.context.additional_chunks.add(chunk_id)
+        self.additional_chunk_order.append(chunk_id)
+        logger.debug("Registered additional chunk %s", chunk_id)
+        return chunk_id
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def record_user_input(self, user_input: str) -> None:
+        """Keep track of the most recent user input."""
+
+        self.last_user_input = user_input or ""
+
+    def has_chunk(self, chunk_id: Any) -> bool:
+        """Return True if the chunk is already part of the baseline or incremental context."""
+
+        normalized = self._normalize_chunk_id(chunk_id)
+        if normalized is None:
+            return False
+        return normalized in self.context.baseline_chunks or normalized in self.context.additional_chunks
+
+    def get_chunk_data(self, chunk_id: Any) -> Optional[Dict[str, Any]]:
+        """Return stored chunk data if available."""
+
+        normalized = self._normalize_chunk_id(chunk_id)
+        if normalized is None:
+            return None
+        return self.chunk_store.get(normalized)
+
+    def get_baseline_chunk_data(self) -> List[Dict[str, Any]]:
+        """Return baseline chunk data in insertion order."""
+
+        return [self.chunk_store[cid] for cid in self.baseline_chunk_order if cid in self.chunk_store]
+
+    def get_incremental_chunk_data(self) -> List[Dict[str, Any]]:
+        """Return incremental chunk data in retrieval order."""
+
+        return [self.chunk_store[cid] for cid in self.additional_chunk_order if cid in self.chunk_store]
+
+    def get_augmented_warm_slice(self, base_slice: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Combine baseline, base warm slice, and incremental chunks without duplication."""
+
+        combined: List[Dict[str, Any]] = []
+        seen: Set[int] = set()
+
+        for chunk in self.get_baseline_chunk_data():
+            chunk_id = self._extract_chunk_id(chunk)
+            if chunk_id is None or chunk_id in seen:
+                continue
+            combined.append(chunk)
+            seen.add(chunk_id)
+
+        for chunk in base_slice or []:
+            chunk_id = self._extract_chunk_id(chunk)
+            if chunk_id is None or chunk_id in seen:
+                continue
+            combined.append(chunk)
+            seen.add(chunk_id)
+
+        for chunk in self.get_incremental_chunk_data():
+            chunk_id = self._extract_chunk_id(chunk)
+            if chunk_id is None or chunk_id in seen:
+                continue
+            combined.append(chunk)
+            seen.add(chunk_id)
+
+        logger.debug("Augmented warm slice to %d chunk(s)", len(combined))
+        return combined
+
+    def get_expected_terms(self) -> Set[str]:
+        """Derive the set of terms considered covered by baseline context."""
+
+        expected: Set[str] = set()
+        for theme in self.context.baseline_themes:
+            if theme:
+                expected.add(theme.lower())
+
+        if isinstance(self.context.baseline_entities, dict):
+            for value in self.context.baseline_entities.values():
+                self._collect_terms(value, expected)
+
+        if self.transition and self.transition.expected_user_themes:
+            for theme in self.transition.expected_user_themes:
+                if theme:
+                    expected.add(str(theme).lower())
+
+        if self.last_analysis:
+            for key in ("entities", "keywords", "themes"):
+                self._collect_terms(self.last_analysis.get(key), expected)
+
+        return expected
+
+    def get_context_summary(self) -> Dict[str, Any]:
+        """Return a serializable snapshot of the current context state."""
+
+        return {
+            "baseline_chunks": sorted(self.context.baseline_chunks),
+            "additional_chunks": sorted(self.context.additional_chunks),
+            "divergence_detected": self.context.divergence_detected,
+            "divergence_confidence": self.context.divergence_confidence,
+            "gap_analysis": self.context.gap_analysis,
+            "expected_user_themes": self.transition.expected_user_themes if self.transition else [],
+            "remaining_budget": self.transition.remaining_budget if self.transition else 0,
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _normalize_chunk_id(self, chunk_id: Any) -> Optional[int]:
+        if chunk_id is None:
+            return None
+        try:
+            return int(chunk_id)
+        except (TypeError, ValueError):
+            return None
+
+    def _extract_chunk_id(self, chunk: Dict[str, Any]) -> Optional[int]:
+        if not isinstance(chunk, dict):
+            return None
+        for key in ("chunk_id", "id"):
+            if key in chunk:
+                normalized = self._normalize_chunk_id(chunk[key])
+                if normalized is not None:
+                    return normalized
+        return None
+
+    def _collect_terms(self, value: Any, sink: Set[str]) -> None:
+        if not value:
+            return
+        if isinstance(value, str):
+            sink.add(value.lower())
+        elif isinstance(value, (list, set, tuple)):
+            for item in value:
+                self._collect_terms(item, sink)
+        elif isinstance(value, dict):
+            for item in value.values():
+                self._collect_terms(item, sink)
+

--- a/nexus/memory/divergence.py
+++ b/nexus/memory/divergence.py
@@ -1,0 +1,131 @@
+"""Divergence detection for LORE's Pass 2 processing."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Set
+
+from .context_state import ContextStateManager
+
+logger = logging.getLogger("nexus.memory.divergence")
+
+
+@dataclass
+class DivergenceResult:
+    """Outcome of divergence detection."""
+
+    detected: bool = False
+    confidence: float = 0.0
+    unexpected_terms: Set[str] = field(default_factory=set)
+    missing_entities: Set[str] = field(default_factory=set)
+    missing_themes: Set[str] = field(default_factory=set)
+    gap_analysis: Dict[str, str] = field(default_factory=dict)
+
+    @property
+    def has_gaps(self) -> bool:
+        return bool(self.gap_analysis)
+
+
+class DivergenceDetector:
+    """Simple heuristic divergence detector."""
+
+    def __init__(self, threshold: float = 0.7) -> None:
+        self.threshold = max(0.0, min(1.0, threshold))
+
+    def evaluate(self, user_input: str, state: ContextStateManager) -> DivergenceResult:
+        """Compare user input with baseline context and detect divergence."""
+
+        logger.debug("Evaluating user input for divergence")
+        result = DivergenceResult()
+
+        if not user_input or not state or not state.transition:
+            logger.debug("No baseline context available for divergence detection")
+            return result
+
+        expected_terms = state.get_expected_terms()
+        logger.debug("Expected terms for comparison: %s", sorted(expected_terms))
+
+        tokens = self._tokenize(user_input)
+        unexpected_terms = {tok for tok in tokens if tok not in expected_terms}
+
+        capitalized = self._extract_entities(user_input)
+        known_entities = self._normalize_terms(self._flatten_entities(state.context.baseline_entities))
+        missing_entities = {ent for ent in capitalized if ent.lower() not in known_entities}
+
+        expected_themes = {theme.lower() for theme in state.context.baseline_themes}
+        missing_themes = {tok for tok in unexpected_terms if tok in capitalized or tok in expected_themes}
+
+        confidence = self._calculate_confidence(tokens, unexpected_terms, missing_entities)
+        detected = bool(unexpected_terms or missing_entities) and confidence >= self.threshold
+
+        gap_analysis: Dict[str, str] = {}
+        if detected:
+            for ent in missing_entities:
+                gap_analysis[ent] = "Referenced entity not present in baseline context"
+            for term in sorted(unexpected_terms):
+                if term not in gap_analysis:
+                    gap_analysis[term] = "Unexpected reference compared to baseline"
+
+        result.detected = detected
+        result.confidence = confidence
+        result.unexpected_terms = unexpected_terms
+        result.missing_entities = missing_entities
+        result.missing_themes = missing_themes
+        result.gap_analysis = gap_analysis
+
+        logger.debug(
+            "Divergence result: detected=%s confidence=%.3f unexpected=%s",
+            detected,
+            confidence,
+            sorted(unexpected_terms),
+        )
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _tokenize(self, text: str) -> Set[str]:
+        words = re.findall(r"[A-Za-z][A-Za-z0-9']+", text)
+        return {w.lower() for w in words if len(w) > 2}
+
+    def _extract_entities(self, text: str) -> Set[str]:
+        candidates = set()
+        for match in re.finditer(r"\b([A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+)*)\b", text):
+            phrase = match.group(1)
+            if phrase in {"You", "The", "And", "But"}:
+                continue
+            candidates.add(phrase.strip())
+        return candidates
+
+    def _flatten_entities(self, entities: Dict[str, Iterable[str]]) -> Set[str]:
+        flattened: Set[str] = set()
+        if not isinstance(entities, dict):
+            return flattened
+        for value in entities.values():
+            if isinstance(value, str):
+                flattened.add(value)
+            elif isinstance(value, Iterable):
+                for item in value:
+                    if isinstance(item, str):
+                        flattened.add(item)
+        return flattened
+
+    def _normalize_terms(self, terms: Iterable[str]) -> Set[str]:
+        return {term.lower() for term in terms if isinstance(term, str)}
+
+    def _calculate_confidence(
+        self,
+        tokens: Set[str],
+        unexpected_terms: Set[str],
+        missing_entities: Set[str],
+    ) -> float:
+        if not tokens:
+            return 0.0
+        base_ratio = len(unexpected_terms) / max(len(tokens), 1)
+        entity_bonus = 0.15 * len(missing_entities)
+        confidence = min(1.0, base_ratio + entity_bonus)
+        return confidence
+

--- a/nexus/memory/incremental.py
+++ b/nexus/memory/incremental.py
@@ -1,0 +1,116 @@
+"""Incremental retrieval logic for Pass 2."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from .context_state import ContextStateManager
+
+logger = logging.getLogger("nexus.memory.incremental")
+
+
+class IncrementalRetriever:
+    """Retrieves additional context for divergence handling."""
+
+    def __init__(
+        self,
+        memnon: Optional[Any] = None,
+        context_state: Optional[ContextStateManager] = None,
+        settings: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.memnon = memnon
+        self.context_state = context_state or ContextStateManager()
+        self.settings = settings or {}
+
+    def update_memnon(self, memnon: Any) -> None:
+        self.memnon = memnon
+
+    # ------------------------------------------------------------------
+    # Retrieval operations
+    # ------------------------------------------------------------------
+    def retrieve_incremental(
+        self,
+        query_requests: Sequence[Tuple[str, str]],
+        token_budget: int,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """Retrieve additional chunks for detected gaps."""
+
+        if not self.memnon or not query_requests or token_budget <= 0:
+            return [], 0
+
+        collected: List[Dict[str, Any]] = []
+        consumed_tokens = 0
+
+        for query, label in query_requests:
+            if token_budget - consumed_tokens <= 0:
+                break
+            try:
+                response = self.memnon.query_memory(query=query, k=8, use_hybrid=True)
+            except Exception as exc:
+                logger.error("Incremental retrieval failed for '%s': %s", query, exc)
+                continue
+
+            for item in response.get("results", []):
+                chunk_id = item.get("chunk_id") or item.get("id")
+                normalized_id = self.context_state._normalize_chunk_id(chunk_id)  # type: ignore[attr-defined]
+                if normalized_id is None or self.context_state.has_chunk(normalized_id):
+                    continue
+
+                # Annotate result with retrieval reason
+                item = dict(item)
+                item.setdefault("metadata", {})
+                item["metadata"]["retrieval_reason"] = label
+                registered_id = self.context_state.register_additional_chunk(item)
+                if registered_id is None:
+                    continue
+
+                collected.append(item)
+                consumed_tokens += self._estimate_tokens(item.get("text", ""))
+                if consumed_tokens >= token_budget:
+                    break
+            if consumed_tokens >= token_budget:
+                break
+
+        return collected, consumed_tokens
+
+    def expand_warm_slice(self, token_budget: int, limit: Optional[int] = None) -> Tuple[List[Dict[str, Any]], int]:
+        """Expand context with additional recent chunks when no divergence is detected."""
+
+        if not self.memnon or token_budget <= 0:
+            return [], 0
+
+        try:
+            if limit is None:
+                limit = max(1, min(5, token_budget // 150 or 1))
+            recent = self.memnon.get_recent_chunks(limit=limit)
+        except Exception as exc:
+            logger.error("Failed to expand warm slice: %s", exc)
+            return [], 0
+
+        additions: List[Dict[str, Any]] = []
+        consumed_tokens = 0
+        for chunk in recent.get("results", []):
+            chunk_id = chunk.get("chunk_id") or chunk.get("id")
+            if self.context_state.has_chunk(chunk_id):
+                continue
+            registered_id = self.context_state.register_additional_chunk(chunk)
+            if registered_id is None:
+                continue
+            additions.append(chunk)
+            consumed_tokens += self._estimate_tokens(chunk.get("text", ""))
+            if consumed_tokens >= token_budget:
+                break
+
+        return additions, consumed_tokens
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+    def _estimate_tokens(self, text: str) -> int:
+        if not text:
+            return 0
+        # Approximate 0.75 tokens per word to keep estimates conservative
+        words = text.split()
+        return int(len(words) / 0.75) if words else 0
+

--- a/nexus/memory/manager.py
+++ b/nexus/memory/manager.py
@@ -1,0 +1,274 @@
+"""High-level interface to the custom memory system."""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from .context_state import ContextPackage, ContextStateManager
+from .divergence import DivergenceDetector
+from .incremental import IncrementalRetriever
+from .query_memory import QueryMemory
+
+logger = logging.getLogger("nexus.memory.manager")
+
+
+class ContextMemoryManager:
+    """Coordinates context storage, divergence detection, and incremental retrieval."""
+
+    def __init__(self, settings: Optional[Dict[str, Any]] = None, memnon: Optional[Any] = None) -> None:
+        self.settings = settings or {}
+        self.memnon = memnon
+
+        self.memory_config = self.settings.get("memory", {})
+        self.pass2_reserve = float(self.memory_config.get("pass2_budget_reserve", 0.25))
+        self.divergence_threshold = float(self.memory_config.get("divergence_threshold", 0.7))
+        self.warm_slice_default = bool(self.memory_config.get("warm_slice_default", True))
+        self.max_iterations = int(self.memory_config.get("max_sql_iterations", 5))
+
+        self.context_state = ContextStateManager()
+        self.divergence_detector = DivergenceDetector(self.divergence_threshold)
+        self.query_memory = QueryMemory(self.max_iterations)
+        self.incremental = IncrementalRetriever(memnon=memnon, context_state=self.context_state, settings=self.memory_config)
+
+        self.total_budget = self._resolve_total_budget()
+        self.pass2_budget = int(self.total_budget * self.pass2_reserve)
+
+    # ------------------------------------------------------------------
+    # Initialization helpers
+    # ------------------------------------------------------------------
+    def update_memnon(self, memnon: Any) -> None:
+        self.memnon = memnon
+        self.incremental.update_memnon(memnon)
+
+    def _resolve_total_budget(self) -> int:
+        lore_settings = self.settings.get("Agent Settings", {}).get("LORE", {})
+        token_settings = lore_settings.get("token_budget", {})
+        return int(token_settings.get("apex_context_window", 200000))
+
+    # ------------------------------------------------------------------
+    # Pass 1 handling
+    # ------------------------------------------------------------------
+    def handle_storyteller_response(self, narrative: str, turn_context: Optional[Any]) -> ContextPackage:
+        """Store baseline context after Storyteller output (Pass 1)."""
+
+        if not narrative:
+            logger.debug("No narrative provided for baseline storage")
+            return self.context_state.context
+
+        warm_slice_chunks = []
+        retrieved_chunks = []
+        token_usage: Dict[str, int] = {}
+        baseline_entities: Dict[str, Any] = {}
+        assembled_context: Dict[str, Any] = {}
+
+        if turn_context is not None:
+            assembled_context = getattr(turn_context, "context_payload", {}) or {}
+            token_usage = getattr(turn_context, "token_counts", {}) or {}
+            baseline_entities = getattr(turn_context, "entity_data", {}) or {}
+
+            warm_info = assembled_context.get("warm_slice", {}) if isinstance(assembled_context, dict) else {}
+            warm_slice_chunks = warm_info.get("chunks", []) or []
+
+            retrieved_info = assembled_context.get("retrieved_passages", {}) if isinstance(assembled_context, dict) else {}
+            retrieved_chunks = retrieved_info.get("results", []) or []
+
+        chunk_details = list(warm_slice_chunks) + list(retrieved_chunks)
+        chunk_ids = self._collect_chunk_ids(chunk_details)
+
+        analysis = self._basic_analysis(narrative)
+        baseline_themes = analysis.get("themes", [])
+        expected_user_themes = self._determine_expected_themes(analysis, turn_context)
+
+        baseline_usage = sum(token_usage.values()) if token_usage else 0
+        remaining_budget = max(0, self.pass2_budget - baseline_usage)
+        self.context_state.store_baseline_context(
+            chunk_ids=chunk_ids,
+            entities=baseline_entities,
+            themes=baseline_themes,
+            token_usage=token_usage,
+            chunk_details=chunk_details,
+            storyteller_output=narrative,
+            expected_user_themes=expected_user_themes,
+            assembled_context=assembled_context,
+            remaining_budget=remaining_budget,
+            analysis=analysis,
+        )
+
+        # Record pass 1 queries for future duplication checks
+        self.query_memory.reset()
+        pass1_queries = []
+        if turn_context is not None:
+            deep_state = getattr(turn_context, "phase_states", {}).get("deep_queries", {})
+            pass1_queries = deep_state.get("query_texts", []) if isinstance(deep_state, dict) else []
+        if pass1_queries:
+            self.query_memory.record_queries(1, pass1_queries)
+        self.query_memory.reset_pass(2)
+
+        logger.info(
+            "Stored baseline context: %d chunks, %d entities, %d themes",
+            len(self.context_state.context.baseline_chunks),
+            len(baseline_entities),
+            len(baseline_themes),
+        )
+        return self.context_state.context
+
+    # ------------------------------------------------------------------
+    # Pass 2 handling
+    # ------------------------------------------------------------------
+    def process_user_input(self, user_input: str) -> Dict[str, Any]:
+        """Detect divergence and retrieve additional context if needed."""
+
+        self.context_state.record_user_input(user_input)
+
+        if not self.context_state.transition:
+            logger.debug("No baseline transition available; skipping divergence handling")
+            return {"status": "no_baseline"}
+
+        divergence = self.divergence_detector.evaluate(user_input, self.context_state)
+        self.context_state.mark_divergence(divergence.detected, divergence.confidence, divergence.gap_analysis)
+
+        remaining_budget = self.context_state.transition.remaining_budget
+        logger.debug("Remaining token budget before Pass 2 retrieval: %s", remaining_budget)
+
+        retrieval_summary: Dict[str, Any] = {
+            "divergence_detected": divergence.detected,
+            "divergence_confidence": divergence.confidence,
+            "gap_terms": list(divergence.gap_analysis.keys()),
+            "queries_reserved": [],
+            "chunks_added": [],
+        }
+
+        if remaining_budget <= 0:
+            logger.debug("No token budget available for Pass 2 retrieval")
+            retrieval_summary["status"] = "no_budget"
+            retrieval_summary["remaining_budget"] = 0
+            return retrieval_summary
+
+        query_requests: List[Tuple[str, str]] = []
+        if divergence.detected and divergence.gap_analysis:
+            for term, reason in divergence.gap_analysis.items():
+                if self.query_memory.reserve_query(2, term):
+                    query_requests.append((term, reason))
+            retrieval_summary["queries_reserved"] = [term for term, _ in query_requests]
+
+        tokens_consumed = 0
+        additional_chunks: List[Dict[str, Any]] = []
+
+        if query_requests:
+            additional_chunks, tokens_consumed = self.incremental.retrieve_incremental(query_requests, remaining_budget)
+            retrieval_summary["status"] = "divergence_handled"
+        elif self.warm_slice_default:
+            additional_chunks, tokens_consumed = self.incremental.expand_warm_slice(remaining_budget)
+            retrieval_summary["queries_reserved"] = []
+            retrieval_summary["status"] = "warm_expansion" if additional_chunks else "no_action"
+        else:
+            retrieval_summary["status"] = "no_action"
+
+        if tokens_consumed:
+            self.context_state.update_remaining_budget(max(0, remaining_budget - tokens_consumed))
+
+        if additional_chunks:
+            retrieval_summary["chunks_added"] = [
+                self.context_state._extract_chunk_id(chunk)  # type: ignore[attr-defined]
+                for chunk in additional_chunks
+            ]
+
+        retrieval_summary["remaining_budget"] = self.get_remaining_budget()
+
+        logger.debug(
+            "Pass 2 retrieval complete: %d chunk(s) added, %d tokens consumed",
+            len(additional_chunks),
+            tokens_consumed,
+        )
+        return retrieval_summary
+
+    # ------------------------------------------------------------------
+    # Query coordination
+    # ------------------------------------------------------------------
+    def prepare_queries_for_pass(self, pass_index: int, queries: Sequence[str]) -> List[str]:
+        allowed: List[str] = []
+        for query in queries:
+            if self.query_memory.reserve_query(pass_index, query):
+                allowed.append(query)
+        return allowed
+
+    # ------------------------------------------------------------------
+    # Context accessors
+    # ------------------------------------------------------------------
+    def augment_warm_slice(self, warm_slice: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        return self.context_state.get_augmented_warm_slice(warm_slice)
+
+    def get_context_package(self) -> ContextPackage:
+        return self.context_state.context
+
+    def get_context_summary(self) -> Dict[str, Any]:
+        return self.context_state.get_context_summary()
+
+    def get_remaining_budget(self) -> int:
+        if not self.context_state.transition:
+            return 0
+        return self.context_state.transition.remaining_budget
+
+    def get_query_history(self, pass_index: Optional[int] = None) -> List[str]:
+        return self.query_memory.get_queries(pass_index)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _collect_chunk_ids(self, chunks: Iterable[Dict[str, Any]]) -> List[int]:
+        ids: List[int] = []
+        for chunk in chunks:
+            if not isinstance(chunk, dict):
+                continue
+            chunk_id = chunk.get("chunk_id") or chunk.get("id")
+            try:
+                ids.append(int(chunk_id))
+            except (TypeError, ValueError):
+                continue
+        return ids
+
+    def _basic_analysis(self, narrative: str) -> Dict[str, Any]:
+        tokens = [tok for tok in narrative.split() if len(tok) > 3]
+        cleaned = [tok.strip(".,!?;:").lower() for tok in tokens if tok.strip(".,!?;:")]
+        freq = Counter(cleaned)
+        top_terms = [term for term, _ in freq.most_common(6)]
+        entities = self._extract_entities(narrative)
+        return {"themes": top_terms[:5], "entities": list(entities)}
+
+    def _determine_expected_themes(self, analysis: Dict[str, Any], turn_context: Optional[Any]) -> List[str]:
+        expected = set(analysis.get("themes", []))
+        if turn_context is not None:
+            warm_analysis = getattr(turn_context, "phase_states", {}).get("warm_analysis", {})
+            if isinstance(warm_analysis, dict):
+                analysis_obj = warm_analysis.get("analysis", {})
+                if isinstance(analysis_obj, dict):
+                    for key in ("themes", "expected_topics", "narrative_goals"):
+                        values = analysis_obj.get(key, [])
+                        if isinstance(values, str):
+                            expected.add(values)
+                        elif isinstance(values, Iterable):
+                            expected.update(str(v) for v in values)
+        return [str(theme).lower() for theme in expected if theme]
+
+    def _extract_entities(self, narrative: str) -> List[str]:
+        entities: List[str] = []
+        current: List[str] = []
+        for token in narrative.split():
+            cleaned = token.strip(".,!?;:")
+            if cleaned.istitle() and cleaned.lower() not in {"the", "and", "with", "from"}:
+                current.append(cleaned)
+            else:
+                if len(current) == 1:
+                    entities.append(current[0])
+                elif len(current) > 1:
+                    entities.append(" ".join(current))
+                current = []
+        if current:
+            if len(current) == 1:
+                entities.append(current[0])
+            else:
+                entities.append(" ".join(current))
+        return entities
+

--- a/nexus/memory/query_memory.py
+++ b/nexus/memory/query_memory.py
@@ -1,0 +1,89 @@
+"""Query tracking for LORE's two-pass memory system."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable, List, Optional, Set
+
+logger = logging.getLogger("nexus.memory.query_memory")
+
+
+class QueryMemory:
+    """Tracks SQL/text queries executed across passes."""
+
+    def __init__(self, max_iterations: int = 5) -> None:
+        self.max_iterations = max(1, int(max_iterations or 5))
+        self._queries: Dict[int, List[str]] = {1: [], 2: []}
+        self._normalized: Dict[int, Set[str]] = {1: set(), 2: set()}
+        self._all_queries: Set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Reset operations
+    # ------------------------------------------------------------------
+    def reset(self) -> None:
+        logger.debug("Resetting query memory for all passes")
+        for pass_index in (1, 2):
+            self.reset_pass(pass_index)
+        self._all_queries.clear()
+
+    def reset_pass(self, pass_index: int) -> None:
+        logger.debug("Resetting query memory for pass %s", pass_index)
+        self._queries[pass_index] = []
+        self._normalized[pass_index] = set()
+        # Rebuild global cache to avoid stale entries
+        self._all_queries = {q for values in self._normalized.values() for q in values}
+
+    # ------------------------------------------------------------------
+    # Query recording
+    # ------------------------------------------------------------------
+    def record_queries(self, pass_index: int, queries: Iterable[str]) -> List[str]:
+        recorded: List[str] = []
+        for query in queries:
+            if self.reserve_query(pass_index, query):
+                recorded.append(query)
+        return recorded
+
+    def reserve_query(self, pass_index: int, query: Optional[str]) -> bool:
+        normalized = self._normalize(query)
+        if not normalized:
+            return False
+        if normalized in self._all_queries:
+            logger.debug("Skipping duplicate query '%s'", normalized)
+            return False
+        if len(self._queries[pass_index]) >= self.max_iterations:
+            logger.debug("Query budget exhausted for pass %s", pass_index)
+            return False
+
+        self._queries[pass_index].append(query.strip())
+        self._normalized[pass_index].add(normalized)
+        self._all_queries.add(normalized)
+        logger.debug("Recorded query '%s' for pass %s", normalized, pass_index)
+        return True
+
+    # ------------------------------------------------------------------
+    # Query inspection
+    # ------------------------------------------------------------------
+    def was_run(self, query: Optional[str]) -> bool:
+        normalized = self._normalize(query)
+        return bool(normalized and normalized in self._all_queries)
+
+    def remaining_budget(self, pass_index: int) -> int:
+        return max(0, self.max_iterations - len(self._queries[pass_index]))
+
+    def get_queries(self, pass_index: Optional[int] = None) -> List[str]:
+        if pass_index is None:
+            merged: List[str] = []
+            for idx in (1, 2):
+                merged.extend(self._queries[idx])
+            return merged
+        return list(self._queries.get(pass_index, []))
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _normalize(self, query: Optional[str]) -> Optional[str]:
+        if not query:
+            return None
+        normalized = " ".join(query.split()).strip().lower()
+        return normalized or None
+

--- a/settings.json
+++ b/settings.json
@@ -115,6 +115,12 @@
             }
         }
     },
+    "memory": {
+        "pass2_budget_reserve": 0.25,
+        "divergence_threshold": 0.7,
+        "warm_slice_default": true,
+        "max_sql_iterations": 5
+    },
     "Agent Settings": {
         "global": {
             "model": {


### PR DESCRIPTION
## Summary
- implement a dedicated `nexus.memory` package with context state, divergence detection, incremental retrieval, and manager orchestration for the two-pass flow
- integrate the new memory manager into LORE's turn cycle to augment warm slices, filter duplicate queries, and persist storyteller responses as baseline context
- extend turn context/state reporting and add memory configuration defaults in `settings.json`

## Testing
- python3 -m compileall nexus/memory nexus/agents/lore


------
https://chatgpt.com/codex/tasks/task_e_68c981c3e1b48323baafd53d2bb42999