### PR TITLE
Wire model-drift checker into CI

### DIFF
--- a/.github/workflows/model-drift-check.yml
+++ b/.github/workflows/model-drift-check.yml
@@ -1,0 +1,29 @@
+name: Model drift check
+
+# Runs scripts/check_model_drift.py on every push and PR. The check fails if a
+# literal gpt-5.X or claude-{sonnet,opus,haiku}-N-N reference appears outside
+# the [global.model.api_models] registry without a "# pin: <reason>" annotation.
+# See issue #181 and CLAUDE.md for the role-based config pattern this enforces.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # The drift checker is stdlib-only; no `poetry install` required.
+      - name: Run drift checker
+        run: python scripts/check_model_drift.py


### PR DESCRIPTION
## Summary

Wires `scripts/check_model_drift.py` (added in #182) into GitHub Actions so it runs automatically on every push to `main` and every PR targeting `main`.

- New file: `.github/workflows/model-drift-check.yml`.
- The checker is stdlib-only; no `poetry install` required, runs in ~5s on `ubuntu-latest`.
- Failures show as a red check on the PR. With branch protection requiring this check, merges of drifting PRs are blocked.

Per the discussion on #181: this is the *enforcement* half of the system. The `# pin: <reason>` annotation remains the contributor-side escape hatch for genuinely-intentional literal model IDs.

## Test plan

- [x] `poetry run python scripts/check_model_drift.py` → `OK: no model-ID drift detected.`
- [x] YAML parses cleanly via PyYAML
- [ ] First CI run (visible on this PR) confirms the workflow registers and the job passes against the current `main`

## Follow-up (not in scope)

- Adding a pre-commit hook (Option B from the design discussion) for faster local feedback. Skipped for now per the "minimum-friction" decision; can add later if drift commits start showing up in PRs.
- Configuring branch protection on `main` to *require* this check. That's a GitHub-settings change, not a code change, and is left for the user to enable when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)