### PR TITLE
Fix Apex audition comparison query aliases

### DIFF
--- a/nexus/api/apex_audition.py
+++ b/nexus/api/apex_audition.py
@@ -104,11 +104,46 @@ async def get_next_comparison(
 
             query = f"""
                 SELECT
-                    p.*,
-                    ca.*,
-                    cb.*,
-                    ga.*,
-                    gb.*
+                    p.id AS prompt_id,
+                    p.chunk_id AS prompt_chunk_id,
+                    p.category AS prompt_category,
+                    p.label AS prompt_label,
+                    p.context AS prompt_context,
+                    p.metadata AS prompt_metadata,
+                    ca.id AS condition_a_id,
+                    ca.slug AS condition_a_slug,
+                    ca.provider AS condition_a_provider,
+                    ca.model_name AS condition_a_model_name,
+                    ca.label AS condition_a_label,
+                    ca.parameters AS condition_a_parameters,
+                    ca.is_active AS condition_a_is_active,
+                    cb.id AS condition_b_id,
+                    cb.slug AS condition_b_slug,
+                    cb.provider AS condition_b_provider,
+                    cb.model_name AS condition_b_model_name,
+                    cb.label AS condition_b_label,
+                    cb.parameters AS condition_b_parameters,
+                    cb.is_active AS condition_b_is_active,
+                    ga.id AS generation_a_id,
+                    ga.condition_id AS generation_a_condition_id,
+                    ga.prompt_id AS generation_a_prompt_id,
+                    ga.replicate_index AS generation_a_replicate_index,
+                    ga.status AS generation_a_status,
+                    ga.response_payload AS generation_a_response_payload,
+                    ga.input_tokens AS generation_a_input_tokens,
+                    ga.output_tokens AS generation_a_output_tokens,
+                    ga.cost_usd AS generation_a_cost_usd,
+                    ga.completed_at AS generation_a_completed_at,
+                    gb.id AS generation_b_id,
+                    gb.condition_id AS generation_b_condition_id,
+                    gb.prompt_id AS generation_b_prompt_id,
+                    gb.replicate_index AS generation_b_replicate_index,
+                    gb.status AS generation_b_status,
+                    gb.response_payload AS generation_b_response_payload,
+                    gb.input_tokens AS generation_b_input_tokens,
+                    gb.output_tokens AS generation_b_output_tokens,
+                    gb.cost_usd AS generation_b_cost_usd,
+                    gb.completed_at AS generation_b_completed_at
                 FROM apex_audition.prompts p
                 JOIN apex_audition.generations ga ON ga.prompt_id = p.id
                     AND ga.status = 'completed'
@@ -135,52 +170,54 @@ async def get_next_comparison(
             # This is simplified - in production, you'd properly parse all fields
             return ComparisonQueueItem(
                 prompt=Prompt(
-                    id=row['id'],
-                    chunk_id=row['chunk_id'],
-                    category=row.get('category'),
-                    label=row.get('label'),
-                    context=row['context'],
-                    metadata=row['metadata']
+                    id=row['prompt_id'],
+                    chunk_id=row['prompt_chunk_id'],
+                    category=row.get('prompt_category'),
+                    label=row.get('prompt_label'),
+                    context=row['prompt_context'],
+                    metadata=row['prompt_metadata']
                 ),
                 condition_a=Condition(
-                    id=row['ca.id'],
-                    slug=row['ca.slug'],
-                    provider=row['ca.provider'],
-                    model_name=row['ca.model_name'],
-                    parameters=row['ca.parameters'],
-                    is_active=row['ca.is_active']
+                    id=row['condition_a_id'],
+                    slug=row['condition_a_slug'],
+                    provider=row['condition_a_provider'],
+                    model_name=row['condition_a_model_name'],
+                    label=row.get('condition_a_label'),
+                    parameters=row['condition_a_parameters'],
+                    is_active=row['condition_a_is_active']
                 ),
                 condition_b=Condition(
-                    id=row['cb.id'],
-                    slug=row['cb.slug'],
-                    provider=row['cb.provider'],
-                    model_name=row['cb.model_name'],
-                    parameters=row['cb.parameters'],
-                    is_active=row['cb.is_active']
+                    id=row['condition_b_id'],
+                    slug=row['condition_b_slug'],
+                    provider=row['condition_b_provider'],
+                    model_name=row['condition_b_model_name'],
+                    label=row.get('condition_b_label'),
+                    parameters=row['condition_b_parameters'],
+                    is_active=row['condition_b_is_active']
                 ),
                 generation_a=Generation(
-                    id=row['ga.id'],
-                    condition_id=row['ga.condition_id'],
-                    prompt_id=row['ga.prompt_id'],
-                    replicate_index=row['ga.replicate_index'],
-                    status=row['ga.status'],
-                    response_payload=row['ga.response_payload'],
-                    input_tokens=row.get('ga.input_tokens'),
-                    output_tokens=row.get('ga.output_tokens'),
-                    cost_usd=row.get('ga.cost_usd'),
-                    completed_at=row.get('ga.completed_at')
+                    id=row['generation_a_id'],
+                    condition_id=row['generation_a_condition_id'],
+                    prompt_id=row['generation_a_prompt_id'],
+                    replicate_index=row['generation_a_replicate_index'],
+                    status=row['generation_a_status'],
+                    response_payload=row['generation_a_response_payload'],
+                    input_tokens=row.get('generation_a_input_tokens'),
+                    output_tokens=row.get('generation_a_output_tokens'),
+                    cost_usd=row.get('generation_a_cost_usd'),
+                    completed_at=row.get('generation_a_completed_at')
                 ),
                 generation_b=Generation(
-                    id=row['gb.id'],
-                    condition_id=row['gb.condition_id'],
-                    prompt_id=row['gb.prompt_id'],
-                    replicate_index=row['gb.replicate_index'],
-                    status=row['gb.status'],
-                    response_payload=row['gb.response_payload'],
-                    input_tokens=row.get('gb.input_tokens'),
-                    output_tokens=row.get('gb.output_tokens'),
-                    cost_usd=row.get('gb.cost_usd'),
-                    completed_at=row.get('gb.completed_at')
+                    id=row['generation_b_id'],
+                    condition_id=row['generation_b_condition_id'],
+                    prompt_id=row['generation_b_prompt_id'],
+                    replicate_index=row['generation_b_replicate_index'],
+                    status=row['generation_b_status'],
+                    response_payload=row['generation_b_response_payload'],
+                    input_tokens=row.get('generation_b_input_tokens'),
+                    output_tokens=row.get('generation_b_output_tokens'),
+                    cost_usd=row.get('generation_b_cost_usd'),
+                    completed_at=row.get('generation_b_completed_at')
                 )
             )
 


### PR DESCRIPTION
## Summary
- alias the apex audition comparison query columns so RealDictCursor preserves both conditions and generation rows
- hydrate the FastAPI response models from the aliased columns to prevent KeyErrors when serving the queue endpoint

## Testing
- ⚠️ `python -m compileall nexus/api/apex_audition.py` *(fails: pyenv missing 3.11.11 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dddc03d1988323a8c73a8c839737c4