### PR TITLE
Fix Claude review orchestration dispatch

### DIFF
--- a/.github/workflows/agent-review-orchestration.yml
+++ b/.github/workflows/agent-review-orchestration.yml
@@ -75,11 +75,26 @@ jobs:
             exit 0
           fi
 
-          gh workflow run claude-code-review.yml \
-            --ref "$BASE_REF" \
-            -f pr_number="$PR_NUMBER" \
-            -f head_sha="$PR_HEAD_SHA" \
-            -f review_prompt="$REVIEW_PROMPT"
+          dispatch_output="$(
+            gh workflow run claude-code-review.yml \
+              --ref "$BASE_REF" \
+              -f pr_number="$PR_NUMBER" \
+              -f head_sha="$PR_HEAD_SHA" \
+              -f review_prompt="$REVIEW_PROMPT" \
+              2>&1
+          )"
+          printf '%s\n' "$dispatch_output"
+
+          claude_run_id="$(
+            printf '%s\n' "$dispatch_output" |
+              sed -nE 's#.*actions/runs/([0-9]+).*#\1#p' |
+              tail -n 1
+          )"
+          if [[ -z "$claude_run_id" ]]; then
+            echo "::error::Unable to determine Claude review workflow run id from dispatch output."
+            exit 1
+          fi
+          echo "CLAUDE_RUN_ID=${claude_run_id}" >> "$GITHUB_ENV"
 
           printf '%s\n%s\n' \
             "$marker" \
@@ -97,6 +112,19 @@ jobs:
         if: env.AGENT_REVIEW_REQUESTED == 'true'
         run: |
           set -euo pipefail
+
+          if [[ -n "${CLAUDE_RUN_ID:-}" ]]; then
+            claude_status="$(gh run view "$CLAUDE_RUN_ID" --json status --jq .status)"
+            claude_conclusion="$(gh run view "$CLAUDE_RUN_ID" --json conclusion --jq '.conclusion // ""')"
+            claude_url="$(gh run view "$CLAUDE_RUN_ID" --json url --jq .url)"
+
+            if [[ "$claude_status" != "completed" || "$claude_conclusion" != "success" ]]; then
+              echo "::error::Claude review workflow ${CLAUDE_RUN_ID} did not complete successfully: status=${claude_status}, conclusion=${claude_conclusion:-none} (${claude_url})"
+              exit 1
+            fi
+          else
+            echo "::warning::No Claude review workflow run id available; unable to verify downstream completion."
+          fi
 
           marker="<!-- nexus-agent-review:ready:${PR_HEAD_SHA} -->"
           if gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate --jq '.[].body' | grep -Fq "$marker"; then

--- a/.github/workflows/agent-review-orchestration.yml
+++ b/.github/workflows/agent-review-orchestration.yml
@@ -69,8 +69,24 @@ jobs:
           fi
 
           marker="<!-- nexus-agent-review:claude-request:${PR_HEAD_SHA} -->"
-          if gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate --jq '.[].body' | grep -Fq "$marker"; then
+          existing_request="$(
+            MARKER="$marker" gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --paginate \
+              --jq '.[] | select(.body | contains(env.MARKER)) | .body'
+          )"
+          if [[ -n "$existing_request" ]]; then
+            claude_run_id="$(
+              printf '%s\n' "$existing_request" |
+                sed -nE 's#.*actions/runs/([0-9]+).*#\1#p' |
+                tail -n 1
+            )"
+            if [[ -z "$claude_run_id" ]]; then
+              echo "::error::Existing Claude request marker for ${PR_HEAD_SHA} does not include a workflow run id, so downstream completion cannot be verified."
+              exit 1
+            fi
+
             echo "Claude review already requested for ${PR_HEAD_SHA}."
+            echo "CLAUDE_RUN_ID=${claude_run_id}" >> "$GITHUB_ENV"
             echo "AGENT_REVIEW_REQUESTED=true" >> "$GITHUB_ENV"
             exit 0
           fi
@@ -94,14 +110,16 @@ jobs:
             echo "::error::Unable to determine Claude review workflow run id from dispatch output."
             exit 1
           fi
-          echo "CLAUDE_RUN_ID=${claude_run_id}" >> "$GITHUB_ENV"
+          claude_run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${claude_run_id}"
 
-          printf '%s\n%s\n' \
+          printf '%s\n%s\n%s\n' \
             "$marker" \
             "Agent review orchestration requested Claude review for commit \`${PR_HEAD_SHA}\`." \
+            "Claude review workflow run: ${claude_run_url}" \
             > /tmp/claude-review-request.md
 
           gh pr comment "$PR_NUMBER" --body-file /tmp/claude-review-request.md
+          echo "CLAUDE_RUN_ID=${claude_run_id}" >> "$GITHUB_ENV"
           echo "AGENT_REVIEW_REQUESTED=true" >> "$GITHUB_ENV"
 
       - name: Wait for Claude review window
@@ -113,17 +131,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ -n "${CLAUDE_RUN_ID:-}" ]]; then
-            claude_status="$(gh run view "$CLAUDE_RUN_ID" --json status --jq .status)"
-            claude_conclusion="$(gh run view "$CLAUDE_RUN_ID" --json conclusion --jq '.conclusion // ""')"
-            claude_url="$(gh run view "$CLAUDE_RUN_ID" --json url --jq .url)"
+          if [[ -z "${CLAUDE_RUN_ID:-}" ]]; then
+            echo "::error::No Claude review workflow run id available; unable to verify downstream completion."
+            exit 1
+          fi
 
-            if [[ "$claude_status" != "completed" || "$claude_conclusion" != "success" ]]; then
-              echo "::error::Claude review workflow ${CLAUDE_RUN_ID} did not complete successfully: status=${claude_status}, conclusion=${claude_conclusion:-none} (${claude_url})"
-              exit 1
-            fi
-          else
-            echo "::warning::No Claude review workflow run id available; unable to verify downstream completion."
+          run_summary="$(
+            gh run view "$CLAUDE_RUN_ID" \
+              --json status,conclusion,url \
+              --jq '[.status, (.conclusion // ""), .url] | @tsv'
+          )"
+          IFS=$'\t' read -r claude_status claude_conclusion claude_url <<< "$run_summary"
+
+          if [[ "$claude_status" != "completed" || "$claude_conclusion" != "success" ]]; then
+            echo "::error::Claude review workflow ${CLAUDE_RUN_ID} did not complete successfully: status=${claude_status}, conclusion=${claude_conclusion:-none} (${claude_url})"
+            exit 1
           fi
 
           marker="<!-- nexus-agent-review:ready:${PR_HEAD_SHA} -->"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,6 +41,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # This workflow is dispatched by the orchestration workflow with the
+          # default GITHUB_TOKEN, so Claude sees github-actions as the initiator.
+          allowed_bots: github-actions,github-actions[bot]
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ inputs.pr_number }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,6 +43,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # This workflow is dispatched by the orchestration workflow with the
           # default GITHUB_TOKEN, so Claude sees github-actions as the initiator.
+          # claude-code-action documents this input as a comma-separated list.
           allowed_bots: github-actions,github-actions[bot]
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Allow the dispatched Claude review workflow to run when initiated by `github-actions` from the orchestrator.
- Capture the dispatched Claude workflow run id so the orchestrator can verify downstream completion.
- Fail the orchestrator if the Claude workflow fails or is still incomplete instead of posting a misleading ready marker.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/agent-review-orchestration.yml .github/workflows/claude-code-review.yml`

Context: PR #229 did dispatch Claude, but the downstream Claude workflow failed because the action rejected the `github-actions` bot actor.