### PR TITLE
Defer LOGON provider initialization

### DIFF
--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -353,14 +353,28 @@ class TurnCycleManager:
         """
         logger.debug("Calling Apex AI...")
         
-        if not self.lore.logon:
+        if not self.lore.enable_logon:
+            logger.warning("LOGON disabled; skipping Apex AI call")
+            turn_context.phase_states["apex_generation"] = {
+                "success": False,
+                "error": "LOGON disabled"
+            }
+            turn_context.apex_response = ""
+            return ""
+
+        if not self.lore.ensure_logon_initialized():
             logger.error("LOGON not available for API calls")
-            return "Error: API communication unavailable"
-        
+            turn_context.phase_states["apex_generation"] = {
+                "success": False,
+                "error": "LOGON unavailable"
+            }
+            turn_context.apex_response = ""
+            return ""
+
         try:
             response = self.lore.logon.generate_narrative(turn_context.context_payload)
             turn_context.apex_response = response.content
-            
+
             turn_context.phase_states["apex_generation"] = {
                 "success": True,
                 "input_tokens": response.input_tokens,


### PR DESCRIPTION
## Summary
- make LogonUtility lazily construct Apex providers on first narrative request
- update LORE orchestration to initialize LOGON on demand and handle disabled providers gracefully
- add regression coverage ensuring LOGON stays dormant until invoked and spins up once used

## Testing
- pytest tests/test_lore/test_pass2_chunk1369.py -s *(fails: pyenv reports Python 3.11.11 is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d856496e1c83239f02ce249b48b5c5