### PR TITLE
Expand Orrery package library with round-2 templates (care + craft + contact)

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -432,6 +432,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
     - actor has `patron` relationship to target
     - actor has `guardian` relationship to target
   - ≥ 12 ticks since last `contact_made` event for (actor, target) pair
+  - ≥ 12 ticks since last `welfare_check` event for (actor, target) pair
   - **NOT:** actor has `under_active_pursuit` ephemeral
   - **NOT:** actor has `grudge_active` ephemeral
 
@@ -620,6 +621,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
     - actor and target share `chosen_kin` relationship (either direction)
     - actor and target share `comrade` relationship (either direction)
   - ≥ 8 ticks since last `contact_made` event for (actor, target) pair
+  - ≥ 8 ticks since last `kin_visit` event for (actor, target) pair
   - **NOT:** actor has `under_active_pursuit` ephemeral
   - **NOT:** actor has `grudge_active` ephemeral
 
@@ -673,6 +675,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
     - recent `threat_issued` event in last 10 ticks
     - recent `faction_realignment` event in last 15 ticks
   - ≥ 20 ticks since last `contact_made` event for (actor, target) pair
+  - ≥ 20 ticks since last `rival_consulted` event for (actor, target) pair
   - **NOT:** actor has `grudge_active` ephemeral
   - **NOT:** actor has `under_active_pursuit` ephemeral
 
@@ -745,7 +748,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 2 — Sit with others who carry the same loss  *(mag 0.38)*
 
-**When:** 1+ other entities with `bereaved` tag co-located with actor
+**When:** 1+ other entities with `bereaved` ephemeral co-located with actor
 
 **Does:** activity → "gathering with co-mourners"
 **Event:** `mourning_act`
@@ -781,7 +784,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **Gate:**
 
 - **AND:**
-  - actor has any of [`combat_trained`, `soldier`, `warrior`, `fighter`, `arcane_caster`, `engineer`, `mechanic`, `tinkerer`, `hacker`, `artificer`, `musician`, `dancer`, `performer`, `artist`, `athlete`, `martial_artist`, `ranger`, `scout`, `monk`, `keeps_shop`, `merchant`, `innkeeper`, `trader`, `domestic_role`, `cares_for_household`, `matriarch`, `patriarch`, `scholar`, `researcher`, `academic`, `loremaster`]
+  - actor has any of [`combat_trained`, `soldier`, `warrior`, `fighter`, `arcane_caster`, `engineer`, `mechanic`, `tinkerer`, `hacker`, `artificer`, `musician`, `dancer`, `performer`, `artist`, `writer`, `artisan`, `athlete`, `martial_artist`, `ranger`, `scout`, `monk`, `keeps_shop`, `merchant`, `innkeeper`, `trader`, `domestic_role`, `cares_for_household`, `matriarch`, `patriarch`, `scholar`, `researcher`, `academic`, `loremaster`]
   - ≥ 4 ticks since last `craft_tended` event for actor
   - **NOT:** actor has `under_active_pursuit` ephemeral
   - **NOT:** actor has `wounded` ephemeral
@@ -816,7 +819,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 4 — Run through the work that keeps the work possible  *(mag 0.18)*
 
-**When:** actor has any of [`musician`, `dancer`, `performer`, `artist`]
+**When:** actor has any of [`musician`, `dancer`, `performer`, `artist`, `writer`, `artisan`]
 
 **Does:** activity → "practicing the unseen work"; adds `recently_tended_craft` to actor
 **Event:** `craft_tended`
@@ -863,7 +866,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 **When:** *(always)*
 
-**Does:** activity → "tending the work that is theirs"
+**Does:** activity → "tending the work that is theirs"; adds `recently_tended_craft` to actor
 **Event:** `craft_tended`
 
 > {actor} does a small thing for the work that defines them — they would not call it that, probably, but that is what it is — and the day is briefly better for it.

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -207,6 +207,76 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ---
 
+## TEND_WOUNDED — priority 88
+
+> A wounded body pulls the actor toward the small work of mending.
+
+**Slots:** ACTOR, TARGET
+**Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
+
+**Gate:**
+
+- **AND:**
+  - target has `wounded` ephemeral
+  - actor and target are co-located
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+  - **NOT:** target has `under_active_pursuit` ephemeral
+  - ≥ 2 ticks since last `tended_wound` event for (actor, target) pair
+
+### Branch 1 — Channel restorative power through hands and voice  *(mag 0.74)*
+
+**When:** actor has `magical_healing` tag
+
+**Does:** activity → "channeling restorative power"; removes `wounded` from target; adds `recently_drained` to actor
+**Event:** `wound_healed`
+
+> {actor} kneels beside {target} and places hands where the damage lives. Something passes between them — a quiet exchange of warmth and pain — and the body begins to remember how to be whole.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} may be close enough to attempt restorative work on {target}'s wound in the active scene. Treat as offered help the scene can accept, defer, or complicate, not as automatic healing.
+
+### Branch 2 — Work the wound with trained hands  *(mag 0.58)*
+
+**When:** actor has any of [`surgical_training`, `medical_skill`]
+
+**Does:** activity → "providing skilled medical care"; removes `wounded` from target; adds `recently_tended` to target
+**Event:** `tended_wound`
+
+> {actor} cleans the wound by feel, finds what needs to be found, and does the work the body cannot do for itself. {target} watches the ceiling and counts something silently.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is moving to provide skilled medical care to {target}. The scene may show this as a quiet competent interruption, a wait for stabilization, or a beat of trust between them.
+
+### Branch 3 — Apply what first-aid the moment allows  *(mag 0.42)*
+
+**When:** actor has `first_aid_trained` tag
+
+**Does:** activity → "applying field first aid"; adds `recently_tended` to target
+**Event:** `tended_wound`
+
+> {actor} works from memory — pressure here, elevation there, the things that buy time when time is the thing you need. It won't be enough on its own, but it's enough for now.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} has practical first-aid training and is at {target}'s side. Treat as a stabilizing presence the scene can use without granting full recovery.
+
+### Branch 4 — Stay with the wound and do what can be done  *(mag 0.24)*
+
+**When:** *(always)*
+
+**Does:** activity → "keeping watch over the wounded"
+**Event:** `tended_wound`
+
+> {actor} has no real skill for this. They press a cloth where there is bleeding and speak softly so {target} has a voice to follow back from wherever the body has gone.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is present at {target}'s side without medical ability. Use this as accompaniment and witness — not as intervention.
+
+---
+
 ## HONOR_DEBT — priority 80
 
 > A binding obligation surfaces from the blank years.
@@ -252,6 +322,56 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ---
 
+## WARN_ALLY — priority 75
+
+> A threat surfaces; word reaches the people who need to know.
+
+**Slots:** ACTOR, TARGET
+**Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
+
+**Gate:**
+
+- **AND:**
+  - **OR:**
+    - actor and target share `family` relationship (either direction)
+    - actor and target share `romantic` relationship (either direction)
+    - actor and target share `chosen_kin` relationship (either direction)
+    - actor and target share `comrade` relationship (either direction)
+    - actor and target share `ally` relationship (either direction)
+  - **OR:**
+    - recent `threat_issued` event targeting target in last 3 ticks
+    - recent `compliance_alert` event targeting target in last 3 ticks
+    - target has `under_active_pursuit` ephemeral
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+
+### Branch 1 — Reach the ally face-to-face before the word gets out  *(mag 0.66)*
+
+**When:** actor and target are co-located
+
+**Does:** activity → "delivering urgent warning in person"; adds `forewarned` to target
+**Event:** `warning_delivered`
+
+> {actor} catches {target} before they have time to compose themselves and tells them quickly, in a voice stripped to the load-bearing words, what is coming and what they should do about it.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is moving to deliver an urgent warning to {target}. The scene may show this as interruption, intrusion, or a beat the storyteller folds into the current moment.
+
+### Branch 2 — Send word through whatever channel will reach them quickest  *(mag 0.52)*
+
+**When:** *(always)*
+
+**Does:** activity → "sending urgent warning"; adds `forewarned` to target
+**Event:** `warning_delivered`
+
+> {actor} sends the warning through whatever channel will reach {target} fastest — a call, a runner, a sealed message, a coded signal, a prayer through a familiar spirit — and hopes the gap between sending and receiving is short enough to matter.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} has sent {target} an urgent warning by remote means. The scene may show this as an incoming message, a vague disturbance, a half-heard signal, or it may not land in time.
+
+---
+
 ## PURSUE_GHOST_LEAD — priority 60
 
 > The fragments of a buried identity tug at the actor.
@@ -292,6 +412,58 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **Event:** `pursue_identity_lead`
 
 > {actor} visits a broker who owes them a favor and leaves with one new question and one dangerous name.
+
+---
+
+## CHECK_ON_DEPENDENT — priority 55
+
+> A duty of care surfaces between the actor and someone in their charge.
+
+**Slots:** ACTOR, TARGET
+**Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
+
+**Gate:**
+
+- **AND:**
+  - **NOT:** actor has `informant_handler` tag
+  - **OR:**
+    - actor has `handler` relationship to target
+    - actor has `mentor` relationship to target
+    - actor has `patron` relationship to target
+    - actor has `guardian` relationship to target
+  - ≥ 12 ticks since last `contact_made` event for (actor, target) pair
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+  - **NOT:** actor has `grudge_active` ephemeral
+
+### Branch 1 — Drop by in person when the moment allows  *(mag 0.44)*
+
+**When:**
+
+- **AND:**
+  - actor and target are co-located
+  - ≥ 6 ticks since last `welfare_check` event for (actor, target) pair
+
+**Does:** activity → "checking on a dependent in person"
+**Event:** `welfare_check`
+
+> {actor} stops by — ostensibly for something else, the way these visits often are — and uses the small window to read {target}'s state: how they look, what they say without saying, what they decline to mention. It will be enough information for now.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is making a casual welfare check on {target}. Treat as a low-key social presence the scene can absorb or use as a beat of relationship texture.
+
+### Branch 2 — Reach out through customary channels  *(mag 0.22)*
+
+**When:** *(always)*
+
+**Does:** activity → "checking in on a dependent"
+**Event:** `contact_made`
+
+> {actor} sends the kind of message they always send — brief, light in tone, asking nothing real but leaving the door open for {target} to say something real if they want to — and watches for what comes back.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} has sent {target} a routine welfare-check message. The scene may use this as an unread notification, an answered exchange, or texture for {target}'s decisions.
 
 ---
 
@@ -364,6 +536,340 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ---
 
