### PR TITLE
Fix async divergence test lifecycle

### DIFF
--- a/nexus/agents/lore/test_lore.py
+++ b/nexus/agents/lore/test_lore.py
@@ -17,9 +17,10 @@ import logging
 import sys
 import time
 import unittest
+import inspect
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 # Add paths for imports
 sys.path.insert(0, str(Path(__file__).parent))
@@ -40,6 +41,7 @@ logger = logging.getLogger("test_lore")
 # Lazily initialize the shared instance so standard unittest/pytest discovery
 # still works without invoking the custom run_tests() helper.
 _shared_lore: Optional[LORE] = None
+_defer_teardown: bool = False
 
 
 def _get_shared_lore() -> LORE:
@@ -64,6 +66,11 @@ def tearDownModule() -> None:
     """unittest hook: release shared LORE when the module finishes."""
 
     global _shared_lore
+    global _defer_teardown
+
+    if _defer_teardown:
+        logger.debug("Deferred teardown requested - skipping immediate cleanup")
+        return
 
     if _shared_lore and _shared_lore.llm_manager:
         try:
@@ -76,6 +83,8 @@ def tearDownModule() -> None:
 
 # Global flag for saving context output to disk (set via --save-context CLI arg)
 _save_context = False
+_divergence_test_chunks: List[int] = []
+_divergence_warm_span: int = 4
 
 
 class TestLOREInitialization(unittest.TestCase):
@@ -395,6 +404,181 @@ class TestTurnCycle(unittest.TestCase):
             self.fail(f"Context assembly failed: {e}")
 
 
