### PR TITLE
Add Orrery place affordance semantics

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -28,7 +28,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **When:**
 
 - **AND:**
-  - actor is in `the_roots` location class
+  - actor is in `the_roots` place affordance
   - weather is one of [rain]
 
 **Does:** activity → "hiding from active pursuit"; adds `off_grid` to actor
@@ -182,7 +182,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 - **AND:**
   - actor has `contacts_available` tag
-  - actor is in `the_glow` location class
+  - actor is in `the_glow` place affordance
 
 **Does:** activity → "running a reputation attack"; adds `reputation_compromised` to target
 **Event:** `retaliation_attempted`
@@ -297,7 +297,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 - **AND:**
   - actor has `ghostprint_active` tag
-  - actor is in `the_roots` location class
+  - actor is in `the_roots` place affordance
 
 **Does:** activity → "signaling through a sympathetic node"
 **Event:** `honor_debt`
@@ -390,7 +390,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 1 — Recon a hideout their body remembers  *(mag 0.64)*
 
-**When:** actor is in `the_roots` location class
+**When:** actor is in `the_roots` place affordance
 
 **Does:** activity → "reconning remembered terrain"
 **Event:** `pursue_identity_lead`
@@ -688,7 +688,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 - **AND:**
   - actor and target are co-located
-  - actor is in `neutral_ground` location class
+  - actor is in `neutral_ground` place affordance
 
 **Does:** activity → "meeting a rival under truce"; adds `under_truce` to actor; adds `under_truce` to target
 **Event:** `rival_consulted`
@@ -742,7 +742,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 1 — Visit the place of remembrance  *(mag 0.42)*
 
-**When:** actor is in `place_of_remembrance` location class
+**When:** actor is in `place_of_remembrance` place affordance
 
 **Does:** activity → "tending the dead"
 **Event:** `mourning_act`
@@ -806,7 +806,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 2 — Sleep at home  *(mag 0.22)*
 
-**When:** actor is in `home` location class
+**When:** actor is in `home` place affordance
 
 **Does:** activity → "sleeping at home"; fulfills `sleep` need, quality `good`, discharge 10
 **Event:** `slept`
@@ -818,8 +818,8 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **When:**
 
 - **OR:**
-  - actor is in `lodgings` location class
-  - actor is in `safe_house` location class
+  - actor is in `lodgings` place affordance
+  - actor is in `safe_house` place affordance
 
 **Does:** activity → "sleeping in safe lodgings"; fulfills `sleep` need, quality `adequate`, discharge 7
 **Event:** `slept`
@@ -863,10 +863,10 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **When:**
 
 - **OR:**
-  - actor is in `tavern` location class
-  - actor is in `teahouse` location class
-  - actor is in `cafe` location class
-  - actor is in `market` location class
+  - actor is in `tavern` place affordance
+  - actor is in `teahouse` place affordance
+  - actor is in `cafe` place affordance
+  - actor is in `market` place affordance
 
 **Does:** activity → "drinking in company"; fulfills `thirst` need, quality `social`, discharge 9999
 **Event:** `drank`
@@ -878,8 +878,8 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **When:**
 
 - **OR:**
-  - actor is in `public_water` location class
-  - actor is in `wilderness` location class
+  - actor is in `public_water` place affordance
+  - actor is in `wilderness` place affordance
 
 **Does:** activity → "drinking from an available source"; fulfills `thirst` need, quality `available_source`, discharge 9999
 **Event:** `drank`
@@ -926,7 +926,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **When:**
 
 - **AND:**
-  - actor is in `home` location class
+  - actor is in `home` place affordance
   - actor has any of [`married`, `parent`, `extended_household`]
 
 **Does:** activity → "sharing a household meal"; fulfills `hunger` need, quality `household_meal`, discharge 9999
@@ -939,10 +939,10 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **When:**
 
 - **OR:**
