### PR TITLE
[codex] Add Orrery dry-run resolve phase

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -1,6 +1,6 @@
 # Off-Screen Behavior Resolver — Orrery Design Plan
 
-**Status:** Foundation implemented in PR #210. The current branch lands the Orrery schema substrate, entity identity spine, config surface, MEMNON read-only SQL expansion, managed Python migration support, and the offline behavior-package harness. The runtime pipeline is still disabled by default (`orrery.enabled = false`) and has no LORE turn-cycle integration yet.
+**Status:** Foundation implemented in PR #210. PR #211 adds the no-write hydration/dry-run resolver and the LORE Phase 4.5 hook. The runtime pipeline is still disabled by default (`orrery.enabled = false`), produces only an inspectable `OrreryTickProposal`, and performs no canonical Orrery writes or storyteller payload injection yet.
 
 **Originating artifacts:** `temp/orrery/off_screen_resolver_spec.md`, `temp/orrery/behavior_substrate.py`, `temp/orrery/package_simulator.jsx`
 **Review trace:** `temp/orrery/design_plan_edited.md` (round 1: GPT-5.5-Pro, Codex, separate-Claude, Gemini) + `temp/orrery/super_table_question.md` (round 2: GPT-5.5-Pro, Claude Opus 4.7 chat) + v4 grounding pass against current `main` (claude-opus-4-7).
@@ -40,20 +40,38 @@
 - `save_01` intentionally remains locked and unmodified
 - `poetry run flake8 ...` remains unavailable because `flake8` is not installed in the Poetry environment
 
+### In PR #211
+
+- Added `OrreryTickProposal` and `OrreryResolutionDraft` as in-memory proposal carriers with no `tick_chunk_id` during resolve.
+- Hydrates read-side `WorldState` from current tags, ephemeral tags, character locations and activities, place classes, relationships, faction memberships, recent primary unsuperseded events, and coarse time/weather context.
+- Composes `ACTOR`-only bindings from recent chunk references, recent primary unsuperseded events, and current ephemeral tags.
+- Evaluates the package stack in a dry-run resolver and attaches the proposal to `TurnContext.orrery_proposal`.
+- Adds `TurnPhase.ORRERY_RESOLVE` between `DEEP_QUERIES` and `PAYLOAD_ASSEMBLY`, plus the `bleed_menu` placeholder needed by the later Bleed slice.
+- Keeps all canonical database writes and storyteller payload effects out of scope.
+
+### Local Verification Completed for PR #211
+
+- `poetry run pytest tests/test_orrery`
+- `poetry run pytest tests/test_orrery tests/test_lore/test_turn_cycle.py tests/test_lore/test_context_validation.py`
+- `poetry run python -m py_compile nexus/agents/orrery/resolver.py nexus/agents/lore/utils/turn_cycle.py tests/test_orrery/test_resolver.py`
+- `git diff --check`
+- Live direct dry-run against slot 5: hydrated evening/rain context, produced proposals, and performed zero writes.
+- Live direct dry-run against slot 2: hydrated mature-state morning/clear context, produced proposals, and performed zero writes.
+- `poetry run flake8 ...` remains unavailable because `flake8` is not installed in the Poetry environment.
+
 ### Next Slice
 
-PR 2 should start from `main` after PR #210 merges and remain a no-write dry-run integration:
+PR 3 should wire commit-time persistence while preserving the accepted-chunk invariant:
 
-- hydrate a read-side `WorldState`
-- compose ACTOR-only bindings
-- evaluate the package stack
-- attach an inspectable `OrreryTickProposal` to `TurnContext`
-- insert LORE Phase 4.5 between `DEEP_QUERIES` and `PAYLOAD_ASSEMBLY`
-- keep all canonical database writes out of scope
+- stamp `tick_chunk_id` onto the in-memory proposal inside the accepted-chunk commit transaction
+- materialize `orrery_resolutions`, related `world_events`, and tag mutations through one unified writer
+- enqueue durable narration jobs only after canonical commit succeeds
+- add Promote/Narrate/Clear plumbing with loud failure behavior
+- verify idempotency, incubator rejection, and warm-slice isolation against live slots
 
 ### Package Author Checkpoint
 
-Start soliciting additional package-library contributions **after PR 2 validates the hydrated `WorldState`, binding composer, and `OrreryTickProposal` shape against both slot 5 and slot 2**. That is the first point where external package authors can target a real runtime surface rather than a synthetic harness, while still avoiding the higher-risk commit/promote/narrate pipeline. Before that checkpoint, package work is useful for examples and stress tests, but the API vocabulary may still move.
+Start soliciting additional package-library contributions **after PR #211 merges**. At that point, package authors can target a real hydrated `WorldState`, binding composer, and `OrreryTickProposal` shape validated against both slot 5 and slot 2, while still avoiding the higher-risk commit/promote/narrate pipeline. The best contribution format is pure template/condition/action logic plus any proposed tag or event-type vocabulary it requires; durable tag backfill and event-type seeding remain controlled schema/data work.
 
 ---
 
