### PR TITLE
Grant pull-requests: write to agent review orchestration

### DIFF
--- a/.github/workflows/agent-review-orchestration.yml
+++ b/.github/workflows/agent-review-orchestration.yml
@@ -16,7 +16,7 @@ permissions:
   actions: write
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   orchestrate:


### PR DESCRIPTION
## Summary

Fixes the orchestration workflow's failure on PR #224's first run:

\`\`\`
GraphQL: Resource not accessible by integration (addComment)
\`\`\`

The workflow uses \`gh pr comment\` at lines 89 and 113 to post a tracking comment for Claude review dispatch and an agent-ready marker. The GraphQL \`addComment\` mutation backing \`gh pr comment\` requires \`pull-requests: write\` — \`issues: write\` does not extend to PR comments even though issues and PRs share an underlying API surface in the REST world.

One-line change: promote \`pull-requests: read\` → \`pull-requests: write\`.

## Diff

\`\`\`diff
 permissions:
   actions: write
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
\`\`\`

## Out of scope

- Removing the now-possibly-unused \`issues: write\` permission. Codex added it in #222 and may have intended it for future use; trimming it is a separate cleanup decision, not a fix.

## Test plan

- [ ] Merge this PR
- [ ] Either re-run the failed job on PR #224 or wait for the next PR to open; the orchestration workflow should now complete past the "Request Claude review" step
- [ ] Confirm the tracking comment and the agent-ready marker comment both post successfully on the next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)