### PR TITLE
Add Orrery Sunhelm need packages

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1118,6 +1118,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/025_orrery_package_library_vocab.py`
 - `migrations/027_orrery_package_library_round2_vocab.py`
 - `migrations/028_orrery_sunhelm_needs.py`
+- `migrations/029_orrery_need_state_init_trigger.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -778,6 +778,210 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ---
 
+## SLEEP — priority 25
+
+> The body asks for the thing without which it cannot continue.
+
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - **OR:**
+    - **AND:**
+      - time of day is one of [night]
+      - actor has `sleep` debt ≥ 8
+    - actor has `sleep` debt ≥ 16
+  - **NOT:** actor has `cns_stimulated` ephemeral
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+
+### Branch 1 — Collapse into deferred sleep  *(mag 0.74)*
+
+**When:** actor has `sleep` debt ≥ 48
+
+**Does:** activity → "collapsing into deferred sleep"; fulfills `sleep` need, quality `collapse_rough`, discharge 4
+**Event:** `slept`
+
+> {actor} stops negotiating with exhaustion. Whatever place they have reached becomes the place where the body claims its overdue sleep.
+
+### Branch 2 — Sleep at home  *(mag 0.22)*
+
+**When:** actor is in `home` location class
+
+**Does:** activity → "sleeping at home"; fulfills `sleep` need, quality `good`, discharge 10
+**Event:** `slept`
+
+> {actor} reaches familiar shelter and lets sleep take them where the room already knows their shape.
+
+### Branch 3 — Sleep in safe lodgings  *(mag 0.28)*
+
+**When:**
+
+- **OR:**
+  - actor is in `lodgings` location class
+  - actor is in `safe_house` location class
+
+**Does:** activity → "sleeping in safe lodgings"; fulfills `sleep` need, quality `adequate`, discharge 7
+**Event:** `slept`
+
+> {actor} finds a place secure enough to become temporary shelter and lets the unfamiliar room do enough of the work.
+
+### Branch 4 — Sleep rough in cover or transit  *(mag 0.36)*
+
+**When:** *(always)*
+
+**Does:** activity → "sleeping rough"; fulfills `sleep` need, quality `rough`, discharge 3
+**Event:** `slept`
+
+> {actor} sleeps in fragments, taking what rest the place allows and waking with some part of the debt still unpaid.
+
+---
+
+## DRINK — priority 24
+
+> The body asks for water; what it accepts shapes the small hour.
+
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor has `thirst` debt ≥ 2
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+
+### Branch 1 — Drink desperately, whatever is available  *(mag 0.56)*
+
+**When:** actor has `thirst` debt ≥ 16
+
+**Does:** activity → "drinking to relieve severe thirst"; fulfills `thirst` need, quality `desperate`, discharge 9999
+**Event:** `drank`
+
+> {actor} drinks with the single-mindedness that severe thirst produces, past concern for source or dignity.
+
+### Branch 2 — Drink in a public room  *(mag 0.22)*
+
+**When:**
+
+- **OR:**
+  - actor is in `tavern` location class
+  - actor is in `teahouse` location class
+  - actor is in `cafe` location class
+  - actor is in `market` location class
+
+**Does:** activity → "drinking in company"; fulfills `thirst` need, quality `social`, discharge 9999
+**Event:** `drank`
+
+> {actor} drinks what the room serves and lets the small ritual of holding a cup make the hour easier.
+
+### Branch 3 — Drink from a public or wild source  *(mag 0.14)*
+
+**When:**
+
+- **OR:**
+  - actor is in `public_water` location class
+  - actor is in `wilderness` location class
+
+**Does:** activity → "drinking from an available source"; fulfills `thirst` need, quality `available_source`, discharge 9999
+**Event:** `drank`
+
+> {actor} drinks from whatever the place provides, and the relief of water makes the rest of the day briefly simpler.
+
+### Branch 4 — Drink routinely from what is at hand  *(mag 0.1)*
+
+**When:** *(always)*
+
+**Does:** activity → "drinking routinely"; fulfills `thirst` need, quality `routine`, discharge 9999
+**Event:** `drank`
+
+> {actor} drinks because the body has been quietly asking, then returns to the shape of the hour.
+
+---
+
+## EAT — priority 22
+
+> The body asks for fuel; what it gets matters more than the cookbook suggests.
+
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor has `hunger` debt ≥ 4
+  - **OR:**
+    - time of day is one of [morning, afternoon, evening]
+    - actor has `hunger` debt ≥ 8
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+
+### Branch 1 — Eat ravenously, whatever is available  *(mag 0.62)*
+
+**When:** actor has `hunger` debt ≥ 16
+
+**Does:** activity → "eating to relieve severe hunger"; fulfills `hunger` need, quality `desperate`, discharge 9999
+**Event:** `ate`
+
+> {actor} eats with the inattention of real hunger, relief overtaking any concern about what the food ought to be.
+
+### Branch 2 — Eat at home with household  *(mag 0.22)*
+
+**When:**
+
+- **AND:**
+  - actor is in `home` location class
+  - actor has any of [`married`, `parent`, `extended_household`]
+
+**Does:** activity → "sharing a household meal"; fulfills `hunger` need, quality `household_meal`, discharge 9999
+**Event:** `ate`
+
+> {actor} sits down to the meal that home means and lets being-with stand in for being-alone for a while.
+
+### Branch 3 — Eat in a public dining place  *(mag 0.26)*
+
+**When:**
+
+- **OR:**
+  - actor is in `tavern` location class
+  - actor is in `restaurant` location class
+  - actor is in `market` location class
+  - actor is in `cookshop` location class
+
+**Does:** activity → "eating in a public place"; fulfills `hunger` need, quality `public_meal`, discharge 9999
+**Event:** `ate`
+
+> {actor} eats something the place can provide and watches the room continue its public life around them.
+
+### Branch 4 — Forage or hunt from the country  *(mag 0.38)*
+
+**When:**
+
+- **AND:**
+  - actor is in `wilderness` location class
+  - actor has any of [`forager`, `hunter`, `survivalist`, `ranger`, `scout`]
+
+**Does:** activity → "foraging for a meal"; fulfills `hunger` need, quality `wild_meal`, discharge 9999
+**Event:** `ate`
+
+> {actor} works the country for what the season has put within reach and makes a meal out of survival knowledge.
+
+### Branch 5 — Eat from rations or what was packed  *(mag 0.18)*
+
+**When:** actor has `travel_provisioned` tag
+
+**Does:** activity → "eating travel rations"; fulfills `hunger` need, quality `rations_meal`, discharge 9999
+**Event:** `ate`
+
+> {actor} eats what was packed for exactly this kind of hour: practical, portable, and enough.
+
+### Branch 6 — Find something and eat it  *(mag 0.14)*
+
+**When:** *(always)*
+
+**Does:** activity → "eating opportunistically"; fulfills `hunger` need, quality `opportunistic_meal`, discharge 9999
+**Event:** `ate`
+
+> {actor} eats what is nearest and workable, attentive mostly to the fact that the body can stop asking for now.
+
+---
+
 ## TEND_CRAFT — priority 15
 
 > A small act of care for the work that defines them.
@@ -913,6 +1117,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/024_orrery_commit_pipeline.sql`
 - `migrations/025_orrery_package_library_vocab.py`
 - `migrations/027_orrery_package_library_round2_vocab.py`
+- `migrations/028_orrery_sunhelm_needs.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 
@@ -930,15 +1135,19 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `devout`
 - `domestic_role`
 - `engineer`
+- `extended_household`
 - `fighter`
 - `first_aid_trained`
+- `forager`
 - `ghostprint_active`
 - `hacker`
+- `hunter`
 - `informant_handler`
 - `innkeeper`
 - `keeps_shop`
 - `loremaster`
 - `magical_healing`
+- `married`
 - `martial_artist`
 - `matriarch`
 - `mechanic`
@@ -946,6 +1155,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `merchant`
 - `monk`
 - `musician`
+- `parent`
 - `patriarch`
 - `performer`
 - `ranger`
@@ -956,8 +1166,10 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `seeking_identity`
 - `soldier`
 - `surgical_training`
+- `survivalist`
 - `tinkerer`
 - `trader`
+- `travel_provisioned`
 - `under_active_pursuit`
 - `vendetta_holder`
 - `violent_history`
@@ -968,6 +1180,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 
 - `bereaved`
 - `captive`
+- `cns_stimulated`
 - `debt_pulse_active`
 - `dying`
 - `grudge_active`
@@ -992,9 +1205,11 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 
 ### Event types
 
+- `ate`
 - `compliance_alert`
 - `contact_made`
 - `craft_tended`
+- `drank`
 - `encoded_message`
 - `evade_pursuit`
 - `faction_realignment`
@@ -1009,6 +1224,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `retaliation_attempted`
 - `retaliation_executed`
 - `rival_consulted`
+- `slept`
 - `tended_wound`
 - `threat_issued`
 - `vigil_held`

--- a/migrations/028_orrery_sunhelm_needs.py
+++ b/migrations/028_orrery_sunhelm_needs.py
@@ -1,0 +1,229 @@
+"""Add Orrery Sunhelm need-state substrate and vocabulary."""
+
+from __future__ import annotations
+
+
+NEED_TYPES = ("sleep", "hunger", "thirst")
+
+SEVERITY_TAGS = (
+    ("sleep_deprived_1_mild", "orrery_need", "Mild sleep debt."),
+    ("sleep_deprived_2_moderate", "orrery_need", "Moderate sleep debt."),
+    ("sleep_deprived_3_severe", "orrery_need", "Severe sleep debt."),
+    ("sleep_deprived_4_critical", "orrery_need", "Critical sleep debt."),
+    ("hungry_1_mild", "orrery_need", "Mild hunger debt."),
+    ("hungry_2_moderate", "orrery_need", "Moderate hunger debt."),
+    ("hungry_3_severe", "orrery_need", "Severe hunger debt."),
+    ("hungry_4_critical", "orrery_need", "Critical hunger debt."),
+    ("thirsty_1_mild", "orrery_need", "Mild thirst debt."),
+    ("thirsty_2_moderate", "orrery_need", "Moderate thirst debt."),
+    ("thirsty_3_severe", "orrery_need", "Severe thirst debt."),
+    ("thirsty_4_critical", "orrery_need", "Critical thirst debt."),
+    (
+        "bodyform:android",
+        "bodyform",
+        "Android bodyform; usually immune to embodied needs.",
+    ),
+    (
+        "bodyform:undead",
+        "bodyform",
+        "Undead bodyform; need behavior is setting-specific.",
+    ),
+    (
+        "bodyform:construct",
+        "bodyform",
+        "Construct bodyform; usually immune to embodied needs.",
+    ),
+    (
+        "bodyform:non_corporeal",
+        "bodyform",
+        "Non-corporeal bodyform; usually immune to embodied needs.",
+    ),
+    (
+        "bodyform:biologically_immortal",
+        "bodyform",
+        "Biologically immortal bodyform with setting-specific need curves.",
+    ),
+    ("sleep_schedule:diurnal", "orrery_schedule", "Default night-sleep schedule."),
+    ("sleep_schedule:nocturnal", "orrery_schedule", "Day-sleep schedule."),
+    ("sleep_schedule:nightshift", "orrery_schedule", "Work-at-night sleep schedule."),
+    ("sleep_schedule:siesta", "orrery_schedule", "Split sleep with a daytime rest."),
+    ("sleep_schedule:polyphasic", "orrery_schedule", "Multiple short sleep windows."),
+)
+
+EPHEMERAL_TAGS = (
+    (
+        "cns_stimulated",
+        "orrery_need_modifier",
+        "semantic",
+        '{"description": "cleared when the stimulant, magic, or equivalent fatigue suppressor wears off"}',
+        "Fatigue is physiologically accruing but sleep behavior is suppressed.",
+    ),
+)
+
+EVENT_TYPES = (
+    ("slept", "physiological", "minor", "A character fulfills sleep need."),
+    ("ate", "physiological", "minor", "A character fulfills hunger need."),
+    ("drank", "physiological", "minor", "A character fulfills thirst need."),
+)
+
+
+def run(conn) -> None:
+    """Apply the Sunhelm need-state migration."""
+
+    _create_need_type_enum(conn)
+    _create_need_state_table(conn)
+    _seed_durable_tags(conn)
+    _seed_ephemeral_tags(conn)
+    _seed_event_types(conn)
+    _backfill_need_states(conn)
+
+
+def _create_need_type_enum(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_type WHERE typname = 'character_need_type'
+                ) THEN
+                    CREATE TYPE character_need_type AS ENUM (
+                        'sleep', 'hunger', 'thirst'
+                    );
+                END IF;
+            END $$;
+            """
+        )
+    conn.commit()
+
+
+def _create_need_state_table(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS character_need_states (
+                character_entity_id bigint NOT NULL
+                    REFERENCES entities(id) ON DELETE CASCADE,
+                need_type character_need_type NOT NULL,
+                debt_score numeric(8, 2) NOT NULL DEFAULT 0,
+                last_evaluated_at timestamptz NOT NULL,
+                last_fulfilled_at timestamptz,
+                metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+                created_at timestamptz NOT NULL DEFAULT now(),
+                updated_at timestamptz NOT NULL DEFAULT now(),
+                PRIMARY KEY (character_entity_id, need_type),
+                CHECK (debt_score >= 0)
+            );
+
+            CREATE INDEX IF NOT EXISTS ix_character_need_states_need_debt
+                ON character_need_states (need_type, debt_score DESC);
+
+            COMMENT ON TABLE character_need_states IS
+                'Orrery Sunhelm need state: timestamp plus debt pressure per character need.';
+            COMMENT ON COLUMN character_need_states.debt_score IS
+                'Hours-equivalent homeostatic debt. Fulfillment may discharge partially.';
+            COMMENT ON COLUMN character_need_states.last_evaluated_at IS
+                'In-world timestamp through which debt_score has already accrued.';
+            COMMENT ON COLUMN character_need_states.last_fulfilled_at IS
+                'Last in-world fulfillment timestamp for audit and prose context.';
+            """
+        )
+    conn.commit()
+
+
+def _seed_durable_tags(conn) -> None:
+    with conn.cursor() as cur:
+        for tag, category, description in SEVERITY_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, %s, FALSE,
+                    NULL, NULL,
+                    NULL, %s
+                )
+                ON CONFLICT (tag) DO NOTHING
+                """,
+                (tag, category, description),
+            )
+    conn.commit()
+
+
+def _seed_ephemeral_tags(conn) -> None:
+    with conn.cursor() as cur:
+        for tag, category, clearance_kind, clear_on_json, description in EPHEMERAL_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, %s, TRUE,
+                    %s::entity_tag_clearance_kind,
+                    'extend_expiry'::entity_tag_reapplication_policy,
+                    %s::jsonb, %s
+                )
+                ON CONFLICT (tag) DO NOTHING
+                """,
+                (tag, category, clearance_kind, clear_on_json, description),
+            )
+    conn.commit()
+
+
+def _seed_event_types(conn) -> None:
+    with conn.cursor() as cur:
+        for event_type, category, severity, description in EVENT_TYPES:
+            cur.execute(
+                """
+                INSERT INTO event_types (
+                    type, category, severity, description
+                ) VALUES (
+                    %s, %s, %s::event_severity_kind, %s
+                )
+                ON CONFLICT (type) DO NOTHING
+                """,
+                (event_type, category, severity, description),
+            )
+    conn.commit()
+
+
+def _backfill_need_states(conn) -> None:
+    """Initialize forgiving need state rows for existing active characters."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            WITH clock AS (
+                SELECT COALESCE(MAX(world_time), now()) AS world_time
+                FROM chunk_metadata
+            ),
+            needs(need_type) AS (
+                VALUES ('sleep'), ('hunger'), ('thirst')
+            )
+            INSERT INTO character_need_states (
+                character_entity_id,
+                need_type,
+                debt_score,
+                last_evaluated_at,
+                metadata
+            )
+            SELECT c.entity_id,
+                   needs.need_type::character_need_type,
+                   0,
+                   clock.world_time,
+                   '{"backfilled": true}'::jsonb
+            FROM characters c
+            JOIN entities e ON e.id = c.entity_id
+            CROSS JOIN needs
+            CROSS JOIN clock
+            WHERE c.entity_id IS NOT NULL
+              AND e.kind = 'character'
+              AND e.is_active = true
+            ON CONFLICT (character_entity_id, need_type) DO NOTHING
+            """
+        )
+    conn.commit()