+## KEEP_VIGIL — priority 50
+
+> The actor remains present through a slow, uncertain hour.
+
+**Slots:** ACTOR, TARGET
+**Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
+
+**Gate:**
+
+- **AND:**
+  - actor and target are co-located
+  - **OR:**
+    - target has `wounded` ephemeral
+    - target has `dying` ephemeral
+    - target has `unconscious` ephemeral
+    - target has `captive` ephemeral
+  - **OR:**
+    - actor has `family` relationship to target
+    - actor has `romantic` relationship to target
+    - actor has `chosen_kin` relationship to target
+    - actor has `comrade` relationship to target
+    - actor has `ward` relationship to target
+    - actor has `guardian` relationship to target
+    - actor has `captor` relationship to target
+  - ≥ 2 ticks since last `vigil_held` event for actor
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+
+### Branch 1 — Maintain prayerful or meditative presence  *(mag 0.46)*
+
+**When:** actor has any of [`devout`, `contemplative`, `ritual_practitioner`]
+
+**Does:** activity → "holding meditative vigil"; adds `at_vigil` to actor
+**Event:** `vigil_held`
+
+> {actor} sits beside {target} with hands quiet, breathing matched to whatever rhythm {target}'s body is still finding. The prayers — if they are prayers — are not for any audience but for the work of staying.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is keeping a contemplative vigil over {target}. Use this as an emotional anchor in the scene, not an active intervention.
+
+### Branch 2 — Speak softly through the long hours  *(mag 0.38)*
+
+**When:** target has `unconscious` ephemeral
+
+**Does:** activity → "speaking through the long hours"; adds `at_vigil` to actor
+**Event:** `vigil_held`
+
+> {actor} tells {target} small things — what the light is doing outside, what the others said today, the kind of stories one tells someone who may or may not be hearing — in the belief that whatever can be reached should be reached.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is speaking to an unresponsive {target} through a long stretch. Treat as audible presence the scene can thread through quieter moments.
+
+### Branch 3 — Stand watch with attention but without intervention  *(mag 0.32)*
+
+**When:** *(always)*
+
+**Does:** activity → "standing vigil"; adds `at_vigil` to actor
+**Event:** `vigil_held`
+
+> {actor} stays. Not doing anything — that's the point of being here. {target} is alone with whatever is happening to them, and {actor} is the witness who makes that aloneness less complete.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is keeping silent vigil over {target}. Use this as ambient presence — a witness who shapes the scene by being there, not by acting.
+
+---
+
+## REACH_OUT_TO_KIN — priority 40
+
+> A small thread of contact between people who hold each other.
+
+**Slots:** ACTOR, TARGET
+**Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
+
+**Gate:**
+
+- **AND:**
+  - **OR:**
+    - actor and target share `family` relationship (either direction)
+    - actor and target share `romantic` relationship (either direction)
+    - actor and target share `chosen_kin` relationship (either direction)
+    - actor and target share `comrade` relationship (either direction)
+  - ≥ 8 ticks since last `contact_made` event for (actor, target) pair
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+  - **NOT:** actor has `grudge_active` ephemeral
+
+### Branch 1 — Find the moment for a real face-to-face conversation  *(mag 0.36)*
+
+**When:**
+
+- **AND:**
+  - actor and target are co-located
+  - ≥ 5 ticks since last `kin_visit` event for (actor, target) pair
+
+**Does:** activity → "spending real time with kin"
+**Event:** `kin_visit`
+
+> {actor} makes the small effort that finding-time-for-someone requires — clearing a half hour, choosing a place, showing up — and {target} arrives, and for a while they are the kind of present together that distance erodes.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is meeting {target} in person for a real conversation. Use this as a relationship beat the scene can fold in or hold for later, not as a guaranteed off-screen event.
+
+### Branch 2 — Send a message that says less than it means  *(mag 0.16)*
+
+**When:** *(always)*
+
+**Does:** activity → "keeping kin contact warm"
+**Event:** `contact_made`
+
+> {actor} sends {target} the small message that means more than the words it contains — a check-in, a shared joke, a question that doesn't really need answering — and the thread between them stays warm for another while.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} has sent {target} a small affectionate message. Treat as ambient relationship-warmth — possibly an incoming notification, possibly not surfaced at all.
+
+---
+
+## CONSULT_RIVAL — priority 35
+
+> Two people who do not trust each other are forced into contact anyway.
+
+**Slots:** ACTOR, TARGET
+**Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
+
+**Gate:**
+
+- **AND:**
+  - **OR:**
+    - actor has `rival` relationship to target
+    - trust actor→target < 0
+  - **OR:**
+    - recent `compliance_alert` event in last 10 ticks
+    - recent `threat_issued` event in last 10 ticks
+    - recent `faction_realignment` event in last 15 ticks
+  - ≥ 20 ticks since last `contact_made` event for (actor, target) pair
+  - **NOT:** actor has `grudge_active` ephemeral
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+
+### Branch 1 — Meet face-to-face on neutral ground  *(mag 0.62)*
+
+**When:**
+
+- **AND:**
+  - actor and target are co-located
+  - actor is in `neutral_ground` location class
+
+**Does:** activity → "meeting a rival under truce"; adds `under_truce` to actor; adds `under_truce` to target
+**Event:** `rival_consulted`
+
+> {actor} and {target} arrange to be in the same place at the same time without quite arranging it — both of them drinking something they don't particularly want, both of them speaking carefully — because whatever is happening is bigger than what they have between them, and they both know it.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is in a tense face-to-face meeting with {target}, a known rival. Treat as charged co-presence — the scene can show this as observed truce, ambient discomfort, or delayed consequence.
+
+### Branch 2 — Send a carefully-worded message through indirect channels  *(mag 0.48)*
+
+**When:** actor has `contacts_available` tag
+
+**Does:** activity → "reaching out to a rival via intermediary"
+**Event:** `rival_consulted`
+
+> {actor} sends {target} a message routed through an intermediary they both trust slightly more than they trust each other — a message worded with enough care that the indirect-channel relay can be denied later, but with enough substance that {target} cannot reasonably ignore it.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} has sent {target} a carefully-routed message via intermediary. Treat as off-screen pressure — the scene may show {target} reacting to it, or it may resurface later.
+
+### Branch 3 — Leave a sign the rival will recognize and a door they can open  *(mag 0.34)*
+
+**When:** *(always)*
+
+**Does:** activity → "leaving a tentative overture for a rival"
+**Event:** `contact_made`
+
+> {actor} doesn't quite reach out — but they place a sign where {target} will see it, the kind of signal that says *I am willing to talk if you are*, without committing to anything. If {target} reads the sign, the contact has begun. If they don't, it hasn't.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} has placed a discreet overture for {target} to find. Treat as a passive hook the scene can pick up if useful, or leave dormant.
+
+---
+
+## MOURN_LOSS — priority 25
+
+> A loss settles into the body across many quiet days.
+
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor has `bereaved` ephemeral
+  - ≥ 3 ticks since last `mourning_act` event for actor
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+
+### Branch 1 — Visit the place of remembrance  *(mag 0.42)*
+
+**When:** actor is in `place_of_remembrance` location class
+
+**Does:** activity → "tending the dead"
+**Event:** `mourning_act`
+
+> {actor} returns to the place where the dead are kept — stone, name, photograph, marker, whatever this world has made for the purpose — and stands long enough to be still and remember, before going back to the work of being alive.
+
+### Branch 2 — Sit with others who carry the same loss  *(mag 0.38)*
+
+**When:** 1+ other entities with `bereaved` tag co-located with actor
+
+**Does:** activity → "gathering with co-mourners"
+**Event:** `mourning_act`
+
+> {actor} finds the others who knew the dead and sits with them — wordlessly, mostly. The presence of someone else who is also not over it makes the grief feel less like evidence of personal failure.
+
+### Branch 3 — Pour the loss into the day's work  *(mag 0.28)*
+
+**When:** actor has any of [`musician`, `writer`, `artisan`, `scholar`, `arcane_caster`, `soldier`, `keeps_shop`, `domestic_role`]
+
+**Does:** activity → "working through grief"
+**Event:** `mourning_act`
+
+> {actor} returns to their work — the thing the loss hasn't taken — and does it with the dead person sitting somewhere just behind them, watching the work with the particular silence the dead have.
+
+### Branch 4 — Carry the weight in private  *(mag 0.14)*
+
+**When:** *(always)*
+
+**Does:** activity → "carrying private grief"
+**Event:** `mourning_act`
+
+> {actor} goes through the day's motions with the loss settled inside them like a second heartbeat — not louder than the day, just underneath it, the way these things tend to be once the first weeks are past.
+
+---
+
+## TEND_CRAFT — priority 15
+
+> A small act of care for the work that defines them.
+
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor has any of [`combat_trained`, `soldier`, `warrior`, `fighter`, `arcane_caster`, `engineer`, `mechanic`, `tinkerer`, `hacker`, `artificer`, `musician`, `dancer`, `performer`, `artist`, `athlete`, `martial_artist`, `ranger`, `scout`, `monk`, `keeps_shop`, `merchant`, `innkeeper`, `trader`, `domestic_role`, `cares_for_household`, `matriarch`, `patriarch`, `scholar`, `researcher`, `academic`, `loremaster`]
+  - ≥ 4 ticks since last `craft_tended` event for actor
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+  - **NOT:** actor has `wounded` ephemeral
+  - **NOT:** actor has `bereaved` ephemeral
+
+### Branch 1 — Make the weapon ready for what comes next  *(mag 0.18)*
+
+**When:** actor has any of [`combat_trained`, `soldier`, `warrior`, `fighter`]
+
+**Does:** activity → "making the weapon ready"; adds `recently_tended_craft` to actor
+**Event:** `craft_tended`
+
+> {actor} takes the weapon apart with the slow patience of someone who has done this enough times to know the geometry of each piece by feel, and puts it back together the same way, attentive to small things only they will notice.
+
+### Branch 2 — Lay hands on the arcane work-in-progress  *(mag 0.18)*
+
+**When:** actor has `arcane_caster` tag
+
+**Does:** activity → "tending arcane work"; adds `recently_tended_craft` to actor
+**Event:** `craft_tended`
+
+> {actor} spends an unhurried hour with whatever is currently between their hands and the world's underlying grammar — checking small things, adjusting smaller things, letting the work tell them what it still needs.
+
+### Branch 3 — Maintain and improve the tools of the trade  *(mag 0.18)*
+
+**When:** actor has any of [`engineer`, `mechanic`, `tinkerer`, `hacker`, `artificer`]
+
+**Does:** activity → "maintaining equipment"; adds `recently_tended_craft` to actor
+**Event:** `craft_tended`
+
+> {actor} attends to the equipment — the part that's been annoying them for weeks, the upgrade they keep meaning to install, the calibration that's been just slightly off — and emerges with the tools a small degree better than they were.
+
+### Branch 4 — Run through the work that keeps the work possible  *(mag 0.18)*
+
+**When:** actor has any of [`musician`, `dancer`, `performer`, `artist`]
+
+**Does:** activity → "practicing the unseen work"; adds `recently_tended_craft` to actor
+**Event:** `craft_tended`
+
+> {actor} works through the practice that no one will ever see — the scales, the exercises, the small motions that the public version of the art rests on — for an hour, the way the practice has to be done if the work is to stay alive.
+
+### Branch 5 — Move the body through its daily reckoning  *(mag 0.18)*
+
+**When:** actor has any of [`athlete`, `martial_artist`, `ranger`, `scout`, `monk`]
+
+**Does:** activity → "conditioning the body"; adds `recently_tended_craft` to actor
+**Event:** `craft_tended`
+
+> {actor} puts the body through its daily reckoning — the run, the forms, the small punishments that keep the body ready for whatever the next demand will be — and finishes marginally sharper than they began.
+
+### Branch 6 — Tend the small shop's quiet machinery  *(mag 0.18)*
+
+**When:** actor has any of [`keeps_shop`, `merchant`, `innkeeper`, `trader`]
+
+**Does:** activity → "tending the shop's rhythms"; adds `recently_tended_craft` to actor
+**Event:** `craft_tended`
+
+> {actor} does the things a place of business needs in order to keep being a place of business: the count, the ledger, the small repairs, the conversations with regulars who came in for something other than the thing they actually bought.
+
+### Branch 7 — Keep the household running  *(mag 0.18)*
+
+**When:** actor has any of [`domestic_role`, `cares_for_household`, `matriarch`, `patriarch`]
+
+**Does:** activity → "tending the household"; adds `recently_tended_craft` to actor
+**Event:** `craft_tended`
+
+> {actor} does the work that holds a household together — the meals, the cleaning, the small attentions no one particularly thanks anyone for but whose absence would be felt immediately. It is enough work for a full day, every day, by itself.
+
+### Branch 8 — Return to the unfinished study  *(mag 0.18)*
+
+**When:** actor has any of [`scholar`, `researcher`, `academic`, `loremaster`]
+
+**Does:** activity → "advancing the long study"; adds `recently_tended_craft` to actor
+**Event:** `craft_tended`
+
+> {actor} returns to the long work that is always almost but never finished — reading carefully, taking notes that may yet matter, following a thread that may yet lead somewhere — and gives the work another quiet evening of the only thing it really needs.
+
+### Branch 9 — Take a small action of care for the work that is theirs  *(mag 0.12)*
+
+**When:** *(always)*
+
+**Does:** activity → "tending the work that is theirs"
+**Event:** `craft_tended`
+
+> {actor} does a small thing for the work that defines them — they would not call it that, probably, but that is what it is — and the day is briefly better for it.
+
+---
+
 ## MAINTAIN_COVER — priority 0
 
 > Baseline activity that keeps the behavioral ledger plausible.
