### PR TITLE
Add deterministic agent review orchestration

### DIFF
--- a/.github/workflows/agent-review-orchestration.yml
+++ b/.github/workflows/agent-review-orchestration.yml
@@ -1,0 +1,83 @@
+name: Agent review orchestration
+
+# GitHub suppresses most workflow events created by GITHUB_TOKEN-authored
+# comments, so this dispatches the Claude review workflow directly instead of
+# relying on an automated `@claude` issue comment to trigger another action.
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, ready_for_review, synchronize]
+
+concurrency:
+  group: agent-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  orchestrate:
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      FIRST_WAIT_SECONDS: ${{ vars.AGENT_REVIEW_FIRST_WAIT_SECONDS || '600' }}
+      SECOND_WAIT_SECONDS: ${{ vars.AGENT_REVIEW_SECOND_WAIT_SECONDS || '600' }}
+      REVIEW_PROMPT: "@claude please review this PR. Don't flag any issues already flagged by Codex. The target audience for your review is a coding agent, not a human."
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Wait for Codex review window
+        run: sleep "$FIRST_WAIT_SECONDS"
+
+      - name: Request Claude review
+        run: |
+          set -euo pipefail
+
+          marker="<!-- nexus-agent-review:claude-request:${PR_HEAD_SHA} -->"
+          if gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate --jq '.[].body' | grep -Fq "$marker"; then
+            echo "Claude review already requested for ${PR_HEAD_SHA}."
+            exit 0
+          fi
+
+          cat > /tmp/claude-review-request.md <<EOF
+          ${marker}
+          Agent review orchestration requested Claude review for commit \`${PR_HEAD_SHA}\`.
+          EOF
+
+          gh issue comment "$PR_NUMBER" --body-file /tmp/claude-review-request.md
+          gh workflow run claude-code-review.yml \
+            --ref "$BASE_REF" \
+            -f pr_number="$PR_NUMBER" \
+            -f head_sha="$PR_HEAD_SHA" \
+            -f review_prompt="$REVIEW_PROMPT"
+
+      - name: Wait for Claude review window
+        run: sleep "$SECOND_WAIT_SECONDS"
+
+      - name: Mark agent reviews ready
+        run: |
+          set -euo pipefail
+
+          marker="<!-- nexus-agent-review:ready:${PR_HEAD_SHA} -->"
+          if gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate --jq '.[].body' | grep -Fq "$marker"; then
+            echo "Agent review-ready marker already posted for ${PR_HEAD_SHA}."
+            exit 0
+          fi
+
+          cat > /tmp/agent-review-ready.md <<EOF
+          ${marker}
+          Agent review window complete for commit \`${PR_HEAD_SHA}\`.
+
+          Local coding agent: pull current Codex and Claude review comments before continuing.
+          EOF
+
+          gh issue comment "$PR_NUMBER" --body-file /tmp/agent-review-ready.md

--- a/.github/workflows/agent-review-orchestration.yml
+++ b/.github/workflows/agent-review-orchestration.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: agent-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   actions: write
@@ -33,8 +33,27 @@ jobs:
       SECOND_WAIT_SECONDS: ${{ vars.AGENT_REVIEW_SECOND_WAIT_SECONDS || '600' }}
       REVIEW_PROMPT: "@claude please review this PR. Don't flag any issues already flagged by Codex. The target audience for your review is a coding agent, not a human."
       GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
 
     steps:
+      - name: Validate wait settings
+        run: |
+          set -euo pipefail
+
+          for name in FIRST_WAIT_SECONDS SECOND_WAIT_SECONDS; do
+            value="${!name}"
+            if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+              echo "::error::${name} must be a non-negative integer number of seconds."
+              exit 1
+            fi
+          done
+
+          total_wait=$((FIRST_WAIT_SECONDS + SECOND_WAIT_SECONDS))
+          if (( total_wait > 1680 )); then
+            echo "::error::Combined agent review waits must be <= 1680 seconds so the 30-minute job timeout has cleanup room."
+            exit 1
+          fi
+
       - name: Wait for Codex review window
         run: sleep "$FIRST_WAIT_SECONDS"
 
@@ -42,28 +61,40 @@ jobs:
         run: |
           set -euo pipefail
 
-          marker="<!-- nexus-agent-review:claude-request:${PR_HEAD_SHA} -->"
-          if gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate --jq '.[].body' | grep -Fq "$marker"; then
-            echo "Claude review already requested for ${PR_HEAD_SHA}."
+          current_head="$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid)"
+          if [[ "$current_head" != "$PR_HEAD_SHA" ]]; then
+            echo "PR head changed from ${PR_HEAD_SHA} to ${current_head}; skipping stale Claude dispatch."
+            echo "AGENT_REVIEW_REQUESTED=false" >> "$GITHUB_ENV"
             exit 0
           fi
 
-          cat > /tmp/claude-review-request.md <<EOF
-          ${marker}
-          Agent review orchestration requested Claude review for commit \`${PR_HEAD_SHA}\`.
-          EOF
+          marker="<!-- nexus-agent-review:claude-request:${PR_HEAD_SHA} -->"
+          if gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate --jq '.[].body' | grep -Fq "$marker"; then
+            echo "Claude review already requested for ${PR_HEAD_SHA}."
+            echo "AGENT_REVIEW_REQUESTED=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
 
-          gh issue comment "$PR_NUMBER" --body-file /tmp/claude-review-request.md
           gh workflow run claude-code-review.yml \
             --ref "$BASE_REF" \
             -f pr_number="$PR_NUMBER" \
             -f head_sha="$PR_HEAD_SHA" \
             -f review_prompt="$REVIEW_PROMPT"
 
+          printf '%s\n%s\n' \
+            "$marker" \
+            "Agent review orchestration requested Claude review for commit \`${PR_HEAD_SHA}\`." \
+            > /tmp/claude-review-request.md
+
+          gh pr comment "$PR_NUMBER" --body-file /tmp/claude-review-request.md
+          echo "AGENT_REVIEW_REQUESTED=true" >> "$GITHUB_ENV"
+
       - name: Wait for Claude review window
+        if: env.AGENT_REVIEW_REQUESTED == 'true'
         run: sleep "$SECOND_WAIT_SECONDS"
 
       - name: Mark agent reviews ready
+        if: env.AGENT_REVIEW_REQUESTED == 'true'
         run: |
           set -euo pipefail
 
@@ -73,11 +104,10 @@ jobs:
             exit 0
           fi
 
-          cat > /tmp/agent-review-ready.md <<EOF
-          ${marker}
-          Agent review window complete for commit \`${PR_HEAD_SHA}\`.
+          printf '%s\n%s\n\n%s\n' \
+            "$marker" \
+            "Agent review window complete for commit \`${PR_HEAD_SHA}\`." \
+            "Local coding agent: pull current Codex and Claude review comments before continuing." \
+            > /tmp/agent-review-ready.md
 
-          Local coding agent: pull current Codex and Claude review comments before continuing.
-          EOF
-
-          gh issue comment "$PR_NUMBER" --body-file /tmp/agent-review-ready.md
+          gh pr comment "$PR_NUMBER" --body-file /tmp/agent-review-ready.md

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,8 +41,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          additional_permissions: |
-            actions: read
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ inputs.pr_number }}
@@ -51,9 +49,9 @@ jobs:
             ${{ inputs.review_prompt }}
 
             Use the repository's CLAUDE.md and AGENTS.md guidance for style and conventions.
-            Read existing PR comments and reviews first with `gh pr view --comments`.
-            Use `gh pr diff` to inspect this PR.
-            Leave your findings as a top-level PR comment with `gh pr comment`.
+            Read existing PR comments and reviews first with `gh pr view ${{ inputs.pr_number }} --comments`.
+            Use `gh pr diff ${{ inputs.pr_number }}` to inspect this PR.
+            Leave your findings as a top-level PR comment with `gh pr comment ${{ inputs.pr_number }}`.
             Do not edit files, push commits, merge the PR, or resolve review threads.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,35 +1,32 @@
 name: Claude Code Review
 
-# Disabled: Automatic PR reviews disabled in favor of @claude mention-based reviews
-# To re-enable automatic reviews, uncomment the section below
-# on:
-#   pull_request:
-#     types: [opened, synchronize]
-#     # Optional: Only run on specific file changes
-#     # paths:
-#     #   - "src/**/*.ts"
-#     #   - "src/**/*.tsx"
-#     #   - "src/**/*.js"
-#     #   - "src/**/*.jsx"
-
-# This workflow is now inactive. Use @claude mentions in PRs to trigger reviews (see claude.yml)
 on:
-  workflow_dispatch:  # Only runs when manually triggered from GitHub Actions UI
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to review
+        required: true
+        type: string
+      head_sha:
+        description: Pull request head SHA being reviewed
+        required: true
+        type: string
+      review_prompt:
+        description: Prompt to send to Claude for the review
+        required: false
+        type: string
+        default: "@claude please review this PR. Don't flag any issues already flagged by Codex. The target audience for your review is a coding agent, not a human."
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: read
-      issues: read
+      issues: write
       id-token: write
+      actions: read
 
     steps:
       - name: Checkout repository
@@ -40,24 +37,25 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ inputs.pr_number }}
+            HEAD SHA: ${{ inputs.head_sha }}
 
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            ${{ inputs.review_prompt }}
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
-
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            Use the repository's CLAUDE.md and AGENTS.md guidance for style and conventions.
+            Read existing PR comments and reviews first with `gh pr view --comments`.
+            Use `gh pr diff` to inspect this PR.
+            Leave your findings as a top-level PR comment with `gh pr comment`.
+            Do not edit files, push commits, merge the PR, or resolve review threads.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-


### PR DESCRIPTION
## Summary
- add a PR-targeted Actions orchestrator that waits for the Codex review window, dispatches Claude review, waits again, then marks the PR ready for local-agent follow-up
- make the existing Claude Code Review workflow dispatchable with explicit PR inputs and the saved coding-agent-focused review prompt
- keep manual `@claude` mention behavior separate in `claude.yml`

## Notes
- Uses `pull_request_target` without checking out PR code, and only runs for non-draft same-repository PRs.
- The orchestrator dispatches `claude-code-review.yml` directly because `GITHUB_TOKEN` comments generally do not trigger follow-up workflows.
- Wait durations default to 600 seconds each and can be tuned with repo variables `AGENT_REVIEW_FIRST_WAIT_SECONDS` and `AGENT_REVIEW_SECOND_WAIT_SECONDS`.

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f} ok" }' .github/workflows/agent-review-orchestration.yml .github/workflows/claude-code-review.yml`
- extracted all workflow `run:` blocks and checked them with `bash -n`
- `git diff --check`
- `poetry run python scripts/check_model_drift.py`

Note: `actionlint` is not installed locally; `npx --yes actionlint ...` failed because npm could not determine an executable for that package.