### PR TITLE
Add Orrery cooldown coverage invariant

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -534,6 +534,10 @@ When a tag or event_type is referenced that the registry hasn't seen:
 
 Every template MUST end with an `ALWAYS`-conditioned branch. Validated at template-load time via pytest fixture.
 
+### Gate-Cooldown Coverage Invariant for Templates
+
+If a template package gate includes `since_last_event_at_least(...)` cooldowns, every `event_type` emitted by any branch MUST appear in that gate's cooldown chain. Otherwise one branch can bypass the template's pacing intent by emitting an event the outer gate never checks. Validated by `tests/test_orrery/test_substrate.py::test_gate_cooldown_chain_covers_branch_events`.
+
 ### Sliding-Window Binding Scope
 
 Binding composer filters to recently-relevant entities: (referenced in `chunk_character_references` in last N chunks) ∪ (has an active ephemeral tag) ∪ (has un-superseded `world_events` in last N chunks). N config-tunable via `nexus.toml` `[orrery.binding] window_chunks`. Default suggested: 30.

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -155,6 +155,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
     - actor and target share `rival` relationship (either direction)
     - trust actor→target < -2
   - ≥ 8 ticks since last `retaliation_attempted` event for actor
+  - ≥ 8 ticks since last `retaliation_executed` event for actor
   - **NOT:** actor has `under_active_pursuit` ephemeral
 
 ### Branch 1 — Strike directly when opportunity opens  *(mag 0.85)*
@@ -222,6 +223,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
   - **NOT:** actor has `under_active_pursuit` ephemeral
   - **NOT:** target has `under_active_pursuit` ephemeral
   - ≥ 2 ticks since last `tended_wound` event for (actor, target) pair
+  - ≥ 2 ticks since last `wound_healed` event for (actor, target) pair
 
 ### Branch 1 — Channel restorative power through hands and voice  *(mag 0.74)*
 
@@ -483,6 +485,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
     - actor has `handler` relationship to target
     - target has `asset` relationship to actor
   - ≥ 4 ticks since last `informant_contact` event for (actor, target) pair
