### PR TITLE
Fix async structured LOGON generation

### DIFF
--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -869,16 +869,22 @@ def validate_story_turn_response(data: Dict[str, Any]) -> StoryTurnResponse:
 
 def create_minimal_response(narrative_text: str) -> StorytellerResponseMinimal:
     """
-    Create a minimal response with just narrative text.
+    Create a minimal response from narrative text.
     Useful for fallback scenarios.
 
     Args:
         narrative_text: The narrative prose
 
     Returns:
-        StorytellerResponseMinimal with just narrative
+        StorytellerResponseMinimal with generic choices
     """
-    return StorytellerResponseMinimal(narrative=narrative_text)
+    return StorytellerResponseMinimal(
+        narrative=narrative_text,
+        choices=[
+            "Continue.",
+            "Wait and observe.",
+        ],
+    )
 
 
 def extract_narrative_text(response: StoryTurnResponse) -> str:

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -15,12 +15,11 @@ import psycopg2
 # Add scripts directory to path for API imports
 sys.path.append(str(Path(__file__).parent.parent.parent.parent))
 
-from scripts.api_openai import OpenAIProvider, LLMResponse
+from scripts.api_openai import OpenAIProvider
 from scripts.api_anthropic import AnthropicProvider
 from nexus.agents.logon.apex_schema import (
     StoryTurnResponse,
     StorytellerResponseExtended,
-    create_minimal_response,
 )
 from nexus.config.loader import get_provider_for_model
 
@@ -183,8 +182,10 @@ class LogonUtility:
         """Public wrapper for provider initialization."""
         self._ensure_provider()
     
-    def generate_narrative(self, context_payload: Dict) -> StoryTurnResponse:
-        """Generate narrative from context payload with structured output"""
+    def generate_narrative(
+        self, context_payload: Dict[str, Any]
+    ) -> StoryTurnResponse:
+        """Generate narrative from context payload with structured output."""
         self._ensure_provider()
         # Format the context into a prompt
         prompt = self._format_context_prompt(context_payload)
@@ -192,18 +193,41 @@ class LogonUtility:
         # Get structured completion from provider
         # This returns a tuple of (parsed_object, llm_response)
         try:
-            parsed_response, llm_response = self.provider.get_structured_completion(
+            parsed_response, _llm_response = self.provider.get_structured_completion(
                 prompt,
                 StorytellerResponseExtended,
             )
-            logger.debug(f"Received structured response with narrative length: {len(parsed_response.narrative)}")
+            logger.debug(
+                "Received structured response with narrative length: %s",
+                len(parsed_response.narrative),
+            )
             return parsed_response  # Return the StoryTurnResponse object
-        except Exception as e:
-            logger.error(f"Failed to get structured response: {e}")
-            # Fall back to plain text if structured output fails
-            response = self.provider.get_completion(prompt)
-            # Create a minimal StoryTurnResponse from plain text
-            return create_minimal_response(response.content)
+        except Exception:
+            logger.exception("Failed to get structured response")
+            raise
+
+    async def generate_narrative_async(
+        self, context_payload: Dict[str, Any]
+    ) -> StoryTurnResponse:
+        """Generate narrative from context payload without blocking the event loop."""
+        self._ensure_provider()
+        prompt = self._format_context_prompt(context_payload)
+
+        try:
+            parsed_response, _llm_response = (
+                await self.provider.get_structured_completion_async(
+                    prompt,
+                    StorytellerResponseExtended,
+                )
+            )
+            logger.debug(
+                "Received structured response with narrative length: %s",
+                len(parsed_response.narrative),
+            )
+            return parsed_response
+        except Exception:
+            logger.exception("Failed to get structured response")
+            raise
     
     def _format_context_prompt(self, context: Dict) -> str:
         """Format context payload into a prompt for the Apex AI"""

--- a/nexus/agents/lore/lore.py
+++ b/nexus/agents/lore/lore.py
@@ -350,9 +350,12 @@ class LORE:
             return response
             
         except Exception as e:
-            logger.error(f"Error in turn cycle phase {self.current_phase}: {e}")
-            self.turn_context.error_log.append(f"{self.current_phase}: {str(e)}")
+            failed_phase = self.current_phase
+            logger.error(f"Error in turn cycle phase {failed_phase}: {e}")
+            self.turn_context.error_log.append(f"{failed_phase}: {str(e)}")
             self.current_phase = TurnPhase.IDLE
+            if failed_phase == TurnPhase.APEX_GENERATION:
+                raise
             return f"Error processing turn: {str(e)}"
         
         finally:

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -579,7 +579,9 @@ class TurnCycleManager:
 
         try:
             # Generate narrative with structured output
-            story_response = self.lore.logon.generate_narrative(turn_context.context_payload)
+            story_response = await self.lore.logon.generate_narrative_async(
+                turn_context.context_payload
+            )
 
             # Store the full structured response
             turn_context.apex_response = story_response
@@ -607,7 +609,7 @@ class TurnCycleManager:
                 "success": False,
                 "error": str(e)
             }