@@ -606,18 +624,18 @@ Per-chunk, not per-event. Stamped only at accepted commit. `world_events.world_t
 - Still needed before event writes: seed initial `event_types` vocabulary
 - Demo: `python -m nexus.agents.orrery.demo` runs four presets against synthetic `WorldState`
 
-### PR 2 — Hydration + Dry-Pass Resolver (no canonical writes)
+### PR 2 — Hydration + Dry-Pass Resolver (implemented in PR #211; no canonical writes)
 
-- `hydrate_world_state(tick_chunk_id) -> WorldState`. One bulk SELECT per source.
-- Sliding-window binding composer for `ACTOR`-only templates
-- Resolver loop produces `OrreryTickProposal` (no `tick_chunk_id` in the proposal — see Stage 1 note above)
-- **New LORE Phase 4.5**: add `TurnPhase.ORRERY_RESOLVE = "orrery_resolve"` to `turn_context.py:12` enum; insert phase between `DEEP_QUERIES` (Phase 4) and `PAYLOAD_ASSEMBLY` (Phase 5) in `lore.py::process_turn` (L289+); add corresponding `TurnCycleManager` method invoked from there.
-- **Extend `TurnContext`** (`turn_context.py:24-41`, a `@dataclass`) with two fields:
+- `hydrate_world_state(session, anchor_chunk_id, window_chunks) -> WorldState` gathers tags, locations, activities, place classes, relationships, faction memberships, recent primary unsuperseded events, and coarse time/weather context.
+- Sliding-window binding composer for `ACTOR`-only templates pulls candidates from recent chunk references, recent primary unsuperseded events, and current ephemeral tags.
+- Resolver loop produces `OrreryTickProposal` with no `tick_chunk_id` in the proposal — see Stage 1 note above.
+- **New LORE Phase 4.5**: `TurnPhase.ORRERY_RESOLVE = "orrery_resolve"` is inserted between `DEEP_QUERIES` (Phase 4) and `PAYLOAD_ASSEMBLY` (Phase 5). `TurnCycleManager.resolve_orrery()` skips cleanly while `[orrery].enabled = false`, and otherwise stores the dry-run proposal on the turn context.
+- **Extended `TurnContext`** with:
   - `orrery_proposal: Optional["OrreryTickProposal"] = None`
   - `bleed_menu: List["BleedCandidate"] = field(default_factory=list)`
 - `[orrery]` section in `nexus.toml` (see "`nexus.toml` Section Layout" above)
-- **No canonical writes yet.** Proposal is buffered, inspectable, but does not mutate any table
-- Verification: real turns against slot 5 (baby narrative state) and slot 2 (mature narrative state); storyteller output identical to control; proposal contents validated
+- **No canonical writes yet.** Proposal is buffered and inspectable, but does not mutate any table or enter the storyteller payload.
+- Verification: unit coverage for disabled/enabled phase behavior, anchor fallback, fallback/non-fallback packages, and SQL filters; live direct dry-runs against slot 5 (baby narrative state) and slot 2 (mature narrative state) with zero writes.
 
 ### PR 3 — CommitOrreryTick + Promote + Narrate + Clear
 
@@ -705,7 +723,7 @@ Verification should use live NEXUS flows where the feature touches LORE, LOGON, 
 
 - **PR 0/1 foundation (#210):** Substrate demo runs against four presets; migration applies cleanly via `scripts/migrate.py --template` and unlocked slots; entity spine backfill validated; kind-enforcement triggers tested; compatibility views return expected unions; MEMNON whitelist updated and tested; `world_layer_type` confirmed or created in template.
 - **Remaining pre-Bleed audit:** Integration test asserting `query_memory` warm-slice is disjoint from `offscreen_narrations`; `execute_readonly_sql` can SELECT from each new public table and cannot select internal queue/raw tag tables.
-- **PR 2:** Dry-pass against slot 5 and slot 2; proposal contents inspected; storyteller output identical to control. Verify `TurnContext.orrery_proposal` carries no `tick_chunk_id` at this phase.
+- **PR 2 (#211):** Dry-pass against slot 5 and slot 2; proposal contents inspected; zero writes observed; `TurnContext.orrery_proposal` carries no `tick_chunk_id` at this phase. Optional full-turn acceptance before PR 3: enable Orrery for a live LORE pass and confirm the storyteller payload remains unaffected while the proposal is attached only to the turn context.
 - **PR 3:** Engineered fifty-chunk motivating scenario (interrogated NPC → fifty ticks → retaliation prose persisted to `offscreen_narrations`, never surfaced); idempotency (regeneration cannot double-write — UNIQUE key fires); rejection (incubator rejection rolls everything back, including the Step 8.5 writes); warm-slice contamination (none); local-LLM failure (Promote fails loud); async-worker state transitions (`queued → leased → succeeded|failed`).
 - **PR 4:** Apt-bleed (audible peripheral surfaces in distant scene); null-bleed (irrelevant resolutions produce empty menu); spoiler-boundary (resolutions before the player's current world-time are eligible; future resolutions are not); chronology tests (`offscreen_narrations` never advance `narrative_view.world_time`); latency-budget overrun produces empty menu and logs loudly.
 

--- a/nexus/agents/lore/lore.py
+++ b/nexus/agents/lore/lore.py
@@ -332,6 +332,10 @@ class LORE:
             # Phase 4: Deep Queries
             self.current_phase = TurnPhase.DEEP_QUERIES
             await self.turn_manager.execute_deep_queries(self.turn_context)
+
+            # Phase 4.5: Orrery dry-run resolution (optional; no canonical writes)
+            self.current_phase = TurnPhase.ORRERY_RESOLVE
+            await self.turn_manager.resolve_orrery(self.turn_context)
             
             # Phase 5: Payload Assembly
             self.current_phase = TurnPhase.PAYLOAD_ASSEMBLY

--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -5,16 +5,21 @@ Manages the state and context of a single turn cycle.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, TYPE_CHECKING
 from enum import Enum
+
+if TYPE_CHECKING:
+    from nexus.agents.orrery.resolver import OrreryTickProposal
 
 
 class TurnPhase(Enum):
     """Phases of the turn cycle"""
+
     USER_INPUT = "user_input"
     WARM_ANALYSIS = "warm_analysis"
     ENTITY_STATE = "entity_state"
     DEEP_QUERIES = "deep_queries"
+    ORRERY_RESOLVE = "orrery_resolve"
     PAYLOAD_ASSEMBLY = "payload_assembly"
     APEX_GENERATION = "apex_generation"
     INTEGRATION = "integration"
@@ -24,6 +29,7 @@ class TurnPhase(Enum):
 @dataclass
 class TurnContext:
     """Context for a single turn cycle"""
+
     turn_id: str
     user_input: str
     start_time: float
@@ -38,4 +44,7 @@ class TurnContext:
     memory_state: Dict[str, Any] = field(default_factory=dict)
     authorial_directives: List[str] = field(default_factory=list)
     target_chunk_id: Optional[int] = None
-    note: Optional[str] = None  # Soft author's note / suggestion for the storyteller (e.g., regen meta-hints)
+    # Soft author's note / suggestion for the storyteller.
+    note: Optional[str] = None
+    orrery_proposal: Optional["OrreryTickProposal"] = None
+    bleed_menu: List[Any] = field(default_factory=list)

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -583,9 +583,8 @@ class TurnCycleManager:
 
         binding_settings = orrery_settings.get("binding", {})
         window_chunks = int(binding_settings.get("window_chunks", 30))
-        anchor_chunk_id = self._orrery_anchor_chunk_id(turn_context)
-
         with self.lore.memnon.Session() as session:
+            anchor_chunk_id = self._orrery_anchor_chunk_id(session, turn_context)
             proposal = resolve_dry_run(
                 session,
                 BUILTIN_TEMPLATES,
@@ -609,7 +608,9 @@ class TurnCycleManager:
             proposal.resolution_count,
         )
 
-    def _orrery_anchor_chunk_id(self, turn_context: TurnContext) -> Optional[int]:
+    def _orrery_anchor_chunk_id(
+        self, session: Any, turn_context: TurnContext
+    ) -> Optional[int]:
         """Choose the current read anchor for a no-write Orrery resolve."""
 
         if turn_context.target_chunk_id is not None:
@@ -626,15 +627,14 @@ class TurnCycleManager:
             except (TypeError, ValueError):
                 logger.warning("Unable to infer Orrery anchor from warm-slice IDs")
 
-        with self.lore.memnon.Session() as session:
-            from sqlalchemy import text
+        from sqlalchemy import text
 
-            row = (
-                session.execute(text("SELECT max(id) AS max_id FROM narrative_chunks"))
-                .mappings()
-                .first()
-            )
-            return row["max_id"] if row and row["max_id"] is not None else None
+        row = (
+            session.execute(text("SELECT max(id) AS max_id FROM narrative_chunks"))
+            .mappings()
+            .first()
+        )
+        return row["max_id"] if row and row["max_id"] is not None else None
 
     async def assemble_context_payload(self, turn_context: TurnContext):
         """

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -25,6 +25,8 @@ try:
         StorytellerResponseStandard,
         extract_narrative_text,
     )
+    from nexus.agents.orrery.resolver import resolve_dry_run
+    from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 except ImportError:
     # If relative import fails, try absolute
     from nexus.agents.lore.utils.turn_context import TurnContext, TurnPhase
@@ -40,6 +42,8 @@ except ImportError:
         StorytellerResponseStandard,
         extract_narrative_text,
     )
+    from nexus.agents.orrery.resolver import resolve_dry_run
+    from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 
 try:
     from nexus.agents.memnon.utils.query_analysis import QueryAnalyzer
@@ -558,6 +562,79 @@ class TurnCycleManager:
         )
 
     # DEPRECATED: Cold Distillation phase removed - cross-encoders handle reranking
+
+    async def resolve_orrery(self, turn_context: TurnContext):
+        """
+        Phase 4.5: Resolve Orrery behavior packages without canonical writes.
+
+        The proposal is intentionally kept on TurnContext only. It is not injected
+        into the storyteller payload until a later phase proves the no-write path.
+        """
+        orrery_settings = self.settings.get("orrery", {})
+        if not orrery_settings.get("enabled", False):
+            turn_context.phase_states["orrery_resolve"] = {
+                "enabled": False,
+                "skipped": True,
+            }
+            return
+
+        if not self.lore.memnon:
+            raise RuntimeError("Orrery resolve requires MEMNON database access")
+
+        binding_settings = orrery_settings.get("binding", {})
+        window_chunks = int(binding_settings.get("window_chunks", 30))
+        anchor_chunk_id = self._orrery_anchor_chunk_id(turn_context)
+
+        with self.lore.memnon.Session() as session:
+            proposal = resolve_dry_run(
+                session,
+                BUILTIN_TEMPLATES,
+                anchor_chunk_id=anchor_chunk_id,
+                window_chunks=window_chunks,
+            )
+
+        turn_context.orrery_proposal = proposal
+        turn_context.phase_states["orrery_resolve"] = {
+            "enabled": True,
+            "anchor_chunk_id": proposal.anchor_chunk_id,
+            "actor_count": proposal.actor_count,
+            "resolution_count": proposal.resolution_count,
+            "template_ids": [
+                resolution.template_id for resolution in proposal.resolutions
+            ],
+        }
+        logger.info(
+            "Orrery dry-run resolved %d actors into %d draft resolutions",
+            proposal.actor_count,
+            proposal.resolution_count,
+        )
+
+    def _orrery_anchor_chunk_id(self, turn_context: TurnContext) -> Optional[int]:
+        """Choose the current read anchor for a no-write Orrery resolve."""
+
+        if turn_context.target_chunk_id is not None:
+            return turn_context.target_chunk_id
+
+        warm_ids = [
+            chunk.get("id")
+            for chunk in turn_context.warm_slice
+            if isinstance(chunk, dict) and chunk.get("id") is not None
+        ]
+        if warm_ids:
+            try:
+                return max(int(chunk_id) for chunk_id in warm_ids)
+            except (TypeError, ValueError):
+                logger.warning("Unable to infer Orrery anchor from warm-slice IDs")
+
+        with self.lore.memnon.Session() as session:
+            from sqlalchemy import text
+
+            row = (
+                session.execute(text("SELECT max(id) AS max_id FROM narrative_chunks"))
+                .mappings()
+                .first()
+            )
+            return row["max_id"] if row and row["max_id"] is not None else None
 
     async def assemble_context_payload(self, turn_context: TurnContext):
         """

--- a/nexus/agents/orrery/__init__.py
+++ b/nexus/agents/orrery/__init__.py
@@ -18,6 +18,7 @@ from nexus.agents.orrery.substrate import (
     evaluate_stack,
     validate_always_fallbacks,
 )
+from nexus.agents.orrery.resolver import OrreryResolutionDraft, OrreryTickProposal
 
 __all__ = [
     "ALWAYS",
@@ -33,6 +34,8 @@ __all__ = [
     "Slot",
     "Template",
     "WorldState",
+    "OrreryResolutionDraft",
+    "OrreryTickProposal",
     "evaluate",
     "evaluate_stack",
     "validate_always_fallbacks",

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -1,0 +1,345 @@
+"""Dry-run resolver integration for Orrery behavior packages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping, Optional, Tuple
+
+from sqlalchemy import text
+
+from nexus.agents.orrery.substrate import (
+    Bindings,
+    EventRecord,
+    Resolution,
+    Slot,
+    Template,
+    WorldState,
+    evaluate_stack,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OrreryResolutionDraft:
+    """Serializable dry-run result for one actor-bound package resolution."""
+
+    template_id: str
+    priority: int
+    binding_hash: str
+    bindings: Mapping[str, Any]
+    branch_label: str
+    narrative_stub: str
+    state_delta: Mapping[str, Any] = field(default_factory=dict)
+    event_type: Optional[str] = None
+    changed_fields: Tuple[str, ...] = ()
+    magnitude: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class OrreryTickProposal:
+    """No-write Orrery proposal produced before accepted chunk commit."""
+
+    anchor_chunk_id: Optional[int]
+    actor_count: int
+    resolutions: Tuple[OrreryResolutionDraft, ...]
+    generated_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    @property
+    def resolution_count(self) -> int:
+        """Return the number of draft resolutions in this proposal."""
+
+        return len(self.resolutions)
+
+
+def hydrate_world_state(
+    session: Any,
+    *,
+    anchor_chunk_id: Optional[int],
+    window_chunks: int,
+) -> WorldState:
+    """Hydrate the read-side Orrery state snapshot from database tables."""
+
+    tags: dict[int, set[str]] = {}
+    ephemeral_tags: dict[int, set[str]] = {}
+    for row in session.execute(
+        text(
+            """
+            SELECT entity_id, tag, is_ephemeral
+            FROM entity_tags_current
+            """
+        )
+    ).mappings():
+        target = ephemeral_tags if row["is_ephemeral"] else tags
+        target.setdefault(row["entity_id"], set()).add(row["tag"])
+
+    locations = {
+        row["entity_id"]: row["current_location"]
+        for row in session.execute(
+            text(
+                """
+                SELECT entity_id, current_location
+                FROM characters
+                WHERE entity_id IS NOT NULL
+                  AND current_location IS NOT NULL
+                """
+            )
+        ).mappings()
+    }
+
+    location_class = {
+        row["id"]: row["location_class"]
+        for row in session.execute(
+            text(
+                """
+                SELECT id, type::text AS location_class
+                FROM places
+                WHERE type IS NOT NULL
+                """
+            )
+        ).mappings()
+    }
+
+    activities = {
+        row["entity_id"]: row["current_activity"]
+        for row in session.execute(
+            text(
+                """
+                SELECT entity_id, current_activity
+                FROM characters
+                WHERE entity_id IS NOT NULL
+                  AND current_activity IS NOT NULL
+                """
+            )
+        ).mappings()
+    }
+
+    relationship_types: dict[tuple[int, int], set[str]] = {}
+    for row in session.execute(
+        text(
+            """
+            SELECT c1.entity_id AS source_entity_id,
+                   c2.entity_id AS target_entity_id,
+                   cr.relationship_type::text AS relationship_type
+            FROM character_relationships cr
+            JOIN characters c1 ON c1.id = cr.character1_id
+            JOIN characters c2 ON c2.id = cr.character2_id
+            WHERE c1.entity_id IS NOT NULL
+              AND c2.entity_id IS NOT NULL
+              AND cr.relationship_type IS NOT NULL
+            """
+        )
+    ).mappings():
+        relationship_types.setdefault(
+            (row["source_entity_id"], row["target_entity_id"]), set()
+        ).add(row["relationship_type"])
+
+    faction_memberships: dict[int, set[int]] = {}
+    for row in session.execute(
+        text(
+            """
+            SELECT c.entity_id AS member_entity_id,
+                   f.entity_id AS faction_entity_id
+            FROM faction_character_relationships fcr
+            JOIN characters c ON c.id = fcr.character_id
+            JOIN factions f ON f.id = fcr.faction_id
+            WHERE c.entity_id IS NOT NULL
+              AND f.entity_id IS NOT NULL
+            """
+        )
+    ).mappings():
+        faction_memberships.setdefault(row["member_entity_id"], set()).add(
+            row["faction_entity_id"]
+        )
+
+    recent_events = _load_recent_events(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        window_chunks=window_chunks,
+    )
+
+    return WorldState(
+        tags={entity_id: frozenset(values) for entity_id, values in tags.items()},
+        ephemeral_tags={
+            entity_id: frozenset(values) for entity_id, values in ephemeral_tags.items()
+        },
+        locations=locations,
+        activities=activities,
+        relationship_types={
+            key: frozenset(values) for key, values in relationship_types.items()
+        },
+        faction_memberships={
+            entity_id: frozenset(values)
+            for entity_id, values in faction_memberships.items()
+        },
+        location_class=location_class,
+        recent_events=recent_events,
+        current_tick=anchor_chunk_id or 0,
+    )
+
+
+def compose_actor_bindings(
+    session: Any,
+    *,
+    anchor_chunk_id: Optional[int],
+    window_chunks: int,
+) -> Tuple[Bindings, ...]:
+    """Compose ACTOR-only bindings for recently relevant character entities."""
+
+    actor_ids: set[int] = set()
+
+    if anchor_chunk_id is not None:
+        lower_bound = max(0, anchor_chunk_id - window_chunks + 1)
+        for row in session.execute(
+            text(
+                """
+                SELECT DISTINCT cer.entity_id
+                FROM chunk_entity_references_v cer
+                JOIN entities e ON e.id = cer.entity_id
+                WHERE e.kind = 'character'
+                  AND e.is_active = true
+                  AND cer.chunk_id BETWEEN :lower_bound AND :anchor_chunk_id
+                """
+            ),
+            {"lower_bound": lower_bound, "anchor_chunk_id": anchor_chunk_id},
+        ).mappings():
+            actor_ids.add(row["entity_id"])
+
+        for row in session.execute(
+            text(
+                """
+                SELECT DISTINCT candidate.entity_id
+                FROM (
+                    SELECT actor_entity_id AS entity_id
+                    FROM world_events
+                    WHERE tick_chunk_id BETWEEN :lower_bound AND :anchor_chunk_id
+                    UNION
+                    SELECT target_entity_id AS entity_id
+                    FROM world_events
+                    WHERE tick_chunk_id BETWEEN :lower_bound AND :anchor_chunk_id
+                ) candidate
+                JOIN entities e ON e.id = candidate.entity_id
+                WHERE candidate.entity_id IS NOT NULL
+                  AND e.kind = 'character'
+                  AND e.is_active = true
+                """
+            ),
+            {"lower_bound": lower_bound, "anchor_chunk_id": anchor_chunk_id},
+        ).mappings():
+            actor_ids.add(row["entity_id"])
+
+    for row in session.execute(
+        text(
+            """
+            SELECT DISTINCT etc.entity_id
+            FROM entity_tags_current etc
+            JOIN entities e ON e.id = etc.entity_id
+            WHERE etc.is_ephemeral = true
+              AND e.kind = 'character'
+              AND e.is_active = true
+            """
+        )
+    ).mappings():
+        actor_ids.add(row["entity_id"])
+
+    return tuple({Slot.ACTOR: actor_id} for actor_id in sorted(actor_ids))
+
+
+def resolve_dry_run(
+    session: Any,
+    templates: Iterable[Template],
+    *,
+    anchor_chunk_id: Optional[int],
+    window_chunks: int,
+) -> OrreryTickProposal:
+    """Hydrate, bind, and evaluate Orrery packages without database writes."""
+
+    state = hydrate_world_state(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        window_chunks=window_chunks,
+    )
+    actor_bindings = compose_actor_bindings(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        window_chunks=window_chunks,
+    )
+    drafts = []
+    for bindings in actor_bindings:
+        resolution = evaluate_stack(templates, state, bindings)
+        if resolution is not None and resolution.passes:
+            drafts.append(_draft_from_resolution(resolution))
+
+    return OrreryTickProposal(
+        anchor_chunk_id=anchor_chunk_id,
+        actor_count=len(actor_bindings),
+        resolutions=tuple(drafts),
+    )
+
+
+def _load_recent_events(
+    session: Any,
+    *,
+    anchor_chunk_id: Optional[int],
+    window_chunks: int,
+) -> Tuple[EventRecord, ...]:
+    if anchor_chunk_id is None:
+        return ()
+
+    lower_bound = max(0, anchor_chunk_id - window_chunks + 1)
+    events = []
+    for row in session.execute(
+        text(
+            """
+            SELECT event_type,
+                   tick_chunk_id,
+                   actor_entity_id,
+                   target_entity_id,
+                   location_id,
+                   changed_fields,
+                   COALESCE(world_layer::text, 'primary') AS world_layer,
+                   payload
+            FROM world_events
+            WHERE tick_chunk_id BETWEEN :lower_bound AND :anchor_chunk_id
+              AND (world_layer IS NULL OR world_layer = 'primary')
+            ORDER BY tick_chunk_id DESC, id DESC
+            """
+        ),
+        {"lower_bound": lower_bound, "anchor_chunk_id": anchor_chunk_id},
+    ).mappings():
+        events.append(
+            EventRecord(
+                event_type=row["event_type"],
+                tick=row["tick_chunk_id"],
+                actor_entity_id=row["actor_entity_id"],
+                target_entity_id=row["target_entity_id"],
+                location_id=row["location_id"],
+                changed_fields=tuple(row["changed_fields"] or ()),
+                world_layer=row["world_layer"],
+                payload=row["payload"] or {},
+            )
+        )
+    return tuple(events)
+
+
+def _draft_from_resolution(resolution: Resolution) -> OrreryResolutionDraft:
+    if resolution.branch_label is None or resolution.narrative_stub is None:
+        raise RuntimeError(
+            f"Passing Orrery resolution {resolution.template_id} lacks branch data"
+        )
+    return OrreryResolutionDraft(
+        template_id=resolution.template_id,
+        priority=resolution.priority,
+        binding_hash=resolution.binding_hash,
+        bindings={
+            slot.value if isinstance(slot, Slot) else str(slot): value
+            for slot, value in resolution.bindings.items()
+        },
+        branch_label=resolution.branch_label,
+        narrative_stub=resolution.narrative_stub,
+        state_delta=resolution.state_delta,
+        event_type=resolution.event_type,
+        changed_fields=resolution.changed_fields,
+        magnitude=resolution.magnitude,
+    )

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -66,6 +66,7 @@ def hydrate_world_state(
     for row in session.execute(
         text(
             """
+            /* orrery:current_tags */
             SELECT entity_id, tag, is_ephemeral
             FROM entity_tags_current
             """
@@ -79,6 +80,7 @@ def hydrate_world_state(
         for row in session.execute(
             text(
                 """
+                /* orrery:character_locations */
                 SELECT entity_id, current_location
                 FROM characters
                 WHERE entity_id IS NOT NULL
@@ -93,6 +95,7 @@ def hydrate_world_state(
         for row in session.execute(
             text(
                 """
+                /* orrery:location_classes */
                 SELECT id, type::text AS location_class
                 FROM places
                 WHERE type IS NOT NULL
@@ -106,6 +109,7 @@ def hydrate_world_state(
         for row in session.execute(
             text(
                 """
+                /* orrery:character_activities */
                 SELECT entity_id, current_activity
                 FROM characters
                 WHERE entity_id IS NOT NULL
@@ -119,6 +123,7 @@ def hydrate_world_state(
     for row in session.execute(
         text(
             """
+            /* orrery:relationship_types */
             SELECT c1.entity_id AS source_entity_id,
                    c2.entity_id AS target_entity_id,
                    cr.relationship_type::text AS relationship_type
@@ -139,6 +144,7 @@ def hydrate_world_state(
     for row in session.execute(
         text(
             """
+            /* orrery:faction_memberships */
             SELECT c.entity_id AS member_entity_id,
                    f.entity_id AS faction_entity_id
             FROM faction_character_relationships fcr
@@ -158,6 +164,8 @@ def hydrate_world_state(
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
     )
+    time_of_day = _load_time_of_day(session, anchor_chunk_id=anchor_chunk_id)
+    weather = _load_weather(session)
 
     return WorldState(
         tags={entity_id: frozenset(values) for entity_id, values in tags.items()},
@@ -166,6 +174,8 @@ def hydrate_world_state(
         },
         locations=locations,
         activities=activities,
+        # TODO: Hydrate trust and orbit_distance when the resolver has an
+        # authoritative source. Current built-in packages do not use them.
         relationship_types={
             key: frozenset(values) for key, values in relationship_types.items()
         },
@@ -175,6 +185,8 @@ def hydrate_world_state(
         },
         location_class=location_class,
         recent_events=recent_events,
+        time_of_day=time_of_day,
+        weather=weather,
         current_tick=anchor_chunk_id or 0,
     )
 
@@ -194,6 +206,7 @@ def compose_actor_bindings(
         for row in session.execute(
             text(
                 """
+                /* orrery:actor_bindings_chunk_refs */
                 SELECT DISTINCT cer.entity_id
                 FROM chunk_entity_references_v cer
                 JOIN entities e ON e.id = cer.entity_id
@@ -209,15 +222,20 @@ def compose_actor_bindings(
         for row in session.execute(
             text(
                 """
+                /* orrery:actor_bindings_events */
                 SELECT DISTINCT candidate.entity_id
                 FROM (
                     SELECT actor_entity_id AS entity_id
                     FROM world_events
                     WHERE tick_chunk_id BETWEEN :lower_bound AND :anchor_chunk_id
+                      AND (world_layer IS NULL OR world_layer = 'primary')
+                      AND superseded_by_event_id IS NULL
                     UNION
                     SELECT target_entity_id AS entity_id
                     FROM world_events
                     WHERE tick_chunk_id BETWEEN :lower_bound AND :anchor_chunk_id
+                      AND (world_layer IS NULL OR world_layer = 'primary')
+                      AND superseded_by_event_id IS NULL
                 ) candidate
                 JOIN entities e ON e.id = candidate.entity_id
                 WHERE candidate.entity_id IS NOT NULL
@@ -232,6 +250,7 @@ def compose_actor_bindings(
     for row in session.execute(
         text(
             """
+            /* orrery:actor_bindings_ephemeral */
             SELECT DISTINCT etc.entity_id
             FROM entity_tags_current etc
             JOIN entities e ON e.id = etc.entity_id
@@ -292,6 +311,7 @@ def _load_recent_events(
     for row in session.execute(
         text(
             """
+            /* orrery:recent_events */
             SELECT event_type,
                    tick_chunk_id,
                    actor_entity_id,
@@ -303,6 +323,7 @@ def _load_recent_events(
             FROM world_events
             WHERE tick_chunk_id BETWEEN :lower_bound AND :anchor_chunk_id
               AND (world_layer IS NULL OR world_layer = 'primary')
+              AND superseded_by_event_id IS NULL
             ORDER BY tick_chunk_id DESC, id DESC
             """
         ),
@@ -323,10 +344,77 @@ def _load_recent_events(
     return tuple(events)
 
 
+def _load_time_of_day(session: Any, *, anchor_chunk_id: Optional[int]) -> str:
+    if anchor_chunk_id is None:
+        return "midday"
+
+    row = (
+        session.execute(
+            text(
+                """
+                /* orrery:anchor_world_time */
+                SELECT world_time
+                FROM chunk_metadata
+                WHERE chunk_id = :anchor_chunk_id
+                """
+            ),
+            {"anchor_chunk_id": anchor_chunk_id},
+        )
+        .mappings()
+        .first()
+    )
+    world_time = row["world_time"] if row else None
+    if world_time is None:
+        return "midday"
+
+    hour = world_time.hour
+    if 5 <= hour < 12:
+        return "morning"
+    if 12 <= hour < 16:
+        return "afternoon"
+    if 16 <= hour < 21:
+        return "evening"
+    return "night"
+
+
+def _load_weather(session: Any) -> str:
+    # TODO: Replace seed-weather classification with GAIA scene weather once
+    # world-state weather has an authoritative runtime table.
+    row = (
+        session.execute(
+            text(
+                """
+                /* orrery:seed_weather */
+                SELECT setting #>> '{story_seed,weather}' AS weather
+                FROM global_variables
+                WHERE id = true
+                """
+            )
+        )
+        .mappings()
+        .first()
+    )
+    raw_weather = (row["weather"] if row else None) or ""
+    return _classify_weather(raw_weather)
+
+
+def _classify_weather(raw_weather: str) -> str:
+    weather = raw_weather.lower()
+    if any(token in weather for token in ("rain", "sleet", "storm", "thunder")):
+        return "rain"
+    if "snow" in weather:
+        return "snow"
+    if "fog" in weather:
+        return "fog"
+    if any(token in weather for token in ("sun", "clear")):
+        return "clear"
+    return "clear"
+
+
 def _draft_from_resolution(resolution: Resolution) -> OrreryResolutionDraft:
     if resolution.branch_label is None or resolution.narrative_stub is None:
         raise RuntimeError(
-            f"Passing Orrery resolution {resolution.template_id} lacks branch data"
+            f"Orrery resolution {resolution.template_id!r} passed gate but lacks branch data"
         )
     return OrreryResolutionDraft(
         template_id=resolution.template_id,

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -1,5 +1,7 @@
 """Tests for Orrery dry-run resolver integration."""
 
+from datetime import datetime, timezone
+
 import pytest
 
 from nexus.agents.lore.utils.turn_context import TurnContext
@@ -27,6 +29,42 @@ class FakeResult:
 class FakeSession:
     """Return deterministic rows keyed by the resolver's read-only queries."""
 
+    def __init__(
+        self,
+        *,
+        tag_rows=None,
+        location_rows=None,
+        location_class_rows=None,
+        activity_rows=None,
+        relationship_rows=None,
+        faction_rows=None,
+        event_rows=None,
+        chunk_ref_actor_rows=None,
+        event_actor_rows=None,
+        ephemeral_actor_rows=None,
+        world_time=None,
+        weather="",
+        max_chunk_id=100,
+    ):
+        self.tag_rows = tag_rows or []
+        self.location_rows = location_rows or [{"entity_id": 1, "current_location": 10}]
+        self.location_class_rows = location_class_rows or [
+            {"id": 10, "location_class": "the_roots"}
+        ]
+        self.activity_rows = activity_rows or [
+            {"entity_id": 1, "current_activity": "idle"}
+        ]
+        self.relationship_rows = relationship_rows or []
+        self.faction_rows = faction_rows or []
+        self.event_rows = event_rows or []
+        self.chunk_ref_actor_rows = chunk_ref_actor_rows or [{"entity_id": 1}]
+        self.event_actor_rows = event_actor_rows or []
+        self.ephemeral_actor_rows = ephemeral_actor_rows or []
+        self.world_time = world_time or datetime(2073, 10, 31, 12, tzinfo=timezone.utc)
+        self.weather = weather
+        self.max_chunk_id = max_chunk_id
+        self.max_id_queries = 0
+
     def __enter__(self):
         return self
 
@@ -35,44 +73,55 @@ class FakeSession:
 
     def execute(self, statement, _params=None):
         sql = str(statement)
-        if "SELECT entity_id, tag, is_ephemeral" in sql:
-            return FakeResult([])
-        if "SELECT entity_id, current_location" in sql:
-            return FakeResult([{"entity_id": 1, "current_location": 10}])
-        if "SELECT id, type::text AS location_class" in sql:
-            return FakeResult([{"id": 10, "location_class": "the_roots"}])
-        if "SELECT entity_id, current_activity" in sql:
-            return FakeResult([{"entity_id": 1, "current_activity": "idle"}])
-        if "FROM character_relationships" in sql:
-            return FakeResult([])
-        if "FROM faction_character_relationships" in sql:
-            return FakeResult([])
-        if "FROM world_events" in sql and "event_type" in sql:
-            return FakeResult([])
-        if "FROM chunk_entity_references_v" in sql:
-            return FakeResult([{"entity_id": 1}])
-        if "SELECT DISTINCT candidate.entity_id" in sql:
-            return FakeResult([])
-        if "SELECT DISTINCT etc.entity_id" in sql:
-            return FakeResult([])
+        if "/* orrery:current_tags */" in sql:
+            return FakeResult(self.tag_rows)
+        if "/* orrery:character_locations */" in sql:
+            return FakeResult(self.location_rows)
+        if "/* orrery:location_classes */" in sql:
+            return FakeResult(self.location_class_rows)
+        if "/* orrery:character_activities */" in sql:
+            return FakeResult(self.activity_rows)
+        if "/* orrery:relationship_types */" in sql:
+            return FakeResult(self.relationship_rows)
+        if "/* orrery:faction_memberships */" in sql:
+            return FakeResult(self.faction_rows)
+        if "/* orrery:recent_events */" in sql:
+            assert "superseded_by_event_id IS NULL" in sql
+            return FakeResult(self.event_rows)
+        if "/* orrery:actor_bindings_chunk_refs */" in sql:
+            return FakeResult(self.chunk_ref_actor_rows)
+        if "/* orrery:actor_bindings_events */" in sql:
+            assert "(world_layer IS NULL OR world_layer = 'primary')" in sql
+            assert "superseded_by_event_id IS NULL" in sql
+            return FakeResult(self.event_actor_rows)
+        if "/* orrery:actor_bindings_ephemeral */" in sql:
+            return FakeResult(self.ephemeral_actor_rows)
+        if "/* orrery:anchor_world_time */" in sql:
+            return FakeResult([{"world_time": self.world_time}])
+        if "/* orrery:seed_weather */" in sql:
+            return FakeResult([{"weather": self.weather}])
         if "SELECT max(id) AS max_id" in sql:
-            return FakeResult([{"max_id": 100}])
+            self.max_id_queries += 1
+            return FakeResult([{"max_id": self.max_chunk_id}])
         raise AssertionError(f"Unexpected resolver query: {sql}")
 
 
 class FakeMemnon:
     """Minimal MEMNON stand-in exposing the Session factory."""
 
+    def __init__(self, session=None):
+        self.session = session or FakeSession()
+
     def Session(self):
-        return FakeSession()
+        return self.session
 
 
 class FakeLore:
     """Minimal LORE stand-in for TurnCycleManager tests."""
 
-    def __init__(self, settings):
+    def __init__(self, settings, session=None):
         self.settings = settings
-        self.memnon = FakeMemnon()
+        self.memnon = FakeMemnon(session)
 
 
 def test_resolve_dry_run_returns_inspectable_proposal() -> None:
@@ -90,6 +139,86 @@ def test_resolve_dry_run_returns_inspectable_proposal() -> None:
     assert proposal.resolution_count == 1
     assert proposal.resolutions[0].template_id == "maintain_cover"
     assert proposal.resolutions[0].bindings == {"actor": 1}
+
+
+@pytest.mark.parametrize(
+    ("session", "template_id", "branch_label"),
+    [
+        (
+            FakeSession(
+                event_rows=[
+                    {
+                        "event_type": "compliance_alert",
+                        "tick_chunk_id": 99,
+                        "actor_entity_id": None,
+                        "target_entity_id": 1,
+                        "location_id": None,
+                        "changed_fields": [],
+                        "world_layer": "primary",
+                        "payload": {},
+                    }
+                ],
+                weather="hard rain",
+            ),
+            "evade_pursuers",
+            "Go to ground in flooded tunnels",
+        ),
+        (
+            FakeSession(
+                tag_rows=[
+                    {
+                        "entity_id": 1,
+                        "tag": "contacts_available",
+                        "is_ephemeral": False,
+                    }
+                ],
+                event_rows=[
+                    {
+                        "event_type": "encoded_message",
+                        "tick_chunk_id": 99,
+                        "actor_entity_id": None,
+                        "target_entity_id": 1,
+                        "location_id": None,
+                        "changed_fields": [],
+                        "world_layer": "primary",
+                        "payload": {},
+                    }
+                ],
+            ),
+            "honor_debt",
+            "Fulfill obligation through a dead-drop",
+        ),
+        (
+            FakeSession(
+                tag_rows=[
+                    {
+                        "entity_id": 1,
+                        "tag": "seeking_identity",
+                        "is_ephemeral": False,
+                    }
+                ],
+                world_time=datetime(2073, 10, 31, 18, tzinfo=timezone.utc),
+            ),
+            "pursue_ghost_lead",
+            "Recon a hideout their body remembers",
+        ),
+    ],
+)
+def test_resolve_dry_run_exercises_priority_packages(
+    session, template_id: str, branch_label: str
+) -> None:
+    """The dry-run resolver covers non-fallback built-in package gates."""
+
+    proposal = resolve_dry_run(
+        session,
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == template_id
+    assert proposal.resolutions[0].branch_label == branch_label
 
 
 @pytest.mark.asyncio
@@ -128,3 +257,23 @@ async def test_resolve_orrery_attaches_proposal_when_enabled() -> None:
     assert context.orrery_proposal.anchor_chunk_id == 100
     assert context.phase_states["orrery_resolve"]["resolution_count"] == 1
     assert context.context_payload == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_orrery_uses_same_session_for_anchor_fallback() -> None:
+    """Anchor fallback reads occur inside the dry-run resolver session."""
+
+    session = FakeSession(max_chunk_id=101)
+    manager = TurnCycleManager(
+        FakeLore(
+            {"orrery": {"enabled": True, "binding": {"window_chunks": 30}}},
+            session=session,
+        )
+    )
+    context = TurnContext(turn_id="t1", user_input="continue", start_time=0)
+
+    await manager.resolve_orrery(context)
+
+    assert session.max_id_queries == 1
+    assert context.orrery_proposal is not None
+    assert context.orrery_proposal.anchor_chunk_id == 101

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -1,0 +1,130 @@
+"""Tests for Orrery dry-run resolver integration."""
+
+import pytest
+
+from nexus.agents.lore.utils.turn_context import TurnContext
+from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
+from nexus.agents.orrery.resolver import resolve_dry_run
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+
+
+class FakeResult:
+    """Tiny SQLAlchemy result stand-in for resolver unit tests."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def mappings(self):
+        return self
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class FakeSession:
+    """Return deterministic rows keyed by the resolver's read-only queries."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        return False
+
+    def execute(self, statement, _params=None):
+        sql = str(statement)
+        if "SELECT entity_id, tag, is_ephemeral" in sql:
+            return FakeResult([])
+        if "SELECT entity_id, current_location" in sql:
+            return FakeResult([{"entity_id": 1, "current_location": 10}])
+        if "SELECT id, type::text AS location_class" in sql:
+            return FakeResult([{"id": 10, "location_class": "the_roots"}])
+        if "SELECT entity_id, current_activity" in sql:
+            return FakeResult([{"entity_id": 1, "current_activity": "idle"}])
+        if "FROM character_relationships" in sql:
+            return FakeResult([])
+        if "FROM faction_character_relationships" in sql:
+            return FakeResult([])
+        if "FROM world_events" in sql and "event_type" in sql:
+            return FakeResult([])
+        if "FROM chunk_entity_references_v" in sql:
+            return FakeResult([{"entity_id": 1}])
+        if "SELECT DISTINCT candidate.entity_id" in sql:
+            return FakeResult([])
+        if "SELECT DISTINCT etc.entity_id" in sql:
+            return FakeResult([])
+        if "SELECT max(id) AS max_id" in sql:
+            return FakeResult([{"max_id": 100}])
+        raise AssertionError(f"Unexpected resolver query: {sql}")
+
+
+class FakeMemnon:
+    """Minimal MEMNON stand-in exposing the Session factory."""
+
+    def Session(self):
+        return FakeSession()
+
+
+class FakeLore:
+    """Minimal LORE stand-in for TurnCycleManager tests."""
+
+    def __init__(self, settings):
+        self.settings = settings
+        self.memnon = FakeMemnon()
+
+
+def test_resolve_dry_run_returns_inspectable_proposal() -> None:
+    """Dry-run resolution hydrates, binds, and produces no-write drafts."""
+
+    proposal = resolve_dry_run(
+        FakeSession(),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.anchor_chunk_id == 100
+    assert proposal.actor_count == 1
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "maintain_cover"
+    assert proposal.resolutions[0].bindings == {"actor": 1}
+
+
+@pytest.mark.asyncio
+async def test_resolve_orrery_skips_when_disabled() -> None:
+    """The LORE phase is inert unless Orrery is explicitly enabled."""
+
+    manager = TurnCycleManager(FakeLore({"orrery": {"enabled": False}}))
+    context = TurnContext(turn_id="t1", user_input="continue", start_time=0)
+
+    await manager.resolve_orrery(context)
+
+    assert context.orrery_proposal is None
+    assert context.phase_states["orrery_resolve"] == {
+        "enabled": False,
+        "skipped": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_resolve_orrery_attaches_proposal_when_enabled() -> None:
+    """Enabled dry-run integration stores the proposal on TurnContext only."""
+
+    manager = TurnCycleManager(
+        FakeLore({"orrery": {"enabled": True, "binding": {"window_chunks": 30}}})
+    )
+    context = TurnContext(
+        turn_id="t1",
+        user_input="continue",
+        start_time=0,
+        warm_slice=[{"id": 100}],
+    )
+
+    await manager.resolve_orrery(context)
+
+    assert context.orrery_proposal is not None
+    assert context.orrery_proposal.anchor_chunk_id == 100
+    assert context.phase_states["orrery_resolve"]["resolution_count"] == 1
+    assert context.context_payload == {}


### PR DESCRIPTION

## Summary
- Add the optional LORE Phase 4.5 Orrery dry-run resolver hook behind `[orrery].enabled`.
- Add `TurnContext.orrery_proposal` and `bleed_menu` placeholders without injecting Orrery data into the storyteller payload yet.
- Add `nexus.agents.orrery.resolver` to hydrate read-side `WorldState`, compose ACTOR-only bindings, evaluate packages, and return an inspectable `OrreryTickProposal` with no canonical writes.
- Add unit coverage for disabled/enabled dry-run behavior and proposal shape.

## Scope Boundary
- No writes to `orrery_resolutions`, `world_events`, `offscreen_narrations`, or narration outbox tables.
- No storyteller payload influence yet; the proposal remains on `TurnContext` for inspection.
- Runtime remains disabled by default through `orrery.enabled = false`.

## Validation
- `poetry run pytest tests/test_orrery tests/test_lore/test_turn_cycle.py tests/test_lore/test_context_validation.py` -> 39 passed
- `poetry run python -m py_compile nexus/agents/orrery/resolver.py nexus/agents/lore/utils/turn_context.py nexus/agents/lore/utils/turn_cycle.py nexus/agents/lore/lore.py tests/test_orrery/test_resolver.py`
- `git diff --check`
- Live direct dry-run against slot 5: 2 actors, 2 draft resolutions, 0 writes
- Live direct dry-run against slot 2: 8 actors, 8 draft resolutions, 0 writes

## Not Run
- `poetry run flake8 ...` because `flake8` is not installed in the Poetry environment (`Command not found: flake8`).
