### PR TITLE
Hydrate Orrery trust from relationship valence

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -1,6 +1,6 @@
 # Off-Screen Behavior Resolver — Orrery Design Plan
 
-**Status:** Foundation implemented in PR #210, dry-run resolve in PR #211, commit/promote/narrate/clear in PR #214, expanded package library in PR #212, present-target scene pressure in PR #216, generated human-readable catalog support in PR #217/#218, and Bleed selector/Storyteller integration in PR #219. The runtime pipeline remains disabled by default (`orrery.enabled = false`). This branch hardens the remaining retrieval-boundary audit around `offscreen_narrations`.
+**Status:** Foundation implemented in PR #210, dry-run resolve in PR #211, commit/promote/narrate/clear in PR #214, expanded package library in PR #212, present-target scene pressure in PR #216, generated human-readable catalog support in PR #217/#218, Bleed selector/Storyteller integration in PR #219, and retrieval-boundary hardening in PR #220. The runtime pipeline remains disabled by default (`orrery.enabled = false`). This branch resolves issue #213 by adding the relationship-valence magnitude read surface and Orrery trust hydration.
 
 **Originating artifacts:** `temp/orrery/off_screen_resolver_spec.md`, `temp/orrery/behavior_substrate.py`, `temp/orrery/package_simulator.jsx`
 **Review trace:** `temp/orrery/design_plan_edited.md` (round 1: GPT-5.5-Pro, Codex, separate-Claude, Gemini) + `temp/orrery/super_table_question.md` (round 2: GPT-5.5-Pro, Claude Opus 4.7 chat) + v4 grounding pass against current `main` (claude-opus-4-7).
@@ -70,9 +70,13 @@
 
 PR #219 implements PR 4: Bleed selection at Storyteller time. It selects a bounded menu of previously narrated off-screen events, records surfacing bookkeeping only after successful generation, and injects optional ambient peripherals into the LOGON prompt without advancing chronology or promoting off-screen narrations into warm-slice memory.
 
+### Landed in PR #220
+
+PR #220 closes the retrieval-boundary audit: warm slices and normal MEMNON search remain accepted-narrative surfaces only, while explicit read-only SQL may still inspect public Orrery tables such as `offscreen_narrations`.
+
 ### Current Slice
 
-This branch closes the lingering retrieval-boundary audit: warm slices and normal MEMNON search must remain accepted-narrative surfaces only, while explicit read-only SQL may still inspect public Orrery tables such as `offscreen_narrations`.
+This branch resolves issue #213's consensus Option B: keep `character_relationships.emotional_valence` as the canonical hybrid enum/label, expose `entity_relationships_v.valence_magnitude` as an explicit integer mapping, and hydrate `WorldState.trust` from that read surface.
 
 ### Package Author Checkpoint
 
