### PR TITLE
Fix NarrativeTab font selection

### DIFF
--- a/ui/client/src/components/NarrativeTab.tsx
+++ b/ui/client/src/components/NarrativeTab.tsx
@@ -10,6 +10,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import type { Episode, NarrativeChunk, ChunkMetadata, Season } from "@shared/schema";
+import { useFonts } from "@/contexts/FontContext";
 
 interface ChunkWithMetadata extends NarrativeChunk {
   metadata?: ChunkMetadata;
@@ -318,6 +319,7 @@ export function NarrativeTab() {
   }, []);
 
   const activeSeasonIds = useMemo(() => new Set(openSeasons), [openSeasons]);
+  const { fonts } = useFonts();
 
   return (
     <div className="flex h-full flex-col md:flex-row">
@@ -375,7 +377,10 @@ export function NarrativeTab() {
                   </div>
                 )}
 
-                <div className="font-sans text-foreground text-base leading-relaxed">
+                <div
+                  className="text-foreground text-base leading-relaxed"
+                  style={{ fontFamily: fonts.narrativeFont }}
+                >
                   <ReactMarkdown components={markdownComponents}>
                     {selectedChunk.rawText || ""}
                   </ReactMarkdown>


### PR DESCRIPTION
## Summary
- ensure the Narrative tab renders story text with the selected narrative font
- read the font preference from FontContext so markdown content honors user changes

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2a7bbfb70832385d8404fa0a74ad5