### PR TITLE
Fix narrative chunk continuation

### DIFF
--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -304,12 +304,14 @@ class NewPlace(BaseModel):
         if not isinstance(raw_type, str):
             return data
 
-        normalized_type = raw_type.strip().lower().replace("-", "_").replace(" ", "_")
-        if normalized_type in PlaceType._value2member_map_:
-            data["type"] = normalized_type
-            return data
-
         data = dict(data)
+        normalized_type = raw_type.strip().lower().replace("-", "_").replace(" ", "_")
+        try:
+            data["type"] = PlaceType(normalized_type).value
+            return data
+        except ValueError:
+            pass
+
         vehicle_terms = {"vehicle", "train", "car", "bus", "tram", "ship", "boat"}
         virtual_terms = {"virtual", "digital", "online", "network", "simulation"}
         if normalized_type in vehicle_terms:
@@ -681,6 +683,10 @@ class FactionStateUpdate(BaseModel):
     faction_name: Optional[str] = Field(
         default=None,
         description="Faction name (if ID unknown)"
+    )
+    current_activity: Optional[str] = Field(
+        default=None,
+        description="Current faction activity or operational focus"
     )
     recent_actions: Optional[List[str]] = Field(
         default_factory=list,

--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -114,13 +114,17 @@ class CharacterTraits(BaseModel):
         default=None, description="Debts, oaths, or duties you must honor"
     )
 
-    # Required wildcard - unique trait that sets this character apart
-    wildcard_name: str = Field(description="Name of the unique custom trait")
-    wildcard_description: str = Field(
+    # Optional wildcard - unique trait that sets this character apart
+    wildcard_name: Optional[str] = Field(
+        default=None,
+        description="Name of the unique custom trait"
+    )
+    wildcard_description: Optional[str] = Field(
+        default=None,
         description="What this trait means - capability, possession, relationship, or curse"
     )
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="allow")
 
 
 class PlaceDetails(BaseModel):
@@ -175,7 +179,7 @@ class PlaceDetails(BaseModel):
         default_factory=list, description="Current rumors or gossip (max 3)"
     )
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="allow")
 
 
 class FactionDetails(BaseModel):
@@ -201,7 +205,7 @@ class FactionDetails(BaseModel):
         default=None, description="Key traditions or rituals"
     )
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="allow")
 
 
 # ============================================================================
@@ -211,32 +215,39 @@ class FactionDetails(BaseModel):
 class NewCharacter(BaseModel):
     """
     Schema for introducing a new character - aligned with DB schema.
-    All fields required except where DB dictates otherwise.
     """
     name: str = Field(description="Character's name")
