### PR TITLE
[codex] Promote narrative choices during continue

### DIFF
--- a/migrations/019_add_incubator_choice_text.sql
+++ b/migrations/019_add_incubator_choice_text.sql
@@ -1,0 +1,37 @@
+-- 019_add_incubator_choice_text.sql
+--
+-- Store the player's resolved response on the pending incubator row before it
+-- is promoted into narrative_chunks.
+
+ALTER TABLE incubator
+ADD COLUMN IF NOT EXISTS choice_text TEXT;
+
+COMMENT ON COLUMN incubator.choice_text IS
+    'Resolved user response text for the pending chunk. Copied into narrative_chunks.choice_text at promotion.';
+
+DROP VIEW IF EXISTS incubator_view;
+CREATE VIEW incubator_view AS
+SELECT
+    i.chunk_id,
+    i.parent_chunk_id,
+    nc.raw_text AS parent_chunk_text,
+    i.user_text,
+    i.storyteller_text,
+    i.choice_object,
+    i.choice_text,
+    i.metadata_updates -> 'chronology' ->> 'episode_transition' AS episode_transition,
+    i.metadata_updates -> 'chronology' ->> 'time_delta_description' AS time_delta,
+    i.metadata_updates ->> 'world_layer' AS world_layer,
+    i.metadata_updates ->> 'pacing' AS pacing,
+    COALESCE(jsonb_array_length(i.entity_updates -> 'characters'), 0)
+        + COALESCE(jsonb_array_length(i.entity_updates -> 'locations'), 0)
+        + COALESCE(jsonb_array_length(i.entity_updates -> 'factions'), 0)
+        AS entity_update_count,
+    i.entity_updates AS entity_changes,
+    i.reference_updates AS "references",
+    i.status,
+    i.session_id,
+    i.created_at
+FROM incubator i
+LEFT JOIN narrative_chunks nc ON nc.id = i.parent_chunk_id
+WHERE i.id = TRUE;

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -6,7 +6,7 @@ Handles the execution of individual turn cycle phases.
 
 import logging
 import time
-from typing import Dict, List, Any, Optional, Union
+from typing import Dict, List, Any, Optional, Union, Iterable
 from datetime import datetime
 
 logger = logging.getLogger("nexus.lore.turn_cycle")
@@ -43,10 +43,13 @@ except ImportError:
 
 try:
     from nexus.agents.memnon.utils.query_analysis import QueryAnalyzer
+
     MEMNON_ANALYZER_AVAILABLE = True
 except ImportError:
     MEMNON_ANALYZER_AVAILABLE = False
