### PR TITLE
Remove Audition module and unify layout theme menus

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -3,7 +3,7 @@ core: bash -lc 'NEXUS_SLOT=${NEXUS_SLOT:-1}; CORE_API_PORT=${CORE_API_PORT:-8001
 narrative: bash -lc 'NEXUS_SLOT=${NEXUS_SLOT:-1}; NARRATIVE_API_PORT=${NARRATIVE_API_PORT:-8002}; NEXUS_SLOT="${NEXUS_SLOT}" poetry run uvicorn nexus.api.narrative:app --reload --host 127.0.0.1 --port ${NARRATIVE_API_PORT}'
 
 # UI also needs NEXUS_SLOT for backend API calls
-ui: bash -lc 'NEXUS_SLOT=${NEXUS_SLOT:-1}; APP_PORT=${APP_PORT:-5001}; API_PORT=${API_PORT:-8000}; CORE_API_PORT=${CORE_API_PORT:-8001}; NARRATIVE_API_PORT=${NARRATIVE_API_PORT:-8002}; NEXUS_SLOT="${NEXUS_SLOT}" PORT="${APP_PORT}" API_PORT="${API_PORT}" CORE_API_PORT="${CORE_API_PORT}" NARRATIVE_API_PORT="${NARRATIVE_API_PORT}" npm --prefix ui run dev'
+ui: bash -lc 'NEXUS_SLOT=${NEXUS_SLOT:-1}; APP_PORT=${APP_PORT:-5001}; CORE_API_PORT=${CORE_API_PORT:-8001}; NARRATIVE_API_PORT=${NARRATIVE_API_PORT:-8002}; NEXUS_SLOT="${NEXUS_SLOT}" PORT="${APP_PORT}" CORE_API_PORT="${CORE_API_PORT}" NARRATIVE_API_PORT="${NARRATIVE_API_PORT}" npm --prefix ui run dev'
 
 # Mock OpenAI server for TEST model (returns cached data with 1500ms delay)
 mock_openai: poetry run uvicorn nexus.api.mock_openai:app --reload --host 127.0.0.1 --port 5102

--- a/ui/client/src/components/NewStoryWizard/WizardShell.tsx
+++ b/ui/client/src/components/NewStoryWizard/WizardShell.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Check, Menu, Home, Settings, Sparkles, Monitor, Wand2, X, Globe, User, MapPin } from "lucide-react";
+import { Menu, Home, Settings, X, Globe, User, MapPin } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { SlotSelector } from "./SlotSelector";
@@ -10,11 +10,11 @@ import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
-    DropdownMenuLabel,
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { CornerSunburst } from "@/components/deco";
+import { ThemeMenu } from "@/components/ThemeMenu";
 import { useToast } from "@/hooks/use-toast";
 import { Card } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -64,7 +64,7 @@ export function NewStoryWizard() {
     const [selectedSlot, setSelectedSlot] = useState<number | null>(null);
     const [resumeThreadId, setResumeThreadId] = useState<string | null>(null);
     const [_, setLocation] = useLocation();
-    const { isGilded, isVector, theme, setTheme, glowClass } = useTheme();
+    const { isGilded, isVector, glowClass } = useTheme();
     const { toast } = useToast();
 
     // State for data collected across phases
@@ -210,28 +210,7 @@ export function NewStoryWizard() {
                                 </div>
                             </Link>
                         </DropdownMenuItem>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuLabel className="text-xs text-muted-foreground">
-                            Theme
-                        </DropdownMenuLabel>
-                        <DropdownMenuItem onClick={() => setTheme('gilded')}>
-                            <div className="flex items-center gap-2 cursor-pointer">
-                                <Sparkles className="h-4 w-4" />
-                                <span>Gilded{theme === 'gilded' ? ' ✓' : ''}</span>
-                            </div>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => setTheme('vector')}>
-                            <div className="flex items-center gap-2 cursor-pointer">
-                                <Monitor className="h-4 w-4" />
-                                <span>Vector{theme === 'vector' ? ' ✓' : ''}</span>
-                            </div>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => setTheme('veil')}>
-                            <div className="flex items-center gap-2 cursor-pointer">
-                                <Wand2 className="h-4 w-4" />
-                                <span>Veil{theme === 'veil' ? ' ✓' : ''}</span>
-                            </div>
-                        </DropdownMenuItem>
+                        <ThemeMenu />
                     </DropdownMenuContent>
                 </DropdownMenu>
 

--- a/ui/client/src/components/StatusBar.tsx
+++ b/ui/client/src/components/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Menu, Home, Settings, Sparkles, Monitor, Wand2 } from "lucide-react";
+import { Menu, Home, Settings } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { toast as showToast } from "@/hooks/use-toast";
 import { Link } from "wouter";
@@ -7,13 +7,12 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useTheme } from "@/contexts/ThemeContext";
-import { useFonts } from "@/contexts/FontContext";
 import { CornerSunburst } from "@/components/deco";
