### PR TITLE
Add structured storyteller choices and propagate previous options

### DIFF
--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -501,6 +501,33 @@ class StateUpdates(BaseModel):
 
 
 # ============================================================================
+# Story Choices (Player-Facing Options)
+# ============================================================================
+
+
+class StoryChoice(BaseModel):
+    """Structured representation of a numbered player option."""
+
+    id: str = Field(
+        description="Visible numeric identifier for the option (e.g., '1').",
+        pattern=r"^\d+$",
+    )
+    label: str = Field(
+        description="Short label shown alongside the option number."
+    )
+    canonical_user_input: str = Field(
+        alias="canonicalUserInput",
+        description=(
+            "Canonical text to send back to the storyteller when the player "
+            "selects this option without editing."
+        ),
+    )
+
+    class Config:
+        extra = "forbid"
+
+
+# ============================================================================
 # Operations
 # ============================================================================
 
@@ -569,6 +596,15 @@ class StorytellerResponseMinimal(BaseModel):
         default=None,
         description="Entities referenced in narrative"
     )
+    choices: Optional[List[StoryChoice]] = Field(
+        default=None,
+        description="Ordered list of player-facing options with numeric IDs",
+    )
+    allow_free_input: bool = Field(
+        default=False,
+        alias="allowFreeInput",
+        description="True when players are invited to propose something else",
+    )
 
     class Config:
         extra = "forbid"
@@ -588,6 +624,15 @@ class StorytellerResponseStandard(BaseModel):
     state_updates: Optional[StateUpdates] = Field(
         default=None,
         description="State changes for entities"
+    )
+    choices: Optional[List[StoryChoice]] = Field(
+        default=None,
+        description="Ordered list of player-facing options with numeric IDs",
+    )
+    allow_free_input: bool = Field(
+        default=False,
+        alias="allowFreeInput",
+        description="True when players are invited to propose something else",
     )
 
     class Config:
@@ -615,6 +660,15 @@ class StorytellerResponseExtended(BaseModel):
     reasoning: Optional[str] = Field(
         default=None,
         description="Storyteller's reasoning (debug mode only)"
+    )
+    choices: Optional[List[StoryChoice]] = Field(
+        default=None,
+        description="Ordered list of player-facing options with numeric IDs",
+    )
+    allow_free_input: bool = Field(
+        default=False,
+        alias="allowFreeInput",
+        description="True when players are invited to propose something else",
     )
 
     class Config:

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -154,6 +154,19 @@ class LogonUtility:
         sections.append("\n=== USER INPUT ===")
         sections.append(context.get("user_input", ""))
 
+        # Add previous turn choices to help resolve references like "#2"
+        previous_choices = context.get("previous_choices") or context.get("metadata", {}).get("previous_choices")
+        if previous_choices:
+            sections.append("\n=== PREVIOUS TURN OPTIONS ===")
+            sections.append("Last turn you offered these numbered options:")
+            for choice in previous_choices:
+                choice_id = choice.get("id", "?")
+                label = choice.get("label", "")
+                sections.append(f"{choice_id}. {label}".strip())
+            sections.append(
+                "When the player refers to #1/#2/#3 or similar, map it to the option with the matching id above."
+            )
+
         # Add entity data with hierarchical support
         entity_data = context.get("entity_data", {})
         if entity_data:

--- a/nexus/agents/lore/lore.py
+++ b/nexus/agents/lore/lore.py
@@ -274,7 +274,12 @@ class LORE:
         if self.logon is None:
             self._initialize_logon()
     
-    async def process_turn(self, user_input: str, parent_chunk_id: Optional[int] = None):
+    async def process_turn(
+        self,
+        user_input: str,
+        parent_chunk_id: Optional[int] = None,
+        previous_choices: Optional[List[Dict[str, Any]]] = None,
+    ):
         """
         Process a complete turn cycle.
 
@@ -292,7 +297,8 @@ class LORE:
             turn_id=f"turn_{int(time.time())}",
             user_input=user_input,
             start_time=time.time(),
-            target_chunk_id=parent_chunk_id
+            target_chunk_id=parent_chunk_id,
+            previous_choices=previous_choices or [],
         )
         
         try:

--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -38,3 +38,4 @@ class TurnContext:
     memory_state: Dict[str, Any] = field(default_factory=dict)
     authorial_directives: List[str] = field(default_factory=list)
     target_chunk_id: Optional[int] = None
+    previous_choices: List[Dict[str, Any]] = field(default_factory=list)

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -515,6 +515,9 @@ class TurnCycleManager:
             "memory_state": turn_context.memory_state
         }
 
+        if turn_context.previous_choices:
+            turn_context.context_payload["previous_choices"] = turn_context.previous_choices
+
         if turn_context.target_chunk_id is not None:
             turn_context.context_payload["metadata"]["target_chunk_id"] = turn_context.target_chunk_id
 

--- a/prompts/storyteller_core.md
+++ b/prompts/storyteller_core.md
@@ -128,6 +128,18 @@ When the user provides specific actions or dialogue, integrate them directly int
 
 **Pause/Resume Protocol:** If the user signals “pause game” or you detect need for meta-discussion, step out of narrative voice to discuss options, then resume when ready.
 
+### Structured Choices (Keep Numbers Stable)
+
+You return structured output in addition to the prose and metadata. Populate the choice fields every turn unless the scene truly offers no numbered options.
+
+- Provide an ordered `choices` list with three options. Each entry must include:
+  - `id`: the visible number as a string ("1", "2", "3").
+  - `label`: the short phrase shown next to that number.
+  - `canonicalUserInput`: the exact text we would send back if the player clicks without editing.
+- Set `allowFreeInput` to `true` when the narrative invites “something else?”; otherwise use `false`.
+- The prose can still mention or format the options, but the UI relies on the structured `choices` array.
+- The system will pass your previous choices back on the next call (formatted as numbered labels). When the player references “#2” or “option 3”, resolve it using the `id` mapping you provided.
+
 ## Violence & Consequences
 
 ### Combat Handling


### PR DESCRIPTION
## Summary
- add structured story choice fields and allowFreeInput to storyteller response schema
- pass previous turn choices into the storyteller prompt and context payload
- update core prompt instructions to require three numbered options with canonical user inputs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69268f0fdf9883238072d508beec515b)