### PR TITLE
Add configuration-driven model validation

### DIFF
--- a/nexus/api/slot_endpoints.py
+++ b/nexus/api/slot_endpoints.py
@@ -239,10 +239,9 @@ async def get_slot_model_endpoint(slot: int):
                 current_model = row.get("model") if row else None
 
         # Get available models from config
-        settings = load_settings_as_dict()
-        available = settings.get("global", {}).get("model", {}).get(
-            "available_models", ["gpt-5.1", "TEST", "claude"]
-        )
+        from nexus.config import get_available_api_models
+
+        available = get_available_api_models()
 
         return SlotModelResponse(
             slot=slot,
@@ -258,7 +257,7 @@ async def get_slot_model_endpoint(slot: int):
 @router.post("/{slot}/model", response_model=SlotModelResponse)
 async def set_slot_model_endpoint(slot: int, request: SlotModelRequest):
     """Set model for a slot."""
-    from nexus.config import load_settings_as_dict
+    from nexus.config import get_available_api_models
 
     if slot < 1 or slot > 5:
         raise HTTPException(status_code=400, detail="Slot must be between 1 and 5")
@@ -267,10 +266,7 @@ async def set_slot_model_endpoint(slot: int, request: SlotModelRequest):
         dbname = slot_dbname(slot)
 
         # Validate model against available models
-        settings = load_settings_as_dict()
-        available = settings.get("global", {}).get("model", {}).get(
-            "available_models", ["gpt-5.1", "TEST", "claude"]
-        )
+        available = get_available_api_models()
 
         if request.model not in available:
             raise HTTPException(

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -611,18 +611,9 @@ def run_model(args: argparse.Namespace) -> Dict[str, Any]:
     try:
         if args.list:
             # List available models from config (no slot required)
-            try:
-                from nexus.config.loader import load_settings_as_dict
+            from nexus.config import get_available_api_models
 
-                settings = load_settings_as_dict()
-                models = (
-                    settings.get("global", {})
-                    .get("model", {})
-                    .get("available_models", ["gpt-5.1", "TEST", "claude"])
-                )
-            except Exception:
-                # Fallback to hardcoded defaults if config unavailable
-                models = ["gpt-5.1", "TEST", "claude"]
+            models = get_available_api_models()
             return {
                 "success": True,
                 "message": f"Available models: {', '.join(models)}",

--- a/nexus/config/__init__.py
+++ b/nexus/config/__init__.py
@@ -1,6 +1,6 @@
 """NEXUS configuration loading and validation."""
 
 from .settings_models import Settings
-from .loader import load_settings, load_settings_as_dict
+from .loader import load_settings, load_settings_as_dict, get_available_api_models
 
-__all__ = ["Settings", "load_settings", "load_settings_as_dict"]
+__all__ = ["Settings", "load_settings", "load_settings_as_dict", "get_available_api_models"]

--- a/nexus/config/loader.py
+++ b/nexus/config/loader.py
@@ -25,13 +25,12 @@ except ModuleNotFoundError:
 from .settings_models import Settings
 
 
-# Cache for available models (avoids repeated config reads)
-_available_models_cache: list[str] | None = None
-
-
 def get_available_api_models() -> list[str]:
     """
-    Get available API models from nexus.toml configuration (cached).
+    Get available API models from nexus.toml configuration.
+
+    Reads fresh from config on each call to ensure changes are picked up
+    without requiring server restart.
 
     Returns:
         List of available model names from config, or fallback defaults
@@ -42,15 +41,12 @@ def get_available_api_models() -> list[str]:
         >>> "gpt-5.1" in models
         True
     """
-    global _available_models_cache
-    if _available_models_cache is None:
-        try:
-            settings = load_settings()
-            _available_models_cache = settings.global_.model.available_models
-        except Exception:
-            # Fallback to hardcoded defaults if config unavailable
-            _available_models_cache = ["gpt-5.1", "TEST", "claude"]
-    return _available_models_cache
+    try:
+        settings = load_settings()
+        return settings.global_.model.available_models
+    except Exception:
+        # Fallback to hardcoded defaults if config unavailable
+        return ["gpt-5.1", "TEST", "claude"]
 
 
 def load_settings(path: Union[str, Path] = "nexus.toml") -> Settings:

--- a/nexus/config/loader.py
+++ b/nexus/config/loader.py
@@ -25,6 +25,34 @@ except ModuleNotFoundError:
 from .settings_models import Settings
 
 
+# Cache for available models (avoids repeated config reads)
+_available_models_cache: list[str] | None = None
+
+
+def get_available_api_models() -> list[str]:
+    """
+    Get available API models from nexus.toml configuration (cached).
+
+    Returns:
+        List of available model names from config, or fallback defaults
+        if configuration is unavailable.
+
+    Examples:
+        >>> models = get_available_api_models()
+        >>> "gpt-5.1" in models
+        True
+    """
+    global _available_models_cache
+    if _available_models_cache is None:
+        try:
+            settings = load_settings()
+            _available_models_cache = settings.global_.model.available_models
+        except Exception:
+            # Fallback to hardcoded defaults if config unavailable
+            _available_models_cache = ["gpt-5.1", "TEST", "claude"]
+    return _available_models_cache
+
+
 def load_settings(path: Union[str, Path] = "nexus.toml") -> Settings:
     """
     Load and validate NEXUS configuration.


### PR DESCRIPTION
## Summary

- Add `get_available_api_models()` helper to `nexus/config/loader.py` with module-level caching
- Replace hardcoded `Literal["gpt-5.1", "TEST", "claude"]` in `ChatRequest.model` with dynamic `field_validator`
- Simplify CLI and slot_endpoints to use centralized helper instead of dict traversal

Fixes Pydantic validation error `"Input should be 'gpt-5.1', 'TEST' or 'claude'"` when users add new models to `nexus.toml`.

## Test plan

- [x] `nexus model --list` returns models from nexus.toml
- [x] `nexus model --slot 5 --set gpt-5.2` succeeds (was failing with Literal validation)
- [x] Invalid model rejected with helpful error: `"Invalid model 'foo'. Available: gpt-5.2, TEST, claude"`
- [x] All imports successful, mypy passes on modified files

## Known issue (separate PR)

Wizard mode `--choice N` hits "Message content must be non-empty" error because wizard choices aren't persisted in `new_story_creator`. This is a pre-existing bug unmasked by fixing the validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)