### PR TITLE
Seed Orrery slot 2 semantic tag vocabulary

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1120,6 +1120,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/028_orrery_sunhelm_needs.py`
 - `migrations/029_orrery_need_state_init_trigger.py`
 - `migrations/030_orrery_place_affordance_vocab.py`
+- `migrations/031_orrery_slot2_semantic_tag_vocab.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 

--- a/migrations/031_orrery_slot2_semantic_tag_vocab.py
+++ b/migrations/031_orrery_slot2_semantic_tag_vocab.py
@@ -1,0 +1,411 @@
+"""Seed semantic tag vocabulary surfaced by the slot 2 backfill draft."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from psycopg2.extensions import connection
+
+
+# (tag, category, description)
+DURABLE_TAGS: Sequence[tuple[str, str, str]] = (
+    # Template-referenced tags that were rediscovered or exposed by the
+    # slot-2 audit but not registered before this migration.
+    (
+        "extended_household",
+        "role",
+        "Character belongs to a household, found-family unit, or equivalent "
+        "shared domestic support structure.",
+    ),
+    (
+        "forager",
+        "capacity",
+        "Character can gather usable food or supplies from wild or marginal "
+        "terrain.",
+    ),
+    (
+        "hunter",
+        "capacity",
+        "Character can track and hunt game or equivalent prey.",
+    ),
+    (
+        "married",
+        "state",
+        "Character is in a marriage or marriage-equivalent household bond.",
+    ),
+    (
+        "parent",
+        "role",
+        "Character has a parent or parent-equivalent relationship role.",
+    ),
+    (
+        "survivalist",
+        "capacity",
+        "Character is skilled at surviving austere, wild, or infrastructure-poor "
+        "conditions.",
+    ),
+    (
+        "travel_provisioned",
+        "orrery_state",
+        "Character is supplied or prepared enough for a travel-oriented package "
+        "to fire.",
+    ),
+    # High-frequency character concepts from the slot-2 proposal report.
+    (
+        "ancient_being",
+        "state",
+        "Character is unusually old, continuous, or pre-Collapse in a way that "
+        "matters narratively.",
+    ),
+    (
+        "archivum_adjacent",
+        "state",
+        "Character is tied to Archivum systems, people, or historical knowledge.",
+    ),
+    (
+        "augmented_prosthetic",
+        "capacity",
+        "Character has a consequential prosthetic or replacement body part.",
+    ),
+    (
+        "black_market_operator",
+        "profession_lite",
+        "Character works through black-market trade, brokerage, or logistics.",
+    ),
+    (
+        "bridge_aware",
+        "state",
+        "Character is aware of or meaningfully affected by the Bridge phenomenon.",
+    ),
+    (
+        "broker",
+        "profession_lite",
+        "Character brokers deals, access, favors, or information.",
+    ),
+    (
+        "cell_handler",
+        "profession_lite",
+        "Character manages cells, assets, or clandestine operators.",
+    ),
+    (
+        "corporate_exile",
+        "state",
+        "Character has been forced out of, hunted by, or materially cut off from "
+        "a corporate power structure.",
+    ),
+    (
+        "cybernetic_augmentation",
+        "capacity",
+        "Character has consequential cybernetic augmentation beyond ordinary "
+        "tools or wearable devices.",
+    ),
+    (
+        "digital_mind",
+        "bodyform",
+        "Character's personhood substantially exists as software, upload, or "
+        "digital consciousness.",
+    ),
+    (
+        "fixer",
+        "profession_lite",
+        "Character habitually solves problems through contacts, leverage, and "
+        "practical arrangement.",
+    ),
+    (
+        "fugitive",
+        "state",
+        "Character is wanted, hunted, or living under an active need to evade "
+        "authorities or pursuers.",
+    ),
+    (
+        "insomniac",
+        "state",
+        "Character has a persistent difficulty sleeping that may modulate sleep "
+        "need packages.",
+    ),
+    (
+        "memory_fragmented",
+        "state",
+        "Character's memory is incomplete, discontinuous, or narratively damaged.",
+    ),
+    (
+        "mutual_aid_patron",
+        "disposition",
+        "Character materially supports mutual-aid networks or vulnerable "
+        "dependents.",
+    ),
+    (
+        "nomad",
+        "role",
+        "Character belongs to or operates through mobile, road, or migrant "
+        "social structures.",
+    ),
+    (
+        "nuclear_specialist",
+        "capacity",
+        "Character has specialized knowledge of nuclear systems, materials, or "
+        "hazards.",
+    ),
+    (
+        "paranoid",
+        "disposition",
+        "Character exhibits persistent suspicion, threat-scanning, or "
+        "conspiracy-minded caution.",
+    ),
+    (
+        "salvager",
+        "role",
+        "Character recovers value from ruins, wreckage, abandoned systems, or "
+        "discarded technology.",
+    ),
+    (
+        "sandboxed",
+        "state",
+        "Character or mind-state is constrained inside a sandbox, containment "
+        "environment, or limited operating context.",
+    ),
+    (
+        "smuggler",
+        "profession_lite",
+        "Character moves goods, people, or information outside ordinary legal "
+        "channels.",
+    ),
+    (
+        "trauma_survivor",
+        "state",
+        "Character has survived major trauma that remains behaviorally relevant.",
+    ),
+    (
+        "uploaded_consciousness",
+        "bodyform",
+        "Character's consciousness has been uploaded, transferred, or hosted "
+        "outside their original body.",
+    ),
+    (
+        "veteran",
+        "role",
+        "Character has significant prior service in military, paramilitary, or "
+        "conflict institutions.",
+    ),
+    (
+        "whistleblower",
+        "role",
+        "Character has exposed or is positioned to expose institutional wrongdoing.",
+    ),
+    # Faction concepts from the slot-2 proposal report.
+    (
+        "ancient_continuous",
+        "history_class",
+        "Faction has unusually long institutional continuity.",
+    ),
+    (
+        "anarchist_collective",
+        "ideology_axis",
+        "Faction operates through anarchist or anti-hierarchical ideals.",
+    ),
+    (
+        "barter_economy",
+        "resource_class",
+        "Faction relies heavily on barter, informal exchange, or nonstandard "
+        "currency.",
+    ),
+    (
+        "cellular_clandestine",
+        "operational_secrecy",
+        "Faction is organized into covert cells or compartmented clandestine units.",
+    ),
+    (
+        "compartmented",
+        "operational_secrecy",
+        "Faction limits knowledge and responsibility across internal compartments.",
+    ),
+    (
+        "contract_kinetic",
+        "power_posture",
+        "Faction sells or deploys force through contract violence or security work.",
+    ),
+    (
+        "covert_loyalty_play",
+        "hidden_agenda_class",
+        "Faction is engaged in covert allegiance, betrayal, or loyalty-shaping "
+        "maneuvers.",
+    ),
+    (
+        "criminal_underground",
+        "legitimacy_status",
+        "Faction operates primarily through criminal or underground legitimacy.",
+    ),
+    (
+        "decentralized_federation",
+        "power_posture",
+        "Faction is a federated network rather than a centralized hierarchy.",
+    ),
+    (
+        "esoteric_metaphysical",
+        "ideology_axis",
+        "Faction is organized around occult, metaphysical, or reality-bending "
+        "beliefs.",
+    ),
+    (
+        "expansionist_ambition",
+        "hidden_agenda_class",
+        "Faction is pushing to expand territory, influence, or institutional reach.",
+    ),
+    (
+        "gray_legal",
+        "legitimacy_status",
+        "Faction operates in a gray zone between lawful, tolerated, and illicit.",
+    ),
+    (
+        "infiltration_specialist",
+        "power_posture",
+        "Faction is especially capable at infiltration and embedded operations.",
+    ),
+    (
+        "information_intensive",
+        "resource_class",
+        "Faction's power depends heavily on information, records, surveillance, "
+        "or analysis.",
+    ),
+    (
+        "materiel_stockpile",
+        "resource_class",
+        "Faction controls significant equipment, supplies, weapons, or materiel.",
+    ),
+    (
+        "militarized",
+        "power_posture",
+        "Faction is organized or armed in a military or paramilitary posture.",
+    ),
+    (
+        "mobile_basing",
+        "power_posture",
+        "Faction can relocate operations or maintain mobile bases.",
+    ),
+    (
+        "mutual_aid_norms",
+        "ideology_axis",
+        "Faction is materially shaped by mutual aid or reciprocal support norms.",
+    ),
+    (
+        "patron_dependent",
+        "resource_class",
+        "Faction depends materially on a patron, sponsor, or larger protector.",
+    ),
+    (
+        "salvage_economy",
+        "resource_class",
+        "Faction's economy or logistics center on salvage and recovery.",
+    ),
+    (
+        "smuggling_corridor",
+        "power_posture",
+        "Faction controls or exploits routes for smuggling goods, people, or "
+        "information.",
+    ),
+    (
+        "transhumanist_program",
+        "ideology_axis",
+        "Faction pursues transhumanist transformation, enhancement, or continuity.",
+    ),
+)
+
+
+# (tag, category, clearance_kind, clear_on_json, description)
+EPHEMERAL_TAGS: Sequence[tuple[str, str, str, str | None, str]] = (
+    (
+        "schismatic_internal_threat",
+        "hidden_agenda_class",
+        "semantic",
+        None,
+        "Faction currently faces an internal schism, split, or factional threat.",
+    ),
+)
+
+
+def run(conn: connection) -> None:
+    """Apply slot-2 semantic vocabulary seed tags."""
+
+    with conn.cursor() as cur:
+        for tag, category, description in DURABLE_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, %s, FALSE,
+                    NULL, NULL,
+                    NULL, %s
+                )
+                ON CONFLICT (tag) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    is_ephemeral = EXCLUDED.is_ephemeral,
+                    clearance_kind = EXCLUDED.clearance_kind,
+                    reapplication_policy = EXCLUDED.reapplication_policy,
+                    clear_on = EXCLUDED.clear_on,
+                    description = EXCLUDED.description
+                """,
+                (tag, category, description),
+            )
+        for tag, category, clearance_kind, clear_on_json, description in EPHEMERAL_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, %s, TRUE,
+                    %s::entity_tag_clearance_kind,
+                    'extend_expiry'::entity_tag_reapplication_policy,
+                    %s::jsonb, %s
+                )
+                ON CONFLICT (tag) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    is_ephemeral = EXCLUDED.is_ephemeral,
+                    clearance_kind = EXCLUDED.clearance_kind,
+                    reapplication_policy = EXCLUDED.reapplication_policy,
+                    clear_on = EXCLUDED.clear_on,
+                    description = EXCLUDED.description
+                """,
+                (tag, category, clearance_kind, clear_on_json, description),
+            )
+        _assert_seeded_categories(cur)
+    conn.commit()
+
+
+def _assert_seeded_categories(cur: Any) -> None:
+    expected = {tag: (category, False) for tag, category, _description in DURABLE_TAGS}
+    expected.update(
+        {
+            tag: (category, True)
+            for tag, category, _clearance, _clear_on, _description in EPHEMERAL_TAGS
+        }
+    )
+    cur.execute(
+        """
+        SELECT tag, category, is_ephemeral
+        FROM tags
+        WHERE tag = ANY(%s)
+        ORDER BY tag
+        """,
+        (list(expected),),
+    )
+    actual = {
+        tag: (category, is_ephemeral) for tag, category, is_ephemeral in cur.fetchall()
+    }
+    missing = sorted(set(expected) - set(actual))
+    mismatched = sorted(
+        f"{tag}=category:{actual[tag][0]},ephemeral:{actual[tag][1]}"
+        for tag in set(expected) & set(actual)
+        if actual[tag] != expected[tag]
+    )
+    if missing or mismatched:
+        message = "Orrery slot-2 semantic vocabulary seed mismatch"
+        if missing:
+            message += f"; missing={missing}"
+        if mismatched:
+            message += f"; mismatched={mismatched}"
+        raise RuntimeError(message)

--- a/migrations/031_orrery_slot2_semantic_tag_vocab.py
+++ b/migrations/031_orrery_slot2_semantic_tag_vocab.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any, Sequence
 
 from psycopg2.extensions import connection
@@ -102,8 +103,9 @@ DURABLE_TAGS: Sequence[tuple[str, str, str]] = (
     (
         "digital_mind",
         "bodyform",
-        "Character's personhood substantially exists as software, upload, or "
-        "digital consciousness.",
+        "Character's personhood substantially exists as software or digital "
+        "consciousness. Sibling of uploaded_consciousness; prefer digital_mind "
+        "when current embodiment is primarily digital.",
     ),
     (
         "fixer",
@@ -179,7 +181,8 @@ DURABLE_TAGS: Sequence[tuple[str, str, str]] = (
         "uploaded_consciousness",
         "bodyform",
         "Character's consciousness has been uploaded, transferred, or hosted "
-        "outside their original body.",
+        "outside their original body. Sibling of digital_mind; prefer "
+        "uploaded_consciousness when the transfer history is the salient trait.",
     ),
     (
         "veteran",
@@ -311,13 +314,48 @@ DURABLE_TAGS: Sequence[tuple[str, str, str]] = (
 )
 
 
+FACTION_CATEGORY_DESCRIPTIONS: Sequence[tuple[str, str]] = (
+    (
+        "history_class",
+        "Durable faction tags describing institutional continuity and origin.",
+    ),
+    (
+        "ideology_axis",
+        "Durable faction tags describing worldview, political, or metaphysical "
+        "orientation.",
+    ),
+    (
+        "resource_class",
+        "Durable faction tags describing material, economic, or informational "
+        "resources.",
+    ),
+    (
+        "operational_secrecy",
+        "Durable faction tags describing secrecy model and compartmentalization.",
+    ),
+    (
+        "legitimacy_status",
+        "Durable faction tags describing public/legal legitimacy posture.",
+    ),
+    (
+        "power_posture",
+        "Durable faction tags describing how the faction projects power.",
+    ),
+    (
+        "hidden_agenda_class",
+        "Faction tags for active covert agendas or internal threats; may be "
+        "durable or ephemeral depending on the specific tag.",
+    ),
+)
+
+
 # (tag, category, clearance_kind, clear_on_json, description)
 EPHEMERAL_TAGS: Sequence[tuple[str, str, str, str | None, str]] = (
     (
         "schismatic_internal_threat",
         "hidden_agenda_class",
         "semantic",
-        None,
+        '{"description": "cleared when the internal schism, split, or factional threat is narratively resolved"}',
         "Faction currently faces an internal schism, split, or factional threat.",
     ),
 )
@@ -377,28 +415,56 @@ def run(conn: connection) -> None:
 
 
 def _assert_seeded_categories(cur: Any) -> None:
-    expected = {tag: (category, False) for tag, category, _description in DURABLE_TAGS}
+    expected = {
+        tag: (category, False, None, None, None)
+        for tag, category, _description in DURABLE_TAGS
+    }
     expected.update(
         {
-            tag: (category, True)
+            tag: (
+                category,
+                True,
+                clearance_kind,
+                "extend_expiry",
+                _normalize_clear_on(clear_on),
+            )
             for tag, category, _clearance, _clear_on, _description in EPHEMERAL_TAGS
+            for clearance_kind, clear_on in ((_clearance, _clear_on),)
         }
     )
     cur.execute(
         """
