### PR TITLE
Retrieval bench: Octen-4B embedder swap + reranker bakeoff infra

### DIFF
--- a/ir_eval/engine/run_executor.py
+++ b/ir_eval/engine/run_executor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import copy
 import time
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from nexus.config import load_settings_as_dict
 from nexus.agents.memnon.utils.cross_encoder import rerank_results
@@ -296,28 +296,34 @@ class RunExecutor:
             "cross_encoder_reranking", {}
         )
 
-        # Resolve which reranker to use. If the run config names a candidate,
-        # look it up in the registry; otherwise fall back to the legacy
-        # cross_encoder_reranking.model_path (and assume "cross_encoder" api_type).
-        candidates = cross_encoder_settings.get("candidates", {}) or {}
-        if run_config.reranker_candidate:
-            candidate = candidates.get(run_config.reranker_candidate)
-            if candidate is None:
-                raise ValueError(
-                    f"Reranker candidate '{run_config.reranker_candidate}' is not registered "
-                    f"in [memnon.retrieval.cross_encoder_reranking.candidates]. "
-                    f"Known: {sorted(candidates.keys())}"
+        # Resolve which reranker to use. Skip entirely when reranking is
+        # disabled — a run can legitimately carry a stale `reranker_candidate`
+        # while running with `--no-cross-encoder` and shouldn't fail validation
+        # on a field that won't be consulted.
+        reranker_model_path: Optional[str] = None
+        reranker_api_type: str = "cross_encoder"
+        if run_config.cross_encoder_enabled:
+            candidates = cross_encoder_settings.get("candidates", {}) or {}
+            if run_config.reranker_candidate:
+                candidate = candidates.get(run_config.reranker_candidate)
+                if candidate is None:
+                    raise ValueError(
+                        f"Reranker candidate '{run_config.reranker_candidate}' is not registered "
+                        f"in [memnon.retrieval.cross_encoder_reranking.candidates]. "
+                        f"Known: {sorted(candidates.keys())}"
+                    )
+                reranker_model_path = str(candidate["local_path"])
+                reranker_api_type = str(candidate.get("api_type", "cross_encoder"))
+            else:
+                reranker_model_path = str(
+                    cross_encoder_settings.get(
+                        "model_path",
+                        "naver-trecdl22-crossencoder-debertav3",
+                    )
                 )
-            reranker_model_path = str(candidate["local_path"])
-            reranker_api_type = str(candidate.get("api_type", "cross_encoder"))
-        else:
-            reranker_model_path = str(
-                cross_encoder_settings.get(
-                    "model_path",
-                    "naver-trecdl22-crossencoder-debertav3",
+                reranker_api_type = str(
+                    cross_encoder_settings.get("api_type", "cross_encoder")
                 )
-            )
-            reranker_api_type = "cross_encoder"
 
         try:
             for query in queries:

--- a/ir_eval/engine/run_executor.py
+++ b/ir_eval/engine/run_executor.py
@@ -296,6 +296,29 @@ class RunExecutor:
             "cross_encoder_reranking", {}
         )
 
+        # Resolve which reranker to use. If the run config names a candidate,
+        # look it up in the registry; otherwise fall back to the legacy
+        # cross_encoder_reranking.model_path (and assume "cross_encoder" api_type).
+        candidates = cross_encoder_settings.get("candidates", {}) or {}
+        if run_config.reranker_candidate:
+            candidate = candidates.get(run_config.reranker_candidate)
+            if candidate is None:
+                raise ValueError(
+                    f"Reranker candidate '{run_config.reranker_candidate}' is not registered "
+                    f"in [memnon.retrieval.cross_encoder_reranking.candidates]. "
+                    f"Known: {sorted(candidates.keys())}"
+                )
+            reranker_model_path = str(candidate["local_path"])
+            reranker_api_type = str(candidate.get("api_type", "cross_encoder"))
+        else:
+            reranker_model_path = str(
+                cross_encoder_settings.get(
+                    "model_path",
+                    "naver-trecdl22-crossencoder-debertav3",
+                )
+            )
+            reranker_api_type = "cross_encoder"
+
         try:
             for query in queries:
                 query_start = time.time()
@@ -336,12 +359,8 @@ class RunExecutor:
                         use_sliding_window=bool(
                             cross_encoder_settings.get("use_sliding_window", True)
                         ),
-                        model_path=str(
-                            cross_encoder_settings.get(
-                                "model_path",
-                                "naver-trecdl22-crossencoder-debertav3",
-                            )
-                        ),
+                        model_path=reranker_model_path,
+                        api_type=reranker_api_type,
                         use_8bit=bool(cross_encoder_settings.get("use_8bit", False)),
                     )
 

--- a/ir_eval/models/schemas.py
+++ b/ir_eval/models/schemas.py
@@ -25,6 +25,7 @@ class EvalRunConfig(BaseModel):
     vector_weight: float = Field(default=0.6, ge=0.0, le=1.0)
     text_weight: float = Field(default=0.4, ge=0.0, le=1.0)
     cross_encoder_enabled: bool = True
+    reranker_candidate: Optional[str] = None
     top_k: int = Field(default=10, ge=1)
     query_ids: Optional[List[int]] = None
     query_categories: Optional[List[str]] = None

