### PR TITLE
[codex] Fix bootstrap LOGON response schema

### DIFF
--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -841,10 +841,10 @@ def validate_entity_references(entities: ReferencedEntities) -> List[str]:
 # Union type for backward compatibility with old logon_schemas
 # Accepts any of the three response types
 StoryTurnResponse = Union[
-    StorytellerResponseBootstrap,
-    StorytellerResponseMinimal,
+    StorytellerResponseExtended,
     StorytellerResponseStandard,
-    StorytellerResponseExtended
+    StorytellerResponseMinimal,
+    StorytellerResponseBootstrap
 ]
 
 

--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -709,6 +709,20 @@ class Operations(BaseModel):
 # Main Response Schema with Hierarchical Options
 # ============================================================================
 
+class StorytellerResponseBootstrap(BaseModel):
+    """Bootstrap response for first-chunk narrative generation."""
+    narrative: str = Field(
+        description="The opening narrative prose"
+    )
+    choices: List[str] = Field(
+        min_length=2,
+        max_length=4,
+        description="Player choices (2-4 options). Each should be a complete, actionable option written from player perspective."
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class StorytellerResponseMinimal(BaseModel):
     """Minimal response for quick narrative generation."""
     narrative: str = Field(
@@ -827,6 +841,7 @@ def validate_entity_references(entities: ReferencedEntities) -> List[str]:
 # Union type for backward compatibility with old logon_schemas
 # Accepts any of the three response types
 StoryTurnResponse = Union[
+    StorytellerResponseBootstrap,
     StorytellerResponseMinimal,
     StorytellerResponseStandard,
     StorytellerResponseExtended
@@ -840,13 +855,14 @@ StoryTurnResponse = Union[
 def validate_story_turn_response(data: Dict[str, Any]) -> StoryTurnResponse:
     """
     Validate and parse a story turn response from raw data.
-    Attempts to parse as Extended first, falls back to Standard, then Minimal.
+    Attempts to parse as Extended first, falls back to Standard, then Minimal,
+    then Bootstrap.
 
     Args:
         data: Raw dictionary from API response
 
     Returns:
-        Validated StoryTurnResponse (one of Minimal/Standard/Extended)
+        Validated StoryTurnResponse (one of Bootstrap/Minimal/Standard/Extended)
 
     Raises:
         ValidationError: If data doesn't match any schema
@@ -863,8 +879,14 @@ def validate_story_turn_response(data: Dict[str, Any]) -> StoryTurnResponse:
     except Exception:
         pass
 
-    # Fall back to Minimal
-    return StorytellerResponseMinimal(**data)
+    # Try Minimal
+    try:
+        return StorytellerResponseMinimal(**data)
+    except Exception:
+        pass
+
+    # Fall back to Bootstrap
+    return StorytellerResponseBootstrap(**data)
 
 
 def create_minimal_response(narrative_text: str) -> StorytellerResponseMinimal:

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -19,6 +19,7 @@ from scripts.api_openai import OpenAIProvider
 from scripts.api_anthropic import AnthropicProvider
 from nexus.agents.logon.apex_schema import (
     StoryTurnResponse,
+    StorytellerResponseBootstrap,
     StorytellerResponseExtended,
 )
 from nexus.config.loader import get_provider_for_model
@@ -189,13 +190,14 @@ class LogonUtility:
         self._ensure_provider()
         # Format the context into a prompt
         prompt = self._format_context_prompt(context_payload)
+        schema_model = self._select_response_schema(context_payload)
 
         # Get structured completion from provider
         # This returns a tuple of (parsed_object, llm_response)
         try:
             parsed_response, _llm_response = self.provider.get_structured_completion(
                 prompt,
-                StorytellerResponseExtended,
+                schema_model,
             )
             logger.debug(
                 "Received structured response with narrative length: %s",
@@ -212,12 +214,13 @@ class LogonUtility:
         """Generate narrative from context payload without blocking the event loop."""
         self._ensure_provider()
         prompt = self._format_context_prompt(context_payload)
+        schema_model = self._select_response_schema(context_payload)
 
         try:
             parsed_response, _llm_response = (
                 await self.provider.get_structured_completion_async(
                     prompt,
-                    StorytellerResponseExtended,
+                    schema_model,
                 )
             )
             logger.debug(
@@ -228,6 +231,20 @@ class LogonUtility:
         except Exception:
             logger.exception("Failed to get structured response")
             raise
+
+    def _select_response_schema(
+        self, context_payload: Dict[str, Any]
+    ) -> type[StorytellerResponseBootstrap] | type[StorytellerResponseExtended]:
+        """Select the structured output schema for the current narrative context."""
+        metadata = context_payload.get("metadata", {})
+        metadata_bootstrap = (
+            metadata.get("is_bootstrap", False) if isinstance(metadata, dict) else False
+        )
+
+        if context_payload.get("is_bootstrap", False) or metadata_bootstrap:
+            return StorytellerResponseBootstrap
+
+        return StorytellerResponseExtended
     
     def _format_context_prompt(self, context: Dict) -> str:
         """Format context payload into a prompt for the Apex AI"""

--- a/nexus/api/storyteller.py
+++ b/nexus/api/storyteller.py
@@ -23,6 +23,7 @@ from nexus.api.session_manager import SessionManager, SessionNotFoundError, Sess
 from nexus.agents.lore.lore import LORE
 from nexus.agents.logon.apex_schema import (
     StoryTurnResponse,
+    StorytellerResponseBootstrap,
     StorytellerResponseMinimal,
     StorytellerResponseStandard,
     StorytellerResponseExtended,
@@ -44,6 +45,13 @@ from nexus.api.chunk_workflow import (
     ChunkRejectResponse,
     EditPreviousRequest,
     EditPreviousResponse,
+)
+
+_STORY_RESPONSE_TYPES = (
+    StorytellerResponseBootstrap,
+    StorytellerResponseMinimal,
+    StorytellerResponseStandard,
+    StorytellerResponseExtended,
 )
 from nexus.api.retry_handler import (
     retry_with_backoff,
@@ -223,7 +231,7 @@ def _format_error(error: str, detail: str, session_id: Optional[str]) -> Dict[st
 def _coerce_story_response(payload: Any) -> StoryTurnResponse:
     """Coerce arbitrary payloads into a StoryTurnResponse."""
 
-    if isinstance(payload, (StorytellerResponseMinimal, StorytellerResponseStandard, StorytellerResponseExtended)):
+    if isinstance(payload, _STORY_RESPONSE_TYPES):
         return payload
     if isinstance(payload, dict):
         try:
@@ -494,7 +502,7 @@ async def story_turn(
     if isinstance(result, str):
         # Error or fallback case - create minimal response
         story_response = create_minimal_response(result)
-    elif isinstance(result, (StorytellerResponseMinimal, StorytellerResponseStandard, StorytellerResponseExtended)):
+    elif isinstance(result, _STORY_RESPONSE_TYPES):
         # Full structured response from Storyteller
         story_response = result
     else:
@@ -599,7 +607,7 @@ async def regenerate_turn(
     if isinstance(result, str):
         # Error or fallback case - create minimal response
         story_response = create_minimal_response(result)
-    elif isinstance(result, (StorytellerResponseMinimal, StorytellerResponseStandard, StorytellerResponseExtended)):
+    elif isinstance(result, _STORY_RESPONSE_TYPES):
         # Full structured response from Storyteller
         story_response = result
     else:

--- a/nexus/api/storyteller.py
+++ b/nexus/api/storyteller.py
@@ -46,13 +46,6 @@ from nexus.api.chunk_workflow import (
     EditPreviousRequest,
     EditPreviousResponse,
 )
-
-_STORY_RESPONSE_TYPES = (
-    StorytellerResponseBootstrap,
-    StorytellerResponseMinimal,
-    StorytellerResponseStandard,
-    StorytellerResponseExtended,
-)
 from nexus.api.retry_handler import (
     retry_with_backoff,
     async_retry_with_backoff,
@@ -64,6 +57,13 @@ from nexus.api.retry_handler import (
 from nexus.api.config_utils import get_new_story_model
 
 logger = logging.getLogger("nexus.api.storyteller")
+
+_STORY_RESPONSE_TYPES = (
+    StorytellerResponseExtended,
+    StorytellerResponseStandard,
+    StorytellerResponseMinimal,
+    StorytellerResponseBootstrap,
+)
 
 ORIGINS = [
     "http://localhost:3000",

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -26,6 +26,13 @@ logger = logging.getLogger("nexus.cli")
 
 # Default API server URL (narrative API handles wizard + story endpoints)
 DEFAULT_API_URL = "http://localhost:8002"
+TERMINAL_GENERATION_STATUSES = {
+    "complete",
+    "completed",
+    "provisional",
+    "approved",
+    "committed",
+}
 
 
 def get_api_url() -> str:
@@ -33,6 +40,11 @@ def get_api_url() -> str:
     import os
 
     return os.environ.get("NEXUS_API_URL", DEFAULT_API_URL)
+
+
+def _is_terminal_generation_status(status: Optional[str]) -> bool:
+    """Return whether narrative generation has produced a loadable result."""
+    return status in TERMINAL_GENERATION_STATUSES
 
 
 def _get_next_phase(current_phase: str) -> Optional[str]:
@@ -554,7 +566,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                     )
                     if status_response.ok:
                         status = status_response.json()
-                        if status.get("status") == "completed":
+                        if _is_terminal_generation_status(status.get("status")):
                             # Fetch incubator for result
                             load_result = run_load(args)
                             return {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,15 @@
+"""Tests for the NEXUS CLI helpers."""
+
+from nexus.cli import _is_terminal_generation_status
+
+
+def test_terminal_generation_statuses_include_api_and_incubator_values() -> None:
+    """CLI polling should accept both progress and incubator completion states."""
+
+    assert _is_terminal_generation_status("complete")
+    assert _is_terminal_generation_status("completed")
+    assert _is_terminal_generation_status("provisional")
+    assert _is_terminal_generation_status("approved")
+    assert _is_terminal_generation_status("committed")
+    assert not _is_terminal_generation_status("processing")
+    assert not _is_terminal_generation_status("error")

--- a/tests/test_lore/test_apex_schema.py
+++ b/tests/test_lore/test_apex_schema.py
@@ -1,6 +1,31 @@
 """Tests for Apex response schema helpers."""
 
-from nexus.agents.logon.apex_schema import create_minimal_response
+import pytest
+from pydantic import ValidationError
+
+from nexus.agents.logon.apex_schema import (
+    StorytellerResponseBootstrap,
+    create_minimal_response,
+)
+
+
+def test_bootstrap_response_schema_only_accepts_narrative_and_choices() -> None:
+    """Bootstrap responses should not request entity metadata."""
+
+    response = StorytellerResponseBootstrap(
+        narrative="The story begins.",
+        choices=["Step forward.", "Look around."],
+    )
+
+    assert response.narrative == "The story begins."
+    assert response.choices == ["Step forward.", "Look around."]
+
+    with pytest.raises(ValidationError):
+        StorytellerResponseBootstrap(
+            narrative="The story begins.",
+            choices=["Step forward.", "Look around."],
+            referenced_entities={"characters": []},
+        )
 
 
 def test_create_minimal_response_includes_valid_choices() -> None:

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -6,7 +6,11 @@ from typing import Any, Dict
 
 import pytest
 
-from nexus.agents.logon.apex_schema import StorytellerResponseMinimal
+from nexus.agents.logon.apex_schema import (
+    StorytellerResponseBootstrap,
+    StorytellerResponseExtended,
+    StorytellerResponseMinimal,
+)
 from nexus.agents.lore.lore import LORE
 from nexus.agents.lore.logon_utility import LogonUtility
 
@@ -26,6 +30,7 @@ class _DummyProvider:
     def __init__(self) -> None:
         self.calls = 0
         self.completion_calls = 0
+        self.schema_models = []
 
     def get_completion(self, prompt: str) -> _DummyResponse:
         self.completion_calls += 1
@@ -35,12 +40,14 @@ class _DummyProvider:
         self, prompt: str, schema_model: type
     ) -> tuple[StorytellerResponseMinimal, _DummyResponse]:
         self.calls += 1
+        self.schema_models.append(schema_model)
         return self._response(prompt), _DummyResponse(prompt)
 
     async def get_structured_completion_async(
         self, prompt: str, schema_model: type
     ) -> tuple[StorytellerResponseMinimal, _DummyResponse]:
         self.calls += 1
+        self.schema_models.append(schema_model)
         return self._response(prompt), _DummyResponse(prompt)
 
     def _response(self, prompt: str) -> StorytellerResponseMinimal:
@@ -108,13 +115,17 @@ def patched_provider(monkeypatch: pytest.MonkeyPatch) -> Dict[str, int]:
     return init_calls
 
 
-def _minimal_payload() -> Dict[str, Any]:
-    return {
+def _minimal_payload(*, is_bootstrap: bool = False) -> Dict[str, Any]:
+    payload = {
         "user_input": "Test",
         "warm_slice": {"chunks": []},
         "entity_data": {},
         "retrieved_passages": {"results": []},
     }
+    if is_bootstrap:
+        payload["is_bootstrap"] = True
+        payload["metadata"] = {"is_bootstrap": True}
+    return payload
 
 
 @pytest.mark.requires_local_llm
@@ -141,6 +152,7 @@ def test_logon_initializes_on_first_use(patched_provider: Dict[str, int]) -> Non
     assert patched_provider["count"] == 1
     assert isinstance(lore.logon.provider, _DummyProvider)
     assert lore.logon.provider.calls == 1
+    assert lore.logon.provider.schema_models == [StorytellerResponseExtended]
     assert response.narrative.startswith("dummy:")
 
 
@@ -156,8 +168,25 @@ async def test_logon_async_generation_uses_structured_provider() -> None:
 
     assert provider.calls == 1
     assert provider.completion_calls == 0
+    assert provider.schema_models == [StorytellerResponseExtended]
     assert response.narrative.startswith("dummy:")
     assert len(response.choices) == 2
+
+
+@pytest.mark.asyncio
+async def test_logon_async_generation_uses_bootstrap_schema_for_bootstrap() -> None:
+    """Bootstrap LOGON generation should only request narrative and choices."""
+
+    provider = _DummyProvider()
+    logon = LogonUtility({}, model_override="dummy-model")
+    logon.provider = provider
+
+    response = await logon.generate_narrative_async(_minimal_payload(is_bootstrap=True))
+
+    assert provider.calls == 1
+    assert provider.completion_calls == 0
+    assert provider.schema_models == [StorytellerResponseBootstrap]
+    assert response.narrative.startswith("dummy:")
 
 
 @pytest.mark.asyncio

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -185,6 +185,7 @@ async def test_logon_async_generation_uses_bootstrap_schema_for_bootstrap() -> N
 
     assert provider.calls == 1
     assert provider.completion_calls == 0
+    # _DummyProvider always returns Minimal; this test verifies schema selection.
     assert provider.schema_models == [StorytellerResponseBootstrap]
     assert response.narrative.startswith("dummy:")
 


### PR DESCRIPTION
## Summary

Fixes #189 by routing bootstrap LOGON generation through a bootstrap-specific structured output schema that asks only for the fields the bootstrap path actually consumes: `narrative` and `choices`.

## Root Cause

After #187 moved LOGON to native async structured output, bootstrap generation still requested the normal full-turn schema. `StorytellerResponseExtended` required `state_updates`, and even `StorytellerResponseStandard` still requires dense `referenced_entities` objects for newly mentioned entities. The first chunk already derives metadata and initial references from setup data, so requiring full entity/reference payloads during cold start made validation fail before a narrative could be produced.

## Changes

- Added `StorytellerResponseBootstrap` for first-chunk generation.
- Updated `LogonUtility` to select the bootstrap schema when `is_bootstrap` is present, while keeping normal turns on `StorytellerResponseExtended`.
- Taught storyteller response coercion about the bootstrap response model.
- Fixed CLI polling so successful status values like `complete` and incubator states do not appear as false `Generation timed out` failures.
- Added tests for bootstrap schema selection, bootstrap schema shape, and terminal CLI statuses.

## Validation

- `poetry run pytest tests/test_cli.py tests/test_lore/test_logon_lazy_init.py tests/test_lore/test_apex_schema.py tests/test_logon_mock_integration.py`
- `poetry run pytest tests/test_lore`
- Live slot-5 bootstrap with `gpt-5.5`: server logged `StorytellerResponseBootstrap`, OpenAI returned 200, status became `complete`, and `poetry run nexus --json load --slot 5` showed chunk 1 with narrative plus four choices.