--- a/migrations/029_orrery_need_state_init_trigger.py
+++ b/migrations/029_orrery_need_state_init_trigger.py
@@ -1,0 +1,106 @@
+"""Initialize Sunhelm need state rows for newly-created characters."""
+
+from __future__ import annotations
+
+
+def run(conn) -> None:
+    """Install a trigger that keeps character_need_states initialized."""
+
+    _create_initializer_function(conn)
+    _install_initializer_trigger(conn)
+    _backfill_missing_need_states(conn)
+
+
+def _create_initializer_function(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE OR REPLACE FUNCTION orrery_initialize_character_need_states()
+            RETURNS trigger AS $$
+            DECLARE
+                anchor_world_time timestamptz;
+            BEGIN
+                IF NEW.entity_id IS NULL THEN
+                    RETURN NEW;
+                END IF;
+
+                SELECT COALESCE(MAX(world_time), now())
+                INTO anchor_world_time
+                FROM chunk_metadata;
+
+                INSERT INTO character_need_states (
+                    character_entity_id,
+                    need_type,
+                    debt_score,
+                    last_evaluated_at,
+                    metadata
+                )
+                SELECT NEW.entity_id,
+                       need_type::character_need_type,
+                       0,
+                       anchor_world_time,
+                       '{"initialized_by": "character_trigger"}'::jsonb
+                FROM (
+                    VALUES ('sleep'), ('hunger'), ('thirst')
+                ) AS needs(need_type)
+                ON CONFLICT (character_entity_id, need_type) DO NOTHING;
+
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+            """
+        )
+    conn.commit()
+
+
+def _install_initializer_trigger(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "DROP TRIGGER IF EXISTS trg_characters_need_state_init ON characters"
+        )
+        cur.execute(
+            """
+            CREATE TRIGGER trg_characters_need_state_init
+            AFTER INSERT OR UPDATE OF entity_id ON characters
+            FOR EACH ROW
+            WHEN (NEW.entity_id IS NOT NULL)
+            EXECUTE FUNCTION orrery_initialize_character_need_states()
+            """
+        )
+    conn.commit()
+
+
+def _backfill_missing_need_states(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            WITH clock AS (
+                SELECT COALESCE(MAX(world_time), now()) AS world_time
+                FROM chunk_metadata
+            ),
+            needs(need_type) AS (
+                VALUES ('sleep'), ('hunger'), ('thirst')
+            )
+            INSERT INTO character_need_states (
+                character_entity_id,
+                need_type,
+                debt_score,
+                last_evaluated_at,
+                metadata
+            )
+            SELECT c.entity_id,
+                   needs.need_type::character_need_type,
+                   0,
+                   clock.world_time,
+                   '{"backfilled_by": "migration_029"}'::jsonb
+            FROM characters c
+            JOIN entities e ON e.id = c.entity_id
+            CROSS JOIN needs
+            CROSS JOIN clock
+            WHERE c.entity_id IS NOT NULL
+              AND e.kind = 'character'
+              AND e.is_active = true
+            ON CONFLICT (character_entity_id, need_type) DO NOTHING
+            """
+        )
+    conn.commit()

--- a/nexus.toml
+++ b/nexus.toml
@@ -176,6 +176,34 @@ candidate_pool_multiplier = 4
 [orrery.promote]
 provider = "local"
 
+[orrery.sunhelm]
+accrual_rates = { sleep = 1.0, hunger = 1.0, thirst = 1.0 }
+priorities = { sleep = 25, thirst = 24, hunger = 22 }
+
+[orrery.sunhelm.severity_thresholds.sleep]
+mild = 16.0
+moderate = 30.0
+severe = 48.0
+critical = 72.0
+
+[orrery.sunhelm.severity_thresholds.hunger]
+mild = 8.0
+moderate = 16.0
+severe = 30.0
+critical = 48.0
+
+[orrery.sunhelm.severity_thresholds.thirst]
+mild = 4.0
+moderate = 8.0
+severe = 16.0
+critical = 24.0
+
+[orrery.sunhelm.pressure]
+min_severity_level = 2
+magnitude_base = 0.35
+magnitude_per_level = 0.10
+magnitude_cap = 0.85
+
 # =============================================================================
 # MEMNON Agent Settings (Memory & Retrieval)
 # =============================================================================

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -245,7 +245,7 @@ class LogonUtility:
             return StorytellerResponseBootstrap
 
         return StorytellerResponseExtended
-    
+
     def _format_context_prompt(self, context: Dict) -> str:
         """Format context payload into a prompt for the Apex AI"""
         sections = []
@@ -384,9 +384,11 @@ class LogonUtility:
         if scene_pressures:
             sections.append("\n=== ORRERY SCENE PRESSURE ===")
             sections.append(
-                "These are off-screen pressures involving current on-screen "
-                "characters. You may adapt, delay, ignore, or incorporate them. "
-                "Do not let Orrery decide what present characters do."
+                "These are Storyteller-mediated pressures involving current "
+                "on-screen characters. Some may originate from off-screen "
+                "actors; some may be present-character need pressure. You may "
+                "adapt, delay, ignore, or incorporate them. Do not let Orrery "
+                "decide what present characters do."
             )
             for pressure in scene_pressures[:5]:
                 if not isinstance(pressure, dict):

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -598,6 +598,7 @@ class TurnCycleManager:
                 BUILTIN_TEMPLATES,
                 anchor_chunk_id=anchor_chunk_id,
                 window_chunks=window_chunks,
+                sunhelm_settings=orrery_settings.get("sunhelm"),
             )
 
         turn_context.orrery_proposal = proposal
@@ -684,10 +685,7 @@ class TurnCycleManager:
         if turn_context.note:
             turn_context.context_payload["note"] = turn_context.note
 
