### PR TITLE
Add Orrery commit pipeline

### DIFF
--- a/migrations/023_orrery_schema.py
+++ b/migrations/023_orrery_schema.py
@@ -508,7 +508,7 @@ def _create_tag_schema(conn) -> None:
             UNIQUE (entity_id, tag_id, applied_at)
         );
 
-        CREATE INDEX IF NOT EXISTS ix_entity_tags_current
+        CREATE UNIQUE INDEX IF NOT EXISTS ix_entity_tags_current
             ON entity_tags (entity_id, tag_id)
             WHERE cleared_at IS NULL;
 

--- a/migrations/024_orrery_commit_pipeline.sql
+++ b/migrations/024_orrery_commit_pipeline.sql
@@ -9,6 +9,11 @@ ADD COLUMN IF NOT EXISTS orrery_proposal JSONB;
 COMMENT ON COLUMN incubator.orrery_proposal IS
     'No-write OrreryTickProposal generated during preview; stamped into canonical Orrery tables only when the incubator chunk is accepted.';
 
+DROP INDEX IF EXISTS ix_entity_tags_current;
+CREATE UNIQUE INDEX ix_entity_tags_current
+    ON entity_tags (entity_id, tag_id)
+    WHERE cleared_at IS NULL;
+
 DROP VIEW IF EXISTS incubator_view;
 CREATE VIEW incubator_view AS
 SELECT

--- a/migrations/024_orrery_commit_pipeline.sql
+++ b/migrations/024_orrery_commit_pipeline.sql
@@ -1,0 +1,107 @@
+-- 024_orrery_commit_pipeline.sql
+--
+-- Persist the dry-run Orrery proposal across the preview/approval boundary and
+-- seed the controlled vocabulary required by the initial built-in packages.
+
+ALTER TABLE incubator
+ADD COLUMN IF NOT EXISTS orrery_proposal JSONB;
+
+COMMENT ON COLUMN incubator.orrery_proposal IS
+    'No-write OrreryTickProposal generated during preview; stamped into canonical Orrery tables only when the incubator chunk is accepted.';
+
+DROP VIEW IF EXISTS incubator_view;
+CREATE VIEW incubator_view AS
+SELECT
+    i.chunk_id,
+    i.parent_chunk_id,
+    nc.raw_text AS parent_chunk_text,
+    i.user_text,
+    i.storyteller_text,
+    i.choice_object,
+    i.choice_text,
+    i.orrery_proposal,
+    i.metadata_updates -> 'chronology' ->> 'episode_transition' AS episode_transition,
+    i.metadata_updates -> 'chronology' ->> 'time_delta_description' AS time_delta,
+    i.metadata_updates ->> 'world_layer' AS world_layer,
+    i.metadata_updates ->> 'pacing' AS pacing,
+    COALESCE(jsonb_array_length(i.entity_updates -> 'characters'), 0)
+        + COALESCE(jsonb_array_length(i.entity_updates -> 'locations'), 0)
+        + COALESCE(jsonb_array_length(i.entity_updates -> 'factions'), 0)
+        AS entity_update_count,
+    i.entity_updates AS entity_changes,
+    i.reference_updates AS "references",
+    i.status,
+    i.session_id,
+    i.created_at
+FROM incubator i
+LEFT JOIN narrative_chunks nc ON nc.id = i.parent_chunk_id
+WHERE i.id = TRUE;
+
+INSERT INTO event_types (type, category, severity, description)
+VALUES
+    ('evade_pursuit', 'orrery_resolution', 'moderate', 'An off-screen character evades active pursuit.'),
+    ('honor_debt', 'orrery_resolution', 'moderate', 'An off-screen character services a binding obligation.'),
+    ('pursue_identity_lead', 'orrery_resolution', 'moderate', 'An off-screen character follows a lead about buried identity.'),
+    ('maintain_cover', 'orrery_resolution', 'minor', 'An off-screen character maintains plausible baseline activity.')
+ON CONFLICT (type) DO NOTHING;
+
+INSERT INTO tags (
+    tag, category, is_ephemeral, clearance_kind, reapplication_policy,
+    clear_on, description
+)
+VALUES
+    (
+        'contacts_available',
+        'orrery_state',
+        false,
+        NULL,
+        NULL,
+        NULL,
+        'Entity has contacts that can plausibly support off-screen action.'
+    ),
+    (
+        'ghostprint_active',
+        'orrery_state',
+        false,
+        NULL,
+        NULL,
+        NULL,
+        'Entity has access to an active Ghostprint Key or equivalent identity artifact.'
+    ),
+    (
+        'off_grid',
+        'orrery_state',
+        false,
+        NULL,
+        NULL,
+        NULL,
+        'Entity has temporarily reduced their observable footprint.'
+    ),
+    (
+        'seeking_identity',
+        'orrery_state',
+        false,
+        NULL,
+        NULL,
+        NULL,
+        'Entity is actively trying to reconstruct or pursue buried identity leads.'
+    ),
+    (
+        'debt_pulse_active',
+        'orrery_signal',
+        true,
+        'event',
+        'replace',
+        '{"event_types": ["honor_debt"]}'::jsonb,
+        'Ephemeral signal that a binding obligation is currently pressing.'
+    ),
+    (
+        'under_active_pursuit',
+        'orrery_signal',
+        true,
+        'event',
+        'replace',
+        '{"event_types": ["evade_pursuit"]}'::jsonb,
+        'Ephemeral signal that an entity is being actively pursued.'
+    )
+ON CONFLICT (tag) DO NOTHING;

--- a/nexus/agents/orrery/__init__.py
+++ b/nexus/agents/orrery/__init__.py
@@ -19,6 +19,7 @@ from nexus.agents.orrery.substrate import (
     validate_always_fallbacks,
 )
 from nexus.agents.orrery.resolver import OrreryResolutionDraft, OrreryTickProposal
