### PR TITLE
Fix PWA icon caching to display updated icons immediately

### DIFF
--- a/ui/client/public/manifest.json
+++ b/ui/client/public/manifest.json
@@ -9,13 +9,13 @@
   "orientation": "any",
   "icons": [
     {
-      "src": "/icons/icon-192.png",
+      "src": "/icons/icon-192.png?v=1729645200000",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-512.png",
+      "src": "/icons/icon-512.png?v=1729645200000",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"

--- a/ui/server/routes.ts
+++ b/ui/server/routes.ts
@@ -492,6 +492,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // Clean up temp file
       await fs.unlink(tempPath);
 
+      // Update manifest.json with cache-busting timestamp
+      const manifestPath = path.join(import.meta.dirname, "..", "client", "public", "manifest.json");
+      const manifestData = await fs.readFile(manifestPath, "utf-8");
+      const manifest = JSON.parse(manifestData);
+      const timestamp = Date.now();
+
+      // Add timestamp query parameter to all icon URLs
+      manifest.icons = manifest.icons.map((icon: any) => ({
+        ...icon,
+        src: icon.src.split('?')[0] + `?v=${timestamp}` // Remove old timestamp if exists, add new one
+      }));
+
+      await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf-8");
+
       res.json({ success: true, message: "PWA icon updated successfully" });
     } catch (error) {
       console.error("Error uploading PWA icon:", error);

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -54,6 +54,22 @@ export default defineConfig({
                 statuses: [0, 200]
               }
             }
+          },
+          {
+            // Network-first strategy for PWA icons to support cache-busting
+            urlPattern: /\/icons\/.*\.png$/i,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'pwa-icons-cache',
+              networkTimeoutSeconds: 3,
+              expiration: {
+                maxEntries: 20,
+                maxAgeSeconds: 60 * 60 * 24 * 7 // 1 week
+              },
+              cacheableResponse: {
+                statuses: [0, 200]
+              }
+            }
           }
         ]
       }


### PR DESCRIPTION
## Summary

Resolves issue where uploaded PWA icons weren't displayed after app restart due to aggressive service worker caching. Icons were being saved correctly but the browser served stale cached versions instead of fetching the updated files.

### Changes Made

**Service Worker Updates:**
- Added NetworkFirst caching strategy for `/icons/*.png` in `vite.config.ts`
- Icons now check the network first before falling back to cache (3s timeout)
- Maintains offline PWA capability while ensuring fresh icons are fetched when available

**Cache-Busting Implementation:**
- Automatically updates `manifest.json` after icon upload in `server/routes.ts`
- Adds timestamp query parameters to icon URLs (`?v=timestamp`)
- Forces browsers to treat updated icons as new resources
- Bypasses service worker cache without requiring manual intervention

**Manifest Updates:**
- Added cache-busting timestamps to existing icon URLs
- Applies retroactively to already-uploaded icons

## Test Plan

- [x] Upload new PWA icon via Settings interface
- [x] Verify icon files are saved correctly to disk
- [x] Verify manifest.json is updated with timestamp query parameters
- [x] Restart application and confirm new icon displays immediately
- [x] Test service worker NetworkFirst strategy fetches from network
- [x] Verify offline functionality still works with cached icons
- [x] Confirm future icon uploads work without manual cache clearing

## Impact

This fix ensures that when users upload a new PWA icon through the Settings interface, the updated icon displays immediately without requiring:
- Manual cache clearing
- Service worker unregistration  
- PWA reinstallation
- Hard browser refreshes

Future icon updates will work seamlessly with automatic cache-busting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)