@@ -400,55 +906,123 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/023_orrery_schema.py`
 - `migrations/024_orrery_commit_pipeline.sql`
 - `migrations/025_orrery_package_library_vocab.py`
+- `migrations/027_orrery_package_library_round2_vocab.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 
+- `academic`
+- `arcane_caster`
+- `artificer`
+- `artisan`
+- `artist`
+- `athlete`
+- `cares_for_household`
+- `combat_trained`
 - `contacts_available`
+- `contemplative`
+- `dancer`
+- `devout`
+- `domestic_role`
+- `engineer`
+- `fighter`
+- `first_aid_trained`
 - `ghostprint_active`
+- `hacker`
 - `informant_handler`
+- `innkeeper`
+- `keeps_shop`
+- `loremaster`
+- `magical_healing`
+- `martial_artist`
+- `matriarch`
+- `mechanic`
+- `medical_skill`
+- `merchant`
+- `monk`
+- `musician`
+- `patriarch`
+- `performer`
+- `ranger`
+- `researcher`
+- `ritual_practitioner`
+- `scholar`
+- `scout`
 - `seeking_identity`
+- `soldier`
+- `surgical_training`
+- `tinkerer`
+- `trader`
 - `under_active_pursuit`
 - `vendetta_holder`
 - `violent_history`
+- `warrior`
+- `writer`
 
 ### Tags queried as ephemeral (via `has_ephemeral`)
 
+- `bereaved`
+- `captive`
 - `debt_pulse_active`
+- `dying`
 - `grudge_active`
+- `unconscious`
 - `under_active_pursuit`
 - `wounded`
 
 ### Tags applied by branch effects (durable vs ephemeral classification per migration)
 
+- `at_vigil`
 - `distressed`
+- `forewarned`
 - `intelligence_asset_active`
 - `off_grid`
+- `recently_drained`
 - `recently_protective`
+- `recently_tended`
+- `recently_tended_craft`
 - `recently_violent`
 - `reputation_compromised`
+- `under_truce`
 
 ### Event types
 
 - `compliance_alert`
+- `contact_made`
+- `craft_tended`
 - `encoded_message`
 - `evade_pursuit`
+- `faction_realignment`
 - `honor_debt`
 - `informant_contact`
 - `intel_acquired`
+- `kin_visit`
 - `maintain_cover`
+- `mourning_act`
 - `protective_intervention`
 - `pursue_identity_lead`
 - `retaliation_attempted`
 - `retaliation_executed`
+- `rival_consulted`
+- `tended_wound`
 - `threat_issued`
+- `vigil_held`
+- `warning_delivered`
+- `welfare_check`
+- `wound_healed`
 
 ### Relationship types
 
+- `ally`
 - `asset`
+- `captor`
 - `chosen_kin`
 - `comrade`
 - `enemy`
 - `family`
+- `guardian`
 - `handler`
+- `mentor`
+- `patron`
 - `rival`
 - `romantic`
+- `ward`

--- a/migrations/027_orrery_package_library_round2_vocab.py
+++ b/migrations/027_orrery_package_library_round2_vocab.py
@@ -1,0 +1,576 @@
+"""Seed vocabulary for the Orrery package-library round 2 expansion.
+
+Adds the tags, event_types, and relationship_type enum values referenced
+by the eight new templates appended to nexus/agents/orrery/templates.py
+in the same change:
+
+  - Section A (universal care): TEND_WOUNDED, MOURN_LOSS, KEEP_VIGIL
+  - Section B (maintenance of self): TEND_CRAFT
+  - Section C (contact quartet): WARN_ALLY, CHECK_ON_DEPENDENT,
+    REACH_OUT_TO_KIN, CONSULT_RIVAL
+
+Vocabulary is intentionally broad — particularly TEND_CRAFT's role tags
+(combat / arcane / engineering / performing / athletic / commerce /
+domestic / scholarly archetypes). ChatClaude's contribution flagged that
+many role tags are nominally distinct but functionally identical for
+gate-discrimination purposes (engineer / mechanic / tinkerer / hacker /
+artificer all fire the same TEND_CRAFT branch via has_any_tag). I kept
+the full set so storyteller-side tagging stays expressive; collapsing
+to canonical names is a follow-up consideration if observed vocabulary
+volume becomes unwieldy.
+
+Two ephemerals seeded with `clear_on` pointing at events that don't
+yet have a resolver-side emitter — `dying` clears on `wound_healed` or
+`death_recorded`; `unconscious` clears on `regained_consciousness` or
+`death_recorded`. These external events are "probably authored externally"
+per ChatClaude's note; the ephemerals are seeded with proper clearance
+predicates so when those events eventually fire (from CommitOrreryTick
+or future world-state systems), the framework honors the clearance.
+
+`captive` is seeded as ephemeral rather than durable: being captive is
+a condition that changes (escape, freed, death) rather than an identity.
+Diverges from ChatClaude's table listing; KEEP_VIGIL's gate is updated
+to use has_ephemeral instead of has_tag accordingly.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from psycopg2 import sql
+
+
+# Relationship-type enum extensions. The asymmetric pair captor↔captive
+# captures the gaoler/prisoner dynamic KEEP_VIGIL models; ward↔guardian
+# captures formal caretaking; mentor and patron are common dependent-
+# relationship roles for CHECK_ON_DEPENDENT.
+NEW_RELATIONSHIP_TYPES: Sequence[str] = (
+    "ward",
+    "guardian",
+    "captor",
+    "mentor",
+    "patron",
+)
+
+
+# (tag, category, description)
+DURABLE_TAGS: Sequence[tuple[str, str, str]] = (
+    # Healing capacities (TEND_WOUNDED branches)
+    (
+        "magical_healing",
+        "capacity",
+        "Can channel restorative power. Highest-magnitude TEND_WOUNDED branch.",
+    ),
+    (
+        "surgical_training",
+        "capacity",
+        "Has formal training in surgery. Mid-magnitude TEND_WOUNDED branch.",
+    ),
+    (
+        "medical_skill",
+        "capacity",
+        "Has general medical skill. Mid-magnitude TEND_WOUNDED branch.",
+    ),
+    (
+        "first_aid_trained",
+        "capacity",
+        "Knows first-aid basics. Low-magnitude TEND_WOUNDED branch.",
+    ),
+    # Dispositions (KEEP_VIGIL contemplative branch)
+    (
+        "devout",
+        "disposition",
+        "Holds active religious or spiritual practice.",
+    ),
+    (
+        "contemplative",
+        "disposition",
+        "Inclined toward meditative or reflective practice.",
+    ),
+    # Roles for KEEP_VIGIL contemplative branch, also MOURN_LOSS
+    (
+        "ritual_practitioner",
+        "role",
+        "Performs structured ritual work in any tradition.",
+    ),
+    # Combat roles (TEND_CRAFT weapon-maintenance branch)
+    (
+        "combat_trained",
+        "capacity",
+        "General combat training. Used by TEND_CRAFT weapon branch.",
+    ),
+    (
+        "soldier",
+        "role",
+        "Military or paramilitary role.",
+    ),
+    (
+        "warrior",
+        "role",
+        "Combatant identity outside formal military structures.",
+    ),
+    (
+        "fighter",
+        "role",
+        "Combatant identity, generic.",
+    ),
+    # Arcane roles (TEND_CRAFT arcane branch, MOURN_LOSS)
+    (
+        "arcane_caster",
+        "capacity",
+        "Practices magic of any tradition.",
+    ),
+    # Engineering / tinkering roles (TEND_CRAFT equipment branch)
+    (
+        "engineer",
+        "role",
+        "Designs and builds technical systems.",
+    ),
+    (
+        "mechanic",
+        "role",
+        "Repairs and maintains mechanical or vehicular systems.",
+    ),
+    (
+        "tinkerer",
+        "role",
+        "Inventive hands-on craft work without formal training.",
+    ),
+    (
+        "hacker",
+        "role",
+        "Manipulates information systems.",
+    ),
+    (
+        "artificer",
+        "role",
+        "Craft work that fuses technical and arcane domains.",
+    ),
+    # Creative roles (TEND_CRAFT practice branch, MOURN_LOSS)
+    (
+        "musician",
+        "role",
+        "Practices musical performance or composition.",
+    ),
+    (
+        "dancer",
+        "role",
+        "Practices dance as discipline.",
+    ),
+    (
+        "performer",
+        "role",
+        "Stage or street performance, generic.",
+    ),
+    (
+        "artist",
+        "role",
+        "Visual or plastic art practice.",
+    ),
+    (
+        "writer",
+        "role",
+        "Practices writing.",
+    ),
+    (
+        "artisan",
+        "role",
+        "Skilled handcraft, generic.",
+    ),
+    # Athletic / physical roles (TEND_CRAFT conditioning branch)
+    (
+        "athlete",
+        "role",
+        "Practices physical conditioning as discipline.",
+    ),
+    (
+        "martial_artist",
+        "role",
+        "Trains in a codified martial art.",
+    ),
+    (
+        "ranger",
+        "role",
+        "Operates in wild or border terrain.",
+    ),
+    (
+        "scout",
+        "role",
+        "Reconnaissance and pathfinding role.",
+    ),
+    (
+        "monk",
+        "role",
+        "Religious or martial monastic discipline.",
+    ),
+    # Commerce roles (TEND_CRAFT shop branch)
+    (
+        "keeps_shop",
+        "role",
+        "Runs a small storefront or stall.",
+    ),
+    (
+        "merchant",
+        "role",
+        "Trades goods, generic.",
+    ),
+    (
+        "innkeeper",
+        "role",
+        "Runs lodging and hospitality.",
+    ),
+    (
+        "trader",
+        "role",
+        "Brokerages and exchange-focused commerce.",
+    ),
+    # Domestic roles (TEND_CRAFT household branch, MOURN_LOSS)
+    (
+        "domestic_role",
+        "role",
+        "Identifies with the work of holding a household together.",
+    ),
+    (
+        "cares_for_household",
+        "role",
+        "Primary caretaker role within a household.",
+    ),
+    (
+        "matriarch",
+        "role",
+        "Senior maternal household authority.",
+    ),
+    (
+        "patriarch",
+        "role",
+        "Senior paternal household authority.",
+    ),
+    # Study roles (TEND_CRAFT study branch)
+    (
+        "scholar",
+        "role",
+        "Practices systematic study.",
+    ),
+    (
+        "researcher",
+        "role",
+        "Investigative or experimental study role.",
+    ),
+    (
+        "academic",
+        "role",
+        "Institutional scholarly role.",
+    ),
+    (
+        "loremaster",
+        "role",
+        "Keeper of specialized knowledge tradition.",
+    ),
+)
+
+
+# (tag, category, clearance_kind, clear_on_json, description)
+EPHEMERAL_TAGS: Sequence[tuple[str, str, str, str | None, str]] = (
+    (
+        "bereaved",
+        "state",
+        "event",
+        '{"event_types": ["mourning_completed"]}',
+        "Actor has lost someone close. Long-lived; gates MOURN_LOSS; "
+        "cleared by an external mourning_completed event (closure ritual, "
+        "passage of time-in-world, new significant relationship — author "
+        "via CommitOrreryTick or external system).",
+    ),
+    (
+        "dying",
+        "state",
+        "event",
+        '{"event_types": ["wound_healed", "death_recorded"]}',
+        "Critical state. Gates KEEP_VIGIL. Cleared by wound_healed "
+        "(recovery) or death_recorded (resolution by mortality). "
+        "death_recorded is authored externally.",
+    ),
+    (
+        "unconscious",
+        "state",
+        "event",
+        '{"event_types": ["regained_consciousness", "death_recorded"]}',
+        "Not currently responsive. Gates KEEP_VIGIL. Cleared by "
+        "regained_consciousness or death_recorded — both authored "
+        "externally today.",
+    ),
+    (
+        "captive",
+        "state",
+        "event",
+        '{"event_types": ["captivity_ended"]}',
+        "Held against will. Diverges from ChatClaude's listing: classified "
+        "ephemeral (not durable) because captivity is a condition that "
+        "ends (escape / freed / death). KEEP_VIGIL gate updated to use "
+        "has_ephemeral accordingly.",
+    ),
+    (
+        "recently_drained",
+        "state",
+        "semantic",
+        None,
+        "Actor recently expended substantial restorative power. Cleared "
+        "by semantic decay.",
+    ),
+    (
+        "recently_tended",
+        "state",
+        "semantic",
+        None,
+        "Target has recently received care. Cleared by semantic decay.",
+    ),
+    (
+        "recently_tended_craft",
+        "state",
+        "semantic",
+        None,
+        "Actor recently tended their craft. Marks recent activity for "
+        "future cooldown / co-presence predicates.",
+    ),
+    (
+        "at_vigil",
+        "state",
+        "semantic",
+        None,
+        "Actor is committed to a vigil. Future templates may read this "
+        "to avoid pulling vigil-keepers into routine activity.",
+    ),
+    (
+        "forewarned",
+        "state",
+        "semantic",
+        None,
+        "Target has been warned by an ally about an imminent threat.",
+    ),
+    (
+        "under_truce",
+        "state",
+        "semantic",
+        None,
+        "Actor is in a brokered truce with a rival. Future templates "
+        "(e.g., BREAK_TRUCE) can gate on this state.",
+    ),
+)
+
+
+# (event_type, category, severity, description)
+NEW_EVENT_TYPES: Sequence[tuple[str, str, str, str]] = (
+    # Care
+    (
+        "tended_wound",
+        "care",
+        "minor",
+        "A non-curative tending action. Preserves wounded ephemeral on target.",
+    ),
+    (
+        "wound_healed",
+        "care",
+        "moderate",
+        "Curative resolution. Clears wounded and dying ephemerals on target.",
+    ),
+    (
+        "vigil_held",
+        "care",
+        "minor",
+        "One tick of vigil activity.",
+    ),
+    # Emotional
+    (
+        "mourning_act",
+        "emotional",
+        "minor",
+        "Single small mourning action; accumulates over time.",
+    ),
+    (
+        "mourning_completed",
+        "emotional",
+        "moderate",
+        "Closure ritual or equivalent. Clears bereaved. Authored externally; "
+        "MOURN_LOSS itself never emits this — only acknowledges its trigger.",
+    ),
+    # Routine
+    (
+        "craft_tended",
+        "routine",
+        "minor",
+        "One tick of craft maintenance.",
+    ),
+    # Interpersonal
+    (
+        "contact_made",
+        "interpersonal",
+        "minor",
+        "Baseline contact event emitted by all contact-quartet templates.",
+    ),
+    (
+        "kin_visit",
+        "interpersonal",
+        "moderate",
+        "In-person kin contact; differentiated from contact_made for cooldown.",
+    ),
+    (
+        "welfare_check",
+        "interpersonal",
+        "minor",
+        "In-person dependent welfare check; differentiated for cooldown.",
+    ),
+    (
+        "warning_delivered",
+        "interpersonal",
+        "moderate",
+        "Successful urgent warning to an ally.",
+    ),
+    (
+        "rival_consulted",
+        "interpersonal",
+        "moderate",
+        "Contact between hostile parties under shared pressure.",
+    ),
+    # State-change events (authored externally; seeded for reference + future use)
+    (
+        "regained_consciousness",
+        "state_change",
+        "moderate",
+        "Clears unconscious ephemeral. Authored externally.",
+    ),
+    (
+        "death_recorded",
+        "state_change",
+        "major",
+        "Canonical death event. Triggers bereaved across related entities; "
+        "clears dying, unconscious, and wounded. Authored externally.",
+    ),
+    (
+        "captivity_ended",
+        "state_change",
+        "moderate",
+        "Resolution of captive state (escape, release, death). Authored " "externally.",
+    ),
+    (
+        "faction_realignment",
+        "political",
+        "moderate",
+        "Significant shift in faction allegiance or structure. Used as "
+        "shared-pressure trigger in CONSULT_RIVAL.",
+    ),
+)
+
+
+def run(conn) -> None:
+    """Apply the package-library round-2 vocabulary migration."""
+
+    _extend_relationship_type_enum(conn)
+    _seed_durable_tags(conn)
+    _seed_ephemeral_tags(conn)
+    _seed_event_types(conn)
+
+
+def _enum_value_exists(conn, type_name: str, value: str) -> bool:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT 1
+            FROM pg_enum
+            WHERE enumtypid = %s::regtype
+              AND enumlabel = %s
+            """,
+            (type_name, value),
+        )
+        return cur.fetchone() is not None
+
+
+def _extend_relationship_type_enum(conn) -> None:
+    """Add relationship_type enum values needed by round-2 templates.
+
+    Commits after each ADD VALUE for the same Postgres-version-compat
+    reason migration 025 cited (ALTER TYPE ... ADD VALUE has subtle
+    transaction semantics; one commit per value is the safe pattern).
+    """
+
+    for value in NEW_RELATIONSHIP_TYPES:
+        if _enum_value_exists(conn, "relationship_type", value):
+            continue
+        with conn.cursor() as cur:
+            cur.execute(
+                sql.SQL("ALTER TYPE relationship_type ADD VALUE {}").format(
+                    sql.Literal(value)
+                )
+            )
+        conn.commit()
+
+
+def _seed_durable_tags(conn) -> None:
+    """Insert durable identity tags. Idempotent via ON CONFLICT (tag)."""
+
+    with conn.cursor() as cur:
+        for tag, category, description in DURABLE_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, %s, FALSE,
+                    NULL, NULL,
+                    NULL, %s
+                )
+                ON CONFLICT (tag) DO NOTHING
+                """,
+                (tag, category, description),
+            )
+    conn.commit()
+
+
+def _seed_ephemeral_tags(conn) -> None:
+    """Insert ephemeral state tags with clearance kinds. Idempotent."""
+
+    with conn.cursor() as cur:
+        for (
+            tag,
+            category,
+            clearance_kind,
+            clear_on_json,
+            description,
+        ) in EPHEMERAL_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, %s, TRUE,
+                    %s::entity_tag_clearance_kind,
+                    'extend_expiry'::entity_tag_reapplication_policy,
+                    %s::jsonb, %s
+                )
+                ON CONFLICT (tag) DO NOTHING
+                """,
+                (tag, category, clearance_kind, clear_on_json, description),
+            )
+    conn.commit()
+
+
+def _seed_event_types(conn) -> None:
+    """Insert new event_types referenced by round-2 templates. Idempotent."""
+
+    with conn.cursor() as cur:
+        for event_type, category, severity, description in NEW_EVENT_TYPES:
+            cur.execute(
+                """
+                INSERT INTO event_types (
+                    type, category, severity, description
+                ) VALUES (
+                    %s, %s, %s::event_severity_kind, %s
+                )
+                ON CONFLICT (type) DO NOTHING
+                """,
+                (event_type, category, severity, description),
+            )
+    conn.commit()

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -96,10 +96,17 @@ _register(
     lambda m: f"{_slot(m.group('a'))} and {_slot(m.group('b'))} are co-located",
 )
 _register(
-    r"count_co_located\((?P<n>\d+)@(?P<slot>\w+)(?:,tag=(?P<tag>[^)]+))?\)",
+    r"count_co_located\((?P<n>\d+)@(?P<slot>\w+)"
+    r"(?:,tag=(?P<tag>[^,)]+))?"
+    r"(?:,ephemeral=(?P<ephemeral>[^,)]+))?\)",
     lambda m: (
         f"{m.group('n')}+ other entities"
         + (f" with `{m.group('tag')}` tag" if m.group("tag") else "")
+        + (
+            f" with `{m.group('ephemeral')}` ephemeral"
+            if m.group("ephemeral")
+            else ""
+        )
         + f" co-located with {_slot(m.group('slot'))}"
     ),
 )

