### PR TITLE
Add Orrery Bleed selector

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -456,7 +456,7 @@ CREATE TABLE offscreen_narrations (
 
 **Hook point.** Bleed runs at the start of LORE Phase 5 (`assemble_context_payload`, `nexus/agents/lore/utils/turn_cycle.py:489`). Its output populates `turn_context.bleed_menu`, which `assemble_context_payload` then reads when building the payload. Concretely, the Bleed entry point is a new method on `TurnCycleManager` invoked from `assemble_context_payload` before payload assembly proper begins.
 
-**Latency budget: hard 2-second cap, enforced via `asyncio.wait_for`.** If the local-LLM call exceeds budget, the bleed menu for this turn is empty and the overrun logged loudly. Empty bleed is a valid outcome.
+**Latency budget: hard 2-second cap, enforced via an async local-LLM request timeout.** If the local-LLM call exceeds budget, the bleed menu for this turn is empty and the overrun logged loudly. Empty bleed is a valid outcome.
 
 **Candidate query is typed**: reads from `orrery_resolutions` JOIN `world_events` JOIN `offscreen_narrations` with filters on age, location proximity, sensory plausibility, surfacing history. The local LLM call uses `LocalLLMManager.structured_query(prompt, response_model)` (`nexus/agents/lore/utils/local_llm.py:642`) — signature is `(prompt, response_model, *, temperature=None, max_tokens=None, system_prompt=None)`. The existing helper handles SDK-vs-fallback parsing; no new structured-output plumbing required.
 
@@ -541,6 +541,7 @@ model_ref = "@anthropic.default"                        # resolved via [global.m
 [orrery.bleed]
 latency_budget_ms = 2000
 max_candidates = 3
+candidate_pool_multiplier = 4
 
 [orrery.promote]
 provider = "local"
@@ -735,7 +736,7 @@ Verification should use live NEXUS flows where the feature touches LORE, LOGON, 
 1. **Hook seams corrected.** `CommitOrreryTick` hooks the *transaction-wrapping* functions (`commit_incubator_to_database` L320 async; `commit_incubator_to_database_sync` L233 sync) at Step 8.5, not the `apply_state_updates*` workers at L223/L451.
 2. **Sync path called out as production.** Only `narrative.py:407` calls a commit function in production code, and it calls the sync variant. Async kept in parity for tests.
 3. **`chunk_workflow.py` removed from PR 0 audit.** It is not on the commit path; replaced with an audit of `narrative.py::_approve_narrative_impl` (L387).
-4. **Bleed hook point named.** Runs at the start of LORE Phase 5 (`assemble_context_payload`, `turn_cycle.py:489`); 2s budget enforced via `asyncio.wait_for`.
+4. **Bleed hook point named.** Runs at the start of LORE Phase 5 (`assemble_context_payload`, `turn_cycle.py:489`); 2s budget enforced by the async local-LLM request timeout.
 5. **Pipeline stages renamed.** "Phase N" reserved for LORE turn cycle; Orrery pipeline uses "Stage N". Deferred "Phase 7" → "Orrery Stage 7".
 6. **`TurnContext` extension spelled out.** Two new dataclass fields + one new `TurnPhase` enum value.
 7. **`world_layer_type` precondition.** Postgres ENUM not in tracked migrations; PR 0 confirms or PR 1 declares.

--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -1,6 +1,6 @@
 # Off-Screen Behavior Resolver — Orrery Design Plan
 
-**Status:** Foundation implemented in PR #210. PR #211 adds the no-write hydration/dry-run resolver and the LORE Phase 4.5 hook. The runtime pipeline is still disabled by default (`orrery.enabled = false`), produces only an inspectable `OrreryTickProposal`, and performs no canonical Orrery writes or storyteller payload injection yet.
+**Status:** Foundation implemented in PR #210, dry-run resolve in PR #211, commit/promote/narrate/clear in PR #214, expanded package library in PR #212, present-target scene pressure in PR #216, and generated human-readable catalog support in PR #217. The runtime pipeline remains disabled by default (`orrery.enabled = false`). This branch adds the PR 4 Bleed selector and Storyteller payload surface.
 
 **Originating artifacts:** `temp/orrery/off_screen_resolver_spec.md`, `temp/orrery/behavior_substrate.py`, `temp/orrery/package_simulator.jsx`
 **Review trace:** `temp/orrery/design_plan_edited.md` (round 1: GPT-5.5-Pro, Codex, separate-Claude, Gemini) + `temp/orrery/super_table_question.md` (round 2: GPT-5.5-Pro, Claude Opus 4.7 chat) + v4 grounding pass against current `main` (claude-opus-4-7).
@@ -59,15 +59,16 @@
 - Live direct dry-run against slot 2: hydrated mature-state morning/clear context, produced proposals, and performed zero writes.
 - `poetry run flake8 ...` remains unavailable because `flake8` is not installed in the Poetry environment.
 
-### Next Slice
+### Landed After PR #211
 
-PR 3 should wire commit-time persistence while preserving the accepted-chunk invariant:
+- PR #214 wires accepted-chunk commit-time persistence, stamps `tick_chunk_id`, materializes Orrery resolutions, world events, and tag mutations, and enqueues durable narration jobs after canonical commit succeeds.
+- PR #212 expands the package library with multi-slot templates and additional scene-pressure-aware package metadata.
+- PR #216 adds present-target scene pressure proposals that are Storyteller-facing only and ignored by canonical Orrery commit writers.
+- PR #217 adds generated human-readable catalog support for package authors and reviewers.
 
-- stamp `tick_chunk_id` onto the in-memory proposal inside the accepted-chunk commit transaction
-- materialize `orrery_resolutions`, related `world_events`, and tag mutations through one unified writer
-- enqueue durable narration jobs only after canonical commit succeeds
-- add Promote/Narrate/Clear plumbing with loud failure behavior
-- verify idempotency, incubator rejection, and warm-slice isolation against live slots
+### Current Slice
+
+This branch implements PR 4: Bleed selection at Storyteller time. It selects a bounded menu of previously narrated off-screen events, records surfacing bookkeeping, and injects optional ambient peripherals into the LOGON prompt without advancing chronology or promoting off-screen narrations into warm-slice memory.
 
 ### Package Author Checkpoint
 
@@ -637,7 +638,7 @@ Per-chunk, not per-event. Stamped only at accepted commit. `world_events.world_t
 - **No canonical writes yet.** Proposal is buffered and inspectable, but does not mutate any table or enter the storyteller payload.
 - Verification: unit coverage for disabled/enabled phase behavior, anchor fallback, fallback/non-fallback packages, and SQL filters; live direct dry-runs against slot 5 (baby narrative state) and slot 2 (mature narrative state) with zero writes.
 
-### PR 3 — CommitOrreryTick + Promote + Narrate + Clear
+### PR 3 — CommitOrreryTick + Promote + Narrate + Clear (implemented in PR #214)
 
 - **`CommitOrreryTick` writer**: Step 8.5 inside `commit_incubator_to_database_sync` (L233 — the production path; insert between `apply_state_updates_sync` at L415 and incubator clear at L418) and parity inside `commit_incubator_to_database` (L320 — async, test-only; insert between `apply_state_updates` at L420 and `clear_incubator` at L423). Both call into the unified event writer in `nexus/agents/orrery/events.py`.
 - **Stamp `tick_chunk_id`** on every proposal row at this step, after `insert_narrative_chunk` returns the new chunk id.
@@ -650,14 +651,14 @@ Per-chunk, not per-event. Stamped only at accepted commit. `world_events.world_t
 - Instrumented counters for the Orrery Stage 7 trigger metrics.
 - Verification: engineered fifty-chunk scenario (motivating test case), idempotency, incubator rejection, warm-slice contamination, local-LLM failure, async-worker state transitions.
 
-### PR 4 — Bleed Selector + Storyteller Integration
+### PR 4 — Bleed Selector + Storyteller Integration (this branch)
 
 - Bleed selector wired into LORE Phase 5 (`assemble_context_payload`, `turn_cycle.py:489`); reads `turn_context.bleed_menu` populated by a new selector method invoked at the start of that phase.
 - Typed candidate query over `orrery_resolutions` ⋈ `world_events` ⋈ `offscreen_narrations`.
 - Hard 2-second latency budget enforced via `asyncio.wait_for`; overrun = empty menu + loud log.
 - Surfacing bookkeeping increments.
 - Menu injected into payload with framing "ambient peripherals — optional, ignore freely, render at any density".
-- System-prompt edit at `lore_system_prompt.md:253-265`.
+- Prompt framing injected by `LogonUtility._format_context_prompt` as optional Orrery ambient peripherals.
 - Verification: apt-bleed + null-bleed + spoiler-boundary + chronology tests.
 
 ### Orrery Stage 7 — Middle-Tier Journalistic Prose (Deferred, Metric-Gated)
@@ -709,7 +710,7 @@ Revisit when: fourth real entity kind appears, compatibility view becomes write 
 
 **Config + system prompt**
 - `nexus.toml` — new `[orrery]`, `[orrery.binding]`, `[orrery.narration]`, `[orrery.bleed]`, `[orrery.promote]` sections; use `@provider.role` syntax per `[global.model.api_models]` registry
-- `nexus/agents/lore/lore_system_prompt.md:253-265` — minor edit in PR 4
+- `nexus/agents/lore/logon_utility.py::_format_context_prompt` — PR 4 Bleed prompt framing
 
 **New artifacts**
 - `migrations/023_orrery_schema.py` — Python migration (multi-transaction; SQL alone insufficient for staged FK backfill)
@@ -724,8 +725,8 @@ Verification should use live NEXUS flows where the feature touches LORE, LOGON, 
 - **PR 0/1 foundation (#210):** Substrate demo runs against four presets; migration applies cleanly via `scripts/migrate.py --template` and unlocked slots; entity spine backfill validated; kind-enforcement triggers tested; compatibility views return expected unions; MEMNON whitelist updated and tested; `world_layer_type` confirmed or created in template.
 - **Remaining pre-Bleed audit:** Integration test asserting `query_memory` warm-slice is disjoint from `offscreen_narrations`; `execute_readonly_sql` can SELECT from each new public table and cannot select internal queue/raw tag tables.
 - **PR 2 (#211):** Dry-pass against slot 5 and slot 2; proposal contents inspected; zero writes observed; `TurnContext.orrery_proposal` carries no `tick_chunk_id` at this phase. Optional full-turn acceptance before PR 3: enable Orrery for a live LORE pass and confirm the storyteller payload remains unaffected while the proposal is attached only to the turn context.
-- **PR 3:** Engineered fifty-chunk motivating scenario (interrogated NPC → fifty ticks → retaliation prose persisted to `offscreen_narrations`, never surfaced); idempotency (regeneration cannot double-write — UNIQUE key fires); rejection (incubator rejection rolls everything back, including the Step 8.5 writes); warm-slice contamination (none); local-LLM failure (Promote fails loud); async-worker state transitions (`queued → leased → succeeded|failed`).
-- **PR 4:** Apt-bleed (audible peripheral surfaces in distant scene); null-bleed (irrelevant resolutions produce empty menu); spoiler-boundary (resolutions before the player's current world-time are eligible; future resolutions are not); chronology tests (`offscreen_narrations` never advance `narrative_view.world_time`); latency-budget overrun produces empty menu and logs loudly.
+- **PR 3 (#214):** Engineered fifty-chunk motivating scenario (interrogated NPC → fifty ticks → retaliation prose persisted to `offscreen_narrations`, never surfaced); idempotency (regeneration cannot double-write — UNIQUE key fires); rejection (incubator rejection rolls everything back, including the Step 8.5 writes); warm-slice contamination (none); local-LLM failure (Promote fails loud); async-worker state transitions (`queued → leased → succeeded|failed`).
+- **PR 4:** Apt-bleed (ambient peripheral surfaces in the Storyteller payload); null-bleed (no candidates produces empty menu and no local-LLM call); chronology/surfacing boundary (only accepted prior narrated resolutions are eligible); latency-budget overrun produces empty menu and logs loudly.
 
 ---
 

--- a/nexus.toml
+++ b/nexus.toml
@@ -171,6 +171,7 @@ model_ref = "@anthropic.default"
 [orrery.bleed]
 latency_budget_ms = 2000
 max_candidates = 3
+candidate_pool_multiplier = 4
 
 [orrery.promote]
 provider = "local"

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -398,6 +398,23 @@ class LogonUtility:
                 if prompt_text:
                     sections.append(f"- {label}: {prompt_text}")
 
+        bleed_menu = context.get("orrery_bleed_menu") or []
+        if bleed_menu:
+            sections.append("\n=== ORRERY AMBIENT PERIPHERALS ===")
+            sections.append(
+                "These are optional ambient peripherals from off-screen events. "
+                "Ignore freely, render subtly, or use them at any density that "
+                "fits the current scene. Do not explain Orrery."
+            )
+            for item in bleed_menu[:5]:
+                channel = item.get("channel") or "ambient"
+                summary = item.get("summary") or item.get("template_id")
+                actor = item.get("actor_name")
+                prefix = f"[{channel}]"
+                if actor:
+                    prefix = f"{prefix} {actor}:"
+                sections.append(f"- {prefix} {summary}")
+
         # Add author's note (soft out-of-character suggestion, used by regenerate).
         # Placed immediately before INSTRUCTIONS so recency bias gives it the influence
         # a soft nudge needs — entity/historical context above would otherwise bury it.

--- a/nexus/agents/lore/utils/local_llm.py
+++ b/nexus/agents/lore/utils/local_llm.py
@@ -687,3 +687,68 @@ Each query should be a complete question or search phrase."""
         except Exception:
             # Return raw content in a dict-like shape
             return {"answer": raw, "reasoning": "unstructured"}
+
+    async def structured_query_async(
+        self,
+        prompt: str,
+        response_model: Type[BaseModel],
+        *,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        system_prompt: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> Union[BaseModel, Dict[str, Any]]:
+        """Query the local LLM through the HTTP API with an async timeout."""
+        import httpx
+
+        request_timeout = timeout if timeout is not None else 60.0
+        schema = response_model.model_json_schema()
+        model_id = self.loaded_model_id or self.model_name
+        prompt_with_schema = (
+            f"{prompt}\n\nReturn only valid JSON matching this schema:\n"
+            f"{json.dumps(schema, sort_keys=True)}"
+        )
+        payload = {
+            "model": model_id,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": system_prompt
+                    or "You are LORE, a narrative intelligence system.",
+                },
+                {"role": "user", "content": prompt_with_schema},
+            ],
+            "temperature": temperature
+            if temperature is not None
+            else self.llm_config.get("temperature", 0.3),
+            "max_tokens": max_tokens
+            if max_tokens is not None
+            else self.llm_config.get("max_tokens", 1024),
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": response_model.__name__,
+                    "schema": schema,
+                },
+            },
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=request_timeout) as client:
+                response = await client.post(
+                    f"{self.base_url.rstrip('/')}/chat/completions",
+                    json=payload,
+                )
+                response.raise_for_status()
+        except httpx.TimeoutException as exc:
+            raise TimeoutError(
+                f"Local structured query exceeded {request_timeout:.3f}s timeout"
+            ) from exc
+
+        data = response.json()
+        content = data["choices"][0]["message"]["content"]
+        if isinstance(content, str):
+            parsed = json.loads(content)
+        else:
+            parsed = content
+        return response_model.model_validate(parsed)

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -27,6 +27,7 @@ try:
     )
     from nexus.agents.orrery.resolver import resolve_dry_run
     from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+    from nexus.agents.orrery.bleed import select_bleed_menu_async
 except ImportError:
     # If relative import fails, try absolute
     from nexus.agents.lore.utils.turn_context import TurnContext, TurnPhase
@@ -44,6 +45,7 @@ except ImportError:
     )
     from nexus.agents.orrery.resolver import resolve_dry_run
     from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+    from nexus.agents.orrery.bleed import select_bleed_menu_async
 
 try:
     from nexus.agents.memnon.utils.query_analysis import QueryAnalyzer
@@ -651,6 +653,8 @@ class TurnCycleManager:
         """
         logger.debug("Assembling context payload...")
 
+        await self.select_orrery_bleed(turn_context)
+
         # Build the context payload
         turn_context.context_payload = {
             "user_input": turn_context.user_input,
@@ -683,6 +687,11 @@ class TurnCycleManager:
                 for pressure in turn_context.orrery_proposal.scene_pressures
             ]
 
+        if turn_context.bleed_menu:
+            turn_context.context_payload["orrery_bleed_menu"] = [
+                candidate.to_prompt_dict() for candidate in turn_context.bleed_menu
+            ]
+
         if turn_context.target_chunk_id is not None:
             turn_context.context_payload["metadata"][
                 "target_chunk_id"
@@ -709,6 +718,58 @@ class TurnCycleManager:
         }
 
         logger.info(f"Context payload assembled: {utilization:.1f}% budget utilization")
+
+    async def select_orrery_bleed(self, turn_context: TurnContext) -> None:
+        """Populate optional Orrery Bleed menu before payload assembly."""
+
+        orrery_settings = self.settings.get("orrery", {})
+        if not orrery_settings.get("enabled", False):
+            return
+
+        bleed_settings = orrery_settings.get("bleed", {})
+        max_candidates = int(bleed_settings.get("max_candidates", 3))
+        if max_candidates <= 0:
+            turn_context.phase_states["orrery_bleed"] = {
+                "enabled": True,
+                "skipped": True,
+                "reason": "max_candidates_zero",
+            }
+            return
+
+        if not self.lore.memnon:
+            raise RuntimeError("Orrery bleed requires MEMNON database access")
+        if not self.lore.llm_manager:
+            raise RuntimeError("Orrery bleed requires local LLM access")
+
+        latency_budget_ms = int(bleed_settings.get("latency_budget_ms", 2000))
+        with self.lore.memnon.Session() as session:
+            anchor_chunk_id = self._orrery_anchor_chunk_id(session, turn_context)
+            if anchor_chunk_id is None:
+                turn_context.phase_states["orrery_bleed"] = {
+                    "enabled": True,
+                    "skipped": True,
+                    "reason": "no_anchor_chunk",
+                }
+                return
+
+            result = await select_bleed_menu_async(
+                session,
+                llm_manager=self.lore.llm_manager,
+                anchor_chunk_id=anchor_chunk_id,
+                user_input=turn_context.user_input,
+                warm_slice=turn_context.warm_slice,
+                max_candidates=max_candidates,
+                latency_budget_ms=latency_budget_ms,
+            )
+
+        turn_context.bleed_menu = result.selected
+        turn_context.phase_states["orrery_bleed"] = {
+            "enabled": True,
+            "anchor_chunk_id": anchor_chunk_id,
+            "candidate_count": result.candidates_considered,
+            "selected_count": len(result.selected),
+            "timed_out": result.timed_out,
+        }
 
     async def call_apex_ai(self, turn_context: TurnContext) -> str:
         """

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -27,7 +27,10 @@ try:
     )
     from nexus.agents.orrery.resolver import resolve_dry_run
     from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
-    from nexus.agents.orrery.bleed import select_bleed_menu_async
+    from nexus.agents.orrery.bleed import (
+        record_bleed_offers,
+        select_bleed_menu_async,
+    )
 except ImportError:
     # If relative import fails, try absolute
     from nexus.agents.lore.utils.turn_context import TurnContext, TurnPhase
@@ -45,7 +48,10 @@ except ImportError:
     )
     from nexus.agents.orrery.resolver import resolve_dry_run
     from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
-    from nexus.agents.orrery.bleed import select_bleed_menu_async
+    from nexus.agents.orrery.bleed import (
+        record_bleed_offers,
+        select_bleed_menu_async,
+    )
 
 try:
     from nexus.agents.memnon.utils.query_analysis import QueryAnalyzer
@@ -728,6 +734,9 @@ class TurnCycleManager:
 
         bleed_settings = orrery_settings.get("bleed", {})
         max_candidates = int(bleed_settings.get("max_candidates", 3))
+        candidate_pool_multiplier = int(
+            bleed_settings.get("candidate_pool_multiplier", 4)
+        )
         if max_candidates <= 0:
             turn_context.phase_states["orrery_bleed"] = {
                 "enabled": True,
@@ -743,7 +752,10 @@ class TurnCycleManager:
 
         latency_budget_ms = int(bleed_settings.get("latency_budget_ms", 2000))
         with self.lore.memnon.Session() as session:
-            anchor_chunk_id = self._orrery_anchor_chunk_id(session, turn_context)
+            if turn_context.orrery_proposal is not None:
+                anchor_chunk_id = turn_context.orrery_proposal.anchor_chunk_id
+            else:
+                anchor_chunk_id = self._orrery_anchor_chunk_id(session, turn_context)
             if anchor_chunk_id is None:
                 turn_context.phase_states["orrery_bleed"] = {
                     "enabled": True,
@@ -759,6 +771,7 @@ class TurnCycleManager:
                 user_input=turn_context.user_input,
                 warm_slice=turn_context.warm_slice,
                 max_candidates=max_candidates,
+                candidate_pool_multiplier=candidate_pool_multiplier,
                 latency_budget_ms=latency_budget_ms,
             )
 
@@ -769,7 +782,33 @@ class TurnCycleManager:
             "candidate_count": result.candidates_considered,
             "selected_count": len(result.selected),
             "timed_out": result.timed_out,
+            "offers_recorded": 0,
         }
+
+    def record_orrery_bleed_offers(self, turn_context: TurnContext) -> None:
+        """Record Bleed offer bookkeeping after successful generation."""
+
+        if not turn_context.bleed_menu:
+            return
+
+        phase_state = turn_context.phase_states.setdefault("orrery_bleed", {})
+        if phase_state.get("offers_recorded"):
+            return
+
+        anchor_chunk_id = phase_state.get("anchor_chunk_id")
+        if anchor_chunk_id is None:
+            raise RuntimeError("Orrery bleed selected candidates without an anchor")
+        if not self.lore.memnon:
+            raise RuntimeError("Orrery bleed offer recording requires MEMNON")
+
+        with self.lore.memnon.Session() as session:
+            record_bleed_offers(
+                session,
+                turn_context.bleed_menu,
+                anchor_chunk_id=int(anchor_chunk_id),
+            )
+
+        phase_state["offers_recorded"] = len(turn_context.bleed_menu)
 
     async def call_apex_ai(self, turn_context: TurnContext) -> str:
         """
@@ -833,6 +872,8 @@ class TurnCycleManager:
                 "has_state_updates": state_updates is not None,
                 "narrative_length": len(narrative_text),
             }
+
+            self.record_orrery_bleed_offers(turn_context)
 
             return story_response  # Return the full StoryTurnResponse
 

--- a/nexus/agents/orrery/__init__.py
+++ b/nexus/agents/orrery/__init__.py
@@ -25,6 +25,7 @@ from nexus.agents.orrery.resolver import (
     OrreryTickProposal,
 )
 from nexus.agents.orrery.events import CommitOrreryTickResult
+from nexus.agents.orrery.bleed import BleedCandidate, BleedSelectorResult
 
 __all__ = [
     "ALWAYS",
@@ -42,6 +43,8 @@ __all__ = [
     "Template",
     "WorldState",
     "CommitOrreryTickResult",
+    "BleedCandidate",
+    "BleedSelectorResult",
     "OrreryResolutionDraft",
     "OrreryScenePressureDraft",
     "OrreryTickProposal",

--- a/nexus/agents/orrery/bleed.py
+++ b/nexus/agents/orrery/bleed.py
@@ -134,6 +134,7 @@ async def select_bleed_menu_async(
     user_input: str,
     warm_slice: list[dict[str, Any]],
     max_candidates: int,
+    candidate_pool_multiplier: int,
     latency_budget_ms: int,
 ) -> BleedSelectorResult:
     """Select a spoiler-safe ambient Bleed menu under a hard latency budget."""
@@ -144,7 +145,7 @@ async def select_bleed_menu_async(
     candidate_pool = load_bleed_candidates(
         session,
         anchor_chunk_id=anchor_chunk_id,
-        limit=max(max_candidates * 4, max_candidates),
+        limit=max_candidates * max(1, candidate_pool_multiplier),
     )
     if not candidate_pool:
         return BleedSelectorResult()
@@ -157,17 +158,15 @@ async def select_bleed_menu_async(
     )
 
     try:
-        selected = await asyncio.wait_for(
-            asyncio.to_thread(
-                _select_candidates_sync,
+        async with asyncio.timeout(latency_budget_ms / 1000):
+            selected = await _select_candidates_async(
                 llm_manager,
                 prompt,
                 candidate_pool,
                 max_candidates,
-            ),
-            timeout=latency_budget_ms / 1000,
-        )
-    except asyncio.TimeoutError:
+                latency_budget_ms / 1000,
+            )
+    except (TimeoutError, asyncio.TimeoutError):
         logger.error(
             "Orrery Bleed selector exceeded %sms latency budget",
             latency_budget_ms,
@@ -175,13 +174,6 @@ async def select_bleed_menu_async(
         return BleedSelectorResult(
             candidates_considered=len(candidate_pool),
             timed_out=True,
-        )
-
-    if selected:
-        record_bleed_offers(
-            session,
-            selected,
-            anchor_chunk_id=anchor_chunk_id,
         )
 
     return BleedSelectorResult(
@@ -283,6 +275,8 @@ def _build_bleed_prompt(
             "channel": candidate.channel,
             "summary": candidate.summary,
             "brief": candidate.brief,
+            # Full narration text is only for selector-side spoiler judgment.
+            # Storyteller injection must use BleedCandidate.to_prompt_dict().
             "text": candidate.text,
             "magnitude": candidate.magnitude,
         }
@@ -303,18 +297,20 @@ def _build_bleed_prompt(
     )
 
 
-def _select_candidates_sync(
+async def _select_candidates_async(
     llm_manager: Any,
     prompt: str,
     candidates: list[BleedCandidate],
     max_candidates: int,
+    timeout_seconds: float,
 ) -> list[BleedCandidate]:
-    raw = llm_manager.structured_query(
+    raw = await llm_manager.structured_query_async(
         prompt,
         BleedSelection,
         temperature=0.1,
         max_tokens=512,
         system_prompt=BLEED_SYSTEM_PROMPT,
+        timeout=timeout_seconds,
     )
     try:
         selection = (

--- a/nexus/agents/orrery/bleed.py
+++ b/nexus/agents/orrery/bleed.py
@@ -1,0 +1,340 @@
+"""Storyteller-time Bleed selector for narrated Orrery resolutions."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from decimal import Decimal
+from typing import Any, Mapping, Optional
+
+from pydantic import BaseModel, Field, ValidationError
+from sqlalchemy import text
+
+logger = logging.getLogger("nexus.orrery.bleed")
+
+
+BLEED_SYSTEM_PROMPT = (
+    "You are the Orrery Bleed selector. Choose only off-screen narrations that "
+    "could plausibly be perceived as ambient peripheral texture in the current "
+    "scene. Prefer sensory, social, or digital traces. Ignore candidates that "
+    "would spoil hidden information or force the Storyteller to use them."
+)
+
+
+class BleedCandidate(BaseModel):
+    """One narrated off-screen resolution eligible for Storyteller-time Bleed."""
+
+    resolution_id: int
+    narration_id: int
+    tick_chunk_id: int
+    template_id: str
+    event_type: Optional[str] = None
+    actor_name: Optional[str] = None
+    target_name: Optional[str] = None
+    channel: Optional[str] = None
+    summary: Optional[str] = None
+    brief: Optional[str] = None
+    text: str
+    magnitude: Optional[float] = None
+
+    def to_prompt_dict(self) -> dict[str, Any]:
+        """Return the spoiler-limited shape injected into the Storyteller prompt."""
+
+        return {
+            "resolution_id": self.resolution_id,
+            "template_id": self.template_id,
+            "channel": self.channel,
+            "summary": self.summary or self.brief,
+            "actor_name": self.actor_name,
+            "target_name": self.target_name,
+            "magnitude": self.magnitude,
+        }
+
+
+class BleedSelection(BaseModel):
+    """Structured local-LLM verdict for Bleed candidates."""
+
+    selected_resolution_ids: list[int] = Field(default_factory=list)
+    reasoning: str = ""
+
+
+class BleedSelectorResult(BaseModel):
+    """Result of a Bleed selector pass."""
+
+    candidates_considered: int = 0
+    selected: list[BleedCandidate] = Field(default_factory=list)
+    timed_out: bool = False
+
+
+def load_bleed_candidates(
+    session: Any,
+    *,
+    anchor_chunk_id: int,
+    limit: int,
+) -> list[BleedCandidate]:
+    """Load narrated Orrery candidates that are eligible before the anchor."""
+
+    if limit <= 0:
+        return []
+
+    rows = session.execute(
+        text(
+            """
+            /* orrery:bleed_candidates */
+            SELECT
+                r.id AS resolution_id,
+                n.id AS narration_id,
+                r.tick_chunk_id,
+                r.template_id,
+                r.brief,
+                r.magnitude,
+                n.text,
+                n.perceptual_descriptor,
+                actor.name AS actor_name,
+                target.name AS target_name,
+                we.event_type
+            FROM orrery_resolutions r
+            JOIN offscreen_narrations n ON n.id = r.narration_chunk_id
+            LEFT JOIN entity_names_v actor ON actor.id = r.actor_entity_id
+            LEFT JOIN LATERAL (
+                SELECT event_type, target_entity_id
+                FROM world_events
+                WHERE resolution_id = r.id
+                ORDER BY id
+                LIMIT 1
+            ) we ON TRUE
+            LEFT JOIN entity_names_v target ON target.id = we.target_entity_id
+            WHERE r.promotion_status = 'promoted'
+              AND r.narration_status = 'succeeded'
+              AND r.tick_chunk_id <= :anchor_chunk_id
+              AND (
+                    r.last_offered_chunk_id IS NULL
+                 OR r.last_offered_chunk_id <> :anchor_chunk_id
+              )
+              AND r.offer_count < 3
+            ORDER BY r.tick_chunk_id DESC,
+                     r.magnitude DESC NULLS LAST,
+                     r.priority DESC,
+                     r.id DESC
+            LIMIT :limit
+            """
+        ),
+        {"anchor_chunk_id": anchor_chunk_id, "limit": limit},
+    ).mappings()
+
+    return [_candidate_from_row(row) for row in rows]
+
+
+async def select_bleed_menu_async(
+    session: Any,
+    *,
+    llm_manager: Any,
+    anchor_chunk_id: int,
+    user_input: str,
+    warm_slice: list[dict[str, Any]],
+    max_candidates: int,
+    latency_budget_ms: int,
+) -> BleedSelectorResult:
+    """Select a spoiler-safe ambient Bleed menu under a hard latency budget."""
+
+    if max_candidates <= 0:
+        return BleedSelectorResult()
+
+    candidate_pool = load_bleed_candidates(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        limit=max(max_candidates * 4, max_candidates),
+    )
+    if not candidate_pool:
+        return BleedSelectorResult()
+
+    prompt = _build_bleed_prompt(
+        candidate_pool,
+        user_input=user_input,
+        warm_slice=warm_slice,
+        max_candidates=max_candidates,
+    )
+
+    try:
+        selected = await asyncio.wait_for(
+            asyncio.to_thread(
+                _select_candidates_sync,
+                llm_manager,
+                prompt,
+                candidate_pool,
+                max_candidates,
+            ),
+            timeout=latency_budget_ms / 1000,
+        )
+    except asyncio.TimeoutError:
+        logger.error(
+            "Orrery Bleed selector exceeded %sms latency budget",
+            latency_budget_ms,
+        )
+        return BleedSelectorResult(
+            candidates_considered=len(candidate_pool),
+            timed_out=True,
+        )
+
+    if selected:
+        record_bleed_offers(
+            session,
+            selected,
+            anchor_chunk_id=anchor_chunk_id,
+        )
+
+    return BleedSelectorResult(
+        candidates_considered=len(candidate_pool),
+        selected=selected,
+    )
+
+
+def record_bleed_offers(
+    session: Any,
+    candidates: list[BleedCandidate],
+    *,
+    anchor_chunk_id: int,
+) -> None:
+    """Update surfacing bookkeeping for candidates offered to the Storyteller."""
+
+    resolution_ids = [candidate.resolution_id for candidate in candidates]
+    if not resolution_ids:
+        return
+
+    session.execute(
+        text(
+            """
+            /* orrery:record_bleed_offers */
+            UPDATE orrery_resolutions
+            SET first_surfaced_chunk_id = COALESCE(
+                    first_surfaced_chunk_id,
+                    :anchor_chunk_id
+                ),
+                last_offered_chunk_id = :anchor_chunk_id,
+                offer_count = offer_count + 1
+            WHERE id = ANY(:resolution_ids)
+            """
+        ),
+        {
+            "anchor_chunk_id": anchor_chunk_id,
+            "resolution_ids": resolution_ids,
+        },
+    )
+    session.commit()
+
+
+def _candidate_from_row(row: Mapping[str, Any]) -> BleedCandidate:
+    descriptor = _coerce_descriptor(row.get("perceptual_descriptor"))
+    return BleedCandidate(
+        resolution_id=int(row["resolution_id"]),
+        narration_id=int(row["narration_id"]),
+        tick_chunk_id=int(row["tick_chunk_id"]),
+        template_id=str(row["template_id"]),
+        event_type=row.get("event_type"),
+        actor_name=row.get("actor_name"),
+        target_name=row.get("target_name"),
+        channel=descriptor.get("channel"),
+        summary=descriptor.get("summary"),
+        brief=row.get("brief") or descriptor.get("brief"),
+        text=str(row.get("text") or ""),
+        magnitude=_float_or_none(row.get("magnitude")),
+    )
+
+
+def _coerce_descriptor(raw: Any) -> dict[str, Any]:
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        return json.loads(raw)
+    if isinstance(raw, Mapping):
+        return dict(raw)
+    raise TypeError(f"Unsupported perceptual_descriptor type: {type(raw).__name__}")
+
+
+def _float_or_none(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return float(value)
+    return float(value)
+
+
+def _build_bleed_prompt(
+    candidates: list[BleedCandidate],
+    *,
+    user_input: str,
+    warm_slice: list[dict[str, Any]],
+    max_candidates: int,
+) -> str:
+    recent_lines = []
+    for chunk in warm_slice[-3:]:
+        text_value = chunk.get("text") or chunk.get("full_text") or ""
+        if text_value:
+            recent_lines.append(" ".join(str(text_value).split())[:500])
+
+    candidate_payload = [
+        {
+            "resolution_id": candidate.resolution_id,
+            "template_id": candidate.template_id,
+            "event_type": candidate.event_type,
+            "actor_name": candidate.actor_name,
+            "target_name": candidate.target_name,
+            "channel": candidate.channel,
+            "summary": candidate.summary,
+            "brief": candidate.brief,
+            "text": candidate.text,
+            "magnitude": candidate.magnitude,
+        }
+        for candidate in candidates
+    ]
+
+    return (
+        "Select ambient Orrery Bleed candidates for the next Storyteller turn.\n\n"
+        f"User input: {user_input}\n\n"
+        "Recent scene excerpts:\n"
+        + "\n".join(f"- {line}" for line in recent_lines)
+        + "\n\nCandidates:\n"
+        + json.dumps(candidate_payload, sort_keys=True)
+        + "\n\nReturn at most "
+        + str(max_candidates)
+        + " selected_resolution_ids. Select none if no candidate is safely "
+        "perceptible from the current scene."
+    )
+
+
+def _select_candidates_sync(
+    llm_manager: Any,
+    prompt: str,
+    candidates: list[BleedCandidate],
+    max_candidates: int,
+) -> list[BleedCandidate]:
+    raw = llm_manager.structured_query(
+        prompt,
+        BleedSelection,
+        temperature=0.1,
+        max_tokens=512,
+        system_prompt=BLEED_SYSTEM_PROMPT,
+    )
+    try:
+        selection = (
+            raw
+            if isinstance(raw, BleedSelection)
+            else BleedSelection.model_validate(raw)
+        )
+    except ValidationError as exc:
+        raise ValueError(f"Malformed Orrery Bleed selection: {raw}") from exc
+
+    candidates_by_id = {candidate.resolution_id: candidate for candidate in candidates}
+    selected: list[BleedCandidate] = []
+    unknown_ids = [
+        resolution_id
+        for resolution_id in selection.selected_resolution_ids
+        if resolution_id not in candidates_by_id
+    ]
+    if unknown_ids:
+        raise ValueError(f"Orrery Bleed selected unknown resolutions: {unknown_ids}")
+
+    for resolution_id in selection.selected_resolution_ids[:max_candidates]:
+        selected.append(candidates_by_id[resolution_id])
+    return selected

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -291,6 +291,7 @@ class OrreryBleedSettings(BaseModel):
 
     latency_budget_ms: int = Field(default=2000, ge=1)
     max_candidates: int = Field(default=3, ge=0)
+    candidate_pool_multiplier: int = Field(default=4, ge=1)
 
 
 class OrreryPromoteSettings(BaseModel):

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -24,3 +24,26 @@ def test_context_prompt_includes_orrery_scene_pressure_controls() -> None:
     assert "You may adapt, delay, ignore, or incorporate them" in prompt
     assert "Do not let Orrery decide what present characters do" in prompt
     assert "Travel toward the target's last known location: Mara is moving" in prompt
+
+
+def test_context_prompt_includes_orrery_bleed_menu_controls() -> None:
+    """Selected Bleed peripherals are framed as optional ambient texture."""
+
+    prompt = LogonUtility({})._format_context_prompt(
+        {
+            "user_input": "Continue.",
+            "orrery_bleed_menu": [
+                {
+                    "template_id": "evade_pursuers",
+                    "channel": "digital",
+                    "summary": "street cameras briefly lose Mara",
+                    "actor_name": "Mara",
+                }
+            ],
+        }
+    )
+
+    assert "=== ORRERY AMBIENT PERIPHERALS ===" in prompt
+    assert "optional ambient peripherals from off-screen events" in prompt
+    assert "Ignore freely, render subtly" in prompt
+    assert "[digital] Mara: street cameras briefly lose Mara" in prompt

--- a/tests/test_orrery/test_bleed.py
+++ b/tests/test_orrery/test_bleed.py
@@ -1,0 +1,253 @@
+"""Tests for Orrery Bleed selector."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import time
+
+import pytest
+
+from nexus.agents.lore.utils.turn_context import TurnContext
+from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
+from nexus.agents.orrery.bleed import (
+    BleedSelection,
+    load_bleed_candidates,
+    select_bleed_menu_async,
+)
+
+
+class FakeResult:
+    """Tiny SQLAlchemy result stand-in."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def mappings(self):
+        return self
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class FakeSession:
+    """Session stand-in keyed by Bleed selector SQL markers."""
+
+    def __init__(self, candidate_rows=None, max_chunk_id=100):
+        self.candidate_rows = candidate_rows or []
+        self.max_chunk_id = max_chunk_id
+        self.executed = []
+        self.commits = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        return False
+
+    def execute(self, statement, params=None):
+        sql = str(statement)
+        self.executed.append((sql, params))
+        if "/* orrery:bleed_candidates */" in sql:
+            assert "r.tick_chunk_id <= :anchor_chunk_id" in sql
+            assert "r.offer_count < 3" in sql
+            return FakeResult(self.candidate_rows)
+        if "/* orrery:record_bleed_offers */" in sql:
+            return FakeResult([])
+        if "SELECT max(id) AS max_id" in sql:
+            return FakeResult([{"max_id": self.max_chunk_id}])
+        raise AssertionError(f"Unexpected Bleed query: {sql}")
+
+    def commit(self):
+        self.commits += 1
+
+
+class FakeLLM:
+    """Local LLM stand-in returning one Bleed selection."""
+
+    def __init__(self, selection):
+        self.selection = selection
+        self.prompts = []
+
+    def structured_query(self, prompt, response_model, **_kwargs):
+        self.prompts.append((prompt, response_model))
+        return self.selection
+
+
+class SlowLLM(FakeLLM):
+    """Local LLM stand-in that exceeds the latency budget."""
+
+    def structured_query(self, prompt, response_model, **kwargs):
+        time.sleep(0.05)
+        return super().structured_query(prompt, response_model, **kwargs)
+
+
+class FakeMemnon:
+    """Minimal MEMNON stand-in exposing the Session factory."""
+
+    def __init__(self, session):
+        self.session = session
+
+    def Session(self):
+        return self.session
+
+
+class FakeLore:
+    """Minimal LORE stand-in for TurnCycleManager tests."""
+
+    token_manager = None
+
+    def __init__(self, settings, session, llm_manager):
+        self.settings = settings
+        self.memnon = FakeMemnon(session)
+        self.llm_manager = llm_manager
+
+
+def _candidate_row():
+    return {
+        "resolution_id": 10,
+        "narration_id": 501,
+        "tick_chunk_id": 99,
+        "template_id": "evade_pursuers",
+        "event_type": "evade_pursuit",
+        "actor_name": "Mara",
+        "target_name": None,
+        "perceptual_descriptor": {
+            "channel": "digital",
+            "summary": "street cameras briefly lose Mara",
+            "brief": "Mara vanishes into a maintenance corridor.",
+        },
+        "brief": "Mara vanishes into a maintenance corridor.",
+        "text": "Mara drops below the platform and vanishes from the cameras.",
+        "magnitude": Decimal("0.720"),
+    }
+
+
+def _settings():
+    return {
+        "orrery": {
+            "enabled": True,
+            "bleed": {
+                "latency_budget_ms": 2000,
+                "max_candidates": 3,
+            },
+        }
+    }
+
+
+def test_load_bleed_candidates_coerces_descriptor() -> None:
+    """Candidate loading keeps the Storyteller-facing descriptor separate."""
+
+    candidates = load_bleed_candidates(
+        FakeSession(candidate_rows=[_candidate_row()]),
+        anchor_chunk_id=100,
+        limit=3,
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].resolution_id == 10
+    assert candidates[0].channel == "digital"
+    assert candidates[0].summary == "street cameras briefly lose Mara"
+    assert candidates[0].magnitude == 0.72
+
+
+@pytest.mark.asyncio
+async def test_select_bleed_menu_records_selected_offers() -> None:
+    """Selected ambient candidates update surfacing bookkeeping."""
+
+    session = FakeSession(candidate_rows=[_candidate_row()])
+    llm = FakeLLM(BleedSelection(selected_resolution_ids=[10], reasoning="apt"))
+
+    result = await select_bleed_menu_async(
+        session,
+        llm_manager=llm,
+        anchor_chunk_id=100,
+        user_input="Continue.",
+        warm_slice=[{"text": "Rain ticks against the transit glass."}],
+        max_candidates=3,
+        latency_budget_ms=2000,
+    )
+
+    update_params = next(
+        params
+        for sql, params in session.executed
+        if "/* orrery:record_bleed_offers */" in sql
+    )
+
+    assert result.candidates_considered == 1
+    assert result.selected[0].resolution_id == 10
+    assert session.commits == 1
+    assert update_params["resolution_ids"] == [10]
+
+
+@pytest.mark.asyncio
+async def test_select_bleed_menu_returns_empty_without_candidates() -> None:
+    """No candidates means no local LLM call and no bookkeeping writes."""
+
+    session = FakeSession(candidate_rows=[])
+    llm = FakeLLM(BleedSelection(selected_resolution_ids=[10], reasoning="unused"))
+
+    result = await select_bleed_menu_async(
+        session,
+        llm_manager=llm,
+        anchor_chunk_id=100,
+        user_input="Continue.",
+        warm_slice=[],
+        max_candidates=3,
+        latency_budget_ms=2000,
+    )
+
+    assert result.candidates_considered == 0
+    assert result.selected == []
+    assert llm.prompts == []
+    assert session.commits == 0
+
+
+@pytest.mark.asyncio
+async def test_select_bleed_menu_timeout_returns_empty() -> None:
+    """Latency overruns produce an empty menu and no offer bookkeeping."""
+
+    session = FakeSession(candidate_rows=[_candidate_row()])
+
+    result = await select_bleed_menu_async(
+        session,
+        llm_manager=SlowLLM(BleedSelection(selected_resolution_ids=[10])),
+        anchor_chunk_id=100,
+        user_input="Continue.",
+        warm_slice=[],
+        max_candidates=3,
+        latency_budget_ms=1,
+    )
+
+    assert result.timed_out is True
+    assert result.selected == []
+    assert session.commits == 0
+
+
+@pytest.mark.asyncio
+async def test_assemble_context_payload_includes_bleed_menu() -> None:
+    """LORE payload assembly injects selected ambient Orrery peripherals."""
+
+    session = FakeSession(candidate_rows=[_candidate_row()])
+    manager = TurnCycleManager(
+        FakeLore(
+            _settings(),
+            session,
+            FakeLLM(BleedSelection(selected_resolution_ids=[10], reasoning="apt")),
+        )
+    )
+    context = TurnContext(
+        turn_id="t1",
+        user_input="Continue.",
+        start_time=0,
+        warm_slice=[{"id": 100, "text": "Rain ticks against the glass."}],
+    )
+
+    await manager.assemble_context_payload(context)
+
+    assert context.phase_states["orrery_bleed"]["selected_count"] == 1
+    assert context.context_payload["orrery_bleed_menu"][0]["summary"] == (
+        "street cameras briefly lose Mara"
+    )

--- a/tests/test_orrery/test_bleed.py
+++ b/tests/test_orrery/test_bleed.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from decimal import Decimal
-import time
+from types import SimpleNamespace
 
 import pytest
 
@@ -71,7 +72,7 @@ class FakeLLM:
         self.selection = selection
         self.prompts = []
 
-    def structured_query(self, prompt, response_model, **_kwargs):
+    async def structured_query_async(self, prompt, response_model, **_kwargs):
         self.prompts.append((prompt, response_model))
         return self.selection
 
@@ -79,9 +80,17 @@ class FakeLLM:
 class SlowLLM(FakeLLM):
     """Local LLM stand-in that exceeds the latency budget."""
 
-    def structured_query(self, prompt, response_model, **kwargs):
-        time.sleep(0.05)
-        return super().structured_query(prompt, response_model, **kwargs)
+    def __init__(self, selection):
+        super().__init__(selection)
+        self.cancelled = False
+
+    async def structured_query_async(self, prompt, response_model, **kwargs):
+        try:
+            await asyncio.sleep(0.05)
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+        return await super().structured_query_async(prompt, response_model, **kwargs)
 
 
 class FakeMemnon:
@@ -94,15 +103,43 @@ class FakeMemnon:
         return self.session
 
 
+class FakeStoryResponse:
+    """Minimal structured response stand-in for LOGON."""
+
+    narrative = "Rain ticks against the glass."
+    chunk_metadata = None
+    referenced_entities = None
+    state_updates = None
+
+
+class FakeLogon:
+    """LOGON stand-in returning a successful structured narrative."""
+
+    async def generate_narrative_async(self, _payload):
+        return FakeStoryResponse()
+
+
+class FailingLogon:
+    """LOGON stand-in that raises before a response is surfaced."""
+
+    async def generate_narrative_async(self, _payload):
+        raise RuntimeError("generation failed")
+
+
 class FakeLore:
     """Minimal LORE stand-in for TurnCycleManager tests."""
 
     token_manager = None
+    enable_logon = True
 
-    def __init__(self, settings, session, llm_manager):
+    def __init__(self, settings, session, llm_manager, logon=None):
         self.settings = settings
         self.memnon = FakeMemnon(session)
         self.llm_manager = llm_manager
+        self.logon = logon or FakeLogon()
+
+    def ensure_logon(self):
+        return None
 
 
 def _candidate_row():
@@ -132,6 +169,7 @@ def _settings():
             "bleed": {
                 "latency_budget_ms": 2000,
                 "max_candidates": 3,
+                "candidate_pool_multiplier": 4,
             },
         }
     }
@@ -154,8 +192,8 @@ def test_load_bleed_candidates_coerces_descriptor() -> None:
 
 
 @pytest.mark.asyncio
-async def test_select_bleed_menu_records_selected_offers() -> None:
-    """Selected ambient candidates update surfacing bookkeeping."""
+async def test_select_bleed_menu_returns_selected_without_recording_offers() -> None:
+    """Selection is pure; offer bookkeeping waits until generation succeeds."""
 
     session = FakeSession(candidate_rows=[_candidate_row()])
     llm = FakeLLM(BleedSelection(selected_resolution_ids=[10], reasoning="apt"))
@@ -167,19 +205,16 @@ async def test_select_bleed_menu_records_selected_offers() -> None:
         user_input="Continue.",
         warm_slice=[{"text": "Rain ticks against the transit glass."}],
         max_candidates=3,
+        candidate_pool_multiplier=4,
         latency_budget_ms=2000,
-    )
-
-    update_params = next(
-        params
-        for sql, params in session.executed
-        if "/* orrery:record_bleed_offers */" in sql
     )
 
     assert result.candidates_considered == 1
     assert result.selected[0].resolution_id == 10
-    assert session.commits == 1
-    assert update_params["resolution_ids"] == [10]
+    assert session.commits == 0
+    assert not any(
+        "/* orrery:record_bleed_offers */" in sql for sql, _ in session.executed
+    )
 
 
 @pytest.mark.asyncio
@@ -196,6 +231,7 @@ async def test_select_bleed_menu_returns_empty_without_candidates() -> None:
         user_input="Continue.",
         warm_slice=[],
         max_candidates=3,
+        candidate_pool_multiplier=4,
         latency_budget_ms=2000,
     )
 
@@ -210,19 +246,43 @@ async def test_select_bleed_menu_timeout_returns_empty() -> None:
     """Latency overruns produce an empty menu and no offer bookkeeping."""
 
     session = FakeSession(candidate_rows=[_candidate_row()])
+    llm = SlowLLM(BleedSelection(selected_resolution_ids=[10]))
 
     result = await select_bleed_menu_async(
         session,
-        llm_manager=SlowLLM(BleedSelection(selected_resolution_ids=[10])),
+        llm_manager=llm,
         anchor_chunk_id=100,
         user_input="Continue.",
         warm_slice=[],
         max_candidates=3,
+        candidate_pool_multiplier=4,
         latency_budget_ms=1,
     )
 
     assert result.timed_out is True
     assert result.selected == []
+    assert llm.cancelled is True
+    assert session.commits == 0
+
+
+@pytest.mark.asyncio
+async def test_select_bleed_menu_rejects_unknown_resolution_ids() -> None:
+    """Hallucinated structured IDs fail loudly instead of silently disappearing."""
+
+    session = FakeSession(candidate_rows=[_candidate_row()])
+
+    with pytest.raises(ValueError, match="unknown resolutions"):
+        await select_bleed_menu_async(
+            session,
+            llm_manager=FakeLLM(BleedSelection(selected_resolution_ids=[9999])),
+            anchor_chunk_id=100,
+            user_input="Continue.",
+            warm_slice=[],
+            max_candidates=3,
+            candidate_pool_multiplier=4,
+            latency_budget_ms=2000,
+        )
+
     assert session.commits == 0
 
 
@@ -250,4 +310,99 @@ async def test_assemble_context_payload_includes_bleed_menu() -> None:
     assert context.phase_states["orrery_bleed"]["selected_count"] == 1
     assert context.context_payload["orrery_bleed_menu"][0]["summary"] == (
         "street cameras briefly lose Mara"
+    )
+
+
+@pytest.mark.asyncio
+async def test_assemble_context_payload_reuses_orrery_proposal_anchor() -> None:
+    """Bleed uses the existing resolve anchor instead of recomputing max chunk."""
+
+    session = FakeSession(candidate_rows=[_candidate_row()])
+    manager = TurnCycleManager(
+        FakeLore(
+            _settings(),
+            session,
+            FakeLLM(BleedSelection(selected_resolution_ids=[10], reasoning="apt")),
+        )
+    )
+    context = TurnContext(
+        turn_id="t1",
+        user_input="Continue.",
+        start_time=0,
+        warm_slice=[],
+    )
+    context.orrery_proposal = SimpleNamespace(anchor_chunk_id=77, pressure_count=0)
+
+    await manager.assemble_context_payload(context)
+
+    candidate_params = next(
+        params
+        for sql, params in session.executed
+        if "/* orrery:bleed_candidates */" in sql
+    )
+    assert candidate_params["anchor_chunk_id"] == 77
+    assert not any("SELECT max(id) AS max_id" in sql for sql, _ in session.executed)
+
+
+@pytest.mark.asyncio
+async def test_call_apex_ai_records_bleed_offers_after_generation_success() -> None:
+    """Surfacing bookkeeping is written only after LOGON returns a response."""
+
+    session = FakeSession()
+    manager = TurnCycleManager(
+        FakeLore(_settings(), session, FakeLLM(BleedSelection()), logon=FakeLogon())
+    )
+    context = TurnContext(turn_id="t1", user_input="Continue.", start_time=0)
+    context.context_payload = {"user_input": "Continue."}
+    context.bleed_menu = load_bleed_candidates(
+        FakeSession(candidate_rows=[_candidate_row()]),
+        anchor_chunk_id=100,
+        limit=1,
+    )
+    context.phase_states["orrery_bleed"] = {
+        "anchor_chunk_id": 100,
+        "offers_recorded": 0,
+    }
+
+    response = await manager.call_apex_ai(context)
+    update_params = next(
+        params
+        for sql, params in session.executed
+        if "/* orrery:record_bleed_offers */" in sql
+    )
+
+    assert response.narrative == "Rain ticks against the glass."
+    assert session.commits == 1
+    assert update_params["resolution_ids"] == [10]
+    assert context.phase_states["orrery_bleed"]["offers_recorded"] == 1
+
+
+@pytest.mark.asyncio
+async def test_call_apex_ai_does_not_record_bleed_offers_on_generation_failure() -> (
+    None
+):
+    """Failed LOGON generation does not consume a Bleed opportunity."""
+
+    session = FakeSession()
+    manager = TurnCycleManager(
+        FakeLore(_settings(), session, FakeLLM(BleedSelection()), logon=FailingLogon())
+    )
+    context = TurnContext(turn_id="t1", user_input="Continue.", start_time=0)
+    context.context_payload = {"user_input": "Continue."}
+    context.bleed_menu = load_bleed_candidates(
+        FakeSession(candidate_rows=[_candidate_row()]),
+        anchor_chunk_id=100,
+        limit=1,
+    )
+    context.phase_states["orrery_bleed"] = {
+        "anchor_chunk_id": 100,
+        "offers_recorded": 0,
+    }
+
+    with pytest.raises(RuntimeError, match="generation failed"):
+        await manager.call_apex_ai(context)
+
+    assert session.commits == 0
+    assert not any(
+        "/* orrery:record_bleed_offers */" in sql for sql, _ in session.executed
     )

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -14,4 +14,5 @@ def test_orrery_settings_resolve_model_reference() -> None:
     expected_model = settings.global_.model.api_models["anthropic"].roles["default"]
     assert settings.orrery.narration.model_ref == expected_model
     assert settings.orrery.bleed.latency_budget_ms == 2000
+    assert settings.orrery.bleed.candidate_pool_multiplier == 4
     assert settings.orrery.promote.provider == "local"


### PR DESCRIPTION
## Summary
- add a typed Orrery Bleed selector over promoted, successfully narrated off-screen resolutions
- select spoiler-limited ambient candidates with the local structured LLM under a hard latency budget and record surfacing bookkeeping
- inject the selected menu into LORE/LOGON as optional Storyteller ambient peripherals
- refresh `docs/orrery_design_plan.md` to reflect landed Orrery phases and this PR 4 slice

## Validation
- `PYTHONPATH=$PWD poetry run python -m py_compile nexus/agents/orrery/bleed.py nexus/agents/orrery/__init__.py nexus/agents/lore/utils/turn_cycle.py nexus/agents/lore/logon_utility.py`
- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery tests/test_lore/test_logon_prompt_formatting.py tests/test_api/test_lore_adapter.py` (73 passed, 2 warnings)
- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery/test_bleed.py tests/test_lore/test_logon_prompt_formatting.py` (7 passed)
- `git diff --check`