-  - actor is in `tavern` location class
-  - actor is in `restaurant` location class
-  - actor is in `market` location class
-  - actor is in `cookshop` location class
+  - actor is in `tavern` place affordance
+  - actor is in `restaurant` place affordance
+  - actor is in `market` place affordance
+  - actor is in `cookshop` place affordance
 
 **Does:** activity → "eating in a public place"; fulfills `hunger` need, quality `public_meal`, discharge 9999
 **Event:** `ate`
@@ -954,7 +954,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **When:**
 
 - **AND:**
-  - actor is in `wilderness` location class
+  - actor is in `wilderness` place affordance
   - actor has any of [`forager`, `hunter`, `survivalist`, `ranger`, `scout`]
 
 **Does:** activity → "foraging for a meal"; fulfills `hunger` need, quality `wild_meal`, discharge 9999
@@ -1090,7 +1090,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 1 — Run a low-level courier job  *(mag 0.16)*
 
-**When:** actor is in `the_glow` location class
+**When:** actor is in `the_glow` place affordance
 
 **Does:** activity → "running low-level cover work"
 **Event:** `maintain_cover`
@@ -1119,6 +1119,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/027_orrery_package_library_round2_vocab.py`
 - `migrations/028_orrery_sunhelm_needs.py`
 - `migrations/029_orrery_need_state_init_trigger.py`
+- `migrations/030_orrery_place_affordance_vocab.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 
@@ -1232,6 +1233,24 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `warning_delivered`
 - `welfare_check`
 - `wound_healed`
+
+### Place affordances queried by location predicates
+
+- `cafe`
+- `cookshop`
+- `home`
+- `lodgings`
+- `market`
+- `neutral_ground`
+- `place_of_remembrance`
+- `public_water`
+- `restaurant`
+- `safe_house`
+- `tavern`
+- `teahouse`
+- `the_glow`
+- `the_roots`
+- `wilderness`
 
 ### Relationship types
 

--- a/migrations/030_orrery_place_affordance_vocab.py
+++ b/migrations/030_orrery_place_affordance_vocab.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Sequence
 
+from psycopg2.extensions import connection
+
 
 # (tag, description)
 PLACE_AFFORDANCE_TAGS: Sequence[tuple[str, str]] = (
@@ -74,7 +76,7 @@ PLACE_AFFORDANCE_TAGS: Sequence[tuple[str, str]] = (
 )
 
 
-def run(conn) -> None:
+def run(conn: connection) -> None:
     """Apply the place-affordance vocabulary migration."""
 
     with conn.cursor() as cur:
@@ -90,8 +92,29 @@ def run(conn) -> None:
                     NULL, NULL,
                     NULL, %s
                 )