--- a/ir_eval/runner.py
+++ b/ir_eval/runner.py
@@ -85,6 +85,7 @@ def cmd_create_run(args: argparse.Namespace) -> None:
         vector_weight=args.vector_weight,
         text_weight=args.text_weight,
         cross_encoder_enabled=args.cross_encoder,
+        reranker_candidate=args.reranker,
         top_k=args.top_k,
         query_ids=parse_csv_ints(args.query_ids),
         query_categories=parse_csv_strings(args.query_categories),
@@ -170,6 +171,14 @@ def build_parser() -> argparse.ArgumentParser:
         action=argparse.BooleanOptionalAction,
         default=True,
         help="Enable/disable cross-encoder reranking",
+    )
+    create.add_argument(
+        "--reranker",
+        default=None,
+        help=(
+            "Name of a candidate in [memnon.retrieval.cross_encoder_reranking.candidates]. "
+            "If omitted, falls back to the legacy cross_encoder_reranking.model_path setting."
+        ),
     )
     create.add_argument("--top-k", type=int, default=10)
     create.add_argument("--query-ids", default=None, help="Comma-separated query IDs")

--- a/migrations/014_add_2560d_4096d_embeddings.sql
+++ b/migrations/014_add_2560d_4096d_embeddings.sql
@@ -1,5 +1,8 @@
 -- migrations/014_add_2560d_4096d_embeddings.sql
--- Description: Add dimension-specific embedding tables for Octen candidate models.
+-- Description: Add dimension-specific embedding tables for Octen candidate models
+-- (Octen-Embedding-4B at 2560 dims, Octen-Embedding-8B at 4096 dims). No HNSW
+-- index on either — both exceed pgvector's HNSW dim caps (2000 for `vector`,
+-- 4000 for `halfvec`). Retrieval uses sequential scan; see #175 for context.
 -- Date: 2026-02-19
 
 CREATE EXTENSION IF NOT EXISTS vector;
@@ -28,12 +31,8 @@ CREATE INDEX IF NOT EXISTS chunk_embeddings_2560d_model_idx
 CREATE INDEX IF NOT EXISTS chunk_embeddings_4096d_model_idx
     ON chunk_embeddings_4096d (model);
 
-CREATE INDEX IF NOT EXISTS chunk_embeddings_2560d_hnsw_idx
-    ON chunk_embeddings_2560d
-    USING hnsw (embedding vector_cosine_ops)
-    WITH (m = 16, ef_construction = 64);
-
-CREATE INDEX IF NOT EXISTS chunk_embeddings_4096d_hnsw_idx
-    ON chunk_embeddings_4096d
-    USING hnsw (embedding vector_cosine_ops)
-    WITH (m = 16, ef_construction = 64);
+-- HNSW/IVFFlat indexes intentionally omitted. pgvector 0.8.0 caps HNSW at
+-- 2000 dims on `vector` and 4000 on `halfvec`; both octen tables exceed
+-- those caps. Sequential scan is the only retrieval path here, which is
+-- acceptable at evaluation corpus scale (~10 ms/query at 1k chunks).
+-- See issue #175 for empirical verification.

--- a/nexus.toml
+++ b/nexus.toml
@@ -366,9 +366,13 @@ theme = 0.3
 general = 0.4
 
 [memnon.retrieval.cross_encoder_reranking]
-# Cross-encoder reranking for improved relevance
+# Cross-encoder reranking for improved relevance.
+# Production default is determined by `model_path` + `api_type` below; the
+# `candidates` registry below is for ir_eval bakeoff selection via
+# `ir_eval.runner create-run --reranker NAME`, not for swapping production.
 enabled = true
 model_path = "/Users/pythagor/nexus/models/naver-trecdl22-crossencoder-debertav3"
+api_type = "cross_encoder"  # "cross_encoder" (SequenceClassification) or "qwen3_lm"
 blend_weight = 0.3  # How much to blend reranker score with original score
 top_k = 30          # Only rerank top 30 results (for speed)
 batch_size = 16     # Batch size for reranker inference
@@ -390,35 +394,32 @@ location = 0.35
 theme = 0.2
 general = 0.3
 
-# Reranker candidate registry for bakeoff testing.
-# The IR eval framework can target any entry via `create-run --reranker NAME`.
+# Reranker candidate registry — entries here can be targeted at bakeoff time
+# via `ir_eval.runner create-run --reranker NAME`. The production default is
+# the top-level `model_path` + `api_type` above; swap by editing those, not
+# by adding/removing entries here.
 # `api_type` selects the inference path: "cross_encoder" for standard
-# SequenceClassification rerankers (DeBERTa-v3, mxbai), "qwen3_lm" for Qwen3-Reranker
-# yes/no causal-LM rerankers. `is_active = true` on exactly one entry marks the
-# production default — this is what `model_path` above resolves to in legacy reads.
+# SequenceClassification rerankers (DeBERTa-v3, mxbai), "qwen3_lm" for
+# Qwen3-Reranker yes/no causal-LM rerankers.
 [memnon.retrieval.cross_encoder_reranking.candidates."deberta-v3-trecdl22"]
-is_active = true
 local_path = "/Users/pythagor/nexus/models/naver-trecdl22-crossencoder-debertav3"
 remote_path = "naver/trecdl22-crossencoder-debertav3"
 api_type = "cross_encoder"
 notes = "DeBERTa-v3-large fine-tuned on TREC-DL 2022; current production default."
 
 [memnon.retrieval.cross_encoder_reranking.candidates."qwen3-reranker-0.6b"]
