### PR TITLE
Discharge schema-doc debt: narrative_chunks column comments + CLAUDE.md pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ Use functions from `nexus/api/slot_utils.py`:
 The NEXUS database schema is self-describing via Postgres table and column comments. **Do not duplicate schema details in this file** — they drift. Use the live schema instead:
 
 - **Interactive inspection**: `psql -d save_NN -c '\d+ <table>'` (`\dt` to list all tables). The `\d+` form shows column comments in the Description column plus foreign-key references — effectively a free, always-current ER diagram in text.
-- **Programmatic access**: `MEMNON.get_schema_summary(tables=[...])` returns a structured summary (the same path LORE uses to build retrieval context — see `nexus/agents/memnon/memnon.py:374`).
+- **Programmatic access**: `MEMNON.get_schema_summary(tables=[...])` in `nexus/agents/memnon/memnon.py` returns a structured summary (the same path LORE uses to build retrieval context).
 - **Convention**: when adding a column, include `COMMENT ON COLUMN <table>.<col> IS '...'` in the same migration. The comment IS the documentation.
 
 ## API Key Management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,10 +105,15 @@ Use functions from `nexus/api/slot_utils.py`:
 - Port: 5432 (default PostgreSQL port)
 - Example connection string: `postgresql://pythagor@localhost:5432/save_01`
 
-### Main Tables (per slot)
-- `narrative_chunks`: Contains the raw text content (fields: id, raw_text, created_at)
-- `chunk_metadata`: Contains metadata for each chunk (fields: id, chunk_id, world_layer, etc.)
-- `chunk_embeddings`: Contains vector embeddings for search (fields: chunk_id, model, embedding)
+### Schema Reference
+
+The NEXUS database schema is self-describing via Postgres table and column comments. **Do not duplicate schema details in this file** — they drift. Use the live schema instead:
+
+- **Interactive inspection**: `psql -d save_NN -c '\d+ <table>'` (`\dt` to list all tables). The `\d+` form shows column comments in the Description column plus foreign-key references — effectively a free, always-current ER diagram in text.
+- **Programmatic access**: `MEMNON.get_schema_summary(tables=[...])` returns a structured summary (the same path LORE uses to build retrieval context — see `nexus/agents/memnon/memnon.py:374`).
+- **Convention**: when adding a column, include `COMMENT ON COLUMN <table>.<col> IS '...'` in the same migration. The comment IS the documentation.
+
+Embedding vectors live in five dimension-sharded tables (`chunk_embeddings_0384d` / `_1024d` / `_1536d` / `_2560d` / `_4096d`); active model + target dimension is configured in `nexus.toml` under `[memnon.models.*]`.
 
 ## API Key Management
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,8 +113,6 @@ The NEXUS database schema is self-describing via Postgres table and column comme
 - **Programmatic access**: `MEMNON.get_schema_summary(tables=[...])` returns a structured summary (the same path LORE uses to build retrieval context — see `nexus/agents/memnon/memnon.py:374`).
 - **Convention**: when adding a column, include `COMMENT ON COLUMN <table>.<col> IS '...'` in the same migration. The comment IS the documentation.
 
-Embedding vectors live in five dimension-sharded tables (`chunk_embeddings_0384d` / `_1024d` / `_1536d` / `_2560d` / `_4096d`); active model + target dimension is configured in `nexus.toml` under `[memnon.models.*]`.
-
 ## API Key Management
 
 **Runtime API key storage is macOS Keychain.** 1Password remains the canonical source of truth used for rotation and audit; `scripts/sync_secrets.py` copies keys from 1Password into Keychain on bootstrap or rotation, and that script is the only place in the codebase that touches `op`.

--- a/migrations/018_narrative_chunks_column_comments.sql
+++ b/migrations/018_narrative_chunks_column_comments.sql
@@ -1,0 +1,34 @@
+-- 018_narrative_chunks_column_comments.sql
+--
+-- Populate descriptive comments on narrative_chunks columns so the schema
+-- is genuinely self-documenting via psql `\d+ narrative_chunks` or
+-- MEMNON.get_schema_summary(). Discharges schema-detail debt previously
+-- duplicated in CLAUDE.md.
+--
+-- COMMENT ON is idempotent (overwrites the prior value), so this migration
+-- is safe to re-run. Refreshes raw_text's existing comment to capture its
+-- derived/surface nature. Adds comments to seven columns that had none.
+
+COMMENT ON COLUMN narrative_chunks.raw_text IS
+    'User-readable prose version of the chunk ("the book version"). For in-system chunks this is the deterministic concatenation storyteller_text || choice_text — no unique information; re-derive if components change. For legacy imports (slot 1) this holds the original undecomposed text and storyteller_text mirrors it because the legacy corpus was never decomposed. Includes scene breaks and markdown formatting.';
+
+COMMENT ON COLUMN narrative_chunks.state IS
+    'Chunk lifecycle state. One of: ''draft'' (initial), ''pending_review'' (storyteller has produced text, user has not yet accepted), ''finalized'' (user accepted; chunk is locked — synonymous with "embedded" in practice). See ChunkState enum in nexus/api/chunk_workflow.py.';
+
+COMMENT ON COLUMN narrative_chunks.finalized_at IS
+    'Timestamp set by ChunkWorkflow.accept_chunk when the chunk transitions to the ''finalized'' state. NULL while the chunk is in ''draft'' or ''pending_review''.';
+
+COMMENT ON COLUMN narrative_chunks.embedding_generated_at IS
+    'Timestamp set by the embedding subprocess (scripts/regenerate_embeddings.py) after writing a row into one of the chunk_embeddings_*d tables for this chunk. NULL until embedding succeeds.';
+
+COMMENT ON COLUMN narrative_chunks.regeneration_count IS
+    'Number of times the storyteller text for this chunk has been regenerated via the regenerate flow. Zero for chunks accepted on first generation.';
+
+COMMENT ON COLUMN narrative_chunks.storyteller_text IS
+    'Authoritative storyteller portion of the chunk (narration only). For in-system chunks this is a strict subset of raw_text — distinct from choice_text (the user response). For legacy imports (slot 1) this equals raw_text because the corpus was never decomposed.';
+
+COMMENT ON COLUMN narrative_chunks.choice_text IS
+    'Authoritative text of the user''s response for this chunk. When the user selects a structured choice via --choice N, holds the text of that presented choice (resolved from choice_object.presented[N-1]). When the user submits freeform input via --user-text, holds that text directly.';
+
+COMMENT ON COLUMN narrative_chunks.choice_object IS
+    'JSON record of the choices offered + the chosen index. Shape: {"presented": [str, ...], "selected": <int 1..N | null>}. presented preserves the full menu the storyteller offered; selected is the 1-indexed pick (or null for --user-text / --accept-fate). This is the underground state that enables undo and audit even though raw_text (the readable surface) omits non-selected choices — a deliberate "surface entropy reduction" choice.';