-    logger.warning("MEMNON QueryAnalyzer not available - using fallback query generation")
+    logger.warning(
+        "MEMNON QueryAnalyzer not available - using fallback query generation"
+    )
 
 STRUCTURED_RESPONSE_TYPES = (
     StorytellerResponseMinimal,
@@ -55,44 +58,56 @@ STRUCTURED_RESPONSE_TYPES = (
 )
 
 
+def _sorted_chunk_ids(chunk_ids: Iterable[Any]) -> List[Any]:
+    """Sort chunk IDs deterministically even if old payloads mixed int/string IDs."""
+
+    def sort_key(chunk_id: Any) -> tuple[int, Any]:
+        try:
+            return (0, int(chunk_id))
+        except (TypeError, ValueError):
+            return (1, str(chunk_id))
+
+    return sorted(chunk_ids, key=sort_key)
+
+
 class TurnCycleManager:
     """Manages the execution of turn cycle phases"""
-    
+
     def __init__(self, lore_agent):
         """
         Initialize with reference to parent LORE agent.
-        
+
         Args:
             lore_agent: Reference to the parent LORE instance
         """
         self.lore = lore_agent
         self.settings = lore_agent.settings
-        
+
         # Initialize MEMNON's QueryAnalyzer if available
         self.query_analyzer = None
         if MEMNON_ANALYZER_AVAILABLE:
             memnon_settings = self.settings.get("Agent Settings", {}).get("MEMNON", {})
             self.query_analyzer = QueryAnalyzer(memnon_settings)
-    
+
     async def process_user_input(self, turn_context: TurnContext):
         """
         Phase 1: Process and validate user input.
-        
+
         Args:
             turn_context: Current turn context
         """
         logger.debug("Processing user input...")
-        
+
         # Calculate token budget
         if self.lore.token_manager:
             turn_context.token_counts = self.lore.token_manager.calculate_budget(
                 turn_context.user_input
             )
-        
+
         # Store processed input
         phase_state = {
             "processed": True,
-            "token_count": turn_context.token_counts.get("user_input", 0)
+            "token_count": turn_context.token_counts.get("user_input", 0),
         }
         if turn_context.target_chunk_id is not None:
             phase_state["target_chunk_id"] = turn_context.target_chunk_id
@@ -113,16 +128,16 @@ class TurnCycleManager:
         if memory_update:
             turn_context.memory_state["pass2"] = memory_update
         phase_state["memory_pass2"] = memory_update
-    
+
     async def perform_warm_analysis(self, turn_context: TurnContext):
         """
         Phase 2: Analyze recent narrative context.
-        
+
         Args:
             turn_context: Current turn context
         """
         logger.debug("Performing warm analysis...")
-        
+
         warm_slice_chunks: List[Dict[str, Any]] = []
         target_chunk_id = getattr(turn_context, "target_chunk_id", None)
 
@@ -136,9 +151,13 @@ class TurnCycleManager:
                         target_entry["text"] = target_entry["full_text"]
                     target_entry["is_target"] = True
                     warm_slice_chunks.append(target_entry)
-                    logger.info(f"Anchored warm slice to requested chunk {target_chunk_id}")
+                    logger.info(
+                        f"Anchored warm slice to requested chunk {target_chunk_id}"
+                    )
                 else:
-                    logger.warning(f"Requested parent chunk {target_chunk_id} not found; using recent chunks instead")
+                    logger.warning(
+                        f"Requested parent chunk {target_chunk_id} not found; using recent chunks instead"
+                    )
             except Exception as exc:
                 logger.error(f"Failed to load requested chunk {target_chunk_id}: {exc}")
 
@@ -146,7 +165,11 @@ class TurnCycleManager:
         if self.lore.memnon:
             try:
                 # Get chunk parameters from settings
-                chunk_params = self.settings.get("Agent Settings", {}).get("LORE", {}).get("chunk_parameters", {})
+                chunk_params = (
+                    self.settings.get("Agent Settings", {})
+                    .get("LORE", {})
+                    .get("chunk_parameters", {})
+                )
                 initial_chunks = chunk_params.get("warm_slice_initial", 10)
 
                 # Get most recent chunks directly
@@ -154,42 +177,53 @@ class TurnCycleManager:
                 recent_list = recent_chunks.get("results", [])
 
                 if target_chunk_id is not None:
-                    recent_list = [chunk for chunk in recent_list if chunk.get("id") != target_chunk_id]
+                    recent_list = [
+                        chunk
+                        for chunk in recent_list
+                        if chunk.get("id") != target_chunk_id
+                    ]
 
                 warm_slice_chunks.extend(recent_list)
                 turn_context.warm_slice = warm_slice_chunks
 
-                logger.info(f"Retrieved {len(turn_context.warm_slice)} warm-slice chunks (including anchors)")
+                logger.info(
+                    f"Retrieved {len(turn_context.warm_slice)} warm-slice chunks (including anchors)"
+                )
             except Exception as e:
                 logger.error(f"Failed to retrieve warm slice: {e}")
                 turn_context.warm_slice = warm_slice_chunks
         else:
             turn_context.warm_slice = warm_slice_chunks
-        
+
         if getattr(self.lore, "memory_manager", None):
-            turn_context.warm_slice = self.lore.memory_manager.augment_warm_slice(turn_context.warm_slice)
+            turn_context.warm_slice = self.lore.memory_manager.augment_warm_slice(
+                turn_context.warm_slice
+            )
 
         # Analyze with local LLM - REQUIRED for LORE to function
         if not self.lore.llm_manager or not self.lore.llm_manager.is_available():
-            raise RuntimeError("FATAL: Local LLM is required for warm analysis. "
-                             "LORE cannot function without semantic understanding. "
-                             "Ensure LM Studio is running with a model loaded.")
-        
+            raise RuntimeError(
+                "FATAL: Local LLM is required for warm analysis. "
+                "LORE cannot function without semantic understanding. "
+                "Ensure LM Studio is running with a model loaded."
+            )
+
         if not turn_context.warm_slice:
-            raise RuntimeError("FATAL: No warm slice chunks retrieved. "
-                             "Cannot analyze narrative context without recent chunks. "
-                             "Check database connection and chunk retrieval.")
-        
+            raise RuntimeError(
+                "FATAL: No warm slice chunks retrieved. "
+                "Cannot analyze narrative context without recent chunks. "
+                "Check database connection and chunk retrieval."
+            )
+
         analysis = self.lore.llm_manager.analyze_narrative_context(
-            turn_context.warm_slice,
-            turn_context.user_input
+            turn_context.warm_slice, turn_context.user_input
         )
-        
+
         turn_context.phase_states["warm_analysis"] = {
             "analysis": analysis,
-            "chunk_count": len(turn_context.warm_slice)
+            "chunk_count": len(turn_context.warm_slice),
         }
-    
+
     async def query_entity_states(self, turn_context: TurnContext):
         """
         Phase 3: Query for entity states using hierarchical baseline + featured structure.
@@ -212,20 +246,30 @@ class TurnCycleManager:
                 "factions": {"baseline": [], "featured": []},
                 "relationships": [],
                 "events": [],
-                "threats": []
+                "threats": [],
             }
             return
 
         # Get entity_inclusion settings
-        entity_settings = self.settings.get("Agent Settings", {}).get("LORE", {}).get("entity_inclusion", {})
+        entity_settings = (
+            self.settings.get("Agent Settings", {})
+            .get("LORE", {})
+            .get("entity_inclusion", {})
+        )
         include_relationships = entity_settings.get("include_all_relationships", True)
         include_events = entity_settings.get("include_all_active_events", True)
         include_threats = entity_settings.get("include_all_active_threats", True)
-        event_statuses = entity_settings.get("active_event_statuses", ["active", "ongoing", "escalating"])
-        threat_statuses = entity_settings.get("active_threat_statuses", ["active", "imminent"])
+        event_statuses = entity_settings.get(
+            "active_event_statuses", ["active", "ongoing", "escalating"]
+        )
+        threat_statuses = entity_settings.get(
+            "active_threat_statuses", ["active", "imminent"]
+        )
 
         # Get chunk IDs from warm slice for featured entity queries
-        warm_chunk_ids = [chunk.get("id") for chunk in turn_context.warm_slice if chunk.get("id")]
+        warm_chunk_ids = [
+            chunk.get("id") for chunk in turn_context.warm_slice if chunk.get("id")
+        ]
 
         if not warm_chunk_ids:
             logger.warning("No chunk IDs in warm slice for entity queries")
@@ -235,8 +279,11 @@ class TurnCycleManager:
         characters_data = {"baseline": [], "featured": []}
         try:
             from sqlalchemy import text
+
             with self.lore.memnon.Session() as session:
-                characters_data = fetch_all_characters_with_references(session, warm_chunk_ids)
+                characters_data = fetch_all_characters_with_references(
+                    session, warm_chunk_ids
+                )
             logger.info(
                 f"Characters: {len(characters_data['baseline'])} baseline, "
                 f"{len(characters_data['featured'])} featured"
@@ -256,7 +303,9 @@ class TurnCycleManager:
         places_data = {"baseline": [], "featured": []}
         try:
             with self.lore.memnon.Session() as session:
-                places_data = fetch_all_places_with_references(session, warm_chunk_ids, featured_place_ids)
+                places_data = fetch_all_places_with_references(
+                    session, warm_chunk_ids, featured_place_ids
+                )
             logger.info(
                 f"Places: {len(places_data['baseline'])} baseline, "
                 f"{len(places_data['featured'])} featured"
@@ -268,7 +317,9 @@ class TurnCycleManager:
         factions_data = {"baseline": [], "featured": []}
         try:
             with self.lore.memnon.Session() as session:
-                factions_data = fetch_all_factions_with_references(session, warm_chunk_ids)
+                factions_data = fetch_all_factions_with_references(
+                    session, warm_chunk_ids
+                )
             logger.info(
                 f"Factions: {len(factions_data['baseline'])} baseline, "
                 f"{len(factions_data['featured'])} featured"
@@ -280,19 +331,25 @@ class TurnCycleManager:
         relationships = []
         if include_relationships and characters_data.get("featured"):
             try:
-                char_ids = [c.get("id") for c in characters_data["featured"] if c.get("id")]
+                char_ids = [
+                    c.get("id") for c in characters_data["featured"] if c.get("id")
+                ]
                 if char_ids:
                     with self.lore.memnon.Session() as session:
-                        rel_query = text("""
+                        rel_query = text(
+                            """
                             SELECT *
                             FROM character_relationships
                             WHERE character1_id = ANY(:char_ids)
                               AND character2_id = ANY(:char_ids)
-                        """)
+                        """
+                        )
                         result = session.execute(rel_query, {"char_ids": char_ids})
                         for row in result:
                             relationships.append(dict(row._mapping))
-                    logger.info(f"Found {len(relationships)} relationships between featured characters")
+                    logger.info(
+                        f"Found {len(relationships)} relationships between featured characters"
+                    )
             except Exception as e:
                 logger.error(f"Failed to query relationships: {e}")
 
@@ -300,16 +357,21 @@ class TurnCycleManager:
         events = []
         if include_events:
             try:
-                max_events = entity_settings.get('max_total_events', 15)
+                max_events = entity_settings.get("max_total_events", 15)
                 with self.lore.memnon.Session() as session:
-                    event_query = text("""
+                    event_query = text(
+                        """
                         SELECT *
                         FROM events
                         WHERE status = ANY(:statuses)
                         ORDER BY id DESC
                         LIMIT :max_events
-                    """)
-                    result = session.execute(event_query, {"statuses": event_statuses, "max_events": max_events})
+                    """
+                    )
+                    result = session.execute(
+                        event_query,
+                        {"statuses": event_statuses, "max_events": max_events},
+                    )
                     for row in result:
                         events.append(dict(row._mapping))
                 logger.info(f"Found {len(events)} active events")
@@ -324,17 +386,19 @@ class TurnCycleManager:
         threats = []
         if include_threats:
             try:
-                max_threats = entity_settings.get('max_total_threats', 10)
+                max_threats = entity_settings.get("max_total_threats", 10)
                 with self.lore.memnon.Session() as session:
                     # Note: threats table uses is_active boolean, not status enum
                     # Lifecycle stages: inception, developing, active, resolved, dormant
-                    threat_query = text("""
+                    threat_query = text(
+                        """
                         SELECT *
                         FROM threats
                         WHERE is_active = true
                         ORDER BY id DESC
                         LIMIT :max_threats
-                    """)
+                    """
+                    )
                     result = session.execute(threat_query, {"max_threats": max_threats})
                     for row in result:
                         threats.append(dict(row._mapping))
@@ -353,7 +417,7 @@ class TurnCycleManager:
             "factions": factions_data,
             "relationships": relationships,
             "events": events,
-            "threats": threats
+            "threats": threats,
         }
 
         turn_context.phase_states["entity_state"] = {
@@ -366,7 +430,7 @@ class TurnCycleManager:
             "relationships_found": len(relationships),
             "events_found": len(events),
             "threats_found": len(threats),
-            "method": "hierarchical_baseline_featured"
+            "method": "hierarchical_baseline_featured",
         }
 
         logger.info(
@@ -376,41 +440,48 @@ class TurnCycleManager:
             f"factions {len(factions_data.get('baseline', []))}+{len(factions_data.get('featured', []))}, "
             f"{len(relationships)} rels, {len(events)} events, {len(threats)} threats"
         )
-    
+
     async def execute_deep_queries(self, turn_context: TurnContext):
         """
         Phase 4: Execute deep memory queries.
-        
+
         LLM generates retrieval queries based on narrative context,
         then MEMNON's QueryAnalyzer classifies them for optimal search.
         """
         logger.debug("Executing deep queries...")
-        
+
         if not self.lore.memnon:
             logger.warning("MEMNON not available for deep queries")
             return
-        
+
         # Step 1: LLM generates retrieval queries based on narrative analysis
         if not self.lore.llm_manager or not self.lore.llm_manager.is_available():
-            raise RuntimeError("FATAL: LLM is required for deep query generation. "
-                             "Cannot generate meaningful retrieval queries without semantic understanding.")
-        
-        analysis = turn_context.phase_states.get("warm_analysis", {}).get("analysis", {})
+            raise RuntimeError(
+                "FATAL: LLM is required for deep query generation. "
+                "Cannot generate meaningful retrieval queries without semantic understanding."
+            )
+
+        analysis = turn_context.phase_states.get("warm_analysis", {}).get(
+            "analysis", {}
+        )
         if not isinstance(analysis, dict):
-            raise RuntimeError("FATAL: Warm analysis failed or returned invalid data. "
-                             "Cannot proceed with deep queries without narrative context analysis.")
-        
-        # LLM generates queries from scratch based on what information 
+            raise RuntimeError(
+                "FATAL: Warm analysis failed or returned invalid data. "
+                "Cannot proceed with deep queries without narrative context analysis."
+            )
+
+        # LLM generates queries from scratch based on what information
         # would help continue the narrative
         llm_queries = self.lore.llm_manager.generate_retrieval_queries(
-            analysis,
-            turn_context.user_input
+            analysis, turn_context.user_input
         )
-        
+
         if not llm_queries:
-            raise RuntimeError("FATAL: LLM failed to generate any retrieval queries. "
-                             "This should not happen - check LLM configuration.")
-        
+            raise RuntimeError(
+                "FATAL: LLM failed to generate any retrieval queries. "
+                "This should not happen - check LLM configuration."
+            )
+
         if getattr(self.lore, "memory_manager", None):
             self.lore.memory_manager.reset_pass1_queries()
 
@@ -422,17 +493,15 @@ class TurnCycleManager:
                 query_info = self.query_analyzer.analyze_query(q_text)
                 query_type = query_info.get("type", "general")
                 logger.debug(f"Query '{q_text[:50]}...' classified as '{query_type}'")
-            
-            queries.append({
-                "text": q_text,
-                "type": query_type,
-                "source": "llm_generated"
-            })
-        
+
+            queries.append(
+                {"text": q_text, "type": query_type, "source": "llm_generated"}
+            )
+
         # Step 3: Execute queries with proper SearchManager configuration
         all_results = []
         query_type_counts = {}
-        
+
         for query_obj in queries[:5]:  # Limit to 5 queries
             if getattr(self.lore, "memory_manager", None):
                 self.lore.memory_manager.record_pass1_query(query_obj["text"])
@@ -442,81 +511,87 @@ class TurnCycleManager:
                 results = self.lore.memnon.query_memory(
                     query=query_obj["text"],
                     k=15,  # Get more results since we'll deduplicate
-                    use_hybrid=True
+                    use_hybrid=True,
                 )
-                
+
                 # Track query types for logging
                 query_type = query_obj["type"]
                 query_type_counts[query_type] = query_type_counts.get(query_type, 0) + 1
-                
+
                 # Tag results with query metadata
                 for result in results.get("results", []):
                     result["query_type"] = query_type
                     result["query_source"] = query_obj["source"]
-                
+
                 all_results.extend(results.get("results", []))
-                
+
             except Exception as e:
                 logger.error(f"Query failed for '{query_obj['text'][:50]}...': {e}")
-        
+
         # Store unique results, preserving highest scores
         seen_ids = {}
         for result in all_results:
             chunk_id = result.get("id")
             if chunk_id:
-                if chunk_id not in seen_ids or result.get("score", 0) > seen_ids[chunk_id].get("score", 0):
+                if chunk_id not in seen_ids or result.get("score", 0) > seen_ids[
+                    chunk_id
+                ].get("score", 0):
                     seen_ids[chunk_id] = result
-        
+
         # Sort by score and take top results
         unique_results = sorted(
-            seen_ids.values(),
-            key=lambda x: x.get("score", 0),
-            reverse=True
-        )[:30]  # Keep top 30 for augmentation
-        
+            seen_ids.values(), key=lambda x: x.get("score", 0), reverse=True
+        )[
+            :30
+        ]  # Keep top 30 for augmentation
+
         turn_context.retrieved_passages = unique_results
         turn_context.phase_states["deep_queries"] = {
             "queries_executed": len(queries),
             "query_types": query_type_counts,
-            "results_retrieved": len(unique_results)
+            "results_retrieved": len(unique_results),
         }
-        
-        logger.info(f"Deep queries complete: {len(queries)} queries executed "
-                   f"({query_type_counts}), {len(unique_results)} unique results retrieved")
-    
+
+        logger.info(
+            f"Deep queries complete: {len(queries)} queries executed "
+            f"({query_type_counts}), {len(unique_results)} unique results retrieved"
+        )
+
     # DEPRECATED: Cold Distillation phase removed - cross-encoders handle reranking
-    
+
     async def assemble_context_payload(self, turn_context: TurnContext):
         """
         Phase 5: Assemble final context payload.
-        
+
         Args:
             turn_context: Current turn context
         """
         logger.debug("Assembling context payload...")
-        
+
         # Build the context payload
         turn_context.context_payload = {
             "user_input": turn_context.user_input,
             "warm_slice": {
                 "chunks": turn_context.warm_slice,
-                "token_count": turn_context.token_counts.get("warm_slice", 0)
+                "token_count": turn_context.token_counts.get("warm_slice", 0),
             },
             "entity_data": turn_context.entity_data,
             "retrieved_passages": {
                 "results": turn_context.retrieved_passages,
-                "token_count": turn_context.token_counts.get("augmentation", 0)
+                "token_count": turn_context.token_counts.get("augmentation", 0),
             },
             "metadata": {
                 "turn_id": turn_context.turn_id,
                 "timestamp": datetime.now().isoformat(),
                 "authorial_directives": turn_context.authorial_directives,
             },
-            "memory_state": turn_context.memory_state
+            "memory_state": turn_context.memory_state,
         }
 
         if turn_context.target_chunk_id is not None:
-            turn_context.context_payload["metadata"]["target_chunk_id"] = turn_context.target_chunk_id
+            turn_context.context_payload["metadata"][
+                "target_chunk_id"
+            ] = turn_context.target_chunk_id
 
         # Calculate utilization
         if self.lore.token_manager:
@@ -525,31 +600,33 @@ class TurnCycleManager:
             )
         else:
             utilization = 0
-        
+
         turn_context.phase_states["payload_assembly"] = {
-            "total_tokens_used": sum([
-                turn_context.token_counts.get("user_input", 0),
-                turn_context.token_counts.get("warm_slice", 0),
-                turn_context.token_counts.get("structured", 0),
-                turn_context.token_counts.get("augmentation", 0)
-            ]),
-            "utilization_percentage": utilization
+            "total_tokens_used": sum(
+                [
+                    turn_context.token_counts.get("user_input", 0),
+                    turn_context.token_counts.get("warm_slice", 0),
+                    turn_context.token_counts.get("structured", 0),
+                    turn_context.token_counts.get("augmentation", 0),
+                ]
+            ),
+            "utilization_percentage": utilization,
         }
-        
+
         logger.info(f"Context payload assembled: {utilization:.1f}% budget utilization")
-    
+
     async def call_apex_ai(self, turn_context: TurnContext) -> str:
         """
         Phase 6: Call Apex AI for narrative generation.
-        
+
         Args:
             turn_context: Current turn context
-            
+
         Returns:
             Generated narrative response
         """
         logger.debug("Calling Apex AI...")
-        
+
         if not self.lore.enable_logon:
             logger.info("LOGON disabled; skipping Apex AI call")
             turn_context.phase_states["apex_generation"] = {
@@ -598,19 +675,19 @@ class TurnCycleManager:
                 "has_metadata": chunk_metadata is not None,
                 "has_entities": referenced_entities is not None,
                 "has_state_updates": state_updates is not None,
-                "narrative_length": len(narrative_text)
+                "narrative_length": len(narrative_text),
             }
 
             return story_response  # Return the full StoryTurnResponse
-            
+
         except Exception as e:
             logger.error("Apex AI call failed: %s", e)
             turn_context.phase_states["apex_generation"] = {
                 "success": False,
-                "error": str(e)
+                "error": str(e),
             }
             raise
-    
+
     async def integrate_response(
         self,
         turn_context: TurnContext,
@@ -645,7 +722,9 @@ class TurnCycleManager:
         }
 
         if structured_response is not None:
-            turn_context.phase_states["integration"]["structured_response"] = structured_response.model_dump()
+            turn_context.phase_states["integration"][
+                "structured_response"
+            ] = structured_response.model_dump()
 
         if getattr(self.lore, "memory_manager", None):
             try:
@@ -659,15 +738,19 @@ class TurnCycleManager:
                 )
                 transition = self.lore.memory_manager.context_state.transition
                 baseline_snapshot = {
-                    "baseline_chunks": sorted(baseline.baseline_chunks),
+                    "baseline_chunks": _sorted_chunk_ids(baseline.baseline_chunks),
                     "baseline_themes": baseline.baseline_themes,
-                    "expected_user_themes": transition.expected_user_themes if transition else [],
+                    "expected_user_themes": (
+                        transition.expected_user_themes if transition else []
+                    ),
                     "remaining_budget": self.lore.memory_manager.context_state.get_remaining_budget(),
                     "authorial_directives": baseline.authorial_directives,
                     "structured_passages": baseline.structured_passages,
                 }
                 turn_context.memory_state["pass1"] = baseline_snapshot
-                turn_context.phase_states["integration"]["memory_baseline"] = baseline_snapshot
+                turn_context.phase_states["integration"][
+                    "memory_baseline"
+                ] = baseline_snapshot
             except Exception as exc:  # pragma: no cover - defensive logging
                 logger.error("Pass 1 baseline storage failed: %s", exc)
                 turn_context.memory_state.setdefault("errors", []).append(str(exc))

--- a/nexus/api/choice_handling.py
+++ b/nexus/api/choice_handling.py
@@ -174,6 +174,23 @@ def normalize_choice_object(raw: Any) -> Optional[Dict[str, Any]]:
 
 def selected_text_from_choice_object(raw: Any) -> Optional[str]:
     """Return selected choice text from a choice_object, if it has one."""
+    decoded = raw
+    if isinstance(decoded, str):
+        try:
+            decoded = json.loads(decoded)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Invalid choice_object JSON") from exc
+
+    if isinstance(decoded, dict):
+        selected_raw = decoded.get("selected")
+        if isinstance(selected_raw, dict):
+            label = selected_raw.get("label")
+            text = (selected_raw.get("text") or "").strip()
+            if label == "freeform":
+                return text or None
+            if isinstance(label, int) and selected_raw.get("edited") and text:
+                return text
+
     choice_object = normalize_choice_object(raw)
     if not choice_object or choice_object.get("selected") is None:
         return None

--- a/nexus/api/choice_handling.py
+++ b/nexus/api/choice_handling.py
@@ -6,11 +6,14 @@ This module provides unified abstractions for:
 - Validating choice indices against available options
 - Resolving user input from choice number, freeform text, or accept-fate
 
-Both wizard and narrative modes use identical choice_object structures:
+Both wizard and narrative modes read identical choice_object structures:
     {
         "presented": ["Option 1", "Option 2", ...],
-        "selected": null | {label: int|"freeform", text: str, edited: bool}
+        "selected": null | int | {label: int|"freeform", text: str, edited: bool}
     }
+
+Narrative mode writes the canonical integer/null shape:
+    {"presented": ["Option 1", ...], "selected": 1 | null}
 
 This module eliminates the divergent implementations that led to:
 - Wizard mode ignoring --choice validation
@@ -18,7 +21,7 @@ This module eliminates the divergent implementations that led to:
 - Duplicated JSON parsing logic
 
 Note on accept-fate semantics:
-    The `resolve_input_text()` function is designed for **narrative mode**, where
+    The `resolve_choice_response()` function is designed for narrative mode, where
     accept-fate mechanically selects the first presented choice.
 
     **Wizard mode** handles accept-fate differently: it's a semantic signal passed
@@ -29,9 +32,10 @@ Note on accept-fate semantics:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 import logging
-from typing import Any, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -67,6 +71,15 @@ class ChoiceObject(BaseModel):
 
     presented: List[str] = Field(default_factory=list)
     selected: Optional[ChoiceSelection] = None
+
+
+@dataclass(frozen=True)
+class ResolvedChoiceResponse:
+    """Canonical response data to persist for a narrative choice."""
+
+    choice_text: str
+    choice_object: Optional[Dict[str, Any]]
+    selected: Optional[int]
 
 
 # =============================================================================
@@ -111,10 +124,140 @@ def parse_choice_object(raw: Any) -> Optional[ChoiceObject]:
     return None
 
 
+def normalize_choice_object(raw: Any) -> Optional[Dict[str, Any]]:
+    """
+    Normalize a stored choice_object into the canonical narrative write shape.
+
+    Readers accept the older selected-object shape for compatibility, but new
+    writes store only the 1-indexed selected choice number or null.
+    """
+    if raw is None:
+        return None
+
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Invalid choice_object JSON") from exc
+
+    if not isinstance(raw, dict):
+        raise ValueError("choice_object must be a JSON object")
+
+    presented_raw = raw.get("presented") or []
+    if not isinstance(presented_raw, list):
+        raise ValueError("choice_object.presented must be a list")
+
+    presented = [str(choice) for choice in presented_raw]
+    selected_raw = raw.get("selected")
+    selected: Optional[int] = None
+
+    if isinstance(selected_raw, int):
+        selected = selected_raw
+    elif isinstance(selected_raw, dict):
+        label = selected_raw.get("label")
+        if isinstance(label, int):
+            selected = label
+        elif label == "freeform":
+            selected = None
+        elif label is not None:
+            raise ValueError("choice_object.selected.label must be an int or freeform")
+    elif selected_raw is not None:
+        raise ValueError("choice_object.selected must be an int, object, or null")
+
+    if selected is not None and not (1 <= selected <= len(presented)):
+        raise ValueError(
+            f"choice_object.selected {selected} out of range (1-{len(presented)})"
+        )
+
+    return {"presented": presented, "selected": selected}
+
+
+def selected_text_from_choice_object(raw: Any) -> Optional[str]:
+    """Return selected choice text from a choice_object, if it has one."""
+    choice_object = normalize_choice_object(raw)
+    if not choice_object or choice_object.get("selected") is None:
+        return None
+
+    selected = choice_object["selected"]
+    presented = choice_object["presented"]
+    return presented[selected - 1]
+
+
+def resolve_choice_response(
+    raw_choice_object: Any,
+    *,
+    choice: Optional[int] = None,
+    user_text: Optional[str] = None,
+    accept_fate: bool = False,
+) -> ResolvedChoiceResponse:
+    """
+    Resolve user input into canonical persisted narrative choice fields.
+
+    Args:
+        raw_choice_object: Stored choice_object from incubator or narrative_chunks
+        choice: Optional 1-indexed structured choice number
+        user_text: Optional freeform/edited user response text
+        accept_fate: Whether to mechanically select the first presented choice
+
+    Returns:
+        Canonical choice_text and choice_object values for persistence.
+
+    Raises:
+        ValueError: If the input cannot be resolved against available choices.
+    """
+    if choice is not None and accept_fate:
+        raise ValueError("Cannot provide both choice and accept_fate")
+
+    choice_object = normalize_choice_object(raw_choice_object)
+    presented = choice_object["presented"] if choice_object else []
+    text = (user_text or "").strip()
+
+    if choice is not None:
+        resolved_text = validate_choice_index(choice, presented)
+        return ResolvedChoiceResponse(
+            choice_text=resolved_text,
+            choice_object={"presented": presented, "selected": choice},
+            selected=choice,
+        )
+
+    if accept_fate:
+        resolved_text = validate_choice_index(1, presented)
+        return ResolvedChoiceResponse(
+            choice_text=resolved_text,
+            choice_object={"presented": presented, "selected": 1},
+            selected=1,
+        )
+
+    if text:
+        selected = _infer_presented_choice_index(text, presented)
+        return ResolvedChoiceResponse(
+            choice_text=text,
+            choice_object=(
+                {"presented": presented, "selected": selected}
+                if choice_object
+                else None
+            ),
+            selected=selected,
+        )
+
+    raise ValueError("No input provided")
+
+
+def _infer_presented_choice_index(text: str, presented: List[str]) -> Optional[int]:
+    """Infer a selected index when a caller flattened a choice into text."""
+    for index, presented_text in enumerate(presented, 1):
+        if text == presented_text:
+            return index
+    return None
+
+
 def _parse_selection(raw: Any) -> Optional[ChoiceSelection]:
     """Parse the 'selected' field from choice_object."""
     if raw is None:
         return None
+
+    if isinstance(raw, int):
+        return ChoiceSelection(label=raw, text="", edited=False)
 
     if isinstance(raw, dict):
         label = raw.get("label")

--- a/nexus/api/chunk_workflow.py
+++ b/nexus/api/chunk_workflow.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Dict, List, Optional, Any
@@ -30,7 +31,7 @@ logger = logging.getLogger("nexus.api.chunk_workflow")
 VALID_DATABASES = {"save_01", "save_02", "save_03", "save_04", "save_05"}
 
 # Security: Valid model name pattern (alphanumeric, hyphens, dots, underscores only)
-VALID_MODEL_PATTERN = re.compile(r'^[a-zA-Z0-9._-]+$')
+VALID_MODEL_PATTERN = re.compile(r"^[a-zA-Z0-9._-]+$")
 
 
 class ChunkState(str, Enum):
@@ -63,8 +64,11 @@ class ChunkRejectRequest(BaseModel):
 
     chunk_id: int = Field(..., description="ID of the chunk to reject")
     session_id: str = Field(..., description="Session ID for context")
-    action: str = Field(..., pattern="^(regenerate|edit_previous)$",
-                       description="Action to take: regenerate or edit_previous")
+    action: str = Field(
+        ...,
+        pattern="^(regenerate|edit_previous)$",
+        description="Action to take: regenerate or edit_previous",
+    )
 
 
 class ChunkRejectResponse(BaseModel):
@@ -114,41 +118,53 @@ class ChunkWorkflow:
         with get_connection(self.dbname) as conn:
             with conn.cursor() as cur:
                 # Check if columns exist, add if not
-                cur.execute("""
+                cur.execute(
+                    """
                     SELECT column_name
                     FROM information_schema.columns
                     WHERE table_name = 'narrative_chunks'
                     AND column_name IN ('state', 'finalized_at', 'embedding_generated_at', 'regeneration_count')
-                """)
+                """
+                )
                 existing_columns = {row[0] for row in cur.fetchall()}
 
                 # Add missing columns
-                if 'state' not in existing_columns:
-                    cur.execute("""
+                if "state" not in existing_columns:
+                    cur.execute(
+                        """
                         ALTER TABLE narrative_chunks
                         ADD COLUMN state VARCHAR(20) DEFAULT 'draft'
-                    """)
+                    """
+                    )
                     logger.info("Added state column to narrative_chunks")
 
-                if 'finalized_at' not in existing_columns:
-                    cur.execute("""
+                if "finalized_at" not in existing_columns:
+                    cur.execute(
+                        """
                         ALTER TABLE narrative_chunks
                         ADD COLUMN finalized_at TIMESTAMPTZ
-                    """)
+                    """
+                    )
                     logger.info("Added finalized_at column to narrative_chunks")
 
-                if 'embedding_generated_at' not in existing_columns:
-                    cur.execute("""
+                if "embedding_generated_at" not in existing_columns:
+                    cur.execute(
+                        """
                         ALTER TABLE narrative_chunks
                         ADD COLUMN embedding_generated_at TIMESTAMPTZ
-                    """)
-                    logger.info("Added embedding_generated_at column to narrative_chunks")
+                    """
+                    )
+                    logger.info(
+                        "Added embedding_generated_at column to narrative_chunks"
+                    )
 
-                if 'regeneration_count' not in existing_columns:
-                    cur.execute("""
+                if "regeneration_count" not in existing_columns:
+                    cur.execute(
+                        """
                         ALTER TABLE narrative_chunks
                         ADD COLUMN regeneration_count INTEGER DEFAULT 0
-                    """)
+                    """
+                    )
                     logger.info("Added regeneration_count column to narrative_chunks")
 
     def accept_chunk(self, chunk_id: int, session_id: str) -> ChunkAcceptResponse:
@@ -166,21 +182,26 @@ class ChunkWorkflow:
             with conn.cursor() as cur:
                 # Security: Atomic state transition to prevent race condition
                 # Only finalize if currently pending_review (prevents double-finalization)
-                cur.execute("""
+                cur.execute(
+                    """
                     UPDATE narrative_chunks
                     SET state = %s, finalized_at = %s
                     WHERE id = %s AND state = %s
                     RETURNING id
-                """, (
-                    ChunkState.FINALIZED.value,
-                    datetime.now(timezone.utc),
-                    chunk_id,
-                    ChunkState.PENDING_REVIEW.value  # Only update if pending
-                ))
+                """,
+                    (
+                        ChunkState.FINALIZED.value,
+                        datetime.now(timezone.utc),
+                        chunk_id,
+                        ChunkState.PENDING_REVIEW.value,  # Only update if pending
+                    ),
+                )
 
                 if not cur.fetchone():
                     # Check if chunk exists but wrong state
-                    cur.execute("SELECT state FROM narrative_chunks WHERE id = %s", (chunk_id,))
+                    cur.execute(
+                        "SELECT state FROM narrative_chunks WHERE id = %s", (chunk_id,)
+                    )
                     result = cur.fetchone()
                     if not result:
                         raise ValueError(f"Chunk {chunk_id} not found")
@@ -190,13 +211,16 @@ class ChunkWorkflow:
                         )
 
                 # Get previous chunk (N-1) to trigger embedding
-                cur.execute("""
+                cur.execute(
+                    """
                     SELECT id, state, raw_text
                     FROM narrative_chunks
                     WHERE id < %s
                     ORDER BY id DESC
                     LIMIT 1
-                """, (chunk_id,))
+                """,
+                    (chunk_id,),
+                )
 
                 previous_chunk = cur.fetchone()
                 embedding_triggered = False
@@ -207,26 +231,33 @@ class ChunkWorkflow:
 
                     # Only generate embeddings if not already done
                     if prev_state == ChunkState.FINALIZED.value:
-                        embedding_job_id = self._trigger_embedding_generation(prev_id)
+                        embedding_job_id = self.trigger_embedding_generation(prev_id)
                         embedding_triggered = True
 
                         # Mark as embedding in progress
-                        cur.execute("""
+                        cur.execute(
+                            """
                             UPDATE narrative_chunks
                             SET state = %s
                             WHERE id = %s
-                        """, (ChunkState.EMBEDDED.value, prev_id))
+                        """,
+                            (ChunkState.EMBEDDED.value, prev_id),
+                        )
 
-                logger.info(f"Accepted chunk {chunk_id}, embedding triggered: {embedding_triggered}")
+                logger.info(
+                    f"Accepted chunk {chunk_id}, embedding triggered: {embedding_triggered}"
+                )
 
                 return ChunkAcceptResponse(
                     chunk_id=chunk_id,
                     state=ChunkState.FINALIZED,
                     previous_chunk_embedded=embedding_triggered,
-                    embedding_job_id=embedding_job_id
+                    embedding_job_id=embedding_job_id,
                 )
 
-    def reject_chunk(self, chunk_id: int, session_id: str, action: str) -> ChunkRejectResponse:
+    def reject_chunk(
+        self, chunk_id: int, session_id: str, action: str
+    ) -> ChunkRejectResponse:
         """
         Reject a Storyteller chunk with specified action.
 
@@ -241,11 +272,14 @@ class ChunkWorkflow:
         with get_connection(self.dbname) as conn:
             with conn.cursor() as cur:
                 # Get current chunk info
-                cur.execute("""
+                cur.execute(
+                    """
                     SELECT state, regeneration_count
                     FROM narrative_chunks
                     WHERE id = %s
-                """, (chunk_id,))
+                """,
+                    (chunk_id,),
+                )
 
                 result = cur.fetchone()
                 if not result:
@@ -260,22 +294,27 @@ class ChunkWorkflow:
                     chunk_id=chunk_id,
                     state=ChunkState.PENDING_REVIEW,
                     action_taken=action,
-                    regeneration_count=regen_count
+                    regeneration_count=regen_count,
                 )
 
                 if action == "regenerate":
                     # Increment regeneration counter
