### PR TITLE
Add Arena passage debug/regeneration tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ log.md
 /time_delta_processor.log
 /lm_studio_log.txt
 /temp/
+logs/
 
 # Ignore binaries and database files
 *.sqlite3

--- a/nexus/api/models.py
+++ b/nexus/api/models.py
@@ -4,7 +4,7 @@ Pydantic models for FastAPI endpoints.
 These match the TypeScript interfaces expected by the iris2 frontend.
 """
 from pydantic import BaseModel, Field
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Literal
 from datetime import datetime
 
 
@@ -108,3 +108,29 @@ class GenerationRun(BaseModel):
     total_generations: int
     completed_generations: int
     failed_generations: int
+
+
+class AsyncGenerationStatus(BaseModel):
+    """Telemetry for asynchronous batch polling."""
+    pending_requests: int
+    pending_batches: int
+    remaining_generations: int
+    last_poll_at: Optional[datetime] = None
+    next_poll_at: Optional[datetime] = None
+    polling_interval_seconds: Optional[int] = None
+    last_duration_seconds: Optional[float] = None
+
+
+class RegenerateGenerationRequest(BaseModel):
+    """Request payload to delete and rerun a specific generation."""
+    generation_id: int
+    async_providers: Optional[List[str]] = None
+
+
+class RegenerateGenerationResponse(BaseModel):
+    """Response describing the regeneration outcome."""
+    mode: Literal["sync", "async"]
+    run_id: str
+    generation_id: Optional[int] = None
+    batch_id: Optional[str] = None
+    comparisons_deleted: int

--- a/nexus/audition/batch_clients.py
+++ b/nexus/audition/batch_clients.py
@@ -1,9 +1,10 @@
-"""Batch API clients for OpenAI, Anthropic, and OpenRouter."""
+"""Batch API clients for OpenAI and Anthropic."""
 
 from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import time
 from dataclasses import dataclass
@@ -22,7 +23,10 @@ try:
 except ImportError:
     openai = None
 
-import requests
+try:
+    import requests
+except ImportError:
+    requests = None
 
 LOGGER = logging.getLogger("nexus.apex_audition.batch_clients")
 
@@ -506,209 +510,6 @@ class OpenAIBatchClient:
         LOGGER.info(f"Cancelled batch {batch_id}")
 
 
-class OpenRouterBatchClient:
-    """Client for OpenRouter batch execution via OpenAI-compatible API."""
-
-    API_BASE = "https://openrouter.ai/api/v1"
-
-    def __init__(self, api_key: Optional[str] = None):
-        """Initialize client with API key from 1Password if not provided."""
-        self.api_key = api_key or self._get_api_key()
-        if openai:
-            self.client = openai.OpenAI(
-                api_key=self.api_key,
-                base_url=self.API_BASE,
-            )
-        else:
-            raise ImportError("openai package not installed")
-
-    def _get_api_key(self) -> str:
-        """Get OpenRouter API key from 1Password CLI."""
-        try:
-            result = subprocess.run(
-                ["op", "read", "op://API/OpenRouter/api key"],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            api_key = result.stdout.strip()
-            if not api_key:
-                raise ValueError("Empty API key returned from 1Password")
-            return api_key
-        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
-            raise ValueError(
-                "Failed to retrieve OpenRouter API key from 1Password. "
-                "Ensure 1Password CLI is installed and signed in."
-            ) from exc
-
-    def create_batch(self, requests: List[BatchRequest], output_dir: Path) -> str:
-        """Create a batch."""
-        output_dir.mkdir(parents=True, exist_ok=True)
-        input_file = output_dir / f"batch_input_{int(time.time())}.jsonl"
-
-        with open(input_file, "w", encoding="utf-8") as handle:
-            for req in requests:
-                messages: List[Dict[str, Any]] = []
-                if req.system_prompt:
-                    messages.append({"role": "system", "content": req.system_prompt})
-                messages.append({"role": "user", "content": req.prompt_text})
-
-                body: Dict[str, Any] = {
-                    "model": req.model,
-                    "messages": messages,
-                    "max_tokens": req.max_tokens,
-                }
-
-                if req.temperature is not None:
-                    body["temperature"] = req.temperature
-
-                if req.reasoning_effort or req.thinking_budget_tokens:
-                    reasoning: Dict[str, Any] = {}
-                    if req.reasoning_effort:
-                        reasoning["effort"] = req.reasoning_effort
-                    if req.thinking_budget_tokens:
-                        reasoning["max_tokens"] = req.thinking_budget_tokens
-                    body["reasoning"] = reasoning
-
-                batch_request = {
-                    "custom_id": req.custom_id,
-                    "method": "POST",
-                    "url": "/v1/chat/completions",
-                    "body": body,
-                }
-                handle.write(json.dumps(batch_request) + "\n")
-
-        LOGGER.info(
-            "Created OpenRouter batch input file: %s (%s requests)",
-            input_file,
-            len(requests),
-        )
-
-        with open(input_file, "rb") as handle:
-            upload_response = self.client.files.create(file=handle, purpose="batch")
-
-        LOGGER.info("Uploaded OpenRouter batch file: %s", upload_response.id)
-
-        batch_response = self.client.batches.create(
-            input_file_id=upload_response.id,
-            endpoint="/v1/chat/completions",
-            completion_window="24h",
-        )
-
-        LOGGER.info(
-            "OpenRouter batch created: %s (status: %s)",
-            batch_response.id,
-            batch_response.status,
-        )
-        return batch_response.id
-
-    def get_status(self, batch_id: str) -> BatchJob:
-        """Get batch status."""
-        response = self.client.batches.retrieve(batch_id)
-
-        status_map = {
-            "validating": BatchStatus.PENDING,
-            "in_progress": BatchStatus.IN_PROGRESS,
-            "finalizing": BatchStatus.IN_PROGRESS,
-            "completed": BatchStatus.COMPLETED,
-            "failed": BatchStatus.FAILED,
-            "expired": BatchStatus.EXPIRED,
-            "cancelling": BatchStatus.IN_PROGRESS,
-            "cancelled": BatchStatus.CANCELLED,
-        }
-        status = status_map.get(response.status, BatchStatus.PENDING)
-
-        return BatchJob(
-            batch_id=batch_id,
-            provider="openrouter",
-            status=status,
-            total_requests=response.request_counts.total,
-            created_at=datetime.fromtimestamp(response.created_at, tz=timezone.utc),
-            completed_at=
-            datetime.fromtimestamp(response.completed_at, tz=timezone.utc)
-            if response.completed_at
-            else None,
-            results_url=response.output_file_id,
-            request_counts={
-                "completed": response.request_counts.completed,
-                "failed": response.request_counts.failed,
-            },
-        )
-
-    def retrieve_results(self, batch_job: BatchJob) -> List[BatchResult]:
-        """Retrieve results from a completed batch."""
-        if not batch_job.results_url:
-            raise ValueError(f"Batch {batch_job.batch_id} has no output_file_id")
-
-        LOGGER.info(
-            "Retrieving OpenRouter batch results from file %s",
-            batch_job.results_url,
-        )
-
-        file_response = self.client.files.content(batch_job.results_url)
-        content = file_response.read().decode("utf-8")
-
-        results: List[BatchResult] = []
-        for line in content.strip().split("\n"):
-            if not line:
-                continue
-            result_data = json.loads(line)
-            response_payload = result_data.get("response")
-
-            if response_payload and response_payload.get("status_code") == 200:
-                body = response_payload.get("body")
-                if isinstance(body, str):
-                    try:
-                        body = json.loads(body)
-                    except json.JSONDecodeError:
-                        LOGGER.warning(
-                            "Failed to decode OpenRouter batch response body for %s; leaving as raw string",
-                            result_data.get("custom_id"),
-                        )
-
-                results.append(
-                    BatchResult(
-                        custom_id=result_data["custom_id"],
-                        status="succeeded",
-                        response=body,
-                    )
-                )
-                continue
-
-            error_msg = result_data.get("error", {}).get("message", "Unknown error")
-            if response_payload:
-                error_body = response_payload.get("body")
-                if isinstance(error_body, str):
-                    try:
-                        error_body = json.loads(error_body)
-                    except json.JSONDecodeError:
-                        error_body = None
-                if isinstance(error_body, dict):
-                    error_field = error_body.get("error")
-                    if isinstance(error_field, dict):
-                        error_msg = error_field.get("message", error_msg)
-
-            results.append(
-                BatchResult(
-                    custom_id=result_data["custom_id"],
-                    status="failed",
-                    error=error_msg,
-                )
-            )
-
-        LOGGER.info(
-            "Retrieved %s results from OpenRouter batch %s",
-            len(results),
-            batch_job.batch_id,
-        )
-        return results
-
-    def cancel_batch(self, batch_id: str) -> None:
-        """Cancel a batch."""
-        self.client.batches.cancel(batch_id)
-        LOGGER.info("Cancelled OpenRouter batch %s", batch_id)
-
-
 __all__ = [
     "BatchStatus",
     "BatchRequest",
@@ -716,5 +517,4 @@ __all__ = [
     "BatchJob",
     "AnthropicBatchClient",
     "OpenAIBatchClient",
-    "OpenRouterBatchClient",
 ]

--- a/scripts/auto_poll_batches.py
+++ b/scripts/auto_poll_batches.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Automatically poll and retrieve results from pending batch jobs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from sqlalchemy import text
+
+from nexus.audition import (
+    AuditionEngine,
+    AuditionRepository,
+    AnthropicBatchClient,
+    OpenAIBatchClient,
+    BatchStatus,
+)
+
+LOGGER = logging.getLogger("nexus.apex_audition.auto_poll")
+STATUS_PATH = Path("logs/auto_poll_status.json")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description="Poll provider batches and ingest results.")
+    parser.add_argument(
+        "--loop",
+        action="store_true",
+        help="Run continuously, polling every INTERVAL seconds instead of exiting after one pass.",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=60,
+        help="Seconds between polls when --loop is enabled (default: 60).",
+    )
+    return parser.parse_args()
+
+
+def get_active_batches(repository: AuditionRepository) -> List[Tuple[str, str]]:
+    """Query database for active batch jobs.
+
+    Returns list of (batch_job_id, provider) tuples for batches that are:
+    - status = 'batch_pending'
+    - batch_job_id IS NOT NULL
+    - started_at within last 24 hours
+    """
+    query = """
+        SELECT DISTINCT g.batch_job_id, c.provider
+        FROM apex_audition.generations g
+        JOIN apex_audition.conditions c ON g.condition_id = c.id
+        WHERE g.status = 'batch_pending'
+          AND g.batch_job_id IS NOT NULL
+          AND g.started_at > NOW() - INTERVAL '24 hours'
+        ORDER BY g.batch_job_id
+    """
+
+    with repository.engine.connect() as conn:
+        result = conn.execute(text(query))
+        return [(row[0], row[1]) for row in result]
+
+
+def poll_and_retrieve_batch(
+    batch_id: str, provider: str, engine: AuditionEngine, client_cache: Dict[str, Any]
+) -> bool:
+    """Poll a single batch and retrieve results if completed.
+
+    Returns True if batch is still in progress, False if terminal state reached.
+    """
+    provider_key = provider.lower()
+    if provider_key not in client_cache:
+        if provider_key == "anthropic":
+            client_cache[provider_key] = AnthropicBatchClient()
+        elif provider_key == "openai":
+            client_cache[provider_key] = OpenAIBatchClient()
+        else:
+            LOGGER.warning("Unknown provider '%s' for batch %s, skipping", provider, batch_id)
+            return False
+
+    client = client_cache.get(provider_key)
+    if client is None:
+        LOGGER.warning("No client available for provider '%s'; skipping batch %s", provider, batch_id)
+        return False
+
+    try:
+        batch_job = client.get_status(batch_id)
+    except Exception as e:
+        LOGGER.error(f"Failed to get status for batch {batch_id} ({provider}): {e}")
+        return False
+
+    LOGGER.info(f"Batch {batch_id} ({provider}): {batch_job.status.value}")
+
+    if batch_job.request_counts:
+        LOGGER.info(f"  Request counts: {batch_job.request_counts}")
+
+    # Handle completed batch
+    if batch_job.status == BatchStatus.COMPLETED:
+        LOGGER.info(f"✓ Batch {batch_id} completed, retrieving results...")
+        try:
+            results = engine.retrieve_batch_results(batch_id, provider.lower())
+            succeeded = sum(1 for r in results if r.status == "completed")
+            failed = sum(1 for r in results if r.status == "error")
+            LOGGER.info(f"  Retrieved: {succeeded} succeeded, {failed} failed")
+            if results:
+                LOGGER.info(f"  Run ID: {results[0].run_id}")
+        except Exception as e:
+            LOGGER.error(f"Failed to retrieve results for batch {batch_id}: {e}")
+        return False
+
+    # Handle failed states
+    if batch_job.status in [BatchStatus.FAILED, BatchStatus.CANCELLED, BatchStatus.EXPIRED]:
+        LOGGER.error(f"✗ Batch {batch_id} ended with status: {batch_job.status.value}")
+        return False
+
+    # Still in progress
+    return True
+
+
+def process_batches(
+    repository: AuditionRepository, engine: AuditionEngine, client_cache: Dict[str, Any]
+) -> Tuple[int, int]:
+    """Run a single polling pass and return (still_pending, total_active)."""
+    active_batches = get_active_batches(repository)
+
+    if not active_batches:
+        LOGGER.debug("No active batches found")
+        return 0, 0
+
+    LOGGER.info("Found %d active batch(es)", len(active_batches))
+
+    still_pending = 0
+    for batch_id, provider in active_batches:
+        if poll_and_retrieve_batch(batch_id, provider, engine, client_cache):
+            still_pending += 1
+
+    return still_pending, len(active_batches)
+
+
+def write_status(still_pending: int, total_active: int, poll_interval: int | None, duration: float) -> None:
+    """Persist the latest polling heartbeat for UI and operators."""
+    timestamp = datetime.now(timezone.utc)
+    payload = {
+        "last_poll_at": timestamp.isoformat(),
+        "active_batches": total_active,
+        "still_pending": still_pending,
+        "last_duration_seconds": round(duration, 2),
+    }
+
+    if poll_interval:
+        payload["polling_interval_seconds"] = poll_interval
+        payload["next_poll_at"] = (timestamp + timedelta(seconds=poll_interval)).isoformat()
+
+    try:
+        STATUS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        STATUS_PATH.write_text(json.dumps(payload))
+    except OSError as exc:  # pragma: no cover - best effort telemetry
+        LOGGER.debug("Failed to write auto-poll status file: %s", exc)
+
+
+def main() -> None:
+    """Main entry point for auto-polling script."""
+    args = parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        handlers=[
+            logging.FileHandler("auto_poll_batches.log"),
+            logging.StreamHandler()
+        ]
+    )
+
+    # Initialize repository and engine
+    repository = AuditionRepository()
+    engine = AuditionEngine(repository=repository)
+    client_cache: Dict[str, Any] = {}
+    poll_interval: int | None = None
+
+    def run_once() -> Tuple[int, int, float]:
+        """Execute a single polling pass, returning still_pending, total_active, elapsed."""
+        pass_start = time.time()
+        try:
+            still_pending, total_active = process_batches(repository, engine, client_cache)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            LOGGER.exception("Auto-poll run failed: %s", exc)
+            still_pending, total_active = 0, 0
+        elapsed = time.time() - pass_start
+        if total_active:
+            LOGGER.info(
+                "Polling cycle complete in %.2fs (%d still pending)",
+                elapsed,
+                still_pending,
+            )
+        write_status(still_pending, total_active, poll_interval, elapsed)
+        return still_pending, total_active, elapsed
+
+    if not args.loop:
+        poll_interval = None
+        _, total_active, elapsed = run_once()
+        if total_active == 0:
+            LOGGER.debug("No active batches found (query took %.2fs)", elapsed)
+        sys.exit(0)
+
+    poll_interval = max(args.interval, 5)
+    LOGGER.info("Starting auto-poll loop with %ds interval", poll_interval)
+
+    try:
+        while True:
+            _, _, _ = run_once()
+            time.sleep(poll_interval)
+    except KeyboardInterrupt:
+        LOGGER.info("Auto-poll loop interrupted by user")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- surface  modal in Arena to inspect slugs and regenerate passages
- add backend regeneration endpoint that deletes comparisons and requeues runs
- harden async batch parsing (Anthropic/OpenAI) and log poll heartbeat
## Testing
- poetry run python scripts/auto_poll_batches.py