-        SELECT tag, category, is_ephemeral
+        SELECT tag,
+               category,
+               is_ephemeral,
+               clearance_kind::text,
+               reapplication_policy::text,
+               clear_on
         FROM tags
         WHERE tag = ANY(%s)
         ORDER BY tag
         """,
         (list(expected),),
     )
-    actual = {
-        tag: (category, is_ephemeral) for tag, category, is_ephemeral in cur.fetchall()
-    }
+    actual = {}
+    for (
+        tag,
+        category,
+        is_ephemeral,
+        clearance_kind,
+        reapplication_policy,
+        clear_on,
+    ) in cur.fetchall():
+        actual[tag] = (
+            category,
+            is_ephemeral,
+            clearance_kind,
+            reapplication_policy,
+            _normalize_clear_on(clear_on),
+        )
     missing = sorted(set(expected) - set(actual))
     mismatched = sorted(
-        f"{tag}=category:{actual[tag][0]},ephemeral:{actual[tag][1]}"
+        f"{tag}={actual[tag]}"
         for tag in set(expected) & set(actual)
         if actual[tag] != expected[tag]
     )
@@ -409,3 +475,9 @@ def _assert_seeded_categories(cur: Any) -> None:
         if mismatched:
             message += f"; mismatched={mismatched}"
         raise RuntimeError(message)
+
+
+def _normalize_clear_on(value: Any) -> Any:
+    if isinstance(value, str):
+        return json.loads(value)
+    return value

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 import scripts.migrate as migrate
 
 
@@ -79,6 +81,8 @@ def test_slot2_semantic_vocab_migration_seeds_template_gate_tags() -> None:
     migration = migrate._load_python_migration(migration_path)
     durable_tags = {tag for tag, _category, _description in migration.DURABLE_TAGS}
 
+    # The full migration self-check validates every seeded tag and category
+    # at execution time; this test pins the template-gate subset.
     assert {
         "extended_household",
         "forager",
@@ -88,3 +92,62 @@ def test_slot2_semantic_vocab_migration_seeds_template_gate_tags() -> None:
         "survivalist",
         "travel_provisioned",
     } <= durable_tags
+
+
+def test_slot2_semantic_vocab_assertion_rejects_runtime_drift() -> None:
+    """Migration 031 self-check catches bad ephemeral policy rows."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "031_orrery_slot2_semantic_tag_vocab.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+
+    class FakeCursor:
+        def execute(self, _sql, _params=None):
+            return None
+
+        def fetchall(self):
+            return [
+                (
+                    "schismatic_internal_threat",
+                    "hidden_agenda_class",
+                    True,
+                    "semantic",
+                    "new_row",
+                    {
+                        "description": (
+                            "cleared when the internal schism, split, or "
+                            "factional threat is narratively resolved"
+                        )
+                    },
+                )
+            ]
+
+    with pytest.raises(RuntimeError, match="mismatched"):
+        migration._assert_seeded_categories(FakeCursor())
+
+
+def test_slot2_semantic_vocab_documents_new_faction_categories() -> None:
+    """Migration 031 names the new faction category namespaces."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "031_orrery_slot2_semantic_tag_vocab.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    documented = {
+        category for category, _description in migration.FACTION_CATEGORY_DESCRIPTIONS
+    }
+
+    assert {
+        "history_class",
+        "ideology_axis",
+        "resource_class",
+        "operational_secrecy",
+        "legitimacy_status",
+        "power_posture",
+        "hidden_agenda_class",
+    } <= documented

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -66,3 +66,25 @@ def test_place_affordance_migration_corrects_category_conflicts() -> None:
     assert "ON CONFLICT (tag) DO UPDATE SET" in migration_source
     assert "category = EXCLUDED.category" in migration_source
     assert "category <> 'place_affordance'" in migration_source
+
+
+def test_slot2_semantic_vocab_migration_seeds_template_gate_tags() -> None:
+    """Slot-2 vocabulary seed covers tags already queried by built-in templates."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "031_orrery_slot2_semantic_tag_vocab.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    durable_tags = {tag for tag, _category, _description in migration.DURABLE_TAGS}
+
+    assert {
+        "extended_household",
+        "forager",
+        "hunter",
+        "married",
+        "parent",
+        "survivalist",
+        "travel_provisioned",
+    } <= durable_tags


### PR DESCRIPTION
## Summary
- add migration 031 to seed conservative Orrery semantic vocabulary from Claude Code's slot 2 backfill report
- register current template-gate tags that were missing from the tag table, including household/travel/survival terms
- seed high-frequency character and faction concepts without applying entity tags yet
- update the generated Orrery catalog migration cross-reference and migration coverage test

## Validation
- PYTHONPATH=$PWD poetry run pytest tests/test_orrery
- PYTHONPATH=$PWD poetry run pytest tests/test_api/test_lore_adapter.py tests/test_lore/test_logon_prompt_formatting.py
- PYTHONPATH=$PWD poetry run python -m nexus.agents.orrery.catalog --check
- PYTHONPATH=$PWD poetry run python -m py_compile migrations/031_orrery_slot2_semantic_tag_vocab.py
- git diff --check
- poetry run python scripts/migrate.py --all --dry-run
- poetry run python scripts/migrate.py --all
- DB sanity query: migration 031 applied and 55 seeded tags present with expected categories in NEXUS_template and slots 2-5

## Notes
- save_01 is still locked/older schema and was skipped by the migration runner.
- This PR registers vocabulary only. It does not import Claude's candidate entity tag proposals into entity_tags.