### PR TITLE
Add structured storyteller choice output

### DIFF
--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -557,6 +557,36 @@ class Operations(BaseModel):
 
 
 # ============================================================================
+# Player Choice Output
+# ============================================================================
+
+class StoryChoice(BaseModel):
+    """Structured representation of a numbered player choice."""
+
+    id: str = Field(
+        description="Number the player sees, e.g., '1', '2', '3'"
+    )
+    label: str = Field(
+        description="Short label shown next to the number"
+    )
+    canonicalUserInput: str = Field(
+        description=(
+            "Canonical text that should be sent back if the player selects this option"
+        )
+    )
+
+    @field_validator("id")
+    @classmethod
+    def validate_numeric_id(cls, value: str) -> str:
+        if not value.isdigit():
+            raise ValueError("Choice id must be a numeric string")
+        return value
+
+    class Config:
+        extra = "forbid"
+
+
+# ============================================================================
 # Main Response Schema with Hierarchical Options
 # ============================================================================
 
@@ -568,6 +598,14 @@ class StorytellerResponseMinimal(BaseModel):
     referenced_entities: Optional[ReferencedEntities] = Field(
         default=None,
         description="Entities referenced in narrative"
+    )
+    choices: Optional[List[StoryChoice]] = Field(
+        default=None,
+        description="Ordered list of structured player options"
+    )
+    allowFreeInput: bool = Field(
+        default=False,
+        description="Whether to show a freeform 'Something else?' option"
     )
 
     class Config:
@@ -588,6 +626,14 @@ class StorytellerResponseStandard(BaseModel):
     state_updates: Optional[StateUpdates] = Field(
         default=None,
         description="State changes for entities"
+    )
+    choices: Optional[List[StoryChoice]] = Field(
+        default=None,
+        description="Ordered list of structured player options"
+    )
+    allowFreeInput: bool = Field(
+        default=False,
+        description="Whether to show a freeform 'Something else?' option"
     )
 
     class Config:
@@ -615,6 +661,14 @@ class StorytellerResponseExtended(BaseModel):
     reasoning: Optional[str] = Field(
         default=None,
         description="Storyteller's reasoning (debug mode only)"
+    )
+    choices: Optional[List[StoryChoice]] = Field(
+        default=None,
+        description="Ordered list of structured player options"
+    )
+    allowFreeInput: bool = Field(
+        default=False,
+        description="Whether to show a freeform 'Something else?' option"
     )
 
     class Config:

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -154,6 +154,18 @@ class LogonUtility:
         sections.append("\n=== USER INPUT ===")
         sections.append(context.get("user_input", ""))
 
+        previous_choices = context.get("metadata", {}).get("previous_choices", [])
+        if previous_choices:
+            sections.append("\n=== PRIOR PLAYER OPTIONS ===")
+            sections.append("Last turn you offered these numbered options:")
+            for choice in previous_choices:
+                choice_id = choice.get("id", "?")
+                label = choice.get("label", "")
+                sections.append(f"{choice_id}. {label}")
+            sections.append(
+                "When the player says '#2' or 'option 2', they mean the option with id \"2\"."
+            )
+
         # Add entity data with hierarchical support
         entity_data = context.get("entity_data", {})
         if entity_data:

--- a/nexus/agents/lore/lore.py
+++ b/nexus/agents/lore/lore.py
@@ -274,7 +274,12 @@ class LORE:
         if self.logon is None:
             self._initialize_logon()
     
-    async def process_turn(self, user_input: str, parent_chunk_id: Optional[int] = None):
+    async def process_turn(
+        self,
+        user_input: str,
+        parent_chunk_id: Optional[int] = None,
+        previous_choices: Optional[List[Dict[str, Any]]] = None,
+    ):
         """
         Process a complete turn cycle.
 
@@ -286,13 +291,14 @@ class LORE:
             StoryTurnResponse with narrative and metadata, or string on error
         """
         logger.info(f"Starting turn cycle with input: {user_input[:100]}...")
-        
+
         # Initialize turn context
         self.turn_context = TurnContext(
             turn_id=f"turn_{int(time.time())}",
             user_input=user_input,
             start_time=time.time(),
-            target_chunk_id=parent_chunk_id
+            target_chunk_id=parent_chunk_id,
+            previous_choices=previous_choices or [],
         )
         
         try:

--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -32,6 +32,7 @@ class TurnContext:
     entity_data: Dict[str, Any] = field(default_factory=dict)
     retrieved_passages: List[Dict] = field(default_factory=list)
     context_payload: Dict[str, Any] = field(default_factory=dict)
+    previous_choices: List[Dict[str, Any]] = field(default_factory=list)
     apex_response: Optional[str] = None
     error_log: List[str] = field(default_factory=list)
     token_counts: Dict[str, int] = field(default_factory=dict)

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -518,6 +518,9 @@ class TurnCycleManager:
         if turn_context.target_chunk_id is not None:
             turn_context.context_payload["metadata"]["target_chunk_id"] = turn_context.target_chunk_id
 
+        if turn_context.previous_choices:
+            turn_context.context_payload["metadata"]["previous_choices"] = turn_context.previous_choices
+
         # Calculate utilization
         if self.lore.token_manager:
             utilization = self.lore.token_manager.calculate_utilization(

--- a/prompts/storyteller_core.md
+++ b/prompts/storyteller_core.md
@@ -162,6 +162,14 @@ Handle intimate moments with literary discretion: build tension, acknowledge des
 
 Your response uses structured output mode with the Pydantic schema (`StorytellerResponseMinimal/Standard/Extended`). The schema defines all required fields and validation rules.
 
+**Structured Choices:** Populate the `choices` array with **exactly three** options every turn unless instructed otherwise. Each option must include:
+- `id`: the visible number (`"1"`, `"2"`, `"3"`, ...)
+- `label`: the short phrase shown next to the number
+- `canonicalUserInput`: the precise text we will send back if the player clicks the option unchanged
+
+Set `allowFreeInput = true` when the narrative invites the player to propose "something else"; otherwise set it to `false`. The prose can still mention the options, but the UI relies on the structured `choices`—do not omit them.
+When the prompt includes a mapping of prior numbered options, interpret `#1`/`option 1` references using that mapping.
+
 ### How to Update State
 
 Simply populate the relevant fields in your response:


### PR DESCRIPTION
## Summary
- add structured StoryChoice schema and allowFreeInput flag across storyteller responses
- feed previous turn choices into context prompts and API calls so numbered references stay stable across turns
- update storyteller system prompt to require three structured options with explicit canonical inputs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69268f0fdf9883238072d508beec515b)