### PR TITLE
[codex] Add Orrery schema foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@
 !/.claude/commands/
 
 # Ignore logs and temporary files
-temp*.*
+/temp*.*
 *.log
 log.md
 /log.txt

--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -1,6 +1,6 @@
-# Off-Screen Behavior Resolver — Design Plan (Post-Review v4)
+# Off-Screen Behavior Resolver — Orrery Design Plan
 
-**Status:** Post-multi-model-review + grounding pass against the live codebase. Round 2's neutrally-framed re-review of the entity super-table converged on a staged identity-spine approach (Option C), changing the round-1 verdict. v4 corrects hook-seam line numbers, disambiguates the "Phase 7" naming collision, tightens schema declarations, and resolves a `tick_chunk_id` timing gap.
+**Status:** Foundation implemented in PR #210. The current branch lands the Orrery schema substrate, entity identity spine, config surface, MEMNON read-only SQL expansion, managed Python migration support, and the offline behavior-package harness. The runtime pipeline is still disabled by default (`orrery.enabled = false`) and has no LORE turn-cycle integration yet.
 
 **Originating artifacts:** `temp/orrery/off_screen_resolver_spec.md`, `temp/orrery/behavior_substrate.py`, `temp/orrery/package_simulator.jsx`
 **Review trace:** `temp/orrery/design_plan_edited.md` (round 1: GPT-5.5-Pro, Codex, separate-Claude, Gemini) + `temp/orrery/super_table_question.md` (round 2: GPT-5.5-Pro, Claude Opus 4.7 chat) + v4 grounding pass against current `main` (claude-opus-4-7).
@@ -8,6 +8,52 @@
 **Terminology in v4:**
 - **LORE Phase N** = a phase of `LORE.process_turn()` (`turn_context.py:12-21`: USER_INPUT, WARM_ANALYSIS, ENTITY_STATE, DEEP_QUERIES, PAYLOAD_ASSEMBLY, APEX_GENERATION, INTEGRATION).
 - **Orrery Stage N** = a stage of the off-screen pipeline (Resolve / Commit / Clear / Promote / Narrate / Bleed / [deferred Stage 7]). v3 used "Phase 7" for the deferred prose stage, which collided with LORE Phase 7 = INTEGRATION; v4 reserves "Phase" for LORE and uses "Stage" for Orrery.
+
+---
+
+## Current Implementation Status
+
+### Landed in PR #210
+
+- Rebranded the feature surface from Radiant to Orrery (`docs/orrery_design_plan.md`, `nexus/agents/orrery/`, `[orrery]` config).
+- Added managed Python migration discovery in `scripts/migrate.py`, while keeping `008_populate_mock_database.py` script-only.
+- Added `migrations/023_orrery_schema.py`:
+  - enum-backed controlled vocabularies for entity kinds, tag provenance, event roles/sources/severity, Orrery statuses, narration jobs, and off-screen embedding state
+  - `entities` identity spine plus staged `entity_id` backfill for `characters`, `factions`, and `places`
+  - kind-correctness triggers for subtype tables
+  - compatibility views over names, chunk references, and relationships
+  - tag, event, Orrery resolution, narration outbox, and off-screen narration tables
+  - `chunk_metadata.world_time` and a statement-level refresh trigger
+- Added pure-Python package substrate in `nexus/agents/orrery/substrate.py`, initial package catalog in `templates.py`, and an offline demo harness in `demo.py`.
+- Added focused tests for the substrate, migration discovery, config resolution, and MEMNON whitelist.
+- Expanded `MEMNON.execute_readonly_sql` to expose only the public Orrery read surfaces, excluding raw/internal queue tables.
+
+### Local Verification Completed for PR #210
+
+- `poetry run pytest tests/test_orrery`
+- `poetry run pytest tests/test_orrery tests/config tests/test_api`
+- `poetry run python scripts/check_model_drift.py`
+- `poetry run python -m nexus.agents.orrery.demo --preset hunted`
+- `poetry run python -m nexus.agents.orrery.demo --preset debt`
+- `poetry run python scripts/migrate.py --status`
+- Live migration and trigger probes against `NEXUS_template`, `save_02`, `save_03`, `save_04`, and `save_05`
+- `save_01` intentionally remains locked and unmodified
+- `poetry run flake8 ...` remains unavailable because `flake8` is not installed in the Poetry environment
+
+### Next Slice
+
+PR 2 should start from `main` after PR #210 merges and remain a no-write dry-run integration:
+
+- hydrate a read-side `WorldState`
+- compose ACTOR-only bindings
+- evaluate the package stack
+- attach an inspectable `OrreryTickProposal` to `TurnContext`
+- insert LORE Phase 4.5 between `DEEP_QUERIES` and `PAYLOAD_ASSEMBLY`
+- keep all canonical database writes out of scope
+
+### Package Author Checkpoint
+
+Start soliciting additional package-library contributions **after PR 2 validates the hydrated `WorldState`, binding composer, and `OrreryTickProposal` shape against both slot 5 and slot 2**. That is the first point where external package authors can target a real runtime surface rather than a synthetic harness, while still avoiding the higher-risk commit/promote/narrate pipeline. Before that checkpoint, package work is useful for examples and stress tests, but the API vocabulary may still move.
 
 ---
 
@@ -296,7 +342,7 @@ CREATE TABLE world_event_entities (
 );
 ```
 
-**`world_layer_type` precondition:** the Python enum `WorldLayerType` exists at `apex_enums.py:196` (`primary`, `flashback`, `dream`, ...), but the *Postgres* type `world_layer_type` is not declared in any tracked migration (only referenced as a JSONB field in `migrations/005_add_incubator_choice_object.sql`). PR 0 must confirm whether `world_layer_type` already exists in `NEXUS_template`; if not, prepend a `CREATE TYPE world_layer_type AS ENUM (...)` to migration 018 (mirroring `WorldLayerType` values) before any column that uses it.
+**`world_layer_type` precondition:** the Python enum `WorldLayerType` exists at `apex_enums.py:196` (`primary`, `flashback`, `dream`, ...). PR #210's `023_orrery_schema.py` now creates the Postgres `world_layer_type` enum if it is not already present, before any Orrery column uses it.
 
 **Locked-in choices:**
 - Append-only; supersession only for in-world retcons
@@ -531,20 +577,20 @@ Per-chunk, not per-event. Stamped only at accepted commit. `world_events.world_t
 
 ## Phased Delivery
 
-### PR 0 — Seam Audit & Invariants
+### PR 0 — Seam Audit & Invariants (Foundation Subset in PR #210)
 
-- Confirm the production commit path is `nexus/api/narrative.py::_approve_narrative_impl` (L387) → `commit_incubator_to_database_sync` (L233). The async sibling `commit_incubator_to_database` (L320) is test-only today; document this in PR 3 commit hook prose.
-- Confirm `query_memory` and `SearchManager` retrieval surfaces never join or union `offscreen_narrations` into warm-slice results; add an integration test asserting the warm slice is disjoint from `offscreen_narrations`. (Note: `memnon.py::get_recent_chunks` at L1486 is already safe — it queries only `narrative_chunks`.)
-- Update `nexus/agents/memnon/memnon.py::execute_readonly_sql` allowed-tables list (L492-495 — current set: `{"characters", "episodes", "seasons", "events", "factions", "places", "chunk_metadata", "narrative_chunks"}`). Additions: `entities`, `entity_names_v`, `entity_tags_current`, `world_events`, `world_event_entities`, `orrery_resolutions`, `offscreen_narrations`, `event_types`, `tags`. Excluded (internal-only): `orrery_narration_jobs`, `tag_clearance_log`, raw `entity_tags`.
-- Confirm `world_layer_type` Postgres ENUM exists in `NEXUS_template`. If not, prepend `CREATE TYPE world_layer_type AS ENUM (...)` to `migrations/018_*` mirroring `apex_enums.py:WorldLayerType`.
+- Confirmed the production commit path is `nexus/api/narrative.py::_approve_narrative_impl` (L387) → `commit_incubator_to_database_sync` (L233). The async sibling `commit_incubator_to_database` (L320) is test-only today; document this in PR 3 commit hook prose.
+- Still needed before Bleed ships: confirm `query_memory` and `SearchManager` retrieval surfaces never join or union `offscreen_narrations` into warm-slice results; add an integration test asserting the warm slice is disjoint from `offscreen_narrations`. (Note: `memnon.py::get_recent_chunks` at L1486 is already safe — it queries only `narrative_chunks`.)
+- Updated `nexus/agents/memnon/memnon.py::execute_readonly_sql` allowed-tables list. Additions: `entities`, `entity_names_v`, `entity_tags_current`, `world_events`, `world_event_entities`, `orrery_resolutions`, `offscreen_narrations`, `event_types`, `tags`. Excluded (internal-only): `orrery_narration_jobs`, `tag_clearance_log`, raw `entity_tags`.
+- Confirmed or created `world_layer_type` via `migrations/023_orrery_schema.py`.
 - Note that `chunk_workflow.py` is *not* on the commit path — it manages downstream embedding state transitions only. Do not hook `CommitOrreryTick` there.
 
-### PR 1 — Substrate + Schema + Identity Spine
+### PR 1 — Substrate + Schema + Identity Spine (Foundation Subset in PR #210)
 
-- Move substrate from `temp/orrery/behavior_substrate.py` to `nexus/agents/orrery/`
-- Port `EVADE_PURSUERS`, `PURSUE_GHOST_LEAD`, `MAINTAIN_COVER` from JSX simulator
-- Extend condition library: `has_relationship_of_type`, `count_co_located`, `since_last_event`, `faction_member`, `relative_orbit_distance`, `recent_event(changed_fields_any_of=..., actor=...)`
-- Add ALWAYS-fallback validator (pytest fixture)
+- Moved substrate from `temp/orrery/behavior_substrate.py` to `nexus/agents/orrery/`
+- Ported `EVADE_PURSUERS`, `HONOR_DEBT`, `PURSUE_GHOST_LEAD`, `MAINTAIN_COVER` from the simulator seed set
+- Extended condition library: `has_relationship_of_type`, `count_co_located`, `since_last_event_at_least`, `faction_member`, `relative_orbit_distance`, `recent_event(changed_fields_any_of=..., actor_slot=..., target_slot=...)`
+- Added ALWAYS-fallback validator and unit coverage
 - **Migration `023_orrery_schema.py`** (Python, not SQL — the staged FK backfill needs multi-transaction control and concurrent indexes):
   - **Type prerequisites**: `entity_kind`, `entity_tag_source_kind`, `event_source_kind`, `event_role_kind`. If `world_layer_type` doesn't already exist in template (per PR 0 audit), create it too.
   - **Identity spine**: `entities` table (id, kind, is_active, timestamps — no name column) + `entity_id` columns on `characters`/`factions`/`places`, added via the staged `NOT VALID → backfill → VALIDATE → CONCURRENTLY UNIQUE INDEX → SET NOT NULL` pattern + kind-correctness triggers
@@ -554,11 +600,11 @@ Per-chunk, not per-event. Stamped only at accepted commit. `world_events.world_t
   - **Event stream**: `event_types`, `world_events` (single-FK actor/target, `source` + `world_event_entities.role` as real enums), `world_event_entities`
   - **Orrery tables**: `orrery_resolutions` (with `UNIQUE` idempotency key + surfacing bookkeeping columns), `orrery_narration_jobs`, `offscreen_narrations`
   - **Time denormalization**: `chunk_metadata.world_time` column + `refresh_world_time_from_chunk` trigger function
-- `EntityRef` Pydantic helper in `nexus/agents/orrery/entity_ref.py` (thin read-side type; uses `EntityKind` enum mirroring the new `entity_kind` Postgres type)
-- Generator script: derive `changed_fields` vocabulary from `apex_schema.py::StateUpdates` Pydantic models (`apex_schema.py:631`)
-- Backfill durable tags from existing entity records (LLM-assisted; reviewed before commit)
-- Seed initial `event_types` vocabulary
-- Demo: `python -m nexus.agents.orrery.demo` runs four templates against synthetic `WorldState`
+- `EntityRef` Pydantic helper in `nexus/agents/orrery/entity_ref.py` (thin read-side type; uses `EntityKind` enum mirroring the new `entity_kind` Postgres type) remains deferred until a runtime reader needs it
+- Still needed before commit-time event emission: generator script deriving `changed_fields` vocabulary from `apex_schema.py::StateUpdates` Pydantic models (`apex_schema.py:631`)
+- Still needed before broad package authoring: durable tag backfill from existing entity records (LLM-assisted; reviewed before commit)
+- Still needed before event writes: seed initial `event_types` vocabulary
+- Demo: `python -m nexus.agents.orrery.demo` runs four presets against synthetic `WorldState`
 
 ### PR 2 — Hydration + Dry-Pass Resolver (no canonical writes)
 
@@ -571,7 +617,7 @@ Per-chunk, not per-event. Stamped only at accepted commit. `world_events.world_t
   - `bleed_menu: List["BleedCandidate"] = field(default_factory=list)`
 - `[orrery]` section in `nexus.toml` (see "`nexus.toml` Section Layout" above)
 - **No canonical writes yet.** Proposal is buffered, inspectable, but does not mutate any table
-- Verification: real turn against `save_01`; storyteller output identical to control; proposal contents validated
+- Verification: real turns against slot 5 (baby narrative state) and slot 2 (mature narrative state); storyteller output identical to control; proposal contents validated
 
 ### PR 3 — CommitOrreryTick + Promote + Narrate + Clear
 
@@ -630,7 +676,7 @@ Revisit when: fourth real entity kind appears, compatibility view becomes write 
 **Schema sources**
 - `nexus/agents/logon/apex_schema.py:631` — `StateUpdates` Pydantic models (source for `changed_fields` vocab)
 - `nexus/agents/logon/apex_enums.py:41` — existing `EntityType` enum (includes `'item'`); spine declares its own narrower `entity_kind`
-- `nexus/agents/logon/apex_enums.py:196` — `WorldLayerType` (Python); `world_layer_type` Postgres ENUM presence to be confirmed in PR 0
+- `nexus/agents/logon/apex_enums.py:196` — `WorldLayerType` (Python); `world_layer_type` Postgres ENUM is created if missing by `023_orrery_schema.py`
 
 **MEMNON**
 - `nexus/agents/memnon/memnon.py:1486` — `get_recent_chunks` (already `narrative_chunks`-only; no change needed)
@@ -655,11 +701,11 @@ Revisit when: fourth real entity kind appears, compatibility view becomes write 
 
 ## Verification Approach
 
-All tests use real LLM calls, no mocks (per `CLAUDE.md` testing philosophy).
+Verification should use live NEXUS flows where the feature touches LORE, LOGON, MEMNON, or database state. Pure substrate/package tests remain deterministic unit tests because their purpose is to validate package logic without paying model or API costs.
 
