### PR TITLE
Fix enum migration regression and apply narrative font choice

### DIFF
--- a/db/migrations/20250104_remove_sonnet_4_0.sql
+++ b/db/migrations/20250104_remove_sonnet_4_0.sql
@@ -4,7 +4,13 @@
 
 BEGIN;
 
--- Step 1: Create new ENUM without claude-sonnet-4-0
+-- Step 1: Remap any lingering claude-sonnet-4-0 rows to the supported alias
+-- This prevents the enum alteration from failing when the value disappears.
+UPDATE apex_audition.conditions
+SET model_name = 'claude-sonnet-4-5'
+WHERE model_name = 'claude-sonnet-4-0';
+
+-- Step 2: Create new ENUM without claude-sonnet-4-0
 CREATE TYPE apex_audition.model_name_enum_new AS ENUM (
     'gpt-5',
     'gpt-4o',
@@ -13,18 +19,18 @@ CREATE TYPE apex_audition.model_name_enum_new AS ENUM (
     'claude-opus-4-1'
 );
 
--- Step 2: Update column to use new ENUM type
+-- Step 3: Update column to use new ENUM type
 ALTER TABLE apex_audition.conditions
     ALTER COLUMN model_name TYPE apex_audition.model_name_enum_new
     USING model_name::text::apex_audition.model_name_enum_new;
 
--- Step 3: Drop old ENUM type
+-- Step 4: Drop old ENUM type
 DROP TYPE apex_audition.model_name_enum;
 
--- Step 4: Rename new ENUM to original name
+-- Step 5: Rename new ENUM to original name
 ALTER TYPE apex_audition.model_name_enum_new RENAME TO model_name_enum;
 
--- Step 5: Update repository.py ENUM definition to match
+-- Step 6: Update repository.py ENUM definition to match
 -- (This is a reminder - you'll need to manually update the Python code)
 
 COMMIT;

--- a/ui/client/src/components/NarrativeTab.tsx
+++ b/ui/client/src/components/NarrativeTab.tsx
@@ -10,6 +10,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import type { Episode, NarrativeChunk, ChunkMetadata, Season } from "@shared/schema";
+import { useFonts } from "@/contexts/FontContext";
 
 interface ChunkWithMetadata extends NarrativeChunk {
   metadata?: ChunkMetadata;
@@ -277,6 +278,7 @@ export function NarrativeTab() {
   const [openSeasons, setOpenSeasons] = useState<number[]>([]);
   const [openEpisodes, setOpenEpisodes] = useState<string[]>([]);
   const [selectedChunk, setSelectedChunk] = useState<ChunkWithMetadata | null>(null);
+  const { fonts } = useFonts();
 
   const {
     data: seasons = [],
@@ -375,7 +377,10 @@ export function NarrativeTab() {
                   </div>
                 )}
 
-                <div className="font-sans text-foreground text-base leading-relaxed">
+                <div
+                  className="text-foreground text-base leading-relaxed"
+                  style={{ fontFamily: fonts.narrativeFont }}
+                >
                   <ReactMarkdown components={markdownComponents}>
                     {selectedChunk.rawText || ""}
                   </ReactMarkdown>


### PR DESCRIPTION
## Summary
- remap legacy `claude-sonnet-4-0` records before altering the `model_name_enum` so the migration succeeds after normalization
- wire the narrative tab content to the `FontContext` so the selected narrative font preference is honored

## Testing
- `npm run dev -- --host 0.0.0.0 --port 4173` *(fails: local tsx binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a7bbfb70832385d8404fa0a74ad5