### PR TITLE
Extend nexus undo for narrative grace window + drop chunk_embeddings_0384d

### DIFF
--- a/migrations/020_drop_chunk_embeddings_0384d.sql
+++ b/migrations/020_drop_chunk_embeddings_0384d.sql
@@ -1,0 +1,17 @@
+-- 020_drop_chunk_embeddings_0384d.sql
+--
+-- Drop the vestigial 384-dimension embedding table. It is a relic of an
+-- abandoned BGE-Small fine-tune attempt; no production code reads from or
+-- writes to it. nexus.agents.memnon.utils.embedding_tables.DIMENSION_TABLE_MAP
+-- has not contained a 384 entry for some time. The table is also missing
+-- ON DELETE CASCADE on its FK to narrative_chunks(id) — the only such gap
+-- among the dimension-sharded tables — which would matter if any future
+-- feature ever deletes from narrative_chunks.
+--
+-- Discharges a recurring sharp edge that has surfaced in three separate
+-- features (issue #175 single-model consolidation, narrative undo design,
+-- and PR review of the embedding-pipeline overhaul).
+--
+-- Idempotent via DROP TABLE IF EXISTS — safe to re-run.
+
+DROP TABLE IF EXISTS chunk_embeddings_0384d;

--- a/nexus/api/chunk_workflow.py
+++ b/nexus/api/chunk_workflow.py
@@ -394,6 +394,72 @@ class ChunkWorkflow:
                     new_generation_triggered=True,
                 )
 
+    def revert_pending_choice(self, parent_chunk_id: int) -> None:
+        """
+        Reset the parent chunk's choice fields after the user undoes a pending turn.
+
+        When the user invokes `nexus undo` while a turn sits in incubator, two
+        things must happen: (1) the incubator row is deleted (the slot endpoint's
+        responsibility), and (2) the parent chunk's recorded choice — which
+        produced that pending turn — is wiped, so the user can re-pick. This
+        method handles (2) atomically.
+
+        Mutations on the parent chunk:
+        - choice_text → NULL
+        - choice_object.selected → JSON null (preserves choice_object.presented)
+        - raw_text → storyteller_text  (re-derived without the choice append)
+
+        The parent chunk should NOT be embedded yet — the lifecycle invariant
+        places the mutable parent at the N-1 position (committed but not yet
+        ironman, embedding fires only when the next chunk is accepted). If we
+        ever hit an embedded chunk here, the design has drifted and silently
+        mutating raw_text would invalidate the embedding's source — surface it.
+
+        Args:
+            parent_chunk_id: ID of the parent chunk whose choice fields to reset.
+        """
+        with get_connection(self.dbname) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT storyteller_text, embedding_generated_at
+                    FROM narrative_chunks
+                    WHERE id = %s
+                    """,
+                    (parent_chunk_id,),
+                )
+                row = cur.fetchone()
+                if not row:
+                    raise ValueError(f"Parent chunk {parent_chunk_id} not found")
+
+                storyteller_text, embedded_at = row
+
+                if embedded_at is not None:
+                    raise ValueError(
+                        f"Cannot revert choice on chunk {parent_chunk_id}: already "
+                        f"embedded (embedding_generated_at={embedded_at}). The undo "
+                        f"grace window has closed; this chunk is ironman."
+                    )
+
+                cur.execute(
+                    """
+                    UPDATE narrative_chunks
+                    SET choice_text = NULL,
+                        raw_text = %s,
+                        choice_object = jsonb_set(
+                            COALESCE(choice_object, '{}'::jsonb),
+                            '{selected}',
+                            'null'::jsonb
+                        )
+                    WHERE id = %s
+                    """,
+                    (storyteller_text or "", parent_chunk_id),
+                )
+                logger.info(
+                    f"Reverted pending choice on chunk {parent_chunk_id} "
+                    f"(raw_text recomputed from storyteller_text only)"
+                )
+
     def trigger_embedding_generation(self, chunk_id: int) -> Optional[str]:
         """
         Generate embeddings for a locked chunk.

--- a/nexus/api/chunk_workflow.py
+++ b/nexus/api/chunk_workflow.py
@@ -394,15 +394,16 @@ class ChunkWorkflow:
                     new_generation_triggered=True,
                 )
 
