### PR TITLE
Add dynamic model configuration from nexus.toml

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,6 +1,3 @@
-# Audition API is save-independent (like IR Eval), no slot needed
-audition: bash -lc 'DB_URL=${DATABASE_URL:-postgresql://pythagor@localhost:5432/NEXUS}; API_PORT=${API_PORT:-8000}; DATABASE_URL="${DB_URL}" poetry run uvicorn nexus.api.apex_audition:app --reload --host 127.0.0.1 --port ${API_PORT}'
-
 # Core and Narrative APIs require NEXUS_SLOT to be set (1-5)
 core: bash -lc 'NEXUS_SLOT=${NEXUS_SLOT:-1}; CORE_API_PORT=${CORE_API_PORT:-8001}; NEXUS_SLOT="${NEXUS_SLOT}" poetry run uvicorn nexus.api.core:app --reload --host 127.0.0.1 --port ${CORE_API_PORT}'
 narrative: bash -lc 'NEXUS_SLOT=${NEXUS_SLOT:-1}; NARRATIVE_API_PORT=${NARRATIVE_API_PORT:-8002}; NEXUS_SLOT="${NEXUS_SLOT}" poetry run uvicorn nexus.api.narrative:app --reload --host 127.0.0.1 --port ${NARRATIVE_API_PORT}'

--- a/nexus.toml
+++ b/nexus.toml
@@ -9,14 +9,11 @@
 # Default LLM model to load for local inference (via LM Studio)
 default_model = "nexveridian/gpt-oss-120b"
 
-# Available API models for UI picker and CLI (not local inference)
-# These are the model endpoints available in the system
-available_models = ["gpt-5.2", "TEST", "claude"]
-
 # Default model for newly created/reset slots
 # Use "TEST" for development (mock responses, no API key needed)
 default_slot_model = "TEST"
 
+# Local model options (for LM Studio inference)
 possible_values = [
     "nousresearch/hermes-4-70b",
     "unsloth-gpt-oss-120b-hi-mlx",
@@ -28,6 +25,26 @@ possible_values = [
     "mixtral-8x22b-instruct-v0.1",
     "llama-3.3-70b-instruct@8bit",
     "llama-4-scout-17b-16e-instruct"
+]
+
+# Provider-grouped API model definitions
+# Each provider section lists models available for that API backend
+[global.model.api_models.openai]
+models = [
+    { id = "gpt-5.1", label = "GPT-5.1" },
+    { id = "gpt-5.2", label = "GPT-5.2" },
+]
+
+[global.model.api_models.anthropic]
+models = [
+    { id = "claude-haiku-4-5", label = "Haiku 4.5" },
+    { id = "claude-sonnet-4-5", label = "Sonnet 4.5" },
+    { id = "claude-opus-4-5", label = "Opus 4.5" },
+]
+
+[global.model.api_models.test]
+models = [
+    { id = "TEST", label = "TEST", description = "Mock server with cached data (dev)" },
 ]
 
 [global.llm]

--- a/nexus/api/core.py
+++ b/nexus/api/core.py
@@ -134,3 +134,20 @@ async def health_check():
         "status": "healthy",
         "service": "NEXUS Core API"
     }
+
+
+@app.get("/api/config/models")
+async def get_config_models():
+    """
+    Get available API models with provider info.
+
+    Returns models in two formats:
+    - models: Flat list with provider info (for UI dropdowns)
+    - by_provider: Grouped by provider (for routing decisions)
+    """
+    from nexus.config.loader import get_all_api_models, get_api_models_by_provider
+
+    return {
+        "models": get_all_api_models(),
+        "by_provider": get_api_models_by_provider(),
+    }

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -182,6 +182,16 @@ async def health_check():
     return {"status": "healthy", "service": "narrative_api"}
 
 
