### PR TITLE
Fix narrative tab font preference application

### DIFF
--- a/ui/client/src/components/NarrativeTab.tsx
+++ b/ui/client/src/components/NarrativeTab.tsx
@@ -10,6 +10,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import type { Episode, NarrativeChunk, ChunkMetadata, Season } from "@shared/schema";
+import { useFonts } from "@/contexts/FontContext";
 
 interface ChunkWithMetadata extends NarrativeChunk {
   metadata?: ChunkMetadata;
@@ -277,6 +278,7 @@ export function NarrativeTab() {
   const [openSeasons, setOpenSeasons] = useState<number[]>([]);
   const [openEpisodes, setOpenEpisodes] = useState<string[]>([]);
   const [selectedChunk, setSelectedChunk] = useState<ChunkWithMetadata | null>(null);
+  const { fonts } = useFonts();
 
   const {
     data: seasons = [],
@@ -375,7 +377,10 @@ export function NarrativeTab() {
                   </div>
                 )}
 
-                <div className="font-sans text-foreground text-base leading-relaxed">
+                <div
+                  className="text-foreground text-base leading-relaxed"
+                  style={{ fontFamily: fonts.narrativeFont }}
+                >
                   <ReactMarkdown components={markdownComponents}>
                     {selectedChunk.rawText || ""}
                   </ReactMarkdown>


### PR DESCRIPTION
## Summary
- use the FontContext hook within NarrativeTab to read the active narrative font selection
- apply the selected narrative font to rendered chunk content so the settings tab affects the narrative view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2a7bbfb70832385d8404fa0a74ad5