-                    cur.execute("""
+                    cur.execute(
+                        """
                         UPDATE narrative_chunks
                         SET regeneration_count = regeneration_count + 1,
                             state = %s
                         WHERE id = %s
                         RETURNING regeneration_count
-                    """, (ChunkState.PENDING_REVIEW.value, chunk_id))
+                    """,
+                        (ChunkState.PENDING_REVIEW.value, chunk_id),
+                    )
 
                     new_count = cur.fetchone()[0]
                     response.regeneration_count = new_count
-                    logger.info(f"Chunk {chunk_id} marked for regeneration (attempt {new_count})")
+                    logger.info(
+                        f"Chunk {chunk_id} marked for regeneration (attempt {new_count})"
+                    )
 
                 elif action == "edit_previous":
                     # Enable editing of previous user input
@@ -284,7 +323,9 @@ class ChunkWorkflow:
 
                 return response
 
-    def edit_previous_input(self, chunk_id: int, new_user_input: str, session_id: str) -> EditPreviousResponse:
+    def edit_previous_input(
+        self, chunk_id: int, new_user_input: str, session_id: str
+    ) -> EditPreviousResponse:
         """
         Edit the user's input from the previous chunk.
 
@@ -302,11 +343,14 @@ class ChunkWorkflow:
                 prev_chunk_id = chunk_id - 1
 
                 # Find the previous user chunk (should be user input)
-                cur.execute("""
+                cur.execute(
+                    """
                     SELECT id, state, raw_text
                     FROM narrative_chunks
                     WHERE id = %s
-                """, (prev_chunk_id,))
+                """,
+                    (prev_chunk_id,),
+                )
 
                 prev_chunk = cur.fetchone()
                 if not prev_chunk:
@@ -319,28 +363,48 @@ class ChunkWorkflow:
                     raise ValueError(f"Cannot edit finalized chunk {prev_id}")
 
                 # Update the user's previous input
-                cur.execute("""
+                cur.execute(
+                    """
                     UPDATE narrative_chunks
                     SET raw_text = %s,
                         state = %s
                     WHERE id = %s
-                """, (new_user_input, ChunkState.DRAFT.value, prev_id))
+                """,
+                    (new_user_input, ChunkState.DRAFT.value, prev_id),
+                )
 
                 # Mark current Storyteller chunk for regeneration
-                cur.execute("""
+                cur.execute(
+                    """
                     UPDATE narrative_chunks
                     SET state = %s,
                         regeneration_count = regeneration_count + 1
                     WHERE id = %s
-                """, (ChunkState.PENDING_REVIEW.value, chunk_id))
+                """,
+                    (ChunkState.PENDING_REVIEW.value, chunk_id),
+                )
 
-                logger.info(f"Updated user input in chunk {prev_id}, triggering regeneration of {chunk_id}")
+                logger.info(
+                    f"Updated user input in chunk {prev_id}, triggering regeneration of {chunk_id}"
+                )
 
                 return EditPreviousResponse(
                     previous_chunk_id=prev_id,
                     updated=True,
-                    new_generation_triggered=True
+                    new_generation_triggered=True,
                 )
+
+    def trigger_embedding_generation(self, chunk_id: int) -> Optional[str]:
+        """
+        Generate embeddings for a locked chunk.
+
+        Args:
+            chunk_id: The chunk to generate embeddings for
+
+        Returns:
+            Job ID if generation succeeds, None otherwise
+        """
+        return self._trigger_embedding_generation(chunk_id)
 
     def _trigger_embedding_generation(self, chunk_id: int) -> Optional[str]:
         """
@@ -355,11 +419,14 @@ class ChunkWorkflow:
         try:
             # Load settings to get embedding configuration
             from nexus.config import load_settings_as_dict
+
             settings = load_settings_as_dict()
 
             # Get the appropriate embedding model from settings
-            embedding_config = settings.get("Agent Settings", {}).get("MEMNON", {}).get("embedding", {})
-            models = embedding_config.get("models", {})
+            memnon_config = settings.get("Agent Settings", {}).get("MEMNON", {})
+            models = memnon_config.get("models") or memnon_config.get(
+                "embedding", {}
+            ).get("models", {})
 
             # Find active model
             active_model = None
@@ -369,8 +436,12 @@ class ChunkWorkflow:
                     break
 
             if not active_model:
-                logger.warning("No active embedding model found in settings - using default")
-                active_model = "inf-retriever-v1-1.5b"  # Best performing model from IR testing
+                logger.warning(
+                    "No active embedding model found in settings - using default"
+                )
+                active_model = (
+                    "Octen-Embedding-4B"  # Production embedder from IR testing
+                )
 
             # Security: Validate inputs before subprocess call
             if not isinstance(chunk_id, int) or chunk_id <= 0:
@@ -386,34 +457,55 @@ class ChunkWorkflow:
 
             # Run embedding generation script
             # TODO: Make async with FastAPI BackgroundTasks or Celery to avoid blocking
-            result = subprocess.run([
-                "python", "scripts/regenerate_embeddings.py",
-                "--chunk", str(chunk_id),  # Safe: validated as positive int
-                "--model", active_model,    # Safe: validated with regex
-                "--database", self.dbname   # Safe: validated in __init__
-            ], capture_output=True, text=True, timeout=300)  # 5 min timeout
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "scripts/regenerate_embeddings.py",
+                    "--chunk",
+                    str(chunk_id),  # Safe: validated as positive int
+                    "--model",
+                    active_model,  # Safe: validated with regex
+                    "--database",
+                    self.dbname,  # Safe: validated in __init__
+                ],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )  # 5 min timeout
 
             if result.returncode == 0:
                 # Mark chunk as embedded
                 with get_connection(self.dbname) as conn:
                     with conn.cursor() as cur:
-                        cur.execute("""
+                        cur.execute(
+                            """
                             UPDATE narrative_chunks
-                            SET embedding_generated_at = %s
+                            SET embedding_generated_at = %s,
+                                state = %s
                             WHERE id = %s
-                        """, (datetime.now(timezone.utc), chunk_id))
+                        """,
+                            (
+                                datetime.now(timezone.utc),
+                                ChunkState.EMBEDDED.value,
+                                chunk_id,
+                            ),
+                        )
 
                 logger.info(f"Successfully generated embeddings for chunk {chunk_id}")
                 return f"embed_{chunk_id}_{datetime.now().timestamp()}"
             else:
-                logger.error(f"Embedding generation failed for chunk {chunk_id}: {result.stderr}")
+                logger.error(
+                    f"Embedding generation failed for chunk {chunk_id}: {result.stderr}"
+                )
                 return None
 
         except Exception as e:
             logger.error(f"Error triggering embedding generation: {e}")
             return None
 
-    def get_chunk_states(self, start_chunk: int, end_chunk: int) -> List[Dict[str, Any]]:
+    def get_chunk_states(
+        self, start_chunk: int, end_chunk: int
+    ) -> List[Dict[str, Any]]:
         """
         Get the states of chunks in a range.
 
@@ -426,12 +518,15 @@ class ChunkWorkflow:
         """
         with get_connection(self.dbname, dict_cursor=True) as conn:
             with conn.cursor() as cur:
-                cur.execute("""
+                cur.execute(
+                    """
                     SELECT id, state, finalized_at, embedding_generated_at, regeneration_count
                     FROM narrative_chunks
                     WHERE id BETWEEN %s AND %s
                     ORDER BY id
-                """, (start_chunk, end_chunk))
+                """,
+                    (start_chunk, end_chunk),
+                )
 
                 return [dict(row) for row in cur.fetchall()]
 

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -16,19 +16,21 @@ import asyncpg
 from nexus.agents.logon.apex_schema import (
     ChronologyUpdate,
     ReferencedEntities,
-    StateUpdates
+    StateUpdates,
 )
 from nexus.api.db_converters import (
     chronology_to_db_values,
     resolve_character_references,
     resolve_place_references,
-    resolve_faction_references
+    resolve_faction_references,
 )
 from nexus.api.summary_triggers import (
     SummaryTask,
     plan_summary_tasks,
-    schedule_summary_generation
+    schedule_summary_generation,
 )
+from nexus.api.choice_handling import normalize_choice_object
+from nexus.api.lore_adapter import compute_raw_text, format_choice_text
 
 logger = logging.getLogger("nexus.api.commit_handler")
 
@@ -37,9 +39,9 @@ logger = logging.getLogger("nexus.api.commit_handler")
 # Database Query Functions
 # ============================================================================
 
+
 async def fetch_incubator_data(
-    conn: asyncpg.Connection,
-    session_id: str
+    conn: asyncpg.Connection, session_id: str
 ) -> Dict[str, Any]:
     """
     Fetch data from incubator table for a given session.
@@ -47,12 +49,13 @@ async def fetch_incubator_data(
     row = await conn.fetchrow(
         """
         SELECT chunk_id, parent_chunk_id, user_text, storyteller_text,
+               choice_object, choice_text,
                metadata_updates, entity_updates, reference_updates,
                llm_response_id, status
         FROM incubator
         WHERE session_id = $1
         """,
-        session_id
+        session_id,
     )
 
     if not row:
@@ -62,8 +65,7 @@ async def fetch_incubator_data(
 
 
 async def fetch_chunk_metadata(
-    conn: asyncpg.Connection,
-    chunk_id: int
+    conn: asyncpg.Connection, chunk_id: int
 ) -> Dict[str, Any]:
     """
     Fetch metadata for an existing chunk.
