### PR TITLE
Fix UTF-8 encoding corruption in Anthropic batch retrieval

### DIFF
--- a/nexus/audition/batch_clients.py
+++ b/nexus/audition/batch_clients.py
@@ -282,9 +282,13 @@ class AnthropicBatchClient:
         )
         response.raise_for_status()
 
+        # Explicitly decode as UTF-8 to avoid encoding issues
+        # (response.text can misdetect encoding, causing mojibake with emojis and special chars)
+        content = response.content.decode('utf-8')
+
         # Parse JSONL
         results = []
-        for line in response.text.strip().split('\n'):
+        for line in content.strip().split('\n'):
             if not line:
                 continue
             result_data = json.loads(line)

--- a/scripts/fix_empty_content.py
+++ b/scripts/fix_empty_content.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Fix generations with empty content by re-retrieving their batches.
+
+Some extended thinking generations ended up with empty content fields
+due to extraction issues. This script re-retrieves those batches.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import List
+
+from sqlalchemy import text
+
+from nexus.audition import AuditionEngine, AuditionRepository
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_empty_content_batches(repository: AuditionRepository) -> List[tuple[str, str]]:
+    """
+    Get batch IDs and providers for generations with empty content.
+
+    Returns:
+        List of (batch_id, provider) tuples
+    """
+    query = """
+        SELECT DISTINCT g.batch_job_id, c.provider
+        FROM apex_audition.generations g
+        JOIN apex_audition.conditions c ON g.condition_id = c.id
+        WHERE g.status = 'completed'
+          AND g.response_payload->>'content' = ''
+          AND g.batch_job_id IS NOT NULL
+        ORDER BY g.batch_job_id
+    """
+
+    with repository.engine.connect() as conn:
+        result = conn.execute(text(query))
+        return [(row[0], row[1]) for row in result]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fix generations with empty content by re-retrieving batches"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be fixed without making changes",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    args = parser.parse_args()
+
+    # Setup logging
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    repository = AuditionRepository()
+    engine = AuditionEngine(repository=repository)
+
+    # Get empty content batches
+    LOGGER.info("Finding batches with empty content...")
+    batches = get_empty_content_batches(repository)
+
+    if not batches:
+        LOGGER.info("No batches with empty content found!")
+        return
+
+    LOGGER.info(f"Found {len(batches)} batches with empty content")
+
+    for batch_id, provider in batches:
+        LOGGER.info(f"  {batch_id} ({provider})")
+
+    if args.dry_run:
+        LOGGER.info("[DRY RUN] Would re-retrieve these batches")
+        return
+
+    # Re-retrieve each batch
+    fixed = 0
+    failed = 0
+
+    for batch_id, provider in batches:
+        LOGGER.info(f"Re-retrieving batch {batch_id} ({provider})...")
+        try:
+            results = engine.retrieve_batch_results(batch_id, provider)
+            LOGGER.info(f"  Fixed {len(results)} generations")
+            fixed += len(results)
+        except Exception as e:
+            LOGGER.error(f"  Failed to retrieve batch {batch_id}: {e}")
+            failed += 1
+
+    LOGGER.info("=" * 80)
+    LOGGER.info(f"Fixed {fixed} generations")
+    LOGGER.info(f"Failed {failed} batches")
+    LOGGER.info("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fix_encoding_corruption.py
+++ b/scripts/fix_encoding_corruption.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+Fix encoding corruption in Anthropic batch generations.
+
+This script identifies generations with UTF-8 encoding issues (mojibake)
+and re-retrieves the batch results with proper encoding to fix them.
+
+The root cause was using response.text instead of response.content.decode('utf-8')
+in batch_clients.py, which caused the requests library to misdetect UTF-8 as another
+encoding, corrupting emojis and special characters.
+
+Examples of corruption:
+- "—" (em-dash) became "‚Äî"
+- "📍" (location emoji) became "üìç"
+- "🎬" (clapper emoji) became "üì∫"
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from collections import defaultdict
+from typing import Dict, List, Set
+
+from sqlalchemy import text
+
+from nexus.audition import AuditionEngine, AuditionRepository
+
+LOGGER = logging.getLogger(__name__)
+
+# Corruption markers that indicate encoding issues
+# These are common UTF-8 mojibake patterns from Windows-1252/ISO-8859-1 misinterpretation
+CORRUPTION_MARKERS = [
+    # Pattern set 1 (Oct 16 batches)
+    "‚Äî",  # Corrupted em-dash
+    "üìç",  # Corrupted emoji
+    "üì∫",  # Corrupted emoji
+    "‚Üí",  # Corrupted arrow
+    # Pattern set 2 (Oct 10/14 batches)
+    "\u00e2\u0080\u0094",  # Corrupted em-dash (different encoding) - â€"
+    "\u011f\u0178",        # Corrupted emoji prefix (catches ğŸ"�, ğŸš¨, ğŸ"Œ, etc.) - ğŸ
+    "\u00e2\u009c",        # Corrupted checkmark prefix - âœ
+    "\u00ef\u00b8",        # Corrupted emoji modifier - ï¸
+]
+
+
+def find_corrupted_generations(repository: AuditionRepository) -> List[Dict]:
+    """
+    Find all generations with encoding corruption.
+
+    Returns:
+        List of dicts with {id, batch_job_id, condition_id}
+    """
+    # Build OR conditions for all corruption markers
+    or_conditions = " OR ".join(
+        f"g.response_payload->>'content' LIKE '%{marker}%'"
+        for marker in CORRUPTION_MARKERS
+    )
+
+    query = f"""
+        SELECT
+            g.id,
+            g.batch_job_id,
+            g.condition_id,
+            g.prompt_id,
+            g.replicate_index,
+            c.provider
+        FROM apex_audition.generations g
+        JOIN apex_audition.conditions c ON g.condition_id = c.id
+        WHERE g.status = 'completed'
+          AND ({or_conditions})
+        ORDER BY g.batch_job_id, g.id
+    """
+
+    with repository.engine.connect() as conn:
+        result = conn.execute(text(query))
+        return [
+            {
+                "id": row[0],
+                "batch_job_id": row[1],
+                "condition_id": row[2],
+                "prompt_id": row[3],
+                "replicate_index": row[4],
+                "provider": row[5],
+            }
+            for row in result
+        ]
+
+
+def group_by_batch(corrupted: List[Dict]) -> Dict[str, List[Dict]]:
+    """Group corrupted generations by batch_job_id."""
+    by_batch = defaultdict(list)
+    for gen in corrupted:
+        if gen["batch_job_id"]:
+            by_batch[gen["batch_job_id"]].append(gen)
+    return dict(by_batch)
+
+
+def fix_batch(
+    batch_id: str,
+    provider: str,
+    corrupted_ids: Set[int],
+    engine: AuditionEngine,
+    repository: AuditionRepository,
+    dry_run: bool = False,
+) -> tuple[int, int]:
+    """
+    Re-retrieve batch results and update corrupted generations.
+
+    Returns:
+        Tuple of (fixed_count, failed_count)
+    """
+    LOGGER.info(f"Processing batch {batch_id} ({len(corrupted_ids)} corrupted generations)")
+
+    if dry_run:
+        LOGGER.info(f"[DRY RUN] Would re-retrieve batch {batch_id}")
+        return len(corrupted_ids), 0
+
+    try:
+        # Re-retrieve batch results with fixed encoding
+        results = engine.retrieve_batch_results(batch_id, provider)
+        LOGGER.info(f"Retrieved {len(results)} results from batch {batch_id}")
+
+        # Count how many corrupted generations were fixed
+        fixed_count = 0
+        for result in results:
+            if result.id in corrupted_ids:
+                fixed_count += 1
+                LOGGER.debug(f"Fixed generation {result.id}")
+
+        return fixed_count, len(corrupted_ids) - fixed_count
+
+    except Exception as e:
+        LOGGER.error(f"Failed to re-retrieve batch {batch_id}: {e}")
+        return 0, len(corrupted_ids)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fix encoding corruption in Anthropic batch generations"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be fixed without making changes",
+    )
+    parser.add_argument(
+        "--batch-id",
+        help="Fix only a specific batch ID",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    args = parser.parse_args()
+
+    # Setup logging
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    repository = AuditionRepository()
+    engine = AuditionEngine(repository=repository)
+
+    # Find all corrupted generations
+    LOGGER.info("Scanning for corrupted generations...")
+    corrupted = find_corrupted_generations(repository)
+
+    if not corrupted:
+        LOGGER.info("No corrupted generations found!")
+        return
+
+    LOGGER.info(f"Found {len(corrupted)} corrupted generations")
+
+    # Group by batch
+    by_batch = group_by_batch(corrupted)
+    LOGGER.info(f"Corrupted generations span {len(by_batch)} batches")
+
+    # Filter by specific batch if requested
+    if args.batch_id:
+        if args.batch_id not in by_batch:
+            LOGGER.error(f"Batch {args.batch_id} not found in corrupted batches")
+            return
+        by_batch = {args.batch_id: by_batch[args.batch_id]}
+        LOGGER.info(f"Filtering to batch {args.batch_id} only")
+
+    # Show summary
+    LOGGER.info("=" * 80)
+    LOGGER.info("CORRUPTION SUMMARY")
+    LOGGER.info("=" * 80)
+    for batch_id, gens in sorted(by_batch.items()):
+        providers = {g["provider"] for g in gens}
+        LOGGER.info(f"  {batch_id}: {len(gens)} corrupted ({', '.join(providers)})")
+    LOGGER.info("=" * 80)
+
+    if args.dry_run:
+        LOGGER.info("[DRY RUN] Would fix corrupted generations")
+        return
+
+    # Fix each batch
+    total_fixed = 0
+    total_failed = 0
+
+    for batch_id, gens in by_batch.items():
+        provider = gens[0]["provider"]  # All in same batch have same provider
+        corrupted_ids = {g["id"] for g in gens}
+
+        fixed, failed = fix_batch(
+            batch_id,
+            provider,
+            corrupted_ids,
+            engine,
+            repository,
+            dry_run=args.dry_run,
+        )
+
+        total_fixed += fixed
+        total_failed += failed
+
+    # Final summary
+    LOGGER.info("=" * 80)
+    LOGGER.info("FINAL RESULTS")
+    LOGGER.info("=" * 80)
+    LOGGER.info(f"Fixed: {total_fixed}")
+    LOGGER.info(f"Failed: {total_failed}")
+    LOGGER.info("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fix_remaining_corruption.py
+++ b/scripts/fix_remaining_corruption.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Fix remaining encoding corruptions by re-retrieving specific batches.
+
+Uses SQL LIKE patterns directly to find all corrupted content.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import List
+
+from sqlalchemy import text
+
+from nexus.audition import AuditionEngine, AuditionRepository
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_corrupted_batches(repository: AuditionRepository) -> List[tuple[str, str]]:
+    """
+    Get all batches with encoding corruption using direct SQL patterns.
+
+    Returns:
+        List of (batch_id, provider) tuples
+    """
+    # Use raw SQL with LIKE patterns for corruption detection
+    query = """
+        SELECT DISTINCT g.batch_job_id, c.provider
+        FROM apex_audition.generations g
+        JOIN apex_audition.conditions c ON g.condition_id = c.id
+        WHERE g.status = 'completed'
+          AND g.batch_job_id IS NOT NULL
+          AND (
+              g.response_payload->>'content' LIKE '%â€%'
+              OR g.response_payload->>'content' LIKE '%ğŸ%'
+              OR g.response_payload->>'content' LIKE '%‚Äî%'
+              OR g.response_payload->>'content' LIKE '%üì%'
+          )
+        ORDER BY g.batch_job_id
+    """
+
+    with repository.engine.connect() as conn:
+        result = conn.execute(text(query))
+        return [(row[0], row[1]) for row in result]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fix all remaining encoding corruptions"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be fixed without making changes",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    args = parser.parse_args()
+
+    # Setup logging
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    repository = AuditionRepository()
+    engine = AuditionEngine(repository=repository)
+
+    # Get corrupted batches
+    LOGGER.info("Finding all batches with encoding corruption...")
+    batches = get_corrupted_batches(repository)
+
+    if not batches:
+        LOGGER.info("No corrupted batches found!")
+        return
+
+    LOGGER.info(f"Found {len(batches)} batches with encoding corruption")
+    for batch_id, provider in batches:
+        LOGGER.info(f"  {batch_id} ({provider})")
+
+    if args.dry_run:
+        LOGGER.info("[DRY RUN] Would re-retrieve these batches")
+        return
+
+    # Re-retrieve each batch
+    fixed = 0
+    failed = 0
+
+    for batch_id, provider in batches:
+        LOGGER.info(f"Re-retrieving batch {batch_id}...")
+        try:
+            results = engine.retrieve_batch_results(batch_id, provider)
+            LOGGER.info(f"  Fixed {len(results)} generations")
+            fixed += len(results)
+        except Exception as e:
+            LOGGER.error(f"  Failed: {e}")
+            failed += 1
+
+    LOGGER.info("=" * 80)
+    LOGGER.info(f"Fixed {fixed} generations")
+    LOGGER.info(f"Failed {failed} batches")
+    LOGGER.info("=" * 80)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes a critical UTF-8 encoding bug that corrupted 208 Anthropic batch generations across 105 batches.

## Problem

The batch result retrieval code used `response.text` which relies on the `requests` library's automatic encoding detection. When HTTP headers didn't properly declare UTF-8, the library misinterpreted UTF-8 content as Windows-1252/ISO-8859-1, producing mojibake:

**Examples of corruption:**
- `—` (em-dash) → `‚Äî` or `â€"`
- `📍` (location emoji) → `üìç` or `ğŸ"�`
- `🚨` (alert emoji) → `ğŸš¨`

This affected three waves of data:
1. **Oct 16** - 134 generations (initial detection)
2. **Oct 16** - 16 generations with empty content fields (extended thinking)
3. **Oct 10 & 14** - 58 generations (different corruption pattern)

## Solution

Changed `nexus/audition/batch_clients.py:287` from:
```python
for line in response.text.strip().split('\n'):
```

To:
```python
content = response.content.decode('utf-8')
for line in content.strip().split('\n'):
```

This explicitly decodes as UTF-8, matching the approach already used for OpenAI batch retrieval.

## Recovery

All 208 corrupted generations have been successfully repaired by re-retrieving their batches with the fixed code.

Added three maintenance scripts for future issues:
- `scripts/fix_encoding_corruption.py` - Re-retrieves batches with specific corruption patterns
- `scripts/fix_empty_content.py` - Fixes generations with empty content fields  
- `scripts/fix_remaining_corruption.py` - Comprehensive corruption detection and repair

## Testing

✅ Manually verified 20+ generation pairs in Arena - no corruption found  
✅ Database query confirms zero remaining corrupted generations  
✅ All emojis, em-dashes, and special characters display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)