+class TestDivergenceDetection(unittest.TestCase):
+    """Async divergence detection validation using real narrative chunks."""
+
+    chunk_ids: List[int] = []
+    warm_span: int = 4
+
+    @classmethod
+    def configure(cls, chunk_ids: Sequence[int], warm_span: int) -> None:
+        unique_ids = list(dict.fromkeys(int(cid) for cid in chunk_ids))
+        cls.chunk_ids = unique_ids
+        cls.warm_span = max(1, int(warm_span)) if warm_span else 4
+
+    def setUp(self):
+        """Prepare shared LORE instance for divergence testing."""
+        self.lore = _get_shared_lore()
+
+        if self.lore.memory_manager and self.lore.memory_manager.context_state:
+            self.lore.memory_manager.context_state._context = None
+            self.lore.memory_manager.context_state._transition = None
+            self.lore.memory_manager.context_state._chunk_cache.clear()
+
+    async def test_divergence_with_chunks(self):
+        """Run divergence detection across configured chunk IDs."""
+
+        if not self.chunk_ids:
+            self.skipTest("No divergence test chunks provided. Pass --test-chunks to enable.")
+
+        if not self.lore.memnon:
+            self.skipTest("MEMNON not available for divergence testing")
+
+        if not self.lore.llm_manager or not self.lore.llm_manager.is_available():
+            self.skipTest("Local LLM unavailable - divergence detection requires LM Studio")
+
+        for chunk_id in self.chunk_ids:
+            with self.subTest(chunk_id=chunk_id):
+                await self._run_chunk_divergence_test(int(chunk_id))
+
+    async def _run_chunk_divergence_test(self, chunk_id: int) -> None:
+        chunk = self.lore.memnon.get_chunk_by_id(chunk_id)
+        if not chunk:
+            self.skipTest(f"Chunk {chunk_id} not found in corpus")
+
+        storyteller_text, user_prompt = self._extract_turn_text(chunk)
+        if not storyteller_text.strip():
+            self.skipTest(f"Chunk {chunk_id} missing storyteller text")
+
+        if not user_prompt.strip():
+            self.skipTest(f"Chunk {chunk_id} does not contain a user prompt for divergence analysis")
+
+        warm_slice = self._build_warm_slice(chunk_id, self.warm_span)
+        if not warm_slice:
+            logger.warning("⚠ Falling back to single-chunk warm slice for chunk %s", chunk_id)
+            warm_slice = [
+                {
+                    "id": chunk_id,
+                    "chunk_id": chunk_id,
+                    "text": storyteller_text,
+                }
+            ]
+
+        turn_context = TurnContext(
+            turn_id=f"divergence_test_{chunk_id}_{int(time.time())}",
+            user_input=user_prompt,
+            start_time=time.time(),
+        )
+
+        turn_context.warm_slice = warm_slice
+
+        await self.lore.turn_manager.process_user_input(turn_context)
+        await self.lore.turn_manager.perform_warm_analysis(turn_context)
+        await self.lore.turn_manager.query_entity_states(turn_context)
+
+        token_counts = turn_context.token_counts or self.lore.token_manager.calculate_budget(user_prompt)
+
+        assembled_context = {
+            "user_input": turn_context.user_input,
+            "warm_slice": {"chunks": turn_context.warm_slice},
+            "entity_data": turn_context.entity_data,
+            "retrieved_passages": {"results": []},
+            "analysis": turn_context.phase_states.get("warm_analysis", {}).get("analysis", {}),
+        }
+
+        baseline = self.lore.memory_manager.handle_storyteller_response(
+            narrative=storyteller_text,
+            warm_slice=turn_context.warm_slice,
+            retrieved_passages=[],
+            token_usage=token_counts,
+            assembled_context=assembled_context,
+            authorial_directives=[],
+        )
+
+        self.assertIsNotNone(baseline, "Baseline package should be created from storyteller text")
+
+        update = self.lore.memory_manager.handle_user_input(
+            user_input=user_prompt,
+            token_counts=token_counts,
+        )
+
+        self.assertTrue(update.baseline_available, "Baseline must be available for divergence analysis")
+        self.assertIsNotNone(update.divergence, "Divergence result should be returned")
+
+        logger.info(
+            "Divergence analysis for chunk %s: detected=%s confidence=%.2f",
+            chunk_id,
+            update.divergence.detected,
+            update.divergence.confidence,
+        )
+
+    @staticmethod
+    def _extract_turn_text(chunk: Dict[str, Any]) -> Sequence[str]:
+        full_text = chunk.get("full_text") or chunk.get("text") or ""
+        if "\n## You" in full_text:
+            storyteller, user_section = full_text.split("\n## You", 1)
+            return storyteller.strip(), user_section.strip()
+
+        storyteller = chunk.get("storyteller_text") or chunk.get("narrative") or ""
+        user_prompt = chunk.get("user_input") or chunk.get("raw_user_input") or ""
+        return storyteller.strip(), user_prompt.strip()
+
+    def _build_warm_slice(self, chunk_id: int, span: int) -> List[Dict[str, Any]]:
+        memnon = self.lore.memnon
+        if not getattr(memnon, "Session", None):
+            logger.warning("⚠ MEMNON session factory unavailable - cannot build warm slice")
+            return []
+
+        try:
+            from sqlalchemy import text
+        except Exception as exc:  # pragma: no cover - optional dependency guard
+            logger.warning("⚠ SQLAlchemy unavailable: %s", exc)
+            return []
+
+        start_id = max(1, chunk_id - max(1, span))
+        end_id = max(chunk_id, start_id)
+
+        try:
+            with memnon.Session() as session:
+                rows = session.execute(
+                    text(
+                        """
+                        SELECT id, raw_text, text
+                        FROM narrative_chunks
+                        WHERE id BETWEEN :start AND :end
+                        ORDER BY id
+                        """
+                    ),
+                    {"start": start_id, "end": end_id},
+                ).fetchall()
+        except Exception as exc:
+            logger.warning("⚠ Failed to load warm slice for chunk %s: %s", chunk_id, exc)
+            return []
+
+        warm_slice: List[Dict[str, Any]] = []
+        for row in rows:
+            mapping = getattr(row, "_mapping", row)
+            text_value = (
+                mapping.get("raw_text")
+                if isinstance(mapping, dict)
+                else getattr(row, "raw_text", "")
+            )
+            if not text_value and isinstance(mapping, dict):
+                text_value = mapping.get("text", "")
+            elif not text_value:
+                text_value = getattr(row, "text", "")
+
+            warm_slice.append(
+                {
+                    "id": getattr(row, "id", mapping.get("id")),
+                    "chunk_id": getattr(row, "id", mapping.get("id")),
+                    "text": text_value or "",
+                }
+            )
+
+        return warm_slice
+
+
 class TestLocalLLM(unittest.TestCase):
     """Test local LLM integration via LM Studio"""
 
@@ -499,13 +683,89 @@ class TestLOGONUtility(unittest.TestCase):
         logger.info(f"  Formatted length: {len(formatted)} characters")
 
 