+@app.get("/api/config/models")
+async def get_config_models():
+    """Get available API models with provider info from nexus.toml."""
+    from nexus.config.loader import get_all_api_models, get_api_models_by_provider
+    return {
+        "models": get_all_api_models(),
+        "by_provider": get_api_models_by_provider(),
+    }
+
+
 @app.post("/api/narrative/continue", response_model=ContinueNarrativeResponse)
 async def continue_narrative(
     request: ContinueNarrativeRequest, background_tasks: BackgroundTasks

--- a/nexus/config/loader.py
+++ b/nexus/config/loader.py
@@ -7,7 +7,7 @@ Falls back to settings.json for backward compatibility during migration.
 
 import sys
 from pathlib import Path
-from typing import Union, Dict, Any
+from typing import Union, Dict, Any, List, Optional
 import json
 
 # Try Python 3.11+ built-in tomllib, fall back to tomli
@@ -25,28 +25,92 @@ except ModuleNotFoundError:
 from .settings_models import Settings
 
 
-def get_available_api_models() -> list[str]:
+def get_available_api_models() -> List[str]:
     """
-    Get available API models from nexus.toml configuration.
+    Get available API model IDs from nexus.toml configuration.
 
     Reads fresh from config on each call to ensure changes are picked up
     without requiring server restart.
 
     Returns:
-        List of available model names from config, or fallback defaults
+        List of available model IDs from config, or fallback defaults
         if configuration is unavailable.
 
     Examples:
         >>> models = get_available_api_models()
-        >>> "gpt-5.1" in models
+        >>> "gpt-5.2" in models
         True
     """
     try:
-        settings = load_settings()
-        return settings.global_.model.available_models
+        return [m["id"] for m in get_all_api_models()]
     except Exception:
         # Fallback to hardcoded defaults if config unavailable
-        return ["gpt-5.1", "TEST", "claude"]
+        return ["gpt-5.2", "TEST", "claude"]
+
+
+def get_api_models_by_provider() -> Dict[str, List[dict]]:
+    """
+    Get API models grouped by provider.
+
+    Returns:
+        Dictionary mapping provider name to list of model dicts.
+        Each model dict contains: id, label, description
+
+    Examples:
+        >>> by_provider = get_api_models_by_provider()
+        >>> "openai" in by_provider
+        True
+        >>> by_provider["openai"][0]["id"]
+        'gpt-5.2'
+    """
+    settings = load_settings()
+    return {
+        provider: [m.model_dump() for m in config.models]
+        for provider, config in settings.global_.model.api_models.items()
+    }
+
+
+def get_all_api_models() -> List[dict]:
+    """
+    Get flat list of all API models with provider info.
+
+    Returns:
+        List of model dicts, each containing: id, label, description, provider
+
+    Examples:
+        >>> models = get_all_api_models()
+        >>> any(m["id"] == "TEST" and m["provider"] == "test" for m in models)
+        True
+    """
+    result = []
+    for provider, models in get_api_models_by_provider().items():
+        for model in models:
+            result.append({**model, "provider": provider})
+    return result
+
+
+def get_provider_for_model(model_id: str) -> Optional[str]:
+    """
+    Look up which provider a model belongs to.
+
+    Args:
+        model_id: The model identifier (e.g., "gpt-5.2", "TEST", "claude")
+
+    Returns:
+        Provider name ("openai", "anthropic", "test") or None if not found
+
+    Examples:
+        >>> get_provider_for_model("gpt-5.2")
+        'openai'
+        >>> get_provider_for_model("TEST")
+        'test'
+        >>> get_provider_for_model("unknown")
+        None
+    """
+    for provider, models in get_api_models_by_provider().items():
+        if any(m["id"] == model_id for m in models):
+            return provider
+    return None
 
 
 def load_settings(path: Union[str, Path] = "nexus.toml") -> Settings:

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -13,19 +13,38 @@ from pydantic import BaseModel, Field, ConfigDict
 # Global Settings Models
 # =============================================================================
 
-class ModelConfig(BaseModel):
-    """Local LLM model configuration."""
+class APIModelEntry(BaseModel):
+    """Single API model definition."""
     model_config = ConfigDict(extra='forbid')
 
-    default_model: str = Field(..., description="Default model to load")
-    possible_values: List[str] = Field(..., description="Available model options")
-    available_models: List[str] = Field(
-        default=["gpt-5.1", "TEST", "claude"],
-        description="Available API models for UI picker and CLI"
+    id: str = Field(..., description="Model identifier (e.g., 'gpt-5.2', 'claude')")
+    label: str = Field(..., description="Display label for UI")
+    description: Optional[str] = Field(default=None, description="Human-readable description (optional)")
+
+
+class ProviderModels(BaseModel):
+    """Models for a single API provider."""
+    model_config = ConfigDict(extra='forbid')
+
+    models: List[APIModelEntry] = Field(
+        default_factory=list,
+        description="List of models available from this provider"
     )
+
+
+class ModelConfig(BaseModel):
+    """LLM model configuration with provider grouping."""
+    model_config = ConfigDict(extra='forbid')
+
+    default_model: str = Field(..., description="Default model to load for local inference")
+    possible_values: List[str] = Field(..., description="Available local model options")
     default_slot_model: str = Field(
         default="TEST",
         description="Default model for newly created/reset slots"
+    )
+    api_models: Dict[str, ProviderModels] = Field(
+        default_factory=dict,
+        description="API models grouped by provider (openai, anthropic, test)"
     )
 
 

--- a/ui/client/src/components/ui/dropdown-menu.tsx
+++ b/ui/client/src/components/ui/dropdown-menu.tsx
@@ -63,7 +63,8 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
         className
       )}
       {...props}
