### PR TITLE
Add Orrery scene pressure proposals

### DIFF
--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -380,6 +380,24 @@ class LogonUtility:
             for passage in context["retrieved_passages"]["results"][:5]:  # Limit to top 5
                 sections.append(f"[Score: {passage.get('score', 0):.2f}] {passage.get('text', '')}")
 
+        scene_pressures = context.get("orrery_scene_pressures") or []
+        if scene_pressures:
+            sections.append("\n=== ORRERY SCENE PRESSURE ===")
+            sections.append(
+                "These are off-screen pressures involving current on-screen "
+                "characters. You may adapt, delay, ignore, or incorporate them. "
+                "Do not let Orrery decide what present characters do."
+            )
+            for pressure in scene_pressures[:5]:
+                if not isinstance(pressure, dict):
+                    continue
+                label = pressure.get("branch_label") or pressure.get("template_id")
+                prompt_text = pressure.get("prompt_text") or pressure.get(
+                    "pressure_stub", ""
+                )
+                if prompt_text:
+                    sections.append(f"- {label}: {prompt_text}")
+
         # Add author's note (soft out-of-character suggestion, used by regenerate).
         # Placed immediately before INSTRUCTIONS so recency bias gives it the influence
         # a soft nudge needs — entity/historical context above would otherwise bury it.

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -598,14 +598,20 @@ class TurnCycleManager:
             "anchor_chunk_id": proposal.anchor_chunk_id,
             "actor_count": proposal.actor_count,
             "resolution_count": proposal.resolution_count,
+            "pressure_count": proposal.pressure_count,
             "template_ids": [
                 resolution.template_id for resolution in proposal.resolutions
             ],