-            return f"Error generating narrative: {str(e)}"
+            raise
     
     async def integrate_response(
         self,

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -604,7 +604,7 @@ class TurnCycleManager:
             return story_response  # Return the full StoryTurnResponse
             
         except Exception as e:
-            logger.error(f"Apex AI call failed: {e}")
+            logger.error("Apex AI call failed: %s", e)
             turn_context.phase_states["apex_generation"] = {
                 "success": False,
                 "error": str(e)

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -354,7 +354,7 @@ async def generate_bootstrap_narrative(
     settings = load_settings()
     dbname = require_slot_dbname(slot=slot)
     logon = LogonUtility(settings, dbname=dbname)
-    story_response = logon.generate_narrative(bootstrap_context)
+    story_response = await logon.generate_narrative_async(bootstrap_context)
 
     # Extract narrative text
     narrative_text = story_response.narrative if hasattr(story_response, 'narrative') else str(story_response)

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -357,7 +357,7 @@ async def generate_bootstrap_narrative(
     story_response = await logon.generate_narrative_async(bootstrap_context)
 
     # Extract narrative text
-    narrative_text = story_response.narrative if hasattr(story_response, 'narrative') else str(story_response)
+    narrative_text = story_response.narrative
 
     # Build incubator data
     incubator_data = {

--- a/scripts/api_anthropic.py
+++ b/scripts/api_anthropic.py
@@ -36,6 +36,7 @@ import os
 import sys
 import abc
 import argparse
+import asyncio
 import logging
 import re
 import json
@@ -421,7 +422,9 @@ class AnthropicProvider(LLMProvider):
             # Re-raise other exceptions
             raise
     
-    def get_structured_completion(self, prompt: str, schema_model: Type):
+    def get_structured_completion(
+        self, prompt: str, schema_model: Type
+    ) -> Tuple[Any, LLMResponse]:
         """
         Get a structured completion using a Pydantic model.
         
@@ -452,6 +455,36 @@ class AnthropicProvider(LLMProvider):
             print(f"Sentiment: {result.sentiment}, Score: {result.score}")
             ```
         """
+        self._raise_if_running_loop(
+            "get_structured_completion",
+            "get_structured_completion_async",
+        )
+        agent = self._build_structured_agent(schema_model)
+        result = agent.run_sync(prompt)
+        return self._structured_result_to_response(result)
+
+    async def get_structured_completion_async(
+        self, prompt: str, schema_model: Type
+    ) -> Tuple[Any, LLMResponse]:
+        """Get a structured completion without blocking an existing event loop."""
+        agent = self._build_structured_agent(schema_model)
+        result = await agent.run(prompt)
+        return self._structured_result_to_response(result)
+
+    def _raise_if_running_loop(self, method_name: str, async_method_name: str) -> None:
+        """Reject sync structured calls from async contexts with a clear error."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+
+        raise RuntimeError(
+            f"AnthropicProvider.{method_name}() cannot be called from a running "
+            f"event loop; use AnthropicProvider.{async_method_name}() instead."
+        )
+
+    def _build_structured_agent(self, schema_model: Type) -> Any:
+        """Build the Pydantic AI agent for structured output."""
         try:
             from pydantic_ai import Agent
             from pydantic_ai.models.anthropic import AnthropicModel
@@ -495,7 +528,10 @@ class AnthropicProvider(LLMProvider):
             retries=0,
         )
 
-        result = agent.run_sync(prompt)
+        return agent
+
+    def _structured_result_to_response(self, result: Any) -> Tuple[Any, LLMResponse]:
+        """Convert a Pydantic AI run result into the local response tuple."""
         parsed_output = result.output
 
         content = (

--- a/scripts/api_openai.py
+++ b/scripts/api_openai.py
@@ -35,6 +35,7 @@ import os
 import sys
 import abc
 import argparse
+import asyncio
 import logging
 import re
 import json
@@ -325,7 +326,9 @@ class OpenAIProvider(LLMProvider):
         """
         return self._get_completion_unified(prompt, cache_key=cache_key)
     
-    def get_structured_completion(self, prompt: str, schema_model: Type):
+    def get_structured_completion(
+        self, prompt: str, schema_model: Type
+    ) -> Tuple[Any, LLMResponse]:
         """
         Get a structured completion using the Responses API with a Pydantic model.
         
@@ -356,6 +359,36 @@ class OpenAIProvider(LLMProvider):
             print(f"Sentiment: {result.sentiment}, Score: {result.score}")
             ```
         """
+        self._raise_if_running_loop(
+            "get_structured_completion",
+            "get_structured_completion_async",
+        )
+        agent = self._build_structured_agent(schema_model)
+        result = agent.run_sync(prompt)
+        return self._structured_result_to_response(result)
+
+    async def get_structured_completion_async(
+        self, prompt: str, schema_model: Type
+    ) -> Tuple[Any, LLMResponse]:
+        """Get a structured completion without blocking an existing event loop."""
+        agent = self._build_structured_agent(schema_model)
+        result = await agent.run(prompt)
+        return self._structured_result_to_response(result)
+
+    def _raise_if_running_loop(self, method_name: str, async_method_name: str) -> None:
+        """Reject sync structured calls from async contexts with a clear error."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+
+        raise RuntimeError(
+            f"OpenAIProvider.{method_name}() cannot be called from a running "
+            f"event loop; use OpenAIProvider.{async_method_name}() instead."
+        )
+
+    def _build_structured_agent(self, schema_model: Type) -> Any:
+        """Build the Pydantic AI agent for structured output."""
         try:
             from pydantic_ai import Agent
             from pydantic_ai.models.openai import OpenAIResponsesModel
@@ -401,7 +434,10 @@ class OpenAIProvider(LLMProvider):
             retries=0,
         )
 
-        result = agent.run_sync(prompt)
+        return agent
+
+    def _structured_result_to_response(self, result: Any) -> Tuple[Any, LLMResponse]:
+        """Convert a Pydantic AI run result into the local response tuple."""
         parsed_output = result.output
 
         content = (

--- a/tests/test_lore/test_apex_schema.py
+++ b/tests/test_lore/test_apex_schema.py
@@ -1,0 +1,15 @@
+"""Tests for Apex response schema helpers."""
+
+from nexus.agents.logon.apex_schema import create_minimal_response
+
+
+def test_create_minimal_response_includes_valid_choices() -> None:
+    """Minimal fallback responses should satisfy the response schema."""
+
+    response = create_minimal_response("A short narrative beat.")
+
+    assert response.narrative == "A short narrative beat."
+    assert response.choices == [
+        "Continue.",
+        "Wait and observe.",
+    ]

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 
 import pytest
 
+from nexus.agents.logon.apex_schema import StorytellerResponseMinimal
 from nexus.agents.lore.lore import LORE
 from nexus.agents.lore.logon_utility import LogonUtility
 
@@ -20,11 +21,53 @@ class _DummyResponse:
 
 
 class _DummyProvider:
+    model = "dummy-model"
+
     def __init__(self) -> None:
         self.calls = 0
+        self.completion_calls = 0
 
     def get_completion(self, prompt: str) -> _DummyResponse:
+        self.completion_calls += 1
+        return _DummyResponse(prompt)
+
+    def get_structured_completion(
+        self, prompt: str, schema_model: type
+    ) -> tuple[StorytellerResponseMinimal, _DummyResponse]:
         self.calls += 1
+        return self._response(prompt), _DummyResponse(prompt)
+
+    async def get_structured_completion_async(
+        self, prompt: str, schema_model: type
+    ) -> tuple[StorytellerResponseMinimal, _DummyResponse]:
+        self.calls += 1
+        return self._response(prompt), _DummyResponse(prompt)
+
+    def _response(self, prompt: str) -> StorytellerResponseMinimal:
+        return StorytellerResponseMinimal(
+            narrative=f"dummy:{prompt[:20]}",
+            choices=[
+                "Continue.",
+                "Wait and observe.",
+            ],
+        )
+
+
+class _FailingProvider:
+    model = "dummy-model"
+
+    def __init__(self) -> None:
+        self.structured_calls = 0
+        self.completion_calls = 0
+
+    async def get_structured_completion_async(
+        self, prompt: str, schema_model: type
+    ) -> tuple[StorytellerResponseMinimal, _DummyResponse]:
+        self.structured_calls += 1
+        raise RuntimeError("structured boom")
+
+    def get_completion(self, prompt: str) -> _DummyResponse:
+        self.completion_calls += 1
         return _DummyResponse(prompt)
 
 
@@ -98,4 +141,41 @@ def test_logon_initializes_on_first_use(patched_provider: Dict[str, int]) -> Non
     assert patched_provider["count"] == 1
     assert isinstance(lore.logon.provider, _DummyProvider)
     assert lore.logon.provider.calls == 1
-    assert response.content.startswith("dummy:")
+    assert response.narrative.startswith("dummy:")
+
+
+@pytest.mark.requires_local_llm
+@pytest.mark.requires_postgres
+@pytest.mark.asyncio
+async def test_logon_async_generation_uses_structured_provider(
+    patched_provider: Dict[str, int],
+) -> None:
+    """Async LOGON generation should use structured provider output directly."""
+
+    lore = LORE(debug=True, enable_logon=True)
+    lore.ensure_logon()
+    assert lore.logon is not None
+
+    response = await lore.logon.generate_narrative_async(_minimal_payload())
+
+    assert patched_provider["count"] == 1
+    assert isinstance(lore.logon.provider, _DummyProvider)
+    assert lore.logon.provider.calls == 1
+    assert lore.logon.provider.completion_calls == 0
+    assert response.narrative.startswith("dummy:")
+    assert len(response.choices) == 2
+
+
+@pytest.mark.asyncio
+async def test_logon_structured_failure_does_not_call_plain_text_fallback() -> None:
+    """Structured LOGON failures should fail fast without a second LLM call."""
+
+    provider = _FailingProvider()
+    logon = LogonUtility({}, model_override="dummy-model")
+    logon.provider = provider
+
+    with pytest.raises(RuntimeError, match="structured boom"):
+        await logon.generate_narrative_async(_minimal_payload())
+
+    assert provider.structured_calls == 1
+    assert provider.completion_calls == 0

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -144,24 +144,18 @@ def test_logon_initializes_on_first_use(patched_provider: Dict[str, int]) -> Non
     assert response.narrative.startswith("dummy:")
 
 
-@pytest.mark.requires_local_llm
-@pytest.mark.requires_postgres
 @pytest.mark.asyncio
-async def test_logon_async_generation_uses_structured_provider(
-    patched_provider: Dict[str, int],
-) -> None:
+async def test_logon_async_generation_uses_structured_provider() -> None:
     """Async LOGON generation should use structured provider output directly."""
 
-    lore = LORE(debug=True, enable_logon=True)
-    lore.ensure_logon()
-    assert lore.logon is not None
+    provider = _DummyProvider()
+    logon = LogonUtility({}, model_override="dummy-model")
+    logon.provider = provider
 
-    response = await lore.logon.generate_narrative_async(_minimal_payload())
+    response = await logon.generate_narrative_async(_minimal_payload())
 
-    assert patched_provider["count"] == 1
-    assert isinstance(lore.logon.provider, _DummyProvider)
-    assert lore.logon.provider.calls == 1
-    assert lore.logon.provider.completion_calls == 0
+    assert provider.calls == 1
+    assert provider.completion_calls == 0
     assert response.narrative.startswith("dummy:")
     assert len(response.choices) == 2
 

--- a/tests/test_lore/test_structured_provider_guards.py
+++ b/tests/test_lore/test_structured_provider_guards.py
@@ -1,0 +1,26 @@
+"""Tests for sync structured provider guardrails."""
+
+import pytest
+
+from scripts.api_anthropic import AnthropicProvider
+from scripts.api_openai import OpenAIProvider
+
+
+@pytest.mark.asyncio
+async def test_openai_sync_structured_completion_rejects_running_loop() -> None:
+    """The sync OpenAI structured API should point async callers to its async twin."""
+
+    provider = OpenAIProvider.__new__(OpenAIProvider)
+
+    with pytest.raises(RuntimeError, match="get_structured_completion_async"):
+        provider.get_structured_completion("prompt", object)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_sync_structured_completion_rejects_running_loop() -> None:
+    """The sync Anthropic structured API should point async callers to its async twin."""
+
+    provider = AnthropicProvider.__new__(AnthropicProvider)
+
+    with pytest.raises(RuntimeError, match="get_structured_completion_async"):
+        provider.get_structured_completion("prompt", object)


### PR DESCRIPTION
## Summary

Fixes #187 by moving LOGON structured narrative generation onto native async Pydantic AI calls instead of invoking `Agent.run_sync()` inside FastAPI's running event loop.

## What changed

- Added async structured completion APIs for both OpenAI and Anthropic providers using `await agent.run(...)`.
- Kept the existing sync structured APIs for script callers, but added running-loop guards that point callers to the async method.
- Added `LogonUtility.generate_narrative_async(...)` and routed bootstrap plus normal LORE Apex generation through it.
- Removed LOGON's structured-to-plain-text fallback so structured failures fail fast instead of doing a second doomed LLM call.
- Made `create_minimal_response(...)` schema-valid by adding two generic choices for non-LOGON coercion paths.

## Root cause

`LogonUtility.generate_narrative()` was called from async FastAPI/LORE paths but delegated to provider `get_structured_completion()`, which used `pydantic_ai.Agent.run_sync()`. That attempts to manage an event loop internally and fails when FastAPI already has one running. The old fallback then called plain-text completion and attempted to construct `StorytellerResponseMinimal` without required `choices`, surfacing a misleading Pydantic validation error.

## Validation

- `poetry run pytest tests/test_lore/test_logon_lazy_init.py tests/test_lore/test_apex_schema.py tests/test_lore/test_structured_provider_guards.py` -> 4 passed, 3 skipped
- `poetry run pytest tests/test_logon_mock_integration.py` -> 2 skipped
- `poetry run pytest tests/test_lore` -> 78 passed, 21 skipped

Manual slot-5 bootstrap acceptance was not run because it begins with `nexus clear --slot 5`, which would wipe live save-slot state.