--- a/migrations/018_narrative_chunks_column_comments.sql
+++ b/migrations/018_narrative_chunks_column_comments.sql
@@ -19,13 +19,13 @@ COMMENT ON COLUMN narrative_chunks.finalized_at IS
     'Timestamp set by ChunkWorkflow.accept_chunk when the chunk transitions to the ''finalized'' state. NULL while the chunk is in ''draft'' or ''pending_review''.';
 
 COMMENT ON COLUMN narrative_chunks.embedding_generated_at IS
-    'Timestamp set by the embedding subprocess (scripts/regenerate_embeddings.py) after writing a row into one of the chunk_embeddings_*d tables for this chunk. NULL until embedding succeeds.';
+    'Timestamp set by ChunkWorkflow._trigger_embedding_generation after the embedding subprocess (scripts/regenerate_embeddings.py) exits with code 0 — i.e., after a row has been written into one of the chunk_embeddings_*d tables. The subprocess itself does not write this column; the workflow does, post-success. NULL until embedding succeeds.';
 
 COMMENT ON COLUMN narrative_chunks.regeneration_count IS
     'Number of times the storyteller text for this chunk has been regenerated via the regenerate flow. Zero for chunks accepted on first generation.';
 
 COMMENT ON COLUMN narrative_chunks.storyteller_text IS
-    'Authoritative storyteller portion of the chunk (narration only). For in-system chunks this is a strict subset of raw_text — distinct from choice_text (the user response). For legacy imports (slot 1) this equals raw_text because the corpus was never decomposed.';
+    'Authoritative storyteller portion of the chunk (narration only). For in-system chunks this is the leading segment of raw_text — concretely, raw_text = storyteller_text || choice_text, so raw_text.startswith(storyteller_text) holds. For legacy imports (slot 1) this equals raw_text because the corpus was never decomposed.';
 
 COMMENT ON COLUMN narrative_chunks.choice_text IS
     'Authoritative text of the user''s response for this chunk. When the user selects a structured choice via --choice N, holds the text of that presented choice (resolved from choice_object.presented[N-1]). When the user submits freeform input via --user-text, holds that text directly.';


### PR DESCRIPTION
## Summary

Two coordinated changes to fix schema documentation drift:

### 1. CLAUDE.md "Main Tables" section → "Schema Reference"

Replaced a stale 3-bullet table listing with a pointer at the **live** schema. Anyone wanting schema details now runs `psql -d save_NN -c '\d+ <table>'` (or calls `MEMNON.get_schema_summary()`) and reads the Description column directly, which can't drift. Adds a convention note: new columns must include `COMMENT ON COLUMN` in their migration.

### 2. Migration 018 — column comments on `narrative_chunks`

`narrative_chunks` had 10 columns but only 3 had comments (id, raw_text, created_at). The migration:
- **Refreshes** `raw_text` to capture its derived/surface nature: it's the concatenation `storyteller_text || choice_text` for in-system chunks (no unique info); equals the raw imported text for legacy slots.
- **Adds** comments for `state`, `finalized_at`, `embedding_generated_at`, `regeneration_count`, `storyteller_text`, `choice_text`, `choice_object` — encoding the design contract (which fields are authoritative vs derived) and the "surface entropy reduction" framing for `choice_object`.

`COMMENT ON` is idempotent, so re-runs are safe.

## Verification

Applied locally to `NEXUS_template`:

```
$ psql -d NEXUS_template -f migrations/018_narrative_chunks_column_comments.sql
COMMENT
COMMENT
COMMENT
COMMENT
COMMENT
COMMENT
COMMENT
COMMENT

$ psql -d NEXUS_template -c '\d+ narrative_chunks' | head
```

→ all 10 columns now show populated Description fields.

## Out of scope

Comments on other tables (`chunk_metadata`, `places`, `characters`, etc.) — same pattern can follow as their semantics need clarification. This PR establishes the pattern + discharges the immediate CLAUDE.md drift.

## Related

- #197 (chunk-promotion write-path bug): the column comments here document the *intended* contract; #197 covers the bug where the write path doesn't honor it for `choice_text` and `choice_object.selected`.
- #198 (slot_state choice display): independent read-path fix that surfaces `choice_object.presented` after commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)