-- **PR 0:** Integration test asserting `query_memory` warm-slice is disjoint from `offscreen_narrations`; `execute_readonly_sql` whitelist updated and tested with a SELECT against each new allowed table; `world_layer_type` confirmed in template.
-- **PR 1:** Substrate demo runs against four templates; migration applies cleanly via `scripts/migrate.py --slot 5` (or `--template` first); entity spine backfill validated (every existing character/faction/place has an `entity_id`; staged FK validation succeeded); kind-enforcement triggers tested; compatibility views return expected unions; durable-tag backfill reviewed.
-- **PR 2:** Dry-pass against `save_01`; proposal contents inspected; storyteller output identical to control. Verify `TurnContext.orrery_proposal` carries no `tick_chunk_id` at this phase.
+- **PR 0/1 foundation (#210):** Substrate demo runs against four presets; migration applies cleanly via `scripts/migrate.py --template` and unlocked slots; entity spine backfill validated; kind-enforcement triggers tested; compatibility views return expected unions; MEMNON whitelist updated and tested; `world_layer_type` confirmed or created in template.
+- **Remaining pre-Bleed audit:** Integration test asserting `query_memory` warm-slice is disjoint from `offscreen_narrations`; `execute_readonly_sql` can SELECT from each new public table and cannot select internal queue/raw tag tables.
+- **PR 2:** Dry-pass against slot 5 and slot 2; proposal contents inspected; storyteller output identical to control. Verify `TurnContext.orrery_proposal` carries no `tick_chunk_id` at this phase.
 - **PR 3:** Engineered fifty-chunk motivating scenario (interrogated NPC → fifty ticks → retaliation prose persisted to `offscreen_narrations`, never surfaced); idempotency (regeneration cannot double-write — UNIQUE key fires); rejection (incubator rejection rolls everything back, including the Step 8.5 writes); warm-slice contamination (none); local-LLM failure (Promote fails loud); async-worker state transitions (`queued → leased → succeeded|failed`).
 - **PR 4:** Apt-bleed (audible peripheral surfaces in distant scene); null-bleed (irrelevant resolutions produce empty menu); spoiler-boundary (resolutions before the player's current world-time are eligible; future resolutions are not); chronology tests (`offscreen_narrations` never advance `narrative_view.world_time`); latency-budget overrun produces empty menu and logs loudly.
 

--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -2,12 +2,12 @@
 
 **Status:** Post-multi-model-review + grounding pass against the live codebase. Round 2's neutrally-framed re-review of the entity super-table converged on a staged identity-spine approach (Option C), changing the round-1 verdict. v4 corrects hook-seam line numbers, disambiguates the "Phase 7" naming collision, tightens schema declarations, and resolves a `tick_chunk_id` timing gap.
 
-**Originating artifacts:** `temp/radiant/off_screen_resolver_spec.md`, `temp/radiant/behavior_substrate.py`, `temp/radiant/package_simulator.jsx`
-**Review trace:** `temp/radiant/design_plan_edited.md` (round 1: GPT-5.5-Pro, Codex, separate-Claude, Gemini) + `temp/radiant/super_table_question.md` (round 2: GPT-5.5-Pro, Claude Opus 4.7 chat) + v4 grounding pass against current `main` (claude-opus-4-7).
+**Originating artifacts:** `temp/orrery/off_screen_resolver_spec.md`, `temp/orrery/behavior_substrate.py`, `temp/orrery/package_simulator.jsx`
+**Review trace:** `temp/orrery/design_plan_edited.md` (round 1: GPT-5.5-Pro, Codex, separate-Claude, Gemini) + `temp/orrery/super_table_question.md` (round 2: GPT-5.5-Pro, Claude Opus 4.7 chat) + v4 grounding pass against current `main` (claude-opus-4-7).
 
 **Terminology in v4:**
 - **LORE Phase N** = a phase of `LORE.process_turn()` (`turn_context.py:12-21`: USER_INPUT, WARM_ANALYSIS, ENTITY_STATE, DEEP_QUERIES, PAYLOAD_ASSEMBLY, APEX_GENERATION, INTEGRATION).
-- **Radiant Stage N** = a stage of the off-screen pipeline (Resolve / Commit / Clear / Promote / Narrate / Bleed / [deferred Stage 7]). v3 used "Phase 7" for the deferred prose stage, which collided with LORE Phase 7 = INTEGRATION; v4 reserves "Phase" for LORE and uses "Stage" for Radiant.
+- **Orrery Stage N** = a stage of the off-screen pipeline (Resolve / Commit / Clear / Promote / Narrate / Bleed / [deferred Stage 7]). v3 used "Phase 7" for the deferred prose stage, which collided with LORE Phase 7 = INTEGRATION; v4 reserves "Phase" for LORE and uses "Stage" for Orrery.
 
 ---
 
@@ -25,36 +25,36 @@ The proposal is a Bethesda-inspired off-screen behavior subsystem: a pipeline (`
 
 | Stage | Cost class | What runs | When |
 |---|---|---|---|
-| **Resolve** (Stage 1) | Free (pure Python) | Evaluate templates against per-entity bindings; produce a `RadiantTickProposal` (no writes, no `tick_chunk_id` yet) | In-cycle, during a new LORE Phase 4.5 (between `DEEP_QUERIES` and `PAYLOAD_ASSEMBLY`) |
-| **Commit** (Stage 2) | Free (SQL transaction) | Stamp `tick_chunk_id`, then atomically materialize the proposal into canonical tables (entity deltas, tag mutations, `world_events`, `radiant_resolutions`, enqueue narration jobs) | Inside the same transaction as accepted-chunk commit |
+| **Resolve** (Stage 1) | Free (pure Python) | Evaluate templates against per-entity bindings; produce an `OrreryTickProposal` (no writes, no `tick_chunk_id` yet) | In-cycle, during a new LORE Phase 4.5 (between `DEEP_QUERIES` and `PAYLOAD_ASSEMBLY`) |
+| **Commit** (Stage 2) | Free (SQL transaction) | Stamp `tick_chunk_id`, then atomically materialize the proposal into canonical tables (entity deltas, tag mutations, `world_events`, `orrery_resolutions`, enqueue narration jobs) | Inside the same transaction as accepted-chunk commit |
 | **Clear** (Stage 3) | Local-LLM (batched) + deterministic | Event-based clearance runs in the commit transaction; semantic clearance runs post-commit, async, results available for next tick | Commit (event) + post-commit (semantic) |
 | **Promote** (Stage 4) | Local-LLM (batched) | Decide which resolutions deserve frontier prose | Post-commit |
 | **Narrate** (Stage 5) | Frontier-LLM, async via durable outbox | Generate prose for promoted resolutions; persist into `offscreen_narrations` (separate from `narrative_chunks`) | Async after commit; durable across process restart |
 | **Bleed** (Stage 6) | Local-LLM at storyteller-time, hard 2s budget | Filter recent narrated resolutions for perceptibility; produce optional menu | LORE Phase 5 (`payload_assembly`), each player turn |
-| **Stage 7 (deferred)** | — | Middle-tier journalistic prose | Metric-gated; see "Deferred — Radiant Stage 7" |
+| **Stage 7 (deferred)** | — | Middle-tier journalistic prose | Metric-gated; see "Deferred — Orrery Stage 7" |
 
 **Cost shape (load-bearing):** Resolve is free and runs at full breadth. Each downstream stage is more expensive per call but operates on a smaller surface. Frontier prose only generates for resolutions that survived two earlier gates.
 
 ---
 
-## Load-Bearing Invariant: CommitRadiantTick
+## Load-Bearing Invariant: CommitOrreryTick
 
 > **The resolver computes; only the accepted-chunk commit path writes.**
 
-Resolve runs in-cycle during `LORE.process_turn()` for latency reasons, but every canonical write — entity deltas, tag mutations, `world_events`, `radiant_resolutions`, narration job enqueue — flows through the same transaction that promotes the incubator chunk to canon. This collapses three concerns into one seam:
+Resolve runs in-cycle during `LORE.process_turn()` for latency reasons, but every canonical write — entity deltas, tag mutations, `world_events`, `orrery_resolutions`, narration job enqueue — flows through the same transaction that promotes the incubator chunk to canon. This collapses three concerns into one seam:
 
 - **Rollback.** Incubator rejection means the transaction never happened. Zero cleanup logic needed.
-- **Idempotency.** Commit is keyed to the accepted tick via `UNIQUE (tick_chunk_id, template_id, binding_hash)` on `radiant_resolutions`. Regeneration cannot double-write.
+- **Idempotency.** Commit is keyed to the accepted tick via `UNIQUE (tick_chunk_id, template_id, binding_hash)` on `orrery_resolutions`. Regeneration cannot double-write.
 - **Visibility.** Nothing canonical exists until acceptance, so warm-slice retrieval cannot see provisional state.
 
 Two phases:
 
-1. **In-cycle (LORE Phase 4.5)**: Resolve produces a `RadiantTickProposal` carried on `TurnContext.radiant_proposal`. No writes. The proposal carries `(template_id, binding_hash, bindings, state_delta, magnitude, ...)` *without* `tick_chunk_id` — that field is unknown at this point.
-2. **Commit-time**: `CommitRadiantTick` runs inside the accepted-chunk commit transaction. The new chunk's id is generated by `insert_narrative_chunk` (returned at `commit_handler.py:394` / `commit_handler_sync.py:354`); every proposal row is stamped with that id, and the `UNIQUE (tick_chunk_id, template_id, binding_hash)` idempotency guard is enforced at write time.
+1. **In-cycle (LORE Phase 4.5)**: Resolve produces an `OrreryTickProposal` carried on `TurnContext.orrery_proposal`. No writes. The proposal carries `(template_id, binding_hash, bindings, state_delta, magnitude, ...)` *without* `tick_chunk_id` — that field is unknown at this point.
+2. **Commit-time**: `CommitOrreryTick` runs inside the accepted-chunk commit transaction. The new chunk's id is generated by `insert_narrative_chunk` (returned at `commit_handler.py:394` / `commit_handler_sync.py:354`); every proposal row is stamped with that id, and the `UNIQUE (tick_chunk_id, template_id, binding_hash)` idempotency guard is enforced at write time.
 
 **Exact hook locations (verified against current `main`):**
-- **Async wrapper** (used only by tests): `nexus/api/commit_handler.py::commit_incubator_to_database` (L320). Transaction opens at L348. Insert `CommitRadiantTick` as **Step 8.5**: after `apply_state_updates(conn, state_updates)` returns at L420, before `clear_incubator(conn, session_id)` at L423.
-- **Sync wrapper** (production path — see PR 3): `nexus/api/commit_handler_sync.py::commit_incubator_to_database_sync` (L233). Insert `CommitRadiantTick` after `apply_state_updates_sync(conn, state_updates)` at L415, before the incubator-clear `DELETE` at L418.
+- **Async wrapper** (used only by tests): `nexus/api/commit_handler.py::commit_incubator_to_database` (L320). Transaction opens at L348. Insert `CommitOrreryTick` as **Step 8.5**: after `apply_state_updates(conn, state_updates)` returns at L420, before `clear_incubator(conn, session_id)` at L423.
+- **Sync wrapper** (production path — see PR 3): `nexus/api/commit_handler_sync.py::commit_incubator_to_database_sync` (L233). Insert `CommitOrreryTick` after `apply_state_updates_sync(conn, state_updates)` at L415, before the incubator-clear `DELETE` at L418.
 - The acceptance seam that *invokes* the sync commit wrapper lives in `nexus/api/narrative.py::_approve_narrative_impl` (L387), which calls `commit_incubator_to_database_sync` at L407.
 
 ---
@@ -63,7 +63,7 @@ Two phases:
 
 ### Entity Identity Spine (Staged Super-Table)
 
-A new `entities` table acts as the identity spine for polymorphic references. Existing subtype tables keep their primary keys unchanged; each gains a unique `entity_id` column FK'd to the spine. All new Radiant tables FK directly to `entities(id)` without a discriminator column. The existing six triplicate relationship/reference tables are NOT touched in this PR — they remain a stable wart with a deferred collapse plan.
+A new `entities` table acts as the identity spine for polymorphic references. Existing subtype tables keep their primary keys unchanged; each gains a unique `entity_id` column FK'd to the spine. All new Orrery tables FK directly to `entities(id)` without a discriminator column. The existing six triplicate relationship/reference tables are NOT touched in this PR — they remain a stable wart with a deferred collapse plan.
 
 The spine uses a dedicated `entity_kind` ENUM (distinct from the existing Python `apex_enums.py:EntityType`, which includes `'item'` — out of scope here):
 
@@ -125,7 +125,7 @@ ALTER TABLE characters
 ALTER TABLE characters ALTER COLUMN entity_id SET NOT NULL;
 ```
 
-Because `scripts/migrate.py` is single-shot (it runs each migration file in one transaction with no inter-stage hooks), the backfill must be a **Python migration** (`migrations/018_radiant_schema.py`, following the precedent of `008_populate_mock_database.py`), not a `.sql` file. The Python migration can run each stage as its own transaction and emit batched UPDATEs for the backfill.
+Because the staged backfill needs inter-stage commits and `CREATE INDEX CONCURRENTLY`, the backfill must be a **Python migration** (`migrations/023_orrery_schema.py` on current `main`), not a `.sql` file. The migration runner now treats `008_populate_mock_database.py` as a manual seed script and discovers managed Python migrations from `023` onward.
 
 ```sql
 -- kind-correctness enforced by triggers (after Stage E)
@@ -138,7 +138,7 @@ CREATE TRIGGER trg_characters_entity_kind BEFORE INSERT OR UPDATE ON characters
 - `entity_tags.entity_id` → `ON DELETE CASCADE`. Tags die with the entity.
 - `world_events.actor_entity_id` and `target_entity_id` → `ON DELETE RESTRICT`. Events outlive their participants; deletion requires explicit reckoning.
 - `world_event_entities.entity_id` → `ON DELETE RESTRICT`. Same rationale.
-- `radiant_resolutions.actor_entity_id` → `ON DELETE RESTRICT`.
+- `orrery_resolutions.actor_entity_id` → `ON DELETE RESTRICT`.
 
 Future polymorphic tables follow this pattern.
 
@@ -183,8 +183,8 @@ CREATE TABLE tags (
   tag                      text UNIQUE NOT NULL,
   category                 text NOT NULL,
   is_ephemeral             boolean NOT NULL DEFAULT false,
-  clearance_kind           text,                   -- 'event' | 'semantic' | 'authored'; NULL when not ephemeral
-  reapplication_policy     text,                   -- 'new_row' | 'extend_expiry' | 'replace'
+  clearance_kind           entity_tag_clearance_kind,       -- NULL when not ephemeral
+  reapplication_policy     entity_tag_reapplication_policy,
   clear_on                 jsonb,
   synonym_for              bigint REFERENCES tags(id),
   deprecated               boolean NOT NULL DEFAULT false,
@@ -226,7 +226,7 @@ CREATE TABLE tag_clearance_log (
   entity_tag_id           bigint NOT NULL REFERENCES entity_tags(id),
   cleared_at              timestamp NOT NULL DEFAULT now(),
   cleared_at_world_time   timestamptz,
-  mechanism               text NOT NULL,                 -- 'event' | 'semantic' | 'authored'
+  mechanism               entity_tag_clearance_kind NOT NULL,
   triggering_event_id     bigint REFERENCES world_events(id),
   justification           jsonb,
   source_chunk_id         bigint REFERENCES narrative_chunks(id)
@@ -257,7 +257,7 @@ CREATE TYPE event_role_kind AS ENUM (
 CREATE TABLE event_types (
   type           text PRIMARY KEY,
   category       text NOT NULL,
-  severity       text,
+  severity       event_severity_kind,
   description    text,
   deprecated     boolean NOT NULL DEFAULT false,
   synonym_for    text REFERENCES event_types(type)
@@ -281,7 +281,7 @@ CREATE TABLE world_events (
   source                 event_source_kind NOT NULL,
   changed_fields         text[] NOT NULL DEFAULT '{}',                   -- controlled vocab, auto-derived from Pydantic StateUpdate models
   magnitude              numeric(4,3),
-  resolution_id          bigint REFERENCES radiant_resolutions(id),
+  resolution_id          bigint REFERENCES orrery_resolutions(id),
   payload                jsonb NOT NULL DEFAULT '{}',
   superseded_by_event_id bigint REFERENCES world_events(id),
   created_at             timestamptz DEFAULT now()
@@ -307,15 +307,15 @@ CREATE TABLE world_event_entities (
 - `source` is an enum (`event_source_kind`), not free text
 - `changed_fields text[]` with controlled vocab auto-derived from `StateUpdate` Pydantic models (see `apex_schema.py:631`)
 - `magnitude` for Promote scoring without unpacking payload
-- `resolution_id` FK back to `radiant_resolutions` when resolver-sourced
+- `resolution_id` FK back to `orrery_resolutions` when resolver-sourced
 - `world_layer` filtering keeps dream/flashback events out of resolver's recent-event window
 - Event-type registry mirrors tags
 - Writer must validate every `entity_id` exists in `entities` before insert (now a real FK, so violation surfaces as a SQL error rather than silent rot — consistent with the project's "errors surface visibly" preference in `CLAUDE.md`)
 
-### Radiant Resolutions
+### Orrery Resolutions
 
 ```sql
-CREATE TABLE radiant_resolutions (
+CREATE TABLE orrery_resolutions (
   id                  bigserial PRIMARY KEY,
   tick_chunk_id       bigint NOT NULL REFERENCES narrative_chunks(id),
   template_id         text NOT NULL,
@@ -326,9 +326,9 @@ CREATE TABLE radiant_resolutions (
   state_delta         jsonb NOT NULL,
   brief               text,                           -- deterministic non-literary one-liner (PR 3)
   event_ids           bigint[],                       -- world_events rows produced by this resolution
-  promotion_status    text NOT NULL DEFAULT 'pending',  -- 'pending' | 'promoted' | 'skipped'
+  promotion_status    orrery_promotion_status NOT NULL DEFAULT 'pending',
   promotion_verdict   jsonb,
-  narration_status    text NOT NULL DEFAULT 'none',   -- 'none' | 'queued' | 'leased' | 'succeeded' | 'failed'
+  narration_status    orrery_narration_status NOT NULL DEFAULT 'none',
   narration_chunk_id  bigint REFERENCES offscreen_narrations(id),
 
   -- bleed surfacing bookkeeping (Codex)
@@ -341,16 +341,16 @@ CREATE TABLE radiant_resolutions (
 );
 ```
 
-Note: `tick_chunk_id` is `NOT NULL`, but the in-cycle `RadiantTickProposal` carries no `tick_chunk_id` — the field is stamped during `CommitRadiantTick` after `insert_narrative_chunk` returns the new chunk's id at `commit_handler.py:394` / `commit_handler_sync.py:354`. The `UNIQUE` constraint therefore fires at write time, not at proposal time.
+Note: `tick_chunk_id` is `NOT NULL`, but the in-cycle `OrreryTickProposal` carries no `tick_chunk_id` — the field is stamped during `CommitOrreryTick` after `insert_narrative_chunk` returns the new chunk's id at `commit_handler.py:394` / `commit_handler_sync.py:354`. The `UNIQUE` constraint therefore fires at write time, not at proposal time.
 
 ### Narration Outbox
 
 ```sql
-CREATE TABLE radiant_narration_jobs (
+CREATE TABLE orrery_narration_jobs (
   id              bigserial PRIMARY KEY,
-  resolution_id   bigint NOT NULL REFERENCES radiant_resolutions(id),
+  resolution_id   bigint NOT NULL REFERENCES orrery_resolutions(id),
   slot            text NOT NULL,                       -- save slot identifier
-  state           text NOT NULL DEFAULT 'queued',      -- 'queued' | 'leased' | 'succeeded' | 'failed'
+  state           orrery_job_state NOT NULL DEFAULT 'queued',
   attempts        integer NOT NULL DEFAULT 0,
   available_at    timestamptz DEFAULT now(),
   lease_until     timestamptz,
@@ -363,20 +363,20 @@ CREATE TABLE radiant_narration_jobs (
 );
 ```
 
-Durable outbox surviving process restart. Dispatched via `FastAPI BackgroundTasks` — mirror the established pattern at `nexus/api/narrative.py:281` and `nexus/api/storyteller.py:561, 666`. Concretely: after `commit_incubator_to_database_sync` returns successfully in `_approve_narrative_impl`, call `background_tasks.add_task(drain_narration_outbox, slot)`. Also drainable via standalone CLI: `python -m nexus.agents.radiant.worker --slot 5`.
+Durable outbox surviving process restart. Dispatched via `FastAPI BackgroundTasks` — mirror the established pattern at `nexus/api/narrative.py:281` and `nexus/api/storyteller.py:561, 666`. Concretely: after `commit_incubator_to_database_sync` returns successfully in `_approve_narrative_impl`, call `background_tasks.add_task(drain_narration_outbox, slot)`. Also drainable via standalone CLI: `python -m nexus.agents.orrery.worker --slot 5`.
 
 ### Off-Screen Narration Storage (Structural Visibility Separation)
 
 ```sql
 CREATE TABLE offscreen_narrations (
   id              bigserial PRIMARY KEY,
-  resolution_id   bigint NOT NULL REFERENCES radiant_resolutions(id),
+  resolution_id   bigint NOT NULL REFERENCES orrery_resolutions(id),
   tick_chunk_id   bigint NOT NULL REFERENCES narrative_chunks(id),
   -- world_time joined from chunk_metadata at read
   world_layer     world_layer_type,                   -- usually 'primary'; not chronologically counted
   text            text NOT NULL,
   perceptual_descriptor jsonb,                        -- thin descriptor consumed by Bleed (sensory channel + brief)
-  embedding_status text DEFAULT 'pending',            -- own embedding pipeline; MEMNON indexes both tables
+  embedding_status offscreen_embedding_status DEFAULT 'pending', -- own embedding pipeline; MEMNON indexes both tables
   created_at      timestamptz DEFAULT now()
 );
 ```
@@ -393,17 +393,17 @@ CREATE TABLE offscreen_narrations (
 
 **Latency budget: hard 2-second cap, enforced via `asyncio.wait_for`.** If the local-LLM call exceeds budget, the bleed menu for this turn is empty and the overrun logged loudly. Empty bleed is a valid outcome.
 
-**Candidate query is typed**: reads from `radiant_resolutions` JOIN `world_events` JOIN `offscreen_narrations` with filters on age, location proximity, sensory plausibility, surfacing history. The local LLM call uses `LocalLLMManager.structured_query(prompt, response_model)` (`nexus/agents/lore/utils/local_llm.py:642`) — signature is `(prompt, response_model, *, temperature=None, max_tokens=None, system_prompt=None)`. The existing helper handles SDK-vs-fallback parsing; no new structured-output plumbing required.
+**Candidate query is typed**: reads from `orrery_resolutions` JOIN `world_events` JOIN `offscreen_narrations` with filters on age, location proximity, sensory plausibility, surfacing history. The local LLM call uses `LocalLLMManager.structured_query(prompt, response_model)` (`nexus/agents/lore/utils/local_llm.py:642`) — signature is `(prompt, response_model, *, temperature=None, max_tokens=None, system_prompt=None)`. The existing helper handles SDK-vs-fallback parsing; no new structured-output plumbing required.
 
-**Surfacing bookkeeping** prevents nag (Codex): `last_offered_chunk_id`, `offer_count`, `first_surfaced_chunk_id` (on `radiant_resolutions`). Distinguish "offered to storyteller" from "actually surfaced" — only the latter creates a visible-world surfacing record.
+**Surfacing bookkeeping** prevents nag (Codex): `last_offered_chunk_id`, `offer_count`, `first_surfaced_chunk_id` (on `orrery_resolutions`). Distinguish "offered to storyteller" from "actually surfaced" — only the latter creates a visible-world surfacing record.
 
 **Payload framing:** "ambient peripherals available — ignore any or all, render at any density from overt to invisible." Zero is a valid inclusion count.
 
 ### Tick, Resolver Firing, World Time
 
-- **Tick = the *accepted* player-visible chunk's id**, not the latest `narrative_chunks` row. The id is generated at `commit_handler.py:394` / `commit_handler_sync.py:354` and stamped onto every Radiant write in the same transaction.
-- **Resolve runs in-cycle** during a new **LORE Phase 4.5**, inserted between `DEEP_QUERIES` (Phase 4) and `PAYLOAD_ASSEMBLY` (Phase 5). Pure Python; produces `RadiantTickProposal` carried on `TurnContext.radiant_proposal`; no writes.
-- **CommitRadiantTick** runs as Step 8.5 inside `commit_incubator_to_database` (L320) / `commit_incubator_to_database_sync` (L233), between the existing `apply_state_updates*` call and `clear_incubator`. All canonical writes happen here.
+- **Tick = the *accepted* player-visible chunk's id**, not the latest `narrative_chunks` row. The id is generated at `commit_handler.py:394` / `commit_handler_sync.py:354` and stamped onto every Orrery write in the same transaction.
+- **Resolve runs in-cycle** during a new **LORE Phase 4.5**, inserted between `DEEP_QUERIES` (Phase 4) and `PAYLOAD_ASSEMBLY` (Phase 5). Pure Python; produces `OrreryTickProposal` carried on `TurnContext.orrery_proposal`; no writes.
+- **CommitOrreryTick** runs as Step 8.5 inside `commit_incubator_to_database` (L320) / `commit_incubator_to_database_sync` (L233), between the existing `apply_state_updates*` call and `clear_incubator`. All canonical writes happen here.
 - **Clear (event)** runs in the same commit transaction as the triggering event.
 - **Clear (semantic)** runs post-commit, async, batched, filtered to entities with recent relevant events.
 - **Promote** runs post-commit, async, batched per tick.
@@ -455,29 +455,29 @@ Every template MUST end with an `ALWAYS`-conditioned branch. Validated at templa
 
 ### Sliding-Window Binding Scope
 
-Binding composer filters to recently-relevant entities: (referenced in `chunk_character_references` in last N chunks) ∪ (has an active ephemeral tag) ∪ (has un-superseded `world_events` in last N chunks). N config-tunable via `nexus.toml` `[radiant.binding] window_chunks`. Default suggested: 30.
+Binding composer filters to recently-relevant entities: (referenced in `chunk_character_references` in last N chunks) ∪ (has an active ephemeral tag) ∪ (has un-superseded `world_events` in last N chunks). N config-tunable via `nexus.toml` `[orrery.binding] window_chunks`. Default suggested: 30.
 
 ### `nexus.toml` Section Layout
 
-Follow the established nesting style from `[lore]` / `[lore.token_budget]` and `[memnon.retrieval.hybrid_search.weights_by_query_type.character]`. The proposed Radiant sections:
+Follow the established nesting style from `[lore]` / `[lore.token_budget]` and `[memnon.retrieval.hybrid_search.weights_by_query_type.character]`. The proposed Orrery sections:
 
 ```toml
-[radiant]
+[orrery]
 enabled = true
 
-[radiant.binding]
+[orrery.binding]
 window_chunks = 30
 
-[radiant.narration]
+[orrery.narration]
 mode = "async"                                          # "async" | "sync"
 provider = "anthropic"
 model_ref = "@anthropic.default"                        # resolved via [global.model.api_models]
 
-[radiant.bleed]
+[orrery.bleed]
 latency_budget_ms = 2000
 max_candidates = 3
 
-[radiant.promote]
+[orrery.promote]
 provider = "local"
 ```
 
@@ -499,11 +499,11 @@ Every model reference uses the `@provider.role` syntax that the existing config 
 
 ### [OPEN 1] Narrate sync/async — RESOLVED: Async with durable outbox
 
-Unanimous. `radiant_narration_jobs` table; enqueued inside accepted-commit transaction; `FastAPI BackgroundTasks` triggers a draining worker function (mirroring `narrative.py:281` and `storyteller.py:561, 666`); standalone CLI for catch-up; `[radiant.narration] mode = "async" | "sync"` config switch. Promoted resolutions durable immediately; narration eventually durable. Bleed reads only succeeded + deterministic briefs.
+Unanimous. `orrery_narration_jobs` table; enqueued inside accepted-commit transaction; `FastAPI BackgroundTasks` triggers a draining worker function (mirroring `narrative.py:281` and `storyteller.py:561, 666`); standalone CLI for catch-up; `[orrery.narration] mode = "async" | "sync"` config switch. Promoted resolutions durable immediately; narration eventually durable. Bleed reads only succeeded + deterministic briefs.
 
 ### [OPEN 2] Producer wiring — RESOLVED: Pattern B (dedicated event writer)
 
-Unanimous. `nexus/agents/radiant/events.py` exports `emit_state_updates_events(state_updates, tick_chunk_id, conn)` and `emit_event(...)`. Both `commit_incubator_to_database` (L320, async) and `commit_incubator_to_database_sync` (L233, sync — the production path) call into it at Step 8.5. Direct INSERTs to `world_events` forbidden by convention. Field-mapping from Pydantic `StateUpdate` models lives as a data table, not branchy code.
+Unanimous. `nexus/agents/orrery/events.py` exports `emit_state_updates_events(state_updates, tick_chunk_id, conn)` and `emit_event(...)`. Both `commit_incubator_to_database` (L320, async) and `commit_incubator_to_database_sync` (L233, sync — the production path) call into it at Step 8.5. Direct INSERTs to `world_events` forbidden by convention. Field-mapping from Pydantic `StateUpdate` models lives as a data table, not branchy code.
 
 ### [OPEN 3] Entity super-table — RESOLVED: Staged identity spine (round-2 consensus)
 
@@ -515,9 +515,9 @@ The round-1 verdict ("defer + EntityRef") was load-bearing on the framing — wh
 
 PR #191 merged to `main` as `44aedba`. All phases unblocked. PR 2's structural split (hydration / dry-pass vs. canonical write wiring) retained for cognitive surface reasons.
 
-### [OPEN 5] Radiant Stage 7 — RESOLVED: Defer Stage 7, promote deterministic briefs into PR 3
+### [OPEN 5] Orrery Stage 7 — RESOLVED: Defer Stage 7, promote deterministic briefs into PR 3
 
-Unanimous. Deterministic briefs (pure string formatting from known fields → `radiant_resolutions.brief`) land in PR 3. Radiant Stage 7's actual LLM prose stage fires only when ≥ 2 of 3 instrumented counters deteriorate over a 50-tick playtest: Promote pass rate < 2%, bleed candidate scarcity < 3/scene, MEMNON retrieval misses on player-described off-screen events.
+Unanimous. Deterministic briefs (pure string formatting from known fields → `orrery_resolutions.brief`) land in PR 3. Orrery Stage 7's actual LLM prose stage fires only when ≥ 2 of 3 instrumented counters deteriorate over a 50-tick playtest: Promote pass rate < 2%, bleed candidate scarcity < 3/scene, MEMNON retrieval misses on player-described off-screen events.
 
 ### [OPEN 6] Denormalized summary columns — RESOLVED: `changed_fields text[]` only
 
@@ -535,68 +535,68 @@ Per-chunk, not per-event. Stamped only at accepted commit. `world_events.world_t
 
 - Confirm the production commit path is `nexus/api/narrative.py::_approve_narrative_impl` (L387) → `commit_incubator_to_database_sync` (L233). The async sibling `commit_incubator_to_database` (L320) is test-only today; document this in PR 3 commit hook prose.
 - Confirm `query_memory` and `SearchManager` retrieval surfaces never join or union `offscreen_narrations` into warm-slice results; add an integration test asserting the warm slice is disjoint from `offscreen_narrations`. (Note: `memnon.py::get_recent_chunks` at L1486 is already safe — it queries only `narrative_chunks`.)
-- Update `nexus/agents/memnon/memnon.py::execute_readonly_sql` allowed-tables list (L492-495 — current set: `{"characters", "episodes", "seasons", "events", "factions", "places", "chunk_metadata", "narrative_chunks"}`). Additions: `entities`, `entity_names_v`, `entity_tags_current`, `world_events`, `world_event_entities`, `radiant_resolutions`, `offscreen_narrations`, `event_types`, `tags`. Excluded (internal-only): `radiant_narration_jobs`, `tag_clearance_log`, raw `entity_tags`.
+- Update `nexus/agents/memnon/memnon.py::execute_readonly_sql` allowed-tables list (L492-495 — current set: `{"characters", "episodes", "seasons", "events", "factions", "places", "chunk_metadata", "narrative_chunks"}`). Additions: `entities`, `entity_names_v`, `entity_tags_current`, `world_events`, `world_event_entities`, `orrery_resolutions`, `offscreen_narrations`, `event_types`, `tags`. Excluded (internal-only): `orrery_narration_jobs`, `tag_clearance_log`, raw `entity_tags`.
 - Confirm `world_layer_type` Postgres ENUM exists in `NEXUS_template`. If not, prepend `CREATE TYPE world_layer_type AS ENUM (...)` to `migrations/018_*` mirroring `apex_enums.py:WorldLayerType`.
-- Note that `chunk_workflow.py` is *not* on the commit path — it manages downstream embedding state transitions only. Do not hook `CommitRadiantTick` there.
+- Note that `chunk_workflow.py` is *not* on the commit path — it manages downstream embedding state transitions only. Do not hook `CommitOrreryTick` there.
 
 ### PR 1 — Substrate + Schema + Identity Spine
 
-- Move substrate from `temp/radiant/behavior_substrate.py` to `nexus/agents/radiant/`
+- Move substrate from `temp/orrery/behavior_substrate.py` to `nexus/agents/orrery/`
 - Port `EVADE_PURSUERS`, `PURSUE_GHOST_LEAD`, `MAINTAIN_COVER` from JSX simulator
 - Extend condition library: `has_relationship_of_type`, `count_co_located`, `since_last_event`, `faction_member`, `relative_orbit_distance`, `recent_event(changed_fields_any_of=..., actor=...)`
 - Add ALWAYS-fallback validator (pytest fixture)
-- **Migration `018_radiant_schema.py`** (Python, not SQL — `scripts/migrate.py` is single-shot per file; the staged FK backfill needs multi-transaction control. Precedent: `008_populate_mock_database.py`):
+- **Migration `023_orrery_schema.py`** (Python, not SQL — the staged FK backfill needs multi-transaction control and concurrent indexes):
   - **Type prerequisites**: `entity_kind`, `entity_tag_source_kind`, `event_source_kind`, `event_role_kind`. If `world_layer_type` doesn't already exist in template (per PR 0 audit), create it too.
   - **Identity spine**: `entities` table (id, kind, is_active, timestamps — no name column) + `entity_id` columns on `characters`/`factions`/`places`, added via the staged `NOT VALID → backfill → VALIDATE → CONCURRENTLY UNIQUE INDEX → SET NOT NULL` pattern + kind-correctness triggers
   - **Polymorphic name view**: `entity_names_v` (UNION over subtype tables; spine has no duplicated name field)
   - **Compatibility views**: `chunk_entity_references_v`, `entity_relationships_v`
   - **Tag system**: `tags`, `entity_tags` (single FK), `entity_tags_current` view, `tag_clearance_log`
   - **Event stream**: `event_types`, `world_events` (single-FK actor/target, `source` + `world_event_entities.role` as real enums), `world_event_entities`
-  - **Radiant tables**: `radiant_resolutions` (with `UNIQUE` idempotency key + surfacing bookkeeping columns), `radiant_narration_jobs`, `offscreen_narrations`
+  - **Orrery tables**: `orrery_resolutions` (with `UNIQUE` idempotency key + surfacing bookkeeping columns), `orrery_narration_jobs`, `offscreen_narrations`
   - **Time denormalization**: `chunk_metadata.world_time` column + `refresh_world_time_from_chunk` trigger function
-- `EntityRef` Pydantic helper in `nexus/agents/radiant/entity_ref.py` (thin read-side type; uses `EntityKind` enum mirroring the new `entity_kind` Postgres type)
+- `EntityRef` Pydantic helper in `nexus/agents/orrery/entity_ref.py` (thin read-side type; uses `EntityKind` enum mirroring the new `entity_kind` Postgres type)
 - Generator script: derive `changed_fields` vocabulary from `apex_schema.py::StateUpdates` Pydantic models (`apex_schema.py:631`)
 - Backfill durable tags from existing entity records (LLM-assisted; reviewed before commit)
 - Seed initial `event_types` vocabulary
-- Demo: `python -m nexus.agents.radiant.demo` runs four templates against synthetic `WorldState`
+- Demo: `python -m nexus.agents.orrery.demo` runs four templates against synthetic `WorldState`
 
 ### PR 2 — Hydration + Dry-Pass Resolver (no canonical writes)
 
 - `hydrate_world_state(tick_chunk_id) -> WorldState`. One bulk SELECT per source.
 - Sliding-window binding composer for `ACTOR`-only templates
-- Resolver loop produces `RadiantTickProposal` (no `tick_chunk_id` in the proposal — see Stage 1 note above)
-- **New LORE Phase 4.5**: add `TurnPhase.RADIANT_RESOLVE = "radiant_resolve"` to `turn_context.py:12` enum; insert phase between `DEEP_QUERIES` (Phase 4) and `PAYLOAD_ASSEMBLY` (Phase 5) in `lore.py::process_turn` (L289+); add corresponding `TurnCycleManager` method invoked from there.
+- Resolver loop produces `OrreryTickProposal` (no `tick_chunk_id` in the proposal — see Stage 1 note above)
+- **New LORE Phase 4.5**: add `TurnPhase.ORRERY_RESOLVE = "orrery_resolve"` to `turn_context.py:12` enum; insert phase between `DEEP_QUERIES` (Phase 4) and `PAYLOAD_ASSEMBLY` (Phase 5) in `lore.py::process_turn` (L289+); add corresponding `TurnCycleManager` method invoked from there.
 - **Extend `TurnContext`** (`turn_context.py:24-41`, a `@dataclass`) with two fields:
-  - `radiant_proposal: Optional["RadiantTickProposal"] = None`
+  - `orrery_proposal: Optional["OrreryTickProposal"] = None`
   - `bleed_menu: List["BleedCandidate"] = field(default_factory=list)`
-- `[radiant]` section in `nexus.toml` (see "`nexus.toml` Section Layout" above)
+- `[orrery]` section in `nexus.toml` (see "`nexus.toml` Section Layout" above)
 - **No canonical writes yet.** Proposal is buffered, inspectable, but does not mutate any table
 - Verification: real turn against `save_01`; storyteller output identical to control; proposal contents validated
 
-### PR 3 — CommitRadiantTick + Promote + Narrate + Clear
+### PR 3 — CommitOrreryTick + Promote + Narrate + Clear
 
-- **`CommitRadiantTick` writer**: Step 8.5 inside `commit_incubator_to_database_sync` (L233 — the production path; insert between `apply_state_updates_sync` at L415 and incubator clear at L418) and parity inside `commit_incubator_to_database` (L320 — async, test-only; insert between `apply_state_updates` at L420 and `clear_incubator` at L423). Both call into the unified event writer in `nexus/agents/radiant/events.py`.
+- **`CommitOrreryTick` writer**: Step 8.5 inside `commit_incubator_to_database_sync` (L233 — the production path; insert between `apply_state_updates_sync` at L415 and incubator clear at L418) and parity inside `commit_incubator_to_database` (L320 — async, test-only; insert between `apply_state_updates` at L420 and `clear_incubator` at L423). Both call into the unified event writer in `nexus/agents/orrery/events.py`.
 - **Stamp `tick_chunk_id`** on every proposal row at this step, after `insert_narrative_chunk` returns the new chunk id.
 - Promote discriminator: `LocalLLMManager.structured_query(prompt, PromotionVerdict)` (existing API at `local_llm.py:642`). Fail loudly on malformed local-model output.
-- Deterministic brief generator → `radiant_resolutions.brief`.
+- Deterministic brief generator → `orrery_resolutions.brief`.
 - Frontier narration via durable outbox; trigger drain via `BackgroundTasks` from `_approve_narrative_impl` after commit returns; standalone CLI worker for catch-up.
 - Narrator persistence to `offscreen_narrations` (not `narrative_chunks`); embedding pipeline shared with MEMNON.
 - Clear (event) in commit transaction; Clear (semantic) post-commit async, batched, filtered.
 - `tag_clearance_log` rows with justification.
-- Instrumented counters for the Radiant Stage 7 trigger metrics.
+- Instrumented counters for the Orrery Stage 7 trigger metrics.
 - Verification: engineered fifty-chunk scenario (motivating test case), idempotency, incubator rejection, warm-slice contamination, local-LLM failure, async-worker state transitions.
 
 ### PR 4 — Bleed Selector + Storyteller Integration
 
 - Bleed selector wired into LORE Phase 5 (`assemble_context_payload`, `turn_cycle.py:489`); reads `turn_context.bleed_menu` populated by a new selector method invoked at the start of that phase.
-- Typed candidate query over `radiant_resolutions` ⋈ `world_events` ⋈ `offscreen_narrations`.
+- Typed candidate query over `orrery_resolutions` ⋈ `world_events` ⋈ `offscreen_narrations`.
 - Hard 2-second latency budget enforced via `asyncio.wait_for`; overrun = empty menu + loud log.
 - Surfacing bookkeeping increments.
 - Menu injected into payload with framing "ambient peripherals — optional, ignore freely, render at any density".
 - System-prompt edit at `lore_system_prompt.md:253-265`.
 - Verification: apt-bleed + null-bleed + spoiler-boundary + chronology tests.
 
-### Radiant Stage 7 — Middle-Tier Journalistic Prose (Deferred, Metric-Gated)
+### Orrery Stage 7 — Middle-Tier Journalistic Prose (Deferred, Metric-Gated)
 
 Fires only when ≥ 2 of 3 instrumented counters deteriorate over a 50-tick playtest. (Renamed from "Phase 7" in v3 to disambiguate from LORE turn-cycle Phase 7 = INTEGRATION.)
 
@@ -610,7 +610,7 @@ Revisit when: fourth real entity kind appears, compatibility view becomes write 
 
 **LORE turn cycle**
 - `nexus/agents/lore/lore.py:289` — `process_turn`; new LORE Phase 4.5 inserts here
-- `nexus/agents/lore/utils/turn_context.py:12-41` — `TurnPhase` enum (add `RADIANT_RESOLVE`) and `TurnContext` dataclass (add `radiant_proposal`, `bleed_menu`)
+- `nexus/agents/lore/utils/turn_context.py:12-41` — `TurnPhase` enum (add `ORRERY_RESOLVE`) and `TurnContext` dataclass (add `orrery_proposal`, `bleed_menu`)
 - `nexus/agents/lore/utils/turn_cycle.py:489` — `assemble_context_payload` (LORE Phase 5); Bleed selector hooks at the start
 - `nexus/agents/lore/utils/local_llm.py:642` — `structured_query(prompt, response_model, *, temperature=None, max_tokens=None, system_prompt=None)` — used by Promote, Clear (semantic), Bleed
 
@@ -618,7 +618,7 @@ Revisit when: fourth real entity kind appears, compatibility view becomes write 
 - `nexus/api/narrative.py:281` — existing `BackgroundTasks` pattern to mirror
 - `nexus/api/narrative.py:387` — `_approve_narrative_impl`; acceptance seam that invokes the commit
 - `nexus/api/narrative.py:407` — calls `commit_incubator_to_database_sync`
-- **`nexus/api/commit_handler_sync.py:233`** — `commit_incubator_to_database_sync`; `CommitRadiantTick` inserts at Step 8.5 (after `apply_state_updates_sync` at L415, before incubator clear at L418)
+- **`nexus/api/commit_handler_sync.py:233`** — `commit_incubator_to_database_sync`; `CommitOrreryTick` inserts at Step 8.5 (after `apply_state_updates_sync` at L415, before incubator clear at L418)
 - `nexus/api/commit_handler_sync.py:354` — where the new chunk id is created in the sync path
 - **`nexus/api/commit_handler.py:320`** — `commit_incubator_to_database`; async parity hook (Step 8.5 between L420 and L423)
 - `nexus/api/commit_handler.py:394` — async path's chunk-id creation point
@@ -644,12 +644,12 @@ Revisit when: fourth real entity kind appears, compatibility view becomes write 
 - Mirror in `_approve_narrative_impl` post-commit to drain the narration outbox
 
 **Config + system prompt**
-- `nexus.toml` — new `[radiant]`, `[radiant.binding]`, `[radiant.narration]`, `[radiant.bleed]`, `[radiant.promote]` sections; use `@provider.role` syntax per `[global.model.api_models]` registry
+- `nexus.toml` — new `[orrery]`, `[orrery.binding]`, `[orrery.narration]`, `[orrery.bleed]`, `[orrery.promote]` sections; use `@provider.role` syntax per `[global.model.api_models]` registry
 - `nexus/agents/lore/lore_system_prompt.md:253-265` — minor edit in PR 4
 
 **New artifacts**
-- `migrations/018_radiant_schema.py` — Python migration (multi-transaction; SQL alone insufficient for staged FK backfill)
-- New module: `nexus/agents/radiant/` (substrate, `events.py` writer, `entity_ref.py`, `worker.py`, `demo.py`)
+- `migrations/023_orrery_schema.py` — Python migration (multi-transaction; SQL alone insufficient for staged FK backfill)
+- New module: `nexus/agents/orrery/` (substrate, `events.py` writer, `entity_ref.py`, `worker.py`, `demo.py`)
 
 ---
 
@@ -659,7 +659,7 @@ All tests use real LLM calls, no mocks (per `CLAUDE.md` testing philosophy).
 
 - **PR 0:** Integration test asserting `query_memory` warm-slice is disjoint from `offscreen_narrations`; `execute_readonly_sql` whitelist updated and tested with a SELECT against each new allowed table; `world_layer_type` confirmed in template.
 - **PR 1:** Substrate demo runs against four templates; migration applies cleanly via `scripts/migrate.py --slot 5` (or `--template` first); entity spine backfill validated (every existing character/faction/place has an `entity_id`; staged FK validation succeeded); kind-enforcement triggers tested; compatibility views return expected unions; durable-tag backfill reviewed.
-- **PR 2:** Dry-pass against `save_01`; proposal contents inspected; storyteller output identical to control. Verify `TurnContext.radiant_proposal` carries no `tick_chunk_id` at this phase.
+- **PR 2:** Dry-pass against `save_01`; proposal contents inspected; storyteller output identical to control. Verify `TurnContext.orrery_proposal` carries no `tick_chunk_id` at this phase.
 - **PR 3:** Engineered fifty-chunk motivating scenario (interrogated NPC → fifty ticks → retaliation prose persisted to `offscreen_narrations`, never surfaced); idempotency (regeneration cannot double-write — UNIQUE key fires); rejection (incubator rejection rolls everything back, including the Step 8.5 writes); warm-slice contamination (none); local-LLM failure (Promote fails loud); async-worker state transitions (`queued → leased → succeeded|failed`).
 - **PR 4:** Apt-bleed (audible peripheral surfaces in distant scene); null-bleed (irrelevant resolutions produce empty menu); spoiler-boundary (resolutions before the player's current world-time are eligible; future resolutions are not); chronology tests (`offscreen_narrations` never advance `narrative_view.world_time`); latency-budget overrun produces empty menu and logs loudly.
 
@@ -667,11 +667,11 @@ All tests use real LLM calls, no mocks (per `CLAUDE.md` testing philosophy).
 
 ## v3 → v4 Change Log
 
-1. **Hook seams corrected.** `CommitRadiantTick` hooks the *transaction-wrapping* functions (`commit_incubator_to_database` L320 async; `commit_incubator_to_database_sync` L233 sync) at Step 8.5, not the `apply_state_updates*` workers at L223/L451.
+1. **Hook seams corrected.** `CommitOrreryTick` hooks the *transaction-wrapping* functions (`commit_incubator_to_database` L320 async; `commit_incubator_to_database_sync` L233 sync) at Step 8.5, not the `apply_state_updates*` workers at L223/L451.
 2. **Sync path called out as production.** Only `narrative.py:407` calls a commit function in production code, and it calls the sync variant. Async kept in parity for tests.
 3. **`chunk_workflow.py` removed from PR 0 audit.** It is not on the commit path; replaced with an audit of `narrative.py::_approve_narrative_impl` (L387).
 4. **Bleed hook point named.** Runs at the start of LORE Phase 5 (`assemble_context_payload`, `turn_cycle.py:489`); 2s budget enforced via `asyncio.wait_for`.
-5. **Pipeline stages renamed.** "Phase N" reserved for LORE turn cycle; Radiant pipeline uses "Stage N". Deferred "Phase 7" → "Radiant Stage 7".
+5. **Pipeline stages renamed.** "Phase N" reserved for LORE turn cycle; Orrery pipeline uses "Stage N". Deferred "Phase 7" → "Orrery Stage 7".
 6. **`TurnContext` extension spelled out.** Two new dataclass fields + one new `TurnPhase` enum value.
 7. **`world_layer_type` precondition.** Postgres ENUM not in tracked migrations; PR 0 confirms or PR 1 declares.
 8. **`entity_kind` ENUM is distinct from `EntityType`** (which includes `'item'`); spine deliberately narrower.
@@ -680,7 +680,7 @@ All tests use real LLM calls, no mocks (per `CLAUDE.md` testing philosophy).
 11. **`world_events.source` and `world_event_entities.role` promoted to real enums** (`event_source_kind`, `event_role_kind`), consistent with the rest of the controlled vocabulary.
 12. **`LocalLLMManager.structured_query` signature noted.** Existing API at `local_llm.py:642`; no new structured-output plumbing needed.
 13. **`BackgroundTasks` pattern cross-referenced** to existing call sites (`narrative.py:281`, `storyteller.py:561, 666`).
-14. **`tick_chunk_id` timing clarified.** Not known during Resolve (Stage 1); stamped during CommitRadiantTick (Stage 2) after `insert_narrative_chunk` returns the new chunk's id. The UNIQUE idempotency constraint fires at write time.
+14. **`tick_chunk_id` timing clarified.** Not known during Resolve (Stage 1); stamped during CommitOrreryTick (Stage 2) after `insert_narrative_chunk` returns the new chunk's id. The UNIQUE idempotency constraint fires at write time.
 15. **MEMNON safety claim sharpened.** `get_recent_chunks` is already safe; real audit target is `query_memory` / `SearchManager`.
 16. **`execute_readonly_sql` whitelist additions enumerated.**
 17. **`nexus.toml` section layout** explicitly modeled on existing `[lore]` / `[memnon]` nesting.

--- a/migrations/023_orrery_schema.py
+++ b/migrations/023_orrery_schema.py
@@ -714,7 +714,7 @@ def _create_world_time_support(conn) -> None:
     _execute(
         conn,
         """
-        CREATE OR REPLACE FUNCTION refresh_world_time_from_chunk(changed_chunk_id bigint)
+        CREATE OR REPLACE FUNCTION refresh_world_time_from_chunk()
         RETURNS void AS $$
         BEGIN
             WITH baseline AS (
@@ -744,8 +744,8 @@ def _create_world_time_support(conn) -> None:
         CREATE OR REPLACE FUNCTION refresh_world_time_from_chunk_trigger()
         RETURNS trigger AS $$
         BEGIN
-            PERFORM refresh_world_time_from_chunk(NEW.chunk_id);
-            RETURN NEW;
+            PERFORM refresh_world_time_from_chunk();
+            RETURN NULL;
         END;
         $$ LANGUAGE plpgsql;
 
@@ -753,10 +753,12 @@ def _create_world_time_support(conn) -> None:
             ON chunk_metadata;
         CREATE TRIGGER trg_chunk_metadata_refresh_world_time
             AFTER INSERT OR UPDATE OF time_delta ON chunk_metadata
-            FOR EACH ROW
+            FOR EACH STATEMENT
             EXECUTE FUNCTION refresh_world_time_from_chunk_trigger();
 
-        SELECT refresh_world_time_from_chunk(NULL);
+        DROP FUNCTION IF EXISTS refresh_world_time_from_chunk(bigint);
+
+        SELECT refresh_world_time_from_chunk();
         """,
     )
     conn.commit()

--- a/migrations/023_orrery_schema.py
+++ b/migrations/023_orrery_schema.py
@@ -1,0 +1,762 @@
+"""Add Orrery identity spine and off-screen behavior schema."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from psycopg2 import sql
+
+
+SUBTYPE_TABLES = (
+    ("characters", "character"),
+    ("factions", "faction"),
+    ("places", "place"),
+)
+
+
+def run(conn) -> None:
+    """Apply the Orrery schema migration."""
+
+    _create_enum_types(conn)
+    _create_entities_table(conn)
+    for table_name, kind in SUBTYPE_TABLES:
+        _add_entity_column(conn, table_name)
+        _add_entity_fk(conn, table_name)
+    _backfill_entity_spine(conn)
+    _create_entity_kind_trigger(conn)
+    for table_name, kind in SUBTYPE_TABLES:
+        _install_entity_kind_trigger(conn, table_name, kind)
+        _validate_existing_entity_kinds(conn, table_name, kind)
+        _validate_entity_fk(conn, table_name)
+        _create_unique_entity_index(conn, table_name)
+        _attach_unique_entity_constraint(conn, table_name)
+        _enforce_entity_not_null(conn, table_name)
+    _create_identity_views(conn)
+    _create_tag_schema(conn)
+    _create_orrery_tables(conn)
+    _create_world_time_support(conn)
+
+
+def _execute(conn, statement: str, params: Sequence[object] | None = None) -> None:
+    with conn.cursor() as cur:
+        cur.execute(statement, params)
+
+
+def _execute_autocommit(conn, statement: sql.Composed | str) -> None:
+    conn.commit()
+    previous = conn.autocommit
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute(statement)
+    finally:
+        conn.autocommit = previous
+
+
+def _exists(conn, query: str, params: Sequence[object]) -> bool:
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        return cur.fetchone() is not None
+
+
+def _column_exists(conn, table_name: str, column_name: str) -> bool:
+    return _exists(
+        conn,
+        """
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = %s
+          AND column_name = %s
+        """,
+        (table_name, column_name),
+    )
+
+
+def _constraint_exists(conn, table_name: str, constraint_name: str) -> bool:
+    return _exists(
+        conn,
+        """
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE table_schema = 'public'
+          AND table_name = %s
+          AND constraint_name = %s
+        """,
+        (table_name, constraint_name),
+    )
+
+
+def _create_enum_types(conn) -> None:
+    _execute(
+        conn,
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'entity_kind') THEN
+                CREATE TYPE entity_kind AS ENUM ('character', 'faction', 'place');
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_type WHERE typname = 'entity_tag_source_kind'
+            ) THEN
+                CREATE TYPE entity_tag_source_kind AS ENUM (
+                    'authored', 'llm_generated', 'system', 'template',
+                    'auto_registered'
+                );
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_type WHERE typname = 'entity_tag_clearance_kind'
+            ) THEN
+                CREATE TYPE entity_tag_clearance_kind AS ENUM (
+                    'event', 'semantic', 'authored'
+                );
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_type
+                WHERE typname = 'entity_tag_reapplication_policy'
+            ) THEN
+                CREATE TYPE entity_tag_reapplication_policy AS ENUM (
+                    'new_row', 'extend_expiry', 'replace'
+                );
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_type WHERE typname = 'event_source_kind'
+            ) THEN
+                CREATE TYPE event_source_kind AS ENUM (
+                    'apex', 'resolver', 'narrator', 'bleed', 'authored'
+                );
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_type WHERE typname = 'event_role_kind'
+            ) THEN
+                CREATE TYPE event_role_kind AS ENUM (
+                    'actor', 'target', 'observer', 'beneficiary', 'witness'
+                );
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_type WHERE typname = 'event_severity_kind'
+            ) THEN
+                CREATE TYPE event_severity_kind AS ENUM (
+                    'minor', 'moderate', 'major', 'critical'
+                );
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_type WHERE typname = 'orrery_promotion_status'
+            ) THEN
+                CREATE TYPE orrery_promotion_status AS ENUM (
+                    'pending', 'promoted', 'skipped'
+                );
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_type WHERE typname = 'orrery_narration_status'
+            ) THEN
+                CREATE TYPE orrery_narration_status AS ENUM (
+                    'none', 'queued', 'leased', 'succeeded', 'failed'
+                );
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_type WHERE typname = 'orrery_job_state'
+            ) THEN
+                CREATE TYPE orrery_job_state AS ENUM (
+                    'queued', 'leased', 'succeeded', 'failed'
+                );
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_type WHERE typname = 'offscreen_embedding_status'
+            ) THEN
+                CREATE TYPE offscreen_embedding_status AS ENUM (
+                    'pending', 'embedded', 'failed'
+                );
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_type WHERE typname = 'world_layer_type'
+            ) THEN
+                CREATE TYPE world_layer_type AS ENUM (
+                    'primary', 'flashback', 'dream', 'extradiegetic'
+                );
+            END IF;
+        END $$;
+        """,
+    )
+    conn.commit()
+
+
+def _create_entities_table(conn) -> None:
+    _execute(
+        conn,
+        """
+        CREATE TABLE IF NOT EXISTS entities (
+            id         bigserial PRIMARY KEY,
+            kind       entity_kind NOT NULL,
+            is_active  boolean NOT NULL DEFAULT true,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now()
+        );
+        CREATE INDEX IF NOT EXISTS ix_entities_kind ON entities (kind);
+        """,
+    )
+    conn.commit()
+
+
+def _add_entity_column(conn, table_name: str) -> None:
+    if _column_exists(conn, table_name, "entity_id"):
+        return
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("ALTER TABLE {} ADD COLUMN entity_id bigint").format(
+                sql.Identifier(table_name)
+            )
+        )
+    conn.commit()
+
+
+def _add_entity_fk(conn, table_name: str) -> None:
+    constraint_name = f"{table_name}_entity_id_fkey"
+    if _constraint_exists(conn, table_name, constraint_name):
+        return
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL(
+                """
+                ALTER TABLE {}
+                ADD CONSTRAINT {}
+                FOREIGN KEY (entity_id) REFERENCES entities(id) NOT VALID
+                """
+            ).format(sql.Identifier(table_name), sql.Identifier(constraint_name))
+        )
+    conn.commit()
+
+
+def _backfill_entity_spine(conn) -> None:
+    for table_name, kind in SUBTYPE_TABLES:
+        with conn.cursor() as cur:
+            cur.execute(
+                sql.SQL("SELECT id FROM {} WHERE entity_id IS NULL ORDER BY id").format(
+                    sql.Identifier(table_name)
+                )
+            )
+            subtype_ids = [row[0] for row in cur.fetchall()]
+
+        for subtype_id in subtype_ids:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO entities (kind) VALUES (%s::entity_kind) RETURNING id",
+                    (kind,),
+                )
+                entity_id = cur.fetchone()[0]
+                cur.execute(
+                    sql.SQL("UPDATE {} SET entity_id = %s WHERE id = %s").format(
+                        sql.Identifier(table_name)
+                    ),
+                    (entity_id, subtype_id),
+                )
+        conn.commit()
+
+
+def _create_entity_kind_trigger(conn) -> None:
+    _execute(
+        conn,
+        """
+        CREATE OR REPLACE FUNCTION orrery_ensure_subtype_entity_kind()
+        RETURNS trigger AS $$
+        DECLARE
+            expected entity_kind := TG_ARGV[0]::entity_kind;
+            actual entity_kind;
+        BEGIN
+            IF NEW.entity_id IS NULL THEN
+                INSERT INTO entities (kind) VALUES (expected)
+                RETURNING id INTO NEW.entity_id;
+            END IF;
+
+            SELECT kind INTO actual FROM entities WHERE id = NEW.entity_id;
+            IF actual IS NULL THEN
+                RAISE EXCEPTION 'Entity id % does not exist', NEW.entity_id;
+            END IF;
+            IF actual <> expected THEN
+                RAISE EXCEPTION 'Entity id % has kind %, expected %',
+                    NEW.entity_id, actual, expected;
+            END IF;
+
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """,
+    )
+    conn.commit()
+
+
+def _install_entity_kind_trigger(conn, table_name: str, kind: str) -> None:
+    trigger_name = f"trg_{table_name}_entity_kind"
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("DROP TRIGGER IF EXISTS {} ON {}").format(
+                sql.Identifier(trigger_name), sql.Identifier(table_name)
+            )
+        )
+        cur.execute(
+            sql.SQL(
+                """
+                CREATE TRIGGER {}
+                BEFORE INSERT OR UPDATE OF entity_id ON {}
+                FOR EACH ROW
+                EXECUTE FUNCTION orrery_ensure_subtype_entity_kind(%s)
+                """
+            ).format(sql.Identifier(trigger_name), sql.Identifier(table_name)),
+            (kind,),
+        )
+    conn.commit()
+
+
+def _validate_existing_entity_kinds(conn, table_name: str, kind: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL(
+                """
+                SELECT COUNT(*)
+                FROM {} subtype
+                JOIN entities e ON e.id = subtype.entity_id
+                WHERE e.kind <> %s::entity_kind
+                """
+            ).format(sql.Identifier(table_name)),
+            (kind,),
+        )
+        mismatch_count = cur.fetchone()[0]
+        if mismatch_count:
+            raise RuntimeError(
+                f"{table_name}.entity_id has {mismatch_count} wrong-kind rows"
+            )
+
+
+def _validate_entity_fk(conn, table_name: str) -> None:
+    constraint_name = f"{table_name}_entity_id_fkey"
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("ALTER TABLE {} VALIDATE CONSTRAINT {}").format(
+                sql.Identifier(table_name), sql.Identifier(constraint_name)
+            )
+        )
+    conn.commit()
+
+
+def _create_unique_entity_index(conn, table_name: str) -> None:
+    index_name = f"ix_{table_name}_entity_id_unique"
+    _execute_autocommit(
+        conn,
+        sql.SQL(
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS {} ON {} (entity_id)"
+        ).format(sql.Identifier(index_name), sql.Identifier(table_name)),
+    )
+
+
+def _attach_unique_entity_constraint(conn, table_name: str) -> None:
+    constraint_name = f"{table_name}_entity_id_unique"
+    if _constraint_exists(conn, table_name, constraint_name):
+        return
+    index_name = f"ix_{table_name}_entity_id_unique"
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("ALTER TABLE {} ADD CONSTRAINT {} UNIQUE USING INDEX {}").format(
+                sql.Identifier(table_name),
+                sql.Identifier(constraint_name),
+                sql.Identifier(index_name),
+            )
+        )
+    conn.commit()
+
+
+def _enforce_entity_not_null(conn, table_name: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("SELECT COUNT(*) FROM {} WHERE entity_id IS NULL").format(
+                sql.Identifier(table_name)
+            )
+        )
+        null_count = cur.fetchone()[0]
+        if null_count:
+            raise RuntimeError(
+                f"{table_name}.entity_id has {null_count} NULL rows after backfill"
+            )
+        cur.execute(
+            """
+            SELECT is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = %s
+              AND column_name = 'entity_id'
+            """,
+            (table_name,),
+        )
+        is_nullable = cur.fetchone()[0]
+        if is_nullable == "YES":
+            cur.execute(
+                sql.SQL("ALTER TABLE {} ALTER COLUMN entity_id SET NOT NULL").format(
+                    sql.Identifier(table_name)
+                )
+            )
+    conn.commit()
+
+
+def _create_identity_views(conn) -> None:
+    _execute(
+        conn,
+        """
+        CREATE OR REPLACE VIEW entity_names_v AS
+            SELECT e.id, e.kind, c.name
+            FROM entities e
+            JOIN characters c ON c.entity_id = e.id
+            WHERE e.kind = 'character'
+        UNION ALL
+            SELECT e.id, e.kind, f.name
+            FROM entities e
+            JOIN factions f ON f.entity_id = e.id
+            WHERE e.kind = 'faction'
+        UNION ALL
+            SELECT e.id, e.kind, p.name
+            FROM entities e
+            JOIN places p ON p.entity_id = e.id
+            WHERE e.kind = 'place';
+
+        CREATE OR REPLACE VIEW chunk_entity_references_v AS
+            SELECT ccr.chunk_id, c.entity_id, ccr.reference::text AS reference_type
+            FROM chunk_character_references ccr
+            JOIN characters c ON c.id = ccr.character_id
+        UNION ALL
+            SELECT cfr.chunk_id, f.entity_id, NULL::text AS reference_type
+            FROM chunk_faction_references cfr
+            JOIN factions f ON f.id = cfr.faction_id
+        UNION ALL
+            SELECT pcr.chunk_id, p.entity_id, pcr.reference_type::text AS reference_type
+            FROM place_chunk_references pcr
+            JOIN places p ON p.id = pcr.place_id;
+
+        CREATE OR REPLACE VIEW entity_relationships_v AS
+            SELECT
+                c1.entity_id AS source_entity_id,
+                c2.entity_id AS target_entity_id,
+                'character'::text AS relationship_scope,
+                cr.relationship_type::text AS relationship_type,
+                cr.emotional_valence::text AS valence,
+                cr.dynamic,
+                cr.recent_events,
+                cr.history,
+                cr.extra_data
+            FROM character_relationships cr
+            JOIN characters c1 ON c1.id = cr.character1_id
+            JOIN characters c2 ON c2.id = cr.character2_id
+        UNION ALL
+            SELECT
+                f1.entity_id AS source_entity_id,
+                f2.entity_id AS target_entity_id,
+                'faction'::text AS relationship_scope,
+                fr.relationship_type::text AS relationship_type,
+                NULL::text AS valence,
+                fr.current_status AS dynamic,
+                NULL::text AS recent_events,
+                fr.history,
+                fr.extra_data
+            FROM faction_relationships fr
+            JOIN factions f1 ON f1.id = fr.faction1_id
+            JOIN factions f2 ON f2.id = fr.faction2_id
+        UNION ALL
+            SELECT
+                f.entity_id AS source_entity_id,
+                c.entity_id AS target_entity_id,
+                'faction_character'::text AS relationship_scope,
+                fcr.role::text AS relationship_type,
+                NULL::text AS valence,
+                fcr.current_status AS dynamic,
+                NULL::text AS recent_events,
+                fcr.history,
+                fcr.extra_data
+            FROM faction_character_relationships fcr
+            JOIN factions f ON f.id = fcr.faction_id
+            JOIN characters c ON c.id = fcr.character_id;
+        """,
+    )
+    conn.commit()
+
+
+def _create_tag_schema(conn) -> None:
+    _execute(
+        conn,
+        """
+        CREATE TABLE IF NOT EXISTS tags (
+            id                   bigserial PRIMARY KEY,
+            tag                  text UNIQUE NOT NULL,
+            category             text NOT NULL,
+            is_ephemeral         boolean NOT NULL DEFAULT false,
+            clearance_kind       entity_tag_clearance_kind,
+            reapplication_policy entity_tag_reapplication_policy,
+            clear_on             jsonb,
+            synonym_for          bigint REFERENCES tags(id),
+            deprecated           boolean NOT NULL DEFAULT false,
+            description          text,
+            created_at           timestamptz NOT NULL DEFAULT now(),
+            CHECK (is_ephemeral = (clearance_kind IS NOT NULL))
+        );
+
+        CREATE TABLE IF NOT EXISTS entity_tags (
+            id                    bigserial PRIMARY KEY,
+            entity_id             bigint NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+            tag_id                bigint NOT NULL REFERENCES tags(id),
+            applied_at            timestamptz NOT NULL DEFAULT now(),
+            applied_at_world_time timestamptz,
+            clear_on_override     jsonb,
+            cleared_at            timestamptz,
+            template_id           text,
+            source_kind           entity_tag_source_kind NOT NULL,
+            UNIQUE (entity_id, tag_id, applied_at)
+        );
+
+        CREATE INDEX IF NOT EXISTS ix_entity_tags_current
+            ON entity_tags (entity_id, tag_id)
+            WHERE cleared_at IS NULL;
+
+        CREATE OR REPLACE VIEW entity_tags_current AS
+            SELECT
+                et.id AS entity_tag_id,
+                et.entity_id,
+                e.kind AS entity_kind,
+                t.tag,
+                t.category,
+                t.is_ephemeral,
+                t.clearance_kind,
+                et.applied_at,
+                et.applied_at_world_time,
+                et.source_kind,
+                et.template_id
+            FROM entity_tags et
+            JOIN entities e ON e.id = et.entity_id
+            JOIN tags t ON t.id = et.tag_id
+            WHERE t.deprecated = false
+              AND et.cleared_at IS NULL
+              AND t.synonym_for IS NULL;
+        """,
+    )
+    conn.commit()
+
+
+def _create_orrery_tables(conn) -> None:
+    _execute(
+        conn,
+        """
+        CREATE TABLE IF NOT EXISTS event_types (
+            type        text PRIMARY KEY,
+            category    text NOT NULL,
+            severity    event_severity_kind,
+            description text,
+            deprecated  boolean NOT NULL DEFAULT false,
+            synonym_for text REFERENCES event_types(type)
+        );
+
+        CREATE TABLE IF NOT EXISTS orrery_resolutions (
+            id                       bigserial PRIMARY KEY,
+            tick_chunk_id            bigint NOT NULL REFERENCES narrative_chunks(id),
+            template_id              text NOT NULL,
+            binding_hash             text NOT NULL,
+            actor_entity_id          bigint REFERENCES entities(id) ON DELETE RESTRICT,
+            priority                 integer NOT NULL,
+            magnitude                numeric(4,3),
+            state_delta              jsonb NOT NULL,
+            brief                    text,
+            event_ids                bigint[],
+            promotion_status         orrery_promotion_status NOT NULL DEFAULT 'pending',
+            promotion_verdict        jsonb,
+            narration_status         orrery_narration_status NOT NULL DEFAULT 'none',
+            narration_chunk_id       bigint,
+            last_offered_chunk_id    bigint REFERENCES narrative_chunks(id),
+            offer_count              integer NOT NULL DEFAULT 0,
+            first_surfaced_chunk_id  bigint REFERENCES narrative_chunks(id),
+            created_at               timestamptz NOT NULL DEFAULT now(),
+            UNIQUE (tick_chunk_id, template_id, binding_hash)
+        );
+
+        CREATE TABLE IF NOT EXISTS world_events (
+            id                     bigserial PRIMARY KEY,
+            event_type             text NOT NULL REFERENCES event_types(type),
+            tick_chunk_id          bigint NOT NULL REFERENCES narrative_chunks(id),
+            narration_chunk_id     bigint,
+            actor_entity_id        bigint REFERENCES entities(id) ON DELETE RESTRICT,
+            target_entity_id       bigint REFERENCES entities(id) ON DELETE RESTRICT,
+            location_id            bigint REFERENCES places(id) ON DELETE RESTRICT,
+            world_layer            world_layer_type,
+            source                 event_source_kind NOT NULL,
+            changed_fields         text[] NOT NULL DEFAULT '{}',
+            magnitude              numeric(4,3),
+            resolution_id          bigint REFERENCES orrery_resolutions(id),
+            payload                jsonb NOT NULL DEFAULT '{}',
+            superseded_by_event_id bigint REFERENCES world_events(id),
+            created_at             timestamptz NOT NULL DEFAULT now()
+        );
+
+        CREATE TABLE IF NOT EXISTS world_event_entities (
+            event_id  bigint NOT NULL REFERENCES world_events(id) ON DELETE CASCADE,
+            role      event_role_kind NOT NULL,
+            entity_id bigint NOT NULL REFERENCES entities(id) ON DELETE RESTRICT,
+            PRIMARY KEY (event_id, role, entity_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS offscreen_narrations (
+            id                    bigserial PRIMARY KEY,
+            resolution_id         bigint NOT NULL REFERENCES orrery_resolutions(id),
+            tick_chunk_id         bigint NOT NULL REFERENCES narrative_chunks(id),
+            world_layer           world_layer_type,
+            text                  text NOT NULL,
+            perceptual_descriptor jsonb,
+            embedding_status      offscreen_embedding_status NOT NULL DEFAULT 'pending',
+            created_at            timestamptz NOT NULL DEFAULT now()
+        );
+
+        CREATE TABLE IF NOT EXISTS orrery_narration_jobs (
+            id            bigserial PRIMARY KEY,
+            resolution_id bigint NOT NULL REFERENCES orrery_resolutions(id),
+            slot          text NOT NULL,
+            state         orrery_job_state NOT NULL DEFAULT 'queued',
+            attempts      integer NOT NULL DEFAULT 0,
+            available_at  timestamptz NOT NULL DEFAULT now(),
+            lease_until   timestamptz,
+            locked_by     text,
+            last_error    text,
+            provider      text,
+            model_ref     text,
+            created_at    timestamptz NOT NULL DEFAULT now(),
+            updated_at    timestamptz NOT NULL DEFAULT now()
+        );
+
+        CREATE TABLE IF NOT EXISTS tag_clearance_log (
+            id                    bigserial PRIMARY KEY,
+            entity_tag_id          bigint NOT NULL REFERENCES entity_tags(id),
+            cleared_at            timestamptz NOT NULL DEFAULT now(),
+            cleared_at_world_time timestamptz,
+            mechanism             entity_tag_clearance_kind NOT NULL,
+            triggering_event_id   bigint REFERENCES world_events(id),
+            justification         jsonb,
+            source_chunk_id       bigint REFERENCES narrative_chunks(id)
+        );
+
+        CREATE INDEX IF NOT EXISTS ix_world_events_tick_chunk_id
+            ON world_events (tick_chunk_id);
+        CREATE INDEX IF NOT EXISTS ix_world_events_actor_entity_id
+            ON world_events (actor_entity_id);
+        CREATE INDEX IF NOT EXISTS ix_world_events_target_entity_id
+            ON world_events (target_entity_id);
+        CREATE INDEX IF NOT EXISTS ix_world_events_location_id
+            ON world_events (location_id);
+        CREATE INDEX IF NOT EXISTS ix_world_events_changed_fields
+            ON world_events USING GIN (changed_fields);
+        CREATE INDEX IF NOT EXISTS ix_world_events_resolution_id
+            ON world_events (resolution_id);
+        CREATE INDEX IF NOT EXISTS ix_orrery_resolutions_tick_chunk_id
+            ON orrery_resolutions (tick_chunk_id);
+        CREATE INDEX IF NOT EXISTS ix_orrery_resolutions_actor_entity_id
+            ON orrery_resolutions (actor_entity_id);
+        CREATE INDEX IF NOT EXISTS ix_orrery_resolutions_status
+            ON orrery_resolutions (promotion_status, narration_status);
+        CREATE INDEX IF NOT EXISTS ix_offscreen_narrations_tick_chunk_id
+            ON offscreen_narrations (tick_chunk_id);
+        CREATE INDEX IF NOT EXISTS ix_orrery_jobs_state_available
+            ON orrery_narration_jobs (state, available_at);
+        """,
+    )
+    _add_fk_if_missing(
+        conn,
+        table_name="orrery_resolutions",
+        constraint_name="orrery_resolutions_narration_chunk_id_fkey",
+        column_name="narration_chunk_id",
+        target_table="offscreen_narrations",
+        target_column="id",
+    )
+    _add_fk_if_missing(
+        conn,
+        table_name="world_events",
+        constraint_name="world_events_narration_chunk_id_fkey",
+        column_name="narration_chunk_id",
+        target_table="offscreen_narrations",
+        target_column="id",
+    )
+    conn.commit()
+
+
+def _add_fk_if_missing(
+    conn,
+    *,
+    table_name: str,
+    constraint_name: str,
+    column_name: str,
+    target_table: str,
+    target_column: str,
+) -> None:
+    if _constraint_exists(conn, table_name, constraint_name):
+        return
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL(
+                """
+                ALTER TABLE {}
+                ADD CONSTRAINT {}
+                FOREIGN KEY ({}) REFERENCES {}({})
+                """
+            ).format(
+                sql.Identifier(table_name),
+                sql.Identifier(constraint_name),
+                sql.Identifier(column_name),
+                sql.Identifier(target_table),
+                sql.Identifier(target_column),
+            )
+        )
+
+
+def _create_world_time_support(conn) -> None:
+    if not _column_exists(conn, "chunk_metadata", "world_time"):
+        _execute(conn, "ALTER TABLE chunk_metadata ADD COLUMN world_time timestamptz")
+        conn.commit()
+
+    _execute(
+        conn,
+        """
+        CREATE OR REPLACE FUNCTION refresh_world_time_from_chunk(changed_chunk_id bigint)
+        RETURNS void AS $$
+        BEGIN
+            WITH baseline AS (
+                SELECT COALESCE(
+                    (SELECT base_timestamp FROM global_variables WHERE id = true),
+                    now()
+                ) AS base_time
+            ),
+            computed AS (
+                SELECT
+                    cm.chunk_id,
+                    baseline.base_time + COALESCE(
+                        SUM(COALESCE(cm.time_delta, '0 seconds'::interval))
+                            OVER (ORDER BY cm.chunk_id),
+                        '0 seconds'::interval
+                    ) AS world_time
+                FROM chunk_metadata cm
+                CROSS JOIN baseline
+            )
+            UPDATE chunk_metadata cm
+            SET world_time = computed.world_time
+            FROM computed
+            WHERE cm.chunk_id = computed.chunk_id;
+        END;
+        $$ LANGUAGE plpgsql;
+
+        CREATE OR REPLACE FUNCTION refresh_world_time_from_chunk_trigger()
+        RETURNS trigger AS $$
+        BEGIN
+            PERFORM refresh_world_time_from_chunk(NEW.chunk_id);
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+
+        DROP TRIGGER IF EXISTS trg_chunk_metadata_refresh_world_time
+            ON chunk_metadata;
+        CREATE TRIGGER trg_chunk_metadata_refresh_world_time
+            AFTER INSERT OR UPDATE OF time_delta ON chunk_metadata
+            FOR EACH ROW
+            EXECUTE FUNCTION refresh_world_time_from_chunk_trigger();
+
+        SELECT refresh_world_time_from_chunk(NULL);
+        """,
+    )
+    conn.commit()

--- a/nexus.toml
+++ b/nexus.toml
@@ -154,6 +154,28 @@ max_total_events = 15
 max_total_threats = 10
 
 # =============================================================================
+# Orrery Settings (Off-Screen Behavior Resolver)
+# =============================================================================
+
+[orrery]
+enabled = false
+
+[orrery.binding]
+window_chunks = 30
+
+[orrery.narration]
+mode = "async"
+provider = "anthropic"
+model_ref = "@anthropic.default"
+
+[orrery.bleed]
+latency_budget_ms = 2000
+max_candidates = 3
+
+[orrery.promote]
+provider = "local"
+
+# =============================================================================
 # MEMNON Agent Settings (Memory & Retrieval)
 # =============================================================================
 

--- a/nexus/agents/memnon/memnon.py
+++ b/nexus/agents/memnon/memnon.py
@@ -121,6 +121,26 @@ logging.basicConfig(
 )
 logger = logging.getLogger("nexus.memnon")
 
+READONLY_SQL_ALLOWED_TABLES = {
+    "characters",
+    "episodes",
+    "seasons",
+    "events",
+    "factions",
+    "places",
+    "chunk_metadata",
+    "narrative_chunks",
+    "entities",
+    "entity_names_v",
+    "entity_tags_current",
+    "world_events",
+    "world_event_entities",
+    "orrery_resolutions",
+    "offscreen_narrations",
+    "event_types",
+    "tags",
+}
+
 # LLM settings
 MODEL_CONFIG = GLOBAL_SETTINGS.get("model", {})
 DEFAULT_MODEL_ID = MODEL_CONFIG.get("default_model", "llama-3.3-70b-instruct@q6_k")
@@ -528,16 +548,7 @@ class MEMNON:
             # Whitelist tables referenced in FROM/JOIN
             import re
 
-            allowed_tables = {
-                "characters",
-                "episodes",
-                "seasons",
-                "events",
-                "factions",
-                "places",
-                "chunk_metadata",
-                "narrative_chunks",
-            }
+            allowed_tables = READONLY_SQL_ALLOWED_TABLES
             referenced: List[str] = []
             for pattern in [
                 r"\\bfrom\\s+([a-zA-Z_\\.\"]+)",

--- a/nexus/agents/orrery/__init__.py
+++ b/nexus/agents/orrery/__init__.py
@@ -1,0 +1,39 @@
+"""Orrery off-screen behavior resolver primitives."""
+
+from nexus.agents.orrery.substrate import (
+    ALWAYS,
+    AND,
+    NOT,
+    OR,
+    Branch,
+    Bindings,
+    Condition,
+    EntityKind,
+    EventRecord,
+    Resolution,
+    Slot,
+    Template,
+    WorldState,
+    evaluate,
+    evaluate_stack,
+    validate_always_fallbacks,
+)
+
+__all__ = [
+    "ALWAYS",
+    "AND",
+    "NOT",
+    "OR",
+    "Branch",
+    "Bindings",
+    "Condition",
+    "EntityKind",
+    "EventRecord",
+    "Resolution",
+    "Slot",
+    "Template",
+    "WorldState",
+    "evaluate",
+    "evaluate_stack",
+    "validate_always_fallbacks",
+]

--- a/nexus/agents/orrery/demo.py
+++ b/nexus/agents/orrery/demo.py
@@ -1,0 +1,131 @@
+"""Offline harness for exercising Orrery behavior packages."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Dict
+
+from nexus.agents.orrery.substrate import (
+    Bindings,
+    EventRecord,
+    Slot,
+    WorldState,
+    evaluate_stack,
+    validate_always_fallbacks,
+)
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+
+ACTOR_ID = 1
+ROOTS_PLACE_ID = 101
+GLOW_PLACE_ID = 102
+STACKS_PLACE_ID = 103
+
+
+def build_presets() -> Dict[str, WorldState]:
+    """Return deterministic demo states that mirror the original JSX simulator."""
+
+    common_locations = {
+        ACTOR_ID: ROOTS_PLACE_ID,
+        2: ROOTS_PLACE_ID,
+        3: GLOW_PLACE_ID,
+    }
+    location_classes = {
+        ROOTS_PLACE_ID: "the_roots",
+        GLOW_PLACE_ID: "the_glow",
+        STACKS_PLACE_ID: "the_stacks",
+    }
+    return {
+        "hunted": WorldState(
+            tags={ACTOR_ID: frozenset({"seeking_identity", "contacts_available"})},
+            ephemeral_tags={ACTOR_ID: frozenset({"under_active_pursuit"})},
+            locations=common_locations,
+            location_class=location_classes,
+            recent_events=(
+                EventRecord(
+                    event_type="compliance_alert",
+                    tick=98,
+                    target_entity_id=ACTOR_ID,
+                ),
+            ),
+            time_of_day="night",
+            weather="rain",
+            current_tick=100,
+        ),
+        "fragment": WorldState(
+            tags={
+                ACTOR_ID: frozenset(
+                    {"seeking_identity", "contacts_available", "ghostprint_active"}
+                )
+            },
+            locations=common_locations,
+            location_class=location_classes,
+            time_of_day="evening",
+            weather="rain",
+            current_tick=100,
+        ),
+        "debt": WorldState(
+            tags={ACTOR_ID: frozenset({"seeking_identity", "contacts_available"})},
+            ephemeral_tags={ACTOR_ID: frozenset({"debt_pulse_active"})},
+            locations={ACTOR_ID: STACKS_PLACE_ID},
+            location_class=location_classes,
+            recent_events=(
+                EventRecord(
+                    event_type="encoded_message",
+                    tick=99,
+                    target_entity_id=ACTOR_ID,
+                ),
+            ),
+            time_of_day="midday",
+            weather="clear",
+            current_tick=100,
+        ),
+        "quiet": WorldState(
+            tags={ACTOR_ID: frozenset({"seeking_identity"})},
+            locations={ACTOR_ID: GLOW_PLACE_ID},
+            location_class=location_classes,
+            time_of_day="midday",
+            weather="clear",
+            current_tick=100,
+        ),
+    }
+
+
+def run_preset(name: str) -> dict:
+    """Evaluate the built-in template stack against one preset."""
+
+    presets = build_presets()
+    if name not in presets:
+        raise ValueError(f"Unknown Orrery demo preset: {name}")
+    validate_always_fallbacks(BUILTIN_TEMPLATES)
+    bindings: Bindings = {Slot.ACTOR: ACTOR_ID}
+    result = evaluate_stack(BUILTIN_TEMPLATES, presets[name], bindings)
+    if result is None:
+        return {"preset": name, "fired": False}
+    return {
+        "preset": name,
+        "fired": True,
+        "template_id": result.template_id,
+        "branch_label": result.branch_label,
+        "state_delta": dict(result.state_delta),
+        "event_type": result.event_type,
+        "magnitude": result.magnitude,
+    }
+
+
+def main() -> None:
+    """Run the offline Orrery package harness."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--preset",
+        choices=sorted(build_presets()),
+        default="hunted",
+        help="Demo preset to evaluate",
+    )
+    args = parser.parse_args()
+    print(json.dumps(run_preset(args.preset), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -1,0 +1,553 @@
+"""Pure-Python substrate for Orrery off-screen behavior packages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from hashlib import sha256
+import json
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Tuple
+
+
+class EntityKind(str, Enum):
+    """Entity kinds supported by the Orrery identity spine."""
+
+    CHARACTER = "character"
+    FACTION = "faction"
+    PLACE = "place"
+
+
+class Slot(str, Enum):
+    """Typed parameter names a behavior package can bind."""
+
+    ACTOR = "actor"
+    TARGET = "target"
+    TARGETS = "targets"
+    LOCATION = "location"
+    LOCATION_CLASS = "location_class"
+    RESOURCE = "resource"
+    THREAT = "threat"
+    FACTION = "faction"
+
+
+Bindings = Dict[Slot, Any]
+Condition = Callable[["WorldState", Bindings], bool]
+
+
+@dataclass(frozen=True, slots=True)
+class EventRecord:
+    """Compact read-side event shape consumed by condition predicates."""
+
+    event_type: str
+    tick: int
+    actor_entity_id: Optional[int] = None
+    target_entity_id: Optional[int] = None
+    location_id: Optional[int] = None
+    changed_fields: Tuple[str, ...] = ()
+    world_layer: str = "primary"
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class WorldState:
+    """Immutable snapshot read by package conditions for one resolver tick."""
+
+    tags: Mapping[int, frozenset[str]] = field(default_factory=dict)
+    ephemeral_tags: Mapping[int, frozenset[str]] = field(default_factory=dict)
+    locations: Mapping[int, int] = field(default_factory=dict)
+    activities: Mapping[int, str] = field(default_factory=dict)
+    trust: Mapping[Tuple[int, int], int] = field(default_factory=dict)
+    relationship_types: Mapping[Tuple[int, int], frozenset[str]] = field(
+        default_factory=dict
+    )
+    faction_memberships: Mapping[int, frozenset[int]] = field(default_factory=dict)
+    location_class: Mapping[int, str] = field(default_factory=dict)
+    orbit_distance: Mapping[Tuple[int, int], int] = field(default_factory=dict)
+    recent_events: Tuple[EventRecord, ...] = ()
+    time_of_day: str = "midday"
+    weather: str = "clear"
+    current_tick: int = 0
+
+
+def _slot_entity(bindings: Bindings, slot: Slot) -> Optional[int]:
+    value = bindings.get(slot)
+    return value if isinstance(value, int) else None
+
+
+def _named(condition: Condition, name: str) -> Condition:
+    condition.__name__ = name
+    return condition
+
+
+def has_tag(tag: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound entity has a durable tag."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        return entity_id is not None and tag in state.tags.get(entity_id, frozenset())
+
+    return _named(_condition, f"has_tag({tag}@{slot.value})")
+
+
+def lacks_tag(tag: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound entity lacks a durable tag."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        return entity_id is None or tag not in state.tags.get(entity_id, frozenset())
+
+    return _named(_condition, f"lacks_tag({tag}@{slot.value})")
+
+
+def has_any_tag(*tags: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound entity has any of the given tags."""
+
+    candidates = frozenset(tags)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        return bool(candidates & state.tags.get(entity_id, frozenset()))
+
+    return _named(_condition, f"has_any_tag({','.join(tags)}@{slot.value})")
+
+
+def has_ephemeral(tag: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound entity has a current ephemeral tag."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        return entity_id is not None and tag in state.ephemeral_tags.get(
+            entity_id, frozenset()
+        )
+
+    return _named(_condition, f"has_ephemeral({tag}@{slot.value})")
+
+
+def in_location_class(location_class: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether an entity is currently in a place of the given class."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        location_id = state.locations.get(entity_id)
+        return (
+            location_id is not None
+            and state.location_class.get(location_id) == location_class
+        )
+
+    return _named(_condition, f"in_location_class({location_class}@{slot.value})")
+
+
+def in_location(location_id: int, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether an entity is currently at a specific place id."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        return entity_id is not None and state.locations.get(entity_id) == location_id
+
+    return _named(_condition, f"in_location({location_id}@{slot.value})")
+
+
+def co_located(slot_a: Slot = Slot.ACTOR, slot_b: Slot = Slot.TARGET) -> Condition:
+    """Return whether two slot-bound entities share a current location."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        left = _slot_entity(bindings, slot_a)
+        right = _slot_entity(bindings, slot_b)
+        if left is None or right is None:
+            return False
+        location_id = state.locations.get(left)
+        return location_id is not None and location_id == state.locations.get(right)
+
+    return _named(_condition, f"co_located({slot_a.value},{slot_b.value})")
+
+
+def count_co_located(
+    minimum: int,
+    slot: Slot = Slot.ACTOR,
+    *,
+    with_tag: Optional[str] = None,
+) -> Condition:
+    """Return whether enough entities share the slot entity's current location."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        location_id = state.locations.get(entity_id)
+        if location_id is None:
+            return False
+        count = 0
+        for other_id, other_location in state.locations.items():
+            if other_id == entity_id or other_location != location_id:
+                continue
+            if with_tag and with_tag not in state.tags.get(other_id, frozenset()):
+                continue
+            count += 1
+        return count >= minimum
+
+    suffix = f",tag={with_tag}" if with_tag else ""
+    return _named(_condition, f"count_co_located({minimum}@{slot.value}{suffix})")
+
+
+def trust_at_least(
+    threshold: int,
+    slot_from: Slot = Slot.ACTOR,
+    slot_to: Slot = Slot.TARGET,
+) -> Condition:
+    """Return whether trust from one entity to another meets a threshold."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        source = _slot_entity(bindings, slot_from)
+        target = _slot_entity(bindings, slot_to)
+        if source is None or target is None:
+            return False
+        return state.trust.get((source, target), 0) >= threshold
+
+    return _named(
+        _condition, f"trust_at_least({threshold},{slot_from.value}->{slot_to.value})"
+    )
+
+
+def trust_below(
+    threshold: int,
+    slot_from: Slot = Slot.ACTOR,
+    slot_to: Slot = Slot.TARGET,
+) -> Condition:
+    """Return whether trust from one entity to another is below a threshold."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        source = _slot_entity(bindings, slot_from)
+        target = _slot_entity(bindings, slot_to)
+        if source is None or target is None:
+            return False
+        return state.trust.get((source, target), 0) < threshold
+
+    return _named(
+        _condition, f"trust_below({threshold},{slot_from.value}->{slot_to.value})"
+    )
+
+
+def has_relationship_of_type(
+    relationship_type: str,
+    slot_from: Slot = Slot.ACTOR,
+    slot_to: Slot = Slot.TARGET,
+) -> Condition:
+    """Return whether a typed relationship exists between two entities."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        source = _slot_entity(bindings, slot_from)
+        target = _slot_entity(bindings, slot_to)
+        if source is None or target is None:
+            return False
+        return relationship_type in state.relationship_types.get(
+            (source, target), frozenset()
+        )
+
+    return _named(
+        _condition,
+        f"has_relationship_of_type({relationship_type},{slot_from.value}->{slot_to.value})",
+    )
+
+
+def faction_member(
+    faction_slot: Slot = Slot.FACTION,
+    member_slot: Slot = Slot.ACTOR,
+) -> Condition:
+    """Return whether a member entity belongs to a faction entity."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        member_id = _slot_entity(bindings, member_slot)
+        faction_id = _slot_entity(bindings, faction_slot)
+        if member_id is None or faction_id is None:
+            return False
+        return faction_id in state.faction_memberships.get(member_id, frozenset())
+
+    return _named(
+        _condition, f"faction_member({member_slot.value}->{faction_slot.value})"
+    )
+
+
+def relative_orbit_distance(
+    max_distance: int,
+    slot_from: Slot = Slot.ACTOR,
+    slot_to: Slot = Slot.TARGET,
+) -> Condition:
+    """Return whether two entities are within an abstract social orbit distance."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        source = _slot_entity(bindings, slot_from)
+        target = _slot_entity(bindings, slot_to)
+        if source is None or target is None:
+            return False
+        distance = state.orbit_distance.get((source, target))
+        return distance is not None and distance <= max_distance
+
+    return _named(
+        _condition,
+        f"relative_orbit_distance(<={max_distance},{slot_from.value}->{slot_to.value})",
+    )
+
+
+def time_of_day_in(*times: str) -> Condition:
+    """Return whether current in-world time of day is in the given set."""
+
+    candidates = frozenset(times)
+
+    def _condition(state: WorldState, _bindings: Bindings) -> bool:
+        return state.time_of_day in candidates
+
+    return _named(_condition, f"time_of_day_in({','.join(times)})")
+
+
+def weather_is(*weather_values: str) -> Condition:
+    """Return whether current weather is in the given set."""
+
+    candidates = frozenset(weather_values)
+
+    def _condition(state: WorldState, _bindings: Bindings) -> bool:
+        return state.weather in candidates
+
+    return _named(_condition, f"weather_is({','.join(weather_values)})")
+
+
+def recent_event(
+    event_type: Optional[str] = None,
+    *,
+    within_ticks: int = 5,
+    actor_slot: Optional[Slot] = None,
+    target_slot: Optional[Slot] = None,
+    changed_fields_any_of: Iterable[str] = (),
+) -> Condition:
+    """Return whether a matching event happened inside the recent tick window."""
+
+    changed_fields = frozenset(changed_fields_any_of)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        actor_id = _slot_entity(bindings, actor_slot) if actor_slot else None
+        target_id = _slot_entity(bindings, target_slot) if target_slot else None
+        cutoff = state.current_tick - within_ticks
+        for event in state.recent_events:
+            if event.tick < cutoff:
+                continue
+            if event_type is not None and event.event_type != event_type:
+                continue
+            if actor_id is not None and actor_id not in (
+                event.actor_entity_id,
+                event.target_entity_id,
+            ):
+                continue
+            if target_id is not None and target_id not in (
+                event.actor_entity_id,
+                event.target_entity_id,
+            ):
+                continue
+            if changed_fields and not changed_fields.intersection(event.changed_fields):
+                continue
+            return True
+        return False
+
+    parts = [event_type or "*", f"<={within_ticks}"]
+    if actor_slot:
+        parts.append(f"actor={actor_slot.value}")
+    if target_slot:
+        parts.append(f"target={target_slot.value}")
+    if changed_fields:
+        parts.append("fields")
+    return _named(_condition, f"recent_event({','.join(parts)})")
+
+
+def since_last_event_at_least(
+    event_type: str,
+    minimum_ticks: int,
+    *,
+    actor_slot: Slot = Slot.ACTOR,
+) -> Condition:
+    """Return whether enough ticks have passed since the last matching event."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        actor_id = _slot_entity(bindings, actor_slot)
+        latest_tick: Optional[int] = None
+        for event in state.recent_events:
+            if event.event_type != event_type:
+                continue
+            if actor_id is not None and actor_id not in (
+                event.actor_entity_id,
+                event.target_entity_id,
+            ):
+                continue
+            latest_tick = (
+                event.tick if latest_tick is None else max(latest_tick, event.tick)
+            )
+        if latest_tick is None:
+            return True
+        return state.current_tick - latest_tick >= minimum_ticks
+
+    return _named(
+        _condition,
+        f"since_last_event_at_least({event_type},{minimum_ticks}@{actor_slot.value})",
+    )
+
+
+def AND(*conditions: Condition) -> Condition:
+    """Compose conditions with logical AND."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        return all(condition(state, bindings) for condition in conditions)
+
+    return _named(_condition, f"AND({len(conditions)})")
+
+
+def OR(*conditions: Condition) -> Condition:
+    """Compose conditions with logical OR."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        return any(condition(state, bindings) for condition in conditions)
+
+    return _named(_condition, f"OR({len(conditions)})")
+
+
+def NOT(condition: Condition) -> Condition:
+    """Compose a condition with logical NOT."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        return not condition(state, bindings)
+
+    return _named(_condition, f"NOT({condition.__name__})")
+
+
+def ALWAYS(_state: WorldState, _bindings: Bindings) -> bool:
+    """Condition that always passes."""
+
+    return True
+
+
+def NEVER(_state: WorldState, _bindings: Bindings) -> bool:
+    """Condition that never passes."""
+
+    return False
+
+
+ALWAYS.__name__ = "ALWAYS"
+NEVER.__name__ = "NEVER"
+
+
+@dataclass(frozen=True, slots=True)
+class Branch:
+    """One procedure-tree branch inside a behavior package."""
+
+    label: str
+    conditions: Condition
+    narrative_stub: str
+    state_delta: Mapping[str, Any] = field(default_factory=dict)
+    event_type: Optional[str] = None
+    changed_fields: Tuple[str, ...] = ()
+    magnitude: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class Template:
+    """Deterministic behavior package evaluated by the resolver."""
+
+    id: str
+    priority: int
+    blurb: str
+    required_slots: Tuple[Slot, ...]
+    package_gate: Condition
+    branches: Tuple[Branch, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class Resolution:
+    """Result of evaluating one template against one set of bindings."""
+
+    template_id: str
+    priority: int
+    binding_hash: str
+    bindings: Bindings
+    passes: bool
+    branch_label: Optional[str] = None
+    narrative_stub: Optional[str] = None
+    state_delta: Mapping[str, Any] = field(default_factory=dict)
+    event_type: Optional[str] = None
+    changed_fields: Tuple[str, ...] = ()
+    magnitude: float = 0.0
+
+
+def binding_hash(bindings: Bindings) -> str:
+    """Return a stable hash for a bindings dictionary."""
+
+    serializable = {
+        slot.value if isinstance(slot, Slot) else str(slot): value
+        for slot, value in sorted(bindings.items(), key=lambda item: item[0].value)
+    }
+    encoded = json.dumps(serializable, sort_keys=True, separators=(",", ":"))
+    return sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def evaluate(template: Template, state: WorldState, bindings: Bindings) -> Resolution:
+    """Evaluate one template and binding set against world state."""
+
+    digest = binding_hash(bindings)
+    if not template.package_gate(state, bindings):
+        return Resolution(
+            template_id=template.id,
+            priority=template.priority,
+            binding_hash=digest,
+            bindings=bindings,
+            passes=False,
+        )
+
+    for branch in template.branches:
+        if branch.conditions(state, bindings):
+            return Resolution(
+                template_id=template.id,
+                priority=template.priority,
+                binding_hash=digest,
+                bindings=bindings,
+                passes=True,
+                branch_label=branch.label,
+                narrative_stub=branch.narrative_stub,
+                state_delta=branch.state_delta,
+                event_type=branch.event_type,
+                changed_fields=branch.changed_fields,
+                magnitude=branch.magnitude,
+            )
+
+    return Resolution(
+        template_id=template.id,
+        priority=template.priority,
+        binding_hash=digest,
+        bindings=bindings,
+        passes=False,
+    )
+
+
+def evaluate_stack(
+    templates: Iterable[Template], state: WorldState, bindings: Bindings
+) -> Optional[Resolution]:
+    """Evaluate templates in priority order and return the first firing branch."""
+
+    for template in sorted(templates, key=lambda item: item.priority, reverse=True):
+        result = evaluate(template, state, bindings)
+        if result.passes:
+            return result
+    return None
+
+
+def validate_always_fallbacks(templates: Iterable[Template]) -> None:
+    """Validate that every template ends with an ALWAYS-conditioned branch."""
+
+    missing = [
+        template.id
+        for template in templates
+        if not template.branches or template.branches[-1].conditions is not ALWAYS
+    ]
+    if missing:
+        raise ValueError(
+            "Orrery templates missing terminal ALWAYS branch: "
+            + ", ".join(sorted(missing))
+        )

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -329,21 +329,19 @@ def recent_event(
     def _condition(state: WorldState, bindings: Bindings) -> bool:
         actor_id = _slot_entity(bindings, actor_slot) if actor_slot else None
         target_id = _slot_entity(bindings, target_slot) if target_slot else None
+        if actor_slot is not None and actor_id is None:
+            return False
+        if target_slot is not None and target_id is None:
+            return False
         cutoff = state.current_tick - within_ticks
         for event in state.recent_events:
             if event.tick < cutoff:
                 continue
             if event_type is not None and event.event_type != event_type:
                 continue
-            if actor_id is not None and actor_id not in (
-                event.actor_entity_id,
-                event.target_entity_id,
-            ):
+            if actor_id is not None and event.actor_entity_id != actor_id:
                 continue
-            if target_id is not None and target_id not in (
-                event.actor_entity_id,
-                event.target_entity_id,
-            ):
+            if target_id is not None and event.target_entity_id != target_id:
                 continue
             if changed_fields and not changed_fields.intersection(event.changed_fields):
                 continue
@@ -370,14 +368,13 @@ def since_last_event_at_least(
 
     def _condition(state: WorldState, bindings: Bindings) -> bool:
         actor_id = _slot_entity(bindings, actor_slot)
+        if actor_id is None:
+            return False
         latest_tick: Optional[int] = None
         for event in state.recent_events:
             if event.event_type != event_type:
                 continue
-            if actor_id is not None and actor_id not in (
-                event.actor_entity_id,
-                event.target_entity_id,
-            ):
+            if event.actor_entity_id != actor_id:
                 continue
             latest_tick = (
                 event.tick if latest_tick is None else max(latest_tick, event.tick)
@@ -480,9 +477,13 @@ class Resolution:
 def binding_hash(bindings: Bindings) -> str:
     """Return a stable hash for a bindings dictionary."""
 
+    def _binding_sort_key(item: Tuple[Any, Any]) -> str:
+        slot = item[0]
+        return slot.value if isinstance(slot, Slot) else str(slot)
+
     serializable = {
         slot.value if isinstance(slot, Slot) else str(slot): value
-        for slot, value in sorted(bindings.items(), key=lambda item: item[0].value)
+        for slot, value in sorted(bindings.items(), key=_binding_sort_key)
     }
     encoded = json.dumps(serializable, sort_keys=True, separators=(",", ":"))
     return sha256(encoded.encode("utf-8")).hexdigest()

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -1,0 +1,224 @@
+"""Built-in Orrery behavior package catalog."""
+
+from __future__ import annotations
+
+from nexus.agents.orrery.substrate import (
+    ALWAYS,
+    AND,
+    NOT,
+    OR,
+    Branch,
+    Slot,
+    Template,
+    has_ephemeral,
+    has_tag,
+    in_location_class,
+    lacks_tag,
+    recent_event,
+    time_of_day_in,
+    weather_is,
+)
+
+
+EVADE_PURSUERS = Template(
+    id="evade_pursuers",
+    priority=100,
+    blurb="When the city is closing in.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=OR(
+        has_ephemeral("under_active_pursuit"),
+        recent_event("compliance_alert", within_ticks=5, target_slot=Slot.ACTOR),
+    ),
+    branches=(
+        Branch(
+            label="Go to ground in flooded tunnels",
+            conditions=AND(in_location_class("the_roots"), weather_is("rain")),
+            narrative_stub=(
+                "{actor} slips off a Rootline platform into a flooded service "
+                "corridor and kills every transmitter on their person."
+            ),
+            state_delta={
+                "character.current_activity": "hiding from active pursuit",
+                "entity_tags.add": ["off_grid"],
+            },
+            event_type="evade_pursuit",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.72,
+        ),
+        Branch(
+            label="Reach a safe house through contacts",
+            conditions=has_tag("contacts_available"),
+            narrative_stub=(
+                "{actor} pings a broker through a low-bandwidth dead-drop and "
+                "takes a four-hop route to a safe house."
+            ),
+            state_delta={
+                "character.current_activity": "relocating through safe contacts",
+            },
+            event_type="evade_pursuit",
+            changed_fields=("character.current_activity",),
+            magnitude=0.58,
+        ),
+        Branch(
+            label="Keep moving, blend into public flow",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} joins the densest pedestrian current nearby, never "
+                "stopping long enough to make a clean pattern."
+            ),
+            state_delta={"character.current_activity": "blending into public flow"},
+            event_type="evade_pursuit",
+            changed_fields=("character.current_activity",),
+            magnitude=0.42,
+        ),
+    ),
+)
+
+
+HONOR_DEBT = Template(
+    id="honor_debt",
+    priority=80,
+    blurb="A binding obligation surfaces from the blank years.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=OR(
+        has_ephemeral("debt_pulse_active"),
+        recent_event("encoded_message", within_ticks=3, target_slot=Slot.ACTOR),
+    ),
+    branches=(
+        Branch(
+            label="Activate the Ghostprint Key at a sympathetic node",
+            conditions=AND(
+                has_tag("ghostprint_active"), in_location_class("the_roots")
+            ),
+            narrative_stub=(
+                "{actor} finds a half-decommissioned authentication terminal "
+                "and pulses the Key against it."
+            ),
+            state_delta={
+                "character.current_activity": "signaling through a sympathetic node",
+            },
+            event_type="honor_debt",
+            changed_fields=("character.current_activity",),
+            magnitude=0.66,
+        ),
+        Branch(
+            label="Fulfill obligation through a dead-drop",
+            conditions=has_tag("contacts_available"),
+            narrative_stub=(
+                "{actor} tucks an encoded microdrive behind a loose ceramic "
+                "tile and leaves a mark for the recipient."
+            ),
+            state_delta={"character.current_activity": "servicing an old debt"},
+            event_type="honor_debt",
+            changed_fields=("character.current_activity",),
+            magnitude=0.5,
+        ),
+        Branch(
+            label="Leave a public sign",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} pays a street artist in physical cash to place a "
+                "specific glyph where only the intended recipient will read it."
+            ),
+            state_delta={"character.current_activity": "leaving a coded public sign"},
+            event_type="honor_debt",
+            changed_fields=("character.current_activity",),
+            magnitude=0.38,
+        ),
+    ),
+)
+
+
+PURSUE_GHOST_LEAD = Template(
+    id="pursue_ghost_lead",
+    priority=60,
+    blurb="The fragments of a buried identity tug at the actor.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        has_tag("seeking_identity"),
+        time_of_day_in("evening", "night"),
+        lacks_tag("under_active_pursuit"),
+        NOT(has_ephemeral("under_active_pursuit")),
+    ),
+    branches=(
+        Branch(
+            label="Recon a hideout their body remembers",
+            conditions=in_location_class("the_roots"),
+            narrative_stub=(
+                "{actor} picks through maintenance corridors to a place their "
+                "body recognizes before memory can explain why."
+            ),
+            state_delta={"character.current_activity": "reconning remembered terrain"},
+            event_type="pursue_identity_lead",
+            changed_fields=("character.current_activity",),
+            magnitude=0.64,
+        ),
+        Branch(
+            label="Probe the data fog with the Key",
+            conditions=has_tag("ghostprint_active"),
+            narrative_stub=(
+                "{actor} brushes against a mid-tier operator, ducks into a "
+                "kiosk, and lets the Key scrape fragments from the ledger noise."
+            ),
+            state_delta={"character.current_activity": "probing identity records"},
+            event_type="pursue_identity_lead",
+            changed_fields=("character.current_activity",),
+            magnitude=0.57,
+        ),
+        Branch(
+            label="Query the broker network",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} visits a broker who owes them a favor and leaves with "
+                "one new question and one dangerous name."
+            ),
+            state_delta={"character.current_activity": "querying the broker network"},
+            event_type="pursue_identity_lead",
+            changed_fields=("character.current_activity",),
+            magnitude=0.44,
+        ),
+    ),
+)
+
+
+MAINTAIN_COVER = Template(
+    id="maintain_cover",
+    priority=0,
+    blurb="Baseline activity that keeps the behavioral ledger plausible.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=ALWAYS,
+    branches=(
+        Branch(
+            label="Run a low-level courier job",
+            conditions=in_location_class("the_glow"),
+            narrative_stub=(
+                "{actor} picks up a benign data packet, walks it across the "
+                "district, and earns just enough to register as ordinary."
+            ),
+            state_delta={"character.current_activity": "running low-level cover work"},
+            event_type="maintain_cover",
+            changed_fields=("character.current_activity",),
+            magnitude=0.16,
+        ),
+        Branch(
+            label="Drift through public space",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} moves through public space at the pace of someone "
+                "with somewhere to be, generating forgettable civilian noise."
+            ),
+            state_delta={"character.current_activity": "maintaining public cover"},
+            event_type="maintain_cover",
+            changed_fields=("character.current_activity",),
+            magnitude=0.1,
+        ),
+    ),
+)
+
+
+BUILTIN_TEMPLATES = (
+    EVADE_PURSUERS,
+    HONOR_DEBT,
+    PURSUE_GHOST_LEAD,
+    MAINTAIN_COVER,
+)

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -26,20 +26,26 @@ class _ModelRegistry:
     """
 
     roles: Dict[str, Dict[str, str]]  # provider name → {role_name → concrete_id}
-    all_ids: Dict[str, str]           # concrete_id → provider, for error messages
+    all_ids: Dict[str, str]  # concrete_id → provider, for error messages
 
 
 # =============================================================================
 # Global Settings Models
 # =============================================================================
 
+
 class APIModelEntry(BaseModel):
     """Single API model definition."""
-    model_config = ConfigDict(extra='forbid')
 
-    id: str = Field(..., description="Concrete model identifier registered with this provider")
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(
+        ..., description="Concrete model identifier registered with this provider"
+    )
     label: str = Field(..., description="Display label for UI")
-    description: Optional[str] = Field(default=None, description="Human-readable description (optional)")
+    description: Optional[str] = Field(
+        default=None, description="Human-readable description (optional)"
+    )
 
 
 class ProviderModels(BaseModel):
@@ -49,7 +55,8 @@ class ProviderModels(BaseModel):
     IDs from this provider's `models` list. Consumer fields reference roles via
     "@provider.role" syntax (resolved at Settings load time).
     """
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     roles: Dict[str, str] = Field(
         default_factory=dict,
@@ -60,8 +67,7 @@ class ProviderModels(BaseModel):
         ),
     )
     models: List[APIModelEntry] = Field(
-        default_factory=list,
-        description="List of models available from this provider"
+        default_factory=list, description="List of models available from this provider"
     )
 
     @model_validator(mode="after")
@@ -81,23 +87,26 @@ class ProviderModels(BaseModel):
 
 class ModelConfig(BaseModel):
     """LLM model configuration with provider grouping."""
-    model_config = ConfigDict(extra='forbid')
 
-    default_model: str = Field(..., description="Default model to load for local inference")
+    model_config = ConfigDict(extra="forbid")
+
+    default_model: str = Field(
+        ..., description="Default model to load for local inference"
+    )
     possible_values: List[str] = Field(..., description="Available local model options")
     default_slot_model: str = Field(
-        default="TEST",
-        description="Default model for newly created/reset slots"
+        default="TEST", description="Default model for newly created/reset slots"
     )
     api_models: Dict[str, ProviderModels] = Field(
         default_factory=dict,
-        description="API models grouped by provider (openai, anthropic, test)"
+        description="API models grouped by provider (openai, anthropic, test)",
     )
 
 
 class LLMConfig(BaseModel):
     """Local LLM API settings (LM Studio)."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     api_base: str = Field(..., description="LM Studio API endpoint")
     context_window: int = Field(..., ge=1024, description="Maximum context length")
@@ -107,12 +116,13 @@ class LLMConfig(BaseModel):
 
 class LLMEndpointConfig(BaseModel):
     """Endpoint configuration for LM Studio backends."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     base_url: str = Field(..., description="Base URL for the LM Studio server")
     model: Optional[str] = Field(
         default=None,
-        description="Model identifier for inference (overrides global default)"
+        description="Model identifier for inference (overrides global default)",
     )
 
 
@@ -123,7 +133,8 @@ class LLMCloudConfig(BaseModel):
     ``nexus.util.secret_manager.get_secret(<provider>)`` which reads from
     macOS Keychain.
     """
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     provider: str = Field(..., pattern="^(openai|anthropic)$")
     model: str = Field(..., description="Cloud model identifier")
@@ -131,7 +142,8 @@ class LLMCloudConfig(BaseModel):
 
 class LLMRoutingConfig(BaseModel):
     """Routing configuration for the pluggable LLM layer."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     mode: Literal["local", "remote", "cloud", "auto"] = Field(
         default="auto",
@@ -153,7 +165,8 @@ class LLMRoutingConfig(BaseModel):
 
 class NarrativeConfig(BaseModel):
     """Narrative test mode settings."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     test_mode: bool = Field(..., description="Enable test mode")
     test_database_suffix: str = Field(..., description="Database suffix for testing")
@@ -161,39 +174,47 @@ class NarrativeConfig(BaseModel):
 
 class GlobalAPIConfig(BaseModel):
     """Global API configuration."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     test_mock_server_url: str = Field(
-        default="http://localhost:5102/v1",
-        description="Mock server URL for TEST model"
+        default="http://localhost:5102/v1", description="Mock server URL for TEST model"
     )
 
 
 class GlobalSettings(BaseModel):
     """Global configuration settings."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     model: ModelConfig
     llm: LLMConfig
     narrative: NarrativeConfig
-    api: Optional[GlobalAPIConfig] = Field(default=None, description="API configuration")
+    api: Optional[GlobalAPIConfig] = Field(
+        default=None, description="API configuration"
+    )
 
 
 # =============================================================================
 # LORE Agent Settings Models
 # =============================================================================
 
+
 class TokenBudgetConfig(BaseModel):
     """Token budget allocation for APEX generation."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     apex_context_window: int = Field(..., ge=1000, description="Total tokens for APEX")
-    system_prompt_tokens: int = Field(..., ge=100, description="Reserved for system prompt")
+    system_prompt_tokens: int = Field(
+        ..., ge=100, description="Reserved for system prompt"
+    )
 
 
 class PayloadBudgetRange(BaseModel):
     """Min/max percentage range for payload budget allocation."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     min: int = Field(..., ge=0, le=100, description="Minimum percentage")
     max: int = Field(..., ge=0, le=100, description="Maximum percentage")
@@ -201,7 +222,8 @@ class PayloadBudgetRange(BaseModel):
 
 class PayloadPercentBudget(BaseModel):
     """Percentage allocations for different context payload sections."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     structured_summaries: PayloadBudgetRange
     contextual_augmentation: PayloadBudgetRange
@@ -210,7 +232,8 @@ class PayloadPercentBudget(BaseModel):
 
 class EntityInclusionConfig(BaseModel):
     """Configuration for entity inclusion in context payloads."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     warm_slice_lookback_chunks: int = Field(..., ge=1)
     max_characters_from_warm_slice: int = Field(..., ge=1)
@@ -228,7 +251,8 @@ class EntityInclusionConfig(BaseModel):
 
 class LORESettings(BaseModel):
     """LORE agent configuration."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     debug: bool
     agentic_sql: bool
@@ -238,12 +262,66 @@ class LORESettings(BaseModel):
 
 
 # =============================================================================
+# Orrery Settings Models
+# =============================================================================
+
+
+class OrreryBindingSettings(BaseModel):
+    """Binding composer settings for Orrery."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    window_chunks: int = Field(default=30, ge=1)
+
+
+class OrreryNarrationSettings(BaseModel):
+    """Frontier narration settings for promoted Orrery resolutions."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["async", "sync"] = "async"
+    provider: str = "anthropic"
+    model_ref: str = Field(..., description="Model ID or @provider.role reference")
+
+
+class OrreryBleedSettings(BaseModel):
+    """Bleed selector settings for storyteller-time ambient candidates."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    latency_budget_ms: int = Field(default=2000, ge=1)
+    max_candidates: int = Field(default=3, ge=0)
+
+
+class OrreryPromoteSettings(BaseModel):
+    """Promotion discriminator settings for Orrery resolutions."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: Literal["local"] = "local"
+
+
+class OrrerySettings(BaseModel):
+    """Orrery off-screen behavior subsystem settings."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    binding: OrreryBindingSettings = Field(default_factory=OrreryBindingSettings)
+    narration: OrreryNarrationSettings
+    bleed: OrreryBleedSettings = Field(default_factory=OrreryBleedSettings)
+    promote: OrreryPromoteSettings = Field(default_factory=OrreryPromoteSettings)
+
+
+# =============================================================================
 # MEMNON Agent Settings Models
 # =============================================================================
 
+
 class DatabaseConfig(BaseModel):
     """Database connection configuration."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     url: str = Field(..., description="PostgreSQL connection URL")
     create_tables: bool
@@ -252,7 +330,8 @@ class DatabaseConfig(BaseModel):
 
 class EmbeddingModelConfig(BaseModel):
     """Configuration for an individual embedding model."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     is_active: bool
     local_path: str
@@ -263,7 +342,8 @@ class EmbeddingModelConfig(BaseModel):
 
 class ImportConfig(BaseModel):
     """Settings for importing narrative chunks."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     base_directory: str
     file_pattern: str
@@ -275,7 +355,8 @@ class ImportConfig(BaseModel):
 
 class QueryConfig(BaseModel):
     """Default query settings."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     default_limit: int = Field(..., ge=1)
     include_vector_results: int = Field(..., ge=0)
@@ -285,7 +366,8 @@ class QueryConfig(BaseModel):
 
 class SourceWeights(BaseModel):
     """Relative weights for different retrieval sources."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     structured_data: float = Field(..., ge=0.0)
     vector_search: float = Field(..., ge=0.0)
@@ -294,7 +376,8 @@ class SourceWeights(BaseModel):
 
 class VectorNormalizationConfig(BaseModel):
     """Vector search score normalization settings."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     enabled: bool
     low_tier_map_enabled: bool
@@ -308,7 +391,8 @@ class VectorNormalizationConfig(BaseModel):
 
 class UserCharacterFocusBoost(BaseModel):
     """Boost settings for user character focus detection."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     enabled: bool
     action_patterns: List[str]
@@ -322,7 +406,8 @@ class UserCharacterFocusBoost(BaseModel):
 
 class QueryTypeWeights(BaseModel):
     """Vector/text weights for a query type."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     vector: float = Field(..., ge=0.0, le=1.0)
     text: float = Field(..., ge=0.0, le=1.0)
@@ -330,7 +415,8 @@ class QueryTypeWeights(BaseModel):
 
 class HybridSearchConfig(BaseModel):
     """Hybrid search (vector + text) configuration."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     enabled: bool
     vector_weight_default: float = Field(..., ge=0.0, le=1.0)
@@ -355,7 +441,8 @@ class RerankerCandidate(BaseModel):
     flag on this candidate entry. This registry is for ir_eval bakeoff
     selection via ``ir_eval.runner create-run --reranker NAME``.
     """
-    model_config = ConfigDict(extra='forbid', protected_namespaces=())
+
+    model_config = ConfigDict(extra="forbid", protected_namespaces=())
 
     local_path: str
     remote_path: str = ""
@@ -365,7 +452,8 @@ class RerankerCandidate(BaseModel):
 
 class CrossEncoderReranking(BaseModel):
     """Cross-encoder reranking configuration."""
-    model_config = ConfigDict(extra='forbid', protected_namespaces=())
+
+    model_config = ConfigDict(extra="forbid", protected_namespaces=())
 
     enabled: bool
     model_path: str
@@ -384,7 +472,8 @@ class CrossEncoderReranking(BaseModel):
 
 class RetrievalConfig(BaseModel):
     """Main retrieval configuration."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     max_results: int = Field(..., ge=1)
     relevance_threshold: float = Field(..., ge=0.0, le=1.0)
@@ -404,7 +493,8 @@ class RetrievalConfig(BaseModel):
 
 class LoggingConfig(BaseModel):
     """Logging configuration."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     file: str
     level: str = Field(..., pattern="^(DEBUG|INFO|WARNING|ERROR|CRITICAL)$")
@@ -413,7 +503,8 @@ class LoggingConfig(BaseModel):
 
 class MEMNONSettings(BaseModel):
     """MEMNON agent configuration."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     debug: bool
     database: DatabaseConfig
@@ -428,9 +519,11 @@ class MEMNONSettings(BaseModel):
 # Memory Manager Settings Models
 # =============================================================================
 
+
 class DivergenceDetectionConfig(BaseModel):
     """Divergence detection configuration."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     use_llm: bool
     use_local_llm: bool
@@ -441,7 +534,8 @@ class DivergenceDetectionConfig(BaseModel):
 
 class MemorySettings(BaseModel):
     """Memory manager configuration."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     phase2_fraction: float = Field(..., ge=0.0, le=1.0)
     raw_search_k: int = Field(..., ge=1)
@@ -457,9 +551,11 @@ class MemorySettings(BaseModel):
 # APEX API Settings Models
 # =============================================================================
 
+
 class APEXSettings(BaseModel):
     """APEX API configuration for story generation."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     provider: str = Field(..., pattern="^(openai|anthropic)$")
     model: str
@@ -471,9 +567,11 @@ class APEXSettings(BaseModel):
 # Wizard Settings Models
 # =============================================================================
 
+
 class WizardSettings(BaseModel):
     """Wizard configuration for new story setup and structured responses."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     default_model: str = Field(..., description="Default model for wizard flow")
     fallback_model: Optional[str] = Field(
@@ -498,24 +596,24 @@ class WizardSettings(BaseModel):
 # API Constraints Settings Models
 # =============================================================================
 
+
 class APIConstraintsConfig(BaseModel):
     """API constraints configuration."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     max_choice_text_length: int = Field(
-        default=1000,
-        ge=1,
-        description="Maximum length of choice text"
+        default=1000, ge=1, description="Maximum length of choice text"
     )
 
 
 class APISettings(BaseModel):
     """Top-level API settings."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     constraints: Optional[APIConstraintsConfig] = Field(
-        default=None,
-        description="API constraints configuration"
+        default=None, description="API constraints configuration"
     )
 
 
@@ -523,9 +621,11 @@ class APISettings(BaseModel):
 # Root Settings Model
 # =============================================================================
 
+
 class IREvalJudgmentConfig(BaseModel):
     """LLM judgment-on-demand configuration for the IR eval V2 runner."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     model: str = Field(..., description="LLM model identifier for relevance judgments")
     reasoning_effort: str = Field(
@@ -536,7 +636,8 @@ class IREvalJudgmentConfig(BaseModel):
 
 class IREvalSettings(BaseModel):
     """Configuration for the IR evaluation V2 subsystem."""
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     judgment: IREvalJudgmentConfig
 
@@ -553,7 +654,8 @@ class SecretsConfig(BaseModel):
     * ``op-item:<item-id>:<field-name>`` -> resolved with ``op item get``.
     * ``op-read:<secret-reference>``     -> resolved with ``op read``.
     """
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     providers: Dict[str, str] = Field(
         default_factory=dict,
@@ -569,7 +671,8 @@ class Settings(BaseModel):
     type-safe access to all settings. All nested models use `extra='forbid'` to
     catch typos and invalid keys at load time.
     """
-    model_config = ConfigDict(extra='forbid')
+
+    model_config = ConfigDict(extra="forbid")
 
     global_: GlobalSettings = Field(..., alias="global")
     llm: Optional[LLMRoutingConfig] = Field(
@@ -581,6 +684,10 @@ class Settings(BaseModel):
         description="Provider -> 1Password reference mappings (sync_secrets.py only)",
     )
     lore: LORESettings
+    orrery: Optional[OrrerySettings] = Field(
+        default=None,
+        description="Off-screen behavior resolver settings",
+    )
     memnon: MEMNONSettings
     memory: MemorySettings
     apex: APEXSettings
@@ -607,6 +714,8 @@ class Settings(BaseModel):
             (self.wizard, "default_model", False),
             (self.wizard, "fallback_model", True),
         ]
+        if self.orrery is not None:
+            targets.append((self.orrery.narration, "model_ref", False))
         if self.ir_eval is not None and self.ir_eval.judgment is not None:
             targets.append((self.ir_eval.judgment, "model", False))
         # [llm.cloud] is the cloud-fallback routing target for the pluggable
@@ -693,7 +802,7 @@ def _resolve_model_reference(
         raise TypeError(f"{source}: expected string, got {type(value).__name__}")
 
     if value.startswith(MODEL_ROLE_PREFIX):
-        body = value[len(MODEL_ROLE_PREFIX):]
+        body = value[len(MODEL_ROLE_PREFIX) :]
         if "." not in body:
             raise ValueError(
                 f"{source}: malformed model role reference '{value}'. "

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -16,11 +16,13 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import logging
 import os
 import re
 import sys
 from pathlib import Path
+from types import ModuleType
 from typing import List, Optional, Tuple
 
 import psycopg2
@@ -33,6 +35,9 @@ logging.basicConfig(
 
 # Migration directory relative to this script
 MIGRATIONS_DIR = Path(__file__).parent.parent / "migrations"
+SCRIPT_ONLY_MIGRATIONS = {
+    "008",  # migrations/008_populate_mock_database.py is a manual seed script.
+}
 
 # All target databases
 TEMPLATE_DB = "NEXUS_template"
@@ -97,9 +102,7 @@ def db_exists(dbname: str) -> bool:
         conn = get_connection("postgres")
         try:
             with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT 1 FROM pg_database WHERE datname = %s", (dbname,)
-                )
+                cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (dbname,))
                 return cur.fetchone() is not None
         finally:
             conn.close()
@@ -126,7 +129,9 @@ def ensure_tracking_table(conn, dry_run: bool = False) -> bool:
         if columns and "version" not in columns:
             # Old schema exists - drop and recreate
             if dry_run:
-                LOG.info("  [DRY-RUN] Would drop old schema_migrations table (incompatible schema)")
+                LOG.info(
+                    "  [DRY-RUN] Would drop old schema_migrations table (incompatible schema)"
+                )
                 return False
             LOG.info("  Dropping old schema_migrations table (incompatible schema)")
             cur.execute("DROP TABLE schema_migrations")
@@ -159,7 +164,10 @@ def needs_bootstrap(conn) -> bool:
 def bootstrap_migrations(conn, dry_run: bool = False) -> None:
     """Seed schema_migrations with pre-existing migrations."""
     if dry_run:
-        LOG.info("  [DRY-RUN] Would bootstrap %d existing migrations", len(BOOTSTRAP_MIGRATIONS))
+        LOG.info(
+            "  [DRY-RUN] Would bootstrap %d existing migrations",
+            len(BOOTSTRAP_MIGRATIONS),
+        )
         return
 
     with conn.cursor() as cur:
@@ -185,23 +193,39 @@ def get_applied_migrations(conn) -> set:
 
 def discover_migrations() -> List[Tuple[str, str, Path]]:
     """
-    Discover SQL migration files.
+    Discover SQL and managed Python migration files.
 
     Returns list of (version, name, path) tuples sorted by version.
     """
     migrations = []
-    pattern = re.compile(r"^(\d{3})_(.+)\.sql$")
+    pattern = re.compile(r"^(\d{3})_(.+)\.(sql|py)$")
 
-    for path in MIGRATIONS_DIR.glob("*.sql"):
+    for path in MIGRATIONS_DIR.iterdir():
         match = pattern.match(path.name)
         if match:
-            version, name = match.groups()
+            version, name, _extension = match.groups()
+            if version in SCRIPT_ONLY_MIGRATIONS:
+                continue
             migrations.append((version, name, path))
 
     return sorted(migrations, key=lambda x: x[0])
 
 
-def apply_migration(conn, version: str, name: str, path: Path, dry_run: bool = False) -> bool:
+def _load_python_migration(path: Path) -> ModuleType:
+    """Load a Python migration module from a filesystem path."""
+
+    module_name = f"nexus_migration_{path.stem}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load Python migration: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def apply_migration(
+    conn, version: str, name: str, path: Path, dry_run: bool = False
+) -> bool:
     """
     Apply a single migration.
 
@@ -212,24 +236,45 @@ def apply_migration(conn, version: str, name: str, path: Path, dry_run: bool = F
         return True
 
     try:
-        sql = path.read_text()
+        if path.suffix == ".sql":
+            sql = path.read_text()
+            with conn.cursor() as cur:
+                cur.execute(sql)
+        elif path.suffix == ".py":
+            # Python migrations may need to manage transaction boundaries
+            # internally (for example CREATE INDEX CONCURRENTLY), so ensure the
+            # connection is not inside an open transaction before handing it off.
+            conn.commit()
+            module = _load_python_migration(path)
+            run = getattr(module, "run", None)
+            if run is None:
+                raise RuntimeError(f"Python migration {path.name} has no run(conn)")
+            run(conn)
+        else:
+            raise RuntimeError(f"Unsupported migration type: {path}")
+
         with conn.cursor() as cur:
-            cur.execute(sql)
-            # Record the migration
             cur.execute(
-                "INSERT INTO schema_migrations (version, name) VALUES (%s, %s)",
+                """
+                INSERT INTO schema_migrations (version, name)
+                VALUES (%s, %s)
+                """,
                 (version, name),
             )
         conn.commit()
         LOG.info("  Applied: %s_%s", version, name)
         return True
-    except psycopg2.Error as e:
+    except Exception as e:
+        if getattr(conn, "autocommit", False):
+            conn.autocommit = False
         conn.rollback()
         LOG.error("  FAILED: %s_%s - %s", version, name, e)
         return False
 
 
-def migrate_database(dbname: str, dry_run: bool = False, skip_locked: bool = True) -> Tuple[int, int]:
+def migrate_database(
+    dbname: str, dry_run: bool = False, skip_locked: bool = True
+) -> Tuple[int, int]:
     """
     Apply pending migrations to a single database.
 
@@ -257,8 +302,15 @@ def migrate_database(dbname: str, dry_run: bool = False, skip_locked: bool = Tru
         if not table_ready:
             # In dry-run mode and table doesn't exist - show all migrations as pending
             all_migrations = discover_migrations()
-            LOG.info("  [DRY-RUN] Would bootstrap %d existing migrations", len(BOOTSTRAP_MIGRATIONS))
-            pending = [m for m in all_migrations if m[0] not in {v for v, _ in BOOTSTRAP_MIGRATIONS}]
+            LOG.info(
+                "  [DRY-RUN] Would bootstrap %d existing migrations",
+                len(BOOTSTRAP_MIGRATIONS),
+            )
+            pending = [
+                m
+                for m in all_migrations
+                if m[0] not in {v for v, _ in BOOTSTRAP_MIGRATIONS}
+            ]
             for version, name, _ in pending:
                 LOG.info("  [DRY-RUN] Would apply: %s_%s", version, name)
             return (len(pending), 0)
@@ -300,7 +352,7 @@ def migrate_database(dbname: str, dry_run: bool = False, skip_locked: bool = Tru
 def show_status() -> None:
     """Show migration status for all databases."""
     all_migrations = discover_migrations()
-    print(f"Found {len(all_migrations)} SQL migrations in {MIGRATIONS_DIR}\n")
+    print(f"Found {len(all_migrations)} managed migrations in {MIGRATIONS_DIR}\n")
 
     databases = [TEMPLATE_DB] + SLOT_DBS
 

--- a/tests/test_orrery/__init__.py
+++ b/tests/test_orrery/__init__.py
@@ -1,0 +1,1 @@
+"""Orrery test package."""

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -1,0 +1,16 @@
+"""Tests for Orrery configuration loading."""
+
+from nexus.config import load_settings
+
+
+def test_orrery_settings_resolve_model_reference() -> None:
+    """Orrery narration config resolves provider role references at load time."""
+
+    settings = load_settings("nexus.toml")
+
+    assert settings.orrery is not None
+    assert settings.orrery.enabled is False
+    assert settings.orrery.binding.window_chunks == 30
+    assert settings.orrery.narration.model_ref == "claude-sonnet-4-6"
+    assert settings.orrery.bleed.latency_budget_ms == 2000
+    assert settings.orrery.promote.provider == "local"

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -11,6 +11,7 @@ def test_orrery_settings_resolve_model_reference() -> None:
     assert settings.orrery is not None
     assert settings.orrery.enabled is False
     assert settings.orrery.binding.window_chunks == 30
-    assert settings.orrery.narration.model_ref == "claude-sonnet-4-6"
+    expected_model = settings.global_.model.api_models["anthropic"].roles["default"]
+    assert settings.orrery.narration.model_ref == expected_model
     assert settings.orrery.bleed.latency_budget_ms == 2000
     assert settings.orrery.promote.provider == "local"

--- a/tests/test_orrery/test_memnon_whitelist.py
+++ b/tests/test_orrery/test_memnon_whitelist.py
@@ -1,0 +1,22 @@
+"""Tests for MEMNON read-only SQL access to Orrery schema surfaces."""
+
+from nexus.agents.memnon.memnon import READONLY_SQL_ALLOWED_TABLES
+
+
+def test_memnon_allows_public_orrery_read_surfaces() -> None:
+    """MEMNON can query Orrery public tables while internal queues stay private."""
+
+    assert {
+        "entities",
+        "entity_names_v",
+        "entity_tags_current",
+        "world_events",
+        "world_event_entities",
+        "orrery_resolutions",
+        "offscreen_narrations",
+        "event_types",
+        "tags",
+    }.issubset(READONLY_SQL_ALLOWED_TABLES)
+    assert "orrery_narration_jobs" not in READONLY_SQL_ALLOWED_TABLES
+    assert "tag_clearance_log" not in READONLY_SQL_ALLOWED_TABLES
+    assert "entity_tags" not in READONLY_SQL_ALLOWED_TABLES

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -1,0 +1,23 @@
+"""Tests for migration discovery around Orrery's Python migration."""
+
+from pathlib import Path
+
+import scripts.migrate as migrate
+
+
+def test_discover_migrations_includes_python_and_skips_seed_script(
+    tmp_path, monkeypatch
+) -> None:
+    """Managed Python migrations are discovered, but the old 008 seed is not."""
+
+    (tmp_path / "001_baseline.sql").write_text("SELECT 1;")
+    (tmp_path / "008_populate_mock_database.py").write_text("raise SystemExit")
+    (tmp_path / "023_orrery_schema.py").write_text("def run(conn): pass")
+    monkeypatch.setattr(migrate, "MIGRATIONS_DIR", Path(tmp_path))
+
+    discovered = migrate.discover_migrations()
+
+    assert [(version, name, path.suffix) for version, name, path in discovered] == [
+        ("001", "baseline", ".sql"),
+        ("023", "orrery_schema", ".py"),
+    ]

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -9,9 +9,11 @@ from nexus.agents.orrery.substrate import (
     Slot,
     Template,
     WorldState,
+    binding_hash,
     count_co_located,
     evaluate_stack,
     recent_event,
+    since_last_event_at_least,
     validate_always_fallbacks,
 )
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
@@ -66,6 +68,31 @@ def test_demo_presets_fire_expected_package(
     assert result["branch_label"] == branch_label
 
 
+def test_targeted_events_fire_builtin_package_gates() -> None:
+    """Built-ins that react to incoming events use target-role matching."""
+
+    from nexus.agents.orrery.substrate import EventRecord
+
+    state = WorldState(
+        locations={1: 10},
+        location_class={10: "the_roots"},
+        recent_events=(
+            EventRecord(
+                event_type="compliance_alert",
+                tick=99,
+                target_entity_id=1,
+            ),
+        ),
+        weather="rain",
+        current_tick=100,
+    )
+
+    result = evaluate_stack(BUILTIN_TEMPLATES, state, {Slot.ACTOR: 1})
+
+    assert result is not None
+    assert result.template_id == "evade_pursuers"
+
+
 def test_count_co_located_condition_filters_by_tag() -> None:
     """Co-location can be counted with a tag filter for crowd-like gates."""
 
@@ -107,6 +134,68 @@ def test_recent_event_can_filter_by_changed_fields() -> None:
         changed_fields_any_of=("character.emotional_state",),
         actor_slot=Slot.ACTOR,
     )(state, {Slot.ACTOR: 1})
+
+
+def test_recent_event_preserves_actor_target_roles() -> None:
+    """Actor and target filters match their corresponding event fields only."""
+
+    from nexus.agents.orrery.substrate import EventRecord
+
+    state = WorldState(
+        recent_events=(
+            EventRecord(
+                event_type="warning",
+                tick=9,
+                actor_entity_id=1,
+                target_entity_id=2,
+            ),
+        ),
+        current_tick=10,
+    )
+
+    assert recent_event("warning", actor_slot=Slot.ACTOR)(state, {Slot.ACTOR: 1})
+    assert recent_event("warning", target_slot=Slot.ACTOR)(state, {Slot.ACTOR: 2})
+    assert not recent_event("warning", actor_slot=Slot.ACTOR)(state, {Slot.ACTOR: 2})
+    assert not recent_event("warning", target_slot=Slot.ACTOR)(state, {Slot.ACTOR: 1})
+    assert recent_event(
+        "warning",
+        actor_slot=Slot.ACTOR,
+        target_slot=Slot.TARGET,
+    )(state, {Slot.ACTOR: 1, Slot.TARGET: 2})
+    assert not recent_event(
+        "warning",
+        actor_slot=Slot.ACTOR,
+        target_slot=Slot.TARGET,
+    )(state, {Slot.ACTOR: 2, Slot.TARGET: 1})
+
+
+def test_since_last_event_at_least_preserves_actor_role() -> None:
+    """Cooldown predicates do not treat target-only events as actor matches."""
+
+    from nexus.agents.orrery.substrate import EventRecord
+
+    state = WorldState(
+        recent_events=(
+            EventRecord(
+                event_type="warning",
+                tick=9,
+                actor_entity_id=2,
+                target_entity_id=1,
+            ),
+        ),
+        current_tick=10,
+    )
+
+    assert since_last_event_at_least("warning", 5)(state, {Slot.ACTOR: 1})
+    assert not since_last_event_at_least("warning", 5)(state, {Slot.ACTOR: 2})
+
+
+def test_binding_hash_handles_runtime_non_slot_keys() -> None:
+    """Runtime callers that pass non-Slot keys get a deterministic hash."""
+
+    assert binding_hash({Slot.ACTOR: 1, "custom": 2}) == binding_hash(
+        {"custom": 2, Slot.ACTOR: 1}
+    )
 
 
 def test_evaluate_stack_returns_none_when_no_template_passes() -> None:

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -1,0 +1,124 @@
+"""Tests for the Orrery pure-Python behavior substrate."""
+
+import pytest
+
+from nexus.agents.orrery.demo import run_preset
+from nexus.agents.orrery.substrate import (
+    ALWAYS,
+    Branch,
+    Slot,
+    Template,
+    WorldState,
+    count_co_located,
+    evaluate_stack,
+    recent_event,
+    validate_always_fallbacks,
+)
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+
+
+def test_builtin_templates_have_always_fallbacks() -> None:
+    """Built-in templates must end in a deterministic fallback branch."""
+
+    validate_always_fallbacks(BUILTIN_TEMPLATES)
+
+
+def test_missing_always_fallback_is_rejected() -> None:
+    """Template authors get a loud error when a fallback branch is missing."""
+
+    template = Template(
+        id="bad_template",
+        priority=1,
+        blurb="No terminal fallback.",
+        required_slots=(Slot.ACTOR,),
+        package_gate=ALWAYS,
+        branches=(
+            Branch(
+                "non-fallback",
+                lambda _state, _bindings: True,
+                "{actor} does a thing.",
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="bad_template"):
+        validate_always_fallbacks((template,))
+
+
+@pytest.mark.parametrize(
+    ("preset", "template_id", "branch_label"),
+    [
+        ("hunted", "evade_pursuers", "Go to ground in flooded tunnels"),
+        ("fragment", "pursue_ghost_lead", "Recon a hideout their body remembers"),
+        ("debt", "honor_debt", "Fulfill obligation through a dead-drop"),
+        ("quiet", "maintain_cover", "Run a low-level courier job"),
+    ],
+)
+def test_demo_presets_fire_expected_package(
+    preset: str, template_id: str, branch_label: str
+) -> None:
+    """The offline harness mirrors the original simulator's key presets."""
+
+    result = run_preset(preset)
+
+    assert result["fired"] is True
+    assert result["template_id"] == template_id
+    assert result["branch_label"] == branch_label
+
+
+def test_count_co_located_condition_filters_by_tag() -> None:
+    """Co-location can be counted with a tag filter for crowd-like gates."""
+
+    state = WorldState(
+        tags={
+            2: frozenset({"pursuer"}),
+            3: frozenset({"bystander"}),
+            4: frozenset({"pursuer"}),
+        },
+        locations={1: 10, 2: 10, 3: 10, 4: 11},
+    )
+
+    assert count_co_located(1, with_tag="pursuer")(state, {Slot.ACTOR: 1})
+    assert not count_co_located(2, with_tag="pursuer")(state, {Slot.ACTOR: 1})
+
+
+def test_recent_event_can_filter_by_changed_fields() -> None:
+    """Recent-event predicates can use the controlled changed_fields surface."""
+
+    from nexus.agents.orrery.substrate import EventRecord
+
+    state = WorldState(
+        recent_events=(
+            EventRecord(
+                event_type="state_update",
+                tick=9,
+                actor_entity_id=1,
+                changed_fields=("character.current_location",),
+            ),
+        ),
+        current_tick=10,
+    )
+
+    assert recent_event(
+        changed_fields_any_of=("character.current_location",),
+        actor_slot=Slot.ACTOR,
+    )(state, {Slot.ACTOR: 1})
+    assert not recent_event(
+        changed_fields_any_of=("character.emotional_state",),
+        actor_slot=Slot.ACTOR,
+    )(state, {Slot.ACTOR: 1})
+
+
+def test_evaluate_stack_returns_none_when_no_template_passes() -> None:
+    """The resolver stack can represent no-op ticks explicitly."""
+
+    template = Template(
+        id="never",
+        priority=1,
+        blurb="Never fires.",
+        required_slots=(Slot.ACTOR,),
+        package_gate=lambda _state, _bindings: False,
+        branches=(Branch("fallback", ALWAYS, "{actor} idles."),),
+    )
+
+    assert evaluate_stack((template,), WorldState(), {Slot.ACTOR: 1}) is None


### PR DESCRIPTION

## Summary
- Rebrand the off-screen behavior resolver foundation from Radiant to Orrery.
- Add migration `023_orrery_schema.py` for the entity identity spine, Orrery tables, off-screen narration tables, world-time support, and schema-owned ENUM vocabularies.
- Add the pure-Python Orrery substrate, built-in behavior templates, and an offline demo harness.
- Wire Orrery config into `nexus.toml` / Pydantic settings and expand MEMNON read-only SQL access to public Orrery surfaces.

## Impact
- Existing character, faction, and place primary keys remain unchanged; each subtype gains a validated `entity_id` pointing at the new `entities` spine.
- The migration supports staged commits and concurrent indexes via managed Python migrations, while preserving `008_populate_mock_database.py` as a manual seed script.
- Slots 2-5 and `NEXUS_template` have been migrated locally; slot 1 remained locked and unmodified.

## Validation
- `poetry run pytest tests/test_orrery` -> 11 passed
- `poetry run pytest tests/test_orrery tests/config tests/test_api` -> 33 passed, 1 skipped
- `poetry run python -m nexus.agents.orrery.demo --preset hunted`
- `poetry run python scripts/migrate.py --status`
- live DB probes on `save_05` and `save_02` confirmed entity backfill counts, no null `world_time`, and trigger-minted character entities inside rollback transactions
- `git diff --check`

## Not Run
- `poetry run flake8 ...` because `flake8` is not installed in the Poetry environment (`Command not found: flake8`).