-                ON CONFLICT (tag) DO NOTHING
+                ON CONFLICT (tag) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    is_ephemeral = EXCLUDED.is_ephemeral,
+                    clearance_kind = EXCLUDED.clearance_kind,
+                    reapplication_policy = EXCLUDED.reapplication_policy,
+                    clear_on = EXCLUDED.clear_on,
+                    description = EXCLUDED.description
                 """,
                 (tag, description),
             )
+        cur.execute(
+            """
+            SELECT tag, category
+            FROM tags
+            WHERE tag = ANY(%s)
+              AND category <> 'place_affordance'
+            ORDER BY tag
+            """,
+            ([tag for tag, _description in PLACE_AFFORDANCE_TAGS],),
+        )
+        mismatches = cur.fetchall()
+        if mismatches:
+            detail = ", ".join(f"{tag}={category}" for tag, category in mismatches)
+            message = f"Unexpected Orrery place-affordance categories: {detail}"
+            raise RuntimeError(message)
     conn.commit()

--- a/migrations/030_orrery_place_affordance_vocab.py
+++ b/migrations/030_orrery_place_affordance_vocab.py
@@ -1,0 +1,97 @@
+"""Seed Orrery semantic place-affordance vocabulary."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+# (tag, description)
+PLACE_AFFORDANCE_TAGS: Sequence[tuple[str, str]] = (
+    (
+        "the_roots",
+        "Place belongs to or behaves like the Roots: underground, "
+        "infrastructural, hidden, or half-maintained transit space.",
+    ),
+    (
+        "the_glow",
+        "Place belongs to or behaves like the Glow: dense public urban space "
+        "where ordinary cover work can blend into civilian flow.",
+    ),
+    (
+        "place_of_remembrance",
+        "Place supports mourning, memorial ritual, grave-tending, or other "
+        "structured remembrance of the dead.",
+    ),
+    (
+        "neutral_ground",
+        "Place can plausibly host tense meetings without clearly favoring "
+        "one participant's territory.",
+    ),
+    ("home", "Place is a character's familiar home or household shelter."),
+    (
+        "lodgings",
+        "Place offers temporary lodging, rented rooms, guest quarters, or "
+        "other ordinary sleep shelter.",
+    ),
+    (
+        "safe_house",
+        "Place can shelter a character discreetly and securely enough for "
+        "off-screen recovery or hiding.",
+    ),
+    (
+        "tavern",
+        "Place provides public food, drink, and informal social contact.",
+    ),
+    (
+        "teahouse",
+        "Place provides public drink and quiet social ritual.",
+    ),
+    (
+        "cafe",
+        "Place provides public drink, light food, and low-stakes presence.",
+    ),
+    (
+        "market",
+        "Place can provide food, drink, goods, and public crowd cover.",
+    ),
+    (
+        "public_water",
+        "Place has an accessible water source for routine or urgent drinking.",
+    ),
+    (
+        "wilderness",
+        "Place is uncultivated or rural enough to support rough travel, "
+        "foraging, hunting, or wild water sources.",
+    ),
+    (
+        "restaurant",
+        "Place primarily provides prepared public meals.",
+    ),
+    (
+        "cookshop",
+        "Place sells prepared food without necessarily being a full restaurant.",
+    ),
+)
+
+
+def run(conn) -> None:
+    """Apply the place-affordance vocabulary migration."""
+
+    with conn.cursor() as cur:
+        for tag, description in PLACE_AFFORDANCE_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, 'place_affordance', FALSE,
+                    NULL, NULL,
+                    NULL, %s
+                )
+                ON CONFLICT (tag) DO NOTHING
+                """,
+                (tag, description),
+            )
+    conn.commit()

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -105,7 +105,7 @@ _register(
 # Location predicates
 _register(
     r"in_location_class\((?P<lc>[^@()]+)@(?P<slot>\w+)\)",
-    lambda m: f"{_slot(m.group('slot'))} is in `{m.group('lc')}` location class",
+    lambda m: f"{_slot(m.group('slot'))} is in `{m.group('lc')}` place affordance",
 )
 _register(
     r"in_location\((?P<lid>\d+)@(?P<slot>\w+)\)",
@@ -402,6 +402,7 @@ _VOCAB_PATTERNS: List[Tuple[str, re.Pattern]] = [
     ("ephemeral_tag", re.compile(r"has_ephemeral\(([^@()]+)@")),
     ("event_type", re.compile(r"recent_event\(([^,*()]+),")),
     ("event_type", re.compile(r"since_last_event_at_least\(([^,()]+),")),
+    ("place_affordance", re.compile(r"in_location_class\(([^@()]+)@")),
     ("relationship", re.compile(r"has_relationship_of_type\(([^,()]+),")),
     (
         "relationship",
@@ -427,6 +428,7 @@ def _collect_vocabulary(
     ephemeral: set[str] = set()
     applied: set[str] = set()
     events: set[str] = set()
+    place_affordances: set[str] = set()
     relationships: set[str] = set()
 
     def visit(condition: Any) -> None:
@@ -449,6 +451,8 @@ def _collect_vocabulary(
                 ephemeral.add(captured)
             elif kind == "event_type":
                 events.add(captured)
+            elif kind == "place_affordance":
+                place_affordances.add(captured)
             elif kind == "relationship":
                 relationships.add(captured)
             # First-match-wins: prevents future overlapping patterns from
@@ -479,6 +483,7 @@ def _collect_vocabulary(
         "ephemeral_tags": sorted(ephemeral),
         "applied_tags": sorted(applied),
         "event_types": sorted(events),
+        "place_affordances": sorted(place_affordances),
         "relationship_types": sorted(relationships),
     }
 
@@ -525,6 +530,10 @@ def _render_vocabulary_appendix(templates: Iterable[Template]) -> List[str]:
             vocab["applied_tags"],
         ),
         ("Event types", vocab["event_types"]),
+        (
+            "Place affordances queried by location predicates",
+            vocab["place_affordances"],
+        ),
         ("Relationship types", vocab["relationship_types"]),
     ]
     for heading, values in sections:

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -228,19 +228,31 @@ def hydrate_world_state(
         ).mappings()
     }
 
-    location_class = {
-        row["id"]: row["location_class"]
-        for row in session.execute(
-            text(
-                """
-                /* orrery:location_classes */
-                SELECT id, type::text AS location_class
-                FROM places
-                WHERE type IS NOT NULL
-                """
-            )
-        ).mappings()
-    }
+    location_class: dict[int, str] = {}
+    location_classes: dict[int, set[str]] = {}
+    for row in session.execute(
+        text(
+            """
+            /* orrery:location_classes */
+            SELECT p.id, p.type::text AS location_class, true AS is_primary
+            FROM places p
+            WHERE p.type IS NOT NULL
+            UNION ALL
+            SELECT p.id, etc.tag AS location_class, false AS is_primary
+            FROM places p
+            JOIN entity_tags_current etc ON etc.entity_id = p.entity_id
+            WHERE etc.entity_kind = 'place'
+              AND etc.category = 'place_affordance'
+            """
+        )
+    ).mappings():
+        place_id = row["id"]
+        class_name = row["location_class"]
+        if class_name is None:
+            continue
+        location_classes.setdefault(place_id, set()).add(class_name)
+        if row.get("is_primary") or place_id not in location_class:
+            location_class[place_id] = class_name
 
     activities = {
         row["entity_id"]: row["current_activity"]
@@ -333,6 +345,10 @@ def hydrate_world_state(
             for entity_id, values in faction_memberships.items()
         },
         location_class=location_class,
+        location_classes={
+            location_id: frozenset(values)
+            for location_id, values in location_classes.items()
+        },
         need_debt_scores=need_debt_scores,
         recent_events=recent_events,
         time_of_day=time_of_day,

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -251,7 +251,7 @@ def hydrate_world_state(
         if class_name is None:
             continue
         location_classes.setdefault(place_id, set()).add(class_name)
-        if row.get("is_primary") or place_id not in location_class:
+        if row["is_primary"]:
             location_class[place_id] = class_name
 
     activities = {

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -71,6 +71,7 @@ class WorldState:
     )
     faction_memberships: Mapping[int, frozenset[int]] = field(default_factory=dict)
     location_class: Mapping[int, str] = field(default_factory=dict)
+    location_classes: Mapping[int, frozenset[str]] = field(default_factory=dict)
     orbit_distance: Mapping[Tuple[int, int], int] = field(default_factory=dict)
     need_debt_scores: Mapping[Tuple[int, str], float] = field(default_factory=dict)
     recent_events: Tuple[EventRecord, ...] = ()
@@ -208,16 +209,24 @@ def has_need_debt_at_or_above(
 
 
 def in_location_class(location_class: str, slot: Slot = Slot.ACTOR) -> Condition:
-    """Return whether an entity is currently in a place of the given class."""
+    """Return whether an entity is currently in a place of the given class.
+
+    Location classes are semantic place tags first. ``state.location_class``
+    remains as a single-value compatibility fallback for older harnesses and
+    structural ``places.type`` values.
+    """
 
     def _condition(state: WorldState, bindings: Bindings) -> bool:
         entity_id = _slot_entity(bindings, slot)
         if entity_id is None:
             return False
         location_id = state.locations.get(entity_id)
+        if location_id is None:
+            return False
+        semantic_classes = state.location_classes.get(location_id, frozenset())
         return (
-            location_id is not None
-            and state.location_class.get(location_id) == location_class
+            location_class in semantic_classes
+            or state.location_class.get(location_id) == location_class
         )
 
     return _named(_condition, f"in_location_class({location_class}@{slot.value})")

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -212,8 +212,8 @@ def in_location_class(location_class: str, slot: Slot = Slot.ACTOR) -> Condition
     """Return whether an entity is currently in a place of the given class.
 
     Location classes are semantic place tags first. ``state.location_class``