@@ -604,7 +608,7 @@ Per-chunk, not per-event. Stamped only at accepted commit. `world_events.world_t
 ### PR 0 — Seam Audit & Invariants (Foundation Subset in PR #210)
 
 - Confirmed the production commit path is `nexus/api/narrative.py::_approve_narrative_impl` (L387) → `commit_incubator_to_database_sync` (L233). The async sibling `commit_incubator_to_database` (L320) is test-only today; document this in PR 3 commit hook prose.
-- Retrieval-boundary audit in this branch: confirm `query_memory`, `SearchManager`, and warm-slice retrieval surfaces never join or union `offscreen_narrations` into standard narrative context. Explicit read-only SQL access to public Orrery tables remains allowed.
+- Retrieval-boundary audit in PR #220: confirm `query_memory`, `SearchManager`, and warm-slice retrieval surfaces never join or union `offscreen_narrations` into standard narrative context. Explicit read-only SQL access to public Orrery tables remains allowed.
 - Updated `nexus/agents/memnon/memnon.py::execute_readonly_sql` allowed-tables list. Additions: `entities`, `entity_names_v`, `entity_tags_current`, `world_events`, `world_event_entities`, `orrery_resolutions`, `offscreen_narrations`, `event_types`, `tags`. Excluded (internal-only): `orrery_narration_jobs`, `tag_clearance_log`, raw `entity_tags`.
 - Confirmed or created `world_layer_type` via `migrations/023_orrery_schema.py`.
 - Note that `chunk_workflow.py` is *not* on the commit path — it manages downstream embedding state transitions only. Do not hook `CommitOrreryTick` there.

--- a/migrations/026_relationship_valence_magnitude.sql
+++ b/migrations/026_relationship_valence_magnitude.sql
@@ -62,3 +62,6 @@ UNION ALL
     FROM faction_character_relationships fcr
     JOIN factions f ON f.id = fcr.faction_id
     JOIN characters c ON c.id = fcr.character_id;
+
+COMMENT ON COLUMN entity_relationships_v.valence_magnitude IS
+    'Signed integer in -5..+5 derived from character_relationships.emotional_valence; NULL for faction and faction_character scopes.';

--- a/migrations/026_relationship_valence_magnitude.sql
+++ b/migrations/026_relationship_valence_magnitude.sql
@@ -1,0 +1,64 @@
+-- Add SQL-side relationship valence magnitude for Orrery trust hydration.
+--
+-- `character_relationships.emotional_valence` remains the canonical hybrid
+-- enum/label. The compatibility view exposes the parseable signed magnitude
+-- as an integer so runtime readers do not embed enum-string parsing rules.
+
+CREATE OR REPLACE VIEW entity_relationships_v AS
+    SELECT
+        c1.entity_id AS source_entity_id,
+        c2.entity_id AS target_entity_id,
+        'character'::text AS relationship_scope,
+        cr.relationship_type::text AS relationship_type,
+        cr.emotional_valence::text AS valence,
+        cr.dynamic,
+        cr.recent_events,
+        cr.history,
+        cr.extra_data,
+        CASE cr.emotional_valence::text
+            WHEN '+5|devoted' THEN 5
+            WHEN '+4|admiring' THEN 4
+            WHEN '+3|trusting' THEN 3
+            WHEN '+2|friendly' THEN 2
+            WHEN '+1|favorable' THEN 1
+            WHEN '0|neutral' THEN 0
+            WHEN '-1|wary' THEN -1
+            WHEN '-2|disapproving' THEN -2
+            WHEN '-3|resentful' THEN -3
+            WHEN '-4|hostile' THEN -4
+            WHEN '-5|hateful' THEN -5
+            ELSE NULL
+        END::integer AS valence_magnitude
+    FROM character_relationships cr
+    JOIN characters c1 ON c1.id = cr.character1_id
+    JOIN characters c2 ON c2.id = cr.character2_id
+UNION ALL
+    SELECT
+        f1.entity_id AS source_entity_id,
+        f2.entity_id AS target_entity_id,
+        'faction'::text AS relationship_scope,
+        fr.relationship_type::text AS relationship_type,
+        NULL::text AS valence,
+        fr.current_status AS dynamic,
+        NULL::text AS recent_events,
+        fr.history,
+        fr.extra_data,
+        NULL::integer AS valence_magnitude
+    FROM faction_relationships fr
+    JOIN factions f1 ON f1.id = fr.faction1_id
+    JOIN factions f2 ON f2.id = fr.faction2_id
+UNION ALL
+    SELECT
+        f.entity_id AS source_entity_id,
+        c.entity_id AS target_entity_id,
+        'faction_character'::text AS relationship_scope,
+        fcr.role::text AS relationship_type,
+        NULL::text AS valence,
+        fcr.current_status AS dynamic,
+        NULL::text AS recent_events,
+        fcr.history,
+        fcr.extra_data,
+        NULL::integer AS valence_magnitude
+    FROM faction_character_relationships fcr
+    JOIN factions f ON f.id = fcr.faction_id
+    JOIN characters c ON c.id = fcr.character_id;

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -170,6 +170,16 @@ class OrreryTickProposal:
         )
 
 
+def _should_replace_trust_magnitude(current: Optional[int], candidate: int) -> bool:
+    """Choose a stable representative if a read surface emits duplicate pairs."""
+
+    if current is None:
+        return True
+    if abs(candidate) != abs(current):
+        return abs(candidate) > abs(current)
+    return candidate < current
+
+
 def hydrate_world_state(
     session: Any,
     *,
@@ -257,7 +267,9 @@ def hydrate_world_state(
         key = (row["source_entity_id"], row["target_entity_id"])
         relationship_types.setdefault(key, set()).add(row["relationship_type"])
         if row.get("valence_magnitude") is not None:
-            trust[key] = int(row["valence_magnitude"])
+            valence_magnitude = int(row["valence_magnitude"])
+            if _should_replace_trust_magnitude(trust.get(key), valence_magnitude):
+                trust[key] = valence_magnitude
 
     faction_memberships: dict[int, set[int]] = {}
     for row in session.execute(

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -237,11 +237,15 @@ def hydrate_world_state(
     }
 
     relationship_types: dict[tuple[int, int], set[str]] = {}
+    trust: dict[tuple[int, int], int] = {}
     for row in session.execute(
         text(
             """
             /* orrery:relationship_types */
-            SELECT source_entity_id, target_entity_id, relationship_type
+            SELECT source_entity_id,
+                   target_entity_id,
+                   relationship_type,
+                   valence_magnitude
             FROM entity_relationships_v
             WHERE relationship_scope = 'character'
               AND source_entity_id IS NOT NULL
@@ -250,9 +254,10 @@ def hydrate_world_state(
             """
         )
     ).mappings():
-        relationship_types.setdefault(
-            (row["source_entity_id"], row["target_entity_id"]), set()
-        ).add(row["relationship_type"])
+        key = (row["source_entity_id"], row["target_entity_id"])
+        relationship_types.setdefault(key, set()).add(row["relationship_type"])
+        if row.get("valence_magnitude") is not None:
+            trust[key] = int(row["valence_magnitude"])
 
     faction_memberships: dict[int, set[int]] = {}
     for row in session.execute(
@@ -288,8 +293,9 @@ def hydrate_world_state(
         },
         locations=locations,
         activities=activities,
-        # TODO: Hydrate trust and orbit_distance when the resolver has an
-        # authoritative source. Current built-in packages do not use them.
+        trust=trust,
+        # TODO: Hydrate orbit_distance when the resolver has an authoritative
+        # source. Relationship trust is hydrated from entity_relationships_v.
         relationship_types={
             key: frozenset(values) for key, values in relationship_types.items()
         },
@@ -606,11 +612,11 @@ def resolve_dry_run(
         for resolution in scene_pressure_results
     )
 
-    unique_actors = {bindings[Slot.ACTOR] for bindings in actor_bindings} | {
-        bindings[Slot.ACTOR] for bindings in actor_target_bindings
-    } | {
-        bindings[Slot.ACTOR] for bindings in present_target_bindings
-    }
+    unique_actors = (
+        {bindings[Slot.ACTOR] for bindings in actor_bindings}
+        | {bindings[Slot.ACTOR] for bindings in actor_target_bindings}
+        | {bindings[Slot.ACTOR] for bindings in present_target_bindings}
+    )
 
     return OrreryTickProposal(
         anchor_chunk_id=anchor_chunk_id,

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -250,12 +250,9 @@ MAINTAIN_COVER = Template(
 #   * present_target_policy=STORYTELLER_PRESSURE allows a present TARGET only
 #     as prompt-only scene pressure. Present ACTORs are still excluded, and
 #     pressure drafts never commit state deltas or world events directly.
-#   * Trust hydration is un-implemented (resolver.py:177 TODO). Any branch
-#     gated on trust_at_least(N) with N > 0 or trust_below(N) with N < 0
-#     is currently unreachable — WorldState.trust defaults to 0 for every
-#     pair. The affected branches are flagged with TODO comments below;
-#     they remain in the catalog because they're the intended firing
-#     paths once trust hydration lands.
+#   * Trust hydration reads entity_relationships_v.valence_magnitude. Keep
+#     package thresholds on the -5..+5 enum-derived integer scale unless a
+#     future package needs a separate normalized float at model-input time.
 # ----------------------------------------------------------------------------
 
 
@@ -273,9 +270,6 @@ EXTRACT_VENGEANCE = Template(
         OR(
             has_symmetric_relationship_of_type("enemy"),
             has_symmetric_relationship_of_type("rival"),
-            # TODO: trust_below(-2) is unreachable until resolver.py:177's
-            # trust hydration TODO is resolved. The OR keeps the predicate
-            # documented; the enemy/rival arms carry the gate today.
             trust_below(-2),
         ),
         since_last_event_at_least("retaliation_attempted", minimum_ticks=8),
@@ -511,9 +505,6 @@ CULTIVATE_INFORMANT = Template(
     branches=(
         Branch(
             label="Press for material intel when trust is sufficient",
-            # TODO: trust_at_least(2) is unreachable until resolver.py:177's
-            # trust hydration TODO is resolved. WorldState.trust defaults
-            # to 0, so this branch routes to the ALWAYS fallback today.
             conditions=AND(
                 co_located(Slot.ACTOR, Slot.TARGET),
                 trust_at_least(2),

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -26,13 +26,18 @@ def test_discover_migrations_includes_python_and_skips_seed_script(
 def test_relationship_valence_migration_uses_explicit_mapping() -> None:
     """Issue #213's view column uses an explicit enum-to-int contract."""
 
-    migration_sql = Path(
-        "migrations/026_relationship_valence_magnitude.sql"
+    migration_sql = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "026_relationship_valence_magnitude.sql"
     ).read_text()
 
     assert "valence_magnitude" in migration_sql
     assert "SUBSTRING" not in migration_sql.upper()
     assert "CASE cr.emotional_valence::text" in migration_sql
+    assert "COMMENT ON COLUMN entity_relationships_v.valence_magnitude" in (
+        migration_sql
+    )
     for label, magnitude in {
         "+5|devoted": "5",
         "+4|admiring": "4",

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -21,3 +21,29 @@ def test_discover_migrations_includes_python_and_skips_seed_script(
         ("001", "baseline", ".sql"),
         ("023", "orrery_schema", ".py"),
     ]
+
+
+def test_relationship_valence_migration_uses_explicit_mapping() -> None:
+    """Issue #213's view column uses an explicit enum-to-int contract."""
+
+    migration_sql = Path(
+        "migrations/026_relationship_valence_magnitude.sql"
+    ).read_text()
+
+    assert "valence_magnitude" in migration_sql
+    assert "SUBSTRING" not in migration_sql.upper()
+    assert "CASE cr.emotional_valence::text" in migration_sql
+    for label, magnitude in {
+        "+5|devoted": "5",
+        "+4|admiring": "4",
+        "+3|trusting": "3",
+        "+2|friendly": "2",
+        "+1|favorable": "1",
+        "0|neutral": "0",
+        "-1|wary": "-1",
+        "-2|disapproving": "-2",
+        "-3|resentful": "-3",
+        "-4|hostile": "-4",
+        "-5|hateful": "-5",
+    }.items():
+        assert f"WHEN '{label}' THEN {magnitude}" in migration_sql

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -318,6 +318,48 @@ def test_hydrate_world_state_populates_trust_from_valence_magnitude() -> None:
     assert state.relationship_types[(2, 1)] == frozenset({"rival"})
 
 
+def test_hydrate_world_state_uses_stable_trust_magnitude_for_duplicate_pairs() -> None:
+    """Defensively collapse duplicate pair rows without depending on row order."""
+
+    state = hydrate_world_state(
+        FakeSession(
+            relationship_rows=[
+                {
+                    "source_entity_id": 1,
+                    "target_entity_id": 2,
+                    "relationship_type": "comrade",
+                    "valence_magnitude": 3,
+                },
+                {
+                    "source_entity_id": 1,
+                    "target_entity_id": 2,
+                    "relationship_type": "enemy",
+                    "valence_magnitude": -4,
+                },
+                {
+                    "source_entity_id": 2,
+                    "target_entity_id": 1,
+                    "relationship_type": "ally",
+                    "valence_magnitude": 3,
+                },
+                {
+                    "source_entity_id": 2,
+                    "target_entity_id": 1,
+                    "relationship_type": "rival",
+                    "valence_magnitude": -3,
+                },
+            ]
+        ),
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert state.trust[(1, 2)] == -4
+    assert state.trust[(2, 1)] == -3
+    assert state.relationship_types[(1, 2)] == frozenset({"comrade", "enemy"})
+    assert state.relationship_types[(2, 1)] == frozenset({"ally", "rival"})
+
+
 @pytest.mark.parametrize(
     ("valence_magnitude", "conditions", "expected_label"),
     [

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -8,14 +8,18 @@ from nexus.agents.lore.utils.turn_context import TurnContext
 from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
 from nexus.agents.orrery.resolver import (
     compose_actor_target_bindings,
+    hydrate_world_state,
     resolve_dry_run,
 )
 from nexus.agents.orrery.substrate import (
     ALWAYS,
+    AND,
     Branch,
     PresentTargetPolicy,
     Slot,
     Template,
+    trust_at_least,
+    trust_below,
 )
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 
@@ -102,6 +106,7 @@ class FakeSession:
         if "/* orrery:character_activities */" in sql:
             return FakeResult(self.activity_rows)
         if "/* orrery:relationship_types */" in sql:
+            assert "valence_magnitude" in sql
             return FakeResult(self.relationship_rows)
         if "/* orrery:faction_memberships */" in sql:
             return FakeResult(self.faction_rows)
@@ -283,6 +288,90 @@ def test_resolve_dry_run_exercises_priority_packages(
     assert proposal.resolutions[0].branch_label == branch_label
 
 
+def test_hydrate_world_state_populates_trust_from_valence_magnitude() -> None:
+    """Orrery trust reads the SQL-derived relationship valence magnitude."""
+
+    state = hydrate_world_state(
+        FakeSession(
+            relationship_rows=[
+                {
+                    "source_entity_id": 1,
+                    "target_entity_id": 2,
+                    "relationship_type": "comrade",
+                    "valence_magnitude": 3,
+                },
+                {
+                    "source_entity_id": 2,
+                    "target_entity_id": 1,
+                    "relationship_type": "rival",
+                    "valence_magnitude": -3,
+                },
+            ]
+        ),
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert state.trust[(1, 2)] == 3
+    assert state.trust[(2, 1)] == -3
+    assert state.relationship_types[(1, 2)] == frozenset({"comrade"})
+    assert state.relationship_types[(2, 1)] == frozenset({"rival"})
+
+
+@pytest.mark.parametrize(
+    ("valence_magnitude", "conditions", "expected_label"),
+    [
+        (3, trust_at_least(2), "Trust above threshold"),
+        (-3, trust_below(-2), "Trust below threshold"),
+    ],
+)
+def test_resolve_dry_run_trust_predicates_use_hydrated_valence(
+    valence_magnitude: int,
+    conditions,
+    expected_label: str,
+) -> None:
+    """Trust-gated packages can fire from entity_relationships_v magnitudes."""
+
+    template = Template(
+        id="trust_gate_test",
+        priority=10,
+        blurb="test trust hydration",
+        required_slots=(Slot.ACTOR, Slot.TARGET),
+        package_gate=ALWAYS,
+        branches=(
+            Branch(
+                label=expected_label,
+                conditions=AND(conditions),
+                narrative_stub="{actor} acts on their trust toward {target}.",
+            ),
+        ),
+    )
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[{"entity_id": 1}],
+            relationship_rows=[
+                {
+                    "source_entity_id": 1,
+                    "target_entity_id": 2,
+                    "relationship_type": "comrade",
+                    "valence_magnitude": valence_magnitude,
+                }
+            ],
+            actor_target_relationship_rows=[
+                {"source_entity_id": 1, "target_entity_id": 2},
+            ],
+        ),
+        [template],
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].branch_label == expected_label
+    assert proposal.resolutions[0].bindings == {"actor": 1, "target": 2}
+
+
 @pytest.mark.asyncio
 async def test_resolve_orrery_skips_when_disabled() -> None:
     """The LORE phase is inert unless Orrery is explicitly enabled."""
@@ -427,7 +516,9 @@ def test_compose_actor_target_bindings_excludes_anchor_present_targets() -> None
     assert pairs == {(1, 3)}
 
 
-def test_compose_actor_target_bindings_can_select_present_targets_for_pressure() -> None:
+def test_compose_actor_target_bindings_can_select_present_targets_for_pressure() -> (
+    None
+):
     """Scene-pressure binding allows present targets but still excludes actors."""
 
     session = FakeSession(
@@ -494,7 +585,9 @@ def test_resolve_dry_run_routes_present_targets_to_scene_pressures() -> None:
     assert "state_delta" not in pressure.to_dict()
 
 
-def test_resolve_dry_run_keeps_default_templates_offscreen_only_for_present_targets() -> None:
+def test_resolve_dry_run_keeps_default_templates_offscreen_only_for_present_targets() -> (
+    None
+):
     """Default multi-slot templates cannot pressure an on-screen target."""
 
     default_template = Template(


### PR DESCRIPTION
## Summary
- add `entity_relationships_v.valence_magnitude` via an explicit emotional-valence enum-to-integer mapping while keeping `character_relationships.emotional_valence` canonical
- hydrate Orrery `WorldState.trust` from that view column so trust-gated packages can fire
- update trust package comments, the Orrery design status, and resolver/migration tests

Closes #213.

## Validation
- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery/test_resolver.py tests/test_orrery/test_migrate.py`
- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery`
- `PYTHONPATH=$PWD poetry run python scripts/migrate.py --status`
- `psql -d save_05 -v ON_ERROR_STOP=1 -c 'BEGIN' -f migrations/026_relationship_valence_magnitude.sql -c 'ROLLBACK'`
- `PYTHONPATH=$PWD poetry run black --check nexus/agents/orrery/resolver.py nexus/agents/orrery/templates.py tests/test_orrery/test_resolver.py tests/test_orrery/test_migrate.py`
- `git diff --check`