### PR TITLE
Retire ChunkState.EMBEDDED — embedding_generated_at is the ironman flag

### DIFF
--- a/migrations/021_dedup_embedded_state.sql
+++ b/migrations/021_dedup_embedded_state.sql
@@ -1,0 +1,23 @@
+-- 021_dedup_embedded_state.sql
+--
+-- Retire the redundant narrative_chunks.state value 'embedded'. The state
+-- 'embedded' carried the same information as embedding_generated_at IS NOT
+-- NULL — the timestamp is the single source of truth for ironman status,
+-- so the state value duplicated it.
+--
+-- This migration backfills existing rows (state='embedded' → 'finalized')
+-- and refreshes the column comment from migration 018 to drop the
+-- "synonymous with 'embedded' in practice" parenthetical. Application
+-- code (ChunkState enum + accept_chunk's prev-chunk guard) has been
+-- updated in the same PR to write 'finalized' and to check
+-- embedding_generated_at IS NULL instead of state == 'finalized'.
+--
+-- Idempotent: re-running on a database where no 'embedded' rows remain
+-- is a no-op UPDATE; COMMENT ON overwrites the prior comment.
+
+UPDATE narrative_chunks
+SET state = 'finalized'
+WHERE state = 'embedded';
+
+COMMENT ON COLUMN narrative_chunks.state IS
+    'Chunk lifecycle state. One of: ''draft'' (initial), ''pending_review'' (storyteller has produced text, user has not yet accepted), ''finalized'' (user accepted; chunk is locked). The authoritative "has been embedded" predicate is embedding_generated_at IS NOT NULL, not a state value. See ChunkState enum in nexus/api/chunk_workflow.py.';

--- a/nexus/api/chunk_workflow.py
+++ b/nexus/api/chunk_workflow.py
@@ -239,6 +239,19 @@ class ChunkWorkflow:
                     # authoritative "not yet ironman" predicate; the old
                     # state=='embedded' value was a redundant proxy for this
                     # same signal and has been retired.
+                    #
+                    # CONCURRENCY PRE-CONDITION (sync-only): this gate is safe
+                    # today because trigger_embedding_generation blocks (single
+                    # thread, single subprocess at a time). When issue #206
+                    # async-ifies the embedding subprocess, this predicate ALONE
+                    # is no longer sufficient — two concurrent accept_chunk
+                    # calls would both see embedded_at IS NULL during the
+                    # subprocess window and launch duplicate workers. The #206
+                    # implementer MUST add a separate in-flight guard
+                    # (advisory lock, in-memory flag, or queued-job dedup)
+                    # before relaxing this site. The prior code's eager
+                    # state='embedded' write served as a de-facto optimistic
+                    # lock; that crutch is gone.
                     if prev_embedded_at is None:
                         embedding_job_id = self.trigger_embedding_generation(prev_id)
                         embedding_triggered = True

--- a/nexus/api/chunk_workflow.py
+++ b/nexus/api/chunk_workflow.py
@@ -35,12 +35,17 @@ VALID_MODEL_PATTERN = re.compile(r"^[a-zA-Z0-9._-]+$")
 
 
 class ChunkState(str, Enum):
-    """States for narrative chunk lifecycle."""
+    """States for narrative chunk lifecycle.
+
+    The authoritative "has been embedded" predicate is
+    narrative_chunks.embedding_generated_at IS NOT NULL — that timestamp is
+    the single source of truth for ironman status. Earlier versions also
+    carried a redundant 'embedded' state value; retired in migration 021.
+    """
 
     DRAFT = "draft"
     PENDING_REVIEW = "pending_review"  # Storyteller text awaiting user decision
     FINALIZED = "finalized"  # User accepted, chunk is locked
-    EMBEDDED = "embedded"  # Embeddings have been generated
 
 
 class ChunkAcceptRequest(BaseModel):
@@ -213,7 +218,7 @@ class ChunkWorkflow:
                 # Get previous chunk (N-1) to trigger embedding
                 cur.execute(
                     """
-                    SELECT id, state, raw_text
+                    SELECT id, embedding_generated_at
                     FROM narrative_chunks
                     WHERE id < %s
                     ORDER BY id DESC
@@ -227,22 +232,16 @@ class ChunkWorkflow:
                 embedding_job_id = None
 
                 if previous_chunk:
-                    prev_id, prev_state, prev_text = previous_chunk
+                    prev_id, prev_embedded_at = previous_chunk
 
-                    # Only generate embeddings if not already done
-                    if prev_state == ChunkState.FINALIZED.value:
+                    # Fire embedding on the previous chunk only if it hasn't
+                    # been embedded yet. embedding_generated_at IS NULL is the
+                    # authoritative "not yet ironman" predicate; the old
+                    # state=='embedded' value was a redundant proxy for this
+                    # same signal and has been retired.
+                    if prev_embedded_at is None:
                         embedding_job_id = self.trigger_embedding_generation(prev_id)
                         embedding_triggered = True
-
-                        # Mark as embedding in progress
-                        cur.execute(
-                            """
-                            UPDATE narrative_chunks
-                            SET state = %s
-                            WHERE id = %s
-                        """,
-                            (ChunkState.EMBEDDED.value, prev_id),
-                        )
 
                 logger.info(
                     f"Accepted chunk {chunk_id}, embedding triggered: {embedding_triggered}"
@@ -557,21 +556,17 @@ class ChunkWorkflow:
             )  # 5 min timeout
 
             if result.returncode == 0:
-                # Mark chunk as embedded
+                # Stamp the embedded-at timestamp. state stays FINALIZED —
+                # embedding_generated_at IS NOT NULL is the ironman predicate.
                 with get_connection(self.dbname) as conn:
                     with conn.cursor() as cur:
                         cur.execute(
                             """
                             UPDATE narrative_chunks
-                            SET embedding_generated_at = %s,
-                                state = %s
+                            SET embedding_generated_at = %s
                             WHERE id = %s
                         """,
-                            (
-                                datetime.now(timezone.utc),
-                                ChunkState.EMBEDDED.value,
-                                chunk_id,
-                            ),
+                            (datetime.now(timezone.utc), chunk_id),
                         )
 
                 logger.info(f"Successfully generated embeddings for chunk {chunk_id}")

--- a/ui/client/src/components/NarrativeTab.tsx
+++ b/ui/client/src/components/NarrativeTab.tsx
@@ -35,7 +35,7 @@ interface ChoiceObject {
 
 export interface ChunkWithMetadata extends Omit<NarrativeChunk, 'choiceObject'> {
   metadata?: ChunkMetadata;
-  state?: "draft" | "pending_review" | "finalized" | "embedded";
+  state?: "draft" | "pending_review" | "finalized";
   regeneration_count?: number;
   // Choice fields - typed more specifically than base schema's `unknown`
   choiceObject?: ChoiceObject | null;
@@ -668,7 +668,6 @@ export function NarrativeTab({
                         "px-1.5 py-0.5 rounded",
                         currentChunkState.state === "pending_review" && `bg-warning/20 text-warning ${glowClass}`,
                         currentChunkState.state === "finalized" && "bg-primary/20 text-primary",
-                        currentChunkState.state === "embedded" && "bg-primary/20 text-primary",
                         currentChunkState.state === "draft" && "bg-muted text-muted-foreground"
                       )}>
                         [{currentChunkState.state.toUpperCase()}]

--- a/ui/client/src/lib/api.ts
+++ b/ui/client/src/lib/api.ts
@@ -2,7 +2,7 @@ import { NarrativeChunk } from "@shared/schema";
 
 export interface ChunkState {
   id: number;
-  state: "draft" | "pending_review" | "finalized" | "embedded";
+  state: "draft" | "pending_review" | "finalized";
   finalized_at?: string;
   embedding_generated_at?: string;
   regeneration_count: number;


### PR DESCRIPTION
## Summary

Drops the redundant `'embedded'` value from `narrative_chunks.state`. The timestamp `embedding_generated_at` was already the source of truth for ironman status; the state value duplicated it without carrying any unique information. Closes the user's "FINALIZED and EMBEDDED are redundant" cleanup item from the Phase A queue.

## What was redundant

- **Two writes** of `state='embedded'`: in `accept_chunk` (anticipatorily, after triggering embedding) and in `_trigger_embedding_generation`'s success path (after subprocess completion). Both happened in lockstep with `embedding_generated_at` being set.
- **Zero reads** of `state == 'embedded'`. The only state check on the previous chunk in `accept_chunk` was `prev_state == FINALIZED` as a "fire embedding on this one" gate — semantically equivalent to `embedding_generated_at IS NULL`.

## Changes

- `nexus/api/chunk_workflow.py`:
  - `ChunkState` enum: dropped `EMBEDDED`. Three values remain: `DRAFT`, `PENDING_REVIEW`, `FINALIZED`.
  - `accept_chunk`: previous-chunk SELECT now reads `(id, embedding_generated_at)`. The gate is `prev_embedded_at IS NULL`. The redundant `UPDATE state = 'embedded'` is gone.
  - `_trigger_embedding_generation` success path: UPDATE now only writes `embedding_generated_at`, not `state`.
- `ui/client/src/components/NarrativeTab.tsx`:
  - Dropped the `state === "embedded"` branch from the className merger — same Tailwind classes as `"finalized"`, so visually identical.
  - Removed `"embedded"` from the `ChunkWithMetadata.state` TypeScript union.
- `migrations/021_dedup_embedded_state.sql`:
  - Backfills existing rows: `UPDATE narrative_chunks SET state='finalized' WHERE state='embedded'`.
  - Refreshes the `state` column comment to drop the "synonymous with 'embedded' in practice" parenthetical (added in migration 018).

## Test plan

- [x] `ChunkState` enum no longer contains `EMBEDDED`; import smoke test passes.
- [x] Migration 021 applied to `save_05` + `NEXUS_template`: chunk 1 in save_05 correctly migrated from `state='embedded'` → `state='finalized'`, `embedding_generated_at` preserved.
- [x] Column comment refreshed.
- [x] `nexus continue --slot 5 --choice 1` exercises `accept_chunk`'s new embedding-gate predicate end-to-end. Post-state: zero chunks with `state='embedded'`; chunk 3 generated into incubator; chunk 1 still embedded via timestamp.

## Companion issue

[#206](https://github.com/pythagorakase/nexus/issues/206) — async-ifying the embedding subprocess. Filed separately; that work and this dedup are independent (this PR ships the dedup against today's sync subprocess; async-ify becomes interesting precisely because it opens a real `FINALIZED-but-subprocess-running` intermediate state worth tracking, which the dedup doesn't preclude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)