### PR TITLE
[codex] Use compound embedding table keys

### DIFF
--- a/docs/vector_embeddings.md
+++ b/docs/vector_embeddings.md
@@ -22,25 +22,26 @@ NEXUS uses a multi-model ensemble approach with weighted combinations of differe
 
 ## Database Storage Strategy
 
-To handle different vector dimensions efficiently, we use a **dimension-specific tables approach**:
+To handle different vector dimensions efficiently, we use a **lazy
+dimension-specific tables approach**. Tables are named
+`chunk_embeddings_<dimensions>d` with four-digit padding for current model
+families, such as `chunk_embeddings_1536d`.
 
-1. **chunk_embeddings_1536d**
-   - Table for 1536-dimensional vectors (inf-retriever-v1-1.5b)
-   - Column type: `embedding Vector(1536)`
+Each table has the same logical shape:
 
-2. **chunk_embeddings_1024d**
-   - Table for 1024-dimensional vectors (E5-Large-V2, BGE-Large-EN)
-   - Column type: `embedding Vector(1024)`
-
-3. **chunk_embeddings_2560d**
-   - Table for 2560-dimensional vectors (Octen-Embedding-4B)
-   - Column type: `embedding Vector(2560)`
-
-4. **chunk_embeddings_4096d**
-   - Table for 4096-dimensional vectors (Octen-Embedding-8B)
-   - Column type: `embedding Vector(4096)`
+```sql
+chunk_id BIGINT NOT NULL REFERENCES narrative_chunks(id) ON DELETE CASCADE,
+model TEXT NOT NULL,
+embedding vector(<dimensions>) NOT NULL,
+created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+PRIMARY KEY (chunk_id, model)
+```
 
 This approach was chosen because pgvector requires fixed dimensions at table creation time, and mixing vectors of different dimensions in the same table would require significant padding and dimensionality management.
+
+Fresh slots do not pre-create every possible embedding table. Write paths call
+`ensure_embedding_table(...)` for the active model dimension when embeddings are
+generated. Read paths inspect existing tables and never create them.
 
 ## Query Routing System
 

--- a/migrations/018_narrative_chunks_column_comments.sql
+++ b/migrations/018_narrative_chunks_column_comments.sql
@@ -5,30 +5,89 @@
 -- MEMNON.get_schema_summary(). Discharges schema-detail debt previously
 -- duplicated in CLAUDE.md.
 --
--- COMMENT ON is idempotent (overwrites the prior value), so this migration
--- is safe to re-run. Refreshes raw_text's existing comment to capture its
--- derived/surface nature. Adds comments to seven columns that had none.
+-- COMMENT ON is idempotent (overwrites the prior value). Some older empty
+-- slots do not have the newer chunk-workflow columns, so each comment is
+-- guarded by a column-existence check.
 
-COMMENT ON COLUMN narrative_chunks.raw_text IS
-    'User-readable prose version of the chunk ("the book version"). For in-system chunks this is the deterministic concatenation storyteller_text || choice_text — no unique information; re-derive if components change. For legacy imports (slot 1) this holds the original undecomposed text and storyteller_text mirrors it because the legacy corpus was never decomposed. Includes scene breaks and markdown formatting.';
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'narrative_chunks'
+          AND column_name = 'raw_text'
+    ) THEN
+        COMMENT ON COLUMN narrative_chunks.raw_text IS
+            'User-readable prose version of the chunk ("the book version"). For in-system chunks this is the deterministic concatenation storyteller_text || choice_text — no unique information; re-derive if components change. For legacy imports (slot 1) this holds the original undecomposed text and storyteller_text mirrors it because the legacy corpus was never decomposed. Includes scene breaks and markdown formatting.';
+    END IF;
 
-COMMENT ON COLUMN narrative_chunks.state IS
-    'Chunk lifecycle state. One of: ''draft'' (initial), ''pending_review'' (storyteller has produced text, user has not yet accepted), ''finalized'' (user accepted; chunk is locked — synonymous with "embedded" in practice). See ChunkState enum in nexus/api/chunk_workflow.py.';
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'narrative_chunks'
+          AND column_name = 'state'
+    ) THEN
+        COMMENT ON COLUMN narrative_chunks.state IS
+            'Chunk lifecycle state. One of: ''draft'' (initial), ''pending_review'' (storyteller has produced text, user has not yet accepted), ''finalized'' (user accepted; chunk is locked — synonymous with "embedded" in practice). See ChunkState enum in nexus/api/chunk_workflow.py.';
+    END IF;
 
-COMMENT ON COLUMN narrative_chunks.finalized_at IS
-    'Timestamp set by ChunkWorkflow.accept_chunk when the chunk transitions to the ''finalized'' state. NULL while the chunk is in ''draft'' or ''pending_review''.';
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'narrative_chunks'
+          AND column_name = 'finalized_at'
+    ) THEN
+        COMMENT ON COLUMN narrative_chunks.finalized_at IS
+            'Timestamp set by ChunkWorkflow.accept_chunk when the chunk transitions to the ''finalized'' state. NULL while the chunk is in ''draft'' or ''pending_review''.';
+    END IF;
 
-COMMENT ON COLUMN narrative_chunks.embedding_generated_at IS
-    'Timestamp set by ChunkWorkflow._trigger_embedding_generation after the embedding subprocess (scripts/regenerate_embeddings.py) exits with code 0 — i.e., after a row has been written into one of the chunk_embeddings_*d tables. The subprocess itself does not write this column; the workflow does, post-success. NULL until embedding succeeds.';
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'narrative_chunks'
+          AND column_name = 'embedding_generated_at'
+    ) THEN
+        COMMENT ON COLUMN narrative_chunks.embedding_generated_at IS
+            'Timestamp set by ChunkWorkflow._trigger_embedding_generation after the embedding subprocess (scripts/regenerate_embeddings.py) exits with code 0 — i.e., after a row has been written into one of the chunk_embeddings_*d tables. The subprocess itself does not write this column; the workflow does, post-success. NULL until embedding succeeds.';
+    END IF;
 
-COMMENT ON COLUMN narrative_chunks.regeneration_count IS
-    'Number of times the storyteller text for this chunk has been regenerated via the regenerate flow. Zero for chunks accepted on first generation.';
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'narrative_chunks'
+          AND column_name = 'regeneration_count'
+    ) THEN
+        COMMENT ON COLUMN narrative_chunks.regeneration_count IS
+            'Number of times the storyteller text for this chunk has been regenerated via the regenerate flow. Zero for chunks accepted on first generation.';
+    END IF;
 
-COMMENT ON COLUMN narrative_chunks.storyteller_text IS
-    'Authoritative storyteller portion of the chunk (narration only). For in-system chunks this is the leading segment of raw_text — concretely, raw_text = storyteller_text || choice_text, so raw_text.startswith(storyteller_text) holds. For legacy imports (slot 1) this equals raw_text because the corpus was never decomposed.';
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'narrative_chunks'
+          AND column_name = 'storyteller_text'
+    ) THEN
+        COMMENT ON COLUMN narrative_chunks.storyteller_text IS
+            'Authoritative storyteller portion of the chunk (narration only). For in-system chunks this is the leading segment of raw_text — concretely, raw_text = storyteller_text || choice_text, so raw_text.startswith(storyteller_text) holds. For legacy imports (slot 1) this equals raw_text because the corpus was never decomposed.';
+    END IF;
 
-COMMENT ON COLUMN narrative_chunks.choice_text IS
-    'Authoritative text of the user''s response for this chunk. When the user selects a structured choice via --choice N, holds the text of that presented choice (resolved from choice_object.presented[N-1]). When the user submits freeform input via --user-text, holds that text directly.';
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'narrative_chunks'
+          AND column_name = 'choice_text'
+    ) THEN
+        COMMENT ON COLUMN narrative_chunks.choice_text IS
+            'Authoritative text of the user''s response for this chunk. When the user selects a structured choice via --choice N, holds the text of that presented choice (resolved from choice_object.presented[N-1]). When the user submits freeform input via --user-text, holds that text directly.';
+    END IF;
 
-COMMENT ON COLUMN narrative_chunks.choice_object IS
-    'JSON record of the choices offered + the chosen index. Shape: {"presented": [str, ...], "selected": <int 1..N | null>}. presented preserves the full menu the storyteller offered; selected is the 1-indexed pick (or null for --user-text / --accept-fate). This is the underground state that enables undo and audit even though raw_text (the readable surface) omits non-selected choices — a deliberate "surface entropy reduction" choice.';
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'narrative_chunks'
+          AND column_name = 'choice_object'
+    ) THEN
+        COMMENT ON COLUMN narrative_chunks.choice_object IS
+            'JSON record of the choices offered + the chosen index. Shape: {"presented": [str, ...], "selected": <int 1..N | null>}. presented preserves the full menu the storyteller offered; selected is the 1-indexed pick (or null for --user-text / --accept-fate). This is the underground state that enables undo and audit even though raw_text (the readable surface) omits non-selected choices — a deliberate "surface entropy reduction" choice.';
+    END IF;
+END $$;

--- a/migrations/021_dedup_embedded_state.sql
+++ b/migrations/021_dedup_embedded_state.sql
@@ -15,9 +15,19 @@
 -- Idempotent: re-running on a database where no 'embedded' rows remain
 -- is a no-op UPDATE; COMMENT ON overwrites the prior comment.
 
-UPDATE narrative_chunks
-SET state = 'finalized'
-WHERE state = 'embedded';
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'narrative_chunks'
+          AND column_name = 'state'
+    ) THEN
+        UPDATE narrative_chunks
+        SET state = 'finalized'
+        WHERE state = 'embedded';
 
-COMMENT ON COLUMN narrative_chunks.state IS
-    'Chunk lifecycle state. One of: ''draft'' (initial), ''pending_review'' (storyteller has produced text, user has not yet accepted), ''finalized'' (user accepted; chunk is locked). The authoritative "has been embedded" predicate is embedding_generated_at IS NOT NULL, not a state value. See ChunkState enum in nexus/api/chunk_workflow.py.';
+        COMMENT ON COLUMN narrative_chunks.state IS
+            'Chunk lifecycle state. One of: ''draft'' (initial), ''pending_review'' (storyteller has produced text, user has not yet accepted), ''finalized'' (user accepted; chunk is locked). The authoritative "has been embedded" predicate is embedding_generated_at IS NOT NULL, not a state value. See ChunkState enum in nexus/api/chunk_workflow.py.';
+    END IF;
+END $$;

--- a/migrations/022_compound_embedding_pk_lazy_tables.sql
+++ b/migrations/022_compound_embedding_pk_lazy_tables.sql
@@ -1,0 +1,125 @@
+-- migrations/022_compound_embedding_pk_lazy_tables.sql
+-- Description: Use (chunk_id, model) as the primary key for dimension-specific
+-- embedding tables and remove empty pre-created tables. Embedding tables are
+-- now created lazily by write paths for the active model dimensions.
+-- Date: 2026-05-16
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+DO $$
+DECLARE
+    embedding_table RECORD;
+    table_oid REGCLASS;
+    row_count BIGINT;
+    duplicate_count BIGINT;
+    pk_name TEXT;
+    unique_constraint RECORD;
+BEGIN
+    FOR embedding_table IN
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_type = 'BASE TABLE'
+          AND table_name ~ '^chunk_embeddings_[0-9]+d$'
+        ORDER BY table_name
+    LOOP
+        table_oid := format('public.%I', embedding_table.table_name)::REGCLASS;
+
+        EXECUTE format('SELECT COUNT(*) FROM %I', embedding_table.table_name)
+            INTO row_count;
+
+        IF row_count = 0 THEN
+            EXECUTE format('DROP TABLE %I', embedding_table.table_name);
+            EXECUTE format(
+                'DROP SEQUENCE IF EXISTS %I',
+                embedding_table.table_name || '_id_seq'
+            );
+            RAISE NOTICE 'Dropped empty embedding table %',
+                embedding_table.table_name;
+            CONTINUE;
+        END IF;
+
+        EXECUTE format(
+            'SELECT COUNT(*) FROM (
+                SELECT chunk_id, model
+                FROM %I
+                GROUP BY chunk_id, model
+                HAVING COUNT(*) > 1
+            ) duplicates',
+            embedding_table.table_name
+        )
+            INTO duplicate_count;
+
+        IF duplicate_count > 0 THEN
+            RAISE EXCEPTION
+                'Cannot migrate %. Found % duplicate (chunk_id, model) pairs.',
+                embedding_table.table_name,
+                duplicate_count;
+        END IF;
+
+        EXECUTE format(
+            'ALTER TABLE %I ALTER COLUMN chunk_id SET NOT NULL',
+            embedding_table.table_name
+        );
+        EXECUTE format(
+            'ALTER TABLE %I ALTER COLUMN model SET NOT NULL',
+            embedding_table.table_name
+        );
+
+        SELECT conname
+        INTO pk_name
+        FROM pg_constraint
+        WHERE conrelid = table_oid
+          AND contype = 'p';
+
+        IF pk_name IS NOT NULL THEN
+            EXECUTE format(
+                'ALTER TABLE %I DROP CONSTRAINT %I',
+                embedding_table.table_name,
+                pk_name
+            );
+        END IF;
+
+        FOR unique_constraint IN
+            SELECT conname
+            FROM pg_constraint c
+            WHERE c.conrelid = table_oid
+              AND c.contype = 'u'
+              AND (
+                  SELECT array_agg(a.attname::TEXT ORDER BY keys.ordinality)
+                  FROM unnest(c.conkey) WITH ORDINALITY AS keys(attnum, ordinality)
+                  JOIN pg_attribute a
+                    ON a.attrelid = c.conrelid
+                   AND a.attnum = keys.attnum
+              ) = ARRAY['chunk_id', 'model']::TEXT[]
+        LOOP
+            EXECUTE format(
+                'ALTER TABLE %I DROP CONSTRAINT %I',
+                embedding_table.table_name,
+                unique_constraint.conname
+            );
+        END LOOP;
+
+        EXECUTE format(
+            'ALTER TABLE %I DROP COLUMN IF EXISTS id CASCADE',
+            embedding_table.table_name
+        );
+        EXECUTE format(
+            'DROP SEQUENCE IF EXISTS %I',
+            embedding_table.table_name || '_id_seq'
+        );
+        EXECUTE format(
+            'ALTER TABLE %I ADD CONSTRAINT %I PRIMARY KEY (chunk_id, model)',
+            embedding_table.table_name,
+            embedding_table.table_name || '_pkey'
+        );
+        EXECUTE format(
+            'CREATE INDEX IF NOT EXISTS %I ON %I (model)',
+            embedding_table.table_name || '_model_idx',
+            embedding_table.table_name
+        );
+
+        RAISE NOTICE 'Migrated embedding table % to compound primary key',
+            embedding_table.table_name;
+    END LOOP;
+END $$;

--- a/migrations/022_compound_embedding_pk_lazy_tables.sql
+++ b/migrations/022_compound_embedding_pk_lazy_tables.sql
@@ -11,6 +11,7 @@ DECLARE
     embedding_table RECORD;
     table_oid REGCLASS;
     row_count BIGINT;
+    null_count BIGINT;
     duplicate_count BIGINT;
     pk_name TEXT;
     unique_constraint RECORD;
@@ -37,6 +38,22 @@ BEGIN
             RAISE NOTICE 'Dropped empty embedding table %',
                 embedding_table.table_name;
             CONTINUE;
+        END IF;
+
+        EXECUTE format(
+            'SELECT COUNT(*)
+             FROM %I
+             WHERE chunk_id IS NULL
+                OR model IS NULL',
+            embedding_table.table_name
+        )
+            INTO null_count;
+
+        IF null_count > 0 THEN
+            RAISE EXCEPTION
+                'Cannot migrate %. Found % rows with NULL chunk_id or model.',
+                embedding_table.table_name,
+                null_count;
         END IF;
 
         EXECUTE format(

--- a/nexus/agents/memnon/memnon.py
+++ b/nexus/agents/memnon/memnon.py
@@ -12,7 +12,7 @@ The architecture has been refactored to use modular utility classes:
 - EmbeddingManager: Handles embedding model lifecycle and vector generation
 - SearchManager: Coordinates different search strategies across data sources
 - QueryAnalyzer: Analyzes user queries to determine optimal search approach
-- DatabaseManager: Provides database connection and schema management 
+- DatabaseManager: Provides database connection and schema management
 - ContentProcessor: Manages content chunking, processing, and storage
 """
 
@@ -33,15 +33,24 @@ from sqlalchemy.dialects.postgresql import UUID, BYTEA, ARRAY
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
 # Import utility modules
-from .utils.db_access import check_vector_extension, execute_vector_search, execute_hybrid_search, setup_database_indexes, prepare_tsquery
-from .utils.continuous_temporal_search import execute_time_aware_search, analyze_temporal_intent
+from .utils.db_access import (
+    check_vector_extension,
+    execute_vector_search,
+    execute_hybrid_search,
+    setup_database_indexes,
+    prepare_tsquery,
+)
+from .utils.continuous_temporal_search import (
+    execute_time_aware_search,
+    analyze_temporal_intent,
+)
 from .utils.idf_dictionary import IDFDictionary
 from .utils.embedding_manager import EmbeddingManager
 from .utils.search import SearchManager
 from .utils.query_analysis import QueryAnalyzer
 from .utils.db_schema import DatabaseManager
 from .utils.content_processor import ContentProcessor
-from .utils.embedding_tables import DIMENSION_TABLES
+from .utils.embedding_tables import list_embedding_tables
 
 # Sentence transformers for embedding
 from sentence_transformers import SentenceTransformer
@@ -58,8 +67,11 @@ settings_logger = logging.getLogger("nexus.memnon.settings")
 settings_logger.setLevel(logging.INFO)
 if not settings_logger.handlers:
     console_handler = logging.StreamHandler()
-    console_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+    console_handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    )
     settings_logger.addHandler(console_handler)
+
 
 # Load settings
 def load_settings() -> Dict[str, Any]:
@@ -71,7 +83,9 @@ def load_settings() -> Dict[str, Any]:
         # Check for environment variable override
         settings_path_env = os.environ.get("NEXUS_SETTINGS_PATH")
         if settings_path_env:
-            settings_logger.info(f"Using settings path from environment: {settings_path_env}")
+            settings_logger.info(
+                f"Using settings path from environment: {settings_path_env}"
+            )
             settings = load_settings_as_dict(settings_path_env)
         else:
             settings = load_settings_as_dict()
@@ -81,6 +95,7 @@ def load_settings() -> Dict[str, Any]:
     except Exception as e:
         settings_logger.error(f"Error loading settings: {e}")
         return {}
+
 
 # Global settings
 SETTINGS = load_settings()
@@ -102,7 +117,7 @@ if log_console:
 logging.basicConfig(
     level=log_level,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    handlers=handlers
+    handlers=handlers,
 )
 logger = logging.getLogger("nexus.memnon")
 
@@ -110,11 +125,13 @@ logger = logging.getLogger("nexus.memnon")
 MODEL_CONFIG = GLOBAL_SETTINGS.get("model", {})
 DEFAULT_MODEL_ID = MODEL_CONFIG.get("default_model", "llama-3.3-70b-instruct@q6_k")
 
+
 # Database settings - use slot-aware resolution
 # Import lazily to avoid circular imports
 def get_default_db_url() -> str:
     """Get the default database URL using slot-aware resolution."""
     from nexus.api.slot_utils import get_slot_db_url
+
     return get_slot_db_url()
 
 
@@ -125,41 +142,23 @@ DEFAULT_DB_URL = None  # Will be resolved at runtime
 # Define SQL Alchemy Base
 Base = declarative_base()
 
+
 # Define ORM models based on the PostgreSQL schema
 class NarrativeChunk(Base):
-    __tablename__ = 'narrative_chunks'
-    
+    __tablename__ = "narrative_chunks"
+
     id = Column(sa.BigInteger, primary_key=True)
     raw_text = Column(sa.Text, nullable=False)
     created_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now())
 
-# ChunkEmbedding class and table removed since we've migrated to dimension-specific tables
-
-class ChunkEmbedding1024D(Base):
-    __tablename__ = 'chunk_embeddings_1024d'
-    
-    id = Column(sa.Integer, primary_key=True)
-    chunk_id = Column(sa.BigInteger, sa.ForeignKey('narrative_chunks.id'), nullable=False)
-    model = Column(sa.String(255), nullable=False)
-    # Note: This is a proper vector type with 1024 dimensions
-    embedding = Column(sa.String, nullable=False)  # Will be treated as vector by PostgreSQL
-    created_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now())
-
-class ChunkEmbedding1536D(Base):
-    __tablename__ = 'chunk_embeddings_1536d'
-    
-    id = Column(sa.Integer, primary_key=True)
-    chunk_id = Column(sa.BigInteger, sa.ForeignKey('narrative_chunks.id'), nullable=False)
-    model = Column(sa.String(255), nullable=False)
-    # Note: This is a proper vector type with 1536 dimensions
-    embedding = Column(sa.String, nullable=False)  # Will be treated as vector by PostgreSQL
-    created_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now())
 
 class ChunkMetadata(Base):
-    __tablename__ = 'chunk_metadata'
-    
+    __tablename__ = "chunk_metadata"
+
     id = Column(sa.BigInteger, primary_key=True)
-    chunk_id = Column(sa.BigInteger, sa.ForeignKey('narrative_chunks.id'), nullable=False)
+    chunk_id = Column(
+        sa.BigInteger, sa.ForeignKey("narrative_chunks.id"), nullable=False
+    )
     season = Column(sa.Integer, nullable=False)
     episode = Column(sa.Integer, nullable=False)
     scene = Column(sa.Integer)
@@ -171,9 +170,10 @@ class ChunkMetadata(Base):
     keywords = Column(ARRAY(sa.String))
     characters = Column(ARRAY(sa.String))
 
+
 class Character(Base):
-    __tablename__ = 'characters'
-    
+    __tablename__ = "characters"
+
     id = Column(sa.BigInteger, primary_key=True)
     name = Column(sa.String(50), nullable=False)
     description = Column(sa.Text)
@@ -183,41 +183,51 @@ class Character(Base):
     status = Column(sa.String(50))
     backstory = Column(sa.Text)
     created_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now())
-    updated_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now())
+    updated_at = Column(
+        sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now()
+    )
+
 
 class Place(Base):
-    __tablename__ = 'places'
-    
+    __tablename__ = "places"
+
     id = Column(sa.BigInteger, primary_key=True)
     name = Column(sa.String(50), nullable=False)
-    type = Column(sa.Enum('fixed_location', 'vehicle', 'other', name='place_type'), nullable=False)
+    type = Column(
+        sa.Enum("fixed_location", "vehicle", "other", name="place_type"), nullable=False
+    )
     zone = Column(sa.BigInteger, nullable=False)
     summary = Column(sa.String(1000))
     inhabitants = Column(ARRAY(sa.String))
     historical_significance = Column(sa.Text)
     current_status = Column(sa.String(500))
     created_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now())
-    updated_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now())
+    updated_at = Column(
+        sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now()
+    )
+
 
 class MEMNON:
     """
     MEMNON Agent - Unified Memory Access System for Narrative Intelligence
-    
+
     This is a standalone version that works without the full Letta framework.
     """
-    
-    def __init__(self,
-                 interface,
-                 agent_state: Optional[Any] = None,
-                 user = None,
-                 db_url: str = None,
-                 model_id: str = None, # This is now only for embedding models
-                 model_path: str = None,
-                 debug: bool = None,
-                 **kwargs):
+
+    def __init__(
+        self,
+        interface,
+        agent_state: Optional[Any] = None,
+        user=None,
+        db_url: str = None,
+        model_id: str = None,  # This is now only for embedding models
+        model_path: str = None,
+        debug: bool = None,
+        **kwargs,
+    ):
         """
         Initialize the MEMNON Agent
-        
+
         Args:
             interface: The interface to use for communication
             agent_state: Agent state from the legacy Letta runtime (optional in direct mode)
@@ -232,28 +242,28 @@ class MEMNON:
         self.interface = interface
         self.agent_state = agent_state
         self.user = user
-        
+
         # Store debug setting
         self.debug = debug
         if debug is None:
             self.debug = MEMNON_SETTINGS.get("debug", False)
-            
+
         # Set up logging if debug is enabled
         if self.debug:
             logger.setLevel(logging.DEBUG)
             logger.debug("Debug logging enabled")
-        
+
         # Set up database connection using DatabaseManager
         # If no db_url provided, use slot-aware resolution
         self.db_url = db_url or get_default_db_url()
         logger.info(f"Using database URL: {self.db_url}")
         self.db_manager = DatabaseManager(self.db_url, settings=MEMNON_SETTINGS)
         self.Session = self.db_manager.Session
-        
+
         # Set up embedding models using EmbeddingManager
         logger.info("Initializing embedding models through EmbeddingManager")
         self.embedding_manager = EmbeddingManager(settings=MEMNON_SETTINGS)
-        
+
         # Initialize IDF dictionary
         logger.info("Initializing IDF dictionary for term weighting...")
         self.idf_dictionary = IDFDictionary(self.db_url)
@@ -261,29 +271,27 @@ class MEMNON:
         if result:
             logger.info(f"IDF dictionary initialized with {len(result)} terms")
         else:
-            logger.warning("IDF dictionary initialization failed or returned empty dictionary")
-        
+            logger.warning(
+                "IDF dictionary initialization failed or returned empty dictionary"
+            )
+
         # Get model weights from settings
         model_weights = {}
         for model_name, model_config in MEMNON_SETTINGS.get("models", {}).items():
             weight = model_config.get("weight", 0.33)  # Default equal weight
             model_weights[model_name] = weight
-        
+
         # Use default weights if none defined in settings
         if not model_weights:
-            model_weights = {
-                "bge-large": 0.4,
-                "e5-large": 0.4,
-                "bge-small-custom": 0.2
-            }
-            
+            model_weights = {"bge-large": 0.4, "e5-large": 0.4, "bge-small-custom": 0.2}
+
         # Flag to prioritize text search for testing
         self.force_text_first = False
-        
+
         # Get query and retrieval settings from configuration
         query_config = MEMNON_SETTINGS.get("query", {})
         retrieval_config = MEMNON_SETTINGS.get("retrieval", {})
-        
+
         # Configure retrieval settings using values from settings.json
         self.retrieval_settings = {
             "default_top_k": query_config.get("default_limit", 10),
@@ -291,11 +299,13 @@ class MEMNON:
             "relevance_threshold": query_config.get("min_similarity", 0.7),
             "entity_boost_factor": retrieval_config.get("entity_boost_factor", 1.2),
             "recency_boost_factor": retrieval_config.get("recency_boost_factor", 1.1),
-            "db_vector_balance": retrieval_config.get("db_vector_balance", 0.6),  # 60% weight to database, 40% to vector
+            "db_vector_balance": retrieval_config.get(
+                "db_vector_balance", 0.6
+            ),  # 60% weight to database, 40% to vector
             "model_weights": model_weights,
-            "highlight_matches": query_config.get("highlight_matches", True)
+            "highlight_matches": query_config.get("highlight_matches", True),
         }
-        
+
         # Initialize SearchManager with required dependencies
         logger.info("Initializing SearchManager...")
         self.search_manager = SearchManager(
@@ -303,72 +313,77 @@ class MEMNON:
             embedding_manager=self.embedding_manager,
             idf_dictionary=self.idf_dictionary,
             settings=MEMNON_SETTINGS,
-            retrieval_settings=self.retrieval_settings
+            retrieval_settings=self.retrieval_settings,
         )
-        
+
         # Initialize QueryAnalyzer
         logger.info("Initializing QueryAnalyzer...")
         self.query_analyzer = QueryAnalyzer(settings=MEMNON_SETTINGS)
-        
+
         # Initialize ContentProcessor
         logger.info("Initializing ContentProcessor...")
         self.content_processor = ContentProcessor(
             db_manager=self.db_manager,
             embedding_manager=self.embedding_manager,
             settings=MEMNON_SETTINGS,
-            load_aliases_func=self._load_aliases
+            load_aliases_func=self._load_aliases,
         )
-        
+
         # Log the retrieval settings
-        logger.debug(f"Retrieval settings: {json.dumps(self.retrieval_settings, indent=2)}")
-        
+        logger.debug(
+            f"Retrieval settings: {json.dumps(self.retrieval_settings, indent=2)}"
+        )
+
         # Memory type registry - maps virtual memory tier to actual storage
         self.memory_tiers = {
-            "strategic": {"type": "database", "tables": ["events", "threats", "ai_notebook"]},
-            "entity": {"type": "database", "tables": ["characters", "places", "factions", "items"]},
+            "strategic": {
+                "type": "database",
+                "tables": ["events", "threats", "ai_notebook"],
+            },
+            "entity": {
+                "type": "database",
+                "tables": ["characters", "places", "factions", "items"],
+            },
             "narrative": {"type": "vector", "collections": ["narrative_chunks"]},
         }
-        
+
         # Query type registry - Simplified, used for rule-based planning
         self.query_types = {
             "character": {
                 "primary_tier": "entity",
                 "primary_tables": ["characters"],
                 "secondary_tier": "narrative",
-                "secondary_search": "hybrid_search" # Default to hybrid
+                "secondary_search": "hybrid_search",  # Default to hybrid
             },
             "location": {
                 "primary_tier": "entity",
                 "primary_tables": ["places"],
                 "secondary_tier": "narrative",
-                "secondary_search": "hybrid_search"
+                "secondary_search": "hybrid_search",
             },
             "event": {
-                "primary_tier": "narrative", # Events likely in narrative text
-                "primary_tables": [], # Assuming no dedicated event table for now
-                "secondary_tier": "entity", # Related characters/places
-                "secondary_search": "hybrid_search"
+                "primary_tier": "narrative",  # Events likely in narrative text
+                "primary_tables": [],  # Assuming no dedicated event table for now
+                "secondary_tier": "entity",  # Related characters/places
+                "secondary_search": "hybrid_search",
             },
-            "theme": {
-                "primary_tier": "narrative",
-                "primary_search": "hybrid_search"
-            },
+            "theme": {"primary_tier": "narrative", "primary_search": "hybrid_search"},
             "relationship": {
                 "primary_tier": "entity",
-                "primary_tables": ["characters"], # Primarily search characters
+                "primary_tables": ["characters"],  # Primarily search characters
                 "secondary_tier": "narrative",
-                "secondary_search": "hybrid_search"
+                "secondary_search": "hybrid_search",
             },
             "narrative": {
                 "primary_tier": "narrative",
-                "primary_search": "hybrid_search"
+                "primary_search": "hybrid_search",
             },
-            "general": { # Default fallback
+            "general": {  # Default fallback
                 "primary_tier": "narrative",
-                "primary_search": "hybrid_search"
-            }
+                "primary_search": "hybrid_search",
+            },
         }
-        
+
         logger.info("MEMNON agent initialized (Headless Mode - No LLM)")
 
     def get_schema_summary(self, tables: Optional[List[str]] = None) -> str:
@@ -378,8 +393,9 @@ class MEMNON:
         """
         try:
             from sqlalchemy import text
+
             inspector = inspect(self.db_manager.engine)
-            
+
             # If no specific tables requested, get all tables dynamically
             if tables:
                 allowed = tables
@@ -388,85 +404,94 @@ class MEMNON:
                 all_tables = inspector.get_table_names()
                 # Exclude embedding tables and other irrelevant tables
                 allowed = [
-                    t for t in all_tables 
-                    if not t.startswith('chunk_embeddings_')
-                    and t != 'alembic_version'  # Skip Alembic migration table
+                    t
+                    for t in all_tables
+                    if not t.startswith("chunk_embeddings_")
+                    and t != "alembic_version"  # Skip Alembic migration table
                 ]
-            
+
             lines: List[str] = []
-            
+
             for table_name in allowed:
                 try:
                     # Check if table exists
                     if not inspector.has_table(table_name):
                         continue
-                    
+
                     # Check if table has any rows (skip empty tables)
                     with self.db_manager.engine.connect() as conn:
-                        count_result = conn.execute(text(f"SELECT COUNT(*) FROM {table_name}"))
+                        count_result = conn.execute(
+                            text(f"SELECT COUNT(*) FROM {table_name}")
+                        )
                         row_count = count_result.scalar()
                         if row_count == 0:
                             continue
-                    
+
                     # Get table comment if available
                     table_comment = ""
                     try:
                         comment_result = conn.execute(
-                            text("SELECT obj_description(c.oid) FROM pg_class c WHERE c.relname = :table"),
-                            {"table": table_name}
+                            text(
+                                "SELECT obj_description(c.oid) FROM pg_class c WHERE c.relname = :table"
+                            ),
+                            {"table": table_name},
                         )
                         comment = comment_result.scalar()
                         if comment:
                             table_comment = f" -- {comment}"
                     except:
                         pass
-                    
+
                     # Get columns with comments
                     cols = inspector.get_columns(table_name)
                     col_descriptions = []
-                    
+
                     for col in cols:
                         col_name = col.get("name", "?")
                         col_type = str(col.get("type", ""))[:20]  # Truncate long types
-                        
+
                         # Try to get column comment
                         col_comment = ""
                         try:
                             comment_result = conn.execute(
-                                text("""
+                                text(
+                                    """
                                 SELECT col_description(c.oid, a.attnum) 
                                 FROM pg_class c 
                                 JOIN pg_attribute a ON a.attrelid = c.oid 
                                 WHERE c.relname = :table AND a.attname = :column
-                                """),
-                                {"table": table_name, "column": col_name}
+                                """
+                                ),
+                                {"table": table_name, "column": col_name},
                             )
                             comment = comment_result.scalar()
                             if comment:
                                 col_comment = f":{comment}"
                         except:
                             pass
-                        
+
                         col_descriptions.append(f"{col_name}{col_comment}")
-                    
+
                     col_list = ", ".join(col_descriptions)
                     lines.append(f"- {table_name}({col_list}){table_comment}")
-                    
+
                 except Exception as e:
                     # Skip tables with errors
                     logger.debug(f"Skipping table {table_name}: {e}")
                     continue
-            
+
             if not lines:
                 return "No populated tables found in database."
-            
+
             return "\n".join(lines)
-            
+
         except Exception as e:
             logger.error(f"Error generating schema summary: {e}")
             return "Error retrieving schema information."
 
-    def execute_readonly_sql(self, sql: str, max_rows: int = 50, timeout_ms: int = 3000) -> Dict[str, Any]:
+    def execute_readonly_sql(
+        self, sql: str, max_rows: int = 50, timeout_ms: int = 3000
+    ) -> Dict[str, Any]:
         """
         Execute a read-only, whitelisted SELECT statement safely.
         - Only allows single-statement SELECT queries
@@ -483,18 +508,41 @@ class MEMNON:
             # Must be a single SELECT
             if not lowered.startswith("select "):
                 return {"error": "Only SELECT statements are allowed"}
-            forbidden = [";", " update ", " insert ", " delete ", " alter ", " create ", " drop ", " grant ", " revoke ", " truncate ", " vacuum ", " copy "]
+            forbidden = [
+                ";",
+                " update ",
+                " insert ",
+                " delete ",
+                " alter ",
+                " create ",
+                " drop ",
+                " grant ",
+                " revoke ",
+                " truncate ",
+                " vacuum ",
+                " copy ",
+            ]
             for kw in forbidden:
                 if kw in f" {lowered} ":
                     return {"error": f"Forbidden keyword in SQL: {kw.strip()}"}
             # Whitelist tables referenced in FROM/JOIN
             import re
+
             allowed_tables = {
-                "characters", "episodes", "seasons", "events",
-                "factions", "places", "chunk_metadata", "narrative_chunks"
+                "characters",
+                "episodes",
+                "seasons",
+                "events",
+                "factions",
+                "places",
+                "chunk_metadata",
+                "narrative_chunks",
             }
             referenced: List[str] = []
-            for pattern in [r"\\bfrom\\s+([a-zA-Z_\\.\"]+)", r"\\bjoin\\s+([a-zA-Z_\\.\"]+)"]:
+            for pattern in [
+                r"\\bfrom\\s+([a-zA-Z_\\.\"]+)",
+                r"\\bjoin\\s+([a-zA-Z_\\.\"]+)",
+            ]:
                 for m in re.finditer(pattern, lowered):
                     name = m.group(1).strip().strip('"')
                     # remove optional schema prefix like public.
@@ -536,12 +584,17 @@ class MEMNON:
         except Exception as e:
             logger.error(f"Error executing read-only SQL: {e}")
             return {"error": str(e)}
-    
+
     def _initialize_memory_blocks(self):
         """Initialize specialized memory blocks if not present."""
         # Check if memory blocks exist and create if needed
-        required_blocks = ["memory_index", "query_templates", "retrieval_stats", "db_schema"]
-        
+        required_blocks = [
+            "memory_index",
+            "query_templates",
+            "retrieval_stats",
+            "db_schema",
+        ]
+
         for block_name in required_blocks:
             if block_name not in self.agent_state.memory.list_block_labels():
                 # Create block with default empty content
@@ -549,54 +602,64 @@ class MEMNON:
                     "label": block_name,
                     "value": "",
                     "limit": 50000,  # Generous limit for memory data
-                    "description": f"Memory {block_name} block"
+                    "description": f"Memory {block_name} block",
                 }
                 # Add block to memory
-                self.block_manager.create_block(block=block, agent_id=self.agent_state.id, actor=self.user)
-    
+                self.block_manager.create_block(
+                    block=block, agent_id=self.agent_state.id, actor=self.user
+                )
+
     def _initialize_database_connection(self) -> sa.engine.Engine:
         """Initialize connection to PostgreSQL database."""
         try:
             engine = create_engine(self.db_url)
-            
+
             # Verify connection
             connection = engine.connect()
             connection.close()
-            
+
             # Create tables if they don't exist
             Base.metadata.create_all(engine)