+            "pressure_template_ids": [
+                pressure.template_id for pressure in proposal.scene_pressures
+            ],
         }
         logger.info(
-            "Orrery dry-run resolved %d actors into %d draft resolutions",
+            "Orrery dry-run resolved %d actors into %d draft resolutions "
+            "and %d scene pressures",
             proposal.actor_count,
             proposal.resolution_count,
+            proposal.pressure_count,
         )
 
     def _orrery_anchor_chunk_id(
@@ -667,6 +673,15 @@ class TurnCycleManager:
 
         if turn_context.note:
             turn_context.context_payload["note"] = turn_context.note
+
+        if (
+            turn_context.orrery_proposal
+            and turn_context.orrery_proposal.pressure_count
+        ):
+            turn_context.context_payload["orrery_scene_pressures"] = [
+                pressure.to_dict()
+                for pressure in turn_context.orrery_proposal.scene_pressures
+            ]
 
         if turn_context.target_chunk_id is not None:
             turn_context.context_payload["metadata"][

--- a/nexus/agents/orrery/__init__.py
+++ b/nexus/agents/orrery/__init__.py
@@ -10,6 +10,7 @@ from nexus.agents.orrery.substrate import (
     Condition,
     EntityKind,
     EventRecord,
+    PresentTargetPolicy,
     Resolution,
     Slot,
     Template,
@@ -18,7 +19,11 @@ from nexus.agents.orrery.substrate import (
     evaluate_stack,
     validate_always_fallbacks,
 )
-from nexus.agents.orrery.resolver import OrreryResolutionDraft, OrreryTickProposal
+from nexus.agents.orrery.resolver import (
+    OrreryResolutionDraft,
+    OrreryScenePressureDraft,
+    OrreryTickProposal,
+)
 from nexus.agents.orrery.events import CommitOrreryTickResult
 
 __all__ = [
@@ -31,12 +36,14 @@ __all__ = [
     "Condition",
     "EntityKind",
     "EventRecord",
+    "PresentTargetPolicy",
     "Resolution",
     "Slot",
     "Template",
     "WorldState",
     "CommitOrreryTickResult",
     "OrreryResolutionDraft",
+    "OrreryScenePressureDraft",
     "OrreryTickProposal",
     "evaluate",
     "evaluate_stack",

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable as IterableABC
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping, Optional, Tuple
@@ -11,6 +12,7 @@ from sqlalchemy import text
 from nexus.agents.orrery.substrate import (
     Bindings,
     EventRecord,
+    PresentTargetPolicy,
     Resolution,
     Slot,
     Template,
@@ -69,12 +71,57 @@ class OrreryResolutionDraft:
 
 
 @dataclass(frozen=True, slots=True)
+class OrreryScenePressureDraft:
+    """Serializable Storyteller-facing pressure involving an on-screen target."""
+
+    template_id: str
+    priority: int
+    binding_hash: str
+    bindings: Mapping[str, Any]
+    branch_label: str
+    pressure_stub: str
+    prompt_text: str
+    magnitude: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of this scene pressure."""
+
+        return {
+            "template_id": self.template_id,
+            "priority": self.priority,
+            "binding_hash": self.binding_hash,
+            "bindings": dict(self.bindings),
+            "branch_label": self.branch_label,
+            "pressure_stub": self.pressure_stub,
+            "prompt_text": self.prompt_text,
+            "magnitude": self.magnitude,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "OrreryScenePressureDraft":
+        """Hydrate a scene pressure draft from incubator JSONB data."""
+
+        pressure_stub = str(data["pressure_stub"])
+        return cls(
+            template_id=str(data["template_id"]),
+            priority=int(data["priority"]),
+            binding_hash=str(data["binding_hash"]),
+            bindings=dict(data.get("bindings") or {}),
+            branch_label=str(data["branch_label"]),
+            pressure_stub=pressure_stub,
+            prompt_text=str(data.get("prompt_text") or pressure_stub),
+            magnitude=float(data.get("magnitude") or 0.0),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class OrreryTickProposal:
     """No-write Orrery proposal produced before accepted chunk commit."""
 
     anchor_chunk_id: Optional[int]
     actor_count: int
     resolutions: Tuple[OrreryResolutionDraft, ...]
+    scene_pressures: Tuple[OrreryScenePressureDraft, ...] = ()
     generated_at: str = field(
         default_factory=lambda: datetime.now(timezone.utc).isoformat()
     )
@@ -85,6 +132,12 @@ class OrreryTickProposal:
 
         return len(self.resolutions)
 
+    @property
+    def pressure_count(self) -> int:
+        """Return the number of Storyteller-mediated scene pressures."""
+
+        return len(self.scene_pressures)
+
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable representation of this proposal."""
 
@@ -93,6 +146,9 @@ class OrreryTickProposal:
             "actor_count": self.actor_count,
             "generated_at": self.generated_at,
             "resolutions": [draft.to_dict() for draft in self.resolutions],
+            "scene_pressures": [
+                pressure.to_dict() for pressure in self.scene_pressures
+            ],
         }
 
     @classmethod
@@ -106,6 +162,10 @@ class OrreryTickProposal:
             resolutions=tuple(
                 OrreryResolutionDraft.from_dict(item)
                 for item in data.get("resolutions", ())
+            ),
+            scene_pressures=tuple(
+                OrreryScenePressureDraft.from_dict(item)
+                for item in data.get("scene_pressures", ())
             ),
         )
 
@@ -359,6 +419,7 @@ def compose_actor_target_bindings(
     anchor_chunk_id: Optional[int],
     window_chunks: int,
     actor_ids: Optional[Iterable[int]] = None,
+    target_presence: str = "offscreen",
 ) -> Tuple[Bindings, ...]:
     """Compose ACTOR+TARGET bindings from actors' relational neighborhoods.
 
@@ -376,7 +437,15 @@ def compose_actor_target_bindings(
     where the two binding passes could see different actor sets if rows
     change between reads. Direct callers (e.g., focused unit tests) may
     omit actor_ids and accept the implicit recomputation.
+
+    target_presence controls whether TARGET may be a character explicitly
+    present at the anchor chunk. The default preserves Orrery's hard
+    off-screen boundary; "present" is reserved for Storyteller-mediated
+    scene-pressure proposals and still never allows a present ACTOR.
     """
+
+    if target_presence not in {"offscreen", "present"}:
+        raise ValueError("target_presence must be 'offscreen' or 'present'")
 
     if actor_ids is None:
         actor_only = compose_actor_bindings(
@@ -415,11 +484,25 @@ def compose_actor_target_bindings(
     ).mappings():
         source = row["source_entity_id"]
         target = row["target_entity_id"]
-        if source in present_actor_ids or target in present_actor_ids:
-            continue
-        if source in actor_id_set:
+        source_present = source in present_actor_ids
+        target_present = target in present_actor_ids
+        if (
+            source in actor_id_set
+            and not source_present
+            and (
+                (target_presence == "offscreen" and not target_present)
+                or (target_presence == "present" and target_present)
+            )
+        ):
             pairs.add((source, target))
-        if target in actor_id_set:
+        if (
+            target in actor_id_set
+            and not target_present
+            and (
+                (target_presence == "offscreen" and not source_present)
+                or (target_presence == "present" and source_present)
+            )
+        ):
             pairs.add((target, source))
 
     return tuple(
@@ -469,6 +552,7 @@ def resolve_dry_run(
         )
 
     drafts: list[OrreryResolutionDraft] = []
+    scene_pressure_results: list[Resolution] = []
 
     actor_bindings = compose_actor_bindings(
         session,
@@ -481,26 +565,58 @@ def resolve_dry_run(
             drafts.append(_draft_from_resolution(resolution))
 
     actor_target_bindings: Tuple[Bindings, ...] = ()
+    present_target_bindings: Tuple[Bindings, ...] = ()
     if actor_target_templates:
         actor_target_bindings = compose_actor_target_bindings(
             session,
             anchor_chunk_id=anchor_chunk_id,
             window_chunks=window_chunks,
             actor_ids={bindings[Slot.ACTOR] for bindings in actor_bindings},
+            target_presence="offscreen",
         )
         for bindings in actor_target_bindings:
             resolution = evaluate_stack(actor_target_templates, state, bindings)
             if resolution is not None and resolution.passes:
                 drafts.append(_draft_from_resolution(resolution))
 
+        pressure_templates = [
+            template
+            for template in actor_target_templates
+            if template.present_target_policy
+            is PresentTargetPolicy.STORYTELLER_PRESSURE
+        ]
+        if pressure_templates:
+            present_target_bindings = compose_actor_target_bindings(
+                session,
+                anchor_chunk_id=anchor_chunk_id,
+                window_chunks=window_chunks,
+                actor_ids={bindings[Slot.ACTOR] for bindings in actor_bindings},
+                target_presence="present",
+            )
+            for bindings in present_target_bindings:
+                resolution = evaluate_stack(pressure_templates, state, bindings)
+                if resolution is not None and resolution.passes:
+                    scene_pressure_results.append(resolution)
+
+    pressure_entity_names = _load_entity_names(
+        session, _entity_ids_from_resolutions(scene_pressure_results)
+    )
+    scene_pressures = tuple(
+        _scene_pressure_from_resolution(resolution, pressure_entity_names)
+        for resolution in scene_pressure_results
+    )
+
     unique_actors = {bindings[Slot.ACTOR] for bindings in actor_bindings} | {
         bindings[Slot.ACTOR] for bindings in actor_target_bindings
+    } | {
+        bindings[Slot.ACTOR] for bindings in present_target_bindings
     }
 
     return OrreryTickProposal(
         anchor_chunk_id=anchor_chunk_id,
         actor_count=len(unique_actors),
         resolutions=tuple(drafts),
+        scene_pressures=scene_pressures,
     )
 
 
@@ -638,3 +754,99 @@ def _draft_from_resolution(resolution: Resolution) -> OrreryResolutionDraft:
         changed_fields=resolution.changed_fields,
         magnitude=resolution.magnitude,
     )
+
+
+def _scene_pressure_from_resolution(
+    resolution: Resolution,
+    entity_names: Mapping[int, str],
+) -> OrreryScenePressureDraft:
+    if resolution.branch_label is None or resolution.scene_pressure_stub is None:
+        raise RuntimeError(
+            f"Orrery pressure {resolution.template_id!r} passed gate but lacks "
+            "scene_pressure_stub"
+        )
+    bindings = {
+        slot.value if isinstance(slot, Slot) else str(slot): value
+        for slot, value in resolution.bindings.items()
+    }
+    return OrreryScenePressureDraft(
+        template_id=resolution.template_id,
+        priority=resolution.priority,
+        binding_hash=resolution.binding_hash,
+        bindings=bindings,
+        branch_label=resolution.branch_label,
+        pressure_stub=resolution.scene_pressure_stub,
+        prompt_text=_render_bound_text(
+            resolution.scene_pressure_stub,
+            bindings,
+            entity_names,
+            template_id=resolution.template_id,
+        ),
+        magnitude=resolution.magnitude,
+    )
+
+
+def _render_bound_text(
+    text_template: str,
+    bindings: Mapping[str, Any],
+    entity_names: Mapping[int, str],
+    *,
+    template_id: str,
+) -> str:
+    values = {
+        slot: _entity_label(value, entity_names) for slot, value in bindings.items()
+    }
+    try:
+        rendered = text_template.format(**values)
+    except KeyError as exc:
+        missing_key = exc.args[0]
+        raise ValueError(
+            "Orrery template "
+            f"{template_id!r} scene_pressure_stub references missing binding "
+            f"{missing_key!r}"
+        ) from exc
+    return " ".join(rendered.split())
+
+
+def _entity_label(value: Any, entity_names: Mapping[int, str]) -> str:
+    if isinstance(value, list):
+        return ", ".join(_entity_label(item, entity_names) for item in value)
+    if value is None:
+        return "unknown"
+    try:
+        entity_id = int(value)
+    except (TypeError, ValueError):
+        return str(value)
+    return entity_names.get(entity_id, f"entity {entity_id}")
+
+
+def _entity_ids_from_resolutions(resolutions: Iterable[Resolution]) -> set[int]:
+    entity_ids: set[int] = set()
+    for resolution in resolutions:
+        for value in resolution.bindings.values():
+            if isinstance(value, IterableABC) and not isinstance(value, (str, bytes)):
+                for item in value:
+                    if isinstance(item, int):
+                        entity_ids.add(item)
+            elif isinstance(value, int):
+                entity_ids.add(value)
+    return entity_ids
+
+
+def _load_entity_names(session: Any, entity_ids: set[int]) -> dict[int, str]:
+    if not entity_ids:
+        return {}
+    return {
+        row["id"]: row["name"]
+        for row in session.execute(
+            text(
+                """
+                /* orrery:entity_names */
+                SELECT id, name
+                FROM entity_names_v
+                WHERE id = ANY(:entity_ids)
+                """
+            ),
+            {"entity_ids": sorted(entity_ids)},
+        ).mappings()
+    }

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -30,6 +30,13 @@ class Slot(str, Enum):
     FACTION = "faction"
 
 
+class PresentTargetPolicy(str, Enum):
+    """How a package treats targets currently owned by the Storyteller scene."""
+
+    OFFSCREEN_ONLY = "offscreen_only"
+    STORYTELLER_PRESSURE = "storyteller_pressure"
+
+
 Bindings = Dict[Slot, Any]
 Condition = Callable[["WorldState", Bindings], bool]
 
@@ -484,6 +491,7 @@ class Branch:
     event_type: Optional[str] = None
     changed_fields: Tuple[str, ...] = ()
     magnitude: float = 0.0
+    scene_pressure_stub: Optional[str] = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -496,6 +504,7 @@ class Template:
     required_slots: Tuple[Slot, ...]
     package_gate: Condition
     branches: Tuple[Branch, ...]
+    present_target_policy: PresentTargetPolicy = PresentTargetPolicy.OFFSCREEN_ONLY
 
 
 @dataclass(frozen=True, slots=True)
@@ -513,6 +522,7 @@ class Resolution:
     event_type: Optional[str] = None
     changed_fields: Tuple[str, ...] = ()
     magnitude: float = 0.0
+    scene_pressure_stub: Optional[str] = None
 
 
 def binding_hash(bindings: Bindings) -> str:
@@ -557,6 +567,7 @@ def evaluate(template: Template, state: WorldState, bindings: Bindings) -> Resol
                 event_type=branch.event_type,
                 changed_fields=branch.changed_fields,
                 magnitude=branch.magnitude,
+                scene_pressure_stub=branch.scene_pressure_stub,
             )
 
     return Resolution(

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -506,6 +506,23 @@ class Template:
     branches: Tuple[Branch, ...]
     present_target_policy: PresentTargetPolicy = PresentTargetPolicy.OFFSCREEN_ONLY
 
+    def __post_init__(self) -> None:
+        """Validate authoring invariants that affect resolver routing."""
+
+        if self.present_target_policy is not PresentTargetPolicy.STORYTELLER_PRESSURE:
+            return
+
+        missing = [
+            branch.label
+            for branch in self.branches
+            if not branch.scene_pressure_stub
+        ]
+        if missing:
+            raise ValueError(
+                f"Template {self.id!r}: STORYTELLER_PRESSURE branches must set "
+                f"scene_pressure_stub; missing on: {missing}"
+            )
+
 
 @dataclass(frozen=True, slots=True)
 class Resolution:

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -8,6 +8,7 @@ from nexus.agents.orrery.substrate import (
     NOT,
     OR,
     Branch,
+    PresentTargetPolicy,
     Slot,
     Template,
     co_located,
@@ -246,6 +247,9 @@ MAINTAIN_COVER = Template(
 #     routed by convention to Slot.TARGET by CommitOrreryTick. Define a
 #     state_delta TypedDict/dataclass if the implicit-string convention
 #     grows past this small vocabulary.
+#   * present_target_policy=STORYTELLER_PRESSURE allows a present TARGET only
+#     as prompt-only scene pressure. Present ACTORs are still excluded, and
+#     pressure drafts never commit state deltas or world events directly.
 #   * Trust hydration is un-implemented (resolver.py:177 TODO). Any branch
 #     gated on trust_at_least(N) with N > 0 or trust_below(N) with N < 0
 #     is currently unreachable — WorldState.trust defaults to 0 for every
@@ -302,6 +306,12 @@ EXTRACT_VENGEANCE = Template(
                 "world_events",
             ),
             magnitude=0.85,
+            scene_pressure_stub=(
+                "{actor}'s grudge is close enough to {target}'s current scene "
+                "to become immediate pressure. Treat it as a possible threat, "
+                "interruption, warning sign, or delayed consequence rather than "
+                "an automatic attack."
+            ),
         ),
         Branch(
             label="Surface a reputation attack in the right channels",
@@ -321,6 +331,12 @@ EXTRACT_VENGEANCE = Template(
             event_type="retaliation_attempted",
             changed_fields=("character.current_activity", "entity_tags"),
             magnitude=0.58,
+            scene_pressure_stub=(
+                "{actor} is trying to compromise {target}'s reputation through "
+                "off-screen channels. If useful, let the current scene show a "
+                "rumor, message, social consequence, or pressure wave instead "
+                "of a direct state change."
+            ),
         ),
         Branch(
             label="Watch and document, waiting for a better window",
@@ -336,8 +352,14 @@ EXTRACT_VENGEANCE = Template(
             event_type="retaliation_attempted",
             changed_fields=("character.current_activity",),
             magnitude=0.34,
+            scene_pressure_stub=(
+                "{actor} is watching {target}'s current patterns from cover. "
+                "This can surface as unease, surveillance traces, or a later "
+                "setup, but {target}'s on-screen choices remain yours."
+            ),
         ),
     ),
+    present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
 )
 
 
@@ -388,6 +410,11 @@ PROTECT_KIN = Template(
                 "world_events",
             ),
             magnitude=0.78,
+            scene_pressure_stub=(
+                "{actor} may be close enough to intervene around {target}'s "
+                "current danger. Treat this as potential off-screen support or "
+                "complication for the scene, not as an automatic rescue."
+            ),
         ),
         Branch(
             label="Travel toward the target's last known location",
@@ -406,6 +433,11 @@ PROTECT_KIN = Template(
             event_type="protective_intervention",
             changed_fields=("character.current_activity",),
             magnitude=0.52,
+            scene_pressure_stub=(
+                "{actor} is moving toward {target}'s current location because "
+                "they believe the danger is real. You may foreshadow, delay, "
+                "or ignore their arrival based on the active scene."
+            ),
         ),
         Branch(
             label="Signal kin networks to converge on the target",
@@ -421,6 +453,11 @@ PROTECT_KIN = Template(
             event_type="protective_intervention",
             changed_fields=("character.current_activity",),
             magnitude=0.41,
+            scene_pressure_stub=(
+                "{actor} has signaled a kin network around {target}. This can "
+                "become outside help, cross-traffic, noise, or a looming option "
+                "if it fits the live scene."
+            ),
         ),
         Branch(
             label="Maintain vigil and wait for resolution",
@@ -437,8 +474,14 @@ PROTECT_KIN = Template(
             event_type="protective_intervention",
             changed_fields=("character.current_activity", "entity_tags"),
             magnitude=0.22,
+            scene_pressure_stub=(
+                "{actor} is monitoring {target}'s danger from off-screen. This "
+                "is emotional and logistical pressure, not a command to change "
+                "what {target} does in the scene."
+            ),
         ),
     ),
+    present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
 )
 
 
@@ -493,6 +536,11 @@ CULTIVATE_INFORMANT = Template(
             event_type="intel_acquired",
             changed_fields=("character.current_activity", "entity_tags"),
             magnitude=0.62,
+            scene_pressure_stub=(
+                "{actor} may be trying to extract material intel from {target} "
+                "while {target} is in the current scene. Use it only if it "
+                "creates a believable opening, signal, or complication."
+            ),
         ),
         Branch(
             label="Routine contact to maintain the relationship",
@@ -512,6 +560,11 @@ CULTIVATE_INFORMANT = Template(
             event_type="informant_contact",
             changed_fields=("character.current_activity",),
             magnitude=0.28,
+            scene_pressure_stub=(
+                "{actor} is maintaining contact with {target} through a subtle "
+                "off-screen channel. It can surface as a message, glance, coded "
+                "exchange, or be deferred."
+            ),
         ),
         Branch(
             label="Place a small overture from a distance",
@@ -528,8 +581,14 @@ CULTIVATE_INFORMANT = Template(
             event_type="informant_contact",
             changed_fields=("character.current_activity",),
             magnitude=0.18,
+            scene_pressure_stub=(
+                "{actor} has placed a small indirect overture for {target}. "
+                "Treat it as optional atmosphere or a hook the Storyteller can "
+                "choose to pick up."
+            ),
         ),
     ),
+    present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
 )
 
 

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -1,0 +1,26 @@
+"""Tests for LOGON prompt formatting."""
+
+from nexus.agents.lore.logon_utility import LogonUtility
+
+
+def test_context_prompt_includes_orrery_scene_pressure_controls() -> None:
+    """Prompt-only Orrery pressures are framed as Storyteller-controlled."""
+
+    prompt = LogonUtility({})._format_context_prompt(
+        {
+            "user_input": "Continue.",
+            "orrery_scene_pressures": [
+                {
+                    "template_id": "protect_kin",
+                    "branch_label": "Travel toward the target's last known location",
+                    "prompt_text": "Mara is moving toward Vale.",
+                }
+            ],
+        }
+    )
+
+    assert "=== ORRERY SCENE PRESSURE ===" in prompt
+    assert "off-screen pressures involving current on-screen characters" in prompt
+    assert "You may adapt, delay, ignore, or incorporate them" in prompt
+    assert "Do not let Orrery decide what present characters do" in prompt
+    assert "Travel toward the target's last known location: Mara is moving" in prompt

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -7,7 +7,11 @@ from dataclasses import replace
 import pytest
 
 from nexus.agents.orrery.events import commit_orrery_tick_sync
-from nexus.agents.orrery.resolver import OrreryResolutionDraft, OrreryTickProposal
+from nexus.agents.orrery.resolver import (
+    OrreryResolutionDraft,
+    OrreryScenePressureDraft,
+    OrreryTickProposal,
+)
 from nexus.api.lore_adapter import response_to_incubator
 
 
@@ -136,12 +140,36 @@ def _proposal() -> OrreryTickProposal:
     )
 
 
+def _scene_pressure() -> OrreryScenePressureDraft:
+    return OrreryScenePressureDraft(
+        template_id="protect_kin",
+        priority=95,
+        binding_hash="pressure-1",
+        bindings={"actor": 1, "target": 2},
+        branch_label="Travel toward the target's last known location",
+        pressure_stub="{actor} is moving toward {target}.",
+        prompt_text="Mara is moving toward Vale.",
+        magnitude=0.52,
+    )
+
+
 def test_proposal_round_trips_through_json_shape() -> None:
     """Commit can hydrate the exact proposal shape stored in incubator JSONB."""
 
     proposal = _proposal()
 
     assert OrreryTickProposal.from_dict(proposal.to_dict()) == proposal
+
+
+def test_proposal_round_trips_scene_pressures_without_state_delta() -> None:
+    """Scene pressure survives incubator JSONB without becoming commit state."""
+
+    base = _proposal()
+    proposal = replace(base, scene_pressures=(_scene_pressure(),))
+    payload = proposal.to_dict()
+
+    assert "state_delta" not in payload["scene_pressures"][0]
+    assert OrreryTickProposal.from_dict(payload) == proposal
 
 
 def test_response_to_incubator_serializes_orrery_proposal() -> None:
@@ -159,6 +187,33 @@ def test_response_to_incubator_serializes_orrery_proposal() -> None:
     assert incubator_data["orrery_proposal"]["resolutions"][0]["template_id"] == (
         "evade_pursuers"
     )
+    assert incubator_data["orrery_proposal"]["scene_pressures"] == []
+
+
+def test_commit_orrery_tick_ignores_scene_pressures() -> None:
+    """Prompt-only pressures do not materialize canonical Orrery writes."""
+
+    proposal = OrreryTickProposal(
+        anchor_chunk_id=99,
+        actor_count=1,
+        resolutions=(),
+        scene_pressures=(_scene_pressure(),),
+        generated_at="2073-10-31T18:00:00+00:00",
+    )
+    cursor = RecordingCursor()
+
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        proposal,
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    assert result.resolution_count == 0
+    assert result.event_count == 0
+    assert result.tag_mutation_count == 0
+    assert cursor.executed == []
 
 
 def test_commit_orrery_tick_materializes_resolution_event_and_tags() -> None:

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -13,6 +13,7 @@ from nexus.agents.orrery.resolver import (
 from nexus.agents.orrery.substrate import (
     ALWAYS,
     Branch,
+    PresentTargetPolicy,
     Slot,
     Template,
 )
@@ -53,6 +54,7 @@ class FakeSession:
         ephemeral_actor_rows=None,
         present_actor_rows=None,
         actor_target_relationship_rows=None,
+        entity_name_rows=None,
         world_time=None,
         weather="",
         max_chunk_id=100,
@@ -73,6 +75,11 @@ class FakeSession:
         self.ephemeral_actor_rows = ephemeral_actor_rows or []
         self.present_actor_rows = present_actor_rows or []
         self.actor_target_relationship_rows = actor_target_relationship_rows or []
+        self.entity_name_rows = entity_name_rows or [
+            {"id": 1, "name": "Mara"},
+            {"id": 2, "name": "Vale"},
+            {"id": 3, "name": "Iris"},
+        ]
         self.world_time = world_time or datetime(2073, 10, 31, 12, tzinfo=timezone.utc)
         self.weather = weather
         self.max_chunk_id = max_chunk_id
@@ -115,6 +122,8 @@ class FakeSession:
         if "/* orrery:actor_target_bindings_character_relationships */" in sql:
             assert "relationship_scope = 'character'" in sql
             return FakeResult(self.actor_target_relationship_rows)
+        if "/* orrery:entity_names */" in sql:
+            return FakeResult(self.entity_name_rows)
         if "/* orrery:anchor_world_time */" in sql:
             return FakeResult([{"world_time": self.world_time}])
         if "/* orrery:seed_weather */" in sql:
@@ -416,6 +425,108 @@ def test_compose_actor_target_bindings_excludes_anchor_present_targets() -> None
 
     pairs = {(b[Slot.ACTOR], b[Slot.TARGET]) for b in bindings}
     assert pairs == {(1, 3)}
+
+
+def test_compose_actor_target_bindings_can_select_present_targets_for_pressure() -> None:
+    """Scene-pressure binding allows present targets but still excludes actors."""
+
+    session = FakeSession(
+        chunk_ref_actor_rows=[{"entity_id": 1}, {"entity_id": 2}],
+        present_actor_rows=[{"entity_id": 2}],
+        actor_target_relationship_rows=[
+            {"source_entity_id": 1, "target_entity_id": 2},
+        ],
+    )
+
+    bindings = compose_actor_target_bindings(
+        session,
+        anchor_chunk_id=100,
+        window_chunks=30,
+        target_presence="present",
+    )
+
+    pairs = {(b[Slot.ACTOR], b[Slot.TARGET]) for b in bindings}
+    assert pairs == {(1, 2)}
+
+
+def test_resolve_dry_run_routes_present_targets_to_scene_pressures() -> None:
+    """Opt-in packages produce prompt-only pressure instead of commit drafts."""
+
+    pressure_template = Template(
+        id="pressure_test",
+        priority=10,
+        blurb="test pressure",
+        required_slots=(Slot.ACTOR, Slot.TARGET),
+        package_gate=ALWAYS,
+        branches=(
+            Branch(
+                label="Press the scene",
+                conditions=ALWAYS,
+                narrative_stub="{actor} would commit a canonical event on {target}.",
+                state_delta={"character.current_activity": "pressuring target"},
+                scene_pressure_stub=(
+                    "{actor} is creating pressure around {target}, but the "
+                    "Storyteller controls whether it appears now."
+                ),
+            ),
+        ),
+        present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
+    )
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[{"entity_id": 1}],
+            present_actor_rows=[{"entity_id": 2}],
+            actor_target_relationship_rows=[
+                {"source_entity_id": 1, "target_entity_id": 2},
+            ],
+        ),
+        [pressure_template],
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 0
+    assert proposal.pressure_count == 1
+    pressure = proposal.scene_pressures[0]
+    assert pressure.template_id == "pressure_test"
+    assert pressure.bindings == {"actor": 1, "target": 2}
+    assert "Mara is creating pressure around Vale" in pressure.prompt_text
+    assert "state_delta" not in pressure.to_dict()
+
+
+def test_resolve_dry_run_keeps_default_templates_offscreen_only_for_present_targets() -> None:
+    """Default multi-slot templates cannot pressure an on-screen target."""
+
+    default_template = Template(
+        id="default_present_target",
+        priority=10,
+        blurb="default policy",
+        required_slots=(Slot.ACTOR, Slot.TARGET),
+        package_gate=ALWAYS,
+        branches=(
+            Branch(
+                label="Would fire",
+                conditions=ALWAYS,
+                narrative_stub="{actor} affects {target}.",
+                scene_pressure_stub="{actor} pressures {target}.",
+            ),
+        ),
+    )
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[{"entity_id": 1}],
+            present_actor_rows=[{"entity_id": 2}],
+            actor_target_relationship_rows=[
+                {"source_entity_id": 1, "target_entity_id": 2},
+            ],
+        ),
+        [default_template],
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 0
+    assert proposal.pressure_count == 0
 
 
 def test_resolve_dry_run_rejects_unsupported_slot_signatures() -> None:

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -529,6 +529,47 @@ def test_resolve_dry_run_keeps_default_templates_offscreen_only_for_present_targ
     assert proposal.pressure_count == 0
 
 
+def test_pressure_templates_still_commit_for_offscreen_targets() -> None:
+    """Pressure opt-in is dual-mode: off-screen targets still commit normally."""
+
+    pressure_template = Template(
+        id="dual_mode_pressure",
+        priority=10,
+        blurb="dual-mode policy",
+        required_slots=(Slot.ACTOR, Slot.TARGET),
+        package_gate=ALWAYS,
+        branches=(
+            Branch(
+                label="Off-screen action",
+                conditions=ALWAYS,
+                narrative_stub="{actor} acts around {target}.",
+                state_delta={"character.current_activity": "acting off-screen"},
+                scene_pressure_stub="{actor} pressures {target}.",
+            ),
+        ),
+        present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
+    )
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[{"entity_id": 1}],
+            present_actor_rows=[],
+            actor_target_relationship_rows=[
+                {"source_entity_id": 1, "target_entity_id": 2},
+            ],
+        ),
+        [pressure_template],
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.pressure_count == 0
+    assert proposal.resolutions[0].template_id == "dual_mode_pressure"
+    assert proposal.resolutions[0].state_delta == {
+        "character.current_activity": "acting off-screen"
+    }
+
+
 def test_resolve_dry_run_rejects_unsupported_slot_signatures() -> None:
     """Templates with non-(ACTOR,)/non-(ACTOR,TARGET) slot tuples fail loud."""
 
@@ -600,3 +641,4 @@ def test_resolve_dry_run_produces_multi_slot_resolution() -> None:
         "Physically intervene at the target's location"
     )
     assert protect_kin_drafts[0].bindings == {"actor": 1, "target": 2}
+    assert proposal.pressure_count == 0

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -6,6 +6,7 @@ from nexus.agents.orrery.demo import run_preset
 from nexus.agents.orrery.substrate import (
     ALWAYS,
     Branch,
+    PresentTargetPolicy,
     Slot,
     Template,
     WorldState,
@@ -46,6 +47,27 @@ def test_missing_always_fallback_is_rejected() -> None:
 
     with pytest.raises(ValueError, match="bad_template"):
         validate_always_fallbacks((template,))
+
+
+def test_storyteller_pressure_templates_require_pressure_stubs() -> None:
+    """Template authors must provide prompt text for every pressure branch."""
+
+    with pytest.raises(ValueError, match="scene_pressure_stub.*missing"):
+        Template(
+            id="bad_pressure_template",
+            priority=1,
+            blurb="Missing prompt-only pressure text.",
+            required_slots=(Slot.ACTOR, Slot.TARGET),
+            package_gate=ALWAYS,
+            branches=(
+                Branch(
+                    "missing pressure",
+                    ALWAYS,
+                    "{actor} affects {target}.",
+                ),
+            ),
+            present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Add prompt-only Orrery scene pressure drafts for opt-in packages that target an on-screen character from an off-screen actor.
- Keep present actors forbidden and keep normal actor-target packages off-screen-only by default.
- Feed scene pressure into LOGON prompt formatting with explicit Storyteller-control language, while canonical Orrery commit writers continue to ignore pressure-only proposals.

## Validation
- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery tests/test_api/test_lore_adapter.py tests/test_lore/test_logon_prompt_formatting.py` → 56 passed
- `PYTHONPATH=$PWD poetry run python -m py_compile nexus/agents/orrery/substrate.py nexus/agents/orrery/resolver.py nexus/agents/orrery/templates.py nexus/agents/orrery/events.py nexus/agents/lore/utils/turn_cycle.py nexus/agents/lore/logon_utility.py nexus/api/lore_adapter.py`
- `git diff --check`

## Notes
- No migration required; `scene_pressures` live in the existing provisional Orrery proposal payload and are not materialized as world events, tag changes, or character state updates.
- Opened ready for review so the automated review flow can trigger.