### PR TITLE
Fix OpenAI strict mode compatibility for wizard tool calls

### DIFF
--- a/nexus/api/new_story_schemas.py
+++ b/nexus/api/new_story_schemas.py
@@ -24,7 +24,10 @@ def make_openai_strict_schema(schema: dict) -> dict:
     3. $ref cannot have sibling keywords (like description)
 
     This recursively processes the schema and any $defs.
+    Returns a new dict to avoid mutating the input schema.
     """
+    import copy
+    schema = copy.deepcopy(schema)
 
     def process_object(obj: dict) -> dict:
         if obj.get("type") != "object":


### PR DESCRIPTION
## Summary
- Fix Accept Fate failing with "Field required" validation errors when LLM omits `trait_rationales`
- Add `make_openai_strict_schema()` helper to transform Pydantic schemas for OpenAI strict mode
- Create `TraitRationales` model with explicit properties (replaces `Dict[str,str]` which is incompatible with strict mode)
- Add `strict: true` to all character sub-phase tool definitions
- Remove redundant `submit_character_sheet` tool (sub-phases accumulate data incrementally)

## Background

OpenAI's strict mode for function calling requires:
1. `additionalProperties: false` on ALL object schemas
2. ALL properties in `required` array (optional = nullable type, not missing from required)
3. `$ref` cannot have sibling keywords like `description`

Without strict mode, the LLM can omit required fields like `trait_rationales`, causing Pydantic validation to fail.

## Test plan
- [ ] Start new game, click Accept Fate through setting phase
- [ ] Click Accept Fate through character concept (phase 2.1)
- [ ] Click Accept Fate through trait selection (phase 2.2)
- [ ] Click Accept Fate through wildcard (phase 2.3)
- [ ] Verify character phase completes and transitions to seed phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)