-            
+
             # Check for vector extension via utility function
             if check_vector_extension(self.db_url):
                 logger.info("Vector extension available")
-                
+
                 # Set up necessary database indexes for efficient search
                 if setup_database_indexes(self.db_url):
                     logger.info("Database indexes setup complete")
                 else:
-                    logger.warning("Database indexes setup failed - vector search may not work correctly")
-                
+                    logger.warning(
+                        "Database indexes setup failed - vector search may not work correctly"
+                    )
+
                 # Set up hybrid search if enabled in settings
-                hybrid_search_enabled = MEMNON_SETTINGS.get("retrieval", {}).get("hybrid_search", {}).get("enabled", False)
+                hybrid_search_enabled = (
+                    MEMNON_SETTINGS.get("retrieval", {})
+                    .get("hybrid_search", {})
+                    .get("enabled", False)
+                )
                 if hybrid_search_enabled:
                     logger.info("Setting up hybrid search capabilities")
                     self._setup_hybrid_search(engine)
             else:
-                logger.warning("Vector extension not found - vector search will not work")
+                logger.warning(
+                    "Vector extension not found - vector search will not work"
+                )
                 logger.warning("Please run scripts/install_pgvector_custom.sh first")
-            
+
             logger.info(f"Successfully connected to database at {self.db_url}")
             return engine
-        
+
         except Exception as e:
             logger.error(f"Failed to connect to database: {e}")
             raise ConnectionError(f"Database connection failed: {e}")
-    
+
     def _setup_hybrid_search(self, engine):
         """
         Set up the database for hybrid search capabilities.
         Creates a GIN index for text search and a hybrid_search SQL function.
-        
+
         Args:
             engine: SQLAlchemy engine
         """
@@ -609,20 +672,27 @@ class MEMNON:
             else:
                 logger.warning("Hybrid search setup failed")
                 # Update settings in memory to reflect disabled status
-                if 'retrieval' in MEMNON_SETTINGS and 'hybrid_search' in MEMNON_SETTINGS['retrieval']:
-                    MEMNON_SETTINGS['retrieval']['hybrid_search']['enabled'] = False
+                if (
+                    "retrieval" in MEMNON_SETTINGS
+                    and "hybrid_search" in MEMNON_SETTINGS["retrieval"]
+                ):
+                    MEMNON_SETTINGS["retrieval"]["hybrid_search"]["enabled"] = False
                 return False
-                
+
         except Exception as e:
             logger.error(f"Error setting up hybrid search: {e}")
             import traceback
+
             logger.error(traceback.format_exc())
             logger.warning("Disabling hybrid search due to setup failure")
             # Update settings to reflect disabled status
-            if 'retrieval' in MEMNON_SETTINGS and 'hybrid_search' in MEMNON_SETTINGS['retrieval']:
-                MEMNON_SETTINGS['retrieval']['hybrid_search']['enabled'] = False
+            if (
+                "retrieval" in MEMNON_SETTINGS
+                and "hybrid_search" in MEMNON_SETTINGS["retrieval"]
+            ):
+                MEMNON_SETTINGS["retrieval"]["hybrid_search"]["enabled"] = False
             return False
-    
+
     def _load_aliases(self) -> Dict[str, List[str]]:
         """Load character aliases from the database."""
         try:
@@ -631,113 +701,141 @@ class MEMNON:
         except Exception as e:
             logger.error(f"Error loading aliases: {e}")
             return ALIAS_LOOKUP  # Use default if loading fails
-    
-    def perform_hybrid_search(self, query_text: str, filters: Dict[str, Any] = None, top_k: int = None) -> List[Dict[str, Any]]:
+
+    def perform_hybrid_search(
+        self, query_text: str, filters: Dict[str, Any] = None, top_k: int = None
+    ) -> List[Dict[str, Any]]:
         """
         Perform hybrid search using both vector embeddings and text search.
         Now supports multi-model search using all active embedding models with their weights.
-        
+
         Args:
             query_text: The query text
             filters: Optional metadata filters to apply
             top_k: Maximum number of results to return
-            
+
         Returns:
             List of matching chunks with scores and metadata
         """
         if top_k is None:
             top_k = self.retrieval_settings.get("default_top_k", 10)
-        
+
         try:
             # Get hybrid search settings
-            hybrid_config = MEMNON_SETTINGS.get("retrieval", {}).get("hybrid_search", {})
+            hybrid_config = MEMNON_SETTINGS.get("retrieval", {}).get(
+                "hybrid_search", {}
+            )
             if not hybrid_config.get("enabled", False):
                 logger.warning("Hybrid search is disabled in settings")
                 return []
-            
+
             # Determine query type for weight adjustment
             query_info = self.query_analyzer.analyze_query(query_text)
             query_type = query_info.get("type", "general")
             logger.debug(f"Query classified as type: {query_type}")
-            
+
             # Get weights based on query type or use defaults
-            if hybrid_config.get("use_query_type_weights", False) and query_type in hybrid_config.get("weights_by_query_type", {}):
+            if hybrid_config.get(
+                "use_query_type_weights", False
+            ) and query_type in hybrid_config.get("weights_by_query_type", {}):
                 weights = hybrid_config["weights_by_query_type"][query_type]
                 vector_weight = weights.get("vector", 0.6)
                 text_weight = weights.get("text", 0.4)
             else:
                 vector_weight = hybrid_config.get("vector_weight_default", 0.6)
                 text_weight = hybrid_config.get("text_weight_default", 0.4)
-            
+
             # Normalize weights to ensure they sum to 1.0
             total_weight = vector_weight + text_weight
             if total_weight != 1.0:
                 vector_weight = vector_weight / total_weight
                 text_weight = text_weight / total_weight
-            
+
             logger.debug(f"Using weights: vector={vector_weight}, text={text_weight}")
-            
+
             # Gather all active models and their weights
             active_models = {}
             model_weights = {}
-            
+
             for model_key, model_config in self.embedding_manager.models.items():
                 if model_key in self.retrieval_settings["model_weights"]:
                     # Get the weight from the retrieval settings
-                    model_weights[model_key] = self.retrieval_settings["model_weights"][model_key]
+                    model_weights[model_key] = self.retrieval_settings["model_weights"][
+                        model_key
+                    ]
                     active_models[model_key] = self.embedding_manager.models[model_key]
-            
+
             if not active_models:
                 logger.error("No active embedding models found.")
                 return []
-            
+
             # Normalize model weights to sum to 1.0
             total_model_weight = sum(model_weights.values())
             if total_model_weight > 0:
-                model_weights = {k: w/total_model_weight for k, w in model_weights.items()}
-            
-            logger.info(f"Using {len(active_models)} active models with weights: {model_weights}")
-            
+                model_weights = {
+                    k: w / total_model_weight for k, w in model_weights.items()
+                }
+
+            logger.info(
+                f"Using {len(active_models)} active models with weights: {model_weights}"
+            )
+
             # Generate embeddings for all active models
             query_embeddings = {}
             for model_key in active_models:
                 try:
-                    query_embeddings[model_key] = self.embedding_manager.generate_embedding(query_text, model_key)
+                    query_embeddings[model_key] = (
+                        self.embedding_manager.generate_embedding(query_text, model_key)
+                    )
                 except Exception as e:
-                    logger.error(f"Error generating embedding for model {model_key}: {e}")
-            
+                    logger.error(
+                        f"Error generating embedding for model {model_key}: {e}"
+                    )
+
             if not query_embeddings:
                 logger.error("Failed to generate embeddings for any active model.")
                 return []
-            
+
             # Analyze the query's temporal intent on a continuous scale
             query_temporal_intent = analyze_temporal_intent(query_text)
-            
+
             # Get default temporal boost factor from settings
             temporal_boost_factor = hybrid_config.get("temporal_boost_factor", 0.3)
-            
+
             # Check if we should use query-type-specific temporal boost factors
-            use_query_type_temporal_factors = hybrid_config.get("use_query_type_temporal_factors", False)
-            
+            use_query_type_temporal_factors = hybrid_config.get(
+                "use_query_type_temporal_factors", False
+            )
+
             # If enabled, get query-type-specific temporal boost factor
-            if use_query_type_temporal_factors and query_type in hybrid_config.get("temporal_boost_factors", {}):
-                query_temporal_factor = hybrid_config["temporal_boost_factors"][query_type]
-                logger.debug(f"Using query-type-specific temporal boost factor for '{query_type}': {query_temporal_factor}")
+            if use_query_type_temporal_factors and query_type in hybrid_config.get(
+                "temporal_boost_factors", {}
+            ):
+                query_temporal_factor = hybrid_config["temporal_boost_factors"][
+                    query_type
+                ]
+                logger.debug(
+                    f"Using query-type-specific temporal boost factor for '{query_type}': {query_temporal_factor}"
+                )
                 temporal_boost_factor = query_temporal_factor
-            
+
             # Determine if this is a temporal query based on how far from neutral (0.5) the intent is
             is_temporal_query = abs(query_temporal_intent - 0.5) > 0.1
-            
+
             # Determine if temporal boosting should be applied based on settings and query intent
             apply_temporal_boosting = temporal_boost_factor > 0.0 and is_temporal_query
-            
+
             # If query has temporal aspects and boosting is enabled, use multi-model time-aware search
             if apply_temporal_boosting:
-                logger.info(f"Using multi-model time-aware search for temporal query (intent: {query_temporal_intent:.2f}, boost factor: {temporal_boost_factor})")
-                
+                logger.info(
+                    f"Using multi-model time-aware search for temporal query (intent: {query_temporal_intent:.2f}, boost factor: {temporal_boost_factor})"
+                )
+
                 # Import multi-model time-aware search
-                from .utils.continuous_temporal_search import execute_multi_model_time_aware_search
-                
+                from .utils.continuous_temporal_search import (
+                    execute_multi_model_time_aware_search,
+                )
+
                 # Execute multi-model time-aware search
                 results = execute_multi_model_time_aware_search(
                     db_url=self.db_url,
@@ -749,15 +847,17 @@ class MEMNON:
                     temporal_boost_factor=temporal_boost_factor,
                     filters=filters,
                     top_k=top_k,
-                    idf_dict=self.idf_dictionary
+                    idf_dict=self.idf_dictionary,
                 )
             else:
                 # Use standard multi-model hybrid search for non-temporal queries
-                logger.debug("Using standard multi-model hybrid search for non-temporal query")
-                
+                logger.debug(
+                    "Using standard multi-model hybrid search for non-temporal query"
+                )
+
                 # Import multi-model hybrid search
                 from .utils.db_access import execute_multi_model_hybrid_search
-                
+
                 # Execute multi-model hybrid search
                 results = execute_multi_model_hybrid_search(
                     db_url=self.db_url,
@@ -768,103 +868,127 @@ class MEMNON:
                     text_weight=text_weight,
                     filters=filters,
                     top_k=top_k,
-                    idf_dict=self.idf_dictionary
+                    idf_dict=self.idf_dictionary,
                 )
-            
+
             logger.info(f"Multi-model hybrid search returned {len(results)} results")
             return results
-            
+
         except Exception as e:
             logger.error(f"Error in hybrid search: {e}")
             import traceback
+
             logger.error(traceback.format_exc())
             return []
-    
-    def _query_vector_search(self, query_text: str, collections: List[str], filters: Dict[str, Any], top_k: int) -> List[Dict[str, Any]]:
+
+    def _query_vector_search(
+        self,
+        query_text: str,
+        collections: List[str],
+        filters: Dict[str, Any],
+        top_k: int,
+    ) -> List[Dict[str, Any]]:
         """
         Query the vector database for chunks similar to the query text.
         Uses all active embedding models with their configured weights.
-        
+
         Args:
             query_text: The text to search for
             collections: Vector collection names to search in
             filters: Metadata filters to apply (season, episode, etc.)
             top_k: Maximum number of results to return
-            
+
         Returns:
             List of matching chunks with scores and metadata
         """
         if top_k is None:
             top_k = self.retrieval_settings["default_top_k"]
-        
+
         try:
             # Gather all active models and their weights
             active_models = {}
             model_weights = {}
-            
+
             for model_key, model in self.embedding_manager.models.items():
                 if model_key in self.retrieval_settings["model_weights"]:
                     # Get the weight from the retrieval settings
-                    model_weights[model_key] = self.retrieval_settings["model_weights"][model_key]
+                    model_weights[model_key] = self.retrieval_settings["model_weights"][
+                        model_key
+                    ]
                     active_models[model_key] = model
-            
+
             if not active_models:
                 logger.error("No active embedding models found.")
                 return []
-            
+
             # Normalize model weights to sum to 1.0
             total_model_weight = sum(model_weights.values())
             if total_model_weight > 0:
-                model_weights = {k: w/total_model_weight for k, w in model_weights.items()}
-            
-            logger.info(f"Using {len(active_models)} active models with weights: {model_weights}")
-            
+                model_weights = {
+                    k: w / total_model_weight for k, w in model_weights.items()
+                }
+
+            logger.info(
+                f"Using {len(active_models)} active models with weights: {model_weights}"
+            )
+
             # Generate embeddings for all active models
             query_embeddings = {}
             for model_key in active_models:
                 try:
-                    query_embeddings[model_key] = self.embedding_manager.generate_embedding(query_text, model_key)
+                    query_embeddings[model_key] = (
+                        self.embedding_manager.generate_embedding(query_text, model_key)
+                    )
                 except Exception as e:
-                    logger.error(f"Error generating embedding for model {model_key}: {e}")
-            
+                    logger.error(
+                        f"Error generating embedding for model {model_key}: {e}"
+                    )
+
             if not query_embeddings:
                 logger.error("Failed to generate embeddings for any active model.")
                 return []
 
             # Use the multi-model hybrid search with 100% vector weight to effectively perform vector-only search
             from .utils.db_access import execute_multi_model_hybrid_search
-            
+
             results = execute_multi_model_hybrid_search(
                 db_url=self.db_url,
                 query_text=query_text,
                 query_embeddings=query_embeddings,
                 model_weights=model_weights,
                 vector_weight=1.0,  # Use 100% vector weight for pure vector search
-                text_weight=0.0,    # No text search weight
+                text_weight=0.0,  # No text search weight
                 filters=filters,
                 top_k=top_k,
-                idf_dict=self.idf_dictionary
+                idf_dict=self.idf_dictionary,
             )
-            
+
             logger.info(f"Multi-model vector search returned {len(results)} results")
             return results
-        
+
         except Exception as e:
             logger.error(f"Error in vector search: {e}")
             import traceback
+
             logger.error(traceback.format_exc())
             return []
-    
-    def _query_structured_data(self, query_text: str, table: str, filters: Dict[str, Any] = None, limit: int = 10) -> List[Dict[str, Any]]:
+
+    def _query_structured_data(
+        self,
+        query_text: str,
+        table: str,
+        filters: Dict[str, Any] = None,
+        limit: int = 10,
+    ) -> List[Dict[str, Any]]:
         """
         Query structured data tables.
-        
+
         Args:
             query_text: The query text
             table: The table to query
             filters: Optional metadata filters
             limit: Maximum number of results to return
-            
+
         Returns:
             List of matching results
         """
@@ -873,7 +997,8 @@ class MEMNON:
                 if table == "characters":
                     # Query characters (schema: id, name, summary, background, personality, emotional_state, current_activity, current_location, extra_data)
                     # Exact name or alias match
-                    name_match_query = text("""
+                    name_match_query = text(
+                        """
                     SELECT DISTINCT c.id, c.name, c.summary, c.current_activity, c.current_location,
                            array_agg(DISTINCT ca.alias) as aliases
                     FROM characters c
@@ -884,26 +1009,34 @@ class MEMNON:
                         WHERE ca2.character_id = c.id AND LOWER(ca2.alias) = LOWER(:query)
                     )
                     GROUP BY c.id, c.name, c.summary, c.current_activity, c.current_location
-                    """)
+                    """
+                    )
                     result = session.execute(name_match_query, {"query": query_text})
                     exact_matches = []
                     for row in result:
-                        aliases = row.aliases if row.aliases and row.aliases[0] is not None else []
-                        exact_matches.append({
-                            "id": row.id,
-                            "name": row.name,
-                            "summary": row.summary,
-                            "current_activity": row.current_activity,
-                            "current_location": row.current_location,
-                            "aliases": aliases,
-                            "score": 1.0,
-                            "content_type": "character",
-                            "source": "structured_data"
-                        })
+                        aliases = (
+                            row.aliases
+                            if row.aliases and row.aliases[0] is not None
+                            else []
+                        )
+                        exact_matches.append(
+                            {
+                                "id": row.id,
+                                "name": row.name,
+                                "summary": row.summary,
+                                "current_activity": row.current_activity,
+                                "current_location": row.current_location,
+                                "aliases": aliases,
+                                "score": 1.0,
+                                "content_type": "character",
+                                "source": "structured_data",
+                            }
+                        )
                     if exact_matches:
                         return exact_matches
                     # Partial match by name or summary text
-                    partial_match_query = text("""
+                    partial_match_query = text(
+                        """
                     SELECT DISTINCT c.id, c.name, c.summary, c.current_activity, c.current_location,
                            array_agg(DISTINCT ca.alias) as aliases
                     FROM characters c
@@ -911,54 +1044,68 @@ class MEMNON:
                     WHERE c.name ILIKE '%' || :query || '%' OR c.summary ILIKE '%' || :query || '%'
                     GROUP BY c.id, c.name, c.summary, c.current_activity, c.current_location
                     LIMIT :limit
-                    """)
-                    result = session.execute(partial_match_query, {"query": query_text, "limit": limit})
+                    """
+                    )
+                    result = session.execute(
+                        partial_match_query, {"query": query_text, "limit": limit}
+                    )
                     partial_matches = []
                     for row in result:
-                        aliases = row.aliases if row.aliases and row.aliases[0] is not None else []
-                        partial_matches.append({
-                            "id": row.id,
-                            "name": row.name,
-                            "summary": row.summary,
-                            "current_activity": row.current_activity,
-                            "current_location": row.current_location,
-                            "aliases": aliases,
-                            "score": 0.75,
-                            "content_type": "character",
-                            "source": "structured_data"
-                        })
+                        aliases = (
+                            row.aliases
+                            if row.aliases and row.aliases[0] is not None
+                            else []
+                        )
+                        partial_matches.append(
+                            {
+                                "id": row.id,
+                                "name": row.name,
+                                "summary": row.summary,
+                                "current_activity": row.current_activity,
+                                "current_location": row.current_location,
+                                "aliases": aliases,
+                                "score": 0.75,
+                                "content_type": "character",
+                                "source": "structured_data",
+                            }
+                        )
                     return partial_matches
-                
+
                 elif table == "places":
                     # Query places
                     # First check for exact name matches
-                    name_match_query = text("""
+                    name_match_query = text(
+                        """
                     SELECT id, name, type, zone, summary, inhabitants, current_status
                     FROM places
                     WHERE LOWER(name) = LOWER(:query)
-                    """)
-                    
+                    """
+                    )
+
                     result = session.execute(name_match_query, {"query": query_text})
                     exact_matches = []
                     for row in result:
-                        exact_matches.append({
-                            "id": row.id,
-                            "name": row.name,
-                            "type": row.type,
-                            "zone": row.zone,
-                            "summary": row.summary,
-                            "inhabitants": row.inhabitants,
-                            "current_status": row.current_status,
-                            "score": 1.0,  # Exact match gets top score
-                            "content_type": "place",
-                            "source": "structured_data"
-                        })
-                    
+                        exact_matches.append(
+                            {
+                                "id": row.id,
+                                "name": row.name,
+                                "type": row.type,
+                                "zone": row.zone,
+                                "summary": row.summary,
+                                "inhabitants": row.inhabitants,
+                                "current_status": row.current_status,
+                                "score": 1.0,  # Exact match gets top score
+                                "content_type": "place",
+                                "source": "structured_data",
+                            }
+                        )
+
                     if exact_matches:
                         return exact_matches
-                    
+
                     # Then look for partial matches
-                    partial_match_query = text("""
+                    partial_match_query = text(
+                        """
                     SELECT id, name, type, zone, summary, inhabitants, current_status,
                            similarity(LOWER(name), LOWER(:query)) AS match_score
                     FROM places
@@ -966,65 +1113,72 @@ class MEMNON:
                     OR LOWER(summary) LIKE '%' || LOWER(:query) || '%'
                     ORDER BY match_score DESC
                     LIMIT :limit
-                    """)
-                    
-                    result = session.execute(partial_match_query, {"query": query_text, "limit": limit})
+                    """
+                    )
+
+                    result = session.execute(
+                        partial_match_query, {"query": query_text, "limit": limit}
+                    )
                     partial_matches = []
                     for row in result:
-                        partial_matches.append({
-                            "id": row.id,
-                            "name": row.name,
-                            "type": row.type,
-                            "zone": row.zone,
-                            "summary": row.summary,
-                            "inhabitants": row.inhabitants,
-                            "current_status": row.current_status,
-                            "score": float(row.match_score),
-                            "content_type": "place",
-                            "source": "structured_data"
-                        })
-                    
+                        partial_matches.append(
+                            {
+                                "id": row.id,
+                                "name": row.name,
+                                "type": row.type,
+                                "zone": row.zone,
+                                "summary": row.summary,
+                                "inhabitants": row.inhabitants,
+                                "current_status": row.current_status,
+                                "score": float(row.match_score),
+                                "content_type": "place",
+                                "source": "structured_data",
+                            }
+                        )
+
                     return partial_matches
-                
+
                 else:
                     logger.warning(f"Unsupported table: {table}")
                     return []
-        
+
         except Exception as e:
             logger.error(f"Error querying structured data: {e}")
             return []
 
-    def _query_text_search(self, query_text: str, filters: Dict[str, Any] = None, limit: int = 10) -> List[Dict[str, Any]]:
+    def _query_text_search(
+        self, query_text: str, filters: Dict[str, Any] = None, limit: int = 10
+    ) -> List[Dict[str, Any]]:
         """
         Perform a keyword-based text search on narrative chunks.
-        
+
         Args:
             query_text: The text to search for
             filters: Optional metadata filters
             limit: Maximum number of results to return
-            
+
         Returns:
             List of matching chunks with scores and metadata
         """
         try:
             # Use prepare_tsquery from db_access for consistent processing
             processed_query = prepare_tsquery(query_text)
-            
+
             with self.Session() as session:
                 # Build query with filters
                 filter_conditions = []
                 if filters:
-                    if 'season' in filters:
+                    if "season" in filters:
                         filter_conditions.append(f"cm.season = :season")
-                    if 'episode' in filters:
+                    if "episode" in filters:
                         filter_conditions.append(f"cm.episode = :episode")
-                    if 'world_layer' in filters:
+                    if "world_layer" in filters:
                         filter_conditions.append(f"cm.world_layer = :world_layer")
-                
+
                 filter_sql = " AND ".join(filter_conditions)
                 if filter_sql:
                     filter_sql = " AND " + filter_sql
-                
+
                 # Execute text search
                 query_sql = f"""
                 SELECT 
@@ -1047,52 +1201,62 @@ class MEMNON:
                 LIMIT 
                     :limit
                 """
-                
+
                 query_params = {"query": processed_query, "limit": limit}
                 if filters:
-                    if 'season' in filters:
-                        query_params["season"] = filters['season']
-                    if 'episode' in filters:
-                        query_params["episode"] = filters['episode']
-                    if 'world_layer' in filters:
-                        query_params["world_layer"] = filters['world_layer']
-                
+                    if "season" in filters:
+                        query_params["season"] = filters["season"]
+                    if "episode" in filters:
+                        query_params["episode"] = filters["episode"]
+                    if "world_layer" in filters:
+                        query_params["world_layer"] = filters["world_layer"]
+
                 result = session.execute(text(query_sql), query_params)
-                
+
                 # Process results
                 text_results = []
                 for row in result:
-                    chunk_id, raw_text, season, episode, scene_number, score, highlights = row
-                    
-                    text_results.append({
-                        'id': str(chunk_id),
-                        'chunk_id': str(chunk_id),
-                        'text': raw_text,
-                        'content_type': 'narrative',
-                        'metadata': {
-                            'season': season,
-                            'episode': episode,
-                            'scene_number': scene_number,
-                            'highlights': highlights
-                        },
-                        'score': float(score),
-                        'source': 'text_search'
-                    })
-                
+                    (
+                        chunk_id,
+                        raw_text,
+                        season,
+                        episode,
+                        scene_number,
+                        score,
+                        highlights,
+                    ) = row
+
+                    text_results.append(
+                        {
+                            "id": str(chunk_id),
+                            "chunk_id": str(chunk_id),
+                            "text": raw_text,
+                            "content_type": "narrative",
+                            "metadata": {
+                                "season": season,
+                                "episode": episode,
+                                "scene_number": scene_number,
+                                "highlights": highlights,
+                            },
+                            "score": float(score),
+                            "source": "text_search",
+                        }
+                    )
+
                 return text_results
-        
+
         except Exception as e:
             logger.error(f"Error in text search: {e}")
             return []
-    
+
     def process_all_narrative_files(self, glob_pattern: str = None) -> int:
         """
         Process all narrative files matching the glob pattern.
-        
+
         Args:
-            glob_pattern: Pattern to match files to process. 
+            glob_pattern: Pattern to match files to process.
                           If None, uses the pattern from settings.json
-            
+
         Returns:
             Total number of chunks processed
         """
@@ -1100,64 +1264,71 @@ class MEMNON:
         try:
             # Get verbosity setting to determine if we should report progress
             verbose = MEMNON_SETTINGS.get("import", {}).get("verbose", True)
-            
+
             # Use ContentProcessor for the actual processing
-            total_chunks = self.content_processor.process_all_narrative_files(glob_pattern)
-            
+            total_chunks = self.content_processor.process_all_narrative_files(
+                glob_pattern
+            )
+
             # Report completion via interface if available
-            if verbose and hasattr(self, 'interface') and self.interface:
-                self.interface.assistant_message(f"Completed processing {total_chunks} total chunks")
-                
+            if verbose and hasattr(self, "interface") and self.interface:
+                self.interface.assistant_message(
+                    f"Completed processing {total_chunks} total chunks"
+                )
+
             return total_chunks
-            
+
         except Exception as e:
             logger.error(f"Error in process_all_narrative_files: {e}")
             import traceback
+
             logger.error(traceback.format_exc())
-            
+
             # Report error via interface if available
-            if hasattr(self, 'interface') and self.interface:
+            if hasattr(self, "interface") and self.interface:
                 self.interface.assistant_message(f"Error processing files: {str(e)}")
-                
+
             raise
-    
+
     def step(self, messages: List[Any]) -> Any:
         """
         Process incoming messages and perform MEMNON functions.
         This is the main entry point maintained for compatibility with the legacy Letta agent framework.
         Returns raw search results without LLM synthesis.
-        
+
         Args:
             messages: Incoming messages to process
-            
+
         Returns:
             Agent response (search results)
         """
         # Extract the last user message
         if not messages:
             return "No messages to process."
-        
+
         user_message = messages[-1]
         if user_message.role != "user":
             return "Expected a user message."
-        
+
         # Extract text from message
         message_text = ""
         for content_item in user_message.content:
             if hasattr(content_item, "text") and content_item.text:
                 message_text += content_item.text
-        
+
         if not message_text.strip():
-            return "I couldn't understand your message. Please provide a query or command."
-        
+            return (
+                "I couldn't understand your message. Please provide a query or command."
+            )
+
         # Check for special commands first
         command = self._parse_command(user_message)
-        
+
         # Handle special commands
         if command.get("action") == "process_files":
             # Process narrative files
             glob_pattern = command.get("pattern", "*_copy_notime.md")
-            
+
             # Execute file processing
             try:
                 total_chunks = self.process_all_narrative_files(glob_pattern)
@@ -1165,46 +1336,51 @@ class MEMNON:
             except Exception as e:
                 logger.error(f"Error processing files: {e}")
                 return f"Error processing files: {str(e)}"
-        
+
         elif command.get("action") == "status":
             # Return status information
             return self._get_status()
-        
+
         elif command.get("action") == "test_hybrid_search":
             # Test hybrid search with provided query
-            test_queries = command.get("queries", ["What happened to Alex?", "Who is Emilia?"])
+            test_queries = command.get(
+                "queries", ["What happened to Alex?", "Who is Emilia?"]
+            )
             return self._test_hybrid_search(test_queries)
-        
+
         # Default action: Memory query
         try:
             # Perform search using query parameters
             filters = command.get("filters", {})
             limit = command.get("limit", self.retrieval_settings["default_top_k"])
-            
+
             # Check hybrid search flag
             use_hybrid = True  # Default
             if command.get("search_type") == "vector_only":
                 use_hybrid = False
-            
+
             # Execute search
-            search_results = self.query_memory(message_text, filters=filters, k=limit, use_hybrid=use_hybrid)
-            
+            search_results = self.query_memory(
+                message_text, filters=filters, k=limit, use_hybrid=use_hybrid
+            )
+
             # Return raw results as JSON
             return search_results
-            
+
         except Exception as e:
             logger.error(f"Error processing message: {e}")
             import traceback
+
             logger.error(traceback.format_exc())
             return f"Error: {str(e)}"
-    
+
     def _parse_command(self, message: Any) -> Dict[str, Any]:
         """
         Parse a user message to extract commands and parameters.
-        
+
         Args:
             message: The user message to parse
-            
+
         Returns:
             Dictionary containing command details
         """
@@ -1213,16 +1389,12 @@ class MEMNON:
         for content_item in message.content:
             if hasattr(content_item, "text") and content_item.text:
                 message_text += content_item.text
-        
+
         message_text = message_text.strip()
-        
+
         # Default: assume it's a query
-        command = {
-            "action": "query",
-            "text": message_text,
-            "filters": {}
-        }
-        
+        command = {"action": "query", "text": message_text, "filters": {}}
+
         # Check for special command patterns
         if message_text.startswith("process files"):
             command["action"] = "process_files"
@@ -1232,14 +1404,16 @@ class MEMNON:
                 command["pattern"] = pattern_match.group(1)
             else:
                 # Default pattern from settings
-                command["pattern"] = MEMNON_SETTINGS.get("import", {}).get("file_pattern", "ALEX_*.md")
-        
+                command["pattern"] = MEMNON_SETTINGS.get("import", {}).get(
+                    "file_pattern", "ALEX_*.md"
+                )
+
         elif message_text.startswith("status"):
             command["action"] = "status"
-        
+
         elif message_text.startswith("test hybrid search"):
             command["action"] = "test_hybrid_search"
-            
+
             # Look for custom queries
             queries_match = re.search(r"queries:\s*(\[.*\])", message_text)
             if queries_match:
@@ -1247,20 +1421,21 @@ class MEMNON:
                     # Extract the JSON array of queries
                     queries_str = queries_match.group(1)
                     import json
+
                     queries = json.loads(queries_str)
                     if isinstance(queries, list):
                         command["queries"] = queries
                 except:
                     # If parsing fails, use default queries
                     command["queries"] = ["What happened to Alex?", "Who is Emilia?"]
-        
+
         elif message_text.startswith("raw"):
             command["action"] = "toggle_raw"
-        
+
         elif message_text.startswith("vector"):
             command["search_type"] = "vector_only"
             command["text"] = message_text[7:].strip()  # Remove "vector " prefix
-            
+
         # Extract filters if present
         filters_match = re.search(r"filters:\s*(\{.*\})", message_text)
         if filters_match:
@@ -1268,13 +1443,14 @@ class MEMNON:
                 # Extract the JSON object for filters
                 filters_str = filters_match.group(1)
                 import json
+
                 filters = json.loads(filters_str)
                 if isinstance(filters, dict):
                     command["filters"] = filters
             except:
                 # If parsing fails, use empty filters
                 pass
-        
+
         # Extract limit if present
         limit_match = re.search(r"limit:\s*(\d+)", message_text)
         if limit_match:
@@ -1284,9 +1460,9 @@ class MEMNON:
             except:
                 # If parsing fails, use default limit
                 pass
-        
+
         return command
-    
+
     def _get_status(self) -> str:
         """Get MEMNON status information."""
         try:
@@ -1294,28 +1470,31 @@ class MEMNON:
             with self.Session() as session:
                 # Count narrative chunks
                 chunk_count = session.query(func.count(NarrativeChunk.id)).scalar() or 0
-                
+
                 # Count embeddings across dimension-specific tables
                 embedding_count = 0
                 model_counts = {}
-                
-                # Check each dimension table
-                dimension_tables = list(DIMENSION_TABLES)
-                
+
+                # Check currently existing dimension tables. Embedding tables
+                # are created lazily by write paths.
+                dimension_tables = list_embedding_tables(session.connection())
+
                 for table_name in dimension_tables:
                     try:
                         # Count total embeddings in this table
                         count_query = text(f"SELECT COUNT(*) FROM {table_name}")
                         table_count = session.execute(count_query).scalar() or 0
                         embedding_count += table_count
-                        
+
                         # Count by model
-                        model_query = text(f"""
+                        model_query = text(
+                            f"""
                         SELECT model, COUNT(*) 
                         FROM {table_name} 
                         GROUP BY model
-                        """)
-                        
+                        """
+                        )
+
                         for row in session.execute(model_query):
                             model, count = row
                             if model in model_counts:
@@ -1323,127 +1502,140 @@ class MEMNON:
                             else:
                                 model_counts[model] = count
                     except Exception as e:
-                        logger.warning(f"Error counting embeddings in {table_name}: {e}")
+                        logger.warning(
+                            f"Error counting embeddings in {table_name}: {e}"
+                        )
                         continue
-                
+
                 # Model counts are now populated from dimension tables
-                
+
                 # Count characters
                 character_count = session.query(func.count(Character.id)).scalar() or 0
-                
+
                 # Count places
                 place_count = session.query(func.count(Place.id)).scalar() or 0
-                
+
             # Format status message
             status = f"MEMNON Status\n"
             status += f"=============\n\n"
             status += f"Database: {self.db_url}\n"
             status += f"Narrative chunks: {chunk_count}\n"
             status += f"Embeddings: {embedding_count}\n"
-            
+
             # Add embedding distribution
             status += f"\nEmbeddings by model:\n"
             for model, count in model_counts.items():
                 status += f"  - {model}: {count}\n"
-            
+
             # Add entity counts
             status += f"\nStructured data:\n"
             status += f"  - Characters: {character_count}\n"
             status += f"  - Places: {place_count}\n"
-            
+
             # Add search configuration
             status += f"\nSearch configuration:\n"
-            
-            hybrid_config = MEMNON_SETTINGS.get("retrieval", {}).get("hybrid_search", {})
+
+            hybrid_config = MEMNON_SETTINGS.get("retrieval", {}).get(
+                "hybrid_search", {}
+            )
             hybrid_enabled = hybrid_config.get("enabled", False)
-            status += f"  - Hybrid search: {'Enabled' if hybrid_enabled else 'Disabled'}\n"
-            
+            status += (
+                f"  - Hybrid search: {'Enabled' if hybrid_enabled else 'Disabled'}\n"
+            )
+
             if hybrid_enabled:
                 status += f"  - Default weights: Vector = {hybrid_config.get('vector_weight_default', 0.6)}, "
                 status += f"Text = {hybrid_config.get('text_weight_default', 0.4)}\n"
-                
+
                 if hybrid_config.get("use_query_type_weights", False):
                     status += f"  - Query-specific weights enabled\n"
-            
+
             # Add model information
             status += f"\nActive embedding models:\n"
             for model_name in self.embedding_manager.get_available_models():
-                weight = self.retrieval_settings["model_weights"].get(model_name, "unknown")
+                weight = self.retrieval_settings["model_weights"].get(
+                    model_name, "unknown"
+                )
                 status += f"  - {model_name} (weight: {weight})\n"
-            
+
             return status
-        
+
         except Exception as e:
             logger.error(f"Error getting status: {e}")
             return f"Error getting status: {str(e)}"
-    
+
     def _test_hybrid_search(self, test_queries: List[str]) -> str:
         """
         Run a test of the hybrid search functionality.
-        
+
         Args:
             test_queries: List of queries to test
-            
+
         Returns:
             String containing test results
         """
         results = "Hybrid Search Test Results\n"
         results += "=======================\n\n"
-        
+
         # Check if hybrid search is enabled
         hybrid_config = MEMNON_SETTINGS.get("retrieval", {}).get("hybrid_search", {})
         if not hybrid_config.get("enabled", False):
             results += "ERROR: Hybrid search is disabled in settings.\n"
             return results
-        
+
         # Run each test query
         for i, query in enumerate(test_queries):
             results += f"Query {i+1}: {query}\n"
             results += f"------------------\n"
-            
+
             try:
                 # Run hybrid search
                 start_time = time.time()
                 search_results = self.perform_hybrid_search(query, top_k=5)
                 elapsed = time.time() - start_time
-                
-                results += f"Found {len(search_results)} results in {elapsed:.3f} seconds\n\n"
-                
+
+                results += (
+                    f"Found {len(search_results)} results in {elapsed:.3f} seconds\n\n"
+                )
+
                 # Show top results
                 for j, result in enumerate(search_results[:3]):
                     results += f"Result {j+1} (Score: {result.get('score', 0):.4f})\n"
-                    
-                    if 'vector_score' in result and 'text_score' in result:
-                        results += f"  Vector score: {result.get('vector_score', 0):.4f}, "
+
+                    if "vector_score" in result and "text_score" in result:
+                        results += (
+                            f"  Vector score: {result.get('vector_score', 0):.4f}, "
+                        )
                         results += f"Text score: {result.get('text_score', 0):.4f}\n"
-                    
+
                     # Get text with truncation
                     text = result.get("text", "")
                     if len(text) > 200:
                         text = text[:197] + "..."
-                    
+
                     results += f"  {text}\n\n"
-                
+
                 results += "\n"
-                
+
             except Exception as e:
                 results += f"Error running query: {str(e)}\n\n"