--- a/nexus/agents/orrery/demo.py
+++ b/nexus/agents/orrery/demo.py
@@ -21,6 +21,8 @@ TARGET_ID = 2
 ROOTS_PLACE_ID = 101
 GLOW_PLACE_ID = 102
 STACKS_PLACE_ID = 103
+REMEMBRANCE_PLACE_ID = 104
+NEUTRAL_PLACE_ID = 105
 
 
 def build_presets() -> Dict[str, WorldState]:
@@ -35,6 +37,8 @@ def build_presets() -> Dict[str, WorldState]:
         ROOTS_PLACE_ID: "the_roots",
         GLOW_PLACE_ID: "the_glow",
         STACKS_PLACE_ID: "the_stacks",
+        REMEMBRANCE_PLACE_ID: "place_of_remembrance",
+        NEUTRAL_PLACE_ID: "neutral_ground",
     }
     return {
         "hunted": WorldState(
@@ -89,6 +93,23 @@ def build_presets() -> Dict[str, WorldState]:
             weather="clear",
             current_tick=100,
         ),
+        # Round-2 solo presets
+        "mourning": WorldState(
+            ephemeral_tags={ACTOR_ID: frozenset({"bereaved"})},
+            locations={ACTOR_ID: REMEMBRANCE_PLACE_ID},
+            location_class=location_classes,
+            time_of_day="evening",
+            weather="clear",
+            current_tick=100,
+        ),
+        "craft_soldier": WorldState(
+            tags={ACTOR_ID: frozenset({"soldier"})},
+            locations={ACTOR_ID: STACKS_PLACE_ID},
+            location_class=location_classes,
+            time_of_day="evening",
+            weather="clear",
+            current_tick=100,
+        ),
     }
 
 
@@ -104,6 +125,8 @@ def build_multi_slot_presets() -> Dict[str, dict]:
         ROOTS_PLACE_ID: "the_roots",
         GLOW_PLACE_ID: "the_glow",
         STACKS_PLACE_ID: "the_stacks",