+import { ThemeMenu } from "@/components/ThemeMenu";
 import { cn } from "@/lib/utils";
 
 interface StatusBarProps {
@@ -51,8 +50,7 @@ export function StatusBar({
   onRefreshModelStatus,
   onNavigate,
 }: StatusBarProps) {
-  const { isGilded, isVector, theme, setTheme, glowClass, generatingClass } = useTheme();
-  const { currentDisplayFont } = useFonts();
+  const { isGilded, isVector, glowClass, generatingClass } = useTheme();
   const [isModelHovered, setIsModelHovered] = useState(false);
   const [isModelOperating, setIsModelOperating] = useState(false);
   const [modelError, setModelError] = useState<string | null>(null);
@@ -298,10 +296,7 @@ export function StatusBar({
 
       {/* Centered NEXUS title - absolutely positioned for true window centering */}
       <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-0">
-        <span
-          className={`text-xl md:text-2xl text-primary ${glowClass} tracking-wider`}
-          style={{ fontFamily: currentDisplayFont }}
-        >
+        <span className={`font-display text-xl md:text-2xl text-primary ${glowClass} tracking-wider`}>
           NEXUS
         </span>
       </div>
@@ -333,28 +328,7 @@ export function StatusBar({
               <span>Settings</span>
             </div>
           </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel className="text-xs text-muted-foreground">
-            Theme
-          </DropdownMenuLabel>
-          <DropdownMenuItem onClick={() => setTheme('gilded')}>
-            <div className="flex items-center gap-2 cursor-pointer">
-              <Sparkles className="h-4 w-4" />
-              <span>Gilded{theme === 'gilded' ? ' ✓' : ''}</span>
-            </div>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setTheme('vector')}>
-            <div className="flex items-center gap-2 cursor-pointer">
-              <Monitor className="h-4 w-4" />
-              <span>Vector{theme === 'vector' ? ' ✓' : ''}</span>
-            </div>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setTheme('veil')}>
-            <div className="flex items-center gap-2 cursor-pointer">
-              <Wand2 className="h-4 w-4" />
-              <span>Veil{theme === 'veil' ? ' ✓' : ''}</span>
-            </div>
-          </DropdownMenuItem>
+          <ThemeMenu />
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/ui/client/src/components/ThemeMenu.tsx
+++ b/ui/client/src/components/ThemeMenu.tsx
@@ -1,0 +1,42 @@
+import { Sparkles, Monitor, Wand2 } from "lucide-react";
+import {
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import { useTheme } from "@/contexts/ThemeContext";
+
+/**
+ * Shared theme menu items for dropdown menus.
+ * Used by both StatusBar and WizardShell to provide consistent theme switching.
+ */
+export function ThemeMenu() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <>
+      <DropdownMenuSeparator />
+      <DropdownMenuLabel className="text-xs text-muted-foreground">
+        Theme
+      </DropdownMenuLabel>
+      <DropdownMenuItem onClick={() => setTheme("gilded")}>
+        <div className="flex items-center gap-2 cursor-pointer">
+          <Sparkles className="h-4 w-4" />
+          <span>Gilded{theme === "gilded" ? " ✓" : ""}</span>
+        </div>
+      </DropdownMenuItem>
+      <DropdownMenuItem onClick={() => setTheme("vector")}>
+        <div className="flex items-center gap-2 cursor-pointer">
+          <Monitor className="h-4 w-4" />
+          <span>Vector{theme === "vector" ? " ✓" : ""}</span>
+        </div>
+      </DropdownMenuItem>
+      <DropdownMenuItem onClick={() => setTheme("veil")}>
+        <div className="flex items-center gap-2 cursor-pointer">
+          <Wand2 className="h-4 w-4" />
+          <span>Veil{theme === "veil" ? " ✓" : ""}</span>
+        </div>
+      </DropdownMenuItem>
+    </>
+  );
+}

--- a/ui/server/routes.ts
+++ b/ui/server/routes.ts
@@ -11,23 +11,10 @@ import sharp from "sharp";
 
 // Register proxy BEFORE body parsing middleware
 export function registerProxyRoutes(app: Express): void {
-  const auditionPort = process.env.API_PORT || "8000";
-  const auditionTarget = process.env.AUDITION_API_URL || `http://localhost:${auditionPort}`;
   const corePort = process.env.CORE_API_PORT || "8001";
   const coreTarget = process.env.CORE_API_URL || `http://localhost:${corePort}`;
   const narrativePort = process.env.NARRATIVE_API_PORT || "8002";
   const narrativeTarget = process.env.NARRATIVE_API_URL || `http://localhost:${narrativePort}`;
-
-  // Proxy for Audition API (FastAPI backend on port 8000)
-  // Express strips /api/audition before passing to middleware, so we need to add it back
-  // IMPORTANT: Must be registered BEFORE express.json() to access raw body stream
-  const auditionProxy = createProxyMiddleware({
-    target: auditionTarget,
-    changeOrigin: true,
-    pathRewrite: (path) => `/api/audition${path}`,
-  });
-
-  app.use("/api/audition", auditionProxy);
 
   // Proxy for Core API (FastAPI backend on port 8001)
   // Handles model management and system operations


### PR DESCRIPTION
- Remove Audition tab from NexusLayout UI
- Remove Audition dropdown menu item from StatusBar and WizardShell
- Remove Audition process from Procfile.dev (no longer running on port 8000)
- Remove Audition proxy routes from ui/server/routes.ts
- Extract shared ThemeMenu component for consistent theme switching
- Update StatusBar to use font-display class for NEXUS title (aligns with WizardShell)

The Audition module can be revived as a standalone application if needed.