+  - ≥ 4 ticks since last `intel_acquired` event for (actor, target) pair
   - time of day is one of [evening, night]
   - **NOT:** actor has `under_active_pursuit` ephemeral
   - **NOT:** actor has `grudge_active` ephemeral

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -265,6 +265,9 @@ EXTRACT_VENGEANCE = Template(
     # grudge has a refractory period after any attempt regardless of
     # target — the actor needs to "calm down," not just back off a
     # specific target.
+    #
+    # Gate must cover both emitted retaliation events; otherwise a direct
+    # execution branch can bypass the attempted-retaliation cooldown.
     package_gate=AND(
         has_ephemeral("grudge_active"),
         OR(
@@ -273,6 +276,7 @@ EXTRACT_VENGEANCE = Template(
             trust_below(-2),
         ),
         since_last_event_at_least("retaliation_attempted", minimum_ticks=8),
+        since_last_event_at_least("retaliation_executed", minimum_ticks=8),
         NOT(has_ephemeral("under_active_pursuit")),
     ),
     branches=(
@@ -487,6 +491,9 @@ CULTIVATE_INFORMANT = Template(
     # Cooldowns here are per-(actor, target) via target_slot=: handler A
     # contacting informant B must not block A from contacting informant C.
     # Contrast with EXTRACT_VENGEANCE's actor-global retaliation cooldown.
+    #
+    # Gate must cover both emitted contact events: material intel and routine
+    # contact are different event types, but both should pace this package.
     package_gate=AND(
         has_tag("informant_handler"),
         OR(
@@ -495,6 +502,11 @@ CULTIVATE_INFORMANT = Template(
         ),
         since_last_event_at_least(
             "informant_contact",
+            minimum_ticks=4,
+            target_slot=Slot.TARGET,
+        ),
+        since_last_event_at_least(
+            "intel_acquired",
             minimum_ticks=4,
             target_slot=Slot.TARGET,
         ),
@@ -630,6 +642,8 @@ TEND_WOUNDED = Template(
     priority=88,
     blurb="A wounded body pulls the actor toward the small work of mending.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
+    # Gate must cover both emitted care events: healing the wound is higher
+    # impact than tending it, but both should reset the package's cadence.
     package_gate=AND(
         has_ephemeral("wounded", slot=Slot.TARGET),
         co_located(Slot.ACTOR, Slot.TARGET),
@@ -637,6 +651,9 @@ TEND_WOUNDED = Template(
         NOT(has_ephemeral("under_active_pursuit", slot=Slot.TARGET)),
         since_last_event_at_least(
             "tended_wound", minimum_ticks=2, target_slot=Slot.TARGET
+        ),
+        since_last_event_at_least(
+            "wound_healed", minimum_ticks=2, target_slot=Slot.TARGET
         ),
     ),
     branches=(

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -1,11 +1,15 @@
 """Tests for the Orrery pure-Python behavior substrate."""
 
+import re
+from typing import Any
+
 import pytest
 
 from nexus.agents.orrery.demo import run_preset
 from nexus.agents.orrery.substrate import (
     ALWAYS,
     Branch,
+    CompoundCondition,
     PresentTargetPolicy,
     Slot,
     Template,
@@ -21,10 +25,51 @@ from nexus.agents.orrery.substrate import (
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 
 
+_SINCE_LAST_EVENT_RE = re.compile(r"since_last_event_at_least\(([^,()]+),")
+
+
+def _collect_since_last_event_types(condition: Any) -> set[str]:
+    """Walk a condition tree and collect package-gate cooldown event types."""
+
+    if isinstance(condition, CompoundCondition):
+        event_types: set[str] = set()
+        for child in condition.children:
+            event_types.update(_collect_since_last_event_types(child))
+        return event_types
+
+    match = _SINCE_LAST_EVENT_RE.search(getattr(condition, "__name__", ""))
+    if not match:
+        return set()
+    return {match.group(1)}
+
+
 def test_builtin_templates_have_always_fallbacks() -> None:
     """Built-in templates must end in a deterministic fallback branch."""
 
     validate_always_fallbacks(BUILTIN_TEMPLATES)
+
+
+def test_gate_cooldown_chain_covers_branch_events() -> None:
+    """Template-level cooldown gates must cover every branch event type."""
+
+    for template in BUILTIN_TEMPLATES:
+        branch_event_types = {
+            branch.event_type for branch in template.branches if branch.event_type
+        }
+        gate_cooldown_event_types = _collect_since_last_event_types(
+            template.package_gate
+        )
+        if not gate_cooldown_event_types:
+            continue
+
+        missing = branch_event_types - gate_cooldown_event_types
+
+        assert not missing, (
+            f"Template {template.id}: branches emit {sorted(missing)} but "
+            "the gate doesn't include them in any "
+            "since_last_event_at_least(...) cooldown. This lets those "
+            "branches bypass the template's pacing intent."
+        )
 
 
 def test_missing_always_fallback_is_rejected() -> None:


### PR DESCRIPTION
## Summary

- Adds a structural unit test that walks every `BUILTIN_TEMPLATES` package gate and asserts branch-emitted events are covered by template-level cooldown chains when the gate has cooldowns.
- Tightens the current template gates for `extract_vengeance`, `tend_wounded`, and `cultivate_informant` so all branch event types are covered.
- Regenerates the human-readable Orrery package catalog and documents the invariant in the design plan.

Closes #226.

## Validation

- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery/test_substrate.py::test_gate_cooldown_chain_covers_branch_events -q`
- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery/test_substrate.py tests/test_orrery/test_catalog.py`
- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery`
- `PYTHONPATH=$PWD poetry run python -m nexus.agents.orrery.catalog --check`
- `poetry run black --check tests/test_orrery/test_substrate.py nexus/agents/orrery/templates.py`
- `git diff --check`