-is_active = false
 local_path = "/Users/pythagor/nexus/models/Qwen3-Reranker-0.6B"
 remote_path = "Qwen/Qwen3-Reranker-0.6B"
 api_type = "qwen3_lm"
 notes = "Qwen3-based yes/no causal-LM reranker, 0.6B params (issue #175 follow-up)."
 
 [memnon.retrieval.cross_encoder_reranking.candidates."qwen3-reranker-4b"]
-is_active = false
 local_path = "/Users/pythagor/nexus/models/Qwen3-Reranker-4B"
 remote_path = "Qwen/Qwen3-Reranker-4B"
 api_type = "qwen3_lm"
 notes = "Qwen3-based yes/no causal-LM reranker, 4B params (issue #175 follow-up)."
 
 [memnon.retrieval.cross_encoder_reranking.candidates."mxbai-rerank-large"]
-is_active = false
 local_path = "/Users/pythagor/nexus/models/mxbai-rerank-large-v2"
 remote_path = "mixedbread-ai/mxbai-rerank-large-v2"
 api_type = "cross_encoder"

--- a/nexus.toml
+++ b/nexus.toml
@@ -382,6 +382,40 @@ location = 0.35
 theme = 0.2
 general = 0.3
 
+# Reranker candidate registry for bakeoff testing.
+# The IR eval framework can target any entry via `create-run --reranker NAME`.
+# `api_type` selects the inference path: "cross_encoder" for standard
+# SequenceClassification rerankers (DeBERTa-v3, mxbai), "qwen3_lm" for Qwen3-Reranker
+# yes/no causal-LM rerankers. `is_active = true` on exactly one entry marks the
+# production default — this is what `model_path` above resolves to in legacy reads.
+[memnon.retrieval.cross_encoder_reranking.candidates."deberta-v3-trecdl22"]
+is_active = true
+local_path = "/Users/pythagor/nexus/models/naver-trecdl22-crossencoder-debertav3"
+remote_path = "naver/trecdl22-crossencoder-debertav3"
+api_type = "cross_encoder"
+notes = "DeBERTa-v3-large fine-tuned on TREC-DL 2022; current production default."
+
+[memnon.retrieval.cross_encoder_reranking.candidates."qwen3-reranker-0.6b"]
+is_active = false
+local_path = "/Users/pythagor/nexus/models/Qwen3-Reranker-0.6B"
+remote_path = "Qwen/Qwen3-Reranker-0.6B"
+api_type = "qwen3_lm"
+notes = "Qwen3-based yes/no causal-LM reranker, 0.6B params (issue #175 follow-up)."
+
+[memnon.retrieval.cross_encoder_reranking.candidates."qwen3-reranker-4b"]
+is_active = false
+local_path = "/Users/pythagor/nexus/models/Qwen3-Reranker-4B"
+remote_path = "Qwen/Qwen3-Reranker-4B"
+api_type = "qwen3_lm"
+notes = "Qwen3-based yes/no causal-LM reranker, 4B params (issue #175 follow-up)."
+
+[memnon.retrieval.cross_encoder_reranking.candidates."mxbai-rerank-large"]
+is_active = false
+local_path = "/Users/pythagor/nexus/models/mxbai-rerank-large-v2"
+remote_path = "mixedbread-ai/mxbai-rerank-large-v2"
+api_type = "cross_encoder"
+notes = "Mixedbread modern cross-encoder reranker (issue #175 follow-up)."
+
 [memnon.logging]
 file = "memnon.log"
 level = "INFO"

--- a/nexus.toml
+++ b/nexus.toml
@@ -188,17 +188,38 @@ remote_path = "infly/inf-retriever-v1-1.5b"
 dimensions = 1536
 weight = 0.5  # Highest weight - best performing model
 
+[memnon.models."Octen-Embedding-0.6B"]
+is_active = false  # Candidate model for issue #175 evaluation campaign
+local_path = "/Users/pythagor/nexus/models/Octen-Embedding-0.6B"
+remote_path = "Octen/Octen-Embedding-0.6B"
+dimensions = 1024
+weight = 0.0
+
 [memnon.models."Octen-Embedding-4B"]
 is_active = false  # Candidate model for issue #175 evaluation campaign
 local_path = "/Users/pythagor/nexus/models/Octen-Embedding-4B"
-remote_path = ""
+remote_path = "Octen/Octen-Embedding-4B"
+dimensions = 2560
+weight = 0.0
+
+[memnon.models."Octen-Embedding-4B-INT8"]
+is_active = false  # Candidate model for issue #175 evaluation campaign (INT8 quantized, CPU-only on Apple Silicon)
+local_path = "/Users/pythagor/nexus/models/Octen-Embedding-4B-INT8"
+remote_path = "Octen/Octen-Embedding-4B-INT8"
 dimensions = 2560
 weight = 0.0
 
 [memnon.models."Octen-Embedding-8B"]
 is_active = false  # Candidate model for issue #175 evaluation campaign
 local_path = "/Users/pythagor/nexus/models/Octen-Embedding-8B"
-remote_path = ""
+remote_path = "Octen/Octen-Embedding-8B"
+dimensions = 4096
+weight = 0.0
+
+[memnon.models."Octen-Embedding-8B-INT8"]
+is_active = false  # Candidate model for issue #175 evaluation campaign (INT8 quantized, CPU-only on Apple Silicon)
+local_path = "/Users/pythagor/nexus/models/Octen-Embedding-8B-INT8"
+remote_path = "Octen/Octen-Embedding-8B-INT8"
 dimensions = 4096
 weight = 0.0
 

