### PR TITLE
Add structured storyteller choices support

### DIFF
--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -16,7 +16,7 @@ All models use Pydantic v2 for validation and serialization.
 """
 
 import logging
-from typing import List, Optional, Dict, Any, Union, Literal
+from typing import List, Optional, Dict, Any, Union, Literal, NewType
 from pydantic import BaseModel, Field, field_validator, model_validator
 from datetime import datetime
 
@@ -560,8 +560,39 @@ class Operations(BaseModel):
 # Main Response Schema with Hierarchical Options
 # ============================================================================
 
+StoryChoiceId = NewType("StoryChoiceId", str)
+
+
+class StoryChoice(BaseModel):
+    """A structured, numbered choice surfaced to the player."""
+
+    id: StoryChoiceId = Field(
+        description="Number the player sees, e.g. '1', '2', '3'.",
+        validation_alias="id",
+        serialization_alias="id",
+    )
+    label: str = Field(
+        description="Short label shown next to the number.",
+        validation_alias="label",
+        serialization_alias="label",
+    )
+    canonical_user_input: str = Field(
+        description=(
+            "Canonical text to send back to the Storyteller if the player "
+            "chooses this option without editing."
+        ),
+        validation_alias="canonicalUserInput",
+        serialization_alias="canonicalUserInput",
+    )
+
+    class Config:
+        extra = "forbid"
+        populate_by_name = True
+
+
 class StorytellerResponseMinimal(BaseModel):
     """Minimal response for quick narrative generation."""
+
     narrative: str = Field(
         description="The narrative prose (500-1500 words)"
     )
@@ -569,13 +600,25 @@ class StorytellerResponseMinimal(BaseModel):
         default=None,
         description="Entities referenced in narrative"
     )
+    choices: Optional[List[StoryChoice]] = Field(
+        default=None,
+        description="Ordered list of numbered player options",
+    )
+    allow_free_input: bool = Field(
+        default=False,
+        description="Whether to invite freeform input alongside choices",
+        validation_alias="allowFreeInput",
+        serialization_alias="allowFreeInput",
+    )
 
     class Config:
         extra = "forbid"
+        populate_by_name = True
 
 
 class StorytellerResponseStandard(BaseModel):
     """Standard response with narrative and essential metadata."""
+
     narrative: str = Field(
         description="The narrative prose (500-1500 words)"
     )
@@ -589,13 +632,25 @@ class StorytellerResponseStandard(BaseModel):
         default=None,
         description="State changes for entities"
     )
+    choices: Optional[List[StoryChoice]] = Field(
+        default=None,
+        description="Ordered list of numbered player options",
+    )
+    allow_free_input: bool = Field(
+        default=False,
+        description="Whether to invite freeform input alongside choices",
+        validation_alias="allowFreeInput",
+        serialization_alias="allowFreeInput",
+    )
 
     class Config:
         extra = "forbid"
+        populate_by_name = True
 
 
 class StorytellerResponseExtended(BaseModel):
     """Extended response with all features including operations."""
+
     narrative: str = Field(
         description="The narrative prose (500-1500 words)"
     )
@@ -616,9 +671,20 @@ class StorytellerResponseExtended(BaseModel):
         default=None,
         description="Storyteller's reasoning (debug mode only)"
     )
+    choices: Optional[List[StoryChoice]] = Field(
+        default=None,
+        description="Ordered list of numbered player options",
+    )
+    allow_free_input: bool = Field(
+        default=False,
+        description="Whether to invite freeform input alongside choices",
+        validation_alias="allowFreeInput",
+        serialization_alias="allowFreeInput",
+    )
 
     class Config:
         extra = "forbid"
+        populate_by_name = True
 
 
 # ============================================================================

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -154,6 +154,21 @@ class LogonUtility:
         sections.append("\n=== USER INPUT ===")
         sections.append(context.get("user_input", ""))
 
+        # Add previous structured choices to preserve numbering context
+        options_context = context.get("options", {}) if isinstance(context.get("options", {}), dict) else {}
+        previous_choices = options_context.get("previous_choices") or options_context.get("choices")
+        if previous_choices:
+            sections.append("\n=== PREVIOUS CHOICES ===")
+            sections.append("Last turn you offered these numbered options (id: label):")
+            for choice in previous_choices:
+                choice_id = choice.get("id") or choice.get("choice_id")
+                label = choice.get("label", "")
+                sections.append(f"{choice_id}. {label}")
+            sections.append(
+                "When the player references #<number> or option <number>, map it to the corresponding id above."
+            )
+
+
         # Add entity data with hierarchical support
         entity_data = context.get("entity_data", {})
         if entity_data:

--- a/nexus/agents/lore/lore.py
+++ b/nexus/agents/lore/lore.py
@@ -274,7 +274,12 @@ class LORE:
         if self.logon is None:
             self._initialize_logon()
     
-    async def process_turn(self, user_input: str, parent_chunk_id: Optional[int] = None):
+    async def process_turn(
+        self,
+        user_input: str,
+        parent_chunk_id: Optional[int] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ):
         """
         Process a complete turn cycle.
 
@@ -292,7 +297,8 @@ class LORE:
             turn_id=f"turn_{int(time.time())}",
             user_input=user_input,
             start_time=time.time(),
-            target_chunk_id=parent_chunk_id
+            target_chunk_id=parent_chunk_id,
+            options=options,
         )
         
         try:

--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -38,3 +38,4 @@ class TurnContext:
     memory_state: Dict[str, Any] = field(default_factory=dict)
     authorial_directives: List[str] = field(default_factory=list)
     target_chunk_id: Optional[int] = None
+    options: Optional[Dict[str, Any]] = None

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -515,6 +515,9 @@ class TurnCycleManager:
             "memory_state": turn_context.memory_state
         }
 
+        if turn_context.options:
+            turn_context.context_payload["options"] = turn_context.options
+
         if turn_context.target_chunk_id is not None:
             turn_context.context_payload["metadata"]["target_chunk_id"] = turn_context.target_chunk_id
 

--- a/prompts/storyteller_core.md
+++ b/prompts/storyteller_core.md
@@ -162,6 +162,13 @@ Handle intimate moments with literary discretion: build tension, acknowledge des
 
 Your response uses structured output mode with the Pydantic schema (`StorytellerResponseMinimal/Standard/Extended`). The schema defines all required fields and validation rules.
 
+**Structured Choices:**
+
+- Populate `choices` with three numbered options. Each entry must include the numeric `id` (`"1"`, `"2"`, `"3"`), a concise `label`, and the full `canonicalUserInput` we should send back if the player selects it unchanged.
+- Set `allowFreeInput` to `true` when the narrative invites the player to propose something else; otherwise `false`.
+- The narrative may reference the options naturally, but the UI reads from the structured `choices` array, so make sure those fields are complete.
+- You may receive a `PREVIOUS CHOICES` context block listing the prior turn's option numbers and labels. When the player references `#<number>` or `option <number>`, resolve it using that mapping.
+
 ### How to Update State
 
 Simply populate the relevant fields in your response:


### PR DESCRIPTION
## Summary
- extend Storyteller response schema with structured choices and allowFreeInput flag
- pass prior choice metadata into LOGON prompts and expose responses with camelCase fields for clients
- update storyteller prompt guidance to fill structured options and handle numbered references across turns

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69268f0fdf9883238072d508beec515b)