### PR TITLE
Add provider/model logos to model pickers

### DIFF
--- a/ui/client/public/icons/providers/anthropic-logo.svg
+++ b/ui/client/public/icons/providers/anthropic-logo.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4278eb78a584084a1857acbc2e89c846a0cc7434e68bbb70a63b6df0baa7b255
+size 1976

--- a/ui/client/public/icons/providers/claude-icon.svg
+++ b/ui/client/public/icons/providers/claude-icon.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d53db4be375e899c937c26cf16684a80d6e869b1928d72b37748bef2560e219
+size 2580

--- a/ui/client/public/icons/providers/openai-icon.svg
+++ b/ui/client/public/icons/providers/openai-icon.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b94ea61d860fae6f82f43571f36f17111fcf5d348e8e9cc22ae4b441c7560011
+size 2961

--- a/ui/client/public/icons/providers/openai-wordmark.svg
+++ b/ui/client/public/icons/providers/openai-wordmark.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:169b683855ef7a431e5a996d01406da76bb206eb777546d29e53613a8d08fb3a
+size 2189

--- a/ui/client/src/lib/model-icons.tsx
+++ b/ui/client/src/lib/model-icons.tsx
@@ -1,0 +1,115 @@
+/**
+ * Shared model icon utilities for provider logo/icon rendering.
+ *
+ * Assets live in /icons/providers/:
+ * - openai-wordmark.svg - OpenAI wordmark (for submenu triggers)
+ * - openai-icon.svg - OpenAI monoblossom (for model items)
+ * - anthropic-logo.svg - Anthropic logo (for submenu triggers)
+ * - claude-icon.svg - Claude Spark (for model items)
+ */
+import { Cpu } from 'lucide-react';
+
+// Provider asset configuration with paths and default sizing
+// OpenAI's SVG includes required brand whitespace (~3x padding), Anthropic's is tight.
+// We use equal total heights with Anthropic getting CSS padding to compensate.
+const providerAssets: Record<string, {
+  wordmark: string;
+  icon: string;
+  wordmarkClass: string;   // Height/width classes for the img
+  wrapperClass: string;    // Wrapper div classes (for padding/alignment)
+  iconClass: string;
+}> = {
+  openai: {
+    wordmark: '/icons/providers/openai-wordmark.svg',
+    icon: '/icons/providers/openai-icon.svg',
+    wordmarkClass: 'h-12 w-auto',  // Includes brand-mandated whitespace
+    wrapperClass: '',              // No extra padding needed
+    iconClass: 'w-5 h-5',
+  },
+  anthropic: {
+    wordmark: '/icons/providers/anthropic-logo.svg',
+    icon: '/icons/providers/claude-icon.svg',
+    wordmarkClass: 'h-4 w-auto',   // Tight crop, text only
+    wrapperClass: 'py-4',          // Add padding to match OpenAI's total height
+    iconClass: 'w-5 h-5',
+  },
+};
+
+// Compact wordmark sizes for smaller UI contexts (toolbars, etc.)
+const compactWordmarkConfig: Record<string, { imgClass: string; wrapperClass: string }> = {
+  openai: { imgClass: 'h-9 w-auto', wrapperClass: '' },
+  anthropic: { imgClass: 'h-3 w-auto', wrapperClass: 'py-3' },
+};
+
+/**
+ * Get the wordmark/logo element for a provider (used in submenu triggers).
+ * Returns null for unknown providers (use fallback text instead).
+ * Use compact=true for smaller UI contexts like toolbars.
+ * Returns a wrapper div with proper padding to ensure equal heights across providers.
+ */
+export function getProviderWordmark(provider: string, compact?: boolean): React.ReactElement | null {
+  const assets = providerAssets[provider];
+  if (!assets) return null;
+
+  let imgClass: string;
+  let wrapperClass: string;
+
+  if (compact) {
+    const config = compactWordmarkConfig[provider] ?? { imgClass: 'h-3 w-auto', wrapperClass: '' };
+    imgClass = config.imgClass;
+    wrapperClass = config.wrapperClass;
+  } else {
+    imgClass = assets.wordmarkClass;
+    wrapperClass = assets.wrapperClass;
+  }
+
+  return (
+    <div className={`flex items-center justify-center ${wrapperClass}`}>
+      <img
+        src={assets.wordmark}
+        alt={provider}
+        className={imgClass}
+      />
+    </div>
+  );
+}
+
+/**
+ * Get the icon element for a provider (used in model items and triggers).
+ * Falls back to Cpu icon for unknown providers.
+ * If no className provided, uses provider-specific default.
+ */
+export function getProviderIcon(provider: string, className?: string): React.ReactElement {
+  const assets = providerAssets[provider];
+  if (!assets) {
+    return <Cpu className={className ?? 'w-5 h-5'} />;
+  }
+
+  return (
+    <img
+      src={assets.icon}
+      alt=""
+      className={className ?? assets.iconClass}
+    />
+  );
+}
+
+/**
+ * Get the icon for a specific model by looking up its provider.
+ * Requires the modelsByProvider map to find the model's provider.
+ * If no className provided, uses provider-specific default.
+ */
+export function getModelIcon(
+  modelId: string,
+  modelsByProvider: Record<string, { id: string; provider: string }[]>,
+  className?: string
+): React.ReactElement {
+  // Find which provider this model belongs to
+  for (const [provider, models] of Object.entries(modelsByProvider)) {
+    if (models.some(m => m.id === modelId)) {
+      return getProviderIcon(provider, className);
+    }
+  }
+  // Fallback for unknown models
+  return <Cpu className={className ?? 'w-5 h-5'} />;
+}


### PR DESCRIPTION
## Summary

- Add official OpenAI and Anthropic brand assets to both model picker UIs
- Settings dropdown now uses nested submenus with provider wordmarks as triggers
- Wizard chat model picker converted from flat Select to nested DropdownMenu
- Shared `model-icons.tsx` helper handles provider-specific sizing (OpenAI SVG includes brand-mandated whitespace)

## Changes

| File | Description |
|------|-------------|
| `ui/client/public/icons/providers/` | New SVG assets (wordmarks + icons) |
| `ui/client/src/lib/model-icons.tsx` | Shared helper for logo rendering |
| `ui/client/src/pages/SettingsTab.tsx` | Logos in nested dropdown |
| `ui/client/src/components/NewStoryWizard/InteractiveWizard.tsx` | Nested dropdown with logos |

## Test plan

- [ ] Settings page: Verify OpenAI/Anthropic wordmarks appear in submenu triggers
- [ ] Settings page: Verify model items show provider icons (monoblossom, Claude Spark)
- [ ] Wizard chat: Verify nested dropdown with provider grouping
- [ ] TEST provider shows Cpu fallback icon
- [ ] All three themes (Gilded, Vector, Veil) render logos correctly on dark backgrounds

🤖 Generated with [Claude Code](https://claude.ai/code)