### PR TITLE
Add GitHub webhook to notify EDI on merge

### DIFF
--- a/.github/workflows/notify-edi.yml
+++ b/.github/workflows/notify-edi.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Setup Tailscale
         uses: tailscale/github-action@v2
@@ -18,21 +19,53 @@ jobs:
       - name: Notify EDI Gateway
         env:
           EDI_GITHUB_SECRET: ${{ secrets.EDI_GITHUB_SECRET }}
+          EDI_WEBHOOK_URL: ${{ vars.EDI_WEBHOOK_URL || 'http://100.104.206.23:19001/github-webhook' }}
         run: |
-          # Build JSON payload
-          PAYLOAD=$(jq -n \
+          # Validate secret is configured
+          if [ -z "$EDI_GITHUB_SECRET" ]; then
+            echo "::error::EDI_GITHUB_SECRET is not set"
+            exit 1
+          fi
+
+          # Build JSON payload (compact format for consistent HMAC)
+          PAYLOAD=$(jq -nc \
             --arg repo "${{ github.repository }}" \
             --arg ref "${{ github.ref }}" \
             --arg sha "${{ github.sha }}" \
             --arg message "${{ github.event.head_commit.message }}" \
             '{repository: $repo, ref: $ref, sha: $sha, message: $message}')
 
+          echo "Notifying EDI of merge..."
+          echo "  Repository: ${{ github.repository }}"
+          echo "  Commit: ${{ github.sha }}"
+
           # Compute HMAC-SHA256 signature
           SIG="sha256=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$EDI_GITHUB_SECRET" | cut -d' ' -f2)"
 
-          # POST to EDI webhook endpoint
-          curl -X POST "http://100.104.206.23:19001/github-webhook" \
-            -H "Content-Type: application/json" \
-            -H "X-Hub-Signature-256: $SIG" \
-            -d "$PAYLOAD" \
-            --fail --silent --show-error
+          # POST to EDI webhook endpoint with retries
+          MAX_ATTEMPTS=3
+          ATTEMPT=1
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            echo "Attempt $ATTEMPT of $MAX_ATTEMPTS..."
+            if curl -X POST "$EDI_WEBHOOK_URL" \
+              -H "Content-Type: application/json" \
+              -H "X-Hub-Signature-256: $SIG" \
+              -d "$PAYLOAD" \
+              --fail --show-error \
+              --max-time 30; then
+              echo "✓ Successfully notified EDI"
+              exit 0
+            else
+              EXIT_CODE=$?
+              echo "::warning::Attempt $ATTEMPT failed with exit code $EXIT_CODE"
+              if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+                SLEEP_TIME=$((ATTEMPT * 5))
+                echo "Retrying in ${SLEEP_TIME}s..."
+                sleep $SLEEP_TIME
+              fi
+            fi
+            ATTEMPT=$((ATTEMPT + 1))
+          done
+
+          echo "::error::Failed to notify EDI after $MAX_ATTEMPTS attempts"
+          exit 1


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that fires on push to `main`
- Uses Tailscale OAuth to connect CI runner to tailnet
- Sends HMAC-signed webhook to EDI server at `/github-webhook`
- EDI wakes up, pulls the repo, and can run tests automatically

## Test plan
- [ ] Verify Tailscale OAuth credentials are configured (done via Settings > Secrets)
- [ ] Verify `EDI_GITHUB_SECRET` is deployed to EDI server
- [ ] Merge this PR and confirm EDI receives the webhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)