@@ -74,7 +76,7 @@ async def fetch_chunk_metadata(
         FROM chunk_metadata
         WHERE chunk_id = $1
         """,
-        chunk_id
+        chunk_id,
     )
 
     if not row:
@@ -87,9 +89,13 @@ async def fetch_chunk_metadata(
 # Insert Functions
 # ============================================================================
 
+
 async def insert_narrative_chunk(
     conn: asyncpg.Connection,
     raw_text: str,
+    storyteller_text: Optional[str],
+    choice_object: Optional[Dict[str, Any]],
+    choice_text: Optional[str],
 ) -> int:
     """
     Insert a new narrative chunk and return its ID.
@@ -98,11 +104,16 @@ async def insert_narrative_chunk(
     """
     chunk_id = await conn.fetchval(
         """
-        INSERT INTO narrative_chunks (raw_text)
-        VALUES ($1)
+        INSERT INTO narrative_chunks (
+            raw_text, storyteller_text, choice_object, choice_text
+        )
+        VALUES ($1, $2, $3::jsonb, $4)
         RETURNING id
         """,
         raw_text,
+        storyteller_text,
+        json.dumps(choice_object) if choice_object else None,
+        choice_text,
     )
     logger.info(f"Created narrative chunk {chunk_id}")
     return chunk_id
@@ -116,7 +127,7 @@ async def insert_chunk_metadata(
     scene: int,
     world_layer: str,
     time_delta: Optional[Any],
-    generation_date: Optional[datetime] = None
+    generation_date: Optional[datetime] = None,
 ) -> None:
     """
     Insert metadata for a chunk.
@@ -145,9 +156,7 @@ async def insert_chunk_metadata(
 
 
 async def insert_place_references(
-    conn: asyncpg.Connection,
-    chunk_id: int,
-    place_refs: list
+    conn: asyncpg.Connection, chunk_id: int, place_refs: list
 ) -> None:
     """
     Insert place-chunk references into junction table.
@@ -164,15 +173,13 @@ async def insert_place_references(
             ref["place_id"],
             chunk_id,
             ref["reference_type"],
-            ref.get("evidence")
+            ref.get("evidence"),
         )
     logger.info(f"Inserted {len(place_refs)} place references for chunk {chunk_id}")
 
 
 async def insert_character_references(
-    conn: asyncpg.Connection,
-    chunk_id: int,
-    char_refs: list
+    conn: asyncpg.Connection, chunk_id: int, char_refs: list
 ) -> None:
     """
     Insert character-chunk references into junction table.
@@ -188,15 +195,13 @@ async def insert_character_references(
             """,
             chunk_id,
             ref["character_id"],
-            ref["reference"]
+            ref["reference"],
         )
     logger.info(f"Inserted {len(char_refs)} character references for chunk {chunk_id}")
 
 
 async def insert_faction_references(
-    conn: asyncpg.Connection,
-    chunk_id: int,
-    faction_refs: list
+    conn: asyncpg.Connection, chunk_id: int, faction_refs: list
 ) -> None:
     """
     Insert faction-chunk references into junction table.
@@ -211,7 +216,7 @@ async def insert_faction_references(
             VALUES ($1, $2)
             """,
             chunk_id,
-            ref["faction_id"]
+            ref["faction_id"],
         )
     logger.info(f"Inserted {len(faction_refs)} faction references for chunk {chunk_id}")
 
@@ -220,9 +225,9 @@ async def insert_faction_references(
 # State Update Functions
 # ============================================================================
 
+
 async def apply_state_updates(
-    conn: asyncpg.Connection,
-    state_updates: StateUpdates
+    conn: asyncpg.Connection, state_updates: StateUpdates
 ) -> None:
     """
     Apply entity state updates from the LLM response.
@@ -260,7 +265,7 @@ async def apply_state_updates(
                     SET {', '.join(updates)}
                     WHERE id = ${param_count}
                     """,
-                    *params
+                    *params,
                 )
                 logger.info(f"Updated character {char_update.character_id}")
 
@@ -274,7 +279,7 @@ async def apply_state_updates(
                 WHERE id = $2
                 """,
                 place_update.current_status,
-                place_update.place_id
+                place_update.place_id,
             )
             logger.info(f"Updated place {place_update.place_id}")
 
@@ -288,25 +293,19 @@ async def apply_state_updates(
                 WHERE id = $2
                 """,
                 faction_update.current_activity,
-                faction_update.faction_id
+                faction_update.faction_id,
             )
             logger.info(f"Updated faction {faction_update.faction_id}")
 
 
-async def clear_incubator(
-    conn: asyncpg.Connection,
-    session_id: str = None
-) -> None:
+async def clear_incubator(conn: asyncpg.Connection, session_id: str = None) -> None:
     """
     Clear incubator after successful commit.
     If session_id is provided, only clear that session.
     Otherwise, clear all (for singleton incubator).
     """
     if session_id:
-        await conn.execute(
-            "DELETE FROM incubator WHERE session_id = $1",
-            session_id
-        )
+        await conn.execute("DELETE FROM incubator WHERE session_id = $1", session_id)
         logger.info(f"Cleared incubator for session {session_id}")
     else:
         await conn.execute("DELETE FROM incubator")
@@ -317,9 +316,9 @@ async def clear_incubator(
 # Main Commit Function
 # ============================================================================
 
+
 async def commit_incubator_to_database(
-    conn: asyncpg.Connection,
-    session_id: str
+    conn: asyncpg.Connection, session_id: str
 ) -> int:
     """
     Complete commit flow from incubator to production tables.
@@ -366,7 +365,9 @@ async def commit_incubator_to_database(
             ref_entities = ReferencedEntities(**incubator["reference_updates"])
 
             # Create new entities and resolve all to IDs
-            character_refs = await resolve_character_references(ref_entities.characters, conn)
+            character_refs = await resolve_character_references(
+                ref_entities.characters, conn
+            )
             place_refs = await resolve_place_references(ref_entities.places, conn)
             faction_refs = await resolve_faction_references(ref_entities.factions, conn)
 
@@ -376,7 +377,7 @@ async def commit_incubator_to_database(
             db_meta = chronology_to_db_values(
                 chronology,
                 current_season=parent_meta["season"],
-                current_episode=parent_meta["episode"]
+                current_episode=parent_meta["episode"],
             )
             summary_tasks = plan_summary_tasks(
                 chronology.episode_transition,
@@ -391,9 +392,23 @@ async def commit_incubator_to_database(
             world_layer = incubator["metadata_updates"].get("world_layer", "primary")
 
             # Step 5: Insert narrative chunk
+            choice_object = incubator.get("choice_object")
+            storyteller_text = incubator.get("storyteller_text") or ""
+            choice_text = incubator.get("choice_text")
+            if choice_object:
+                choice_object = normalize_choice_object(choice_object)
+                if not choice_text and choice_object.get("selected"):
+                    choice_text = format_choice_text(
+                        choice_object, include_selection=True
+                    )
+
+            raw_text = compute_raw_text(storyteller_text, choice_object, choice_text)
             chunk_id = await insert_narrative_chunk(
                 conn,
-                raw_text=incubator["storyteller_text"],
+                raw_text=raw_text,
+                storyteller_text=storyteller_text,
+                choice_object=choice_object,
+                choice_text=choice_text,
             )
             if chunk_id is None:
                 raise ValueError("Failed to obtain chunk_id after insert")
@@ -406,7 +421,7 @@ async def commit_incubator_to_database(
                 episode=db_meta["episode"],
                 scene=db_meta["scene"],
                 world_layer=world_layer,
-                time_delta=db_meta["time_delta"]
+                time_delta=db_meta["time_delta"],
             )
 
             # Step 7: Insert junction table references
@@ -430,7 +445,9 @@ async def commit_incubator_to_database(
         try:
             schedule_summary_generation(summary_tasks)
         except Exception as exc:  # pragma: no cover - defensive logging
-            logger.error("Failed to schedule summaries for session %s: %s", session_id, exc)
+            logger.error(
+                "Failed to schedule summaries for session %s: %s", session_id, exc
+            )
 
     logger.info("Successfully committed chunk %s from session %s", chunk_id, session_id)
     return chunk_id

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -29,8 +29,11 @@ from nexus.api.summary_triggers import (
     plan_summary_tasks,
     schedule_summary_generation,
 )
-from nexus.api.choice_handling import normalize_choice_object
-from nexus.api.lore_adapter import compute_raw_text, format_choice_text
+from nexus.api.choice_handling import (
+    normalize_choice_object,
+    selected_text_from_choice_object,
+)
+from nexus.api.lore_adapter import compute_raw_text
 
 logger = logging.getLogger("nexus.api.commit_handler")
 
@@ -396,11 +399,9 @@ async def commit_incubator_to_database(
             storyteller_text = incubator.get("storyteller_text") or ""
             choice_text = incubator.get("choice_text")
             if choice_object:
+                if not choice_text:
+                    choice_text = selected_text_from_choice_object(choice_object)
                 choice_object = normalize_choice_object(choice_object)
-                if not choice_text and choice_object.get("selected"):
-                    choice_text = format_choice_text(
-                        choice_object, include_selection=True
-                    )
 
             raw_text = compute_raw_text(storyteller_text, choice_object, choice_text)
             chunk_id = await insert_narrative_chunk(

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -27,8 +27,11 @@ from nexus.api.summary_triggers import (
     plan_summary_tasks,
     schedule_summary_generation,
 )
-from nexus.api.lore_adapter import compute_raw_text, format_choice_text
-from nexus.api.choice_handling import normalize_choice_object
+from nexus.api.lore_adapter import compute_raw_text
+from nexus.api.choice_handling import (
+    normalize_choice_object,
+    selected_text_from_choice_object,
+)
 
 logger = logging.getLogger("nexus.api.commit_handler_sync")
 
@@ -376,12 +379,9 @@ def commit_incubator_to_database_sync(
             choice_text: Optional[str] = incubator.get("choice_text")
 
             if choice_object:
+                if not choice_text:
+                    choice_text = selected_text_from_choice_object(choice_object)
                 choice_object = normalize_choice_object(choice_object)
-
-                if not choice_text and choice_object.get("selected"):
-                    choice_text = format_choice_text(
-                        choice_object, include_selection=True
-                    )
 
             raw_text = compute_raw_text(storyteller_text, choice_object, choice_text)
 

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -19,15 +19,16 @@ from nexus.agents.logon.apex_schema import (
     PlaceReference,
     CharacterReference,
     FactionReference,
-    StateUpdates
+    StateUpdates,
 )
 from nexus.api.db_converters import chronology_to_db_values
 from nexus.api.summary_triggers import (
     SummaryTask,
     plan_summary_tasks,
-    schedule_summary_generation
+    schedule_summary_generation,
 )
 from nexus.api.lore_adapter import compute_raw_text, format_choice_text
+from nexus.api.choice_handling import normalize_choice_object
 
 logger = logging.getLogger("nexus.api.commit_handler_sync")
 
@@ -46,9 +47,9 @@ def _json_dumps_model(value: Any) -> Optional[str]:
 # Entity Resolution Functions (Synchronous)
 # ============================================================================
 
+
 def resolve_place_references_sync(
-    place_references: List[PlaceReference],
-    conn
+    place_references: List[PlaceReference], conn
 ) -> List[dict]:
     """Synchronous version of resolve_place_references"""
     resolved_refs = []
@@ -74,11 +75,13 @@ def resolve_place_references_sync(
                 place_id = create_new_place_sync(cur, ref.new_place)
 
         # Build junction table entry
-        resolved_refs.append({
-            "place_id": place_id,
-            "reference_type": ref.reference_type.value,
-            "evidence": ref.evidence
-        })
+        resolved_refs.append(
+            {
+                "place_id": place_id,
+                "reference_type": ref.reference_type.value,
+                "evidence": ref.evidence,
+            }
+        )
 
     return resolved_refs
 
@@ -86,28 +89,30 @@ def resolve_place_references_sync(
 def create_new_place_sync(cur, new_place):
     """Create a new place synchronously"""
     # Insert place
-    cur.execute("""
+    cur.execute(
+        """
         INSERT INTO places (
             name, type, summary, history, current_status, secrets,
             extra_data
         ) VALUES (%s, %s, %s, %s, %s, %s, %s)
         RETURNING id
-    """, (
-        new_place.name,
-        new_place.type.value if new_place.type else None,
-        new_place.summary,
-        new_place.history,
-        new_place.current_status,
-        new_place.secrets,
-        _json_dumps_model(new_place.extra_data),
-    ))
+    """,
+        (
+            new_place.name,
+            new_place.type.value if new_place.type else None,
+            new_place.summary,
+            new_place.history,
+            new_place.current_status,
+            new_place.secrets,
+            _json_dumps_model(new_place.extra_data),
+        ),
+    )
 
     return cur.fetchone()[0]
 
 
 def resolve_character_references_sync(
-    character_references: List[CharacterReference],
-    conn
+    character_references: List[CharacterReference], conn
 ) -> List[dict]:
     """Synchronous version of resolve_character_references"""
     resolved_refs = []
@@ -119,7 +124,9 @@ def resolve_character_references_sync(
             if ref.character_id:
                 char_id = ref.character_id
             elif ref.character_name:
-                cur.execute("SELECT id FROM characters WHERE name = %s", (ref.character_name,))
+                cur.execute(
+                    "SELECT id FROM characters WHERE name = %s", (ref.character_name,)
+                )
                 result = cur.fetchone()
                 if result:
                     char_id = result[0]
@@ -131,10 +138,9 @@ def resolve_character_references_sync(
                 char_id = create_new_character_sync(cur, ref.new_character)
 
         # Build junction table entry
-        resolved_refs.append({
-            "character_id": char_id,
-            "reference": ref.reference_type.value
-        })
+        resolved_refs.append(
+            {"character_id": char_id, "reference": ref.reference_type.value}
+        )
 
     return resolved_refs
 
@@ -145,33 +151,37 @@ def create_new_character_sync(cur, new_char):
     if new_char.current_location:
         cur.execute("SELECT id FROM places WHERE id = %s", (new_char.current_location,))
         if not cur.fetchone():
-            raise ValueError(f"Place ID {new_char.current_location} not found for character location")
+            raise ValueError(
+                f"Place ID {new_char.current_location} not found for character location"
+            )
 
     # Insert character
-    cur.execute("""
+    cur.execute(
+        """
         INSERT INTO characters (
             name, summary, appearance, background, personality,
             emotional_state, current_activity, current_location, extra_data
         ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
         RETURNING id
-    """, (
-        new_char.name,
-        new_char.summary,
-        new_char.appearance,
-        new_char.background,
-        new_char.personality,
-        new_char.emotional_state,
-        new_char.current_activity,
-        new_char.current_location,
-        _json_dumps_model(new_char.extra_data),
-    ))
+    """,
+        (
+            new_char.name,
+            new_char.summary,
+            new_char.appearance,
+            new_char.background,
+            new_char.personality,
+            new_char.emotional_state,
+            new_char.current_activity,
+            new_char.current_location,
+            _json_dumps_model(new_char.extra_data),
+        ),
+    )
 
     return cur.fetchone()[0]
 
 
 def resolve_faction_references_sync(
-    faction_references: List[FactionReference],
-    conn
+    faction_references: List[FactionReference], conn
 ) -> List[dict]:
     """Synchronous version of resolve_faction_references"""
     resolved_refs = []
@@ -183,7 +193,9 @@ def resolve_faction_references_sync(
             if ref.faction_id:
                 faction_id = ref.faction_id
             elif ref.faction_name:
-                cur.execute("SELECT id FROM factions WHERE name = %s", (ref.faction_name,))
+                cur.execute(
+                    "SELECT id FROM factions WHERE name = %s", (ref.faction_name,)
+                )
                 result = cur.fetchone()
                 if result:
                     faction_id = result[0]
@@ -195,9 +207,7 @@ def resolve_faction_references_sync(
                 faction_id = create_new_faction_sync(cur, ref.new_faction)
 
         # Build junction table entry
-        resolved_refs.append({
-            "faction_id": faction_id
-        })
+        resolved_refs.append({"faction_id": faction_id})
 
     return resolved_refs
 
@@ -206,36 +216,43 @@ def create_new_faction_sync(cur, new_faction):
     """Create a new faction synchronously"""
     # Validate primary_location exists
     if new_faction.primary_location:
-        cur.execute("SELECT id FROM places WHERE id = %s", (new_faction.primary_location,))
+        cur.execute(
+            "SELECT id FROM places WHERE id = %s", (new_faction.primary_location,)
+        )
         if not cur.fetchone():
-            raise ValueError(f"Place ID {new_faction.primary_location} not found for faction location")
+            raise ValueError(
+                f"Place ID {new_faction.primary_location} not found for faction location"
+            )
 
     cur.execute("LOCK TABLE factions IN SHARE ROW EXCLUSIVE MODE")
     cur.execute("SELECT COALESCE(MAX(id), 0) + 1 FROM factions")
     faction_id = cur.fetchone()[0]
 
     # Insert faction
-    cur.execute("""
+    cur.execute(
+        """
         INSERT INTO factions (
             id, name, summary, ideology, history, current_activity,
             hidden_agenda, territory, power_level, resources,
             primary_location, extra_data
         ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         RETURNING id
-    """, (
-        faction_id,
-        new_faction.name,
-        new_faction.summary,
-        new_faction.ideology,
-        new_faction.history,
-        new_faction.current_activity,
-        new_faction.hidden_agenda,
-        new_faction.territory,
-        new_faction.power_level,
-        new_faction.resources,
-        new_faction.primary_location,
-        _json_dumps_model(new_faction.extra_data),
-    ))
+    """,
+        (
+            faction_id,
+            new_faction.name,
+            new_faction.summary,
+            new_faction.ideology,
+            new_faction.history,
+            new_faction.current_activity,
+            new_faction.hidden_agenda,
+            new_faction.territory,
+            new_faction.power_level,
+            new_faction.resources,
+            new_faction.primary_location,
+            _json_dumps_model(new_faction.extra_data),
+        ),
+    )
 
     return cur.fetchone()[0]
 
@@ -244,7 +261,10 @@ def create_new_faction_sync(cur, new_faction):
 # Main Synchronous Commit Function
 # ============================================================================
 
-def commit_incubator_to_database_sync(conn, session_id: str, slot: Optional[int] = None) -> int:
+
+def commit_incubator_to_database_sync(
+    conn, session_id: str, slot: Optional[int] = None
+) -> int:
     """
     Synchronous version of commit flow from incubator to production tables.
 
@@ -261,17 +281,23 @@ def commit_incubator_to_database_sync(conn, session_id: str, slot: Optional[int]
         with conn:  # This creates a transaction context
             with conn.cursor(cursor_factory=RealDictCursor) as cur:
                 # Step 1: Get incubator data
-                cur.execute("""
+                cur.execute(
+                    """
                     SELECT chunk_id, parent_chunk_id, user_text, storyteller_text,
-                           choice_object, metadata_updates, entity_updates, reference_updates,
+                           choice_object, choice_text,
+                           metadata_updates, entity_updates, reference_updates,
                            llm_response_id, status
                     FROM incubator
                     WHERE session_id = %s
-                """, (session_id,))
+                """,
+                    (session_id,),
+                )
                 incubator = cur.fetchone()
 
                 if not incubator:
-                    raise ValueError(f"No incubator data found for session {session_id}")
+                    raise ValueError(
+                        f"No incubator data found for session {session_id}"
+                    )
 
                 logger.info("Processing incubator session %s", session_id)
 
@@ -289,15 +315,20 @@ def commit_incubator_to_database_sync(conn, session_id: str, slot: Optional[int]
                 logger.info("Bootstrap chunk - using default metadata (S1E1 scene 1)")
             else:
                 with conn.cursor(cursor_factory=RealDictCursor) as cur:
-                    cur.execute("""
+                    cur.execute(
+                        """
                         SELECT season, episode, scene, world_layer, time_delta
                         FROM chunk_metadata
                         WHERE chunk_id = %s
-                    """, (incubator["parent_chunk_id"],))
+                    """,
+                        (incubator["parent_chunk_id"],),
+                    )
                     parent_meta = cur.fetchone()
 
                     if not parent_meta:
-                        raise ValueError(f"No metadata found for parent chunk {incubator['parent_chunk_id']}")
+                        raise ValueError(
+                            f"No metadata found for parent chunk {incubator['parent_chunk_id']}"
+                        )
 
                     logger.info(
                         "Parent chunk %s: S%sE%s scene %s",
@@ -312,7 +343,9 @@ def commit_incubator_to_database_sync(conn, session_id: str, slot: Optional[int]
             ref_entities = ReferencedEntities(**incubator["reference_updates"])
 
             # Create new entities and resolve all to IDs
-            character_refs = resolve_character_references_sync(ref_entities.characters, conn)
+            character_refs = resolve_character_references_sync(
+                ref_entities.characters, conn
+            )
             place_refs = resolve_place_references_sync(ref_entities.places, conn)
             faction_refs = resolve_faction_references_sync(ref_entities.factions, conn)
 
@@ -322,7 +355,7 @@ def commit_incubator_to_database_sync(conn, session_id: str, slot: Optional[int]
             db_meta = chronology_to_db_values(
                 chronology,
                 current_season=parent_meta["season"],
-                current_episode=parent_meta["episode"]
+                current_episode=parent_meta["episode"],
             )
             summary_tasks = plan_summary_tasks(
                 chronology.episode_transition,
@@ -340,31 +373,34 @@ def commit_incubator_to_database_sync(conn, session_id: str, slot: Optional[int]
             # Compute finalized text based on any choice selection made in the incubator
             choice_object = incubator.get("choice_object")
             storyteller_text = incubator.get("storyteller_text") or ""
-            raw_text = storyteller_text
-            choice_text: Optional[str] = None
+            choice_text: Optional[str] = incubator.get("choice_text")
 
             if choice_object:
-                if isinstance(choice_object, str):
-                    choice_object = json.loads(choice_object)
+                choice_object = normalize_choice_object(choice_object)
 
-                raw_text = compute_raw_text(storyteller_text, choice_object)
+                if not choice_text and choice_object.get("selected"):
+                    choice_text = format_choice_text(
+                        choice_object, include_selection=True
+                    )
 
-                if choice_object.get("selected"):
-                    choice_text = format_choice_text(choice_object, include_selection=True)
+            raw_text = compute_raw_text(storyteller_text, choice_object, choice_text)
 
             with conn.cursor() as cur:
-                cur.execute("""
+                cur.execute(
+                    """
                     INSERT INTO narrative_chunks (
                         raw_text, storyteller_text, choice_object, choice_text
                     )
                     VALUES (%s, %s, %s, %s)
                     RETURNING id
-                """, (
-                    raw_text,
-                    storyteller_text,
-                    json.dumps(choice_object) if choice_object else None,
-                    choice_text,
-                ))
+                """,
+                    (
+                        raw_text,
+                        storyteller_text,
+                        json.dumps(choice_object) if choice_object else None,
+                        choice_text,
+                    ),
+                )
                 chunk_id = cur.fetchone()[0]
                 if chunk_id is None:
                     raise ValueError("Failed to obtain chunk_id after insert")
@@ -375,21 +411,24 @@ def commit_incubator_to_database_sync(conn, session_id: str, slot: Optional[int]
                 # Generate slug (e.g., "S05E06_001")
                 slug = f"S{db_meta['season']:02d}E{db_meta['episode']:02d}_{db_meta['scene']:03d}"
 
-                cur.execute("""
+                cur.execute(
+                    """
                     INSERT INTO chunk_metadata (
                         chunk_id, season, episode, scene, world_layer,
                         time_delta, generation_date, slug
                     ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-                """, (
-                    chunk_id,
-                    db_meta["season"],
-                    db_meta["episode"],
-                    db_meta["scene"],
-                    world_layer,
-                    db_meta["time_delta"],
-                    datetime.utcnow(),
-                    slug,
-                ))
+                """,
+                    (
+                        chunk_id,
+                        db_meta["season"],
+                        db_meta["episode"],
+                        db_meta["scene"],
+                        world_layer,
+                        db_meta["time_delta"],
+                        datetime.utcnow(),
+                        slug,
+                    ),
+                )
                 logger.info("Created metadata for chunk %s: %s", chunk_id, slug)
 
             # Step 7: Insert junction table references
@@ -397,31 +436,51 @@ def commit_incubator_to_database_sync(conn, session_id: str, slot: Optional[int]
             if place_refs:
                 with conn.cursor() as cur:
                     for ref in place_refs:
-                        cur.execute("""
+                        cur.execute(
+                            """
                             INSERT INTO place_chunk_references (place_id, chunk_id, reference_type, evidence)
                             VALUES (%s, %s, %s, %s)
-                        """, (ref["place_id"], chunk_id, ref["reference_type"], ref.get("evidence")))
-                    logger.info(f"Inserted {len(place_refs)} place references for chunk {chunk_id}")
+                        """,
+                            (
+                                ref["place_id"],
+                                chunk_id,
+                                ref["reference_type"],
+                                ref.get("evidence"),
+                            ),
+                        )
+                    logger.info(
+                        f"Inserted {len(place_refs)} place references for chunk {chunk_id}"
+                    )
 
             # Insert character references
             if character_refs:
                 with conn.cursor() as cur:
                     for ref in character_refs:
-                        cur.execute("""
+                        cur.execute(
+                            """
                             INSERT INTO chunk_character_references (chunk_id, character_id, reference)
                             VALUES (%s, %s, %s)
-                        """, (chunk_id, ref["character_id"], ref["reference"]))
-                    logger.info(f"Inserted {len(character_refs)} character references for chunk {chunk_id}")
+                        """,
+                            (chunk_id, ref["character_id"], ref["reference"]),
+                        )
+                    logger.info(
+                        f"Inserted {len(character_refs)} character references for chunk {chunk_id}"
+                    )
 
             # Insert faction references
             if faction_refs:
                 with conn.cursor() as cur:
                     for ref in faction_refs:
-                        cur.execute("""
+                        cur.execute(
+                            """
                             INSERT INTO chunk_faction_references (chunk_id, faction_id)
                             VALUES (%s, %s)
-                        """, (chunk_id, ref["faction_id"]))
-                    logger.info(f"Inserted {len(faction_refs)} faction references for chunk {chunk_id}")
+                        """,
+                            (chunk_id, ref["faction_id"]),
+                        )
+                    logger.info(
+                        f"Inserted {len(faction_refs)} faction references for chunk {chunk_id}"
+                    )
 
             # Step 8: Update entity states (if provided)
             if incubator.get("entity_updates"):
@@ -430,7 +489,9 @@ def commit_incubator_to_database_sync(conn, session_id: str, slot: Optional[int]
 
             # Step 9: Clear incubator
             with conn.cursor() as cur:
-                cur.execute("DELETE FROM incubator WHERE session_id = %s", (session_id,))
+                cur.execute(
+                    "DELETE FROM incubator WHERE session_id = %s", (session_id,)
+                )
                 logger.info("Cleared incubator for session %s", session_id)
 
     except Exception as e:
@@ -442,7 +503,9 @@ def commit_incubator_to_database_sync(conn, session_id: str, slot: Optional[int]
         try:
             schedule_summary_generation(summary_tasks, slot=slot)
         except Exception as exc:  # pragma: no cover - defensive logging
-            logger.error("Failed to schedule summaries for session %s: %s", session_id, exc)
+            logger.error(
+                "Failed to schedule summaries for session %s: %s", session_id, exc
+            )
 
     logger.info("Successfully committed chunk %s from session %s", chunk_id, session_id)
     return chunk_id
@@ -473,7 +536,7 @@ def apply_state_updates_sync(conn, state_updates: StateUpdates):
                     params.append(char_update.character_id)
                     cur.execute(
                         f"UPDATE characters SET {', '.join(updates)} WHERE id = %s",
-                        params
+                        params,
                     )
                     logger.info(f"Updated character {char_update.character_id}")
 
@@ -482,7 +545,7 @@ def apply_state_updates_sync(conn, state_updates: StateUpdates):
             if place_update.place_id and place_update.current_status:
                 cur.execute(
                     "UPDATE places SET current_status = %s WHERE id = %s",
-                    (place_update.current_status, place_update.place_id)
+                    (place_update.current_status, place_update.place_id),
                 )
                 logger.info(f"Updated place {place_update.place_id}")
 
@@ -491,6 +554,6 @@ def apply_state_updates_sync(conn, state_updates: StateUpdates):
             if faction_update.faction_id and faction_update.current_activity:
                 cur.execute(
                     "UPDATE factions SET current_activity = %s WHERE id = %s",
-                    (faction_update.current_activity, faction_update.faction_id)
+                    (faction_update.current_activity, faction_update.faction_id),
                 )
                 logger.info(f"Updated faction {faction_update.faction_id}")

--- a/nexus/api/lore_adapter.py
+++ b/nexus/api/lore_adapter.py
@@ -9,7 +9,11 @@ Handles conversion between structured Pydantic models and database JSONB fields.
 import logging
 from typing import Dict, Any, Optional, List
 from nexus.agents.logon.apex_schema import StoryTurnResponse
-from nexus.api.choice_handling import ChoiceObject
+from nexus.api.choice_handling import (
+    ChoiceObject,
+    normalize_choice_object,
+    selected_text_from_choice_object,
+)
 
 logger = logging.getLogger("nexus.api.lore_adapter")
 
@@ -47,45 +51,26 @@ def format_choice_text(
     choice_object: Dict[str, Any], include_selection: bool = True
 ) -> str:
     """
-    Generate markdown-formatted text from choice object.
+    Resolve the selected user's response text from a choice object.
 
     Args:
         choice_object: The structured choice data
-        include_selection: Whether to include the user's selection
+        include_selection: Whether to return the user's selection
 
     Returns:
-        Markdown-formatted string representing choices and selection
+        Selected response text, or an empty string if no selection is present
     """
-    if not choice_object or not choice_object.get("presented"):
+    if not include_selection or not choice_object:
         return ""
 
-    lines = ["", "**Your options were:**"]
-
-    # List all presented choices
-    for i, choice in enumerate(choice_object["presented"], 1):
-        lines.append(f"{i}. {choice}")
-
-    # Add user selection if present
-    if include_selection and choice_object.get("selected"):
-        selected = choice_object["selected"]
-        label = selected.get("label")
-        text = selected.get("text", "")
-        edited = selected.get("edited", False)
-
-        lines.append("")
-
-        if label == "freeform":
-            lines.append(f'**You chose:** "{text}"')
-        elif edited:
-            lines.append(f'**You chose:** "{text}" (edited from option {label})')
-        else:
-            lines.append(f"**You chose:** Option {label}")
-
-    return "\n".join(lines)
+    selected_text = selected_text_from_choice_object(choice_object)
+    return selected_text or ""
 
 
 def compute_raw_text(
-    storyteller_text: str, choice_object: Optional[Dict[str, Any]]
+    storyteller_text: str,
+    choice_object: Optional[Dict[str, Any]],
+    choice_text: Optional[str] = None,
 ) -> str:
     """
     Compute full raw_text by combining storyteller prose with choice text.
@@ -95,19 +80,19 @@ def compute_raw_text(
     Args:
         storyteller_text: The narrative prose from the storyteller
         choice_object: The structured choice data (may be None for legacy/freeform)
+        choice_text: Resolved user response text, if already persisted
 
     Returns:
         Combined text for embeddings and search
     """
-    if not choice_object or not choice_object.get("selected"):
-        # No choices or selection not yet made - just use storyteller text
+    resolved_choice_text = (choice_text or "").strip()
+    if not resolved_choice_text and choice_object:
+        resolved_choice_text = format_choice_text(choice_object, include_selection=True)
+
+    if not resolved_choice_text:
         return storyteller_text
 
-    choice_text = format_choice_text(choice_object, include_selection=True)
-    if choice_text:
-        return storyteller_text + "\n" + choice_text
-
-    return storyteller_text
+    return f"{storyteller_text.rstrip()}\n\n{resolved_choice_text}"
 
 
 def response_to_incubator(
@@ -134,7 +119,9 @@ def response_to_incubator(
     # Extract choice object (presented choices, no selection yet)
     choice_obj = extract_choice_object(response)
     # Convert to dict for database JSONB storage (None if no choices)
-    choice_object_dict = choice_obj.model_dump() if choice_obj else None
+    choice_object_dict = (
+        normalize_choice_object(choice_obj.model_dump()) if choice_obj else None
+    )
 
     # Build incubator data structure
     incubator_data = {

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -215,6 +215,11 @@ def _persist_chunk_response(
                 chunk_id,
             ),
         )
+        if cur.rowcount != 1:
+            raise HTTPException(
+                status_code=409,
+                detail="Incubator chunk_id mismatch; concurrent generation may have replaced it.",
+            )
     else:
         cur.execute(
             """
@@ -231,6 +236,11 @@ def _persist_chunk_response(
                 chunk_id,
             ),
         )
+        if cur.rowcount != 1:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Chunk {chunk_id} not found",
+            )
 
     return raw_text
 
@@ -250,7 +260,11 @@ def _record_player_response_for_chunk(
     Returns:
         The response text that should be sent into the next generation.
     """
-    conn = get_db_connection(slot)
+    try:
+        conn = get_db_connection(slot)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     try:
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
             cur.execute(
@@ -536,11 +550,7 @@ async def continue_narrative(
             logger.info(
                 f"Resolved chunk_id={request.chunk_id} from slot {request.slot}"
             )
-    elif (
-        request.chunk_id
-        and request.slot is not None
-        and _has_player_response_input(request)
-    ):
+    elif request.chunk_id and _has_player_response_input(request):
         resolved_user_text = _record_player_response_for_chunk(
             slot=request.slot,
             chunk_id=request.chunk_id,
@@ -585,7 +595,7 @@ async def continue_narrative(
         load_settings=load_settings,
         manager=manager,
     )
-    if not is_bootstrap:
+    if not is_bootstrap and request.slot is not None:
         background_tasks.add_task(
             _trigger_locked_chunk_embedding,
             slot=request.slot,

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -29,8 +29,12 @@ from nexus.agents.lore.lore import LORE
 from nexus.api.lore_adapter import (
     response_to_incubator,
     validate_incubator_data,
-    format_choice_text,
     compute_raw_text,
+)
+from nexus.api.choice_handling import (
+    normalize_choice_object,
+    resolve_choice_response,
+    validate_choice_index,
 )
 from nexus.api.chunk_workflow import (
     ChunkWorkflow,
@@ -74,11 +78,11 @@ app.add_middleware(
 )
 
 
-
 # Include modular routers
 app.include_router(slot_router)
 app.include_router(setup_router)
 app.include_router(wizard_chat_router)
+
 
 # WebSocket connection manager
 class ConnectionManager:
@@ -138,13 +142,14 @@ def get_db_connection(slot: Optional[int] = None):
         host=os.environ.get("PGHOST", "localhost"),
         database=dbname,
         user=os.environ.get("PGUSER", "pythagor"),
-        port=os.environ.get("PGPORT", "5432")
+        port=os.environ.get("PGPORT", "5432"),
     )
 
 
 def load_settings():
     """Load settings using centralized config loader."""
     from nexus.config import load_settings_as_dict
+
     return load_settings_as_dict()
 
 
@@ -175,6 +180,255 @@ from nexus.api.narrative_schemas import (
 )
 
 
+def _has_player_response_input(request: ContinueNarrativeRequest) -> bool:
+    """Return whether a continue request carries player response input."""
+    return (
+        bool(request.user_text.strip())
+        or request.choice is not None
+        or request.accept_fate
+    )
+
+
+def _persist_chunk_response(
+    cur,
+    *,
+    is_incubator: bool,
+    chunk_id: int,
+    storyteller_text: str,
+    choice_object: Optional[Dict[str, Any]],
+    choice_text: str,
+) -> str:
+    """Persist resolved player response fields for a chunk."""
+    raw_text = compute_raw_text(storyteller_text, choice_object, choice_text)
+
+    if is_incubator:
+        cur.execute(
+            """
+            UPDATE incubator
+            SET choice_object = %s,
+                choice_text = %s
+            WHERE chunk_id = %s
+            """,
+            (
+                json.dumps(choice_object) if choice_object else None,
+                choice_text,
+                chunk_id,
+            ),
+        )
+    else:
+        cur.execute(
+            """
+            UPDATE narrative_chunks
+            SET choice_object = %s,
+                choice_text = %s,
+                raw_text = %s
+            WHERE id = %s
+            """,
+            (
+                json.dumps(choice_object) if choice_object else None,
+                choice_text,
+                raw_text,
+                chunk_id,
+            ),
+        )
+
+    return raw_text
+
+
+def _record_player_response_for_chunk(
+    *,
+    slot: Optional[int],
+    chunk_id: int,
+    user_text: str,
+    choice: Optional[int],
+    accept_fate: bool,
+    require_response: bool,
+) -> str:
+    """
+    Resolve and persist the player's response for an incubator/committed chunk.
+
+    Returns:
+        The response text that should be sent into the next generation.
+    """
+    conn = get_db_connection(slot)
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT chunk_id AS id, storyteller_text, choice_object, choice_text
+                FROM incubator
+                WHERE chunk_id = %s
+                """,
+                (chunk_id,),
+            )
+            chunk = cur.fetchone()
+            is_incubator = chunk is not None
+
+            if not chunk:
+                cur.execute(
+                    """
+                    SELECT id, storyteller_text, choice_object, choice_text
+                    FROM narrative_chunks
+                    WHERE id = %s
+                    """,
+                    (chunk_id,),
+                )
+                chunk = cur.fetchone()
+
+            if not chunk:
+                raise HTTPException(
+                    status_code=404, detail=f"Chunk {chunk_id} not found"
+                )
+
+            existing_choice_text = (chunk.get("choice_text") or "").strip()
+            try:
+                choice_object = normalize_choice_object(chunk.get("choice_object"))
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            has_new_input = bool(user_text.strip()) or choice is not None or accept_fate
+
+            if existing_choice_text:
+                if has_new_input:
+                    try:
+                        resolved = resolve_choice_response(
+                            choice_object,
+                            choice=choice,
+                            user_text=user_text,
+                            accept_fate=accept_fate,
+                        )
+                    except ValueError as exc:
+                        raise HTTPException(status_code=400, detail=str(exc)) from exc
+                    if resolved.choice_text != existing_choice_text:
+                        raise HTTPException(
+                            status_code=409,
+                            detail=f"Choice already selected for chunk {chunk_id}.",
+                        )
+                return existing_choice_text
+
+            if not has_new_input and not require_response:
+                return user_text
+
+            if not has_new_input:
+                raise HTTPException(status_code=400, detail="No input provided")
+
+            try:
+                resolved = resolve_choice_response(
+                    choice_object,
+                    choice=choice,
+                    user_text=user_text,
+                    accept_fate=accept_fate,
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+            max_choice_text_length = get_max_choice_text_length()
+            if len(resolved.choice_text) > max_choice_text_length:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Selection text too long ({len(resolved.choice_text)} "
+                        f"chars). Max: {max_choice_text_length}"
+                    ),
+                )
+
+            _persist_chunk_response(
+                cur,
+                is_incubator=is_incubator,
+                chunk_id=chunk_id,
+                storyteller_text=chunk.get("storyteller_text") or "",
+                choice_object=resolved.choice_object,
+                choice_text=resolved.choice_text,
+            )
+
+        conn.commit()
+        return resolved.choice_text
+
+    except HTTPException:
+        conn.rollback()
+        raise
+    except Exception as exc:
+        conn.rollback()
+        logger.error("Error recording player response for chunk %s: %s", chunk_id, exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    finally:
+        conn.close()
+
+
+def _trigger_locked_chunk_embedding(
+    *, slot: Optional[int], parent_chunk_id: int
+) -> None:
+    """
+    Embed the chunk that becomes locked when starting from parent_chunk_id.
+
+    Continuing from chunk n-1 creates provisional chunk n. That leaves chunk
+    n-1 undoable, while chunk n-2 is now locked and eligible for embeddings.
+    """
+    locked_chunk_id = parent_chunk_id - 1
+    if locked_chunk_id < 1:
+        return
+
+    try:
+        dbname = require_slot_dbname(slot=slot)
+    except Exception as exc:
+        logger.warning(
+            "Skipping locked chunk embedding for chunk %s: %s",
+            locked_chunk_id,
+            exc,
+        )
+        return
+
+    try:
+        with get_connection(dbname, dict_cursor=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT embedding_generated_at
+                    FROM narrative_chunks
+                    WHERE id = %s
+                    """,
+                    (locked_chunk_id,),
+                )
+                row = cur.fetchone()
+
+        if not row:
+            logger.warning(
+                "Skipping locked chunk embedding: chunk %s not found in %s",
+                locked_chunk_id,
+                dbname,
+            )
+            return
+
+        if row.get("embedding_generated_at"):
+            logger.info(
+                "Skipping locked chunk embedding: chunk %s already embedded",
+                locked_chunk_id,
+            )
+            return
+
+        workflow = ChunkWorkflow(dbname)
+        job_id = workflow.trigger_embedding_generation(locked_chunk_id)
+        if job_id:
+            logger.info(
+                "Generated embeddings for locked chunk %s in %s (%s)",
+                locked_chunk_id,
+                dbname,
+                job_id,
+            )
+        else:
+            logger.warning(
+                "Embedding generation did not complete for locked chunk %s in %s",
+                locked_chunk_id,
+                dbname,
+            )
+    except Exception as exc:
+        logger.error(
+            "Error embedding locked chunk %s for slot %s: %s",
+            locked_chunk_id,
+            slot,
+            exc,
+        )
+
+
 # API Endpoints
 @app.get("/health")
 async def health_check():
@@ -186,6 +440,7 @@ async def health_check():
 async def get_config_models():
     """Get available API models with provider info from nexus.toml."""
     from nexus.config.loader import get_all_api_models, get_api_models_by_provider
+
     return {
         "models": get_all_api_models(),
         "by_provider": get_api_models_by_provider(),
@@ -213,10 +468,12 @@ async def continue_narrative(
                 detail="Model override requires a slot to persist the selection.",
             )
         from nexus.api.save_slots import upsert_slot
+
         upsert_slot(request.slot, model=request.model, dbname=slot_dbname(request.slot))
         logger.info("Persisted model %s to slot %s", request.model, request.slot)
 
     # Resolve chunk_id from slot state if not provided
+    resolved_user_text = request.user_text
     if request.chunk_id is None and request.slot is not None:
         from nexus.api.slot_state import get_slot_state
 
@@ -224,7 +481,7 @@ async def continue_narrative(
         if state.is_wizard_mode:
             raise HTTPException(
                 status_code=400,
-                detail="Slot is in wizard mode. Use /api/story/new/chat for wizard."
+                detail="Slot is in wizard mode. Use /api/story/new/chat for wizard.",
             )
         if state.narrative_state is not None:
             narrative_state = state.narrative_state
@@ -232,12 +489,20 @@ async def continue_narrative(
                 if narrative_state.session_id is None:
                     raise HTTPException(
                         status_code=409,
-                        detail="Slot has pending incubator content that must be approved before continuing."
+                        detail="Slot has pending incubator content that must be approved before continuing.",
                     )
                 logger.info(
                     "Auto-approving pending incubator session %s for slot %s",
                     narrative_state.session_id,
                     request.slot,
+                )
+                resolved_user_text = _record_player_response_for_chunk(
+                    slot=request.slot,
+                    chunk_id=narrative_state.current_chunk_id,
+                    user_text=request.user_text,
+                    choice=request.choice,
+                    accept_fate=request.accept_fate,
+                    require_response=True,
                 )
                 approval = await approve_narrative(
                     session_id=narrative_state.session_id,
@@ -250,12 +515,40 @@ async def continue_narrative(
                 if not approved_chunk_id:
                     raise HTTPException(
                         status_code=409,
-                        detail="Pending incubator content must be approved before continuing."
+                        detail="Pending incubator content must be approved before continuing.",
                     )
                 request.chunk_id = approved_chunk_id
             else:
                 request.chunk_id = narrative_state.current_chunk_id
-            logger.info(f"Resolved chunk_id={request.chunk_id} from slot {request.slot}")
+                if _has_player_response_input(request) and (
+                    request.choice is not None
+                    or request.accept_fate
+                    or narrative_state.choices
+                ):
+                    resolved_user_text = _record_player_response_for_chunk(
+                        slot=request.slot,
+                        chunk_id=narrative_state.current_chunk_id,
+                        user_text=request.user_text,
+                        choice=request.choice,
+                        accept_fate=request.accept_fate,
+                        require_response=False,
+                    )
+            logger.info(
+                f"Resolved chunk_id={request.chunk_id} from slot {request.slot}"
+            )
+    elif (
+        request.chunk_id
+        and request.slot is not None
+        and _has_player_response_input(request)
+    ):
+        resolved_user_text = _record_player_response_for_chunk(
+            slot=request.slot,
+            chunk_id=request.chunk_id,
+            user_text=request.user_text,
+            choice=request.choice,
+            accept_fate=request.accept_fate,
+            require_response=False,
+        )
 
     session_id = str(uuid.uuid4())
 
@@ -268,13 +561,17 @@ async def continue_narrative(
     else:
         logger.info(f"Starting narrative continuation for chunk {parent_chunk_id}")
     logger.info(f"Session ID: {session_id}")
-    logger.info(f"User text: {request.user_text[:100]}...")
+    logger.info(f"User text: {resolved_user_text[:100]}...")
 
     # Send initial progress
     await manager.send_progress(
         session_id,
         "initiated",
-        {"chunk_id": parent_chunk_id, "parent_chunk_id": parent_chunk_id, "is_bootstrap": is_bootstrap},
+        {
+            "chunk_id": parent_chunk_id,
+            "parent_chunk_id": parent_chunk_id,
+            "is_bootstrap": is_bootstrap,
+        },
     )
 
     # Start async generation in background
@@ -282,14 +579,24 @@ async def continue_narrative(
         generate_narrative_async,
         session_id,
         parent_chunk_id,
-        request.user_text,
+        resolved_user_text,
         request.slot,
         get_db_connection=get_db_connection,
         load_settings=load_settings,
         manager=manager,
     )
+    if not is_bootstrap:
+        background_tasks.add_task(
+            _trigger_locked_chunk_embedding,
+            slot=request.slot,
+            parent_chunk_id=parent_chunk_id,
+        )
 
-    message = "Narrative bootstrap started" if is_bootstrap else f"Narrative generation started for chunk {parent_chunk_id}"
+    message = (
+        "Narrative bootstrap started"
+        if is_bootstrap
+        else f"Narrative generation started for chunk {parent_chunk_id}"
+    )
     return ContinueNarrativeResponse(
         session_id=session_id,
         status="processing",
@@ -350,8 +657,7 @@ async def approve_narrative_unified(request: ApproveNarrativeRequest):
     if session_id is None:
         if slot is None:
             raise HTTPException(
-                status_code=400,
-                detail="Either session_id or slot must be provided"
+                status_code=400, detail="Either session_id or slot must be provided"
             )
         from nexus.api.slot_utils import slot_dbname
 
@@ -365,17 +671,23 @@ async def approve_narrative_unified(request: ApproveNarrativeRequest):
                 if not row:
                     raise HTTPException(
                         status_code=404,
-                        detail="No pending session to approve in incubator"
+                        detail="No pending session to approve in incubator",
                     )
                 session_id = row["session_id"]
-                logger.info(f"Resolved session_id={session_id} from slot {slot} incubator")
+                logger.info(
+                    f"Resolved session_id={session_id} from slot {slot} incubator"
+                )
 
     # Now call the implementation
     return await _approve_narrative_impl(session_id, request.commit, slot)
 
 
 @app.post("/api/narrative/approve/{session_id}")
-async def approve_narrative(session_id: str, request: Optional[ApproveNarrativeRequest] = None, slot: Optional[int] = None):
+async def approve_narrative(
+    session_id: str,
+    request: Optional[ApproveNarrativeRequest] = None,
+    slot: Optional[int] = None,
+):
     """
     Approve narrative and optionally commit to database (path-based for backward compatibility).
     """
@@ -445,42 +757,51 @@ async def select_choice(request: SelectChoiceRequest):
     try:
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
             # First try narrative_chunks
-            cur.execute("""
-                SELECT id, storyteller_text, choice_object
+            cur.execute(
+                """
+                SELECT id, storyteller_text, choice_object, choice_text
                 FROM narrative_chunks
                 WHERE id = %s
-            """, (request.chunk_id,))
+            """,
+                (request.chunk_id,),
+            )
             chunk = cur.fetchone()
 
             # Fall back to incubator if not found in narrative_chunks
             if not chunk:
-                cur.execute("""
-                    SELECT chunk_id as id, storyteller_text, choice_object
+                cur.execute(
+                    """
+                    SELECT chunk_id as id, storyteller_text, choice_object, choice_text
                     FROM incubator
                     WHERE chunk_id = %s
-                """, (request.chunk_id,))
+                """,
+                    (request.chunk_id,),
+                )
                 chunk = cur.fetchone()
                 is_incubator = True
 
             if not chunk:
                 raise HTTPException(
-                    status_code=404,
-                    detail=f"Chunk {request.chunk_id} not found"
+                    status_code=404, detail=f"Chunk {request.chunk_id} not found"
                 )
 
             # Validate choice_object exists
-            choice_object = chunk.get("choice_object")
+            try:
+                choice_object = normalize_choice_object(chunk.get("choice_object"))
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+
             if not choice_object:
                 raise HTTPException(
                     status_code=400,
-                    detail=f"Chunk {request.chunk_id} has no choices to select from"
+                    detail=f"Chunk {request.chunk_id} has no choices to select from",
                 )
 
             # P1: Check if choice already selected (prevent race condition)
-            if choice_object.get("selected"):
+            if choice_object.get("selected") or chunk.get("choice_text"):
                 raise HTTPException(
                     status_code=409,
-                    detail=f"Choice already selected for chunk {request.chunk_id}. Cannot re-select."
+                    detail=f"Choice already selected for chunk {request.chunk_id}. Cannot re-select.",
                 )
 
             # P0: Validate selection label is valid
@@ -488,60 +809,51 @@ async def select_choice(request: SelectChoiceRequest):
             if request.selection.label != "freeform":
                 if not isinstance(request.selection.label, int):
                     raise HTTPException(status_code=400, detail="Invalid label type")
-                if not (1 <= request.selection.label <= len(presented)):
+                try:
+                    selected_choice_text = validate_choice_index(
+                        request.selection.label, presented
+                    )
+                except ValueError as exc:
                     raise HTTPException(
                         status_code=400,
-                        detail=f"Invalid choice label: {request.selection.label}. Must be 1-{len(presented)} or 'freeform'"
-                    )
+                        detail=str(exc),
+                    ) from exc
+                choice_text = (
+                    request.selection.text
+                    if request.selection.edited
+                    else selected_choice_text
+                )
+                selected_index: Optional[int] = request.selection.label
+            else:
+                choice_text = request.selection.text
+                selected_index = None
 
             # P0: Validate text length (prevent abuse)
             max_choice_text_length = get_max_choice_text_length()
-            if len(request.selection.text) > max_choice_text_length:
+            if len(choice_text) > max_choice_text_length:
                 raise HTTPException(
                     status_code=400,
-                    detail=f"Selection text too long ({len(request.selection.text)} chars). Max: {max_choice_text_length}"
+                    detail=f"Selection text too long ({len(choice_text)} chars). Max: {max_choice_text_length}",
                 )
 
             # Update choice_object with selection
-            choice_object["selected"] = {
-                "label": request.selection.label,
-                "text": request.selection.text,
-                "edited": request.selection.edited,
-            }
-
-            # Generate choice_text markdown
-            choice_text = format_choice_text(choice_object, include_selection=True)
-
-            # Compute final raw_text for embeddings
+            choice_object["selected"] = selected_index
             storyteller_text = chunk.get("storyteller_text") or ""
-            raw_text = compute_raw_text(storyteller_text, choice_object)
 
             # Update the chunk in the appropriate table
+            raw_text = _persist_chunk_response(
+                cur,
+                is_incubator=is_incubator,
+                chunk_id=request.chunk_id,
+                storyteller_text=storyteller_text,
+                choice_object=choice_object,
+                choice_text=choice_text,
+            )
             if is_incubator:
-                # For incubator, only update choice_object (raw_text computed at commit)
-                cur.execute("""
-                    UPDATE incubator
-                    SET choice_object = %s
-                    WHERE chunk_id = %s
-                """, (
-                    json.dumps(choice_object),
-                    request.chunk_id
-                ))
-                logger.info(f"Recorded choice selection for incubator chunk {request.chunk_id}")
+                logger.info(
+                    f"Recorded choice selection for incubator chunk {request.chunk_id}"
+                )
             else:
-                # For committed chunks, update all fields
-                cur.execute("""
-                    UPDATE narrative_chunks
-                    SET choice_object = %s,
-                        choice_text = %s,
-                        raw_text = %s
-                    WHERE id = %s
-                """, (
-                    json.dumps(choice_object),
-                    choice_text,
-                    raw_text,
-                    request.chunk_id
-                ))
                 logger.info(f"Finalized choice selection for chunk {request.chunk_id}")
 
         conn.commit()
@@ -549,7 +861,7 @@ async def select_choice(request: SelectChoiceRequest):
         return SelectChoiceResponse(
             status="pending" if is_incubator else "finalized",
             chunk_id=request.chunk_id,
-            raw_text=raw_text
+            raw_text=raw_text,
         )
 
     except HTTPException:
@@ -687,12 +999,14 @@ async def get_user_character(slot: Optional[int] = None):
         )
         with conn:
             with conn.cursor() as cur:
-                cur.execute("""
+                cur.execute(
+                    """
                     SELECT c.name
                     FROM global_variables gv
                     JOIN characters c ON c.id = gv.user_character
                     WHERE gv.id = TRUE
-                """)
+                """
+                )
                 row = cur.fetchone()
                 if row:
                     return {"name": row[0]}
@@ -701,7 +1015,7 @@ async def get_user_character(slot: Optional[int] = None):
         logger.error(f"Database error fetching user character: {e}")
         raise HTTPException(status_code=500, detail="Database error")
     finally:
-        if 'conn' in locals():
+        if "conn" in locals():
             conn.close()
 
 

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -48,14 +48,19 @@ def _describe_lore_failure(lore: LORE, response: Any) -> Optional[str]:
         )
 
     if isinstance(response, str) and response:
-        return f"Narrative turn failed before APEX returned structured output: {response}"
+        return (
+            f"Narrative turn failed before APEX returned structured output: {response}"
+        )
 
     return "Narrative turn did not return structured APEX output."
 
 
 class ProgressManager(Protocol):
     """Protocol for progress notification manager."""
-    async def send_progress(self, session_id: str, status: str, data: Dict = None) -> None:
+
+    async def send_progress(
+        self, session_id: str, status: str, data: Dict = None
+    ) -> None:
         """Send progress update for a specific session."""
         ...
 
@@ -107,7 +112,9 @@ async def generate_narrative_async(
                 "episode": 1,
                 "place_name": "Starting Location",
             }
-            logger.info("Bootstrap mode: skipping parent chunk load, using global state")
+            logger.info(
+                "Bootstrap mode: skipping parent chunk load, using global state"
+            )
         else:
             chunk_info = await get_chunk_info(conn, parent_chunk_id)
 
@@ -128,7 +135,9 @@ async def generate_narrative_async(
         if is_bootstrap:
             # Bootstrap mode: Generate first chunk using story seed directly
             # Skip LORE entirely (requires warm slice and local LLM)
-            logger.info("Bootstrap mode: calling apex AI directly with story seed context")
+            logger.info(
+                "Bootstrap mode: calling apex AI directly with story seed context"
+            )
 
             # Send progress: calling LLM
             await manager.send_progress(session_id, "calling_llm")
@@ -141,7 +150,8 @@ async def generate_narrative_async(
             except Exception as e:
                 logger.error(f"Bootstrap generation failed: {e}")
                 raise HTTPException(
-                    status_code=500, detail=f"Failed to generate bootstrap narrative: {str(e)}"
+                    status_code=500,
+                    detail=f"Failed to generate bootstrap narrative: {str(e)}",
                 )
         else:
             # Real LORE integration for continuation
@@ -163,7 +173,8 @@ async def generate_narrative_async(
                 error_detail = _exception_detail(e)
                 logger.error(f"LORE process_turn failed: {error_detail}")
                 raise HTTPException(
-                    status_code=500, detail=f"Failed to generate narrative: {error_detail}"
+                    status_code=500,
+                    detail=f"Failed to generate narrative: {error_detail}",
                 )
 
             # Send progress: processing response
@@ -252,10 +263,11 @@ async def write_to_incubator(conn, data: Dict[str, Any]):
         query = """
         INSERT INTO incubator (
             id, chunk_id, parent_chunk_id, user_text, storyteller_text,
-            choice_object, metadata_updates, entity_updates, reference_updates,
+            choice_object, choice_text,
+            metadata_updates, entity_updates, reference_updates,
             session_id, llm_response_id, status
         ) VALUES (
-            TRUE, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+            TRUE, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
         )
         """
 
@@ -266,7 +278,12 @@ async def write_to_incubator(conn, data: Dict[str, Any]):
                 data["parent_chunk_id"],
                 data["user_text"],
                 data["storyteller_text"],
-                json.dumps(data.get("choice_object")) if data.get("choice_object") else None,
+                (
+                    json.dumps(data.get("choice_object"))
+                    if data.get("choice_object")
+                    else None
+                ),
+                data.get("choice_text"),
                 json.dumps(data["metadata_updates"]),
                 json.dumps(data["entity_updates"]),
                 json.dumps(data["reference_updates"]),
@@ -304,10 +321,14 @@ async def generate_bootstrap_narrative(
 
     # Load story context from global_variables
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
-        cur.execute("SELECT setting, user_character FROM global_variables WHERE id = true")
+        cur.execute(
+            "SELECT setting, user_character FROM global_variables WHERE id = true"
+        )
         row = cur.fetchone()
         if not row or not row["setting"]:
-            raise ValueError("No setting found in global_variables - transition may not have completed")
+            raise ValueError(
+                "No setting found in global_variables - transition may not have completed"
+            )
 
         setting_data = row["setting"]
         character_id = row["user_character"]
@@ -315,7 +336,7 @@ async def generate_bootstrap_narrative(
         # Get character details
         cur.execute(
             "SELECT name, appearance, background FROM characters WHERE id = %s",
-            (character_id,)
+            (character_id,),
         )
         char_row = cur.fetchone()
         character_name = char_row["name"] if char_row else "Unknown"
@@ -345,10 +366,7 @@ async def generate_bootstrap_narrative(
     bootstrap_context = {
         "user_input": user_text,
         "is_bootstrap": True,
-        "warm_slice": {
-            "chunks": [],  # No prior chunks for bootstrap
-            "token_count": 0
-        },
+        "warm_slice": {"chunks": [], "token_count": 0},  # No prior chunks for bootstrap
         "bootstrap_data": {
             "setting": {
                 "world_name": setting_data.get("world_name", "Unknown World"),
@@ -418,7 +436,11 @@ async def generate_bootstrap_narrative(
         },
         "entity_updates": {},
         "reference_updates": {
-            "characters": [{"character_id": character_id, "reference_type": "present"}] if character_id else [],
+            "characters": (
+                [{"character_id": character_id, "reference_type": "present"}]
+                if character_id
+                else []
+            ),
             "places": [],
             "factions": [],
         },
@@ -429,7 +451,7 @@ async def generate_bootstrap_narrative(
 
     # Extract choices if present
     # NOTE: Key must be "presented" to match schema used by select_choice() and lore_adapter
-    if hasattr(story_response, 'choices') and story_response.choices:
+    if hasattr(story_response, "choices") and story_response.choices:
         incubator_data["choice_object"] = {
             "presented": story_response.choices,
             "selected": None,

--- a/nexus/api/narrative_schemas.py
+++ b/nexus/api/narrative_schemas.py
@@ -26,9 +26,17 @@ class ContinueNarrativeRequest(BaseModel):
         default=None,
         description="Parent chunk ID to continue from. None or 0 for bootstrap (first chunk).",
     )
-    user_text: str = Field(description="User's completion text")
+    user_text: str = Field(default="", description="User's completion text")
+    choice: Optional[int] = Field(
+        default=None, description="Structured choice number (1-indexed)"
+    )
+    accept_fate: bool = Field(
+        default=False, description="Auto-advance by selecting the first choice"
+    )
     slot: Optional[int] = Field(default=None, description="Active save slot")
-    model: Optional[str] = Field(default=None, description="Override model for this request")
+    model: Optional[str] = Field(
+        default=None, description="Override model for this request"
+    )
 
     @field_validator("model")
     @classmethod
@@ -202,7 +210,9 @@ class SlotUndoResponse(BaseModel):
 class SlotModelRequest(BaseModel):
     """Request model for setting slot model."""
 
-    model: str = Field(description="Model to set (a registry ID; see /api/config/models)")
+    model: str = Field(
+        description="Model to set (a registry ID; see /api/config/models)"
+    )
 
 
 class SlotModelResponse(BaseModel):

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -521,32 +521,15 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
         # (Also reached after wizard transition above)
         if not state.get("is_wizard_mode"):
             # Narrative mode - call continue directly
-            # Resolve choice to user_text if provided
             model_to_use = args.model or state.get("model")
             user_text = args.user_text or ""
-            if args.choice is not None and state.get("choices"):
-                choices = state.get("choices", [])
-                if 1 <= args.choice <= len(choices):
-                    user_text = choices[args.choice - 1]
-                else:
-                    return {
-                        "success": False,
-                        "error": f"Choice {args.choice} out of range (1-{len(choices)})",
-                    }
-
-            # Approve pending content if exists
-            if state.get("has_pending"):
-                approve_url = f"{get_api_url()}/api/narrative/approve"
-                approve_response = requests.post(
-                    approve_url, json={"slot": args.slot, "commit": True}, timeout=30
-                )
-                if not approve_response.ok:
-                    logger.warning("Auto-approve failed: %s", approve_response.text)
 
             url = f"{get_api_url()}/api/narrative/continue"
             payload = {
                 "slot": args.slot,
                 "user_text": user_text,
+                "choice": args.choice,
+                "accept_fate": args.accept_fate,
                 # chunk_id resolved by backend
             }
             if model_to_use:
@@ -836,7 +819,8 @@ Examples:
     model_parser = subparsers.add_parser("model", help="Get or set model for a slot")
     model_parser.add_argument("--slot", type=int, help="Slot number (1-5)")
     model_parser.add_argument(
-        "--set", help="Set the model (use a registry ID; run with --list to see options)"
+        "--set",
+        help="Set the model (use a registry ID; run with --list to see options)",
     )
     model_parser.add_argument(
         "--list", action="store_true", help="List available models"

--- a/scripts/create_incubator_table.sql
+++ b/scripts/create_incubator_table.sql
@@ -7,9 +7,10 @@ CREATE TABLE IF NOT EXISTS incubator (
     parent_chunk_id BIGINT NOT NULL,                        -- Where we're continuing from (e.g., 1425)
     user_text TEXT,                                         -- User's completion text for parent chunk
     storyteller_text TEXT,                                  -- Generated text for new chunk
+    choice_object JSONB,                                    -- Structured choices presented by LOGON
     choice_text TEXT,                                       -- User response text resolved before commit
     metadata_updates JSONB DEFAULT '{}',                    -- Time delta, episode transition, etc
-    entity_updates JSONB DEFAULT '[]',                      -- Character/place/faction state changes
+    entity_updates JSONB DEFAULT '{}',                      -- Character/place/faction state changes
     reference_updates JSONB DEFAULT '{}',                   -- Entity references (present/mentioned)
     session_id UUID NOT NULL DEFAULT gen_random_uuid(),     -- Track generation attempts
     llm_response_id TEXT,                                   -- API response ID for debugging
@@ -24,9 +25,10 @@ COMMENT ON COLUMN incubator.chunk_id IS 'ID of the new chunk being created (not 
 COMMENT ON COLUMN incubator.parent_chunk_id IS 'ID of existing chunk being continued from';
 COMMENT ON COLUMN incubator.user_text IS 'User completion text for the parent chunk';
 COMMENT ON COLUMN incubator.storyteller_text IS 'AI-generated storyteller text for the new chunk';
+COMMENT ON COLUMN incubator.choice_object IS 'Structured choice data: {presented: string[], selected: int|null}';
 COMMENT ON COLUMN incubator.choice_text IS 'Resolved user response text for the pending chunk';
 COMMENT ON COLUMN incubator.metadata_updates IS 'JSON: {episode_transition, time_delta_seconds, time_delta_description, world_layer, pacing}';
-COMMENT ON COLUMN incubator.entity_updates IS 'JSON array of entity state changes: [{type, id, field, old_value, new_value}]';
+COMMENT ON COLUMN incubator.entity_updates IS 'JSON object of entity state changes: {characters: [], locations: [], factions: []}';
 COMMENT ON COLUMN incubator.reference_updates IS 'JSON: {character_present: [], character_referenced: [], place_referenced: []}';
 COMMENT ON COLUMN incubator.session_id IS 'UUID for tracking regeneration attempts';
 COMMENT ON COLUMN incubator.llm_response_id IS 'OpenAI or LM Studio response ID for debugging';
@@ -40,19 +42,24 @@ SELECT
     nc.raw_text as parent_chunk_text,
     i.user_text,
     i.storyteller_text,
+    i.choice_object,
     i.choice_text,
-    i.metadata_updates->>'episode_transition' as episode_transition,
-    i.metadata_updates->>'time_delta_description' as time_delta,
-    i.metadata_updates->>'world_layer' as world_layer,
-    i.metadata_updates->>'pacing' as pacing,
-    jsonb_array_length(i.entity_updates) as entity_update_count,
-    i.entity_updates as entity_changes,
-    i.reference_updates as references,
+    i.metadata_updates -> 'chronology' ->> 'episode_transition' AS episode_transition,
+    i.metadata_updates -> 'chronology' ->> 'time_delta_description' AS time_delta,
+    i.metadata_updates ->> 'world_layer' AS world_layer,
+    i.metadata_updates ->> 'pacing' AS pacing,
+    COALESCE(jsonb_array_length(i.entity_updates -> 'characters'), 0)
+        + COALESCE(jsonb_array_length(i.entity_updates -> 'locations'), 0)
+        + COALESCE(jsonb_array_length(i.entity_updates -> 'factions'), 0)
+        AS entity_update_count,
+    i.entity_updates AS entity_changes,
+    i.reference_updates AS "references",
     i.status,
     i.session_id,
     i.created_at
 FROM incubator i
-LEFT JOIN narrative_chunks nc ON nc.id = i.parent_chunk_id;
+LEFT JOIN narrative_chunks nc ON nc.id = i.parent_chunk_id
+WHERE i.id = TRUE;
 
 COMMENT ON VIEW incubator_view IS 'Human-readable view of incubator contents with parent chunk context';
 

--- a/scripts/create_incubator_table.sql
+++ b/scripts/create_incubator_table.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS incubator (
     parent_chunk_id BIGINT NOT NULL,                        -- Where we're continuing from (e.g., 1425)
     user_text TEXT,                                         -- User's completion text for parent chunk
     storyteller_text TEXT,                                  -- Generated text for new chunk
+    choice_text TEXT,                                       -- User response text resolved before commit
     metadata_updates JSONB DEFAULT '{}',                    -- Time delta, episode transition, etc
     entity_updates JSONB DEFAULT '[]',                      -- Character/place/faction state changes
     reference_updates JSONB DEFAULT '{}',                   -- Entity references (present/mentioned)
@@ -23,6 +24,7 @@ COMMENT ON COLUMN incubator.chunk_id IS 'ID of the new chunk being created (not 
 COMMENT ON COLUMN incubator.parent_chunk_id IS 'ID of existing chunk being continued from';
 COMMENT ON COLUMN incubator.user_text IS 'User completion text for the parent chunk';
 COMMENT ON COLUMN incubator.storyteller_text IS 'AI-generated storyteller text for the new chunk';
+COMMENT ON COLUMN incubator.choice_text IS 'Resolved user response text for the pending chunk';
 COMMENT ON COLUMN incubator.metadata_updates IS 'JSON: {episode_transition, time_delta_seconds, time_delta_description, world_layer, pacing}';
 COMMENT ON COLUMN incubator.entity_updates IS 'JSON array of entity state changes: [{type, id, field, old_value, new_value}]';
 COMMENT ON COLUMN incubator.reference_updates IS 'JSON: {character_present: [], character_referenced: [], place_referenced: []}';
@@ -38,6 +40,7 @@ SELECT
     nc.raw_text as parent_chunk_text,
     i.user_text,
     i.storyteller_text,
+    i.choice_text,
     i.metadata_updates->>'episode_transition' as episode_transition,
     i.metadata_updates->>'time_delta_description' as time_delta,
     i.metadata_updates->>'world_layer' as world_layer,

--- a/scripts/regenerate_embeddings.py
+++ b/scripts/regenerate_embeddings.py
@@ -1103,7 +1103,7 @@ class EmbeddingRegenerator:
                 missing_sql = f"""
                 SELECT c.id FROM narrative_chunks c
                 LEFT JOIN {table_name} e ON c.id = e.chunk_id AND e.model = :model_name
-                WHERE e.id IS NULL;
+                WHERE e.chunk_id IS NULL;
                 """
                 missing_ids = [row[0] for row in conn.execute(text(missing_sql), {"model_name": self.model_name}).fetchall()]
                 
@@ -1352,6 +1352,78 @@ def regenerate_missing_chunks(model_name: str, missing_file: str, batch_size: in
         return {"total": 0, "success": 0, "failed": 0}
 
 
+def delete_existing_chunk_embedding(
+    model_name: str,
+    chunk_id: int,
+    db_url: str = None,
+    dry_run: bool = False,
+) -> int:
+    """
+    Delete one existing embedding row before targeted regeneration.
+
+    Args:
+        model_name: Embedding model to delete
+        chunk_id: Narrative chunk ID to delete
+        db_url: Database URL
+        dry_run: If True, don't make actual changes
+
+    Returns:
+        Number of deleted rows
+    """
+    if dry_run:
+        logger.info(
+            f"[DRY RUN] Would delete existing {model_name} embedding for chunk {chunk_id}"
+        )
+        return 0
+
+    if not db_url:
+        try:
+            from nexus.api.slot_utils import get_slot_db_url
+
+            db_url = get_slot_db_url()
+        except (ImportError, RuntimeError):
+            db_url = os.environ.get("NEXUS_DB_URL")
+            if not db_url:
+                raise RuntimeError(
+                    "No database URL provided. Set NEXUS_SLOT (1-5) or NEXUS_DB_URL."
+                )
+
+    dimensions = get_model_dimensions(model_name)
+    table_name = f"chunk_embeddings_{dimensions:04d}d"
+    engine = create_engine(db_url)
+
+    with engine.begin() as conn:
+        table_exists = conn.execute(
+            text(
+                """
+                SELECT EXISTS (
+                    SELECT FROM information_schema.tables
+                    WHERE LOWER(table_name) = LOWER(:table_name)
+                );
+                """
+            ),
+            {"table_name": table_name},
+        ).scalar()
+        if not table_exists:
+            return 0
+
+        result = conn.execute(
+            text(f"""
+                DELETE FROM {table_name}
+                WHERE chunk_id = :chunk_id
+                  AND model = :model_name
+            """),
+            {"chunk_id": chunk_id, "model_name": model_name},
+        )
+        deleted = result.rowcount or 0
+
+    if deleted:
+        logger.info(
+            f"Deleted existing {model_name} embedding for chunk {chunk_id}"
+        )
+    return deleted
+
+
 def regenerate_specific_chunk(
     model_name: str,
     chunk_id: int,
@@ -1376,6 +1448,13 @@ def regenerate_specific_chunk(
     """
     if chunk_id <= 0:
         raise ValueError(f"chunk_id must be positive, got {chunk_id}")
+
+    delete_existing_chunk_embedding(
+        model_name=model_name,
+        chunk_id=chunk_id,
+        db_url=db_url,
+        dry_run=dry_run,
+    )
 
     missing_path = None
     try:

--- a/scripts/regenerate_embeddings.py
+++ b/scripts/regenerate_embeddings.py
@@ -20,6 +20,9 @@ python scripts/regenerate_embeddings.py --model infly/inf-retriever-v1-1.5b --on
 # Resume embedding generation from a missing chunks file:
 python scripts/regenerate_embeddings.py --model infly/inf-retriever-v1-1.5b --resume-from missing_chunks.txt
 
+# Generate embeddings for one locked narrative chunk in a slot database:
+python scripts/regenerate_embeddings.py --model Octen-Embedding-4B --chunk 42 --database save_05
+
 # Do a dry run without making changes:
 python scripts/regenerate_embeddings.py --model infly/inf-retriever-v1-1.5b --dry-run
 
@@ -33,6 +36,8 @@ ARGUMENTS:
 --create-indexes          Create vector indexes after data loading
 --only-indexes            Only create indexes, skip embedding generation
 --resume-from FILE        Resume from a file of missing chunk IDs
+--chunk ID                Generate or update embeddings for one chunk ID
+--database DBNAME         Slot database name (save_01 through save_05)
 
 Dependencies:
     - pgvector 
@@ -46,6 +51,7 @@ import sys
 import json
 import logging
 import time
+import tempfile
 from typing import Dict, List, Tuple, Any, Optional, Union
 import tqdm
 import argparse
@@ -75,6 +81,7 @@ except ImportError:
         
         # High-dimensional models
         "infly/inf-retriever-v1-1.5b": 1536,
+        "inf-retriever-v1-1.5b": 1536,
     }
     
     def get_model_dimensions(model_name: str) -> int:
@@ -254,7 +261,8 @@ class EmbeddingRegenerator:
     """Regenerates embeddings for all narrative chunks"""
     
     def __init__(self, model_name: str, batch_size: int = 10, db_url: str = None, dry_run: bool = False,
-                 create_indexes: bool = False, truncate_table: bool = False):
+                 create_indexes: bool = False, truncate_table: bool = False,
+                 preserve_existing: bool = False):
         """
         Initialize the regenerator with database connection and model.
         
@@ -266,12 +274,15 @@ class EmbeddingRegenerator:
             create_indexes: If True, create vector indexes after data is loaded
                            If False, only create basic indexes (faster for data loading)
             truncate_table: If True, completely truncate the table before starting (clean slate)
+            preserve_existing: If True, keep existing rows for this model
         """
         self.model_name = model_name
         self.batch_size = batch_size
         self.dry_run = dry_run
         self.create_indexes = create_indexes
         self.truncate_table = truncate_table
+        self.preserve_existing = preserve_existing
+        self.align_ids_with_chunk_ids = False
         self.dimensions = get_model_dimensions(model_name)
         self.sequence_reset_done = False  # Track if we've reset the sequence
         self.force_id_for_first_insert = False  # Will be set to True if needed
@@ -479,6 +490,16 @@ class EmbeddingRegenerator:
         dim_str = f"{self.dimensions:04d}"  # Format with leading zeros
         # PostgreSQL converts identifiers to lowercase by default
         return f"chunk_embeddings_{dim_str}d"
+
+    def sync_id_sequence_to_max(self) -> None:
+        """Move the table ID sequence to the current max(id)."""
+        table_name = self.get_table_name()
+        with self.engine.begin() as conn:
+            conn.execute(text(f"""
+                SELECT setval('{table_name}_id_seq',
+                    (SELECT COALESCE(MAX(id), 1) FROM {table_name}),
+                    true);
+            """))
     
     def get_all_chunks(self) -> List[Dict[str, Any]]:
         """
@@ -604,10 +625,15 @@ class EmbeddingRegenerator:
         if not self.sequence_reset_done:
             with self.engine.begin() as conn:
                 try:
-                    # First ensure there are no existing rows for this model (belt and suspenders)
-                    delete_query = f"DELETE FROM {table_name} WHERE model = :model_name;"
-                    conn.execute(text(delete_query), {"model_name": self.model_name})
-                    logger.info(f"✅ Removed any existing rows for model {self.model_name}")
+                    if self.preserve_existing:
+                        logger.info(
+                            f"Preserving existing rows for model {self.model_name}"
+                        )
+                    else:
+                        # First ensure there are no existing rows for this model (belt and suspenders)
+                        delete_query = f"DELETE FROM {table_name} WHERE model = :model_name;"
+                        conn.execute(text(delete_query), {"model_name": self.model_name})
+                        logger.info(f"✅ Removed any existing rows for model {self.model_name}")
                     
                     # Check if other models are using this table
                     other_models_sql = f"""
@@ -620,6 +646,24 @@ class EmbeddingRegenerator:
                                               {"this_model": self.model_name}).fetchall()
                     
                     has_other_models = len(other_models) > 0
+
+                    if self.preserve_existing and not has_other_models:
+                        self.align_ids_with_chunk_ids = True
+                        conn.execute(text(f"""
+                            UPDATE {table_name}
+                            SET id = -chunk_id
+                            WHERE model = :model_name
+                              AND id <> chunk_id;
+                        """), {"model_name": self.model_name})
+                        conn.execute(text(f"""
+                            UPDATE {table_name}
+                            SET id = chunk_id
+                            WHERE model = :model_name
+                              AND id < 0;
+                        """), {"model_name": self.model_name})
+                        logger.info(
+                            f"Aligned {table_name}.id with chunk_id for {self.model_name}"
+                        )
                     
                     # Next get minimum and maximum existing IDs
                     count_sql = f"SELECT COUNT(*), MIN(id), MAX(id) FROM {table_name};"
@@ -641,7 +685,7 @@ class EmbeddingRegenerator:
                         # to avoid conflicts with existing rows
                         reset_sql = f"""
                         SELECT setval('{table_name}_id_seq', 
-                                     (SELECT COALESCE(MAX(id), 0) FROM {table_name}),
+                                     (SELECT COALESCE(MAX(id), 1) FROM {table_name}),
                                      true);
                         """
                         conn.execute(text(reset_sql))
@@ -662,7 +706,7 @@ class EmbeddingRegenerator:
                         # No other models but not truncating - just reset to next available ID
                         reset_sql = f"""
                         SELECT setval('{table_name}_id_seq', 
-                                     (SELECT COALESCE(MAX(id), 0) FROM {table_name}),
+                                     (SELECT COALESCE(MAX(id), 1) FROM {table_name}),
                                      true);
                         """
                         conn.execute(text(reset_sql))
@@ -711,7 +755,17 @@ class EmbeddingRegenerator:
                     embedding_str = "[" + ",".join(str(x) for x in embedding) + "]"
                     
                     # For the very first insert on a truncated table, force ID=1
-                    if is_first_insert and self.force_id_for_first_insert:
+                    if self.align_ids_with_chunk_ids:
+                        insert_sql = text(f"""
+                            INSERT INTO {table_name}
+                            (id, chunk_id, model, embedding, created_at)
+                            VALUES (:embedding_id, :chunk_id, :model_name, '{embedding_str}'::vector({self.dimensions}), NOW())
+                            ON CONFLICT (chunk_id, model) DO UPDATE
+                            SET id = EXCLUDED.id,
+                                embedding = '{embedding_str}'::vector({self.dimensions}),
+                                created_at = NOW();
+                        """)
+                    elif is_first_insert and self.force_id_for_first_insert:
                         insert_sql = text(f"""
                             INSERT INTO {table_name} 
                             (id, chunk_id, model, embedding, created_at) 
@@ -738,6 +792,7 @@ class EmbeddingRegenerator:
                     
                     # Execute the statement with just the standard parameters
                     session.execute(insert_sql, {
+                        "embedding_id": int(chunk_id),
                         "chunk_id": int(chunk_id), 
                         "model_name": self.model_name
                     })
@@ -753,6 +808,8 @@ class EmbeddingRegenerator:
             
             if success_count > 0:
                 logger.info(f"Stored {success_count}/{len(batch)} embeddings in {table_name}")
+                if self.align_ids_with_chunk_ids:
+                    self.sync_id_sequence_to_max()
             
             return success_count
         
@@ -1243,7 +1300,8 @@ def regenerate_missing_chunks(model_name: str, missing_file: str, batch_size: in
             db_url=db_url, 
             dry_run=dry_run,
             create_indexes=create_indexes,
-            truncate_table=truncate_table
+            truncate_table=truncate_table,
+            preserve_existing=True
         )
         
         # Process each chunk in batches
@@ -1293,6 +1351,60 @@ def regenerate_missing_chunks(model_name: str, missing_file: str, batch_size: in
         logger.error(f"Error processing missing chunks: {e}")
         return {"total": 0, "success": 0, "failed": 0}
 
+
+def regenerate_specific_chunk(
+    model_name: str,
+    chunk_id: int,
+    batch_size: int = 1,
+    db_url: str = None,
+    dry_run: bool = False,
+    create_indexes: bool = False,
+):
+    """
+    Generate or update embeddings for one narrative chunk.
+
+    Args:
+        model_name: Embedding model to use
+        chunk_id: Narrative chunk ID to embed
+        batch_size: Batch size for processing
+        db_url: Database URL
+        dry_run: If True, don't make actual changes
+        create_indexes: If True, create vector indexes after data loading
+
+    Returns:
+        Dict with results
+    """
+    if chunk_id <= 0:
+        raise ValueError(f"chunk_id must be positive, got {chunk_id}")
+
+    missing_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            delete=False,
+            prefix=f"nexus_chunk_{chunk_id}_",
+            suffix=".txt",
+        ) as missing_file:
+            missing_file.write(f"{chunk_id}\n")
+            missing_path = missing_file.name
+
+        return regenerate_missing_chunks(
+            model_name=model_name,
+            missing_file=missing_path,
+            batch_size=batch_size,
+            db_url=db_url,
+            dry_run=dry_run,
+            create_indexes=create_indexes,
+            truncate_table=False,
+        )
+    finally:
+        if missing_path:
+            try:
+                os.unlink(missing_path)
+            except OSError as exc:
+                logger.warning(f"Could not delete temporary chunk file: {exc}")
+
+
 def main():
     """Main function to run the regeneration process"""
     parser = argparse.ArgumentParser(description="Regenerate embeddings for narrative chunks")
@@ -1306,17 +1418,76 @@ def main():
     parser.add_argument("--only-indexes", action="store_true",
                        help="Only create indexes, skip embedding generation (use after running without indexes)")
     parser.add_argument("--resume-from", help="Resume from a file of missing chunk IDs")
+    parser.add_argument("--chunk", type=int, help="Generate embeddings for one chunk ID")
+    parser.add_argument("--database", help="Slot database name (save_01 through save_05)")
     parser.add_argument("--truncate-table", action="store_true", 
                        help="Completely truncate the table and reset sequence before starting (clean slate approach)")
     args = parser.parse_args()
+
+    if args.database:
+        if args.db_url:
+            print("Error: Use either --database or --db-url, not both")
+            sys.exit(1)
+        try:
+            from nexus.api.slot_utils import get_slot_db_url
+
+            args.db_url = get_slot_db_url(dbname=args.database)
+        except Exception as exc:
+            print(f"Error: {exc}")
+            sys.exit(1)
     
     # Check input validity
-    if not args.model and not args.all_models and not args.only_indexes and not args.resume_from:
-        print("Error: Either --model, --all-models, --only-indexes, or --resume-from must be specified")
+    if (
+        not args.model
+        and not args.all_models
+        and not args.only_indexes
+        and not args.resume_from
+        and args.chunk is None
+    ):
+        print(
+            "Error: Either --model, --all-models, --only-indexes, "
+            "--resume-from, or --chunk must be specified"
+        )
         parser.print_help()
         sys.exit(1)
     
     try:
+        if args.chunk is not None:
+            if not args.model:
+                print("Error: --model must be specified when using --chunk")
+                sys.exit(1)
+            if args.chunk <= 0:
+                print("Error: --chunk must be a positive integer")
+                sys.exit(1)
+
+            logger.info(
+                f"Generating embedding for chunk {args.chunk} with {args.model}"
+            )
+            results = regenerate_specific_chunk(
+                model_name=args.model,
+                chunk_id=args.chunk,
+                batch_size=args.batch_size,
+                db_url=args.db_url,
+                dry_run=args.dry_run,
+                create_indexes=args.create_indexes,
+            )
+
+            print("\nChunk Embedding Generation Complete:")
+            print(f"Model: {args.model}")
+            print(f"Chunk ID: {args.chunk}")
+            print(f"Total chunks processed: {results['total']}")
+            print(f"Successful embeddings: {results['success']}")
+            print(f"Failed embeddings: {results['failed']}")
+
+            if args.dry_run:
+                print("\nThis was a dry run, no changes were made to the database.")
+
+            if results["failed"] > 0 or results["success"] < 1:
+                print("\nChunk embedding failed. Check the log for details.")
+                sys.exit(1)
+
+            return
+
         # If resuming from missing chunks, handle that separately
         if args.resume_from:
             if not args.model:

--- a/scripts/utils/embedding_utils.py
+++ b/scripts/utils/embedding_utils.py
@@ -31,6 +31,7 @@ MODEL_DIMENSIONS = {
     # High-dimensional models
     "infly/inf-retriever-v1": 3584,  # Original model - too high for efficient indexing
     "infly/inf-retriever-v1-1.5b": 1536,  # Lightweight version with 1536 dimensions
+    "inf-retriever-v1-1.5b": 1536,
     "Octen-Embedding-0.6B": 1024,
     "Octen-Embedding-4B": 2560,
     "Octen-Embedding-4B-INT8": 2560,

--- a/tests/test_api/test_choice_promotion.py
+++ b/tests/test_api/test_choice_promotion.py
@@ -80,6 +80,27 @@ def test_legacy_selected_object_normalizes_to_integer() -> None:
     assert selected_text_from_choice_object(choice_object) == "Stay hidden."
 
 
+def test_legacy_freeform_selection_preserves_text() -> None:
+    """Readers should recover freeform text before canonical normalization."""
+    choice_object = {
+        "presented": ["Cross the street.", "Stay hidden."],
+        "selected": {
+            "label": "freeform",
+            "text": "Circle around through the loading dock.",
+            "edited": True,
+        },
+    }
+
+    assert normalize_choice_object(choice_object)["selected"] is None
+    assert (
+        selected_text_from_choice_object(choice_object)
+        == "Circle around through the loading dock."
+    )
+    assert compute_raw_text("Rain silvered the street.", choice_object) == (
+        "Rain silvered the street.\n\nCircle around through the loading dock."
+    )
+
+
 def test_compute_raw_text_uses_choice_text_not_full_menu() -> None:
     """raw_text is storyteller prose plus the selected/freeform response only."""
     raw_text = compute_raw_text(

--- a/tests/test_api/test_choice_promotion.py
+++ b/tests/test_api/test_choice_promotion.py
@@ -1,0 +1,91 @@
+"""Tests for narrative choice promotion helpers."""
+
+from __future__ import annotations
+
+from nexus.api.choice_handling import (
+    normalize_choice_object,
+    resolve_choice_response,
+    selected_text_from_choice_object,
+)
+from nexus.api.lore_adapter import compute_raw_text
+
+
+def test_resolve_choice_response_writes_canonical_selected_index() -> None:
+    """Structured choices should persist selected as an integer."""
+    choice_object = {
+        "presented": ["Cross the street.", "Stay hidden."],
+        "selected": None,
+    }
+
+    resolved = resolve_choice_response(choice_object, choice=2)
+
+    assert resolved.choice_text == "Stay hidden."
+    assert resolved.selected == 2
+    assert resolved.choice_object == {
+        "presented": ["Cross the street.", "Stay hidden."],
+        "selected": 2,
+    }
+
+
+def test_resolve_choice_response_accept_fate_selects_first_choice() -> None:
+    """Narrative accept-fate is auditable as the first presented choice."""
+    choice_object = {
+        "presented": ["Cross the street.", "Stay hidden."],
+        "selected": None,
+    }
+
+    resolved = resolve_choice_response(choice_object, accept_fate=True)
+
+    assert resolved.choice_text == "Cross the street."
+    assert resolved.selected == 1
+    assert resolved.choice_object["selected"] == 1
+
+
+def test_resolve_choice_response_infers_flattened_choice_text() -> None:
+    """Old callers that flatten --choice into text should still preserve selected."""
+    choice_object = {
+        "presented": ["Cross the street.", "Stay hidden."],
+        "selected": None,
+    }
+
+    resolved = resolve_choice_response(choice_object, user_text="Cross the street.")
+
+    assert resolved.choice_text == "Cross the street."
+    assert resolved.selected == 1
+    assert resolved.choice_object["selected"] == 1
+
+
+def test_resolve_choice_response_freeform_keeps_selected_null() -> None:
+    """Freeform responses keep choice_text without claiming a menu index."""
+    choice_object = {
+        "presented": ["Cross the street.", "Stay hidden."],
+        "selected": None,
+    }
+
+    resolved = resolve_choice_response(choice_object, user_text="I call Jonas instead.")
+
+    assert resolved.choice_text == "I call Jonas instead."
+    assert resolved.selected is None
+    assert resolved.choice_object["selected"] is None
+
+
+def test_legacy_selected_object_normalizes_to_integer() -> None:
+    """Readers tolerate the previous selected-object shape."""
+    choice_object = {
+        "presented": ["Cross the street.", "Stay hidden."],
+        "selected": {"label": 2, "text": "Stay hidden.", "edited": False},
+    }
+
+    assert normalize_choice_object(choice_object)["selected"] == 2
+    assert selected_text_from_choice_object(choice_object) == "Stay hidden."
+
+
+def test_compute_raw_text_uses_choice_text_not_full_menu() -> None:
+    """raw_text is storyteller prose plus the selected/freeform response only."""
+    raw_text = compute_raw_text(
+        "Rain silvered the street.",
+        {"presented": ["Cross the street.", "Stay hidden."], "selected": 1},
+        "Cross the street.",
+    )
+
+    assert raw_text == "Rain silvered the street.\n\nCross the street."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,29 @@
 """Tests for the NEXUS CLI helpers."""
 
+from argparse import Namespace
+from typing import Any
+
+from nexus import cli
 from nexus.cli import GENERATION_POLL_SECONDS, _is_terminal_generation_status
+
+
+class DummyResponse:
+    """Minimal requests.Response double for CLI tests."""
+
+    def __init__(
+        self, payload: dict[str, Any], ok: bool = True, text: str = ""
+    ) -> None:
+        self.payload = payload
+        self.ok = ok
+        self.text = text
+
+    def json(self) -> dict[str, Any]:
+        """Return response JSON."""
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        """Mimic a successful HTTP response."""
+        return None
 
 
 def test_terminal_generation_statuses_include_api_and_incubator_values() -> None:
@@ -19,3 +42,60 @@ def test_generation_poll_window_covers_live_reasoning_models() -> None:
     """CLI polling should outlast slow structured generation calls."""
 
     assert GENERATION_POLL_SECONDS >= 180
+
+
+def test_continue_posts_choice_to_backend_without_preapproving(
+    monkeypatch,
+) -> None:
+    """The CLI should let /api/narrative/continue record and approve atomically."""
+    posts: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_get(url: str, **kwargs: Any) -> DummyResponse:
+        if url.endswith("/api/slot/5/state"):
+            return DummyResponse(
+                {
+                    "is_empty": False,
+                    "is_wizard_mode": False,
+                    "has_pending": True,
+                    "choices": ["Cross the street.", "Stay hidden."],
+                    "model": None,
+                }
+            )
+        if "/api/narrative/status/" in url:
+            return DummyResponse({"status": "completed", "chunk_id": 2})
+        raise AssertionError(f"Unexpected GET {url}")
+
+    def fake_post(url: str, json: dict[str, Any], **kwargs: Any) -> DummyResponse:
+        posts.append((url, json))
+        if url.endswith("/api/narrative/approve"):
+            raise AssertionError("CLI should not pre-approve pending narrative")
+        if url.endswith("/api/narrative/continue"):
+            return DummyResponse({"session_id": "session-2"})
+        raise AssertionError(f"Unexpected POST {url}")
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+    monkeypatch.setattr(cli.requests, "post", fake_post)
+    monkeypatch.setattr(
+        cli,
+        "run_load",
+        lambda args: {"message": "Next chunk", "choices": ["Continue."]},
+    )
+
+    result = cli.run_continue(
+        Namespace(
+            slot=5,
+            model=None,
+            user_text=None,
+            choice=1,
+            accept_fate=False,
+            dev=False,
+        )
+    )
+
+    assert result["success"] is True
+    assert len(posts) == 1
+    url, payload = posts[0]
+    assert url.endswith("/api/narrative/continue")
+    assert payload["choice"] == 1
+    assert payload["accept_fate"] is False
+    assert payload["user_text"] == ""

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -57,7 +57,9 @@ def _stub_baseline(
     return package
 
 
-def test_integrate_response_passes_authorial_directives(turn_manager: TurnCycleManager, monkeypatch: pytest.MonkeyPatch):
+def test_integrate_response_passes_authorial_directives(
+    turn_manager: TurnCycleManager, monkeypatch: pytest.MonkeyPatch
+):
     ctx = TurnContext(
         turn_id="turn_directive",
         user_input="Test input",
@@ -66,7 +68,12 @@ def test_integrate_response_passes_authorial_directives(turn_manager: TurnCycleM
     ctx.authorial_directives = ["Directive A", "Directive B"]
     ctx.warm_slice = [{"chunk_id": 999, "text": "Recent narrative."}]
     ctx.retrieved_passages = []
-    ctx.token_counts = {"total_available": 1000, "warm_slice": 100, "structured": 0, "augmentation": 0}
+    ctx.token_counts = {
+        "total_available": 1000,
+        "warm_slice": 100,
+        "structured": 0,
+        "augmentation": 0,
+    }
 
     captured: Dict[str, Any] = {}
 
@@ -92,3 +99,45 @@ def test_integrate_response_passes_authorial_directives(turn_manager: TurnCycleM
     baseline_snapshot = ctx.memory_state["pass1"]
     assert baseline_snapshot["authorial_directives"] == ctx.authorial_directives
     assert baseline_snapshot["structured_passages"] == []
+
+
+def test_integrate_response_sorts_mixed_chunk_id_payloads(
+    turn_manager: TurnCycleManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pass 1 snapshots should tolerate older string chunk IDs."""
+    ctx = TurnContext(
+        turn_id="turn_mixed_ids",
+        user_input="Test input",
+        start_time=time.time(),
+    )
+    ctx.warm_slice = []
+    ctx.retrieved_passages = []
+    ctx.token_counts = {"total_available": 1000}
+
+    def fake_handle_storyteller_response(**kwargs: Any) -> ContextPackage:
+        package = ContextPackage(
+            baseline_chunks={3, "2", 1},
+            baseline_entities={},
+            baseline_themes=[],
+            authorial_directives=[],
+            structured_passages=[],
+            token_usage=kwargs.get("token_usage", {}),
+        )
+        transition = PassTransition(
+            storyteller_output=kwargs.get("narrative", ""),
+            remaining_budget=1000,
+        )
+        turn_manager.lore.memory_manager.context_state.store_baseline(
+            package, transition
+        )
+        return package
+
+    monkeypatch.setattr(
+        turn_manager.lore.memory_manager,
+        "handle_storyteller_response",
+        fake_handle_storyteller_response,
+    )
+
+    asyncio.run(turn_manager.integrate_response(ctx, "Story chunk text"))
+
+    assert ctx.memory_state["pass1"]["baseline_chunks"] == [1, "2", 3]


### PR DESCRIPTION
## Summary

- Moves narrative choice promotion into `/api/narrative/continue` so CLI choice/accept-fate requests are recorded and approved atomically by the backend.
- Stores canonical LOGON choice data as presented choices plus `selected` index/null, with `choice_text` as the selected or freeform player response.
- Adds `incubator.choice_text` migration support and keeps `raw_text` to storyteller prose plus the chosen response only.
- Implements the clarified undo boundary: starting from parent chunk `n-1` leaves `n-1` provisional/undoable and schedules embeddings for locked chunk `n-2`.
- Repairs targeted embedding generation for slot databases and fixes the Pass 1 mixed chunk-ID sort warning seen during live testing.

## Validation

- `poetry run pytest tests/test_api tests/test_cli.py`
- `poetry run pytest tests/test_lore`
- `poetry run pytest tests/test_ir_eval_v2/test_embedding_tables.py`
- `git diff --check`

## Live Check

- Applied migration 019 to slot 5.
- Posted live continuation to slot 5 with `choice=1`; generation completed and wrote provisional chunk 3.
- Verified chunk 2 recorded the selected choice and updated `raw_text`.
- Verified the embedding lock boundary by generating embeddings for chunk 1 with `Octen-Embedding-4B`; chunk 1 is embedded, chunk 2 remains draft/unembedded.