--- a/nexus.toml
+++ b/nexus.toml
@@ -160,19 +160,27 @@ drop_existing = true
 # Embedding models configuration
 # Multiple models are ensembled for better retrieval quality
 
+# Active retrieval embedder: Octen-Embedding-4B (issue #175 winner).
+# Beat the prior bge+e5+inf-retriever ensemble on all 5 IR metrics
+# (P@5 +0.015, P@10 +0.015, MRR +0.025, bpref +0.003, NDCG@10 +0.021)
+# while cutting production query latency by ~31% (single model encode +
+# single-table vector search instead of 3 sequential encodes + 3-table SQL).
+# Statistical significance approached but didn't reach p<0.05 at n=130;
+# direction was consistent on all 5 metrics.
+
 [memnon.models.bge-large]
-is_active = true
+is_active = false  # Deprecated by Octen-4B (issue #175)
 local_path = "/Users/pythagor/nexus/models/bge-large-en"
 remote_path = "BAAI/bge-large-en"
 dimensions = 1024
-weight = 0.2  # Ensemble weight for this model
+weight = 0.0
 
 [memnon.models.e5-large]
-is_active = true
+is_active = false  # Deprecated by Octen-4B (issue #175)
 local_path = "/Users/pythagor/nexus/models/e5-large-v2"
 remote_path = "intfloat/e5-large-v2"
 dimensions = 1024
-weight = 0.3
+weight = 0.0
 
 [memnon.models.bge-small-custom]
 is_active = false  # Fine-tuned model, currently disabled
@@ -182,11 +190,11 @@ dimensions = 384
 weight = 0.0
 
 [memnon.models."inf-retriever-v1-1.5b"]
-is_active = true
+is_active = false  # Deprecated by Octen-4B (issue #175)
 local_path = "/Users/pythagor/nexus/models/inf-retriever-v1-1.5b"
 remote_path = "infly/inf-retriever-v1-1.5b"
 dimensions = 1536
-weight = 0.5  # Highest weight - best performing model
+weight = 0.0
 
 [memnon.models."Octen-Embedding-0.6B"]
 is_active = false  # Candidate model for issue #175 evaluation campaign
@@ -196,11 +204,11 @@ dimensions = 1024
 weight = 0.0
 
 [memnon.models."Octen-Embedding-4B"]
-is_active = false  # Candidate model for issue #175 evaluation campaign
+is_active = true  # Production embedder (winner of issue #175 bakeoff)
 local_path = "/Users/pythagor/nexus/models/Octen-Embedding-4B"
 remote_path = "Octen/Octen-Embedding-4B"
 dimensions = 2560
-weight = 0.0
+weight = 1.0
 
 [memnon.models."Octen-Embedding-4B-INT8"]
 is_active = false  # Candidate model for issue #175 evaluation campaign (INT8 quantized, CPU-only on Apple Silicon)

--- a/nexus/agents/memnon/memnon.py
+++ b/nexus/agents/memnon/memnon.py
@@ -1749,9 +1749,13 @@ class MEMNON:
                 batch_size = cross_encoder_config.get("batch_size", 8)
                 use_sliding_window = cross_encoder_config.get("use_sliding_window", True)
                 model_path = cross_encoder_config.get("model_path", "naver-trecdl22-crossencoder-debertav3")
-                
+                # api_type must accompany model_path so that swapping production
+                # to a Qwen3-Reranker checkpoint doesn't silently load it as a
+                # SequenceClassification CrossEncoder.
+                api_type = cross_encoder_config.get("api_type", "cross_encoder")
+
                 rerank_start_time = time.time()
-                
+
                 # Apply reranking
                 # Get use_8bit parameter from settings
                 use_8bit = cross_encoder_config.get("use_8bit", False)
@@ -1764,6 +1768,7 @@ class MEMNON:
                     batch_size=batch_size,
                     use_sliding_window=use_sliding_window,
                     model_path=model_path,
+                    api_type=api_type,
                     use_8bit=use_8bit
                 )
                 

--- a/nexus/agents/memnon/utils/cross_encoder.py
+++ b/nexus/agents/memnon/utils/cross_encoder.py
@@ -271,6 +271,10 @@ class Qwen3LMReranker:
         '"no".<|im_end|>\n<|im_start|>user\n'
     )
     _SUFFIX = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+    # TODO(issue #175): the model-card default instruction is tuned for web
+    # search; a narrative-domain instruction (e.g., "Given a narrative query,
+    # retrieve relevant story passages...") may improve scores. Re-bakeoff
+    # before changing.
     _INSTRUCTION = (
         "Given a web search query, retrieve relevant passages that answer the query"
     )
@@ -314,6 +318,19 @@ class Qwen3LMReranker:
 
         self._token_yes = self.tokenizer.convert_tokens_to_ids("yes")
         self._token_no = self.tokenizer.convert_tokens_to_ids("no")
