### PR TITLE
Fix slot_state: surface choices on committed narrative chunks

### DIFF
--- a/nexus/api/slot_state.py
+++ b/nexus/api/slot_state.py
@@ -301,7 +301,7 @@ def _get_narrative_state(cur) -> NarrativeState:
     # No pending content - get latest committed chunk
     cur.execute(
         """
-        SELECT nc.id, nc.raw_text
+        SELECT nc.id, nc.raw_text, nc.choice_object
         FROM narrative_chunks nc
         ORDER BY nc.id DESC
         LIMIT 1
@@ -310,13 +310,12 @@ def _get_narrative_state(cur) -> NarrativeState:
     chunk_row = cur.fetchone()
 
     if chunk_row:
-        # Get choices from the last chunk's choice_object if stored
-        # Note: committed chunks may not have choice_object preserved
+        choices = extract_presented_choices(chunk_row.get("choice_object"))
         return NarrativeState(
             current_chunk_id=chunk_row.get("id"),
             has_pending=False,
             storyteller_text=chunk_row.get("raw_text"),
-            choices=[],  # No pending choices for committed chunks
+            choices=choices,
             session_id=None,
         )
 


### PR DESCRIPTION
## Summary

`slot_state._get_narrative_state` hardcoded `choices=[]` for committed chunks, even though `narrative_chunks.choice_object` actually preserves the structured choices on commit. This made `nexus load` (and the `GET /api/slot/{slot}/state` payload) show empty choices after any chunk acceptance, forcing users into `--user-text` instead of `--choice N`.

The fix: include `choice_object` in the SELECT and run it through `extract_presented_choices()` — the same helper the wizard path already uses (`slot_state.py:226`).

3 insertions, 4 deletions. Read-path only.

## How discovered

Prepping the embedding-pipeline smoke test (Phase A) on slot 5. The slot state API returned `"choices": []` for chunk 2 despite the underlying column holding all four structured options exactly as you'd expect.

## Related (NOT addressed here)

Issue #197 captures an adjacent write-path bug: `choice_object.selected` and `choice_text` are NULL on committed chunks. This PR only fixes the read path. Once #197 lands, full audit/undo becomes possible.

## Test plan

- [x] `psql -d save_05 -c "SELECT choice_object FROM narrative_chunks WHERE id=2;"` shows 4 presented choices
- [x] `curl http://127.0.0.1:8002/api/slot/5/state` returns the 4 choices (was `[]`)
- [x] `nexus load --slot 5` displays numbered choices block at end of output (was missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)