+class AsyncAwareTestLoader(unittest.TestLoader):
+    """Custom loader that skips coroutine-based unittest methods."""
+
+    def getTestCaseNames(self, testCaseClass):  # noqa: N802 - unittest API contract
+        names = super().getTestCaseNames(testCaseClass)
+        filtered: List[str] = []
+        for name in names:
+            attr = getattr(testCaseClass, name, None)
+            if inspect.iscoroutinefunction(attr):
+                continue
+            filtered.append(name)
+        return filtered
+
+
+def _get_async_test_methods(test_case_class: type[unittest.TestCase]) -> List[str]:
+    loader = unittest.TestLoader()
+    candidate_methods = loader.getTestCaseNames(test_case_class)
+    return [
+        name
+        for name in candidate_methods
+        if inspect.iscoroutinefunction(getattr(test_case_class, name, None))
+    ]
+
+
+async def _run_async_test_case(
+    test_case_class: type[unittest.TestCase],
+    lore_instance: LORE,
+) -> List[str]:
+    failures: List[str] = []
+    method_names = _get_async_test_methods(test_case_class)
+
+    if not method_names:
+        return failures
+
+    for method_name in method_names:
+        case = test_case_class(method_name)
+        if hasattr(case, "lore"):
+            case.lore = lore_instance
+
+        try:
+            case.setUp()
+        except unittest.SkipTest as skip_exc:
+            print(f"⚠ {test_case_class.__name__}.{method_name} skipped during setUp: {skip_exc}")
+            case.doCleanups()
+            continue
+        except Exception as exc:  # pragma: no cover - defensive guard
+            print(f"✗ {test_case_class.__name__}.{method_name} setup failed: {exc}")
+            failures.append(f"setup:{test_case_class.__name__}.{method_name}:{exc}")
+            case.doCleanups()
+            continue
+
+        try:
+            await getattr(case, method_name)()
+        except unittest.SkipTest as skip_exc:
+            print(f"⚠ {test_case_class.__name__}.{method_name} skipped: {skip_exc}")
+        except Exception as exc:
+            print(f"✗ {test_case_class.__name__}.{method_name} failed: {exc}")
+            failures.append(f"failure:{test_case_class.__name__}.{method_name}:{exc}")
+        else:
+            print(f"✓ {test_case_class.__name__}.{method_name} passed")
+        finally:
+            try:
+                case.tearDown()
+            except unittest.SkipTest as skip_exc:
+                print(f"⚠ {test_case_class.__name__}.{method_name} teardown skipped: {skip_exc}")
+            except Exception as exc:  # pragma: no cover - defensive guard
+                print(f"⚠ {test_case_class.__name__}.{method_name} teardown error: {exc}")
+                failures.append(f"teardown:{test_case_class.__name__}.{method_name}:{exc}")
+            case.doCleanups()
+
+    return failures
+
+
 # Test runner
 def run_tests():
     """Run all LORE tests"""
-    # Initialize shared instance using helper (ensures consistency with module hooks)
-    logger.info("="*60)
+
+    global _defer_teardown
+
+    logger.info("=" * 60)
     logger.info("Initializing shared LORE instance for test suite")
-    logger.info("="*60)
+    logger.info("=" * 60)
+
     try:
         lore_instance = _get_shared_lore()
         logger.info("✓ Shared LORE instance initialized successfully (LOGON disabled)")
@@ -513,70 +773,82 @@ def run_tests():
         logger.error(f"✗ Failed to initialize shared LORE instance: {e}")
         raise
 
+    loader = AsyncAwareTestLoader()
+    suite = unittest.TestSuite()
+
+    synchronous_cases = [
+        TestLOREInitialization,
+        TestMEMNONIntegration,
+        TestTokenBudget,
+        TestLocalLLM,
+        TestLOGONUtility,
+    ]
+
+    for case in synchronous_cases:
+        suite.addTests(loader.loadTestsFromTestCase(case))
+
+    runner = unittest.TextTestRunner(verbosity=2)
+
+    result: Optional[unittest.result.TestResult] = None
+    async_failures: List[str] = []
+
+    # Ensure unittest's tearDownModule does not unload models before async tests run
+    _defer_teardown = True
+
     try:
-        # Create test suite
-        loader = unittest.TestLoader()
-        suite = unittest.TestSuite()
-
-        # Add test classes
-        suite.addTests(loader.loadTestsFromTestCase(TestLOREInitialization))
-        suite.addTests(loader.loadTestsFromTestCase(TestMEMNONIntegration))
-        suite.addTests(loader.loadTestsFromTestCase(TestTokenBudget))
-        suite.addTests(loader.loadTestsFromTestCase(TestLocalLLM))
-        suite.addTests(loader.loadTestsFromTestCase(TestLOGONUtility))
-
-        # Run tests (module fixtures won't be called since we're using custom runner)
-        runner = unittest.TextTestRunner(verbosity=2)
         result = runner.run(suite)
 
-        # Run async tests BEFORE cleanup
-        print("\n" + "="*60)
-        print("Running Async Turn Cycle Tests")
-        print("="*60)
+        async_cases: List[type[unittest.TestCase]] = [TestTurnCycle]
+        TestDivergenceDetection.configure(_divergence_test_chunks, _divergence_warm_span)
+        if _divergence_test_chunks:
+            async_cases.append(TestDivergenceDetection)
 
