### PR TITLE
Fix Apex audition comparison hydration and skip flow

### DIFF
--- a/ui/client/src/pages/AuditionTab.tsx
+++ b/ui/client/src/pages/AuditionTab.tsx
@@ -6,7 +6,6 @@ import { useComparison } from '@/hooks/useComparison';
 import { ComparisonLayout } from '@/components/audition/ComparisonLayout';
 import { LeaderboardView } from '@/components/audition/LeaderboardView';
 import { Button } from '@/components/ui/button';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Loader2 } from 'lucide-react';
 
 export default function AuditionTab() {
@@ -25,6 +24,10 @@ export default function AuditionTab() {
   const handleComparisonComplete = () => {
     setComparisonCount((c) => c + 1);
     refetch(); // Fetch next comparison
+  };
+
+  const handleSkip = () => {
+    refetch();
   };
 
   if (activeView === 'leaderboard') {
@@ -107,6 +110,7 @@ export default function AuditionTab() {
           comparison={comparison}
           evaluator={evaluator}
           onComplete={handleComparisonComplete}
+          onSkip={handleSkip}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- alias Apex audition comparison query columns to hydrate Pydantic models reliably and randomize A/B order while avoiding duplicate pairings
- execute FastAPI audition endpoints synchronously to prevent event loop blocking with psycopg2 connections
- allow the React comparison view to skip a matchup without logging a tie and guard against duplicate submissions while refetching the queue

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dddc03d1988323a8c73a8c839737c4