### PR TITLE
Fix Apex Audition engine compatibility after entity tracking refactor

### DIFF
--- a/scripts/generate_apex_audition_contexts.py
+++ b/scripts/generate_apex_audition_contexts.py
@@ -1804,6 +1804,16 @@ class ContextSeedBuilder:
             characters_data, places_data, factions_data, structured_seed
         )
 
+        # Build backward-compatible entity_data for audition engine
+        # Flatten baseline + featured into simple lists that engine expects
+        all_characters = characters_data["baseline"] + characters_data["featured"]
+        all_places = places_data["baseline"] + places_data["featured"]
+
+        entity_data = {
+            "characters": all_characters,
+            "locations": all_places,  # Engine expects "locations" key
+        }
+
         # Build warm_slice with warm_span object
         warm_first = warm_slice[0].chunk_id if warm_slice else config.chunk_id
         warm_last = warm_slice[-1].chunk_id if warm_slice else config.chunk_id
@@ -1820,8 +1830,9 @@ class ContextSeedBuilder:
             "retrieved_passages": {
                 "results": authorial_passages,
             },
+            "entity_data": entity_data,  # Backward compatibility for audition engine
             "structured_passages": structured_passages,
-            "structured": structured_object,
+            "structured": structured_object,  # New hierarchical format
         }
 
         baseline = self.memory_manager.handle_storyteller_response(


### PR DESCRIPTION
## Summary

Fixes critical bug where recent universal entity tracking refactor (PR #59) broke Apex Audition prompts by removing `entity_data` key that the engine expects.

## Problem

Commit `f2cfbe6` refactored context generation to use a hierarchical `structured` format with baseline/featured entity separation. However, it removed the `entity_data` key that `nexus/audition/engine.py:987-1094` still consumes to render the **ENTITY DOSSIER** section.

**Impact:**
- All Apex Audition prompts generated after merge were missing entity dossiers
- Characters and locations not surfaced to model during generation
- Identified by Codex code review

## Solution

Add backward-compatibility layer that produces **both formats** simultaneously:

### Old Format (Engine Compatibility)
```json
"entity_data": {
  "characters": [...],  // All 38 characters (35 baseline + 3 featured)
  "locations": [...]    // All 74 places (72 baseline + 2 featured)
}
```

### New Format (Future Enhancements)
```json
"structured": {
  "characters": {"baseline": [...], "featured": [...], "relationships": [...]},
  "places": {"baseline": [...], "featured": [...]},
  "factions": {"baseline": [...], "featured": [...]}
}
```

## Architecture Context

**Production LORE** (`nexus/agents/lore/`) - **Unaffected**
- Already uses reference tables correctly in `turn_cycle.py:190`
- Simple flat `entity_data` format works fine
- No changes needed

**Apex Audition** (`scripts/generate_apex_audition_contexts.py`) - **Fixed**
- Test harness for model selection
- Needed backward compatibility for existing engine
- Now produces both old and new formats

## Testing

Verified with chunk 3 generation:
- ✅ `entity_data.characters`: 38 items (35 baseline + 3 featured)
- ✅ `entity_data.locations`: 74 items (72 baseline + 2 featured)  
- ✅ `structured` hierarchy: Complete with baseline/featured/relationships
- ✅ No conflicts between formats

## Files Changed

- `scripts/generate_apex_audition_contexts.py` (+12 lines)
  - Added entity flattening logic before context assembly
  - Both formats now coexist in `assembled_context`

## Next Steps

Future PR could update `nexus/audition/engine.py` to consume the new `structured` format, then deprecate `entity_data`. Not urgent since audition is just a test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-adds `entity_data` (flattened `characters` and `locations`) to `assembled_context` while retaining the new hierarchical `structured` format.
> 
> - **Apex Audition context builder (`scripts/generate_apex_audition_contexts.py`)**:
>   - **Backward compatibility**: Build and include `entity_data` using flattened lists:
>     - `entity_data.characters` = `characters_data.baseline + featured`
>     - `entity_data.locations` = `places_data.baseline + featured`
>   - **Context payload**: Inject `entity_data` into `assembled_context` alongside `structured_passages` and the hierarchical `structured` object.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51de676567b2f80a6a2e265acdd4e5928f7ec881. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->