+        # Fail fast if the tokenizer doesn't have unique tokens for "yes"/"no".
+        # `convert_tokens_to_ids` returns `unk_token_id` for missing tokens,
+        # which would silently produce garbage relevance scores at scoring
+        # time. This catches future tokenizer variants (e.g., BPE that
+        # encodes "yes" as " yes" or "Ġyes").
+        unk = self.tokenizer.unk_token_id
+        if self._token_yes == unk or self._token_no == unk:
+            raise ValueError(
+                f"Qwen3-Reranker tokenizer at {model_name_or_path} does not "
+                f"map 'yes' or 'no' to a unique vocab id "
+                f"(got yes={self._token_yes}, no={self._token_no}, unk={unk}). "
+                f"Check token surface forms (e.g., 'Ġyes' / '▁yes')."
+            )
         self._prefix_tokens = self.tokenizer.encode(
             self._PREFIX, add_special_tokens=False
         )
@@ -377,7 +394,9 @@ class Qwen3LMReranker:
 # Module-level cache for reranker instances. Loading a 0.6B model is seconds;
 # a 4B model is ~10s. Per-query reloads would dominate eval wall time, so we
 # keep the instance alive across calls within the process.
-_RERANKER_CACHE: Dict[Tuple[str, str, bool], Any] = {}
+# Key includes `device` so a workflow that loads first on (say) MPS doesn't
+# silently return that instance to a later caller that requests CPU.
+_RERANKER_CACHE: Dict[Tuple[str, str, Optional[str], bool], Any] = {}
 
 
 def _get_or_create_reranker(
@@ -387,7 +406,7 @@ def _get_or_create_reranker(
     use_8bit: bool,
 ):
     """Return a cached reranker, constructing it on first request."""
-    key = (model_path, api_type, use_8bit)
+    key = (model_path, api_type, device, use_8bit)
     cached = _RERANKER_CACHE.get(key)
     if cached is not None:
         return cached

--- a/nexus/agents/memnon/utils/cross_encoder.py
+++ b/nexus/agents/memnon/utils/cross_encoder.py
@@ -217,41 +217,193 @@ class CrossEncoderReranker:
         return [s.strip() for s in text.split('[SEP]') if s.strip()]
     
     def rerank_batch(
-        self, 
-        query: str, 
-        passages: List[str], 
-        batch_size: int = 8, 
+        self,
+        query: str,
+        passages: List[str],
+        batch_size: int = 8,
         use_sliding_window: bool = True
     ) -> List[float]:
         """
         Rerank a batch of passages against a query.
-        
+
         Args:
             query: The search query
             passages: List of passages to score
             batch_size: Batch size for model inference
             use_sliding_window: Whether to use sliding window for long texts
-            
+
         Returns:
             List of relevance scores for each passage
         """
         scores = []
-        
+
         # Process in batches
         for i in range(0, len(passages), batch_size):
             batch_passages = passages[i:i+batch_size]
             batch_scores = []
-            
+
             for passage in batch_passages:
                 if use_sliding_window:
                     score = self.score_pair_with_sliding_window(query, passage)
                 else:
                     score = self.score_pair(query, passage)
                 batch_scores.append(score)
-            
+
             scores.extend(batch_scores)
-        
+
         return scores
+
+
+class Qwen3LMReranker:
+    """Qwen3-Reranker yes/no causal-LM scorer for (query, document) pairs.
+
+    Qwen3-Reranker is a causal LM (not a SequenceClassification head). Scoring
+    a pair runs the model once over `<Instruct>... <Query>... <Document>...`
+    and reads P("yes") from the last-token logits over the {"yes", "no"} tokens.
+    This class wraps that into the same ``rerank_batch(query, passages, ...)``
+    surface as ``CrossEncoderReranker`` so callers don't branch.
+    """
+
+    _PREFIX = (
+        '<|im_start|>system\n'
+        'Judge whether the Document meets the requirements based on the Query '
+        'and the Instruct provided. Note that the answer can only be "yes" or '
+        '"no".<|im_end|>\n<|im_start|>user\n'
+    )
+    _SUFFIX = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+    _INSTRUCTION = (
+        "Given a web search query, retrieve relevant passages that answer the query"
+    )
+
+    def __init__(
+        self,
+        model_name_or_path: str,
+        device: Optional[str] = None,
+        max_length: int = 8192,
+    ):
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+
+        if device is None:
+            if torch.cuda.is_available():
+                device = "cuda"
+            elif hasattr(torch, "has_mps") and torch.backends.mps.is_built():
+                device = "mps"
+            else:
+                device = "cpu"
+        self.device = device
+        self.max_length = max_length
+
+        logger.info(f"Loading Qwen3-Reranker from {model_name_or_path} on {device}")
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_name_or_path, padding_side="left"
+        )
+        # MPS doesn't support all kernels at fp16; use fp32 on CPU, fp16 elsewhere.
+        dtype = torch.float32 if device == "cpu" else torch.float16
+        self.model = (
+            AutoModelForCausalLM.from_pretrained(model_name_or_path, torch_dtype=dtype)
+            .to(device)
+            .eval()
+        )
+
+        self._token_yes = self.tokenizer.convert_tokens_to_ids("yes")
+        self._token_no = self.tokenizer.convert_tokens_to_ids("no")
+        self._prefix_tokens = self.tokenizer.encode(
+            self._PREFIX, add_special_tokens=False
+        )
+        self._suffix_tokens = self.tokenizer.encode(
+            self._SUFFIX, add_special_tokens=False
+        )
+        logger.info(
+            f"Qwen3-Reranker ready: yes_id={self._token_yes}, no_id={self._token_no}"
+        )
+
+    def _format_pair(self, query: str, doc: str) -> str:
+        return (
+            f"<Instruct>: {self._INSTRUCTION}\n"
+            f"<Query>: {query}\n"
+            f"<Document>: {doc}"
+        )
+
+    def _build_inputs(self, pairs: List[str]):
+        body_budget = self.max_length - len(self._prefix_tokens) - len(self._suffix_tokens)
+        inputs = self.tokenizer(
+            pairs,
+            padding=False,
+            truncation="longest_first",
+            return_attention_mask=False,
+            max_length=body_budget,
+        )
+        for i, body in enumerate(inputs["input_ids"]):
+            inputs["input_ids"][i] = self._prefix_tokens + body + self._suffix_tokens
+        inputs = self.tokenizer.pad(
+            inputs, padding=True, return_tensors="pt", max_length=self.max_length
+        )
+        return {k: v.to(self.device) for k, v in inputs.items()}
+
+    @torch.no_grad()
+    def _score_batch(self, pairs: List[str]) -> List[float]:
+        inputs = self._build_inputs(pairs)
+        logits = self.model(**inputs).logits[:, -1, :]
+        yes_logit = logits[:, self._token_yes]
+        no_logit = logits[:, self._token_no]
+        stacked = torch.stack([no_logit, yes_logit], dim=1)
+        log_probs = torch.nn.functional.log_softmax(stacked, dim=1)
+        return log_probs[:, 1].exp().tolist()
+
+    def rerank_batch(
+        self,
+        query: str,
+        passages: List[str],
+        batch_size: int = 8,
+        use_sliding_window: bool = True,  # API-compat; Qwen3 truncates internally.
+    ) -> List[float]:
+        if not passages:
+            return []
+        formatted = [self._format_pair(query, p or "") for p in passages]
+        scores: List[float] = []
+        for start in range(0, len(formatted), batch_size):
+            batch = formatted[start:start + batch_size]
+            scores.extend(self._score_batch(batch))
+        return scores
+
+
+# Module-level cache for reranker instances. Loading a 0.6B model is seconds;
+# a 4B model is ~10s. Per-query reloads would dominate eval wall time, so we
+# keep the instance alive across calls within the process.
+_RERANKER_CACHE: Dict[Tuple[str, str, bool], Any] = {}
+
+
+def _get_or_create_reranker(
+    model_path: str,
+    api_type: str,
+    device: Optional[str],
+    use_8bit: bool,
+):
+    """Return a cached reranker, constructing it on first request."""
+    key = (model_path, api_type, use_8bit)
+    cached = _RERANKER_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    if api_type == "cross_encoder":
+        instance = CrossEncoderReranker(
+            model_name_or_path=model_path,
+            device=device,
+            use_8bit=use_8bit,
+        )
+    elif api_type == "qwen3_lm":
+        instance = Qwen3LMReranker(
+            model_name_or_path=model_path,
+            device=device,
+        )
+    else:
+        raise ValueError(
+            f"Unknown reranker api_type: {api_type!r}. "
+            "Expected 'cross_encoder' or 'qwen3_lm'."
+        )
+
+    _RERANKER_CACHE[key] = instance
+    return instance
 
 
 def rerank_results(
@@ -262,12 +414,13 @@ def rerank_results(
     batch_size: int = 8,
     use_sliding_window: bool = True,
     model_path: str = "naver/trecdl22-crossencoder-debertav3",
+    api_type: str = "cross_encoder",
     device: Optional[str] = None,
     use_8bit: bool = False,
 ) -> List[Dict[str, Any]]:
     """
-    Rerank results using cross-encoder model.
-    
+    Rerank results using a reranker model.
+
     Args:
         query: The search query
         results: List of result dicts from initial retrieval
@@ -277,23 +430,27 @@ def rerank_results(
               final_score = alpha * original_score + (1 - alpha) * reranker_score
         batch_size: Batch size for model inference
         use_sliding_window: Whether to use sliding window for long texts
-        model_path: Path to the cross-encoder model
+        model_path: Path to the reranker model
+        api_type: "cross_encoder" (SequenceClassification: DeBERTa-v3, mxbai)
+                  or "qwen3_lm" (Qwen3-Reranker yes/no causal-LM)
         device: Device to use for inference
-        use_8bit: Whether to use 8-bit quantization
-        
+        use_8bit: Whether to use 8-bit quantization (cross_encoder only)
+
     Returns:
         Reranked list of result dicts with updated scores
     """
     if not results:
         logger.warning("No results to rerank")
         return []
-    
+
     try:
-        # Initialize the reranker
-        reranker = CrossEncoderReranker(
-            model_name_or_path=model_path,
+        # Get cached reranker (loaded once per process; eviction is not needed
+        # at our scale and would defeat the latency win).
+        reranker = _get_or_create_reranker(
+            model_path=model_path,
+            api_type=api_type,
             device=device,
-            use_8bit=use_8bit
+            use_8bit=use_8bit,
         )
         
         # Extract passages from results

--- a/nexus/agents/memnon/utils/cross_encoder.py
+++ b/nexus/agents/memnon/utils/cross_encoder.py
@@ -279,16 +279,22 @@ class Qwen3LMReranker:
         self,
         model_name_or_path: str,
         device: Optional[str] = None,
-        max_length: int = 8192,
+        max_length: int = 2048,
     ):
+        # NOTE: max_length defaults to 2048 (vs the model card's 8192) and
+        # device defaults to CPU on Apple Silicon, both for MPS-stability
+        # reasons. On MPS, Qwen3 inference with batched long sequences hits
+        # "NDArray dimension length > INT_MAX" inside Metal regardless of
+        # attention implementation (eager or SDPA, fp16 or bf16, max_length
+        # 2048 or 8192 — all reproduce). CPU is slower but reliable.
         from transformers import AutoModelForCausalLM, AutoTokenizer
 
         if device is None:
             if torch.cuda.is_available():
                 device = "cuda"
-            elif hasattr(torch, "has_mps") and torch.backends.mps.is_built():
-                device = "mps"
             else:
+                # Apple Silicon path: prefer CPU over MPS for Qwen3 because of
+                # the Metal indexing bug noted above.
                 device = "cpu"
         self.device = device
         self.max_length = max_length
@@ -297,8 +303,9 @@ class Qwen3LMReranker:
         self.tokenizer = AutoTokenizer.from_pretrained(
             model_name_or_path, padding_side="left"
         )
-        # MPS doesn't support all kernels at fp16; use fp32 on CPU, fp16 elsewhere.
-        dtype = torch.float32 if device == "cpu" else torch.float16
+        # fp32 on CPU (no native bf16 acceleration on most CPUs); bf16 on CUDA
+        # to match Qwen3's native dtype.
+        dtype = torch.float32 if device == "cpu" else torch.bfloat16
         self.model = (
             AutoModelForCausalLM.from_pretrained(model_name_or_path, torch_dtype=dtype)
             .to(device)

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -345,10 +345,14 @@ class RerankerCandidate(BaseModel):
     `api_type` selects the inference path in ``cross_encoder.rerank_results``:
       - "cross_encoder": standard SequenceClassification (DeBERTa-v3, mxbai, BGE-v2, etc.)
       - "qwen3_lm": Qwen3-Reranker causal-LM with yes/no logit head
+
+    Note: the production reranker is selected by the top-level
+    ``CrossEncoderReranking.model_path`` + ``api_type`` fields, not by any
+    flag on this candidate entry. This registry is for ir_eval bakeoff
+    selection via ``ir_eval.runner create-run --reranker NAME``.
     """
     model_config = ConfigDict(extra='forbid', protected_namespaces=())
 
-    is_active: bool = False
     local_path: str
     remote_path: str = ""
     api_type: Literal["cross_encoder", "qwen3_lm"] = "cross_encoder"
@@ -361,6 +365,7 @@ class CrossEncoderReranking(BaseModel):
 
     enabled: bool
     model_path: str
+    api_type: Literal["cross_encoder", "qwen3_lm"] = "cross_encoder"
     blend_weight: float = Field(..., ge=0.0, le=1.0)
     top_k: int = Field(..., ge=1)
     batch_size: int = Field(..., ge=1)

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -339,6 +339,22 @@ class HybridSearchConfig(BaseModel):
     temporal_boost_factor: float = Field(..., ge=0.0)
 
 
+class RerankerCandidate(BaseModel):
+    """One reranker model entry in the bakeoff candidate registry.
+
+    `api_type` selects the inference path in ``cross_encoder.rerank_results``:
+      - "cross_encoder": standard SequenceClassification (DeBERTa-v3, mxbai, BGE-v2, etc.)
+      - "qwen3_lm": Qwen3-Reranker causal-LM with yes/no logit head
+    """
+    model_config = ConfigDict(extra='forbid', protected_namespaces=())
+
+    is_active: bool = False
+    local_path: str
+    remote_path: str = ""
+    api_type: Literal["cross_encoder", "qwen3_lm"] = "cross_encoder"
+    notes: str = ""
+
+
 class CrossEncoderReranking(BaseModel):
     """Cross-encoder reranking configuration."""
     model_config = ConfigDict(extra='forbid', protected_namespaces=())
@@ -354,6 +370,7 @@ class CrossEncoderReranking(BaseModel):
     weights_by_query_type: Dict[str, float]
     use_query_type_weights: bool
     use_8bit: bool
+    candidates: Dict[str, RerankerCandidate] = Field(default_factory=dict)
 
 
 class RetrievalConfig(BaseModel):

--- a/scripts/regenerate_embeddings.py
+++ b/scripts/regenerate_embeddings.py
@@ -197,13 +197,18 @@ class ModelLoader:
                         except Exception as e:
                             logger.warning(f"Failed to load from snapshot: {e}")
             
+            # INT8-quantized models use bitsandbytes, which has no working MPS
+            # backend on Apple Silicon — force CPU to avoid mixed-device matmul
+            # errors. Other models use SentenceTransformer's auto-detection.
+            device = "cpu" if "INT8" in model_name else None
+
             # For other models or fallback
             if model_local_path and os.path.exists(model_local_path):
-                logger.info(f"Loading model from local path: {model_local_path}")
-                return SentenceTransformer(model_local_path)
+                logger.info(f"Loading model from local path: {model_local_path} (device={device or 'auto'})")
+                return SentenceTransformer(model_local_path, device=device)
             else:
-                logger.info(f"Loading model from Hugging Face hub: {model_name}")
-                return SentenceTransformer(model_name)
+                logger.info(f"Loading model from Hugging Face hub: {model_name} (device={device or 'auto'})")
+                return SentenceTransformer(model_name, device=device)
                 
         except ImportError:
             logger.error("sentence-transformers not found. Install with: pip install sentence-transformers")

--- a/scripts/utils/embedding_utils.py
+++ b/scripts/utils/embedding_utils.py
@@ -31,8 +31,11 @@ MODEL_DIMENSIONS = {
     # High-dimensional models
     "infly/inf-retriever-v1": 3584,  # Original model - too high for efficient indexing
     "infly/inf-retriever-v1-1.5b": 1536,  # Lightweight version with 1536 dimensions
+    "Octen-Embedding-0.6B": 1024,
     "Octen-Embedding-4B": 2560,
+    "Octen-Embedding-4B-INT8": 2560,
     "Octen-Embedding-8B": 4096,
+    "Octen-Embedding-8B-INT8": 4096,
 }
 
 


### PR DESCRIPTION
## Summary
- Swap production retrieval embedder from the 3-model ensemble (bge-large + e5-large + inf-retriever-v1-1.5b) to **Octen-Embedding-4B** — winner of the #175 bakeoff on quality AND latency
- Add infrastructure to run reranker bakeoffs (candidate registry in `nexus.toml`, `--reranker NAME` flag, Qwen3-Reranker LM yes/no inference support)
- Ran the reranker bakeoff (Qwen3-0.6B, mxbai-rerank-large-v2, Qwen3-4B vs. DeBERTa-v3): Qwen3-4B wins quality (+0.022 P@5, +0.008 NDCG@10, both p<0.05) but loses ~7x latency on MPS due to a Metal indexing bug — **kept DeBERTa-v3 in production**; full evidence in [issue #175 comment](https://github.com/pythagorakase/nexus/issues/175#issuecomment-4428216002)

## Commits (oldest → newest)

1. `0eb3864` **Add Octen embedding plumbing and skip HNSW for high-dim tables** — Register the 5 Octen-Embedding variants; rewrite migration 014 to omit HNSW indexes on 2560d/4096d tables (exceed pgvector 0.8.0's caps); force CPU device when model name contains `INT8` (bitsandbytes has no MPS backend); add MODEL_DIMENSIONS entries.

2. `4bd12cc` **Add reranker candidate registry and Qwen3-Reranker support for bakeoff** — New `[memnon.retrieval.cross_encoder_reranking.candidates.*]` registry with 4 entries (DeBERTa-v3 default + Qwen3-0.6B + Qwen3-4B + mxbai-large); `EvalRunConfig.reranker_candidate` field; `--reranker NAME` flag; `Qwen3LMReranker` class implementing yes/no causal-LM scoring; module-level instance cache (load once per process, not per-query).

3. `d436cd9` **Swap retrieval embedder to Octen-Embedding-4B per issue #175** — Production active set becomes `{Octen-Embedding-4B}` (weight=1.0); prior 3-model ensemble all marked `is_active = false`.

4. `a7ff688` **Force CPU and reduce max_length for Qwen3-Reranker on Apple Silicon** — `Qwen3LMReranker` defaults to CPU on non-CUDA (MPS Metal bug `NDArray dimension length > INT_MAX` on real-length chunks regardless of attention impl / dtype / max_length); cap max_length at 2048; bf16 default on CUDA to match Qwen3 native checkpoint dtype.

## Evidence (in NEXUS DB)

| Run ID | Name | Reranker | Wall time | Status |
|---|---|---|---|---|
| 10 | octen-4b-solo | DeBERTa-v3 (production) | 21m | baseline |
| 15 | octen-4b-rerank-qwen3-0.6b | Qwen3-Reranker-0.6B (CPU) | 15m | tied with baseline |
| 16 | octen-4b-rerank-mxbai | mxbai-rerank-large-v2 | 7m | worse than baseline |
| 17 | octen-4b-rerank-qwen3-4b | Qwen3-Reranker-4B (CPU) | 75m | quality winner |

## Why the reranker stayed DeBERTa-v3

Qwen3-Reranker-4B improved P@5 by 2.2 percentage points and NDCG@10 by 0.8 points (both significant at p<0.05). But it must run on CPU because MPS hits a Metal indexing bug for batched long-sequence Qwen3 inference (reproduced across SDPA/eager attention, fp16/bf16, max_length 2048/8192). The wall-time penalty (~7x slower than DeBERTa-v3 on MPS) would erase the 31% latency win from the embedder swap. Infrastructure is in place to flip the reranker via one TOML edit when (a) PyTorch fixes the MPS bug or (b) we move to CUDA hosting.

## Test plan
- [x] Existing IR eval v2 unit tests pass (6/6)
- [x] Pydantic config loader parses the new reranker candidate registry
- [x] `python -m ir_eval.runner create-run --help` shows the `--reranker NAME` flag
- [x] `Qwen3LMReranker` smoke-tested against real Qwen3-Reranker-0.6B weights (sensible relevance scores: 0.999 for relevant passage, 0.000 for irrelevant)
- [x] Three full reranker bakeoff runs completed end-to-end through the IR eval framework (runs 15, 16, 17 in NEXUS)
- [x] Embedder swap config loads with exactly one active model (Octen-Embedding-4B, weight=1.0)
- [ ] Reviewer: spot-check a representative query in NEXUS CLI after merge to confirm retrieval still produces reasonable results with Octen-4B-only configuration

Resolves #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)