### PR TITLE
Add nexus regenerate CLI verb with --note for soft steering

### DIFF
--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -260,17 +260,6 @@ class LogonUtility:
         sections.append("\n=== USER INPUT ===")
         sections.append(context.get("user_input", ""))
 
-        # Add author's note (soft out-of-character suggestion, used by regenerate)
-        note = context.get("note")
-        if note:
-            sections.append("\n=== AUTHOR'S NOTE ===")
-            sections.append(
-                "The player is also leaving a soft, out-of-character suggestion for this "
-                "generation — treat it as authorial intent, not a hard constraint. It may "
-                "be a tonal nudge, a continuity correction, or an outcome preference:"
-            )
-            sections.append(note)
-
         # Add entity data with hierarchical support
         entity_data = context.get("entity_data", {})
         if entity_data:
@@ -390,6 +379,19 @@ class LogonUtility:
             sections.append("\n=== HISTORICAL CONTEXT ===")
             for passage in context["retrieved_passages"]["results"][:5]:  # Limit to top 5
                 sections.append(f"[Score: {passage.get('score', 0):.2f}] {passage.get('text', '')}")
+
+        # Add author's note (soft out-of-character suggestion, used by regenerate).
+        # Placed immediately before INSTRUCTIONS so recency bias gives it the influence
+        # a soft nudge needs — entity/historical context above would otherwise bury it.
+        note = context.get("note")
+        if note:
+            sections.append("\n=== AUTHOR'S NOTE ===")
+            sections.append(
+                "The player is also leaving a soft, out-of-character suggestion for this "
+                "generation — treat it as authorial intent, not a hard constraint. It may "
+                "be a tonal nudge, a continuity correction, or an outcome preference:"
+            )
+            sections.append(note)
 
         # Add instructions
         sections.append("\n=== INSTRUCTIONS ===")

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -260,6 +260,17 @@ class LogonUtility:
         sections.append("\n=== USER INPUT ===")
         sections.append(context.get("user_input", ""))
 
+        # Add author's note (soft out-of-character suggestion, used by regenerate)
+        note = context.get("note")
+        if note:
+            sections.append("\n=== AUTHOR'S NOTE ===")
+            sections.append(
+                "The player is also leaving a soft, out-of-character suggestion for this "
+                "generation — treat it as authorial intent, not a hard constraint. It may "
+                "be a tonal nudge, a continuity correction, or an outcome preference:"
+            )
+            sections.append(note)
+
         # Add entity data with hierarchical support
         entity_data = context.get("entity_data", {})
         if entity_data:

--- a/nexus/agents/lore/lore.py
+++ b/nexus/agents/lore/lore.py
@@ -286,25 +286,30 @@ class LORE:
         if self.logon is None:
             self._initialize_logon()
     
-    async def process_turn(self, user_input: str, parent_chunk_id: Optional[int] = None):
+    async def process_turn(self, user_input: str, parent_chunk_id: Optional[int] = None, note: Optional[str] = None):
         """
         Process a complete turn cycle.
 
         Args:
             user_input: The user's input text
             parent_chunk_id: Optional chunk id that should be continued
+            note: Optional soft author's note to nudge the storyteller (used by regenerate
+                for meta-hints like "darker, plz" or continuity corrections; out-of-character).
 
         Returns:
             StoryTurnResponse with narrative and metadata, or string on error
         """
         logger.info(f"Starting turn cycle with input: {user_input[:100]}...")
-        
+        if note:
+            logger.info(f"Author's note: {note[:200]}")
+
         # Initialize turn context
         self.turn_context = TurnContext(
             turn_id=f"turn_{int(time.time())}",
             user_input=user_input,
             start_time=time.time(),
-            target_chunk_id=parent_chunk_id
+            target_chunk_id=parent_chunk_id,
+            note=note,
         )
         
         try:

--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -38,3 +38,4 @@ class TurnContext:
     memory_state: Dict[str, Any] = field(default_factory=dict)
     authorial_directives: List[str] = field(default_factory=list)
     target_chunk_id: Optional[int] = None
