### PR TITLE
Drop unused orchestrator issue permission

### DIFF
--- a/.github/workflows/agent-review-orchestration.yml
+++ b/.github/workflows/agent-review-orchestration.yml
@@ -15,7 +15,6 @@ concurrency:
 permissions:
   actions: write
   contents: read
-  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary
- Removes the unused `issues: write` permission from the agent review orchestration workflow.
- Keeps the narrower permissions the workflow actually needs: `actions: write`, `contents: read`, and `pull-requests: write`.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/agent-review-orchestration.yml"); puts "ok .github/workflows/agent-review-orchestration.yml"'`
- `actionlint .github/workflows/agent-review-orchestration.yml`

Closes #228