-    def revert_pending_choice(self, parent_chunk_id: int) -> None:
+    def revert_pending_choice(self, cur, parent_chunk_id: int) -> None:
         """
         Reset the parent chunk's choice fields after the user undoes a pending turn.
 
-        When the user invokes `nexus undo` while a turn sits in incubator, two
-        things must happen: (1) the incubator row is deleted (the slot endpoint's
-        responsibility), and (2) the parent chunk's recorded choice — which
-        produced that pending turn — is wiped, so the user can re-pick. This
-        method handles (2) atomically.
+        Runs inside the caller's open cursor/transaction (no connection
+        management here). Designed this way so the slot undo endpoint can
+        compose this with its own DELETE FROM incubator inside one
+        transaction — if either fails, both roll back and the slot stays
+        consistent. (Codex P1 review on PR #205 caught the prior split-
+        transaction version.)
 
         Mutations on the parent chunk:
         - choice_text → NULL
@@ -411,54 +412,70 @@ class ChunkWorkflow:
 
         The parent chunk should NOT be embedded yet — the lifecycle invariant
         places the mutable parent at the N-1 position (committed but not yet
-        ironman, embedding fires only when the next chunk is accepted). If we
+        ironman; embedding fires only when the next chunk is accepted). If we
         ever hit an embedded chunk here, the design has drifted and silently
         mutating raw_text would invalidate the embedding's source — surface it.
+        Same fail-loud principle applies to the other lifecycle invariants
+        (NULL/empty storyteller_text, NULL choice_object): a parent that
+        produced a pending child should have both populated.
 
         Args:
+            cur: An open psycopg2 cursor owned by the caller's transaction.
             parent_chunk_id: ID of the parent chunk whose choice fields to reset.
         """
-        with get_connection(self.dbname) as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    SELECT storyteller_text, embedding_generated_at
-                    FROM narrative_chunks
-                    WHERE id = %s
-                    """,
-                    (parent_chunk_id,),
-                )
-                row = cur.fetchone()
-                if not row:
-                    raise ValueError(f"Parent chunk {parent_chunk_id} not found")
+        cur.execute(
+            """
+            SELECT storyteller_text, choice_object, embedding_generated_at
+            FROM narrative_chunks
+            WHERE id = %s
+            """,
+            (parent_chunk_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            raise ValueError(f"Parent chunk {parent_chunk_id} not found")
 
-                storyteller_text, embedded_at = row
+        storyteller_text, choice_object, embedded_at = row
 
-                if embedded_at is not None:
-                    raise ValueError(
-                        f"Cannot revert choice on chunk {parent_chunk_id}: already "
-                        f"embedded (embedding_generated_at={embedded_at}). The undo "
-                        f"grace window has closed; this chunk is ironman."
-                    )
+        if embedded_at is not None:
+            raise ValueError(
+                f"Cannot revert choice on chunk {parent_chunk_id}: already "
+                f"embedded (embedding_generated_at={embedded_at}). The undo "
+                f"grace window has closed; this chunk is ironman."
+            )
 
-                cur.execute(
-                    """
-                    UPDATE narrative_chunks
-                    SET choice_text = NULL,
-                        raw_text = %s,
-                        choice_object = jsonb_set(
-                            COALESCE(choice_object, '{}'::jsonb),
-                            '{selected}',
-                            'null'::jsonb
-                        )
-                    WHERE id = %s
-                    """,
-                    (storyteller_text or "", parent_chunk_id),
-                )
-                logger.info(
-                    f"Reverted pending choice on chunk {parent_chunk_id} "
-                    f"(raw_text recomputed from storyteller_text only)"
-                )
+        if not storyteller_text:
+            raise ValueError(
+                f"Parent chunk {parent_chunk_id} has NULL/empty storyteller_text; "
+                f"cannot revert raw_text (lifecycle violation)."
+            )
+
+        if choice_object is None:
+            raise ValueError(
+                f"Parent chunk {parent_chunk_id} has NULL choice_object; "
+                f"a parent that produced a pending child should always have "
+                f"presented choices recorded (lifecycle violation)."
+            )
+
+        cur.execute(
+            """
+            UPDATE narrative_chunks
+            SET choice_text = NULL,
+                raw_text = %s,
+                choice_object = jsonb_set(choice_object, '{selected}', 'null'::jsonb)
+            WHERE id = %s
+            """,
+            (storyteller_text, parent_chunk_id),
+        )
+        if cur.rowcount == 0:
+            raise ValueError(
+                f"UPDATE matched 0 rows for chunk {parent_chunk_id}; "
+                f"row may have been deleted between SELECT and UPDATE."
+            )
+        logger.info(
+            f"Reverted pending choice on chunk {parent_chunk_id} "
+            f"(raw_text recomputed from storyteller_text only)"
+        )
 
     def trigger_embedding_generation(self, chunk_id: int) -> Optional[str]:
         """

