### PR TITLE
Fix tab content blank pane layout

### DIFF
--- a/ui/client/src/components/CharactersTab.tsx
+++ b/ui/client/src/components/CharactersTab.tsx
@@ -321,7 +321,7 @@ export function CharactersTab({ slot = null }: { slot?: number | null }) {
   };
 
   return (
-    <div className="flex h-full bg-background">
+    <div className="flex h-full min-h-0 w-full bg-background">
       <aside className="w-72 border-r border-border bg-card/40 flex flex-col">
         <div className="px-4 py-3 border-b border-border">
           <h2 className="text-sm font-mono text-primary terminal-glow">[CHARACTER INDEX]</h2>
@@ -363,7 +363,7 @@ export function CharactersTab({ slot = null }: { slot?: number | null }) {
         </ScrollArea>
       </aside>
 
-      <main className="flex-1 overflow-hidden">
+      <main className="flex-1 min-h-0 overflow-hidden">
         {selectedCharacter ? (
           <div className="h-full overflow-auto p-6 space-y-6">
             <Card className="bg-card/70 border-border">

--- a/ui/client/src/components/MapTab.tsx
+++ b/ui/client/src/components/MapTab.tsx
@@ -626,7 +626,7 @@ export function MapTab({ currentChunkLocation = null, slot = null }: MapTabProps
   }, [geoJsonToSvgPath]);
 
   return (
-    <div className="flex h-full bg-background">
+    <div className="flex h-full min-h-0 w-full bg-background">
       {/* Map Area */}
       <div className="flex-1 relative overflow-hidden">
         {(isLoading) && (

--- a/ui/client/src/components/NexusLayout.tsx
+++ b/ui/client/src/components/NexusLayout.tsx
@@ -360,6 +360,7 @@ export function NexusLayout() {
   const referencedCharacters = Array.isArray(referenceChanges) ? referenceChanges.filter((r) => r.entityType === 'character') : [];
   const referencedPlaces = Array.isArray(referenceChanges) ? referenceChanges.filter((r) => r.entityType === 'place') : [];
   const referencedFactions = Array.isArray(referenceChanges) ? referenceChanges.filter((r) => r.entityType === 'faction') : [];
+  const tabContentClass = "flex-1 min-h-0 overflow-hidden flex flex-col data-[state=inactive]:hidden";
   const chunkLabel =
     narrative.generationParentChunk?.metadata?.season !== null &&
       narrative.generationParentChunk?.metadata?.season !== undefined &&
@@ -397,9 +398,9 @@ export function NexusLayout() {
         <Tabs
           value={activeTab}
           onValueChange={setActiveTab}
-          className={`flex-1 flex flex-col overflow-hidden bg-background ${isCyberpunk ? "terminal-scanlines" : ""}`}
+          className={`flex-1 flex flex-col min-h-0 overflow-hidden bg-background ${isCyberpunk ? "terminal-scanlines" : ""}`}
         >
-          <div className="border-b border-border bg-card/50 overflow-x-auto">
+          <div className="border-b border-border bg-card/50 overflow-x-auto flex-shrink-0">
             <TabsList className="h-10 bg-transparent border-0 rounded-none p-0 inline-flex min-w-full">
               <TabsTrigger
                 value="narrative"
@@ -430,7 +431,7 @@ export function NexusLayout() {
             </TabsList>
           </div>
 
-          <TabsContent value="narrative" className="flex-1 overflow-hidden m-0 min-h-0 flex flex-col">
+          <TabsContent value="narrative" className={tabContentClass}>
             <NarrativeTab
               onChunkSelected={handleChunkSelection}
               sessionId={narrative.activeNarrativeSession ?? undefined}
@@ -438,19 +439,19 @@ export function NexusLayout() {
             />
           </TabsContent>
 
-          <TabsContent value="map" className="flex-1 overflow-hidden m-0">
+          <TabsContent value="map" className={tabContentClass}>
             <MapTab currentChunkLocation={currentChunkLocation} slot={activeSlot} />
           </TabsContent>
 
-          <TabsContent value="characters" className="flex-1 overflow-hidden m-0">
+          <TabsContent value="characters" className={tabContentClass}>
             <CharactersTab slot={activeSlot} />
           </TabsContent>
 
-          <TabsContent value="audition" className="flex-1 overflow-hidden m-0">
+          <TabsContent value="audition" className={tabContentClass}>
             <AuditionTab />
           </TabsContent>
 
-          <TabsContent value="settings" className="flex-1 overflow-hidden m-0">
+          <TabsContent value="settings" className={tabContentClass}>
             <SettingsTab />
           </TabsContent>
         </Tabs>

--- a/ui/client/src/components/ui/tabs.tsx
+++ b/ui/client/src/components/ui/tabs.tsx
@@ -42,7 +42,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "mt-0 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       className
     )}
     {...props}

--- a/ui/client/src/pages/AuditionTab.tsx
+++ b/ui/client/src/pages/AuditionTab.tsx
@@ -200,7 +200,7 @@ export default function AuditionTab() {
   };
 
   return (
-    <div className="h-full flex flex-col">
+    <div className="h-full min-h-0 flex flex-col w-full">
       <div className="border-b border-border px-4 py-2 flex items-center justify-between font-mono text-xs sm:text-sm">
         <div className="flex items-center gap-3">
           <Button
@@ -278,7 +278,7 @@ export default function AuditionTab() {
         </div>
       </div>
 
-      <div className="flex-1 overflow-hidden">
+      <div className="flex-1 min-h-0 overflow-hidden">
         {mode === 'judge' ? (
           renderJudgeMode()
         ) : mode === 'generate' ? (

--- a/ui/client/src/pages/SettingsTab.tsx
+++ b/ui/client/src/pages/SettingsTab.tsx
@@ -246,7 +246,7 @@ export function SettingsTab() {
   const hasUnsavedChanges = apexContextWindow !== originalApexContextWindow;
 
   return (
-    <ScrollArea className="h-full">
+    <ScrollArea className="h-full min-h-0 w-full">
       <div className="container max-w-4xl py-8 px-6 space-y-6">
         <div className="space-y-2">
           <h2 className={`text-2xl font-mono font-bold text-primary ${glowClass}`}>Settings</h2>


### PR DESCRIPTION
  - Unified tab panes to flex-fill and hide inactive content, eliminating the void pane while keeping Narrative behavior intact.
  - Ensured the tab header doesn’t grow and restored TabsContent margins to zero for consistent spacing.
  - Adjusted each tab’s root container (Map, Characters, Audition, Settings) to stretch full width within the new layout.

  Tests not run (UI-only change). Closes #111 