-        if (
-            turn_context.orrery_proposal
-            and turn_context.orrery_proposal.pressure_count
-        ):
+        if turn_context.orrery_proposal and turn_context.orrery_proposal.pressure_count:
             turn_context.context_payload["orrery_scene_pressures"] = [
                 pressure.to_dict()
                 for pressure in turn_context.orrery_proposal.scene_pressures

--- a/nexus/agents/memnon/memnon.py
+++ b/nexus/agents/memnon/memnon.py
@@ -133,6 +133,7 @@ READONLY_SQL_ALLOWED_TABLES = {
     "entities",
     "entity_names_v",
     "entity_tags_current",
+    "character_need_states",
     "world_events",
     "world_event_entities",
     "orrery_resolutions",

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -81,6 +81,26 @@ _register(
     r"has_ephemeral\((?P<tag>[^@()]+)@(?P<slot>\w+)\)",
     lambda m: f"{_slot(m.group('slot'))} has `{m.group('tag')}` ephemeral",
 )
+_register(
+    r"has_severity_tag\((?P<prefix>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: f"{_slot(m.group('slot'))} has `{m.group('prefix')}` severity",
+)
+_register(
+    r"has_severity_tag_at_or_above\("
+    r"(?P<prefix>[^,()]+),(?P<level>\d+)@(?P<slot>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('slot'))} has `{m.group('prefix')}` severity "
+        f"level {m.group('level')}+"
+    ),
+)
+_register(
+    r"has_need_debt_at_or_above\("
+    r"(?P<need>[^,()]+),(?P<threshold>[\d.]+)@(?P<slot>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('slot'))} has `{m.group('need')}` debt ≥ "
+        f"{m.group('threshold')}"
+    ),
+)
 
 # Location predicates
 _register(
@@ -102,11 +122,7 @@ _register(
     lambda m: (
         f"{m.group('n')}+ other entities"
         + (f" with `{m.group('tag')}` tag" if m.group("tag") else "")
-        + (
-            f" with `{m.group('ephemeral')}` ephemeral"
-            if m.group("ephemeral")
-            else ""
-        )
+        + (f" with `{m.group('ephemeral')}` ephemeral" if m.group("ephemeral") else "")
         + f" co-located with {_slot(m.group('slot'))}"
     ),
 )
@@ -277,6 +293,20 @@ def _render_state_delta(delta: Mapping[str, Any]) -> str:
             target = "actor" if key == "entity_tags.remove" else "target"
             tags = ", ".join(f"`{t}`" for t in value)
             parts.append(f"removes {tags} from {target}")
+            continue
+        if key == "need.fulfill":
+            if isinstance(value, Mapping):
+                need = value.get("type") or value.get("need")
+                quality = value.get("quality")
+                discharge = value.get("discharge_debt") or value.get("discharge")
+                bits = [f"fulfills `{need}` need"]
+                if quality:
+                    bits.append(f"quality `{quality}`")
+                if discharge is not None:
+                    bits.append(f"discharge {discharge}")
+                parts.append(", ".join(bits))
+            else:
+                parts.append(f"fulfills `{value}` need")
             continue
         parts.append(f"`{key}` = `{value}`")
     return "; ".join(parts)

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -409,6 +409,11 @@ def _apply_state_delta_sync(
     if not draft.state_delta:
         return 0
     if actor_entity_id is None:
+        if "need.fulfill" in draft.state_delta:
+            raise ValueError(
+                f"need.fulfill in template {draft.template_id!r} "
+                "requires an actor binding"
+            )
         raise ValueError(f"Orrery draft {draft.template_id} has no actor binding")
 
     tag_mutations = 0
@@ -480,6 +485,11 @@ async def _apply_state_delta_async(
     if not draft.state_delta:
         return 0
     if actor_entity_id is None:
+        if "need.fulfill" in draft.state_delta:
+            raise ValueError(
+                f"need.fulfill in template {draft.template_id!r} "
+                "requires an actor binding"
+            )
         raise ValueError(f"Orrery draft {draft.template_id} has no actor binding")
 
     tag_mutations = 0
@@ -568,12 +578,17 @@ def _coerce_need_fulfillment(raw: Any) -> dict[str, Any]:
 def _apply_need_fulfillment_sync(
     cur: Any,
     *,
-    actor_entity_id: int,
+    actor_entity_id: Optional[int],
     fulfillment: Any,
     template_id: str,
     source_chunk_id: int,
     need_tuning: NeedTuning,
 ) -> int:
+    if actor_entity_id is None:
+        raise ValueError(
+            f"need.fulfill in template {template_id!r} requires an actor binding"
+        )
+
     payload = _coerce_need_fulfillment(fulfillment)
     need_type = payload["type"]
     world_time = _tick_world_time_sync(cur, source_chunk_id)
@@ -619,12 +634,17 @@ def _apply_need_fulfillment_sync(
 async def _apply_need_fulfillment_async(
     conn: Any,
     *,
-    actor_entity_id: int,
+    actor_entity_id: Optional[int],
     fulfillment: Any,
     template_id: str,
     source_chunk_id: int,
     need_tuning: NeedTuning,
 ) -> int:
+    if actor_entity_id is None:
+        raise ValueError(
+            f"need.fulfill in template {template_id!r} requires an actor binding"
+        )
+
     payload = _coerce_need_fulfillment(fulfillment)
     need_type = payload["type"]
     world_time = await _tick_world_time_async(conn, source_chunk_id)
@@ -783,7 +803,14 @@ def _sync_need_severity_tags_sync(
 ) -> int:
     mutations = 0
     desired = severity_tag_for_debt(need_type, debt_score, tuning=need_tuning)
-    for tag in severity_tags_for_need(need_type):
+    current_tags = _current_need_severity_tags_sync(
+        cur,
+        actor_entity_id=actor_entity_id,
+        need_type=need_type,
+    )
+    for tag in current_tags:
+        if tag == desired:
+            continue
         mutations += _remove_entity_tag_sync(
             cur,
             actor_entity_id,
@@ -792,7 +819,11 @@ def _sync_need_severity_tags_sync(
             source_chunk_id=source_chunk_id,
             delta_key="need.fulfill",
         )
-    if desired and _add_entity_tag_sync(cur, actor_entity_id, desired, template_id):
+    if (
+        desired
+        and desired not in current_tags
+        and _add_entity_tag_sync(cur, actor_entity_id, desired, template_id)
+    ):
         mutations += 1
     return mutations
 
@@ -809,7 +840,14 @@ async def _sync_need_severity_tags_async(
 ) -> int:
     mutations = 0
     desired = severity_tag_for_debt(need_type, debt_score, tuning=need_tuning)
-    for tag in severity_tags_for_need(need_type):
+    current_tags = await _current_need_severity_tags_async(
+        conn,
+        actor_entity_id=actor_entity_id,
+        need_type=need_type,
+    )
+    for tag in current_tags:
+        if tag == desired:
+            continue
         mutations += await _remove_entity_tag_async(
             conn,
             actor_entity_id,
@@ -818,11 +856,56 @@ async def _sync_need_severity_tags_async(
             source_chunk_id=source_chunk_id,
             delta_key="need.fulfill",
         )
-    if desired and await _add_entity_tag_async(
-        conn, actor_entity_id, desired, template_id
+    if (
+        desired
+        and desired not in current_tags
+        and await _add_entity_tag_async(conn, actor_entity_id, desired, template_id)
     ):
         mutations += 1
     return mutations
+
+
+def _current_need_severity_tags_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    need_type: str,
+) -> frozenset[str]:
+    tags = severity_tags_for_need(need_type)
+    cur.execute(
+        """
+        SELECT t.tag
+        FROM entity_tags et
+        JOIN tags t ON t.id = et.tag_id
+        WHERE et.entity_id = %s
+          AND t.tag = ANY(%s)
+          AND et.cleared_at IS NULL
+        """,
+        (actor_entity_id, list(tags)),
+    )
+    return frozenset(str(_row_get(row, "tag", 0)) for row in cur.fetchall())
+
+
+async def _current_need_severity_tags_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    need_type: str,
+) -> frozenset[str]:
+    tags = severity_tags_for_need(need_type)
+    rows = await conn.fetch(
+        """
+        SELECT t.tag
+        FROM entity_tags et
+        JOIN tags t ON t.id = et.tag_id
+        WHERE et.entity_id = $1
+          AND t.tag = ANY($2::text[])
+          AND et.cleared_at IS NULL
+        """,
+        actor_entity_id,
+        list(tags),
+    )
+    return frozenset(str(_row_get(row, "tag", 0)) for row in rows)
 
 
 def _add_entity_tag_sync(

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -12,7 +12,8 @@ import json
 from typing import Any, Mapping, Optional
 
 from nexus.agents.orrery.needs import (
-    NEED_ACCRUAL_RATES,
+    NeedTuning,
+    coerce_need_tuning,
     severity_tag_for_debt,
     severity_tags_for_need,
     normalize_need_type,
@@ -68,6 +69,7 @@ def commit_orrery_tick_sync(
     tick_chunk_id: int,
     slot: Optional[int] = None,
     world_layer: Optional[str] = "primary",
+    sunhelm_settings: Optional[Any] = None,
 ) -> CommitOrreryTickResult:
     """Materialize a preview proposal inside the accepted-chunk transaction."""
 
@@ -75,6 +77,7 @@ def commit_orrery_tick_sync(
     if coerced is None or not coerced.resolutions:
         return CommitOrreryTickResult()
 
+    need_tuning = coerce_need_tuning(sunhelm_settings)
     _validate_proposal(coerced)
     with conn.cursor() as cur:
         entity_ids = _entity_ids_from_proposal(coerced)
@@ -109,6 +112,7 @@ def commit_orrery_tick_sync(
                 actor_entity_id=actor_entity_id,
                 target_entity_id=target_entity_id,
                 source_chunk_id=tick_chunk_id,
+                need_tuning=need_tuning,
             )
             event_id = _emit_world_event_sync(
                 cur,
@@ -147,6 +151,7 @@ async def commit_orrery_tick_async(
     tick_chunk_id: int,
     slot: Optional[int] = None,
     world_layer: Optional[str] = "primary",
+    sunhelm_settings: Optional[Any] = None,
 ) -> CommitOrreryTickResult:
     """Async parity wrapper for tests and non-production commit callers."""
 
@@ -154,6 +159,7 @@ async def commit_orrery_tick_async(
     if coerced is None or not coerced.resolutions:
         return CommitOrreryTickResult()
 
+    need_tuning = coerce_need_tuning(sunhelm_settings)
     _validate_proposal(coerced)
     entity_ids = _entity_ids_from_proposal(coerced)
     await _validate_entity_ids_async(conn, entity_ids)
@@ -187,6 +193,7 @@ async def commit_orrery_tick_async(
             actor_entity_id=actor_entity_id,
             target_entity_id=target_entity_id,
             source_chunk_id=tick_chunk_id,
+            need_tuning=need_tuning,
         )
         event_id = await _emit_world_event_async(
             conn,
@@ -397,6 +404,7 @@ def _apply_state_delta_sync(
     actor_entity_id: Optional[int],
     target_entity_id: Optional[int],
     source_chunk_id: int,
+    need_tuning: NeedTuning,
 ) -> int:
     if not draft.state_delta:
         return 0
@@ -455,6 +463,7 @@ def _apply_state_delta_sync(
             fulfillment=draft.state_delta["need.fulfill"],
             template_id=draft.template_id,
             source_chunk_id=source_chunk_id,
+            need_tuning=need_tuning,
         )
     return tag_mutations
 
@@ -466,6 +475,7 @@ async def _apply_state_delta_async(
     actor_entity_id: Optional[int],
     target_entity_id: Optional[int],
     source_chunk_id: int,
+    need_tuning: NeedTuning,
 ) -> int:
     if not draft.state_delta:
         return 0
@@ -526,6 +536,7 @@ async def _apply_state_delta_async(
             fulfillment=draft.state_delta["need.fulfill"],
             template_id=draft.template_id,
             source_chunk_id=source_chunk_id,
+            need_tuning=need_tuning,
         )
     return tag_mutations
 
@@ -540,7 +551,11 @@ def _coerce_need_fulfillment(raw: Any) -> dict[str, Any]:
     else:
         raise ValueError("need.fulfill must be a string or mapping")
 
-    need_type = normalize_need_type(str(payload.get("type") or payload.get("need")))
+    raw_need_type = payload.get("type") or payload.get("need")
+    if raw_need_type is None:
+        raise ValueError("need.fulfill must include a 'type' or 'need' field")
+
+    need_type = normalize_need_type(str(raw_need_type))
     discharge = payload.get("discharge_debt", payload.get("discharge", 9999.0))
     try:
         payload["discharge_debt"] = float(discharge)
@@ -557,6 +572,7 @@ def _apply_need_fulfillment_sync(
     fulfillment: Any,
     template_id: str,
     source_chunk_id: int,
+    need_tuning: NeedTuning,
 ) -> int:
     payload = _coerce_need_fulfillment(fulfillment)
     need_type = payload["type"]
@@ -566,6 +582,7 @@ def _apply_need_fulfillment_sync(
         actor_entity_id=actor_entity_id,
         need_type=need_type,
         world_time=world_time,
+        need_tuning=need_tuning,
     )
     new_debt = max(0.0, current_debt - float(payload["discharge_debt"]))
     cur.execute(
@@ -595,6 +612,7 @@ def _apply_need_fulfillment_sync(
         debt_score=new_debt,
         template_id=template_id,
         source_chunk_id=source_chunk_id,
+        need_tuning=need_tuning,
     )
 
 
@@ -605,6 +623,7 @@ async def _apply_need_fulfillment_async(
     fulfillment: Any,
     template_id: str,
     source_chunk_id: int,
+    need_tuning: NeedTuning,
 ) -> int:
     payload = _coerce_need_fulfillment(fulfillment)
     need_type = payload["type"]
@@ -614,6 +633,7 @@ async def _apply_need_fulfillment_async(
         actor_entity_id=actor_entity_id,
         need_type=need_type,
         world_time=world_time,
+        need_tuning=need_tuning,
     )
     new_debt = max(0.0, current_debt - float(payload["discharge_debt"]))
     await conn.execute(
@@ -641,6 +661,7 @@ async def _apply_need_fulfillment_async(
         debt_score=new_debt,
         template_id=template_id,
         source_chunk_id=source_chunk_id,
+        need_tuning=need_tuning,
     )
 
 
@@ -672,6 +693,7 @@ def _load_or_create_need_debt_sync(
     actor_entity_id: int,
     need_type: str,
     world_time: Any,
+    need_tuning: NeedTuning,
 ) -> float:
     cur.execute(
         """
@@ -703,7 +725,7 @@ def _load_or_create_need_debt_sync(
     elapsed = (world_time - last_evaluated_at).total_seconds() / 3600.0
     if elapsed <= 0:
         return max(0.0, debt_score)
-    return max(0.0, debt_score + elapsed * NEED_ACCRUAL_RATES[need_type])
+    return max(0.0, debt_score + elapsed * need_tuning.accrual_rates[need_type])
 
 
 async def _load_or_create_need_debt_async(
@@ -712,6 +734,7 @@ async def _load_or_create_need_debt_async(
     actor_entity_id: int,
     need_type: str,
     world_time: Any,
+    need_tuning: NeedTuning,
 ) -> float:
     await conn.execute(
         """
@@ -745,7 +768,7 @@ async def _load_or_create_need_debt_async(
     elapsed = (world_time - last_evaluated_at).total_seconds() / 3600.0
     if elapsed <= 0:
         return max(0.0, debt_score)
-    return max(0.0, debt_score + elapsed * NEED_ACCRUAL_RATES[need_type])
+    return max(0.0, debt_score + elapsed * need_tuning.accrual_rates[need_type])
 
 
 def _sync_need_severity_tags_sync(
@@ -756,9 +779,10 @@ def _sync_need_severity_tags_sync(
     debt_score: float,
     template_id: str,
     source_chunk_id: int,
+    need_tuning: NeedTuning,
 ) -> int:
     mutations = 0
-    desired = severity_tag_for_debt(need_type, debt_score)
+    desired = severity_tag_for_debt(need_type, debt_score, tuning=need_tuning)
     for tag in severity_tags_for_need(need_type):
         mutations += _remove_entity_tag_sync(
             cur,
@@ -781,9 +805,10 @@ async def _sync_need_severity_tags_async(
     debt_score: float,
     template_id: str,
     source_chunk_id: int,
+    need_tuning: NeedTuning,
 ) -> int:
     mutations = 0
-    desired = severity_tag_for_debt(need_type, debt_score)
+    desired = severity_tag_for_debt(need_type, debt_score, tuning=need_tuning)
     for tag in severity_tags_for_need(need_type):
         mutations += await _remove_entity_tag_async(
             conn,

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -11,6 +11,12 @@ from dataclasses import dataclass
 import json
 from typing import Any, Mapping, Optional
 
+from nexus.agents.orrery.needs import (
+    NEED_ACCRUAL_RATES,
+    severity_tag_for_debt,
+    severity_tags_for_need,
+    normalize_need_type,
+)
 from nexus.agents.orrery.resolver import (
     OrreryResolutionDraft,
     OrreryTickProposal,
@@ -25,6 +31,7 @@ SUPPORTED_STATE_DELTA_KEYS = frozenset(
         "entity_tags.remove",
         "entity_tags_target.add",
         "entity_tags_target.remove",
+        "need.fulfill",
     }
 )
 
@@ -441,6 +448,14 @@ def _apply_state_delta_sync(
             source_chunk_id=source_chunk_id,
             delta_key="entity_tags_target.remove",
         )
+    if "need.fulfill" in draft.state_delta:
+        tag_mutations += _apply_need_fulfillment_sync(
+            cur,
+            actor_entity_id=actor_entity_id,
+            fulfillment=draft.state_delta["need.fulfill"],
+            template_id=draft.template_id,
+            source_chunk_id=source_chunk_id,
+        )
     return tag_mutations
 
 
@@ -504,7 +519,285 @@ async def _apply_state_delta_async(
             source_chunk_id=source_chunk_id,
             delta_key="entity_tags_target.remove",
         )
+    if "need.fulfill" in draft.state_delta:
+        tag_mutations += await _apply_need_fulfillment_async(
+            conn,
+            actor_entity_id=actor_entity_id,
+            fulfillment=draft.state_delta["need.fulfill"],
+            template_id=draft.template_id,
+            source_chunk_id=source_chunk_id,
+        )
     return tag_mutations
+
+
+def _coerce_need_fulfillment(raw: Any) -> dict[str, Any]:
+    """Normalize a template's typed need-fulfillment effect."""
+
+    if isinstance(raw, str):
+        payload: dict[str, Any] = {"type": raw}
+    elif isinstance(raw, Mapping):
+        payload = dict(raw)
+    else:
+        raise ValueError("need.fulfill must be a string or mapping")
+
+    need_type = normalize_need_type(str(payload.get("type") or payload.get("need")))
+    discharge = payload.get("discharge_debt", payload.get("discharge", 9999.0))
+    try:
+        payload["discharge_debt"] = float(discharge)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("need.fulfill discharge_debt must be numeric") from exc
+    payload["type"] = need_type
+    return payload
+
+
+def _apply_need_fulfillment_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    fulfillment: Any,
+    template_id: str,
+    source_chunk_id: int,
+) -> int:
+    payload = _coerce_need_fulfillment(fulfillment)
+    need_type = payload["type"]
+    world_time = _tick_world_time_sync(cur, source_chunk_id)
+    current_debt = _load_or_create_need_debt_sync(
+        cur,
+        actor_entity_id=actor_entity_id,
+        need_type=need_type,
+        world_time=world_time,
+    )
+    new_debt = max(0.0, current_debt - float(payload["discharge_debt"]))
+    cur.execute(
+        """
+        UPDATE character_need_states
+        SET debt_score = %s,
+            last_evaluated_at = %s,
+            last_fulfilled_at = %s,
+            updated_at = now(),
+            metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb
+        WHERE character_entity_id = %s
+          AND need_type = %s::character_need_type
+        """,
+        (
+            new_debt,
+            world_time,
+            world_time,
+            json.dumps({"last_fulfillment": payload}),
+            actor_entity_id,
+            need_type,
+        ),
+    )
+    return _sync_need_severity_tags_sync(
+        cur,
+        actor_entity_id=actor_entity_id,
+        need_type=need_type,
+        debt_score=new_debt,
+        template_id=template_id,
+        source_chunk_id=source_chunk_id,
+    )
+
+
+async def _apply_need_fulfillment_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    fulfillment: Any,
+    template_id: str,
+    source_chunk_id: int,
+) -> int:
+    payload = _coerce_need_fulfillment(fulfillment)
+    need_type = payload["type"]
+    world_time = await _tick_world_time_async(conn, source_chunk_id)
+    current_debt = await _load_or_create_need_debt_async(
+        conn,
+        actor_entity_id=actor_entity_id,
+        need_type=need_type,
+        world_time=world_time,
+    )
+    new_debt = max(0.0, current_debt - float(payload["discharge_debt"]))
+    await conn.execute(
+        """
+        UPDATE character_need_states
+        SET debt_score = $1,
+            last_evaluated_at = $2,
+            last_fulfilled_at = $3,
+            updated_at = now(),
+            metadata = COALESCE(metadata, '{}'::jsonb) || $4::jsonb
+        WHERE character_entity_id = $5
+          AND need_type = $6::character_need_type
+        """,
+        new_debt,
+        world_time,
+        world_time,
+        json.dumps({"last_fulfillment": payload}),
+        actor_entity_id,
+        need_type,
+    )
+    return await _sync_need_severity_tags_async(
+        conn,
+        actor_entity_id=actor_entity_id,
+        need_type=need_type,
+        debt_score=new_debt,
+        template_id=template_id,
+        source_chunk_id=source_chunk_id,
+    )
+
+
+def _tick_world_time_sync(cur: Any, source_chunk_id: int) -> Any:
+    cur.execute(
+        "SELECT world_time FROM chunk_metadata WHERE chunk_id = %s",
+        (source_chunk_id,),
+    )
+    row = cur.fetchone()
+    if row and _row_get(row, "world_time", 0) is not None:
+        return _row_get(row, "world_time", 0)
+    cur.execute("SELECT now() AS world_time")
+    return _row_get(cur.fetchone(), "world_time", 0)
+
+
+async def _tick_world_time_async(conn: Any, source_chunk_id: int) -> Any:
+    world_time = await conn.fetchval(
+        "SELECT world_time FROM chunk_metadata WHERE chunk_id = $1",
+        source_chunk_id,
+    )
+    if world_time is not None:
+        return world_time
+    return await conn.fetchval("SELECT now()")
+
+
+def _load_or_create_need_debt_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    need_type: str,
+    world_time: Any,
+) -> float:
+    cur.execute(
+        """
+        INSERT INTO character_need_states (
+            character_entity_id, need_type, debt_score, last_evaluated_at
+        ) VALUES (
+            %s, %s::character_need_type, 0, %s
+        )
+        ON CONFLICT (character_entity_id, need_type) DO NOTHING
+        """,
+        (actor_entity_id, need_type, world_time),
+    )
+    cur.execute(
+        """
+        SELECT debt_score, last_evaluated_at
+        FROM character_need_states
+        WHERE character_entity_id = %s
+          AND need_type = %s::character_need_type
+        """,
+        (actor_entity_id, need_type),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(
+            f"Orrery need state missing for actor {actor_entity_id} {need_type}"
+        )
+    debt_score = float(_row_get(row, "debt_score", 0) or 0.0)
+    last_evaluated_at = _row_get(row, "last_evaluated_at", 1)
+    elapsed = (world_time - last_evaluated_at).total_seconds() / 3600.0
+    if elapsed <= 0:
+        return max(0.0, debt_score)
+    return max(0.0, debt_score + elapsed * NEED_ACCRUAL_RATES[need_type])
+
+
+async def _load_or_create_need_debt_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    need_type: str,
+    world_time: Any,
+) -> float:
+    await conn.execute(
+        """
+        INSERT INTO character_need_states (
+            character_entity_id, need_type, debt_score, last_evaluated_at
+        ) VALUES (
+            $1, $2::character_need_type, 0, $3
+        )
+        ON CONFLICT (character_entity_id, need_type) DO NOTHING
+        """,
+        actor_entity_id,
+        need_type,
+        world_time,
+    )
+    row = await conn.fetchrow(
+        """
+        SELECT debt_score, last_evaluated_at
+        FROM character_need_states
+        WHERE character_entity_id = $1
+          AND need_type = $2::character_need_type
+        """,
+        actor_entity_id,
+        need_type,
+    )
+    if row is None:
+        raise ValueError(
+            f"Orrery need state missing for actor {actor_entity_id} {need_type}"
+        )
+    debt_score = float(_row_get(row, "debt_score", 0) or 0.0)
+    last_evaluated_at = _row_get(row, "last_evaluated_at", 1)
+    elapsed = (world_time - last_evaluated_at).total_seconds() / 3600.0
+    if elapsed <= 0:
+        return max(0.0, debt_score)
+    return max(0.0, debt_score + elapsed * NEED_ACCRUAL_RATES[need_type])
+
+
+def _sync_need_severity_tags_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    need_type: str,
+    debt_score: float,
+    template_id: str,
+    source_chunk_id: int,
+) -> int:
+    mutations = 0
+    desired = severity_tag_for_debt(need_type, debt_score)
+    for tag in severity_tags_for_need(need_type):
+        mutations += _remove_entity_tag_sync(
+            cur,
+            actor_entity_id,
+            tag,
+            template_id,
+            source_chunk_id=source_chunk_id,
+            delta_key="need.fulfill",
+        )
+    if desired and _add_entity_tag_sync(cur, actor_entity_id, desired, template_id):
+        mutations += 1
+    return mutations
+
+
+async def _sync_need_severity_tags_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    need_type: str,
+    debt_score: float,
+    template_id: str,
+    source_chunk_id: int,
+) -> int:
+    mutations = 0
+    desired = severity_tag_for_debt(need_type, debt_score)
+    for tag in severity_tags_for_need(need_type):
+        mutations += await _remove_entity_tag_async(
+            conn,
+            actor_entity_id,
+            tag,
+            template_id,
+            source_chunk_id=source_chunk_id,
+            delta_key="need.fulfill",
+        )
+    if desired and await _add_entity_tag_async(
+        conn, actor_entity_id, desired, template_id
+    ):
+        mutations += 1
+    return mutations
 
 
 def _add_entity_tag_sync(

--- a/nexus/agents/orrery/needs.py
+++ b/nexus/agents/orrery/needs.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Mapping, Optional, Sequence
+from functools import lru_cache
+from typing import Any, Mapping, Optional
 
 
 class NeedType(str, Enum):
@@ -16,37 +18,182 @@ class NeedType(str, Enum):
 
 
 NEED_TYPES: tuple[str, ...] = tuple(item.value for item in NeedType)
-NEED_ACCRUAL_RATES: Mapping[str, float] = {
-    NeedType.SLEEP.value: 1.0,
-    NeedType.HUNGER.value: 1.0,
-    NeedType.THIRST.value: 1.0,
-}
 NEED_SEVERITY_PREFIX: Mapping[str, str] = {
     NeedType.SLEEP.value: "sleep_deprived",
     NeedType.HUNGER.value: "hungry",
     NeedType.THIRST.value: "thirsty",
 }
-
-NEED_SEVERITY_THRESHOLDS: Mapping[str, Sequence[tuple[float, int, str]]] = {
-    NeedType.SLEEP.value: (
-        (72.0, 4, "critical"),
-        (48.0, 3, "severe"),
-        (30.0, 2, "moderate"),
-        (16.0, 1, "mild"),
-    ),
-    NeedType.HUNGER.value: (
-        (48.0, 4, "critical"),
-        (30.0, 3, "severe"),
-        (16.0, 2, "moderate"),
-        (8.0, 1, "mild"),
-    ),
-    NeedType.THIRST.value: (
-        (24.0, 4, "critical"),
-        (16.0, 3, "severe"),
-        (8.0, 2, "moderate"),
-        (4.0, 1, "mild"),
-    ),
+NEED_SEVERITY_LEVELS: tuple[tuple[int, str], ...] = (
+    (4, "critical"),
+    (3, "severe"),
+    (2, "moderate"),
+    (1, "mild"),
+)
+DEFAULT_NEED_ACCRUAL_RATES: Mapping[str, float] = {
+    NeedType.SLEEP.value: 1.0,
+    NeedType.HUNGER.value: 1.0,
+    NeedType.THIRST.value: 1.0,
 }
+DEFAULT_NEED_SEVERITY_THRESHOLDS: Mapping[str, Mapping[str, float]] = {
+    NeedType.SLEEP.value: {
+        "mild": 16.0,
+        "moderate": 30.0,
+        "severe": 48.0,
+        "critical": 72.0,
+    },
+    NeedType.HUNGER.value: {
+        "mild": 8.0,
+        "moderate": 16.0,
+        "severe": 30.0,
+        "critical": 48.0,
+    },
+    NeedType.THIRST.value: {
+        "mild": 4.0,
+        "moderate": 8.0,
+        "severe": 16.0,
+        "critical": 24.0,
+    },
+}
+DEFAULT_NEED_PRIORITIES: Mapping[str, int] = {
+    NeedType.SLEEP.value: 25,
+    NeedType.THIRST.value: 24,
+    NeedType.HUNGER.value: 22,
+}
+
+# Backward-compatible aliases for older tests and scripts that import constants.
+NEED_ACCRUAL_RATES = DEFAULT_NEED_ACCRUAL_RATES
+
+
+@dataclass(frozen=True, slots=True)
+class NeedPressureTuning:
+    """Configurable prompt-pressure behavior for present-character needs."""
+
+    min_severity_level: int = 2
+    magnitude_base: float = 0.35
+    magnitude_per_level: float = 0.10
+    magnitude_cap: float = 0.85
+
+    @classmethod
+    def from_mapping(cls, raw: Optional[Mapping[str, Any]]) -> "NeedPressureTuning":
+        """Build tuning from a settings mapping, preserving defaults."""
+
+        if raw is None:
+            return cls()
+        return cls(
+            min_severity_level=int(raw.get("min_severity_level", 2)),
+            magnitude_base=float(raw.get("magnitude_base", 0.35)),
+            magnitude_per_level=float(raw.get("magnitude_per_level", 0.10)),
+            magnitude_cap=float(raw.get("magnitude_cap", 0.85)),
+        )
+
+    def magnitude_for_level(self, level: int) -> float:
+        """Return a bounded scene-pressure magnitude for a severity level."""
+
+        return min(
+            self.magnitude_cap,
+            self.magnitude_base + float(level) * self.magnitude_per_level,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class NeedTuning:
+    """Configurable Sunhelm need tuning loaded from ``nexus.toml``."""
+
+    accrual_rates: Mapping[str, float]
+    severity_thresholds: Mapping[str, Mapping[str, float]]
+    priorities: Mapping[str, int]
+    pressure: NeedPressureTuning
+
+    @classmethod
+    def default(cls) -> "NeedTuning":
+        """Return default tuning matching the committed ``nexus.toml`` values."""
+
+        return cls(
+            accrual_rates=dict(DEFAULT_NEED_ACCRUAL_RATES),
+            severity_thresholds={
+                need_type: dict(thresholds)
+                for need_type, thresholds in DEFAULT_NEED_SEVERITY_THRESHOLDS.items()
+            },
+            priorities=dict(DEFAULT_NEED_PRIORITIES),
+            pressure=NeedPressureTuning(),
+        )
+
+    @classmethod
+    def from_mapping(cls, raw: Optional[Mapping[str, Any]]) -> "NeedTuning":
+        """Build tuning from a Sunhelm settings mapping."""
+
+        if raw is None:
+            return cls.default()
+
+        accrual_rates = _coerce_need_mapping(
+            raw.get("accrual_rates"),
+            defaults=DEFAULT_NEED_ACCRUAL_RATES,
+            cast=float,
+        )
+        priorities = _coerce_need_mapping(
+            raw.get("priorities"),
+            defaults=DEFAULT_NEED_PRIORITIES,
+            cast=int,
+        )
+        raw_thresholds = raw.get("severity_thresholds") or {}
+        severity_thresholds: dict[str, dict[str, float]] = {}
+        for need_type in NEED_TYPES:
+            configured = raw_thresholds.get(need_type) or {}
+            defaults = DEFAULT_NEED_SEVERITY_THRESHOLDS[need_type]
+            severity_thresholds[need_type] = {
+                name: float(configured.get(name, defaults[name]))
+                for _level, name in NEED_SEVERITY_LEVELS
+            }
+
+        return cls(
+            accrual_rates=accrual_rates,
+            severity_thresholds=severity_thresholds,
+            priorities=priorities,
+            pressure=NeedPressureTuning.from_mapping(raw.get("pressure")),
+        )
+
+
+def _coerce_need_mapping(
+    raw: Any,
+    *,
+    defaults: Mapping[str, Any],
+    cast: type,
+) -> dict[str, Any]:
+    values = dict(defaults)
+    if raw:
+        for need_type, value in dict(raw).items():
+            values[normalize_need_type(str(need_type))] = cast(value)
+    return values
+
+
+def coerce_need_tuning(raw: Optional[Any] = None) -> NeedTuning:
+    """Return need tuning from settings, a ``NeedTuning``, or ``nexus.toml``."""
+
+    if isinstance(raw, NeedTuning):
+        return raw
+    if raw is None:
+        return load_need_tuning()
+    if hasattr(raw, "model_dump"):
+        raw = raw.model_dump()
+    if isinstance(raw, Mapping):
+        if "orrery" in raw:
+            raw = (raw.get("orrery") or {}).get("sunhelm")
+        elif "sunhelm" in raw:
+            raw = raw.get("sunhelm")
+        return NeedTuning.from_mapping(raw)
+    raise TypeError(f"Unsupported Sunhelm tuning payload: {type(raw).__name__}")
+
+
+@lru_cache(maxsize=1)
+def load_need_tuning() -> NeedTuning:
+    """Load Sunhelm tuning from ``nexus.toml`` through the validated config."""
+
+    from nexus.config import load_settings
+
+    settings = load_settings()
+    if settings.orrery is None:
+        return NeedTuning.default()
+    return NeedTuning.from_mapping(settings.orrery.sunhelm.model_dump())
 
 
 def normalize_need_type(need_type: str) -> str:
@@ -64,9 +211,11 @@ def effective_debt_score(
     *,
     last_evaluated_at: Optional[datetime],
     current_world_time: Optional[datetime],
+    tuning: Optional[NeedTuning] = None,
 ) -> float:
     """Return debt after accruing elapsed world time without mutating state."""
 
+    tuning = tuning or load_need_tuning()
     normalized = normalize_need_type(need_type)
     if last_evaluated_at is None or current_world_time is None:
         return max(0.0, float(debt_score))
@@ -76,25 +225,37 @@ def effective_debt_score(
         return max(0.0, float(debt_score))
 
     elapsed_hours = elapsed_seconds / 3600.0
-    accrued = elapsed_hours * NEED_ACCRUAL_RATES[normalized]
+    accrued = elapsed_hours * tuning.accrual_rates[normalized]
     return max(0.0, float(debt_score) + accrued)
 
 
-def severity_for_debt(need_type: str, debt_score: float) -> Optional[tuple[int, str]]:
+def severity_for_debt(
+    need_type: str,
+    debt_score: float,
+    *,
+    tuning: Optional[NeedTuning] = None,
+) -> Optional[tuple[int, str]]:
     """Return the severity level/name for a need debt score, if any."""
 
+    tuning = tuning or load_need_tuning()
     normalized = normalize_need_type(need_type)
-    for threshold, level, name in NEED_SEVERITY_THRESHOLDS[normalized]:
-        if debt_score >= threshold:
+    thresholds = tuning.severity_thresholds[normalized]
+    for level, name in NEED_SEVERITY_LEVELS:
+        if debt_score >= thresholds[name]:
             return level, name
     return None
 
 
-def severity_tag_for_debt(need_type: str, debt_score: float) -> Optional[str]:
+def severity_tag_for_debt(
+    need_type: str,
+    debt_score: float,
+    *,
+    tuning: Optional[NeedTuning] = None,
+) -> Optional[str]:
     """Return the registered severity tag for a need debt score, if any."""
 
     normalized = normalize_need_type(need_type)
-    severity = severity_for_debt(normalized, debt_score)
+    severity = severity_for_debt(normalized, debt_score, tuning=tuning)
     if severity is None:
         return None
     level, name = severity
@@ -107,6 +268,5 @@ def severity_tags_for_need(need_type: str) -> tuple[str, ...]:
     normalized = normalize_need_type(need_type)
     prefix = NEED_SEVERITY_PREFIX[normalized]
     return tuple(
-        f"{prefix}_{level}_{name}"
-        for _threshold, level, name in reversed(NEED_SEVERITY_THRESHOLDS[normalized])
+        f"{prefix}_{level}_{name}" for level, name in reversed(NEED_SEVERITY_LEVELS)
     )

--- a/nexus/agents/orrery/needs.py
+++ b/nexus/agents/orrery/needs.py
@@ -1,0 +1,112 @@
+"""Shared helpers for Orrery basic-need state."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Mapping, Optional, Sequence
+
+
+class NeedType(str, Enum):
+    """Basic physiological needs tracked by the Sunhelm substrate."""
+
+    SLEEP = "sleep"
+    HUNGER = "hunger"
+    THIRST = "thirst"
+
+
+NEED_TYPES: tuple[str, ...] = tuple(item.value for item in NeedType)
+NEED_ACCRUAL_RATES: Mapping[str, float] = {
+    NeedType.SLEEP.value: 1.0,
+    NeedType.HUNGER.value: 1.0,
+    NeedType.THIRST.value: 1.0,
+}
+NEED_SEVERITY_PREFIX: Mapping[str, str] = {
+    NeedType.SLEEP.value: "sleep_deprived",
+    NeedType.HUNGER.value: "hungry",
+    NeedType.THIRST.value: "thirsty",
+}
+
+NEED_SEVERITY_THRESHOLDS: Mapping[str, Sequence[tuple[float, int, str]]] = {
+    NeedType.SLEEP.value: (
+        (72.0, 4, "critical"),
+        (48.0, 3, "severe"),
+        (30.0, 2, "moderate"),
+        (16.0, 1, "mild"),
+    ),
+    NeedType.HUNGER.value: (
+        (48.0, 4, "critical"),
+        (30.0, 3, "severe"),
+        (16.0, 2, "moderate"),
+        (8.0, 1, "mild"),
+    ),
+    NeedType.THIRST.value: (
+        (24.0, 4, "critical"),
+        (16.0, 3, "severe"),
+        (8.0, 2, "moderate"),
+        (4.0, 1, "mild"),
+    ),
+}
+
+
+def normalize_need_type(need_type: str) -> str:
+    """Return a canonical need type or raise for unsupported input."""
+
+    normalized = str(need_type).lower()
+    if normalized not in NEED_TYPES:
+        raise ValueError(f"Unsupported Orrery need type: {need_type!r}")
+    return normalized
+
+
+def effective_debt_score(
+    need_type: str,
+    debt_score: float,
+    *,
+    last_evaluated_at: Optional[datetime],
+    current_world_time: Optional[datetime],
+) -> float:
+    """Return debt after accruing elapsed world time without mutating state."""
+
+    normalized = normalize_need_type(need_type)
+    if last_evaluated_at is None or current_world_time is None:
+        return max(0.0, float(debt_score))
+
+    elapsed_seconds = (current_world_time - last_evaluated_at).total_seconds()
+    if elapsed_seconds <= 0:
+        return max(0.0, float(debt_score))
+
+    elapsed_hours = elapsed_seconds / 3600.0
+    accrued = elapsed_hours * NEED_ACCRUAL_RATES[normalized]
+    return max(0.0, float(debt_score) + accrued)
+
+
+def severity_for_debt(need_type: str, debt_score: float) -> Optional[tuple[int, str]]:
+    """Return the severity level/name for a need debt score, if any."""
+
+    normalized = normalize_need_type(need_type)
+    for threshold, level, name in NEED_SEVERITY_THRESHOLDS[normalized]:
+        if debt_score >= threshold:
+            return level, name
+    return None
+
+
+def severity_tag_for_debt(need_type: str, debt_score: float) -> Optional[str]:
+    """Return the registered severity tag for a need debt score, if any."""
+
+    normalized = normalize_need_type(need_type)
+    severity = severity_for_debt(normalized, debt_score)
+    if severity is None:
+        return None
+    level, name = severity
+    return f"{NEED_SEVERITY_PREFIX[normalized]}_{level}_{name}"
+
+
+def severity_tags_for_need(need_type: str) -> tuple[str, ...]:
+    """Return all severity tags in the mutex track for a need."""
+
+    normalized = normalize_need_type(need_type)
+    prefix = NEED_SEVERITY_PREFIX[normalized]
+    return tuple(
+        f"{prefix}_{level}_{name}"
+        for _threshold, level, name in reversed(NEED_SEVERITY_THRESHOLDS[normalized])
+    )

--- a/nexus/agents/orrery/needs.py
+++ b/nexus/agents/orrery/needs.py
@@ -60,9 +60,6 @@ DEFAULT_NEED_PRIORITIES: Mapping[str, int] = {
     NeedType.HUNGER.value: 22,
 }
 
-# Backward-compatible aliases for older tests and scripts that import constants.
-NEED_ACCRUAL_RATES = DEFAULT_NEED_ACCRUAL_RATES
-
 
 @dataclass(frozen=True, slots=True)
 class NeedPressureTuning:

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -22,6 +22,8 @@ from nexus.agents.orrery.substrate import (
 )
 from nexus.agents.orrery.needs import (
     NEED_SEVERITY_PREFIX,
+    NeedTuning,
+    coerce_need_tuning,
     effective_debt_score,
     severity_for_debt,
 )
@@ -191,8 +193,11 @@ def hydrate_world_state(
     *,
     anchor_chunk_id: Optional[int],
     window_chunks: int,
+    need_tuning: Optional[NeedTuning] = None,
 ) -> WorldState:
     """Hydrate the read-side Orrery state snapshot from database tables."""
+
+    need_tuning = coerce_need_tuning(need_tuning)
 
     tags: dict[int, set[str]] = {}
     ephemeral_tags: dict[int, set[str]] = {}
@@ -301,10 +306,14 @@ def hydrate_world_state(
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
     )
-    time_of_day = _load_time_of_day(session, anchor_chunk_id=anchor_chunk_id)
-    weather = _load_weather(session)
     world_time = _load_world_time(session, anchor_chunk_id=anchor_chunk_id)
-    need_debt_scores = _load_need_debt_scores(session, current_world_time=world_time)
+    time_of_day = _load_time_of_day(world_time)
+    weather = _load_weather(session)
+    need_debt_scores = _load_need_debt_scores(
+        session,
+        current_world_time=world_time,
+        need_tuning=need_tuning,
+    )
 
     return WorldState(
         tags={entity_id: frozenset(values) for entity_id, values in tags.items()},
@@ -548,13 +557,16 @@ def resolve_dry_run(
     *,
     anchor_chunk_id: Optional[int],
     window_chunks: int,
+    sunhelm_settings: Optional[Any] = None,
 ) -> OrreryTickProposal:
     """Hydrate, bind, and evaluate Orrery packages without database writes."""
 
+    need_tuning = coerce_need_tuning(sunhelm_settings)
     state = hydrate_world_state(
         session,
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
+        need_tuning=need_tuning,
     )
 
     templates_list = list(templates)
@@ -630,6 +642,7 @@ def resolve_dry_run(
         present_actor_ids=_present_actor_ids_at_anchor(
             session, anchor_chunk_id=anchor_chunk_id
         ),
+        need_tuning=need_tuning,
     )
     pressure_entity_ids = _entity_ids_from_resolutions(scene_pressure_results) | {
         spec["actor_entity_id"] for spec in present_need_pressure_specs
@@ -639,7 +652,11 @@ def resolve_dry_run(
         _scene_pressure_from_resolution(resolution, pressure_entity_names)
         for resolution in scene_pressure_results
     ) + tuple(
-        _scene_pressure_from_need_spec(spec, pressure_entity_names)
+        _scene_pressure_from_need_spec(
+            spec,
+            pressure_entity_names,
+            need_tuning=need_tuning,
+        )
         for spec in present_need_pressure_specs
     )
 
@@ -704,8 +721,7 @@ def _load_recent_events(
     return tuple(events)
 
 
-def _load_time_of_day(session: Any, *, anchor_chunk_id: Optional[int]) -> str:
-    world_time = _load_world_time(session, anchor_chunk_id=anchor_chunk_id)
+def _load_time_of_day(world_time: Optional[datetime]) -> str:
     if world_time is None:
         return "midday"
 
@@ -743,7 +759,10 @@ def _load_world_time(
 
 
 def _load_need_debt_scores(
-    session: Any, *, current_world_time: Optional[datetime]
+    session: Any,
+    *,
+    current_world_time: Optional[datetime],
+    need_tuning: NeedTuning,
 ) -> dict[tuple[int, str], float]:
     """Load effective need debt scores without mutating canonical state."""
 
@@ -756,7 +775,11 @@ def _load_need_debt_scores(
                    need_type::text AS need_type,
                    debt_score,
                    last_evaluated_at
-            FROM character_need_states
+            FROM character_need_states cns
+            JOIN entities e
+              ON e.id = cns.character_entity_id
+             AND e.kind = 'character'
+             AND e.is_active = true
             """
         )
     ).mappings():
@@ -766,6 +789,7 @@ def _load_need_debt_scores(
             float(row["debt_score"] or 0.0),
             last_evaluated_at=row["last_evaluated_at"],
             current_world_time=current_world_time,
+            tuning=need_tuning,
         )
     return scores
 
@@ -857,7 +881,10 @@ def _scene_pressure_from_resolution(
 
 
 def _present_need_pressure_specs(
-    state: WorldState, *, present_actor_ids: set[int]
+    state: WorldState,
+    *,
+    present_actor_ids: set[int],
+    need_tuning: NeedTuning,
 ) -> tuple[dict[str, Any], ...]:
     """Build prompt-only pressure specs from present-character need debt."""
 
@@ -865,12 +892,15 @@ def _present_need_pressure_specs(
     for actor_id in sorted(present_actor_ids):
         for need_type, prefix in NEED_SEVERITY_PREFIX.items():
             debt_score = state.need_debt_scores.get((actor_id, need_type), 0.0)
-            severity = severity_for_debt(need_type, debt_score)
+            severity = severity_for_debt(
+                need_type,
+                debt_score,
+                tuning=need_tuning,
+            )
             if severity is None:
                 continue
             level, severity_name = severity
-            # Mild need pressure is too chatty for every visible scene.
-            if level < 2:
+            if level < need_tuning.pressure.min_severity_level:
                 continue
             specs.append(
                 {
@@ -888,6 +918,8 @@ def _present_need_pressure_specs(
 def _scene_pressure_from_need_spec(
     spec: Mapping[str, Any],
     entity_names: Mapping[int, str],
+    *,
+    need_tuning: NeedTuning,
 ) -> OrreryScenePressureDraft:
     """Convert present-character need pressure into Storyteller prompt data."""
 
@@ -907,13 +939,13 @@ def _scene_pressure_from_need_spec(
     )
     return OrreryScenePressureDraft(
         template_id=f"{need_type}_need_pressure",
-        priority=25,
+        priority=need_tuning.priorities[need_type],
         binding_hash=binding_hash({Slot.ACTOR: actor_id, Slot.RESOURCE: need_type}),
         bindings=bindings,
         branch_label=f"Present-character {need_type} pressure",
         pressure_stub=pressure_stub,
         prompt_text=prompt_text,
-        magnitude=min(0.85, 0.35 + float(spec["severity_level"]) * 0.1),
+        magnitude=need_tuning.pressure.magnitude_for_level(int(spec["severity_level"])),
     )
 
 

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -17,7 +17,13 @@ from nexus.agents.orrery.substrate import (
     Slot,
     Template,
     WorldState,
+    binding_hash,
     evaluate_stack,
+)
+from nexus.agents.orrery.needs import (
+    NEED_SEVERITY_PREFIX,
+    effective_debt_score,
+    severity_for_debt,
 )
 
 
@@ -297,6 +303,8 @@ def hydrate_world_state(
     )
     time_of_day = _load_time_of_day(session, anchor_chunk_id=anchor_chunk_id)
     weather = _load_weather(session)
+    world_time = _load_world_time(session, anchor_chunk_id=anchor_chunk_id)
+    need_debt_scores = _load_need_debt_scores(session, current_world_time=world_time)
 
     return WorldState(
         tags={entity_id: frozenset(values) for entity_id, values in tags.items()},
@@ -316,6 +324,7 @@ def hydrate_world_state(
             for entity_id, values in faction_memberships.items()
         },
         location_class=location_class,
+        need_debt_scores=need_debt_scores,
         recent_events=recent_events,
         time_of_day=time_of_day,
         weather=weather,
@@ -616,12 +625,22 @@ def resolve_dry_run(
                 if resolution is not None and resolution.passes:
                     scene_pressure_results.append(resolution)
 
-    pressure_entity_names = _load_entity_names(
-        session, _entity_ids_from_resolutions(scene_pressure_results)
+    present_need_pressure_specs = _present_need_pressure_specs(
+        state,
+        present_actor_ids=_present_actor_ids_at_anchor(
+            session, anchor_chunk_id=anchor_chunk_id
+        ),
     )
+    pressure_entity_ids = _entity_ids_from_resolutions(scene_pressure_results) | {
+        spec["actor_entity_id"] for spec in present_need_pressure_specs
+    }
+    pressure_entity_names = _load_entity_names(session, pressure_entity_ids)
     scene_pressures = tuple(
         _scene_pressure_from_resolution(resolution, pressure_entity_names)
         for resolution in scene_pressure_results
+    ) + tuple(
+        _scene_pressure_from_need_spec(spec, pressure_entity_names)
+        for spec in present_need_pressure_specs
     )
 
     unique_actors = (
@@ -686,9 +705,25 @@ def _load_recent_events(
 
 
 def _load_time_of_day(session: Any, *, anchor_chunk_id: Optional[int]) -> str:
-    if anchor_chunk_id is None:
+    world_time = _load_world_time(session, anchor_chunk_id=anchor_chunk_id)
+    if world_time is None:
         return "midday"
 
+    hour = world_time.hour
+    if 5 <= hour < 12:
+        return "morning"
+    if 12 <= hour < 16:
+        return "afternoon"
+    if 16 <= hour < 21:
+        return "evening"
+    return "night"
+
+
+def _load_world_time(
+    session: Any, *, anchor_chunk_id: Optional[int]
+) -> Optional[datetime]:
+    if anchor_chunk_id is None:
+        return None
     row = (
         session.execute(
             text(
@@ -704,18 +739,35 @@ def _load_time_of_day(session: Any, *, anchor_chunk_id: Optional[int]) -> str:
         .mappings()
         .first()
     )
-    world_time = row["world_time"] if row else None
-    if world_time is None:
-        return "midday"
+    return row["world_time"] if row else None
 
-    hour = world_time.hour
-    if 5 <= hour < 12:
-        return "morning"
-    if 12 <= hour < 16:
-        return "afternoon"
-    if 16 <= hour < 21:
-        return "evening"
-    return "night"
+
+def _load_need_debt_scores(
+    session: Any, *, current_world_time: Optional[datetime]
+) -> dict[tuple[int, str], float]:
+    """Load effective need debt scores without mutating canonical state."""
+
+    scores: dict[tuple[int, str], float] = {}
+    for row in session.execute(
+        text(
+            """
+            /* orrery:need_debt_scores */
+            SELECT character_entity_id,
+                   need_type::text AS need_type,
+                   debt_score,
+                   last_evaluated_at
+            FROM character_need_states
+            """
+        )
+    ).mappings():
+        need_type = str(row["need_type"])
+        scores[(row["character_entity_id"], need_type)] = effective_debt_score(
+            need_type,
+            float(row["debt_score"] or 0.0),
+            last_evaluated_at=row["last_evaluated_at"],
+            current_world_time=current_world_time,
+        )
+    return scores
 
 
 def _load_weather(session: Any) -> str:
@@ -801,6 +853,93 @@ def _scene_pressure_from_resolution(
             template_id=resolution.template_id,
         ),
         magnitude=resolution.magnitude,
+    )
+
+
+def _present_need_pressure_specs(
+    state: WorldState, *, present_actor_ids: set[int]
+) -> tuple[dict[str, Any], ...]:
+    """Build prompt-only pressure specs from present-character need debt."""
+
+    specs: list[dict[str, Any]] = []
+    for actor_id in sorted(present_actor_ids):
+        for need_type, prefix in NEED_SEVERITY_PREFIX.items():
+            debt_score = state.need_debt_scores.get((actor_id, need_type), 0.0)
+            severity = severity_for_debt(need_type, debt_score)
+            if severity is None:
+                continue
+            level, severity_name = severity
+            # Mild need pressure is too chatty for every visible scene.
+            if level < 2:
+                continue
+            specs.append(
+                {
+                    "actor_entity_id": actor_id,
+                    "need_type": need_type,
+                    "severity_prefix": prefix,
+                    "severity_level": level,
+                    "severity_name": severity_name,
+                    "debt_score": debt_score,
+                }
+            )
+    return tuple(specs)
+
+
+def _scene_pressure_from_need_spec(
+    spec: Mapping[str, Any],
+    entity_names: Mapping[int, str],
+) -> OrreryScenePressureDraft:
+    """Convert present-character need pressure into Storyteller prompt data."""
+
+    actor_id = int(spec["actor_entity_id"])
+    need_type = str(spec["need_type"])
+    severity_name = str(spec["severity_name"])
+    debt_score = float(spec["debt_score"])
+    bindings = {"actor": actor_id, "resource": need_type}
+    pressure_stub = _need_pressure_stub(
+        need_type, severity_name=severity_name, debt_score=debt_score
+    )
+    prompt_text = _render_bound_text(
+        pressure_stub,
+        bindings,
+        entity_names,
+        template_id=f"{need_type}_need_pressure",
+    )
+    return OrreryScenePressureDraft(
+        template_id=f"{need_type}_need_pressure",
+        priority=25,
+        binding_hash=binding_hash({Slot.ACTOR: actor_id, Slot.RESOURCE: need_type}),
+        bindings=bindings,
+        branch_label=f"Present-character {need_type} pressure",
+        pressure_stub=pressure_stub,
+        prompt_text=prompt_text,
+        magnitude=min(0.85, 0.35 + float(spec["severity_level"]) * 0.1),
+    )
+
+
+def _need_pressure_stub(
+    need_type: str, *, severity_name: str, debt_score: float
+) -> str:
+    label = f"{severity_name} {need_type} debt"
+    if need_type == "sleep":
+        return (
+            "{actor} is carrying "
+            f"{label} ({debt_score:.1f}). You may render fatigue, dulled "
+            "judgment, irritability, or the pull toward rest, but Orrery "
+            "does not decide what {actor} does in scene."
+        )
+    if need_type == "hunger":
+        return (
+            "{actor} is carrying "
+            f"{label} ({debt_score:.1f}). You may render distraction, "
+            "irritability, or interest in food, but Orrery does not decide "
+            "what {actor} does in scene."
+        )
+    return (
+        "{actor} is carrying "
+        f"{label} ({debt_score:.1f}). You may render thirst, discomfort, "
+        "or urgency around water, but Orrery does not decide what {actor} "
+        "does in scene."
     )
 
 

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -70,6 +70,7 @@ class WorldState:
     faction_memberships: Mapping[int, frozenset[int]] = field(default_factory=dict)
     location_class: Mapping[int, str] = field(default_factory=dict)
     orbit_distance: Mapping[Tuple[int, int], int] = field(default_factory=dict)
+    need_debt_scores: Mapping[Tuple[int, str], float] = field(default_factory=dict)
     recent_events: Tuple[EventRecord, ...] = ()
     time_of_day: str = "midday"
     weather: str = "clear"
@@ -130,6 +131,78 @@ def has_ephemeral(tag: str, slot: Slot = Slot.ACTOR) -> Condition:
         )
 
     return _named(_condition, f"has_ephemeral({tag}@{slot.value})")
+
+
+def has_severity_tag(prefix: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound entity has any tag in a severity track."""
+
+    marker = f"{prefix}_"
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        tags = state.tags.get(entity_id, frozenset()) | state.ephemeral_tags.get(
+            entity_id, frozenset()
+        )
+        return any(tag.startswith(marker) for tag in tags)
+
+    return _named(_condition, f"has_severity_tag({prefix}@{slot.value})")
+
+
+def has_severity_tag_at_or_above(
+    prefix: str,
+    level: int,
+    slot: Slot = Slot.ACTOR,
+) -> Condition:
+    """Return whether a slot-bound entity has a severity tag at a threshold."""
+
+    marker = f"{prefix}_"
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        tags = state.tags.get(entity_id, frozenset()) | state.ephemeral_tags.get(
+            entity_id, frozenset()
+        )
+        for tag in tags:
+            if not tag.startswith(marker):
+                continue
+            remainder = tag.removeprefix(marker)
+            numeric, _sep, _label = remainder.partition("_")
+            try:
+                if int(numeric) >= level:
+                    return True
+            except ValueError:
+                continue
+        return False
+
+    return _named(
+        _condition,
+        f"has_severity_tag_at_or_above({prefix},{level}@{slot.value})",
+    )
+
+
+def has_need_debt_at_or_above(
+    need_type: str,
+    threshold: float,
+    slot: Slot = Slot.ACTOR,
+) -> Condition:
+    """Return whether a slot-bound entity has need debt at the threshold."""
+
+    normalized = str(need_type).lower()
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        return state.need_debt_scores.get((entity_id, normalized), 0.0) >= threshold
+
+    return _named(
+        _condition,
+        f"has_need_debt_at_or_above({normalized},{threshold:g}@{slot.value})",
+    )
 
 
 def in_location_class(location_class: str, slot: Slot = Slot.ACTOR) -> Condition:

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -8,6 +8,8 @@ from hashlib import sha256
 import json
 from typing import Any, Callable, Dict, Iterable, Literal, Mapping, Optional, Tuple
 
+from nexus.agents.orrery.needs import normalize_need_type
+
 
 class EntityKind(str, Enum):
     """Entity kinds supported by the Orrery identity spine."""
@@ -191,7 +193,7 @@ def has_need_debt_at_or_above(
 ) -> Condition:
     """Return whether a slot-bound entity has need debt at the threshold."""
 
-    normalized = str(need_type).lower()
+    normalized = normalize_need_type(need_type)
 
     def _condition(state: WorldState, bindings: Bindings) -> bool:
         entity_id = _slot_entity(bindings, slot)

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -15,6 +15,7 @@ from nexus.agents.orrery.substrate import (
     count_co_located,
     has_any_tag,
     has_ephemeral,
+    has_need_debt_at_or_above,
     has_relationship_of_type,
     has_symmetric_relationship_of_type,
     has_tag,
@@ -1537,6 +1538,394 @@ CONSULT_RIVAL = Template(
 )
 
 
+SLEEP = Template(
+    id="sleep",
+    priority=25,
+    blurb="The body asks for the thing without which it cannot continue.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        OR(
+            AND(
+                time_of_day_in("night"),
+                has_need_debt_at_or_above("sleep", 8),
+            ),
+            has_need_debt_at_or_above("sleep", 16),
+        ),
+        NOT(has_ephemeral("cns_stimulated")),
+        NOT(has_ephemeral("under_active_pursuit")),
+    ),
+    branches=(
+        Branch(
+            label="Collapse into deferred sleep",
+            conditions=has_need_debt_at_or_above("sleep", 48),
+            narrative_stub=(
+                "{actor} stops negotiating with exhaustion. Whatever place "
+                "they have reached becomes the place where the body claims "
+                "its overdue sleep."
+            ),
+            state_delta={
+                "character.current_activity": "collapsing into deferred sleep",
+                "need.fulfill": {
+                    "type": "sleep",
+                    "duration_hours": 4,
+                    "quality": "collapse_rough",
+                    "discharge_debt": 4,
+                },
+            },
+            event_type="slept",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.74,
+        ),
+        Branch(
+            label="Sleep at home",
+            conditions=in_location_class("home"),
+            narrative_stub=(
+                "{actor} reaches familiar shelter and lets sleep take them "
+                "where the room already knows their shape."
+            ),
+            state_delta={
+                "character.current_activity": "sleeping at home",
+                "need.fulfill": {
+                    "type": "sleep",
+                    "duration_hours": 8,
+                    "quality": "good",
+                    "discharge_debt": 10,
+                },
+            },
+            event_type="slept",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.22,
+        ),
+        Branch(
+            label="Sleep in safe lodgings",
+            conditions=OR(
+                in_location_class("lodgings"),
+                in_location_class("safe_house"),
+            ),
+            narrative_stub=(
+                "{actor} finds a place secure enough to become temporary "
+                "shelter and lets the unfamiliar room do enough of the work."
+            ),
+            state_delta={
+                "character.current_activity": "sleeping in safe lodgings",
+                "need.fulfill": {
+                    "type": "sleep",
+                    "duration_hours": 7,
+                    "quality": "adequate",
+                    "discharge_debt": 7,
+                },
+            },
+            event_type="slept",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.28,
+        ),
+        Branch(
+            label="Sleep rough in cover or transit",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} sleeps in fragments, taking what rest the place "
+                "allows and waking with some part of the debt still unpaid."
+            ),
+            state_delta={
+                "character.current_activity": "sleeping rough",
+                "need.fulfill": {
+                    "type": "sleep",
+                    "duration_hours": 5,
+                    "quality": "rough",
+                    "discharge_debt": 3,
+                },
+            },
+            event_type="slept",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.36,
+        ),
+    ),
+)
+
+
+DRINK = Template(
+    id="drink",
+    priority=24,
+    blurb="The body asks for water; what it accepts shapes the small hour.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        has_need_debt_at_or_above("thirst", 2),
+        NOT(has_ephemeral("under_active_pursuit")),
+    ),
+    branches=(
+        Branch(
+            label="Drink desperately, whatever is available",
+            conditions=has_need_debt_at_or_above("thirst", 16),
+            narrative_stub=(
+                "{actor} drinks with the single-mindedness that severe "
+                "thirst produces, past concern for source or dignity."
+            ),
+            state_delta={
+                "character.current_activity": "drinking to relieve severe thirst",
+                "need.fulfill": {
+                    "type": "thirst",
+                    "quality": "desperate",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="drank",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.56,
+        ),
+        Branch(
+            label="Drink in a public room",
+            conditions=OR(
+                in_location_class("tavern"),
+                in_location_class("teahouse"),
+                in_location_class("cafe"),
+                in_location_class("market"),
+            ),
+            narrative_stub=(
+                "{actor} drinks what the room serves and lets the small "
+                "ritual of holding a cup make the hour easier."
+            ),
+            state_delta={
+                "character.current_activity": "drinking in company",
+                "need.fulfill": {
+                    "type": "thirst",
+                    "quality": "social",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="drank",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.22,
+        ),
+        Branch(
+            label="Drink from a public or wild source",
+            conditions=OR(
+                in_location_class("public_water"),
+                in_location_class("wilderness"),
+            ),
+            narrative_stub=(
+                "{actor} drinks from whatever the place provides, and the "
+                "relief of water makes the rest of the day briefly simpler."
+            ),
+            state_delta={
+                "character.current_activity": "drinking from an available source",
+                "need.fulfill": {
+                    "type": "thirst",
+                    "quality": "available_source",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="drank",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.14,
+        ),
+        Branch(
+            label="Drink routinely from what is at hand",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} drinks because the body has been quietly asking, "
+                "then returns to the shape of the hour."
+            ),
+            state_delta={
+                "character.current_activity": "drinking routinely",
+                "need.fulfill": {
+                    "type": "thirst",
+                    "quality": "routine",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="drank",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.10,
+        ),
+    ),
+)
+
+
+EAT = Template(
+    id="eat",
+    priority=22,
+    blurb="The body asks for fuel; what it gets matters more than the cookbook suggests.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        has_need_debt_at_or_above("hunger", 4),
+        OR(
+            time_of_day_in("morning", "afternoon", "evening"),
+            has_need_debt_at_or_above("hunger", 8),
+        ),
+        NOT(has_ephemeral("under_active_pursuit")),
+    ),
+    branches=(
+        Branch(
+            label="Eat ravenously, whatever is available",
+            conditions=has_need_debt_at_or_above("hunger", 16),
+            narrative_stub=(
+                "{actor} eats with the inattention of real hunger, relief "
+                "overtaking any concern about what the food ought to be."
+            ),
+            state_delta={
+                "character.current_activity": "eating to relieve severe hunger",
+                "need.fulfill": {
+                    "type": "hunger",
+                    "quality": "desperate",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="ate",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.62,
+        ),
+        Branch(
+            label="Eat at home with household",
+            conditions=AND(
+                in_location_class("home"),
+                has_any_tag("married", "parent", "extended_household"),
+            ),
+            narrative_stub=(
+                "{actor} sits down to the meal that home means and lets "
+                "being-with stand in for being-alone for a while."
+            ),
+            state_delta={
+                "character.current_activity": "sharing a household meal",
+                "need.fulfill": {
+                    "type": "hunger",
+                    "quality": "household_meal",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="ate",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.22,
+        ),
+        Branch(
+            label="Eat in a public dining place",
+            conditions=OR(
+                in_location_class("tavern"),
+                in_location_class("restaurant"),
+                in_location_class("market"),
+                in_location_class("cookshop"),
+            ),
+            narrative_stub=(
+                "{actor} eats something the place can provide and watches "
+                "the room continue its public life around them."
+            ),
+            state_delta={
+                "character.current_activity": "eating in a public place",
+                "need.fulfill": {
+                    "type": "hunger",
+                    "quality": "public_meal",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="ate",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.26,
+        ),
+        Branch(
+            label="Forage or hunt from the country",
+            conditions=AND(
+                in_location_class("wilderness"),
+                has_any_tag("forager", "hunter", "survivalist", "ranger", "scout"),
+            ),
+            narrative_stub=(
+                "{actor} works the country for what the season has put "
+                "within reach and makes a meal out of survival knowledge."
+            ),
+            state_delta={
+                "character.current_activity": "foraging for a meal",
+                "need.fulfill": {
+                    "type": "hunger",
+                    "quality": "wild_meal",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="ate",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.38,
+        ),
+        Branch(
+            label="Eat from rations or what was packed",
+            conditions=has_tag("travel_provisioned"),
+            narrative_stub=(
+                "{actor} eats what was packed for exactly this kind of hour: "
+                "practical, portable, and enough."
+            ),
+            state_delta={
+                "character.current_activity": "eating travel rations",
+                "need.fulfill": {
+                    "type": "hunger",
+                    "quality": "rations_meal",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="ate",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.18,
+        ),
+        Branch(
+            label="Find something and eat it",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} eats what is nearest and workable, attentive mostly "
+                "to the fact that the body can stop asking for now."
+            ),
+            state_delta={
+                "character.current_activity": "eating opportunistically",
+                "need.fulfill": {
+                    "type": "hunger",
+                    "quality": "opportunistic_meal",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="ate",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.14,
+        ),
+    ),
+)
+
+
 BUILTIN_TEMPLATES = (
     EVADE_PURSUERS,
     PROTECT_KIN,
@@ -1552,5 +1941,8 @@ BUILTIN_TEMPLATES = (
     CONSULT_RIVAL,
     MOURN_LOSS,
     TEND_CRAFT,
+    SLEEP,
+    DRINK,
+    EAT,
     MAINTAIN_COVER,
 )

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -302,6 +302,99 @@ class OrreryPromoteSettings(BaseModel):
     provider: Literal["local"] = "local"
 
 
+def _default_need_accrual_rates() -> Dict[str, float]:
+    return {"sleep": 1.0, "hunger": 1.0, "thirst": 1.0}
+
+
+def _default_need_priorities() -> Dict[str, int]:
+    return {"sleep": 25, "thirst": 24, "hunger": 22}
+
+
+def _default_need_severity_thresholds() -> Dict[str, "OrreryNeedThresholdSettings"]:
+    return {
+        "sleep": OrreryNeedThresholdSettings(
+            mild=16.0,
+            moderate=30.0,
+            severe=48.0,
+            critical=72.0,
+        ),
+        "hunger": OrreryNeedThresholdSettings(
+            mild=8.0,
+            moderate=16.0,
+            severe=30.0,
+            critical=48.0,
+        ),
+        "thirst": OrreryNeedThresholdSettings(
+            mild=4.0,
+            moderate=8.0,
+            severe=16.0,
+            critical=24.0,
+        ),
+    }
+
+
+class OrreryNeedThresholdSettings(BaseModel):
+    """Debt thresholds for one Sunhelm need severity track."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mild: float = Field(..., ge=0.0)
+    moderate: float = Field(..., ge=0.0)
+    severe: float = Field(..., ge=0.0)
+    critical: float = Field(..., ge=0.0)
+
+    @model_validator(mode="after")
+    def _validate_monotonic(self) -> "OrreryNeedThresholdSettings":
+        if not (self.mild <= self.moderate <= self.severe <= self.critical):
+            raise ValueError(
+                "Need severity thresholds must be monotonic: "
+                "mild <= moderate <= severe <= critical"
+            )
+        return self
+
+
+class OrreryNeedPressureSettings(BaseModel):
+    """Present-character need pressure tuning for Storyteller prompt injection."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    min_severity_level: int = Field(default=2, ge=1, le=4)
+    magnitude_base: float = Field(default=0.35, ge=0.0)
+    magnitude_per_level: float = Field(default=0.10, ge=0.0)
+    magnitude_cap: float = Field(default=0.85, ge=0.0, le=1.0)
+
+
+class OrrerySunhelmSettings(BaseModel):
+    """Timestamp-plus-debt tuning for Orrery basic needs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    accrual_rates: Dict[str, float] = Field(default_factory=_default_need_accrual_rates)
+    severity_thresholds: Dict[str, OrreryNeedThresholdSettings] = Field(
+        default_factory=_default_need_severity_thresholds
+    )
+    priorities: Dict[str, int] = Field(default_factory=_default_need_priorities)
+    pressure: OrreryNeedPressureSettings = Field(
+        default_factory=OrreryNeedPressureSettings
+    )
+
+    @model_validator(mode="after")
+    def _validate_need_keys(self) -> "OrrerySunhelmSettings":
+        required = {"sleep", "hunger", "thirst"}
+        for field_name, mapping in (
+            ("accrual_rates", self.accrual_rates),
+            ("severity_thresholds", self.severity_thresholds),
+            ("priorities", self.priorities),
+        ):
+            keys = set(mapping)
+            if keys != required:
+                raise ValueError(
+                    f"orrery.sunhelm.{field_name} must define exactly "
+                    f"{sorted(required)}; got {sorted(keys)}"
+                )
+        return self
+
+
 class OrrerySettings(BaseModel):
     """Orrery off-screen behavior subsystem settings."""
 
@@ -312,6 +405,7 @@ class OrrerySettings(BaseModel):
     narration: OrreryNarrationSettings
     bleed: OrreryBleedSettings = Field(default_factory=OrreryBleedSettings)
     promote: OrreryPromoteSettings = Field(default_factory=OrreryPromoteSettings)
+    sunhelm: OrrerySunhelmSettings = Field(default_factory=OrrerySunhelmSettings)
 
 
 # =============================================================================

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -20,7 +20,11 @@ def test_context_prompt_includes_orrery_scene_pressure_controls() -> None:
     )
 
     assert "=== ORRERY SCENE PRESSURE ===" in prompt
-    assert "off-screen pressures involving current on-screen characters" in prompt
+    assert (
+        "Storyteller-mediated pressures involving current on-screen characters"
+        in prompt
+    )
+    assert "present-character need pressure" in prompt
     assert "You may adapt, delay, ignore, or incorporate them" in prompt
     assert "Do not let Orrery decide what present characters do" in prompt
     assert "Travel toward the target's last known location: Mara is moving" in prompt

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -16,3 +16,15 @@ def test_orrery_settings_resolve_model_reference() -> None:
     assert settings.orrery.bleed.latency_budget_ms == 2000
     assert settings.orrery.bleed.candidate_pool_multiplier == 4
     assert settings.orrery.promote.provider == "local"
+    assert settings.orrery.sunhelm.accrual_rates == {
+        "sleep": 1.0,
+        "hunger": 1.0,
+        "thirst": 1.0,
+    }
+    assert settings.orrery.sunhelm.severity_thresholds["sleep"].moderate == 30.0
+    assert settings.orrery.sunhelm.priorities == {
+        "sleep": 25,
+        "thirst": 24,
+        "hunger": 22,
+    }
+    assert settings.orrery.sunhelm.pressure.min_severity_level == 2

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from dataclasses import replace
 
 import pytest
@@ -25,11 +26,15 @@ class RecordingCursor:
         known_tags=None,
         current_tags=None,
         clear_tag_ids=None,
+        world_time=None,
+        need_state=None,
     ):
         self.duplicate_resolution = duplicate_resolution
         self.known_tags = {"off_grid": 77} if known_tags is None else known_tags
         self.current_tags = set() if current_tags is None else current_tags
         self.clear_tag_ids = [] if clear_tag_ids is None else clear_tag_ids
+        self.world_time = world_time or datetime(2073, 10, 31, 18, tzinfo=timezone.utc)
+        self.need_state = {} if need_state is None else need_state
         self.executed = []
         self.rowcount = 1
         self._fetchone = None
@@ -72,6 +77,30 @@ class RecordingCursor:
                 self._fetchone = {"id": 88}
         elif "FROM event_types WHERE type" in normalized:
             self._fetchone = {"type": params[0]}
+        elif "SELECT world_time FROM chunk_metadata" in normalized:
+            self._fetchone = {"world_time": self.world_time}
+        elif "SELECT now() AS world_time" in normalized:
+            self._fetchone = {"world_time": self.world_time}
+        elif "INSERT INTO character_need_states" in normalized:
+            entity_id, need_type, world_time = params
+            self.need_state.setdefault(
+                (entity_id, need_type),
+                {"debt_score": 0, "last_evaluated_at": world_time},
+            )
+        elif (
+            "SELECT debt_score, last_evaluated_at FROM character_need_states"
+            in normalized
+        ):
+            entity_id, need_type = params
+            self._fetchone = self.need_state.get((entity_id, need_type))
+        elif "UPDATE character_need_states" in normalized:
+            debt_score, world_time, _fulfilled_at, _metadata, entity_id, need_type = (
+                params
+            )
+            self.need_state[(entity_id, need_type)] = {
+                "debt_score": debt_score,
+                "last_evaluated_at": world_time,
+            }
         elif "SELECT current_location FROM characters" in normalized:
             self._fetchone = {"current_location": 99}
         elif "INSERT INTO world_events" in normalized:
@@ -381,3 +410,70 @@ def test_commit_orrery_tick_applies_target_tag_deltas() -> None:
     assert "VALUES (%s, 'target', %s)" in statements
     assert "mechanism, justification, source_chunk_id" in statements
     assert event_params[3] == 2
+
+
+def test_commit_orrery_tick_applies_need_fulfillment_delta() -> None:
+    """Need fulfillment accrues debt, discharges it, and syncs severity tags."""
+
+    world_time = datetime(2073, 10, 31, 18, tzinfo=timezone.utc)
+    draft = OrreryResolutionDraft(
+        template_id="sleep",
+        priority=25,
+        binding_hash="sleep-1",
+        bindings={"actor": 1},
+        branch_label="Sleep rough in cover or transit",
+        narrative_stub="{actor} sleeps in fragments.",
+        state_delta={
+            "character.current_activity": "sleeping rough",
+            "need.fulfill": {
+                "type": "sleep",
+                "quality": "rough",
+                "discharge_debt": 4,
+            },
+        },
+        event_type="slept",
+        changed_fields=(
+            "character.current_activity",
+            "character_need_states.debt_score",
+        ),
+        magnitude=0.36,
+    )
+    proposal = OrreryTickProposal(
+        anchor_chunk_id=99,
+        actor_count=1,
+        resolutions=(draft,),
+        generated_at="2073-10-31T18:00:00+00:00",
+    )
+    cursor = RecordingCursor(
+        known_tags={
+            "sleep_deprived_1_mild": 101,
+            "sleep_deprived_2_moderate": 102,
+            "sleep_deprived_3_severe": 103,
+            "sleep_deprived_4_critical": 104,
+        },
+        current_tags={(1, "sleep_deprived_2_moderate")},
+        world_time=world_time,
+        need_state={
+            (1, "sleep"): {
+                "debt_score": 20,
+                "last_evaluated_at": world_time - timedelta(hours=2),
+            }
+        },
+    )
+
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        proposal,
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+
+    assert result.resolution_count == 1
+    assert result.event_count == 1
+    assert result.tag_mutation_count == 2
+    assert cursor.need_state[(1, "sleep")]["debt_score"] == 18
+    assert "UPDATE character_need_states" in statements
+    assert "sleep_deprived_1_mild" in str(cursor.known_tags)

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -477,3 +477,35 @@ def test_commit_orrery_tick_applies_need_fulfillment_delta() -> None:
     assert cursor.need_state[(1, "sleep")]["debt_score"] == 18
     assert "UPDATE character_need_states" in statements
     assert "sleep_deprived_1_mild" in str(cursor.known_tags)
+
+
+def test_commit_orrery_tick_reports_missing_need_type() -> None:
+    """Malformed need.fulfill payloads get an actionable error."""
+
+    draft = OrreryResolutionDraft(
+        template_id="sleep",
+        priority=25,
+        binding_hash="sleep-1",
+        bindings={"actor": 1},
+        branch_label="Sleep rough in cover or transit",
+        narrative_stub="{actor} sleeps in fragments.",
+        state_delta={"need.fulfill": {"quality": "rough"}},
+        event_type="slept",
+        changed_fields=("character_need_states.debt_score",),
+        magnitude=0.36,
+    )
+    proposal = OrreryTickProposal(
+        anchor_chunk_id=99,
+        actor_count=1,
+        resolutions=(draft,),
+        generated_at="2073-10-31T18:00:00+00:00",
+    )
+
+    with pytest.raises(ValueError, match="must include a 'type' or 'need' field"):
+        commit_orrery_tick_sync(
+            RecordingConn(RecordingCursor()),
+            proposal,
+            tick_chunk_id=100,
+            slot=5,
+            world_layer="primary",
+        )

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -101,6 +101,11 @@ class RecordingCursor:
                 "debt_score": debt_score,
                 "last_evaluated_at": world_time,
             }
+        elif "SELECT t.tag FROM entity_tags et JOIN tags t" in normalized:
+            entity_id, tags = params
+            self._fetchall = [
+                {"tag": tag} for tag in tags if (entity_id, tag) in self.current_tags
+            ]
         elif "SELECT current_location FROM characters" in normalized:
             self._fetchone = {"current_location": 99}
         elif "INSERT INTO world_events" in normalized:
@@ -476,7 +481,10 @@ def test_commit_orrery_tick_applies_need_fulfillment_delta() -> None:
     assert result.tag_mutation_count == 2
     assert cursor.need_state[(1, "sleep")]["debt_score"] == 18
     assert "UPDATE character_need_states" in statements
-    assert "sleep_deprived_1_mild" in str(cursor.known_tags)
+    assert any(
+        "INSERT INTO entity_tags" in sql and params == (1, 101, "sleep")
+        for sql, params in cursor.executed
+    )
 
 
 def test_commit_orrery_tick_reports_missing_need_type() -> None:
@@ -502,6 +510,38 @@ def test_commit_orrery_tick_reports_missing_need_type() -> None:
     )
 
     with pytest.raises(ValueError, match="must include a 'type' or 'need' field"):
+        commit_orrery_tick_sync(
+            RecordingConn(RecordingCursor()),
+            proposal,
+            tick_chunk_id=100,
+            slot=5,
+            world_layer="primary",
+        )
+
+
+def test_commit_orrery_tick_reports_missing_need_actor() -> None:
+    """Malformed need.fulfill templates fail before database integrity errors."""
+
+    draft = OrreryResolutionDraft(
+        template_id="sleep",
+        priority=25,
+        binding_hash="sleep-1",
+        bindings={},
+        branch_label="Sleep rough in cover or transit",
+        narrative_stub="Someone sleeps in fragments.",
+        state_delta={"need.fulfill": {"type": "sleep", "quality": "rough"}},
+        event_type="slept",
+        changed_fields=("character_need_states.debt_score",),
+        magnitude=0.36,
+    )
+    proposal = OrreryTickProposal(
+        anchor_chunk_id=99,
+        actor_count=1,
+        resolutions=(draft,),
+        generated_at="2073-10-31T18:00:00+00:00",
+    )
+
+    with pytest.raises(ValueError, match="requires an actor binding"):
         commit_orrery_tick_sync(
             RecordingConn(RecordingCursor()),
             proposal,

--- a/tests/test_orrery/test_memnon_whitelist.py
+++ b/tests/test_orrery/test_memnon_whitelist.py
@@ -10,6 +10,7 @@ def test_memnon_allows_public_orrery_read_surfaces() -> None:
         "entities",
         "entity_names_v",
         "entity_tags_current",
+        "character_need_states",
         "world_events",
         "world_event_entities",
         "orrery_resolutions",

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -90,6 +90,7 @@ class FakeSession:
         self.weather = weather
         self.max_chunk_id = max_chunk_id
         self.max_id_queries = 0
+        self.world_time_queries = 0
 
     def __enter__(self):
         return self
@@ -132,8 +133,11 @@ class FakeSession:
         if "/* orrery:entity_names */" in sql:
             return FakeResult(self.entity_name_rows)
         if "/* orrery:need_debt_scores */" in sql:
+            assert "JOIN entities e" in sql
+            assert "e.is_active = true" in sql
             return FakeResult(self.need_debt_rows)
         if "/* orrery:anchor_world_time */" in sql:
+            self.world_time_queries += 1
             return FakeResult([{"world_time": self.world_time}])
         if "/* orrery:seed_weather */" in sql:
             return FakeResult([{"weather": self.weather}])
@@ -394,23 +398,25 @@ def test_hydrate_world_state_uses_stable_trust_magnitude_for_duplicate_pairs() -
 def test_hydrate_world_state_computes_effective_need_debt() -> None:
     """Need debt accrues from last_evaluated_at without resolver writes."""
 
+    session = FakeSession(
+        world_time=datetime(2073, 10, 31, 12, tzinfo=timezone.utc),
+        need_debt_rows=[
+            {
+                "character_entity_id": 1,
+                "need_type": "sleep",
+                "debt_score": 6,
+                "last_evaluated_at": datetime(2073, 10, 31, 8, tzinfo=timezone.utc),
+            }
+        ],
+    )
     state = hydrate_world_state(
-        FakeSession(
-            world_time=datetime(2073, 10, 31, 12, tzinfo=timezone.utc),
-            need_debt_rows=[
-                {
-                    "character_entity_id": 1,
-                    "need_type": "sleep",
-                    "debt_score": 6,
-                    "last_evaluated_at": datetime(2073, 10, 31, 8, tzinfo=timezone.utc),
-                }
-            ],
-        ),
+        session,
         anchor_chunk_id=100,
         window_chunks=30,
     )
 
     assert state.need_debt_scores[(1, "sleep")] == 10
+    assert session.world_time_queries == 1
 
 
 @pytest.mark.parametrize(
@@ -710,6 +716,52 @@ def test_resolve_dry_run_routes_present_need_debt_to_scene_pressure() -> None:
     assert pressure.bindings == {"actor": 1, "resource": "sleep"}
     assert "Mara is carrying moderate sleep debt" in pressure.prompt_text
     assert "Orrery does not decide what Mara does" in pressure.prompt_text
+
+
+def test_resolve_dry_run_uses_configured_present_need_pressure_tuning() -> None:
+    """Present-character need pressure uses config thresholds and priorities."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[{"entity_id": 1}],
+            present_actor_rows=[{"entity_id": 1}],
+            need_debt_rows=[
+                {
+                    "character_entity_id": 1,
+                    "need_type": "thirst",
+                    "debt_score": 3,
+                    "last_evaluated_at": datetime(
+                        2073, 10, 31, 12, tzinfo=timezone.utc
+                    ),
+                }
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+        sunhelm_settings={
+            "accrual_rates": {"sleep": 1, "hunger": 1, "thirst": 1},
+            "severity_thresholds": {
+                "sleep": {"mild": 16, "moderate": 30, "severe": 48, "critical": 72},
+                "hunger": {"mild": 8, "moderate": 16, "severe": 30, "critical": 48},
+                "thirst": {"mild": 1, "moderate": 3, "severe": 6, "critical": 9},
+            },
+            "priorities": {"sleep": 25, "thirst": 7, "hunger": 22},
+            "pressure": {
+                "min_severity_level": 2,
+                "magnitude_base": 0.2,
+                "magnitude_per_level": 0.05,
+                "magnitude_cap": 0.5,
+            },
+        },
+    )
+
+    assert proposal.resolution_count == 0
+    assert proposal.pressure_count == 1
+    pressure = proposal.scene_pressures[0]
+    assert pressure.template_id == "thirst_need_pressure"
+    assert pressure.priority == 7
+    assert pressure.magnitude == pytest.approx(0.3)
 
 
 def test_resolve_dry_run_keeps_default_templates_offscreen_only_for_present_targets() -> (

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -59,6 +59,7 @@ class FakeSession:
         present_actor_rows=None,
         actor_target_relationship_rows=None,
         entity_name_rows=None,
+        need_debt_rows=None,
         world_time=None,
         weather="",
         max_chunk_id=100,
@@ -84,6 +85,7 @@ class FakeSession:
             {"id": 2, "name": "Vale"},
             {"id": 3, "name": "Iris"},
         ]
+        self.need_debt_rows = need_debt_rows or []
         self.world_time = world_time or datetime(2073, 10, 31, 12, tzinfo=timezone.utc)
         self.weather = weather
         self.max_chunk_id = max_chunk_id
@@ -129,6 +131,8 @@ class FakeSession:
             return FakeResult(self.actor_target_relationship_rows)
         if "/* orrery:entity_names */" in sql:
             return FakeResult(self.entity_name_rows)
+        if "/* orrery:need_debt_scores */" in sql:
+            return FakeResult(self.need_debt_rows)
         if "/* orrery:anchor_world_time */" in sql:
             return FakeResult([{"world_time": self.world_time}])
         if "/* orrery:seed_weather */" in sql:
@@ -288,6 +292,33 @@ def test_resolve_dry_run_exercises_priority_packages(
     assert proposal.resolutions[0].branch_label == branch_label
 
 
+def test_resolve_dry_run_fires_sunhelm_need_template() -> None:
+    """Off-screen need debt resolves through SLEEP/EAT/DRINK packages."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            world_time=datetime(2073, 10, 31, 23, tzinfo=timezone.utc),
+            need_debt_rows=[
+                {
+                    "character_entity_id": 1,
+                    "need_type": "sleep",
+                    "debt_score": 10,
+                    "last_evaluated_at": datetime(
+                        2073, 10, 31, 23, tzinfo=timezone.utc
+                    ),
+                }
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "sleep"
+    assert proposal.resolutions[0].state_delta["need.fulfill"]["type"] == "sleep"
+
+
 def test_hydrate_world_state_populates_trust_from_valence_magnitude() -> None:
     """Orrery trust reads the SQL-derived relationship valence magnitude."""
 
@@ -358,6 +389,28 @@ def test_hydrate_world_state_uses_stable_trust_magnitude_for_duplicate_pairs() -
     assert state.trust[(2, 1)] == -3
     assert state.relationship_types[(1, 2)] == frozenset({"comrade", "enemy"})
     assert state.relationship_types[(2, 1)] == frozenset({"ally", "rival"})
+
+
+def test_hydrate_world_state_computes_effective_need_debt() -> None:
+    """Need debt accrues from last_evaluated_at without resolver writes."""
+
+    state = hydrate_world_state(
+        FakeSession(
+            world_time=datetime(2073, 10, 31, 12, tzinfo=timezone.utc),
+            need_debt_rows=[
+                {
+                    "character_entity_id": 1,
+                    "need_type": "sleep",
+                    "debt_score": 6,
+                    "last_evaluated_at": datetime(2073, 10, 31, 8, tzinfo=timezone.utc),
+                }
+            ],
+        ),
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert state.need_debt_scores[(1, "sleep")] == 10
 
 
 @pytest.mark.parametrize(
@@ -625,6 +678,38 @@ def test_resolve_dry_run_routes_present_targets_to_scene_pressures() -> None:
     assert pressure.bindings == {"actor": 1, "target": 2}
     assert "Mara is creating pressure around Vale" in pressure.prompt_text
     assert "state_delta" not in pressure.to_dict()
+
+
+def test_resolve_dry_run_routes_present_need_debt_to_scene_pressure() -> None:
+    """On-screen actors get prompt-only need pressure, not resolutions."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[{"entity_id": 1}],
+            present_actor_rows=[{"entity_id": 1}],
+            need_debt_rows=[
+                {
+                    "character_entity_id": 1,
+                    "need_type": "sleep",
+                    "debt_score": 30,
+                    "last_evaluated_at": datetime(
+                        2073, 10, 31, 12, tzinfo=timezone.utc
+                    ),
+                }
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 0
+    assert proposal.pressure_count == 1
+    pressure = proposal.scene_pressures[0]
+    assert pressure.template_id == "sleep_need_pressure"
+    assert pressure.bindings == {"actor": 1, "resource": "sleep"}
+    assert "Mara is carrying moderate sleep debt" in pressure.prompt_text
+    assert "Orrery does not decide what Mara does" in pressure.prompt_text
 
 
 def test_resolve_dry_run_keeps_default_templates_offscreen_only_for_present_targets() -> (

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -300,6 +300,13 @@ def test_need_debt_condition_reads_world_state_scores() -> None:
     assert not has_need_debt_at_or_above("sleep", 16)(state, {Slot.ACTOR: 1})
 
 
+def test_need_debt_condition_rejects_unknown_need_type() -> None:
+    """Typos in authored need predicates fail at construction time."""
+
+    with pytest.raises(ValueError, match="Unsupported Orrery need type"):
+        has_need_debt_at_or_above("hungr", 8)
+
+
 def test_severity_tag_threshold_parses_level_prefix() -> None:
     """Severity predicates compare the numeric segment of graduated tags."""
 

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -17,6 +17,8 @@ from nexus.agents.orrery.substrate import (
     binding_hash,
     count_co_located,
     evaluate_stack,
+    has_need_debt_at_or_above,
+    has_severity_tag_at_or_above,
     has_symmetric_relationship_of_type,
     recent_event,
     since_last_event_at_least,
@@ -287,6 +289,24 @@ def test_count_co_located_condition_filters_by_tag() -> None:
 
     assert count_co_located(1, with_tag="pursuer")(state, {Slot.ACTOR: 1})
     assert not count_co_located(2, with_tag="pursuer")(state, {Slot.ACTOR: 1})
+
+
+def test_need_debt_condition_reads_world_state_scores() -> None:
+    """Sunhelm gates read effective need debt from hydrated world state."""
+
+    state = WorldState(need_debt_scores={(1, "sleep"): 12.5})
+
+    assert has_need_debt_at_or_above("sleep", 8)(state, {Slot.ACTOR: 1})
+    assert not has_need_debt_at_or_above("sleep", 16)(state, {Slot.ACTOR: 1})
+
+
+def test_severity_tag_threshold_parses_level_prefix() -> None:
+    """Severity predicates compare the numeric segment of graduated tags."""
+
+    state = WorldState(tags={1: frozenset({"sleep_deprived_3_severe"})})
+
+    assert has_severity_tag_at_or_above("sleep_deprived", 2)(state, {Slot.ACTOR: 1})
+    assert not has_severity_tag_at_or_above("sleep_deprived", 4)(state, {Slot.ACTOR: 1})
 
 
 def test_recent_event_can_filter_by_changed_fields() -> None:


### PR DESCRIPTION
## Summary
- add generalized Orrery need-state plumbing for sleep, hunger, and thirst using timestamp-plus-debt rows
- add Sunhelm SLEEP, DRINK, and EAT packages with commit-time need fulfillment and severity-tag synchronization
- route present-character need pressure into Storyteller prompt material only, while keeping canonical Orrery commits conservative
- regenerate the human-readable Orrery package catalog

## Verification
- PYTHONPATH=$PWD poetry run pytest tests/test_orrery tests/test_lore/test_logon_prompt_formatting.py
- PYTHONPATH=$PWD poetry run pytest tests/test_api/test_lore_adapter.py tests/test_lore/test_turn_cycle.py tests/test_lore/test_context_validation.py
- PYTHONPATH=$PWD poetry run python -m nexus.agents.orrery.catalog --check
- poetry run python -m py_compile migrations/028_orrery_sunhelm_needs.py nexus/agents/orrery/needs.py nexus/agents/orrery/substrate.py nexus/agents/orrery/resolver.py nexus/agents/orrery/events.py nexus/agents/orrery/templates.py
- poetry run python scripts/migrate.py --all
- live rollback smoke on save_02: primed off-screen sleep debt and confirmed Sunhelm sleep resolutions
- live rollback commit smoke on save_02: fulfilled sleep need, emitted event, discharged debt, and rolled back

## Migration Notes
- migration 028 applied locally to NEXUS_template and unlocked slots 2-5
- save_01 remains locked, so migration status reports it as locked rather than applied
