### PR TITLE
Add setting context to Storyteller system prompt

### DIFF
--- a/scripts/import_setting.py
+++ b/scripts/import_setting.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Import the setting backstory document into global_variables.setting
+"""
+
+import json
+import psycopg2
+from pathlib import Path
+
+
+def main():
+    # Read the backstory document
+    backstory_path = Path(__file__).parent.parent / "temp" / "global_backstory.md"
+
+    with open(backstory_path, 'r') as f:
+        content = f.read()
+
+    # Create minimal JSON wrapper
+    setting_data = {
+        "format": "markdown",
+        "title": "The Zenith Pulse & Fractured Future",
+        "content": content,
+        "metadata": {
+            "era": "2025-2073",
+            "medium": "found document, historical dossier",
+            "provenance": "compiled in 2073 from municipal archives, corporate white-books, and eyewitness logs"
+        }
+    }
+
+    # Connect to database
+    conn = psycopg2.connect(
+        host="localhost",
+        database="NEXUS",
+        user="pythagor"
+    )
+
+    try:
+        with conn.cursor() as cur:
+            # Update the single row in global_variables
+            cur.execute(
+                "UPDATE global_variables SET setting = %s WHERE id = true",
+                (json.dumps(setting_data),)
+            )
+            conn.commit()
+
+            # Verify the update
+            cur.execute("SELECT setting FROM global_variables WHERE id = true")
+            result = cur.fetchone()
+
+            if result and result[0]:
+                print("✓ Setting data imported successfully")
+                print(f"  Title: {result[0]['title']}")
+                print(f"  Era: {result[0]['metadata']['era']}")
+                print(f"  Content length: {len(result[0]['content'])} characters")
+            else:
+                print("✗ Failed to import setting data")
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds story setting/worldbuilding context to the Storyteller's system prompt by storing it in a new `global_variables.setting` JSONB column and loading it alongside the core prompt.

## Changes

### Database Schema
- Added `setting` JSONB column to `global_variables` table
- Stores setting with minimal JSON wrapper: `{format, title, content, metadata}`
- Added/updated SQL comments for schema documentation

### System Prompt Loading
- Modified `logon_utility.py` to:
  - Load `prompts/storyteller_core.md` (universal storytelling instructions)
  - Query `global_variables.setting` from database
  - Combine into complete system prompt (~14.5k chars)
  - Pass to OpenAI/Anthropic providers

### Import Utility
- Created `scripts/import_setting.py` for importing/updating setting data
- Preserves markdown format and in-world metadata

## Testing

Generated test narrative with prompt "Describe the scene outside the cafe window in downtown Night City." Results showed strong cyberpunk atmosphere influence:
- ✓ Neon signage and bleeding reflections
- ✓ Fiber conduit infrastructure and jackpoints
- ✓ Corporate surveillance (sedans, drones)
- ✓ Cable-first connectivity culture
- ✓ Post-Pulse world-building details

The Zenith Pulse backstory is clearly shaping narrative voice and environmental descriptions.

## Impact

Every Storyteller generation now includes rich setting context automatically, establishing genre atmosphere without requiring it in the user message or narrative context. The ~5k character backstory document sets priors for cyberpunk style, post-disaster infrastructure, and cable-based connectivity culture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)