+        REMEMBRANCE_PLACE_ID: "place_of_remembrance",
+        NEUTRAL_PLACE_ID: "neutral_ground",
     }
     return {
         "vengeance": {
@@ -137,6 +160,89 @@ def build_multi_slot_presets() -> Dict[str, dict]:
                 relationship_types={(ACTOR_ID, TARGET_ID): frozenset({"handler"})},
                 locations={ACTOR_ID: GLOW_PLACE_ID, TARGET_ID: GLOW_PLACE_ID},
                 location_class=location_classes,
+                time_of_day="evening",
+                weather="clear",
+                current_tick=100,
+            ),
+            "bindings": {Slot.ACTOR: ACTOR_ID, Slot.TARGET: TARGET_ID},
+        },
+        # Round-2 multi-slot presets
+        "wounded_healing": {
+            "state": WorldState(
+                tags={ACTOR_ID: frozenset({"magical_healing"})},
+                ephemeral_tags={TARGET_ID: frozenset({"wounded"})},
+                locations={ACTOR_ID: STACKS_PLACE_ID, TARGET_ID: STACKS_PLACE_ID},
+                location_class=location_classes,
+                time_of_day="evening",
+                weather="clear",
+                current_tick=100,
+            ),
+            "bindings": {Slot.ACTOR: ACTOR_ID, Slot.TARGET: TARGET_ID},
+        },
+        "vigil_devout": {
+            "state": WorldState(
+                tags={ACTOR_ID: frozenset({"devout"})},
+                ephemeral_tags={TARGET_ID: frozenset({"dying"})},
+                relationship_types={(ACTOR_ID, TARGET_ID): frozenset({"family"})},
+                locations={ACTOR_ID: STACKS_PLACE_ID, TARGET_ID: STACKS_PLACE_ID},
+                location_class=location_classes,
+                time_of_day="night",
+                weather="clear",
+                current_tick=100,
+            ),
+            "bindings": {Slot.ACTOR: ACTOR_ID, Slot.TARGET: TARGET_ID},
+        },
+        "warning": {
+            "state": WorldState(
+                relationship_types={(ACTOR_ID, TARGET_ID): frozenset({"ally"})},
+                locations={ACTOR_ID: GLOW_PLACE_ID, TARGET_ID: GLOW_PLACE_ID},
+                location_class=location_classes,
+                recent_events=(
+                    EventRecord(
+                        event_type="threat_issued",
+                        tick=99,
+                        target_entity_id=TARGET_ID,
+                    ),
+                ),
+                time_of_day="evening",
+                weather="clear",
+                current_tick=100,
+            ),
+            "bindings": {Slot.ACTOR: ACTOR_ID, Slot.TARGET: TARGET_ID},
+        },
+        "welfare_check": {
+            "state": WorldState(
+                relationship_types={(ACTOR_ID, TARGET_ID): frozenset({"mentor"})},
+                locations={ACTOR_ID: GLOW_PLACE_ID, TARGET_ID: GLOW_PLACE_ID},
+                location_class=location_classes,
+                time_of_day="afternoon",
+                weather="clear",
+                current_tick=100,
+            ),
+            "bindings": {Slot.ACTOR: ACTOR_ID, Slot.TARGET: TARGET_ID},
+        },
+        "kin_visit": {
+            "state": WorldState(
+                relationship_types={(ACTOR_ID, TARGET_ID): frozenset({"family"})},
+                locations={ACTOR_ID: GLOW_PLACE_ID, TARGET_ID: GLOW_PLACE_ID},
+                location_class=location_classes,
+                time_of_day="afternoon",
+                weather="clear",
+                current_tick=100,
+            ),
+            "bindings": {Slot.ACTOR: ACTOR_ID, Slot.TARGET: TARGET_ID},
+        },
+        "rival_truce": {
+            "state": WorldState(
+                relationship_types={(ACTOR_ID, TARGET_ID): frozenset({"rival"})},
+                locations={ACTOR_ID: NEUTRAL_PLACE_ID, TARGET_ID: NEUTRAL_PLACE_ID},
+                location_class=location_classes,
+                recent_events=(
+                    EventRecord(
+                        event_type="compliance_alert",
+                        tick=95,
+                    ),
+                ),
                 time_of_day="evening",
                 weather="clear",
                 current_tick=100,

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -177,8 +177,14 @@ def count_co_located(
     slot: Slot = Slot.ACTOR,
     *,
     with_tag: Optional[str] = None,
+    with_ephemeral: Optional[str] = None,
 ) -> Condition:
-    """Return whether enough entities share the slot entity's current location."""
+    """Return whether enough entities share the slot entity's current location.
+
+    Filters by ``with_tag`` against the durable ``state.tags`` map; filters
+    by ``with_ephemeral`` against ``state.ephemeral_tags``. Both filters can
+    be combined; both default to None (no tag filter).
+    """
 
     def _condition(state: WorldState, bindings: Bindings) -> bool:
         entity_id = _slot_entity(bindings, slot)
@@ -193,10 +199,19 @@ def count_co_located(
                 continue
             if with_tag and with_tag not in state.tags.get(other_id, frozenset()):
                 continue
+            if with_ephemeral and with_ephemeral not in state.ephemeral_tags.get(
+                other_id, frozenset()
+            ):
+                continue
             count += 1
         return count >= minimum
 
-    suffix = f",tag={with_tag}" if with_tag else ""
+    filters = []
+    if with_tag:
+        filters.append(f"tag={with_tag}")
+    if with_ephemeral:
+        filters.append(f"ephemeral={with_ephemeral}")
+    suffix = "," + ",".join(filters) if filters else ""
     return _named(_condition, f"count_co_located({minimum}@{slot.value}{suffix})")
 
 

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -762,7 +762,7 @@ MOURN_LOSS = Template(
         ),
         Branch(
             label="Sit with others who carry the same loss",
-            conditions=count_co_located(1, with_tag="bereaved"),
+            conditions=count_co_located(1, with_ephemeral="bereaved"),
             narrative_stub=(
                 "{actor} finds the others who knew the dead and sits with "
                 "them — wordlessly, mostly. The presence of someone else "
@@ -953,6 +953,8 @@ TEND_CRAFT = Template(
             "dancer",
             "performer",
             "artist",
+            "writer",
+            "artisan",
             # athletic / physical
             "athlete",
             "martial_artist",
@@ -1038,7 +1040,9 @@ TEND_CRAFT = Template(
         ),
         Branch(
             label="Run through the work that keeps the work possible",
-            conditions=has_any_tag("musician", "dancer", "performer", "artist"),
+            conditions=has_any_tag(
+                "musician", "dancer", "performer", "artist", "writer", "artisan"
+            ),
             narrative_stub=(
                 "{actor} works through the practice that no one will ever "
                 "see — the scales, the exercises, the small motions that "
@@ -1139,9 +1143,10 @@ TEND_CRAFT = Template(
             ),
             state_delta={
                 "character.current_activity": "tending the work that is theirs",
+                "entity_tags.add": ["recently_tended_craft"],
             },
             event_type="craft_tended",
-            changed_fields=("character.current_activity",),
+            changed_fields=("character.current_activity", "entity_tags"),
             magnitude=0.12,
         ),
     ),
@@ -1246,6 +1251,11 @@ CHECK_ON_DEPENDENT = Template(
     # informant-tradecraft handler/asset relationship. Exclude actors
     # tagged informant_handler so welfare-check and intel-cultivation
     # don't fight over the same binding.
+    #
+    # Cooldown: gate must check BOTH events any branch can emit
+    # (welfare_check from the face-to-face branch, contact_made from the
+    # remote branch). Checking only one lets the other bypass the
+    # cooldown — the gate-vs-event asymmetry caught by claude[bot] on PR #223.
     package_gate=AND(
         NOT(has_tag("informant_handler")),
         OR(
@@ -1256,6 +1266,9 @@ CHECK_ON_DEPENDENT = Template(
         ),
         since_last_event_at_least(
             "contact_made", minimum_ticks=12, target_slot=Slot.TARGET
+        ),
+        since_last_event_at_least(
+            "welfare_check", minimum_ticks=12, target_slot=Slot.TARGET
         ),
         NOT(has_ephemeral("under_active_pursuit")),
         NOT(has_ephemeral("grudge_active")),
@@ -1320,6 +1333,9 @@ REACH_OUT_TO_KIN = Template(
     priority=40,
     blurb="A small thread of contact between people who hold each other.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
+    # Cooldown: gate must check BOTH events any branch can emit
+    # (kin_visit from the face-to-face branch, contact_made from the
+    # remote branch). See CHECK_ON_DEPENDENT for the same pattern.
     package_gate=AND(
         OR(
             has_symmetric_relationship_of_type("family"),
@@ -1329,6 +1345,9 @@ REACH_OUT_TO_KIN = Template(
         ),
         since_last_event_at_least(
             "contact_made", minimum_ticks=8, target_slot=Slot.TARGET
+        ),
+        since_last_event_at_least(
+            "kin_visit", minimum_ticks=8, target_slot=Slot.TARGET
         ),
         NOT(has_ephemeral("under_active_pursuit")),
         NOT(has_ephemeral("grudge_active")),
@@ -1396,6 +1415,11 @@ CONSULT_RIVAL = Template(
     # shared-circumstance OR; the same gate excludes it via NOT below. The
     # OR-arm is removed. EXTRACT_VENGEANCE (priority 90) owns grudge-active
     # space; the NOT here is the documented safety belt.
+    #
+    # Cooldown: gate must check BOTH events any branch can emit
+    # (rival_consulted from the meaningful branches, contact_made from the
+    # ALWAYS fallback). Without the rival_consulted cooldown the high-
+    # magnitude branches could refire next tick — caught by Codex on PR #223.
     package_gate=AND(
         OR(
             has_relationship_of_type("rival"),
@@ -1408,6 +1432,9 @@ CONSULT_RIVAL = Template(
         ),
         since_last_event_at_least(
             "contact_made", minimum_ticks=20, target_slot=Slot.TARGET
+        ),
+        since_last_event_at_least(
+            "rival_consulted", minimum_ticks=20, target_slot=Slot.TARGET
         ),
         NOT(has_ephemeral("grudge_active")),
         NOT(has_ephemeral("under_active_pursuit")),

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -583,12 +583,930 @@ CULTIVATE_INFORMANT = Template(
 )
 
 
+# ----------------------------------------------------------------------------
+# Round 2 expansion (universal care + maintenance + contact quartet)
+#
+# Eight templates drafted by the frontier-model conversation partner in
+# temp/orrery/orrery_package_contributions_round2.md, integrated here with
+# the divergences documented below. Authoring intent: universal shape with
+# culturally-specific branches — the same gate fires in fantasy, cyberpunk,
+# contemporary, or pigeon-dating-sim contexts; tag-discriminated branches
+# express the cultural specifics.
+#
+# Deliberate divergences from the contribution draft:
+#
+#   * CONSULT_RIVAL gate: the contribution had `has_ephemeral("grudge_active")`
+#     in the shared-circumstance OR clause AND `NOT(has_ephemeral("grudge_active"))`
+#     in the same gate's AND list — a logical contradiction. The NOT is the
+#     intended exclusion (EXTRACT_VENGEANCE owns grudge-active space; priority
+#     90 vs CONSULT_RIVAL's 35 ensures vengeance fires first anyway, but the
+#     NOT is the documented safety belt). The contradictory OR-arm is removed
+#     here.
+#
+#   * KEEP_VIGIL gate: the contribution used `has_tag("captive", slot=TARGET)`
+#     for the captive-vigil case. The migration seeds `captive` as ephemeral
+#     (captivity is a condition, not an identity — escape/freedom/death ends
+#     it), so this gate uses `has_ephemeral` instead. Branch prose unchanged.
+#
+#   * TEND_WOUNDED's magical-healing branch clears `wounded` from the target
+#     via `entity_tags_target.remove` — closing the loop with PROTECT_KIN
+#     (which reads `wounded` but had no template emitting `wound_healed`
+#     until now).
+#
+#   * `bereaved` / `dying` / `unconscious` ephemerals are seeded with
+#     event-based clearance pointing at `mourning_completed` / `death_recorded`
+#     / `regained_consciousness`. These events are authored externally
+#     (CommitOrreryTick or future world-state systems); MOURN_LOSS and
+#     KEEP_VIGIL never emit them. The framework will need to honor the
+#     clearance predicates when those events eventually fire.
+# ----------------------------------------------------------------------------
+
+
+# Section A — Universal care behaviors
+
+
+TEND_WOUNDED = Template(
+    id="tend_wounded",
+    priority=88,
+    blurb="A wounded body pulls the actor toward the small work of mending.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    package_gate=AND(
+        has_ephemeral("wounded", slot=Slot.TARGET),
+        co_located(Slot.ACTOR, Slot.TARGET),
+        NOT(has_ephemeral("under_active_pursuit")),
+        NOT(has_ephemeral("under_active_pursuit", slot=Slot.TARGET)),
+        since_last_event_at_least(
+            "tended_wound", minimum_ticks=2, target_slot=Slot.TARGET
+        ),
+    ),
+    branches=(
+        Branch(
+            label="Channel restorative power through hands and voice",
+            conditions=has_tag("magical_healing"),
+            narrative_stub=(
+                "{actor} kneels beside {target} and places hands where the "
+                "damage lives. Something passes between them — a quiet "
+                "exchange of warmth and pain — and the body begins to "
+                "remember how to be whole."
+            ),
+            state_delta={
+                "character.current_activity": "channeling restorative power",
+                "entity_tags_target.remove": ["wounded"],
+                "entity_tags.add": ["recently_drained"],
+            },
+            event_type="wound_healed",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.74,
+            scene_pressure_stub=(
+                "{actor} may be close enough to attempt restorative work on "
+                "{target}'s wound in the active scene. Treat as offered help "
+                "the scene can accept, defer, or complicate, not as automatic "
+                "healing."
+            ),
+        ),
+        Branch(
+            label="Work the wound with trained hands",
+            conditions=has_any_tag("surgical_training", "medical_skill"),
+            narrative_stub=(
+                "{actor} cleans the wound by feel, finds what needs to be "
+                "found, and does the work the body cannot do for itself. "
+                "{target} watches the ceiling and counts something silently."
+            ),
+            state_delta={
+                "character.current_activity": "providing skilled medical care",
+                "entity_tags_target.remove": ["wounded"],
+                "entity_tags_target.add": ["recently_tended"],
+            },
+            event_type="tended_wound",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.58,
+            scene_pressure_stub=(
+                "{actor} is moving to provide skilled medical care to "
+                "{target}. The scene may show this as a quiet competent "
+                "interruption, a wait for stabilization, or a beat of "
+                "trust between them."
+            ),
+        ),
+        Branch(
+            label="Apply what first-aid the moment allows",
+            conditions=has_tag("first_aid_trained"),
+            narrative_stub=(
+                "{actor} works from memory — pressure here, elevation there, "
+                "the things that buy time when time is the thing you need. "
+                "It won't be enough on its own, but it's enough for now."
+            ),
+            state_delta={
+                "character.current_activity": "applying field first aid",
+                "entity_tags_target.add": ["recently_tended"],
+            },
+            event_type="tended_wound",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.42,
+            scene_pressure_stub=(
+                "{actor} has practical first-aid training and is at "
+                "{target}'s side. Treat as a stabilizing presence the scene "
+                "can use without granting full recovery."
+            ),
+        ),
+        Branch(
+            label="Stay with the wound and do what can be done",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} has no real skill for this. They press a cloth "
+                "where there is bleeding and speak softly so {target} has "
+                "a voice to follow back from wherever the body has gone."
+            ),
+            state_delta={
+                "character.current_activity": "keeping watch over the wounded",
+            },
+            event_type="tended_wound",
+            changed_fields=("character.current_activity",),
+            magnitude=0.24,
+            scene_pressure_stub=(
+                "{actor} is present at {target}'s side without medical "
+                "ability. Use this as accompaniment and witness — not as "
+                "intervention."
+            ),
+        ),
+    ),
+    present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
+)
+
+
+MOURN_LOSS = Template(
+    id="mourn_loss",
+    priority=25,
+    blurb="A loss settles into the body across many quiet days.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        has_ephemeral("bereaved"),
+        since_last_event_at_least("mourning_act", minimum_ticks=3),
+        NOT(has_ephemeral("under_active_pursuit")),
+    ),
+    branches=(
+        Branch(
+            label="Visit the place of remembrance",
+            conditions=in_location_class("place_of_remembrance"),
+            narrative_stub=(
+                "{actor} returns to the place where the dead are kept — "
+                "stone, name, photograph, marker, whatever this world has "
+                "made for the purpose — and stands long enough to be still "
+                "and remember, before going back to the work of being alive."
+            ),
+            state_delta={
+                "character.current_activity": "tending the dead",
+            },
+            event_type="mourning_act",
+            changed_fields=("character.current_activity",),
+            magnitude=0.42,
+        ),
+        Branch(
+            label="Sit with others who carry the same loss",
+            conditions=count_co_located(1, with_tag="bereaved"),
+            narrative_stub=(
+                "{actor} finds the others who knew the dead and sits with "
+                "them — wordlessly, mostly. The presence of someone else "
+                "who is also not over it makes the grief feel less like "
+                "evidence of personal failure."
+            ),
+            state_delta={
+                "character.current_activity": "gathering with co-mourners",
+            },
+            event_type="mourning_act",
+            changed_fields=("character.current_activity",),
+            magnitude=0.38,
+        ),
+        Branch(
+            label="Pour the loss into the day's work",
+            conditions=has_any_tag(
+                "musician",
+                "writer",
+                "artisan",
+                "scholar",
+                "arcane_caster",
+                "soldier",
+                "keeps_shop",
+                "domestic_role",
+            ),
+            narrative_stub=(
+                "{actor} returns to their work — the thing the loss hasn't "
+                "taken — and does it with the dead person sitting somewhere "
+                "just behind them, watching the work with the particular "
+                "silence the dead have."
+            ),
+            state_delta={
+                "character.current_activity": "working through grief",
+            },
+            event_type="mourning_act",
+            changed_fields=("character.current_activity",),
+            magnitude=0.28,
+        ),
+        Branch(
+            label="Carry the weight in private",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} goes through the day's motions with the loss "
+                "settled inside them like a second heartbeat — not louder "
+                "than the day, just underneath it, the way these things "
+                "tend to be once the first weeks are past."
+            ),
+            state_delta={
+                "character.current_activity": "carrying private grief",
+            },
+            event_type="mourning_act",
+            changed_fields=("character.current_activity",),
+            magnitude=0.14,
+        ),
+    ),
+)
+
+
+KEEP_VIGIL = Template(
+    id="keep_vigil",
+    priority=50,
+    blurb="The actor remains present through a slow, uncertain hour.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    # Divergence: `captive` is ephemeral (per migration 027), so the captive
+    # case uses has_ephemeral rather than the draft's has_tag.
+    package_gate=AND(
+        co_located(Slot.ACTOR, Slot.TARGET),
+        OR(
+            has_ephemeral("wounded", slot=Slot.TARGET),
+            has_ephemeral("dying", slot=Slot.TARGET),
+            has_ephemeral("unconscious", slot=Slot.TARGET),
+            has_ephemeral("captive", slot=Slot.TARGET),
+        ),
+        OR(
+            has_relationship_of_type("family"),
+            has_relationship_of_type("romantic"),
+            has_relationship_of_type("chosen_kin"),
+            has_relationship_of_type("comrade"),
+            has_relationship_of_type("ward"),
+            has_relationship_of_type("guardian"),
+            has_relationship_of_type("captor"),
+        ),
+        since_last_event_at_least("vigil_held", minimum_ticks=2),
+        NOT(has_ephemeral("under_active_pursuit")),
+    ),
+    branches=(
+        Branch(
+            label="Maintain prayerful or meditative presence",
+            conditions=has_any_tag("devout", "contemplative", "ritual_practitioner"),
+            narrative_stub=(
+                "{actor} sits beside {target} with hands quiet, breathing "
+                "matched to whatever rhythm {target}'s body is still "
+                "finding. The prayers — if they are prayers — are not for "
+                "any audience but for the work of staying."
+            ),
+            state_delta={
+                "character.current_activity": "holding meditative vigil",
+                "entity_tags.add": ["at_vigil"],
+            },
+            event_type="vigil_held",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.46,
+            scene_pressure_stub=(
+                "{actor} is keeping a contemplative vigil over {target}. "
+                "Use this as an emotional anchor in the scene, not an "
+                "active intervention."
+            ),
+        ),
+        Branch(
+            label="Speak softly through the long hours",
+            conditions=has_ephemeral("unconscious", slot=Slot.TARGET),
+            narrative_stub=(
+                "{actor} tells {target} small things — what the light is "
+                "doing outside, what the others said today, the kind of "
+                "stories one tells someone who may or may not be hearing — "
+                "in the belief that whatever can be reached should be reached."
+            ),
+            state_delta={
+                "character.current_activity": "speaking through the long hours",
+                "entity_tags.add": ["at_vigil"],
+            },
+            event_type="vigil_held",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.38,
+            scene_pressure_stub=(
+                "{actor} is speaking to an unresponsive {target} through "
+                "a long stretch. Treat as audible presence the scene can "
+                "thread through quieter moments."
+            ),
+        ),
+        Branch(
+            label="Stand watch with attention but without intervention",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} stays. Not doing anything — that's the point of "
+                "being here. {target} is alone with whatever is happening "
+                "to them, and {actor} is the witness who makes that "
+                "aloneness less complete."
+            ),
+            state_delta={
+                "character.current_activity": "standing vigil",
+                "entity_tags.add": ["at_vigil"],
+            },
+            event_type="vigil_held",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.32,
+            scene_pressure_stub=(
+                "{actor} is keeping silent vigil over {target}. Use this "
+                "as ambient presence — a witness who shapes the scene by "
+                "being there, not by acting."
+            ),
+        ),
+    ),
+    present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
+)
+
+
+# Section B — Maintenance of self
+
+
+TEND_CRAFT = Template(
+    id="tend_craft",
+    priority=15,
+    blurb="A small act of care for the work that defines them.",
+    required_slots=(Slot.ACTOR,),
+    # Discipline: TEND_CRAFT is for characters with identity-defining
+    # craft. Without this gate filter, the ALWAYS-fallback branch would
+    # fire for every actor every tick and displace MAINTAIN_COVER
+    # (priority 0) entirely. Restrict to actors carrying at least one
+    # craft tag; non-craft actors fall through to MAINTAIN_COVER.
+    package_gate=AND(
+        has_any_tag(
+            # combat
+            "combat_trained",
+            "soldier",
+            "warrior",
+            "fighter",
+            # arcane
+            "arcane_caster",
+            # engineering / tinkering
+            "engineer",
+            "mechanic",
+            "tinkerer",
+            "hacker",
+            "artificer",
+            # creative
+            "musician",
+            "dancer",
+            "performer",
+            "artist",
+            # athletic / physical
+            "athlete",
+            "martial_artist",
+            "ranger",
+            "scout",
+            "monk",
+            # commerce
+            "keeps_shop",
+            "merchant",
+            "innkeeper",
+            "trader",
+            # domestic
+            "domestic_role",
+            "cares_for_household",
+            "matriarch",
+            "patriarch",
+            # scholarly
+            "scholar",
+            "researcher",
+            "academic",
+            "loremaster",
+        ),
+        since_last_event_at_least("craft_tended", minimum_ticks=4),
+        NOT(has_ephemeral("under_active_pursuit")),
+        NOT(has_ephemeral("wounded")),
+        NOT(has_ephemeral("bereaved")),
+    ),
+    branches=(
+        Branch(
+            label="Make the weapon ready for what comes next",
+            conditions=has_any_tag("combat_trained", "soldier", "warrior", "fighter"),
+            narrative_stub=(
+                "{actor} takes the weapon apart with the slow patience of "
+                "someone who has done this enough times to know the "
+                "geometry of each piece by feel, and puts it back together "
+                "the same way, attentive to small things only they will "
+                "notice."
+            ),
+            state_delta={
+                "character.current_activity": "making the weapon ready",
+                "entity_tags.add": ["recently_tended_craft"],
+            },
+            event_type="craft_tended",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.18,
+        ),
+        Branch(
+            label="Lay hands on the arcane work-in-progress",
+            conditions=has_tag("arcane_caster"),
+            narrative_stub=(
+                "{actor} spends an unhurried hour with whatever is "
+                "currently between their hands and the world's underlying "
+                "grammar — checking small things, adjusting smaller things, "
+                "letting the work tell them what it still needs."
+            ),
+            state_delta={
+                "character.current_activity": "tending arcane work",
+                "entity_tags.add": ["recently_tended_craft"],
+            },
+            event_type="craft_tended",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.18,
+        ),
+        Branch(
+            label="Maintain and improve the tools of the trade",
+            conditions=has_any_tag(
+                "engineer", "mechanic", "tinkerer", "hacker", "artificer"
+            ),
+            narrative_stub=(
+                "{actor} attends to the equipment — the part that's been "
+                "annoying them for weeks, the upgrade they keep meaning to "
+                "install, the calibration that's been just slightly off — "
+                "and emerges with the tools a small degree better than "
+                "they were."
+            ),
+            state_delta={
+                "character.current_activity": "maintaining equipment",
+                "entity_tags.add": ["recently_tended_craft"],
+            },
+            event_type="craft_tended",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.18,
+        ),
+        Branch(
+            label="Run through the work that keeps the work possible",
+            conditions=has_any_tag("musician", "dancer", "performer", "artist"),
+            narrative_stub=(
+                "{actor} works through the practice that no one will ever "
+                "see — the scales, the exercises, the small motions that "
+                "the public version of the art rests on — for an hour, the "
+                "way the practice has to be done if the work is to stay "
+                "alive."
+            ),
+            state_delta={
+                "character.current_activity": "practicing the unseen work",
+                "entity_tags.add": ["recently_tended_craft"],
+            },
+            event_type="craft_tended",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.18,
+        ),
+        Branch(
+            label="Move the body through its daily reckoning",
+            conditions=has_any_tag(
+                "athlete", "martial_artist", "ranger", "scout", "monk"
+            ),
+            narrative_stub=(
+                "{actor} puts the body through its daily reckoning — the "
+                "run, the forms, the small punishments that keep the body "
+                "ready for whatever the next demand will be — and finishes "
+                "marginally sharper than they began."
+            ),
+            state_delta={
+                "character.current_activity": "conditioning the body",
+                "entity_tags.add": ["recently_tended_craft"],
+            },
+            event_type="craft_tended",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.18,
+        ),
+        Branch(
+            label="Tend the small shop's quiet machinery",
+            conditions=has_any_tag("keeps_shop", "merchant", "innkeeper", "trader"),
+            narrative_stub=(
+                "{actor} does the things a place of business needs in "
+                "order to keep being a place of business: the count, the "
+                "ledger, the small repairs, the conversations with regulars "
+                "who came in for something other than the thing they "
+                "actually bought."
+            ),
+            state_delta={
+                "character.current_activity": "tending the shop's rhythms",
+                "entity_tags.add": ["recently_tended_craft"],
+            },
+            event_type="craft_tended",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.18,
+        ),
+        Branch(
+            label="Keep the household running",
+            conditions=has_any_tag(
+                "domestic_role", "cares_for_household", "matriarch", "patriarch"
+            ),
+            narrative_stub=(
+                "{actor} does the work that holds a household together — "
+                "the meals, the cleaning, the small attentions no one "
+                "particularly thanks anyone for but whose absence would be "
+                "felt immediately. It is enough work for a full day, every "
+                "day, by itself."
+            ),
+            state_delta={
+                "character.current_activity": "tending the household",
+                "entity_tags.add": ["recently_tended_craft"],
+            },
+            event_type="craft_tended",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.18,
+        ),
+        Branch(
+            label="Return to the unfinished study",
+            conditions=has_any_tag("scholar", "researcher", "academic", "loremaster"),
+            narrative_stub=(
+                "{actor} returns to the long work that is always almost "
+                "but never finished — reading carefully, taking notes that "
+                "may yet matter, following a thread that may yet lead "
+                "somewhere — and gives the work another quiet evening of "
+                "the only thing it really needs."
+            ),
+            state_delta={
+                "character.current_activity": "advancing the long study",
+                "entity_tags.add": ["recently_tended_craft"],
+            },
+            event_type="craft_tended",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.18,
+        ),
+        Branch(
+            label="Take a small action of care for the work that is theirs",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} does a small thing for the work that defines "
+                "them — they would not call it that, probably, but that "
+                "is what it is — and the day is briefly better for it."
+            ),
+            state_delta={
+                "character.current_activity": "tending the work that is theirs",
+            },
+            event_type="craft_tended",
+            changed_fields=("character.current_activity",),
+            magnitude=0.12,
+        ),
+    ),
+)
+
+
+# Section C — The contact quartet
+#
+# All four templates set present_target_policy=STORYTELLER_PRESSURE so contact
+# with an on-screen target manifests as scene pressure (a ring, a knock, an
+# arriving message) instead of silent off-screen state mutation.
+
+
+WARN_ALLY = Template(
+    id="warn_ally",
+    priority=75,
+    blurb="A threat surfaces; word reaches the people who need to know.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    # No contact cooldown — urgency overrides ordinary contact pacing.
+    package_gate=AND(
+        OR(
+            has_symmetric_relationship_of_type("family"),
+            has_symmetric_relationship_of_type("romantic"),
+            has_symmetric_relationship_of_type("chosen_kin"),
+            has_symmetric_relationship_of_type("comrade"),
+            has_symmetric_relationship_of_type("ally"),
+        ),
+        OR(
+            recent_event(
+                "threat_issued",
+                within_ticks=3,
+                target_slot=Slot.TARGET,
+            ),
+            recent_event(
+                "compliance_alert",
+                within_ticks=3,
+                target_slot=Slot.TARGET,
+            ),
+            has_ephemeral("under_active_pursuit", slot=Slot.TARGET),
+        ),
+        NOT(has_ephemeral("under_active_pursuit")),
+    ),
+    branches=(
+        Branch(
+            label="Reach the ally face-to-face before the word gets out",
+            conditions=co_located(Slot.ACTOR, Slot.TARGET),
+            narrative_stub=(
+                "{actor} catches {target} before they have time to "
+                "compose themselves and tells them quickly, in a voice "
+                "stripped to the load-bearing words, what is coming and "
+                "what they should do about it."
+            ),
+            state_delta={
+                "character.current_activity": "delivering urgent warning in person",
+                "entity_tags_target.add": ["forewarned"],
+            },
+            event_type="warning_delivered",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.66,
+            scene_pressure_stub=(
+                "{actor} is moving to deliver an urgent warning to "
+                "{target}. The scene may show this as interruption, "
+                "intrusion, or a beat the storyteller folds into the "
+                "current moment."
+            ),
+        ),
+        Branch(
+            label="Send word through whatever channel will reach them quickest",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} sends the warning through whatever channel will "
+                "reach {target} fastest — a call, a runner, a sealed "
+                "message, a coded signal, a prayer through a familiar "
+                "spirit — and hopes the gap between sending and receiving "
+                "is short enough to matter."
+            ),
+            state_delta={
+                "character.current_activity": "sending urgent warning",
+                "entity_tags_target.add": ["forewarned"],
+            },
+            event_type="warning_delivered",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.52,
+            scene_pressure_stub=(
+                "{actor} has sent {target} an urgent warning by remote "
+                "means. The scene may show this as an incoming message, "
+                "a vague disturbance, a half-heard signal, or it may not "
+                "land in time."
+            ),
+        ),
+    ),
+    present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
+)
+
+
+CHECK_ON_DEPENDENT = Template(
+    id="check_on_dependent",
+    priority=55,
+    blurb="A duty of care surfaces between the actor and someone in their charge.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    # Discipline: CULTIVATE_INFORMANT (priority 50) owns the
+    # informant-tradecraft handler/asset relationship. Exclude actors
+    # tagged informant_handler so welfare-check and intel-cultivation
+    # don't fight over the same binding.
+    package_gate=AND(
+        NOT(has_tag("informant_handler")),
+        OR(
+            has_relationship_of_type("handler", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("mentor", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("patron", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("guardian", Slot.ACTOR, Slot.TARGET),
+        ),
+        since_last_event_at_least(
+            "contact_made", minimum_ticks=12, target_slot=Slot.TARGET
+        ),
+        NOT(has_ephemeral("under_active_pursuit")),
+        NOT(has_ephemeral("grudge_active")),
+    ),
+    branches=(
+        Branch(
+            label="Drop by in person when the moment allows",
+            conditions=AND(
+                co_located(Slot.ACTOR, Slot.TARGET),
+                since_last_event_at_least(
+                    "welfare_check", minimum_ticks=6, target_slot=Slot.TARGET
+                ),
+            ),
+            narrative_stub=(
+                "{actor} stops by — ostensibly for something else, the way "
+                "these visits often are — and uses the small window to "
+                "read {target}'s state: how they look, what they say "
+                "without saying, what they decline to mention. It will "
+                "be enough information for now."
+            ),
+            state_delta={
+                "character.current_activity": "checking on a dependent in person",
+            },
+            event_type="welfare_check",
+            changed_fields=("character.current_activity",),
+            magnitude=0.44,
+            scene_pressure_stub=(
+                "{actor} is making a casual welfare check on {target}. "
+                "Treat as a low-key social presence the scene can absorb "
+                "or use as a beat of relationship texture."
+            ),
+        ),
+        Branch(
+            label="Reach out through customary channels",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} sends the kind of message they always send — "
+                "brief, light in tone, asking nothing real but leaving the "
+                "door open for {target} to say something real if they "
+                "want to — and watches for what comes back."
+            ),
+            state_delta={
+                "character.current_activity": "checking in on a dependent",
+            },
+            event_type="contact_made",
+            changed_fields=("character.current_activity",),
+            magnitude=0.22,
+            scene_pressure_stub=(
+                "{actor} has sent {target} a routine welfare-check "
+                "message. The scene may use this as an unread notification, "
+                "an answered exchange, or texture for {target}'s "
+                "decisions."
+            ),
+        ),
+    ),
+    present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
+)
+
+
+REACH_OUT_TO_KIN = Template(
+    id="reach_out_to_kin",
+    priority=40,
+    blurb="A small thread of contact between people who hold each other.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    package_gate=AND(
+        OR(
+            has_symmetric_relationship_of_type("family"),
+            has_symmetric_relationship_of_type("romantic"),
+            has_symmetric_relationship_of_type("chosen_kin"),
+            has_symmetric_relationship_of_type("comrade"),
+        ),
+        since_last_event_at_least(
+            "contact_made", minimum_ticks=8, target_slot=Slot.TARGET
+        ),
+        NOT(has_ephemeral("under_active_pursuit")),
+        NOT(has_ephemeral("grudge_active")),
+    ),
+    branches=(
+        Branch(
+            label="Find the moment for a real face-to-face conversation",
+            conditions=AND(
+                co_located(Slot.ACTOR, Slot.TARGET),
+                since_last_event_at_least(
+                    "kin_visit", minimum_ticks=5, target_slot=Slot.TARGET
+                ),
+            ),
+            narrative_stub=(
+                "{actor} makes the small effort that finding-time-for-someone "
+                "requires — clearing a half hour, choosing a place, "
+                "showing up — and {target} arrives, and for a while they "
+                "are the kind of present together that distance erodes."
+            ),
+            state_delta={
+                "character.current_activity": "spending real time with kin",
+            },
+            event_type="kin_visit",
+            changed_fields=("character.current_activity",),
+            magnitude=0.36,
+            scene_pressure_stub=(
+                "{actor} is meeting {target} in person for a real "
+                "conversation. Use this as a relationship beat the scene "
+                "can fold in or hold for later, not as a guaranteed "
+                "off-screen event."
+            ),
+        ),
+        Branch(
+            label="Send a message that says less than it means",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} sends {target} the small message that means "
+                "more than the words it contains — a check-in, a shared "
+                "joke, a question that doesn't really need answering — "
+                "and the thread between them stays warm for another while."
+            ),
+            state_delta={
+                "character.current_activity": "keeping kin contact warm",
+            },
+            event_type="contact_made",
+            changed_fields=("character.current_activity",),
+            magnitude=0.16,
+            scene_pressure_stub=(
+                "{actor} has sent {target} a small affectionate message. "
+                "Treat as ambient relationship-warmth — possibly an "
+                "incoming notification, possibly not surfaced at all."
+            ),
+        ),
+    ),
+    present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
+)
+
+
+CONSULT_RIVAL = Template(
+    id="consult_rival",
+    priority=35,
+    blurb="Two people who do not trust each other are forced into contact anyway.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    # Divergence: the draft included `has_ephemeral("grudge_active")` in the
+    # shared-circumstance OR; the same gate excludes it via NOT below. The
+    # OR-arm is removed. EXTRACT_VENGEANCE (priority 90) owns grudge-active
+    # space; the NOT here is the documented safety belt.
+    package_gate=AND(
+        OR(
+            has_relationship_of_type("rival"),
+            trust_below(0),
+        ),
+        OR(
+            recent_event("compliance_alert", within_ticks=10),
+            recent_event("threat_issued", within_ticks=10),
+            recent_event("faction_realignment", within_ticks=15),
+        ),
+        since_last_event_at_least(
+            "contact_made", minimum_ticks=20, target_slot=Slot.TARGET
+        ),
+        NOT(has_ephemeral("grudge_active")),
+        NOT(has_ephemeral("under_active_pursuit")),
+    ),
+    branches=(
+        Branch(
+            label="Meet face-to-face on neutral ground",
+            conditions=AND(
+                co_located(Slot.ACTOR, Slot.TARGET),
+                in_location_class("neutral_ground"),
+            ),
+            narrative_stub=(
+                "{actor} and {target} arrange to be in the same place at "
+                "the same time without quite arranging it — both of them "
+                "drinking something they don't particularly want, both of "
+                "them speaking carefully — because whatever is happening "
+                "is bigger than what they have between them, and they "
+                "both know it."
+            ),
+            state_delta={
+                "character.current_activity": "meeting a rival under truce",
+                "entity_tags.add": ["under_truce"],
+                "entity_tags_target.add": ["under_truce"],
+            },
+            event_type="rival_consulted",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.62,
+            scene_pressure_stub=(
+                "{actor} is in a tense face-to-face meeting with {target}, "
+                "a known rival. Treat as charged co-presence — the scene "
+                "can show this as observed truce, ambient discomfort, or "
+                "delayed consequence."
+            ),
+        ),
+        Branch(
+            label="Send a carefully-worded message through indirect channels",
+            conditions=has_tag("contacts_available"),
+            narrative_stub=(
+                "{actor} sends {target} a message routed through an "
+                "intermediary they both trust slightly more than they "
+                "trust each other — a message worded with enough care "
+                "that the indirect-channel relay can be denied later, "
+                "but with enough substance that {target} cannot reasonably "
+                "ignore it."
+            ),
+            state_delta={
+                "character.current_activity": "reaching out to a rival via intermediary",
+            },
+            event_type="rival_consulted",
+            changed_fields=("character.current_activity",),
+            magnitude=0.48,
+            scene_pressure_stub=(
+                "{actor} has sent {target} a carefully-routed message via "
+                "intermediary. Treat as off-screen pressure — the scene "
+                "may show {target} reacting to it, or it may resurface "
+                "later."
+            ),
+        ),
+        Branch(
+            label="Leave a sign the rival will recognize and a door they can open",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} doesn't quite reach out — but they place a sign "
+                "where {target} will see it, the kind of signal that says "
+                "*I am willing to talk if you are*, without committing to "
+                "anything. If {target} reads the sign, the contact has "
+                "begun. If they don't, it hasn't."
+            ),
+            state_delta={
+                "character.current_activity": "leaving a tentative overture for a rival",
+            },
+            event_type="contact_made",
+            changed_fields=("character.current_activity",),
+            magnitude=0.34,
+            scene_pressure_stub=(
+                "{actor} has placed a discreet overture for {target} to "
+                "find. Treat as a passive hook the scene can pick up if "
+                "useful, or leave dormant."
+            ),
+        ),
+    ),
+    present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
+)
+
+
 BUILTIN_TEMPLATES = (
     EVADE_PURSUERS,
     PROTECT_KIN,
     EXTRACT_VENGEANCE,
+    TEND_WOUNDED,
     HONOR_DEBT,
+    WARN_ALLY,
     PURSUE_GHOST_LEAD,
+    CHECK_ON_DEPENDENT,
     CULTIVATE_INFORMANT,
+    KEEP_VIGIL,
+    REACH_OUT_TO_KIN,
+    CONSULT_RIVAL,
+    MOURN_LOSS,
+    TEND_CRAFT,
     MAINTAIN_COVER,
 )

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -92,6 +92,47 @@ def test_storyteller_pressure_templates_require_pressure_stubs() -> None:
             "cultivate_informant",
             "Routine contact to maintain the relationship",
         ),
