### PR TITLE
Refresh stale 1Password refs in docs after Keychain migration

### DIFF
--- a/.claude/agents/scribe.md
+++ b/.claude/agents/scribe.md
@@ -59,7 +59,7 @@ You are Scribe, a meticulous documentation auditor powered by Claude Haiku 4.5. 
 3. **Project-Specific Requirements**: Adhere to the established patterns in this codebase:
    - Follow the code style guidelines in CLAUDE.md (Black formatting, type annotations, etc.)
    - Document database schemas and connection patterns as specified
-   - Include security notes for API key management and 1Password integration
+   - Include security notes for API key management: runtime reads via `nexus.util.secret_manager.get_secret(<provider>)` from macOS Keychain (service `nexus-api`); 1Password is the canonical store, synced into Keychain by `scripts/sync_secrets.py`
    - Reference the Poetry-based build and test commands
    - Document any settings that should be configurable in settings.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ For detailed, task-specific workflows and guides, see the Claude Code skills in 
 - **test-lore-agent**: Run LORE agent tests with context saving, divergence detection testing, and jq query helpers
 - **audit-settings**: Validate `settings.json` for configuration errors, constraint violations, and cross-agent consistency
 - **inspect-chunk-context**: Query NEXUS database for chunk details, metadata, entity references, and temporal relationships
-- **update-1password-keys**: Manage API key retrieval from 1Password, verify CLI configuration, and rotate credentials
+- **manage-api-keys**: Manage NEXUS API keys via macOS Keychain (runtime) and 1Password (canonical source), bootstrap fresh checkouts, rotate keys, and troubleshoot silent retrieval
 - **openai-structured-output**: Implement OpenAI structured outputs with Pydantic models or JSON schemas
 - **analyze-divergence**: Debug divergence detection behavior, understand the LLM-based architecture, and tune thresholds
 


### PR DESCRIPTION
## Summary

- `CLAUDE.md`: rename `update-1password-keys` skill bullet to `manage-api-keys` (matches the actual directory)
- `.claude/agents/scribe.md`: replace "1Password integration" framing in security-notes guidance with the current runtime story (Keychain via `get_secret`, 1Password as canonical source synced by `sync_secrets.py`)

Both refs predate the Keychain runtime path landed in PRs #185/#186.

## Test plan

- [x] Final grep across `CLAUDE.md`, `AGENTS.md`, `README.md`, `.claude/` confirmed zero remaining references to `update-1password-keys` or "1Password-based key" / "1Password integration"
- [x] Diff is two single-line replacements, no incidental drift