### PR TITLE
Add LLM judgment-on-demand to IR eval v2 runner

### DIFF
--- a/ir_eval/engine/__init__.py
+++ b/ir_eval/engine/__init__.py
@@ -1,13 +1,16 @@
 """IR evaluation V2 engine modules."""
 
 from ir_eval.engine.comparison import ComparisonEngine
+from ir_eval.engine.judge import JudgmentEngine, RelevanceAssessment
 from ir_eval.engine.metrics import MetricsCalculator
 from ir_eval.engine.run_executor import RunExecutor
 from ir_eval.engine.storage import EvaluationStore
 
 __all__ = [
     "ComparisonEngine",
+    "JudgmentEngine",
     "MetricsCalculator",
+    "RelevanceAssessment",
     "RunExecutor",
     "EvaluationStore",
 ]

--- a/ir_eval/engine/judge.py
+++ b/ir_eval/engine/judge.py
@@ -51,15 +51,26 @@ class JudgmentEngine:
     ):
         """Create a judgment engine backed by an OpenAI structured-output call.
 
+        The OpenAI provider is constructed lazily on first ``judge()`` call so
+        that runs which don't trigger any LLM judgments (e.g. retrievals fully
+        covered by existing judgments) don't require API credentials.
+
         Errors from the underlying API call propagate to the caller — this
         engine has no fallback or default-score behavior.
         """
         self.model = model
         self.reasoning_effort = reasoning_effort
