### PR TITLE
Preserve batch run metadata in Apex Audition

### DIFF
--- a/nexus/audition/engine.py
+++ b/nexus/audition/engine.py
@@ -339,6 +339,7 @@ class AuditionEngine:
             storyteller_prompt=condition.system_prompt,
             created_by=created_by,
             notes=notes,
+            description=run_label,
         )
         run = self.repository.create_generation_run(run)
 

--- a/scripts/run_apex_audition_batch.py
+++ b/scripts/run_apex_audition_batch.py
@@ -150,6 +150,8 @@ def main() -> None:
             limit=args.limit,
             replicate_count=args.replicates,
             enable_cache=not args.no_cache,
+            created_by=args.created_by,
+            notes=args.notes,
         )
 
         LOGGER.info("=== BATCH SUBMITTED ===")


### PR DESCRIPTION
## Summary
- ensure asynchronous batch submissions persist run labels on the stored GenerationRun record
- forward CLI audit metadata to batch submissions so created_by and notes are saved consistently

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e002d497208323922dc4fe7516cbcb