### PR TITLE
Expand Orrery package library with multi-slot templates

### DIFF
--- a/migrations/025_orrery_package_library_vocab.py
+++ b/migrations/025_orrery_package_library_vocab.py
@@ -8,12 +8,9 @@ needed for the new templates to fire without violating the Vocabulary Growth
 Contract (resolver-sourced unknowns fail loudly — templates must register
 their vocabulary before use).
 
-Scope is intentionally narrow: only the vocabulary the three new templates
-reference. The existing built-in templates (EVADE_PURSUERS, HONOR_DEBT,
-PURSUE_GHOST_LEAD, MAINTAIN_COVER) reference further tags and event_types
-that are still unseeded; those become PR 3's seeding task because PR 3
-(CommitOrreryTick) is the first slice that actually attempts canonical
-writes against the registries.
+Scope is intentionally narrow: migration 024 seeds the initial built-in
+package vocabulary, and this migration adds only the new vocabulary needed
+by the three package-library templates introduced here.
 """
 
 from __future__ import annotations

--- a/migrations/025_orrery_package_library_vocab.py
+++ b/migrations/025_orrery_package_library_vocab.py
@@ -1,0 +1,282 @@
+"""Seed vocabulary for the Orrery package-library expansion.
+
+Adds the tags, event_types, and relationship_type enum values referenced by
+the EXTRACT_VENGEANCE, PROTECT_KIN, and CULTIVATE_INFORMANT templates appended
+to nexus/agents/orrery/templates.py in the same change. Migration 023 created
+the empty registries; this migration seeds them with the minimum vocabulary
+needed for the new templates to fire without violating the Vocabulary Growth
+Contract (resolver-sourced unknowns fail loudly — templates must register
+their vocabulary before use).
+
+Scope is intentionally narrow: only the vocabulary the three new templates
+reference. The existing built-in templates (EVADE_PURSUERS, HONOR_DEBT,
+PURSUE_GHOST_LEAD, MAINTAIN_COVER) reference further tags and event_types
+that are still unseeded; those become PR 3's seeding task because PR 3
+(CommitOrreryTick) is the first slice that actually attempts canonical
+writes against the registries.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from psycopg2 import sql
+
+
+NEW_RELATIONSHIP_TYPES: Sequence[str] = (
+    "chosen_kin",
+    "comrade",
+    "handler",
+    "asset",
+)
+
+
+# (tag, category, description)
+DURABLE_TAGS: Sequence[tuple[str, str, str]] = (
+    (
+        "vendetta_holder",
+        "disposition",
+        "Identity tag — characters whose narrative arc includes "
+        "pursuing grievances. Priority hint for EXTRACT_VENGEANCE.",
+    ),
+    (
+        "kin_protector",
+        "disposition",
+        "Identity tag — characters with strong protective instincts "
+        "toward relational kin.",
+    ),
+    (
+        "informant_handler",
+        "profession_lite",
+        "Identity tag — characters who run informant networks. "
+        "Eligibility filter for CULTIVATE_INFORMANT.",
+    ),
+    (
+        "violent_history",
+        "disposition",
+        "Identity tag — characters with a track record of physical "
+        "violence. Branch condition for EXTRACT_VENGEANCE's direct-strike "
+        "branch.",
+    ),
+)
+
+
+# (tag, category, clearance_kind, clear_on_json, description)
+EPHEMERAL_TAGS: Sequence[tuple[str, str, str, str | None, str]] = (
+    (
+        "grudge_active",
+        "state",
+        "event",
+        '{"event_types": ["retaliation_executed"]}',
+        "Ephemeral — actor was the target of a wronging event significant "
+        "enough to produce a vendetta. Cleared by retaliation_executed.",
+    ),
+    (
+        "wounded",
+        "state",
+        "semantic",
+        None,
+        "Ephemeral — entity has a recent physical injury. Cleared by "
+        "post-commit semantic evaluation of narrative recovery indicators.",
+    ),
+    (
+        "recently_violent",
+        "state",
+        "semantic",
+        None,
+        "Ephemeral — actor has executed violence in the recent past. "
+        "Cleared by semantic decay (narrative distance from the event).",
+    ),
+    (
+        "recently_protective",
+        "state",
+        "semantic",
+        None,
+        "Ephemeral — actor has intervened protectively on a kin's behalf "
+        "in the recent past. Cleared by semantic decay.",
+    ),
+    (
+        "reputation_compromised",
+        "state",
+        "semantic",
+        None,
+        "Ephemeral — target has been the subject of a recent reputation "
+        "attack. Cleared by semantic evaluation of restoration efforts or "
+        "narrative distance.",
+    ),
+    (
+        "distressed",
+        "state",
+        "semantic",
+        None,
+        "Ephemeral — actor is in acute emotional distress, typically "
+        "from inability to act on behalf of endangered kin. Cleared by "
+        "semantic evaluation of resolution.",
+    ),
+    (
+        "intelligence_asset_active",
+        "state",
+        "semantic",
+        None,
+        "Ephemeral — actor is actively running an intelligence asset who "
+        "is producing material intel. Cleared by semantic evaluation of "
+        "asset burn-out, reassignment, or termination.",
+    ),
+)
+
+
+# (event_type, category, severity, description)
+NEW_EVENT_TYPES: Sequence[tuple[str, str, str, str]] = (
+    (
+        "retaliation_executed",
+        "interpersonal",
+        "major",
+        "Actor moved against a grudge target with intent to harm. "
+        "Clears grudge_active.",
+    ),
+    (
+        "retaliation_attempted",
+        "interpersonal",
+        "moderate",
+        "Actor attempted retaliation against a grudge target but did not "
+        "complete or escalate (surveillance, reputation attack, abort). "
+        "Grudge remains active.",
+    ),
+    (
+        "protective_intervention",
+        "interpersonal",
+        "moderate",
+        "Actor moved to shield a relational kin from active threat or " "ongoing harm.",
+    ),
+    (
+        "informant_contact",
+        "intelligence",
+        "minor",
+        "Routine handler/asset meeting, intelligence trade-craft "
+        "maintenance. Resets cultivation cooldown.",
+    ),
+    (
+        "intel_acquired",
+        "intelligence",
+        "moderate",
+        "Material intelligence obtained from a cultivated informant " "source.",
+    ),
+    (
+        "threat_issued",
+        "interpersonal",
+        "moderate",
+        "An explicit threat was directed at the target entity. Surfacing "
+        "signal for protective behavior in those who hold relational ties "
+        "to the target.",
+    ),
+)
+
+
+def run(conn) -> None:
+    """Apply the package-library vocabulary migration."""
+
+    _extend_relationship_type_enum(conn)
+    _seed_durable_tags(conn)
+    _seed_ephemeral_tags(conn)
+    _seed_event_types(conn)
+
+
+def _enum_value_exists(conn, type_name: str, value: str) -> bool:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT 1
+            FROM pg_enum
+            WHERE enumtypid = %s::regtype
+              AND enumlabel = %s
+            """,
+            (type_name, value),
+        )
+        return cur.fetchone() is not None
+
+
+def _extend_relationship_type_enum(conn) -> None:
+    """Add relationship_type enum values needed by the new templates.
+
+    ALTER TYPE ... ADD VALUE cannot run inside a multi-statement transaction
+    block on PostgreSQL prior to 12. Even on 12+, the new value is only
+    usable after the transaction commits. We commit after each ADD VALUE
+    so the migration's later statements can reference them safely if needed.
+    """
+
+    for value in NEW_RELATIONSHIP_TYPES:
+        if _enum_value_exists(conn, "relationship_type", value):
+            continue
+        with conn.cursor() as cur:
+            cur.execute(
+                sql.SQL("ALTER TYPE relationship_type ADD VALUE {}").format(
+                    sql.Literal(value)
+                )
+            )
+        conn.commit()
+
+
+def _seed_durable_tags(conn) -> None:
+    """Insert durable identity tags. Idempotent via ON CONFLICT (tag)."""
+
+    with conn.cursor() as cur:
+        for tag, category, description in DURABLE_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, %s, FALSE,
+                    NULL, NULL,
+                    NULL, %s
+                )
+                ON CONFLICT (tag) DO NOTHING
+                """,
+                (tag, category, description),
+            )
+    conn.commit()
+
+
+def _seed_ephemeral_tags(conn) -> None:
+    """Insert ephemeral state tags with clearance kinds. Idempotent."""
+
+    with conn.cursor() as cur:
+        for tag, category, clearance_kind, clear_on_json, description in EPHEMERAL_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, %s, TRUE,
+                    %s::entity_tag_clearance_kind,
+                    'extend_expiry'::entity_tag_reapplication_policy,
+                    %s::jsonb, %s
+                )
+                ON CONFLICT (tag) DO NOTHING
+                """,
+                (tag, category, clearance_kind, clear_on_json, description),
+            )
+    conn.commit()
+
+
+def _seed_event_types(conn) -> None:
+    """Insert new event_types referenced by the new templates. Idempotent."""
+
+    with conn.cursor() as cur:
+        for event_type, category, severity, description in NEW_EVENT_TYPES:
+            cur.execute(
+                """
+                INSERT INTO event_types (
+                    type, category, severity, description
+                ) VALUES (
+                    %s, %s, %s::event_severity_kind, %s
+                )
+                ON CONFLICT (type) DO NOTHING
+                """,
+                (event_type, category, severity, description),
+            )
+    conn.commit()

--- a/migrations/025_orrery_package_library_vocab.py
+++ b/migrations/025_orrery_package_library_vocab.py
@@ -40,12 +40,6 @@ DURABLE_TAGS: Sequence[tuple[str, str, str]] = (
         "pursuing grievances. Priority hint for EXTRACT_VENGEANCE.",
     ),
     (
-        "kin_protector",
-        "disposition",
-        "Identity tag — characters with strong protective instincts "
-        "toward relational kin.",
-    ),
-    (
         "informant_handler",
         "profession_lite",
         "Identity tag — characters who run informant networks. "

--- a/nexus/agents/orrery/demo.py
+++ b/nexus/agents/orrery/demo.py
@@ -17,6 +17,7 @@ from nexus.agents.orrery.substrate import (
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 
 ACTOR_ID = 1
+TARGET_ID = 2
 ROOTS_PLACE_ID = 101
 GLOW_PLACE_ID = 102
 STACKS_PLACE_ID = 103
@@ -91,15 +92,78 @@ def build_presets() -> Dict[str, WorldState]:
     }
 
 
+def build_multi_slot_presets() -> Dict[str, dict]:
+    """Multi-slot demo states for the package-library expansion templates.
+
+    Each entry carries both a WorldState and an explicit (ACTOR, TARGET)
+    binding, matching how the multi-slot binding composer would yield pairs
+    against real database state.
+    """
+
+    location_classes = {
+        ROOTS_PLACE_ID: "the_roots",
+        GLOW_PLACE_ID: "the_glow",
+        STACKS_PLACE_ID: "the_stacks",
+    }
+    return {
+        "vengeance": {
+            "state": WorldState(
+                tags={ACTOR_ID: frozenset({"vendetta_holder"})},
+                ephemeral_tags={ACTOR_ID: frozenset({"grudge_active"})},
+                relationship_types={(ACTOR_ID, TARGET_ID): frozenset({"enemy"})},
+                locations={ACTOR_ID: ROOTS_PLACE_ID, TARGET_ID: ROOTS_PLACE_ID},
+                location_class=location_classes,
+                time_of_day="night",
+                weather="clear",
+                current_tick=100,
+            ),
+            "bindings": {Slot.ACTOR: ACTOR_ID, Slot.TARGET: TARGET_ID},
+        },
+        "kin_danger": {
+            "state": WorldState(
+                ephemeral_tags={TARGET_ID: frozenset({"under_active_pursuit"})},
+                relationship_types={(ACTOR_ID, TARGET_ID): frozenset({"family"})},
+                locations={ACTOR_ID: GLOW_PLACE_ID, TARGET_ID: GLOW_PLACE_ID},
+                location_class=location_classes,
+                time_of_day="evening",
+                weather="clear",
+                current_tick=100,
+            ),
+            "bindings": {Slot.ACTOR: ACTOR_ID, Slot.TARGET: TARGET_ID},
+        },
+        "informant": {
+            "state": WorldState(
+                tags={ACTOR_ID: frozenset({"informant_handler"})},
+                relationship_types={(ACTOR_ID, TARGET_ID): frozenset({"handler"})},
+                locations={ACTOR_ID: GLOW_PLACE_ID, TARGET_ID: GLOW_PLACE_ID},
+                location_class=location_classes,
+                time_of_day="evening",
+                weather="clear",
+                current_tick=100,
+            ),
+            "bindings": {Slot.ACTOR: ACTOR_ID, Slot.TARGET: TARGET_ID},
+        },
+    }
+
+
 def run_preset(name: str) -> dict:
     """Evaluate the built-in template stack against one preset."""
 
-    presets = build_presets()
-    if name not in presets:
-        raise ValueError(f"Unknown Orrery demo preset: {name}")
+    actor_only_presets = build_presets()
+    multi_slot_presets = build_multi_slot_presets()
     validate_always_fallbacks(BUILTIN_TEMPLATES)
-    bindings: Bindings = {Slot.ACTOR: ACTOR_ID}
-    result = evaluate_stack(BUILTIN_TEMPLATES, presets[name], bindings)
+
+    if name in actor_only_presets:
+        state = actor_only_presets[name]
+        bindings: Bindings = {Slot.ACTOR: ACTOR_ID}
+    elif name in multi_slot_presets:
+        preset = multi_slot_presets[name]
+        state = preset["state"]
+        bindings = preset["bindings"]
+    else:
+        raise ValueError(f"Unknown Orrery demo preset: {name}")
+
+    result = evaluate_stack(BUILTIN_TEMPLATES, state, bindings)
     if result is None:
         return {"preset": name, "fired": False}
     return {
@@ -113,13 +177,19 @@ def run_preset(name: str) -> dict:
     }
 
 
+def _all_preset_names() -> list[str]:
+    """All known preset names across actor-only and multi-slot harnesses."""
+
+    return sorted(set(build_presets()) | set(build_multi_slot_presets()))
+
+
 def main() -> None:
     """Run the offline Orrery package harness."""
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--preset",
-        choices=sorted(build_presets()),
+        choices=_all_preset_names(),
         default="hunted",
         help="Demo preset to evaluate",
     )

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -22,6 +22,9 @@ SUPPORTED_STATE_DELTA_KEYS = frozenset(
     {
         "character.current_activity",
         "entity_tags.add",
+        "entity_tags.remove",
+        "entity_tags_target.add",
+        "entity_tags_target.remove",
     }
 )
 
@@ -79,6 +82,7 @@ def commit_orrery_tick_sync(
 
         for draft in coerced.resolutions:
             actor_entity_id = _scalar_entity_binding(draft.bindings, "actor")
+            target_entity_id = _scalar_entity_binding(draft.bindings, "target")
             brief = _render_brief(draft, entity_names)
             resolution_id = _insert_resolution_sync(
                 cur,
@@ -96,6 +100,8 @@ def commit_orrery_tick_sync(
                 cur,
                 draft,
                 actor_entity_id=actor_entity_id,
+                target_entity_id=target_entity_id,
+                source_chunk_id=tick_chunk_id,
             )
             event_id = _emit_world_event_sync(
                 cur,
@@ -103,6 +109,7 @@ def commit_orrery_tick_sync(
                 tick_chunk_id=tick_chunk_id,
                 resolution_id=resolution_id,
                 actor_entity_id=actor_entity_id,
+                target_entity_id=target_entity_id,
                 world_layer=world_layer,
             )
             if event_id is not None:
@@ -153,6 +160,7 @@ async def commit_orrery_tick_async(
 
     for draft in coerced.resolutions:
         actor_entity_id = _scalar_entity_binding(draft.bindings, "actor")
+        target_entity_id = _scalar_entity_binding(draft.bindings, "target")
         brief = _render_brief(draft, entity_names)
         resolution_id = await _insert_resolution_async(
             conn,
@@ -170,6 +178,8 @@ async def commit_orrery_tick_async(
             conn,
             draft,
             actor_entity_id=actor_entity_id,
+            target_entity_id=target_entity_id,
+            source_chunk_id=tick_chunk_id,
         )
         event_id = await _emit_world_event_async(
             conn,
@@ -177,6 +187,7 @@ async def commit_orrery_tick_async(
             tick_chunk_id=tick_chunk_id,
             resolution_id=resolution_id,
             actor_entity_id=actor_entity_id,
+            target_entity_id=target_entity_id,
             world_layer=world_layer,
         )
         if event_id is not None:
@@ -377,6 +388,8 @@ def _apply_state_delta_sync(
     draft: OrreryResolutionDraft,
     *,
     actor_entity_id: Optional[int],
+    target_entity_id: Optional[int],
+    source_chunk_id: int,
 ) -> int:
     if not draft.state_delta:
         return 0
@@ -400,6 +413,34 @@ def _apply_state_delta_sync(
     for tag in draft.state_delta.get("entity_tags.add", ()) or ():
         if _add_entity_tag_sync(cur, actor_entity_id, str(tag), draft.template_id):
             tag_mutations += 1
+    for tag in draft.state_delta.get("entity_tags.remove", ()) or ():
+        tag_mutations += _remove_entity_tag_sync(
+            cur,
+            actor_entity_id,
+            str(tag),
+            draft.template_id,
+            source_chunk_id=source_chunk_id,
+            delta_key="entity_tags.remove",
+        )
+
+    if (
+        draft.state_delta.get("entity_tags_target.add")
+        or draft.state_delta.get("entity_tags_target.remove")
+    ) and target_entity_id is None:
+        raise ValueError(f"Orrery draft {draft.template_id} has no target binding")
+
+    for tag in draft.state_delta.get("entity_tags_target.add", ()) or ():
+        if _add_entity_tag_sync(cur, target_entity_id, str(tag), draft.template_id):
+            tag_mutations += 1
+    for tag in draft.state_delta.get("entity_tags_target.remove", ()) or ():
+        tag_mutations += _remove_entity_tag_sync(
+            cur,
+            target_entity_id,
+            str(tag),
+            draft.template_id,
+            source_chunk_id=source_chunk_id,
+            delta_key="entity_tags_target.remove",
+        )
     return tag_mutations
 
 
@@ -408,6 +449,8 @@ async def _apply_state_delta_async(
     draft: OrreryResolutionDraft,
     *,
     actor_entity_id: Optional[int],
+    target_entity_id: Optional[int],
+    source_chunk_id: int,
 ) -> int:
     if not draft.state_delta:
         return 0
@@ -431,6 +474,36 @@ async def _apply_state_delta_async(
             conn, actor_entity_id, str(tag), draft.template_id
         ):
             tag_mutations += 1
+    for tag in draft.state_delta.get("entity_tags.remove", ()) or ():
+        tag_mutations += await _remove_entity_tag_async(
+            conn,
+            actor_entity_id,
+            str(tag),
+            draft.template_id,
+            source_chunk_id=source_chunk_id,
+            delta_key="entity_tags.remove",
+        )
+
+    if (
+        draft.state_delta.get("entity_tags_target.add")
+        or draft.state_delta.get("entity_tags_target.remove")
+    ) and target_entity_id is None:
+        raise ValueError(f"Orrery draft {draft.template_id} has no target binding")
+
+    for tag in draft.state_delta.get("entity_tags_target.add", ()) or ():
+        if await _add_entity_tag_async(
+            conn, target_entity_id, str(tag), draft.template_id
+        ):
+            tag_mutations += 1
+    for tag in draft.state_delta.get("entity_tags_target.remove", ()) or ():
+        tag_mutations += await _remove_entity_tag_async(
+            conn,
+            target_entity_id,
+            str(tag),
+            draft.template_id,
+            source_chunk_id=source_chunk_id,
+            delta_key="entity_tags_target.remove",
+        )
     return tag_mutations
 
 
@@ -440,20 +513,7 @@ def _add_entity_tag_sync(
     tag: str,
     template_id: str,
 ) -> bool:
-    cur.execute(
-        """
-        SELECT id
-        FROM tags
-        WHERE tag = %s
-          AND deprecated = false
-          AND synonym_for IS NULL
-        """,
-        (tag,),
-    )
-    row = cur.fetchone()
-    if not row:
-        raise ValueError(f"Orrery tag {tag!r} is not registered")
-    tag_id = _row_get(row, "id", 0)
+    tag_id = _registered_tag_id_sync(cur, tag)
 
     cur.execute(
         """