-        self.provider = OpenAIProvider(
-            model=model,
-            reasoning_effort=reasoning_effort,
-        )
+        self._provider: Optional[OpenAIProvider] = None
+
+    @property
+    def provider(self) -> OpenAIProvider:
+        """Lazily construct the OpenAI provider on first access."""
+        if self._provider is None:
+            self._provider = OpenAIProvider(
+                model=self.model,
+                reasoning_effort=self.reasoning_effort,
+            )
+        return self._provider
 
     def judge(
         self,

--- a/ir_eval/engine/judge.py
+++ b/ir_eval/engine/judge.py
@@ -46,7 +46,7 @@ class JudgmentEngine:
 
     def __init__(
         self,
-        model: str = "gpt-5.1",
+        model: str = "gpt-5.5",
         reasoning_effort: str = "high",
     ):
         """Create a judgment engine backed by an OpenAI structured-output call.

--- a/ir_eval/engine/judge.py
+++ b/ir_eval/engine/judge.py
@@ -1,0 +1,83 @@
+"""LLM-based relevance judgment for IR evaluation V2."""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from scripts.api_openai import OpenAIProvider
+
+
+SYSTEM_PROMPT = """You are a specialized evaluator for narrative information retrieval systems. Your task is to determine the relevance of retrieved content to specific queries about a narrative story.
+
+## Task Definition:
+1. You will receive query texts and retrieved narrative chunks.
+2. For each chunk, assign a relevance score (0-3) based on how well it answers the query.
+3. Be consistent in your scoring approach across all judgments.
+
+## Relevance Scale:
+0: Irrelevant - Does not match the query at all
+1: Marginally relevant - Mentions the topic but not very helpful
+2: Relevant - Contains useful information about the query
+3: Highly relevant - Perfect match for the query
+
+## Special Considerations:
+- For character-related queries, consider both explicit mentions and clearly implied references
+- For relationship queries, assess both factual statements and emotional/interpersonal context
+- For temporal queries (first, after, etc.), prioritize content that directly addresses the temporal aspect
+- For abstract concept queries, look for direct explanations or clear demonstrations of the concept
+"""
+
+
+class RelevanceAssessment(BaseModel):
+    """Structured judgment returned by the LLM for a single (query, chunk) pair."""
+
+    relevance_score: Literal[0, 1, 2, 3] = Field(
+        description="Relevance score from 0-3 where 0=Irrelevant, 1=Marginally relevant, 2=Relevant, 3=Highly relevant"
+    )
+    justification: str = Field(
+        description="Brief explanation of why this score was assigned"
+    )
+
+
+class JudgmentEngine:
+    """Call an LLM to score the relevance of a chunk to a query."""
+
+    def __init__(
+        self,
+        model: str = "gpt-5.1",
+        reasoning_effort: str = "high",
+    ):
+        """Create a judgment engine backed by an OpenAI structured-output call.
+
+        Errors from the underlying API call propagate to the caller — this
+        engine has no fallback or default-score behavior.
+        """
+        self.model = model
+        self.reasoning_effort = reasoning_effort
+        self.provider = OpenAIProvider(
+            model=model,
+            reasoning_effort=reasoning_effort,
+        )
+
+    def judge(
+        self,
+        query_text: str,
+        chunk_text: str,
+        query_category: Optional[str] = None,
+    ) -> RelevanceAssessment:
+        """Return a structured relevance assessment for one (query, chunk) pair."""
+        prompt_parts = [SYSTEM_PROMPT, f"\nQUERY: {query_text}\n"]
+        if query_category:
+            prompt_parts.append(f"QUERY CATEGORY: {query_category}\n")
+        prompt_parts.append(f"\nDOCUMENT TO EVALUATE:\n{chunk_text}\n")
+        prompt = "".join(prompt_parts)
+
+        response = self.provider.client.responses.parse(
+            model=self.model,
+            input=[{"role": "user", "content": prompt}],
+            text_format=RelevanceAssessment,
+            reasoning={"effort": self.reasoning_effort},
+        )
+        return response.output_parsed

--- a/ir_eval/engine/run_executor.py
+++ b/ir_eval/engine/run_executor.py
@@ -13,9 +13,11 @@ from nexus.agents.memnon.utils.idf_dictionary import IDFDictionary
 from nexus.agents.memnon.utils.query_analysis import QueryAnalyzer
 from nexus.agents.memnon.utils.search import SearchManager
 
+from ir_eval.engine.judge import JudgmentEngine
 from ir_eval.engine.metrics import MetricsCalculator
 from ir_eval.engine.storage import EvaluationStore
 from ir_eval.models.schemas import (
+    EvalQuery,
     EvalRunConfig,
     QueryExecutionResult,
     RetrievedDocument,
@@ -32,8 +34,13 @@ class RunExecutor:
         *,
         settings_dict: Dict[str, Any] | None = None,
         db_url: str | None = None,
+        judgment_engine: JudgmentEngine | None = None,
     ):
-        """Create a run executor with repository and base settings."""
+        """Create a run executor with repository and base settings.
+
+        If *judgment_engine* is provided, ``execute_run`` will fill missing
+        relevance judgments via LLM calls before metrics are computed.
+        """
         self.store = store
         self.settings_dict = settings_dict or load_settings_as_dict()
         self.base_memnon_settings = copy.deepcopy(
@@ -44,6 +51,8 @@ class RunExecutor:
         self.db_url = db_url or configured_db_url
         if not self.db_url:
             raise ValueError("MEMNON database.url is not configured")
+
+        self.judgment_engine = judgment_engine
 
     @staticmethod
     def _normalize_model_weights(config: EvalRunConfig) -> Dict[str, float]:
@@ -201,6 +210,57 @@ class RunExecutor:
             results=typed_results,
         )
 
+    def _judge_unjudged_results(
+        self,
+        queries: List[EvalQuery],
+        query_results: List[QueryExecutionResult],
+    ) -> None:
+        """Call the LLM judgment engine for any retrieved (query, chunk) pair
+        that lacks a relevance judgment, and persist the result.
+        """
+        if self.judgment_engine is None:
+            return
+
+        existing_judgments = self.store.fetch_judgments(
+            [query.id for query in queries]
+        )
+        queries_by_id = {query.id: query for query in queries}
+
+        unjudged_pairs: List[Tuple[int, int]] = []
+        unjudged_chunk_ids: set[int] = set()
+        for query_result in query_results:
+            judged_for_query = existing_judgments.get(query_result.query_id, {})
+            for retrieved in query_result.results:
+                if retrieved.chunk_id in judged_for_query:
+                    continue
+                unjudged_pairs.append((query_result.query_id, retrieved.chunk_id))
+                unjudged_chunk_ids.add(retrieved.chunk_id)
+
+        if not unjudged_pairs:
+            return
+
+        chunk_texts = self.store.fetch_chunk_texts(unjudged_chunk_ids)
+        missing = unjudged_chunk_ids - chunk_texts.keys()
+        if missing:
+            raise ValueError(
+                f"Cannot judge chunks not present in narrative_chunks: {sorted(missing)}"
+            )
+
+        for query_id, chunk_id in unjudged_pairs:
+            query = queries_by_id[query_id]
+            assessment = self.judgment_engine.judge(
+                query_text=query.text,
+                chunk_text=chunk_texts[chunk_id],
+                query_category=query.category,
+            )
+            self.store.upsert_judgment(
+                query_id=query_id,
+                chunk_id=chunk_id,
+                relevance=assessment.relevance_score,
+                doc_text=chunk_texts[chunk_id],
+                justification=assessment.justification,
+            )
+
     def create_run(self, config: EvalRunConfig) -> int:
         """Persist a run configuration and return its run ID."""
         if not config.settings_snapshot:
@@ -296,6 +356,8 @@ class RunExecutor:
 
                 query_results.append(typed_query_result)
                 self.store.insert_query_results(run_id, typed_query_result)
+
+            self._judge_unjudged_results(queries, query_results)
 
             metrics_calculator = MetricsCalculator()
             judgments_by_query = self.store.fetch_judgments(

--- a/ir_eval/engine/storage.py
+++ b/ir_eval/engine/storage.py
@@ -244,6 +244,53 @@ class EvaluationStore:
                 )
             conn.commit()
 
+    def fetch_chunk_texts(self, chunk_ids: Iterable[int]) -> Dict[int, str]:
+        """Return ``{chunk_id: raw_text}`` for the requested chunk IDs."""
+        chunk_id_list = list(chunk_ids)
+        if not chunk_id_list:
+            return {}
+
+        with self._connect() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT id, raw_text
+                    FROM public.narrative_chunks
+                    WHERE id = ANY(%s)
+                    """,
+                    (chunk_id_list,),
+                )
+                rows = cursor.fetchall()
+
+        return {int(chunk_id): raw_text for chunk_id, raw_text in rows}
+
+    def upsert_judgment(
+        self,
+        query_id: int,
+        chunk_id: int,
+        relevance: int,
+        doc_text: Optional[str] = None,
+        justification: Optional[str] = None,
+    ) -> None:
+        """Insert or update a relevance judgment for a (query, chunk) pair."""
+        with self._connect() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    INSERT INTO ir_eval.judgments
+                        (query_id, chunk_id, relevance, doc_text, justification)
+                    VALUES (%s, %s, %s, %s, %s)
+                    ON CONFLICT (query_id, chunk_id) DO UPDATE SET
+                        relevance = EXCLUDED.relevance,
+                        doc_text = COALESCE(EXCLUDED.doc_text, ir_eval.judgments.doc_text),
+                        justification = COALESCE(
+                            EXCLUDED.justification, ir_eval.judgments.justification
+                        )
+                    """,
+                    (query_id, chunk_id, relevance, doc_text, justification),
+                )
+            conn.commit()
+
     def fetch_judgments(self, query_ids: Iterable[int]) -> Dict[int, Dict[int, int]]:
         """Return relevance judgments keyed by query and chunk ID."""
         query_id_list = list(query_ids)

--- a/ir_eval/runner.py
+++ b/ir_eval/runner.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 from nexus.config import load_settings_as_dict
 
 from ir_eval.engine import ComparisonEngine, EvaluationStore, RunExecutor
+from ir_eval.engine.judge import JudgmentEngine
 from ir_eval.models import EvalModelConfig, EvalRunConfig
 
 
@@ -93,10 +94,29 @@ def cmd_create_run(args: argparse.Namespace) -> None:
     print(json.dumps({"run_id": run_id}, indent=2))
 
 
+def _build_judgment_engine() -> JudgmentEngine:
+    """Construct a JudgmentEngine using ``[ir_eval.judgment]`` settings."""
+    settings = load_settings_as_dict()
+    judgment_cfg = (settings.get("ir_eval") or {}).get("judgment") or {}
+    if not judgment_cfg.get("model"):
+        raise ValueError(
+            "ir_eval.judgment.model is not configured in nexus.toml"
+        )
+    return JudgmentEngine(
+        model=judgment_cfg["model"],
+        reasoning_effort=judgment_cfg.get("reasoning_effort", "high"),
+    )
+
+
 def cmd_execute_run(args: argparse.Namespace) -> None:
     """Execute a previously created run."""
     store = EvaluationStore(args.db_url)
-    executor = RunExecutor(store=store, db_url=args.db_url)
+    judgment_engine = _build_judgment_engine() if args.judge_on_demand else None
+    executor = RunExecutor(
+        store=store,
+        db_url=args.db_url,
+        judgment_engine=judgment_engine,
+    )
     summary = executor.execute_run(args.run_id)
     print(json.dumps(summary.model_dump(mode="json"), indent=2))
 
@@ -162,6 +182,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     execute = subparsers.add_parser("execute-run", help="Execute an existing run")
     execute.add_argument("--run-id", type=int, required=True)
+    execute.add_argument(
+        "--judge-on-demand",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Call the LLM to score relevance for any retrieved chunk that lacks a judgment",
+    )
     execute.set_defaults(func=cmd_execute_run)
 
     compare = subparsers.add_parser("compare-runs", help="Compare two runs")

--- a/migrations/017_add_judgment_justification.sql
+++ b/migrations/017_add_judgment_justification.sql
@@ -1,0 +1,10 @@
+-- migrations/017_add_judgment_justification.sql
+-- Description: Ensure ir_eval.judgments has a justification column for storing
+--   the LLM's reasoning when relevance is judged on demand.  Existing
+--   databases (e.g. NEXUS) already have this column from prior ad-hoc
+--   ALTERs; this migration makes it part of the formal schema for fresh
+--   targets.
+-- Date: 2026-05-06
+
+ALTER TABLE ir_eval.judgments
+    ADD COLUMN IF NOT EXISTS justification TEXT;

--- a/nexus.toml
+++ b/nexus.toml
@@ -29,15 +29,13 @@ possible_values = [
 # Each provider section lists models available for that API backend
 [global.model.api_models.openai]
 models = [
-    { id = "gpt-5.1", label = "GPT-5.1" },
-    { id = "gpt-5.2", label = "GPT-5.2" },
+    { id = "gpt-5.5", label = "GPT-5.5" },
 ]
 
 [global.model.api_models.anthropic]
 models = [
-    { id = "claude-haiku-4-5", label = "Haiku 4.5" },
-    { id = "claude-sonnet-4-5", label = "Sonnet 4.5" },
-    { id = "claude-opus-4-5", label = "Opus 4.5" },
+    { id = "claude-sonnet-4-6", label = "Sonnet 4.6" },
+    { id = "claude-opus-4-7", label = "Opus 4.7" },
 ]
 
 [global.model.api_models.test]
@@ -392,7 +390,7 @@ max_output_tokens = 25000     # Maximum tokens for generated narrative
 # =============================================================================
 
 [ir_eval.judgment]
-model = "gpt-5.1"             # LLM used to score relevance when a retrieved chunk lacks a judgment
+model = "gpt-5.5"             # LLM used to score relevance when a retrieved chunk lacks a judgment
 reasoning_effort = "high"     # Reasoning effort level (low/medium/high)
 
 # =============================================================================

--- a/nexus.toml
+++ b/nexus.toml
@@ -388,6 +388,14 @@ reasoning_effort = "medium"   # Reasoning effort level (low/medium/high)
 max_output_tokens = 25000     # Maximum tokens for generated narrative
 
 # =============================================================================
+# IR Evaluation V2 Settings
+# =============================================================================
+
+[ir_eval.judgment]
+model = "gpt-5.1"             # LLM used to score relevance when a retrieved chunk lacks a judgment
+reasoning_effort = "high"     # Reasoning effort level (low/medium/high)
+
+# =============================================================================
 # API Settings
 # =============================================================================
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -450,6 +450,24 @@ class APISettings(BaseModel):
 # Root Settings Model
 # =============================================================================
 
+class IREvalJudgmentConfig(BaseModel):
+    """LLM judgment-on-demand configuration for the IR eval V2 runner."""
+    model_config = ConfigDict(extra='forbid')
+
+    model: str = Field(..., description="LLM model identifier for relevance judgments")
+    reasoning_effort: str = Field(
+        default="high",
+        description="Reasoning effort for the judgment model (e.g. minimal/medium/high)",
+    )
+
+
+class IREvalSettings(BaseModel):
+    """Configuration for the IR evaluation V2 subsystem."""
+    model_config = ConfigDict(extra='forbid')
+
+    judgment: IREvalJudgmentConfig
+
+
 class Settings(BaseModel):
     """
     Root configuration model for NEXUS.