@@ -81,7 +82,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
       inset && "pl-8",
       className
     )}

--- a/ui/client/src/contexts/ModelContext.tsx
+++ b/ui/client/src/contexts/ModelContext.tsx
@@ -2,47 +2,108 @@
  * Model selection context for managing LLM model choice across the application.
  *
  * Provides per-call model selection with localStorage persistence.
- * Available models: gpt-5.1 (default), TEST (mock server), claude (future)
+ * Models are fetched dynamically from /api/config/models to reflect nexus.toml changes.
  */
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 
-export type Model = 'gpt-5.1' | 'TEST' | 'claude';
+// Model info from API
+interface ModelInfo {
+  id: string;
+  label: string;
+  description?: string;  // Optional now
+  provider: string;
+}
 
 interface ModelContextType {
-  model: Model;
-  setModel: (model: Model) => void;
+  model: string;
+  setModel: (model: string) => void;
   isTestMode: boolean;
-  // Available models for UI picker
-  availableModels: { id: Model; label: string; description: string }[];
+  // Available models for UI picker (fetched from backend)
+  availableModels: ModelInfo[];
+  // Models grouped by provider (for nested dropdown menus)
+  modelsByProvider: Record<string, ModelInfo[]>;
+  isLoading: boolean;
 }
 
 const ModelContext = createContext<ModelContextType | undefined>(undefined);
 
 const STORAGE_KEY = 'nexus-model';
-const DEFAULT_MODEL: Model = 'gpt-5.1';
+const DEFAULT_MODEL = 'gpt-5.2';
 