-        
+
         return results
-    
+
     def get_chunk_by_id(self, chunk_id: int) -> Optional[Dict[str, Any]]:
         """
         Retrieve a specific chunk by ID with minimal scene metadata.
-        
+
         Args:
             chunk_id: The ID of the chunk to retrieve
-            
+
         Returns:
             Dictionary containing the chunk text and scene header info
         """
         try:
             with self.Session() as session:
-                query = text("""
+                query = text(
+                    """
                     SELECT 
                         nc.id,
                         nc.raw_text,
@@ -1466,10 +1658,11 @@ class MEMNON:
                         cm.episode,
                         cm.scene,
                         nv.world_time
-                """)
-                
+                """
+                )
+
                 result = session.execute(query, {"chunk_id": chunk_id}).fetchone()
-                
+
                 if result:
                     # Format the scene header
                     header = f"Season {result.season}, Episode {result.episode}, Scene {result.scene}\n"
@@ -1478,112 +1671,122 @@ class MEMNON:
                         header += f"{result.world_time}\n"
                     if result.place_names:
                         header += f"{result.place_names}\n"
-                    
+
                     return {
                         "id": result.id,
                         "text": result.raw_text,
                         "header": header,
-                        "full_text": header + "\n" + result.raw_text
+                        "full_text": header + "\n" + result.raw_text,
                     }
                 return None
-                
+
         except Exception as e:
             logger.error(f"Error fetching chunk {chunk_id}: {str(e)}")
             return None
-    
+
     def get_recent_chunks(self, limit: int = 10) -> Dict[str, Any]:
         """
         Retrieve the most recent narrative chunks.
-        
+
         Args:
             limit: Maximum number of chunks to retrieve
-            
+
         Returns:
             Dictionary containing the recent chunks and metadata
         """
         try:
             with self.Session() as session:
-                query = text("""
+                query = text(
+                    """
                     SELECT nc.id, nc.raw_text, cm.season, cm.episode, cm.scene AS scene_number,
                            cm.world_layer
                     FROM narrative_chunks nc
                     LEFT JOIN chunk_metadata cm ON nc.id = cm.chunk_id
                     ORDER BY nc.id DESC
                     LIMIT :limit
-                """)
-                
+                """
+                )
+
                 results = session.execute(query, {"limit": limit}).fetchall()
-                
+
                 chunks = []
                 for result in results:
-                    chunks.append({
-                        "id": result.id,
-                        "text": result.raw_text,
-                        "metadata": {
-                            "season": result.season,
-                            "episode": result.episode,
-                            "scene_number": result.scene_number,
-                            "world_layer": result.world_layer
-                        },
-                        "score": 1.0,  # Recent chunks have perfect relevance
-                        "source": "recent_chunks"
-                    })
-                
-                return {
-                    "query": "recent_chunks",
-                    "query_type": "recent",
-                    "results": chunks,
-                    "metadata": {
-                        "search_strategies": ["recent_chunks"],
-                        "result_count": len(chunks)
-                    }
-                }
-        except Exception as e:
-            logger.error(f"Error retrieving recent chunks: {e}")
-            raise RuntimeError(f"FATAL: Failed to retrieve recent chunks from database: {e}")
-    
-    def _get_chunk_by_id(self, chunk_id: int) -> Dict[str, Any]:
-        """
-        Retrieve a specific chunk by its ID.
-        
-        Args:
-            chunk_id: The ID of the chunk to retrieve
-            
-        Returns:
-            Dictionary containing the chunk data and metadata
-        """
-        try:
-            with self.Session() as session:
-                query = text("""
-                    SELECT nc.id, nc.raw_text, cm.season, cm.episode, cm.scene AS scene_number,
-                           cm.world_layer
-                    FROM narrative_chunks nc
-                    LEFT JOIN chunk_metadata cm ON nc.id = cm.chunk_id
-                    WHERE nc.id = :chunk_id
-                """)
-                
-                result = session.execute(query, {"chunk_id": chunk_id}).fetchone()
-                
-                if result:
-                    return {
-                        "query": f"chunk_id:{chunk_id}",
-                        "query_type": "direct_id",
-                        "results": [{
+                    chunks.append(
+                        {
                             "id": result.id,
                             "text": result.raw_text,
                             "metadata": {
                                 "season": result.season,
                                 "episode": result.episode,
                                 "scene_number": result.scene_number,
-                                "world_layer": result.world_layer
+                                "world_layer": result.world_layer,
                             },
-                            "score": 1.0,  # Perfect match for ID query
-                            "source": "direct_id_lookup"
-                        }],
+                            "score": 1.0,  # Recent chunks have perfect relevance
+                            "source": "recent_chunks",
+                        }
+                    )
+
+                return {
+                    "query": "recent_chunks",
+                    "query_type": "recent",
+                    "results": chunks,
+                    "metadata": {
+                        "search_strategies": ["recent_chunks"],
+                        "result_count": len(chunks),
+                    },
+                }
+        except Exception as e:
+            logger.error(f"Error retrieving recent chunks: {e}")
+            raise RuntimeError(
+                f"FATAL: Failed to retrieve recent chunks from database: {e}"
+            )
+
+    def _get_chunk_by_id(self, chunk_id: int) -> Dict[str, Any]:
+        """
+        Retrieve a specific chunk by its ID.
+
+        Args:
+            chunk_id: The ID of the chunk to retrieve
+
+        Returns:
+            Dictionary containing the chunk data and metadata
+        """
+        try:
+            with self.Session() as session:
+                query = text(
+                    """
+                    SELECT nc.id, nc.raw_text, cm.season, cm.episode, cm.scene AS scene_number,
+                           cm.world_layer
+                    FROM narrative_chunks nc
+                    LEFT JOIN chunk_metadata cm ON nc.id = cm.chunk_id
+                    WHERE nc.id = :chunk_id
+                """
+                )
+
+                result = session.execute(query, {"chunk_id": chunk_id}).fetchone()
+
+                if result:
+                    return {
+                        "query": f"chunk_id:{chunk_id}",
+                        "query_type": "direct_id",
+                        "results": [
+                            {
+                                "id": result.id,
+                                "text": result.raw_text,
+                                "metadata": {
+                                    "season": result.season,
+                                    "episode": result.episode,
+                                    "scene_number": result.scene_number,
+                                    "world_layer": result.world_layer,
+                                },
+                                "score": 1.0,  # Perfect match for ID query
+                                "source": "direct_id_lookup",
+                            }
+                        ],
                         "metadata": {
                             "search_strategies": ["direct_id_lookup"],
-                            "result_count": 1
-                        }
+                            "result_count": 1,
+                        },
                     }
                 else:
                     return {
@@ -1593,8 +1796,8 @@ class MEMNON:
                         "metadata": {
                             "search_strategies": ["direct_id_lookup"],
                             "result_count": 0,
-                            "error": f"Chunk with ID {chunk_id} not found"
-                        }
+                            "error": f"Chunk with ID {chunk_id} not found",
+                        },
                     }
         except Exception as e:
             logger.error(f"Error retrieving chunk by ID {chunk_id}: {e}")
@@ -1605,29 +1808,34 @@ class MEMNON:
                 "metadata": {
                     "search_strategies": ["direct_id_lookup"],
                     "result_count": 0,
-                    "error": str(e)
-                }
+                    "error": str(e),
+                },
             }
-    
-    def query_memory(self, query: str, query_type: Optional[str] = None, 
-                   filters: Optional[Dict[str, Any]] = None, 
-                   k: Optional[int] = None, use_hybrid: bool = True) -> Dict[str, Any]:
+
+    def query_memory(
+        self,
+        query: str,
+        query_type: Optional[str] = None,
+        filters: Optional[Dict[str, Any]] = None,
+        k: Optional[int] = None,
+        use_hybrid: bool = True,
+    ) -> Dict[str, Any]:
         """
         Execute a query against memory and return matching results.
-        
+
         Args:
             query: The query text
             query_type: Optional query type (character, location, etc.)
             filters: Optional metadata filters
             k: Maximum number of results to return
             use_hybrid: Whether to use hybrid search
-            
+
         Returns:
             Dictionary containing query results and metadata
         """
         # Log the query
         logger.info(f"Querying memory: {query}")
-        
+
         # Check if this is a direct chunk ID query
         if query.startswith("chunk_id:"):
             try:
@@ -1636,127 +1844,155 @@ class MEMNON:
             except ValueError:
                 logger.error(f"Invalid chunk_id format in query: {query}")
                 # Fall through to regular query processing
-        
+
         # Use default limit if not specified
         if k is None:
             k = self.retrieval_settings["default_top_k"]
-        
+
         search_start_time = time.time()
-        
+
         # Get query type from SearchManager if not specified
         if not query_type:
             query_info = self.query_analyzer.analyze_query(query)
             query_type = query_info.get("type", "general")
-        
+
         logger.info(f"Query type: {query_type}")
-        
+
         # Initialize search metadata
         search_metadata = {
             "query_time": 0,
             "total_candidate_results": 0,
             "final_result_count": 0,
-            "strategies_used": []
+            "strategies_used": [],
         }
-        
+
         # Determine search strategy based on query type
         strategies = []
-        
-        hybrid_enabled = MEMNON_SETTINGS.get("retrieval", {}).get("hybrid_search", {}).get("enabled", False)
-        
+
+        hybrid_enabled = (
+            MEMNON_SETTINGS.get("retrieval", {})
+            .get("hybrid_search", {})
+            .get("enabled", False)
+        )
+
         if use_hybrid and hybrid_enabled:
             # Add hybrid search strategy
-            strategies.append({
-                "type": "hybrid_search",
-                "query": query,
-                "filters": filters,
-                "limit": k
-            })
-            
+            strategies.append(
+                {
+                    "type": "hybrid_search",
+                    "query": query,
+                    "filters": filters,
+                    "limit": k,
+                }
+            )
+
             # Log strategy
             logger.debug("Using hybrid search strategy")
             search_metadata["strategies_used"].append("hybrid_search")
         else:
             # Fallback to vector search
-            strategies.append({
-                "type": "vector_search",
-                "query": query,
-                "filters": filters,
-                "limit": k
-            })
-            
+            strategies.append(
+                {
+                    "type": "vector_search",
+                    "query": query,
+                    "filters": filters,
+                    "limit": k,
+                }
+            )
+
             # Log strategy
             logger.debug("Using vector search strategy")
             search_metadata["strategies_used"].append("vector_search")
-        
+
         # Execute search strategies
         all_results = []
-        
+
         for strategy in strategies:
             strategy_type = strategy["type"]
-            
+
             try:
                 if strategy_type == "hybrid_search":
                     # Execute hybrid search using SearchManager
                     results = self.search_manager.perform_hybrid_search(
                         query_text=strategy["query"],
                         filters=strategy.get("filters"),
-                        top_k=strategy.get("limit", k)
+                        top_k=strategy.get("limit", k),
                     )
                     all_results.extend(results)
-                    
+
                 elif strategy_type == "vector_search":
                     # Execute vector search using SearchManager
                     results = self.search_manager.query_vector_search(
                         query_text=strategy["query"],
                         collections=["narrative_chunks"],
                         filters=strategy.get("filters"),
-                        top_k=strategy.get("limit", k)
+                        top_k=strategy.get("limit", k),
                     )
                     all_results.extend(results)
-                    
+
                 else:
                     logger.warning(f"Unknown search strategy: {strategy_type}")
-            
+
             except Exception as e:
                 logger.error(f"Error in {strategy_type}: {e}")
                 import traceback
+
                 logger.error(traceback.format_exc())
-        
+
         # Final results selection - Deduplicate by ID and sort by score
         seen_ids = set()
         final_results = []
-        
+
         for result in all_results:
             result_id = result.get("id", None)
             if result_id and result_id not in seen_ids:
                 seen_ids.add(result_id)
                 final_results.append(result)
-        
+
         # Sort by score, descending
-        final_results = sorted(final_results, key=lambda x: x.get("score", 0), reverse=True)
-        
+        final_results = sorted(
+            final_results, key=lambda x: x.get("score", 0), reverse=True
+        )
+
         # Truncate to requested limit
         search_results_initial = final_results[:k]
-        
+
         # Apply cross-encoder reranking if enabled
-        cross_encoder_config = MEMNON_SETTINGS.get("retrieval", {}).get("cross_encoder_reranking", {})
-        if cross_encoder_config.get("enabled", False) and len(search_results_initial) > 0:
+        cross_encoder_config = MEMNON_SETTINGS.get("retrieval", {}).get(
+            "cross_encoder_reranking", {}
+        )
+        if (
+            cross_encoder_config.get("enabled", False)
+            and len(search_results_initial) > 0
+        ):
             try:
                 logger.info("Applying cross-encoder reranking")
                 search_metadata["strategies_used"].append("cross_encoder_reranking")
-                
+
                 # Get query type specific weight if available
                 alpha = cross_encoder_config.get("blend_weight", 0.3)
                 if cross_encoder_config.get("use_query_type_weights", False):
-                    if query_type in cross_encoder_config.get("weights_by_query_type", {}):
-                        alpha = cross_encoder_config["weights_by_query_type"][query_type]
-                        logger.debug(f"Using query-type-specific weight for '{query_type}': {alpha}")
-                
+                    if query_type in cross_encoder_config.get(
+                        "weights_by_query_type", {}
+                    ):
+                        alpha = cross_encoder_config["weights_by_query_type"][
+                            query_type
+                        ]
+                        logger.debug(
+                            f"Using query-type-specific weight for '{query_type}': {alpha}"
+                        )
+
                 # Determine other parameters
-                top_k_rerank = min(cross_encoder_config.get("top_k", 10), len(search_results_initial))
+                top_k_rerank = min(
+                    cross_encoder_config.get("top_k", 10), len(search_results_initial)
+                )
                 batch_size = cross_encoder_config.get("batch_size", 8)
-                use_sliding_window = cross_encoder_config.get("use_sliding_window", True)
-                model_path = cross_encoder_config.get("model_path", "naver-trecdl22-crossencoder-debertav3")
+                use_sliding_window = cross_encoder_config.get(
+                    "use_sliding_window", True
+                )
+                model_path = cross_encoder_config.get(
+                    "model_path", "naver-trecdl22-crossencoder-debertav3"
+                )
                 # api_type must accompany model_path so that swapping production
                 # to a Qwen3-Reranker checkpoint doesn't silently load it as a
                 # SequenceClassification CrossEncoder.
@@ -1777,16 +2013,19 @@ class MEMNON:
                     use_sliding_window=use_sliding_window,
                     model_path=model_path,
                     api_type=api_type,
-                    use_8bit=use_8bit
+                    use_8bit=use_8bit,
                 )
-                
+
                 rerank_time = time.time() - rerank_start_time
                 search_metadata["rerank_time"] = rerank_time
-                logger.info(f"Cross-encoder reranking completed in {rerank_time:.3f} seconds")
-                
+                logger.info(
+                    f"Cross-encoder reranking completed in {rerank_time:.3f} seconds"
+                )
+
             except Exception as e:
                 logger.error(f"Error in cross-encoder reranking: {e}")
                 import traceback
+
                 logger.error(traceback.format_exc())
                 # Fall back to initial results if reranking fails
                 final_results = search_results_initial
@@ -1794,71 +2033,75 @@ class MEMNON:
         else:
             # Use initial results if reranking is disabled
             final_results = search_results_initial
-        
+
         # Complete search metadata
         search_metadata["query_time"] = time.time() - search_start_time
         search_metadata["total_candidate_results"] = len(all_results)
         search_metadata["final_result_count"] = len(final_results)
-        
+
         # Print results to console if debug mode
         if self.debug:
             print("\n--- Search results for query ---")
             print(f"Query: {query}")
             print(f"Type: {query_type}")
-            print(f"Found {len(final_results)} results in {search_metadata['query_time']:.3f} seconds")
-            
+            print(
+                f"Found {len(final_results)} results in {search_metadata['query_time']:.3f} seconds"
+            )
+
             # Print raw results for inspection
             for i, result in enumerate(all_results):
                 score = result.get("score", 0.0)
                 vector_score = result.get("vector_score", None)
                 text_score = result.get("text_score", None)
-                
+
                 score_info = f"Score: {score:.4f}"
                 if vector_score is not None and text_score is not None:
                     score_info += f" (V: {vector_score:.4f}, T: {text_score:.4f})"
-                    
+
                 text = result.get("text", "")
                 if len(text) > 200:
                     text = text[:197] + "..."
                 print(f"Result {i+1} ({score_info}): {text}")
             else:
                 print("No results found")
-            
+
             print("\n--- Final results ---")
             for i, result in enumerate(final_results):
                 source = result.get("source", "unknown")
                 score = result.get("score", 0.0)
-                
+
                 # Add reranker score if available
                 reranker_score = result.get("reranker_score", None)
                 original_score = result.get("original_score", None)
                 score_info = f"Score: {score:.4f}"
                 if reranker_score is not None and original_score is not None:
                     score_info = f"Score: {score:.4f} (Orig: {original_score:.4f}, Rerank: {reranker_score:.4f})"
-                
+
                 # Extract metadata for display
                 metadata_str = ""
                 if "metadata" in result:
                     metadata = result.get("metadata", {})
                     meta_items = []
                     if "season" in metadata and "episode" in metadata:
-                        meta_items.append(f"S{metadata['season']}E{metadata['episode']}")
+                        meta_items.append(
+                            f"S{metadata['season']}E{metadata['episode']}"
+                        )
                     if "scene_number" in metadata:
                         meta_items.append(f"Scene {metadata['scene_number']}")
                     if "matched_keyword" in metadata:
                         meta_items.append(f"Matched '{metadata['matched_keyword']}'")
-                    
+
                     if meta_items:
                         metadata_str = f" [{', '.join(meta_items)}]"
-                
+
                 # Get text with truncation
                 text = result.get("text", "")
                 if len(text) > 200:
                     text = text[:197] + "..."
-                
+
                 print(f"Result {i+1} ({score_info}){metadata_str}: {text}")
             print("=============================\n")
-            
+
         # Format final response
         response = {
             "query": query,
@@ -1868,48 +2111,50 @@ class MEMNON:
                 "search_strategies": search_metadata["strategies_used"],
                 "search_stats": search_metadata,
                 "result_count": len(final_results),
-                "filters_applied": filters
-            }
+                "filters_applied": filters,
+            },
         }
-        
+
         return response
-    
+
     def process_chunked_file(self, file_path: str) -> int:
         """
         Process a file containing chunked narrative text.
-        
+
         Args:
             file_path: Path to the file to process
-            
+
         Returns:
             Number of chunks processed
         """
         # Delegate to ContentProcessor
         return self.content_processor.process_chunked_file(file_path)
-    
+
     def store_narrative_chunk(self, text: str, metadata: Dict[str, Any]) -> int:
         """
         Store a narrative chunk in the database and generate embeddings.
-        
+
         Args:
             text: The chunk text
             metadata: Metadata dictionary with season, episode, etc.
-            
+
         Returns:
             The ID of the stored chunk
         """
         # Delegate to ContentProcessor
         return self.content_processor.store_narrative_chunk(text, metadata)
-    
+
     def _generate_chunk_embeddings(self, session, chunk_id: int, text: str):
         """
         Generate embeddings for a chunk using all active models.
         Stores embeddings in dimension-specific tables with proper vector types.
-        
+
         Args:
             session: The active database session
             chunk_id: The ID of the chunk
             text: The text to encode
         """
         # Delegate to ContentProcessor
-        return self.content_processor._generate_chunk_embeddings(session, chunk_id, text)
+        return self.content_processor._generate_chunk_embeddings(
+            session, chunk_id, text
+        )

--- a/nexus/agents/memnon/utils/alias_search.py
+++ b/nexus/agents/memnon/utils/alias_search.py
@@ -4,10 +4,13 @@ Alias-aware search utilities for MEMNON
 This module provides functionality to enhance search with character alias awareness,
 especially for handling cases where 'You' and 'Alex' are equivalent in 2nd-person POV.
 """
+
 import logging
 import re
 from typing import Dict, List, Optional, Any, Tuple
 from sqlalchemy import text
+
+from .embedding_tables import embedding_table_exists, table_name_for_dimensions
 
 logger = logging.getLogger("nexus.memnon.alias_search")
 
@@ -20,27 +23,32 @@ ALIAS_LOOKUP: Dict[str, List[str]] = {
     # Add more characters as needed
 }
 
+
 def load_aliases_from_db(conn) -> Dict[str, List[str]]:
     """
     Load character aliases from the database.
-    
+
     Args:
         conn: SQLAlchemy database connection
-    
+
     Returns:
         Dict mapping lowercase character names to their aliases
     """
     alias_lookup = {}
     try:
         # Query all characters with their aliases from the normalized table
-        result = conn.execute(text("""
+        result = conn.execute(
+            text(
+                """
             SELECT c.name, array_agg(DISTINCT ca.alias) as aliases
             FROM characters c
             LEFT JOIN character_aliases ca ON c.id = ca.character_id
             GROUP BY c.id, c.name
             HAVING array_agg(DISTINCT ca.alias) IS NOT NULL
-        """))
-        
+        """
+            )
+        )
+
         for row in result:
             name = row[0]
             aliases = row[1] if isinstance(row[1], list) else []
@@ -77,78 +85,86 @@ def load_aliases_from_db(conn) -> Dict[str, List[str]]:
                         character_row[0],
                     )
         except Exception as alias_exc:  # pragma: no cover - defensive logging
-            logger.warning("Failed to extend aliases with user character pronouns: %s", alias_exc)
-            
+            logger.warning(
+                "Failed to extend aliases with user character pronouns: %s", alias_exc
+            )
+
     except Exception as e:
         logger.error(f"Error loading aliases from database: {e}")
         # Fall back to default ALIAS_LOOKUP
         return ALIAS_LOOKUP
-    
+
     return alias_lookup if alias_lookup else ALIAS_LOOKUP
 
-def alias_terms(query: str, alias_lookup: Optional[Dict[str, List[str]]] = None) -> List[str]:
+
+def alias_terms(
+    query: str, alias_lookup: Optional[Dict[str, List[str]]] = None
+) -> List[str]:
     """
     Extract character alias terms from a query.
-    
+
     Args:
         query: The search query text
         alias_lookup: Optional dictionary of character aliases. If None, uses the module's ALIAS_LOOKUP.
-    
+
     Returns:
         List of alias terms to include in the search
     """
     if not query or not isinstance(query, str):
         return []
-    
+
     if alias_lookup is None:
         alias_lookup = ALIAS_LOOKUP
-    
+
     lowered_query = query.lower()
     all_aliases = []
-    
+
     # Special case for possessive forms like "your" -> "Alex"
     if any(term in lowered_query for term in ["your", "yours", "yourself"]):
         # Add Alex and all her aliases when "your" is detected
         if "alex" in alias_lookup:
             all_aliases.extend(alias_lookup["alex"])
             logger.debug("Added Alex's aliases due to 'your' in query")
-    
+
     # Look for character names in the query
     for name, variants in alias_lookup.items():
         # Check for the name or any of its aliases in the query
-        name_pattern = r'\b{}\b'.format(re.escape(name))
-        variant_patterns = [r'\b{}\b'.format(re.escape(variant.lower())) for variant in variants]
-        
+        name_pattern = r"\b{}\b".format(re.escape(name))
+        variant_patterns = [
+            r"\b{}\b".format(re.escape(variant.lower())) for variant in variants
+        ]
+
         # If any match, add all aliases for this character
-        if re.search(name_pattern, lowered_query) or any(re.search(pattern, lowered_query) for pattern in variant_patterns):
+        if re.search(name_pattern, lowered_query) or any(
+            re.search(pattern, lowered_query) for pattern in variant_patterns
+        ):
             all_aliases.extend(variants)
-    
+
     # Return unique aliases
     return list(set(all_aliases))
 
+
 def create_hybrid_alias_search_sql(
-    table_name: str,
-    dimensions: int,
-    alias_terms: List[str] = None
+    table_name: str, dimensions: int, alias_terms: List[str] = None
 ) -> Tuple[str, Dict[str, Any]]:
     """
     Creates a SQL query for hybrid search with alias awareness.
-    
+
     Args:
         table_name: Base table name for embeddings
         dimensions: Number of dimensions in the embedding model
         alias_terms: Optional list of character aliases to include in search
-    
+
     Returns:
         Tuple of (SQL query text, parameter dict)
     """
     has_alias_terms = alias_terms is not None and len(alias_terms) > 0
-    
+
     # Base query parameters
     params = {
         "alias_terms": alias_terms if has_alias_terms else [],
     }
-    
+
     # Different query based on whether we have alias terms
     if has_alias_terms:
         # For characters stored as "Name:status", we use a simplified approach:
@@ -187,7 +203,7 @@ def create_hybrid_alias_search_sql(
         )
         LIMIT :limit;
         """
-        
+
         # Add alias parameters
         for i, alias in enumerate(alias_terms):
             params[f"alias_{i}"] = alias
