### PR TITLE
Defer LOGON provider initialization

### DIFF
--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -20,19 +20,18 @@ logger = logging.getLogger("nexus.lore.logon")
 
 class LogonUtility:
     """Wrapper for Apex AI API calls using existing providers"""
-    
+
     def __init__(self, settings: Dict[str, Any]):
         """Initialize LOGON utility with configured provider"""
         self.settings = settings
-        self.provider = None
-        self._initialize_provider()
-    
-    def _initialize_provider(self):
+        self.provider: Optional[object] = None
+
+    def _initialize_provider(self) -> None:
         """Initialize the appropriate API provider based on settings"""
         apex_settings = self.settings.get("API Settings", {}).get("apex", {})
         provider_type = apex_settings.get("provider", "openai")
         model = apex_settings.get("model", "gpt-4o")
-        
+
         if provider_type == "openai":
             self.provider = OpenAIProvider(
                 model=model,
@@ -48,32 +47,43 @@ class LogonUtility:
             )
         else:
             raise ValueError(f"Unsupported provider type: {provider_type}")
-        
+
         logger.info(f"LOGON initialized with {provider_type} provider using model {model}")
-    
+
+    def _ensure_provider(self) -> None:
+        """Ensure the provider is initialized before use."""
+        if self.provider is None:
+            self._initialize_provider()
+
+    def ensure_provider(self) -> None:
+        """Public wrapper for provider initialization."""
+        self._ensure_provider()
+
     def generate_narrative(self, context_payload: Dict) -> LLMResponse:
         """Generate narrative from context payload"""
+        self._ensure_provider()
+
         # Format the context into a prompt
         prompt = self._format_context_prompt(context_payload)
-        
+
         # Get completion from provider
         response = self.provider.get_completion(prompt)
         return response
-    
+
     def _format_context_prompt(self, context: Dict) -> str:
         """Format context payload into a prompt for the Apex AI"""
         sections = []
-        
+
         # Add warm slice
         if context.get("warm_slice"):
             sections.append("=== RECENT NARRATIVE ===")
             for chunk in context["warm_slice"]["chunks"]:
                 sections.append(chunk.get("text", ""))
-        
+
         # Add user input
         sections.append("\n=== USER INPUT ===")
         sections.append(context.get("user_input", ""))
-        
+
         # Add entity data
         if context.get("entity_data"):
             sections.append("\n=== RELEVANT ENTITIES ===")
@@ -81,21 +91,21 @@ class LogonUtility:
                 sections.append("Characters:")
                 for char in context["entity_data"]["characters"]:
                     sections.append(f"- {char.get('name', 'Unknown')}: {char.get('summary', '')}")
-            
+
             if context["entity_data"].get("locations"):
                 sections.append("Locations:")
                 for loc in context["entity_data"]["locations"]:
                     sections.append(f"- {loc.get('name', 'Unknown')}: {loc.get('description', '')}")
-        
+
         # Add retrieved passages
         if context.get("retrieved_passages"):
             sections.append("\n=== HISTORICAL CONTEXT ===")
             for passage in context["retrieved_passages"]["results"][:5]:  # Limit to top 5
                 sections.append(f"[Score: {passage.get('score', 0):.2f}] {passage.get('text', '')}")
-        
+
         # Add instructions
         sections.append("\n=== INSTRUCTIONS ===")
         sections.append("Continue the narrative based on the provided context and user input.")
         sections.append("Maintain consistency with established characters, locations, and plot.")
-        
+
         return "\n".join(sections)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    requires_postgres: Tests that need a running PostgreSQL instance.
+    requires_local_llm: Tests that need the local LM Studio endpoint.

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -1,0 +1,73 @@
+"""Tests for lazy initialization of LOGON provider."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from nexus.agents.lore.lore import LORE
+from nexus.agents.lore.logon_utility import LogonUtility
+
+
+class _DummyResponse:
+    def __init__(self, prompt: str):
+        self.content = f"dummy:{prompt[:20]}"
+        self.input_tokens = 1
+        self.output_tokens = 1
+        self.model = "dummy-model"
+        self.raw_response = {"prompt": prompt}
+
+
+class _DummyProvider:
+    def get_completion(self, prompt: str) -> _DummyResponse:
+        return _DummyResponse(prompt)
+
+
+@pytest.fixture()
+def patched_provider(monkeypatch: pytest.MonkeyPatch) -> Dict[str, int]:
+    """Patch provider initialization so tests never hit real services."""
+
+    init_calls = {"count": 0}
+
+    def _fake_initialize(self: LogonUtility) -> None:
+        init_calls["count"] += 1
+        self.provider = _DummyProvider()
+
+    monkeypatch.setattr(LogonUtility, "_initialize_provider", _fake_initialize)
+    return init_calls
+
+
+def _minimal_payload() -> Dict[str, Any]:
+    return {
+        "user_input": "Test user input",
+        "warm_slice": {"chunks": []},
+        "entity_data": {},
+        "retrieved_passages": {"results": []},
+    }
+
+
+@pytest.mark.requires_local_llm
+@pytest.mark.requires_postgres
+def test_lore_leaves_logon_lazy(patched_provider: Dict[str, int]) -> None:
+    """LORE should not initialize LOGON on construction when lazy."""
+
+    lore = LORE(debug=True, enable_logon=True)
+    assert patched_provider["count"] == 0
+    assert lore.logon is None
+
+
+@pytest.mark.requires_local_llm
+@pytest.mark.requires_postgres
+def test_logon_initializes_on_first_use(patched_provider: Dict[str, int]) -> None:
+    """LOGON provider should initialize when narrative generation is requested."""
+
+    lore = LORE(debug=True, enable_logon=True)
+    lore.ensure_logon()
+    assert lore.logon is not None
+    assert patched_provider["count"] == 0
+
+    response = lore.logon.generate_narrative(_minimal_payload())
+
+    assert patched_provider["count"] == 1
+    assert response.content.startswith("dummy:")


### PR DESCRIPTION
## Summary
- make the LOGON utility lazily construct its Apex provider and guard narrative calls with an on-demand ensure helper
- delay LOGON creation in LORE until first use, validating configuration and short-circuiting Apex requests when disabled or unavailable
- add regression coverage for the lazy initialization flow and register pytest markers for the required services

## Testing
- pytest tests/test_lore/test_logon_lazy_init.py -m "not requires_local_llm" -q *(fails: pyenv version `3.11.11` is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d856496e1c83239f02ce249b48b5c5