### PR TITLE
Add embedding evaluation v2 setup

### DIFF
--- a/docs/vector_embeddings.md
+++ b/docs/vector_embeddings.md
@@ -15,6 +15,11 @@ NEXUS uses a multi-model ensemble approach with weighted combinations of differe
    - **E5-Large-V2** (intfloat/e5-large-v2) - Weight: 0.3
    - **BGE-Large-EN** (BAAI/bge-large-en) - Weight: 0.2
 
+3. **Octen Candidate Models (Issue #175 evaluation path)**
+   - **Octen-Embedding-4B** (2560 dimensions)
+   - **Octen-Embedding-8B** (4096 dimensions)
+   - Configured in `nexus.toml` / `settings.json` as inactive-by-default.
+
 ## Database Storage Strategy
 
 To handle different vector dimensions efficiently, we use a **dimension-specific tables approach**:
@@ -26,6 +31,14 @@ To handle different vector dimensions efficiently, we use a **dimension-specific
 2. **chunk_embeddings_1024d**
    - Table for 1024-dimensional vectors (E5-Large-V2, BGE-Large-EN)
    - Column type: `embedding Vector(1024)`
+
+3. **chunk_embeddings_2560d**
+   - Table for 2560-dimensional vectors (Octen-Embedding-4B)
+   - Column type: `embedding Vector(2560)`
+
+4. **chunk_embeddings_4096d**
+   - Table for 4096-dimensional vectors (Octen-Embedding-8B)
+   - Column type: `embedding Vector(4096)`
 
 This approach was chosen because pgvector requires fixed dimensions at table creation time, and mixing vectors of different dimensions in the same table would require significant padding and dimensionality management.
 

--- a/ir_eval/README.md
+++ b/ir_eval/README.md
@@ -1,5 +1,59 @@
 # NEXUS IR Evaluation System
 
+## V2 Embedding Evaluation Setup (Issue #175)
+
+The new V2 runner supports explicit model selection with immutable run configs.
+It is intended for solo-model and head-to-head embedding comparisons (including
+Octen-4B and Octen-8B) without mutating global MEMNON settings.
+
+### Quick start (V2)
+
+1. Apply DB migrations:
+
+```bash
+python scripts/migrate.py --slot 1
+```
+
+2. Seed queries:
+
+```bash
+python -m ir_eval.runner --db-url postgresql://pythagor@localhost/NEXUS seed-queries --file ir_eval/golden_queries_backup.json
+```
+
+3. Create a run (example: Octen-8B solo):
+
+```bash
+python -m ir_eval.runner --db-url postgresql://pythagor@localhost/NEXUS create-run \
+  --name "octen-8b-solo" \
+  --model "Octen-Embedding-8B:1.0" \
+  --hybrid \
+  --vector-weight 0.6 \
+  --text-weight 0.4 \
+  --cross-encoder \
+  --top-k 10
+```
+
+4. Execute and inspect:
+
+```bash
+python -m ir_eval.runner --db-url postgresql://pythagor@localhost/NEXUS execute-run --run-id 1
+python -m ir_eval.runner --db-url postgresql://pythagor@localhost/NEXUS list-runs --limit 10
+```
+
+5. Compare two runs:
+
+```bash
+python -m ir_eval.runner --db-url postgresql://pythagor@localhost/NEXUS compare-runs --run-a 1 --run-b 2
+```
+
+### Octen embedding generation helper
+
+```bash
+python scripts/generate_octen_embeddings.py --model all --parallel --create-indexes
+```
+
+## Legacy System
+
 This system provides a comprehensive toolkit for evaluating and comparing information retrieval performance in the NEXUS project. It implements a pooled relevance judgment approach that helps systematically evaluate and improve search quality across different embedding configurations.
 
 ## Key Features

--- a/ir_eval/__init__.py
+++ b/ir_eval/__init__.py
@@ -4,3 +4,12 @@ NEXUS IR Evaluation Package
 This package contains modules for evaluating the information retrieval performance
 of the NEXUS system using PostgreSQL database.
 """
+
+from ir_eval.engine import ComparisonEngine, EvaluationStore, MetricsCalculator, RunExecutor
+
+__all__ = [
+    "ComparisonEngine",
+    "EvaluationStore",
+    "MetricsCalculator",
+    "RunExecutor",
+]

--- a/ir_eval/engine/__init__.py
+++ b/ir_eval/engine/__init__.py
@@ -1,0 +1,13 @@
+"""IR evaluation V2 engine modules."""
+
+from ir_eval.engine.comparison import ComparisonEngine
+from ir_eval.engine.metrics import MetricsCalculator
+from ir_eval.engine.run_executor import RunExecutor
+from ir_eval.engine.storage import EvaluationStore
+
+__all__ = [
+    "ComparisonEngine",
+    "MetricsCalculator",
+    "RunExecutor",
+    "EvaluationStore",
+]

--- a/ir_eval/engine/comparison.py
+++ b/ir_eval/engine/comparison.py
@@ -1,0 +1,130 @@
+"""Run-to-run metric comparison utilities for IR evaluation."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+
+from ir_eval.engine.storage import EvaluationStore
+
+
+class ComparisonEngine:
+    """Compare run metrics with paired significance estimates."""
+
+    METRICS = ["p_at_5", "p_at_10", "mrr", "bpref", "ndcg_at_10"]
+
+    def __init__(self, store: EvaluationStore):
+        """Create a comparison engine bound to one evaluation store."""
+        self.store = store
+
+    @staticmethod
+    def _paired_arrays(
+        metrics_a: Dict[int, Dict[str, Any]],
+        metrics_b: Dict[int, Dict[str, Any]],
+        metric_name: str,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Build paired metric arrays on the intersection of query IDs."""
+        shared_query_ids = sorted(set(metrics_a.keys()).intersection(metrics_b.keys()))
+        if not shared_query_ids:
+            raise ValueError("Runs do not share any query IDs for comparison")
+
+        array_a = np.array(
+            [float(metrics_a[query_id][metric_name]) for query_id in shared_query_ids]
+        )
+        array_b = np.array(
+            [float(metrics_b[query_id][metric_name]) for query_id in shared_query_ids]
+        )
+        return array_a, array_b
+
+    @staticmethod
+    def _paired_permutation_pvalue(
+        scores_a: np.ndarray,
+        scores_b: np.ndarray,
+        iterations: int = 10000,
+        seed: int = 42,
+    ) -> float:
+        """Estimate a paired permutation p-value for mean difference."""
+        differences = scores_a - scores_b
+        observed = abs(float(np.mean(differences)))
+
+        if observed == 0.0:
+            return 1.0
+
+        rng = np.random.default_rng(seed)
+        extreme = 0
+
+        for _ in range(iterations):
+            signs = rng.choice([-1.0, 1.0], size=differences.shape[0])
+            permuted = differences * signs
+            if abs(float(np.mean(permuted))) >= observed:
+                extreme += 1
+
+        # Add-one smoothing to avoid 0.0 p-values.
+        return float((extreme + 1) / float(iterations + 1))
+
+    @staticmethod
+    def _bootstrap_ci(
+        scores_a: np.ndarray,
+        scores_b: np.ndarray,
+        iterations: int = 2000,
+        alpha: float = 0.95,
+        seed: int = 42,
+    ) -> Tuple[float, float]:
+        """Bootstrap confidence interval for mean metric delta (A - B)."""
+        if not (0.0 < alpha < 1.0):
+            raise ValueError("alpha must be between 0 and 1")
+
+        deltas = scores_a - scores_b
+        rng = np.random.default_rng(seed)
+        bootstrap_means = []
+
+        for _ in range(iterations):
+            sampled = rng.choice(deltas, size=deltas.shape[0], replace=True)
+            bootstrap_means.append(float(np.mean(sampled)))
+
+        lower_percentile = ((1.0 - alpha) / 2.0) * 100.0
+        upper_percentile = (alpha + (1.0 - alpha) / 2.0) * 100.0
+
+        return (
+            float(np.percentile(bootstrap_means, lower_percentile)),
+            float(np.percentile(bootstrap_means, upper_percentile)),
+        )
+
+    def compare_runs(self, run_a_id: int, run_b_id: int) -> Dict[str, Any]:
+        """Compare two runs and persist comparison output."""
+        metrics_a = self.store.get_query_metrics(run_a_id)
+        metrics_b = self.store.get_query_metrics(run_b_id)
+
+        if not metrics_a:
+            raise ValueError(f"No query metrics found for run {run_a_id}")
+        if not metrics_b:
+            raise ValueError(f"No query metrics found for run {run_b_id}")
+
+        metric_comparison: Dict[str, Dict[str, Any]] = {}
+
+        for metric in self.METRICS:
+            scores_a, scores_b = self._paired_arrays(metrics_a, metrics_b, metric)
+            mean_a = float(np.mean(scores_a))
+            mean_b = float(np.mean(scores_b))
+            delta = mean_a - mean_b
+            p_value = self._paired_permutation_pvalue(scores_a, scores_b)
+            ci_low, ci_high = self._bootstrap_ci(scores_a, scores_b)
+
+            metric_comparison[metric] = {
+                "run_a_mean": mean_a,
+                "run_b_mean": mean_b,
+                "delta": delta,
+                "paired_permutation_pvalue": p_value,
+                "significant_at_05": p_value < 0.05,
+                "bootstrap_ci_95": [ci_low, ci_high],
+            }
+
+        output = {
+            "run_a_id": run_a_id,
+            "run_b_id": run_b_id,
+            "metrics": metric_comparison,
+        }
+
+        self.store.save_comparison(run_a_id, run_b_id, output)
+        return output

--- a/ir_eval/engine/metrics.py
+++ b/ir_eval/engine/metrics.py
@@ -1,0 +1,188 @@
+"""IR metrics calculations for evaluation runs."""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from typing import Any, Dict, Iterable, List
+
+from ir_eval.models.schemas import QueryExecutionResult
+
+
+class MetricsCalculator:
+    """Calculate standard IR metrics for evaluation runs."""
+
+    @staticmethod
+    def _precision_at_k(
+        ranked_chunk_ids: List[int],
+        judgments: Dict[int, int],
+        k: int,
+        relevance_threshold: int = 1,
+    ) -> float:
+        """Compute precision at rank ``k``."""
+        if k <= 0:
+            raise ValueError("k must be greater than 0")
+
+        top_k = ranked_chunk_ids[:k]
+        relevant = 0
+        for chunk_id in top_k:
+            if judgments.get(chunk_id, 0) >= relevance_threshold:
+                relevant += 1
+
+        return relevant / float(k)
+
+    @staticmethod
+    def _mrr(
+        ranked_chunk_ids: List[int],
+        judgments: Dict[int, int],
+        relevance_threshold: int = 1,
+    ) -> float:
+        """Compute reciprocal rank of the first relevant result."""
+        for index, chunk_id in enumerate(ranked_chunk_ids, start=1):
+            if judgments.get(chunk_id, 0) >= relevance_threshold:
+                return 1.0 / float(index)
+        return 0.0
+
+    @staticmethod
+    def _bpref(
+        ranked_chunk_ids: List[int],
+        judgments: Dict[int, int],
+        relevance_threshold: int = 1,
+    ) -> float:
+        """Compute BPREF using judged relevant/non-relevant sets only."""
+        relevant_docs = {
+            chunk_id
+            for chunk_id, rel in judgments.items()
+            if rel >= relevance_threshold
+        }
+        non_relevant_docs = {
+            chunk_id for chunk_id, rel in judgments.items() if rel < relevance_threshold
+        }
+
+        relevant_total = len(relevant_docs)
+        if relevant_total == 0:
+            return 0.0
+
+        bpref_total = 0.0
+        non_relevant_seen = 0
+
+        for chunk_id in ranked_chunk_ids:
+            if chunk_id not in judgments:
+                continue
+            if chunk_id in non_relevant_docs:
+                non_relevant_seen += 1
+                continue
+            if chunk_id in relevant_docs:
+                penalty = min(non_relevant_seen, relevant_total) / float(relevant_total)
+                bpref_total += 1.0 - penalty
+
+        return bpref_total / float(relevant_total)
+
+    @staticmethod
+    def _ndcg_at_k(
+        ranked_chunk_ids: List[int], judgments: Dict[int, int], k: int = 10
+    ) -> float:
+        """Compute NDCG@k using 0-3 relevance labels."""
+        if k <= 0:
+            raise ValueError("k must be greater than 0")
+
+        def dcg(scores: Iterable[int]) -> float:
+            total = 0.0
+            for index, score in enumerate(scores, start=1):
+                total += float(score) / math.log2(index + 1)
+            return total
+
+        ranked_scores = [
+            judgments.get(chunk_id, 0) for chunk_id in ranked_chunk_ids[:k]
+        ]
+        ideal_scores = sorted(judgments.values(), reverse=True)[:k]
+
+        ideal_dcg = dcg(ideal_scores)
+        if ideal_dcg <= 0:
+            return 0.0
+
+        return dcg(ranked_scores) / ideal_dcg
+
+    def calculate_per_query(
+        self,
+        query_results: List[QueryExecutionResult],
+        judgments_by_query: Dict[int, Dict[int, int]],
+    ) -> Dict[int, Dict[str, Any]]:
+        """Calculate metrics for each query result set."""
+        metrics: Dict[int, Dict[str, Any]] = {}
+
+        for query_result in query_results:
+            ranked_chunk_ids = [result.chunk_id for result in query_result.results]
+            judgments = judgments_by_query.get(query_result.query_id, {})
+
+            judged_chunk_ids = set(judgments.keys())
+            returned_chunk_ids = set(ranked_chunk_ids)
+            judged_total = len(judged_chunk_ids.intersection(returned_chunk_ids))
+            unjudged_count = len(returned_chunk_ids) - judged_total
+
+            metrics[query_result.query_id] = {
+                "p_at_5": self._precision_at_k(ranked_chunk_ids, judgments, 5),
+                "p_at_10": self._precision_at_k(ranked_chunk_ids, judgments, 10),
+                "mrr": self._mrr(ranked_chunk_ids, judgments),
+                "bpref": self._bpref(ranked_chunk_ids, judgments),
+                "ndcg_at_10": self._ndcg_at_k(ranked_chunk_ids, judgments, 10),
+                "judged_total": judged_total,
+                "unjudged_count": unjudged_count,
+            }
+
+        return metrics
+
+    def aggregate_metrics(
+        self,
+        per_query_metrics: Dict[int, Dict[str, Any]],
+        query_categories: Dict[int, str],
+    ) -> Dict[str, Dict[str, Any]]:
+        """Aggregate query metrics overall and by category."""
+        metric_keys = ["p_at_5", "p_at_10", "mrr", "bpref", "ndcg_at_10"]
+
+        overall: Dict[str, float] = {key: 0.0 for key in metric_keys}
+        overall["judged_total"] = 0.0
+        overall["unjudged_count"] = 0.0
+
+        by_category_sums: Dict[str, Dict[str, float]] = defaultdict(
+            lambda: {
+                **{key: 0.0 for key in metric_keys},
+                "judged_total": 0.0,
+                "unjudged_count": 0.0,
+            }
+        )
+        by_category_counts: Dict[str, int] = defaultdict(int)
+
+        query_count = len(per_query_metrics)
+        if query_count == 0:
+            return {"overall": overall, "by_category": {}}
+
+        for query_id, metrics in per_query_metrics.items():
+            category = query_categories.get(query_id, "unknown")
+            by_category_counts[category] += 1
+
+            for key in metric_keys:
+                value = float(metrics.get(key, 0.0))
+                overall[key] += value
+                by_category_sums[category][key] += value
+
+            judged_total = float(metrics.get("judged_total", 0.0))
+            unjudged_count = float(metrics.get("unjudged_count", 0.0))
+            overall["judged_total"] += judged_total
+            overall["unjudged_count"] += unjudged_count
+            by_category_sums[category]["judged_total"] += judged_total
+            by_category_sums[category]["unjudged_count"] += unjudged_count
+
+        for key in metric_keys:
+            overall[key] = overall[key] / float(query_count)
+
+        by_category: Dict[str, Dict[str, float]] = {}
+        for category, sums in by_category_sums.items():
+            category_count = by_category_counts[category]
+            by_category[category] = {}
+            for key in metric_keys:
+                by_category[category][key] = sums[key] / float(category_count)
+            by_category[category]["judged_total"] = sums["judged_total"]
+            by_category[category]["unjudged_count"] = sums["unjudged_count"]
+
+        return {"overall": overall, "by_category": by_category}

--- a/ir_eval/engine/run_executor.py
+++ b/ir_eval/engine/run_executor.py
@@ -1,0 +1,330 @@
+"""Run execution engine for embedding-model evaluation."""
+
+from __future__ import annotations
+
+import copy
+import time
+from typing import Any, Dict, List, Tuple
+
+from nexus.config import load_settings_as_dict
+from nexus.agents.memnon.utils.cross_encoder import rerank_results
+from nexus.agents.memnon.utils.embedding_manager import EmbeddingManager
+from nexus.agents.memnon.utils.idf_dictionary import IDFDictionary
+from nexus.agents.memnon.utils.query_analysis import QueryAnalyzer
+from nexus.agents.memnon.utils.search import SearchManager
+
+from ir_eval.engine.metrics import MetricsCalculator
+from ir_eval.engine.storage import EvaluationStore
+from ir_eval.models.schemas import (
+    EvalRunConfig,
+    QueryExecutionResult,
+    RetrievedDocument,
+    RunExecutionSummary,
+)
+
+
+class RunExecutor:
+    """Execute eval runs with explicit, immutable model selection."""
+
+    def __init__(
+        self,
+        store: EvaluationStore,
+        *,
+        settings_dict: Dict[str, Any] | None = None,
+        db_url: str | None = None,
+    ):
+        """Create a run executor with repository and base settings."""
+        self.store = store
+        self.settings_dict = settings_dict or load_settings_as_dict()
+        self.base_memnon_settings = copy.deepcopy(
+            self.settings_dict["Agent Settings"]["MEMNON"]
+        )
+
+        configured_db_url = self.base_memnon_settings.get("database", {}).get("url")
+        self.db_url = db_url or configured_db_url
+        if not self.db_url:
+            raise ValueError("MEMNON database.url is not configured")
+
+    @staticmethod
+    def _normalize_model_weights(config: EvalRunConfig) -> Dict[str, float]:
+        """Normalize selected model weights so they sum to 1.0."""
+        total = sum(model.weight for model in config.embedding_models)
+        if total <= 0:
+            raise ValueError("embedding_models must include weight > 0")
+
+        return {
+            model.model: (model.weight / total) for model in config.embedding_models
+        }
+
+    def _build_run_memnon_settings(
+        self, config: EvalRunConfig
+    ) -> Tuple[Dict[str, Any], Dict[str, float]]:
+        """Build a per-run MEMNON config copy from the immutable run config."""
+        run_settings = copy.deepcopy(self.base_memnon_settings)
+        run_settings.setdefault("database", {})["url"] = self.db_url
+
+        selected_model_weights = self._normalize_model_weights(config)
+        model_configs = run_settings.get("models", {})
+
+        for model_name in selected_model_weights:
+            if model_name not in model_configs:
+                raise ValueError(
+                    f"Run references model '{model_name}', but it is not configured in MEMNON settings"
+                )
+
+        # Disable all models first, then activate selected ones with normalized weights.
+        for model_name, model_config in model_configs.items():
+            model_config["is_active"] = model_name in selected_model_weights
+            model_config["weight"] = selected_model_weights.get(model_name, 0.0)
+
+        retrieval = run_settings.setdefault("retrieval", {})
+        hybrid = retrieval.setdefault("hybrid_search", {})
+        hybrid["enabled"] = config.hybrid_search
+        hybrid["vector_weight_default"] = config.vector_weight
+        hybrid["text_weight_default"] = config.text_weight
+        hybrid["use_query_type_weights"] = False
+
+        cross_encoder = retrieval.setdefault("cross_encoder_reranking", {})
+        cross_encoder["enabled"] = config.cross_encoder_enabled
+
+        query_settings = run_settings.setdefault("query", {})
+        query_settings["default_limit"] = config.top_k
+
+        return run_settings, selected_model_weights
+
+    @staticmethod
+    def _build_retrieval_settings(memnon_settings: Dict[str, Any]) -> Dict[str, Any]:
+        """Build SearchManager retrieval settings from MEMNON settings."""
+        query_config = memnon_settings.get("query", {})
+        retrieval_config = memnon_settings.get("retrieval", {})
+
+        model_weights: Dict[str, float] = {}
+        for model_name, model_config in memnon_settings.get("models", {}).items():
+            if model_config.get("is_active", False):
+                model_weights[model_name] = float(model_config.get("weight", 0.0))
+
+        return {
+            "default_top_k": int(query_config.get("default_limit", 10)),
+            "max_query_results": int(retrieval_config.get("max_results", 50)),
+            "relevance_threshold": float(
+                retrieval_config.get("relevance_threshold", 0.65)
+            ),
+            "entity_boost_factor": float(
+                retrieval_config.get("entity_boost_factor", 1.2)
+            ),
+            "recency_boost_factor": float(
+                retrieval_config.get("recency_boost_factor", 1.1)
+            ),
+            "db_vector_balance": float(retrieval_config.get("db_vector_balance", 0.6)),
+            "model_weights": model_weights,
+            "highlight_matches": bool(query_config.get("highlight_matches", True)),
+        }
+
+    def _initialize_search_stack(
+        self,
+        memnon_settings: Dict[str, Any],
+        selected_model_weights: Dict[str, float],
+    ) -> Tuple[SearchManager, QueryAnalyzer]:
+        """Initialize EmbeddingManager/SearchManager for the selected models."""
+        embedding_manager = EmbeddingManager(settings=memnon_settings)
+        available_models = set(embedding_manager.get_available_models())
+        required_models = set(selected_model_weights.keys())
+        missing_models = required_models - available_models
+
+        if missing_models:
+            raise RuntimeError(
+                "Selected models failed to load: " + ", ".join(sorted(missing_models))
+            )
+
+        idf_dictionary = IDFDictionary(self.db_url)
+        idf_dictionary.build_dictionary()
+
+        retrieval_settings = self._build_retrieval_settings(memnon_settings)
+        search_manager = SearchManager(
+            db_url=self.db_url,
+            embedding_manager=embedding_manager,
+            idf_dictionary=idf_dictionary,
+            settings=memnon_settings,
+            retrieval_settings=retrieval_settings,
+        )
+        query_analyzer = QueryAnalyzer(settings=memnon_settings)
+
+        return search_manager, query_analyzer
+
+    @staticmethod
+    def _to_query_execution_result(
+        query_id: int,
+        query_text: str,
+        query_category: str,
+        raw_results: List[Dict[str, Any]],
+        elapsed_seconds: float,
+    ) -> QueryExecutionResult:
+        """Convert raw search results to typed query execution results."""
+        typed_results: List[RetrievedDocument] = []
+
+        for index, result in enumerate(raw_results, start=1):
+            chunk_id = int(result["id"])
+            model_scores_raw = result.get("model_scores", {}) or {}
+            model_scores = {
+                key: float(value) for key, value in model_scores_raw.items()
+            }
+
+            typed_results.append(
+                RetrievedDocument(
+                    chunk_id=chunk_id,
+                    rank=index,
+                    final_score=float(result.get("score", 0.0)),
+                    vector_score=float(result.get("vector_score", 0.0)),
+                    text_score=float(result.get("text_score", 0.0)),
+                    reranker_score=(
+                        float(result["reranker_score"])
+                        if result.get("reranker_score") is not None
+                        else None
+                    ),
+                    model_scores=model_scores,
+                    source=str(result.get("source", "unknown")),
+                    metadata=result.get("metadata", {}) or {},
+                )
+            )
+
+        return QueryExecutionResult(
+            query_id=query_id,
+            query_text=query_text,
+            query_category=query_category,
+            elapsed_seconds=elapsed_seconds,
+            results=typed_results,
+        )
+
+    def create_run(self, config: EvalRunConfig) -> int:
+        """Persist a run configuration and return its run ID."""
+        if not config.settings_snapshot:
+            config = config.model_copy(
+                update={"settings_snapshot": copy.deepcopy(self.base_memnon_settings)}
+            )
+        return self.store.create_run(config)
+
+    def execute_run(self, run_id: int) -> RunExecutionSummary:
+        """Execute a persisted run and store query results + metrics."""
+        run_config = self.store.get_run_config(run_id)
+        run_settings, selected_model_weights = self._build_run_memnon_settings(
+            run_config
+        )
+        search_manager, query_analyzer = self._initialize_search_stack(
+            run_settings,
+            selected_model_weights,
+        )
+
+        queries = self.store.get_queries(
+            query_ids=run_config.query_ids,
+            query_categories=run_config.query_categories,
+        )
+
+        self.store.set_run_status(run_id, "running", started=True)
+
+        started_at = time.time()
+        query_results: List[QueryExecutionResult] = []
+
+        cross_encoder_settings = run_settings.get("retrieval", {}).get(
+            "cross_encoder_reranking", {}
+        )
+
+        try:
+            for query in queries:
+                query_start = time.time()
+
+                if run_config.hybrid_search:
+                    raw_results = search_manager.perform_hybrid_search(
+                        query_text=query.text,
+                        filters=None,
+                        top_k=run_config.top_k,
+                    )
+                else:
+                    raw_results = search_manager.query_vector_search(
+                        query_text=query.text,
+                        collections=["narrative_chunks"],
+                        filters=None,
+                        top_k=run_config.top_k,
+                    )
+
+                if run_config.cross_encoder_enabled and raw_results:
+                    query_type = query_analyzer.analyze_query(query.text).get(
+                        "type", "general"
+                    )
+                    alpha = float(cross_encoder_settings.get("blend_weight", 0.3))
+
+                    if cross_encoder_settings.get("use_query_type_weights", False):
+                        query_type_weights = cross_encoder_settings.get(
+                            "weights_by_query_type", {}
+                        )
+                        if query_type in query_type_weights:
+                            alpha = float(query_type_weights[query_type])
+
+                    raw_results = rerank_results(
+                        query=query.text,
+                        results=raw_results,
+                        top_k=run_config.top_k,
+                        alpha=alpha,
+                        batch_size=int(cross_encoder_settings.get("batch_size", 8)),
+                        use_sliding_window=bool(
+                            cross_encoder_settings.get("use_sliding_window", True)
+                        ),
+                        model_path=str(
+                            cross_encoder_settings.get(
+                                "model_path",
+                                "naver-trecdl22-crossencoder-debertav3",
+                            )
+                        ),
+                        use_8bit=bool(cross_encoder_settings.get("use_8bit", False)),
+                    )
+
+                elapsed_seconds = time.time() - query_start
+                typed_query_result = self._to_query_execution_result(
+                    query_id=query.id,
+                    query_text=query.text,
+                    query_category=query.category,
+                    raw_results=raw_results,
+                    elapsed_seconds=elapsed_seconds,
+                )
+
+                query_results.append(typed_query_result)
+                self.store.insert_query_results(run_id, typed_query_result)
+
+            metrics_calculator = MetricsCalculator()
+            judgments_by_query = self.store.fetch_judgments(
+                [query.id for query in queries]
+            )
+            per_query_metrics = metrics_calculator.calculate_per_query(
+                query_results, judgments_by_query
+            )
+            query_categories = {query.id: query.category for query in queries}
+            aggregate = metrics_calculator.aggregate_metrics(
+                per_query_metrics, query_categories
+            )
+
+            self.store.store_metrics(
+                run_id=run_id,
+                per_query_metrics=per_query_metrics,
+                query_categories=query_categories,
+                overall_metrics=aggregate["overall"],
+                category_metrics=aggregate["by_category"],
+            )
+
+            self.store.set_run_status(run_id, "completed", completed=True)
+
+            return RunExecutionSummary(
+                run_id=run_id,
+                status="completed",
+                query_count=len(query_results),
+                total_elapsed_seconds=time.time() - started_at,
+                overall_metrics=aggregate["overall"],
+                category_metrics=aggregate["by_category"],
+            )
+
+        except Exception as exc:
+            self.store.set_run_status(
+                run_id,
+                "failed",
+                error_message=str(exc),
+                completed=True,
+            )
+            raise

--- a/ir_eval/engine/run_executor.py
+++ b/ir_eval/engine/run_executor.py
@@ -57,10 +57,16 @@ class RunExecutor:
         }
 
     def _build_run_memnon_settings(
-        self, config: EvalRunConfig
+        self,
+        config: EvalRunConfig,
+        base_settings: Dict[str, Any] | None = None,
     ) -> Tuple[Dict[str, Any], Dict[str, float]]:
-        """Build a per-run MEMNON config copy from the immutable run config."""
-        run_settings = copy.deepcopy(self.base_memnon_settings)
+        """Build a per-run MEMNON config copy from the immutable run config.
+
+        When *base_settings* is provided (e.g. from a stored snapshot), it is
+        used instead of the executor's current ``base_memnon_settings``.
+        """
+        run_settings = copy.deepcopy(base_settings or self.base_memnon_settings)
         run_settings.setdefault("database", {})["url"] = self.db_url
 
         selected_model_weights = self._normalize_model_weights(config)
@@ -206,8 +212,10 @@ class RunExecutor:
     def execute_run(self, run_id: int) -> RunExecutionSummary:
         """Execute a persisted run and store query results + metrics."""
         run_config = self.store.get_run_config(run_id)
+        snapshot = run_config.settings_snapshot or None
         run_settings, selected_model_weights = self._build_run_memnon_settings(
-            run_config
+            run_config,
+            base_settings=snapshot,
         )
         search_manager, query_analyzer = self._initialize_search_stack(
             run_settings,

--- a/ir_eval/engine/storage.py
+++ b/ir_eval/engine/storage.py
@@ -1,0 +1,384 @@
+"""Database storage layer for IR evaluation V2."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import psycopg2
+import psycopg2.extras
+
+from ir_eval.models.schemas import EvalQuery, EvalRunConfig, QueryExecutionResult
+
+
+class EvaluationStore:
+    """Persist and retrieve evaluation runs/results from PostgreSQL."""
+
+    def __init__(self, db_url: str):
+        """Initialize the store with a PostgreSQL DSN/URL."""
+        self.db_url = db_url
+
+    def _connect(self) -> psycopg2.extensions.connection:
+        """Create a new PostgreSQL connection."""
+        return psycopg2.connect(self.db_url)
+
+    def create_run(self, config: EvalRunConfig) -> int:
+        """Insert a pending run and return its ID."""
+        with self._connect() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    INSERT INTO ir_eval.eval_runs (name, description, config)
+                    VALUES (%s, %s, %s)
+                    RETURNING id
+                    """,
+                    (
+                        config.name,
+                        config.description,
+                        psycopg2.extras.Json(config.model_dump(mode="json")),
+                    ),
+                )
+                run_id = cursor.fetchone()[0]
+            conn.commit()
+
+        return int(run_id)
+
+    def list_runs(self, limit: int = 20) -> List[Dict[str, Any]]:
+        """Return recent runs ordered by creation time."""
+        with self._connect() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                cursor.execute(
+                    """
+                    SELECT id, name, status, created_at, started_at, completed_at, error_message
+                    FROM ir_eval.eval_runs
+                    ORDER BY created_at DESC
+                    LIMIT %s
+                    """,
+                    (limit,),
+                )
+                rows = cursor.fetchall()
+
+        return [dict(row) for row in rows]
+
+    def get_run_config(self, run_id: int) -> EvalRunConfig:
+        """Load and validate a run configuration."""
+        with self._connect() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                cursor.execute(
+                    "SELECT config FROM ir_eval.eval_runs WHERE id = %s",
+                    (run_id,),
+                )
+                row = cursor.fetchone()
+
+        if not row:
+            raise ValueError(f"Run {run_id} does not exist")
+
+        return EvalRunConfig.model_validate(row["config"])
+
+    def set_run_status(
+        self,
+        run_id: int,
+        status: str,
+        *,
+        error_message: Optional[str] = None,
+        started: bool = False,
+        completed: bool = False,
+    ) -> None:
+        """Update run status and optional timestamps."""
+        updates = ["status = %s", "error_message = %s"]
+        params: List[Any] = [status, error_message]
+
+        if started:
+            updates.append("started_at = NOW()")
+        if completed:
+            updates.append("completed_at = NOW()")
+
+        params.append(run_id)
+
+        with self._connect() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    f"UPDATE ir_eval.eval_runs SET {', '.join(updates)} WHERE id = %s",
+                    tuple(params),
+                )
+            conn.commit()
+
+    def get_queries(
+        self,
+        query_ids: Optional[List[int]] = None,
+        query_categories: Optional[List[str]] = None,
+    ) -> List[EvalQuery]:
+        """Fetch evaluation queries from `ir_eval.queries`."""
+        where_clauses: List[str] = []
+        params: List[Any] = []
+
+        if query_ids:
+            where_clauses.append("id = ANY(%s)")
+            params.append(query_ids)
+
+        if query_categories:
+            where_clauses.append("category = ANY(%s)")
+            params.append(query_categories)
+
+        sql = "SELECT id, text, COALESCE(category, 'unknown') AS category, COALESCE(name, '') AS name FROM ir_eval.queries"
+        if where_clauses:
+            sql += " WHERE " + " AND ".join(where_clauses)
+        sql += " ORDER BY id ASC"
+
+        with self._connect() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                cursor.execute(sql, tuple(params))
+                rows = cursor.fetchall()
+
+        queries = [EvalQuery.model_validate(dict(row)) for row in rows]
+        if not queries:
+            raise ValueError(
+                "No queries found in ir_eval.queries for the selected filters"
+            )
+
+        return queries
+
+    def seed_queries_from_json(self, json_path: str) -> int:
+        """Load golden queries from JSON and upsert into `ir_eval.queries`."""
+        path = Path(json_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Missing golden queries file: {json_path}")
+
+        data = json.loads(path.read_text())
+        inserted = 0
+
+        with self._connect() as conn:
+            with conn.cursor() as cursor:
+                for category, payload in data.items():
+                    if category == "settings" or not isinstance(payload, dict):
+                        continue
+
+                    for name, query_payload in payload.items():
+                        if (
+                            not isinstance(query_payload, dict)
+                            or "query" not in query_payload
+                        ):
+                            continue
+
+                        cursor.execute(
+                            """
+                            INSERT INTO ir_eval.queries (text, category, name)
+                            VALUES (%s, %s, %s)
+                            ON CONFLICT (text)
+                            DO UPDATE SET category = EXCLUDED.category, name = EXCLUDED.name
+                            """,
+                            (query_payload["query"], category, name),
+                        )
+                        inserted += 1
+
+            conn.commit()
+
+        return inserted
+
+    def insert_query_results(
+        self, run_id: int, query_result: QueryExecutionResult
+    ) -> None:
+        """Persist scored retrieval results for one query."""
+        if not query_result.results:
+            return
+
+        rows = []
+        for result in query_result.results:
+            rows.append(
+                (
+                    run_id,
+                    query_result.query_id,
+                    result.chunk_id,
+                    result.rank,
+                    result.final_score,
+                    result.vector_score,
+                    result.text_score,
+                    result.reranker_score,
+                    psycopg2.extras.Json(result.model_scores),
+                    result.source,
+                    psycopg2.extras.Json(result.metadata),
+                )
+            )
+
+        with self._connect() as conn:
+            with conn.cursor() as cursor:
+                psycopg2.extras.execute_values(
+                    cursor,
+                    """
+                    INSERT INTO ir_eval.eval_results (
+                        run_id,
+                        query_id,
+                        chunk_id,
+                        rank,
+                        final_score,
+                        vector_score,
+                        text_score,
+                        reranker_score,
+                        model_scores,
+                        source,
+                        metadata
+                    )
+                    VALUES %s
+                    ON CONFLICT (run_id, query_id, chunk_id)
+                    DO UPDATE SET
+                        rank = EXCLUDED.rank,
+                        final_score = EXCLUDED.final_score,
+                        vector_score = EXCLUDED.vector_score,
+                        text_score = EXCLUDED.text_score,
+                        reranker_score = EXCLUDED.reranker_score,
+                        model_scores = EXCLUDED.model_scores,
+                        source = EXCLUDED.source,
+                        metadata = EXCLUDED.metadata
+                    """,
+                    rows,
+                )
+            conn.commit()
+
+    def fetch_judgments(self, query_ids: Iterable[int]) -> Dict[int, Dict[int, int]]:
+        """Return relevance judgments keyed by query and chunk ID."""
+        query_id_list = list(query_ids)
+        if not query_id_list:
+            return {}
+
+        with self._connect() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT query_id, chunk_id, relevance
+                    FROM ir_eval.judgments
+                    WHERE query_id = ANY(%s)
+                    """,
+                    (query_id_list,),
+                )
+                rows = cursor.fetchall()
+
+        by_query: Dict[int, Dict[int, int]] = {
+            query_id: {} for query_id in query_id_list
+        }
+        for query_id, chunk_id, relevance in rows:
+            by_query[int(query_id)][int(chunk_id)] = int(relevance)
+
+        return by_query
+
+    def store_metrics(
+        self,
+        run_id: int,
+        per_query_metrics: Dict[int, Dict[str, Any]],
+        query_categories: Dict[int, str],
+        overall_metrics: Dict[str, float],
+        category_metrics: Dict[str, Dict[str, float]],
+    ) -> None:
+        """Persist query-level and aggregate metrics for a run."""
+        with self._connect() as conn:
+            with conn.cursor() as cursor:
+                for query_id, metrics in per_query_metrics.items():
+                    cursor.execute(
+                        """
+                        INSERT INTO ir_eval.eval_query_metrics (
+                            run_id,
+                            query_id,
+                            category,
+                            p_at_5,
+                            p_at_10,
+                            mrr,
+                            bpref,
+                            ndcg_at_10,
+                            judged_total,
+                            unjudged_count
+                        )
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        ON CONFLICT (run_id, query_id)
+                        DO UPDATE SET
+                            category = EXCLUDED.category,
+                            p_at_5 = EXCLUDED.p_at_5,
+                            p_at_10 = EXCLUDED.p_at_10,
+                            mrr = EXCLUDED.mrr,
+                            bpref = EXCLUDED.bpref,
+                            ndcg_at_10 = EXCLUDED.ndcg_at_10,
+                            judged_total = EXCLUDED.judged_total,
+                            unjudged_count = EXCLUDED.unjudged_count
+                        """,
+                        (
+                            run_id,
+                            query_id,
+                            query_categories.get(query_id, "unknown"),
+                            metrics.get("p_at_5", 0.0),
+                            metrics.get("p_at_10", 0.0),
+                            metrics.get("mrr", 0.0),
+                            metrics.get("bpref", 0.0),
+                            metrics.get("ndcg_at_10", 0.0),
+                            metrics.get("judged_total", 0),
+                            metrics.get("unjudged_count", 0),
+                        ),
+                    )
+
+                cursor.execute(
+                    """
+                    INSERT INTO ir_eval.eval_run_metrics (
+                        run_id,
+                        overall_metrics,
+                        category_metrics,
+                        per_query_metrics
+                    )
+                    VALUES (%s, %s, %s, %s)
+                    ON CONFLICT (run_id)
+                    DO UPDATE SET
+                        overall_metrics = EXCLUDED.overall_metrics,
+                        category_metrics = EXCLUDED.category_metrics,
+                        per_query_metrics = EXCLUDED.per_query_metrics
+                    """,
+                    (
+                        run_id,
+                        psycopg2.extras.Json(overall_metrics),
+                        psycopg2.extras.Json(category_metrics),
+                        psycopg2.extras.Json(per_query_metrics),
+                    ),
+                )
+
+            conn.commit()
+
+    def get_query_metrics(self, run_id: int) -> Dict[int, Dict[str, Any]]:
+        """Load per-query metrics for a run."""
+        with self._connect() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                cursor.execute(
+                    """
+                    SELECT query_id, category, p_at_5, p_at_10, mrr, bpref, ndcg_at_10
+                    FROM ir_eval.eval_query_metrics
+                    WHERE run_id = %s
+                    ORDER BY query_id
+                    """,
+                    (run_id,),
+                )
+                rows = cursor.fetchall()
+
+        metrics: Dict[int, Dict[str, Any]] = {}
+        for row in rows:
+            metrics[int(row["query_id"])] = {
+                "category": row["category"],
+                "p_at_5": float(row["p_at_5"] or 0.0),
+                "p_at_10": float(row["p_at_10"] or 0.0),
+                "mrr": float(row["mrr"] or 0.0),
+                "bpref": float(row["bpref"] or 0.0),
+                "ndcg_at_10": float(row["ndcg_at_10"] or 0.0),
+            }
+
+        return metrics
+
+    def save_comparison(
+        self, run_a_id: int, run_b_id: int, comparison: Dict[str, Any]
+    ) -> None:
+        """Persist run comparison output."""
+        with self._connect() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    INSERT INTO ir_eval.eval_comparisons (run_a_id, run_b_id, comparison)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT (run_a_id, run_b_id)
+                    DO UPDATE SET comparison = EXCLUDED.comparison
+                    """,
+                    (run_a_id, run_b_id, psycopg2.extras.Json(comparison)),
+                )
+            conn.commit()

--- a/ir_eval/engine/storage.py
+++ b/ir_eval/engine/storage.py
@@ -124,10 +124,10 @@ class EvaluationStore:
             params.append(query_ids)
 
         if query_categories:
-            where_clauses.append("category = ANY(%s)")
+            where_clauses.append("category::text = ANY(%s)")
             params.append(query_categories)
 
-        sql = "SELECT id, text, COALESCE(category, 'unknown') AS category, COALESCE(name, '') AS name FROM ir_eval.queries"
+        sql = "SELECT id, text, COALESCE(category::text, 'unknown') AS category, COALESCE(name, '') AS name FROM ir_eval.queries"
         if where_clauses:
             sql += " WHERE " + " AND ".join(where_clauses)
         sql += " ORDER BY id ASC"
@@ -203,7 +203,10 @@ class EvaluationStore:
                     result.reranker_score,
                     psycopg2.extras.Json(result.model_scores),
                     result.source,
-                    psycopg2.extras.Json(result.metadata),
+                    psycopg2.extras.Json(
+                        result.metadata,
+                        dumps=lambda obj: json.dumps(obj, default=str),
+                    ),
                 )
             )
 

--- a/ir_eval/engine/storage.py
+++ b/ir_eval/engine/storage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -19,9 +20,14 @@ class EvaluationStore:
         """Initialize the store with a PostgreSQL DSN/URL."""
         self.db_url = db_url
 
-    def _connect(self) -> psycopg2.extensions.connection:
-        """Create a new PostgreSQL connection."""
-        return psycopg2.connect(self.db_url)
+    @contextmanager
+    def _connect(self):
+        """Create a new PostgreSQL connection with guaranteed close."""
+        conn = psycopg2.connect(self.db_url)
+        try:
+            yield conn
+        finally:
+            conn.close()
 
     def create_run(self, config: EvalRunConfig) -> int:
         """Insert a pending run and return its ID."""

--- a/ir_eval/models/__init__.py
+++ b/ir_eval/models/__init__.py
@@ -1,0 +1,19 @@
+"""Schema models for IR evaluation V2."""
+
+from ir_eval.models.schemas import (
+    EvalModelConfig,
+    EvalQuery,
+    EvalRunConfig,
+    QueryExecutionResult,
+    RetrievedDocument,
+    RunExecutionSummary,
+)
+
+__all__ = [
+    "EvalModelConfig",
+    "EvalQuery",
+    "EvalRunConfig",
+    "QueryExecutionResult",
+    "RetrievedDocument",
+    "RunExecutionSummary",
+]

--- a/ir_eval/models/schemas.py
+++ b/ir_eval/models/schemas.py
@@ -1,0 +1,90 @@
+"""Pydantic schemas for the IR evaluation V2 engine."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class EvalModelConfig(BaseModel):
+    """Embedding model selection for an evaluation run."""
+
+    model: str = Field(..., min_length=1)
+    weight: float = Field(..., ge=0.0, le=1.0)
+
+
+class EvalRunConfig(BaseModel):
+    """Immutable run configuration persisted in the database."""
+
+    name: str = Field(..., min_length=1)
+    description: str = ""
+    embedding_models: List[EvalModelConfig] = Field(..., min_length=1)
+    hybrid_search: bool = True
+    vector_weight: float = Field(default=0.6, ge=0.0, le=1.0)
+    text_weight: float = Field(default=0.4, ge=0.0, le=1.0)
+    cross_encoder_enabled: bool = True
+    top_k: int = Field(default=10, ge=1)
+    query_ids: Optional[List[int]] = None
+    query_categories: Optional[List[str]] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    settings_snapshot: Dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_weights(self) -> "EvalRunConfig":
+        """Validate weight sums for deterministic scoring behavior."""
+        if self.hybrid_search:
+            total = self.vector_weight + self.text_weight
+            if abs(total - 1.0) > 1e-6:
+                raise ValueError("vector_weight + text_weight must equal 1.0")
+
+        model_weight_total = sum(model.weight for model in self.embedding_models)
+        if model_weight_total <= 0:
+            raise ValueError("At least one embedding model must have weight > 0")
+
+        return self
+
+
+class EvalQuery(BaseModel):
+    """Query payload used by the run executor."""
+
+    id: int
+    text: str
+    category: str = "unknown"
+    name: str = ""
+
+
+class RetrievedDocument(BaseModel):
+    """Single retrieved document with full score breakdown."""
+
+    chunk_id: int
+    rank: int
+    final_score: float = 0.0
+    vector_score: float = 0.0
+    text_score: float = 0.0
+    reranker_score: Optional[float] = None
+    model_scores: Dict[str, float] = Field(default_factory=dict)
+    source: str = "unknown"
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class QueryExecutionResult(BaseModel):
+    """Execution output for one query in a run."""
+
+    query_id: int
+    query_text: str
+    query_category: str
+    elapsed_seconds: float
+    results: List[RetrievedDocument] = Field(default_factory=list)
+
+
+class RunExecutionSummary(BaseModel):
+    """Top-level execution summary returned after a run completes."""
+
+    run_id: int
+    status: str
+    query_count: int
+    total_elapsed_seconds: float
+    overall_metrics: Dict[str, float] = Field(default_factory=dict)
+    category_metrics: Dict[str, Dict[str, float]] = Field(default_factory=dict)

--- a/ir_eval/runner.py
+++ b/ir_eval/runner.py
@@ -121,8 +121,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="IR evaluation V2 runner")
     parser.add_argument(
         "--db-url",
-        default=default_db_url(),
-        help="PostgreSQL URL (for example: postgresql://pythagor@localhost/NEXUS)",
+        default=None,
+        help="PostgreSQL URL (default: from MEMNON settings)",
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -180,6 +180,8 @@ def main() -> int:
     """Entry point for CLI execution."""
     parser = build_parser()
     args = parser.parse_args()
+    if args.db_url is None:
+        args.db_url = default_db_url()
     args.func(args)
     return 0
 

--- a/ir_eval/runner.py
+++ b/ir_eval/runner.py
@@ -1,0 +1,188 @@
+"""CLI entrypoint for the IR evaluation V2 system."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import List, Optional
+
+from nexus.config import load_settings_as_dict
+
+from ir_eval.engine import ComparisonEngine, EvaluationStore, RunExecutor
+from ir_eval.models import EvalModelConfig, EvalRunConfig
+
+
+def default_db_url() -> str:
+    """Resolve default DB URL from MEMNON settings."""
+    settings = load_settings_as_dict()
+    db_url = settings["Agent Settings"]["MEMNON"]["database"]["url"]
+    if not db_url:
+        raise ValueError("MEMNON database.url is not configured")
+    return db_url
+
+
+def parse_csv_ints(value: Optional[str]) -> Optional[List[int]]:
+    """Parse comma-separated integers."""
+    if not value:
+        return None
+    values = [item.strip() for item in value.split(",") if item.strip()]
+    return [int(item) for item in values]
+
+
+def parse_csv_strings(value: Optional[str]) -> Optional[List[str]]:
+    """Parse comma-separated strings."""
+    if not value:
+        return None
+    values = [item.strip() for item in value.split(",") if item.strip()]
+    return values or None
+
+
+def parse_model_specs(specs: List[str]) -> List[EvalModelConfig]:
+    """Parse ``model:weight`` specifications into typed configs."""
+    if not specs:
+        raise ValueError("At least one --model spec is required")
+
+    model_configs: List[EvalModelConfig] = []
+    for spec in specs:
+        if ":" not in spec:
+            raise ValueError(
+                f"Invalid model spec '{spec}'. Expected format model:weight"
+            )
+
+        model_name, weight_text = spec.split(":", 1)
+        model_name = model_name.strip()
+        if not model_name:
+            raise ValueError(f"Invalid model spec '{spec}'. Model name is empty")
+
+        try:
+            weight = float(weight_text)
+        except ValueError as exc:
+            raise ValueError(f"Invalid model weight in spec '{spec}'") from exc
+
+        model_configs.append(EvalModelConfig(model=model_name, weight=weight))
+
+    return model_configs
+
+
+def cmd_seed_queries(args: argparse.Namespace) -> None:
+    """Seed `ir_eval.queries` from a golden queries JSON file."""
+    store = EvaluationStore(args.db_url)
+    inserted = store.seed_queries_from_json(args.file)
+    print(json.dumps({"seeded_queries": inserted}, indent=2))
+
+
+def cmd_create_run(args: argparse.Namespace) -> None:
+    """Create a new evaluation run with immutable config."""
+    store = EvaluationStore(args.db_url)
+    executor = RunExecutor(store=store, db_url=args.db_url)
+
+    run_config = EvalRunConfig(
+        name=args.name,
+        description=args.description or "",
+        embedding_models=parse_model_specs(args.model),
+        hybrid_search=args.hybrid,
+        vector_weight=args.vector_weight,
+        text_weight=args.text_weight,
+        cross_encoder_enabled=args.cross_encoder,
+        top_k=args.top_k,
+        query_ids=parse_csv_ints(args.query_ids),
+        query_categories=parse_csv_strings(args.query_categories),
+    )
+
+    run_id = executor.create_run(run_config)
+    print(json.dumps({"run_id": run_id}, indent=2))
+
+
+def cmd_execute_run(args: argparse.Namespace) -> None:
+    """Execute a previously created run."""
+    store = EvaluationStore(args.db_url)
+    executor = RunExecutor(store=store, db_url=args.db_url)
+    summary = executor.execute_run(args.run_id)
+    print(json.dumps(summary.model_dump(mode="json"), indent=2))
+
+
+def cmd_compare_runs(args: argparse.Namespace) -> None:
+    """Compare two completed runs."""
+    store = EvaluationStore(args.db_url)
+    engine = ComparisonEngine(store)
+    output = engine.compare_runs(args.run_a, args.run_b)
+    print(json.dumps(output, indent=2))
+
+
+def cmd_list_runs(args: argparse.Namespace) -> None:
+    """List recent run statuses."""
+    store = EvaluationStore(args.db_url)
+    runs = store.list_runs(limit=args.limit)
+    print(json.dumps(runs, indent=2, default=str))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description="IR evaluation V2 runner")
+    parser.add_argument(
+        "--db-url",
+        default=default_db_url(),
+        help="PostgreSQL URL (for example: postgresql://pythagor@localhost/NEXUS)",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    seed = subparsers.add_parser(
+        "seed-queries", help="Load queries from a golden JSON file"
+    )
+    seed.add_argument("--file", required=True, help="Path to golden_queries JSON")
+    seed.set_defaults(func=cmd_seed_queries)
+
+    create = subparsers.add_parser("create-run", help="Create a run configuration")
+    create.add_argument("--name", required=True, help="Run name")
+    create.add_argument("--description", default="", help="Run description")
+    create.add_argument(
+        "--model",
+        action="append",
+        required=True,
+        help="Model spec in model:weight format (repeatable)",
+    )
+    create.add_argument("--hybrid", action=argparse.BooleanOptionalAction, default=True)
+    create.add_argument("--vector-weight", type=float, default=0.6)
+    create.add_argument("--text-weight", type=float, default=0.4)
+    create.add_argument(
+        "--cross-encoder",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable/disable cross-encoder reranking",
+    )
+    create.add_argument("--top-k", type=int, default=10)
+    create.add_argument("--query-ids", default=None, help="Comma-separated query IDs")
+    create.add_argument(
+        "--query-categories",
+        default=None,
+        help="Comma-separated query category filters",
+    )
+    create.set_defaults(func=cmd_create_run)
+
+    execute = subparsers.add_parser("execute-run", help="Execute an existing run")
+    execute.add_argument("--run-id", type=int, required=True)
+    execute.set_defaults(func=cmd_execute_run)
+
+    compare = subparsers.add_parser("compare-runs", help="Compare two runs")
+    compare.add_argument("--run-a", type=int, required=True)
+    compare.add_argument("--run-b", type=int, required=True)
+    compare.set_defaults(func=cmd_compare_runs)
+
+    list_runs = subparsers.add_parser("list-runs", help="List recent runs")
+    list_runs.add_argument("--limit", type=int, default=20)
+    list_runs.set_defaults(func=cmd_list_runs)
+
+    return parser
+
+
+def main() -> int:
+    """Entry point for CLI execution."""
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/migrations/014_add_2560d_4096d_embeddings.sql
+++ b/migrations/014_add_2560d_4096d_embeddings.sql
@@ -1,0 +1,39 @@
+-- migrations/014_add_2560d_4096d_embeddings.sql
+-- Description: Add dimension-specific embedding tables for Octen candidate models.
+-- Date: 2026-02-19
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS chunk_embeddings_2560d (
+    id SERIAL PRIMARY KEY,
+    chunk_id BIGINT NOT NULL REFERENCES narrative_chunks(id) ON DELETE CASCADE,
+    model TEXT NOT NULL,
+    embedding vector(2560) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (chunk_id, model)
+);
+
+CREATE TABLE IF NOT EXISTS chunk_embeddings_4096d (
+    id SERIAL PRIMARY KEY,
+    chunk_id BIGINT NOT NULL REFERENCES narrative_chunks(id) ON DELETE CASCADE,
+    model TEXT NOT NULL,
+    embedding vector(4096) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (chunk_id, model)
+);
+
+CREATE INDEX IF NOT EXISTS chunk_embeddings_2560d_model_idx
+    ON chunk_embeddings_2560d (model);
+
+CREATE INDEX IF NOT EXISTS chunk_embeddings_4096d_model_idx
+    ON chunk_embeddings_4096d (model);
+
+CREATE INDEX IF NOT EXISTS chunk_embeddings_2560d_hnsw_idx
+    ON chunk_embeddings_2560d
+    USING hnsw (embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64);
+
+CREATE INDEX IF NOT EXISTS chunk_embeddings_4096d_hnsw_idx
+    ON chunk_embeddings_4096d
+    USING hnsw (embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64);

--- a/migrations/015_add_ir_eval_v2_tables.sql
+++ b/migrations/015_add_ir_eval_v2_tables.sql
@@ -1,0 +1,76 @@
+-- migrations/015_add_ir_eval_v2_tables.sql
+-- Description: Add IR evaluation V2 tables for immutable run configs and scored results.
+-- Date: 2026-02-19
+
+CREATE SCHEMA IF NOT EXISTS ir_eval;
+
+CREATE TABLE IF NOT EXISTS ir_eval.eval_runs (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    config JSONB NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'running', 'completed', 'failed')),
+    error_message TEXT,
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS ir_eval.eval_results (
+    id SERIAL PRIMARY KEY,
+    run_id INT NOT NULL REFERENCES ir_eval.eval_runs(id) ON DELETE CASCADE,
+    query_id INT NOT NULL,
+    chunk_id BIGINT NOT NULL,
+    rank INT NOT NULL,
+    final_score DOUBLE PRECISION,
+    vector_score DOUBLE PRECISION,
+    text_score DOUBLE PRECISION,
+    reranker_score DOUBLE PRECISION,
+    model_scores JSONB,
+    source TEXT,
+    metadata JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (run_id, query_id, chunk_id)
+);
+
+CREATE TABLE IF NOT EXISTS ir_eval.eval_query_metrics (
+    run_id INT NOT NULL REFERENCES ir_eval.eval_runs(id) ON DELETE CASCADE,
+    query_id INT NOT NULL,
+    category TEXT,
+    p_at_5 DOUBLE PRECISION,
+    p_at_10 DOUBLE PRECISION,
+    mrr DOUBLE PRECISION,
+    bpref DOUBLE PRECISION,
+    ndcg_at_10 DOUBLE PRECISION,
+    judged_total INT NOT NULL DEFAULT 0,
+    unjudged_count INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (run_id, query_id)
+);
+
+CREATE TABLE IF NOT EXISTS ir_eval.eval_run_metrics (
+    run_id INT PRIMARY KEY REFERENCES ir_eval.eval_runs(id) ON DELETE CASCADE,
+    overall_metrics JSONB NOT NULL,
+    category_metrics JSONB,
+    per_query_metrics JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS ir_eval.eval_comparisons (
+    id SERIAL PRIMARY KEY,
+    run_a_id INT NOT NULL REFERENCES ir_eval.eval_runs(id) ON DELETE CASCADE,
+    run_b_id INT NOT NULL REFERENCES ir_eval.eval_runs(id) ON DELETE CASCADE,
+    comparison JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (run_a_id, run_b_id)
+);
+
+CREATE INDEX IF NOT EXISTS eval_results_run_query_idx
+    ON ir_eval.eval_results (run_id, query_id);
+
+CREATE INDEX IF NOT EXISTS eval_results_query_chunk_idx
+    ON ir_eval.eval_results (query_id, chunk_id);
+
+CREATE INDEX IF NOT EXISTS eval_query_metrics_run_idx
+    ON ir_eval.eval_query_metrics (run_id);

--- a/migrations/016_add_ir_eval_v1_query_tables.sql
+++ b/migrations/016_add_ir_eval_v1_query_tables.sql
@@ -1,0 +1,29 @@
+-- migrations/016_add_ir_eval_v1_query_tables.sql
+-- Description: Add ir_eval.queries and ir_eval.judgments tables required by the
+--   V2 evaluation engine.  These were previously created ad-hoc by pg_schema.sql;
+--   a numbered migration ensures fresh databases get them automatically.
+-- Date: 2026-04-16
+
+CREATE SCHEMA IF NOT EXISTS ir_eval;
+
+-- Golden queries used as input for evaluation runs.
+CREATE TABLE IF NOT EXISTS ir_eval.queries (
+    id SERIAL PRIMARY KEY,
+    text TEXT NOT NULL,
+    category TEXT,
+    name TEXT,
+    UNIQUE(text)
+);
+
+-- Human relevance judgments for query/chunk pairs (0-3 scale).
+CREATE TABLE IF NOT EXISTS ir_eval.judgments (
+    id SERIAL PRIMARY KEY,
+    query_id INTEGER NOT NULL REFERENCES ir_eval.queries(id) ON DELETE CASCADE,
+    chunk_id BIGINT NOT NULL,
+    relevance INTEGER CHECK (relevance >= 0 AND relevance <= 3),
+    doc_text TEXT,
+    UNIQUE(query_id, chunk_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_judgments_query_id ON ir_eval.judgments(query_id);
+CREATE INDEX IF NOT EXISTS idx_judgments_chunk_id ON ir_eval.judgments(chunk_id);

--- a/nexus.toml
+++ b/nexus.toml
@@ -178,6 +178,20 @@ remote_path = "infly/inf-retriever-v1-1.5b"
 dimensions = 1536
 weight = 0.5  # Highest weight - best performing model
 
+[memnon.models."Octen-Embedding-4B"]
+is_active = false  # Candidate model for issue #175 evaluation campaign
+local_path = "/Users/pythagor/nexus/models/Octen-Embedding-4B"
+remote_path = ""
+dimensions = 2560
+weight = 0.0
+
+[memnon.models."Octen-Embedding-8B"]
+is_active = false  # Candidate model for issue #175 evaluation campaign
+local_path = "/Users/pythagor/nexus/models/Octen-Embedding-8B"
+remote_path = ""
+dimensions = 4096
+weight = 0.0
+
 [memnon.import]
 # Settings for importing narrative chunks from markdown files
 base_directory = "."

--- a/nexus/agents/memnon/utils/embedding_tables.py
+++ b/nexus/agents/memnon/utils/embedding_tables.py
@@ -8,6 +8,8 @@ from typing import Dict, List, Optional
 DIMENSION_TABLE_MAP: Dict[int, str] = {
     1024: "chunk_embeddings_1024d",
     1536: "chunk_embeddings_1536d",
+    2560: "chunk_embeddings_2560d",
+    4096: "chunk_embeddings_4096d",
 }
 
 # Convenience list of known dimension-specific tables.
@@ -17,4 +19,3 @@ DIMENSION_TABLES: List[str] = list(DIMENSION_TABLE_MAP.values())
 def resolve_dimension_table(dimensions: int) -> Optional[str]:
     """Return the embedding table that stores vectors for ``dimensions``."""
     return DIMENSION_TABLE_MAP.get(dimensions)
-

--- a/scripts/create_vector_index.py
+++ b/scripts/create_vector_index.py
@@ -14,21 +14,24 @@ import logging
 from sqlalchemy import create_engine, text
 
 # Set up logging
-logging.basicConfig(level=logging.INFO,
-                   format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger("nexus.embeddings")
 
 # Add parent directory to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Try to load settings using centralized config loader
 try:
     from nexus.config import load_settings_as_dict
+
     _all_settings = load_settings_as_dict()
     SETTINGS = _all_settings.get("Agent Settings", {}).get("MEMNON", {})
 except Exception as e:
     logger.warning(f"Could not load settings via config loader: {e}")
     SETTINGS = {}
+
 
 def get_model_dimensions(model_name: str) -> int:
     """Get the dimensions for a model name"""
@@ -39,7 +42,7 @@ def get_model_dimensions(model_name: str) -> int:
             dimensions = SETTINGS["models"][model_key].get("dimensions")
             if dimensions:
                 return dimensions
-    
+
     # Hard-coded fallbacks
     model_dimensions = {
         "bge-small-custom": 384,
@@ -47,23 +50,28 @@ def get_model_dimensions(model_name: str) -> int:
         "bge-small-en-v1.5": 384,
         "infly/inf-retriever-v1-1.5b": 1536,
         "infly/inf-retriever-v1": 3584,
+        "Octen-Embedding-4B": 2560,
+        "Octen-Embedding-8B": 4096,
         "bge-large-en-v1.5": 1024,
         "bge-large-en": 1024,
         "e5-large-v2": 1024,
     }
-    
+
     # Check for exact match
     if model_name in model_dimensions:
         return model_dimensions[model_name]
-    
+
     # Check for partial match
     for name, dim in model_dimensions.items():
         if name in model_name:
             return dim
-    
+
     # Default
-    logger.warning(f"Could not determine dimensions for {model_name}, using default (1024)")
+    logger.warning(
+        f"Could not determine dimensions for {model_name}, using default (1024)"
+    )
     return 1024
+
 
 def get_table_name(model_name: str) -> str:
     """Get table name for a model"""
@@ -72,31 +80,34 @@ def get_table_name(model_name: str) -> str:
     # PostgreSQL converts identifiers to lowercase by default
     return f"chunk_embeddings_{dim_str}d"
 
+
 def create_vector_indexes(model_name: str, db_url: str = None):
     """
     Create optimized vector indexes for a model's embedding table
-    
+
     Args:
         model_name: Name of the embedding model
         db_url: Database URL (optional)
-    
+
     Returns:
         True if indexes were created successfully, False otherwise
     """
     # Set default db_url if not provided
     if not db_url:
-        db_url = SETTINGS.get("database", {}).get("url", "postgresql://pythagor@localhost/NEXUS")
-    
+        db_url = SETTINGS.get("database", {}).get(
+            "url", "postgresql://pythagor@localhost/NEXUS"
+        )
+
     # Get dimensions and table name
     dimensions = get_model_dimensions(model_name)
     table_name = get_table_name(model_name)
-    
+
     logger.info(f"Creating vector indexes for {model_name} ({dimensions}D)")
     logger.info(f"Table: {table_name}")
-    
+
     # Connect to database
     engine = create_engine(db_url)
-    
+
     # First check if table exists and has data
     with engine.connect() as conn:
         # Check if table exists
@@ -107,24 +118,24 @@ def create_vector_indexes(model_name: str, db_url: str = None):
         );
         """
         table_exists = conn.execute(text(check_sql)).scalar()
-        
+
         if not table_exists:
             logger.error(f"Table {table_name} does not exist!")
             return False
-        
+
         # Count embeddings
         count_sql = f"""
         SELECT COUNT(*) FROM {table_name} 
         WHERE model = :model_name;
         """
         count = conn.execute(text(count_sql), {"model_name": model_name}).scalar()
-        
+
         logger.info(f"Found {count} embeddings for {model_name}")
-        
+
         if count == 0:
             logger.warning("No embeddings found for this model!")
             return False
-        
+
         # Check for existing vector indexes
         index_sql = f"""
         SELECT indexname, indexdef
@@ -133,27 +144,27 @@ def create_vector_indexes(model_name: str, db_url: str = None):
         AND indexdef LIKE '%vector_cosine_ops%';
         """
         indexes = list(conn.execute(text(index_sql)))
-        
+
         if indexes:
             logger.info("Vector indexes already exist:")
             for idx in indexes:
                 logger.info(f"- {idx[0]}: {idx[1]}")
-            
+
             # Ask for confirmation before recreating
-            if input("Indexes already exist. Recreate? (y/n): ").lower() != 'y':
+            if input("Indexes already exist. Recreate? (y/n): ").lower() != "y":
                 logger.info("Keeping existing indexes")
                 return True
-            
+
             # Drop existing vector indexes
             for idx in indexes:
                 drop_sql = f"DROP INDEX IF EXISTS {idx[0]};"
                 conn.execute(text(drop_sql))
                 logger.info(f"Dropped index: {idx[0]}")
-            
+
             conn.commit()
-    
+
     success = False
-    
+
     # Now create the vector indexes based on dimensions
     with engine.begin() as conn:
         # Create specialized indexes based on dimensions
@@ -162,20 +173,20 @@ def create_vector_indexes(model_name: str, db_url: str = None):
             try:
                 logger.info(f"Creating IVFFLAT index for {dimensions}D vectors...")
                 start_time = time.time()
-                
+
                 ivf_sql = f"""
                 CREATE INDEX {table_name}_ivf_idx 
                 ON {table_name} USING ivfflat (embedding vector_cosine_ops)
                 WITH (lists=100);
                 """
                 conn.execute(text(ivf_sql))
-                
+
                 elapsed_time = time.time() - start_time
                 logger.info(f"✓ Created IVFFLAT index in {elapsed_time:.2f} seconds")
                 success = True
             except Exception as e:
                 logger.error(f"Failed to create IVFFLAT index: {e}")
-                
+
                 # Try plain index as fallback
                 try:
                     logger.info("Creating plain index as fallback...")
@@ -188,11 +199,13 @@ def create_vector_indexes(model_name: str, db_url: str = None):
                     success = True
                 except Exception as e2:
                     logger.error(f"Failed to create plain index: {e2}")
-                
+
         else:
             # For super high dimensions, try but don't expect success
-            logger.warning(f"Dimensions ({dimensions}) exceed 2000, vector indexes may not work")
-            
+            logger.warning(
+                f"Dimensions ({dimensions}) exceed 2000, vector indexes may not work"
+            )
+
             try:
                 logger.info("Attempting to create plain vector index anyway...")
                 plain_sql = f"""
@@ -205,16 +218,19 @@ def create_vector_indexes(model_name: str, db_url: str = None):
             except Exception as e:
                 logger.error(f"Failed to create vector index: {e}")
                 logger.info("Will use sequential scan for searches")
-    
+
     return success
+
 
 def main():
     """Main entry point for the script"""
-    parser = argparse.ArgumentParser(description="Create vector indexes for embedding tables")
+    parser = argparse.ArgumentParser(
+        description="Create vector indexes for embedding tables"
+    )
     parser.add_argument("--model", required=True, help="Model name")
     parser.add_argument("--db-url", help="Database URL")
     args = parser.parse_args()
-    
+
     try:
         success = create_vector_indexes(args.model, args.db_url)
         if success:
@@ -226,6 +242,7 @@ def main():
     except Exception as e:
         logger.error(f"Error creating vector indexes: {e}")
         return 1
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/generate_octen_embeddings.py
+++ b/scripts/generate_octen_embeddings.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Generate Octen embeddings using the existing regeneration pipeline.
+
+This wrapper standardizes model names and options for issue #175 so Octen-4B
+and Octen-8B can be generated with one command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+OCTEN_MODELS = ["Octen-Embedding-4B", "Octen-Embedding-8B"]
+
+
+def build_command(
+    model_name: str,
+    regenerate_script: Path,
+    batch_size: int,
+    db_url: str | None,
+    create_indexes: bool,
+    dry_run: bool,
+) -> List[str]:
+    """Build the subprocess command for one model regeneration run."""
+    command = [
+        sys.executable,
+        str(regenerate_script),
+        "--model",
+        model_name,
+        "--batch-size",
+        str(batch_size),
+    ]
+
+    if db_url:
+        command.extend(["--db-url", db_url])
+    if create_indexes:
+        command.append("--create-indexes")
+    if dry_run:
+        command.append("--dry-run")
+
+    return command
+
+
+def run_model(command: List[str]) -> int:
+    """Run a single model generation command and return the exit code."""
+    process = subprocess.run(command, check=False)
+    return process.returncode
+
+
+def main() -> int:
+    """Parse CLI arguments and dispatch Octen embedding generation."""
+    parser = argparse.ArgumentParser(description="Generate Octen embeddings for MEMNON")
+    parser.add_argument(
+        "--model",
+        default="all",
+        choices=["all", *OCTEN_MODELS],
+        help="Which Octen model to generate",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=8,
+        help="Chunk batch size passed through to scripts/regenerate_embeddings.py",
+    )
+    parser.add_argument(
+        "--db-url", type=str, default=None, help="PostgreSQL connection URL"
+    )
+    parser.add_argument(
+        "--create-indexes",
+        action="store_true",
+        help="Create vector indexes after generation",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Pass through dry-run mode"
+    )
+    parser.add_argument(
+        "--parallel",
+        action="store_true",
+        help="Run both Octen models in parallel (only valid with --model all)",
+    )
+
+    args = parser.parse_args()
+
+    if args.batch_size <= 0:
+        raise ValueError("--batch-size must be greater than 0")
+
+    script_path = Path(__file__).resolve().parent / "regenerate_embeddings.py"
+    if not script_path.exists():
+        raise FileNotFoundError(f"Missing script: {script_path}")
+
+    if args.parallel and args.model != "all":
+        raise ValueError("--parallel is only valid when --model all")
+
+    target_models = OCTEN_MODELS if args.model == "all" else [args.model]
+
+    if args.parallel:
+        processes = []
+        for model_name in target_models:
+            command = build_command(
+                model_name=model_name,
+                regenerate_script=script_path,
+                batch_size=args.batch_size,
+                db_url=args.db_url,
+                create_indexes=args.create_indexes,
+                dry_run=args.dry_run,
+            )
+            processes.append(subprocess.Popen(command))
+
+        exit_codes = [process.wait() for process in processes]
+        if any(code != 0 for code in exit_codes):
+            return 1
+        return 0
+
+    for model_name in target_models:
+        command = build_command(
+            model_name=model_name,
+            regenerate_script=script_path,
+            batch_size=args.batch_size,
+            db_url=args.db_url,
+            create_indexes=args.create_indexes,
+            dry_run=args.dry_run,
+        )
+        exit_code = run_model(command)
+        if exit_code != 0:
+            return exit_code
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/utils/embedding_utils.py
+++ b/scripts/utils/embedding_utils.py
@@ -10,8 +10,9 @@ from typing import Dict, List, Tuple, Any, Optional, Union
 import numpy as np
 
 # Set up logging
-logging.basicConfig(level=logging.INFO,
-                   format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 # Model dimension mapping
@@ -21,49 +22,51 @@ MODEL_DIMENSIONS = {
     "bge-small-en": 384,
     "bge-small-en-v1.5": 384,
     "bge-small": 384,
-    
     # Large models (1024D)
     "bge-large-en-v1.5": 1024,
     "bge-large-en": 1024,
     "bge-large": 1024,
     "e5-large-v2": 1024,
     "e5-large": 1024,
-    
     # High-dimensional models
     "infly/inf-retriever-v1": 3584,  # Original model - too high for efficient indexing
     "infly/inf-retriever-v1-1.5b": 1536,  # Lightweight version with 1536 dimensions
+    "Octen-Embedding-4B": 2560,
+    "Octen-Embedding-8B": 4096,
 }
+
 
 def get_model_dimensions(model_name: str) -> int:
     """
     Get the vector dimensions for a given model name.
-    
+
     Args:
         model_name (str): The name of the embedding model
-        
+
     Returns:
         int: The number of dimensions (384, 1024, etc.)
     """
     # Check for exact matches
     if model_name in MODEL_DIMENSIONS:
         return MODEL_DIMENSIONS[model_name]
-    
+
     # Check for partial matches
     for key, value in MODEL_DIMENSIONS.items():
         if key in model_name:
             return value
-    
+
     # Default to 1024 for unknown models
     logger.warning(f"Unknown model '{model_name}', defaulting to 1024 dimensions")
     return 1024
 
+
 def get_table_for_model(model_name: str) -> str:
     """
     Get the appropriate database table for a given model.
-    
+
     Args:
         model_name (str): The name of the embedding model
-        
+
     Returns:
         str: Table name for embeddings
     """
@@ -73,34 +76,35 @@ def get_table_for_model(model_name: str) -> str:
     # PostgreSQL converts identifiers to lowercase by default
     return f"chunk_embeddings_{dim_str}d"
 
+
 def construct_vector_search_sql(
-    model_name: str, 
-    filter_conditions: Optional[str] = None,
-    limit: int = 10
+    model_name: str, filter_conditions: Optional[str] = None, limit: int = 10
 ) -> Tuple[str, str]:
     """
     Construct SQL for vector similarity search based on model dimensions.
-    
+
     Args:
         model_name (str): The name of the embedding model
         filter_conditions (str, optional): Additional WHERE clauses for filtering results
         limit (int): Maximum number of results to return
-        
+
     Returns:
         Tuple[str, str]: (SQL query string, table name used)
     """
     table_name = get_table_for_model(model_name)
     dimensions = get_model_dimensions(model_name)
-    
+
     # Alias for the embeddings table
     table_alias = "ce"  # Use consistent alias
-    
+
     # For very high dimensions, PostgreSQL cannot efficiently use cosine operators directly in ORDER BY
     # For those cases, we need a different approach or a workaround
     if dimensions > 2000:
         # Warning about potential inefficiency
-        logger.warning(f"Using high-dimensional vector ({dimensions}D) which may be slow without index")
-        
+        logger.warning(
+            f"Using high-dimensional vector ({dimensions}D) which may be slow without index"
+        )
+
     # Base SQL with proper table
     sql = f"""
     SELECT c.id, c.raw_text, {table_alias}.model, 
@@ -111,30 +115,31 @@ def construct_vector_search_sql(
     LEFT JOIN chunk_metadata m ON c.id = m.chunk_id
     WHERE {table_alias}.model = :model_name
     """
-    
+
     # Add any additional filter conditions
     if filter_conditions:
         sql += f" AND {filter_conditions}"
-    
+
     # Add order by and limit
     sql += f"""
     ORDER BY {table_alias}.embedding <=> :query_vector
     LIMIT {limit};
     """
-    
+
     return sql, table_name
-    
+
+
 def construct_hybrid_search_sql(
     model_name: str,
     text_keywords: str,
     vector_weight: float = 0.6,
     text_weight: float = 0.4,
     filter_conditions: Optional[str] = None,
-    limit: int = 10
+    limit: int = 10,
 ) -> Tuple[str, str]:
     """
     Construct SQL for hybrid search combining vector similarity and text search.
-    
+
     Args:
         model_name (str): The name of the embedding model
         text_keywords (str): Keywords for text search
@@ -142,12 +147,12 @@ def construct_hybrid_search_sql(
         text_weight (float): Weight for text search score (0.0 to 1.0)
         filter_conditions (str, optional): Additional WHERE clauses
         limit (int): Maximum number of results
-        
+
     Returns:
         Tuple[str, str]: (SQL query string, table name used)
     """
     table_name = get_table_for_model(model_name)
-    
+
     # Construct the SQL for hybrid search
     sql = f"""
     WITH vector_search AS (
@@ -179,47 +184,49 @@ def construct_hybrid_search_sql(
     LEFT JOIN text_search ts ON c.id = ts.id
     LEFT JOIN chunk_metadata m ON c.id = m.chunk_id
     """
-    
+
     # Add any additional filter conditions
     if filter_conditions:
         sql += f" WHERE {filter_conditions}"
-    
+
     # Add order by and limit
     sql += """
     ORDER BY hybrid_score ASC
     LIMIT :limit;
     """
-    
+
     return sql, table_name
-    
+
+
 def get_all_model_tables() -> List[str]:
     """
     Get a list of all embedding table names that use the new naming convention
-    
+
     Returns:
         List of table names
     """
     tables = []
-    
-    for dim in [384, 1024, 1536]:
+
+    for dim in [384, 1024, 1536, 2560, 4096]:
         dim_str = f"{dim:04d}"
         tables.append(f"chunk_embeddings_{dim_str}d")
-    
+
     return tables
+
 
 def normalize_vector(vector: Union[List[float], np.ndarray]) -> np.ndarray:
     """
     Normalize a vector to unit length.
-    
+
     Args:
         vector (Union[List[float], np.ndarray]): Input vector
-        
+
     Returns:
         np.ndarray: Normalized vector
     """
     if isinstance(vector, list):
         vector = np.array(vector, dtype=np.float32)
-    
+
     norm = np.linalg.norm(vector)
     if norm > 0:
         return vector / norm

--- a/scripts/verify_pgvector_max_dim.sql
+++ b/scripts/verify_pgvector_max_dim.sql
@@ -6,13 +6,13 @@ DROP TABLE IF EXISTS pgvector_test;
 -- Show pgvector version
 SELECT extversion FROM pg_extension WHERE extname = 'vector';
 
--- Create a test table with a vector of 3584 dimensions
+-- Create a test table with a vector of 4096 dimensions
 CREATE TABLE pgvector_test (
   id SERIAL PRIMARY KEY,
-  embedding vector(3584) NOT NULL
+  embedding vector(4096) NOT NULL
 );
 
--- Try to create HNSW index (only works if HNSW_MAX_DIM >= 3584)
+-- Try to create HNSW index (only works if HNSW_MAX_DIM >= 4096)
 CREATE INDEX pgvector_test_hnsw_idx ON pgvector_test USING hnsw (embedding vector_cosine_ops);
 
 -- Try to create IVFFLAT index (may fail if MAX_DIM < 3584)
@@ -30,7 +30,7 @@ END $$;
 
 -- Insert a test vector
 INSERT INTO pgvector_test (embedding) 
-SELECT ARRAY_AGG(random()) FROM generate_series(1, 3584) AS x;
+SELECT ARRAY_AGG(random()) FROM generate_series(1, 4096) AS x;
 
 -- Query the vector for similarity (this will use the index if it was created)
 SELECT id, embedding <=> embedding AS self_distance
@@ -41,5 +41,5 @@ LIMIT 1;
 -- Show message indicating success
 DO $$
 BEGIN
-  RAISE NOTICE 'Success! pgvector is working with 3584 dimensions';
+  RAISE NOTICE 'Success! pgvector is working with 4096 dimensions';
 END $$;

--- a/settings.json
+++ b/settings.json
@@ -262,6 +262,20 @@
                     "remote_path": "infly/inf-retriever-v1-1.5b",
                     "dimensions": 1536,
                     "weight": 0.5
+                },
+                "Octen-Embedding-4B": {
+                    "is_active": false,
+                    "local_path": "/Users/pythagor/nexus/models/Octen-Embedding-4B",
+                    "remote_path": "",
+                    "dimensions": 2560,
+                    "weight": 0.0
+                },
+                "Octen-Embedding-8B": {
+                    "is_active": false,
+                    "local_path": "/Users/pythagor/nexus/models/Octen-Embedding-8B",
+                    "remote_path": "",
+                    "dimensions": 4096,
+                    "weight": 0.0
                 }
             },
             "import": {

--- a/tests/test_ir_eval_v2/test_embedding_tables.py
+++ b/tests/test_ir_eval_v2/test_embedding_tables.py
@@ -1,0 +1,9 @@
+"""Tests for dimension-specific embedding table resolution."""
+
+from nexus.agents.memnon.utils.embedding_tables import resolve_dimension_table
+
+
+def test_resolve_octen_dimension_tables() -> None:
+    """Octen dimensions resolve to dedicated embedding tables."""
+    assert resolve_dimension_table(2560) == "chunk_embeddings_2560d"
+    assert resolve_dimension_table(4096) == "chunk_embeddings_4096d"

--- a/tests/test_ir_eval_v2/test_metrics.py
+++ b/tests/test_ir_eval_v2/test_metrics.py
@@ -1,0 +1,83 @@
+"""Unit tests for IR evaluation V2 metrics."""
+
+import pytest
+
+from ir_eval.engine.metrics import MetricsCalculator
+from ir_eval.models.schemas import QueryExecutionResult, RetrievedDocument
+
+
+def make_result(
+    query_id: int, category: str, chunk_ids: list[int]
+) -> QueryExecutionResult:
+    """Build a minimal QueryExecutionResult for test cases."""
+    return QueryExecutionResult(
+        query_id=query_id,
+        query_text=f"query-{query_id}",
+        query_category=category,
+        elapsed_seconds=0.01,
+        results=[
+            RetrievedDocument(
+                chunk_id=chunk_id, rank=index + 1, final_score=1.0 - index * 0.01
+            )
+            for index, chunk_id in enumerate(chunk_ids)
+        ],
+    )
+
+
+def test_calculate_per_query_metrics() -> None:
+    """Calculator returns deterministic per-query metrics from judgments."""
+    calculator = MetricsCalculator()
+
+    query_results = [
+        make_result(1, "character", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+        make_result(2, "location", [11, 12, 13, 14, 15]),
+    ]
+
+    judgments = {
+        1: {1: 3, 3: 2, 4: 0, 6: 1},
+        2: {13: 3},
+    }
+
+    metrics = calculator.calculate_per_query(query_results, judgments)
+
+    assert metrics[1]["p_at_5"] == 0.4
+    assert metrics[1]["mrr"] == 1.0
+    assert 0.0 <= metrics[1]["bpref"] <= 1.0
+    assert 0.0 <= metrics[1]["ndcg_at_10"] <= 1.0
+
+    assert metrics[2]["p_at_5"] == 0.2
+    assert metrics[2]["mrr"] == 1.0 / 3.0
+
+
+def test_aggregate_metrics_by_category() -> None:
+    """Aggregator computes overall and category-level averages."""
+    calculator = MetricsCalculator()
+
+    per_query = {
+        1: {
+            "p_at_5": 0.4,
+            "p_at_10": 0.3,
+            "mrr": 1.0,
+            "bpref": 0.8,
+            "ndcg_at_10": 0.9,
+            "judged_total": 3,
+            "unjudged_count": 7,
+        },
+        2: {
+            "p_at_5": 0.2,
+            "p_at_10": 0.2,
+            "mrr": 0.3333333333,
+            "bpref": 0.5,
+            "ndcg_at_10": 0.4,
+            "judged_total": 1,
+            "unjudged_count": 4,
+        },
+    }
+    categories = {1: "character", 2: "location"}
+
+    aggregate = calculator.aggregate_metrics(per_query, categories)
+
+    assert aggregate["overall"]["p_at_5"] == pytest.approx(0.3)
+    assert aggregate["overall"]["p_at_10"] == pytest.approx(0.25)
+    assert aggregate["by_category"]["character"]["mrr"] == 1.0
+    assert aggregate["by_category"]["location"]["p_at_5"] == 0.2

--- a/tests/test_ir_eval_v2/test_schemas.py
+++ b/tests/test_ir_eval_v2/test_schemas.py
@@ -1,0 +1,50 @@
+"""Unit tests for IR evaluation V2 schemas."""
+
+import pytest
+
+from ir_eval.models.schemas import EvalRunConfig
+
+
+def test_eval_run_config_accepts_normalized_hybrid_weights() -> None:
+    """Run config accepts valid model and hybrid weighting."""
+    config = EvalRunConfig(
+        name="octen-8b-solo",
+        embedding_models=[{"model": "Octen-Embedding-8B", "weight": 1.0}],
+        hybrid_search=True,
+        vector_weight=0.6,
+        text_weight=0.4,
+    )
+
+    assert config.name == "octen-8b-solo"
+    assert len(config.embedding_models) == 1
+
+
+def test_eval_run_config_rejects_invalid_hybrid_weight_sum() -> None:
+    """Hybrid runs require vector/text weights to sum to 1.0."""
+    with pytest.raises(
+        ValueError, match=r"vector_weight \+ text_weight must equal 1.0"
+    ):
+        EvalRunConfig(
+            name="invalid-weights",
+            embedding_models=[{"model": "bge-large", "weight": 1.0}],
+            hybrid_search=True,
+            vector_weight=0.7,
+            text_weight=0.4,
+        )
+
+
+def test_eval_run_config_requires_positive_model_weight_total() -> None:
+    """Run configs must include at least one weighted model."""
+    with pytest.raises(
+        ValueError, match="At least one embedding model must have weight > 0"
+    ):
+        EvalRunConfig(
+            name="zero-model-weights",
+            embedding_models=[
+                {"model": "bge-large", "weight": 0.0},
+                {"model": "e5-large", "weight": 0.0},
+            ],
+            hybrid_search=False,
+            vector_weight=1.0,
+            text_weight=0.0,
+        )


### PR DESCRIPTION
**Summary**
- document and implement the new IR eval v2 embedding testing engine, schemas, and runner
- add migrations, scripts, and config knobs for larger-dimension pgvector support
- extend memnon utilities and add targeted unit tests for the new embedding tables, schemas, and metric calculations

**Testing**
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new Postgres schemas/tables and new run execution code that exercises MEMNON retrieval paths; main risk is migration correctness and runtime assumptions about model/table availability rather than changes to production query behavior.
> 
> **Overview**
> Adds a new IR eval **V2** subsystem (`ir_eval.engine`, `ir_eval.runner`) that creates immutable run configs, executes retrieval runs against MEMNON with explicit model selection, stores scored results/metrics in Postgres, and supports run-to-run comparisons with significance estimates.
> 
> Extends embedding infrastructure to support Octen candidate models by adding new 2560D/4096D pgvector tables + HNSW indexes (migration `014`), wiring those dimensions into table-resolution utilities, and adding inactive-by-default Octen model configs to `nexus.toml`/`settings.json`. Also adds migration `015` for the new `ir_eval` schema/tables, a helper script to generate Octen embeddings, and updates docs/tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 185cc714a2df6e7f30de11bca1faeda2b7756acf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->