@@ -471,6 +489,10 @@ class Settings(BaseModel):
     apex: APEXSettings
     wizard: WizardSettings
     api: Optional[APISettings] = Field(default=None, description="API settings")
+    ir_eval: Optional[IREvalSettings] = Field(
+        default=None,
+        description="IR evaluation subsystem settings",
+    )
 
     def model_dump(self, **kwargs) -> dict:
         """


### PR DESCRIPTION
## Summary
- New `JudgmentEngine` calls the OpenAI structured-output API to score relevance (0–3 + justification) for any retrieved chunk that lacks a judgment
- `RunExecutor.execute_run()` now fills missing judgments between retrieval and metrics, so v2 produces meaningful scores even when a new embedding model surfaces unfamiliar chunks
- Configured via a new `[ir_eval.judgment]` section in `nexus.toml` (validated by `IREvalSettings`); enabled by default on the `execute-run` subcommand, opt-out with `--no-judge-on-demand`

## Why
With dense LLM-generated relevance judgments, the v1 assumption of a frozen judgment pool falls apart as new retrieval models surface chunks no prior run touched. Without on-demand judgment, those retrievals were silently dropped from `bpref` and counted as `unjudged_count` in metrics. Now the system closes the loop automatically: retrieve → judge missing → score.

Errors from the LLM call propagate (no fallback to score=0); the existing `try/except` in `execute_run` marks the run as failed so issues surface visibly.

## Test plan
- [x] Existing unit tests still pass (`poetry run pytest tests/test_ir_eval_v2/`)
- [x] End-to-end: created run with `e5-large` on `theme` queries; the 4 chunks unfamiliar to bge-large were judged on demand (4 OpenAI calls in httpx logs); resulting `unjudged_count: 0`
- [x] `--no-judge-on-demand` flag verified (no HTTP calls when set)
- [x] `psycopg2` connection cleanup remains tight (0 idle connections after runs)
- [x] New judgments persisted with `justification` field populated (8642 → 8646)

## Notable comparative result from the smoke test
e5-large outperformed bge-large on the theme category (P@5 0.92 vs 0.88, NDCG@10 0.765 vs 0.71) — the kind of head-to-head signal this whole framework was built to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)