-    remains as a single-value compatibility fallback for older harnesses and
-    structural ``places.type`` values.
+    remains as a single-value fallback for directly constructed ``WorldState``
+    instances and structural ``places.type`` values.
     """
 
     def _condition(state: WorldState, bindings: Bindings) -> bool:

--- a/tests/test_orrery/test_catalog.py
+++ b/tests/test_orrery/test_catalog.py
@@ -77,6 +77,8 @@ def test_catalog_vocabulary_appendix_collects_referenced_terms() -> None:
     assert "vendetta_holder" in vocab["durable_tags"]
     assert "grudge_active" in vocab["ephemeral_tags"]
     assert "retaliation_executed" in vocab["event_types"]
+    assert "home" in vocab["place_affordances"]
+    assert "wilderness" in vocab["place_affordances"]
     assert "family" in vocab["relationship_types"]
     assert "handler" in vocab["relationship_types"]
 

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -52,3 +52,17 @@ def test_relationship_valence_migration_uses_explicit_mapping() -> None:
         "-5|hateful": "-5",
     }.items():
         assert f"WHEN '{label}' THEN {magnitude}" in migration_sql
+
+
+def test_place_affordance_migration_corrects_category_conflicts() -> None:
+    """Place affordance vocabulary must not silently keep wrong categories."""
+
+    migration_source = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "030_orrery_place_affordance_vocab.py"
+    ).read_text()
+
+    assert "ON CONFLICT (tag) DO UPDATE SET" in migration_source
+    assert "category = EXCLUDED.category" in migration_source
+    assert "category <> 'place_affordance'" in migration_source

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -105,6 +105,7 @@ class FakeSession:
         if "/* orrery:character_locations */" in sql:
             return FakeResult(self.location_rows)
         if "/* orrery:location_classes */" in sql:
+            assert "place_affordance" in sql
             return FakeResult(self.location_class_rows)
         if "/* orrery:character_activities */" in sql:
             return FakeResult(self.activity_rows)
@@ -393,6 +394,27 @@ def test_hydrate_world_state_uses_stable_trust_magnitude_for_duplicate_pairs() -
     assert state.trust[(2, 1)] == -3
     assert state.relationship_types[(1, 2)] == frozenset({"comrade", "enemy"})
     assert state.relationship_types[(2, 1)] == frozenset({"ally", "rival"})
+
+
+def test_hydrate_world_state_loads_semantic_place_affordances() -> None:
+    """Place tags supplement structural place types for location predicates."""
+
+    state = hydrate_world_state(
+        FakeSession(
+            location_class_rows=[
+                {"id": 10, "location_class": "fixed_location", "is_primary": True},
+                {"id": 10, "location_class": "home", "is_primary": False},
+                {"id": 10, "location_class": "safe_house", "is_primary": False},
+            ],
+        ),
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert state.location_class[10] == "fixed_location"
+    assert state.location_classes[10] == frozenset(
+        {"fixed_location", "home", "safe_house"}
+    )
 
 
 def test_hydrate_world_state_computes_effective_need_debt() -> None:

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -67,7 +67,7 @@ class FakeSession:
         self.tag_rows = tag_rows or []
         self.location_rows = location_rows or [{"entity_id": 1, "current_location": 10}]
         self.location_class_rows = location_class_rows or [
-            {"id": 10, "location_class": "the_roots"}
+            {"id": 10, "location_class": "the_roots", "is_primary": True}
         ]
         self.activity_rows = activity_rows or [
             {"entity_id": 1, "current_activity": "idle"}
@@ -402,9 +402,9 @@ def test_hydrate_world_state_loads_semantic_place_affordances() -> None:
     state = hydrate_world_state(
         FakeSession(
             location_class_rows=[
-                {"id": 10, "location_class": "fixed_location", "is_primary": True},
                 {"id": 10, "location_class": "home", "is_primary": False},
                 {"id": 10, "location_class": "safe_house", "is_primary": False},
+                {"id": 10, "location_class": "fixed_location", "is_primary": True},
             ],
         ),
         anchor_chunk_id=100,
@@ -899,7 +899,9 @@ def test_resolve_dry_run_produces_multi_slot_resolution() -> None:
             {"entity_id": 1, "current_location": 10},
             {"entity_id": 2, "current_location": 10},
         ],
-        location_class_rows=[{"id": 10, "location_class": "the_glow"}],
+        location_class_rows=[
+            {"id": 10, "location_class": "the_glow", "is_primary": True}
+        ],
         activity_rows=[],
         tag_rows=[
             {"entity_id": 2, "tag": "under_active_pursuit", "is_ephemeral": True},

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -20,6 +20,7 @@ from nexus.agents.orrery.substrate import (
     has_need_debt_at_or_above,
     has_severity_tag_at_or_above,
     has_symmetric_relationship_of_type,
+    in_location_class,
     recent_event,
     since_last_event_at_least,
     validate_always_fallbacks,
@@ -298,6 +299,27 @@ def test_need_debt_condition_reads_world_state_scores() -> None:
 
     assert has_need_debt_at_or_above("sleep", 8)(state, {Slot.ACTOR: 1})
     assert not has_need_debt_at_or_above("sleep", 16)(state, {Slot.ACTOR: 1})
+
+
+def test_location_class_condition_reads_semantic_place_classes() -> None:
+    """Location predicates can match one of several place affordance tags."""
+
+    state = WorldState(
+        locations={1: 10},
+        location_classes={10: frozenset({"fixed_location", "home", "safe_house"})},
+    )
+
+    assert in_location_class("home")(state, {Slot.ACTOR: 1})
+    assert in_location_class("safe_house")(state, {Slot.ACTOR: 1})
+    assert not in_location_class("wilderness")(state, {Slot.ACTOR: 1})
+
+
+def test_location_class_condition_preserves_single_value_fallback() -> None:
+    """Older harnesses using location_class keep working."""
+
+    state = WorldState(locations={1: 10}, location_class={10: "the_roots"})
+
+    assert in_location_class("the_roots")(state, {Slot.ACTOR: 1})
 
 
 def test_need_debt_condition_rejects_unknown_need_type() -> None:


### PR DESCRIPTION
## Summary
- hydrate Orrery location predicates from registered place-affordance tags as well as legacy structural place types
- seed the place-affordance vocabulary currently referenced by built-in templates
- expose place affordances in the generated Orrery package catalog and add resolver/substrate coverage

## Validation
- PYTHONPATH=$PWD poetry run pytest tests/test_orrery
- PYTHONPATH=$PWD poetry run pytest tests/test_api/test_lore_adapter.py tests/test_lore/test_logon_prompt_formatting.py
- PYTHONPATH=$PWD poetry run python -m nexus.agents.orrery.catalog --check
- PYTHONPATH=$PWD poetry run python -m py_compile nexus/agents/orrery/substrate.py nexus/agents/orrery/resolver.py nexus/agents/orrery/catalog.py migrations/030_orrery_place_affordance_vocab.py
- git diff --check
- poetry run python scripts/migrate.py --all --dry-run
- poetry run python scripts/migrate.py --all
- rollback smoke in save_02 and save_05: temporary home affordance on a place hydrates and satisfies in_location_class('home')

## Notes
- Migration 030 applied locally to NEXUS_template and slots 2-5; save_01 is still locked/older schema and was skipped.
- This gives Claude Code's backfill branch a stable target: apply registered place_affordance tags to place entities, without expanding places.type.