### PR TITLE
Add structured storyteller choices to structured responses

### DIFF
--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -273,6 +273,7 @@ class ReferencedEntities(BaseModel):
 
     class Config:
         extra = "forbid"
+        populate_by_name = True
 
 
 # ============================================================================
@@ -519,6 +520,30 @@ class SummaryRequest(BaseModel):
         extra = "forbid"
 
 
+class StoryChoice(BaseModel):
+    """Structured representation of a numbered story option."""
+
+    id: str = Field(
+        pattern=r"^\d+$",
+        description="Visible numeric identifier for the option (e.g., '1', '2').",
+    )
+    label: str = Field(
+        description="Short label shown next to the option number."
+    )
+    canonical_user_input: str = Field(
+        alias="canonicalUserInput",
+        serialization_alias="canonicalUserInput",
+        description=(
+            "Canonical text we would send back to the LLM if the player selects"
+            " this option without editing it."
+        ),
+    )
+
+    class Config:
+        extra = "forbid"
+        populate_by_name = True
+
+
 class RegenerationRequest(BaseModel):
     """Request to regenerate this narrative chunk."""
     reason: str = Field(
@@ -565,6 +590,16 @@ class StorytellerResponseMinimal(BaseModel):
     narrative: str = Field(
         description="The narrative prose (500-1500 words)"
     )
+    choices: Optional[List[StoryChoice]] = Field(
+        default=None,
+        description="Ordered numbered options for the player."
+    )
+    allow_free_input: bool = Field(
+        default=False,
+        alias="allowFreeInput",
+        serialization_alias="allowFreeInput",
+        description="Whether to show a freeform 'something else?' option to the player."
+    )
     referenced_entities: Optional[ReferencedEntities] = Field(
         default=None,
         description="Entities referenced in narrative"
@@ -572,12 +607,23 @@ class StorytellerResponseMinimal(BaseModel):
 
     class Config:
         extra = "forbid"
+        populate_by_name = True
 
 
 class StorytellerResponseStandard(BaseModel):
     """Standard response with narrative and essential metadata."""
     narrative: str = Field(
         description="The narrative prose (500-1500 words)"
+    )
+    choices: Optional[List[StoryChoice]] = Field(
+        default=None,
+        description="Ordered numbered options for the player."
+    )
+    allow_free_input: bool = Field(
+        default=False,
+        alias="allowFreeInput",
+        serialization_alias="allowFreeInput",
+        description="Whether to show a freeform 'something else?' option to the player."
     )
     chunk_metadata: ChunkMetadataUpdate = Field(
         description="Essential chunk metadata"
@@ -592,12 +638,23 @@ class StorytellerResponseStandard(BaseModel):
 
     class Config:
         extra = "forbid"
+        populate_by_name = True
 
 
 class StorytellerResponseExtended(BaseModel):
     """Extended response with all features including operations."""
     narrative: str = Field(
         description="The narrative prose (500-1500 words)"
+    )
+    choices: Optional[List[StoryChoice]] = Field(
+        default=None,
+        description="Ordered numbered options for the player."
+    )
+    allow_free_input: bool = Field(
+        default=False,
+        alias="allowFreeInput",
+        serialization_alias="allowFreeInput",
+        description="Whether to show a freeform 'something else?' option to the player."
     )
     chunk_metadata: ChunkMetadataUpdate = Field(
         description="Essential chunk metadata"
@@ -619,6 +676,7 @@ class StorytellerResponseExtended(BaseModel):
 
     class Config:
         extra = "forbid"
+        populate_by_name = True
 
 
 # ============================================================================

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -154,6 +154,21 @@ class LogonUtility:
         sections.append("\n=== USER INPUT ===")
         sections.append(context.get("user_input", ""))
 
+        # Provide previous structured options for reference resolution
+        metadata = context.get("metadata", {})
+        previous_choices = metadata.get("previous_choices") if isinstance(metadata, dict) else None
+        if previous_choices:
+            sections.append("\n=== PREVIOUS CHOICES ===")
+            sections.append("Last turn you offered these numbered options:")
+            for choice in previous_choices:
+                choice_id = choice.get("id") if isinstance(choice, dict) else None
+                label = choice.get("label") if isinstance(choice, dict) else None
+                if choice_id and label:
+                    sections.append(f"{choice_id}. {label}")
+            sections.append(
+                "When the player references #2, option 2, or similar, map it to the option with that id."
+            )
+
         # Add entity data with hierarchical support
         entity_data = context.get("entity_data", {})
         if entity_data:

--- a/nexus/agents/lore/lore.py
+++ b/nexus/agents/lore/lore.py
@@ -274,7 +274,12 @@ class LORE:
         if self.logon is None:
             self._initialize_logon()
     
-    async def process_turn(self, user_input: str, parent_chunk_id: Optional[int] = None):
+    async def process_turn(
+        self,
+        user_input: str,
+        parent_chunk_id: Optional[int] = None,
+        previous_choices: Optional[List[Dict[str, Any]]] = None,
+    ):
         """
         Process a complete turn cycle.
 
@@ -292,7 +297,8 @@ class LORE:
             turn_id=f"turn_{int(time.time())}",
             user_input=user_input,
             start_time=time.time(),
-            target_chunk_id=parent_chunk_id
+            target_chunk_id=parent_chunk_id,
+            previous_choices=previous_choices,
         )
         
         try:

--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -38,3 +38,4 @@ class TurnContext:
     memory_state: Dict[str, Any] = field(default_factory=dict)
     authorial_directives: List[str] = field(default_factory=list)
     target_chunk_id: Optional[int] = None
+    previous_choices: Optional[List[Dict[str, Any]]] = None

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -518,6 +518,9 @@ class TurnCycleManager:
         if turn_context.target_chunk_id is not None:
             turn_context.context_payload["metadata"]["target_chunk_id"] = turn_context.target_chunk_id
 
+        if turn_context.previous_choices:
+            turn_context.context_payload["metadata"]["previous_choices"] = turn_context.previous_choices
+
         # Calculate utilization
         if self.lore.token_manager:
             utilization = self.lore.token_manager.calculate_utilization(

--- a/prompts/storyteller_core.md
+++ b/prompts/storyteller_core.md
@@ -162,6 +162,12 @@ Handle intimate moments with literary discretion: build tension, acknowledge des
 
 Your response uses structured output mode with the Pydantic schema (`StorytellerResponseMinimal/Standard/Extended`). The schema defines all required fields and validation rules.
 
+**Structured choices:**
+- Populate the `choices` array with three numbered options whenever you present explicit choices. Each entry includes a numeric `id` string ("1", "2", "3"), a short `label`, and the `canonicalUserInput` text we would send back unchanged if the player clicks it.
+- Set `allowFreeInput` to `true` when you invite the player to choose “something else?”; otherwise set it to `false`.
+- You may still mention the options in prose, but the structured `choices` control the UI.
+- You will receive the previous turn’s numbered options in context; resolve references like “#3 then #1” using that mapping.
+
 ### How to Update State
 
 Simply populate the relevant fields in your response:


### PR DESCRIPTION
## Summary
- add structured choice metadata and allowFreeInput flag to storyteller response schemas
- pass previous turn choices into the storyteller prompt context and return API responses with aliased fields
- update the storyteller prompt to request structured options alongside existing narrative output

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69268f0fdf9883238072d508beec515b)