+from nexus.agents.orrery.events import CommitOrreryTickResult
 
 __all__ = [
     "ALWAYS",
@@ -34,6 +35,7 @@ __all__ = [
     "Slot",
     "Template",
     "WorldState",
+    "CommitOrreryTickResult",
     "OrreryResolutionDraft",
     "OrreryTickProposal",
     "evaluate",

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -1,0 +1,795 @@
+"""Canonical Orrery event writer.
+
+The resolver is allowed to compute proposals during preview. This module is the
+only place that materializes those proposals into canonical Orrery tables.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+import json
+from typing import Any, Mapping, Optional
+
+from nexus.agents.orrery.resolver import (
+    OrreryResolutionDraft,
+    OrreryTickProposal,
+)
+
+
+ENTITY_BINDING_SLOTS = frozenset({"actor", "target", "targets", "faction"})
+SUPPORTED_STATE_DELTA_KEYS = frozenset(
+    {
+        "character.current_activity",
+        "entity_tags.add",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CommitOrreryTickResult:
+    """Summary of a canonical Orrery commit."""
+
+    resolution_count: int = 0
+    event_count: int = 0
+    tag_mutation_count: int = 0
+    cleared_tag_count: int = 0
+    skipped_existing_count: int = 0
+
+
+def coerce_proposal(proposal: Any) -> Optional[OrreryTickProposal]:
+    """Coerce incubator JSONB data into an Orrery proposal."""
+
+    if proposal is None:
+        return None
+    if isinstance(proposal, OrreryTickProposal):
+        return proposal
+    if isinstance(proposal, str):
+        proposal = json.loads(proposal)
+    if isinstance(proposal, Mapping):
+        return OrreryTickProposal.from_dict(proposal)
+    raise TypeError(f"Unsupported Orrery proposal payload: {type(proposal).__name__}")
+
+
+def commit_orrery_tick_sync(
+    conn: Any,
+    proposal: Any,
+    *,
+    tick_chunk_id: int,
+    slot: Optional[int] = None,
+    world_layer: Optional[str] = "primary",
+) -> CommitOrreryTickResult:
+    """Materialize a preview proposal inside the accepted-chunk transaction."""
+
+    coerced = coerce_proposal(proposal)
+    if coerced is None or not coerced.resolutions:
+        return CommitOrreryTickResult()
+
+    _validate_proposal(coerced)
+    with conn.cursor() as cur:
+        entity_ids = _entity_ids_from_proposal(coerced)
+        _validate_entity_ids_sync(cur, entity_ids)
+        entity_names = _entity_names_sync(cur, entity_ids)
+
+        resolution_count = 0
+        event_count = 0
+        tag_mutation_count = 0
+        cleared_tag_count = 0
+        skipped_existing_count = 0
+
+        for draft in coerced.resolutions:
+            actor_entity_id = _scalar_entity_binding(draft.bindings, "actor")
+            brief = _render_brief(draft, entity_names)
+            resolution_id = _insert_resolution_sync(
+                cur,
+                draft,
+                tick_chunk_id=tick_chunk_id,
+                actor_entity_id=actor_entity_id,
+                brief=brief,
+            )
+            if resolution_id is None:
+                skipped_existing_count += 1
+                continue
+
+            resolution_count += 1
+            tag_mutation_count += _apply_state_delta_sync(
+                cur,
+                draft,
+                actor_entity_id=actor_entity_id,
+            )
+            event_id = _emit_world_event_sync(
+                cur,
+                draft,
+                tick_chunk_id=tick_chunk_id,
+                resolution_id=resolution_id,
+                actor_entity_id=actor_entity_id,
+                world_layer=world_layer,
+            )
+            if event_id is not None:
+                event_count += 1
+                _update_resolution_events_sync(cur, resolution_id, [event_id])
+                if actor_entity_id is not None:
+                    cleared_tag_count += _clear_event_tags_sync(
+                        cur,
+                        entity_id=actor_entity_id,
+                        event_type=str(draft.event_type),
+                        triggering_event_id=event_id,
+                        source_chunk_id=tick_chunk_id,
+                    )
+
+    return CommitOrreryTickResult(
+        resolution_count=resolution_count,
+        event_count=event_count,
+        tag_mutation_count=tag_mutation_count,
+        cleared_tag_count=cleared_tag_count,
+        skipped_existing_count=skipped_existing_count,
+    )
+
+
+async def commit_orrery_tick_async(
+    conn: Any,
+    proposal: Any,
+    *,
+    tick_chunk_id: int,
+    slot: Optional[int] = None,
+    world_layer: Optional[str] = "primary",
+) -> CommitOrreryTickResult:
+    """Async parity wrapper for tests and non-production commit callers."""
+
+    coerced = coerce_proposal(proposal)
+    if coerced is None or not coerced.resolutions:
+        return CommitOrreryTickResult()
+
+    _validate_proposal(coerced)
+    entity_ids = _entity_ids_from_proposal(coerced)
+    await _validate_entity_ids_async(conn, entity_ids)
+    entity_names = await _entity_names_async(conn, entity_ids)
+
+    resolution_count = 0
+    event_count = 0
+    tag_mutation_count = 0
+    cleared_tag_count = 0
+    skipped_existing_count = 0
+
+    for draft in coerced.resolutions:
+        actor_entity_id = _scalar_entity_binding(draft.bindings, "actor")
+        brief = _render_brief(draft, entity_names)
+        resolution_id = await _insert_resolution_async(
+            conn,
+            draft,
+            tick_chunk_id=tick_chunk_id,
+            actor_entity_id=actor_entity_id,
+            brief=brief,
+        )
+        if resolution_id is None:
+            skipped_existing_count += 1
+            continue
+
+        resolution_count += 1
+        tag_mutation_count += await _apply_state_delta_async(
+            conn,
+            draft,
+            actor_entity_id=actor_entity_id,
+        )
+        event_id = await _emit_world_event_async(
+            conn,
+            draft,
+            tick_chunk_id=tick_chunk_id,
+            resolution_id=resolution_id,
+            actor_entity_id=actor_entity_id,
+            world_layer=world_layer,
+        )
+        if event_id is not None:
+            event_count += 1
+            await _update_resolution_events_async(conn, resolution_id, [event_id])
+            if actor_entity_id is not None:
+                cleared_tag_count += await _clear_event_tags_async(
+                    conn,
+                    entity_id=actor_entity_id,
+                    event_type=str(draft.event_type),
+                    triggering_event_id=event_id,
+                    source_chunk_id=tick_chunk_id,
+                )
+
+    return CommitOrreryTickResult(
+        resolution_count=resolution_count,
+        event_count=event_count,
+        tag_mutation_count=tag_mutation_count,
+        cleared_tag_count=cleared_tag_count,
+        skipped_existing_count=skipped_existing_count,
+    )
+
+
+def _validate_proposal(proposal: OrreryTickProposal) -> None:
+    for draft in proposal.resolutions:
+        unsupported = set(draft.state_delta) - SUPPORTED_STATE_DELTA_KEYS
+        if unsupported:
+            raise ValueError(
+                "Unsupported Orrery state_delta keys for "
+                f"{draft.template_id}: {', '.join(sorted(unsupported))}"
+            )
+
+
+def _entity_ids_from_proposal(proposal: OrreryTickProposal) -> set[int]:
+    entity_ids: set[int] = set()
+    for draft in proposal.resolutions:
+        for slot, value in draft.bindings.items():
+            if slot not in ENTITY_BINDING_SLOTS:
+                continue
+            if (
+                slot == "targets"
+                and isinstance(value, Iterable)
+                and not isinstance(value, (str, bytes))
+            ):
+                entity_ids.update(
+                    _coerce_int(item, label=f"{slot} binding") for item in value
+                )
+            elif value is not None:
+                entity_ids.add(_coerce_int(value, label=f"{slot} binding"))
+    return entity_ids
+
+
+def _validate_entity_ids_sync(cur: Any, entity_ids: set[int]) -> None:
+    if not entity_ids:
+        return
+    cur.execute(
+        "SELECT id FROM entities WHERE id = ANY(%s)",
+        (sorted(entity_ids),),
+    )
+    found = {_row_get(row, "id", 0) for row in cur.fetchall()}
+    missing = entity_ids - found
+    if missing:
+        raise ValueError(
+            f"Orrery proposal references missing entities: {sorted(missing)}"
+        )
+
+
+async def _validate_entity_ids_async(conn: Any, entity_ids: set[int]) -> None:
+    if not entity_ids:
+        return
+    rows = await conn.fetch(
+        "SELECT id FROM entities WHERE id = ANY($1::bigint[])",
+        sorted(entity_ids),
+    )
+    found = {_row_get(row, "id", 0) for row in rows}
+    missing = entity_ids - found
+    if missing:
+        raise ValueError(
+            f"Orrery proposal references missing entities: {sorted(missing)}"
+        )
+
+
+def _entity_names_sync(cur: Any, entity_ids: set[int]) -> dict[int, str]:
+    if not entity_ids:
+        return {}
+    cur.execute(
+        "SELECT id, name FROM entity_names_v WHERE id = ANY(%s)",
+        (sorted(entity_ids),),
+    )
+    return {_row_get(row, "id", 0): _row_get(row, "name", 1) for row in cur.fetchall()}
+
+
+async def _entity_names_async(conn: Any, entity_ids: set[int]) -> dict[int, str]:
+    if not entity_ids:
+        return {}
+    rows = await conn.fetch(
+        "SELECT id, name FROM entity_names_v WHERE id = ANY($1::bigint[])",
+        sorted(entity_ids),
+    )
+    return {_row_get(row, "id", 0): _row_get(row, "name", 1) for row in rows}
+
+
+def _render_brief(draft: OrreryResolutionDraft, entity_names: Mapping[int, str]) -> str:
+    values: dict[str, str] = {}
+    for slot, value in draft.bindings.items():
+        if isinstance(value, list):
+            values[slot] = ", ".join(
+                _entity_label(item, entity_names) for item in value
+            )
+        else:
+            values[slot] = _entity_label(value, entity_names)
+    rendered = draft.narrative_stub.format(**values)
+    return " ".join(rendered.split())
+
+
+def _entity_label(value: Any, entity_names: Mapping[int, str]) -> str:
+    if value is None:
+        return "unknown"
+    try:
+        entity_id = int(value)
+    except (TypeError, ValueError):
+        return str(value)
+    return entity_names.get(entity_id, f"entity {entity_id}")
+
+
+def _insert_resolution_sync(
+    cur: Any,
+    draft: OrreryResolutionDraft,
+    *,
+    tick_chunk_id: int,
+    actor_entity_id: Optional[int],
+    brief: str,
+) -> Optional[int]:
+    cur.execute(
+        """
+        INSERT INTO orrery_resolutions (
+            tick_chunk_id, template_id, binding_hash, actor_entity_id,
+            priority, magnitude, state_delta, brief
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s)
+        ON CONFLICT (tick_chunk_id, template_id, binding_hash) DO NOTHING
+        RETURNING id
+        """,
+        (
+            tick_chunk_id,
+            draft.template_id,
+            draft.binding_hash,
+            actor_entity_id,
+            draft.priority,
+            draft.magnitude,
+            json.dumps(draft.state_delta),
+            brief,
+        ),
+    )
+    row = cur.fetchone()
+    if not row:
+        return None
+    return _row_get(row, "id", 0)
+
+
+async def _insert_resolution_async(
+    conn: Any,
+    draft: OrreryResolutionDraft,
+    *,
+    tick_chunk_id: int,
+    actor_entity_id: Optional[int],
+    brief: str,
+) -> Optional[int]:
+    return await conn.fetchval(
+        """
+        INSERT INTO orrery_resolutions (
+            tick_chunk_id, template_id, binding_hash, actor_entity_id,
+            priority, magnitude, state_delta, brief
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+        ON CONFLICT (tick_chunk_id, template_id, binding_hash) DO NOTHING
+        RETURNING id
+        """,
+        tick_chunk_id,
+        draft.template_id,
+        draft.binding_hash,
+        actor_entity_id,
+        draft.priority,
+        draft.magnitude,
+        json.dumps(draft.state_delta),
+        brief,
+    )
+
+
+def _apply_state_delta_sync(
+    cur: Any,
+    draft: OrreryResolutionDraft,
+    *,
+    actor_entity_id: Optional[int],
+) -> int:
+    if not draft.state_delta:
+        return 0
+    if actor_entity_id is None:
+        raise ValueError(f"Orrery draft {draft.template_id} has no actor binding")
+
+    tag_mutations = 0
+    if "character.current_activity" in draft.state_delta:
+        cur.execute(
+            "UPDATE characters SET current_activity = %s WHERE entity_id = %s",
+            (draft.state_delta["character.current_activity"], actor_entity_id),
+        )
+        if getattr(cur, "rowcount", 1) == 0:
+            raise ValueError(
+                f"Orrery actor entity {actor_entity_id} has no character row"
+            )
+
+    for tag in draft.state_delta.get("entity_tags.add", ()) or ():
+        if _add_entity_tag_sync(cur, actor_entity_id, str(tag), draft.template_id):
+            tag_mutations += 1
+    return tag_mutations
+
+
+async def _apply_state_delta_async(
+    conn: Any,
+    draft: OrreryResolutionDraft,
+    *,
+    actor_entity_id: Optional[int],
+) -> int:
+    if not draft.state_delta:
+        return 0
+    if actor_entity_id is None:
+        raise ValueError(f"Orrery draft {draft.template_id} has no actor binding")
+
+    tag_mutations = 0
+    if "character.current_activity" in draft.state_delta:
+        status = await conn.execute(
+            "UPDATE characters SET current_activity = $1 WHERE entity_id = $2",
+            draft.state_delta["character.current_activity"],
+            actor_entity_id,
+        )
+        if _affected_count(status) == 0:
+            raise ValueError(
+                f"Orrery actor entity {actor_entity_id} has no character row"
+            )
+
+    for tag in draft.state_delta.get("entity_tags.add", ()) or ():
+        if await _add_entity_tag_async(
+            conn, actor_entity_id, str(tag), draft.template_id
+        ):
+            tag_mutations += 1
+    return tag_mutations
+
+
+def _add_entity_tag_sync(
+    cur: Any,
+    entity_id: int,
+    tag: str,
+    template_id: str,
+) -> bool:
+    cur.execute(
+        """
+        SELECT id
+        FROM tags
+        WHERE tag = %s
+          AND deprecated = false
+          AND synonym_for IS NULL
+        """,
+        (tag,),
+    )
+    row = cur.fetchone()
+    if not row:
+        raise ValueError(f"Orrery tag {tag!r} is not registered")
+    tag_id = _row_get(row, "id", 0)
+
+    cur.execute(
+        """
+        SELECT 1
+        FROM entity_tags_current
+        WHERE entity_id = %s
+          AND tag = %s
+        """,
+        (entity_id, tag),
+    )
+    if cur.fetchone():
+        return False
+
+    cur.execute(
+        """
+        INSERT INTO entity_tags (entity_id, tag_id, template_id, source_kind)
+        VALUES (%s, %s, %s, 'template')
+        """,
+        (entity_id, tag_id, template_id),
+    )
+    return True
+
+
+async def _add_entity_tag_async(
+    conn: Any,
+    entity_id: int,
+    tag: str,
+    template_id: str,
+) -> bool:
+    tag_id = await conn.fetchval(
+        """
+        SELECT id
+        FROM tags
+        WHERE tag = $1
+          AND deprecated = false
+          AND synonym_for IS NULL
+        """,
+        tag,
+    )
+    if tag_id is None:
+        raise ValueError(f"Orrery tag {tag!r} is not registered")
+
+    exists = await conn.fetchval(
+        """
+        SELECT 1
+        FROM entity_tags_current
+        WHERE entity_id = $1
+          AND tag = $2
+        """,
+        entity_id,
+        tag,
+    )
+    if exists:
+        return False
+
+    await conn.execute(
+        """
+        INSERT INTO entity_tags (entity_id, tag_id, template_id, source_kind)
+        VALUES ($1, $2, $3, 'template')
+        """,
+        entity_id,
+        tag_id,
+        template_id,
+    )
+    return True
+
+
+def _emit_world_event_sync(
+    cur: Any,
+    draft: OrreryResolutionDraft,
+    *,
+    tick_chunk_id: int,
+    resolution_id: int,
+    actor_entity_id: Optional[int],
+    world_layer: Optional[str],
+) -> Optional[int]:
+    if not draft.event_type:
+        return None
+
+    _ensure_event_type_sync(cur, draft.event_type)
+    location_id = _actor_location_sync(cur, actor_entity_id)
+    payload = {
+        "template_id": draft.template_id,
+        "binding_hash": draft.binding_hash,
+        "bindings": dict(draft.bindings),
+        "branch_label": draft.branch_label,
+        "narrative_stub": draft.narrative_stub,
+    }
+    cur.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, location_id,
+            world_layer, source, changed_fields, magnitude, resolution_id,
+            payload
+        ) VALUES (%s, %s, %s, %s, %s, 'resolver', %s, %s, %s, %s::jsonb)
+        RETURNING id
+        """,
+        (
+            draft.event_type,
+            tick_chunk_id,
+            actor_entity_id,
+            location_id,
+            world_layer,
+            list(draft.changed_fields),
+            draft.magnitude,
+            resolution_id,
+            json.dumps(payload),
+        ),
+    )
+    event_id = _row_get(cur.fetchone(), "id", 0)
+    if actor_entity_id is not None:
+        cur.execute(
+            """
+            INSERT INTO world_event_entities (event_id, role, entity_id)
+            VALUES (%s, 'actor', %s)
+            ON CONFLICT DO NOTHING
+            """,
+            (event_id, actor_entity_id),
+        )
+    return event_id
+
+
+async def _emit_world_event_async(
+    conn: Any,
+    draft: OrreryResolutionDraft,
+    *,
+    tick_chunk_id: int,
+    resolution_id: int,
+    actor_entity_id: Optional[int],
+    world_layer: Optional[str],
+) -> Optional[int]:
+    if not draft.event_type:
+        return None
+
+    await _ensure_event_type_async(conn, draft.event_type)
+    location_id = await _actor_location_async(conn, actor_entity_id)
+    payload = {
+        "template_id": draft.template_id,
+        "binding_hash": draft.binding_hash,
+        "bindings": dict(draft.bindings),
+        "branch_label": draft.branch_label,
+        "narrative_stub": draft.narrative_stub,
+    }
+    event_id = await conn.fetchval(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, location_id,
+            world_layer, source, changed_fields, magnitude, resolution_id,
+            payload
+        ) VALUES (
+            $1, $2, $3, $4, $5::world_layer_type, 'resolver',
+            $6::text[], $7, $8, $9::jsonb
+        )
+        RETURNING id
+        """,
+        draft.event_type,
+        tick_chunk_id,
+        actor_entity_id,
+        location_id,
+        world_layer,
+        list(draft.changed_fields),
+        draft.magnitude,
+        resolution_id,
+        json.dumps(payload),
+    )
+    if actor_entity_id is not None:
+        await conn.execute(
+            """
+            INSERT INTO world_event_entities (event_id, role, entity_id)
+            VALUES ($1, 'actor', $2)
+            ON CONFLICT DO NOTHING
+            """,
+            event_id,
+            actor_entity_id,
+        )
+    return event_id
+
+
+def _ensure_event_type_sync(cur: Any, event_type: str) -> None:
+    cur.execute(
+        "SELECT type FROM event_types WHERE type = %s AND deprecated = false",
+        (event_type,),
+    )
+    if not cur.fetchone():
+        raise ValueError(f"Orrery event type {event_type!r} is not registered")
+
+
+async def _ensure_event_type_async(conn: Any, event_type: str) -> None:
+    exists = await conn.fetchval(
+        "SELECT type FROM event_types WHERE type = $1 AND deprecated = false",
+        event_type,
+    )
+    if exists is None:
+        raise ValueError(f"Orrery event type {event_type!r} is not registered")
+
+
+def _actor_location_sync(cur: Any, actor_entity_id: Optional[int]) -> Optional[int]:
+    if actor_entity_id is None:
+        return None
+    cur.execute(
+        "SELECT current_location FROM characters WHERE entity_id = %s",
+        (actor_entity_id,),
+    )
+    row = cur.fetchone()
+    return _row_get(row, "current_location", 0) if row else None
+
+
+async def _actor_location_async(
+    conn: Any, actor_entity_id: Optional[int]
+) -> Optional[int]:
+    if actor_entity_id is None:
+        return None
+    return await conn.fetchval(
+        "SELECT current_location FROM characters WHERE entity_id = $1",
+        actor_entity_id,
+    )
+
+
+def _update_resolution_events_sync(
+    cur: Any, resolution_id: int, event_ids: list[int]
+) -> None:
+    cur.execute(
+        "UPDATE orrery_resolutions SET event_ids = %s WHERE id = %s",
+        (event_ids, resolution_id),
+    )
+
+
+async def _update_resolution_events_async(
+    conn: Any, resolution_id: int, event_ids: list[int]
+) -> None:
+    await conn.execute(
+        "UPDATE orrery_resolutions SET event_ids = $1::bigint[] WHERE id = $2",
+        event_ids,
+        resolution_id,
+    )
+
+
+def _clear_event_tags_sync(
+    cur: Any,
+    *,
+    entity_id: int,
+    event_type: str,
+    triggering_event_id: int,
+    source_chunk_id: int,
+) -> int:
+    cur.execute(
+        """
+        SELECT et.id
+        FROM entity_tags et
+        JOIN tags t ON t.id = et.tag_id
+        WHERE et.entity_id = %s
+          AND et.cleared_at IS NULL
+          AND t.clearance_kind = 'event'
+          AND t.clear_on IS NOT NULL
+          AND t.clear_on -> 'event_types' ? %s
+        """,
+        (entity_id, event_type),
+    )
+    tag_ids = [_row_get(row, "id", 0) for row in cur.fetchall()]
+    for entity_tag_id in tag_ids:
+        cur.execute(
+            "UPDATE entity_tags SET cleared_at = now() WHERE id = %s", (entity_tag_id,)
+        )
+        cur.execute(
+            """
+            INSERT INTO tag_clearance_log (
+                entity_tag_id, mechanism, triggering_event_id,
+                justification, source_chunk_id
+            ) VALUES (%s, 'event', %s, %s::jsonb, %s)
+            """,
+            (
+                entity_tag_id,
+                triggering_event_id,
+                json.dumps({"event_type": event_type}),
+                source_chunk_id,
+            ),
+        )
+    return len(tag_ids)
+
+
+async def _clear_event_tags_async(
+    conn: Any,
+    *,
+    entity_id: int,
+    event_type: str,
+    triggering_event_id: int,
+    source_chunk_id: int,
+) -> int:
+    rows = await conn.fetch(
+        """
+        SELECT et.id
+        FROM entity_tags et
+        JOIN tags t ON t.id = et.tag_id
+        WHERE et.entity_id = $1
+          AND et.cleared_at IS NULL
+          AND t.clearance_kind = 'event'
+          AND t.clear_on IS NOT NULL
+          AND t.clear_on -> 'event_types' ? $2
+        """,
+        entity_id,
+        event_type,
+    )
+    tag_ids = [_row_get(row, "id", 0) for row in rows]
+    for entity_tag_id in tag_ids:
+        await conn.execute(
+            "UPDATE entity_tags SET cleared_at = now() WHERE id = $1",
+            entity_tag_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO tag_clearance_log (
+                entity_tag_id, mechanism, triggering_event_id,
+                justification, source_chunk_id
+            ) VALUES ($1, 'event', $2, $3::jsonb, $4)
+            """,
+            entity_tag_id,
+            triggering_event_id,
+            json.dumps({"event_type": event_type}),
+            source_chunk_id,
+        )
+    return len(tag_ids)
+
+
+def _scalar_entity_binding(bindings: Mapping[str, Any], slot: str) -> Optional[int]:
+    value = bindings.get(slot)
+    if value is None:
+        return None
+    return _coerce_int(value, label=f"{slot} binding")
+
+
+def _coerce_int(value: Any, *, label: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"Orrery {label} must be an integer entity id")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Orrery {label} must be an integer entity id") from exc
+
+
+def _row_get(row: Any, key: str, index: int) -> Any:
+    if isinstance(row, Mapping):
+        return row[key]
+    return row[index]
+
+
+def _affected_count(status: str) -> int:
+    try:
+        return int(status.rsplit(" ", 1)[1])
+    except (IndexError, ValueError):
+        return 0

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -288,7 +288,15 @@ def _render_brief(draft: OrreryResolutionDraft, entity_names: Mapping[int, str])
             )
         else:
             values[slot] = _entity_label(value, entity_names)