-    appearance: str = Field(
+    appearance: Optional[str] = Field(
+        default=None,
         description="Physical description - how the character looks"
     )
-    background: str = Field(
+    background: Optional[str] = Field(
+        default=None,
         description="Character backstory and history"
     )
-    personality: str = Field(
+    personality: Optional[str] = Field(
+        default=None,
         description="Personality traits and quirks (prose format, e.g., 'Methodical problem-solver. Paranoid about digital traces.')"
     )
-    emotional_state: str = Field(
+    emotional_state: Optional[str] = Field(
+        default=None,
         description="Current emotional state"
     )
-    current_activity: str = Field(
+    current_activity: Optional[str] = Field(
+        default=None,
         description="What the character is currently doing"
     )
-    current_location: int = Field(
+    current_location: Optional[int] = Field(
+        default=None,
         description="Place ID where character is located (FK to places.id)"
     )
-    summary: str = Field(
+    summary: Optional[str] = Field(
+        default=None,
         max_length=500,
         description="Brief character description (max 500 chars)"
     )
-    extra_data: CharacterTraits = Field(
+    extra_data: Optional[CharacterTraits] = Field(
+        default=None,
         description="Character traits (3 of 10 optional traits + required wildcard)"
     )
 
@@ -248,56 +259,106 @@ class NewPlace(BaseModel):
     """
     name: str = Field(description="Place name")
     type: PlaceType = Field(
+        default=PlaceType.FIXED_LOCATION,
         description="Type of place (fixed_location, vehicle, virtual, other)"
     )
-    summary: str = Field(
+    summary: Optional[str] = Field(
+        default=None,
         max_length=500,
         description="Brief place description (max 500 chars)"
     )
-    history: str = Field(
+    history: Optional[str] = Field(
+        default=None,
         description="Place history and past events"
     )
-    current_status: str = Field(
+    current_status: Optional[str] = Field(
+        default=None,
         description="Current state, conditions, and activity at this location"
     )
-    secrets: str = Field(
-        description="Hidden information, plot hooks, and narrative opportunities (REQUIRED - invaluable for storytelling)"
+    secrets: Optional[str] = Field(
+        default=None,
+        description="Hidden information, plot hooks, and narrative opportunities"
     )
-    coordinates: Coordinates = Field(
+    coordinates: Optional[Coordinates] = Field(
+        default=None,
         description="Geographic coordinates (lat/lon on Earth-shaped planet). Zone calculated from this."
     )
     inhabitants: Optional[List[int]] = Field(
         default_factory=list,
         description="Character IDs of inhabitants (usually empty for newly introduced places)"
     )
-    extra_data: PlaceDetails = Field(
+    extra_data: Optional[PlaceDetails] = Field(
+        default=None,
         description="Additional place attributes (atmosphere, features, dangers, etc.)"
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_place_type(cls, data: Any) -> Any:
+        """Coerce descriptive place categories into the database enum."""
+
+        if not isinstance(data, dict):
+            return data
+
+        raw_type = data.get("type")
+        if not isinstance(raw_type, str):
+            return data
+
+        normalized_type = raw_type.strip().lower().replace("-", "_").replace(" ", "_")
+        if normalized_type in PlaceType._value2member_map_:
+            data["type"] = normalized_type
+            return data
+
+        data = dict(data)
+        vehicle_terms = {"vehicle", "train", "car", "bus", "tram", "ship", "boat"}
+        virtual_terms = {"virtual", "digital", "online", "network", "simulation"}
+        if normalized_type in vehicle_terms:
+            data["type"] = PlaceType.VEHICLE.value
+        elif normalized_type in virtual_terms:
+            data["type"] = PlaceType.VIRTUAL.value
+        else:
+            data["type"] = PlaceType.FIXED_LOCATION.value
+
+        extra_data = data.get("extra_data")
+        if isinstance(extra_data, dict):
+            extra_data = dict(extra_data)
+            extra_data.setdefault("category", raw_type)
+            data["extra_data"] = extra_data
+        elif extra_data is None:
+            data["extra_data"] = {"category": raw_type}
+
+        return data
 
 
 class NewFaction(BaseModel):
     """
     Schema for introducing a new faction - aligned with DB schema.
-    All fields required. Leader info goes in extra_data or character relationships.
+    Leader info goes in extra_data or character relationships.
     """
     name: str = Field(description="Faction name")
-    summary: str = Field(
+    summary: Optional[str] = Field(
+        default=None,
         max_length=500,
         description="Brief faction description (max 500 chars)"
     )
-    ideology: str = Field(
+    ideology: Optional[str] = Field(
+        default=None,
         description="Faction's core ideology or purpose"
     )
-    history: str = Field(
+    history: Optional[str] = Field(
+        default=None,
         description="Faction origins, past events, and evolution"
     )
-    current_activity: str = Field(
+    current_activity: Optional[str] = Field(
+        default=None,
         description="What the faction is currently doing"
     )
-    hidden_agenda: str = Field(
+    hidden_agenda: Optional[str] = Field(
+        default=None,
         description="Secret goals, plots, and agendas (like place secrets - narrative gold!)"
     )
-    territory: str = Field(
+    territory: Optional[str] = Field(
+        default=None,
         description="Controlled areas, zones of influence, or operational reach"
     )
     power_level: float = Field(
@@ -306,13 +367,16 @@ class NewFaction(BaseModel):
         le=1.0,
         description="Faction influence/power rating (0.0-1.0, default 0.5 for new factions)"
     )
-    resources: str = Field(
+    resources: Optional[str] = Field(
+        default=None,
         description="Assets, capabilities, personnel, and resources"
     )
-    primary_location: int = Field(
+    primary_location: Optional[int] = Field(
+        default=None,
         description="Place ID of faction headquarters/primary base (FK to places.id)"
     )
-    extra_data: FactionDetails = Field(
+    extra_data: Optional[FactionDetails] = Field(
+        default=None,
         description="Additional faction attributes (leader, members, allies, rivals, etc.)"
     )
 

--- a/nexus/agents/memnon/memnon.py
+++ b/nexus/agents/memnon/memnon.py
@@ -1450,14 +1450,22 @@ class MEMNON:
                         cm.season,
                         cm.episode,
                         cm.scene,
-                        cm.place,
                         nv.world_time,
-                        p.name as place_name
+                        string_agg(DISTINCT p.name, ', ' ORDER BY p.name)
+                            FILTER (WHERE p.name IS NOT NULL) AS place_names
                     FROM narrative_chunks nc
                     LEFT JOIN chunk_metadata cm ON nc.id = cm.chunk_id
                     LEFT JOIN narrative_view nv ON nc.id = nv.id
-                    LEFT JOIN places p ON cm.place = p.id
+                    LEFT JOIN place_chunk_references pcr ON nc.id = pcr.chunk_id
+                    LEFT JOIN places p ON pcr.place_id = p.id
                     WHERE nc.id = :chunk_id
+                    GROUP BY
+                        nc.id,
+                        nc.raw_text,
+                        cm.season,
+                        cm.episode,
+                        cm.scene,
+                        nv.world_time
                 """)
                 
                 result = session.execute(query, {"chunk_id": chunk_id}).fetchone()
@@ -1468,8 +1476,8 @@ class MEMNON:
                     header += f"(chunk {chunk_id})\n"
                     if result.world_time:
                         header += f"{result.world_time}\n"
-                    if result.place_name:
-                        header += f"{result.place_name}\n"
+                    if result.place_names:
+                        header += f"{result.place_names}\n"
                     
                     return {
                         "id": result.id,
@@ -1480,7 +1488,7 @@ class MEMNON:
                 return None
                 
         except Exception as e:
-            self.logger.error(f"Error fetching chunk {chunk_id}: {str(e)}")
+            logger.error(f"Error fetching chunk {chunk_id}: {str(e)}")
             return None
     
     def get_recent_chunks(self, limit: int = 10) -> Dict[str, Any]:

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -32,6 +32,16 @@ from nexus.api.lore_adapter import compute_raw_text, format_choice_text
 logger = logging.getLogger("nexus.api.commit_handler_sync")
 
 
+def _json_dumps_model(value: Any) -> Optional[str]:
+    """Serialize dicts or Pydantic models for JSONB columns."""
+
+    if value is None:
+        return None
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="json", exclude_none=True)
+    return json.dumps(value)
+
+
 # ============================================================================
 # Entity Resolution Functions (Synchronous)
 # ============================================================================
@@ -55,6 +65,8 @@ def resolve_place_references_sync(
                 result = cur.fetchone()
                 if result:
                     place_id = result[0]
+                elif ref.new_place:
+                    place_id = create_new_place_sync(cur, ref.new_place)
                 else:
                     raise ValueError(f"Place '{ref.place_name}' not found in database")
             elif ref.new_place:
@@ -73,28 +85,21 @@ def resolve_place_references_sync(
 
 def create_new_place_sync(cur, new_place):
     """Create a new place synchronously"""
-    # Validate zone exists if provided
-    if new_place.zone:
-        cur.execute("SELECT id FROM zones WHERE id = %s", (new_place.zone,))
-        if not cur.fetchone():
-            raise ValueError(f"Zone ID {new_place.zone} not found")
-
     # Insert place
     cur.execute("""
         INSERT INTO places (
-            name, summary, history, current_status, secrets,
-            extra_data, zone, place_type
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            name, type, summary, history, current_status, secrets,
+            extra_data
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s)
         RETURNING id
     """, (
         new_place.name,
+        new_place.type.value if new_place.type else None,
         new_place.summary,
         new_place.history,
         new_place.current_status,
         new_place.secrets,
-        json.dumps(new_place.extra_data) if new_place.extra_data else None,
-        new_place.zone,
-        new_place.place_type.value if new_place.place_type else None
+        _json_dumps_model(new_place.extra_data),
     ))
 
     return cur.fetchone()[0]
@@ -118,6 +123,8 @@ def resolve_character_references_sync(
                 result = cur.fetchone()
                 if result:
                     char_id = result[0]
+                elif ref.new_character:
+                    char_id = create_new_character_sync(cur, ref.new_character)
                 else:
                     raise ValueError(f"Character '{ref.character_name}' not found")
             elif ref.new_character:
@@ -156,7 +163,7 @@ def create_new_character_sync(cur, new_char):
         new_char.emotional_state,
         new_char.current_activity,
         new_char.current_location,
-        json.dumps(new_char.extra_data) if new_char.extra_data else None
+        _json_dumps_model(new_char.extra_data),
     ))
 
     return cur.fetchone()[0]
@@ -180,6 +187,8 @@ def resolve_faction_references_sync(
                 result = cur.fetchone()
                 if result:
                     faction_id = result[0]
+                elif ref.new_faction:
+                    faction_id = create_new_faction_sync(cur, ref.new_faction)
                 else:
                     raise ValueError(f"Faction '{ref.faction_name}' not found")
             elif ref.new_faction:
@@ -201,15 +210,20 @@ def create_new_faction_sync(cur, new_faction):
         if not cur.fetchone():
             raise ValueError(f"Place ID {new_faction.primary_location} not found for faction location")
 
+    cur.execute("LOCK TABLE factions IN SHARE ROW EXCLUSIVE MODE")
+    cur.execute("SELECT COALESCE(MAX(id), 0) + 1 FROM factions")
+    faction_id = cur.fetchone()[0]
+
     # Insert faction
     cur.execute("""
         INSERT INTO factions (
-            name, summary, ideology, history, current_activity,
+            id, name, summary, ideology, history, current_activity,
             hidden_agenda, territory, power_level, resources,
             primary_location, extra_data
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         RETURNING id
     """, (
+        faction_id,
         new_faction.name,
         new_faction.summary,
         new_faction.ideology,
@@ -220,7 +234,7 @@ def create_new_faction_sync(cur, new_faction):
         new_faction.power_level,
         new_faction.resources,
         new_faction.primary_location,
-        json.dumps(new_faction.extra_data) if new_faction.extra_data else None
+        _json_dumps_model(new_faction.extra_data),
     ))
 
     return cur.fetchone()[0]

--- a/nexus/api/db_converters.py
+++ b/nexus/api/db_converters.py
@@ -24,6 +24,16 @@ from nexus.agents.logon.apex_schema import (
 )
 
 
+def _json_dumps_model(value: Any) -> Optional[str]:
+    """Serialize dicts or Pydantic models for JSONB columns."""
+
+    if value is None:
+        return None
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="json", exclude_none=True)
+    return json.dumps(value)
+
+
 # ============================================================================
 # Time Conversion Functions
 # ============================================================================
@@ -151,7 +161,9 @@ async def resolve_place_references(
         elif ref.place_name:
             # Look up existing place by name
             place_id = await lookup_place_by_name(conn, ref.place_name)
-            if not place_id:
+            if not place_id and ref.new_place:
+                place_id = await create_new_place(conn, ref.new_place)
+            elif not place_id:
                 raise ValueError(f"Place '{ref.place_name}' not found in database")
         elif ref.new_place:
             # Create new place and get ID
@@ -183,31 +195,21 @@ async def create_new_place(conn: asyncpg.Connection, new_place: NewPlace) -> int
     Returns:
         ID of newly created place
     """
-    # Validate zone exists if provided
-    if new_place.zone:
-        zone_exists = await conn.fetchval(
-            "SELECT id FROM zones WHERE id = $1",
-            new_place.zone
-        )
-        if not zone_exists:
-            raise ValueError(f"Zone ID {new_place.zone} not found")
-
     # Insert place
     place_id = await conn.fetchval("""
         INSERT INTO places (
-            name, summary, history, current_status, secrets,
-            extra_data, zone, place_type
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            name, type, summary, history, current_status, secrets,
+            extra_data
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7)
         RETURNING id
     """,
         new_place.name,
+        new_place.type.value if new_place.type else None,
         new_place.summary,
         new_place.history,
         new_place.current_status,
         new_place.secrets,
-        json.dumps(new_place.extra_data) if new_place.extra_data else None,
-        new_place.zone,
-        new_place.place_type.value if new_place.place_type else None
+        _json_dumps_model(new_place.extra_data),
     )
 
     return place_id
@@ -238,7 +240,9 @@ async def resolve_character_references(
             char_id = ref.character_id
         elif ref.character_name:
             char_id = await lookup_character_by_name(conn, ref.character_name)
-            if not char_id:
+            if not char_id and ref.new_character:
+                char_id = await create_new_character(conn, ref.new_character)
+            elif not char_id:
                 raise ValueError(f"Character '{ref.character_name}' not found")
         elif ref.new_character:
             # Create new character
@@ -293,7 +297,7 @@ async def create_new_character(conn: asyncpg.Connection, new_char: NewCharacter)
         new_char.emotional_state,
         new_char.current_activity,
         new_char.current_location,
-        json.dumps(new_char.extra_data) if new_char.extra_data else None
+        _json_dumps_model(new_char.extra_data),
     )
 
     return char_id
@@ -324,7 +328,9 @@ async def resolve_faction_references(
             faction_id = ref.faction_id
         elif ref.faction_name:
             faction_id = await lookup_faction_by_name(conn, ref.faction_name)
-            if not faction_id:
+            if not faction_id and ref.new_faction:
+                faction_id = await create_new_faction(conn, ref.new_faction)
+            elif not faction_id:
                 raise ValueError(f"Faction '{ref.faction_name}' not found")
         elif ref.new_faction:
             # Create new faction
@@ -358,15 +364,19 @@ async def create_new_faction(conn: asyncpg.Connection, new_faction: NewFaction) 
         if not location_exists:
             raise ValueError(f"Place ID {new_faction.primary_location} not found for faction location")
 
+    await conn.execute("LOCK TABLE factions IN SHARE ROW EXCLUSIVE MODE")
+    faction_id = await conn.fetchval("SELECT COALESCE(MAX(id), 0) + 1 FROM factions")
+
     # Insert faction
     faction_id = await conn.fetchval("""
         INSERT INTO factions (
-            name, summary, ideology, history, current_activity,
+            id, name, summary, ideology, history, current_activity,
             hidden_agenda, territory, power_level, resources,
             primary_location, extra_data
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
         RETURNING id
     """,
+        faction_id,
         new_faction.name,
         new_faction.summary,
         new_faction.ideology,
@@ -377,7 +387,7 @@ async def create_new_faction(conn: asyncpg.Connection, new_faction: NewFaction) 
         new_faction.power_level,
         new_faction.resources,
         new_faction.primary_location,
-        json.dumps(new_faction.extra_data) if new_faction.extra_data else None
+        _json_dumps_model(new_faction.extra_data),
     )
 
     return faction_id

--- a/nexus/api/lore_adapter.py
+++ b/nexus/api/lore_adapter.py
@@ -14,6 +14,16 @@ from nexus.api.choice_handling import ChoiceObject
 logger = logging.getLogger("nexus.api.lore_adapter")
 
 
+def _model_to_json_dict(model: Any) -> Dict[str, Any]:
+    """Serialize Pydantic models into JSON-compatible dictionaries."""
+
+    if hasattr(model, "model_dump"):
+        return model.model_dump(mode="json", exclude_none=True)
+    if isinstance(model, dict):
+        return {key: value for key, value in model.items() if value is not None}
+    return {}
+
+
 # =============================================================================
 # Choice Handling Functions
 # =============================================================================
@@ -153,8 +163,11 @@ def extract_metadata_updates(response: StoryTurnResponse) -> Dict[str, Any]:
     """
     metadata_updates = {}
 
-    if hasattr(response, "metadata") and response.metadata:
-        metadata = response.metadata
+    metadata = getattr(response, "chunk_metadata", None) or getattr(
+        response, "metadata", None
+    )
+
+    if metadata:
 
         # Extract chronology updates with new time field structure
         if hasattr(metadata, "chronology") and metadata.chronology:
@@ -262,37 +275,20 @@ def extract_reference_updates(response: StoryTurnResponse) -> Dict[str, Any]:
     if not refs:
         return reference_updates
 
-    def _append_reference(
-        entity: Any, id_key: str, name_key: str, target_list: list
-    ) -> None:
-        ref_data: Dict[str, Any] = {}
-        entity_id = getattr(entity, "entity_id", None)
-        if entity_id is not None:
-            ref_data[id_key] = entity_id
-        entity_name = getattr(entity, "entity_name", None)
-        if entity_name:
-            ref_data[name_key] = entity_name
-        prominence = getattr(entity, "prominence", None)
-        if prominence:
-            ref_data["reference_type"] = prominence
-        target_list.append(ref_data)
-
     for char in getattr(refs, "characters", []):
-        _append_reference(
-            char, "character_id", "character_name", reference_updates["characters"]
-        )
+        ref_data = _model_to_json_dict(char)
+        if ref_data:
+            reference_updates["characters"].append(ref_data)
 
-    for location in getattr(refs, "locations", []):
-        _append_reference(
-            location, "place_id", "place_name", reference_updates["places"]
-        )
+    for place in getattr(refs, "places", []):
+        ref_data = _model_to_json_dict(place)
+        if ref_data:
+            reference_updates["places"].append(ref_data)
 
-    # Factions are reported through the generic "other" list in StoryTurnResponse
-    for entity in getattr(refs, "other", []):
-        if getattr(entity, "entity_type", None) == "faction":
-            _append_reference(
-                entity, "faction_id", "faction_name", reference_updates["factions"]
-            )
+    for faction in getattr(refs, "factions", []):
+        ref_data = _model_to_json_dict(faction)
+        if ref_data:
+            reference_updates["factions"].append(ref_data)
 
     return reference_updates
 

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -11,7 +11,7 @@ This module handles async narrative generation including:
 import json
 import logging
 import uuid
-from typing import Callable, Dict, Any, Optional, Protocol
+from typing import Any, Callable, Dict, Optional, Protocol
 
 from fastapi import HTTPException
 from psycopg2.extras import RealDictCursor
@@ -23,6 +23,34 @@ from nexus.api.lore_adapter import (
 )
 
 logger = logging.getLogger("nexus.api.narrative_generation")
+
+
+def _exception_detail(exc: Exception) -> str:
+    """Return the most useful user-facing detail from an exception."""
+    if isinstance(exc, HTTPException) and exc.detail:
+        return str(exc.detail)
+    return str(exc)
+
+
+def _describe_lore_failure(lore: LORE, response: Any) -> Optional[str]:
+    """Describe a LORE turn failure before adapter coercion hides the phase."""
+    narrative_text = getattr(response, "narrative", None)
+    if narrative_text:
+        return None
+
+    turn_context = getattr(lore, "turn_context", None)
+    error_log = getattr(turn_context, "error_log", []) if turn_context else []
+    phase_errors = [str(error) for error in error_log if error]
+    if phase_errors:
+        return (
+            "Narrative turn failed before APEX returned structured output: "
+            + " | ".join(phase_errors)
+        )
+
+    if isinstance(response, str) and response:
+        return f"Narrative turn failed before APEX returned structured output: {response}"
+
+    return "Narrative turn did not return structured APEX output."
 
 
 class ProgressManager(Protocol):
@@ -120,7 +148,7 @@ async def generate_narrative_async(
             logger.info("Initializing LORE for narrative generation")
 
             # Initialize LORE with LOGON enabled for API calls
-            lore = LORE(enable_logon=True, debug=True)
+            lore = LORE(enable_logon=True, debug=True, slot=slot)
 
             # Send progress: calling LLM
             await manager.send_progress(session_id, "calling_llm")
@@ -132,13 +160,23 @@ async def generate_narrative_async(
                 )
                 logger.info(f"LORE response received for session {session_id}")
             except Exception as e:
-                logger.error(f"LORE process_turn failed: {e}")
+                error_detail = _exception_detail(e)
+                logger.error(f"LORE process_turn failed: {error_detail}")
                 raise HTTPException(
-                    status_code=500, detail=f"Failed to generate narrative: {str(e)}"
+                    status_code=500, detail=f"Failed to generate narrative: {error_detail}"
                 )
 
             # Send progress: processing response
             await manager.send_progress(session_id, "processing_response")
+
+            failure_detail = _describe_lore_failure(lore, response)
+            if failure_detail:
+                logger.error(
+                    "Narrative turn failed for session %s: %s",
+                    session_id,
+                    failure_detail,
+                )
+                raise HTTPException(status_code=500, detail=failure_detail)
 
             # Transform LORE response to incubator format
             incubator_data = response_to_incubator(
@@ -167,8 +205,9 @@ async def generate_narrative_async(
         logger.info(f"Narrative generation complete for session {session_id}")
 
     except Exception as e:
-        logger.error(f"Error generating narrative: {e}")
-        await manager.send_progress(session_id, "error", {"error": str(e)})
+        error_detail = _exception_detail(e)
+        logger.error(f"Error generating narrative: {error_detail}")
+        await manager.send_progress(session_id, "error", {"error": error_detail})
     finally:
         if conn:
             conn.close()

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -33,6 +33,7 @@ TERMINAL_GENERATION_STATUSES = {
     "approved",
     "committed",
 }
+GENERATION_POLL_SECONDS = 240
 
 
 def get_api_url() -> str:
@@ -559,7 +560,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
             session_id = data.get("session_id")
             if session_id:
                 # Poll for completion (simplified - real implementation would use websocket)
-                for _ in range(60):  # Max 60 seconds
+                for _ in range(GENERATION_POLL_SECONDS):
                     status_url = f"{get_api_url()}/api/narrative/status/{session_id}"
                     status_response = requests.get(
                         status_url, params={"slot": args.slot}, timeout=30

--- a/nexus/llm/model_manager.py
+++ b/nexus/llm/model_manager.py
@@ -166,10 +166,7 @@ class ModelManager:
                 entries = self._extract_model_entries(payload)
                 if not entries:
                     logger.debug(f"LM Studio endpoint {endpoint} returned no model entries")
-                loaded_identifiers = self._extract_loaded_identifiers(entries)
-                if loaded_identifiers:
-                    return loaded_identifiers
-                return loaded_identifiers
+                return self._extract_loaded_identifiers(entries)
             except requests.RequestException as http_error:
                 logger.warning(f"Failed to query LM Studio via {endpoint}: {http_error}")
             except ValueError as json_error:

--- a/nexus/llm/model_manager.py
+++ b/nexus/llm/model_manager.py
@@ -147,25 +147,9 @@ class ModelManager:
                 loaded.append(str(identifier))
         return loaded
 
-    def _extract_model_identifiers(self, entries: List[Dict[str, Any]]) -> List[str]:
-        """Extract model identifiers from an already-filtered model list."""
-        identifiers: List[str] = []
-        for entry in entries:
-            identifier = (
-                entry.get("id")
-                or entry.get("identifier")
-                or entry.get("model_id")
-                or entry.get("name")
-                or entry.get("path")
-            )
-            if identifier:
-                identifiers.append(str(identifier))
-        return identifiers
-
     def _get_loaded_models_via_http(self) -> Optional[List[str]]:
         """Query LM Studio's HTTP API for loaded models."""
         endpoints = [
-            f"{self.lmstudio_api_base}/v1/models",
             f"{self.lmstudio_api_base}/api/v0/models",
             f"{self.lmstudio_api_base}/api/v0/models/list",
             f"{self.lmstudio_api_base}/api/models",
@@ -185,8 +169,6 @@ class ModelManager:
                 loaded_identifiers = self._extract_loaded_identifiers(entries)
                 if loaded_identifiers:
                     return loaded_identifiers
-                if endpoint.endswith("/v1/models"):
-                    return self._extract_model_identifiers(entries)
                 return loaded_identifiers
             except requests.RequestException as http_error:
                 logger.warning(f"Failed to query LM Studio via {endpoint}: {http_error}")
@@ -276,8 +258,8 @@ class ModelManager:
         return self._get_loaded_models_via_sdk()
 
     def _set_current_model_handle(self, model_id: str) -> None:
-        """Attach to the currently loaded LM Studio model without loading it."""
-        self.current_model = lms.llm()
+        """Attach to a specific loaded LM Studio model without loading it."""
+        self.current_model = lms.llm(model_id)
         self.current_model_id = model_id
 
     def _log_loaded_model_probe(self, model_id: str) -> None:

--- a/nexus/llm/model_manager.py
+++ b/nexus/llm/model_manager.py
@@ -7,8 +7,7 @@ Uses centralized config loader (nexus.toml with settings.json fallback).
 
 import logging
 import time
-from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Optional
 
 import requests
 
@@ -148,9 +147,25 @@ class ModelManager:
                 loaded.append(str(identifier))
         return loaded
 
+    def _extract_model_identifiers(self, entries: List[Dict[str, Any]]) -> List[str]:
+        """Extract model identifiers from an already-filtered model list."""
+        identifiers: List[str] = []
+        for entry in entries:
+            identifier = (
+                entry.get("id")
+                or entry.get("identifier")
+                or entry.get("model_id")
+                or entry.get("name")
+                or entry.get("path")
+            )
+            if identifier:
+                identifiers.append(str(identifier))
+        return identifiers
+
     def _get_loaded_models_via_http(self) -> Optional[List[str]]:
         """Query LM Studio's HTTP API for loaded models."""
         endpoints = [
+            f"{self.lmstudio_api_base}/v1/models",
             f"{self.lmstudio_api_base}/api/v0/models",
             f"{self.lmstudio_api_base}/api/v0/models/list",
             f"{self.lmstudio_api_base}/api/models",
@@ -167,7 +182,12 @@ class ModelManager:
                 entries = self._extract_model_entries(payload)
                 if not entries:
                     logger.debug(f"LM Studio endpoint {endpoint} returned no model entries")
-                return self._extract_loaded_identifiers(entries)
+                loaded_identifiers = self._extract_loaded_identifiers(entries)
+                if loaded_identifiers:
+                    return loaded_identifiers
+                if endpoint.endswith("/v1/models"):
+                    return self._extract_model_identifiers(entries)
+                return loaded_identifiers
             except requests.RequestException as http_error:
                 logger.warning(f"Failed to query LM Studio via {endpoint}: {http_error}")
             except ValueError as json_error:
@@ -255,6 +275,29 @@ class ModelManager:
             return http_result
         return self._get_loaded_models_via_sdk()
 
+    def _set_current_model_handle(self, model_id: str) -> None:
+        """Attach to the currently loaded LM Studio model without loading it."""
+        self.current_model = lms.llm()
+        self.current_model_id = model_id
+
+    def _log_loaded_model_probe(self, model_id: str) -> None:
+        """Log the loaded-model probe result without running model inference."""
+        loaded = self.get_loaded_models()
+        if model_id in loaded:
+            logger.info(f"Model {model_id} is reported loaded by LM Studio")
+        elif loaded:
+            logger.warning(
+                "Loaded-model probe did not find %s; LM Studio reports: %s",
+                model_id,
+                loaded,
+            )
+        else:
+            logger.info(
+                "Loaded-model probe returned no loaded models; treating acquired "
+                "LM Studio handle for %s as successful",
+                model_id,
+            )
+
     def unload_model(self, model_id: Optional[str] = None) -> bool:
         """
         Unload a model from LM Studio
@@ -305,6 +348,14 @@ class ModelManager:
         try:
             logger.info(f"Loading model: {model_id}")
 
+            loaded = self.get_loaded_models()
+            if model_id in loaded:
+                logger.info(
+                    f"Model {model_id} already loaded; attaching to existing handle"
+                )
+                self._set_current_model_handle(model_id)
+                return True
+
             # First unload any existing model
             if self.current_model:
                 self.unload_model()
@@ -334,18 +385,11 @@ class ModelManager:
             # Wait for model to initialize
             time.sleep(5)
 
-            # Verify the model works
-            logger.info("Verifying model...")
-            chat = lms.Chat("You are a test assistant.")
-            chat.add_user_message("Respond with 'OK'")
-
-            result = self.current_model.respond(chat, config={"maxTokens": 10})
-            if result and result.content:
-                logger.info(f"Model {model_id} loaded and verified successfully")
-                return True
-            else:
-                logger.error("Model verification failed: no response")
-                return False
+            # Avoid chat-completion verification here. Some LM Studio SDK/runtime
+            # combinations crash large reasoning models during that first probe.
+            self._log_loaded_model_probe(model_id)
+            logger.info(f"Model {model_id} loaded successfully")
+            return True
 
         except Exception as e:
             logger.error(f"Failed to load model {model_id}: {e}")
@@ -381,8 +425,7 @@ class ModelManager:
             if current == default_model:
                 logger.info(f"Default model {default_model} already loaded")
                 # Get the model handle
-                self.current_model = lms.llm()
-                self.current_model_id = default_model
+                self._set_current_model_handle(default_model)
                 return default_model
             else:
                 logger.info(f"Current model {current} != default {default_model}")
@@ -393,8 +436,7 @@ class ModelManager:
                 else:
                     logger.info("Keeping current model due to unload_on_exit=False")
                     # Return the current model instead of switching
-                    self.current_model = lms.llm()
-                    self.current_model_id = current
+                    self._set_current_model_handle(current)
                     return current
 
         # Load the default model

--- a/scripts/api_anthropic.py
+++ b/scripts/api_anthropic.py
@@ -244,6 +244,7 @@ class AnthropicProvider(LLMProvider):
 
     # Default model if none specified
     DEFAULT_MODEL = "claude-3-haiku-20240307"
+    STRUCTURED_OUTPUT_RETRIES = 1
 
     def __init__(self,
                 api_key: Optional[str] = None,
@@ -525,7 +526,7 @@ class AnthropicProvider(LLMProvider):
             output_type=schema_model,
             system_prompt=self.system_prompt,
             model_settings=model_settings,
-            retries=0,
+            retries=self.STRUCTURED_OUTPUT_RETRIES,
         )
 
         return agent

--- a/scripts/api_openai.py
+++ b/scripts/api_openai.py
@@ -245,6 +245,7 @@ class OpenAIProvider(LLMProvider):
     
     # Default model if none specified
     DEFAULT_MODEL = "gpt-4.1"
+    STRUCTURED_OUTPUT_RETRIES = 1
     
     # Valid reasoning effort levels (model-specific)
     VALID_REASONING_EFFORTS = ["minimal", "medium", "high", "low", None]
@@ -431,7 +432,7 @@ class OpenAIProvider(LLMProvider):
             output_type=schema_model,
             system_prompt=self.system_prompt,
             model_settings=model_settings,
-            retries=0,
+            retries=self.STRUCTURED_OUTPUT_RETRIES,
         )
 
         return agent

--- a/tests/test_api/test_lore_adapter.py
+++ b/tests/test_api/test_lore_adapter.py
@@ -1,0 +1,78 @@
+"""Tests for adapting LOGON responses into incubator payloads."""
+
+from nexus.agents.logon.apex_schema import ReferencedEntities, StorytellerResponseExtended
+from nexus.api.lore_adapter import response_to_incubator
+
+
+def test_response_to_incubator_serializes_current_reference_schema() -> None:
+    """Current LOGON references should survive incubator conversion."""
+
+    response = StorytellerResponseExtended(
+        narrative="Jonas waits beneath the pharmacy sign.",
+        choices=["Follow Jonas.", "Answer the phone."],
+        chunk_metadata={
+            "chronology": {
+                "episode_transition": "continue",
+                "time_delta_minutes": 1,
+            },
+            "world_layer": "primary",
+        },
+        referenced_entities={
+            "characters": [
+                {"character_name": "Eleanor Voss", "reference_type": "present"},
+                {
+                    "new_character": {
+                        "name": "Jonas Vale",
+                        "appearance": "A raincoated man with a milky prosthetic eye.",
+                    },
+                    "reference_type": "present",
+                },
+            ],
+            "places": [
+                {
+                    "new_place": {
+                        "name": "Kettering Street Transit Stop",
+                        "type": "transit stop",
+                    },
+                    "reference_type": "setting",
+                }
+            ],
+            "factions": [
+                {
+                    "new_faction": {"name": "Project Palimpsest"},
+                    "reference_type": "mentioned",
+                }
+            ],
+        },
+        state_updates={
+            "characters": [],
+            "relationships": [],
+            "locations": [],
+            "factions": [],
+        },
+    )
+
+    incubator = response_to_incubator(
+        response=response,
+        parent_chunk_id=1,
+        user_text="I cross the street.",
+        session_id="session-1",
+    )
+
+    assert incubator["metadata_updates"]["chronology"]["time_delta_minutes"] == 1
+    reference_updates = incubator["reference_updates"]
+    assert reference_updates["characters"][0]["character_name"] == "Eleanor Voss"
+    assert reference_updates["characters"][1]["new_character"]["name"] == "Jonas Vale"
+    assert reference_updates["places"][0]["new_place"]["type"] == "fixed_location"
+    assert (
+        reference_updates["places"][0]["new_place"]["extra_data"]["category"]
+        == "transit stop"
+    )
+    assert (
+        reference_updates["factions"][0]["new_faction"]["name"]
+        == "Project Palimpsest"
+    )
+
+    # The commit path reparses this JSONB payload into the current schema.
+    reparsed = ReferencedEntities(**reference_updates)
+    assert reparsed.characters[1].new_character.name == "Jonas Vale"

--- a/tests/test_api/test_narrative_generation.py
+++ b/tests/test_api/test_narrative_generation.py
@@ -1,0 +1,94 @@
+"""Tests for narrative generation orchestration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from nexus.api import narrative_generation
+
+
+class DummyProgressManager:
+    """Capture progress events sent by narrative generation."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    async def send_progress(
+        self, session_id: str, status: str, data: dict[str, Any] | None = None
+    ) -> None:
+        """Record a progress event."""
+        self.events.append((session_id, status, data))
+
+
+class DummyConnection:
+    """Minimal connection object for orchestration tests."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        """Record connection closure."""
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_lore_phase_failure_is_reported_before_adapter_coercion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed LORE phase should not become a generic no-narrative error."""
+
+    class FailingLore:
+        """LORE double that mimics a warm-analysis failure return."""
+
+        instances: list["FailingLore"] = []
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+            self.turn_context = SimpleNamespace(
+                error_log=[
+                    "TurnPhase.WARM_ANALYSIS: FATAL: No warm slice chunks retrieved."
+                ]
+            )
+            self.instances.append(self)
+
+        async def process_turn(self, user_text: str, parent_chunk_id: int) -> str:
+            """Return the legacy failure string from LORE.process_turn."""
+            return "Error processing turn: FATAL: No warm slice chunks retrieved."
+
+    async def fake_get_chunk_info(
+        conn: DummyConnection, chunk_id: int
+    ) -> dict[str, Any]:
+        """Return enough parent metadata to reach LORE orchestration."""
+        return {"season": 1, "episode": 1, "place_name": "Halcyon Row"}
+
+    async def fail_write(*args: Any, **kwargs: Any) -> None:
+        pytest.fail("write_to_incubator should not run after a LORE phase failure")
+
+    monkeypatch.setattr(narrative_generation, "LORE", FailingLore)
+    monkeypatch.setattr(narrative_generation, "get_chunk_info", fake_get_chunk_info)
+    monkeypatch.setattr(narrative_generation, "write_to_incubator", fail_write)
+
+    manager = DummyProgressManager()
+    conn = DummyConnection()
+
+    await narrative_generation.generate_narrative_async(
+        session_id="session-1",
+        parent_chunk_id=1,
+        user_text="continue",
+        slot=5,
+        get_db_connection=lambda slot: conn,
+        load_settings=lambda: {},
+        manager=manager,
+    )
+
+    error_events = [event for event in manager.events if event[1] == "error"]
+    assert len(error_events) == 1
+    error_message = error_events[0][2]["error"]
+    assert "TurnPhase.WARM_ANALYSIS" in error_message
+    assert "FATAL: No warm slice chunks retrieved." in error_message
+    assert "No narrative text in LORE response" not in error_message
+    assert FailingLore.instances[0].kwargs["slot"] == 5
+    assert conn.closed is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 """Tests for the NEXUS CLI helpers."""
 
-from nexus.cli import _is_terminal_generation_status
+from nexus.cli import GENERATION_POLL_SECONDS, _is_terminal_generation_status
 
 
 def test_terminal_generation_statuses_include_api_and_incubator_values() -> None:
@@ -13,3 +13,9 @@ def test_terminal_generation_statuses_include_api_and_incubator_values() -> None
     assert _is_terminal_generation_status("committed")
     assert not _is_terminal_generation_status("processing")
     assert not _is_terminal_generation_status("error")
+
+
+def test_generation_poll_window_covers_live_reasoning_models() -> None:
+    """CLI polling should outlast slow structured generation calls."""
+
+    assert GENERATION_POLL_SECONDS >= 180

--- a/tests/test_llm_model_manager.py
+++ b/tests/test_llm_model_manager.py
@@ -74,16 +74,50 @@ def test_load_model_attaches_when_requested_model_is_already_loaded(
 
     assert manager.load_model("nexveridian/gpt-oss-120b") is True
     assert manager.current_model_id == "nexveridian/gpt-oss-120b"
-    assert stub_lms.llm_calls == [(None, None)]
+    assert stub_lms.llm_calls == [("nexveridian/gpt-oss-120b", None)]
 
 
-def test_v1_models_endpoint_identifiers_count_as_loaded(monkeypatch) -> None:
-    """The OpenAI-compatible LM Studio model list contains loaded model IDs."""
+def test_openai_compatible_models_endpoint_is_not_loaded_inventory(
+    monkeypatch,
+) -> None:
+    """/v1/models is not a reliable loaded-model inventory endpoint."""
     manager = _bare_manager()
     requested_urls: list[str] = []
 
     class Response:
-        """HTTP response double for the /v1/models probe."""
+        """HTTP response double for unavailable loaded-model endpoints."""
+
+        status_code = 404
+
+        def raise_for_status(self) -> None:
+            """Represent a response that should be skipped before raising."""
+            return None
+
+        def json(self) -> dict[str, Any]:
+            """Return an empty payload."""
+            return {"data": []}
+
+    def fake_get(url: str, timeout: int) -> Response:
+        requested_urls.append(url)
+        return Response()
+
+    monkeypatch.setattr(model_manager.requests, "get", fake_get)
+
+    assert manager._get_loaded_models_via_http() is None
+    assert requested_urls == [
+        "http://localhost:1234/api/v0/models",
+        "http://localhost:1234/api/v0/models/list",
+        "http://localhost:1234/api/models",
+        "http://localhost:1234/models",
+    ]
+
+
+def test_unflagged_model_entries_are_not_counted_as_loaded(monkeypatch) -> None:
+    """Downloaded model entries without loaded state should not skip loading."""
+    manager = _bare_manager()
+
+    class Response:
+        """HTTP response double with unflagged model entries."""
 
         status_code = 200
 
@@ -92,14 +126,12 @@ def test_v1_models_endpoint_identifiers_count_as_loaded(monkeypatch) -> None:
             return None
 
         def json(self) -> dict[str, Any]:
-            """Return an OpenAI-compatible model list payload."""
+            """Return model IDs without loaded-state fields."""
             return {"data": [{"id": "nexveridian/gpt-oss-120b"}]}
 
     def fake_get(url: str, timeout: int) -> Response:
-        requested_urls.append(url)
         return Response()
 
     monkeypatch.setattr(model_manager.requests, "get", fake_get)
 
-    assert manager._get_loaded_models_via_http() == ["nexveridian/gpt-oss-120b"]
-    assert requested_urls == ["http://localhost:1234/v1/models"]
+    assert manager._get_loaded_models_via_http() == []

--- a/tests/test_llm_model_manager.py
+++ b/tests/test_llm_model_manager.py
@@ -1,0 +1,105 @@
+"""Tests for LM Studio model lifecycle management."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nexus.llm import model_manager
+from nexus.llm.model_manager import ModelManager
+
+
+class HandleThatMustNotVerify:
+    """Model handle double that fails if chat verification is attempted."""
+
+    def respond(self, *args: Any, **kwargs: Any) -> None:
+        """Raise if the old verification path is invoked."""
+        raise AssertionError("load_model should not run chat verification")
+
+
+class StubLms:
+    """Small stand-in for the lmstudio module."""
+
+    def __init__(self) -> None:
+        self.llm_calls: list[tuple[str | None, dict[str, Any] | None]] = []
+
+    def llm(
+        self, model_id: str | None = None, config: dict[str, Any] | None = None
+    ) -> HandleThatMustNotVerify:
+        """Capture load/attach calls and return a model handle."""
+        self.llm_calls.append((model_id, config))
+        return HandleThatMustNotVerify()
+
+
+def _bare_manager() -> ModelManager:
+    """Build a ModelManager without configuring the real LM Studio client."""
+    manager = ModelManager.__new__(ModelManager)
+    manager.settings = {
+        "Agent Settings": {
+            "global": {
+                "llm": {"context_window": 2048},
+            }
+        }
+    }
+    manager.current_model = None
+    manager.current_model_id = None
+    manager.unload_on_exit = True
+    manager.lmstudio_api_base = "http://localhost:1234"
+    return manager
+
+
+def test_load_model_skips_chat_verification(monkeypatch) -> None:
+    """Loading should succeed once a handle is acquired without respond()."""
+    manager = _bare_manager()
+    loaded_sequences = iter([[], ["nexveridian/gpt-oss-120b"]])
+    stub_lms = StubLms()
+
+    monkeypatch.setattr(model_manager, "lms", stub_lms)
+    monkeypatch.setattr(model_manager.time, "sleep", lambda seconds: None)
+    manager.get_loaded_models = lambda: next(loaded_sequences)
+
+    assert manager.load_model("nexveridian/gpt-oss-120b", context_window=4096) is True
+    assert manager.current_model_id == "nexveridian/gpt-oss-120b"
+    assert stub_lms.llm_calls == [("nexveridian/gpt-oss-120b", {"contextLength": 4096})]
+
+
+def test_load_model_attaches_when_requested_model_is_already_loaded(
+    monkeypatch,
+) -> None:
+    """load_model should share the ensure_default_model pre-loaded fast path."""
+    manager = _bare_manager()
+    stub_lms = StubLms()
+
+    monkeypatch.setattr(model_manager, "lms", stub_lms)
+    manager.get_loaded_models = lambda: ["nexveridian/gpt-oss-120b"]
+
+    assert manager.load_model("nexveridian/gpt-oss-120b") is True
+    assert manager.current_model_id == "nexveridian/gpt-oss-120b"
+    assert stub_lms.llm_calls == [(None, None)]
+
+
+def test_v1_models_endpoint_identifiers_count_as_loaded(monkeypatch) -> None:
+    """The OpenAI-compatible LM Studio model list contains loaded model IDs."""
+    manager = _bare_manager()
+    requested_urls: list[str] = []
+
+    class Response:
+        """HTTP response double for the /v1/models probe."""
+
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            """Represent a successful response."""
+            return None
+
+        def json(self) -> dict[str, Any]:
+            """Return an OpenAI-compatible model list payload."""
+            return {"data": [{"id": "nexveridian/gpt-oss-120b"}]}
+
+    def fake_get(url: str, timeout: int) -> Response:
+        requested_urls.append(url)
+        return Response()
+
+    monkeypatch.setattr(model_manager.requests, "get", fake_get)
+
+    assert manager._get_loaded_models_via_http() == ["nexveridian/gpt-oss-120b"]
+    assert requested_urls == ["http://localhost:1234/v1/models"]

--- a/tests/test_lore/test_apex_schema.py
+++ b/tests/test_lore/test_apex_schema.py
@@ -4,7 +4,9 @@ import pytest
 from pydantic import ValidationError
 
 from nexus.agents.logon.apex_schema import (
+    PlaceType,
     StorytellerResponseBootstrap,
+    StorytellerResponseExtended,
     create_minimal_response,
 )
 
@@ -38,3 +40,82 @@ def test_create_minimal_response_includes_valid_choices() -> None:
         "Continue.",
         "Wait and observe.",
     ]
+
+
+def test_extended_response_accepts_partial_new_character_context() -> None:
+    """Normal narrative turns may introduce NPCs before all DB fields are known."""
+
+    response = StorytellerResponseExtended(
+        narrative="The watcher steps into the pharmacy light.",
+        choices=["Ask his name.", "Step back."],
+        chunk_metadata={
+            "chronology": {
+                "episode_transition": "continue",
+                "time_delta_minutes": 1,
+            },
+            "world_layer": "primary",
+        },
+        referenced_entities={
+            "characters": [
+                {
+                    "new_character": {
+                        "name": "Adrian Vale",
+                        "appearance": "A raincoated figure with tired eyes.",
+                        "background": "An informant with missing records.",
+                        "current_location": None,
+                        "extra_data": {
+                            "role": "Erased intelligence operative",
+                            "asset": "A brass token stamped with an angel",
+                        },
+                    },
+                    "reference_type": "present",
+                }
+            ],
+            "places": [
+                {
+                    "new_place": {
+                        "name": "Vey Street Transit Stop",
+                        "type": "transit stop",
+                        "coordinates": None,
+                        "extra_data": {"atmosphere": "uneasy"},
+                    },
+                    "reference_type": "setting",
+                }
+            ],
+            "factions": [
+                {
+                    "new_faction": {
+                        "name": "The Glass Choir",
+                        "ideology": "Control the city by controlling what it remembers.",
+                        "history": "Formed after the station fire.",
+                        "hidden_agenda": "Recover a witness list before dawn.",
+                        "territory": "Transit stops, pharmacies, and late-night diners.",
+                        "resources": "Lookouts, dead drops, and radio scanners.",
+                        "primary_location": None,
+                        "extra_data": {"leader": "unknown"},
+                    },
+                    "reference_type": "mentioned",
+                }
+            ],
+        },
+        state_updates={
+            "characters": [],
+            "relationships": [],
+            "locations": [],
+            "factions": [],
+        },
+    )
+
+    new_character = response.referenced_entities.characters[0].new_character
+    assert new_character is not None
+    assert new_character.personality is None
+    assert new_character.current_location is None
+    assert new_character.extra_data.role == "Erased intelligence operative"
+    new_place = response.referenced_entities.places[0].new_place
+    assert new_place is not None
+    assert new_place.type == PlaceType.FIXED_LOCATION
+    assert new_place.coordinates is None
+    assert new_place.extra_data.category == "transit stop"
+    new_faction = response.referenced_entities.factions[0].new_faction
+    assert new_faction is not None
+    assert new_faction.primary_location is None

--- a/tests/test_lore/test_apex_schema.py
+++ b/tests/test_lore/test_apex_schema.py
@@ -4,6 +4,8 @@ import pytest
 from pydantic import ValidationError
 
 from nexus.agents.logon.apex_schema import (
+    FactionStateUpdate,
+    NewPlace,
     PlaceType,
     StorytellerResponseBootstrap,
     StorytellerResponseExtended,
@@ -40,6 +42,29 @@ def test_create_minimal_response_includes_valid_choices() -> None:
         "Continue.",
         "Wait and observe.",
     ]
+
+
+def test_new_place_normalization_does_not_mutate_input_payload() -> None:
+    """Place type normalization should not leak mutations to caller data."""
+
+    payload = {"name": "Mirror Tram", "type": "fixed location"}
+    original_payload = dict(payload)
+
+    place = NewPlace.model_validate(payload)
+
+    assert payload == original_payload
+    assert place.type == PlaceType.FIXED_LOCATION
+
+
+def test_faction_state_update_accepts_current_activity() -> None:
+    """Faction updates can carry the activity field commit handlers persist."""
+
+    update = FactionStateUpdate(
+        faction_id=42,
+        current_activity="Watching the station exits.",
+    )
+
+    assert update.current_activity == "Watching the station exits."
 
 
 def test_extended_response_accepts_partial_new_character_context() -> None:

--- a/tests/test_lore/test_memnon_chunk_fetch.py
+++ b/tests/test_lore/test_memnon_chunk_fetch.py
@@ -1,0 +1,81 @@
+"""Tests for MEMNON direct chunk retrieval."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+from nexus.agents.memnon.memnon import MEMNON
+
+
+class CapturingSession:
+    """Minimal SQLAlchemy session double for direct chunk lookup tests."""
+
+    def __init__(self, row: Any = None, error: Exception | None = None) -> None:
+        self.row = row
+        self.error = error
+        self.query_text = ""
+        self.params: dict[str, Any] = {}
+
+    def __enter__(self) -> "CapturingSession":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+    def execute(self, query: Any, params: dict[str, Any]) -> "CapturingSession":
+        if self.error:
+            raise self.error
+        self.query_text = str(query)
+        self.params = params
+        return self
+
+    def fetchone(self) -> Any:
+        return self.row
+
+
+def _memnon_with_session(session: CapturingSession) -> MEMNON:
+    """Build a MEMNON instance without running heavyweight initialization."""
+    memnon = MEMNON.__new__(MEMNON)
+    memnon.Session = lambda: session
+    return memnon
+
+
+def test_get_chunk_by_id_uses_place_references_for_header() -> None:
+    """Direct chunk lookup should use current place reference schema."""
+    row = SimpleNamespace(
+        id=1,
+        raw_text="Rain comes down like static.",
+        season=1,
+        episode=1,
+        scene=1,
+        world_time="Night",
+        place_names="Halcyon Row, Metro Entrance",
+    )
+    session = CapturingSession(row=row)
+    memnon = _memnon_with_session(session)
+
+    chunk = memnon.get_chunk_by_id(1)
+
+    assert chunk is not None
+    assert chunk["id"] == 1
+    assert "Halcyon Row, Metro Entrance" in chunk["header"]
+    assert "place_chunk_references pcr" in session.query_text
+    assert "LEFT JOIN places p ON pcr.place_id = p.id" in session.query_text
+    assert "cm.place" not in session.query_text
+    assert session.params == {"chunk_id": 1}
+
+
+def test_get_chunk_by_id_logs_fetch_errors_without_instance_logger(
+    caplog,
+) -> None:
+    """Fetch failures should log the real error instead of masking it."""
+    session = CapturingSession(error=RuntimeError("database boom"))
+    memnon = _memnon_with_session(session)
+
+    with caplog.at_level(logging.ERROR, logger="nexus.memnon"):
+        chunk = memnon.get_chunk_by_id(1)
+
+    assert chunk is None
+    assert "Error fetching chunk 1: database boom" in caplog.text

--- a/tests/test_lore/test_structured_provider_guards.py
+++ b/tests/test_lore/test_structured_provider_guards.py
@@ -24,3 +24,10 @@ async def test_anthropic_sync_structured_completion_rejects_running_loop() -> No
 
     with pytest.raises(RuntimeError, match="get_structured_completion_async"):
         provider.get_structured_completion("prompt", object)
+
+
+def test_structured_providers_allow_one_schema_repair_attempt() -> None:
+    """Structured output should retry validation once before failing fast."""
+
+    assert OpenAIProvider.STRUCTURED_OUTPUT_RETRIES == 1
+    assert AnthropicProvider.STRUCTURED_OUTPUT_RETRIES == 1


### PR DESCRIPTION
## Summary
- fix MEMNON chunk fetch to use place references and preserve the real fetch error
- pass the active slot into LORE generation and surface phase failures before adapter coercion
- allow structured LOGON to emit partial new entity references, normalize descriptive place types, and retry one structured validation repair
- update incubator/commit conversion for the current reference schema, partial entity JSONB, and faction IDs without defaults
- avoid LM Studio chat verification for already-loaded models and extend CLI polling for long reasoning runs

Fixes #192, #193, #194.

## Validation
- `poetry run pytest tests/test_lore tests/test_api tests/test_llm_model_manager.py tests/test_cli.py`
- `poetry run pytest tests/test_db_converters.py tests/test_logon_mock_integration.py tests/test_new_story_schemas.py tests/test_summary_triggers.py`
- `poetry run python -m py_compile nexus/agents/logon/apex_schema.py nexus/agents/memnon/memnon.py nexus/api/narrative_generation.py nexus/api/lore_adapter.py nexus/api/commit_handler_sync.py nexus/api/db_converters.py nexus/cli.py nexus/llm/model_manager.py scripts/api_openai.py scripts/api_anthropic.py`
- `git diff --check`
- Live slot 5: generated chunk 2 from chunk 1 with `I cross the street and confront the watcher.`, then approved it; API committed narrative chunk 2 with metadata and entity/place/faction references.