@@ -467,24 +527,30 @@ def _add_entity_tag_sync(
     return cur.fetchone() is not None
 
 
+def _registered_tag_id_sync(cur: Any, tag: str) -> int:
+    cur.execute(
+        """
+        SELECT id
+        FROM tags
+        WHERE tag = %s
+          AND deprecated = false
+          AND synonym_for IS NULL
+        """,
+        (tag,),
+    )
+    row = cur.fetchone()
+    if not row:
+        raise ValueError(f"Orrery tag {tag!r} is not registered")
+    return _row_get(row, "id", 0)
+
+
 async def _add_entity_tag_async(
     conn: Any,
     entity_id: int,
     tag: str,
     template_id: str,
 ) -> bool:
-    tag_id = await conn.fetchval(
-        """
-        SELECT id
-        FROM tags
-        WHERE tag = $1
-          AND deprecated = false
-          AND synonym_for IS NULL
-        """,
-        tag,
-    )
-    if tag_id is None:
-        raise ValueError(f"Orrery tag {tag!r} is not registered")
+    tag_id = await _registered_tag_id_async(conn, tag)
 
     inserted_id = await conn.fetchval(
         """
@@ -500,6 +566,103 @@ async def _add_entity_tag_async(
     return inserted_id is not None
 
 
+async def _registered_tag_id_async(conn: Any, tag: str) -> int:
+    tag_id = await conn.fetchval(
+        """
+        SELECT id
+        FROM tags
+        WHERE tag = $1
+          AND deprecated = false
+          AND synonym_for IS NULL
+        """,
+        tag,
+    )
+    if tag_id is None:
+        raise ValueError(f"Orrery tag {tag!r} is not registered")
+    return tag_id
+
+
+def _remove_entity_tag_sync(
+    cur: Any,
+    entity_id: int,
+    tag: str,
+    template_id: str,
+    *,
+    source_chunk_id: int,
+    delta_key: str,
+) -> int:
+    tag_id = _registered_tag_id_sync(cur, tag)
+    cur.execute(
+        """
+        SELECT et.id
+        FROM entity_tags et
+        WHERE et.entity_id = %s
+          AND et.tag_id = %s
+          AND et.cleared_at IS NULL
+        """,
+        (entity_id, tag_id),
+    )
+    entity_tag_ids = [_row_get(row, "id", 0) for row in cur.fetchall()]
+    for entity_tag_id in entity_tag_ids:
+        cur.execute(
+            "UPDATE entity_tags SET cleared_at = now() WHERE id = %s",
+            (entity_tag_id,),
+        )
+        cur.execute(
+            """
+            INSERT INTO tag_clearance_log (
+                entity_tag_id, mechanism, justification, source_chunk_id
+            ) VALUES (%s, 'authored', %s::jsonb, %s)
+            """,
+            (
+                entity_tag_id,
+                json.dumps({"template_id": template_id, "state_delta": delta_key}),
+                source_chunk_id,
+            ),
+        )
+    return len(entity_tag_ids)
+
+
+async def _remove_entity_tag_async(
+    conn: Any,
+    entity_id: int,
+    tag: str,
+    template_id: str,
+    *,
+    source_chunk_id: int,
+    delta_key: str,
+) -> int:
+    tag_id = await _registered_tag_id_async(conn, tag)
+    rows = await conn.fetch(
+        """
+        SELECT et.id
+        FROM entity_tags et
+        WHERE et.entity_id = $1
+          AND et.tag_id = $2
+          AND et.cleared_at IS NULL
+        """,
+        entity_id,
+        tag_id,
+    )
+    entity_tag_ids = [_row_get(row, "id", 0) for row in rows]
+    for entity_tag_id in entity_tag_ids:
+        await conn.execute(
+            "UPDATE entity_tags SET cleared_at = now() WHERE id = $1",
+            entity_tag_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO tag_clearance_log (
+                entity_tag_id, mechanism, justification, source_chunk_id
+            ) VALUES ($1, 'authored', $2::jsonb, $3)
+            """,
+            entity_tag_id,
+            json.dumps({"template_id": template_id, "state_delta": delta_key}),
+            source_chunk_id,
+        )
+    return len(entity_tag_ids)
+
+
 def _emit_world_event_sync(
     cur: Any,
     draft: OrreryResolutionDraft,
@@ -507,6 +670,7 @@ def _emit_world_event_sync(
     tick_chunk_id: int,
     resolution_id: int,
     actor_entity_id: Optional[int],
+    target_entity_id: Optional[int],
     world_layer: Optional[str],
 ) -> Optional[int]:
     if not draft.event_type:
@@ -524,16 +688,17 @@ def _emit_world_event_sync(
     cur.execute(
         """
         INSERT INTO world_events (
-            event_type, tick_chunk_id, actor_entity_id, location_id,
+            event_type, tick_chunk_id, actor_entity_id, target_entity_id, location_id,
             world_layer, source, changed_fields, magnitude, resolution_id,
             payload
-        ) VALUES (%s, %s, %s, %s, %s, 'resolver', %s, %s, %s, %s::jsonb)
+        ) VALUES (%s, %s, %s, %s, %s, %s, 'resolver', %s, %s, %s, %s::jsonb)
         RETURNING id
         """,
         (
             draft.event_type,
             tick_chunk_id,
             actor_entity_id,
+            target_entity_id,
             location_id,
             world_layer,
             list(draft.changed_fields),
@@ -552,6 +717,15 @@ def _emit_world_event_sync(
             """,
             (event_id, actor_entity_id),
         )
+    if target_entity_id is not None:
+        cur.execute(
+            """
+            INSERT INTO world_event_entities (event_id, role, entity_id)
+            VALUES (%s, 'target', %s)
+            ON CONFLICT DO NOTHING
+            """,
+            (event_id, target_entity_id),
+        )
     return event_id
 
 
@@ -562,6 +736,7 @@ async def _emit_world_event_async(
     tick_chunk_id: int,
     resolution_id: int,
     actor_entity_id: Optional[int],
+    target_entity_id: Optional[int],
     world_layer: Optional[str],
 ) -> Optional[int]:
     if not draft.event_type:
@@ -579,18 +754,19 @@ async def _emit_world_event_async(
     event_id = await conn.fetchval(
         """
         INSERT INTO world_events (
-            event_type, tick_chunk_id, actor_entity_id, location_id,
+            event_type, tick_chunk_id, actor_entity_id, target_entity_id, location_id,
             world_layer, source, changed_fields, magnitude, resolution_id,
             payload
         ) VALUES (
-            $1, $2, $3, $4, $5::world_layer_type, 'resolver',
-            $6::text[], $7, $8, $9::jsonb
+            $1, $2, $3, $4, $5, $6::world_layer_type, 'resolver',
+            $7::text[], $8, $9, $10::jsonb
         )
         RETURNING id
         """,
         draft.event_type,
         tick_chunk_id,
         actor_entity_id,
+        target_entity_id,
         location_id,
         world_layer,
         list(draft.changed_fields),
@@ -607,6 +783,16 @@ async def _emit_world_event_async(
             """,
             event_id,
             actor_entity_id,
+        )
+    if target_entity_id is not None:
+        await conn.execute(
+            """
+            INSERT INTO world_event_entities (event_id, role, entity_id)
+            VALUES ($1, 'target', $2)
+            ON CONFLICT DO NOTHING
+            """,
+            event_id,
+            target_entity_id,
         )
     return event_id
 

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -387,6 +387,10 @@ def compose_actor_target_bindings(
         actor_id_set = {bindings[Slot.ACTOR] for bindings in actor_only}
     else:
         actor_id_set = set(actor_ids)
+    present_actor_ids = _present_actor_ids_at_anchor(
+        session, anchor_chunk_id=anchor_chunk_id
+    )
+    actor_id_set -= present_actor_ids
     if not actor_id_set:
         return ()
 
@@ -411,6 +415,8 @@ def compose_actor_target_bindings(
     ).mappings():
         source = row["source_entity_id"]
         target = row["target_entity_id"]
+        if source in present_actor_ids or target in present_actor_ids:
+            continue
         if source in actor_id_set:
             pairs.add((source, target))
         if target in actor_id_set:

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -356,6 +356,67 @@ def _present_actor_ids_at_anchor(
     }
 
 
+def compose_actor_target_bindings(
+    session: Any,
+    *,
+    anchor_chunk_id: Optional[int],
+    window_chunks: int,
+) -> Tuple[Bindings, ...]:
+    """Compose ACTOR+TARGET bindings from actors' relational neighborhoods.
+
+    Yields {Slot.ACTOR: a, Slot.TARGET: t} for each character-to-character
+    relationship row where the actor side is in the recently-relevant set.
+    Each stored relationship row produces up to two bindings (forward and
+    reverse) so templates with symmetric semantics see both orderings; gate
+    predicates with asymmetric semantics (handler/asset) filter via
+    role-explicit OR clauses.
+    """
+
+    actor_only = compose_actor_bindings(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        window_chunks=window_chunks,
+    )
+    actor_id_set = {bindings[Slot.ACTOR] for bindings in actor_only}
+    if not actor_id_set:
+        return ()
+
+    pairs: set[Tuple[int, int]] = set()
+    for row in session.execute(
+        text(
+            """
+            /* orrery:actor_target_bindings_character_relationships */
+            SELECT er.source_entity_id, er.target_entity_id
+            FROM entity_relationships_v er
+            JOIN entities es ON es.id = er.source_entity_id
+            JOIN entities et ON et.id = er.target_entity_id
+            WHERE er.relationship_scope = 'character'
+              AND er.source_entity_id IS NOT NULL
+              AND er.target_entity_id IS NOT NULL
+              AND es.kind = 'character'
+              AND et.kind = 'character'
+              AND es.is_active = true
+              AND et.is_active = true
+            """
+        )
+    ).mappings():
+        source = row["source_entity_id"]
+        target = row["target_entity_id"]
+        if source in actor_id_set:
+            pairs.add((source, target))
+        if target in actor_id_set:
+            pairs.add((target, source))
+
+    return tuple(
+        {Slot.ACTOR: actor_id, Slot.TARGET: target_id}
+        for actor_id, target_id in sorted(pairs)
+    )
+
+
+_ACTOR_ONLY_SLOTS: Tuple[Slot, ...] = (Slot.ACTOR,)
+_ACTOR_TARGET_SLOTS: Tuple[Slot, ...] = (Slot.ACTOR, Slot.TARGET)
+
+
 def resolve_dry_run(
     session: Any,
     templates: Iterable[Template],
@@ -370,20 +431,59 @@ def resolve_dry_run(
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
     )
+
+    templates_list = list(templates)
+    actor_only_templates = [
+        t for t in templates_list if t.required_slots == _ACTOR_ONLY_SLOTS
+    ]
+    actor_target_templates = [
+        t for t in templates_list if t.required_slots == _ACTOR_TARGET_SLOTS
+    ]
+    unsupported = [
+        t
+        for t in templates_list
+        if t.required_slots not in (_ACTOR_ONLY_SLOTS, _ACTOR_TARGET_SLOTS)
+    ]
+    if unsupported:
+        raise ValueError(
+            "Orrery resolver does not yet compose bindings for required_slots="
+            + ", ".join(
+                f"{t.id}:{tuple(s.value for s in t.required_slots)}"
+                for t in unsupported
+            )
+        )
+
+    drafts: list[OrreryResolutionDraft] = []
+
     actor_bindings = compose_actor_bindings(
         session,
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
     )
-    drafts = []
     for bindings in actor_bindings:
-        resolution = evaluate_stack(templates, state, bindings)
+        resolution = evaluate_stack(actor_only_templates, state, bindings)
         if resolution is not None and resolution.passes:
             drafts.append(_draft_from_resolution(resolution))
 
+    actor_target_bindings: Tuple[Bindings, ...] = ()
+    if actor_target_templates:
+        actor_target_bindings = compose_actor_target_bindings(
+            session,
+            anchor_chunk_id=anchor_chunk_id,
+            window_chunks=window_chunks,
+        )
+        for bindings in actor_target_bindings:
+            resolution = evaluate_stack(actor_target_templates, state, bindings)
+            if resolution is not None and resolution.passes:
+                drafts.append(_draft_from_resolution(resolution))
+
+    unique_actors = {bindings[Slot.ACTOR] for bindings in actor_bindings} | {
+        bindings[Slot.ACTOR] for bindings in actor_target_bindings
+    }
+
     return OrreryTickProposal(
         anchor_chunk_id=anchor_chunk_id,
-        actor_count=len(actor_bindings),
+        actor_count=len(unique_actors),
         resolutions=tuple(drafts),
     )
 

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -181,15 +181,12 @@ def hydrate_world_state(
         text(
             """
             /* orrery:relationship_types */
-            SELECT c1.entity_id AS source_entity_id,
-                   c2.entity_id AS target_entity_id,
-                   cr.relationship_type::text AS relationship_type
-            FROM character_relationships cr
-            JOIN characters c1 ON c1.id = cr.character1_id
-            JOIN characters c2 ON c2.id = cr.character2_id
-            WHERE c1.entity_id IS NOT NULL
-              AND c2.entity_id IS NOT NULL
-              AND cr.relationship_type IS NOT NULL
+            SELECT source_entity_id, target_entity_id, relationship_type
+            FROM entity_relationships_v
+            WHERE relationship_scope = 'character'
+              AND source_entity_id IS NOT NULL
+              AND target_entity_id IS NOT NULL
+              AND relationship_type IS NOT NULL
             """
         )
     ).mappings():
@@ -361,6 +358,7 @@ def compose_actor_target_bindings(
     *,
     anchor_chunk_id: Optional[int],
     window_chunks: int,
+    actor_ids: Optional[Iterable[int]] = None,
 ) -> Tuple[Bindings, ...]:
     """Compose ACTOR+TARGET bindings from actors' relational neighborhoods.
 
@@ -370,14 +368,25 @@ def compose_actor_target_bindings(
     reverse) so templates with symmetric semantics see both orderings; gate
     predicates with asymmetric semantics (handler/asset) filter via
     role-explicit OR clauses.
+
+    When actor_ids is provided (typical: resolve_dry_run threads through
+    the actor set it already computed), this skips the redundant
+    compose_actor_bindings call. That avoids two costs: the duplicate DB
+    queries on every tick, and the READ COMMITTED inconsistency window
+    where the two binding passes could see different actor sets if rows
+    change between reads. Direct callers (e.g., focused unit tests) may
+    omit actor_ids and accept the implicit recomputation.
     """
 
-    actor_only = compose_actor_bindings(
-        session,
-        anchor_chunk_id=anchor_chunk_id,
-        window_chunks=window_chunks,
-    )
-    actor_id_set = {bindings[Slot.ACTOR] for bindings in actor_only}
+    if actor_ids is None:
+        actor_only = compose_actor_bindings(
+            session,
+            anchor_chunk_id=anchor_chunk_id,
+            window_chunks=window_chunks,
+        )
+        actor_id_set = {bindings[Slot.ACTOR] for bindings in actor_only}
+    else:
+        actor_id_set = set(actor_ids)
     if not actor_id_set:
         return ()
 
@@ -471,6 +480,7 @@ def resolve_dry_run(
             session,
             anchor_chunk_id=anchor_chunk_id,
             window_chunks=window_chunks,
+            actor_ids={bindings[Slot.ACTOR] for bindings in actor_bindings},
         )
         for bindings in actor_target_bindings:
             resolution = evaluate_stack(actor_target_templates, state, bindings)

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -253,6 +253,31 @@ def has_relationship_of_type(
     )
 
 
+def has_symmetric_relationship_of_type(
+    relationship_type: str,
+    slot_a: Slot = Slot.ACTOR,
+    slot_b: Slot = Slot.TARGET,
+) -> Condition:
+    """Return whether a directionally-symmetric typed relationship exists.
+
+    WorldState hydration stores each relationship row in its stored direction
+    only, preserving asymmetric semantics for handler/asset and similar pairs.
+    Templates wanting symmetric semantics (family, romantic, comrade) check
+    both directions; this helper expresses that intent without an explicit OR.
+    """
+
+    forward = has_relationship_of_type(relationship_type, slot_a, slot_b)
+    reverse = has_relationship_of_type(relationship_type, slot_b, slot_a)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        return forward(state, bindings) or reverse(state, bindings)
+
+    return _named(
+        _condition,
+        f"has_symmetric_relationship_of_type({relationship_type},{slot_a.value}<->{slot_b.value})",
+    )
+
+
 def faction_member(
     faction_slot: Slot = Slot.FACTION,
     member_slot: Slot = Slot.ACTOR,

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -388,18 +388,32 @@ def since_last_event_at_least(
     minimum_ticks: int,
     *,
     actor_slot: Slot = Slot.ACTOR,
+    target_slot: Optional[Slot] = None,
 ) -> Condition:
-    """Return whether enough ticks have passed since the last matching event."""
+    """Return whether enough ticks have passed since the last matching event.
+
+    When target_slot is provided, the match also requires the event's
+    target to bind to the same entity — making the cooldown per-
+    (actor, target) rather than actor-global. Use this in multi-slot
+    templates whose cooldown is meant to bound interaction frequency with
+    one specific target (e.g., handler/informant cadence), not the actor's
+    behavior class across all targets.
+    """
 
     def _condition(state: WorldState, bindings: Bindings) -> bool:
         actor_id = _slot_entity(bindings, actor_slot)
         if actor_id is None:
+            return False
+        target_id = _slot_entity(bindings, target_slot) if target_slot else None
+        if target_slot is not None and target_id is None:
             return False
         latest_tick: Optional[int] = None
         for event in state.recent_events:
             if event.event_type != event_type:
                 continue
             if event.actor_entity_id != actor_id:
+                continue
+            if target_id is not None and event.target_entity_id != target_id:
                 continue
             latest_tick = (
                 event.tick if latest_tick is None else max(latest_tick, event.tick)
@@ -408,9 +422,11 @@ def since_last_event_at_least(
             return True
         return state.current_tick - latest_tick >= minimum_ticks
 
+    suffix = f",target={target_slot.value}" if target_slot else ""
     return _named(
         _condition,
-        f"since_last_event_at_least({event_type},{minimum_ticks}@{actor_slot.value})",
+        f"since_last_event_at_least({event_type},{minimum_ticks}"
+        f"@{actor_slot.value}{suffix})",
     )
 
 

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -239,10 +239,21 @@ MAINTAIN_COVER = Template(
 #     enemy/rival for vendetta) use has_symmetric_relationship_of_type to keep
 #     the gates readable; the helper expresses bidirectional lookup against the
 #     stored-direction-only WorldState hydration.
-#   * Cross-actor state_delta keys (entity_tags_target.add/remove) are preserved
-#     verbatim from the draft as a contract for PR 3's CommitOrreryTick writer;
-#     the substrate accepts arbitrary Mapping keys, so they are decorative here
-#     and load-bearing downstream.
+#
+# Two contracts that PR 3 (CommitOrreryTick) will need to honor or revisit:
+#
+#   * Cross-actor state_delta keys (entity_tags_target.add/remove) are
+#     preserved verbatim from the draft. The substrate accepts arbitrary
+#     Mapping keys, so they're decorative here; PR 3 must parse and route
+#     them by convention (no enum/TypedDict yet). Define a state_delta
+#     schema alongside the writer if the implicit-string approach proves
+#     too brittle in implementation.
+#   * Trust hydration is un-implemented (resolver.py:177 TODO). Any branch
+#     gated on trust_at_least(N) with N > 0 or trust_below(N) with N < 0
+#     is currently unreachable — WorldState.trust defaults to 0 for every
+#     pair. The affected branches are flagged with TODO comments below;
+#     they remain in the catalog because they're the intended firing
+#     paths once trust hydration lands.
 # ----------------------------------------------------------------------------
 
 
@@ -251,11 +262,18 @@ EXTRACT_VENGEANCE = Template(
     priority=90,
     blurb="A grudge ripens until the moment is right to settle it.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
+    # Cooldown is intentionally actor-global (no target_slot=): an active
+    # grudge has a refractory period after any attempt regardless of
+    # target — the actor needs to "calm down," not just back off a
+    # specific target.
     package_gate=AND(
         has_ephemeral("grudge_active"),
         OR(
             has_symmetric_relationship_of_type("enemy"),
             has_symmetric_relationship_of_type("rival"),
+            # TODO: trust_below(-2) is unreachable until resolver.py:177's
+            # trust hydration TODO is resolved. The OR keeps the predicate
+            # documented; the enemy/rival arms carry the gate today.
             trust_below(-2),
         ),
         since_last_event_at_least("retaliation_attempted", minimum_ticks=8),
@@ -431,13 +449,20 @@ CULTIVATE_INFORMANT = Template(
     priority=50,
     blurb="Patient intelligence work with a specific asset.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
+    # Cooldowns here are per-(actor, target) via target_slot=: handler A
+    # contacting informant B must not block A from contacting informant C.
+    # Contrast with EXTRACT_VENGEANCE's actor-global retaliation cooldown.
     package_gate=AND(
         has_tag("informant_handler"),
         OR(
             has_relationship_of_type("handler", Slot.ACTOR, Slot.TARGET),
             has_relationship_of_type("asset", Slot.TARGET, Slot.ACTOR),
         ),
-        since_last_event_at_least("informant_contact", minimum_ticks=4),
+        since_last_event_at_least(
+            "informant_contact",
+            minimum_ticks=4,
+            target_slot=Slot.TARGET,
+        ),
         time_of_day_in("evening", "night"),
         NOT(has_ephemeral("under_active_pursuit")),
         NOT(has_ephemeral("grudge_active")),
@@ -445,10 +470,17 @@ CULTIVATE_INFORMANT = Template(
     branches=(
         Branch(
             label="Press for material intel when trust is sufficient",
+            # TODO: trust_at_least(2) is unreachable until resolver.py:177's
+            # trust hydration TODO is resolved. WorldState.trust defaults
+            # to 0, so this branch routes to the ALWAYS fallback today.
             conditions=AND(
                 co_located(Slot.ACTOR, Slot.TARGET),
                 trust_at_least(2),
-                since_last_event_at_least("intel_acquired", minimum_ticks=6),
+                since_last_event_at_least(
+                    "intel_acquired",
+                    minimum_ticks=6,
+                    target_slot=Slot.TARGET,
+                ),
             ),
             narrative_stub=(
                 "{actor} meets {target} in a place that looks ordinary to "

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -240,14 +240,12 @@ MAINTAIN_COVER = Template(
 #     the gates readable; the helper expresses bidirectional lookup against the
 #     stored-direction-only WorldState hydration.
 #
-# Two contracts that PR 3 (CommitOrreryTick) will need to honor or revisit:
+# Writer contract:
 #
 #   * Cross-actor state_delta keys (entity_tags_target.add/remove) are
-#     preserved verbatim from the draft. The substrate accepts arbitrary
-#     Mapping keys, so they're decorative here; PR 3 must parse and route
-#     them by convention (no enum/TypedDict yet). Define a state_delta
-#     schema alongside the writer if the implicit-string approach proves
-#     too brittle in implementation.
+#     routed by convention to Slot.TARGET by CommitOrreryTick. Define a
+#     state_delta TypedDict/dataclass if the implicit-string convention
+#     grows past this small vocabulary.
 #   * Trust hydration is un-implemented (resolver.py:177 TODO). Any branch
 #     gated on trust_at_least(N) with N > 0 or trust_below(N) with N < 0
 #     is currently unreachable — WorldState.trust defaults to 0 for every

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -10,12 +10,20 @@ from nexus.agents.orrery.substrate import (
     Branch,
     Slot,
     Template,
+    co_located,
+    count_co_located,
+    has_any_tag,
     has_ephemeral,
+    has_relationship_of_type,
+    has_symmetric_relationship_of_type,
     has_tag,
     in_location_class,
     lacks_tag,
     recent_event,
+    since_last_event_at_least,
     time_of_day_in,
+    trust_at_least,
+    trust_below,
     weather_is,
 )
 
@@ -216,9 +224,291 @@ MAINTAIN_COVER = Template(
 )
 
 
+# ----------------------------------------------------------------------------
+# Package-library expansion (multi-slot templates)
+#
+# The three templates below depend on the multi-slot binding composer in
+# resolver.py::compose_actor_target_bindings. They share an authoring lineage:
+# drafted by a frontier-model conversation partner (temp/orrery/orrery_
+# package_contributions.md), integrated here with the following deliberate
+# divergences:
+#
+#   * PROTECT_KIN: the contribution draft listed `lover` as a relationship_type;
+#     substituted with `romantic` (already in the enum and semantically broader).
+#   * Symmetric relationships (family/romantic/chosen_kin/comrade for kin,
+#     enemy/rival for vendetta) use has_symmetric_relationship_of_type to keep
+#     the gates readable; the helper expresses bidirectional lookup against the
+#     stored-direction-only WorldState hydration.
+#   * Cross-actor state_delta keys (entity_tags_target.add/remove) are preserved
+#     verbatim from the draft as a contract for PR 3's CommitOrreryTick writer;
+#     the substrate accepts arbitrary Mapping keys, so they are decorative here
+#     and load-bearing downstream.
+# ----------------------------------------------------------------------------
+
+
+EXTRACT_VENGEANCE = Template(
+    id="extract_vengeance",
+    priority=90,
+    blurb="A grudge ripens until the moment is right to settle it.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    package_gate=AND(
+        has_ephemeral("grudge_active"),
+        OR(
+            has_symmetric_relationship_of_type("enemy"),
+            has_symmetric_relationship_of_type("rival"),
+            trust_below(-2),
+        ),
+        since_last_event_at_least("retaliation_attempted", minimum_ticks=8),
+        NOT(has_ephemeral("under_active_pursuit")),
+    ),
+    branches=(
+        Branch(
+            label="Strike directly when opportunity opens",
+            conditions=AND(
+                co_located(Slot.ACTOR, Slot.TARGET),
+                NOT(count_co_located(2, slot=Slot.TARGET)),
+                has_any_tag("vendetta_holder", "violent_history"),
+            ),
+            narrative_stub=(
+                "{actor} moves on {target} in the moment the corridor clears — "
+                "no warning, no negotiation, the years of waiting compressed "
+                "into the time it takes to close a few meters of distance."
+            ),
+            state_delta={
+                "character.current_activity": "executing retaliation",
+                "entity_tags.add": ["recently_violent"],
+                "entity_tags_target.remove": ["grudge_active"],
+            },
+            event_type="retaliation_executed",
+            changed_fields=(
+                "character.current_activity",
+                "entity_tags",
+                "world_events",
+            ),
+            magnitude=0.85,
+        ),
+        Branch(
+            label="Surface a reputation attack in the right channels",
+            conditions=AND(
+                has_tag("contacts_available"),
+                in_location_class("the_glow"),
+            ),
+            narrative_stub=(
+                "{actor} feeds a curated dossier on {target} into three brokers "
+                "in the Glow, taking pains to make the leak look like an accident "
+                "of incautious clients rather than deliberate sabotage."
+            ),
+            state_delta={
+                "character.current_activity": "running a reputation attack",
+                "entity_tags_target.add": ["reputation_compromised"],
+            },
+            event_type="retaliation_attempted",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.58,
+        ),
+        Branch(
+            label="Watch and document, waiting for a better window",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} continues to observe {target}'s patterns from cover — "
+                "shift changes, contacts, the geometry of their movements — "
+                "letting the grudge stay sharp without spending it prematurely."
+            ),
+            state_delta={
+                "character.current_activity": "surveilling a grudge target",
+            },
+            event_type="retaliation_attempted",
+            changed_fields=("character.current_activity",),
+            magnitude=0.34,
+        ),
+    ),
+)
+
+
+PROTECT_KIN = Template(
+    id="protect_kin",
+    priority=95,
+    blurb="A bond pulls the actor toward someone in active danger.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    package_gate=AND(
+        OR(
+            has_symmetric_relationship_of_type("family"),
+            has_symmetric_relationship_of_type("romantic"),
+            has_symmetric_relationship_of_type("chosen_kin"),
+            has_symmetric_relationship_of_type("comrade"),
+        ),
+        OR(
+            has_ephemeral("under_active_pursuit", slot=Slot.TARGET),
+            has_ephemeral("wounded", slot=Slot.TARGET),
+            recent_event(
+                "threat_issued",
+                within_ticks=4,
+                target_slot=Slot.TARGET,
+            ),
+        ),
+        NOT(has_ephemeral("under_active_pursuit")),
+    ),
+    branches=(
+        Branch(
+            label="Physically intervene at the target's location",
+            conditions=AND(
+                co_located(Slot.ACTOR, Slot.TARGET),
+                has_ephemeral("under_active_pursuit", slot=Slot.TARGET),
+            ),
+            narrative_stub=(
+                "{actor} reaches {target} as the noose tightens — pulling them "
+                "off the line of sight, into a service corridor whose layout "
+                "{actor} has memorized for exactly this kind of moment."
+            ),
+            state_delta={
+                "character.current_activity": "shielding kin from active threat",
+                "entity_tags.add": ["recently_protective"],
+                "entity_tags_target.remove": ["under_active_pursuit"],
+            },
+            event_type="protective_intervention",
+            changed_fields=(
+                "character.current_activity",
+                "entity_tags",
+                "world_events",
+            ),
+            magnitude=0.78,
+        ),
+        Branch(
+            label="Travel toward the target's last known location",
+            conditions=AND(
+                has_tag("contacts_available"),
+                NOT(co_located(Slot.ACTOR, Slot.TARGET)),
+            ),
+            narrative_stub=(
+                "{actor} drops what they were doing and starts moving — calling "
+                "in favors at every transit checkpoint to shave minutes off the "
+                "route to {target}, knowing the minutes might matter."
+            ),
+            state_delta={
+                "character.current_activity": "moving to reach kin in danger",
+            },
+            event_type="protective_intervention",
+            changed_fields=("character.current_activity",),
+            magnitude=0.52,
+        ),
+        Branch(
+            label="Signal kin networks to converge on the target",
+            conditions=has_symmetric_relationship_of_type("comrade"),
+            narrative_stub=(
+                "{actor} pushes a coded distress beacon through the kin network — "
+                "the kind of signal that pulls three or four people toward "
+                "{target} from different directions without coordination."
+            ),
+            state_delta={
+                "character.current_activity": "coordinating kin response",
+            },
+            event_type="protective_intervention",
+            changed_fields=("character.current_activity",),
+            magnitude=0.41,
+        ),
+        Branch(
+            label="Maintain vigil and wait for resolution",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} can't reach {target} in time, can't call who they would "
+                "need to call — and stays close to a comm, monitoring channels, "
+                "waiting for the news that will determine what comes next."
+            ),
+            state_delta={
+                "character.current_activity": "waiting on news of kin",
+                "entity_tags.add": ["distressed"],
+            },
+            event_type="protective_intervention",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.22,
+        ),
+    ),
+)
+
+
+CULTIVATE_INFORMANT = Template(
+    id="cultivate_informant",
+    priority=50,
+    blurb="Patient intelligence work with a specific asset.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    package_gate=AND(
+        has_tag("informant_handler"),
+        OR(
+            has_relationship_of_type("handler", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("asset", Slot.TARGET, Slot.ACTOR),
+        ),
+        since_last_event_at_least("informant_contact", minimum_ticks=4),
+        time_of_day_in("evening", "night"),
+        NOT(has_ephemeral("under_active_pursuit")),
+        NOT(has_ephemeral("grudge_active")),
+    ),
+    branches=(
+        Branch(
+            label="Press for material intel when trust is sufficient",
+            conditions=AND(
+                co_located(Slot.ACTOR, Slot.TARGET),
+                trust_at_least(2),
+                since_last_event_at_least("intel_acquired", minimum_ticks=6),
+            ),
+            narrative_stub=(
+                "{actor} meets {target} in a place that looks ordinary to "
+                "anyone watching and asks the question they've been working "
+                "toward for weeks. {target} doesn't answer immediately. Then "
+                "they do."
+            ),
+            state_delta={
+                "character.current_activity": "acquiring material intelligence",
+                "entity_tags.add": ["intelligence_asset_active"],
+            },
+            event_type="intel_acquired",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.62,
+        ),
+        Branch(
+            label="Routine contact to maintain the relationship",
+            conditions=AND(
+                co_located(Slot.ACTOR, Slot.TARGET),
+                trust_at_least(0),
+            ),
+            narrative_stub=(
+                "{actor} sees {target} in passing — a transactional exchange "
+                "with nothing to it, except that the exchange itself is the "
+                "point. The relationship needs maintenance whether or not "
+                "there is anything to report."
+            ),
+            state_delta={
+                "character.current_activity": "maintaining informant contact",
+            },
+            event_type="informant_contact",
+            changed_fields=("character.current_activity",),
+            magnitude=0.28,
+        ),
+        Branch(
+            label="Place a small overture from a distance",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} routes a small gift or unexpected courtesy to "
+                "{target} through indirect channels — the kind of gesture "
+                "that lands without obligation but accumulates over time "
+                "into something the asset will eventually want to repay."
+            ),
+            state_delta={
+                "character.current_activity": "courting an informant remotely",
+            },
+            event_type="informant_contact",
+            changed_fields=("character.current_activity",),
+            magnitude=0.18,
+        ),
+    ),
+)
+
+
 BUILTIN_TEMPLATES = (
     EVADE_PURSUERS,
+    PROTECT_KIN,
+    EXTRACT_VENGEANCE,
     HONOR_DEBT,
     PURSUE_GHOST_LEAD,
+    CULTIVATE_INFORMANT,
     MAINTAIN_COVER,
 )

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -47,7 +47,11 @@ class RecordingCursor:
             entity_ids = params[0]
             self._fetchall = [{"id": entity_id} for entity_id in entity_ids]
         elif "FROM entity_names_v WHERE id = ANY" in normalized:
-            self._fetchall = [{"id": 1, "name": "Mara"}]
+            names = {1: "Mara", 2: "Vale"}
+            self._fetchall = [
+                {"id": entity_id, "name": names.get(entity_id, f"Entity {entity_id}")}
+                for entity_id in params[0]
+            ]
         elif "INSERT INTO orrery_resolutions" in normalized:
             self._fetchone = None if self.duplicate_resolution else {"id": 10}
         elif "UPDATE characters SET current_activity" in normalized:
@@ -68,8 +72,14 @@ class RecordingCursor:
             self._fetchone = {"current_location": 99}
         elif "INSERT INTO world_events" in normalized:
             self._fetchone = {"id": 20}
-        elif "SELECT et.id FROM entity_tags" in normalized:
+        elif "SELECT et.id FROM entity_tags et JOIN tags t" in normalized:
             self._fetchall = [{"id": tag_id} for tag_id in self.clear_tag_ids]
+        elif "SELECT et.id FROM entity_tags et WHERE" in normalized:
+            entity_id, tag_id = params
+            tags_by_id = {value: key for key, value in self.known_tags.items()}
+            tag = tags_by_id[tag_id]
+            if (entity_id, tag) in self.current_tags:
+                self._fetchall = [{"id": tag_id + 1000}]
 
     def fetchone(self):
         return self._fetchone
@@ -260,3 +270,59 @@ def test_commit_orrery_tick_skips_duplicate_active_tag_insert() -> None:
 
     assert result.tag_mutation_count == 0
     assert "ON CONFLICT DO NOTHING" in statements
+
+
+def test_commit_orrery_tick_applies_target_tag_deltas() -> None:
+    """Multi-slot packages can mutate actor and target tag state explicitly."""
+
+    draft = OrreryResolutionDraft(
+        template_id="extract_vengeance",
+        priority=90,
+        binding_hash="vengeance-1",
+        bindings={"actor": 1, "target": 2},
+        branch_label="Surface a reputation attack",
+        narrative_stub="{actor} compromises {target}'s reputation.",
+        state_delta={
+            "character.current_activity": "running a reputation attack",
+            "entity_tags.add": ["off_grid"],
+            "entity_tags_target.add": ["reputation_compromised"],
+            "entity_tags_target.remove": ["grudge_active"],
+        },
+        event_type="retaliation_attempted",
+        changed_fields=("character.current_activity", "entity_tags"),
+        magnitude=0.58,
+    )
+    proposal = OrreryTickProposal(
+        anchor_chunk_id=99,
+        actor_count=1,
+        resolutions=(draft,),
+        generated_at="2073-10-31T18:00:00+00:00",
+    )
+    cursor = RecordingCursor(
+        known_tags={
+            "off_grid": 77,
+            "reputation_compromised": 78,
+            "grudge_active": 79,
+        },
+        current_tags={(2, "grudge_active")},
+    )
+
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        proposal,
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+    event_params = next(
+        params for sql, params in cursor.executed if "INSERT INTO world_events" in sql
+    )
+
+    assert result.resolution_count == 1
+    assert result.event_count == 1
+    assert result.tag_mutation_count == 3
+    assert "VALUES (%s, 'target', %s)" in statements
+    assert "mechanism, justification, source_chunk_id" in statements
+    assert event_params[3] == 2

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -6,7 +6,16 @@ import pytest
 
 from nexus.agents.lore.utils.turn_context import TurnContext
 from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
-from nexus.agents.orrery.resolver import resolve_dry_run
+from nexus.agents.orrery.resolver import (
+    compose_actor_target_bindings,
+    resolve_dry_run,
+)
+from nexus.agents.orrery.substrate import (
+    ALWAYS,
+    Branch,
+    Slot,
+    Template,
+)
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 
 
@@ -43,6 +52,7 @@ class FakeSession:
         event_actor_rows=None,
         ephemeral_actor_rows=None,
         present_actor_rows=None,
+        actor_target_relationship_rows=None,
         world_time=None,
         weather="",
         max_chunk_id=100,
@@ -62,6 +72,7 @@ class FakeSession:
         self.event_actor_rows = event_actor_rows or []
         self.ephemeral_actor_rows = ephemeral_actor_rows or []
         self.present_actor_rows = present_actor_rows or []
+        self.actor_target_relationship_rows = actor_target_relationship_rows or []
         self.world_time = world_time or datetime(2073, 10, 31, 12, tzinfo=timezone.utc)
         self.weather = weather
         self.max_chunk_id = max_chunk_id
@@ -101,6 +112,9 @@ class FakeSession:
             return FakeResult(self.ephemeral_actor_rows)
         if "/* orrery:present_actor_ids_at_anchor */" in sql:
             return FakeResult(self.present_actor_rows)
+        if "/* orrery:actor_target_bindings_character_relationships */" in sql:
+            assert "relationship_scope = 'character'" in sql
+            return FakeResult(self.actor_target_relationship_rows)
         if "/* orrery:anchor_world_time */" in sql:
             return FakeResult([{"world_time": self.world_time}])
         if "/* orrery:seed_weather */" in sql:
@@ -316,3 +330,140 @@ async def test_resolve_orrery_uses_same_session_for_anchor_fallback() -> None:
     assert session.max_id_queries == 1
     assert context.orrery_proposal is not None
     assert context.orrery_proposal.anchor_chunk_id == 101
+
+
+def test_compose_actor_target_bindings_is_empty_without_relationships() -> None:
+    """No stored relationships ⇒ no actor-target pairs to evaluate."""
+
+    bindings = compose_actor_target_bindings(
+        FakeSession(),
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert bindings == ()
+
+
+def test_compose_actor_target_bindings_yields_both_directions() -> None:
+    """Each stored relationship row yields forward + reverse bindings.
+
+    The actor side filter restricts pairs to actors in the recently-relevant
+    set; both directions are emitted so symmetric templates can fire under
+    either ordering and asymmetric templates can role-invert via OR clauses.
+    """
+
+    session = FakeSession(
+        chunk_ref_actor_rows=[{"entity_id": 1}, {"entity_id": 2}],
+        actor_target_relationship_rows=[
+            {"source_entity_id": 1, "target_entity_id": 2},
+        ],
+    )
+
+    bindings = compose_actor_target_bindings(
+        session,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    pairs = {(b[Slot.ACTOR], b[Slot.TARGET]) for b in bindings}
+    assert pairs == {(1, 2), (2, 1)}
+
+
+def test_compose_actor_target_bindings_filters_to_recently_relevant_actors() -> None:
+    """A pair (X, Y) emits only when X is in the recently-relevant actor set.
+
+    The bidirectional emission in test_compose_actor_target_bindings_
+    yields_both_directions requires BOTH actors to be in the set; here only
+    actor 1 is, so only the (1, 2) direction emits and the (3, 4) pair is
+    fully skipped.
+    """
+
+    session = FakeSession(
+        chunk_ref_actor_rows=[{"entity_id": 1}],
+        actor_target_relationship_rows=[
+            {"source_entity_id": 1, "target_entity_id": 2},
+            {"source_entity_id": 3, "target_entity_id": 4},
+        ],
+    )
+
+    bindings = compose_actor_target_bindings(
+        session,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    pairs = {(b[Slot.ACTOR], b[Slot.TARGET]) for b in bindings}
+    assert pairs == {(1, 2)}
+
+
+def test_resolve_dry_run_rejects_unsupported_slot_signatures() -> None:
+    """Templates with non-(ACTOR,)/non-(ACTOR,TARGET) slot tuples fail loud."""
+
+    weird_template = Template(
+        id="weird",
+        priority=1,
+        blurb="declares an unsupported slot signature",
+        required_slots=(Slot.ACTOR, Slot.FACTION),
+        package_gate=ALWAYS,
+        branches=(Branch("fallback", ALWAYS, "{actor} acts."),),
+    )
+
+    with pytest.raises(ValueError, match="required_slots"):
+        resolve_dry_run(
+            FakeSession(),
+            [weird_template],
+            anchor_chunk_id=100,
+            window_chunks=30,
+        )
+
+
+def test_resolve_dry_run_produces_multi_slot_resolution() -> None:
+    """A multi-slot template fires when its hydrated state + bindings line up.
+
+    Builds a FakeSession that produces a single character→character
+    relationship plus the ephemeral tag and event needed to satisfy
+    PROTECT_KIN's gate. The reverse binding fires the intervene branch.
+    """
+
+    session = FakeSession(
+        chunk_ref_actor_rows=[{"entity_id": 1}, {"entity_id": 2}],
+        location_rows=[
+            {"entity_id": 1, "current_location": 10},
+            {"entity_id": 2, "current_location": 10},
+        ],
+        location_class_rows=[{"id": 10, "location_class": "the_glow"}],
+        activity_rows=[],
+        tag_rows=[
+            {"entity_id": 2, "tag": "under_active_pursuit", "is_ephemeral": True},
+        ],
+        relationship_rows=[
+            {
+                "source_entity_id": 1,
+                "target_entity_id": 2,
+                "relationship_type": "family",
+            },
+        ],
+        actor_target_relationship_rows=[
+            {"source_entity_id": 1, "target_entity_id": 2},
+        ],
+        ephemeral_actor_rows=[{"entity_id": 2}],
+    )
+
+    proposal = resolve_dry_run(
+        session,
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    protect_kin_drafts = [
+        draft for draft in proposal.resolutions if draft.template_id == "protect_kin"
+    ]
+    assert protect_kin_drafts, (
+        "PROTECT_KIN expected to fire under the constructed hydrated state; "
+        f"got resolutions for {[d.template_id for d in proposal.resolutions]}"
+    )
+    assert protect_kin_drafts[0].branch_label == (
+        "Physically intervene at the target's location"
+    )
+    assert protect_kin_drafts[0].bindings == {"actor": 1, "target": 2}

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -396,6 +396,28 @@ def test_compose_actor_target_bindings_filters_to_recently_relevant_actors() -> 
     assert pairs == {(1, 2)}
 
 
+def test_compose_actor_target_bindings_excludes_anchor_present_targets() -> None:
+    """Multi-slot packages do not drive actors currently owned by storyteller."""
+
+    session = FakeSession(
+        chunk_ref_actor_rows=[{"entity_id": 1}, {"entity_id": 2}],
+        present_actor_rows=[{"entity_id": 2}],
+        actor_target_relationship_rows=[
+            {"source_entity_id": 1, "target_entity_id": 2},
+            {"source_entity_id": 1, "target_entity_id": 3},
+        ],
+    )
+
+    bindings = compose_actor_target_bindings(
+        session,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    pairs = {(b[Slot.ACTOR], b[Slot.TARGET]) for b in bindings}
+    assert pairs == {(1, 3)}
+
+
 def test_resolve_dry_run_rejects_unsupported_slot_signatures() -> None:
     """Templates with non-(ACTOR,)/non-(ACTOR,TARGET) slot tuples fail loud."""
 

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -102,6 +102,44 @@ def test_has_symmetric_relationship_of_type_matches_either_direction() -> None:
     assert not predicate(empty_state, bindings)
 
 
+def test_since_last_event_at_least_target_slot_scopes_cooldown() -> None:
+    """When target_slot is given, the cooldown is per-(actor, target) pair.
+
+    Models the CULTIVATE_INFORMANT case: handler A contacting informant B
+    must not block A from contacting informant C in the same window.
+    """
+
+    from nexus.agents.orrery.substrate import EventRecord
+
+    state = WorldState(
+        recent_events=(
+            EventRecord(
+                event_type="informant_contact",
+                tick=9,
+                actor_entity_id=1,
+                target_entity_id=2,
+            ),
+        ),
+        current_tick=10,
+    )
+
+    actor_global = since_last_event_at_least("informant_contact", 5)
+    per_target = since_last_event_at_least(
+        "informant_contact",
+        5,
+        target_slot=Slot.TARGET,
+    )
+
+    # Actor-global: the recent contact resets the cooldown regardless of
+    # which target the binding names.
+    assert not actor_global(state, {Slot.ACTOR: 1, Slot.TARGET: 2})
+    assert not actor_global(state, {Slot.ACTOR: 1, Slot.TARGET: 3})
+
+    # Per-target: only the same (actor, target) pair sees the cooldown.
+    assert not per_target(state, {Slot.ACTOR: 1, Slot.TARGET: 2})
+    assert per_target(state, {Slot.ACTOR: 1, Slot.TARGET: 3})
+
+
 def test_targeted_events_fire_builtin_package_gates() -> None:
     """Built-ins that react to incoming events use target-role matching."""
 

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -12,6 +12,7 @@ from nexus.agents.orrery.substrate import (
     binding_hash,
     count_co_located,
     evaluate_stack,
+    has_symmetric_relationship_of_type,
     recent_event,
     since_last_event_at_least,
     validate_always_fallbacks,
@@ -54,6 +55,21 @@ def test_missing_always_fallback_is_rejected() -> None:
         ("fragment", "pursue_ghost_lead", "Recon a hideout their body remembers"),
         ("debt", "honor_debt", "Fulfill obligation through a dead-drop"),
         ("quiet", "maintain_cover", "Run a low-level courier job"),
+        (
+            "vengeance",
+            "extract_vengeance",
+            "Strike directly when opportunity opens",
+        ),
+        (
+            "kin_danger",
+            "protect_kin",
+            "Physically intervene at the target's location",
+        ),
+        (
+            "informant",
+            "cultivate_informant",
+            "Routine contact to maintain the relationship",
+        ),
     ],
 )
 def test_demo_presets_fire_expected_package(
@@ -66,6 +82,24 @@ def test_demo_presets_fire_expected_package(
     assert result["fired"] is True
     assert result["template_id"] == template_id
     assert result["branch_label"] == branch_label
+
+
+def test_has_symmetric_relationship_of_type_matches_either_direction() -> None:
+    """Symmetric helper finds a typed relationship regardless of stored order."""
+
+    forward_state = WorldState(
+        relationship_types={(1, 2): frozenset({"family"})},
+    )
+    reverse_state = WorldState(
+        relationship_types={(2, 1): frozenset({"family"})},
+    )
+    empty_state = WorldState()
+    predicate = has_symmetric_relationship_of_type("family")
+    bindings = {Slot.ACTOR: 1, Slot.TARGET: 2}
+
+    assert predicate(forward_state, bindings)
+    assert predicate(reverse_state, bindings)
+    assert not predicate(empty_state, bindings)
 
 
 def test_targeted_events_fire_builtin_package_gates() -> None:


### PR DESCRIPTION
## Summary

- Adds three multi-slot behavior templates (`EXTRACT_VENGEANCE`, `PROTECT_KIN`, `CULTIVATE_INFORMANT`) authored by a frontier-model conversation partner during the Orrery design phase (`temp/orrery/orrery_package_contributions.md`); integrated here with deliberate divergences documented inline in `templates.py`
- Extends `nexus/agents/orrery/resolver.py` with `compose_actor_target_bindings` (yields actor-target pairs from each actor's relational neighborhood) plus a dispatcher that partitions templates by `required_slots`
- Adds `has_symmetric_relationship_of_type` substrate helper for templates whose relationships are semantically symmetric (`family` / `romantic` / `chosen_kin` / `comrade` / `enemy` / `rival`); `CULTIVATE_INFORMANT` keeps explicit role-inversion (`has_relationship_of_type` with directional slots) for asymmetric `handler` / `asset`
- Migration `025_orrery_package_library_vocab.py` seeds 11 tags (4 durable identity, 7 ephemeral state), 6 event_types, and 4 new `relationship_type` enum values (`chosen_kin`, `comrade`, `handler`, `asset`)
- 3 new demo presets (`vengeance`, `kin_danger`, `informant`) exercise the templates' highest-magnitude branches in `nexus.agents.orrery.demo`

## Deliberate divergences from the contribution draft

- Substituted `lover` with `romantic` (already in enum; semantically broader)
- Cross-actor `state_delta` keys (`entity_tags_target.add/remove`) preserved verbatim from the draft as a contract for PR 3's `CommitOrreryTick` writer

## Coordination with the in-flight PR 3 work

Codex's branch `feature/orrery-commit-pipeline` (not yet pushed/PR'd at time of writing) claims migration number `024` (`024_orrery_commit_pipeline.sql`) and seeds vocabulary for the **existing** four built-in templates plus an `incubator.orrery_proposal` JSONB column. My migration was originally also `024_*` but I renumbered to `025_*` so the two land cleanly when both PRs merge. Vocabulary is fully disjoint between the two migrations.

## Verification

- [x] `poetry run pytest tests/test_orrery` — 32 passed
- [x] `poetry run pytest tests/test_orrery tests/test_lore/test_turn_cycle.py tests/test_lore/test_context_validation.py tests/config tests/test_api` — 73 passed, 1 skipped
- [x] `poetry run black --check nexus/agents/orrery/ tests/test_orrery/ migrations/025_orrery_package_library_vocab.py` — clean (after format pass)
- [x] `poetry run python -m nexus.agents.orrery.demo --preset vengeance` → `extract_vengeance` / "Strike directly when opportunity opens" / mag 0.85
- [x] `poetry run python -m nexus.agents.orrery.demo --preset kin_danger` → `protect_kin` / "Physically intervene at the target's location" / mag 0.78
- [x] `poetry run python -m nexus.agents.orrery.demo --preset informant` → `cultivate_informant` / "Routine contact to maintain the relationship" / mag 0.28
- [x] Migration applied to `NEXUS_template` + `save_02` / `save_03` / `save_04` / `save_05` (`save_01` locked, skipped per slot organization)
- [x] Live dry-run against slot 5: 2 actor-only bindings, 0 actor-target pairs (no `character_relationships` rows yet in this small slot), 2 `maintain_cover` fallback resolutions, **zero new-template firings** — expected, since the new templates' gates require ephemeral state that PR 3's `CommitOrreryTick` will start writing

## Test plan

- [ ] Re-run `pytest tests/test_orrery` from a fresh checkout
- [ ] Confirm migration 025 applies idempotently (re-running `migrate.py --all` is a no-op)
- [ ] Confirm `BUILTIN_TEMPLATES` is now 7 templates (4 actor-only + 3 actor-target) and `validate_always_fallbacks` passes
- [ ] Run the three new demo presets and confirm template + branch + magnitude match the verification table above
- [ ] After PR 3 lands and starts seeding ephemeral tags onto entities in test scenarios, the new templates should begin firing in production dry-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)