-// Models available in the UI picker
-const AVAILABLE_MODELS: { id: Model; label: string; description: string }[] = [
-  { id: 'gpt-5.1', label: 'GPT-5.1', description: 'OpenAI GPT-5.1 (production)' },
-  { id: 'TEST', label: 'TEST', description: 'Mock server with cached data (dev)' },
-  { id: 'claude', label: 'Claude', description: 'Anthropic Claude (coming soon)' },
+// Fallback models if API fails (matches nexus.toml defaults)
+const FALLBACK_MODELS: ModelInfo[] = [
+  { id: 'gpt-5.2', label: 'GPT-5.2', provider: 'openai' },
+  { id: 'TEST', label: 'TEST', provider: 'test' },
+  { id: 'claude', label: 'Claude', provider: 'anthropic' },
 ];
 
-export function ModelProvider({ children }: { children: ReactNode }) {
-  const [model, setModelState] = useState<Model>(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    // Validate stored value is a valid model
-    if (stored === 'gpt-5.1' || stored === 'TEST' || stored === 'claude') {
-      return stored;
-    }
-    return DEFAULT_MODEL;
-  });
+// Build fallback by_provider from flat list
+const FALLBACK_BY_PROVIDER: Record<string, ModelInfo[]> = FALLBACK_MODELS.reduce((acc, m) => {
+  if (!acc[m.provider]) acc[m.provider] = [];
+  acc[m.provider].push(m);
+  return acc;
+}, {} as Record<string, ModelInfo[]>);
 
+export function ModelProvider({ children }: { children: ReactNode }) {
+  const [model, setModelState] = useState<string>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored || DEFAULT_MODEL;
+  });
+  const [availableModels, setAvailableModels] = useState<ModelInfo[]>(FALLBACK_MODELS);
+  const [modelsByProvider, setModelsByProvider] = useState<Record<string, ModelInfo[]>>(FALLBACK_BY_PROVIDER);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Fetch available models from backend on mount
+  useEffect(() => {
+    const fetchModels = async () => {
+      try {
+        console.log('[ModelContext] Fetching models from API...');
+        const response = await fetch('/api/config/models');
+        if (response.ok) {
+          const data = await response.json();
+          console.log('[ModelContext] API response:', data);
+          if (data.models && Array.isArray(data.models) && data.models.length > 0) {
+            setAvailableModels(data.models);
+
+            // Compute modelsByProvider from the flat models list
+            // (more reliable than using by_provider since models already have provider field)
+            const byProvider = (data.models as ModelInfo[]).reduce((acc, m) => {
+              const provider = m.provider || 'other';
+              if (!acc[provider]) acc[provider] = [];
+              acc[provider].push(m);
+              return acc;
+            }, {} as Record<string, ModelInfo[]>);
+            console.log('[ModelContext] Computed byProvider:', byProvider);
+            setModelsByProvider(byProvider);
+
+            // Validate stored model is still valid
+            const validIds = data.models.map((m: ModelInfo) => m.id);
+            const storedModel = localStorage.getItem(STORAGE_KEY);
+            if (storedModel && !validIds.includes(storedModel)) {
+              // Stored model no longer valid, reset to default
+              const newDefault = validIds.includes(DEFAULT_MODEL) ? DEFAULT_MODEL : validIds[0];
+              setModelState(newDefault);
+              localStorage.setItem(STORAGE_KEY, newDefault);
+            }
+          }
+        }
+      } catch (error) {
+        console.warn('Failed to fetch models from API, using fallback:', error);
+        // Keep using fallback models
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchModels();
+  }, []);
+
+  // Persist model selection to localStorage
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, model);
   }, [model]);
 
-  const setModel = (newModel: Model) => setModelState(newModel);
+  const setModel = (newModel: string) => setModelState(newModel);
 
   const isTestMode = model === 'TEST';
 
@@ -51,7 +112,9 @@ export function ModelProvider({ children }: { children: ReactNode }) {
       model,
       setModel,
       isTestMode,
-      availableModels: AVAILABLE_MODELS,
+      availableModels,
+      modelsByProvider,
+      isLoading,
     }}>
       {children}
     </ModelContext.Provider>