-    rendered = draft.narrative_stub.format(**values)
+    try:
+        rendered = draft.narrative_stub.format(**values)
+    except KeyError as exc:
+        missing_key = exc.args[0]
+        raise ValueError(
+            "Orrery template "
+            f"{draft.template_id!r} narrative_stub references missing binding "
+            f"{missing_key!r}"
+        ) from exc
     return " ".join(rendered.split())
 
 
@@ -381,7 +389,10 @@ def _apply_state_delta_sync(
             "UPDATE characters SET current_activity = %s WHERE entity_id = %s",
             (draft.state_delta["character.current_activity"], actor_entity_id),
         )
-        if getattr(cur, "rowcount", 1) == 0:
+        rowcount = getattr(cur, "rowcount", None)
+        if rowcount is None or rowcount < 0:
+            raise ValueError("Unable to verify Orrery character update rowcount")
+        if rowcount == 0:
             raise ValueError(
                 f"Orrery actor entity {actor_entity_id} has no character row"
             )
@@ -446,24 +457,14 @@ def _add_entity_tag_sync(
 
     cur.execute(
         """
-        SELECT 1
-        FROM entity_tags_current
-        WHERE entity_id = %s
-          AND tag = %s
-        """,
-        (entity_id, tag),
-    )
-    if cur.fetchone():
-        return False
-
-    cur.execute(
-        """
         INSERT INTO entity_tags (entity_id, tag_id, template_id, source_kind)
         VALUES (%s, %s, %s, 'template')
+        ON CONFLICT DO NOTHING
+        RETURNING id
         """,
         (entity_id, tag_id, template_id),
     )
-    return True
+    return cur.fetchone() is not None
 
 
 async def _add_entity_tag_async(
@@ -485,29 +486,18 @@ async def _add_entity_tag_async(
     if tag_id is None:
         raise ValueError(f"Orrery tag {tag!r} is not registered")
 
-    exists = await conn.fetchval(
-        """
-        SELECT 1
-        FROM entity_tags_current
-        WHERE entity_id = $1
-          AND tag = $2
-        """,
-        entity_id,
-        tag,
-    )
-    if exists:
-        return False
-
-    await conn.execute(
+    inserted_id = await conn.fetchval(
         """
         INSERT INTO entity_tags (entity_id, tag_id, template_id, source_kind)
         VALUES ($1, $2, $3, 'template')
+        ON CONFLICT DO NOTHING
+        RETURNING id
         """,
         entity_id,
         tag_id,
         template_id,
     )
-    return True
+    return inserted_id is not None
 
 
 def _emit_world_event_sync(

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -254,9 +254,12 @@ def compose_actor_bindings(
     anchor_chunk_id: Optional[int],
     window_chunks: int,
 ) -> Tuple[Bindings, ...]:
-    """Compose ACTOR-only bindings for recently relevant character entities."""
+    """Compose ACTOR-only bindings for recently relevant off-screen characters."""
 
     actor_ids: set[int] = set()
+    present_actor_ids = _present_actor_ids_at_anchor(
+        session, anchor_chunk_id=anchor_chunk_id
+    )
 
     if anchor_chunk_id is not None:
         lower_bound = max(0, anchor_chunk_id - window_chunks + 1)
@@ -269,6 +272,7 @@ def compose_actor_bindings(
                 JOIN entities e ON e.id = cer.entity_id
                 WHERE e.kind = 'character'
                   AND e.is_active = true
+                  AND cer.reference_type IS DISTINCT FROM 'present'
                   AND cer.chunk_id BETWEEN :lower_bound AND :anchor_chunk_id
                 """
             ),
@@ -319,7 +323,37 @@ def compose_actor_bindings(
     ).mappings():
         actor_ids.add(row["entity_id"])
 
-    return tuple({Slot.ACTOR: actor_id} for actor_id in sorted(actor_ids))
+    offscreen_actor_ids = actor_ids - present_actor_ids
+    return tuple({Slot.ACTOR: actor_id} for actor_id in sorted(offscreen_actor_ids))
+
+
+def _present_actor_ids_at_anchor(
+    session: Any, *, anchor_chunk_id: Optional[int]
+) -> set[int]:
+    """Return character entities explicitly present in the current scene anchor."""
+
+    if anchor_chunk_id is None:
+        return set()
+
+    return {
+        row["entity_id"]
+        for row in session.execute(
+            text(
+                """
+                /* orrery:present_actor_ids_at_anchor */
+                SELECT DISTINCT c.entity_id
+                FROM chunk_character_references ccr
+                JOIN characters c ON c.id = ccr.character_id
+                JOIN entities e ON e.id = c.entity_id
+                WHERE ccr.chunk_id = :anchor_chunk_id
+                  AND ccr.reference = 'present'
+                  AND e.kind = 'character'
+                  AND e.is_active = true
+                """
+            ),
+            {"anchor_chunk_id": anchor_chunk_id},
+        ).mappings()
+    }
 
 
 def resolve_dry_run(

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -34,6 +34,39 @@ class OrreryResolutionDraft:
     changed_fields: Tuple[str, ...] = ()
     magnitude: float = 0.0
 
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of this draft."""
+
+        return {
+            "template_id": self.template_id,
+            "priority": self.priority,
+            "binding_hash": self.binding_hash,
+            "bindings": dict(self.bindings),
+            "branch_label": self.branch_label,
+            "narrative_stub": self.narrative_stub,
+            "state_delta": dict(self.state_delta),
+            "event_type": self.event_type,
+            "changed_fields": list(self.changed_fields),
+            "magnitude": self.magnitude,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "OrreryResolutionDraft":
+        """Hydrate a draft from incubator JSONB data."""
+
+        return cls(
+            template_id=str(data["template_id"]),
+            priority=int(data["priority"]),
+            binding_hash=str(data["binding_hash"]),
+            bindings=dict(data.get("bindings") or {}),
+            branch_label=str(data["branch_label"]),
+            narrative_stub=str(data["narrative_stub"]),
+            state_delta=dict(data.get("state_delta") or {}),
+            event_type=data.get("event_type"),
+            changed_fields=tuple(data.get("changed_fields") or ()),
+            magnitude=float(data.get("magnitude") or 0.0),
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class OrreryTickProposal:
@@ -51,6 +84,30 @@ class OrreryTickProposal:
         """Return the number of draft resolutions in this proposal."""
 
         return len(self.resolutions)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of this proposal."""
+
+        return {
+            "anchor_chunk_id": self.anchor_chunk_id,
+            "actor_count": self.actor_count,
+            "generated_at": self.generated_at,
+            "resolutions": [draft.to_dict() for draft in self.resolutions],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "OrreryTickProposal":
+        """Hydrate a proposal from incubator JSONB data."""
+
+        return cls(
+            anchor_chunk_id=data.get("anchor_chunk_id"),
+            actor_count=int(data.get("actor_count") or 0),
+            generated_at=str(data["generated_at"]),
+            resolutions=tuple(
+                OrreryResolutionDraft.from_dict(item)
+                for item in data.get("resolutions", ())
+            ),
+        )
 
 
 def hydrate_world_state(

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -1,0 +1,451 @@
+"""Post-commit Orrery promotion and narration worker."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Mapping, Optional
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+from pydantic import BaseModel, Field, ValidationError
+
+from nexus.agents.lore.utils.local_llm import LocalLLMManager
+from nexus.config import load_settings_as_dict
+
+logger = logging.getLogger("nexus.orrery.worker")
+
+
+PROMOTION_SYSTEM_PROMPT = (
+    "You are the Orrery promotion discriminator. Decide whether an off-screen "
+    "resolution deserves durable prose. Promote only events that create future "
+    "retrieval value, dramatic irony, concrete world change, or a perceivable "
+    "ambient consequence. Do not promote routine maintenance."
+)
+
+NARRATION_SYSTEM_PROMPT = (
+    "You write concise off-screen narrative records for NEXUS. The prose is "
+    "canonical but not directly shown to the player. Keep it specific, sensory "
+    "where useful, and free of second-person address."
+)
+
+
+class PromotionVerdict(BaseModel):
+    """Structured local-LLM promotion verdict for an Orrery resolution."""
+
+    promote: bool
+    reason: str = Field(min_length=1)
+    perceptual_channel: Optional[str] = Field(
+        default=None,
+        description="Optional channel such as audio, visual, social, digital, or none.",
+    )
+    perceptual_summary: Optional[str] = Field(
+        default=None,
+        description="Short spoiler-safe cue a later Bleed selector could inspect.",
+    )
+
+
+class OrreryWorkerResult(BaseModel):
+    """Summary of one worker drain."""
+
+    promoted: int = 0
+    skipped: int = 0
+    narrated: int = 0
+    failed: int = 0
+
+
+def process_orrery_outbox_sync(
+    slot: Optional[int] = None,
+    *,
+    promotion_limit: int = 20,
+    narration_limit: int = 5,
+    settings: Optional[Mapping[str, Any]] = None,
+    llm_manager: Optional[Any] = None,
+    narration_provider: Optional[Any] = None,
+) -> OrreryWorkerResult:
+    """Promote pending resolutions, then drain queued narration jobs."""
+
+    promoted, skipped = promote_pending_resolutions_sync(
+        slot,
+        limit=promotion_limit,
+        settings=settings,
+        llm_manager=llm_manager,
+    )
+    narrated, failed = drain_narration_outbox_sync(
+        slot,
+        limit=narration_limit,
+        settings=settings,
+        narration_provider=narration_provider,
+    )
+    return OrreryWorkerResult(
+        promoted=promoted,
+        skipped=skipped,
+        narrated=narrated,
+        failed=failed,
+    )
+
+
+def promote_pending_resolutions_sync(
+    slot: Optional[int] = None,
+    *,
+    limit: int = 20,
+    settings: Optional[Mapping[str, Any]] = None,
+    llm_manager: Optional[Any] = None,
+    conn: Optional[Any] = None,
+) -> tuple[int, int]:
+    """Use the local LLM to mark pending resolutions promoted or skipped."""
+
+    owns_conn = conn is None
+    conn = conn or _connect_for_slot(slot)
+    settings_dict = dict(settings or load_settings_as_dict())
+    try:
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT
+                        r.id,
+                        r.tick_chunk_id,
+                        r.template_id,
+                        r.actor_entity_id,
+                        r.priority,
+                        r.magnitude,
+                        r.state_delta,
+                        r.brief,
+                        r.event_ids,
+                        n.name AS actor_name
+                    FROM orrery_resolutions r
+                    LEFT JOIN entity_names_v n ON n.id = r.actor_entity_id
+                    WHERE r.promotion_status = 'pending'
+                    ORDER BY r.tick_chunk_id, r.priority DESC, r.id
+                    LIMIT %s
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    (limit,),
+                )
+                rows = cur.fetchall()
+                if not rows:
+                    return (0, 0)
+
+                manager = llm_manager or LocalLLMManager(settings_dict)
+                promoted = 0
+                skipped = 0
+                slot_label = _slot_label(slot)
+                for row in rows:
+                    verdict = _promotion_verdict(manager, row)
+                    if verdict.promote:
+                        _mark_promoted(cur, row, verdict, slot_label, settings_dict)
+                        promoted += 1
+                    else:
+                        _mark_skipped(cur, row, verdict)
+                        skipped += 1
+                return (promoted, skipped)
+    finally:
+        if owns_conn:
+            conn.close()
+
+
+def drain_narration_outbox_sync(
+    slot: Optional[int] = None,
+    *,
+    limit: int = 5,
+    settings: Optional[Mapping[str, Any]] = None,
+    narration_provider: Optional[Any] = None,
+    conn: Optional[Any] = None,
+) -> tuple[int, int]:
+    """Generate off-screen narrations for queued Orrery jobs."""
+
+    owns_conn = conn is None
+    conn = conn or _connect_for_slot(slot)
+    settings_dict = dict(settings or load_settings_as_dict())
+    try:
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT
+                        j.id AS job_id,
+                        j.resolution_id,
+                        j.slot,
+                        r.tick_chunk_id,
+                        r.template_id,
+                        r.actor_entity_id,
+                        r.magnitude,
+                        r.state_delta,
+                        r.brief,
+                        r.promotion_verdict,
+                        r.event_ids,
+                        cm.world_layer::text AS world_layer,
+                        n.name AS actor_name
+                    FROM orrery_narration_jobs j
+                    JOIN orrery_resolutions r ON r.id = j.resolution_id
+                    LEFT JOIN chunk_metadata cm ON cm.chunk_id = r.tick_chunk_id
+                    LEFT JOIN entity_names_v n ON n.id = r.actor_entity_id
+                    WHERE j.state = 'queued'
+                      AND j.available_at <= now()
+                    ORDER BY j.available_at, j.id
+                    LIMIT %s
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    (limit,),
+                )
+                rows = cur.fetchall()
+                if not rows:
+                    return (0, 0)
+
+                for row in rows:
+                    cur.execute(
+                        """
+                        UPDATE orrery_narration_jobs
+                        SET state = 'leased',
+                            lease_until = now() + interval '5 minutes',
+                            attempts = attempts + 1,
+                            updated_at = now()
+                        WHERE id = %s
+                        """,
+                        (row["job_id"],),
+                    )
+        provider = narration_provider or _narration_provider(settings_dict)
+        narrated = 0
+        failed = 0
+        for row in rows:
+            try:
+                narration_text = _generate_narration(provider, row)
+                descriptor = _perceptual_descriptor(row)
+                with conn:
+                    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                        _mark_narration_succeeded(
+                            cur,
+                            row=row,
+                            narration_text=narration_text,
+                            descriptor=descriptor,
+                        )
+                narrated += 1
+            except Exception as exc:
+                failed += 1
+                with conn:
+                    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                        _mark_narration_failed(cur, row=row, error=str(exc))
+                logger.exception("Failed to narrate Orrery job %s", row["job_id"])
+        return (narrated, failed)
+    finally:
+        if owns_conn:
+            conn.close()
+
+
+def _mark_narration_succeeded(
+    cur: Any,
+    *,
+    row: Mapping[str, Any],
+    narration_text: str,
+    descriptor: Mapping[str, Any],
+) -> None:
+    cur.execute(
+        """
+        INSERT INTO offscreen_narrations (
+            resolution_id, tick_chunk_id, world_layer,
+            text, perceptual_descriptor
+        ) VALUES (%s, %s, %s, %s, %s::jsonb)
+        RETURNING id
+        """,
+        (
+            row["resolution_id"],
+            row["tick_chunk_id"],
+            row["world_layer"],
+            narration_text,
+            json.dumps(descriptor),
+        ),
+    )
+    narration_id = cur.fetchone()["id"]
+    cur.execute(
+        """
+        UPDATE orrery_resolutions
+        SET narration_status = 'succeeded',
+            narration_chunk_id = %s
+        WHERE id = %s
+        """,
+        (narration_id, row["resolution_id"]),
+    )
+    cur.execute(
+        """
+        UPDATE orrery_narration_jobs
+        SET state = 'succeeded',
+            lease_until = NULL,
+            updated_at = now()
+        WHERE id = %s
+        """,
+        (row["job_id"],),
+    )
+
+
+def _mark_narration_failed(
+    cur: Any,
+    *,
+    row: Mapping[str, Any],
+    error: str,
+) -> None:
+    cur.execute(
+        """
+        UPDATE orrery_narration_jobs
+        SET state = 'failed',
+            lease_until = NULL,
+            last_error = %s,
+            updated_at = now()
+        WHERE id = %s
+        """,
+        (error, row["job_id"]),
+    )
+    cur.execute(
+        """
+        UPDATE orrery_resolutions
+        SET narration_status = 'failed'
+        WHERE id = %s
+        """,
+        (row["resolution_id"],),
+    )
+
+
+def _promotion_verdict(manager: Any, row: Mapping[str, Any]) -> PromotionVerdict:
+    prompt = (
+        "Evaluate this off-screen resolution for durable narration.\n\n"
+        f"Template: {row['template_id']}\n"
+        f"Actor: {row.get('actor_name') or row.get('actor_entity_id')}\n"
+        f"Priority: {row['priority']}\n"
+        f"Magnitude: {row.get('magnitude')}\n"
+        f"Brief: {row.get('brief')}\n"
+        f"State delta: {json.dumps(row.get('state_delta') or {}, sort_keys=True)}\n\n"
+        "Return promote=true only if this deserves off-screen prose."
+    )
+    raw = manager.structured_query(
+        prompt,
+        PromotionVerdict,
+        temperature=0.1,
+        max_tokens=512,
+        system_prompt=PROMOTION_SYSTEM_PROMPT,
+    )
+    try:
+        if isinstance(raw, PromotionVerdict):
+            return raw
+        return PromotionVerdict.model_validate(raw)
+    except ValidationError as exc:
+        raise ValueError(f"Malformed Orrery promotion verdict: {raw}") from exc
+
+
+def _mark_promoted(
+    cur: Any,
+    row: Mapping[str, Any],
+    verdict: PromotionVerdict,
+    slot_label: str,
+    settings: Mapping[str, Any],
+) -> None:
+    narration_settings = (settings.get("orrery") or {}).get("narration") or {}
+    provider = narration_settings.get("provider")
+    model_ref = narration_settings.get("model_ref")
+    cur.execute(
+        """
+        UPDATE orrery_resolutions
+        SET promotion_status = 'promoted',
+            promotion_verdict = %s::jsonb,
+            narration_status = 'queued'
+        WHERE id = %s
+        """,
+        (verdict.model_dump_json(), row["id"]),
+    )
+    cur.execute(
+        """
+        INSERT INTO orrery_narration_jobs (
+            resolution_id, slot, provider, model_ref
+        ) VALUES (%s, %s, %s, %s)
+        """,
+        (row["id"], slot_label, provider, model_ref),
+    )
+
+
+def _mark_skipped(cur: Any, row: Mapping[str, Any], verdict: PromotionVerdict) -> None:
+    cur.execute(
+        """
+        UPDATE orrery_resolutions
+        SET promotion_status = 'skipped',
+            promotion_verdict = %s::jsonb,
+            narration_status = 'none'
+        WHERE id = %s
+        """,
+        (verdict.model_dump_json(), row["id"]),
+    )
+
+
+def _generate_narration(provider: Any, row: Mapping[str, Any]) -> str:
+    prompt = (
+        "Write one concise off-screen narration record.\n\n"
+        f"Template: {row['template_id']}\n"
+        f"Actor: {row.get('actor_name') or row.get('actor_entity_id')}\n"
+        f"Brief: {row.get('brief')}\n"
+        f"Promotion verdict: {json.dumps(row.get('promotion_verdict') or {}, sort_keys=True)}\n"
+        f"State delta: {json.dumps(row.get('state_delta') or {}, sort_keys=True)}\n\n"
+        "Length: 80-180 words. Do not address the player."
+    )
+    response = provider.get_completion(prompt)
+    text = response.content.strip()
+    if not text:
+        raise ValueError("Orrery narration provider returned empty text")
+    return text
+
+
+def _perceptual_descriptor(row: Mapping[str, Any]) -> dict[str, Any]:
+    verdict = row.get("promotion_verdict") or {}
+    if isinstance(verdict, str):
+        verdict = json.loads(verdict)
+    return {
+        "channel": verdict.get("perceptual_channel"),
+        "summary": verdict.get("perceptual_summary"),
+        "brief": row.get("brief"),
+    }
+
+
+def _narration_provider(settings: Mapping[str, Any]) -> Any:
+    from nexus.config.loader import get_provider_for_model
+    from scripts.api_anthropic import AnthropicProvider
+    from scripts.api_openai import OpenAIProvider
+
+    narration_settings = (settings.get("orrery") or {}).get("narration") or {}
+    provider_name = narration_settings.get("provider")
+    model = narration_settings.get("model_ref")
+    provider_name = provider_name or get_provider_for_model(model)
+
+    if provider_name in {"openai", "test"}:
+        return OpenAIProvider(
+            model=model,
+            temperature=0.4,
+            max_output_tokens=1200,
+            system_prompt=NARRATION_SYSTEM_PROMPT,
+        )
+    if provider_name == "anthropic":
+        return AnthropicProvider(
+            model=model,
+            temperature=0.4,
+            max_tokens=1200,
+            system_prompt=NARRATION_SYSTEM_PROMPT,
+        )
+    raise ValueError(f"Unsupported Orrery narration provider: {provider_name}")
+
+
+def _connect_for_slot(slot: Optional[int]) -> Any:
+    from nexus.api.slot_utils import require_slot_dbname
+
+    dbname = require_slot_dbname(slot=slot)
+    return psycopg2.connect(
+        host=os.environ.get("PGHOST", "localhost"),
+        database=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+def _slot_label(slot: Optional[int]) -> str:
+    if slot is not None:
+        return str(slot)
+    value = os.environ.get("NEXUS_SLOT")
+    if value:
+        return value
+    return "default"

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -17,6 +17,9 @@ from nexus.config import load_settings_as_dict
 logger = logging.getLogger("nexus.orrery.worker")
 
 
+DEFAULT_NARRATION_MAX_ATTEMPTS = 3
+DEFAULT_NARRATION_RETRY_DELAY_SECONDS = 300
+
 PROMOTION_SYSTEM_PROMPT = (
     "You are the Orrery promotion discriminator. Decide whether an off-screen "
     "resolution deserves durable prose. Promote only events that create future "
@@ -159,6 +162,7 @@ def drain_narration_outbox_sync(
     owns_conn = conn is None
     conn = conn or _connect_for_slot(slot)
     settings_dict = dict(settings or load_settings_as_dict())
+    max_attempts, retry_delay_seconds = _narration_retry_settings(settings_dict)
     try:
         with conn:
             with conn.cursor(cursor_factory=RealDictCursor) as cur:
@@ -168,6 +172,7 @@ def drain_narration_outbox_sync(
                         j.id AS job_id,
                         j.resolution_id,
                         j.slot,
+                        j.attempts,
                         r.tick_chunk_id,
                         r.template_id,
                         r.actor_entity_id,
@@ -194,6 +199,7 @@ def drain_narration_outbox_sync(
                 if not rows:
                     return (0, 0)
 
+                provider = narration_provider or _narration_provider(settings_dict)
                 for row in rows:
                     cur.execute(
                         """
@@ -206,7 +212,6 @@ def drain_narration_outbox_sync(
                         """,
                         (row["job_id"],),
                     )
-        provider = narration_provider or _narration_provider(settings_dict)
         narrated = 0
         failed = 0
         for row in rows:
@@ -226,7 +231,13 @@ def drain_narration_outbox_sync(
                 failed += 1
                 with conn:
                     with conn.cursor(cursor_factory=RealDictCursor) as cur:
-                        _mark_narration_failed(cur, row=row, error=str(exc))
+                        _mark_narration_failed(
+                            cur,
+                            row=row,
+                            error=str(exc),
+                            max_attempts=max_attempts,
+                            retry_delay_seconds=retry_delay_seconds,
+                        )
                 logger.exception("Failed to narrate Orrery job %s", row["job_id"])
         return (narrated, failed)
     finally:
@@ -284,7 +295,33 @@ def _mark_narration_failed(
     *,
     row: Mapping[str, Any],
     error: str,
+    max_attempts: int,
+    retry_delay_seconds: int,
 ) -> None:
+    attempt_count = int(row.get("attempts") or 0) + 1
+    if attempt_count < max_attempts:
+        cur.execute(
+            """
+            UPDATE orrery_narration_jobs
+            SET state = 'queued',
+                available_at = now() + (%s * interval '1 second'),
+                lease_until = NULL,
+                last_error = %s,
+                updated_at = now()
+            WHERE id = %s
+            """,
+            (retry_delay_seconds, error, row["job_id"]),
+        )
+        cur.execute(
+            """
+            UPDATE orrery_resolutions
+            SET narration_status = 'queued'
+            WHERE id = %s
+            """,
+            (row["resolution_id"],),
+        )
+        return
+
     cur.execute(
         """
         UPDATE orrery_narration_jobs
@@ -428,6 +465,19 @@ def _narration_provider(settings: Mapping[str, Any]) -> Any:
             system_prompt=NARRATION_SYSTEM_PROMPT,
         )
     raise ValueError(f"Unsupported Orrery narration provider: {provider_name}")
+
+
+def _narration_retry_settings(settings: Mapping[str, Any]) -> tuple[int, int]:
+    narration_settings = (settings.get("orrery") or {}).get("narration") or {}
+    max_attempts = int(
+        narration_settings.get("max_attempts", DEFAULT_NARRATION_MAX_ATTEMPTS)
+    )
+    retry_delay_seconds = int(
+        narration_settings.get(
+            "retry_delay_seconds", DEFAULT_NARRATION_RETRY_DELAY_SECONDS
+        )
+    )
+    return max(1, max_attempts), max(0, retry_delay_seconds)
 
 
 def _connect_for_slot(slot: Optional[int]) -> Any:

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -120,7 +120,7 @@ def promote_pending_resolutions_sync(
                     WHERE r.promotion_status = 'pending'
                     ORDER BY r.tick_chunk_id, r.priority DESC, r.id
                     LIMIT %s
-                    FOR UPDATE SKIP LOCKED
+                    FOR UPDATE OF r SKIP LOCKED
                     """,
                     (limit,),
                 )
@@ -186,7 +186,7 @@ def drain_narration_outbox_sync(
                       AND j.available_at <= now()
                     ORDER BY j.available_at, j.id
                     LIMIT %s
-                    FOR UPDATE SKIP LOCKED
+                    FOR UPDATE OF j SKIP LOCKED
                     """,
                     (limit,),
                 )

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -18,6 +18,7 @@ from nexus.agents.logon.apex_schema import (
     ReferencedEntities,
     StateUpdates,
 )
+from nexus.agents.orrery.events import commit_orrery_tick_async
 from nexus.api.db_converters import (
     chronology_to_db_values,
     resolve_character_references,
@@ -52,7 +53,7 @@ async def fetch_incubator_data(
     row = await conn.fetchrow(
         """
         SELECT chunk_id, parent_chunk_id, user_text, storyteller_text,
-               choice_object, choice_text,
+               choice_object, choice_text, orrery_proposal,
                metadata_updates, entity_updates, reference_updates,
                llm_response_id, status
         FROM incubator
@@ -434,6 +435,25 @@ async def commit_incubator_to_database(
             if incubator.get("entity_updates"):
                 state_updates = StateUpdates(**incubator["entity_updates"])
                 await apply_state_updates(conn, state_updates)
+
+            # Step 8.5: Commit Orrery proposal inside the accepted-chunk transaction
+            orrery_result = await commit_orrery_tick_async(
+                conn,
+                incubator.get("orrery_proposal"),
+                tick_chunk_id=chunk_id,
+                world_layer=world_layer,
+            )
+            if orrery_result.resolution_count or orrery_result.skipped_existing_count:
+                logger.info(
+                    "Committed Orrery tick for chunk %s: %s resolutions, %s events, "
+                    "%s tag mutations, %s cleared tags, %s existing skipped",
+                    chunk_id,
+                    orrery_result.resolution_count,
+                    orrery_result.event_count,
+                    orrery_result.tag_mutation_count,
+                    orrery_result.cleared_tag_count,
+                    orrery_result.skipped_existing_count,
+                )
 
             # Step 9: Clear incubator
             await clear_incubator(conn, session_id)

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -322,7 +322,7 @@ async def clear_incubator(conn: asyncpg.Connection, session_id: str = None) -> N
 
 
 async def commit_incubator_to_database(
-    conn: asyncpg.Connection, session_id: str
+    conn: asyncpg.Connection, session_id: str, slot: Optional[int] = None
 ) -> int:
     """
     Complete commit flow from incubator to production tables.
@@ -441,6 +441,7 @@ async def commit_incubator_to_database(
                 conn,
                 incubator.get("orrery_proposal"),
                 tick_chunk_id=chunk_id,
+                slot=slot,
                 world_layer=world_layer,
             )
             if orrery_result.resolution_count or orrery_result.skipped_existing_count:

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -21,6 +21,7 @@ from nexus.agents.logon.apex_schema import (
     FactionReference,
     StateUpdates,
 )
+from nexus.agents.orrery.events import commit_orrery_tick_sync
 from nexus.api.db_converters import chronology_to_db_values
 from nexus.api.summary_triggers import (
     SummaryTask,
@@ -287,7 +288,7 @@ def commit_incubator_to_database_sync(
                 cur.execute(
                     """
                     SELECT chunk_id, parent_chunk_id, user_text, storyteller_text,
-                           choice_object, choice_text,
+                           choice_object, choice_text, orrery_proposal,
                            metadata_updates, entity_updates, reference_updates,
                            llm_response_id, status
                     FROM incubator
@@ -486,6 +487,26 @@ def commit_incubator_to_database_sync(
             if incubator.get("entity_updates"):
                 state_updates = StateUpdates(**incubator["entity_updates"])
                 apply_state_updates_sync(conn, state_updates)
+
+            # Step 8.5: Commit Orrery proposal inside the accepted-chunk transaction
+            orrery_result = commit_orrery_tick_sync(
+                conn,
+                incubator.get("orrery_proposal"),
+                tick_chunk_id=chunk_id,
+                slot=slot,
+                world_layer=world_layer,
+            )
+            if orrery_result.resolution_count or orrery_result.skipped_existing_count:
+                logger.info(
+                    "Committed Orrery tick for chunk %s: %s resolutions, %s events, "
+                    "%s tag mutations, %s cleared tags, %s existing skipped",
+                    chunk_id,
+                    orrery_result.resolution_count,
+                    orrery_result.event_count,
+                    orrery_result.tag_mutation_count,
+                    orrery_result.cleared_tag_count,
+                    orrery_result.skipped_existing_count,
+                )
 
             # Step 9: Clear incubator
             with conn.cursor() as cur:

--- a/nexus/api/lore_adapter.py
+++ b/nexus/api/lore_adapter.py
@@ -96,7 +96,11 @@ def compute_raw_text(
 
 
 def response_to_incubator(
-    response: StoryTurnResponse, parent_chunk_id: int, user_text: str, session_id: str
+    response: StoryTurnResponse,
+    parent_chunk_id: int,
+    user_text: str,
+    session_id: str,
+    orrery_proposal: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """
     Transform a LORE StoryTurnResponse into incubator table format.
@@ -106,6 +110,7 @@ def response_to_incubator(
         parent_chunk_id: The parent chunk being continued from
         user_text: The user's input text
         session_id: Session ID for tracking
+        orrery_proposal: Optional no-write Orrery proposal from TurnContext
 
     Returns:
         Dictionary formatted for incubator table insertion
@@ -134,12 +139,25 @@ def response_to_incubator(
         "metadata_updates": extract_metadata_updates(response),
         "entity_updates": extract_entity_updates(response),
         "reference_updates": extract_reference_updates(response),
+        "orrery_proposal": _serialize_orrery_proposal(orrery_proposal),
         "session_id": session_id,
         "llm_response_id": getattr(response, "response_id", None),
         "status": "provisional",
     }
 
     return incubator_data
+
+
+def _serialize_orrery_proposal(proposal: Optional[Any]) -> Optional[Dict[str, Any]]:
+    """Serialize an optional Orrery proposal for incubator JSONB storage."""
+
+    if proposal is None:
+        return None
+    if hasattr(proposal, "to_dict"):
+        return proposal.to_dict()
+    if isinstance(proposal, dict):
+        return proposal
+    raise TypeError(f"Unsupported Orrery proposal type: {type(proposal).__name__}")
 
 
 def extract_metadata_updates(response: StoryTurnResponse) -> Dict[str, Any]:

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -522,6 +522,7 @@ async def continue_narrative(
                 )
                 approval = await approve_narrative(
                     session_id=narrative_state.session_id,
+                    background_tasks=background_tasks,
                     request=ApproveNarrativeRequest(
                         session_id=narrative_state.session_id, commit=True
                     ),
@@ -737,7 +738,9 @@ async def regenerate_narrative(
 
 
 @app.post("/api/narrative/approve")
-async def approve_narrative_unified(request: ApproveNarrativeRequest):
+async def approve_narrative_unified(
+    request: ApproveNarrativeRequest, background_tasks: BackgroundTasks
+):
     """
     Approve narrative and optionally commit to database.
 
@@ -772,12 +775,15 @@ async def approve_narrative_unified(request: ApproveNarrativeRequest):
                 )
 
     # Now call the implementation
-    return await _approve_narrative_impl(session_id, request.commit, slot)
+    return await _approve_narrative_impl(
+        session_id, request.commit, slot, background_tasks
+    )
 
 
 @app.post("/api/narrative/approve/{session_id}")
 async def approve_narrative(
     session_id: str,
+    background_tasks: BackgroundTasks,
     request: Optional[ApproveNarrativeRequest] = None,
     slot: Optional[int] = None,
 ):
@@ -786,10 +792,17 @@ async def approve_narrative(
     """
     should_commit = request.commit if request else True
     effective_slot = request.slot if request and request.slot else slot
-    return await _approve_narrative_impl(session_id, should_commit, effective_slot)
+    return await _approve_narrative_impl(
+        session_id, should_commit, effective_slot, background_tasks
+    )
 
 
-async def _approve_narrative_impl(session_id: str, commit: bool, slot: Optional[int]):
+async def _approve_narrative_impl(
+    session_id: str,
+    commit: bool,
+    slot: Optional[int],
+    background_tasks: Optional[BackgroundTasks] = None,
+):
     """Internal implementation for approve narrative."""
     conn = get_db_connection(slot)
     try:
@@ -810,6 +823,10 @@ async def _approve_narrative_impl(session_id: str, commit: bool, slot: Optional[
             try:
                 # Commit to database
                 chunk_id = commit_incubator_to_database_sync(conn, session_id, slot)
+                if background_tasks is not None:
+                    from nexus.agents.orrery.worker import process_orrery_outbox_sync
+
+                    background_tasks.add_task(process_orrery_outbox_sync, slot)
 
                 return {
                     "status": "committed",

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -198,6 +198,9 @@ async def generate_narrative_async(
                 parent_chunk_id=parent_chunk_id,
                 user_text=user_text,
                 session_id=session_id,
+                orrery_proposal=(
+                    lore.turn_context.orrery_proposal if lore.turn_context else None
+                ),
             )
 
             # Validate the data before writing
@@ -267,10 +270,10 @@ async def write_to_incubator(conn, data: Dict[str, Any]):
         INSERT INTO incubator (
             id, chunk_id, parent_chunk_id, user_text, storyteller_text,
             choice_object, choice_text,
-            metadata_updates, entity_updates, reference_updates,
+            metadata_updates, entity_updates, reference_updates, orrery_proposal,
             session_id, llm_response_id, status
         ) VALUES (
-            TRUE, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+            TRUE, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
         )
         """
 
@@ -290,6 +293,11 @@ async def write_to_incubator(conn, data: Dict[str, Any]):
                 json.dumps(data["metadata_updates"]),
                 json.dumps(data["entity_updates"]),
                 json.dumps(data["reference_updates"]),
+                (
+                    json.dumps(data.get("orrery_proposal"))
+                    if data.get("orrery_proposal")
+                    else None
+                ),
                 data["session_id"],
                 data["llm_response_id"],
                 data["status"],

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from nexus.agents.orrery.events import commit_orrery_tick_sync
@@ -54,11 +56,12 @@ class RecordingCursor:
             tag = params[0]
             if tag in self.known_tags:
                 self._fetchone = {"id": self.known_tags[tag]}
-        elif "FROM entity_tags_current" in normalized:
-            entity_id, tag = params
-            self._fetchone = (
-                {"exists": 1} if (entity_id, tag) in self.current_tags else None
-            )
+        elif "INSERT INTO entity_tags" in normalized:
+            entity_id, tag_id, _template_id = params
+            tags_by_id = {value: key for key, value in self.known_tags.items()}
+            tag = tags_by_id[tag_id]
+            if (entity_id, tag) not in self.current_tags:
+                self._fetchone = {"id": 88}
         elif "FROM event_types WHERE type" in normalized:
             self._fetchone = {"type": params[0]}
         elif "SELECT current_location FROM characters" in normalized:
@@ -213,3 +216,47 @@ def test_commit_orrery_tick_rejects_unregistered_tags() -> None:
             slot=5,
             world_layer="primary",
         )
+
+
+def test_commit_orrery_tick_reports_missing_template_binding() -> None:
+    """Template authoring errors identify the bad template and binding."""
+
+    proposal = _proposal()
+    broken = replace(
+        proposal.resolutions[0],
+        narrative_stub="{missing} vanishes into a maintenance corridor.",
+    )
+    broken_proposal = OrreryTickProposal(
+        anchor_chunk_id=proposal.anchor_chunk_id,
+        actor_count=proposal.actor_count,
+        resolutions=(broken,),
+        generated_at=proposal.generated_at,
+    )
+
+    with pytest.raises(ValueError, match="evade_pursuers.*missing binding 'missing'"):
+        commit_orrery_tick_sync(
+            RecordingConn(RecordingCursor()),
+            broken_proposal,
+            tick_chunk_id=100,
+            slot=5,
+            world_layer="primary",
+        )
+
+
+def test_commit_orrery_tick_skips_duplicate_active_tag_insert() -> None:
+    """Active tag uniqueness conflicts do not double-count tag mutations."""
+
+    cursor = RecordingCursor(current_tags={(1, "off_grid")})
+
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _proposal(),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+
+    assert result.tag_mutation_count == 0
+    assert "ON CONFLICT DO NOTHING" in statements

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -1,0 +1,215 @@
+"""Tests for canonical Orrery commit-time event materialization."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.agents.orrery.events import commit_orrery_tick_sync
+from nexus.agents.orrery.resolver import OrreryResolutionDraft, OrreryTickProposal
+from nexus.api.lore_adapter import response_to_incubator
+
+
+class RecordingCursor:
+    """Small psycopg cursor stand-in keyed by the Orrery writer's SQL."""
+
+    def __init__(
+        self,
+        *,
+        duplicate_resolution: bool = False,
+        known_tags=None,
+        current_tags=None,
+        clear_tag_ids=None,
+    ):
+        self.duplicate_resolution = duplicate_resolution
+        self.known_tags = {"off_grid": 77} if known_tags is None else known_tags
+        self.current_tags = set() if current_tags is None else current_tags
+        self.clear_tag_ids = [] if clear_tag_ids is None else clear_tag_ids
+        self.executed = []
+        self.rowcount = 1
+        self._fetchone = None
+        self._fetchall = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        return False
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+        self._fetchone = None
+        self._fetchall = []
+        normalized = " ".join(str(sql).split())
+
+        if "FROM entities WHERE id = ANY" in normalized:
+            entity_ids = params[0]
+            self._fetchall = [{"id": entity_id} for entity_id in entity_ids]
+        elif "FROM entity_names_v WHERE id = ANY" in normalized:
+            self._fetchall = [{"id": 1, "name": "Mara"}]
+        elif "INSERT INTO orrery_resolutions" in normalized:
+            self._fetchone = None if self.duplicate_resolution else {"id": 10}
+        elif "UPDATE characters SET current_activity" in normalized:
+            self.rowcount = 1
+        elif "FROM tags WHERE tag" in normalized:
+            tag = params[0]
+            if tag in self.known_tags:
+                self._fetchone = {"id": self.known_tags[tag]}
+        elif "FROM entity_tags_current" in normalized:
+            entity_id, tag = params
+            self._fetchone = (
+                {"exists": 1} if (entity_id, tag) in self.current_tags else None
+            )
+        elif "FROM event_types WHERE type" in normalized:
+            self._fetchone = {"type": params[0]}
+        elif "SELECT current_location FROM characters" in normalized:
+            self._fetchone = {"current_location": 99}
+        elif "INSERT INTO world_events" in normalized:
+            self._fetchone = {"id": 20}
+        elif "SELECT et.id FROM entity_tags" in normalized:
+            self._fetchall = [{"id": tag_id} for tag_id in self.clear_tag_ids]
+
+    def fetchone(self):
+        return self._fetchone
+
+    def fetchall(self):
+        return self._fetchall
+
+
+class RecordingConn:
+    """Connection stand-in returning one recording cursor."""
+
+    def __init__(self, cursor: RecordingCursor):
+        self.cursor_obj = cursor
+
+    def cursor(self):
+        return self.cursor_obj
+
+
+class MinimalStoryResponse:
+    """Tiny response object for lore_adapter serialization tests."""
+
+    narrative = "The corridor hums."
+    response_id = "resp-1"
+    chunk_metadata = None
+    metadata = None
+    state_updates = None
+    entity_updates = None
+    referenced_entities = None
+    references = None
+    choices = None
+
+
+def _proposal() -> OrreryTickProposal:
+    draft = OrreryResolutionDraft(
+        template_id="evade_pursuers",
+        priority=100,
+        binding_hash="abc123",
+        bindings={"actor": 1},
+        branch_label="Go to ground",
+        narrative_stub="{actor} vanishes into a maintenance corridor.",
+        state_delta={
+            "character.current_activity": "hiding from active pursuit",
+            "entity_tags.add": ["off_grid"],
+        },
+        event_type="evade_pursuit",
+        changed_fields=("character.current_activity", "entity_tags"),
+        magnitude=0.72,
+    )
+    return OrreryTickProposal(
+        anchor_chunk_id=99,
+        actor_count=1,
+        resolutions=(draft,),
+        generated_at="2073-10-31T18:00:00+00:00",
+    )
+
+
+def test_proposal_round_trips_through_json_shape() -> None:
+    """Commit can hydrate the exact proposal shape stored in incubator JSONB."""
+
+    proposal = _proposal()
+
+    assert OrreryTickProposal.from_dict(proposal.to_dict()) == proposal
+
+
+def test_response_to_incubator_serializes_orrery_proposal() -> None:
+    """The preview-to-approval handoff carries Orrery proposals durably."""
+
+    incubator_data = response_to_incubator(
+        MinimalStoryResponse(),
+        parent_chunk_id=99,
+        user_text="Continue.",
+        session_id="session-1",
+        orrery_proposal=_proposal(),
+    )
+
+    assert incubator_data["orrery_proposal"]["anchor_chunk_id"] == 99
+    assert incubator_data["orrery_proposal"]["resolutions"][0]["template_id"] == (
+        "evade_pursuers"
+    )
+
+
+def test_commit_orrery_tick_materializes_resolution_event_and_tags() -> None:
+    """Accepted commits stamp the preview proposal into canonical Orrery tables."""
+
+    cursor = RecordingCursor(clear_tag_ids=[55])
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _proposal().to_dict(),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+    resolution_params = next(
+        params
+        for sql, params in cursor.executed
+        if "INSERT INTO orrery_resolutions" in sql
+    )
+
+    assert result.resolution_count == 1
+    assert result.event_count == 1
+    assert result.tag_mutation_count == 1
+    assert result.cleared_tag_count == 1
+    assert result.skipped_existing_count == 0
+    assert "INSERT INTO orrery_resolutions" in statements
+    assert "INSERT INTO world_events" in statements
+    assert "INSERT INTO world_event_entities" in statements
+    assert "INSERT INTO tag_clearance_log" in statements
+    assert resolution_params[-1] == "Mara vanishes into a maintenance corridor."
+
+
+def test_commit_orrery_tick_skips_existing_resolution_without_double_writes() -> None:
+    """The unique resolution key prevents duplicate event/state side effects."""
+
+    cursor = RecordingCursor(duplicate_resolution=True)
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _proposal(),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+
+    assert result.resolution_count == 0
+    assert result.event_count == 0
+    assert result.skipped_existing_count == 1
+    assert "INSERT INTO world_events" not in statements
+    assert "UPDATE characters SET current_activity" not in statements
+
+
+def test_commit_orrery_tick_rejects_unregistered_tags() -> None:
+    """State deltas cannot silently invent tag vocabulary at commit time."""
+
+    cursor = RecordingCursor(known_tags={})
+
+    with pytest.raises(ValueError, match="not registered"):
+        commit_orrery_tick_sync(
+            RecordingConn(cursor),
+            _proposal(),
+            tick_chunk_id=100,
+            slot=5,
+            world_layer="primary",
+        )

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -42,6 +42,7 @@ class FakeSession:
         chunk_ref_actor_rows=None,
         event_actor_rows=None,
         ephemeral_actor_rows=None,
+        present_actor_rows=None,
         world_time=None,
         weather="",
         max_chunk_id=100,
@@ -60,6 +61,7 @@ class FakeSession:
         self.chunk_ref_actor_rows = chunk_ref_actor_rows or [{"entity_id": 1}]
         self.event_actor_rows = event_actor_rows or []
         self.ephemeral_actor_rows = ephemeral_actor_rows or []
+        self.present_actor_rows = present_actor_rows or []
         self.world_time = world_time or datetime(2073, 10, 31, 12, tzinfo=timezone.utc)
         self.weather = weather
         self.max_chunk_id = max_chunk_id
@@ -89,6 +91,7 @@ class FakeSession:
             assert "superseded_by_event_id IS NULL" in sql
             return FakeResult(self.event_rows)
         if "/* orrery:actor_bindings_chunk_refs */" in sql:
+            assert "reference_type IS DISTINCT FROM 'present'" in sql
             return FakeResult(self.chunk_ref_actor_rows)
         if "/* orrery:actor_bindings_events */" in sql:
             assert "(world_layer IS NULL OR world_layer = 'primary')" in sql
@@ -96,6 +99,8 @@ class FakeSession:
             return FakeResult(self.event_actor_rows)
         if "/* orrery:actor_bindings_ephemeral */" in sql:
             return FakeResult(self.ephemeral_actor_rows)
+        if "/* orrery:present_actor_ids_at_anchor */" in sql:
+            return FakeResult(self.present_actor_rows)
         if "/* orrery:anchor_world_time */" in sql:
             return FakeResult([{"world_time": self.world_time}])
         if "/* orrery:seed_weather */" in sql:
@@ -139,6 +144,40 @@ def test_resolve_dry_run_returns_inspectable_proposal() -> None:
     assert proposal.resolution_count == 1
     assert proposal.resolutions[0].template_id == "maintain_cover"
     assert proposal.resolutions[0].bindings == {"actor": 1}
+
+
+def test_resolve_dry_run_excludes_anchor_present_characters() -> None:
+    """Orrery does not drive characters currently owned by the storyteller."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[{"entity_id": 1}, {"entity_id": 2}],
+            event_actor_rows=[{"entity_id": 3}],
+            ephemeral_actor_rows=[{"entity_id": 4}],
+            present_actor_rows=[{"entity_id": 1}, {"entity_id": 3}],
+            location_rows=[
+                {"entity_id": 1, "current_location": 10},
+                {"entity_id": 2, "current_location": 10},
+                {"entity_id": 3, "current_location": 10},
+                {"entity_id": 4, "current_location": 10},
+            ],
+            activity_rows=[
+                {"entity_id": 1, "current_activity": "in scene"},
+                {"entity_id": 2, "current_activity": "mentioned elsewhere"},
+                {"entity_id": 3, "current_activity": "recent event"},
+                {"entity_id": 4, "current_activity": "ephemeral pressure"},
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.actor_count == 2
+    assert [resolution.bindings for resolution in proposal.resolutions] == [
+        {"actor": 2},
+        {"actor": 4},
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -1,0 +1,207 @@
+"""Tests for Orrery post-commit promotion and narration worker."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.agents.orrery.worker import (
+    PromotionVerdict,
+    drain_narration_outbox_sync,
+    promote_pending_resolutions_sync,
+)
+
+
+class WorkerCursor:
+    """Recording cursor for worker SQL branches."""
+
+    def __init__(self, *, promotion_rows=None, job_rows=None):
+        self.promotion_rows = promotion_rows or []
+        self.job_rows = job_rows or []
+        self.executed = []
+        self._fetchall = []
+        self._fetchone = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        return False
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+        self._fetchall = []
+        self._fetchone = None
+        normalized = " ".join(str(sql).split())
+        if "FROM orrery_resolutions r" in normalized:
+            self._fetchall = self.promotion_rows
+        elif "FROM orrery_narration_jobs j" in normalized:
+            self._fetchall = self.job_rows
+        elif "INSERT INTO offscreen_narrations" in normalized:
+            self._fetchone = {"id": 501}
+
+    def fetchall(self):
+        return self._fetchall
+
+    def fetchone(self):
+        return self._fetchone
+
+
+class WorkerConn:
+    """Connection stand-in with transaction/context-manager behavior."""
+
+    def __init__(self, cursor: WorkerCursor):
+        self.cursor_obj = cursor
+        self.closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        return False
+
+    def cursor(self, *args, **kwargs):
+        return self.cursor_obj
+
+    def close(self):
+        self.closed = True
+
+
+class FakeLLM:
+    """Local LLM stand-in returning one structured verdict."""
+
+    def __init__(self, verdict):
+        self.verdict = verdict
+        self.prompts = []
+
+    def structured_query(self, prompt, response_model, **_kwargs):
+        self.prompts.append((prompt, response_model))
+        return self.verdict
+
+
+class FakeProviderResponse:
+    """Provider response stand-in."""
+
+    content = "Mara disappears below the platform, leaving only static behind."
+
+
+class FakeNarrationProvider:
+    """Frontier provider stand-in."""
+
+    def __init__(self):
+        self.prompts = []
+
+    def get_completion(self, prompt):
+        self.prompts.append(prompt)
+        return FakeProviderResponse()
+
+
+def _settings():
+    return {
+        "orrery": {
+            "narration": {
+                "provider": "anthropic",
+                "model_ref": "claude-sonnet-4-6",
+            }
+        }
+    }
+
+
+def _promotion_row():
+    return {
+        "id": 10,
+        "tick_chunk_id": 100,
+        "template_id": "evade_pursuers",
+        "actor_entity_id": 1,
+        "actor_name": "Mara",
+        "priority": 100,
+        "magnitude": 0.72,
+        "state_delta": {"character.current_activity": "hiding"},
+        "brief": "Mara vanishes into a maintenance corridor.",
+        "event_ids": [20],
+    }
+
+
+def _job_row():
+    return {
+        "job_id": 90,
+        "resolution_id": 10,
+        "slot": "5",
+        "tick_chunk_id": 100,
+        "template_id": "evade_pursuers",
+        "actor_entity_id": 1,
+        "actor_name": "Mara",
+        "magnitude": 0.72,
+        "state_delta": {"character.current_activity": "hiding"},
+        "brief": "Mara vanishes into a maintenance corridor.",
+        "promotion_verdict": {
+            "promote": True,
+            "reason": "It creates a future off-screen consequence.",
+            "perceptual_channel": "digital",
+            "perceptual_summary": "street cameras briefly lose Mara",
+        },
+        "event_ids": [20],
+        "world_layer": "primary",
+    }
+
+
+def test_promote_pending_resolutions_queues_narration_job() -> None:
+    """Promoted resolutions are marked and placed into the durable outbox."""
+
+    cursor = WorkerCursor(promotion_rows=[_promotion_row()])
+    verdict = PromotionVerdict(
+        promote=True,
+        reason="It creates future retrieval value.",
+        perceptual_channel="digital",
+        perceptual_summary="street cameras briefly lose Mara",
+    )
+
+    promoted, skipped = promote_pending_resolutions_sync(
+        slot=5,
+        settings=_settings(),
+        llm_manager=FakeLLM(verdict),
+        conn=WorkerConn(cursor),
+    )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+
+    assert promoted == 1
+    assert skipped == 0
+    assert "promotion_status = 'promoted'" in statements
+    assert "INSERT INTO orrery_narration_jobs" in statements
+
+
+def test_promote_pending_resolutions_rejects_malformed_llm_output() -> None:
+    """Malformed local-LLM promotion data fails visibly."""
+
+    cursor = WorkerCursor(promotion_rows=[_promotion_row()])
+
+    with pytest.raises(ValueError, match="Malformed Orrery promotion verdict"):
+        promote_pending_resolutions_sync(
+            slot=5,
+            settings=_settings(),
+            llm_manager=FakeLLM({"answer": "sure"}),
+            conn=WorkerConn(cursor),
+        )
+
+
+def test_drain_narration_outbox_persists_offscreen_narration() -> None:
+    """Queued narration jobs persist into offscreen_narrations."""
+
+    cursor = WorkerCursor(job_rows=[_job_row()])
+    provider = FakeNarrationProvider()
+
+    narrated, failed = drain_narration_outbox_sync(
+        slot=5,
+        settings=_settings(),
+        narration_provider=provider,
+        conn=WorkerConn(cursor),
+    )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+
+    assert narrated == 1
+    assert failed == 0
+    assert provider.prompts
+    assert "INSERT INTO offscreen_narrations" in statements
+    assert "narration_status = 'succeeded'" in statements
+    assert "state = 'succeeded'" in statements

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -166,6 +166,7 @@ def test_promote_pending_resolutions_queues_narration_job() -> None:
 
     assert promoted == 1
     assert skipped == 0
+    assert "FOR UPDATE OF r SKIP LOCKED" in statements
     assert "promotion_status = 'promoted'" in statements
     assert "INSERT INTO orrery_narration_jobs" in statements
 
@@ -202,6 +203,7 @@ def test_drain_narration_outbox_persists_offscreen_narration() -> None:
     assert narrated == 1
     assert failed == 0
     assert provider.prompts
+    assert "FOR UPDATE OF j SKIP LOCKED" in statements
     assert "INSERT INTO offscreen_narrations" in statements
     assert "narration_status = 'succeeded'" in statements
     assert "state = 'succeeded'" in statements

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -95,6 +95,13 @@ class FakeNarrationProvider:
         return FakeProviderResponse()
 
 
+class FailingNarrationProvider:
+    """Provider stand-in that raises while generating narration."""
+
+    def get_completion(self, _prompt):
+        raise TimeoutError("temporary provider failure")
+
+
 def _settings():
     return {
         "orrery": {
@@ -140,6 +147,7 @@ def _job_row():
             "perceptual_summary": "street cameras briefly lose Mara",
         },
         "event_ids": [20],
+        "attempts": 0,
         "world_layer": "primary",
     }
 
@@ -207,3 +215,63 @@ def test_drain_narration_outbox_persists_offscreen_narration() -> None:
     assert "INSERT INTO offscreen_narrations" in statements
     assert "narration_status = 'succeeded'" in statements
     assert "state = 'succeeded'" in statements
+
+
+def test_drain_narration_outbox_does_not_lease_before_provider_ready() -> None:
+    """Provider setup failures leave queued jobs available for a later drain."""
+
+    cursor = WorkerCursor(job_rows=[_job_row()])
+
+    with pytest.raises(ValueError, match="Unsupported Orrery narration provider"):
+        drain_narration_outbox_sync(
+            slot=5,
+            settings={"orrery": {"narration": {"provider": "missing"}}},
+            conn=WorkerConn(cursor),
+        )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+
+    assert "state = 'leased'" not in statements
+
+
+def test_drain_narration_outbox_requeues_transient_failures() -> None:
+    """Narration attempts retry with backoff before becoming terminal."""
+
+    cursor = WorkerCursor(job_rows=[_job_row()])
+
+    narrated, failed = drain_narration_outbox_sync(
+        slot=5,
+        settings=_settings(),
+        narration_provider=FailingNarrationProvider(),
+        conn=WorkerConn(cursor),
+    )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+
+    assert narrated == 0
+    assert failed == 1
+    assert "state = 'queued'" in statements
+    assert "available_at = now() + (%s * interval '1 second')" in statements
+    assert "narration_status = 'queued'" in statements
+    assert "narration_status = 'failed'" not in statements
+
+
+def test_drain_narration_outbox_marks_terminal_after_max_attempts() -> None:
+    """Retries stop once the configured max attempts is reached."""
+
+    job = dict(_job_row(), attempts=2)
+    cursor = WorkerCursor(job_rows=[job])
+
+    narrated, failed = drain_narration_outbox_sync(
+        slot=5,
+        settings=_settings(),
+        narration_provider=FailingNarrationProvider(),
+        conn=WorkerConn(cursor),
+    )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+
+    assert narrated == 0
+    assert failed == 1
+    assert "state = 'failed'" in statements
+    assert "narration_status = 'failed'" in statements


### PR DESCRIPTION
## Summary
- materialize Orrery dry-run proposals during accepted narrative commits
- add promotion/narration outbox worker for post-commit Orrery resolutions
- seed initial Orrery event/tag metadata and carry proposals through incubator storage

## Live validation
- generated Octen-Embedding-4B embeddings once for slot 2 and copied the matching rows to slot 1
- verified slot 1 was re-locked and both slots have 1,425 Octen-4B rows
- ran a live slot 2 continuation with Orrery enabled: 8 actors, 8 draft resolutions, 7,719-char structured narrative, 4 choices
- approved the live turn; committed chunk 1427, 8 resolver world_events, 8 Orrery resolutions, and drained worker queue to 8 skipped / 0 pending

## Validation
- `poetry run pytest tests/test_orrery tests/test_api/test_choice_promotion.py`
- `poetry run python -m py_compile nexus/agents/orrery/worker.py`
- `git diff --check`

## Notes
- migration `024_orrery_commit_pipeline.sql` was applied locally to template and slots 2-5; save_01 stayed schema-locked except for the explicit embedding table/data backfill and was re-locked afterward
- pgvector cannot index 2,560-d vectors with HNSW/IVFFlat, so live MEMNON retrieval used exact/default vector lookup for Octen-4B
- the live slot 2 commit landed as chunk 1427 because an earlier failed live attempt consumed sequence value 1426; PostgreSQL sequences do not roll back
