### PR TITLE
Add narrative test mode toggle and approval UI

### DIFF
--- a/ui/client/src/components/CommandBar.tsx
+++ b/ui/client/src/components/CommandBar.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
 
 interface CommandBarProps {
   onCommand: (command: string) => void;
@@ -9,6 +10,9 @@ interface CommandBarProps {
   isAwaitingConfirmation?: boolean;
   showButton?: boolean;
   onButtonClick?: () => void;
+  onExpandInput?: () => void;
+  isGenerating?: boolean;
+  continueDisabled?: boolean;
 }
 
 export function CommandBar({
@@ -18,6 +22,9 @@ export function CommandBar({
   isAwaitingConfirmation = false,
   showButton = false,
   onButtonClick,
+  onExpandInput,
+  isGenerating = false,
+  continueDisabled = false,
 }: CommandBarProps) {
   const [command, setCommand] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
@@ -35,15 +42,33 @@ export function CommandBar({
   return (
     <div className="h-12 md:h-14 border-t border-border bg-card terminal-scanlines">
       {showButton ? (
-        <div className="h-full flex items-center px-2 md:px-4">
+        <div className="h-full flex items-center px-2 md:px-4 gap-2">
           <Button
             onClick={onButtonClick}
             variant="ghost"
+            disabled={continueDisabled || isGenerating}
             className="font-mono text-xs md:text-sm text-muted-foreground hover:text-primary hover:bg-transparent transition-colors terminal-glow"
             data-testid="button-continue-story"
           >
-            continue the story
+            {isGenerating ? (
+              <>
+                <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+                generating...
+              </>
+            ) : (
+              "continue the story"
+            )}
           </Button>
+          {onExpandInput && (
+            <Button
+              onClick={onExpandInput}
+              variant="ghost"
+              size="sm"
+              className="font-mono text-[10px] md:text-xs text-muted-foreground hover:text-primary hover:bg-transparent transition-colors"
+            >
+              custom input
+            </Button>
+          )}
         </div>
       ) : (
         <form onSubmit={handleSubmit} className="h-full flex items-center px-2 md:px-4 gap-2 md:gap-3">
@@ -60,6 +85,7 @@ export function CommandBar({
             onChange={(e) => setCommand(e.target.value)}
             placeholder={placeholder}
             className="flex-1 bg-transparent border-0 text-foreground font-mono text-xs md:text-sm focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-muted-foreground/50 min-w-0"
+            disabled={isGenerating}
             data-testid="input-command"
             autoFocus
           />

--- a/ui/client/src/components/StatusBar.tsx
+++ b/ui/client/src/components/StatusBar.tsx
@@ -11,6 +11,7 @@ interface StatusBarProps {
   scene: number;
   apexStatus: "OFFLINE" | "READY" | "TRANSMITTING" | "GENERATING" | "RECEIVING";
   isStoryMode: boolean;
+  isTestModeEnabled?: boolean;
   modelStatus?: "unloaded" | "loading" | "loaded" | "generating";
   onHamburgerClick?: () => void;
   onModelStatusChange?: (status: "unloaded" | "loading" | "loaded" | "generating") => void;
@@ -25,6 +26,7 @@ export function StatusBar({
   scene,
   apexStatus,
   isStoryMode,
+  isTestModeEnabled = false,
   modelStatus = "unloaded",
   onHamburgerClick,
   onModelStatusChange,
@@ -309,6 +311,13 @@ export function StatusBar({
           <div className="flex items-center gap-1 md:gap-2" data-testid="text-apex-status">
             <span className="text-muted-foreground hidden sm:inline">APEX:</span>
             <span className={`${getStatusColor()} terminal-glow text-sm md:text-base`}>{apexStatus}</span>
+          </div>
+        )}
+        {isTestModeEnabled && (
+          <div className="flex items-center gap-1 md:gap-2" data-testid="text-test-mode">
+            <span className="px-2 py-1 rounded-sm border border-destructive/40 bg-destructive/10 text-[10px] md:text-xs font-semibold tracking-wide text-destructive">
+              TEST MODE
+            </span>
           </div>
         )}
       </div>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -70,6 +70,7 @@
         "recharts": "^2.15.2",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
+        "toml": "^3.0.0",
         "topojson-client": "^3.1.0",
         "tw-animate-css": "^1.2.5",
         "vaul": "^1.1.2",
@@ -12772,6 +12773,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/topojson-client": {
       "version": "3.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -73,6 +73,7 @@
     "recharts": "^2.15.2",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "toml": "^3.0.0",
     "topojson-client": "^3.1.0",
     "tw-animate-css": "^1.2.5",
     "vaul": "^1.1.2",
@@ -82,11 +83,11 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.15",
+    "@tailwindcss/vite": "^4.1.3",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",
-    "@tailwindcss/typography": "^0.5.15",
-    "@tailwindcss/vite": "^4.1.3",
     "@types/connect-pg-simple": "^7.0.3",
     "@types/express": "4.17.21",
     "@types/express-session": "^1.18.0",
@@ -106,8 +107,8 @@
     "tsx": "^4.20.5",
     "typescript": "5.6.3",
     "vite": "^5.4.20",
-    "vitest": "^2.1.3",
-    "vite-plugin-pwa": "^1.0.3"
+    "vite-plugin-pwa": "^1.0.3",
+    "vitest": "^2.1.3"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/ui/server/routes.ts
+++ b/ui/server/routes.ts
@@ -7,6 +7,7 @@ import { exec } from "child_process";
 import { promisify } from "util";
 import fs from "fs/promises";
 import path from "path";
+import { parse as parseToml } from "toml";
 
 const execAsync = promisify(exec);
 
@@ -16,6 +17,8 @@ export function registerProxyRoutes(app: Express): void {
   const auditionTarget = process.env.AUDITION_API_URL || `http://localhost:${auditionPort}`;
   const corePort = process.env.CORE_API_PORT || "8001";
   const coreTarget = process.env.CORE_API_URL || `http://localhost:${corePort}`;
+  const narrativePort = process.env.NARRATIVE_API_PORT || "8002";
+  const narrativeTarget = process.env.NARRATIVE_API_URL || `http://localhost:${narrativePort}`;
 
   // Proxy for Audition API (FastAPI backend on port 8000)
   // Express strips /api/audition before passing to middleware, so we need to add it back
@@ -46,16 +49,36 @@ export function registerProxyRoutes(app: Express): void {
   app.use("/api/health", coreHealthProxy);
 
   // Proxy for Narrative API (FastAPI backend on port 8002)
-  // Handles narrative generation and incubator management
-  const narrativeTarget = `http://localhost:8002`;
+  // Handles generation + incubator management without intercepting local narrative read routes
   const narrativeProxy = createProxyMiddleware({
     target: narrativeTarget,
     changeOrigin: true,
-    ws: true,  // Enable WebSocket support
   });
 
-  app.use("/api/narrative", narrativeProxy);
-  app.use("/ws/narrative", narrativeProxy);
+  const shouldProxyNarrative = (pathname: string) => {
+    return (
+      pathname.startsWith("/api/narrative/continue") ||
+      pathname.startsWith("/api/narrative/status") ||
+      pathname.startsWith("/api/narrative/incubator") ||
+      pathname.startsWith("/api/narrative/approve")
+    );
+  };
+
+  app.use((req, res, next) => {
+    if (shouldProxyNarrative(req.path)) {
+      return narrativeProxy(req, res, next);
+    }
+    return next();
+  });
+
+  app.use(
+    "/ws/narrative",
+    createProxyMiddleware({
+      target: narrativeTarget,
+      changeOrigin: true,
+      ws: true,
+    }),
+  );
 }
 
 export async function registerRoutes(app: Express): Promise<Server> {
@@ -230,14 +253,77 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Settings routes
-  app.get("/api/settings", async (req, res) => {
+  const rootDir = path.join(process.cwd(), "..");
+  const tomlSettingsPath = path.join(rootDir, "nexus.toml");
+  const legacySettingsPath = path.join(rootDir, "settings.json");
+
+  const buildSettingsPayload = (rawSettings: any) => ({
+    ...rawSettings,
+    "Agent Settings": {
+      global: rawSettings?.global ?? {},
+      LORE: rawSettings?.lore ?? rawSettings?.LORE ?? {},
+      MEMNON: rawSettings?.memnon ?? rawSettings?.MEMNON ?? {},
+    },
+    "API Settings": {
+      apex: rawSettings?.apex ?? rawSettings?.API?.apex ?? {},
+    },
+  });
+
+  const readSettings = async () => {
     try {
-      const fs = await import("fs/promises");
-      const path = await import("path");
-      const settingsPath = path.join(process.cwd(), "..", "settings.json");
-      const settingsData = await fs.readFile(settingsPath, "utf-8");
-      const settings = JSON.parse(settingsData);
-      res.json(settings);
+      const tomlContent = await fs.readFile(tomlSettingsPath, "utf-8");
+      return parseToml(tomlContent);
+    } catch (error: any) {
+      if (error?.code === "ENOENT") {
+        const legacyContent = await fs.readFile(legacySettingsPath, "utf-8");
+        return JSON.parse(legacyContent);
+      }
+      throw error;
+    }
+  };
+
+  const replaceTomlValue = (content: string, section: string, key: string, rawValue: string) => {
+    const sectionPattern = new RegExp(
+      `\\[${section.replace(/\./g, "\\.")}\\]\\s*\\n([\\s\\S]*?)(?=\\n\\[|$)`,
+      "m",
+    );
+    const sectionMatch = content.match(sectionPattern);
+    if (!sectionMatch) {
+      throw new Error(`Section [${section}] not found in nexus.toml`);
+    }
+
+    const sectionBody = sectionMatch[1];
+    const keyPattern = new RegExp(`(^\\s*${key}\\s*=\\s*)([^#\\n]*?)(\\s*(#.*)?)$`, "m");
+
+    let updatedBody: string;
+    if (keyPattern.test(sectionBody)) {
+      updatedBody = sectionBody.replace(keyPattern, (_match, prefix: string, _value: string, suffix: string) => {
+        const trailing = suffix ?? "";
+        return `${prefix}${rawValue}${trailing}`;
+      });
+    } else {
+      const trimmed = sectionBody.trimEnd();
+      const newline = trimmed.endsWith("\n") ? "" : "\n";
+      updatedBody = `${trimmed}${newline}${key} = ${rawValue}\n`;
+    }
+
+    return content.replace(sectionPattern, `[${section}]\n${updatedBody}`);
+  };
+
+  app.head("/api/settings", async (_req, res) => {
+    try {
+      await readSettings();
+      res.status(200).end();
+    } catch (error) {
+      console.error("Error fetching settings (HEAD):", error);
+      res.status(500).end();
+    }
+  });
+
+  app.get("/api/settings", async (_req, res) => {
+    try {
+      const settings = await readSettings();
+      res.json(buildSettingsPayload(settings));
     } catch (error) {
       console.error("Error fetching settings:", error);
       res.status(500).json({ error: "Failed to fetch settings" });
@@ -246,36 +332,38 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.patch("/api/settings", async (req, res) => {
     try {
-      const fs = await import("fs/promises");
-      const path = await import("path");
-      const settingsPath = path.join(process.cwd(), "..", "settings.json");
-
-      // Read current settings
-      const settingsData = await fs.readFile(settingsPath, "utf-8");
-      const settings = JSON.parse(settingsData);
-
-      // Deep merge the updates
+      let tomlContent = await fs.readFile(tomlSettingsPath, "utf-8");
       const updates = req.body;
+      let appliedUpdates = 0;
 
-      // Helper function to deep merge objects
-      const deepMerge = (target: any, source: any): any => {
-        for (const key in source) {
-          if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
-            target[key] = target[key] || {};
-            deepMerge(target[key], source[key]);
-          } else {
-            target[key] = source[key];
-          }
-        }
-        return target;
-      };
+      const narrativeUpdates = updates?.["Agent Settings"]?.global?.narrative ?? updates?.global?.narrative;
+      if (narrativeUpdates && typeof narrativeUpdates === "object" && "test_mode" in narrativeUpdates) {
+        const testMode = Boolean(narrativeUpdates.test_mode);
+        tomlContent = replaceTomlValue(tomlContent, "global.narrative", "test_mode", `${testMode}`);
+        appliedUpdates += 1;
+      }
 
-      deepMerge(settings, updates);
+      const apexContextWindow =
+        updates?.["Agent Settings"]?.LORE?.token_budget?.apex_context_window ??
+        updates?.lore?.token_budget?.apex_context_window;
+      if (typeof apexContextWindow === "number") {
+        tomlContent = replaceTomlValue(
+          tomlContent,
+          "lore.token_budget",
+          "apex_context_window",
+          `${apexContextWindow}`,
+        );
+        appliedUpdates += 1;
+      }
 
-      // Write back to file with proper formatting
-      await fs.writeFile(settingsPath, JSON.stringify(settings, null, 4), "utf-8");
+      if (!appliedUpdates) {
+        return res.status(400).json({ error: "No supported settings provided" });
+      }
 
-      res.json({ success: true, settings });
+      await fs.writeFile(tomlSettingsPath, tomlContent, "utf-8");
+      const updatedSettings = await readSettings();
+
+      res.json({ success: true, settings: buildSettingsPayload(updatedSettings) });
     } catch (error) {
       console.error("Error updating settings:", error);
       res.status(500).json({ error: "Failed to update settings" });


### PR DESCRIPTION
  - Read/write nexus.toml in the UI server; proxy only generation endpoints
  - Add Test Narrative Mode toggle (writes TOML, updates cache) and badge
  - Wire “Continue” to /api/narrative/continue via WebSocket progress; chunk 1425 rollout guard
  - Add approval modal with narrative preview, entity/reference diffs, Approve/Regenerate/Cancel
  - Progress banner + elapsed time; command bar quick-continue and custom input
  - Tests: not run (UI)
  - @claude please review