### PR TITLE
Add wizard choice persistence for CLI --choice support

### DIFF
--- a/migrations/012_add_wizard_choice_object.sql
+++ b/migrations/012_add_wizard_choice_object.sql
@@ -1,0 +1,13 @@
+-- Migration 012: Add choice_object column to new_story_creator table
+--
+-- The new_story_creator table stores wizard state during story setup.
+-- Adding choice_object allows the wizard to persist the choices presented
+-- to the user, enabling the CLI's --choice flag to work correctly.
+--
+-- This mirrors the pattern used in the incubator table for narrative mode.
+
+ALTER TABLE assets.new_story_creator
+ADD COLUMN IF NOT EXISTS choice_object JSONB;
+
+COMMENT ON COLUMN assets.new_story_creator.choice_object IS
+'Structured choice data from last wizard response: {presented: string[], selected: {label, text, edited}}';

--- a/nexus/api/setup_endpoints.py
+++ b/nexus/api/setup_endpoints.py
@@ -29,6 +29,8 @@ from nexus.api.new_story_flow import (
     reset_setup,
     activate_slot,
 )
+from nexus.api.new_story_cache import write_wizard_choices
+from nexus.api.slot_utils import slot_dbname
 from nexus.api.config_utils import get_new_story_model
 
 logger = logging.getLogger("nexus.api.setup_endpoints")
@@ -60,6 +62,10 @@ async def start_setup_endpoint(request: StartSetupRequest) -> Dict[str, Any]:
             model_to_use = request.model or get_new_story_model()
             client = ConversationsClient(model=model_to_use)
             client.add_message(thread_id, "assistant", welcome_message)
+
+        # Store welcome choices for CLI --choice resolution
+        if welcome_choices:
+            write_wizard_choices(welcome_choices, slot_dbname(request.slot))
 
         return {
             "status": "started",

--- a/nexus/api/slot_endpoints.py
+++ b/nexus/api/slot_endpoints.py
@@ -63,6 +63,7 @@ async def get_slot_state_endpoint(slot: int):
                 is_wizard_mode=True,
                 phase=state.wizard_state.phase,
                 thread_id=state.wizard_state.thread_id,
+                choices=state.wizard_state.choices,
                 model=state.model,
             )
 


### PR DESCRIPTION
## Summary

- Add migration `012_add_wizard_choice_object.sql` for `choice_object JSONB` column in `assets.new_story_creator`
- Add `write_wizard_choices()` helper to persist choices after wizard responses
- Store choices in both wizard chat response paths and initial setup endpoint
- Return choices from slot state endpoint for wizard mode

This mirrors the `incubator.choice_object` pattern used in narrative mode, enabling architectural symmetry between wizard and narrative choice handling.

## Test plan

- [x] `nexus clear --slot 5` then `nexus continue --slot 5` shows choices
- [x] `nexus continue --slot 5 --choice 3` resolves correctly (no empty message error)
- [x] Subsequent `--choice N` commands work through wizard phases

## Root cause

Welcome choices were loaded from frontmatter and returned in HTTP response, but never persisted to the database. When CLI fetched state for the next command, choices were empty → sent empty message to OpenAI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)