### PR TITLE
Add Orrery semantic clearance and status

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -1,6 +1,6 @@
 # Off-Screen Behavior Resolver — Orrery Design Plan
 
-**Status:** Foundation implemented in PR #210, dry-run resolve in PR #211, commit/promote/narrate/clear in PR #214, expanded package library in PR #212, present-target scene pressure in PR #216, generated human-readable catalog support in PR #217/#218, Bleed selector/Storyteller integration in PR #219, and retrieval-boundary hardening in PR #220. The runtime pipeline remains disabled by default (`orrery.enabled = false`). This branch resolves issue #213 by adding the relationship-valence magnitude read surface and Orrery trust hydration.
+**Status:** Foundation implemented in PR #210, dry-run resolve in PR #211, commit/promote/narrate/clear in PR #214, expanded package library in PR #212, present-target scene pressure in PR #216, generated human-readable catalog support in PR #217/#218, Bleed selector/Storyteller integration in PR #219, retrieval-boundary hardening in PR #220, relationship-trust hydration in PR #221, and deterministic review orchestration in PR #222. The runtime pipeline remains disabled by default (`orrery.enabled = false`). This branch completes the post-commit semantic tag-clearance worker pass and adds a compact Orrery worker status surface.
 
 **Originating artifacts:** `temp/orrery/off_screen_resolver_spec.md`, `temp/orrery/behavior_substrate.py`, `temp/orrery/package_simulator.jsx`
 **Review trace:** `temp/orrery/design_plan_edited.md` (round 1: GPT-5.5-Pro, Codex, separate-Claude, Gemini) + `temp/orrery/super_table_question.md` (round 2: GPT-5.5-Pro, Claude Opus 4.7 chat) + v4 grounding pass against current `main` (claude-opus-4-7).
@@ -74,9 +74,17 @@ PR #219 implements PR 4: Bleed selection at Storyteller time. It selects a bound
 
 PR #220 closes the retrieval-boundary audit: warm slices and normal MEMNON search remain accepted-narrative surfaces only, while explicit read-only SQL may still inspect public Orrery tables such as `offscreen_narrations`.
 
+### Landed in PR #221
+
+PR #221 resolves issue #213's consensus Option B: `character_relationships.emotional_valence` remains the canonical hybrid enum/label, `entity_relationships_v.valence_magnitude` exposes the explicit integer mapping, and `WorldState.trust` hydrates from that read surface.
+
+### Landed in PR #222
+
+PR #222 adds deterministic review orchestration so newly opened PRs can schedule the delayed review-check workflow without relying on a model-specific local hook.
+
 ### Current Slice
 
-This branch resolves issue #213's consensus Option B: keep `character_relationships.emotional_valence` as the canonical hybrid enum/label, expose `entity_relationships_v.valence_magnitude` as an explicit integer mapping, and hydrate `WorldState.trust` from that read surface.
+This branch adds batched post-commit semantic clearance for ephemeral tags and exposes `python -m nexus.agents.orrery.worker --slot N --status` as a compact operational snapshot for pending Orrery background work.
 
 ### Package Author Checkpoint
 
@@ -436,7 +444,7 @@ CREATE TABLE orrery_narration_jobs (
 );
 ```
 
-Durable outbox surviving process restart. Dispatched via `FastAPI BackgroundTasks` — mirror the established pattern at `nexus/api/narrative.py:281` and `nexus/api/storyteller.py:561, 666`. Concretely: after `commit_incubator_to_database_sync` returns successfully in `_approve_narrative_impl`, call `background_tasks.add_task(drain_narration_outbox, slot)`. Also drainable via standalone CLI: `python -m nexus.agents.orrery.worker --slot 5`.
+Durable outbox surviving process restart. Dispatched via `FastAPI BackgroundTasks` — mirror the established pattern at `nexus/api/narrative.py:281` and `nexus/api/storyteller.py:561, 666`. Concretely: after `commit_incubator_to_database_sync` returns successfully in `_approve_narrative_impl`, call `background_tasks.add_task(process_orrery_outbox_sync, slot)`. Also drainable via standalone CLI: `python -m nexus.agents.orrery.worker --slot 5`; status-only inspection is `python -m nexus.agents.orrery.worker --slot 5 --status`.
 
 ### Off-Screen Narration Storage (Structural Visibility Separation)
 
@@ -647,7 +655,7 @@ Per-chunk, not per-event. Stamped only at accepted commit. `world_events.world_t
 - **No canonical writes yet.** Proposal is buffered and inspectable, but does not mutate any table or enter the storyteller payload.
 - Verification: unit coverage for disabled/enabled phase behavior, anchor fallback, fallback/non-fallback packages, and SQL filters; live direct dry-runs against slot 5 (baby narrative state) and slot 2 (mature narrative state) with zero writes.
 
-### PR 3 — CommitOrreryTick + Promote + Narrate + Clear (implemented in PR #214)
+### PR 3 — CommitOrreryTick + Promote + Narrate + Clear (implemented in PR #214 plus semantic-clearance follow-up)
 
 - **`CommitOrreryTick` writer**: Step 8.5 inside `commit_incubator_to_database_sync` (L233 — the production path; insert between `apply_state_updates_sync` at L415 and incubator clear at L418) and parity inside `commit_incubator_to_database` (L320 — async, test-only; insert between `apply_state_updates` at L420 and `clear_incubator` at L423). Both call into the unified event writer in `nexus/agents/orrery/events.py`.
 - **Stamp `tick_chunk_id`** on every proposal row at this step, after `insert_narrative_chunk` returns the new chunk id.
