### PR TITLE
Defer LOGON provider initialization until first use

### DIFF
--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -353,14 +353,27 @@ class TurnCycleManager:
         """
         logger.debug("Calling Apex AI...")
         
-        if not self.lore.logon:
+        if not self.lore.enable_logon:
+            logger.info("LOGON disabled; skipping Apex AI call")
+            turn_context.phase_states["apex_generation"] = {
+                "success": False,
+                "skipped": True,
+                "reason": "LOGON disabled"
+            }
+            return "LOGON disabled"
+
+        if not self.lore.ensure_logon():
             logger.error("LOGON not available for API calls")
+            turn_context.phase_states["apex_generation"] = {
+                "success": False,
+                "error": "LOGON unavailable"
+            }
             return "Error: API communication unavailable"
-        
+
         try:
             response = self.lore.logon.generate_narrative(turn_context.context_payload)
             turn_context.apex_response = response.content
-            
+
             turn_context.phase_states["apex_generation"] = {
                 "success": True,
                 "input_tokens": response.input_tokens,


### PR DESCRIPTION
## Summary
- lazily create LOGON providers on demand to avoid shelling out during LORE construction
- defer LOGON setup inside LORE and guard Apex calls when the utility is disabled or unavailable
- cover lazy initialization with new LOGON-focused tests alongside the existing Pass 2 regression

## Testing
- PYENV_VERSION=3.11.12 poetry run pytest tests/test_lore/test_pass2_chunk1369.py -s *(fails: ModuleNotFoundError: psycopg2)*

------
https://chatgpt.com/codex/tasks/task_e_68d856496e1c83239f02ce249b48b5c5