-        async def run_async_tests():
-            """Run async test methods"""
-            test_instance = TestTurnCycle()
-            test_instance.lore = lore_instance
+        if async_cases:
+            print("\n" + "=" * 60)
+            print("Running Async Turn Cycle Tests")
+            print("=" * 60)
 
-            try:
-                await test_instance.test_full_turn_cycle()
-                print("✓ Full turn cycle test passed")
-            except Exception as e:
-                print(f"✗ Full turn cycle test failed: {e}")
+            async def run_async_tests() -> List[str]:
+                failures: List[str] = []
+                for case_cls in async_cases:
+                    failures.extend(await _run_async_test_case(case_cls, lore_instance))
+                return failures
 
-            try:
-                await test_instance.test_context_assembly_with_chunk_1425()
-                print("✓ Context assembly test passed")
-            except Exception as e:
-                print(f"✗ Context assembly test failed: {e}")
-
-        # Run async tests
-        asyncio.run(run_async_tests())
+            async_failures = asyncio.run(run_async_tests())
 
     finally:
-        # Manual cleanup after ALL tests (sync and async)
-        logger.info("="*60)
+        _defer_teardown = False
+        logger.info("=" * 60)
         logger.info("Cleaning up shared LORE instance")
-        logger.info("="*60)
+        logger.info("=" * 60)
         tearDownModule()
         logger.info("✓ Shared LORE instance cleaned up")
 
-    # Summary
-    print("\n" + "="*60)
-    print("TEST SUMMARY")
-    print("="*60)
+    success = (result.wasSuccessful() if result else False) and not async_failures
 
-    if result.wasSuccessful():
+    print("\n" + "=" * 60)
+    print("TEST SUMMARY")
+    print("=" * 60)
+
+    if result and result.wasSuccessful():
         print("✅ All synchronous tests passed!")
-    else:
-        print(f"❌ {len(result.failures)} failures, {len(result.errors)} errors")
+    elif result:
+        print(f"❌ {len(result.failures)} synchronous failures, {len(result.errors)} errors")
         for failure in result.failures:
             print(f"  Failed: {failure[0]}")
         for error in result.errors:
             print(f"  Error: {error[0]}")
+    else:
+        print("❌ Synchronous suite did not produce a result")
 
-    return result.wasSuccessful()
+    if async_failures:
+        print(f"❌ {len(async_failures)} async test issues detected")
+        for failure in async_failures:
+            print(f"  Async failure: {failure}")
+    else:
+        print("✅ All async tests passed!")
+
+    return success
 
 
 if __name__ == "__main__":
@@ -598,6 +870,23 @@ Examples:
         action='store_true',
         help='Save assembled context payload to temp/ directory for inspection'
     )
+    parser.add_argument(
+        '--test-chunks',
+        metavar='CHUNK',
+        type=int,
+        nargs='+',
+        help=(
+            'Run async divergence detection against specific chunk IDs. '
+            'If the final value is small (e.g., 3 or 4) and --warm-span is not provided, '
+            'it will be interpreted as the warm slice span.'
+        )
+    )
+    parser.add_argument(
+        '--warm-span',
+        type=int,
+        default=None,
+        help='Override warm slice span (number of preceding chunks) for divergence tests.'
+    )
 
     args = parser.parse_args()
 
@@ -606,6 +895,27 @@ Examples:
 
     if _save_context:
         logger.info("Context saving enabled - output will be written to temp/ directory")
+
+    # Configure divergence testing options from CLI
+    if args.test_chunks:
+        chunk_args = list(args.test_chunks)
+        warm_span_override = args.warm_span
+
+        if warm_span_override is None and len(chunk_args) > 1 and chunk_args[-1] < 50:
+            warm_span_override = chunk_args.pop()
+
+        _divergence_test_chunks = chunk_args
+        if warm_span_override is not None:
+            _divergence_warm_span = max(1, warm_span_override)
+
+        logger.info(
+            "Divergence chunk tests enabled: chunks=%s warm_span=%s",
+            _divergence_test_chunks,
+            _divergence_warm_span,
+        )
+    elif args.warm_span is not None:
+        _divergence_warm_span = max(1, args.warm_span)
+        logger.info("Warm span override set to %s (no chunk IDs provided)", _divergence_warm_span)
 
     # Run tests with manual lifecycle management
     success = run_tests()


### PR DESCRIPTION
## Summary
- add an async-only TestDivergenceDetection harness that can exercise specific chunks
- update the custom runner to defer teardown, skip coroutine tests in the sync suite, and run async cases via a helper
- extend the CLI with --test-chunks/--warm-span flags to configure divergence checks at runtime

## Testing
- python3 -m compileall nexus/agents/lore/test_lore.py

------
https://chatgpt.com/codex/tasks/task_e_690b8f903ac48323ab485810531b021a