@@ -655,7 +663,7 @@ Per-chunk, not per-event. Stamped only at accepted commit. `world_events.world_t
 - Deterministic brief generator → `orrery_resolutions.brief`.
 - Frontier narration via durable outbox; trigger drain via `BackgroundTasks` from `_approve_narrative_impl` after commit returns; standalone CLI worker for catch-up.
 - Narrator persistence to `offscreen_narrations` (not `narrative_chunks`); embedding pipeline shared with MEMNON.
-- Clear (event) in commit transaction; Clear (semantic) post-commit async, batched, filtered.
+- Clear (event) in commit transaction; Clear (semantic) post-commit async, batched, filtered, and logged through `tag_clearance_log`.
 - `tag_clearance_log` rows with justification.
 - Instrumented counters for the Orrery Stage 7 trigger metrics.
 - Verification: engineered fifty-chunk scenario (motivating test case), idempotency, incubator rejection, warm-slice contamination, local-LLM failure, async-worker state transitions.

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 import os
@@ -19,6 +20,8 @@ logger = logging.getLogger("nexus.orrery.worker")
 
 DEFAULT_NARRATION_MAX_ATTEMPTS = 3
 DEFAULT_NARRATION_RETRY_DELAY_SECONDS = 300
+DEFAULT_SEMANTIC_CLEARANCE_LIMIT = 20
+DEFAULT_SEMANTIC_CLEARANCE_RECENT_CHUNKS = 10
 
 PROMOTION_SYSTEM_PROMPT = (
     "You are the Orrery promotion discriminator. Decide whether an off-screen "
@@ -31,6 +34,13 @@ NARRATION_SYSTEM_PROMPT = (
     "You write concise off-screen narrative records for NEXUS. The prose is "
     "canonical but not directly shown to the player. Keep it specific, sensory "
     "where useful, and free of second-person address."
+)
+
+SEMANTIC_CLEARANCE_SYSTEM_PROMPT = (
+    "You are the Orrery semantic tag-clearance judge. Decide whether an "
+    "ephemeral off-screen state tag is no longer active based only on the "
+    "recent canonical narrative and Orrery events provided. Clear tags only "
+    "when the evidence is concrete; uncertainty means keep the tag."
 )
 
 
@@ -49,6 +59,13 @@ class PromotionVerdict(BaseModel):
     )
 
 
+class SemanticClearanceVerdict(BaseModel):
+    """Structured local-LLM verdict for semantic ephemeral-tag clearance."""
+
+    clear: bool
+    reason: str = Field(min_length=1)
+
+
 class OrreryWorkerResult(BaseModel):
     """Summary of one worker drain."""
 
@@ -56,6 +73,21 @@ class OrreryWorkerResult(BaseModel):
     skipped: int = 0
     narrated: int = 0
     failed: int = 0
+    semantically_cleared: int = 0
+
+
+class OrreryStatus(BaseModel):
+    """Operational snapshot for Orrery outbox and tag-clearance state."""
+
+    pending_promotions: int = 0
+    queued_narration_jobs: int = 0
+    leased_narration_jobs: int = 0
+    failed_narration_jobs: int = 0
+    pending_offscreen_embeddings: int = 0
+    failed_offscreen_embeddings: int = 0
+    active_semantic_tags: int = 0
+    recent_resolutions: int = 0
+    recent_narrations: int = 0
 
 
 def process_orrery_outbox_sync(
@@ -63,11 +95,13 @@ def process_orrery_outbox_sync(
     *,
     promotion_limit: int = 20,
     narration_limit: int = 5,
+    semantic_clearance_limit: int = DEFAULT_SEMANTIC_CLEARANCE_LIMIT,
+    semantic_clearance_recent_chunks: int = DEFAULT_SEMANTIC_CLEARANCE_RECENT_CHUNKS,
     settings: Optional[Mapping[str, Any]] = None,
     llm_manager: Optional[Any] = None,
     narration_provider: Optional[Any] = None,
 ) -> OrreryWorkerResult:
-    """Promote pending resolutions, then drain queued narration jobs."""
+    """Promote, narrate, and clear pending Orrery background work."""
 
     promoted, skipped = promote_pending_resolutions_sync(
         slot,
@@ -81,11 +115,19 @@ def process_orrery_outbox_sync(
         settings=settings,
         narration_provider=narration_provider,
     )
+    semantically_cleared = clear_semantic_tags_sync(
+        slot,
+        limit=semantic_clearance_limit,
+        recent_chunk_window=semantic_clearance_recent_chunks,
+        settings=settings,
+        llm_manager=llm_manager,
+    )
     return OrreryWorkerResult(
         promoted=promoted,
         skipped=skipped,
         narrated=narrated,
         failed=failed,
+        semantically_cleared=semantically_cleared,
     )
 
 
@@ -240,6 +282,197 @@ def drain_narration_outbox_sync(
                         )
                 logger.exception("Failed to narrate Orrery job %s", row["job_id"])
         return (narrated, failed)
+    finally:
+        if owns_conn:
+            conn.close()
+
+
+def clear_semantic_tags_sync(
+    slot: Optional[int] = None,
+    *,
+    limit: int = DEFAULT_SEMANTIC_CLEARANCE_LIMIT,
+    recent_chunk_window: int = DEFAULT_SEMANTIC_CLEARANCE_RECENT_CHUNKS,
+    settings: Optional[Mapping[str, Any]] = None,
+    llm_manager: Optional[Any] = None,
+    conn: Optional[Any] = None,
+) -> int:
+    """Use the local LLM to clear stale semantic ephemeral tags."""
+
+    if limit <= 0 or recent_chunk_window <= 0:
+        return 0
+
+    owns_conn = conn is None
+    conn = conn or _connect_for_slot(slot)
+    settings_dict = dict(settings or load_settings_as_dict())
+    try:
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    WITH recent_ticks AS (
+                        SELECT id
+                        FROM narrative_chunks
+                        ORDER BY id DESC
+                        LIMIT %s
+                    )
+                    SELECT
+                        et.id AS entity_tag_id,
+                        et.entity_id,
+                        et.applied_at,
+                        et.applied_at_world_time,
+                        et.template_id,
+                        t.tag,
+                        t.category,
+                        t.description,
+                        n.name AS entity_name
+                    FROM entity_tags et
+                    JOIN tags t ON t.id = et.tag_id
+                    LEFT JOIN entity_names_v n ON n.id = et.entity_id
+                    WHERE et.cleared_at IS NULL
+                      AND t.deprecated = false
+                      AND t.is_ephemeral = true
+                      AND t.clearance_kind = 'semantic'
+                      AND (
+                          EXISTS (
+                              SELECT 1
+                              FROM chunk_entity_references_v cer
+                              JOIN recent_ticks rt ON rt.id = cer.chunk_id
+                              WHERE cer.entity_id = et.entity_id
+                          )
+                          OR EXISTS (
+                              SELECT 1
+                              FROM world_events we
+                              JOIN recent_ticks rt ON rt.id = we.tick_chunk_id
+                              WHERE we.actor_entity_id = et.entity_id
+                                 OR we.target_entity_id = et.entity_id
+                                 OR EXISTS (
+                                      SELECT 1
+                                      FROM world_event_entities wee
+                                      WHERE wee.event_id = we.id
+                                        AND wee.entity_id = et.entity_id
+                                 )
+                          )
+                      )
+                    ORDER BY et.applied_at, et.id
+                    LIMIT %s
+                    FOR UPDATE OF et SKIP LOCKED
+                    """,
+                    (recent_chunk_window, limit),
+                )
+                rows = cur.fetchall()
+                if not rows:
+                    return 0
+
+                manager = llm_manager or LocalLLMManager(settings_dict)
+                cleared = 0
+                for row in rows:
+                    evidence = _semantic_clearance_evidence_sync(
+                        cur, entity_id=int(row["entity_id"])
+                    )
+                    verdict = _semantic_clearance_verdict(manager, row, evidence)
+                    if verdict.clear:
+                        _mark_semantic_tag_cleared_sync(
+                            cur,
+                            row=row,
+                            verdict=verdict,
+                            source_chunk_id=_latest_evidence_chunk_id(evidence),
+                        )
+                        cleared += 1
+                return cleared
+    finally:
+        if owns_conn:
+            conn.close()
+
+
+def load_orrery_status_sync(
+    slot: Optional[int] = None,
+    *,
+    conn: Optional[Any] = None,
+) -> OrreryStatus:
+    """Return a compact operational snapshot for Orrery background work."""
+
+    owns_conn = conn is None
+    conn = conn or _connect_for_slot(slot)
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            return OrreryStatus(
+                pending_promotions=_count_sync(
+                    cur,
+                    """
+                    SELECT count(*) AS count
+                    FROM orrery_resolutions
+                    WHERE promotion_status = 'pending'
+                    """,
+                ),
+                queued_narration_jobs=_count_sync(
+                    cur,
+                    """
+                    SELECT count(*) AS count
+                    FROM orrery_narration_jobs
+                    WHERE state = 'queued'
+                    """,
+                ),
+                leased_narration_jobs=_count_sync(
+                    cur,
+                    """
+                    SELECT count(*) AS count
+                    FROM orrery_narration_jobs
+                    WHERE state = 'leased'
+                    """,
+                ),
+                failed_narration_jobs=_count_sync(
+                    cur,
+                    """
+                    SELECT count(*) AS count
+                    FROM orrery_narration_jobs
+                    WHERE state = 'failed'
+                    """,
+                ),
+                pending_offscreen_embeddings=_count_sync(
+                    cur,
+                    """
+                    SELECT count(*) AS count
+                    FROM offscreen_narrations
+                    WHERE embedding_status = 'pending'
+                    """,
+                ),
+                failed_offscreen_embeddings=_count_sync(
+                    cur,
+                    """
+                    SELECT count(*) AS count
+                    FROM offscreen_narrations
+                    WHERE embedding_status = 'failed'
+                    """,
+                ),
+                active_semantic_tags=_count_sync(
+                    cur,
+                    """
+                    SELECT count(*) AS count
+                    FROM entity_tags et
+                    JOIN tags t ON t.id = et.tag_id
+                    WHERE et.cleared_at IS NULL
+                      AND t.deprecated = false
+                      AND t.is_ephemeral = true
+                      AND t.clearance_kind = 'semantic'
+                    """,
+                ),
+                recent_resolutions=_count_sync(
+                    cur,
+                    """
+                    SELECT count(*) AS count
+                    FROM orrery_resolutions
+                    WHERE created_at >= now() - interval '24 hours'
+                    """,
+                ),
+                recent_narrations=_count_sync(
+                    cur,
+                    """
+                    SELECT count(*) AS count
+                    FROM offscreen_narrations
+                    WHERE created_at >= now() - interval '24 hours'
+                    """,
+                ),
+            )
     finally:
         if owns_conn:
             conn.close()
@@ -412,6 +645,149 @@ def _mark_skipped(cur: Any, row: Mapping[str, Any], verdict: PromotionVerdict) -
     )
 
 
+def _semantic_clearance_evidence_sync(cur: Any, *, entity_id: int) -> dict[str, Any]:
+    """Load bounded canonical evidence for one semantic clearance decision."""
+
+    cur.execute(
+        """
+        SELECT nc.id, left(nc.raw_text, 1200) AS text
+        FROM chunk_entity_references_v cer
+        JOIN narrative_chunks nc ON nc.id = cer.chunk_id
+        WHERE cer.entity_id = %s
+        ORDER BY nc.id DESC
+        LIMIT 5
+        """,
+        (entity_id,),
+    )
+    chunks = [
+        {"chunk_id": row["id"], "text": row.get("text")} for row in cur.fetchall()
+    ]
+
+    cur.execute(
+        """
+        SELECT
+            we.id,
+            we.tick_chunk_id,
+            we.event_type,
+            we.changed_fields,
+            we.magnitude,
+            we.payload
+        FROM world_events we
+        WHERE we.actor_entity_id = %s
+           OR we.target_entity_id = %s
+           OR EXISTS (
+                SELECT 1
+                FROM world_event_entities wee
+                WHERE wee.event_id = we.id
+                  AND wee.entity_id = %s
+           )
+        ORDER BY we.tick_chunk_id DESC, we.id DESC
+        LIMIT 6
+        """,
+        (entity_id, entity_id, entity_id),
+    )
+    events = [
+        {
+            "event_id": row["id"],
+            "tick_chunk_id": row["tick_chunk_id"],
+            "event_type": row["event_type"],
+            "changed_fields": list(row.get("changed_fields") or ()),
+            "magnitude": _json_scalar(row.get("magnitude")),
+            "payload": row.get("payload") or {},
+        }
+        for row in cur.fetchall()
+    ]
+    return {"recent_chunks": chunks, "recent_events": events}
+
+
+def _semantic_clearance_verdict(
+    manager: Any, row: Mapping[str, Any], evidence: Mapping[str, Any]
+) -> SemanticClearanceVerdict:
+    prompt = (
+        "Evaluate whether this semantic ephemeral Orrery tag should be cleared.\n\n"
+        f"Entity: {row.get('entity_name') or row['entity_id']}\n"
+        f"Tag: {row['tag']}\n"
+        f"Category: {row.get('category')}\n"
+        f"Description: {row.get('description')}\n"
+        f"Applied at: {row.get('applied_at')}\n"
+        f"Applied world time: {row.get('applied_at_world_time')}\n"
+        f"Template source: {row.get('template_id')}\n\n"
+        "Evidence:\n"
+        f"{json.dumps(evidence, sort_keys=True, default=str)}\n\n"
+        "Return clear=true only if the tag is now stale, resolved, or no "
+        "longer active. Return clear=false when evidence is missing, weak, "
+        "ambiguous, or the state still plausibly applies."
+    )
+    raw = manager.structured_query(
+        prompt,
+        SemanticClearanceVerdict,
+        temperature=0.1,
+        max_tokens=512,
+        system_prompt=SEMANTIC_CLEARANCE_SYSTEM_PROMPT,
+    )
+    try:
+        if isinstance(raw, SemanticClearanceVerdict):
+            return raw
+        return SemanticClearanceVerdict.model_validate(raw)
+    except ValidationError as exc:
+        raise ValueError(f"Malformed Orrery semantic clearance verdict: {raw}") from exc
+
+
+def _mark_semantic_tag_cleared_sync(
+    cur: Any,
+    *,
+    row: Mapping[str, Any],
+    verdict: SemanticClearanceVerdict,
+    source_chunk_id: Optional[int],
+) -> None:
+    cur.execute(
+        "UPDATE entity_tags SET cleared_at = now() WHERE id = %s",
+        (row["entity_tag_id"],),
+    )
+    cur.execute(
+        """
+        INSERT INTO tag_clearance_log (
+            entity_tag_id, mechanism, justification, source_chunk_id
+        ) VALUES (%s, 'semantic', %s::jsonb, %s)
+        """,
+        (
+            row["entity_tag_id"],
+            json.dumps(
+                {
+                    "tag": row["tag"],
+                    "reason": verdict.reason,
+                }
+            ),
+            source_chunk_id,
+        ),
+    )
+
+
+def _latest_evidence_chunk_id(evidence: Mapping[str, Any]) -> Optional[int]:
+    chunk_ids: list[int] = []
+    for chunk in evidence.get("recent_chunks") or ():
+        chunk_id = chunk.get("chunk_id")
+        if chunk_id is not None:
+            chunk_ids.append(int(chunk_id))
+    for event in evidence.get("recent_events") or ():
+        chunk_id = event.get("tick_chunk_id")
+        if chunk_id is not None:
+            chunk_ids.append(int(chunk_id))
+    return max(chunk_ids) if chunk_ids else None
+
+
+def _count_sync(cur: Any, sql: str) -> int:
+    cur.execute(sql)
+    row = cur.fetchone()
+    return int(row.get("count") if row else 0)
+
+
+def _json_scalar(value: Any) -> Any:
+    if hasattr(value, "as_tuple"):
+        return float(value)
+    return value
+
+
 def _generate_narration(provider: Any, row: Mapping[str, Any]) -> str:
     prompt = (
         "Write one concise off-screen narration record.\n\n"
@@ -499,3 +875,57 @@ def _slot_label(slot: Optional[int]) -> str:
     if value:
         return value
     return "default"
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point for Orrery worker catch-up and status checks."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--slot", type=int, default=None, help="Save slot to inspect.")
+    parser.add_argument(
+        "--status",
+        action="store_true",
+        help="Print an Orrery background-work status snapshot instead of draining.",
+    )
+    parser.add_argument(
+        "--promotion-limit",
+        type=int,
+        default=20,
+        help="Maximum pending resolutions to promote in this run.",
+    )
+    parser.add_argument(
+        "--narration-limit",
+        type=int,
+        default=5,
+        help="Maximum queued narration jobs to drain in this run.",
+    )
+    parser.add_argument(
+        "--semantic-clearance-limit",
+        type=int,
+        default=DEFAULT_SEMANTIC_CLEARANCE_LIMIT,
+        help="Maximum semantic ephemeral tags to evaluate in this run.",
+    )
+    parser.add_argument(
+        "--semantic-clearance-recent-chunks",
+        type=int,
+        default=DEFAULT_SEMANTIC_CLEARANCE_RECENT_CHUNKS,
+        help="Recent chunk window used to find relevant semantic tag evidence.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.status:
+        payload = load_orrery_status_sync(args.slot).model_dump()
+    else:
+        payload = process_orrery_outbox_sync(
+            args.slot,
+            promotion_limit=args.promotion_limit,
+            narration_limit=args.narration_limit,
+            semantic_clearance_limit=args.semantic_clearance_limit,
+            semantic_clearance_recent_chunks=args.semantic_clearance_recent_chunks,
+        ).model_dump()
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -22,6 +22,8 @@ DEFAULT_NARRATION_MAX_ATTEMPTS = 3
 DEFAULT_NARRATION_RETRY_DELAY_SECONDS = 300
 DEFAULT_SEMANTIC_CLEARANCE_LIMIT = 20
 DEFAULT_SEMANTIC_CLEARANCE_RECENT_CHUNKS = 10
+DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_CHUNKS = 5
+DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_EVENTS = 6
 
 PROMOTION_SYSTEM_PROMPT = (
     "You are the Orrery promotion discriminator. Decide whether an off-screen "
@@ -97,6 +99,12 @@ def process_orrery_outbox_sync(
     narration_limit: int = 5,
     semantic_clearance_limit: int = DEFAULT_SEMANTIC_CLEARANCE_LIMIT,
     semantic_clearance_recent_chunks: int = DEFAULT_SEMANTIC_CLEARANCE_RECENT_CHUNKS,
+    semantic_clearance_evidence_chunks: int = (
+        DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_CHUNKS
+    ),
+    semantic_clearance_evidence_events: int = (
+        DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_EVENTS
+    ),
     settings: Optional[Mapping[str, Any]] = None,
     llm_manager: Optional[Any] = None,
     narration_provider: Optional[Any] = None,
@@ -119,6 +127,8 @@ def process_orrery_outbox_sync(
         slot,
         limit=semantic_clearance_limit,
         recent_chunk_window=semantic_clearance_recent_chunks,
+        evidence_chunk_limit=semantic_clearance_evidence_chunks,
+        evidence_event_limit=semantic_clearance_evidence_events,
         settings=settings,
         llm_manager=llm_manager,
     )
@@ -292,93 +302,56 @@ def clear_semantic_tags_sync(
     *,
     limit: int = DEFAULT_SEMANTIC_CLEARANCE_LIMIT,
     recent_chunk_window: int = DEFAULT_SEMANTIC_CLEARANCE_RECENT_CHUNKS,
+    evidence_chunk_limit: int = DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_CHUNKS,
+    evidence_event_limit: int = DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_EVENTS,
     settings: Optional[Mapping[str, Any]] = None,
     llm_manager: Optional[Any] = None,
     conn: Optional[Any] = None,
 ) -> int:
     """Use the local LLM to clear stale semantic ephemeral tags."""
 
-    if limit <= 0 or recent_chunk_window <= 0:
+    if (
+        limit <= 0
+        or recent_chunk_window <= 0
+        or evidence_chunk_limit <= 0
+        or evidence_event_limit <= 0
+    ):
         return 0
 
     owns_conn = conn is None
     conn = conn or _connect_for_slot(slot)
     settings_dict = dict(settings or load_settings_as_dict())
     try:
-        with conn:
-            with conn.cursor(cursor_factory=RealDictCursor) as cur:
-                cur.execute(
-                    """
-                    WITH recent_ticks AS (
-                        SELECT id
-                        FROM narrative_chunks
-                        ORDER BY id DESC
-                        LIMIT %s
-                    )
-                    SELECT
-                        et.id AS entity_tag_id,
-                        et.entity_id,
-                        et.applied_at,
-                        et.applied_at_world_time,
-                        et.template_id,
-                        t.tag,
-                        t.category,
-                        t.description,
-                        n.name AS entity_name
-                    FROM entity_tags et
-                    JOIN tags t ON t.id = et.tag_id
-                    LEFT JOIN entity_names_v n ON n.id = et.entity_id
-                    WHERE et.cleared_at IS NULL
-                      AND t.deprecated = false
-                      AND t.is_ephemeral = true
-                      AND t.clearance_kind = 'semantic'
-                      AND (
-                          EXISTS (
-                              SELECT 1
-                              FROM chunk_entity_references_v cer
-                              JOIN recent_ticks rt ON rt.id = cer.chunk_id
-                              WHERE cer.entity_id = et.entity_id
-                          )
-                          OR EXISTS (
-                              SELECT 1
-                              FROM world_events we
-                              JOIN recent_ticks rt ON rt.id = we.tick_chunk_id
-                              WHERE we.actor_entity_id = et.entity_id
-                                 OR we.target_entity_id = et.entity_id
-                                 OR EXISTS (
-                                      SELECT 1
-                                      FROM world_event_entities wee
-                                      WHERE wee.event_id = we.id
-                                        AND wee.entity_id = et.entity_id
-                                 )
-                          )
-                      )
-                    ORDER BY et.applied_at, et.id
-                    LIMIT %s
-                    FOR UPDATE OF et SKIP LOCKED
-                    """,
-                    (recent_chunk_window, limit),
-                )
-                rows = cur.fetchall()
-                if not rows:
-                    return 0
+        rows = _semantic_clearance_candidates_sync(
+            conn,
+            limit=limit,
+            recent_chunk_window=recent_chunk_window,
+        )
+        if not rows:
+            return 0
 
-                manager = llm_manager or LocalLLMManager(settings_dict)
-                cleared = 0
-                for row in rows:
+        manager = llm_manager or LocalLLMManager(settings_dict)
+        cleared = 0
+        for row in rows:
+            with conn:
+                with conn.cursor(cursor_factory=RealDictCursor) as cur:
                     evidence = _semantic_clearance_evidence_sync(
-                        cur, entity_id=int(row["entity_id"])
+                        cur,
+                        entity_id=int(row["entity_id"]),
+                        chunk_limit=evidence_chunk_limit,
+                        event_limit=evidence_event_limit,
                     )
-                    verdict = _semantic_clearance_verdict(manager, row, evidence)
-                    if verdict.clear:
-                        _mark_semantic_tag_cleared_sync(
-                            cur,
-                            row=row,
-                            verdict=verdict,
-                            source_chunk_id=_latest_evidence_chunk_id(evidence),
-                        )
-                        cleared += 1
-                return cleared
+            verdict = _semantic_clearance_verdict(manager, row, evidence)
+            if verdict.clear:
+                did_clear = _mark_semantic_tag_cleared_sync(
+                    conn,
+                    row=row,
+                    verdict=verdict,
+                    source_chunk_id=_latest_evidence_chunk_id(evidence),
+                )
+                if did_clear:
+                    cleared += 1
+        return cleared
     finally:
         if owns_conn:
             conn.close()
@@ -394,85 +367,86 @@ def load_orrery_status_sync(
     owns_conn = conn is None
     conn = conn or _connect_for_slot(slot)
     try:
-        with conn.cursor(cursor_factory=RealDictCursor) as cur:
-            return OrreryStatus(
-                pending_promotions=_count_sync(
-                    cur,
-                    """
-                    SELECT count(*) AS count
-                    FROM orrery_resolutions
-                    WHERE promotion_status = 'pending'
-                    """,
-                ),
-                queued_narration_jobs=_count_sync(
-                    cur,
-                    """
-                    SELECT count(*) AS count
-                    FROM orrery_narration_jobs
-                    WHERE state = 'queued'
-                    """,
-                ),
-                leased_narration_jobs=_count_sync(
-                    cur,
-                    """
-                    SELECT count(*) AS count
-                    FROM orrery_narration_jobs
-                    WHERE state = 'leased'
-                    """,
-                ),
-                failed_narration_jobs=_count_sync(
-                    cur,
-                    """
-                    SELECT count(*) AS count
-                    FROM orrery_narration_jobs
-                    WHERE state = 'failed'
-                    """,
-                ),
-                pending_offscreen_embeddings=_count_sync(
-                    cur,
-                    """
-                    SELECT count(*) AS count
-                    FROM offscreen_narrations
-                    WHERE embedding_status = 'pending'
-                    """,
-                ),
-                failed_offscreen_embeddings=_count_sync(
-                    cur,
-                    """
-                    SELECT count(*) AS count
-                    FROM offscreen_narrations
-                    WHERE embedding_status = 'failed'
-                    """,
-                ),
-                active_semantic_tags=_count_sync(
-                    cur,
-                    """
-                    SELECT count(*) AS count
-                    FROM entity_tags et
-                    JOIN tags t ON t.id = et.tag_id
-                    WHERE et.cleared_at IS NULL
-                      AND t.deprecated = false
-                      AND t.is_ephemeral = true
-                      AND t.clearance_kind = 'semantic'
-                    """,
-                ),
-                recent_resolutions=_count_sync(
-                    cur,
-                    """
-                    SELECT count(*) AS count
-                    FROM orrery_resolutions
-                    WHERE created_at >= now() - interval '24 hours'
-                    """,
-                ),
-                recent_narrations=_count_sync(
-                    cur,
-                    """
-                    SELECT count(*) AS count
-                    FROM offscreen_narrations
-                    WHERE created_at >= now() - interval '24 hours'
-                    """,
-                ),
-            )
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                return OrreryStatus(
+                    pending_promotions=_count_sync(
+                        cur,
+                        """
+                        SELECT count(*) AS count
+                        FROM orrery_resolutions
+                        WHERE promotion_status = 'pending'
+                        """,
+                    ),
+                    queued_narration_jobs=_count_sync(
+                        cur,
+                        """
+                        SELECT count(*) AS count
+                        FROM orrery_narration_jobs
+                        WHERE state = 'queued'
+                        """,
+                    ),
+                    leased_narration_jobs=_count_sync(
+                        cur,
+                        """
+                        SELECT count(*) AS count
+                        FROM orrery_narration_jobs
+                        WHERE state = 'leased'
+                        """,
+                    ),
+                    failed_narration_jobs=_count_sync(
+                        cur,
+                        """
+                        SELECT count(*) AS count
+                        FROM orrery_narration_jobs
+                        WHERE state = 'failed'
+                        """,
+                    ),
+                    pending_offscreen_embeddings=_count_sync(
+                        cur,
+                        """
+                        SELECT count(*) AS count
+                        FROM offscreen_narrations
+                        WHERE embedding_status = 'pending'
+                        """,
+                    ),
+                    failed_offscreen_embeddings=_count_sync(
+                        cur,
+                        """
+                        SELECT count(*) AS count
+                        FROM offscreen_narrations
+                        WHERE embedding_status = 'failed'
+                        """,
+                    ),
+                    active_semantic_tags=_count_sync(
+                        cur,
+                        """
+                        SELECT count(*) AS count
+                        FROM entity_tags et
+                        JOIN tags t ON t.id = et.tag_id
+                        WHERE et.cleared_at IS NULL
+                          AND t.deprecated = false
+                          AND t.is_ephemeral = true
+                          AND t.clearance_kind = 'semantic'
+                        """,
+                    ),
+                    recent_resolutions=_count_sync(
+                        cur,
+                        """
+                        SELECT count(*) AS count
+                        FROM orrery_resolutions
+                        WHERE created_at >= now() - interval '24 hours'
+                        """,
+                    ),
+                    recent_narrations=_count_sync(
+                        cur,
+                        """
+                        SELECT count(*) AS count
+                        FROM offscreen_narrations
+                        WHERE created_at >= now() - interval '24 hours'
+                        """,
+                    ),
+                )
     finally:
         if owns_conn:
             conn.close()
@@ -645,8 +619,78 @@ def _mark_skipped(cur: Any, row: Mapping[str, Any], verdict: PromotionVerdict) -
     )
 
 
-def _semantic_clearance_evidence_sync(cur: Any, *, entity_id: int) -> dict[str, Any]:
-    """Load bounded canonical evidence for one semantic clearance decision."""
+def _semantic_clearance_candidates_sync(
+    conn: Any,
+    *,
+    limit: int,
+    recent_chunk_window: int,
+) -> list[Mapping[str, Any]]:
+    """Load semantic tag candidates without holding row locks across inference."""
+
+    with conn:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                WITH recent_ticks AS (
+                    SELECT id
+                    FROM narrative_chunks
+                    ORDER BY id DESC
+                    LIMIT %s
+                )
+                SELECT
+                    et.id AS entity_tag_id,
+                    et.entity_id,
+                    et.applied_at,
+                    et.applied_at_world_time,
+                    et.template_id,
+                    t.tag,
+                    t.category,
+                    t.description,
+                    n.name AS entity_name
+                FROM entity_tags et
+                JOIN tags t ON t.id = et.tag_id
+                LEFT JOIN entity_names_v n ON n.id = et.entity_id
+                WHERE et.cleared_at IS NULL
+                  AND t.deprecated = false
+                  AND t.is_ephemeral = true
+                  AND t.clearance_kind = 'semantic'
+                  AND (
+                      EXISTS (
+                          SELECT 1
+                          FROM chunk_entity_references_v cer
+                          JOIN recent_ticks rt ON rt.id = cer.chunk_id
+                          WHERE cer.entity_id = et.entity_id
+                      )
+                      OR EXISTS (
+                          SELECT 1
+                          FROM world_events we
+                          JOIN recent_ticks rt ON rt.id = we.tick_chunk_id
+                          WHERE we.actor_entity_id = et.entity_id
+                             OR we.target_entity_id = et.entity_id
+                             OR EXISTS (
+                                  SELECT 1
+                                  FROM world_event_entities wee
+                                  WHERE wee.event_id = we.id
+                                    AND wee.entity_id = et.entity_id
+                             )
+                      )
+                  )
+                ORDER BY et.applied_at, et.id
+                LIMIT %s
+                """,
+                (recent_chunk_window, limit),
+            )
+            return list(cur.fetchall())
+
+
+def _semantic_clearance_evidence_sync(
+    cur: Any,
+    *,
+    entity_id: int,
+    chunk_limit: int = DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_CHUNKS,
+    event_limit: int = DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_EVENTS,
+) -> dict[str, Any]:
+    """Load bounded canonical evidence, not only the candidate trigger window."""
 
     cur.execute(
         """
@@ -655,9 +699,9 @@ def _semantic_clearance_evidence_sync(cur: Any, *, entity_id: int) -> dict[str, 
         JOIN narrative_chunks nc ON nc.id = cer.chunk_id
         WHERE cer.entity_id = %s
         ORDER BY nc.id DESC
-        LIMIT 5
+        LIMIT %s
         """,
-        (entity_id,),
+        (entity_id, chunk_limit),
     )
     chunks = [
         {"chunk_id": row["id"], "text": row.get("text")} for row in cur.fetchall()
@@ -682,9 +726,9 @@ def _semantic_clearance_evidence_sync(cur: Any, *, entity_id: int) -> dict[str, 
                   AND wee.entity_id = %s
            )
         ORDER BY we.tick_chunk_id DESC, we.id DESC
-        LIMIT 6
+        LIMIT %s
         """,
-        (entity_id, entity_id, entity_id),
+        (entity_id, entity_id, entity_id, event_limit),
     )
     events = [
         {
@@ -734,33 +778,50 @@ def _semantic_clearance_verdict(
 
 
 def _mark_semantic_tag_cleared_sync(
-    cur: Any,
+    conn: Any,
     *,
     row: Mapping[str, Any],
     verdict: SemanticClearanceVerdict,
     source_chunk_id: Optional[int],
-) -> None:
-    cur.execute(
-        "UPDATE entity_tags SET cleared_at = now() WHERE id = %s",
-        (row["entity_tag_id"],),
-    )
-    cur.execute(
-        """
-        INSERT INTO tag_clearance_log (
-            entity_tag_id, mechanism, justification, source_chunk_id
-        ) VALUES (%s, 'semantic', %s::jsonb, %s)
-        """,
-        (
-            row["entity_tag_id"],
-            json.dumps(
-                {
-                    "tag": row["tag"],
-                    "reason": verdict.reason,
-                }
-            ),
-            source_chunk_id,
-        ),
-    )
+) -> bool:
+    with conn:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                UPDATE entity_tags et
+                SET cleared_at = now()
+                FROM tags t
+                WHERE et.id = %s
+                  AND t.id = et.tag_id
+                  AND et.cleared_at IS NULL
+                  AND t.deprecated = false
+                  AND t.is_ephemeral = true
+                  AND t.clearance_kind = 'semantic'
+                RETURNING et.id
+                """,
+                (row["entity_tag_id"],),
+            )
+            updated = cur.fetchone()
+            if not updated:
+                return False
+            cur.execute(
+                """
+                INSERT INTO tag_clearance_log (
+                    entity_tag_id, mechanism, justification, source_chunk_id
+                ) VALUES (%s, 'semantic', %s::jsonb, %s)
+                """,
+                (
+                    row["entity_tag_id"],
+                    json.dumps(
+                        {
+                            "tag": row["tag"],
+                            "reason": verdict.reason,
+                        }
+                    ),
+                    source_chunk_id,
+                ),
+            )
+            return True
 
 
 def _latest_evidence_chunk_id(evidence: Mapping[str, Any]) -> Optional[int]:
@@ -779,7 +840,7 @@ def _latest_evidence_chunk_id(evidence: Mapping[str, Any]) -> Optional[int]:
 def _count_sync(cur: Any, sql: str) -> int:
     cur.execute(sql)
     row = cur.fetchone()
-    return int(row.get("count") if row else 0)
+    return int((row or {}).get("count") or 0)
 
 
 def _json_scalar(value: Any) -> Any:
@@ -911,6 +972,18 @@ def main(argv: Optional[list[str]] = None) -> int:
         default=DEFAULT_SEMANTIC_CLEARANCE_RECENT_CHUNKS,
         help="Recent chunk window used to find relevant semantic tag evidence.",
     )
+    parser.add_argument(
+        "--semantic-clearance-evidence-chunks",
+        type=int,
+        default=DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_CHUNKS,
+        help="Maximum recent narrative chunks included per semantic tag verdict.",
+    )
+    parser.add_argument(
+        "--semantic-clearance-evidence-events",
+        type=int,
+        default=DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_EVENTS,
+        help="Maximum recent Orrery events included per semantic tag verdict.",
+    )
     args = parser.parse_args(argv)
 
     if args.status:
@@ -922,6 +995,8 @@ def main(argv: Optional[list[str]] = None) -> int:
             narration_limit=args.narration_limit,
             semantic_clearance_limit=args.semantic_clearance_limit,
             semantic_clearance_recent_chunks=args.semantic_clearance_recent_chunks,
+            semantic_clearance_evidence_chunks=args.semantic_clearance_evidence_chunks,
+            semantic_clearance_evidence_events=args.semantic_clearance_evidence_events,
         ).model_dump()
     print(json.dumps(payload, indent=2, sort_keys=True))
     return 0

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -6,17 +6,34 @@ import pytest
 
 from nexus.agents.orrery.worker import (
     PromotionVerdict,
+    SemanticClearanceVerdict,
+    clear_semantic_tags_sync,
     drain_narration_outbox_sync,
+    load_orrery_status_sync,
     promote_pending_resolutions_sync,
+    process_orrery_outbox_sync,
 )
 
 
 class WorkerCursor:
     """Recording cursor for worker SQL branches."""
 
-    def __init__(self, *, promotion_rows=None, job_rows=None):
+    def __init__(
+        self,
+        *,
+        promotion_rows=None,
+        job_rows=None,
+        semantic_rows=None,
+        semantic_chunk_rows=None,
+        semantic_event_rows=None,
+        count_rows=None,
+    ):
         self.promotion_rows = promotion_rows or []
         self.job_rows = job_rows or []
+        self.semantic_rows = semantic_rows or []
+        self.semantic_chunk_rows = semantic_chunk_rows or []
+        self.semantic_event_rows = semantic_event_rows or []
+        self.count_rows = list(count_rows or [])
         self.executed = []
         self._fetchall = []
         self._fetchone = None
@@ -32,10 +49,18 @@ class WorkerCursor:
         self._fetchall = []
         self._fetchone = None
         normalized = " ".join(str(sql).split())
-        if "FROM orrery_resolutions r" in normalized:
+        if "SELECT count(*) AS count" in normalized:
+            self._fetchone = {"count": self.count_rows.pop(0)}
+        elif "FROM orrery_resolutions r" in normalized:
             self._fetchall = self.promotion_rows
         elif "FROM orrery_narration_jobs j" in normalized:
             self._fetchall = self.job_rows
+        elif "FROM entity_tags et JOIN tags t" in normalized:
+            self._fetchall = self.semantic_rows
+        elif "FROM chunk_entity_references_v cer" in normalized:
+            self._fetchall = self.semantic_chunk_rows
+        elif "FROM world_events we" in normalized:
+            self._fetchall = self.semantic_event_rows
         elif "INSERT INTO offscreen_narrations" in normalized:
             self._fetchone = {"id": 501}
 
@@ -70,12 +95,12 @@ class FakeLLM:
     """Local LLM stand-in returning one structured verdict."""
 
     def __init__(self, verdict):
-        self.verdict = verdict
+        self.verdicts = list(verdict) if isinstance(verdict, list) else [verdict]
         self.prompts = []
 
     def structured_query(self, prompt, response_model, **_kwargs):
         self.prompts.append((prompt, response_model))
-        return self.verdict
+        return self.verdicts.pop(0)
 
 
 class FakeProviderResponse:
@@ -149,6 +174,38 @@ def _job_row():
         "event_ids": [20],
         "attempts": 0,
         "world_layer": "primary",
+    }
+
+
+def _semantic_tag_row():
+    return {
+        "entity_tag_id": 700,
+        "entity_id": 1,
+        "entity_name": "Mara",
+        "applied_at": "2073-10-31T18:00:00+00:00",
+        "applied_at_world_time": None,
+        "template_id": "evade_pursuers",
+        "tag": "wounded",
+        "category": "state",
+        "description": "Entity has a recent physical injury.",
+    }
+
+
+def _semantic_chunk_row():
+    return {
+        "id": 105,
+        "text": "Mara limps at first, then steadies herself and keeps moving.",
+    }
+
+
+def _semantic_event_row():
+    return {
+        "id": 20,
+        "tick_chunk_id": 104,
+        "event_type": "evade_pursuit",
+        "changed_fields": ["character.current_activity"],
+        "magnitude": 0.72,
+        "payload": {"branch_label": "Go to ground"},
     }
 
 
@@ -275,3 +332,141 @@ def test_drain_narration_outbox_marks_terminal_after_max_attempts() -> None:
     assert failed == 1
     assert "state = 'failed'" in statements
     assert "narration_status = 'failed'" in statements
+
+
+def test_clear_semantic_tags_clears_when_verdict_true() -> None:
+    """Semantic ephemeral tags clear only after a structured positive verdict."""
+
+    cursor = WorkerCursor(
+        semantic_rows=[_semantic_tag_row()],
+        semantic_chunk_rows=[_semantic_chunk_row()],
+        semantic_event_rows=[_semantic_event_row()],
+    )
+    verdict = SemanticClearanceVerdict(clear=True, reason="Mara recovered.")
+    llm = FakeLLM(verdict)
+
+    cleared = clear_semantic_tags_sync(
+        slot=5,
+        settings=_settings(),
+        llm_manager=llm,
+        conn=WorkerConn(cursor),
+    )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+
+    assert cleared == 1
+    assert "WITH recent_ticks AS" in statements
+    assert "FOR UPDATE OF et SKIP LOCKED" in statements
+    assert "UPDATE entity_tags SET cleared_at = now()" in statements
+    assert "INSERT INTO tag_clearance_log" in statements
+    assert "VALUES (%s, 'semantic', %s::jsonb, %s)" in statements
+    assert cursor.executed[-1][1][2] == 105
+    assert llm.prompts[0][1] is SemanticClearanceVerdict
+    assert "Tag: wounded" in llm.prompts[0][0]
+    assert "Mara limps at first" in llm.prompts[0][0]
+
+
+def test_clear_semantic_tags_keeps_when_verdict_false() -> None:
+    """A negative semantic verdict leaves the current tag untouched."""
+
+    cursor = WorkerCursor(
+        semantic_rows=[_semantic_tag_row()],
+        semantic_chunk_rows=[_semantic_chunk_row()],
+        semantic_event_rows=[_semantic_event_row()],
+    )
+    verdict = SemanticClearanceVerdict(clear=False, reason="Recovery is ambiguous.")
+
+    cleared = clear_semantic_tags_sync(
+        slot=5,
+        settings=_settings(),
+        llm_manager=FakeLLM(verdict),
+        conn=WorkerConn(cursor),
+    )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+
+    assert cleared == 0
+    assert "UPDATE entity_tags SET cleared_at" not in statements
+    assert "INSERT INTO tag_clearance_log" not in statements
+
+
+def test_clear_semantic_tags_rejects_malformed_llm_output() -> None:
+    """Malformed semantic-clearance data fails visibly."""
+
+    cursor = WorkerCursor(
+        semantic_rows=[_semantic_tag_row()],
+        semantic_chunk_rows=[_semantic_chunk_row()],
+        semantic_event_rows=[_semantic_event_row()],
+    )
+
+    with pytest.raises(ValueError, match="Malformed Orrery semantic clearance verdict"):
+        clear_semantic_tags_sync(
+            slot=5,
+            settings=_settings(),
+            llm_manager=FakeLLM({"answer": "maybe"}),
+            conn=WorkerConn(cursor),
+        )
+
+
+def test_process_orrery_outbox_includes_semantic_clearance(monkeypatch) -> None:
+    """The background entry point drains semantic clearance with other work."""
+
+    calls = []
+
+    def fake_promote(*_args, **kwargs):
+        calls.append(("promote", kwargs["limit"]))
+        return (1, 2)
+
+    def fake_drain(*_args, **kwargs):
+        calls.append(("drain", kwargs["limit"]))
+        return (3, 4)
+
+    def fake_clear(*_args, **kwargs):
+        calls.append(("clear", kwargs["limit"], kwargs["recent_chunk_window"]))
+        return 5
+
+    monkeypatch.setattr(
+        "nexus.agents.orrery.worker.promote_pending_resolutions_sync",
+        fake_promote,
+    )
+    monkeypatch.setattr(
+        "nexus.agents.orrery.worker.drain_narration_outbox_sync",
+        fake_drain,
+    )
+    monkeypatch.setattr(
+        "nexus.agents.orrery.worker.clear_semantic_tags_sync",
+        fake_clear,
+    )
+
+    result = process_orrery_outbox_sync(
+        slot=5,
+        promotion_limit=6,
+        narration_limit=7,
+        semantic_clearance_limit=8,
+        semantic_clearance_recent_chunks=9,
+    )
+
+    assert result.promoted == 1
+    assert result.skipped == 2
+    assert result.narrated == 3
+    assert result.failed == 4
+    assert result.semantically_cleared == 5
+    assert calls == [("promote", 6), ("drain", 7), ("clear", 8, 9)]
+
+
+def test_load_orrery_status_sync_counts_background_work() -> None:
+    """Status snapshots expose the background-work backlog."""
+
+    cursor = WorkerCursor(count_rows=[1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    status = load_orrery_status_sync(conn=WorkerConn(cursor))
+
+    assert status.pending_promotions == 1
+    assert status.queued_narration_jobs == 2
+    assert status.leased_narration_jobs == 3
+    assert status.failed_narration_jobs == 4
+    assert status.pending_offscreen_embeddings == 5
+    assert status.failed_offscreen_embeddings == 6
+    assert status.active_semantic_tags == 7
+    assert status.recent_resolutions == 8
+    assert status.recent_narrations == 9

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -55,7 +55,9 @@ class WorkerCursor:
             self._fetchall = self.promotion_rows
         elif "FROM orrery_narration_jobs j" in normalized:
             self._fetchall = self.job_rows
-        elif "FROM entity_tags et JOIN tags t" in normalized:
+        elif (
+            "WITH recent_ticks AS" in normalized and "FROM entity_tags et" in normalized
+        ):
             self._fetchall = self.semantic_rows
         elif "FROM chunk_entity_references_v cer" in normalized:
             self._fetchall = self.semantic_chunk_rows
@@ -63,6 +65,8 @@ class WorkerCursor:
             self._fetchall = self.semantic_event_rows
         elif "INSERT INTO offscreen_narrations" in normalized:
             self._fetchone = {"id": 501}
+        elif "UPDATE entity_tags et SET cleared_at = now()" in normalized:
+            self._fetchone = {"id": params[0]}
 
     def fetchall(self):
         return self._fetchall
@@ -189,6 +193,20 @@ def _semantic_tag_row():
         "category": "state",
         "description": "Entity has a recent physical injury.",
     }
+
+
+def _semantic_tag_row_2():
+    row = dict(_semantic_tag_row())
+    row.update(
+        {
+            "entity_tag_id": 701,
+            "entity_id": 2,
+            "entity_name": "Toma",
+            "tag": "recently_violent",
+            "description": "Actor has executed violence in the recent past.",
+        }
+    )
+    return row
 
 
 def _semantic_chunk_row():
@@ -356,8 +374,9 @@ def test_clear_semantic_tags_clears_when_verdict_true() -> None:
 
     assert cleared == 1
     assert "WITH recent_ticks AS" in statements
-    assert "FOR UPDATE OF et SKIP LOCKED" in statements
-    assert "UPDATE entity_tags SET cleared_at = now()" in statements
+    assert "FOR UPDATE OF et SKIP LOCKED" not in statements
+    assert "UPDATE entity_tags et" in statements
+    assert "SET cleared_at = now()" in statements
     assert "INSERT INTO tag_clearance_log" in statements
     assert "VALUES (%s, 'semantic', %s::jsonb, %s)" in statements
     assert cursor.executed[-1][1][2] == 105
@@ -391,21 +410,32 @@ def test_clear_semantic_tags_keeps_when_verdict_false() -> None:
 
 
 def test_clear_semantic_tags_rejects_malformed_llm_output() -> None:
-    """Malformed semantic-clearance data fails visibly."""
+    """Malformed semantic-clearance data fails after prior row commits survive."""
 
     cursor = WorkerCursor(
-        semantic_rows=[_semantic_tag_row()],
+        semantic_rows=[_semantic_tag_row(), _semantic_tag_row_2()],
         semantic_chunk_rows=[_semantic_chunk_row()],
         semantic_event_rows=[_semantic_event_row()],
+    )
+    llm = FakeLLM(
+        [
+            SemanticClearanceVerdict(clear=True, reason="Mara recovered."),
+            {"answer": "maybe"},
+        ]
     )
 
     with pytest.raises(ValueError, match="Malformed Orrery semantic clearance verdict"):
         clear_semantic_tags_sync(
             slot=5,
             settings=_settings(),
-            llm_manager=FakeLLM({"answer": "maybe"}),
+            llm_manager=llm,
             conn=WorkerConn(cursor),
         )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+
+    assert statements.count("UPDATE entity_tags et") == 1
+    assert statements.count("INSERT INTO tag_clearance_log") == 1
 
 
 def test_process_orrery_outbox_includes_semantic_clearance(monkeypatch) -> None:
@@ -422,7 +452,15 @@ def test_process_orrery_outbox_includes_semantic_clearance(monkeypatch) -> None:
         return (3, 4)
 
     def fake_clear(*_args, **kwargs):
-        calls.append(("clear", kwargs["limit"], kwargs["recent_chunk_window"]))
+        calls.append(
+            (
+                "clear",
+                kwargs["limit"],
+                kwargs["recent_chunk_window"],
+                kwargs["evidence_chunk_limit"],
+                kwargs["evidence_event_limit"],
+            )
+        )
         return 5
 
     monkeypatch.setattr(
@@ -444,6 +482,8 @@ def test_process_orrery_outbox_includes_semantic_clearance(monkeypatch) -> None:
         narration_limit=7,
         semantic_clearance_limit=8,
         semantic_clearance_recent_chunks=9,
+        semantic_clearance_evidence_chunks=10,
+        semantic_clearance_evidence_events=11,
     )
 
     assert result.promoted == 1
@@ -451,7 +491,7 @@ def test_process_orrery_outbox_includes_semantic_clearance(monkeypatch) -> None:
     assert result.narrated == 3
     assert result.failed == 4
     assert result.semantically_cleared == 5
-    assert calls == [("promote", 6), ("drain", 7), ("clear", 8, 9)]
+    assert calls == [("promote", 6), ("drain", 7), ("clear", 8, 9, 10, 11)]
 
 
 def test_load_orrery_status_sync_counts_background_work() -> None:


### PR DESCRIPTION
## Summary

- Adds a batched semantic ephemeral-tag clearance pass to the Orrery worker.
- Filters semantic clearance candidates to entities with recent canonical chunk references or recent Orrery events before calling the local LLM.
- Adds a compact worker status model and CLI status command for pending promotions, narration jobs, off-screen embedding backlog, active semantic tags, and recent activity.
- Updates the Orrery design plan to reflect PR #221/#222 and this follow-up slice.

## Validation

- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery`
- `PYTHONPATH=$PWD poetry run pytest tests/test_api/test_lore_adapter.py tests/test_lore/test_turn_cycle.py`
- `poetry run black --check nexus/agents/orrery/worker.py tests/test_orrery/test_worker.py`
- `PYTHONPATH=$PWD poetry run python -m py_compile nexus/agents/orrery/worker.py`
- `git diff --check`
- `PYTHONPATH=$PWD poetry run python -m nexus.agents.orrery.worker --slot 5 --status`