--- a/nexus/api/slot_endpoints.py
+++ b/nexus/api/slot_endpoints.py
@@ -9,7 +9,7 @@ This module handles slot state queries and operations including:
 """
 
 import logging
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException
 
@@ -191,25 +191,55 @@ async def slot_undo_endpoint(slot: int):
             narrative = state.narrative_state
 
             if narrative.has_pending and narrative.session_id:
-                # Delete pending incubator content
+                # Capture the parent chunk ID before deleting the incubator row,
+                # then delete the row. The parent chunk's choice fields will be
+                # reset below (closes the loop on the user's un-made choice).
+                parent_chunk_id: Optional[int] = None
                 with get_connection(dbname) as conn:
                     with conn.cursor() as cur:
+                        cur.execute(
+                            "SELECT parent_chunk_id FROM incubator WHERE session_id = %s",
+                            (narrative.session_id,),
+                        )
+                        row = cur.fetchone()
+                        if row:
+                            parent_chunk_id = row[0]
+
                         cur.execute(
                             "DELETE FROM incubator WHERE session_id = %s",
                             (narrative.session_id,),
                         )
 
+                # Reset the parent chunk's choice fields. Skipped for bootstrap
+                # (parent_chunk_id == 0): chunk 1 has no preceding choice to revert.
+                reverted_parent = False
+                if parent_chunk_id and parent_chunk_id > 0:
+                    from nexus.api.chunk_workflow import ChunkWorkflow
+
+                    workflow = ChunkWorkflow(dbname=dbname)
+                    workflow.revert_pending_choice(parent_chunk_id)
+                    reverted_parent = True
+
+                message = (
+                    f"Deleted pending content and reverted choice on chunk {parent_chunk_id}"
+                    if reverted_parent
+                    else "Deleted pending content"
+                )
                 return SlotUndoResponse(
                     success=True,
-                    message="Deleted pending content",
+                    message=message,
                     previous_state=str(narrative.current_chunk_id),
                 )
 
             else:
-                # No pending content - cannot undo committed chunks
+                # No pending content - the grace window has closed (last chunk
+                # is now ironman / embedded under the lifecycle invariant).
                 return SlotUndoResponse(
                     success=False,
-                    message="Cannot undo committed chunks - only pending content can be undone",
+                    message=(
+                        "Cannot undo: no live turn. The last response is already "
+                        "committed (the parent chunk is ironman / embedded)."
+                    ),
                 )
 
         return SlotUndoResponse(

--- a/nexus/api/slot_endpoints.py
+++ b/nexus/api/slot_endpoints.py
@@ -13,6 +13,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException
 
+from nexus.api.chunk_workflow import ChunkWorkflow
 from nexus.api.db_pool import get_connection
 from nexus.api.narrative_schemas import (
     SlotStateResponse,
@@ -191,10 +192,13 @@ async def slot_undo_endpoint(slot: int):
             narrative = state.narrative_state
 
             if narrative.has_pending and narrative.session_id:
-                # Capture the parent chunk ID before deleting the incubator row,
-                # then delete the row. The parent chunk's choice fields will be
-                # reset below (closes the loop on the user's un-made choice).
+                # Single transaction spanning incubator delete + parent's
+                # choice-reset, so either both succeed or both roll back.
+                # (Codex P1 review on PR #205: a previously-split version
+                # left state inconsistent if revert_pending_choice raised.)
+                workflow = ChunkWorkflow(dbname=dbname)
                 parent_chunk_id: Optional[int] = None
+                reverted_parent = False
                 with get_connection(dbname) as conn:
                     with conn.cursor() as cur:
                         cur.execute(
@@ -210,15 +214,13 @@ async def slot_undo_endpoint(slot: int):
                             (narrative.session_id,),
                         )
 
-                # Reset the parent chunk's choice fields. Skipped for bootstrap
-                # (parent_chunk_id == 0): chunk 1 has no preceding choice to revert.
-                reverted_parent = False
-                if parent_chunk_id and parent_chunk_id > 0:
-                    from nexus.api.chunk_workflow import ChunkWorkflow
-
-                    workflow = ChunkWorkflow(dbname=dbname)
-                    workflow.revert_pending_choice(parent_chunk_id)
-                    reverted_parent = True
+                        # Reset the parent chunk's choice fields within the
+                        # same cursor/transaction. Skipped for bootstrap
+                        # (parent_chunk_id == 0): chunk 1 has no preceding
+                        # choice to revert.
+                        if parent_chunk_id and parent_chunk_id > 0:
+                            workflow.revert_pending_choice(cur, parent_chunk_id)
+                            reverted_parent = True
 
                 message = (
                     f"Deleted pending content and reverted choice on chunk {parent_chunk_id}"

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -598,10 +598,13 @@ def run_undo(args: argparse.Namespace) -> Dict[str, Any]:
         response.raise_for_status()
         data = response.json()
 
-        return {
-            "success": data.get("success", True),
-            "message": data.get("message"),
-        }
+        success = data.get("success", True)
+        message = data.get("message")
+        if not success:
+            # Surface the API's reason via "error" so main() prints something
+            # informative instead of the generic "Unknown error" fallback.
+            return {"success": False, "error": message or "Undo failed"}
+        return {"success": True, "message": message}
 
     except requests.exceptions.ConnectionError:
         return {


### PR DESCRIPTION
## Summary

Discharges Part 2 of the Phase A out-of-scope queue:

1. **`nexus undo` now closes the grace-window loop in narrative mode.** Previously it only deleted the incubator row, leaving the parent chunk's `choice_object.selected` and `choice_text` populated — the chunk recorded a "selected" choice the user had effectively un-made. Now the parent's choice fields are reset atomically alongside the incubator deletion.
2. **Drops the vestigial `chunk_embeddings_0384d` table.** Relic of an abandoned BGE-Small fine-tune. No production code reads from or writes to it (`DIMENSION_TABLE_MAP` has not contained `384` for some time), and it was the only embedding-shard table missing `ON DELETE CASCADE` on its FK — a sharp edge that has surfaced in three separate features.
3. **Pre-existing CLI bug fix:** `run_undo` was dropping the API's `message` field on failures, so the closed-grace-window case (and any "nothing to undo" from wizard mode) showed `"Error: Unknown error"`. Now mapped to `error` so users see the actual reason.

## Lifecycle context

The user-stated design: when chunk M sits in the incubator, M-1 is the mutable parent — committed but not yet ironman. The lifecycle places M-1 at `state=FINALIZED` with `embedding_generated_at IS NULL` (per memory: `accept_chunk(N)` finalizes N and fires embedding on N-1, so M-1's embedding only fires when chunk M is accepted).

The new `revert_pending_choice` enforces this invariant: it refuses to operate on an embedded chunk because mutating `raw_text` would invalidate the embedding's source text. If we ever hit that case, the design has drifted and should be surfaced rather than silently corrupting state.

## What changed

- `nexus/api/chunk_workflow.py`: New `revert_pending_choice(parent_chunk_id)` method. Single-transaction reset of `choice_text → NULL`, `choice_object.selected → JSON null` (preserves `presented`), `raw_text → storyteller_text`. Refuses on already-embedded chunks.
- `nexus/api/slot_endpoints.py`: `slot_undo_endpoint` narrative branch captures `parent_chunk_id` from the incubator row before deletion, then calls `revert_pending_choice` on it. Skipped for `parent_chunk_id == 0` (bootstrap chunk has no preceding choice).
- `nexus/cli.py`: `run_undo` surfaces failure messages via `error` field so they reach the user.
- `migrations/020_drop_chunk_embeddings_0384d.sql`: `DROP TABLE IF EXISTS chunk_embeddings_0384d;` (idempotent, applied to save_05 + NEXUS_template + save_02; saves 03/04 had pre-existing 018 drift unrelated to this PR).

## Test plan

- [x] **Open grace window**: With chunk 3 in incubator + chunk 2 carrying a selected choice (raw_text=7281, choice_text=86, selected=1), `nexus undo --slot 5` deletes incubator and resets chunk 2 (raw_text=7193 == storyteller_text exactly, choice_text NULL, selected null). CLI prints "Deleted pending content and reverted choice on chunk 2".
- [x] **Closed grace window**: Re-running `nexus undo --slot 5` against the now-empty incubator surfaces "Cannot undo: no live turn. The last response is already committed (the parent chunk is ironman / embedded)."
- [x] **Migration 020**: `chunk_embeddings_0384d` confirmed absent from save_05 and NEXUS_template. Migration is idempotent (`DROP TABLE IF EXISTS`).
- [x] All modified modules import clean.

## Out of scope (queued)

- Async-ifying the embedding subprocess (existing TODO at `chunk_workflow.py:388`).
- Reconciling the user's "FINALIZED and EMBEDDED are redundant" preference with the runtime usage at `chunk_workflow.py:244` — small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)