--- a/ui/client/src/contexts/ModelContext.tsx
+++ b/ui/client/src/contexts/ModelContext.tsx
@@ -89,7 +89,15 @@ export function ModelProvider({ children }: { children: ReactNode }) {
         }
       } catch (error) {
         console.warn('Failed to fetch models from API, using fallback:', error);
-        // Keep using fallback models
+        // Validate stored model against fallback list to prevent stale invalid models
+        const fallbackIds = FALLBACK_MODELS.map(m => m.id);
+        const storedModel = localStorage.getItem(STORAGE_KEY);
+        if (storedModel && !fallbackIds.includes(storedModel)) {
+          const newDefault = fallbackIds.includes(DEFAULT_MODEL) ? DEFAULT_MODEL : fallbackIds[0];
+          console.warn(`[ModelContext] Stored model "${storedModel}" not in fallback list, resetting to "${newDefault}"`);
+          setModelState(newDefault);
+          localStorage.setItem(STORAGE_KEY, newDefault);
+        }
       } finally {
         setIsLoading(false);
       }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -23,7 +23,7 @@
         "@radix-ui/react-collapsible": "^1.1.4",
         "@radix-ui/react-context-menu": "^2.2.7",
         "@radix-ui/react-dialog": "^1.1.15",
-        "@radix-ui/react-dropdown-menu": "^2.1.7",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-hover-card": "^1.1.7",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-label": "^2.1.3",
@@ -4299,17 +4299,18 @@
       }
     },
     "node_modules/@radix-ui/react-dropdown-menu": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.7.tgz",
-      "integrity": "sha512-7/1LiuNZuCQE3IzdicGoHdQOHkS2Q08+7p8w6TXZ6ZjgAULaCI85ZY15yPl4o4FVgoKLRT43/rsfNVN8osClQQ==",
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-context": "1.1.2",
         "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-menu": "2.1.7",
-        "@radix-ui/react-primitive": "2.0.3",
-        "@radix-ui/react-use-controllable-state": "1.1.1"
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4322,6 +4323,339 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,7 @@
     "@radix-ui/react-collapsible": "^1.1.4",
     "@radix-ui/react-context-menu": "^2.2.7",
     "@radix-ui/react-dialog": "^1.1.15",
-    "@radix-ui/react-dropdown-menu": "^2.1.7",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-hover-card": "^1.1.7",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.3",

--- a/ui/server/routes.ts
+++ b/ui/server/routes.ts
@@ -92,6 +92,12 @@ export function registerProxyRoutes(app: Express): void {
     pathRewrite: (path) => `/api/user-character${path}`,
   }));
 
+  // Proxy for config endpoint (serves model configuration from nexus.toml)
+  app.use("/api/config", createProxyMiddleware({
+    ...narrativeProxyOptions,
+    pathRewrite: (path) => `/api/config${path}`,
+  }));
+
   app.use("/ws/narrative", createProxyMiddleware({ ...narrativeProxyOptions, ws: true }));
 }
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -98,7 +98,7 @@ export default defineConfig({
     },
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: 'http://localhost:8002',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

Replace hardcoded model lists with provider-grouped configuration from `nexus.toml`. This enables:
- Adding/removing models without code changes
- Provider grouping for nested UI dropdowns
- Structured model metadata (id, label, description)

## Changes

### Backend
| File | Description |
|------|-------------|
| `nexus.toml` | New `[global.model.api_models.*]` sections for OpenAI, Anthropic, TEST |
| `nexus/config/loader.py` | `get_api_models_by_provider()`, `get_all_api_models()` |
| `nexus/config/settings_models.py` | Pydantic models for config schema |
| `nexus/api/core.py` | New `/api/config/models` endpoint |

### Frontend
| File | Description |
|------|-------------|
| `ModelContext.tsx` | Fetch models from API, expose `modelsByProvider` |
| `ui/server/routes.ts` | Proxy route for `/api/config` |

### Cleanup
- Remove audition API from `Procfile.dev` (module removed in 1561fe6)

## Relationship to Other PRs

This PR provides the `modelsByProvider` data structure required by #156 (provider logos). Should be merged **before** #156.

## Test plan

- [ ] Verify `/api/config/models` returns correct structure
- [ ] Verify UI model picker shows models from config
- [ ] Verify adding a model to `nexus.toml` appears in UI after refresh
- [ ] Verify TEST mode still works

🤖 Generated with [Claude Code](https://claude.ai/code)