### PR TITLE
Ensure NarrativeTab respects font preferences

### DIFF
--- a/ui/client/src/components/NarrativeTab.tsx
+++ b/ui/client/src/components/NarrativeTab.tsx
@@ -9,6 +9,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { useFonts } from "@/contexts/FontContext";
 import type { Episode, NarrativeChunk, ChunkMetadata, Season } from "@shared/schema";
 
 interface ChunkWithMetadata extends NarrativeChunk {
@@ -277,6 +278,7 @@ export function NarrativeTab() {
   const [openSeasons, setOpenSeasons] = useState<number[]>([]);
   const [openEpisodes, setOpenEpisodes] = useState<string[]>([]);
   const [selectedChunk, setSelectedChunk] = useState<ChunkWithMetadata | null>(null);
+  const { fonts } = useFonts();
 
   const {
     data: seasons = [],
@@ -375,7 +377,10 @@ export function NarrativeTab() {
                   </div>
                 )}
 
-                <div className="font-sans text-foreground text-base leading-relaxed">
+                <div
+                  className="text-foreground text-base leading-relaxed"
+                  style={{ fontFamily: fonts.narrativeFont }}
+                >
                   <ReactMarkdown components={markdownComponents}>
                     {selectedChunk.rawText || ""}
                   </ReactMarkdown>


### PR DESCRIPTION
## Summary
- import the font context inside NarrativeTab so the component can access persisted preferences
- apply the selected narrative font to rendered markdown so story chunks respect the customization

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2a7bbfb70832385d8404fa0a74ad5