+    note: Optional[str] = None  # Soft author's note / suggestion for the storyteller (e.g., regen meta-hints)

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -586,8 +586,10 @@ class TurnCycleManager:
                 "authorial_directives": turn_context.authorial_directives,
             },
             "memory_state": turn_context.memory_state,
-            "note": turn_context.note,
         }
+
+        if turn_context.note:
+            turn_context.context_payload["note"] = turn_context.note
 
         if turn_context.target_chunk_id is not None:
             turn_context.context_payload["metadata"][

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -586,6 +586,7 @@ class TurnCycleManager:
                 "authorial_directives": turn_context.authorial_directives,
             },
             "memory_state": turn_context.memory_state,
+            "note": turn_context.note,
         }
 
         if turn_context.target_chunk_id is not None:

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -691,10 +691,11 @@ async def regenerate_narrative(
             chunk_id = row["chunk_id"]
             parent_chunk_id = row["parent_chunk_id"]
             user_text = row["user_text"] or ""
-
-            # Clear the existing incubator row so generate_narrative_async can write fresh content.
-            cur.execute("DELETE FROM incubator WHERE id = TRUE")
-            conn.commit()
+            # Intentionally NOT deleting the incubator row here. write_to_incubator
+            # (called inside generate_narrative_async on success) does DELETE+INSERT
+            # atomically. If we deleted eagerly and generation later failed (LLM error,
+            # timeout, etc.), the slot would be left with no pending turn — irrecoverable
+            # data loss of the draft the user was trying to re-roll.
     finally:
         conn.close()
 

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -157,6 +157,7 @@ def load_settings():
 from nexus.api.narrative_schemas import (
     ContinueNarrativeRequest,
     ContinueNarrativeResponse,
+    RegenerateNarrativeRequest,
     ApproveNarrativeRequest,
     NarrativeStatus,
     ChoiceSelection,
@@ -651,6 +652,86 @@ async def get_narrative_status(session_id: str, slot: Optional[int] = None):
 
     finally:
         conn.close()
+
+
+@app.post("/api/narrative/regenerate", response_model=ContinueNarrativeResponse)
+async def regenerate_narrative(
+    request: RegenerateNarrativeRequest,
+    background_tasks: BackgroundTasks,
+):
+    """
+    Regenerate the storyteller turn currently in the incubator.
+
+    Replaces the incubator's pending content with a fresh generation,
+    reusing the same parent_chunk_id, user_text, and session_id for
+    "replace in place" semantics. The CLI/UI polls
+    /api/narrative/status/{session_id} for completion.
+    """
+    conn = get_db_connection(request.slot)
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT session_id, chunk_id, parent_chunk_id, user_text
+                FROM incubator
+                WHERE id = TRUE
+                """
+            )
+            row = cur.fetchone()
+            if not row:
+                raise HTTPException(
+                    status_code=404,
+                    detail=(
+                        "No live turn to regenerate. "
+                        "Regenerate is only available while a turn is pending in the incubator."
+                    ),
+                )
+
+            session_id = str(row["session_id"])
+            chunk_id = row["chunk_id"]
+            parent_chunk_id = row["parent_chunk_id"]
+            user_text = row["user_text"] or ""
+
+            # Clear the existing incubator row so generate_narrative_async can write fresh content.
+            cur.execute("DELETE FROM incubator WHERE id = TRUE")
+            conn.commit()
+    finally:
+        conn.close()
+
+    note = request.note.strip() if request.note else None
+    logger.info(
+        f"Regenerating chunk {chunk_id} (parent={parent_chunk_id}) for session {session_id}"
+        f"{' [with note]' if note else ''}"
+    )
+
+    await manager.send_progress(
+        session_id,
+        "initiated",
+        {
+            "chunk_id": chunk_id,
+            "parent_chunk_id": parent_chunk_id,
+            "is_bootstrap": parent_chunk_id == 0,
+            "regenerate": True,
+        },
+    )
+
+    background_tasks.add_task(
+        generate_narrative_async,
+        session_id,
+        parent_chunk_id,
+        user_text,
+        request.slot,
+        get_db_connection=get_db_connection,
+        load_settings=load_settings,
+        manager=manager,
+        note=note,
+    )
+
+    return ContinueNarrativeResponse(
+        session_id=session_id,
+        status="processing",
+        message=f"Regenerating chunk {chunk_id}",
+    )
 
 
 @app.post("/api/narrative/approve")

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -74,6 +74,7 @@ async def generate_narrative_async(
     get_db_connection: Callable[[Optional[int]], Any],
     load_settings: Callable[[], Dict[str, Any]],
     manager: ProgressManager,
+    note: Optional[str] = None,
 ) -> None:
     """
     Async function to generate narrative.
@@ -93,6 +94,8 @@ async def generate_narrative_async(
         get_db_connection: Database connection factory function
         load_settings: Settings loader function
         manager: Progress notification manager
+        note: Optional soft author's note for the storyteller (used by regenerate
+            for meta-hints; ignored by bootstrap path).
     """
     conn = None
     is_bootstrap = parent_chunk_id == 0
@@ -166,7 +169,7 @@ async def generate_narrative_async(
             # Process the turn with LORE (builds context and generates narrative)
             try:
                 response = await lore.process_turn(
-                    user_text, parent_chunk_id=parent_chunk_id
+                    user_text, parent_chunk_id=parent_chunk_id, note=note
                 )
                 logger.info(f"LORE response received for session {session_id}")
             except Exception as e:

--- a/nexus/api/narrative_schemas.py
+++ b/nexus/api/narrative_schemas.py
@@ -66,12 +66,14 @@ class RegenerateNarrativeRequest(BaseModel):
     slot: Optional[int] = Field(default=None, description="Active save slot")
     note: Optional[str] = Field(
         default=None,
+        max_length=500,
         description=(
             "Optional out-of-character note to the storyteller for this regen — a soft "
             "suggestion, not a directive. Examples: 'darker, plz', 'I want to win the fight "
             "despite my poor choices', 'continuity correction: the artifact was found in "
             "Vienna, not Prague'. Does NOT replace user_text (that's what undo is for); it's "
-            "an author's aside that nudges tone, fixes errors, or signals preferences."
+            "an author's aside that nudges tone, fixes errors, or signals preferences. "
+            "Capped at 500 chars to keep it from compressing the context budget."
         ),
     )
 

--- a/nexus/api/narrative_schemas.py
+++ b/nexus/api/narrative_schemas.py
@@ -60,6 +60,22 @@ class ContinueNarrativeResponse(BaseModel):
     message: str = Field(description="Status message")
 
 
+class RegenerateNarrativeRequest(BaseModel):
+    """Request to regenerate the storyteller turn currently in the incubator."""
+
+    slot: Optional[int] = Field(default=None, description="Active save slot")
+    note: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional out-of-character note to the storyteller for this regen — a soft "
+            "suggestion, not a directive. Examples: 'darker, plz', 'I want to win the fight "
+            "despite my poor choices', 'continuity correction: the artifact was found in "
+            "Vienna, not Prague'. Does NOT replace user_text (that's what undo is for); it's "
+            "an author's aside that nudges tone, fixes errors, or signals preferences."
+        ),
+    )
+
+
 class ApproveNarrativeRequest(BaseModel):
     """Request to approve and commit narrative"""
 
@@ -154,6 +170,7 @@ class SlotStateResponse(BaseModel):
     has_pending: bool = False  # True if incubator has pending content
     storyteller_text: Optional[str] = None
     choices: List[str] = []
+    session_id: Optional[str] = None  # Live session ID while incubator pending; basis for regenerate
     model: Optional[str] = None
     # Trait selection menu (character phase, traits subphase)
     trait_menu: Optional[List[TraitMenuItemResponse]] = None

--- a/nexus/api/slot_endpoints.py
+++ b/nexus/api/slot_endpoints.py
@@ -105,6 +105,7 @@ async def get_slot_state_endpoint(slot: int):
                 has_pending=state.narrative_state.has_pending,
                 storyteller_text=state.narrative_state.storyteller_text,
                 choices=state.narrative_state.choices,
+                session_id=state.narrative_state.session_id,
                 model=state.model,
             )
 

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -5,6 +5,7 @@ Commands:
     nexus load --slot N         Display current slot state
     nexus continue --slot N     Advance the story (wizard or narrative)
     nexus undo --slot N         Revert the last action
+    nexus regenerate --slot N   Regenerate the last storyteller turn
     nexus model --slot N        Get or set the model for a slot
 
 The CLI is slot-centric: only --slot N is required. The backend resolves
@@ -613,6 +614,68 @@ def run_undo(args: argparse.Namespace) -> Dict[str, Any]:
         return {"success": False, "error": str(e)}
 
 
+def run_regenerate(args: argparse.Namespace) -> Dict[str, Any]:
+    """
+    Regenerate the last storyteller turn for a slot.
+
+    Calls POST /api/narrative/regenerate, then polls /api/narrative/status
+    until generation completes, matching run_continue's pattern.
+    """
+    url = f"{get_api_url()}/api/narrative/regenerate"
+    payload: Dict[str, Any] = {"slot": args.slot}
+    if args.note:
+        payload["note"] = args.note
+
+    try:
+        response = requests.post(url, json=payload, timeout=120)
+        response.raise_for_status()
+        data = response.json()
+
+        session_id = data.get("session_id")
+        if not session_id:
+            return {"success": False, "error": "No session ID returned from regenerate"}
+
+        for _ in range(GENERATION_POLL_SECONDS):
+            status_url = f"{get_api_url()}/api/narrative/status/{session_id}"
+            try:
+                status_response = requests.get(
+                    status_url, params={"slot": args.slot}, timeout=30
+                )
+            except requests.exceptions.RequestException:
+                # Transient hang on a single status GET (event loop briefly slammed
+                # by sync work in generate_narrative_async). Sleep and retry rather
+                # than aborting the whole polling loop.
+                time.sleep(1)
+                continue
+            if status_response.ok:
+                status = status_response.json()
+                if _is_terminal_generation_status(status.get("status")):
+                    load_result = run_load(args)
+                    return {
+                        "success": True,
+                        "message": load_result.get("message"),
+                        "choices": load_result.get("choices", []),
+                        "chunk_id": status.get("chunk_id"),
+                    }
+                elif status.get("status") == "error":
+                    return {
+                        "success": False,
+                        "error": status.get("error", "Regeneration failed"),
+                    }
+            time.sleep(1)
+        return {"success": False, "error": "Regeneration timed out"}
+
+    except requests.exceptions.ConnectionError:
+        return {
+            "success": False,
+            "error": f"Cannot connect to API server at {get_api_url()}",
+        }
+    except requests.exceptions.HTTPError as e:
+        return {"success": False, "error": f"API error: {e.response.text}"}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
 def run_model(args: argparse.Namespace) -> Dict[str, Any]:
     """
     Get or set the model for a slot.
@@ -815,6 +878,22 @@ Examples:
         "--slot", type=int, required=True, help="Slot number (1-5)"
     )
 
+    # regenerate command
+    regenerate_parser = subparsers.add_parser(
+        "regenerate", help="Regenerate the last storyteller turn"
+    )
+    regenerate_parser.add_argument(
+        "--slot", type=int, required=True, help="Slot number (1-5)"
+    )
+    regenerate_parser.add_argument(
+        "--note",
+        help=(
+            "Optional out-of-character note to the storyteller — a soft suggestion "
+            "for this regen (e.g., 'darker, plz', 'I want to win the fight despite "
+            "my poor choices', 'continuity correction: artifact was found in Vienna')"
+        ),
+    )
+
     # model command
     model_parser = subparsers.add_parser("model", help="Get or set model for a slot")
     model_parser.add_argument("--slot", type=int, help="Slot number (1-5)")
@@ -859,7 +938,7 @@ def main() -> int:
     args = parser.parse_args()
 
     # Validate slot for commands that require it
-    if args.command in ("load", "continue", "undo", "clear", "lock", "unlock"):
+    if args.command in ("load", "continue", "undo", "regenerate", "clear", "lock", "unlock"):
         if args.slot < 1 or args.slot > 5:
             emit_error("Slot must be between 1 and 5", args.json)
             return 1
@@ -879,6 +958,8 @@ def main() -> int:
         result = run_continue(args)
     elif args.command == "undo":
         result = run_undo(args)
+    elif args.command == "regenerate":
+        result = run_regenerate(args)
     elif args.command == "model":
         result = run_model(args)
     elif args.command == "clear":


### PR DESCRIPTION
## Summary

- Adds `nexus regenerate --slot N` for re-rolling the last storyteller turn while it sits in the incubator. Discharges a deferred Phase A out-of-scope item.
- Adds optional `--note "..."` for soft out-of-character steering (e.g., `"darker, plz"`, `"continuity correction: the artifact was in Vienna, not Prague"`). Threaded all the way to the Apex prompt as a new `=== AUTHOR'S NOTE ===` section. Does **not** replace `user_text` — that's what `undo` is for.

## Why a new backend endpoint

The original plan pointed at `POST /api/story/regenerate` in `nexus/api/storyteller.py:575`, but that route lives on a separate FastAPI app that isn't deployed (the production daemon is `nexus.api.narrative:app` on port 8002, which never includes the storyteller app's routes). So this PR wires a real implementation:

- `POST /api/narrative/regenerate` looks up the singleton incubator row, captures `parent_chunk_id` and `user_text`, deletes the row, and re-invokes `generate_narrative_async` with the **same** `session_id` for replace-in-place semantics.
- The CLI then polls `/api/narrative/status/{session_id}` exactly like `run_continue` does.

## Soft steering channel (`note`)

A note is a single soft suggestion the player attaches to a regen — *not* a directive. Examples the user proposed: `"darker, plz"`, `"I want to win the fight despite my poor choices"`, `"hey you made a continuity error, the thing from 500 chunks ago was this, not that"`.

Plumbing:
- `RegenerateNarrativeRequest.note` → endpoint passes to background task → `generate_narrative_async(..., note=note)` → `lore.process_turn(..., note=note)` → stashed on `TurnContext.note` → included in `context_payload["note"]` → rendered as `=== AUTHOR'S NOTE ===` section in the Apex prompt via `logon_utility._format_context_prompt`.

Kept **separate** from the existing `authorial_directives` plumbing because that's a heavier mechanism — each directive triggers an extra MEMNON retrieval pass (`memory/manager.py:689`). A `note` is a single soft suggestion that bypasses retrieval entirely.

## Incidental fix

Surfaces `session_id` on `/api/slot/{slot}/state`. The field was already on `NarrativeState` (populated only while an incubator row exists — i.e., exactly the lifecycle window where regenerate is meaningful) but never made it into the API response schema. Independently useful for any slot-scoped CLI that needs the live session.

## Test plan

- [x] CLI `nexus regenerate --slot 5` succeeds end-to-end against an incubator-pending turn.
- [x] `nexus regenerate --slot 5 --note "darker, plz"` produces demonstrably darker output (body horror, uncanny callbacks, patient menace) while preserving the established narrative arc.
- [x] Same `chunk_id` and `session_id` after regen (replace-in-place verified).
- [x] Polling loop tolerates transient status-GET hangs without aborting the whole regen.

## Out of scope (queued)

- Narrative-mode `nexus undo` extension + drop of `chunk_embeddings_0384d` — separate follow-up PR (see plan file).
- Async-ifying the embedding subprocess (existing TODO at `chunk_workflow.py:388`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)