### PR TITLE
fix: Reference actual tracking issue #168 in model_manager.py

### DIFF
--- a/nexus/agents/lore/utils/model_manager.py
+++ b/nexus/agents/lore/utils/model_manager.py
@@ -97,7 +97,7 @@ class ModelManager:
 
         TODO: Migrate to TOML write support when nexus.config gains a save_settings() function.
         Currently writes to settings.json because the centralized loader only reads configs.
-        See: https://github.com/pythagorakase/nexus/issues/XXX (create tracking issue)
+        See: https://github.com/pythagorakase/nexus/issues/168
         """
         try:
             with open(self._json_settings_path, 'w') as f:


### PR DESCRIPTION
Replaces placeholder `XXX` with the actual issue number now that #168 exists.

Trivial one-liner — just updating a comment.