+        # Round-2 templates
+        (
+            "mourning",
+            "mourn_loss",
+            "Visit the place of remembrance",
+        ),
+        (
+            "craft_soldier",
+            "tend_craft",
+            "Make the weapon ready for what comes next",
+        ),
+        (
+            "wounded_healing",
+            "tend_wounded",
+            "Channel restorative power through hands and voice",
+        ),
+        (
+            "vigil_devout",
+            "keep_vigil",
+            "Maintain prayerful or meditative presence",
+        ),
+        (
+            "warning",
+            "warn_ally",
+            "Reach the ally face-to-face before the word gets out",
+        ),
+        (
+            "welfare_check",
+            "check_on_dependent",
+            "Drop by in person when the moment allows",
+        ),
+        (
+            "kin_visit",
+            "reach_out_to_kin",
+            "Find the moment for a real face-to-face conversation",
+        ),
+        (
+            "rival_truce",
+            "consult_rival",
+            "Meet face-to-face on neutral ground",
+        ),
     ],
 )
 def test_demo_presets_fire_expected_package(


### PR DESCRIPTION
## Summary

Integrates the round-2 contribution from the frontier-model conversation partner ([`temp/orrery/orrery_package_contributions_round2.md`](https://github.com/pythagorakase/nexus/blob/main/temp/orrery/orrery_package_contributions_round2.md)): eight new behavior templates organized into three sections, doubling the catalog from 7 to 15 templates.

### Section A — Universal care behaviors

| Template | Priority | What it closes |
|---|---|---|
| `TEND_WOUNDED` | 88 | Closes the loop on the `wounded` ephemeral that `PROTECT_KIN` has been reading but no template was clearing — `magical_healing` branch fires `wound_healed` event + clears the ephemeral from target |
| `MOURN_LOSS` | 25 | Long-burn grief processing across many quiet ticks; low magnitudes; mourning manifests as content of other activities rather than overriding urgent ones |
| `KEEP_VIGIL` | 50 | Witness-without-acting pattern over wounded/dying/unconscious/captive kin |

### Section B — Maintenance of self

| Template | Priority | Pattern |
|---|---|---|
| `TEND_CRAFT` | 15 | Universal-shape, culturally-specific branches: soldier cleans her rifle, wizard tends an enchantment, musician practices scales, shopkeeper does inventory. Nine archetypal branches plus an ALWAYS fallback |

### Section C — The contact quartet

| Template | Priority | Cooldown |
|---|---|---|
| `WARN_ALLY` | 75 | None — urgency overrides ordinary contact pacing |
| `CHECK_ON_DEPENDENT` | 55 | 12 ticks per (actor, target); face-to-face branch has additional 6-tick cooldown |
| `REACH_OUT_TO_KIN` | 40 | 8 ticks per (actor, target) |
| `CONSULT_RIVAL` | 35 | 20 ticks per (actor, target) — rivals don't reach out casually |

All four contact templates set `present_target_policy=STORYTELLER_PRESSURE` with branch-level `scene_pressure_stub` prose, so contact with an on-screen target manifests as scene-pressure prompt to the storyteller LLM (their phone rings during the scene) rather than silent off-screen state mutation. This is the affordance PR #216 designed for.

## Deliberate divergences from the contribution draft

- **`CONSULT_RIVAL` gate logical contradiction**: draft had `has_ephemeral("grudge_active")` in the shared-circumstance OR clause AND `NOT(has_ephemeral("grudge_active"))` in the same gate. Removed the contradictory OR-arm; the NOT is the intended exclusion (EXTRACT_VENGEANCE owns grudge-active space per priority 90 > 35).
- **`KEEP_VIGIL` captive case**: draft used `has_tag("captive")`, but captive is semantically ephemeral (state ends via escape / freedom / death). Migration seeds `captive` as ephemeral with `clear_on={"event_types":["captivity_ended"]}`; gate uses `has_ephemeral` accordingly.

## Priority-interaction bugs caught by existing tests

Both surfaced via PR #212's `test_demo_presets_fire_expected_package` regression tests when round-2 templates were dropped in:

- **`CHECK_ON_DEPENDENT` (priority 55) was firing before `CULTIVATE_INFORMANT` (priority 50)** for handler relationships. Both match `has_relationship_of_type("handler", ACTOR, TARGET)`, but CULTIVATE_INFORMANT was designed for the specific intel-tradecraft pattern. Fix: `NOT(has_tag("informant_handler"))` in CHECK_ON_DEPENDENT's gate.
- **`TEND_CRAFT` (priority 15) was firing for every actor every tick** via its ALWAYS-fallback, displacing MAINTAIN_COVER entirely. Fix: gate requires `has_any_tag(<every craft role>)`; non-craft actors fall through to MAINTAIN_COVER as designed.

## Migration 027 — vocabulary scale

- **5 new `relationship_type` enum values**: `ward`, `guardian`, `captor`, `mentor`, `patron`
- **40 durable tags**: 4 healing capacities, 2 dispositions, 1 ritual role, ~30 role tags spanning combat / arcane / engineering / creative / athletic / commerce / domestic / scholarly archetypes
- **10 ephemeral tags**: `bereaved`, `dying`, `unconscious`, `captive` (event-cleared by externally-authored events like `death_recorded` and `mourning_completed`), plus semantic-cleared markers
- **15 new event types** including state-change events (`death_recorded`, `regained_consciousness`, `captivity_ended`) that are seeded for reference even though no template emits them — they'd be authored externally by CommitOrreryTick or future world-state systems

Note on tag volume: ChatClaude flagged that many role tags are nominally distinct but functionally identical for gate-discrimination (engineer / mechanic / tinkerer / hacker / artificer all fire the same TEND_CRAFT branch). I kept the full set so storyteller-side tagging stays expressive; collapsing to canonical names is a follow-up consideration if observed vocabulary volume becomes unwieldy.

## Verification

- [x] `poetry run pytest tests/test_orrery` — 91 passed, 0 failed (+8 from new preset tests)
- [x] `poetry run black --check ...` — clean
- [x] Migration 027 applied to `NEXUS_template` + `save_02/03/04/05` (save_01 locked per slot organization). Slot 5 now has 57 tags + 25 event_types + 23 relationship_type enum values.
- [x] Catalog regenerated via pre-commit hook (`docs/orrery_packages.md` is in lockstep)
- [x] `BUILTIN_TEMPLATES` grew 7 → 15; all pass `validate_always_fallbacks` discipline
- [x] All 8 new demo presets fire their expected highest-magnitude branch via `python -m nexus.agents.orrery.demo --preset <name>`

## Test plan

- [ ] Spot-check the rendered catalog at `docs/orrery_packages.md` — every new template and branch has prose
- [ ] Run `python -m nexus.agents.orrery.demo --preset mourning` (and `craft_soldier` / `wounded_healing` / `vigil_devout` / `warning` / `welfare_check` / `kin_visit` / `rival_truce`) to see the JSON resolution shape
- [ ] Confirm `dying`, `unconscious`, `captive`, and `bereaved` ephemerals have proper `clear_on` predicates in the `tags` table after migration

## Out of scope

- Cross-template ephemeral exclusions (e.g., `NOT(has_ephemeral("at_vigil"))` to prevent yanking vigil-keepers into routine activity) — ChatClaude was conservative about adding these; left to a follow-up if observed playtest reveals the need
- Collapsing role tag synonyms — see Migration 027 note above
- External emitters for `death_recorded` / `regained_consciousness` / `captivity_ended` events — those live with CommitOrreryTick or future world-state systems; the ephemerals here are seeded with the right `clear_on` predicates so that when those events eventually fire, the framework honors the clearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)