### PR TITLE
Delete dead _get_wizard_state function (closes #200)

### DIFF
--- a/nexus/api/slot_state.py
+++ b/nexus/api/slot_state.py
@@ -235,40 +235,6 @@ def _get_wizard_state_from_row(row: dict) -> WizardState:
     )
 
 
-def _get_wizard_state(cur) -> WizardState:
-    """
-    Get wizard state from new_story_creator cache and assets.traits.
-    """
-    cur.execute(
-        """
-        SELECT nsc.thread_id,
-               nsc.setting_genre,
-               nsc.character_name,
-               nsc.seed_type,
-               nsc.layer_name,
-               nsc.zone_name,
-               nsc.initial_location,
-               nsc.traits_confirmed,
-               (SELECT rationale FROM assets.traits WHERE id = 11) as wildcard_rationale
-        FROM assets.new_story_creator nsc
-        WHERE nsc.id = TRUE
-        """
-    )
-    row = cur.fetchone()
-
-    if row is None:
-        return WizardState(
-            phase="setting",
-            thread_id=None,
-            choices=[],
-            has_concept=False,
-            has_traits=False,
-            has_wildcard=False,
-        )
-
-    return _get_wizard_state_from_row(row)
-
-
 def _get_narrative_state(cur) -> NarrativeState:
     """
     Get narrative state from incubator and narrative_chunks.


### PR DESCRIPTION
Trivial deletion of a 32-line function with zero callers and a latent bug (its SELECT omitted `choice_object`). Flagged by claude[bot] in the PR #198 review.

Verified safe via:
```
grep -rn '_get_wizard_state\b' --include='*.py'
nexus/api/slot_state.py:238:def _get_wizard_state(cur) -> WizardState:
```
Only the definition; nothing else.

Closes #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)