@@ -218,8 +234,9 @@ def create_hybrid_alias_search_sql(
         ORDER BY (ce.embedding <=> :query_vector) * 0.8 + ts.text_score * 0.2
         LIMIT :limit;
         """
-    
+
     return sql, params
+
 
 def hybrid_alias_search(
     conn,
@@ -228,11 +245,11 @@ def hybrid_alias_search(
     model_name: str,
     dimensions: int,
     limit: int = 10,
-    alias_lookup: Optional[Dict[str, List[str]]] = None
+    alias_lookup: Optional[Dict[str, List[str]]] = None,
 ) -> List[Dict[str, Any]]:
     """
     Perform a hybrid search with alias awareness.
-    
+
     Args:
         conn: SQLAlchemy database connection
         query_text: The search query text
@@ -241,31 +258,37 @@ def hybrid_alias_search(
         dimensions: Number of dimensions in the embedding model
         limit: Maximum number of results to return
         alias_lookup: Optional dictionary of character aliases
-    
+
     Returns:
         List of search results
     """
     # Get alias terms from the query
     terms = alias_terms(query_text, alias_lookup)
     logger.info(f"Query '{query_text}' contains character references: {terms}")
-    
-    # Create appropriate table name
-    table_name = f"chunk_embeddings_{dimensions}d"
-    
+
+    table_name = table_name_for_dimensions(dimensions)
+    if not embedding_table_exists(conn, table_name):
+        logger.warning(
+            "Embedding table %s does not exist; alias vector search skipped", table_name
+        )
+        return []
+
     # Format vector for SQL query
     query_vector_str = f"[{','.join(str(x) for x in query_vector)}]"
-    
+
     # Get SQL and params
     sql, params = create_hybrid_alias_search_sql(table_name, dimensions, terms)
-    
+
     # Add the remaining parameters
-    params.update({
-        "raw_query": query_text,
-        "query_vector": query_vector_str,  # Use the formatted string version
-        "model_name": model_name,
-        "limit": limit
-    })
-    
+    params.update(
+        {
+            "raw_query": query_text,
+            "query_vector": query_vector_str,  # Use the formatted string version
+            "model_name": model_name,
+            "limit": limit,
+        }
+    )
+
     # First try a direct text search for the specific items we know exist
     if "gender" in query_text.lower():
         try:
@@ -278,7 +301,7 @@ def hybrid_alias_search(
             """
             results = []
             direct_results = conn.execute(text(direct_sql), {"limit": limit})
-            
+
             for row in direct_results:
                 result = {
                     "id": row.id,
@@ -286,21 +309,23 @@ def hybrid_alias_search(
                     "model": row.model,
                     "distance": float(row.distance),
                     "score": 1.0,  # Direct match gets perfect score
-                    "source": "direct_text_search"
+                    "source": "direct_text_search",
                 }
                 results.append(result)
-            
+
             if results:
-                logger.info(f"Direct text search found {len(results)} results for 'gender'")
+                logger.info(
+                    f"Direct text search found {len(results)} results for 'gender'"
+                )
                 return results
         except Exception as e:
             logger.warning(f"Direct text search failed: {e}")
-    
+
     # Execute the main hybrid search query
     try:
         results = []
         result_set = conn.execute(text(sql), params)
-        
+
         for row in result_set:
             # Convert to dict format for compatibility with existing code
             result = {
@@ -308,8 +333,11 @@ def hybrid_alias_search(
                 "text": row.raw_text,
                 "model": row.model,
                 "distance": float(row.distance),
-                "text_score": float(row.text_score) if hasattr(row, "text_score") else 0.0,
-                "score": 1.0 - float(row.distance),  # Convert distance to similarity score
+                "text_score": (
+                    float(row.text_score) if hasattr(row, "text_score") else 0.0
+                ),
+                "score": 1.0
+                - float(row.distance),  # Convert distance to similarity score
                 "characters": row.characters if hasattr(row, "characters") else None,
                 "season": row.season if hasattr(row, "season") else None,
                 "episode": row.episode if hasattr(row, "episode") else None,
@@ -318,38 +346,40 @@ def hybrid_alias_search(
                 "place": row.place if hasattr(row, "place") else None,
                 "atmosphere": row.atmosphere if hasattr(row, "atmosphere") else None,
                 "time_delta": row.time_delta if hasattr(row, "time_delta") else None,
-                "source": "hybrid_alias_search"
+                "source": "hybrid_alias_search",
             }
             results.append(result)
-        
+
         logger.info(f"Hybrid alias search returned {len(results)} results")
         return results
-        
+
     except Exception as e:
         logger.error(f"Error executing hybrid alias search: {e}")
         import traceback
+
         logger.error(traceback.format_exc())
         return []
+
 
 # Testing function
 def test_alias_search(conn, query_text: str):
     """Test the alias search functionality with a specific query."""
     from sentence_transformers import SentenceTransformer
-    
+
     # Load the model
     model = SentenceTransformer("BAAI/bge-large-en")
-    
+
     # Generate embedding
     query_vector = model.encode(query_text).tolist()
-    
+
     # Load aliases from DB
     aliases = load_aliases_from_db(conn)
-    
+
     # Print the detected aliases
     terms = alias_terms(query_text, aliases)
     print(f"Query: '{query_text}'")
     print(f"Detected character references: {terms}")
-    
+
     # Perform search
     results = hybrid_alias_search(
         conn=conn,
@@ -358,13 +388,17 @@ def test_alias_search(conn, query_text: str):
         model_name="bge-large-en",
         dimensions=1024,
         limit=5,
-        alias_lookup=aliases
+        alias_lookup=aliases,
     )
-    
+
     # Print results
     print(f"\nGot {len(results)} results:")
     for i, result in enumerate(results):
         print(f"\nResult {i+1}: Score {result['score']:.4f}")
-        text_snippet = result['text'][:150].replace('\n', ' ') + "..." if len(result['text']) > 150 else result['text']
+        text_snippet = (
+            result["text"][:150].replace("\n", " ") + "..."
+            if len(result["text"]) > 150
+            else result["text"]
+        )
         print(f"Characters: {result.get('characters', [])}")
         print(f"Text: {text_snippet}")

--- a/nexus/agents/memnon/utils/content_processor.py
+++ b/nexus/agents/memnon/utils/content_processor.py
@@ -12,23 +12,26 @@ from typing import Dict, List, Optional, Any, Set, Tuple, Union
 from sqlalchemy import text
 
 from .embedding_manager import EmbeddingManager
-from .embedding_tables import resolve_dimension_table
+from .embedding_tables import ensure_embedding_table, resolve_dimension_table
 
 logger = logging.getLogger("nexus.memnon.content_processor")
+
 
 class ContentProcessor:
     """
     Handles processing, chunking, and storage of narrative content for MEMNON.
     """
-    
-    def __init__(self, 
-                db_manager, 
-                embedding_manager: EmbeddingManager, 
-                settings: Dict[str, Any],
-                load_aliases_func=None):
+
+    def __init__(
+        self,
+        db_manager,
+        embedding_manager: EmbeddingManager,
+        settings: Dict[str, Any],
+        load_aliases_func=None,
+    ):
         """
         Initialize the ContentProcessor.
-        
+
         Args:
             db_manager: Database manager for storing content
             embedding_manager: Embedding manager for generating embeddings
@@ -39,67 +42,73 @@ class ContentProcessor:
         self.embedding_manager = embedding_manager
         self.settings = settings
         self.load_aliases_func = load_aliases_func
-        
+
         # Cache for character aliases
         self._character_aliases = None
-        
+
         logger.info("ContentProcessor initialized")
-    
+
     def process_all_narrative_files(self, glob_pattern: str = None) -> int:
         """
         Process all narrative files matching the glob pattern.
-        
+
         Args:
-            glob_pattern: Pattern to match files to process. 
+            glob_pattern: Pattern to match files to process.
                           If None, uses the pattern from settings.json
-            
+
         Returns:
             Total number of chunks processed
         """
         # Use pattern from settings if not provided
         if glob_pattern is None:
-            glob_pattern = self.settings.get("import", {}).get("file_pattern", "ALEX_*.md")
-        
+            glob_pattern = self.settings.get("import", {}).get(
+                "file_pattern", "ALEX_*.md"
+            )
+
         # Get batch size from settings
         batch_size = self.settings.get("import", {}).get("batch_size", 10)
         verbose = self.settings.get("import", {}).get("verbose", True)
-        
+
         # Find all files matching the pattern
         files = glob.glob(glob_pattern)
-        
+
         if not files:
             logger.warning(f"No files found matching pattern: {glob_pattern}")
             return 0
-        
+
         # Log settings used
         logger.info(f"Processing files with pattern: {glob_pattern}")
         logger.info(f"Batch size: {batch_size}")
-        
+
         total_chunks = 0
         for i, file_path in enumerate(files):
             logger.info(f"Processing file {i+1}/{len(files)}: {file_path}")
             try:
                 chunks_processed = self.process_chunked_file(file_path)
                 total_chunks += chunks_processed
-                
+
                 # Process in batches to avoid overloading the system
                 if batch_size > 0 and (i + 1) % batch_size == 0 and i < len(files) - 1:
-                    logger.info(f"Completed batch of {batch_size} files. Taking a short break...")
+                    logger.info(
+                        f"Completed batch of {batch_size} files. Taking a short break..."
+                    )
                     time.sleep(2)  # Brief pause between batches
-            
+
             except Exception as e:
                 logger.error(f"Error processing file {file_path}: {e}")
-        
-        logger.info(f"Completed processing {total_chunks} total chunks from {len(files)} files")
+
+        logger.info(
+            f"Completed processing {total_chunks} total chunks from {len(files)} files"
+        )
         return total_chunks
-    
+
     def process_chunked_file(self, file_path: str) -> int:
         """
         Process a file containing chunked narrative text.
-        
+
         Args:
             file_path: Path to the file to process
-            
+
         Returns:
             Number of chunks processed
         """
@@ -110,27 +119,29 @@ class ContentProcessor:
         except Exception as e:
             logger.error(f"Error reading file {file_path}: {e}")
             raise
-        
+
         # Get regex pattern for chunk separation
-        chunk_regex = self.settings.get("import", {}).get("chunk_regex", r"<!--\s*SCENE BREAK:\s*(S(\d+)E(\d+))_(\d+).*-->")
-        
+        chunk_regex = self.settings.get("import", {}).get(
+            "chunk_regex", r"<!--\s*SCENE BREAK:\s*(S(\d+)E(\d+))_(\d+).*-->"
+        )
+
         # Compile the pattern
         pattern = re.compile(chunk_regex)
-        
+
         # Split by chunk markers
         chunks = []
         current_chunk = ""
-        
+
         # Metadata tracking
         current_metadata = {
             "season": None,
             "episode": None,
             "scene": None,
         }
-        
+
         # Map to track chunk IDs by their unique scene identifier
         chunk_id_map = {}
-        
+
         # Process line by line
         lines = file_content.split("\n")
         for line in lines:
@@ -139,42 +150,46 @@ class ContentProcessor:
             if match:
                 # Store previous chunk if it exists
                 if current_chunk.strip():
-                    chunks.append({
-                        "text": current_chunk.strip(),
-                        "metadata": current_metadata.copy()
-                    })
-                
+                    chunks.append(
+                        {
+                            "text": current_chunk.strip(),
+                            "metadata": current_metadata.copy(),
+                        }
+                    )
+
                 # Start new chunk
                 current_chunk = ""
-                
+
                 # Update metadata
                 scene_id = match.group(1)
                 current_metadata = {
                     "season": int(match.group(2)),
                     "episode": int(match.group(3)),
                     "scene": int(match.group(4)),
-                    "scene_id": scene_id
+                    "scene_id": scene_id,
                 }
-                
+
                 # Parse any additional metadata in the comment
                 # Formatted like: <!-- SCENE BREAK: S01E01_1 PERSPECTIVE:Alex LOCATION:"Night City Alley" -->
-                metadata_text = line.split("SCENE BREAK:")[1] if "SCENE BREAK:" in line else ""
-                
+                metadata_text = (
+                    line.split("SCENE BREAK:")[1] if "SCENE BREAK:" in line else ""
+                )
+
                 # Parse perspective
                 perspective_match = re.search(r"PERSPECTIVE:(\w+)", metadata_text)
                 if perspective_match:
                     current_metadata["perspective"] = perspective_match.group(1)
-                
+
                 # Parse location
                 location_match = re.search(r'LOCATION:"([^"]+)"', metadata_text)
                 if location_match:
                     current_metadata["location"] = location_match.group(1)
-                
+
                 # Parse timecode
                 time_match = re.search(r'TIME:"([^"]+)"', metadata_text)
                 if time_match:
                     current_metadata["time_code"] = time_match.group(1)
-                
+
                 # Look for world layer marker
                 world_layer_match = re.search(r'LAYER:"([^"]+)"', metadata_text)
                 if world_layer_match:
@@ -182,96 +197,101 @@ class ContentProcessor:
             else:
                 # Not a marker, append to current chunk
                 current_chunk += line + "\n"
-        
+
         # Store last chunk if it exists
         if current_chunk.strip():
-            chunks.append({
-                "text": current_chunk.strip(),
-                "metadata": current_metadata.copy()
-            })
-        
+            chunks.append(
+                {"text": current_chunk.strip(), "metadata": current_metadata.copy()}
+            )
+
         logger.info(f"Found {len(chunks)} chunks in file {file_path}")
-        
+
         # Process chunks
         processed_count = 0
         for chunk in chunks:
             try:
                 # Process chunk
                 chunk_id = self.store_narrative_chunk(chunk["text"], chunk["metadata"])
-                
+
                 # Update tracking map
                 if "scene_id" in chunk["metadata"]:
                     scene_id = chunk["metadata"]["scene_id"]
                     chunk_id_map[scene_id] = chunk_id
-                
+
                 processed_count += 1
             except Exception as e:
                 logger.error(f"Error processing chunk: {e}")
-        
+
         logger.info(f"Processed {processed_count} chunks from file {file_path}")
         return processed_count
-    
+
     def store_narrative_chunk(self, text: str, metadata: Dict[str, Any]) -> int:
         """
         Store a narrative chunk in the database and generate embeddings.
-        
+
         Args:
             text: The chunk text
             metadata: Metadata dictionary with season, episode, etc.
-            
+
         Returns:
             The ID of the stored chunk
         """
         try:
             # Extract characters mentioned in the text
             character_mentions = self._extract_character_mentions(text)
-            
+
             # Extract keywords
             keywords = self._extract_keywords(text)
-            
+
             # Create session
             session = self.db_manager.create_session()
-            
+
             try:
                 # Start transaction
                 with session.begin():
                     # Check if chunk already exists with this scene ID
                     if "scene_id" in metadata:
                         scene_id = metadata["scene_id"]
-                        existing_id_query = text("""
+                        existing_id_query = text(
+                            """
                         SELECT nc.id 
                         FROM narrative_chunks nc
                         JOIN chunk_metadata cm ON nc.id = cm.chunk_id
                         WHERE cm.season = :season AND cm.episode = :episode AND cm.scene = :scene
-                        """)
-                        
+                        """
+                        )
+
                         result = session.execute(
                             existing_id_query,
                             {
                                 "season": metadata["season"],
                                 "episode": metadata["episode"],
-                                "scene": metadata["scene"]
-                            }
+                                "scene": metadata["scene"],
+                            },
                         )
-                        
+
                         existing_id = result.scalar()
                         if existing_id:
-                            logger.info(f"Chunk already exists with ID {existing_id}, updating")
-                            
+                            logger.info(
+                                f"Chunk already exists with ID {existing_id}, updating"
+                            )
+
                             # Update the chunk
-                            chunk_update = text("""
+                            chunk_update = text(
+                                """
                             UPDATE narrative_chunks
                             SET raw_text = :text
                             WHERE id = :id
-                            """)
-                            
-                            session.execute(
-                                chunk_update,
-                                {"text": text, "id": existing_id}
+                            """
                             )
-                            
+
+                            session.execute(
+                                chunk_update, {"text": text, "id": existing_id}
+                            )
+
                             # Update metadata
-                            metadata_update = text("""
+                            metadata_update = text(
+                                """
                             UPDATE chunk_metadata
                             SET perspective = :perspective,
                                 location = :location,
@@ -280,8 +300,9 @@ class ContentProcessor:
                                 keywords = :keywords,
                                 characters = :characters
                             WHERE chunk_id = :id
-                            """)
-                            
+                            """
+                            )
+
                             session.execute(
                                 metadata_update,
                                 {
@@ -291,32 +312,36 @@ class ContentProcessor:
                                     "time_code": metadata.get("time_code"),
                                     "world_layer": metadata.get("world_layer"),
                                     "keywords": keywords,
-                                    "characters": character_mentions
-                                }
+                                    "characters": character_mentions,
+                                },
                             )
-                            
+
                             # Generate embeddings for this chunk
                             self._generate_chunk_embeddings(session, existing_id, text)
-                            
+
                             return existing_id
-                    
+
                     # Create new chunk
                     # First, insert the chunk
                     result = session.execute(
-                        text("INSERT INTO narrative_chunks (raw_text) VALUES (:text) RETURNING id"),
-                        {"text": text}
+                        text(
+                            "INSERT INTO narrative_chunks (raw_text) VALUES (:text) RETURNING id"
+                        ),
+                        {"text": text},
                     )
                     chunk_id = result.scalar()
-                    
+
                     # Then insert metadata
-                    metadata_insert = text("""
+                    metadata_insert = text(
+                        """
                     INSERT INTO chunk_metadata (
                         chunk_id, season, episode, scene, perspective, location, time_code, world_layer, keywords, characters
                     ) VALUES (
                         :chunk_id, :season, :episode, :scene, :perspective, :location, :time_code, :world_layer, :keywords, :characters
                     )
-                    """)
-                    
+                    """
+                    )
+
                     session.execute(
                         metadata_insert,
                         {
@@ -329,30 +354,31 @@ class ContentProcessor:
                             "time_code": metadata.get("time_code"),
                             "world_layer": metadata.get("world_layer"),
                             "keywords": keywords,
-                            "characters": character_mentions
-                        }
+                            "characters": character_mentions,
+                        },
                     )
-                    
+
                     # Generate embeddings for this chunk
                     self._generate_chunk_embeddings(session, chunk_id, text)
-                    
+
                 # Transaction is automatically committed if no exceptions occurred
                 logger.debug(f"Stored chunk {chunk_id} with metadata: {metadata}")
                 return chunk_id
             finally:
                 session.close()
-                
+
         except Exception as e:
             logger.error(f"Error storing narrative chunk: {e}")
             import traceback
+
             logger.error(traceback.format_exc())
             raise
-    
+
     def _generate_chunk_embeddings(self, session, chunk_id: int, text: str):
         """
         Generate embeddings for a chunk using all active models.
         Stores embeddings in dimension-specific tables with proper vector types.
-        
+
         Args:
             session: The active database session
             chunk_id: The ID of the chunk
@@ -363,126 +389,123 @@ class ContentProcessor:
             try:
                 # Generate embedding using embedding manager
                 embedding = self.embedding_manager.generate_embedding(text, model_name)
-                
+
                 if embedding is None:
-                    logger.warning(f"Embedding generation failed for model {model_name}, skipping")
+                    logger.warning(
+                        f"Embedding generation failed for model {model_name}, skipping"
+                    )
                     continue
-                    
+
                 # Get embedding dimensions
                 dim = len(embedding)
                 logger.debug(f"Model {model_name} generated {dim}D embedding")
-                
+
                 # Format embedding as string for vector type
                 embedding_str = f"[{','.join(str(x) for x in embedding)}]"
-                
+
                 # Determine which table to use based on dimensions
                 table_name = resolve_dimension_table(dim)
-                if not table_name:
-                    # No specific table exists for this dimension, log error
-                    logger.error(f"No dimension-specific table for {dim}D vectors. Cannot store embedding.")
-                    continue
-                
+                ensure_embedding_table(session.connection(), dim)
+
                 # Use dimension-specific table with proper vector type
-                logger.debug(f"Using dimension-specific table {table_name} for {model_name}")
-                
-                # Check if embedding already exists in dimension table
-                existing_query = text(f"""
-                SELECT id FROM {table_name}
-                WHERE chunk_id = :chunk_id AND model = :model
-                """)
-                
-                result = session.execute(
-                    existing_query,
-                    {"chunk_id": chunk_id, "model": model_name}
+                logger.debug(
+                    f"Using dimension-specific table {table_name} for {model_name}"
                 )
-                
-                existing_id = result.scalar()
-                
-                if existing_id:
-                    # Update existing embedding with proper vector cast
-                    embedding_update = text(f"""
-                    UPDATE {table_name}
-                    SET embedding = :embedding::vector({dim})
-                    WHERE id = :id
-                    """)
-                    
-                    session.execute(
-                        embedding_update,
-                        {"id": existing_id, "embedding": embedding_str}
-                    )
-                else:
-                    # Insert new embedding with proper vector cast
-                    embedding_insert = text(f"""
-                    INSERT INTO {table_name} (chunk_id, model, embedding)
-                    VALUES (:chunk_id, :model, :embedding::vector({dim}))
-                    """)
-                    
-                    session.execute(
-                        embedding_insert,
-                        {
-                            "chunk_id": chunk_id,
-                            "model": model_name,
-                            "embedding": embedding_str
-                        }
-                    )
-                
+
+                embedding_upsert = text(
+                    f"""
+                INSERT INTO {table_name} (chunk_id, model, embedding, created_at)
+                VALUES (:chunk_id, :model, (:embedding)::vector({dim}), NOW())
+                ON CONFLICT (chunk_id, model) DO UPDATE
+                SET embedding = EXCLUDED.embedding,
+                    created_at = EXCLUDED.created_at
+                """
+                )
+
+                session.execute(
+                    embedding_upsert,
+                    {
+                        "chunk_id": chunk_id,
+                        "model": model_name,
+                        "embedding": embedding_str,
+                    },
+                )
+
                 logger.debug(f"Generated {model_name} embedding for chunk {chunk_id}")
-                
+
             except Exception as e:
-                logger.error(f"Error generating {model_name} embedding for chunk {chunk_id}: {e}")
+                logger.error(
+                    f"Error generating {model_name} embedding for chunk {chunk_id}: {e}"
+                )
                 import traceback
+
                 logger.error(traceback.format_exc())
-    
+
     def _extract_character_mentions(self, text: str) -> List[str]:
         """
         Extract character mentions from text.
-        
+
         Args:
             text: The text to analyze
-            
+
         Returns:
             List of character names mentioned
         """
         # Load aliases if needed
         if self._character_aliases is None and self.load_aliases_func:
             self._character_aliases = self.load_aliases_func()
-        
+
         # Default empty aliases dictionary if loading failed
         if not self._character_aliases:
             self._character_aliases = {}
-        
+
         character_mentions = []
-        
+
         # Check all possible character names
         for canonical_name, aliases in self._character_aliases.items():
             for alias in aliases:
-                if re.search(r'\b' + re.escape(alias) + r'\b', text, re.IGNORECASE):
+                if re.search(r"\b" + re.escape(alias) + r"\b", text, re.IGNORECASE):
                     if canonical_name not in character_mentions:
                         character_mentions.append(canonical_name)
-        
+
         return character_mentions
-    
+
     def _extract_keywords(self, text: str) -> List[str]:
         """
         Extract keywords from text.
-        
+
         Args:
             text: The text to analyze
-            
+
         Returns:
             List of keywords
         """
         keywords = []
-        
+
         # Common themes and elements
         theme_terms = [
-            "neural implant", "cybernetics", "augmentation", "corporation", "conspiracy",
-            "memory", "identity", "consciousness", "AI", "network", "virtual", "hack",
-            "combat", "mission", "operation", "corporate", "virus", "encryption"
+            "neural implant",
+            "cybernetics",
+            "augmentation",
+            "corporation",
+            "conspiracy",
+            "memory",
+            "identity",
+            "consciousness",
+            "AI",
+            "network",
+            "virtual",
+            "hack",
+            "combat",
+            "mission",
+            "operation",
+            "corporate",
+            "virus",
+            "encryption",
         ]
-        
+
         for term in theme_terms:
-            if re.search(r'\b' + re.escape(term) + r'\b', text, re.IGNORECASE):
+            if re.search(r"\b" + re.escape(term) + r"\b", text, re.IGNORECASE):
                 keywords.append(term.lower())
-        
-        return keywords 
+
+        return keywords

--- a/nexus/agents/memnon/utils/db_access.py
+++ b/nexus/agents/memnon/utils/db_access.py
@@ -8,21 +8,52 @@ and hybrid search capabilities with PostgreSQL.
 import logging
 import json
 import psycopg2
-from typing import Dict, List, Tuple, Optional, Union, Any, Set
+from typing import Dict, List, Tuple, Optional, Union, Any
 from urllib.parse import urlparse
 
-from .embedding_tables import DIMENSION_TABLES, resolve_dimension_table
+from .embedding_tables import resolve_dimension_table
 
 # Set up logging
 logger = logging.getLogger("nexus.memnon.db_access")
 
+
+def _embedding_table_exists(cursor, table_name: str) -> bool:
+    """Return whether an embedding table exists without creating it."""
+    cursor.execute(
+        """
+        SELECT EXISTS (
+            SELECT FROM information_schema.tables
+            WHERE table_schema = 'public'
+              AND table_name = %s
+        )
+        """,
+        (table_name,),
+    )
+    return bool(cursor.fetchone()[0])
+
+
+def _list_existing_embedding_tables(cursor) -> List[str]:
+    """List existing dimension-specific embedding tables."""
+    cursor.execute(
+        """
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_type = 'BASE TABLE'
+          AND table_name ~ '^chunk_embeddings_[0-9]+d$'
+        ORDER BY table_name
+        """
+    )
+    return [row[0] for row in cursor.fetchall()]
+
+
 def check_vector_extension(db_url: str) -> bool:
     """
     Check if the pgvector extension is installed and available.
-    
+
     Args:
         db_url: PostgreSQL database URL
-        
+
     Returns:
         Boolean indicating if pgvector is available
     """
@@ -34,50 +65,58 @@ def check_vector_extension(db_url: str) -> bool:
         database = parsed_url.path[1:]  # Remove leading slash
         hostname = parsed_url.hostname
         port = parsed_url.port or 5432
-        
+
         # Connect to the database
         conn = psycopg2.connect(
             host=hostname,
             port=port,
             user=username,
             password=password,
-            database=database
+            database=database,
         )
-        
+
         with conn.cursor() as cursor:
             # Check if vector extension exists
             cursor.execute("SELECT extname FROM pg_extension WHERE extname = 'vector'")
             result = cursor.fetchone()
-            
+
             if result:
                 # Get extension version
-                cursor.execute("SELECT extversion FROM pg_extension WHERE extname = 'vector'")
+                cursor.execute(
+                    "SELECT extversion FROM pg_extension WHERE extname = 'vector'"
+                )
                 version = cursor.fetchone()[0]
                 logger.info(f"pgvector extension found (version {version})")
                 return True
             else:
                 logger.warning("pgvector extension not found")
                 return False
-                
+
     except Exception as e:
         logger.error(f"Error checking pgvector extension: {e}")
         return False
     finally:
-        if 'conn' in locals():
+        if "conn" in locals():
             conn.close()
 
-def execute_vector_search(db_url: str, query_embedding: list, model_key: str, 
-                         filters: Dict[str, Any] = None, top_k: int = 10) -> List[Dict[str, Any]]:
+
+def execute_vector_search(
+    db_url: str,
+    query_embedding: list,
+    model_key: str,
+    filters: Dict[str, Any] = None,
+    top_k: int = 10,
+) -> List[Dict[str, Any]]:
     """
     Execute a vector similarity search against the database using dimension-specific tables.
-    
+
     Args:
         db_url: PostgreSQL database URL
         query_embedding: Vector embedding for the query
         model_key: The embedding model key
         filters: Optional metadata filters
         top_k: Maximum number of results to return
-        
+
     Returns:
         List of matching chunks with scores and metadata
     """
@@ -89,48 +128,55 @@ def execute_vector_search(db_url: str, query_embedding: list, model_key: str,
         database = parsed_url.path[1:]  # Remove leading slash
         hostname = parsed_url.hostname
         port = parsed_url.port or 5432
-        
+
         # Connect to the database
         conn = psycopg2.connect(
             host=hostname,
             port=port,
             user=username,
             password=password,
-            database=database
+            database=database,
         )
-        
+
         results = {}
-        
+
         try:
             with conn.cursor() as cursor:
                 # Build filter conditions
                 filter_conditions = []
                 if filters:
-                    if 'season' in filters:
+                    if "season" in filters:
                         filter_conditions.append(f"cm.season = {filters['season']}")
-                    if 'episode' in filters:
+                    if "episode" in filters:
                         filter_conditions.append(f"cm.episode = {filters['episode']}")
-                    if 'world_layer' in filters:
-                        filter_conditions.append(f"cm.world_layer = '{filters['world_layer']}'")
-                
+                    if "world_layer" in filters:
+                        filter_conditions.append(
+                            f"cm.world_layer = '{filters['world_layer']}'"
+                        )
+
                 filter_sql = " AND ".join(filter_conditions)
                 if filter_sql:
                     filter_sql = " AND " + filter_sql
-                
+
                 # Get dimensions of the query embedding to determine which table to use
                 dimensions = len(query_embedding)
-                
+
                 # Map dimensions to table names
                 table_name = resolve_dimension_table(dimensions)
-                if not table_name:
-                    logger.error(f"No dimension-specific table for {dimensions}D vectors")
+                if not _embedding_table_exists(cursor, table_name):
+                    logger.warning(
+                        "Embedding table %s does not exist; vector search has no rows",
+                        table_name,
+                    )
                     return []
-                
-                logger.info(f"Using {table_name} for vector search with {dimensions}D embeddings")
-                
+
+                logger.info(
+                    f"Using {table_name} for vector search with {dimensions}D embeddings"
+                )
+
                 # Build embedding array as a string - pgvector expects [x,y,z] format
-                embedding_str = '[' + ','.join(str(x) for x in query_embedding) + ']'
-                
+                embedding_str = "[" + ",".join(str(x) for x in query_embedding) + "]"
+
                 # Use proper vector similarity search with the <=> operator
                 # This works now that we're using the correct vector type tables
                 sql = f"""
@@ -158,47 +204,59 @@ def execute_vector_search(db_url: str, query_embedding: list, model_key: str,
                 LIMIT 
                     %s
                 """
-                
+
                 # Execute the query with vector similarity search
                 cursor.execute(sql, (embedding_str, model_key, top_k))
                 query_results = cursor.fetchall()
-                
+
                 # Process results
                 for result in query_results:
-                    chunk_id, raw_text, season, episode, scene_number, world_time, score = result
+                    (
+                        chunk_id,
+                        raw_text,
+                        season,
+                        episode,
+                        scene_number,
+                        world_time,
+                        score,
+                    ) = result
                     chunk_id = str(chunk_id)
-                    
+
                     if chunk_id not in results:
                         results[chunk_id] = {
-                            'id': chunk_id,
-                            'chunk_id': chunk_id,
-                            'text': raw_text,
-                            'content_type': 'narrative',
-                            'metadata': {
-                                'season': season,
-                                'episode': episode,
-                                'scene_number': scene_number,
-                                'world_time': world_time
+                            "id": chunk_id,
+                            "chunk_id": chunk_id,
+                            "text": raw_text,
+                            "content_type": "narrative",
+                            "metadata": {
+                                "season": season,
+                                "episode": episode,
+                                "scene_number": scene_number,
+                                "world_time": world_time,
                             },
-                            'model_scores': {},
-                            'score': float(score) if score is not None else 0.0,
-                            'source': 'vector_search'
+                            "model_scores": {},
+                            "score": float(score) if score is not None else 0.0,
+                            "source": "vector_search",
                         }
-                    
+
                     # Store score from this model
-                    results[chunk_id]['model_scores'][model_key] = float(score) if score is not None else 0.0
-                
+                    results[chunk_id]["model_scores"][model_key] = (
+                        float(score) if score is not None else 0.0
+                    )
+
         finally:
             conn.close()
-        
+
         # Return as list of values
         return list(results.values())
-    
+
     except Exception as e:
         logger.error(f"Error in vector search: {e}")
         import traceback
+
         logger.error(traceback.format_exc())
         return []
+
 
 def prepare_tsquery(query_text: str) -> str:
     """
@@ -206,29 +264,52 @@ def prepare_tsquery(query_text: str) -> str:
     - Escapes single quotes
     - Handles special operators
     - Creates a proper tsquery expression
-    
+
     Args:
         query_text: Original query text
-        
+
     Returns:
         Properly escaped and formatted tsquery expression
     """
     # Remove any existing quotes that might cause problems
     query_text = query_text.replace("'", " ")
-    
-    # Split by spaces and filter out stopwords
-    stopwords = ['a', 'an', 'the', 'in', 'on', 'at', 'to', 'for', 'with', 'by', 'of', 'and', 'or']
-    query_words = [word for word in query_text.lower().split() if word not in stopwords]
-    
-    # Join with OR operator
-    return ' | '.join(query_words)
 
-def execute_hybrid_search(db_url: str, query_text: str, query_embedding: list, 
-                         model_key: str, vector_weight: float = 0.6, text_weight: float = 0.4, 
-                         filters: Dict[str, Any] = None, top_k: int = 10, idf_dict = None) -> List[Dict[str, Any]]:
+    # Split by spaces and filter out stopwords
+    stopwords = [
+        "a",
+        "an",
+        "the",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "with",
+        "by",
+        "of",
+        "and",
+        "or",
+    ]
+    query_words = [word for word in query_text.lower().split() if word not in stopwords]
+
+    # Join with OR operator
+    return " | ".join(query_words)
+
+
+def execute_hybrid_search(
+    db_url: str,
+    query_text: str,
+    query_embedding: list,
+    model_key: str,
+    vector_weight: float = 0.6,
+    text_weight: float = 0.4,
+    filters: Dict[str, Any] = None,
+    top_k: int = 10,
+    idf_dict=None,
+) -> List[Dict[str, Any]]:
     """
     Execute a hybrid search combining vector similarity and text search.
-    
+
     Args:
         db_url: PostgreSQL database URL
         query_text: The text query for keyword search
@@ -239,7 +320,7 @@ def execute_hybrid_search(db_url: str, query_text: str, query_embedding: list,
         filters: Optional metadata filters
         top_k: Maximum number of results to return
         idf_dict: Optional IDF dictionary for term weighting
-        
+
     Returns:
         List of matching chunks with scores and metadata
     """
@@ -251,64 +332,72 @@ def execute_hybrid_search(db_url: str, query_text: str, query_embedding: list,
         database = parsed_url.path[1:]  # Remove leading slash
         hostname = parsed_url.hostname
         port = parsed_url.port or 5432
-        
+
         # Validate weights
         if vector_weight + text_weight != 1.0:
-            logger.warning(f"Vector weight ({vector_weight}) + text weight ({text_weight}) != 1.0. Normalizing.")
+            logger.warning(
+                f"Vector weight ({vector_weight}) + text weight ({text_weight}) != 1.0. Normalizing."
+            )
             total = vector_weight + text_weight
             vector_weight = vector_weight / total
             text_weight = text_weight / total
-        
-        logger.debug(f"Hybrid search weights: vector={vector_weight}, text={text_weight}")
-        
+
+        logger.debug(
+            f"Hybrid search weights: vector={vector_weight}, text={text_weight}"
+        )
+
         # Connect to the database
         conn = psycopg2.connect(
             host=hostname,
             port=port,
             user=username,
             password=password,
-            database=database
+            database=database,
         )
-        
+
         results = []
-        
+
         try:
             with conn.cursor() as cursor:
                 # Build filter conditions
                 filter_conditions = []
                 if filters:
-                    if 'season' in filters:
+                    if "season" in filters:
                         filter_conditions.append(f"cm.season = {filters['season']}")
-                    if 'episode' in filters:
+                    if "episode" in filters:
                         filter_conditions.append(f"cm.episode = {filters['episode']}")
-                    if 'world_layer' in filters:
-                        filter_conditions.append(f"cm.world_layer = '{filters['world_layer']}'")
-                
+                    if "world_layer" in filters:
+                        filter_conditions.append(
+                            f"cm.world_layer = '{filters['world_layer']}'"
+                        )
+
                 filter_sql = " AND ".join(filter_conditions)
                 if filter_sql:
                     filter_sql = " AND " + filter_sql
-                
+
                 # Check if vector extension is installed
                 cursor.execute("SELECT 1 FROM pg_extension WHERE extname = 'vector'")
                 has_vector_extension = cursor.fetchone() is not None
-                
+
                 if not has_vector_extension:
-                    logger.error("Vector extension not installed. Install pgvector first.")
+                    logger.error(
+                        "Vector extension not installed. Install pgvector first."
+                    )
                     return []
-                
+
                 # Check if tsvector functionality is available for text search
                 cursor.execute("SELECT 1 FROM pg_proc WHERE proname = 'to_tsvector'")
                 has_text_search = cursor.fetchone() is not None
-                
+
                 if not has_text_search:
                     logger.error("Text search functionality not available.")
                     return []
-                
+
                 # When building the text search SQL query, use weighted query if IDF is available
-                if idf_dict and hasattr(idf_dict, 'generate_weighted_query'):
+                if idf_dict and hasattr(idf_dict, "generate_weighted_query"):
                     weighted_query = idf_dict.generate_weighted_query(query_text)
                     logger.debug(f"Using weighted query: {weighted_query}")
-                    
+
                     text_search_sql = f"""
                     SELECT 
                         nc.id, 
@@ -332,20 +421,23 @@ def execute_hybrid_search(db_url: str, query_text: str, query_embedding: list,
                         text_score DESC
                     LIMIT %s
                     """
-                    
+
                     # Use weighted query for both parameters
-                    cursor.execute(text_search_sql, (
-                        weighted_query, 
-                        weighted_query, 
-                        top_k * 2  # Double for text search
-                    ))
+                    cursor.execute(
+                        text_search_sql,
+                        (
+                            weighted_query,
+                            weighted_query,
+                            top_k * 2,  # Double for text search
+                        ),
+                    )
                 else:
                     # Use our new prepare_tsquery function to safely process the query
                     ts_query = prepare_tsquery(query_text)
-                    
+
                     # Log the processed query with OR operators
                     logger.info(f"Text search using OR-based query: '{ts_query}'")
-                    
+
                     text_search_sql = f"""
                     SELECT 
                         nc.id, 
@@ -369,68 +461,89 @@ def execute_hybrid_search(db_url: str, query_text: str, query_embedding: list,
                         text_score DESC
                     LIMIT %s
                     """
-                    
+
                     # Execute text search
-                    cursor.execute(text_search_sql, (
-                        ts_query,  # Use the processed query with OR operators 
-                        ts_query,  # Use the processed query with OR operators
-                        top_k * 2  # Double for text search
-                    ))
-                
+                    cursor.execute(
+                        text_search_sql,
+                        (
+                            ts_query,  # Use the processed query with OR operators
+                            ts_query,  # Use the processed query with OR operators
+                            top_k * 2,  # Double for text search
+                        ),
+                    )
+
                 text_results = {}
                 all_text_scores = []
-                
+
                 # First pass: collect all text scores to find max for normalization
                 for result in cursor.fetchall():
-                    chunk_id, raw_text, season, episode, scene_number, world_time, text_score = result
+                    (
+                        chunk_id,
+                        raw_text,
+                        season,
+                        episode,
+                        scene_number,
+                        world_time,
+                        text_score,
+                    ) = result
                     text_score = float(text_score)
                     all_text_scores.append(text_score)
                     chunk_id = str(chunk_id)
                     text_results[chunk_id] = {
-                        'id': chunk_id,
-                        'text': raw_text,
-                        'metadata': {
-                            'season': season,
-                            'episode': episode,
-                            'scene_number': scene_number,
-                            'world_time': world_time
+                        "id": chunk_id,
+                        "text": raw_text,
+                        "metadata": {
+                            "season": season,
+                            "episode": episode,
+                            "scene_number": scene_number,
+                            "world_time": world_time,
                         },
-                        'raw_text_score': text_score,  # Keep raw score temporarily
-                        'vector_score': 0.0  # Default until we get vector scores
+                        "raw_text_score": text_score,  # Keep raw score temporarily
+                        "vector_score": 0.0,  # Default until we get vector scores
                     }
-                
+
                 # Find max text score for normalization (if any results)
                 max_text_score = max(all_text_scores) if all_text_scores else 1.0
                 logger.info(f"Normalizing text scores with max value: {max_text_score}")
-                
+
                 # Second pass: normalize text scores to 0-1 range
                 for chunk_id, result in text_results.items():
                     # Normalize to 0-1 range
-                    normalized_text_score = result['raw_text_score'] / max_text_score if max_text_score > 0 else 0.0
-                    result['text_score'] = normalized_text_score
+                    normalized_text_score = (
+                        result["raw_text_score"] / max_text_score
+                        if max_text_score > 0
+                        else 0.0
+                    )
+                    result["text_score"] = normalized_text_score
                     # Remove temporary raw score
-                    del result['raw_text_score']
-                
-                logger.info(f"Text search found {len(text_results)} results with non-zero scores")
-                
+                    del result["raw_text_score"]
+
+                logger.info(
+                    f"Text search found {len(text_results)} results with non-zero scores"
+                )
+
                 # Next, run proper vector search with dimension-specific tables
                 logger.info("Executing vector search portion of hybrid search")
-                
+
                 # Get dimensions of the query embedding to determine which table to use
                 dimensions = len(query_embedding)
-                
+
                 # Map dimensions to table names
                 table_name = resolve_dimension_table(dimensions)
-                if not table_name:
-                    logger.error(f"No dimension-specific table for {dimensions}D vectors")
-                    # Continue with text search only results
+                if not _embedding_table_exists(cursor, table_name):
+                    logger.warning(
+                        "Embedding table %s does not exist; returning text search only",
+                        table_name,
+                    )
                     return [text_results[id] for id in text_results]
-                
-                logger.info(f"Using {table_name} for vector portion of hybrid search with {dimensions}D embeddings")
-                
+
+                logger.info(
+                    f"Using {table_name} for vector portion of hybrid search with {dimensions}D embeddings"
+                )
+
                 # Build embedding array as a string - pgvector expects [x,y,z] format
-                embedding_str = '[' + ','.join(str(x) for x in query_embedding) + ']'
-                
+                embedding_str = "[" + ",".join(str(x) for x in query_embedding) + "]"
+
                 # Use proper vector search with cosine similarity
                 vector_sql = f"""
                 SELECT 
@@ -449,23 +562,24 @@ def execute_hybrid_search(db_url: str, query_text: str, query_embedding: list,
                     vector_score DESC
                 LIMIT %s
                 """
-                
+
                 logger.debug(f"Vector search SQL: {vector_sql}")
-                
+
                 # Execute proper vector search
                 cursor.execute(vector_sql, (embedding_str, model_key, top_k * 2))
-                
+
                 # Process vector results
                 for result in cursor.fetchall():
                     chunk_id, vector_score = result
                     chunk_id = str(chunk_id)
-                    
+
                     if chunk_id in text_results:
                         # If already in text results, update vector score
-                        text_results[chunk_id]['vector_score'] = float(vector_score)
+                        text_results[chunk_id]["vector_score"] = float(vector_score)
                     else:
                         # Get the full details for this chunk
-                        cursor.execute(f"""
+                        cursor.execute(
+                            f"""
                         SELECT 
                             nc.raw_text, 
                             cm.season, 
@@ -477,113 +591,147 @@ def execute_hybrid_search(db_url: str, query_text: str, query_embedding: list,
                             chunk_metadata cm ON nc.id = cm.chunk_id
                         WHERE 
                             nc.id = %s
-                        """, (chunk_id,))
-                        
+                        """,
+                            (chunk_id,),
+                        )
+
                         # There should be exactly one result
                         details = cursor.fetchone()
                         if details:
                             raw_text, season, episode, scene_number = details
-                            
+
                             # Calculate a proper text score for this document
                             # Use the same ts_query we prepared for text search
-                            if idf_dict and hasattr(idf_dict, 'generate_weighted_query'):
+                            if idf_dict and hasattr(
+                                idf_dict, "generate_weighted_query"
+                            ):
                                 # Use the weighted query for better scoring
-                                weighted_query = idf_dict.generate_weighted_query(query_text)
-                                cursor.execute("""
+                                weighted_query = idf_dict.generate_weighted_query(
+                                    query_text
+                                )
+                                cursor.execute(
+                                    """
                                 SELECT ts_rank(to_tsvector('english', raw_text), 
                                         to_tsquery('english', %s)) AS text_score
                                 FROM narrative_chunks
                                 WHERE id = %s
-                                """, (weighted_query, chunk_id))
+                                """,
+                                    (weighted_query, chunk_id),
+                                )
                             else:
                                 # Use our prepared ts_query
                                 ts_query = prepare_tsquery(query_text)
-                                cursor.execute("""
+                                cursor.execute(
+                                    """
                                 SELECT ts_rank(to_tsvector('english', raw_text), 
                                         to_tsquery('english', %s)) AS text_score
                                 FROM narrative_chunks
                                 WHERE id = %s
-                                """, (ts_query, chunk_id))
-                            
+                                """,
+                                    (ts_query, chunk_id),
+                                )
+
                             calculated_text_score = cursor.fetchone()[0] or 0.0
-                            
+
                             # Normalize the calculated score using the same max_text_score
-                            normalized_text_score = calculated_text_score / max_text_score if max_text_score > 0 else 0.0
-                            
-                            logger.debug(f"Vector-only match {chunk_id} got calculated text_score: {normalized_text_score:.4f}")
-                            
+                            normalized_text_score = (
+                                calculated_text_score / max_text_score
+                                if max_text_score > 0
+                                else 0.0
+                            )
+
+                            logger.debug(
+                                f"Vector-only match {chunk_id} got calculated text_score: {normalized_text_score:.4f}"
+                            )
+
                             text_results[chunk_id] = {
-                                'id': chunk_id,
-                                'text': raw_text,
-                                'metadata': {
-                                    'season': season,
-                                    'episode': episode,
-                                    'scene_number': scene_number
+                                "id": chunk_id,
+                                "text": raw_text,
+                                "metadata": {
+                                    "season": season,
+                                    "episode": episode,
+                                    "scene_number": scene_number,
                                 },
-                                'text_score': float(normalized_text_score),
-                                'vector_score': float(vector_score)
+                                "text_score": float(normalized_text_score),
+                                "vector_score": float(vector_score),
                             }
-                
+
                 # Count how many were originally vector-only matches (before we calculated text scores)
-                low_text_score_count = sum(1 for result in text_results.values() if result.get('text_score', 0) < 0.01)
-                logger.info(f"Combined search found {len(text_results)} total results ({low_text_score_count} with very low text scores)")
-                
+                low_text_score_count = sum(
+                    1
+                    for result in text_results.values()
+                    if result.get("text_score", 0) < 0.01
+                )
+                logger.info(
+                    f"Combined search found {len(text_results)} total results ({low_text_score_count} with very low text scores)"
+                )
+
                 # Calculate combined scores
                 for chunk_id, result in text_results.items():
                     # Make sure vector_score and text_score exist and are proper floats
-                    if 'vector_score' not in result or result['vector_score'] is None:
+                    if "vector_score" not in result or result["vector_score"] is None:
                         # This is important - logging this as it's likely a key issue
-                        logger.warning(f"Missing vector_score for chunk {chunk_id} - using default 0.0")
-                        result['vector_score'] = 0.0
-                    
-                    if 'text_score' not in result or result['text_score'] is None:
-                        logger.warning(f"Missing text_score for chunk {chunk_id} - using default 0.0")
-                        result['text_score'] = 0.0
-                        
+                        logger.warning(
+                            f"Missing vector_score for chunk {chunk_id} - using default 0.0"
+                        )
+                        result["vector_score"] = 0.0
+
+                    if "text_score" not in result or result["text_score"] is None:
+                        logger.warning(
+                            f"Missing text_score for chunk {chunk_id} - using default 0.0"
+                        )
+                        result["text_score"] = 0.0
+
                     # Ensure they're floats
-                    vector_score = float(result['vector_score'])
-                    text_score = float(result['text_score'])
-                    
+                    vector_score = float(result["vector_score"])
+                    text_score = float(result["text_score"])
+
                     # Calculate weighted average
-                    combined_score = (vector_score * vector_weight) + (text_score * text_weight)
-                    
+                    combined_score = (vector_score * vector_weight) + (
+                        text_score * text_weight
+                    )
+
                     # Add to results list with explicit scores
-                    results.append({
-                        'id': chunk_id,
-                        'chunk_id': chunk_id,
-                        'text': result['text'],
-                        'content_type': 'narrative',
-                        'metadata': result['metadata'],
-                        'score': float(combined_score),
-                        'vector_score': vector_score,  # Explicitly using our converted value
-                        'text_score': text_score,      # Explicitly using our converted value
-                        'source': 'hybrid_search'
-                    })
-                
+                    results.append(
+                        {
+                            "id": chunk_id,
+                            "chunk_id": chunk_id,
+                            "text": result["text"],
+                            "content_type": "narrative",
+                            "metadata": result["metadata"],
+                            "score": float(combined_score),
+                            "vector_score": vector_score,  # Explicitly using our converted value
+                            "text_score": text_score,  # Explicitly using our converted value
+                            "source": "hybrid_search",
+                        }
+                    )
+
                 # Sort by combined score
-                results.sort(key=lambda x: x['score'], reverse=True)
-                
+                results.sort(key=lambda x: x["score"], reverse=True)
+
                 # Limit to top_k
                 results = results[:top_k]
-                
+
         finally:
             conn.close()
-        
+
         return results
-    
+
     except Exception as e:
         logger.error(f"Error in hybrid search: {e}")
         import traceback
+
         logger.error(traceback.format_exc())
         return []
+
 
 def setup_database_indexes(db_url: str) -> bool:
     """
     Set up necessary database indexes for efficient search.
-    
+
     Args:
         db_url: PostgreSQL database URL
-        
+
     Returns:
         Boolean indicating success
     """
@@ -595,24 +743,24 @@ def setup_database_indexes(db_url: str) -> bool:
         database = parsed_url.path[1:]  # Remove leading slash
         hostname = parsed_url.hostname
         port = parsed_url.port or 5432
-        
+
         # Connect to the database
         conn = psycopg2.connect(
             host=hostname,
             port=port,
             user=username,
             password=password,
-            database=database
+            database=database,
         )
-        
+
         conn.autocommit = True
-        
+
         try:
             with conn.cursor() as cursor:
                 # Check if vector extension is installed
                 cursor.execute("SELECT 1 FROM pg_extension WHERE extname = 'vector'")
                 has_vector_extension = cursor.fetchone() is not None
-                
+
                 if not has_vector_extension:
                     logger.info("Creating vector extension...")
                     try:
@@ -620,120 +768,134 @@ def setup_database_indexes(db_url: str) -> bool:
                         logger.info("Vector extension created successfully")
                     except Exception as e:
                         logger.error(f"Failed to create vector extension: {e}")
-                        logger.error("Please run scripts/install_pgvector_custom.sh first")
+                        logger.error(
+                            "Please run scripts/install_pgvector_custom.sh first"
+                        )
                         return False
-                
+
                 # Create GIN index for text search if it doesn't exist
                 logger.info("Creating GIN index for text search...")
-                cursor.execute("""
+                cursor.execute(
+                    """
                 CREATE INDEX IF NOT EXISTS narrative_chunks_text_idx 
                 ON narrative_chunks USING GIN (to_tsvector('english', raw_text))
-                """)
-                
-                # Create indexes on dimension-specific tables if they don't exist
-                existing_dimension_tables: Set[str] = set()
-                if DIMENSION_TABLES:
-                    cursor.execute(
-                        """
-                        SELECT table_name
-                        FROM information_schema.tables
-                        WHERE table_schema = 'public'
-                          AND table_name = ANY(%s::text[])
-                        """,
-                        (list(DIMENSION_TABLES),),
-                    )
-                    existing_dimension_tables = {row[0] for row in cursor.fetchall()}
+                """
+                )
 
-                for dim_table in sorted(existing_dimension_tables):
+                # Create indexes on existing dimension-specific tables only.
+                for dim_table in _list_existing_embedding_tables(cursor):
                     try:
                         logger.info(f"Creating model index on {dim_table}...")
-                        cursor.execute(f"""
+                        cursor.execute(
+                            f"""
                         CREATE INDEX IF NOT EXISTS {dim_table}_model_idx 
                         ON {dim_table} (model)
-                        """)
+                        """
+                        )
                     except Exception as e:
                         logger.warning(f"Error creating index on {dim_table}: {e}")
                         continue
-                
+
                 # Create vector indexes for dimension-specific tables
                 for dim_table in sorted(existing_dimension_tables):
                     try:
                         # Check if table exists
-                        cursor.execute(f"""
+                        cursor.execute(
+                            f"""
                         SELECT EXISTS (
                             SELECT FROM information_schema.tables 
                             WHERE table_name = '{dim_table}'
                         )
-                        """)
+                        """
+                        )
                         table_exists = cursor.fetchone()[0]
-                        
+
                         if not table_exists:
-                            logger.warning(f"Table {dim_table} does not exist, skipping index creation")
+                            logger.warning(
+                                f"Table {dim_table} does not exist, skipping index creation"
+                            )
                             continue
-                            
+
                         # Check for existing HNSW index
-                        cursor.execute(f"""
+                        cursor.execute(
+                            f"""
                         SELECT exists (
                             SELECT 1 FROM pg_indexes 
                             WHERE indexname = '{dim_table}_hnsw_idx'
                         )
-                        """)
+                        """
+                        )
                         has_hnsw_index = cursor.fetchone()[0]
-                        
+
                         if not has_hnsw_index:
                             logger.info(f"Creating HNSW index on {dim_table}...")
                             # Try to create an HNSW index with ivfflat fallback
                             try:
-                                cursor.execute(f"""
+                                cursor.execute(
+                                    f"""
                                 CREATE INDEX {dim_table}_hnsw_idx ON {dim_table} 
                                 USING hnsw (embedding vector_l2_ops) 
                                 WITH (m = 16, ef_construction = 64)
-                                """)
-                                logger.info(f"HNSW index created successfully for {dim_table}")
+                                """
+                                )
+                                logger.info(
+                                    f"HNSW index created successfully for {dim_table}"
+                                )
                             except Exception as e:
-                                logger.warning(f"Failed to create HNSW index for {dim_table}: {e}")
-                                logger.info(f"Trying to create IVFFlat index for {dim_table} as fallback...")
-                                
+                                logger.warning(
+                                    f"Failed to create HNSW index for {dim_table}: {e}"
+                                )
+                                logger.info(
+                                    f"Trying to create IVFFlat index for {dim_table} as fallback..."
+                                )
+
                                 try:
-                                    cursor.execute(f"""
+                                    cursor.execute(
+                                        f"""
                                     CREATE INDEX {dim_table}_ivfflat_idx ON {dim_table} 
                                     USING ivfflat (embedding vector_l2_ops) 
                                     WITH (lists = 100)
-                                    """)
-                                    logger.info(f"IVFFlat index created successfully for {dim_table}")
+                                    """
+                                    )
+                                    logger.info(
+                                        f"IVFFlat index created successfully for {dim_table}"
+                                    )
                                 except Exception as e2:
-                                    logger.error(f"Failed to create IVFFlat index for {dim_table}: {e2}")
+                                    logger.error(
+                                        f"Failed to create IVFFlat index for {dim_table}: {e2}"
+                                    )
                                     logger.info(f"Using default index for {dim_table}")
                         else:
                             logger.info(f"HNSW index already exists for {dim_table}")
                     except Exception as e:
                         logger.error(f"Error setting up indexes for {dim_table}: {e}")
                         continue
-                
+
                 logger.info("Database indexes setup completed")
                 return True
-                
+
         finally:
             conn.close()
-    
+
     except Exception as e:
         logger.error(f"Error setting up database indexes: {e}")
         return False
+
 
 def execute_multi_model_hybrid_search(
     db_url: str,
     query_text: str,
     query_embeddings: Dict[str, list],  # Dictionary of model_key -> embedding
-    model_weights: Dict[str, float],    # Dictionary of model_key -> weight
+    model_weights: Dict[str, float],  # Dictionary of model_key -> weight
     vector_weight: float = 0.6,
     text_weight: float = 0.4,
     filters: Dict[str, Any] = None,
     top_k: int = 10,
-    idf_dict = None
+    idf_dict=None,
 ) -> List[Dict[str, Any]]:
     """
     Execute a hybrid search using multiple embedding models simultaneously.
-    
+
     Args:
         db_url: PostgreSQL database URL
         query_text: The text query for keyword search
@@ -744,7 +906,7 @@ def execute_multi_model_hybrid_search(
         filters: Optional metadata filters
         top_k: Maximum number of results to return
         idf_dict: Optional IDF dictionary for term weighting
-        
+
     Returns:
         List of matching chunks with scores and metadata
     """
@@ -756,50 +918,58 @@ def execute_multi_model_hybrid_search(
         database = parsed_url.path[1:]  # Remove leading slash
         hostname = parsed_url.hostname
         port = parsed_url.port or 5432
-        
+
         # Validate weights
         if vector_weight + text_weight != 1.0:
-            logger.warning(f"Vector weight ({vector_weight}) + text weight ({text_weight}) != 1.0. Normalizing.")
+            logger.warning(
+                f"Vector weight ({vector_weight}) + text weight ({text_weight}) != 1.0. Normalizing."
+            )
             total = vector_weight + text_weight
             vector_weight = vector_weight / total
             text_weight = text_weight / total
-        
+
         # Ensure model weights are normalized
         total_weight = sum(model_weights.values())
         if total_weight != 1.0 and total_weight > 0:
             logger.warning(f"Model weights sum to {total_weight}, normalizing to 1.0")
-            model_weights = {model: weight/total_weight for model, weight in model_weights.items()}
-        
-        logger.debug(f"Multi-model hybrid search weights: vector={vector_weight}, text={text_weight}")
+            model_weights = {
+                model: weight / total_weight for model, weight in model_weights.items()
+            }
+
+        logger.debug(
+            f"Multi-model hybrid search weights: vector={vector_weight}, text={text_weight}"
+        )
         logger.debug(f"Model weights: {model_weights}")
-        
+
         # Connect to the database
         conn = psycopg2.connect(
             host=hostname,
             port=port,
             user=username,
             password=password,
-            database=database
+            database=database,
         )
-        
+
         results = {}  # Will hold all results by chunk_id
-        
+
         try:
             with conn.cursor() as cursor:
                 # Build filter conditions
                 filter_conditions = []
                 if filters:
-                    if 'season' in filters:
+                    if "season" in filters:
                         filter_conditions.append(f"cm.season = {filters['season']}")
-                    if 'episode' in filters:
+                    if "episode" in filters:
                         filter_conditions.append(f"cm.episode = {filters['episode']}")
-                    if 'world_layer' in filters:
-                        filter_conditions.append(f"cm.world_layer = '{filters['world_layer']}'")
-                
+                    if "world_layer" in filters:
+                        filter_conditions.append(
+                            f"cm.world_layer = '{filters['world_layer']}'"
+                        )
+
                 filter_sql = " AND ".join(filter_conditions)
                 if filter_sql:
                     filter_sql = " AND " + filter_sql
-                
+
                 # First, run text search to get initial text scores
                 text_search_sql_tsquery = f"""
                 SELECT
@@ -854,16 +1024,17 @@ def execute_multi_model_hybrid_search(
                 text_query_value = ""
 
                 weighted_query = ""
-                if idf_dict and hasattr(idf_dict, 'generate_weighted_query'):
+                if idf_dict and hasattr(idf_dict, "generate_weighted_query"):
                     weighted_query = idf_dict.generate_weighted_query(query_text)
 
                 if weighted_query:
-                    logger.info(f"Text search using weighted to_tsquery: '{weighted_query}'")
-                    cursor.execute(text_search_sql_tsquery, (
-                        weighted_query,
-                        weighted_query,
-                        top_k * 3
-                    ))
+                    logger.info(
+                        f"Text search using weighted to_tsquery: '{weighted_query}'"
+                    )
+                    cursor.execute(
+                        text_search_sql_tsquery,
+                        (weighted_query, weighted_query, top_k * 3),
+                    )
                     text_rows = cursor.fetchall()
                     text_query_kind = "to_tsquery"
                     text_query_value = weighted_query
@@ -871,23 +1042,24 @@ def execute_multi_model_hybrid_search(
                 if not text_rows:
                     prepared_query = prepare_tsquery(query_text)
                     if prepared_query:
-                        logger.info(f"Text search using OR-based query: '{prepared_query}'")
-                        cursor.execute(text_search_sql_tsquery, (
-                            prepared_query,
-                            prepared_query,
-                            top_k * 3
-                        ))
+                        logger.info(
+                            f"Text search using OR-based query: '{prepared_query}'"
+                        )
+                        cursor.execute(
+                            text_search_sql_tsquery,
+                            (prepared_query, prepared_query, top_k * 3),
+                        )
                         text_rows = cursor.fetchall()
                         text_query_kind = "to_tsquery"
                         text_query_value = prepared_query
 
                 if not text_rows:
-                    logger.info(f"Text search using websearch_to_tsquery fallback: '{query_text}'")
-                    cursor.execute(text_search_sql_websearch, (
-                        query_text,
-                        query_text,
-                        top_k * 3
-                    ))
+                    logger.info(
+                        f"Text search using websearch_to_tsquery fallback: '{query_text}'"
+                    )
+                    cursor.execute(
+                        text_search_sql_websearch, (query_text, query_text, top_k * 3)
+                    )
                     text_rows = cursor.fetchall()
                     text_query_kind = "websearch_to_tsquery"
                     text_query_value = query_text
@@ -896,44 +1068,58 @@ def execute_multi_model_hybrid_search(
 
                 # First pass: collect all text scores to find max for normalization
                 for result in text_rows:
-                    chunk_id, raw_text, season, episode, scene_number, world_time, text_score = result
+                    (
+                        chunk_id,
+                        raw_text,
+                        season,
+                        episode,
+                        scene_number,
+                        world_time,
+                        text_score,
+                    ) = result
                     text_score = float(text_score)
                     all_text_scores.append(text_score)
                     chunk_id = str(chunk_id)
-                    
+
                     if chunk_id not in results:
                         results[chunk_id] = {
-                            'id': chunk_id,
-                            'chunk_id': chunk_id,
-                            'text': raw_text,
-                            'content_type': 'narrative',
-                            'metadata': {
-                                'season': season,
-                                'episode': episode,
-                                'scene_number': scene_number,
-                                'world_time': world_time
+                            "id": chunk_id,
+                            "chunk_id": chunk_id,
+                            "text": raw_text,
+                            "content_type": "narrative",
+                            "metadata": {
+                                "season": season,
+                                "episode": episode,
+                                "scene_number": scene_number,
+                                "world_time": world_time,
                             },
-                            'model_scores': {},  # Will store scores for each model
-                            'text_score': 0.0,   # Will be normalized
-                            'vector_score': 0.0, # Will be calculated as weighted average of model scores
-                            'raw_text_score': text_score  # Keep raw score temporarily
+                            "model_scores": {},  # Will store scores for each model
+                            "text_score": 0.0,  # Will be normalized
+                            "vector_score": 0.0,  # Will be calculated as weighted average of model scores
+                            "raw_text_score": text_score,  # Keep raw score temporarily
                         }
                     else:
-                        results[chunk_id]['raw_text_score'] = text_score
-                
+                        results[chunk_id]["raw_text_score"] = text_score
+
                 # Find max text score for normalization (if any results)
                 max_text_score = max(all_text_scores) if all_text_scores else 1.0
                 logger.info(f"Normalizing text scores with max value: {max_text_score}")
-                
+
                 # Normalize text scores
                 for chunk_id, result in results.items():
-                    if 'raw_text_score' in result:
+                    if "raw_text_score" in result:
                         # Normalize to 0-1 range
-                        result['text_score'] = result['raw_text_score'] / max_text_score if max_text_score > 0 else 0.0
+                        result["text_score"] = (
+                            result["raw_text_score"] / max_text_score
+                            if max_text_score > 0
+                            else 0.0
+                        )
                         # Remove temporary raw score
-                        del result['raw_text_score']
-                
-                logger.info(f"Text search found {len(results)} results with non-zero scores")
+                        del result["raw_text_score"]
+
+                logger.info(
+                    f"Text search found {len(results)} results with non-zero scores"
+                )
 
                 # Fallback: if no text results and single-token query, try ILIKE
                 if not results:
@@ -960,34 +1146,45 @@ def execute_multi_model_hybrid_search(
                         """
                         cursor.execute(like_sql, (single, top_k * 3))
                         for row in cursor.fetchall():
-                            chunk_id, raw_text, season, episode, scene_number, world_time = row
+                            (
+                                chunk_id,
+                                raw_text,
+                                season,
+                                episode,
+                                scene_number,
+                                world_time,
+                            ) = row
                             chunk_id = str(chunk_id)
                             if chunk_id not in results:
                                 results[chunk_id] = {
-                                    'id': chunk_id,
-                                    'chunk_id': chunk_id,
-                                    'text': raw_text,
-                                    'content_type': 'narrative',
-                                    'metadata': {
-                                        'season': season,
-                                        'episode': episode,
-                                        'scene_number': scene_number,
-                                        'world_time': world_time
+                                    "id": chunk_id,
+                                    "chunk_id": chunk_id,
+                                    "text": raw_text,
+                                    "content_type": "narrative",
+                                    "metadata": {
+                                        "season": season,
+                                        "episode": episode,
+                                        "scene_number": scene_number,
+                                        "world_time": world_time,
                                     },
-                                    'model_scores': {},
-                                    'text_score': 0.05,
-                                    'vector_score': 0.0
+                                    "model_scores": {},
+                                    "text_score": 0.05,
+                                    "vector_score": 0.0,
                                 }
-                
+
                 # Now run vector searches for each model
                 for model_key, embedding in query_embeddings.items():
                     if model_key not in model_weights or model_weights[model_key] <= 0:
-                        logger.debug(f"Skipping model {model_key} (zero or negative weight)")
+                        logger.debug(
+                            f"Skipping model {model_key} (zero or negative weight)"
+                        )
                         continue
 
                     # Skip if embedding generation failed
                     if embedding is None:
-                        logger.warning(f"Skipping model {model_key} (embedding is None)")
+                        logger.warning(
+                            f"Skipping model {model_key} (embedding is None)"
+                        )
                         continue
 
                     logger.info(f"Running vector search for model {model_key}")
@@ -996,15 +1193,21 @@ def execute_multi_model_hybrid_search(
                     dimensions = len(embedding)
 
                     table_name = resolve_dimension_table(dimensions)
-                    if not table_name:
-                        logger.error(f"No dimension-specific table for {dimensions}D vectors")
+                    if not _embedding_table_exists(cursor, table_name):
+                        logger.warning(
+                            "Embedding table %s does not exist; skipping model %s",
+                            table_name,
+                            model_key,
+                        )
                         continue  # Skip this model but continue with others
-                    
-                    logger.debug(f"Using {table_name} for model {model_key} with {dimensions}D embeddings")
-                    
+
+                    logger.debug(
+                        f"Using {table_name} for model {model_key} with {dimensions}D embeddings"
+                    )
+
                     # Build embedding array as a string - pgvector expects [x,y,z] format
-                    embedding_str = '[' + ','.join(str(x) for x in embedding) + ']'
-                    
+                    embedding_str = "[" + ",".join(str(x) for x in embedding) + "]"
+
                     # Use proper vector search with cosine similarity
                     vector_sql = f"""
                     SELECT 
@@ -1023,22 +1226,23 @@ def execute_multi_model_hybrid_search(
                         vector_score DESC
                     LIMIT %s
                     """
-                    
+
                     # Execute vector search for this model
                     cursor.execute(vector_sql, (embedding_str, model_key, top_k * 3))
-                    
+
                     # Process vector results
                     for result in cursor.fetchall():
                         chunk_id, vector_score = result
                         chunk_id = str(chunk_id)
                         vector_score = float(vector_score)
-                        
+
                         if chunk_id in results:
                             # Store model-specific score
-                            results[chunk_id]['model_scores'][model_key] = vector_score
+                            results[chunk_id]["model_scores"][model_key] = vector_score
                         else:
                             # For chunks not found in text search, get full details
-                            cursor.execute(f"""
+                            cursor.execute(
+                                f"""
                             SELECT 
                                 nc.raw_text, 
                                 cm.season, 
@@ -1050,87 +1254,110 @@ def execute_multi_model_hybrid_search(
                                 chunk_metadata cm ON nc.id = cm.chunk_id
                             WHERE 
                                 nc.id = %s
-                            """, (chunk_id,))
-                            
+                            """,
+                                (chunk_id,),
+                            )
+
                             details = cursor.fetchone()
                             if details:
                                 raw_text, season, episode, scene_number = details
-                                
+
                                 # Calculate text score for this vector-only result using the same query form
                                 calculated_text_score = 0.0
                                 if text_query_value:
                                     if text_query_kind == "websearch_to_tsquery":
-                                        cursor.execute("""
+                                        cursor.execute(
+                                            """
                                         SELECT ts_rank(to_tsvector('english', raw_text),
                                                 websearch_to_tsquery('english', %s)) AS text_score
                                         FROM narrative_chunks
                                         WHERE id = %s
-                                        """, (text_query_value, chunk_id))
+                                        """,
+                                            (text_query_value, chunk_id),
+                                        )
                                     else:
-                                        cursor.execute("""
+                                        cursor.execute(
+                                            """
                                         SELECT ts_rank(to_tsvector('english', raw_text),
                                                 to_tsquery('english', %s)) AS text_score
                                         FROM narrative_chunks
                                         WHERE id = %s
-                                        """, (text_query_value, chunk_id))
+                                        """,
+                                            (text_query_value, chunk_id),
+                                        )
 
                                     fetched = cursor.fetchone()
-                                    calculated_text_score = (fetched[0] if fetched and fetched[0] is not None else 0.0)
+                                    calculated_text_score = (
+                                        fetched[0]
+                                        if fetched and fetched[0] is not None
+                                        else 0.0
+                                    )
 
-                                normalized_text_score = calculated_text_score / max_text_score if max_text_score > 0 else 0.0
-                                
+                                normalized_text_score = (
+                                    calculated_text_score / max_text_score
+                                    if max_text_score > 0
+                                    else 0.0
+                                )
+
                                 # Add to results with this model's score
                                 results[chunk_id] = {
-                                    'id': chunk_id,
-                                    'chunk_id': chunk_id,
-                                    'text': raw_text,
-                                    'content_type': 'narrative',
-                                    'metadata': {
-                                        'season': season,
-                                        'episode': episode,
-                                        'scene_number': scene_number
+                                    "id": chunk_id,
+                                    "chunk_id": chunk_id,
+                                    "text": raw_text,
+                                    "content_type": "narrative",
+                                    "metadata": {
+                                        "season": season,
+                                        "episode": episode,
+                                        "scene_number": scene_number,
                                     },
-                                    'model_scores': {model_key: vector_score},
-                                    'text_score': float(normalized_text_score),
-                                    'vector_score': 0.0  # Will be calculated next
+                                    "model_scores": {model_key: vector_score},
+                                    "text_score": float(normalized_text_score),
+                                    "vector_score": 0.0,  # Will be calculated next
                                 }
-                
+
                 # Calculate weighted average vector score using model weights
-                logger.debug(f"Calculating weighted average vector scores with weights: {model_weights}")
-                
+                logger.debug(
+                    f"Calculating weighted average vector scores with weights: {model_weights}"
+                )
+
                 for chunk_id, result in results.items():
                     # Calculate weighted vector score based on all models
                     weighted_score = 0.0
                     total_weight = 0.0
-                    
+
                     for model, weight in model_weights.items():
-                        if model in result.get('model_scores', {}):
-                            model_score = result['model_scores'][model]
+                        if model in result.get("model_scores", {}):
+                            model_score = result["model_scores"][model]
                             weighted_score += model_score * weight
                             total_weight += weight
-                    
+
                     # Store the weighted average vector score
                     if total_weight > 0:
-                        result['vector_score'] = weighted_score / total_weight
+                        result["vector_score"] = weighted_score / total_weight
                     else:
                         # Keep default 0.0 if no models contributed
                         pass
-                    
+
                     # Calculate combined score (weighted average of text and vector scores)
-                    result['score'] = (result['vector_score'] * vector_weight) + (result['text_score'] * text_weight)
-                    result['source'] = 'multi_model_hybrid_search'
-                
+                    result["score"] = (result["vector_score"] * vector_weight) + (
+                        result["text_score"] * text_weight
+                    )
+                    result["source"] = "multi_model_hybrid_search"
+
                 # Create a list from the results dictionary and sort by score
-                sorted_results = sorted(results.values(), key=lambda x: x['score'], reverse=True)
-                
+                sorted_results = sorted(
+                    results.values(), key=lambda x: x["score"], reverse=True
+                )
+
                 # Return only the top k results
                 return sorted_results[:top_k]
-                
+
         finally:
             conn.close()
-        
+
     except Exception as e:
         logger.error(f"Error in multi-model hybrid search: {e}")
         import traceback
+
         logger.error(traceback.format_exc())
         return []

--- a/nexus/agents/memnon/utils/db_access.py
+++ b/nexus/agents/memnon/utils/db_access.py
@@ -796,26 +796,9 @@ def setup_database_indexes(db_url: str) -> bool:
                         logger.warning(f"Error creating index on {dim_table}: {e}")
                         continue
 
-                # Create vector indexes for dimension-specific tables
-                for dim_table in sorted(existing_dimension_tables):
+                # Create vector indexes for existing dimension-specific tables only.
+                for dim_table in _list_existing_embedding_tables(cursor):
                     try:
-                        # Check if table exists
-                        cursor.execute(
-                            f"""
-                        SELECT EXISTS (
-                            SELECT FROM information_schema.tables 
-                            WHERE table_name = '{dim_table}'
-                        )
-                        """
-                        )
-                        table_exists = cursor.fetchone()[0]
-
-                        if not table_exists:
-                            logger.warning(
-                                f"Table {dim_table} does not exist, skipping index creation"
-                            )
-                            continue
-
                         # Check for existing HNSW index
                         cursor.execute(
                             f"""

--- a/nexus/agents/memnon/utils/db_schema.py
+++ b/nexus/agents/memnon/utils/db_schema.py
@@ -16,39 +16,23 @@ logger = logging.getLogger("nexus.memnon.db_schema")
 # Define SQL Alchemy Base
 Base = declarative_base()
 
+
 # Define ORM models based on the PostgreSQL schema
 class NarrativeChunk(Base):
-    __tablename__ = 'narrative_chunks'
-    
+    __tablename__ = "narrative_chunks"
+
     id = Column(sa.BigInteger, primary_key=True)
     raw_text = Column(sa.Text, nullable=False)
     created_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now())
 
-class ChunkEmbedding1024D(Base):
-    __tablename__ = 'chunk_embeddings_1024d'
-    
-    id = Column(sa.Integer, primary_key=True)
-    chunk_id = Column(sa.BigInteger, sa.ForeignKey('narrative_chunks.id'), nullable=False)
-    model = Column(sa.String(255), nullable=False)
-    # Note: This is a proper vector type with 1024 dimensions
-    embedding = Column(sa.String, nullable=False)  # Will be treated as vector by PostgreSQL
-    created_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now())
-
-class ChunkEmbedding1536D(Base):
-    __tablename__ = 'chunk_embeddings_1536d'
-    
-    id = Column(sa.Integer, primary_key=True)
-    chunk_id = Column(sa.BigInteger, sa.ForeignKey('narrative_chunks.id'), nullable=False)
-    model = Column(sa.String(255), nullable=False)
-    # Note: This is a proper vector type with 1536 dimensions
-    embedding = Column(sa.String, nullable=False)  # Will be treated as vector by PostgreSQL
-    created_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now())
 
 class ChunkMetadata(Base):
-    __tablename__ = 'chunk_metadata'
-    
+    __tablename__ = "chunk_metadata"
+
     id = Column(sa.BigInteger, primary_key=True)
-    chunk_id = Column(sa.BigInteger, sa.ForeignKey('narrative_chunks.id'), nullable=False)
+    chunk_id = Column(
+        sa.BigInteger, sa.ForeignKey("narrative_chunks.id"), nullable=False
+    )
     season = Column(sa.Integer, nullable=False)
     episode = Column(sa.Integer, nullable=False)
     scene = Column(sa.Integer)
@@ -60,9 +44,10 @@ class ChunkMetadata(Base):
     keywords = Column(ARRAY(sa.String))
     characters = Column(ARRAY(sa.String))
 
+
 class Character(Base):
-    __tablename__ = 'characters'
-    
+    __tablename__ = "characters"
+
     id = Column(sa.BigInteger, primary_key=True)
     name = Column(sa.String(50), nullable=False)
     description = Column(sa.Text)
@@ -72,31 +57,39 @@ class Character(Base):
     status = Column(sa.String(50))
     backstory = Column(sa.Text)
     created_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now())
-    updated_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now())
+    updated_at = Column(
+        sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now()
+    )
+
 
 class Place(Base):
-    __tablename__ = 'places'
-    
+    __tablename__ = "places"
+
     id = Column(sa.BigInteger, primary_key=True)
     name = Column(sa.String(50), nullable=False)
-    type = Column(sa.Enum('fixed_location', 'vehicle', 'other', name='place_type'), nullable=False)
+    type = Column(
+        sa.Enum("fixed_location", "vehicle", "other", name="place_type"), nullable=False
+    )
     zone = Column(sa.BigInteger, nullable=False)
     summary = Column(sa.String(1000))
     inhabitants = Column(ARRAY(sa.String))
     historical_significance = Column(sa.Text)
     current_status = Column(sa.String(500))
     created_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now())
-    updated_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now())
+    updated_at = Column(
+        sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now()
+    )
+
 
 class DatabaseManager:
     """
     Manages database connections and operations for MEMNON agent.
     """
-    
+
     def __init__(self, db_url: str, settings: Optional[Dict[str, Any]] = None):
         """
         Initialize the DatabaseManager.
-        
+
         Args:
             db_url: PostgreSQL database URL
             settings: Optional settings dictionary
@@ -105,66 +98,74 @@ class DatabaseManager:
         self.settings = settings or {}
         self.engine = self._initialize_database_connection()
         self.Session = sessionmaker(bind=self.engine)
-        
+
         logger.info("DatabaseManager initialized")
-    
+
     def _initialize_database_connection(self) -> sa.engine.Engine:
         """
         Initialize connection to PostgreSQL database.
-        
+
         Returns:
             SQLAlchemy engine instance
         """
         try:
             engine = create_engine(self.db_url)
-            
+
             # Verify connection
             connection = engine.connect()
             connection.close()
-            
+
             # Create tables if they don't exist
             Base.metadata.create_all(engine)
-            
+
             # Check for vector extension
             from .db_access import check_vector_extension, setup_database_indexes
-            
+
             if check_vector_extension(self.db_url):
                 logger.info("Vector extension available")
-                
+
                 # Set up necessary database indexes for efficient search
                 if setup_database_indexes(self.db_url):
                     logger.info("Database indexes setup complete")
                 else:
-                    logger.warning("Database indexes setup failed - vector search may not work correctly")
-                
+                    logger.warning(
+                        "Database indexes setup failed - vector search may not work correctly"
+                    )
+
                 # Set up hybrid search if enabled in settings
-                hybrid_search_enabled = self.settings.get("retrieval", {}).get("hybrid_search", {}).get("enabled", False)
+                hybrid_search_enabled = (
+                    self.settings.get("retrieval", {})
+                    .get("hybrid_search", {})
+                    .get("enabled", False)
+                )
                 if hybrid_search_enabled:
                     logger.info("Setting up hybrid search capabilities")
                     self._setup_hybrid_search(engine)
             else:
-                logger.warning("Vector extension not found - vector search will not work")
+                logger.warning(
+                    "Vector extension not found - vector search will not work"
+                )
                 logger.warning("Please run scripts/install_pgvector_custom.sh first")
-            
+
             logger.info(f"Successfully connected to database at {self.db_url}")
             return engine
-        
+
         except Exception as e:
             logger.error(f"Failed to connect to database: {e}")
             raise ConnectionError(f"Database connection failed: {e}")
-    
+
     def _setup_hybrid_search(self, engine):
         """
         Set up the database for hybrid search capabilities.
         Creates a GIN index for text search and a hybrid_search SQL function.
-        
+
         Args:
             engine: SQLAlchemy engine
         """
         try:
             # Use our database access utilities to set up necessary indexes and functions
             from .db_access import setup_database_indexes
-            
+
             logger.info("Setting up hybrid search capabilities using db_access utility")
             if setup_database_indexes(self.db_url):
                 logger.info("Hybrid search database setup completed successfully")
@@ -172,27 +173,28 @@ class DatabaseManager:
             else:
                 logger.warning("Hybrid search setup failed")
                 return False
-                
+
         except Exception as e:
             logger.error(f"Error setting up hybrid search: {e}")
             import traceback
+
             logger.error(traceback.format_exc())
             logger.warning("Disabling hybrid search due to setup failure")
             return False
-    
+
     def create_session(self) -> Session:
         """
         Create a new database session.
-        
+
         Returns:
             SQLAlchemy session
         """
         return self.Session()
-    
+
     def get_model_classes(self) -> Dict[str, Any]:
         """
         Get dictionary of model classes defined in this module.
-        
+
         Returns:
             Dictionary mapping table names to model classes
         """
@@ -201,6 +203,4 @@ class DatabaseManager:
             "chunk_metadata": ChunkMetadata,
             "characters": Character,
             "places": Place,
-            "chunk_embeddings_1024d": ChunkEmbedding1024D,
-            "chunk_embeddings_1536d": ChunkEmbedding1536D
         }

--- a/nexus/agents/memnon/utils/embedding_tables.py
+++ b/nexus/agents/memnon/utils/embedding_tables.py
@@ -77,11 +77,11 @@ def ensure_embedding_table(connection: Connection, dimensions: int) -> str:
     Ensure the embedding table for ``dimensions`` exists.
 
     Embedding tables are created lazily by write paths. Read/retrieval paths
-    should inspect existing tables instead of calling this helper.
+    should inspect existing tables instead of calling this helper. The pgvector
+    extension is a database setup prerequisite and must already exist.
     """
     table_name = table_name_for_dimensions(dimensions)
 
-    connection.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
     connection.execute(
         text(
             f"""

--- a/nexus/agents/memnon/utils/embedding_tables.py
+++ b/nexus/agents/memnon/utils/embedding_tables.py
@@ -1,21 +1,107 @@
-"""Shared constants and helpers for MEMNON's embedding tables."""
+"""Shared helpers for MEMNON's dimension-specific embedding tables."""
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+import re
+from typing import List, Optional
 
-# Mapping of embedding dimensionality to the backing PostgreSQL table.
-DIMENSION_TABLE_MAP: Dict[int, str] = {
-    1024: "chunk_embeddings_1024d",
-    1536: "chunk_embeddings_1536d",
-    2560: "chunk_embeddings_2560d",
-    4096: "chunk_embeddings_4096d",
-}
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
 
-# Convenience list of known dimension-specific tables.
-DIMENSION_TABLES: List[str] = list(DIMENSION_TABLE_MAP.values())
+EMBEDDING_TABLE_PATTERN = re.compile(r"^chunk_embeddings_(?P<dimensions>\d+)d$")
+
+# Historical dimensions that may exist in older slots. New dimensions should not
+# be added here; table names are generated from the model output dimensionality.
+LEGACY_EMBEDDING_DIMENSIONS = (1024, 1536, 2560, 4096)
+DIMENSION_TABLES: List[str] = [
+    f"chunk_embeddings_{dimensions:04d}d" for dimensions in LEGACY_EMBEDDING_DIMENSIONS
+]
 
 
-def resolve_dimension_table(dimensions: int) -> Optional[str]:
+def table_name_for_dimensions(dimensions: int) -> str:
+    """Return the canonical embedding table name for ``dimensions``."""
+    if dimensions <= 0:
+        raise ValueError(f"Embedding dimensions must be positive, got {dimensions}")
+    return f"chunk_embeddings_{dimensions:04d}d"
+
+
+def resolve_dimension_table(dimensions: int) -> str:
     """Return the embedding table that stores vectors for ``dimensions``."""
-    return DIMENSION_TABLE_MAP.get(dimensions)
+    return table_name_for_dimensions(dimensions)
+
+
+def parse_embedding_table_dimensions(table_name: str) -> Optional[int]:
+    """Return dimensions encoded in an embedding table name, if it matches."""
+    match = EMBEDDING_TABLE_PATTERN.match(table_name)
+    if not match:
+        return None
+    return int(match.group("dimensions"))
+
+
+def list_embedding_tables(connection: Connection) -> List[str]:
+    """List existing dimension-specific embedding tables in the current schema."""
+    rows = connection.execute(
+        text(
+            """
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema = 'public'
+              AND table_type = 'BASE TABLE'
+              AND table_name ~ '^chunk_embeddings_[0-9]+d$'
+            ORDER BY table_name
+            """
+        )
+    )
+    return [row[0] for row in rows]
+
+
+def embedding_table_exists(connection: Connection, table_name: str) -> bool:
+    """Return whether ``table_name`` exists in the current public schema."""
+    exists = connection.execute(
+        text(
+            """
+            SELECT EXISTS (
+                SELECT FROM information_schema.tables
+                WHERE table_schema = 'public'
+                  AND table_name = :table_name
+            )
+            """
+        ),
+        {"table_name": table_name},
+    ).scalar()
+    return bool(exists)
+
+
+def ensure_embedding_table(connection: Connection, dimensions: int) -> str:
+    """
+    Ensure the embedding table for ``dimensions`` exists.
+
+    Embedding tables are created lazily by write paths. Read/retrieval paths
+    should inspect existing tables instead of calling this helper.
+    """
+    table_name = table_name_for_dimensions(dimensions)
+
+    connection.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+    connection.execute(
+        text(
+            f"""
+            CREATE TABLE IF NOT EXISTS {table_name} (
+                chunk_id BIGINT NOT NULL
+                    REFERENCES narrative_chunks(id) ON DELETE CASCADE,
+                model TEXT NOT NULL,
+                embedding vector({dimensions}) NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                PRIMARY KEY (chunk_id, model)
+            )
+            """
+        )
+    )
+    connection.execute(
+        text(
+            f"""
+            CREATE INDEX IF NOT EXISTS {table_name}_model_idx
+            ON {table_name} (model)
+            """
+        )
+    )
+    return table_name

--- a/scripts/README_embedding.md
+++ b/scripts/README_embedding.md
@@ -6,12 +6,16 @@ This document describes the implementation details of how we manage multiple vec
 
 ## Approach Summary
 
-After investigation, we decided to keep the vector embeddings in separate tables based on their dimensions:
+After investigation, we decided to keep vector embeddings in separate tables
+based on their dimensions:
 
-1. **chunk_embeddings**: Table for 1024-dimensional vectors (BGE-Large, E5-Large)
-2. **chunk_embeddings_small**: Table for 384-dimensional vectors (BGE-Small-Custom)
+1. **chunk_embeddings_1024d**: Table for 1024-dimensional vectors (BGE-Large, E5-Large)
+2. **chunk_embeddings_1536d**: Table for 1536-dimensional vectors (inf-retriever-v1-1.5b)
+3. **chunk_embeddings_2560d**: Table for 2560-dimensional vectors (Octen-Embedding-4B)
 
 This approach works better with PostgreSQL's pgvector extension, which requires fixed dimensions at table creation time.
+Tables are created lazily by embedding write paths and use `(chunk_id, model)`
+as the primary key. Fresh slots do not pre-create unused dimension tables.
 
 ## Key Components
 
@@ -44,12 +48,8 @@ if EMBEDDING_UTILS_AVAILABLE:
     dimensions = get_model_dimensions(model)
 else:
     # Fallback logic if utilities aren't available
-    if model.startswith("bge-small"):
-        embedding_table = "chunk_embeddings_small"
-        dimensions = 384
-    else:
-        embedding_table = "chunk_embeddings"
-        dimensions = 1024
+    dimensions = 384 if model.startswith("bge-small") else 1024
+    embedding_table = f"chunk_embeddings_{dimensions:04d}d"
 ```
 
 ### 3. Validation Scripts
@@ -70,14 +70,14 @@ from scripts.query_narratives_vector import NarrativeSearcher
 # Initialize the searcher
 searcher = NarrativeSearcher()
 
-# Search with large model (will use chunk_embeddings table)
+# Search with large model (will use chunk_embeddings_1024d)
 large_results = searcher.semantic_search(
     "What did Alex discover in the temple?",
     model="bge-large",
     limit=5
 )
 
-# Search with small model (will use chunk_embeddings_small table)
+# Search with small model (will use chunk_embeddings_0384d if active)
 small_results = searcher.semantic_search(
     "What did Alex discover in the temple?",
     model="bge-small-custom",
@@ -91,7 +91,7 @@ small_results = searcher.semantic_search(
 from scripts.utils.embedding_utils import get_table_for_model, construct_vector_search_sql
 
 # Get table name
-table = get_table_for_model("bge-small-custom")  # Returns "chunk_embeddings_small"
+table = get_table_for_model("bge-small-custom")  # Returns "chunk_embeddings_0384d"
 
 # Build SQL query
 sql, used_table = construct_vector_search_sql(

--- a/scripts/create_vector_index.py
+++ b/scripts/create_vector_index.py
@@ -22,6 +22,8 @@ logger = logging.getLogger("nexus.embeddings")
 # Add parent directory to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from nexus.agents.memnon.utils.embedding_tables import table_name_for_dimensions
+
 # Try to load settings using centralized config loader
 try:
     from nexus.config import load_settings_as_dict
@@ -76,9 +78,7 @@ def get_model_dimensions(model_name: str) -> int:
 def get_table_name(model_name: str) -> str:
     """Get table name for a model"""
     dimensions = get_model_dimensions(model_name)
-    dim_str = f"{dimensions:04d}"  # Format with leading zeros
-    # PostgreSQL converts identifiers to lowercase by default
-    return f"chunk_embeddings_{dim_str}d"
+    return table_name_for_dimensions(dimensions)
 
 
 def create_vector_indexes(model_name: str, db_url: str = None):
@@ -175,7 +175,7 @@ def create_vector_indexes(model_name: str, db_url: str = None):
                 start_time = time.time()
 
                 ivf_sql = f"""
-                CREATE INDEX {table_name}_ivf_idx 
+                CREATE INDEX IF NOT EXISTS {table_name}_ivf_idx
                 ON {table_name} USING ivfflat (embedding vector_cosine_ops)
                 WITH (lists=100);
                 """
@@ -191,7 +191,7 @@ def create_vector_indexes(model_name: str, db_url: str = None):
                 try:
                     logger.info("Creating plain index as fallback...")
                     plain_sql = f"""
-                    CREATE INDEX {table_name}_plain_idx 
+                    CREATE INDEX IF NOT EXISTS {table_name}_plain_idx
                     ON {table_name} (embedding vector_cosine_ops);
                     """
                     conn.execute(text(plain_sql))
@@ -209,7 +209,7 @@ def create_vector_indexes(model_name: str, db_url: str = None):
             try:
                 logger.info("Attempting to create plain vector index anyway...")
                 plain_sql = f"""
-                CREATE INDEX {table_name}_vector_idx 
+                CREATE INDEX IF NOT EXISTS {table_name}_vector_idx
                 ON {table_name} (embedding vector_cosine_ops);
                 """
                 conn.execute(text(plain_sql))

--- a/scripts/install_pgvector.sh
+++ b/scripts/install_pgvector.sh
@@ -75,9 +75,7 @@ $$
     SELECT 1 - (a <=> b) FROM (SELECT a::vector, b::vector FROM (VALUES (\\$1, \\$2)) AS t(a, b)) AS v
 $$;
 
--- Create indexes on chunk_embeddings table
-CREATE INDEX IF NOT EXISTS idx_chunk_embeddings_model 
-    ON chunk_embeddings (model);
+-- Embedding tables are created lazily by active write paths.
 
 -- Check if extension is installed correctly
 SELECT TRUE as extension_installed FROM pg_extension WHERE extname = 'vector';

--- a/scripts/propagate_schema.py
+++ b/scripts/propagate_schema.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 """
-Propagate schema migrations from NEXUS_template to all databases.
+Propagate schema migrations to NEXUS_template and all slot databases.
 
-The template database contains:
-  - The canonical schema (all tables empty)
-  - schema_migrations table tracking what's applied where
+Each database contains its own schema_migrations table with version/name rows.
 
 Usage:
     python scripts/propagate_schema.py           # Apply pending to all
@@ -46,32 +44,47 @@ def get_target_connection(db_name: str) -> PGConnection:
 
 
 def ensure_schema_migrations_table(conn: PGConnection) -> None:
-    """Create schema_migrations table in template if missing."""
+    """Create the per-database schema_migrations table if missing."""
 
     with conn.cursor() as cur:
         cur.execute(
             """
+            SELECT EXISTS (
+                SELECT FROM information_schema.tables
+                WHERE table_schema = 'public'
+                  AND table_name = 'schema_migrations'
+            )
+            """
+        )
+        if cur.fetchone()[0]:
+            return
+
+        cur.execute(
+            """
             CREATE TABLE IF NOT EXISTS schema_migrations (
-                migration_name TEXT NOT NULL,
-                database_name TEXT NOT NULL,
+                version TEXT NOT NULL,
+                name TEXT NOT NULL,
                 applied_at TIMESTAMPTZ DEFAULT NOW(),
-                PRIMARY KEY (migration_name, database_name)
+                PRIMARY KEY (version)
             )
             """
         )
     conn.commit()
 
 
+def migration_identity(migration_path: Path) -> tuple[str, str]:
+    """Return the version and descriptive name encoded in a migration file."""
+    version, _, name = migration_path.stem.partition("_")
+    return version, name or migration_path.stem
+
+
 def get_applied_migrations(db_name: str) -> set[str]:
-    """Query template for migrations already applied to this database."""
-    conn = get_template_connection()
+    """Query a database for migration versions already applied there."""
+    conn = get_target_connection(db_name)
     try:
         ensure_schema_migrations_table(conn)
         with conn.cursor() as cur:
-            cur.execute(
-                "SELECT migration_name FROM schema_migrations WHERE database_name = %s",
-                (db_name,),
-            )
+            cur.execute("SELECT version FROM schema_migrations")
             return {row[0] for row in cur.fetchall()}
     finally:
         conn.close()
@@ -87,7 +100,7 @@ def get_all_migrations() -> list[Path]:
 def get_pending_migrations(db_name: str) -> list[Path]:
     """Get migrations not yet applied to this database."""
     applied = get_applied_migrations(db_name)
-    return [m for m in get_all_migrations() if m.name not in applied]
+    return [m for m in get_all_migrations() if migration_identity(m)[0] not in applied]
 
 
 def apply_migration(db_name: str, migration_path: Path, dry_run: bool = False) -> bool:
@@ -97,6 +110,7 @@ def apply_migration(db_name: str, migration_path: Path, dry_run: bool = False) -
     Returns True on success, False on failure.
     """
     sql = migration_path.read_text()
+    version, name = migration_identity(migration_path)
 
     if dry_run:
         print(f"  [DRY RUN] Would apply {migration_path.name}")
@@ -106,8 +120,19 @@ def apply_migration(db_name: str, migration_path: Path, dry_run: bool = False) -
     try:
         target_conn = get_target_connection(db_name)
         try:
+            ensure_schema_migrations_table(target_conn)
             with target_conn.cursor() as cur:
                 cur.execute(sql)
+                cur.execute(
+                    """
+                    INSERT INTO schema_migrations (version, name)
+                    VALUES (%s, %s)
+                    ON CONFLICT (version) DO UPDATE
+                    SET name = EXCLUDED.name,
+                        applied_at = NOW()
+                    """,
+                    (version, name),
+                )
             target_conn.commit()
         finally:
             target_conn.close()
@@ -115,53 +140,7 @@ def apply_migration(db_name: str, migration_path: Path, dry_run: bool = False) -
         print(f"  \u2717 {migration_path.name}: {e}")
         return False
 
-    # Record in template
-    try:
-        template_conn = get_template_connection()
-        try:
-            ensure_schema_migrations_table(template_conn)
-            with template_conn.cursor() as cur:
-                cur.execute(
-                    "INSERT INTO schema_migrations (migration_name, database_name) VALUES (%s, %s)",
-                    (migration_path.name, db_name),
-                )
-            template_conn.commit()
-        finally:
-            template_conn.close()
-    except Exception as e:
-        print(f"  \u2717 Failed to record migration: {e}")
-        return False
-
     print(f"  \u2713 {migration_path.name}")
-    return True
-
-
-def apply_migration_to_template(migration_path: Path, dry_run: bool = False) -> bool:
-    """
-    Apply migration to template database itself (for future clones).
-
-    This ensures new slots created via `createdb -T NEXUS_template` have the schema.
-    """
-    sql = migration_path.read_text()
-
-    if dry_run:
-        print(f"  [DRY RUN] Would apply to template: {migration_path.name}")
-        return True
-
-    try:
-        conn = get_template_connection()
-        try:
-            with conn.cursor() as cur:
-                cur.execute(sql)
-            conn.commit()
-            print(f"  [TEMPLATE] ✓ {migration_path.name}")
-        finally:
-            conn.close()
-    except Exception as e:
-        # Surface errors visibly per CLAUDE.md - don't silently continue
-        print(f"  [TEMPLATE] ✗ {migration_path.name}: {e}")
-        return False
-
     return True
 
 
@@ -186,10 +165,11 @@ def show_status():
     print("-" * (37 + len(all_dbs) * 11))
 
     # Each migration row
-    for migration in all_migrations:
-        print(f"{migration:<35} |", end="")
+    for migration_path in get_all_migrations():
+        version, _ = migration_identity(migration_path)
+        print(f"{migration_path.name:<35} |", end="")
         for db in all_dbs:
-            applied = migration in get_applied_migrations(db)
+            applied = version in get_applied_migrations(db)
             status = "\u2713" if applied else "\u2717"
             print(f" {status:<8} |", end="")
         print()
@@ -235,12 +215,12 @@ Examples:
         show_status()
         return
 
-    targets = [args.db] if args.db else TARGET_DBS
+    targets = [args.db] if args.db else [TEMPLATE_DB] + TARGET_DBS
 
     # Validate target database
     if args.db and args.db not in TARGET_DBS and args.db != TEMPLATE_DB:
         print(f"Warning: {args.db} is not in the standard target list.")
-        print(f"Standard targets: {', '.join(TARGET_DBS)}")
+        print(f"Standard targets: {TEMPLATE_DB}, {', '.join(TARGET_DBS)}")
 
     any_applied = False
     for db in targets:
@@ -254,11 +234,6 @@ Examples:
             success = apply_migration(db, migration, dry_run=args.dry_run)
             if success:
                 any_applied = True
-                # Also apply to template (for future clones)
-                template_success = apply_migration_to_template(migration, dry_run=args.dry_run)
-                if not template_success:
-                    print(f"  ⚠ Template migration failed - target DB was updated but template may be out of sync")
-                    sys.exit(1)
             else:
                 print(f"  Stopping due to error.")
                 sys.exit(1)

--- a/scripts/propagate_schema.py
+++ b/scripts/propagate_schema.py
@@ -57,6 +57,7 @@ def ensure_schema_migrations_table(conn: PGConnection) -> None:
             """
         )
         if cur.fetchone()[0]:
+            conn.commit()
             return
 
         cur.execute(

--- a/scripts/query_narratives_vector.py
+++ b/scripts/query_narratives_vector.py
@@ -3,7 +3,7 @@
 Query Narratives Script for NEXUS with vector search support
 
 This script provides semantic search functionality across the stored narrative chunks
-using pgvector for similarity search. It supports both 1024D (BGE-Large, E5-Large) 
+using pgvector for similarity search. It supports both 1024D (BGE-Large, E5-Large)
 and 384D (BGE-Small) embeddings stored in separate tables.
 
 Usage:
@@ -21,7 +21,7 @@ import json
 from typing import List, Dict, Any, Tuple, Optional
 
 # Add parent directory to sys.path to import from nexus package
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Import embedding utilities
 try:
@@ -29,10 +29,12 @@ try:
         get_model_dimensions,
         get_table_for_model,
         construct_vector_search_sql,
-        normalize_vector
+        normalize_vector,
     )
 except ImportError:
-    print("Embedding utilities not found. Please ensure scripts/utils/embedding_utils.py exists.")
+    print(
+        "Embedding utilities not found. Please ensure scripts/utils/embedding_utils.py exists."
+    )
     EMBEDDING_UTILS_AVAILABLE = False
 else:
     EMBEDDING_UTILS_AVAILABLE = True
@@ -40,6 +42,7 @@ else:
 # Try to load settings using centralized config loader
 try:
     from nexus.config import load_settings_as_dict
+
     _all_settings = load_settings_as_dict()
     SETTINGS = _all_settings.get("Agent Settings", {}).get("MEMNON", {})
 except Exception as e:
@@ -64,7 +67,7 @@ if log_console:
 logging.basicConfig(
     level=log_level,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    handlers=handlers
+    handlers=handlers,
 )
 logger = logging.getLogger("nexus.query")
 
@@ -72,7 +75,9 @@ logger = logging.getLogger("nexus.query")
 try:
     from sentence_transformers import SentenceTransformer
 except ImportError:
-    logger.error("sentence-transformers not found. Please install with: pip install sentence-transformers")
+    logger.error(
+        "sentence-transformers not found. Please install with: pip install sentence-transformers"
+    )
     sys.exit(1)
 
 # Try to import SQLAlchemy
@@ -88,6 +93,7 @@ except ImportError:
 try:
     import pgvector
     from pgvector.sqlalchemy import Vector
+
     HAS_PGVECTOR = True
 except ImportError:
     logger.error("pgvector not found. Please install with: pip install pgvector")
@@ -96,117 +102,154 @@ except ImportError:
 # Try to import numpy for vector operations
 try:
     import numpy as np
+
     HAS_NUMPY = True
 except ImportError:
     logger.error("numpy not found. Please install with: pip install numpy")
     HAS_NUMPY = False
 
+
 class NarrativeSearcher:
     """
     Performs semantic search over narrative chunks using vector embeddings.
     """
-    
+
     def __init__(self, db_url: str = None):
         """
         Initialize the searcher with database connection.
-        
+
         Args:
             db_url: PostgreSQL database URL
         """
         # Set default database URL if not provided
-        default_db_url = SETTINGS.get("database", {}).get("url", "postgresql://pythagor@localhost/NEXUS")
+        default_db_url = SETTINGS.get("database", {}).get(
+            "url", "postgresql://pythagor@localhost/NEXUS"
+        )
         self.db_url = db_url or os.environ.get("NEXUS_DB_URL", default_db_url)
-        
+
         # Initialize database connection
         self.engine = create_engine(self.db_url)
         self.Session = sessionmaker(bind=self.engine)
-        
+
         # Initialize embedding models
         self.embedding_models = self._initialize_embedding_models()
-        
+
         # Check pgvector extension
         self._check_pgvector()
-        
+
         logger.info(f"Connected to database: {self.db_url}")
-        logger.info(f"Available embedding models: {', '.join(self.embedding_models.keys())}")
-    
+        logger.info(
+            f"Available embedding models: {', '.join(self.embedding_models.keys())}"
+        )
+
     def _check_pgvector(self):
         """Check if pgvector extension is properly installed."""
         try:
             with self.engine.connect() as connection:
-                result = connection.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")).scalar()
+                result = connection.execute(
+                    text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")
+                ).scalar()
                 if not result:
-                    logger.error("pgvector extension not found in database. Please install it first.")
+                    logger.error(
+                        "pgvector extension not found in database. Please install it first."
+                    )
                     sys.exit(1)
                 logger.info("pgvector extension found in database.")
         except Exception as e:
             logger.error(f"Error checking pgvector extension: {e}")
             sys.exit(1)
-    
+
     def _initialize_embedding_models(self) -> Dict[str, Any]:
         """Initialize embedding models for semantic retrieval."""
         embedding_models = {}
-        
+
         # Define model paths from settings, falling back to defaults if not available
         settings_models = SETTINGS.get("models", {})
-        
+
         model_paths = {
             "bge-large": [
-                settings_models.get("bge-large", {}).get("local_path", os.path.expanduser("~/nexus/models/models--BAAI--bge-large-en")),
-                settings_models.get("bge-large", {}).get("remote_path", "BAAI/bge-large-en")
+                settings_models.get("bge-large", {}).get(
+                    "local_path",
+                    os.path.expanduser("~/nexus/models/models--BAAI--bge-large-en"),
+                ),
+                settings_models.get("bge-large", {}).get(
+                    "remote_path", "BAAI/bge-large-en"
+                ),
             ],
             "e5-large": [
-                settings_models.get("e5-large", {}).get("local_path", os.path.expanduser("~/nexus/models/models--intfloat--e5-large-v2")),
-                settings_models.get("e5-large", {}).get("remote_path", "intfloat/e5-large-v2")
+                settings_models.get("e5-large", {}).get(
+                    "local_path",
+                    os.path.expanduser("~/nexus/models/models--intfloat--e5-large-v2"),
+                ),
+                settings_models.get("e5-large", {}).get(
+                    "remote_path", "intfloat/e5-large-v2"
+                ),
             ],
             "bge-small-custom": [
-                settings_models.get("bge-small-custom", {}).get("local_path", os.path.expanduser("~/nexus/models/bge_small_finetuned_20250320_153654")),
-                settings_models.get("bge-small-custom", {}).get("remote_path")  # May be None
+                settings_models.get("bge-small-custom", {}).get(
+                    "local_path",
+                    os.path.expanduser(
+                        "~/nexus/models/bge_small_finetuned_20250320_153654"
+                    ),
+                ),
+                settings_models.get("bge-small-custom", {}).get(
+                    "remote_path"
+                ),  # May be None
             ],
             "bge-small": [
                 None,  # No local path for standard model
-                "BAAI/bge-small-en"
-            ]
+                "BAAI/bge-small-en",
+            ],
         }
-        
+
         try:
             # Try to load each model
             for model_key, paths in model_paths.items():
                 local_path, remote_path = paths
-                
+
                 # Skip if this is the standard BGE-small and we already have the custom one
                 if model_key == "bge-small" and "bge-small-custom" in embedding_models:
                     continue
-                
+
                 # Try local path first if it exists
                 if local_path and os.path.exists(local_path):
                     try:
-                        logger.info(f"Loading {model_key} from local path: {local_path}")
+                        logger.info(
+                            f"Loading {model_key} from local path: {local_path}"
+                        )
                         model = SentenceTransformer(local_path)
                         embedding_models[model_key] = model
                         logger.info(f"Successfully loaded {model_key} from local path")
                         continue
                     except Exception as e:
-                        logger.warning(f"Failed to load {model_key} from local path: {e}")
-                
+                        logger.warning(
+                            f"Failed to load {model_key} from local path: {e}"
+                        )
+
                 # Fall back to remote path if available
                 if remote_path:
                     try:
-                        logger.info(f"Loading {model_key} from HuggingFace: {remote_path}")
+                        logger.info(
+                            f"Loading {model_key} from HuggingFace: {remote_path}"
+                        )
                         model = SentenceTransformer(remote_path)
                         embedding_models[model_key] = model
                         logger.info(f"Successfully loaded {model_key} from HuggingFace")
                     except Exception as e:
-                        logger.warning(f"Failed to load {model_key} from HuggingFace: {e}")
-            
+                        logger.warning(
+                            f"Failed to load {model_key} from HuggingFace: {e}"
+                        )
+
             # Log summary of loaded models
             if embedding_models:
-                logger.info(f"Loaded {len(embedding_models)} embedding models: {', '.join(embedding_models.keys())}")
+                logger.info(
+                    f"Loaded {len(embedding_models)} embedding models: {', '.join(embedding_models.keys())}"
+                )
             else:
                 logger.error("Failed to load any embedding models")
-            
+
             return embedding_models
-        
+
         except Exception as e:
             logger.error(f"Error in embedding model initialization process: {e}")
             # Return any successfully loaded models rather than failing completely
@@ -215,32 +258,36 @@ class NarrativeSearcher:
     def generate_embedding(self, query: str, model_key: str) -> List[float]:
         """
         Generate an embedding for the query using the specified model.
-        
+
         Args:
             query: Search query to embed
             model_key: Key of the model to use
-            
+
         Returns:
             Embedding as a list of floats
         """
         if model_key not in self.embedding_models:
             logger.error(f"Model {model_key} not found in available embedding models")
-            raise ValueError(f"Model {model_key} not found in available embedding models")
-        
+            raise ValueError(
+                f"Model {model_key} not found in available embedding models"
+            )
+
         model = self.embedding_models[model_key]
         embedding = model.encode(query)
-        
+
         return embedding.tolist()
 
-    def semantic_search(self, query: str, model: str = "bge-large", limit: int = 5) -> List[Dict[str, Any]]:
+    def semantic_search(
+        self, query: str, model: str = "bge-large", limit: int = 5
+    ) -> List[Dict[str, Any]]:
         """
         Perform semantic search using vector similarity.
-        
+
         Args:
             query: The search query
             model: The embedding model to use
             limit: Maximum number of results to return
-            
+
         Returns:
             List of matching chunks with scores
         """
@@ -250,46 +297,47 @@ class NarrativeSearcher:
         except Exception as e:
             logger.error(f"Error generating embedding: {e}")
             return []
-        
+
         # Create a session
         session = self.Session()
-        
+
         try:
             # Use the embedding utilities if available
             if EMBEDDING_UTILS_AVAILABLE:
                 # Normalize the embedding for better results
                 if HAS_NUMPY:
                     query_embedding = normalize_vector(query_embedding).tolist()
-                
+
                 # Get the correct table for this model
                 embedding_table = get_table_for_model(model)
-                
+
                 # Get the vector dimensions for this model
                 dimensions = get_model_dimensions(model)
-                
+
                 # Construct the SQL query using our utility function
                 sql_query, table_used = construct_vector_search_sql(
-                    model_name=model,
-                    filter_conditions=None,
-                    limit=limit
+                    model_name=model, filter_conditions=None, limit=limit
                 )
-                
-                logger.info(f"Using table {table_used} for model {model} ({dimensions}D)")
+
+                logger.info(
+                    f"Using table {table_used} for model {model} ({dimensions}D)"
+                )
             else:
                 # Fall back to the original logic if utilities aren't available
-                logger.warning("Embedding utilities not available, using fallback table selection")
-                
+                logger.warning(
+                    "Embedding utilities not available, using fallback table selection"
+                )
+
                 # Determine the table and dimensions based on the model name
                 if model.startswith("bge-small"):
-                    embedding_table = "chunk_embeddings_small"
                     dimensions = 384
                 else:
-                    embedding_table = "chunk_embeddings"
                     dimensions = 1024
-            
+                embedding_table = f"chunk_embeddings_{dimensions:04d}d"
+
             # Create the query vector string representation directly in SQL
             query_vector_str = f"[{','.join(str(x) for x in query_embedding)}]"
-            
+
             # Construct the SQL query
             raw_sql = f"""
                 SELECT 
@@ -311,10 +359,10 @@ class NarrativeSearcher:
                     ce.embedding <=> '{query_vector_str}'::vector
                 LIMIT {limit}
             """
-            
+
             # Execute the raw SQL query
             result = session.execute(text(raw_sql))
-            
+
             # Process results
             search_results = []
             for row in result:
@@ -322,7 +370,7 @@ class NarrativeSearcher:
                 raw_text = row.raw_text
                 if len(raw_text) > 500:
                     raw_text = raw_text[:497] + "..."
-                
+
                 # Extract characters if available
                 characters = []
                 if row.characters:
@@ -330,43 +378,46 @@ class NarrativeSearcher:
                         characters = list(set(eval(row.characters)))
                     except:
                         pass
-                
+
                 # Format the result
-                search_results.append({
-                    "id": str(row.id),
-                    "similarity": float(row.similarity),
-                    "season": row.season or 0,
-                    "episode": row.episode or 0,
-                    "characters": characters,
-                    "text": raw_text
-                })
-            
+                search_results.append(
+                    {
+                        "id": str(row.id),
+                        "similarity": float(row.similarity),
+                        "season": row.season or 0,
+                        "episode": row.episode or 0,
+                        "characters": characters,
+                        "text": raw_text,
+                    }
+                )
+
             return search_results
-        
+
         except Exception as e:
             logger.error(f"Error in semantic search: {e}")
             return []
-        
+
         finally:
             session.close()
-    
+
     def text_search(self, query: str, limit: int = 5) -> List[Dict[str, Any]]:
         """
         Perform text-based search using PostgreSQL ILIKE.
-        
+
         Args:
             query: The search query
             limit: Maximum number of results to return
-            
+
         Returns:
             List of matching chunks
         """
         # Create a session
         session = self.Session()
-        
+
         try:
             # Construct the SQL query with ILIKE for text matching
-            sql_query = text("""
+            sql_query = text(
+                """
                 SELECT 
                     nc.id, 
                     nc.raw_text,
@@ -380,17 +431,14 @@ class NarrativeSearcher:
                 WHERE
                     nc.raw_text ILIKE :query_pattern
                 LIMIT :limit
-            """)
-            
+            """
+            )
+
             # Execute the query with parameters
             result = session.execute(
-                sql_query,
-                {
-                    "query_pattern": f"%{query}%",
-                    "limit": limit
-                }
+                sql_query, {"query_pattern": f"%{query}%", "limit": limit}
             )
-            
+
             # Process results
             search_results = []
             for row in result:
@@ -398,7 +446,7 @@ class NarrativeSearcher:
                 raw_text = row.raw_text
                 if len(raw_text) > 500:
                     raw_text = raw_text[:497] + "..."
-                
+
                 # Extract characters if available
                 characters = []
                 if row.characters:
@@ -406,24 +454,27 @@ class NarrativeSearcher:
                         characters = list(set(eval(row.characters)))
                     except:
                         pass
-                
+
                 # Format the result
-                search_results.append({
-                    "id": str(row.id),
-                    "season": row.season or 0,
-                    "episode": row.episode or 0,
-                    "characters": characters,
-                    "text": raw_text
-                })
-            
+                search_results.append(
+                    {
+                        "id": str(row.id),
+                        "season": row.season or 0,
+                        "episode": row.episode or 0,
+                        "characters": characters,
+                        "text": raw_text,
+                    }
+                )
+
             return search_results
-        
+
         except Exception as e:
             logger.error(f"Error in text search: {e}")
             return []
-        
+
         finally:
             session.close()
+
 
 def main():
     """
@@ -431,47 +482,65 @@ def main():
     """
     parser = argparse.ArgumentParser(description="Query narrative chunks in NEXUS")
     parser.add_argument("query", help="Search query")
-    
+
     # Get default values from settings
     default_model = SETTINGS.get("query", {}).get("default_model", "bge-large")
     default_limit = SETTINGS.get("query", {}).get("default_limit", 5)
-    
-    parser.add_argument("--model", choices=["bge-large", "e5-large", "bge-small-custom", "bge-small"], 
-                        default=default_model, help="Embedding model to use for semantic search")
-    parser.add_argument("--limit", type=int, default=default_limit, help="Maximum number of results to return")
-    parser.add_argument("--text-only", action="store_true", help="Use text search instead of vector search")
+
+    parser.add_argument(
+        "--model",
+        choices=["bge-large", "e5-large", "bge-small-custom", "bge-small"],
+        default=default_model,
+        help="Embedding model to use for semantic search",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=default_limit,
+        help="Maximum number of results to return",
+    )
+    parser.add_argument(
+        "--text-only",
+        action="store_true",
+        help="Use text search instead of vector search",
+    )
     parser.add_argument("--db-url", dest="db_url", help="PostgreSQL database URL")
     args = parser.parse_args()
-    
+
     # Initialize searcher
     searcher = NarrativeSearcher(db_url=args.db_url)
-    
+
     # Perform search
     if args.text_only:
         print(f"Performing text search for: '{args.query}'")
         results = searcher.text_search(args.query, limit=args.limit)
     else:
-        print(f"Performing semantic search for: '{args.query}' using model: {args.model}")
-        results = searcher.semantic_search(args.query, model=args.model, limit=args.limit)
-    
+        print(
+            f"Performing semantic search for: '{args.query}' using model: {args.model}"
+        )
+        results = searcher.semantic_search(
+            args.query, model=args.model, limit=args.limit
+        )
+
     # Print results
     if not results:
         print("No results found.")
     else:
         print(f"\nFound {len(results)} results:")
         print("-" * 80)
-        
+
         for i, result in enumerate(results):
             print(f"Result {i+1}:")
             if "similarity" in result:
                 print(f"Similarity: {result['similarity']:.4f}")
             print(f"S{result['season']:02d}E{result['episode']:02d}")
-            
+
             if result["characters"]:
                 print(f"Characters: {', '.join(result['characters'])}")
-            
+
             print(f"\n{result['text']}\n")
             print("-" * 80)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/regenerate_embeddings.py
+++ b/scripts/regenerate_embeddings.py
@@ -40,8 +40,8 @@ ARGUMENTS:
 --database DBNAME         Slot database name (save_01 through save_05)
 
 Dependencies:
-    - pgvector 
-    - sentence-transformers 
+    - pgvector
+    - sentence-transformers
     - sqlalchemy
     - tqdm (for progress bars)
 """
@@ -58,7 +58,7 @@ import argparse
 import numpy as np
 
 # Add parent directory to sys.path to import from nexus package
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Import utils package
 try:
@@ -71,36 +71,42 @@ except ImportError:
         "bge-small-en": 384,
         "bge-small-en-v1.5": 384,
         "bge-small": 384,
-        
         # Large models (1024D)
         "bge-large-en-v1.5": 1024,
         "bge-large-en": 1024,
         "bge-large": 1024,
         "e5-large-v2": 1024,
         "e5-large": 1024,
-        
         # High-dimensional models
         "infly/inf-retriever-v1-1.5b": 1536,
         "inf-retriever-v1-1.5b": 1536,
     }
-    
+
     def get_model_dimensions(model_name: str) -> int:
         """Get the vector dimensions for a given model name."""
         # Check for exact matches
         if model_name in MODEL_DIMENSIONS:
             return MODEL_DIMENSIONS[model_name]
-        
+
         # Check for partial matches
         for key, value in MODEL_DIMENSIONS.items():
             if key in model_name:
                 return value
-        
+
         # Default to 1024 for unknown models
         return 1024
+
+
+from nexus.agents.memnon.utils.embedding_tables import (
+    embedding_table_exists,
+    ensure_embedding_table,
+    table_name_for_dimensions,
+)
 
 # Try to load settings using centralized config loader
 try:
     from nexus.config import load_settings_as_dict
+
     _all_settings = load_settings_as_dict()
     SETTINGS = _all_settings.get("Agent Settings", {}).get("MEMNON", {})
 except Exception as e:
@@ -125,7 +131,7 @@ if log_console:
 logging.basicConfig(
     level=log_level,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    handlers=handlers
+    handlers=handlers,
 )
 logger = logging.getLogger("nexus.embeddings")
 
@@ -142,38 +148,46 @@ except ImportError:
 try:
     import pgvector
     from pgvector.sqlalchemy import Vector
+
     HAS_PGVECTOR = True
 except ImportError:
     logger.error("pgvector not found. Please install with: pip install pgvector")
     sys.exit(1)
 
+
 class ModelLoader:
     """Handles loading different types of embedding models"""
-    
+
     @staticmethod
     def load_model(model_name: str) -> Any:
         """
         Load a model based on its name/type
-        
+
         Args:
             model_name: Name of the model to load
-            
+
         Returns:
             Loaded model
-        
+
         Raises:
             ImportError: If required libraries aren't installed
             ValueError: If model can't be loaded
         """
         logger.info(f"Loading model: {model_name}")
-        
+
         # Check for settings that might provide local paths
         model_local_path = None
         try:
-            if SETTINGS.get("models") and SETTINGS["models"].get(model_name.replace("/", "_")):
-                model_local_path = SETTINGS["models"][model_name.replace("/", "_")].get("local_path")
+            if SETTINGS.get("models") and SETTINGS["models"].get(
+                model_name.replace("/", "_")
+            ):
+                model_local_path = SETTINGS["models"][model_name.replace("/", "_")].get(
+                    "local_path"
+                )
                 if model_local_path:
-                    logger.info(f"Found local path for {model_name}: {model_local_path}")
+                    logger.info(
+                        f"Found local path for {model_name}: {model_local_path}"
+                    )
         except Exception as e:
             logger.warning(f"Error checking settings for local path: {e}")
 
@@ -181,29 +195,41 @@ class ModelLoader:
         if "infly/inf-retriever" in model_name and not model_local_path:
             # Extract model name to use as directory name
             model_dir = model_name.split("/")[-1]  # Just get the part after the slash
-            model_local_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'models', model_dir))
+            model_local_path = os.path.abspath(
+                os.path.join(os.path.dirname(__file__), "..", "models", model_dir)
+            )
             if os.path.exists(model_local_path):
-                logger.info(f"Using default local path for {model_name}: {model_local_path}")
-        
+                logger.info(
+                    f"Using default local path for {model_name}: {model_local_path}"
+                )
+
         # Load using sentence-transformers for all models
         try:
             from sentence_transformers import SentenceTransformer
-            
+
             # Special handling for inf-retriever models which may use a snapshot structure
-            if "infly/inf-retriever" in model_name and model_local_path and os.path.exists(model_local_path):
-                snapshot_dir = os.path.join(model_local_path, 'snapshots')
+            if (
+                "infly/inf-retriever" in model_name
+                and model_local_path
+                and os.path.exists(model_local_path)
+            ):
+                snapshot_dir = os.path.join(model_local_path, "snapshots")
                 if os.path.exists(snapshot_dir):
                     snapshot_candidates = os.listdir(snapshot_dir)
                     if snapshot_candidates:
                         # Get first snapshot directory
-                        snapshot_path = os.path.join(snapshot_dir, snapshot_candidates[0])
-                        logger.info(f"Loading model from snapshot path: {snapshot_path}")
-                        
+                        snapshot_path = os.path.join(
+                            snapshot_dir, snapshot_candidates[0]
+                        )
+                        logger.info(
+                            f"Loading model from snapshot path: {snapshot_path}"
+                        )
+
                         try:
                             return SentenceTransformer(snapshot_path)
                         except Exception as e:
                             logger.warning(f"Failed to load from snapshot: {e}")
-            
+
             # INT8-quantized models use bitsandbytes, which has no working MPS
             # backend on Apple Silicon — force CPU to avoid mixed-device matmul
             # errors. Other models use SentenceTransformer's auto-detection.
@@ -211,14 +237,20 @@ class ModelLoader:
 
             # For other models or fallback
             if model_local_path and os.path.exists(model_local_path):
-                logger.info(f"Loading model from local path: {model_local_path} (device={device or 'auto'})")
+                logger.info(
+                    f"Loading model from local path: {model_local_path} (device={device or 'auto'})"
+                )
                 return SentenceTransformer(model_local_path, device=device)
             else:
-                logger.info(f"Loading model from Hugging Face hub: {model_name} (device={device or 'auto'})")
+                logger.info(
+                    f"Loading model from Hugging Face hub: {model_name} (device={device or 'auto'})"
+                )
                 return SentenceTransformer(model_name, device=device)
-                
+
         except ImportError:
-            logger.error("sentence-transformers not found. Install with: pip install sentence-transformers")
+            logger.error(
+                "sentence-transformers not found. Install with: pip install sentence-transformers"
+            )
             raise ImportError("sentence-transformers library required")
         except Exception as e:
             logger.error(f"Error loading model {model_name}: {e}")
@@ -228,12 +260,12 @@ class ModelLoader:
     def get_embedding(model: Any, text: str, model_name: str) -> np.ndarray:
         """
         Generate an embedding using the appropriate method for the model
-        
+
         Args:
             model: Loaded SentenceTransformer model
             text: Text to embed
             model_name: Name of the model
-            
+
         Returns:
             Embedding as numpy array
         """
@@ -241,31 +273,41 @@ class ModelLoader:
         try:
             # SentenceTransformer has a simple encode method
             embedding = model.encode(text)
-            
+
             # If the result is already a numpy array, return it directly
             if isinstance(embedding, np.ndarray):
                 return embedding
-                
+
             # If it's a list, convert to numpy array
             if isinstance(embedding, list):
                 return np.array(embedding)
-                
+
             # Otherwise, try to convert to numpy array
             return np.array(embedding)
-                
+
         except Exception as e:
             logger.error(f"Error generating embedding with {model_name}: {e}")
             raise
 
+
 class EmbeddingRegenerator:
     """Regenerates embeddings for all narrative chunks"""
-    
-    def __init__(self, model_name: str, batch_size: int = 10, db_url: str = None, dry_run: bool = False,
-                 create_indexes: bool = False, truncate_table: bool = False,
-                 preserve_existing: bool = False):
+
+    def __init__(
+        self,
+        model_name: str,
+        batch_size: int = 10,
+        db_url: str = None,
+        dry_run: bool = False,
+        create_indexes: bool = False,
+        truncate_table: bool = False,
+        preserve_existing: bool = False,
+        ensure_table: bool = True,
+        load_model: bool = True,
+    ):
         """
         Initialize the regenerator with database connection and model.
-        
+
         Args:
             model_name: Name of the embedding model to use
             batch_size: Number of chunks to process at once
@@ -275,6 +317,8 @@ class EmbeddingRegenerator:
                            If False, only create basic indexes (faster for data loading)
             truncate_table: If True, completely truncate the table before starting (clean slate)
             preserve_existing: If True, keep existing rows for this model
+            ensure_table: If True, create the embedding table during initialization
+            load_model: If True, load the embedding model for generation
         """
         self.model_name = model_name
         self.batch_size = batch_size
@@ -282,11 +326,8 @@ class EmbeddingRegenerator:
         self.create_indexes = create_indexes
         self.truncate_table = truncate_table
         self.preserve_existing = preserve_existing
-        self.align_ids_with_chunk_ids = False
         self.dimensions = get_model_dimensions(model_name)
-        self.sequence_reset_done = False  # Track if we've reset the sequence
-        self.force_id_for_first_insert = False  # Will be set to True if needed
-        
+
         # Set database URL using slot-aware resolution
         if db_url:
             self.db_url = db_url
@@ -294,6 +335,7 @@ class EmbeddingRegenerator:
             # Try slot-aware resolution first, fall back to env var or error
             try:
                 from nexus.api.slot_utils import get_slot_db_url
+
                 self.db_url = get_slot_db_url()
             except (ImportError, RuntimeError) as e:
                 # If slot_utils not available or NEXUS_SLOT not set, require explicit URL
@@ -304,21 +346,25 @@ class EmbeddingRegenerator:
                         "environment variable, or pass --db-url explicitly."
                     ) from e
                 self.db_url = explicit_url
-        
+
         # Initialize database connection
         self.engine = create_engine(self.db_url)
         self.Session = sessionmaker(bind=self.engine)
-        
-        # First make sure pgvector extension is available and dimension-specific table exists
+
+        # First make sure pgvector extension is available and, for write paths,
+        # the dimension-specific table exists.
         with self.engine.connect() as connection:
-            # Create pgvector extension if needed
-            connection.execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
-            
-            # Ensure the dimension-specific table exists (without vector indexes initially)
-            self._ensure_dimension_table_exists(connection, create_vector_indexes=False)
-            
-            # If truncate table option is specified, drop and recreate the table
-            if self.truncate_table and not self.dry_run:
+            if ensure_table and not self.dry_run:
+                connection.execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
+                self._ensure_dimension_table_exists(
+                    connection,
+                    create_vector_indexes=False,
+                )
+
+            # If truncate table option is specified, clear rows without relying
+            # on a singleton id sequence. Embedding rows are keyed by
+            # (chunk_id, model), so preserving other models is straightforward.
+            if self.truncate_table and ensure_table and not self.dry_run:
                 table_name = self.get_table_name()
                 try:
                     # Check if table is shared with other models
@@ -328,64 +374,78 @@ class EmbeddingRegenerator:
                     WHERE model != :model_name
                     GROUP BY model;
                     """
-                    
+
                     other_models = []
                     try:
                         # Table might not exist yet
-                        other_models = connection.execute(text(check_other_models_sql), 
-                                                        {"model_name": self.model_name}).fetchall()
+                        other_models = connection.execute(
+                            text(check_other_models_sql),
+                            {"model_name": self.model_name},
+                        ).fetchall()
                         connection.commit()
                     except:
                         # Table doesn't exist yet, so no other models to worry about
                         pass
-                    
+
                     if other_models:
                         # Table is shared with other models, just delete entries for this model
-                        logger.warning(f"⚠️ Table {table_name} is shared with other models:")
+                        logger.warning(
+                            f"⚠️ Table {table_name} is shared with other models:"
+                        )
                         for model, count in other_models:
                             logger.warning(f"  - {model}: {count} entries")
-                        logger.warning(f"⚠️ Will NOT truncate table to preserve other models")
-                        
+                        logger.warning(
+                            f"⚠️ Will NOT truncate table to preserve other models"
+                        )
+
                         # Delete only entries for this model
-                        delete_sql = f"DELETE FROM {table_name} WHERE model = :model_name;"
-                        connection.execute(text(delete_sql), {"model_name": self.model_name})
-                        logger.info(f"✅ Deleted all entries for {self.model_name} from {table_name}")
+                        delete_sql = (
+                            f"DELETE FROM {table_name} WHERE model = :model_name;"
+                        )
+                        connection.execute(
+                            text(delete_sql), {"model_name": self.model_name}
+                        )
+                        logger.info(
+                            f"✅ Deleted all entries for {self.model_name} from {table_name}"
+                        )
                         connection.commit()
-                        
-                        # Don't force ID=1 since other models are using the table
-                        self.force_id_for_first_insert = False
-                        self.sequence_reset_done = True
+
                     else:
-                        # Table is not shared or doesn't exist, safe to drop/recreate
-                        drop_sql = f"DROP TABLE IF EXISTS {table_name} CASCADE;"
-                        connection.execute(text(drop_sql))
-                        logger.info(f"✅ Dropped table {table_name} completely")
-                        
-                        # Force the table to be recreated with a fresh sequence
-                        self._ensure_dimension_table_exists(connection, force_recreate=True)
-                        logger.info(f"✅ Recreated table {table_name} with fresh identity sequence")
-                        self.sequence_reset_done = True  # Mark sequence as already reset
-                        self.force_id_for_first_insert = True
+                        # Table is not shared, so a simple truncate is enough.
+                        truncate_sql = f"TRUNCATE TABLE {table_name};"
+                        connection.execute(text(truncate_sql))
+                        logger.info(f"✅ Truncated table {table_name}")
                 except Exception as e:
                     logger.error(f"Failed to handle table {table_name}: {e}")
-            
+
             connection.commit()
-            logger.info(f"Verified pgvector extension and {self.get_table_name()} table in database")
-        
-        # Load the model
-        try:
-            self.model = ModelLoader.load_model(model_name)
-            logger.info(f"Successfully loaded {model_name} model")
-        except Exception as e:
-            logger.error(f"Failed to load {model_name} model: {e}")
-            sys.exit(1)
-        
+            if ensure_table and not self.dry_run:
+                logger.info(
+                    f"Verified pgvector extension and {self.get_table_name()} table in database"
+                )
+            else:
+                logger.info(f"Connected without creating {self.get_table_name()}")
+
+        self.model = None
+        if load_model:
+            try:
+                self.model = ModelLoader.load_model(model_name)
+                logger.info(f"Successfully loaded {model_name} model")
+            except Exception as e:
+                logger.error(f"Failed to load {model_name} model: {e}")
+                sys.exit(1)
+
         logger.info(f"Connected to database: {self.db_url}")
-    
-    def _ensure_dimension_table_exists(self, connection, create_vector_indexes: bool = False, force_recreate: bool = False):
+
+    def _ensure_dimension_table_exists(
+        self,
+        connection,
+        create_vector_indexes: bool = False,
+        force_recreate: bool = False,
+    ):
         """
         Ensure the dimension-specific embedding table exists
-        
+
         Args:
             connection: SQLAlchemy connection object
             create_vector_indexes: If True, create vector-specific indexes. If False, only create basic indexes.
@@ -393,595 +453,352 @@ class EmbeddingRegenerator:
         """
         dimensions = self.dimensions
         table_name = self.get_table_name()
-        
-        # Check if table exists (case-insensitive)
+
         try:
-            check_table_sql = f"""
-            SELECT EXISTS (
-                SELECT FROM information_schema.tables 
-                WHERE LOWER(table_name) = LOWER('{table_name}')
-            );
-            """
-            table_exists = connection.execute(text(check_table_sql)).scalar()
-            connection.commit()  # Commit this query to avoid transaction issues
-            
-            # If we're about to recreate a table, also check if there are entries for any other models
-            # to avoid accidentally dropping embeddings for other models with the same dimensions
-            if force_recreate and table_exists:
-                check_models_sql = f"""
-                SELECT model, COUNT(*) 
-                FROM {table_name} 
-                WHERE model != :this_model
-                GROUP BY model;
-                """
-                other_models = connection.execute(text(check_models_sql), 
-                                                 {"this_model": self.model_name}).fetchall()
-                connection.commit()
-                
-                if other_models:
-                    # There are other models using this table, so don't recreate the table
-                    logger.warning(f"⚠️ Table {table_name} has entries for other models:")
-                    for model, count in other_models:
-                        logger.warning(f"  - {model}: {count} entries")
-                    logger.warning(f"⚠️ Will NOT drop and recreate table to preserve other models")
-                    logger.warning(f"⚠️ Will delete only entries for {self.model_name} instead")
-                    force_recreate = False
-                    
-                    # Since we're not recreating the table, delete entries for this model
-                    delete_sql = f"""
-                    DELETE FROM {table_name} WHERE model = :model_name;
-                    """
-                    connection.execute(text(delete_sql), {"model_name": self.model_name})
-                    logger.info(f"✅ Deleted all entries for {self.model_name} from {table_name}")
-                    connection.commit()
-            
-            if not table_exists or force_recreate:
-                logger.info(f"Creating dimension-specific table: {table_name}")
-                
-                # For all dimensions, create the table with basic indexes first
-                with self.engine.begin() as separate_connection:
-                    # First create the table without any vector indexes
-                    create_table_sql = f"""
-                    CREATE TABLE {table_name} (
-                        id SERIAL PRIMARY KEY,
-                        chunk_id BIGINT NOT NULL,
-                        model VARCHAR(255) NOT NULL,
-                        embedding vector({dimensions}) NOT NULL,
-                        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-                        CONSTRAINT unique_{table_name}_chunk_model UNIQUE(chunk_id, model),
-                        CONSTRAINT fk_{table_name}_chunk_id FOREIGN KEY (chunk_id) REFERENCES narrative_chunks(id) ON DELETE CASCADE
-                    );
-                    """
-                    separate_connection.execute(text(create_table_sql))
-                    logger.info(f"Created table {table_name}")
-                    
-                    # Create basic indexes (these are fast and help with lookups)
-                    try:
-                        separate_connection.execute(text(f"CREATE INDEX {table_name}_chunk_id_idx ON {table_name} (chunk_id);"))
-                        logger.info(f"Created chunk_id index on {table_name}")
-                    except Exception as e:
-                        logger.warning(f"Error creating chunk_id index: {e}")
-                        
-                    try:
-                        separate_connection.execute(text(f"CREATE INDEX {table_name}_model_idx ON {table_name} (model);"))
-                        logger.info(f"Created model index on {table_name}")
-                    except Exception as e:
-                        logger.warning(f"Error creating model index: {e}")
-                
-                # Only create vector indexes if specifically requested
-                # These are expensive to build and maintain during data loading
-                if create_vector_indexes:
-                    self.create_vector_indexes()
-            
-            # Legacy migration code removed since old chunk_embeddings table has been dropped
-                
+            if force_recreate:
+                connection.execute(text(f"DROP TABLE IF EXISTS {table_name} CASCADE;"))
+
+            ensure_embedding_table(connection, dimensions)
+            logger.info(f"Verified dimension-specific table: {table_name}")
+
+            # Only create vector indexes if specifically requested. These are
+            # expensive to build and maintain during data loading.
+            if create_vector_indexes:
+                self.create_vector_indexes()
+
         except Exception as e:
             logger.error(f"Error checking/creating table {table_name}: {e}")
-            # Don't re-raise the exception, allow the code to continue and try other models
-            connection.rollback()  # Explicitly rollback so we can continue
-    
+            connection.rollback()
+            raise
+
     def get_table_name(self) -> str:
         """
         Get the appropriate table name for the current model dimension
-        
+
         Returns:
             Table name to use for embeddings
         """
-        dim_str = f"{self.dimensions:04d}"  # Format with leading zeros
-        # PostgreSQL converts identifiers to lowercase by default
-        return f"chunk_embeddings_{dim_str}d"
+        return table_name_for_dimensions(self.dimensions)
 
     def sync_id_sequence_to_max(self) -> None:
-        """Move the table ID sequence to the current max(id)."""
-        table_name = self.get_table_name()
-        with self.engine.begin() as conn:
-            conn.execute(text(f"""
-                SELECT setval('{table_name}_id_seq',
-                    (SELECT COALESCE(MAX(id), 1) FROM {table_name}),
-                    true);
-            """))
-    
+        """Legacy no-op: embedding tables are keyed by (chunk_id, model)."""
+
     def get_all_chunks(self) -> List[Dict[str, Any]]:
         """
         Retrieve all narrative chunks from the database.
-        
+
         Returns:
             List of dicts containing chunk_id and raw_text
         """
         session = self.Session()
         try:
             # Query for all chunks
-            query = text("""
+            query = text(
+                """
                 SELECT id, raw_text 
                 FROM narrative_chunks 
                 ORDER BY id
-            """)
-            
+            """
+            )
+
             result = session.execute(query).fetchall()
-            
+
             # Convert to list of dicts
             chunks = [{"chunk_id": str(row[0]), "raw_text": row[1]} for row in result]
-            
+
             logger.info(f"Retrieved {len(chunks)} narrative chunks from database")
             return chunks
-        
+
         except Exception as e:
             logger.error(f"Error retrieving chunks: {e}")
             return []
-        
+
         finally:
             session.close()
-    
+
     def delete_existing_embeddings(self) -> int:
         """
         Delete any existing embeddings for the current model.
-        
+
         Returns:
             Number of embeddings deleted
         """
         if self.dry_run:
             logger.info(f"[DRY RUN] Would delete existing {self.model_name} embeddings")
             return 0
-        
+
         table_name = self.get_table_name()
         session = self.Session()
         deleted_count = 0
-        
+
         try:
             # Check if the table exists first
             with self.engine.connect() as check_conn:
-                table_exists_query = text(f"""
+                table_exists_query = text(
+                    f"""
                     SELECT EXISTS (
                         SELECT FROM information_schema.tables 
                         WHERE LOWER(table_name) = LOWER('{table_name}')
                     );
-                """)
+                """
+                )
                 table_exists = check_conn.execute(table_exists_query).scalar()
-                
+
                 if not table_exists:
-                    logger.info(f"Table {table_name} doesn't exist yet, no need to delete anything")
+                    logger.info(
+                        f"Table {table_name} doesn't exist yet, no need to delete anything"
+                    )
                     return 0
-            
+
             # Delete from the dimension-specific table
-            delete_query = text(f"""
+            delete_query = text(
+                f"""
                 DELETE FROM {table_name} 
                 WHERE model = :model_name
-            """)
-            
+            """
+            )
+
             result = session.execute(delete_query, {"model_name": self.model_name})
             dimension_deleted = result.rowcount
             session.commit()
-            
+
             deleted_count += dimension_deleted
-            logger.info(f"Deleted {dimension_deleted} existing {self.model_name} embeddings from {table_name}")
-            
+            logger.info(
+                f"Deleted {dimension_deleted} existing {self.model_name} embeddings from {table_name}"
+            )
+
             # Legacy code for old chunk_embeddings table removed since table has been dropped
-            
-            # Truncate the table and reset sequence if requested to fully reset IDs
-            if deleted_count > 0:
-                try:
-                    with self.engine.begin() as conn:
-                        # Option 1: Reset sequence directly (if there are remaining rows, this will prevent ID clashes)
-                        reset_seq_sql = f"""
-                        SELECT setval('{table_name}_id_seq', 
-                           (SELECT COALESCE(MIN(id), 1) - 1 FROM {table_name}), 
-                           true);
-                        """
-                        conn.execute(text(reset_seq_sql))
-                        logger.info(f"Reset ID sequence for {table_name} to restart from the beginning")
-                except Exception as e:
-                    logger.warning(f"Could not reset table sequence: {e}")
-            
             return deleted_count
-        
+
         except Exception as e:
             session.rollback()
             logger.error(f"Error deleting existing embeddings: {e}")
             return 0
-        
+
         finally:
             session.close()
-    
+
     def store_embedding_batch(self, batch: List[Tuple[str, List[float]]]) -> int:
         """
         Store a batch of embeddings
-        
+
         Args:
             batch: List of (chunk_id, embedding) tuples
-            
+
         Returns:
             Number of embeddings successfully stored
         """
         if not batch:
             return 0
-            
+
         if self.dry_run:
             return len(batch)
-        
+
         table_name = self.get_table_name()
         success_count = 0
-        
-        # Only reset the sequence once at the beginning of the process
-        if not self.sequence_reset_done:
-            with self.engine.begin() as conn:
-                try:
-                    if self.preserve_existing:
-                        logger.info(
-                            f"Preserving existing rows for model {self.model_name}"
-                        )
-                    else:
-                        # First ensure there are no existing rows for this model (belt and suspenders)
-                        delete_query = f"DELETE FROM {table_name} WHERE model = :model_name;"
-                        conn.execute(text(delete_query), {"model_name": self.model_name})
-                        logger.info(f"✅ Removed any existing rows for model {self.model_name}")
-                    
-                    # Check if other models are using this table
-                    other_models_sql = f"""
-                    SELECT model, COUNT(*) 
-                    FROM {table_name} 
-                    WHERE model != :this_model 
-                    GROUP BY model;
-                    """
-                    other_models = conn.execute(text(other_models_sql), 
-                                              {"this_model": self.model_name}).fetchall()
-                    
-                    has_other_models = len(other_models) > 0
+        with self.engine.begin() as conn:
+            ensure_embedding_table(conn, self.dimensions)
 
-                    if self.preserve_existing and not has_other_models:
-                        self.align_ids_with_chunk_ids = True
-                        conn.execute(text(f"""
-                            UPDATE {table_name}
-                            SET id = -chunk_id
-                            WHERE model = :model_name
-                              AND id <> chunk_id;
-                        """), {"model_name": self.model_name})
-                        conn.execute(text(f"""
-                            UPDATE {table_name}
-                            SET id = chunk_id
-                            WHERE model = :model_name
-                              AND id < 0;
-                        """), {"model_name": self.model_name})
-                        logger.info(
-                            f"Aligned {table_name}.id with chunk_id for {self.model_name}"
-                        )
-                    
-                    # Next get minimum and maximum existing IDs
-                    count_sql = f"SELECT COUNT(*), MIN(id), MAX(id) FROM {table_name};"
-                    count_row = conn.execute(text(count_sql)).fetchone()
-                    remaining_count, min_id, max_id = count_row[0] or 0, count_row[1] or 0, count_row[2] or 0
-                    
-                    if remaining_count > 0:
-                        logger.info(f"Still {remaining_count} rows in table from other models (ID range: {min_id}-{max_id})")
-                        
-                        # Log the other models using this table
-                        if has_other_models:
-                            logger.info(f"Table {table_name} is shared with other models:")
-                            for model, count in other_models:
-                                logger.info(f"  - {model}: {count} entries")
-                    
-                    # Reset sequence differently depending on whether there are other models
-                    if has_other_models:
-                        # For tables with other models, we need to get next available ID
-                        # to avoid conflicts with existing rows
-                        reset_sql = f"""
-                        SELECT setval('{table_name}_id_seq', 
-                                     (SELECT COALESCE(MAX(id), 1) FROM {table_name}),
-                                     true);
-                        """
-                        conn.execute(text(reset_sql))
-                        logger.info(f"✅ Set ID sequence for {table_name} to continue after existing rows")
-                        
-                        # Don't force ID since other models are using the table
-                        self.force_id_for_first_insert = False
-                    elif self.truncate_table:
-                        # For truncated tables with no other models, we can restart from 1
-                        reset_sql = f"ALTER SEQUENCE {table_name}_id_seq RESTART WITH 1;"
-                        conn.execute(text(reset_sql))
-                        logger.info(f"✅ Reset ID sequence for {table_name} to start from 1")
-                        
-                        # Force ID=1 for first insert
-                        self.force_id_for_first_insert = True
-                        logger.info("✅ Will force ID=1 for first insertion")
-                    else:
-                        # No other models but not truncating - just reset to next available ID
-                        reset_sql = f"""
-                        SELECT setval('{table_name}_id_seq', 
-                                     (SELECT COALESCE(MAX(id), 1) FROM {table_name}),
-                                     true);
-                        """
-                        conn.execute(text(reset_sql))
-                        logger.info(f"✅ Set ID sequence for {table_name} to next available ID")
-                        self.force_id_for_first_insert = False
-                        
-                    # Mark sequence handling as done
-                    self.sequence_reset_done = True
-                        
-                    # Verify the sequence setting
-                    try:
-                        next_sql = f"SELECT nextval('{table_name}_id_seq');"
-                        next_val = conn.execute(text(next_sql)).scalar()
-                        logger.info(f"Next ID will be: {next_val}")
-                        
-                        # Revert the nextval operation to keep sequence in sync
-                        if next_val > 1:
-                            revert_sql = f"""
-                            SELECT setval('{table_name}_id_seq', 
-                                        (SELECT COALESCE(currval('{table_name}_id_seq'), 1) - 1),
-                                        true);
-                            """
-                            conn.execute(text(revert_sql))
-                    except Exception:
-                        # If there are no existing sequence values, this might fail
-                        logger.info("Sequence hasn't been used yet")
-                        
-                except Exception as e:
-                    logger.warning(f"⚠️ Could not properly setup sequence: {e}")
-        
         # For high-dimensional vectors, process one at a time to avoid SQL issues
         # with extremely long statements
         if self.dimensions > 2000:
-            logger.info(f"Using per-row insert strategy for high-dimensional vectors ({self.dimensions}D)")
-            
-            # Keep track if we need to force ID=1 for first insert
-            is_first_insert = True
-            
+            logger.info(
+                f"Using per-row insert strategy for high-dimensional vectors ({self.dimensions}D)"
+            )
+
             for chunk_id, embedding in batch:
                 session = self.Session()
                 try:
                     # Format embedding string without using Python string concatenation
                     # to avoid memory issues with huge vectors
-                    
+
                     # Convert embedding to string format for pgvector
                     embedding_str = "[" + ",".join(str(x) for x in embedding) + "]"
-                    
-                    # For the very first insert on a truncated table, force ID=1
-                    if self.align_ids_with_chunk_ids:
-                        insert_sql = text(f"""
-                            INSERT INTO {table_name}
-                            (id, chunk_id, model, embedding, created_at)
-                            VALUES (:embedding_id, :chunk_id, :model_name, '{embedding_str}'::vector({self.dimensions}), NOW())
-                            ON CONFLICT (chunk_id, model) DO UPDATE
-                            SET id = EXCLUDED.id,
-                                embedding = '{embedding_str}'::vector({self.dimensions}),
-                                created_at = NOW();
-                        """)
-                    elif is_first_insert and self.force_id_for_first_insert:
-                        insert_sql = text(f"""
-                            INSERT INTO {table_name} 
-                            (id, chunk_id, model, embedding, created_at) 
-                            VALUES (1, :chunk_id, :model_name, '{embedding_str}'::vector({self.dimensions}), NOW())
-                            ON CONFLICT (chunk_id, model) DO UPDATE
-                            SET embedding = '{embedding_str}'::vector({self.dimensions}),
-                                created_at = NOW();
-                        """)
-                        logger.info(f"👉 Forcing ID=1 for first row")
-                        is_first_insert = False  # No longer the first insert
-                        self.force_id_for_first_insert = False  # Only force once
-                    else:
-                        # Normal insert without forcing ID - explicit casting to vector with dimensions
-                        # Add explicit RETURNING clause to ensure we get feedback that the update worked
-                        insert_sql = text(f"""
-                            INSERT INTO {table_name} 
-                            (chunk_id, model, embedding, created_at) 
-                            VALUES (:chunk_id, :model_name, '{embedding_str}'::vector({self.dimensions}), NOW())
-                            ON CONFLICT (chunk_id, model) DO UPDATE
-                            SET embedding = '{embedding_str}'::vector({self.dimensions}),
-                                created_at = NOW()
-                            RETURNING id;
-                        """)
-                    
-                    # Execute the statement with just the standard parameters
-                    session.execute(insert_sql, {
-                        "embedding_id": int(chunk_id),
-                        "chunk_id": int(chunk_id), 
-                        "model_name": self.model_name
-                    })
+                    insert_sql = text(
+                        f"""
+                        INSERT INTO {table_name}
+                        (chunk_id, model, embedding, created_at)
+                        VALUES (:chunk_id, :model_name, '{embedding_str}'::vector({self.dimensions}), NOW())
+                        ON CONFLICT (chunk_id, model) DO UPDATE
+                        SET embedding = '{embedding_str}'::vector({self.dimensions}),
+                            created_at = NOW();
+                    """
+                    )
+
+                    session.execute(
+                        insert_sql,
+                        {"chunk_id": int(chunk_id), "model_name": self.model_name},
+                    )
                     session.commit()
                     success_count += 1
-                    
+
                 except Exception as e:
                     session.rollback()
                     logger.error(f"Error storing embedding for chunk {chunk_id}: {e}")
-                    
+
                 finally:
                     session.close()
-            
+
             if success_count > 0:
-                logger.info(f"Stored {success_count}/{len(batch)} embeddings in {table_name}")
-                if self.align_ids_with_chunk_ids:
-                    self.sync_id_sequence_to_max()
-            
+                logger.info(
+                    f"Stored {success_count}/{len(batch)} embeddings in {table_name}"
+                )
+
             return success_count
-        
+
         # For normal-sized vectors, use batch insert
         session = self.Session()
         try:
-            # If this is a truncated table and we need to force ID=1 for the first insert,
-            # we need to handle the first row separately
-            if self.force_id_for_first_insert and len(batch) > 0:
-                # Handle the first row separately to force ID=1
-                chunk_id, embedding = batch[0]
-                embedding_str = f"[{','.join(str(x) for x in embedding)}]"
-                
-                # Force ID=1 for the first row - explicit casting to vector with dimensions
-                force_first_sql = text(f"""
-                    INSERT INTO {table_name} 
-                    (id, chunk_id, model, embedding, created_at) 
-                    VALUES (1, :chunk_id, :model_name, '{embedding_str}'::vector({self.dimensions}), NOW())
-                    ON CONFLICT (chunk_id, model) DO UPDATE
-                    SET embedding = '{embedding_str}'::vector({self.dimensions}),
-                        created_at = NOW()
-                    RETURNING id;
-                """)
-                
-                session.execute(force_first_sql, {
-                    "chunk_id": int(chunk_id), 
-                    "model_name": self.model_name
-                })
-                session.commit()
-                logger.info(f"👉 Forced ID=1 for first row with chunk_id={chunk_id}")
-                
-                # Remove the first row from the batch since we've handled it
-                batch = batch[1:]
-                success_count += 1
-                
-                # Turn off forcing for future inserts
-                self.force_id_for_first_insert = False
-                
-                # If the batch is now empty, we're done
-                if not batch:
-                    return success_count
-            
             # For multi-row insert, we need to format each vector directly in the SQL
             values_parts = []
             params = {}
-            
+
             for i, (chunk_id, embedding) in enumerate(batch):
                 # Format embedding string directly in SQL with the :: cast to vector with explicit dimensions
                 embedding_str = f"[{','.join(str(x) for x in embedding)}]"
-                values_parts.append(f"(:chunk_id_{i}, :model_name, '{embedding_str}'::vector({self.dimensions}), NOW())")
+                values_parts.append(
+                    f"(:chunk_id_{i}, :model_name, '{embedding_str}'::vector({self.dimensions}), NOW())"
+                )
                 params[f"chunk_id_{i}"] = int(chunk_id)
-            
+
             params["model_name"] = self.model_name
-            
+
             # Skip empty batches (could happen if we removed the first row)
             if not values_parts:
                 return success_count
-                
+
             # Create multi-row insert statement
             values_sql = ",".join(values_parts)
-            insert_sql = text(f"""
+            insert_sql = text(
+                f"""
                 INSERT INTO {table_name} 
                 (chunk_id, model, embedding, created_at) 
                 VALUES {values_sql}
                 ON CONFLICT (chunk_id, model) DO UPDATE
                 SET embedding = EXCLUDED.embedding,
                     created_at = EXCLUDED.created_at;
-            """)
-            
+            """
+            )
+
             session.execute(insert_sql, params)
             session.commit()
             success_count = len(batch)
-            
+
             logger.info(f"Stored {len(batch)} embeddings in {table_name}")
-        
+
         except Exception as e:
             session.rollback()
             logger.error(f"Error storing batch of embeddings: {e}")
-            
+
             # Try individual inserts if batch insert fails
             for chunk_id, embedding in batch:
                 try:
                     # Format embedding string
                     embedding_str = f"[{','.join(str(x) for x in embedding)}]"
-                    
+
                     # Insert single row - explicitly cast to vector with dimensions
-                    single_insert_sql = text(f"""
+                    single_insert_sql = text(
+                        f"""
                         INSERT INTO {table_name} 
                         (chunk_id, model, embedding, created_at) 
                         VALUES (:chunk_id, :model_name, '{embedding_str}'::vector({self.dimensions}), NOW())
                         ON CONFLICT (chunk_id, model) DO UPDATE
                         SET embedding = '{embedding_str}'::vector({self.dimensions}),
-                            created_at = NOW()
-                        RETURNING id;
-                    """)
-                    
-                    session.execute(single_insert_sql, {
-                        "chunk_id": int(chunk_id), 
-                        "model_name": self.model_name
-                    })
+                            created_at = NOW();
+                    """
+                    )
+
+                    session.execute(
+                        single_insert_sql,
+                        {"chunk_id": int(chunk_id), "model_name": self.model_name},
+                    )
                     session.commit()
                     success_count += 1
-                
+
                 except Exception as e2:
                     session.rollback()
-                    logger.error(f"Error storing individual embedding for chunk {chunk_id}: {e2}")
-        
+                    logger.error(
+                        f"Error storing individual embedding for chunk {chunk_id}: {e2}"
+                    )
+
         finally:
             session.close()
             return success_count
-    
+
     def create_vector_indexes(self) -> bool:
         """
         Create vector indexes for the current model's table.
         This should be called after all data is loaded to avoid index maintenance overhead.
-        
+
         Returns:
             True if at least one index was created successfully, False otherwise
         """
         table_name = self.get_table_name()
         dimensions = self.dimensions
         success = False
-        
+
         logger.info(f"Creating vector indexes for {table_name} table ({dimensions}D)")
-        
+
+        with self.engine.connect() as conn:
+            if not embedding_table_exists(conn, table_name):
+                logger.error(f"Table {table_name} does not exist")
+                return False
+
         # Now create specialized vector indexes in a separate transaction
         with self.engine.begin() as idx_conn:
             # First try HNSW index (preferred for performance)
             try:
                 logger.info(f"Creating HNSW index for {table_name}...")
                 start_time = time.time()
-                
+
                 # HNSW index with optimized parameters
                 hnsw_sql = f"""
-                CREATE INDEX {table_name}_hnsw_idx 
+                CREATE INDEX IF NOT EXISTS {table_name}_hnsw_idx
                 ON {table_name} USING hnsw (embedding vector_cosine_ops)
                 WITH (ef_construction=64, m=16);
                 """
                 idx_conn.execute(text(hnsw_sql))
-                
+
                 elapsed_time = time.time() - start_time
-                logger.info(f"✅ Successfully created HNSW index for {dimensions}D vectors in {elapsed_time:.2f}s")
+                logger.info(
+                    f"✅ Successfully created HNSW index for {dimensions}D vectors in {elapsed_time:.2f}s"
+                )
                 success = True
             except Exception as e:
                 logger.warning(f"⚠️ Could not create HNSW index: {e}")
-                
+
                 # If HNSW fails, try IVFFLAT as backup
                 try:
-                    logger.info(f"Creating IVFFLAT index for {table_name} as fallback...")
+                    logger.info(
+                        f"Creating IVFFLAT index for {table_name} as fallback..."
+                    )
                     start_time = time.time()
-                    
+
                     # IVFFLAT index with optimized parameters
                     ivf_sql = f"""
-                    CREATE INDEX {table_name}_ivf_idx 
+                    CREATE INDEX IF NOT EXISTS {table_name}_ivf_idx
                     ON {table_name} USING ivfflat (embedding vector_cosine_ops)
                     WITH (lists=100);
                     """
                     idx_conn.execute(text(ivf_sql))
-                    
+
                     elapsed_time = time.time() - start_time
-                    logger.info(f"✅ Created IVFFLAT index for {dimensions}D vectors in {elapsed_time:.2f}s")
+                    logger.info(
+                        f"✅ Created IVFFLAT index for {dimensions}D vectors in {elapsed_time:.2f}s"
+                    )
                     success = True
                 except Exception as e2:
                     logger.warning(f"⚠️ Could not create IVFFLAT index: {e2}")
-                    logger.warning(f"Table will remain without specialized vector index, searches will be slower")
-        
+                    logger.warning(
+                        f"Table will remain without specialized vector index, searches will be slower"
+                    )
+
         return success
-    
+
     def regenerate_all_embeddings(self) -> Dict[str, int]:
         """
         Regenerate all embeddings for the current model.
-        
+
         Returns:
             Dict with counts of processed, successful, and failed embeddings
         """
@@ -990,42 +807,41 @@ class EmbeddingRegenerator:
         if not chunks:
             logger.error("No chunks found to process")
             return {"total": 0, "success": 0, "failed": 0}
-        
+
         # Count existing embeddings before deleting
         with self.engine.connect() as conn:
             table_name = self.get_table_name()
-            count_sql = f"""
-            SELECT COUNT(*) FROM {table_name} 
-            WHERE model = :model_name;
-            """
-            existing_count = conn.execute(text(count_sql), {"model_name": self.model_name}).scalar() or 0
-            
-            # Get current sequence value to show the problem
-            try:
-                seq_val_sql = f"SELECT last_value FROM {table_name}_id_seq;"
-                seq_value = conn.execute(text(seq_val_sql)).scalar() or 0
-                if seq_value > 1:
-                    logger.info(f"⚠️ Current sequence value for {table_name}_id_seq is {seq_value}")
-                    logger.info(f"✅ This will be reset to 1 during embedding generation")
-            except Exception as e:
-                logger.warning(f"Could not check current sequence value: {e}")
-            
+            if embedding_table_exists(conn, table_name):
+                count_sql = f"""
+                SELECT COUNT(*) FROM {table_name}
+                WHERE model = :model_name;
+                """
+                existing_count = (
+                    conn.execute(
+                        text(count_sql),
+                        {"model_name": self.model_name},
+                    ).scalar()
+                    or 0
+                )
+            else:
+                existing_count = 0
+
             if existing_count > 0:
-                logger.info(f"Found {existing_count} existing embeddings for {self.model_name}")
+                logger.info(
+                    f"Found {existing_count} existing embeddings for {self.model_name}"
+                )
                 # Ask for confirmation if not running in headless mode
                 if not self.dry_run and os.isatty(sys.stdout.fileno()):
-                    confirm = input(f"Delete {existing_count} existing embeddings for {self.model_name}? (y/n): ")
-                    if confirm.lower() != 'y':
+                    confirm = input(
+                        f"Delete {existing_count} existing embeddings for {self.model_name}? (y/n): "
+                    )
+                    if confirm.lower() != "y":
                         logger.info("Aborting embedding regeneration")
                         return {"total": 0, "success": 0, "failed": 0}
-        
+
         # Delete existing embeddings
         self.delete_existing_embeddings()
-        
-        # Mark sequence as not reset yet to ensure it happens during first batch
-        self.sequence_reset_done = False
-        logger.info("✅ ID sequence will be reset during the first batch insertion")
-        
+
         # Counters
         total = len(chunks)
         success = 0
@@ -1033,59 +849,69 @@ class EmbeddingRegenerator:
         batch = []
         last_save_point = 0
         checkpoint_interval = 50  # Save progress every 50 chunks
-        
+
         # Process each chunk in batches
-        logger.info(f"Starting embedding generation for {total} chunks with {self.model_name}")
-        
+        logger.info(
+            f"Starting embedding generation for {total} chunks with {self.model_name}"
+        )
+
         # Use tqdm for progress bar
         start_time = time.time()
-        progress_bar = tqdm.tqdm(chunks, desc=f"Generating {self.model_name} embeddings")
-        
+        progress_bar = tqdm.tqdm(
+            chunks, desc=f"Generating {self.model_name} embeddings"
+        )
+
         for i, chunk in enumerate(progress_bar):
             try:
                 # Skip chunks that already have embeddings (should be none after deletion)
                 chunk_id = chunk["chunk_id"]
-                
+
                 # Generate embedding
-                embedding = ModelLoader.get_embedding(self.model, chunk["raw_text"], self.model_name)
-                
+                embedding = ModelLoader.get_embedding(
+                    self.model, chunk["raw_text"], self.model_name
+                )
+
                 # Convert to list
                 embedding_list = embedding.tolist()
-                
+
                 # Add to batch
                 batch.append((chunk_id, embedding_list))
-                
+
                 # Process batch if reached batch size
                 if len(batch) >= self.batch_size:
                     success_count = self.store_embedding_batch(batch)
                     success += success_count
                     failed += len(batch) - success_count
                     batch = []
-                    
+
                 # Log progress at checkpoints
                 if i - last_save_point >= checkpoint_interval:
                     elapsed = time.time() - start_time
                     rate = i / elapsed if elapsed > 0 else 0
                     remaining = (total - i) / rate if rate > 0 else 0
-                    
-                    logger.info(f"Progress: {i}/{total} chunks ({i/total*100:.1f}%) - " +
-                               f"Success: {success}, Failed: {failed} - " +
-                               f"Est. remaining time: {remaining/60:.1f} minutes")
+
+                    logger.info(
+                        f"Progress: {i}/{total} chunks ({i/total*100:.1f}%) - "
+                        + f"Success: {success}, Failed: {failed} - "
+                        + f"Est. remaining time: {remaining/60:.1f} minutes"
+                    )
                     last_save_point = i
-            
+
             except Exception as e:
                 logger.error(f"Error processing chunk {chunk['chunk_id']}: {e}")
                 failed += 1
-        
+
         # Process final batch
         if batch:
             success_count = self.store_embedding_batch(batch)
             success += success_count
             failed += len(batch) - success_count
-        
+
         elapsed_time = time.time() - start_time
-        logger.info(f"Completed embedding generation in {elapsed_time:.2f}s: {success} successful, {failed} failed out of {total} total")
-        
+        logger.info(
+            f"Completed embedding generation in {elapsed_time:.2f}s: {success} successful, {failed} failed out of {total} total"
+        )
+
         # Double-check we have all embeddings
         with self.engine.connect() as conn:
             table_name = self.get_table_name()
@@ -1093,29 +919,47 @@ class EmbeddingRegenerator:
             SELECT COUNT(*) FROM {table_name} 
             WHERE model = :model_name;
             """
-            final_count = conn.execute(text(count_sql), {"model_name": self.model_name}).scalar() or 0
-            
+            final_count = (
+                conn.execute(text(count_sql), {"model_name": self.model_name}).scalar()
+                or 0
+            )
+
             if final_count < total:
-                logger.warning(f"⚠️ Expected {total} embeddings but found only {final_count}")
-                logger.warning(f"⚠️ {total - final_count} chunks were not processed correctly.")
-                
+                logger.warning(
+                    f"⚠️ Expected {total} embeddings but found only {final_count}"
+                )
+                logger.warning(
+                    f"⚠️ {total - final_count} chunks were not processed correctly."
+                )
+
                 # Save missing chunks to file for resuming later
                 missing_sql = f"""
                 SELECT c.id FROM narrative_chunks c
                 LEFT JOIN {table_name} e ON c.id = e.chunk_id AND e.model = :model_name
                 WHERE e.chunk_id IS NULL;
                 """
-                missing_ids = [row[0] for row in conn.execute(text(missing_sql), {"model_name": self.model_name}).fetchall()]
-                
+                missing_ids = [
+                    row[0]
+                    for row in conn.execute(
+                        text(missing_sql), {"model_name": self.model_name}
+                    ).fetchall()
+                ]
+
                 if missing_ids:
                     missing_file = f"missing_{self.model_name.replace('/', '_')}_{int(time.time())}.txt"
-                    with open(missing_file, 'w') as f:
-                        f.write('\n'.join(str(id) for id in missing_ids))
-                    logger.warning(f"⚠️ Saved {len(missing_ids)} missing chunk IDs to {missing_file}")
-                    logger.warning(f"⚠️ You can resume embedding generation for these chunks later.")
+                    with open(missing_file, "w") as f:
+                        f.write("\n".join(str(id) for id in missing_ids))
+                    logger.warning(
+                        f"⚠️ Saved {len(missing_ids)} missing chunk IDs to {missing_file}"
+                    )
+                    logger.warning(
+                        f"⚠️ You can resume embedding generation for these chunks later."
+                    )
             else:
-                logger.info(f"✅ Successfully generated embeddings for all {final_count} chunks")
-        
+                logger.info(
+                    f"✅ Successfully generated embeddings for all {final_count} chunks"
+                )
+
         # Create vector indexes if requested
         if self.create_indexes and success > 0:
             logger.info("Creating vector indexes now that data is loaded...")
@@ -1124,18 +968,32 @@ class EmbeddingRegenerator:
                 logger.info("✅ Successfully created vector indexes")
             else:
                 logger.warning("⚠️ Failed to create vector indexes")
-                logger.info("You can create indexes later with: python scripts/create_vector_index.py --model " + self.model_name)
+                logger.info(
+                    "You can create indexes later with: python scripts/create_vector_index.py --model "
+                    + self.model_name
+                )
         elif success > 0:
-            logger.info("Skipping vector index creation (use --create-indexes flag to create them)")
-            logger.info("You can create indexes later with: python scripts/create_vector_index.py --model " + self.model_name)
-        
+            logger.info(
+                "Skipping vector index creation (use --create-indexes flag to create them)"
+            )
+            logger.info(
+                "You can create indexes later with: python scripts/create_vector_index.py --model "
+                + self.model_name
+            )
+
         return {"total": total, "success": success, "failed": failed}
 
-def regenerate_all_models(db_url: str = None, batch_size: int = 10, dry_run: bool = False, 
-                     create_indexes: bool = False, truncate_table: bool = False):
+
+def regenerate_all_models(
+    db_url: str = None,
+    batch_size: int = 10,
+    dry_run: bool = False,
+    create_indexes: bool = False,
+    truncate_table: bool = False,
+):
     """
     Regenerate embeddings for all active models in settings.json
-    
+
     Args:
         db_url: Database URL
         batch_size: Number of chunks to process in each batch
@@ -1145,10 +1003,10 @@ def regenerate_all_models(db_url: str = None, batch_size: int = 10, dry_run: boo
     """
     # Get active models from settings
     active_models = []
-    
+
     # Print header
     print("\n========== Regenerating Embeddings for Active Models ==========")
-    
+
     try:
         models_config = SETTINGS.get("models", {})
         for model_key, config in models_config.items():
@@ -1158,79 +1016,92 @@ def regenerate_all_models(db_url: str = None, batch_size: int = 10, dry_run: boo
                     model_name = model_key.replace("_", "/")
                 else:
                     model_name = model_key
-                    
+
                 # Get local path if available
                 local_path = config.get("local_path")
                 remote_path = config.get("remote_path")
-                
+
                 # Check if local path exists
                 local_path_exists = local_path and os.path.exists(local_path)
-                
+
                 # If remote_path is provided, use that as the model name
                 if remote_path:
                     model_name = remote_path
-                
+
                 active_models.append(model_name)
-                
+
                 if local_path:
                     status = "✅ Found" if local_path_exists else "❌ Not found"
-                    logger.info(f"Found active model in settings: {model_name} (Local path: {status})")
+                    logger.info(
+                        f"Found active model in settings: {model_name} (Local path: {status})"
+                    )
                     print(f"- {model_name}: Active, Local path: {status}")
                 else:
-                    logger.info(f"Found active model in settings (remote only): {model_name}")
+                    logger.info(
+                        f"Found active model in settings (remote only): {model_name}"
+                    )
                     print(f"- {model_name}: Active, Using HuggingFace remote")
     except Exception as e:
         logger.error(f"Error processing models from settings: {e}")
         print(f"Error loading models from settings: {e}")
-        
+
     if not active_models:
         logger.warning("No active models found in settings.json")
-        print("No active models found in settings.json, defaulting to infly/inf-retriever-v1")
+        print(
+            "No active models found in settings.json, defaulting to infly/inf-retriever-v1"
+        )
         # Default to infly/inf-retriever-v1 if no active models
         active_models = ["infly/inf-retriever-v1"]
-    
+
     total_results = {"total": 0, "success": 0, "failed": 0}
-    
+
     # Process each active model
     for model_name in active_models:
         logger.info(f"Processing model: {model_name}")
-        
+
         try:
             # Initialize the regenerator
             regenerator = EmbeddingRegenerator(
                 model_name=model_name,
                 batch_size=batch_size,
-                db_url=db_url, 
+                db_url=db_url,
                 dry_run=dry_run,
                 create_indexes=create_indexes,
-                truncate_table=truncate_table
+                truncate_table=truncate_table,
             )
-            
+
             # Regenerate embeddings for this model
             results = regenerator.regenerate_all_embeddings()
-            
+
             # Add to total results
             total_results["total"] += results["total"]
             total_results["success"] += results["success"]
             total_results["failed"] += results["failed"]
-            
+
             # Print model summary
             print(f"\nCompleted model: {model_name}")
             print(f"Dimensions: {regenerator.dimensions}")
             print(f"Successful: {results['success']}/{results['total']}")
-            
+
         except Exception as e:
             logger.error(f"Error processing model {model_name}: {e}")
             total_results["failed"] += 1
-    
+
     return total_results
 
-def regenerate_missing_chunks(model_name: str, missing_file: str, batch_size: int = 10, 
-                         db_url: str = None, dry_run: bool = False, create_indexes: bool = False,
-                         truncate_table: bool = False):
+
+def regenerate_missing_chunks(
+    model_name: str,
+    missing_file: str,
+    batch_size: int = 10,
+    db_url: str = None,
+    dry_run: bool = False,
+    create_indexes: bool = False,
+    truncate_table: bool = False,
+):
     """
     Regenerate embeddings for missing chunks specified in a file.
-    
+
     Args:
         model_name: Embedding model to use
         missing_file: File containing IDs of chunks to process
@@ -1239,26 +1110,27 @@ def regenerate_missing_chunks(model_name: str, missing_file: str, batch_size: in
         dry_run: If True, don't make actual changes
         create_indexes: If True, create vector indexes after data loading
         truncate_table: If True, completely truncate the table before starting (clean slate)
-        
+
     Returns:
         Dict with results
     """
     logger.info(f"Reading missing chunk IDs from {missing_file}")
     try:
-        with open(missing_file, 'r') as f:
+        with open(missing_file, "r") as f:
             chunk_ids = [line.strip() for line in f if line.strip()]
-        
+
         missing_count = len(chunk_ids)
         logger.info(f"Found {missing_count} missing chunk IDs to process")
-        
+
         if not missing_count:
             logger.warning("No missing chunk IDs found, nothing to do")
             return {"total": 0, "success": 0, "failed": 0}
-        
+
         # Connect to database using slot-aware resolution
         if not db_url:
             try:
                 from nexus.api.slot_utils import get_slot_db_url
+
                 db_url = get_slot_db_url()
             except (ImportError, RuntimeError):
                 db_url = os.environ.get("NEXUS_DB_URL")
@@ -1267,86 +1139,96 @@ def regenerate_missing_chunks(model_name: str, missing_file: str, batch_size: in
                         "No database URL provided. Set NEXUS_SLOT (1-5) or NEXUS_DB_URL."
                     )
         engine = create_engine(db_url)
-        
+
         # Get the chunks for these IDs
         chunks = []
         with engine.connect() as conn:
             # Query in batches to avoid too many parameters
             for i in range(0, len(chunk_ids), 100):
-                batch_ids = chunk_ids[i:i+100]
-                placeholders = ', '.join(f':id{j}' for j in range(len(batch_ids)))
-                params = {f'id{j}': int(id) for j, id in enumerate(batch_ids)}
-                
-                query = text(f"""
+                batch_ids = chunk_ids[i : i + 100]
+                placeholders = ", ".join(f":id{j}" for j in range(len(batch_ids)))
+                params = {f"id{j}": int(id) for j, id in enumerate(batch_ids)}
+
+                query = text(
+                    f"""
                     SELECT id, raw_text 
                     FROM narrative_chunks 
                     WHERE id IN ({placeholders})
                     ORDER BY id
-                """)
-                
+                """
+                )
+
                 result = conn.execute(query, params).fetchall()
-                chunks.extend([{"chunk_id": str(row[0]), "raw_text": row[1]} for row in result])
-        
+                chunks.extend(
+                    [{"chunk_id": str(row[0]), "raw_text": row[1]} for row in result]
+                )
+
         if not chunks:
             logger.error("No chunks found for the provided IDs")
             return {"total": 0, "success": 0, "failed": 0}
-        
+
         logger.info(f"Retrieved {len(chunks)} chunks from database")
-        
+
         # Create regenerator and process these chunks
         regenerator = EmbeddingRegenerator(
             model_name=model_name,
             batch_size=batch_size,
-            db_url=db_url, 
+            db_url=db_url,
             dry_run=dry_run,
             create_indexes=create_indexes,
             truncate_table=truncate_table,
-            preserve_existing=True
+            preserve_existing=True,
         )
-        
+
         # Process each chunk in batches
         total = len(chunks)
         success = 0
         failed = 0
         batch = []
-        
+
         # Use tqdm for progress bar
         start_time = time.time()
-        progress_bar = tqdm.tqdm(chunks, desc=f"Generating {model_name} embeddings (resume)")
-        
+        progress_bar = tqdm.tqdm(
+            chunks, desc=f"Generating {model_name} embeddings (resume)"
+        )
+
         for chunk in progress_bar:
             try:
                 # Generate embedding
-                embedding = ModelLoader.get_embedding(regenerator.model, chunk["raw_text"], model_name)
-                
+                embedding = ModelLoader.get_embedding(
+                    regenerator.model, chunk["raw_text"], model_name
+                )
+
                 # Convert to list
                 embedding_list = embedding.tolist()
-                
+
                 # Add to batch
                 batch.append((chunk["chunk_id"], embedding_list))
-                
+
                 # Process batch if reached batch size
                 if len(batch) >= batch_size:
                     success_count = regenerator.store_embedding_batch(batch)
                     success += success_count
                     failed += len(batch) - success_count
                     batch = []
-            
+
             except Exception as e:
                 logger.error(f"Error processing chunk {chunk['chunk_id']}: {e}")
                 failed += 1
-        
+
         # Process final batch
         if batch:
             success_count = regenerator.store_embedding_batch(batch)
             success += success_count
             failed += len(batch) - success_count
-        
+
         elapsed_time = time.time() - start_time
-        logger.info(f"Completed resume embedding generation in {elapsed_time:.2f}s: {success} successful, {failed} failed out of {total} total")
-        
+        logger.info(
+            f"Completed resume embedding generation in {elapsed_time:.2f}s: {success} successful, {failed} failed out of {total} total"
+        )
+
         return {"total": total, "success": success, "failed": failed}
-    
+
     except Exception as e:
         logger.error(f"Error processing missing chunks: {e}")
         return {"total": 0, "success": 0, "failed": 0}
@@ -1389,7 +1271,7 @@ def delete_existing_chunk_embedding(
                 )
 
     dimensions = get_model_dimensions(model_name)
-    table_name = f"chunk_embeddings_{dimensions:04d}d"
+    table_name = table_name_for_dimensions(dimensions)
     engine = create_engine(db_url)
 
     with engine.begin() as conn:
@@ -1408,19 +1290,19 @@ def delete_existing_chunk_embedding(
             return 0
 
         result = conn.execute(
-            text(f"""
+            text(
+                f"""
                 DELETE FROM {table_name}
                 WHERE chunk_id = :chunk_id
                   AND model = :model_name
-            """),
+            """
+            ),
             {"chunk_id": chunk_id, "model_name": model_name},
         )
         deleted = result.rowcount or 0
 
     if deleted:
-        logger.info(
-            f"Deleted existing {model_name} embedding for chunk {chunk_id}"
-        )
+        logger.info(f"Deleted existing {model_name} embedding for chunk {chunk_id}")
     return deleted
 
 
@@ -1486,21 +1368,51 @@ def regenerate_specific_chunk(
 
 def main():
     """Main function to run the regeneration process"""
-    parser = argparse.ArgumentParser(description="Regenerate embeddings for narrative chunks")
-    parser.add_argument("--model", help="Embedding model to use (e.g., infly/inf-retriever-v1)")
-    parser.add_argument("--all-models", action="store_true", help="Process all active models from settings.json")
-    parser.add_argument("--batch-size", type=int, default=10, help="Number of chunks to process in each batch")
+    parser = argparse.ArgumentParser(
+        description="Regenerate embeddings for narrative chunks"
+    )
+    parser.add_argument(
+        "--model", help="Embedding model to use (e.g., infly/inf-retriever-v1)"
+    )
+    parser.add_argument(
+        "--all-models",
+        action="store_true",
+        help="Process all active models from settings.json",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=10,
+        help="Number of chunks to process in each batch",
+    )
     parser.add_argument("--db-url", dest="db_url", help="PostgreSQL database URL")
-    parser.add_argument("--dry-run", action="store_true", help="Perform a dry run without making changes")
-    parser.add_argument("--create-indexes", action="store_true", 
-                       help="Create vector indexes after data loading (can be slow but improves query performance)")
-    parser.add_argument("--only-indexes", action="store_true",
-                       help="Only create indexes, skip embedding generation (use after running without indexes)")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Perform a dry run without making changes",
+    )
+    parser.add_argument(
+        "--create-indexes",
+        action="store_true",
+        help="Create vector indexes after data loading (can be slow but improves query performance)",
+    )
+    parser.add_argument(
+        "--only-indexes",
+        action="store_true",
+        help="Only create indexes, skip embedding generation (use after running without indexes)",
+    )
     parser.add_argument("--resume-from", help="Resume from a file of missing chunk IDs")
-    parser.add_argument("--chunk", type=int, help="Generate embeddings for one chunk ID")
-    parser.add_argument("--database", help="Slot database name (save_01 through save_05)")
-    parser.add_argument("--truncate-table", action="store_true", 
-                       help="Completely truncate the table and reset sequence before starting (clean slate approach)")
+    parser.add_argument(
+        "--chunk", type=int, help="Generate embeddings for one chunk ID"
+    )
+    parser.add_argument(
+        "--database", help="Slot database name (save_01 through save_05)"
+    )
+    parser.add_argument(
+        "--truncate-table",
+        action="store_true",
+        help="Completely truncate this model's embedding table before starting",
+    )
     args = parser.parse_args()
 
     if args.database:
@@ -1514,7 +1426,7 @@ def main():
         except Exception as exc:
             print(f"Error: {exc}")
             sys.exit(1)
-    
+
     # Check input validity
     if (
         not args.model
@@ -1529,7 +1441,7 @@ def main():
         )
         parser.print_help()
         sys.exit(1)
-    
+
     try:
         if args.chunk is not None:
             if not args.model:
@@ -1572,8 +1484,10 @@ def main():
             if not args.model:
                 print("Error: --model must be specified when using --resume-from")
                 sys.exit(1)
-                
-            logger.info(f"Resuming embedding generation for {args.model} from {args.resume_from}")
+
+            logger.info(
+                f"Resuming embedding generation for {args.model} from {args.resume_from}"
+            )
             results = regenerate_missing_chunks(
                 model_name=args.model,
                 missing_file=args.resume_from,
@@ -1581,9 +1495,9 @@ def main():
                 db_url=args.db_url,
                 dry_run=args.dry_run,
                 create_indexes=args.create_indexes,
-                truncate_table=args.truncate_table
+                truncate_table=args.truncate_table,
             )
-            
+
             # Print summary
             print("\nResume Embedding Generation Complete:")
             print(f"Model: {args.model}")
@@ -1591,47 +1505,55 @@ def main():
             print(f"Total chunks processed: {results['total']}")
             print(f"Successful embeddings: {results['success']}")
             print(f"Failed embeddings: {results['failed']}")
-            
+
             if args.dry_run:
                 print("\nThis was a dry run, no changes were made to the database.")
-            
-            if results['failed'] > 0:
-                print("\nSome embeddings failed to generate. Check the log for details.")
+
+            if results["failed"] > 0:
+                print(
+                    "\nSome embeddings failed to generate. Check the log for details."
+                )
                 sys.exit(1)
-                
+
             return
-            
+
         # If only creating indexes, handle that separately
         if args.only_indexes:
             if not args.model:
                 print("Error: --model must be specified when using --only-indexes")
                 sys.exit(1)
-                
+
             logger.info(f"Creating vector indexes for model: {args.model}")
-            
+
             # Initialize the regenerator just for index creation
             regenerator = EmbeddingRegenerator(
                 model_name=args.model,
                 batch_size=args.batch_size,
-                db_url=args.db_url, 
+                db_url=args.db_url,
                 dry_run=args.dry_run,
                 create_indexes=True,  # Always true for this mode
-                truncate_table=args.truncate_table
+                truncate_table=args.truncate_table,
+                ensure_table=False,
+                load_model=False,
             )
-            
+
             # Create indexes
             success = regenerator.create_vector_indexes()
-            
+
             if success:
-                print(f"\nSuccessfully created vector indexes for {regenerator.get_table_name()}")
+                print(
+                    f"\nSuccessfully created vector indexes for {regenerator.get_table_name()}"
+                )
                 print(f"Vector similarity queries should now be much faster")
             else:
-                print(f"\nFailed to create vector indexes for {regenerator.get_table_name()}")
+                print(
+                    f"\nFailed to create vector indexes for {regenerator.get_table_name()}"
+                )
                 print(f"Check the log for details")
                 sys.exit(1)
-                
+
             return
-        
+
         # Normal embedding generation
         if args.all_models:
             logger.info("Starting embedding generation for all active models")
@@ -1640,9 +1562,9 @@ def main():
                 batch_size=args.batch_size,
                 dry_run=args.dry_run,
                 create_indexes=args.create_indexes,
-                truncate_table=args.truncate_table
+                truncate_table=args.truncate_table,
             )
-            
+
             # Print overall summary
             print("\nAll Models Embedding Generation Complete:")
             print(f"Total chunks processed: {results['total']}")
@@ -1650,20 +1572,20 @@ def main():
             print(f"Total failed operations: {results['failed']}")
         else:
             logger.info(f"Starting embedding generation with model: {args.model}")
-            
+
             # Initialize the regenerator for single model
             regenerator = EmbeddingRegenerator(
                 model_name=args.model,
                 batch_size=args.batch_size,
-                db_url=args.db_url, 
+                db_url=args.db_url,
                 dry_run=args.dry_run,
                 create_indexes=args.create_indexes,
-                truncate_table=args.truncate_table
+                truncate_table=args.truncate_table,
             )
-            
+
             # Regenerate embeddings for this model
             results = regenerator.regenerate_all_embeddings()
-            
+
             # Print summary
             print("\nEmbedding Generation Complete:")
             print(f"Model: {args.model}")
@@ -1671,23 +1593,26 @@ def main():
             print(f"Total chunks processed: {results['total']}")
             print(f"Successful embeddings: {results['success']}")
             print(f"Failed embeddings: {results['failed']}")
-            
-            if not args.create_indexes and results['success'] > 0:
+
+            if not args.create_indexes and results["success"] > 0:
                 print("\nNote: Vector indexes were not created.")
-                print("You can create them later with: python scripts/regenerate_embeddings.py --model " +
-                      f"{args.model} --only-indexes")
-        
+                print(
+                    "You can create them later with: python scripts/regenerate_embeddings.py --model "
+                    + f"{args.model} --only-indexes"
+                )
+
         if args.dry_run:
             print("\nThis was a dry run, no changes were made to the database.")
-        
-        if results['failed'] > 0:
+
+        if results["failed"] > 0:
             print("\nSome embeddings failed to generate. Check the log for details.")
             sys.exit(1)
-        
+
     except Exception as e:
         logger.error(f"Error during embedding generation: {e}")
         print(f"Error: {e}")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/regenerate_embeddings.py
+++ b/scripts/regenerate_embeddings.py
@@ -468,7 +468,6 @@ class EmbeddingRegenerator:
 
         except Exception as e:
             logger.error(f"Error checking/creating table {table_name}: {e}")
-            connection.rollback()
             raise
 
     def get_table_name(self) -> str:

--- a/scripts/utils/embedding_utils.py
+++ b/scripts/utils/embedding_utils.py
@@ -9,6 +9,10 @@ import logging
 from typing import Dict, List, Tuple, Any, Optional, Union
 import numpy as np
 
+from nexus.agents.memnon.utils.embedding_tables import (
+    table_name_for_dimensions,
+)
+
 # Set up logging
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -76,9 +80,7 @@ def get_table_for_model(model_name: str) -> str:
     """
     # Use the new standardized naming convention
     dimensions = get_model_dimensions(model_name)
-    dim_str = f"{dimensions:04d}"  # Format dimensions with leading zeros (e.g., 0384)
-    # PostgreSQL converts identifiers to lowercase by default
-    return f"chunk_embeddings_{dim_str}d"
+    return table_name_for_dimensions(dimensions)
 
 
 def construct_vector_search_sql(
@@ -209,13 +211,10 @@ def get_all_model_tables() -> List[str]:
     Returns:
         List of table names
     """
-    tables = []
-
-    for dim in [384, 1024, 1536, 2560, 4096]:
-        dim_str = f"{dim:04d}"
-        tables.append(f"chunk_embeddings_{dim_str}d")
-
-    return tables
+    return [
+        table_name_for_dimensions(dimensions)
+        for dimensions in sorted(set(MODEL_DIMENSIONS.values()))
+    ]
 
 
 def normalize_vector(vector: Union[List[float], np.ndarray]) -> np.ndarray:

--- a/tests/test_ir_eval_v2/test_embedding_tables.py
+++ b/tests/test_ir_eval_v2/test_embedding_tables.py
@@ -20,6 +20,12 @@ def test_resolve_unknown_dimension_table() -> None:
     assert resolve_dimension_table(3072) == "chunk_embeddings_3072d"
 
 
+def test_sub_1000_dimension_table_name_is_zero_padded() -> None:
+    """Sub-1000 dimensions round-trip through the zero-padded table name."""
+    assert table_name_for_dimensions(384) == "chunk_embeddings_0384d"
+    assert parse_embedding_table_dimensions("chunk_embeddings_0384d") == 384
+
+
 def test_table_name_requires_positive_dimensions() -> None:
     """Invalid dimensions fail before producing unsafe SQL identifiers."""
     with pytest.raises(ValueError):

--- a/tests/test_ir_eval_v2/test_embedding_tables.py
+++ b/tests/test_ir_eval_v2/test_embedding_tables.py
@@ -1,9 +1,32 @@
-"""Tests for dimension-specific embedding table resolution."""
+"""Tests for dimension-specific embedding table helpers."""
 
-from nexus.agents.memnon.utils.embedding_tables import resolve_dimension_table
+import pytest
+
+from nexus.agents.memnon.utils.embedding_tables import (
+    parse_embedding_table_dimensions,
+    resolve_dimension_table,
+    table_name_for_dimensions,
+)
 
 
 def test_resolve_octen_dimension_tables() -> None:
     """Octen dimensions resolve to dedicated embedding tables."""
     assert resolve_dimension_table(2560) == "chunk_embeddings_2560d"
     assert resolve_dimension_table(4096) == "chunk_embeddings_4096d"
+
+
+def test_resolve_unknown_dimension_table() -> None:
+    """New embedding dimensions use the same canonical naming convention."""
+    assert resolve_dimension_table(3072) == "chunk_embeddings_3072d"
+
+
+def test_table_name_requires_positive_dimensions() -> None:
+    """Invalid dimensions fail before producing unsafe SQL identifiers."""
+    with pytest.raises(ValueError):
+        table_name_for_dimensions(0)
+
+
+def test_parse_embedding_table_dimensions() -> None:
+    """Dimension parser recognizes canonical embedding table names only."""
+    assert parse_embedding_table_dimensions("chunk_embeddings_1536d") == 1536
+    assert parse_embedding_table_dimensions("chunk_embeddings_small") is None

--- a/tests/test_lore/test_infrastructure.py
+++ b/tests/test_lore/test_infrastructure.py
@@ -16,200 +16,218 @@ pytestmark = [pytest.mark.requires_postgres, pytest.mark.requires_local_llm]
 
 class TestInfrastructure:
     """Test that all required infrastructure is available."""
-    
+
     def test_postgresql_connection(self, settings):
         """Test that PostgreSQL is accessible with correct database."""
         db_config = settings.get("Database", {})
-        
+
         # This should fail hard if PostgreSQL is not available
         conn = psycopg2.connect(
             dbname=db_config.get("name", "NEXUS"),
             user=db_config.get("user", "pythagor"),
             host=db_config.get("host", "localhost"),
-            port=db_config.get("port", 5432)
+            port=db_config.get("port", 5432),
         )
-        
+
         cursor = conn.cursor()
-        
+
         # Verify NEXUS database exists
         cursor.execute("SELECT current_database()")
         db_name = cursor.fetchone()[0]
         expected_db = db_config.get("name", db_name)
         assert db_name == expected_db, f"Connected to wrong database: {db_name}"
-        
+
         # Verify required tables exist
-        cursor.execute("""
+        cursor.execute(
+            """
             SELECT table_name 
             FROM information_schema.tables 
             WHERE table_schema = 'public' 
             AND (table_name IN ('narrative_chunks', 'chunk_metadata')
                  OR table_name LIKE 'chunk_embeddings_%')
             ORDER BY table_name
-        """)
-        
+        """
+        )
+
         tables = [row[0] for row in cursor.fetchall()]
-        assert 'narrative_chunks' in tables, "narrative_chunks table missing"
-        assert 'chunk_metadata' in tables, "chunk_metadata table missing"
-        # Check for any embeddings table variant
-        embeddings_tables = [t for t in tables if t.startswith('chunk_embeddings_')]
-        assert len(embeddings_tables) > 0, f"No chunk_embeddings tables found (found: {tables})"
-        
+        assert "narrative_chunks" in tables, "narrative_chunks table missing"
+        assert "chunk_metadata" in tables, "chunk_metadata table missing"
+        # Embedding tables are created lazily by active embedding write paths.
+        embeddings_tables = [t for t in tables if t.startswith("chunk_embeddings_")]
+        assert all(t.endswith("d") for t in embeddings_tables)
+
         cursor.close()
         conn.close()
-    
+
     def test_narrative_view_exists(self, db_connection):
         """Test that narrative_view is available and functional."""
         cursor = db_connection.cursor()
-        
+
         # Check view exists
-        cursor.execute("""
+        cursor.execute(
+            """
             SELECT viewname 
             FROM pg_views 
             WHERE schemaname = 'public' 
             AND viewname = 'narrative_view'
-        """)
-        
+        """
+        )
+
         view = cursor.fetchone()
         assert view is not None, "narrative_view does not exist"
-        
+
         # Test view is queryable
         cursor.execute("SELECT COUNT(*) FROM narrative_view")
         count = cursor.fetchone()[0]
         assert count > 0, f"narrative_view has no data (count: {count})"
-        
+
         # Verify view has expected columns
-        cursor.execute("""
+        cursor.execute(
+            """
             SELECT column_name 
             FROM information_schema.columns 
             WHERE table_name = 'narrative_view'
             ORDER BY ordinal_position
-        """)
-        
+        """
+        )
+
         columns = [row[0] for row in cursor.fetchall()]
-        required_columns = ['id', 'raw_text', 'season', 'episode', 'scene', 'world_layer']
-        
+        required_columns = [
+            "id",
+            "raw_text",
+            "season",
+            "episode",
+            "scene",
+            "world_layer",
+        ]
+
         for col in required_columns:
             assert col in columns, f"narrative_view missing column: {col}"
-        
+
         cursor.close()
-    
+
     def test_lm_studio_availability(self, settings):
         """Test that LM Studio is running and accessible - MUST FAIL HARD if not."""
         lm_settings = settings.get("Agent Settings", {}).get("LORE", {}).get("llm", {})
         base_url = lm_settings.get("lmstudio_url", "http://localhost:1234/v1")
-        
+
         # Strip /v1 if present for health check
         health_url = base_url.replace("/v1", "") + "/health"
-        
+
         # This MUST fail hard if LM Studio is not running
         try:
             response = requests.get(health_url, timeout=5)
-            assert response.status_code == 200, f"LM Studio health check failed: {response.status_code}"
+            assert (
+                response.status_code == 200
+            ), f"LM Studio health check failed: {response.status_code}"
         except requests.exceptions.RequestException as e:
             # Fail hard - no graceful fallback
             raise RuntimeError(f"LM Studio is not available at {base_url}: {e}")
-    
+
     def test_lm_studio_models(self, settings):
         """Test that required models are loaded in LM Studio."""
         lm_settings = settings.get("Agent Settings", {}).get("LORE", {}).get("llm", {})
         base_url = lm_settings.get("lmstudio_url", "http://localhost:1234/v1")
-        
+
         # Check models endpoint
         models_url = f"{base_url}/models"
-        
+
         try:
             response = requests.get(models_url, timeout=5)
-            assert response.status_code == 200, f"Failed to get models: {response.status_code}"
-            
+            assert (
+                response.status_code == 200
+            ), f"Failed to get models: {response.status_code}"
+
             data = response.json()
-            models = data.get('data', [])
-            
+            models = data.get("data", [])
+
             # Must have at least one model loaded
             assert len(models) > 0, "No models loaded in LM Studio"
-            
+
             # Log available models for debugging
-            model_ids = [m.get('id') for m in models]
+            model_ids = [m.get("id") for m in models]
             print(f"Available models: {model_ids}")
-            
+
         except requests.exceptions.RequestException as e:
             raise RuntimeError(f"Cannot query LM Studio models: {e}")
-    
+
     def test_tiktoken_encoding(self, settings):
         """Test tiktoken with newer model encodings."""
         # Test o200k_base encoding for newer models
         try:
             encoding = tiktoken.get_encoding("o200k_base")
             assert encoding is not None
-            
+
             # Test it can encode text
             test_text = "This is a test of the token counter with newer models."
             tokens = encoding.encode(test_text)
             assert len(tokens) > 0
-            
+
         except Exception as e:
             # Try fallback to cl100k_base
             encoding = tiktoken.get_encoding("cl100k_base")
             assert encoding is not None
             print(f"Using cl100k_base encoding (o200k_base not available): {e}")
-    
+
     def test_settings_structure(self, settings):
         """Test that settings.json has required LORE configuration."""
         # Check LORE agent settings exist
         assert "Agent Settings" in settings
         assert "LORE" in settings["Agent Settings"]
-        
+
         lore_settings = settings["Agent Settings"]["LORE"]
-        
+
         # Check required sections
         assert "token_budget" in lore_settings
         assert "payload_percent_budget" in lore_settings
         assert "llm" in lore_settings
-        
+
         # Verify token budget structure
         token_budget = lore_settings["token_budget"]
         assert "apex_context_window" in token_budget
         assert "utilization" in token_budget
-        
+
         # Verify percentage ranges
         percent_budget = lore_settings["payload_percent_budget"]
         assert "warm_slice" in percent_budget
         assert "structured_summaries" in percent_budget
         assert "contextual_augmentation" in percent_budget
-        
+
         # Each range should have min/max
         for key in ["warm_slice", "structured_summaries", "contextual_augmentation"]:
             assert "min" in percent_budget[key]
             assert "max" in percent_budget[key]
-    
+
     def test_project_structure(self):
         """Test that required LORE modules exist."""
         nexus_root = Path(__file__).parent.parent.parent
         lore_path = nexus_root / "nexus" / "agents" / "lore"
-        
+
         # Check main directory exists
         assert lore_path.exists(), f"LORE agent directory not found: {lore_path}"
-        
+
         # Check required modules
         required_files = [
             "lore_system_prompt.md",
             "utils/chunk_operations.py",
             "utils/context_validation.py",
             "utils/token_budget.py",
-            "utils/local_llm.py"
+            "utils/local_llm.py",
         ]
-        
+
         for file_path in required_files:
             full_path = lore_path / file_path
             assert full_path.exists(), f"Required file missing: {full_path}"
-    
+
     def test_test_scenes_available(self, sample_chunks, test_scenes):
         """Verify all 18 test scenes are available in database."""
         # Check we got all expected chunks
-        assert len(sample_chunks) == len(test_scenes), \
-            f"Missing test chunks: expected {len(test_scenes)}, got {len(sample_chunks)}"
-        
+        assert len(sample_chunks) == len(
+            test_scenes
+        ), f"Missing test chunks: expected {len(test_scenes)}, got {len(sample_chunks)}"
+
         # Verify each scene has content
         for scene_name, chunk_data in sample_chunks.items():
             assert chunk_data is not None, f"Scene {scene_name} not found in database"
-            assert 'raw_text' in chunk_data, f"Scene {scene_name} missing raw_text"
-            assert len(chunk_data['raw_text']) > 0, f"Scene {scene_name} has empty text"
+            assert "raw_text" in chunk_data, f"Scene {scene_name} missing raw_text"
+            assert len(chunk_data["raw_text"]) > 0, f"Scene {scene_name} has empty text"


### PR DESCRIPTION
## Summary

Fixes #203.

This migrates dimension-specific chunk embedding tables from a singleton `id` primary key plus unique `(chunk_id, model)` constraint to `(chunk_id, model)` as the primary key. It also makes embedding tables lazy-created by active embedding write paths, so fresh slots do not pre-create unused dimension tables.

## What changed

- Added migration `022_compound_embedding_pk_lazy_tables.sql`:
  - preserves non-empty embedding tables
  - fails fast on duplicate `(chunk_id, model)` pairs
  - drops `id` and old id sequences
  - drops empty pre-created embedding tables
- Added shared embedding table helpers for canonical naming, existence checks, listing, and lazy creation.
- Removed static MEMNON ORM embedding classes that were recreating `1024d`/`1536d` tables.
- Updated embedding regeneration/upsert code to use `(chunk_id, model)` only.
- Made `--only-indexes` inspect existing tables without creating missing ones.
- Fixed `scripts/propagate_schema.py` to match the live per-database `schema_migrations(version, name)` tracker.
- Made migrations `018` and `021` safe on older empty slots missing chunk-workflow columns.
- Refreshed embedding docs/tests for the lazy table model.

## Live migration notes

- Cloned slot 1 into slot 2 before migration.
- Preserved a backup of old slot 2 as `save_02_pre203_20260516_122902`.
- Explicitly unlocked slot 1 for migration, then relocked it afterward.
- Confirmed all slots and `NEXUS_template` are now migrated through `022`.
- Final live shape:
  - `NEXUS_template`, `save_03`, `save_04`: no embedding tables
  - `save_01`, `save_02`: `chunk_embeddings_1024d`, `chunk_embeddings_1536d`, no `id`, PK `(chunk_id, model)`
  - `save_05`: `chunk_embeddings_2560d`, no `id`, PK `(chunk_id, model)`

## Validation

- `poetry run python -m py_compile nexus/agents/memnon/utils/embedding_tables.py nexus/agents/memnon/utils/content_processor.py nexus/agents/memnon/utils/db_access.py nexus/agents/memnon/utils/alias_search.py nexus/agents/memnon/memnon.py nexus/agents/memnon/utils/db_schema.py scripts/regenerate_embeddings.py scripts/create_vector_index.py scripts/propagate_schema.py scripts/utils/embedding_utils.py scripts/query_narratives_vector.py`
- `poetry run pytest tests/test_ir_eval_v2/test_embedding_tables.py tests/test_api tests/test_cli.py`
- `NEXUS_RUN_POSTGRES=1 poetry run pytest tests/test_api/test_chunk_workflow_integration.py`
- Live lazy-create check from `NEXUS_template`
- `--only-indexes` missing-table check confirms no table is created by index maintenance