### PR TITLE
Record Orrery role vocabulary decision

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -617,7 +617,7 @@ Per-chunk, not per-event. Stamped only at accepted commit. `world_events.world_t
 
 Keep the expressive role-tag vocabulary seeded by migration 027 rather than collapsing it to a smaller canonical set yet.
 
-This preserves the narrative signal PR #223 intentionally kept in storyteller-side tagging: `carpenter`, `mason`, `blacksmith`, `scribe`, and similar tags carry different social and world-state affordances even when the current package resolver treats them similarly. Collapsing now would lose information before there is evidence that the vocabulary is hurting package authoring, UI workflows, or resolver performance.
+This preserves the narrative signal PR #223 intentionally kept in storyteller-side tagging: `musician`, `dancer`, `performer`, `artist`, `writer`, and `artisan` carry different social and world-state affordances even though the current package resolver gates them through the same `TEND_CRAFT` practice branch. Collapsing now would lose information before there is evidence that the vocabulary is hurting package authoring, UI workflows, or resolver performance.
 
 The alias-oriented hybrid remains the right future escape hatch if that pain appears: use `tags.synonym_for` to group expressive tags under canonical families, then teach substrate hydration to resolve both canonical tags and aliases. That is a real implementation change, with query semantics and tests, so it should be driven by observed need rather than folded into the current cleanup thread.
 

--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -613,6 +613,14 @@ Unanimous. No fixed boolean columns. Controlled vocabulary auto-generated from `
 
 Per-chunk, not per-event. Stamped only at accepted commit. `world_events.world_time` becomes a JOIN at read time. Off-screen narrations never advance chronology.
 
+### [OPEN 8] `TEND_CRAFT` role-tag vocabulary — RESOLVED: Keep expressive tags for now
+
+Keep the expressive role-tag vocabulary seeded by migration 027 rather than collapsing it to a smaller canonical set yet.
+
+This preserves the narrative signal PR #223 intentionally kept in storyteller-side tagging: `carpenter`, `mason`, `blacksmith`, `scribe`, and similar tags carry different social and world-state affordances even when the current package resolver treats them similarly. Collapsing now would lose information before there is evidence that the vocabulary is hurting package authoring, UI workflows, or resolver performance.
+
+The alias-oriented hybrid remains the right future escape hatch if that pain appears: use `tags.synonym_for` to group expressive tags under canonical families, then teach substrate hydration to resolve both canonical tags and aliases. That is a real implementation change, with query semantics and tests, so it should be driven by observed need rather than folded into the current cleanup thread.
+
 ---
 
 ## Phased Delivery


### PR DESCRIPTION
## Summary
- Records the issue #227 decision to keep the expressive TEND_CRAFT role-tag vocabulary for now.
- Documents why collapsing to canonical role tags would lose useful narrative signal before we have evidence of friction.
- Leaves the synonym/alias hydration path as the future escape hatch if package authoring or UI workflows need it.

## Validation
- `git diff --check`

Closes #227