### PR TITLE
Add Orrery interpersonal need packages

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -95,6 +95,12 @@ PR #222 adds deterministic review orchestration so newly opened PRs can schedule
 
 PR #243 extends `character_need_states` from physiological needs into interpersonal pressure by adding `socialize` and `intimacy` need types, controlled severity/suppressor vocabulary, conservative SOCIALIZE and INTIMACY templates, and catalog coverage. `INTIMACY` remains single-slot and substrate-only: it can notice established-partner co-location, private conditions, venues, suppressors, and deferral, but it does not autonomously pair characters or decide scene-level relationship outcomes.
 
+### Next Planned Slice
+
+After PR #243, the next Orrery slice should be **Work + Travel packages plus additive location semantics**. `WORK` should model routine livelihood, duty, household labor, maintenance, and organizational obligations without collapsing the existing `TEND_CRAFT` package, which is still about expressive practice and craft identity. `TRAVEL` should model off-screen movement at turn granularity: destination intent, provisions, route progress, arrival, delay, and travel risk.
+
+This slice should not replace `characters.current_location` or migrate it away from its existing `places(id)` role. The safer migration is additive: keep `characters.current_location` as the semantic place anchor, normalize resolver reads and Orrery state deltas around that place id, and add any travel-specific support tables or fields needed for destination, route, progress, adjacency, or coordinates. If richer geography becomes necessary, layer it onto `places` or a dedicated spatial side table instead of making every existing current-location caller absorb a high-blast-radius type change.
+
 ### Package Author Checkpoint
 
 Package authors can contribute now. The cleanest contribution format is a small template sketch or markdown catalog note that names: package goal, slots, gate, branches, event types, state deltas, required tags, and any pressure-only behavior. The current source of truth for implemented packages is `nexus/agents/orrery/templates.py`; the human-readable generated reference is `docs/orrery_packages.md`. New durable vocabulary still belongs in explicit migrations, and backfill/application of tags remains controlled data work rather than package-author side effects.
@@ -634,6 +640,8 @@ The alias-oriented hybrid remains the right future escape hatch if that pain app
 
 ## Phased Delivery
 
+This section is now mostly historical. The active queue is: finish PR #243's interpersonal need layer, then tackle **Work + Travel packages plus additive location semantics** as the next implementation slice. The PR 0-4 headings below are preserved as landing notes for the foundation, resolver, commit pipeline, and Bleed integration rather than as the current forward plan.
+
 ### PR 0 — Seam Audit & Invariants (Foundation Subset in PR #210)
 
 - Confirmed the production commit path is `nexus/api/narrative.py::_approve_narrative_impl` (L387) → `commit_incubator_to_database_sync` (L233). The async sibling `commit_incubator_to_database` (L320) is test-only today; document this in PR 3 commit hook prose.
@@ -658,9 +666,7 @@ The alias-oriented hybrid remains the right future escape hatch if that pain app
   - **Orrery tables**: `orrery_resolutions` (with `UNIQUE` idempotency key + surfacing bookkeeping columns), `orrery_narration_jobs`, `offscreen_narrations`
   - **Time denormalization**: `chunk_metadata.world_time` column + `refresh_world_time_from_chunk` trigger function
 - `EntityRef` Pydantic helper in `nexus/agents/orrery/entity_ref.py` (thin read-side type; uses `EntityKind` enum mirroring the new `entity_kind` Postgres type) remains deferred until a runtime reader needs it
-- Still needed before commit-time event emission: generator script deriving `changed_fields` vocabulary from `apex_schema.py::StateUpdates` Pydantic models (`apex_schema.py:631`)
-- Still needed before broad package authoring: durable tag backfill from existing entity records (LLM-assisted; reviewed before commit)
-- Still needed before event writes: seed initial `event_types` vocabulary
+- Follow-up slices now seed `event_types` and tag vocabulary through explicit migrations, and PR #237 applies the first reviewed slot 2 semantic tag backfill. `changed_fields` remains a controlled branch/template surface, with the longer-term generator from `apex_schema.py::StateUpdates` still useful but no longer a blocker for package delivery.
 - Demo: `python -m nexus.agents.orrery.demo` runs four presets against synthetic `WorldState`
 
 ### PR 2 — Hydration + Dry-Pass Resolver (implemented in PR #211; no canonical writes)

--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -1,6 +1,6 @@
 # Off-Screen Behavior Resolver — Orrery Design Plan
 
-**Status:** Foundation implemented in PR #210, dry-run resolve in PR #211, commit/promote/narrate/clear in PR #214, expanded package library in PR #212, present-target scene pressure in PR #216, generated human-readable catalog support in PR #217/#218, Bleed selector/Storyteller integration in PR #219, retrieval-boundary hardening in PR #220, relationship-trust hydration in PR #221, and deterministic review orchestration in PR #222. The runtime pipeline remains disabled by default (`orrery.enabled = false`). This branch completes the post-commit semantic tag-clearance worker pass and adds a compact Orrery worker status surface.
+**Status:** Foundation implemented in PR #210, dry-run resolve in PR #211, commit/promote/narrate/clear in PR #214, expanded package library in PR #212/#223, present-target scene pressure in PR #216, generated human-readable catalog support in PR #217/#218, Bleed selector/Storyteller integration in PR #219, retrieval-boundary hardening in PR #220, relationship-trust hydration in PR #221, deterministic review orchestration in PR #222/#236/#238, semantic-clearance worker/status in PR #224, Sunhelm need-state packages in the Sunhelm phase, place affordance semantics in the location phase, and slot 2 semantic tag seeding in PR #237. The runtime pipeline remains disabled by default (`orrery.enabled = false`). This branch adds the interpersonal need layer (`SOCIALIZE` and `INTIMACY`) on top of the existing timestamp-plus-debt substrate.
 
 **Originating artifacts:** `temp/orrery/off_screen_resolver_spec.md`, `temp/orrery/behavior_substrate.py`, `temp/orrery/package_simulator.jsx`
 **Review trace:** `temp/orrery/design_plan_edited.md` (round 1: GPT-5.5-Pro, Codex, separate-Claude, Gemini) + `temp/orrery/super_table_question.md` (round 2: GPT-5.5-Pro, Claude Opus 4.7 chat) + v4 grounding pass against current `main` (claude-opus-4-7).
@@ -82,9 +82,18 @@ PR #221 resolves issue #213's consensus Option B: `character_relationships.emoti
 
 PR #222 adds deterministic review orchestration so newly opened PRs can schedule the delayed review-check workflow without relying on a model-specific local hook.
 
+### Landed After PR #222
+
+- PR #223 expands the package library with round-2 care, craft, and contact templates.
+- PR #224 adds batched post-commit semantic clearance for ephemeral tags and exposes `python -m nexus.agents.orrery.worker --slot N --status` as a compact operational snapshot for pending Orrery background work.
+- The Sunhelm phase adds `character_need_states`, timestamp-plus-debt need tracking, and SLEEP/DRINK/EAT packages.
+- The location phase adds place-affordance semantics used by need and package gates.
+- PR #237 applies slot 2 semantic tag seeding so mature-state dry runs have real package vocabulary to work with.
+- PR #236/#238 tighten deterministic review orchestration so fix commits do not trigger duplicate review windows.
+
 ### Current Slice
 
-This branch adds batched post-commit semantic clearance for ephemeral tags and exposes `python -m nexus.agents.orrery.worker --slot N --status` as a compact operational snapshot for pending Orrery background work.
+This branch extends `character_need_states` from physiological needs into interpersonal pressure by adding `socialize` and `intimacy` need types, controlled severity/suppressor vocabulary, conservative SOCIALIZE and INTIMACY templates, and catalog coverage. The INTIMACY template records pressure and partial fulfillment conditions only; it does not autonomously pair characters or decide scene-level relationship outcomes.
 
 ### Package Author Checkpoint
 

--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -1,6 +1,6 @@
 # Off-Screen Behavior Resolver — Orrery Design Plan
 
-**Status:** Foundation implemented in PR #210, dry-run resolve in PR #211, commit/promote/narrate/clear in PR #214, expanded package library in PR #212/#223, present-target scene pressure in PR #216, generated human-readable catalog support in PR #217/#218, Bleed selector/Storyteller integration in PR #219, retrieval-boundary hardening in PR #220, relationship-trust hydration in PR #221, deterministic review orchestration in PR #222/#236/#238, semantic-clearance worker/status in PR #224, Sunhelm need-state packages in the Sunhelm phase, place affordance semantics in the location phase, and slot 2 semantic tag seeding in PR #237. The runtime pipeline remains disabled by default (`orrery.enabled = false`). This branch adds the interpersonal need layer (`SOCIALIZE` and `INTIMACY`) on top of the existing timestamp-plus-debt substrate.
+**Status:** The Orrery build path is now past foundation and into package-library depth. Main has landed the identity spine and schema, dry-run resolver, accepted-chunk commit path, narration outbox, Bleed selector, retrieval-boundary hardening, relationship-trust hydration, semantic-clearance worker/status surface, Sunhelm needs, place affordance semantics, slot 2 semantic tag seeding, and deterministic review orchestration. The runtime pipeline remains disabled by default (`orrery.enabled = false`). PR #243 is the active slice: it adds the interpersonal need layer (`SOCIALIZE` and `INTIMACY`) on top of the existing timestamp-plus-debt substrate.
 
 **Originating artifacts:** `temp/orrery/off_screen_resolver_spec.md`, `temp/orrery/behavior_substrate.py`, `temp/orrery/package_simulator.jsx`
 **Review trace:** `temp/orrery/design_plan_edited.md` (round 1: GPT-5.5-Pro, Codex, separate-Claude, Gemini) + `temp/orrery/super_table_question.md` (round 2: GPT-5.5-Pro, Claude Opus 4.7 chat) + v4 grounding pass against current `main` (claude-opus-4-7).
@@ -40,7 +40,7 @@
 - `save_01` intentionally remains locked and unmodified
 - `poetry run flake8 ...` remains unavailable because `flake8` is not installed in the Poetry environment
 
-### In PR #211
+### Landed in PR #211
 
 - Added `OrreryTickProposal` and `OrreryResolutionDraft` as in-memory proposal carriers with no `tick_chunk_id` during resolve.
 - Hydrates read-side `WorldState` from current tags, ephemeral tags, character locations and activities, place classes, relationships, faction memberships, recent primary unsuperseded events, and coarse time/weather context.
@@ -93,11 +93,11 @@ PR #222 adds deterministic review orchestration so newly opened PRs can schedule
 
 ### Current Slice
 
-This branch extends `character_need_states` from physiological needs into interpersonal pressure by adding `socialize` and `intimacy` need types, controlled severity/suppressor vocabulary, conservative SOCIALIZE and INTIMACY templates, and catalog coverage. The INTIMACY template records pressure and partial fulfillment conditions only; it does not autonomously pair characters or decide scene-level relationship outcomes.
+PR #243 extends `character_need_states` from physiological needs into interpersonal pressure by adding `socialize` and `intimacy` need types, controlled severity/suppressor vocabulary, conservative SOCIALIZE and INTIMACY templates, and catalog coverage. `INTIMACY` remains single-slot and substrate-only: it can notice established-partner co-location, private conditions, venues, suppressors, and deferral, but it does not autonomously pair characters or decide scene-level relationship outcomes.
 
 ### Package Author Checkpoint
 
-Start soliciting additional package-library contributions **after PR #211 merges**. At that point, package authors can target a real hydrated `WorldState`, binding composer, and `OrreryTickProposal` shape validated against both slot 5 and slot 2, while still avoiding the higher-risk commit/promote/narrate pipeline. The best contribution format is pure template/condition/action logic plus any proposed tag or event-type vocabulary it requires; durable tag backfill and event-type seeding remain controlled schema/data work.
+Package authors can contribute now. The cleanest contribution format is a small template sketch or markdown catalog note that names: package goal, slots, gate, branches, event types, state deltas, required tags, and any pressure-only behavior. The current source of truth for implemented packages is `nexus/agents/orrery/templates.py`; the human-readable generated reference is `docs/orrery_packages.md`. New durable vocabulary still belongs in explicit migrations, and backfill/application of tags remains controlled data work rather than package-author side effects.
 
 ---
 

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -982,6 +982,164 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ---
 
+## SOCIALIZE — priority 18
+
+> The need for the company of others, on whatever terms a character can have it.
+
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor has `socialize` debt ≥ 24
+  - ≥ 4 ticks since last `socialized` event for actor
+  - ≥ 4 ticks since last `socialized_alone` event for actor
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+  - **NOT:** actor has `bereaved` ephemeral
+  - **NOT:** actor has `wounded` ephemeral
+
+### Branch 1 — Seek company after extended isolation  *(mag 0.54)*
+
+**When:** actor has `socialize` debt ≥ 168
+
+**Does:** activity → "seeking company after isolation"; fulfills `socialize` need, quality `sought_company_after_isolation`, discharge 9999
+**Event:** `socialized`
+
+> {actor} feels the particular pressure that comes from going too long without other people in their life, and moves toward somewhere there will be voices, even if those voices are not for them.
+
+### Branch 2 — Engage with company already present  *(mag 0.22)*
+
+**When:** 1+ other entities co-located with actor
+
+**Does:** activity → "engaging with present company"; fulfills `socialize` need, quality `present_company`, discharge 9999
+**Event:** `socialized`
+
+> {actor} spends real attention on the people around them — not transactional attention, the other kind — for long enough that the social need is briefly met without anyone naming it as such.
+
+### Branch 3 — Go where people are  *(mag 0.2)*
+
+**When:**
+
+- **OR:**
+  - actor is in `tavern` place affordance
+  - actor is in `teahouse` place affordance
+  - actor is in `market` place affordance
+  - actor is in `town_square` place affordance
+  - actor is in `public_space` place affordance
+  - actor is in `general_social_venue` place affordance
+
+**Does:** activity → "passing time in a populated place"; fulfills `socialize` need, quality `public_company`, discharge 9999
+**Event:** `socialized`
+
+> {actor} goes to one of the places built around the fact that people gather there, and stays long enough to become part of the room's ordinary texture.
+
+### Branch 4 — Reach out to a contact for no urgent reason  *(mag 0.24)*
+
+**When:** actor has `contacts_available` tag
+
+**Does:** activity → "reconnecting with a contact"; fulfills `socialize` need, quality `remote_contact`, discharge 72
+**Event:** `socialized`
+
+> {actor} thinks of someone they have not spoken with in too long and reaches out for no urgent reason, which is its own kind of reason.
+
+### Branch 5 — Practice parasocial company  *(mag 0.16)*
+
+**When:** *(always)*
+
+**Does:** activity → "spending time with a stranger's voice"; fulfills `socialize` need, quality `parasocial`, discharge 12
+**Event:** `socialized_alone`
+
+> {actor} spends an hour with the voice of a stranger — a book, a serial, a recording — which is not the same as company but is enough like company to take the worst edge off.
+
+---
+
+## INTIMACY — priority 16
+
+> The body asks for the kind of connection that is not conversation.
+
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor has `intimacy` debt ≥ 72
+  - **NOT:** actor has an intimacy suppressor
+  - ≥ 8 ticks since last `intimacy_fulfilled` event for actor
+  - ≥ 8 ticks since last `intimacy_pursued` event for actor
+  - ≥ 8 ticks since last `intimacy_partial` event for actor
+  - ≥ 8 ticks since last `intimacy_deferred` event for actor
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+  - **NOT:** actor has `wounded` ephemeral
+  - **NOT:** actor has `bereaved` ephemeral
+
+### Branch 1 — Spend private time with an established partner  *(mag 0.32)*
+
+**When:**
+
+- **AND:**
+  - actor is in `home` place affordance
+  - actor has an established partner co-located
+
+**Does:** activity → "spending private time with partner"; fulfills `intimacy` need, quality `established_partner`, discharge 9999
+**Event:** `intimacy_fulfilled`
+
+> {actor} closes the door on the day and lets private time with an established partner answer a need the public world has no claim on.
+
+### Branch 2 — Visit a place where compatible company gathers  *(mag 0.48)*
+
+**When:**
+
+- **AND:**
+  - actor is in `intimate_social_venue` place affordance
+  - actor has `intimacy` debt ≥ 168
+  - **NOT:** actor has `partnered_exclusively` tag
+
+**Does:** activity → "seeking compatible company"; fulfills `intimacy` need, quality `pursued_possibility`, discharge 24
+**Event:** `intimacy_pursued`
+
+> {actor} goes to the kind of place where someone like them might meet someone they would want to meet, alert to the possibility without presuming the outcome.
+
+### Branch 3 — Engage contracted intimate company  *(mag 0.28)*
+
+**When:**
+
+- **AND:**
+  - actor is in `intimate_services_establishment` place affordance
+  - actor has `contacts_available` tag
+  - **NOT:** actor has `partnered_exclusively` tag
+  - **NOT:** actor has any of [`vow_of_celibacy`, `religiously_abstinent`, `ethically_opposed_to_contracted_intimacy`]
+
+**Does:** activity → "engaging contracted intimate company"; fulfills `intimacy` need, quality `contracted_companion`, discharge 9999
+**Event:** `intimacy_fulfilled`
+
+> {actor} arranges what can be arranged, in one of the places where the transaction is understood by everyone involved and made ordinary by that clarity.
+
+### Branch 4 — Attend to the need in private  *(mag 0.06)*
+
+**When:**
+
+- **AND:**
+  - **OR:**
+    - actor is in `home` place affordance
+    - actor is in `private_quarters` place affordance
+  - **NOT:** 1+ other entities co-located with actor
+
+**Does:** activity → "private personal time"; fulfills `intimacy` need, quality `private_solo`, discharge 48
+**Event:** `intimacy_partial`
+
+> {actor} attends to the body's quieter demands in private — an unremarkable hour the rest of the world has no business knowing about.
+
+### Branch 5 — Let the want stay where it is  *(mag 0.1)*
+
+**When:** *(always)*
+
+**Does:** activity → "carrying an unaddressed want"
+**Event:** `intimacy_deferred`
+
+> {actor} does not pursue what the body is asking for — the wrong company, the wrong hour, the wrong life — and the want stays where it has been for a while now.
+
+---
+
 ## TEND_CRAFT — priority 15
 
 > A small act of care for the work that defines them.
@@ -1121,6 +1279,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/029_orrery_need_state_init_trigger.py`
 - `migrations/030_orrery_place_affordance_vocab.py`
 - `migrations/031_orrery_slot2_semantic_tag_vocab.py`
+- `migrations/032_orrery_interpersonal_needs.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 
@@ -1138,6 +1297,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `devout`
 - `domestic_role`
 - `engineer`
+- `ethically_opposed_to_contracted_intimacy`
 - `extended_household`
 - `fighter`
 - `first_aid_trained`
@@ -1159,9 +1319,11 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `monk`
 - `musician`
 - `parent`
+- `partnered_exclusively`
 - `patriarch`
 - `performer`
 - `ranger`
+- `religiously_abstinent`
 - `researcher`
 - `ritual_practitioner`
 - `scholar`
@@ -1176,6 +1338,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `under_active_pursuit`
 - `vendetta_holder`
 - `violent_history`
+- `vow_of_celibacy`
 - `warrior`
 - `writer`
 
@@ -1219,6 +1382,10 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `honor_debt`
 - `informant_contact`
 - `intel_acquired`
+- `intimacy_deferred`
+- `intimacy_fulfilled`
+- `intimacy_partial`
+- `intimacy_pursued`
 - `kin_visit`
 - `maintain_cover`
 - `mourning_act`
@@ -1228,6 +1395,8 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `retaliation_executed`
 - `rival_consulted`
 - `slept`
+- `socialized`
+- `socialized_alone`
 - `tended_wound`
 - `threat_issued`
 - `vigil_held`
@@ -1239,11 +1408,16 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 
 - `cafe`
 - `cookshop`
+- `general_social_venue`
 - `home`
+- `intimate_services_establishment`
+- `intimate_social_venue`
 - `lodgings`
 - `market`
 - `neutral_ground`
 - `place_of_remembrance`
+- `private_quarters`
+- `public_space`
 - `public_water`
 - `restaurant`
 - `safe_house`
@@ -1251,6 +1425,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `teahouse`
 - `the_glow`
 - `the_roots`
+- `town_square`
 - `wilderness`
 
 ### Relationship types

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1105,7 +1105,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 - **AND:**
   - actor is in `intimate_services_establishment` place affordance
-  - actor has `contacts_available` tag
+  - actor has `intimate_services_contact` tag
   - **NOT:** actor has `partnered_exclusively` tag
   - **NOT:** actor has any of [`vow_of_celibacy`, `religiously_abstinent`, `ethically_opposed_to_contracted_intimacy`]
 
@@ -1307,6 +1307,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `hunter`
 - `informant_handler`
 - `innkeeper`
+- `intimate_services_contact`
 - `keeps_shop`
 - `loremaster`
 - `magical_healing`

--- a/migrations/032_orrery_interpersonal_needs.py
+++ b/migrations/032_orrery_interpersonal_needs.py
@@ -62,6 +62,11 @@ SEVERITY_TAGS = (
         "Excludes contracted-intimacy branches.",
     ),
     (
+        "intimate_services_contact",
+        "orrery_intimacy_context",
+        "Has contacts at an intimate services establishment.",
+    ),
+    (
         "vow_of_celibacy",
         "orrery_intimacy_suppressor",
         "Principled abstention suppressing intimacy-package fulfillment.",

--- a/migrations/032_orrery_interpersonal_needs.py
+++ b/migrations/032_orrery_interpersonal_needs.py
@@ -1,0 +1,335 @@
+"""Add Orrery interpersonal need-state vocabulary."""
+
+from __future__ import annotations
+
+
+NEED_TYPES = ("socialize", "intimacy")
+
+SEVERITY_TAGS = (
+    ("under_socialized_1_mild", "orrery_need", "Mild socialization debt."),
+    ("under_socialized_2_moderate", "orrery_need", "Moderate socialization debt."),
+    ("under_socialized_3_severe", "orrery_need", "Severe socialization debt."),
+    ("under_socialized_4_critical", "orrery_need", "Critical socialization debt."),
+    ("intimacy_starved_1_mild", "orrery_need", "Mild intimacy debt."),
+    ("intimacy_starved_2_moderate", "orrery_need", "Moderate intimacy debt."),
+    ("intimacy_starved_3_severe", "orrery_need", "Severe intimacy debt."),
+    ("intimacy_starved_4_critical", "orrery_need", "Critical intimacy debt."),
+    (
+        "extroversion_low",
+        "orrery_social_modulator",
+        "Lower social-contact need threshold pressure.",
+    ),
+    (
+        "extroversion_moderate",
+        "orrery_social_modulator",
+        "Default social-contact need threshold pressure.",
+    ),
+    (
+        "extroversion_high",
+        "orrery_social_modulator",
+        "Higher social-contact need threshold pressure.",
+    ),
+    (
+        "libido_absent",
+        "orrery_intimacy_modulator",
+        "Intimacy need does not apply to this character.",
+    ),
+    (
+        "libido_low",
+        "orrery_intimacy_modulator",
+        "Lower intimacy need threshold pressure.",
+    ),
+    (
+        "libido_moderate",
+        "orrery_intimacy_modulator",
+        "Default intimacy need threshold pressure.",
+    ),
+    (
+        "libido_high",
+        "orrery_intimacy_modulator",
+        "Higher intimacy need threshold pressure.",
+    ),
+    (
+        "partnered_exclusively",
+        "orrery_intimacy_context",
+        "Routes intimacy behavior toward established-partner branches.",
+    ),
+    (
+        "ethically_opposed_to_contracted_intimacy",
+        "orrery_intimacy_context",
+        "Excludes contracted-intimacy branches.",
+    ),
+    (
+        "vow_of_celibacy",
+        "orrery_intimacy_suppressor",
+        "Principled abstention suppressing intimacy-package fulfillment.",
+    ),
+    (
+        "religiously_abstinent",
+        "orrery_intimacy_suppressor",
+        "Cultural or spiritual abstention suppressing intimacy-package fulfillment.",
+    ),
+    (
+        "closeted",
+        "orrery_intimacy_suppressor",
+        "Identity or circumstance suppresses intimacy-package fulfillment.",
+    ),
+)
+
+EPHEMERAL_TAGS = (
+    (
+        "grieving_recent_partner",
+        "orrery_intimacy_suppressor",
+        "semantic",
+        '{"description": "cleared when grief no longer suppresses intimacy behavior"}',
+        "Recent partner grief suppresses intimacy-package fulfillment.",
+    ),
+    (
+        "recently_traumatized_intimate",
+        "orrery_intimacy_suppressor",
+        "semantic",
+        '{"description": "cleared by authored healing or durable safety"}',
+        "Recent intimate trauma suppresses intimacy-package fulfillment.",
+    ),
+    (
+        "focus_committed",
+        "orrery_intimacy_suppressor",
+        "semantic",
+        '{"description": "cleared when the consuming work or mission resolves"}',
+        "Voluntary mission focus suppresses intimacy-package fulfillment.",
+    ),
+)
+
+PLACE_AFFORDANCE_TAGS = (
+    ("town_square", "A civic public space where people gather."),
+    ("public_space", "A general public space with routine social presence."),
+    ("general_social_venue", "A venue built for ordinary social contact."),
+    (
+        "intimate_social_venue",
+        "A venue where intimate possibility is socially legible.",
+    ),
+    (
+        "intimate_services_establishment",
+        "A venue where contracted intimate companionship can be arranged.",
+    ),
+    ("private_quarters", "Private quarters suitable for solitary intimate privacy."),
+)
+
+EVENT_TYPES = (
+    ("socialized", "social", "minor", "A character fulfills social-contact need."),
+    (
+        "socialized_alone",
+        "social",
+        "minor",
+        "A character partially fulfills social-contact need alone.",
+    ),
+    (
+        "intimacy_fulfilled",
+        "embodied",
+        "minor",
+        "A character fulfills intimacy need.",
+    ),
+    (
+        "intimacy_pursued",
+        "embodied",
+        "minor",
+        "A character seeks conditions for intimacy without an assumed outcome.",
+    ),
+    (
+        "intimacy_partial",
+        "embodied",
+        "minor",
+        "A character partially fulfills intimacy need privately.",
+    ),
+    (
+        "intimacy_deferred",
+        "embodied",
+        "minor",
+        "A character leaves intimacy pressure unresolved.",
+    ),
+)
+
+
+def run(conn) -> None:
+    """Apply the interpersonal need-state migration."""
+
+    _extend_need_type_enum(conn)
+    _seed_durable_tags(conn)
+    _seed_ephemeral_tags(conn)
+    _seed_place_affordance_tags(conn)
+    _seed_event_types(conn)
+    _replace_need_initializer_function(conn)
+    _backfill_need_states(conn)
+
+
+def _extend_need_type_enum(conn) -> None:
+    with conn.cursor() as cur:
+        for need_type in NEED_TYPES:
+            cur.execute(
+                f"ALTER TYPE character_need_type ADD VALUE IF NOT EXISTS '{need_type}'"
+            )
+    conn.commit()
+
+
+def _seed_durable_tags(conn) -> None:
+    with conn.cursor() as cur:
+        for tag, category, description in SEVERITY_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, %s, FALSE,
+                    NULL, NULL,
+                    NULL, %s
+                )
+                ON CONFLICT (tag) DO NOTHING
+                """,
+                (tag, category, description),
+            )
+    conn.commit()
+
+
+def _seed_ephemeral_tags(conn) -> None:
+    with conn.cursor() as cur:
+        for tag, category, clearance_kind, clear_on_json, description in EPHEMERAL_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, %s, TRUE,
+                    %s::entity_tag_clearance_kind,
+                    'extend_expiry'::entity_tag_reapplication_policy,
+                    %s::jsonb, %s
+                )
+                ON CONFLICT (tag) DO NOTHING
+                """,
+                (tag, category, clearance_kind, clear_on_json, description),
+            )
+    conn.commit()
+
+
+def _seed_place_affordance_tags(conn) -> None:
+    with conn.cursor() as cur:
+        for tag, description in PLACE_AFFORDANCE_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, 'place_affordance', FALSE,
+                    NULL, NULL,
+                    NULL, %s
+                )
+                ON CONFLICT (tag) DO NOTHING
+                """,
+                (tag, description),
+            )
+    conn.commit()
+
+
+def _seed_event_types(conn) -> None:
+    with conn.cursor() as cur:
+        for event_type, category, severity, description in EVENT_TYPES:
+            cur.execute(
+                """
+                INSERT INTO event_types (
+                    type, category, severity, description
+                ) VALUES (
+                    %s, %s, %s::event_severity_kind, %s
+                )
+                ON CONFLICT (type) DO NOTHING
+                """,
+                (event_type, category, severity, description),
+            )
+    conn.commit()
+
+
+def _replace_need_initializer_function(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE OR REPLACE FUNCTION orrery_initialize_character_need_states()
+            RETURNS trigger AS $$
+            DECLARE
+                anchor_world_time timestamptz;
+            BEGIN
+                IF NEW.entity_id IS NULL THEN
+                    RETURN NEW;
+                END IF;
+
+                SELECT COALESCE(MAX(world_time), now())
+                INTO anchor_world_time
+                FROM chunk_metadata;
+
+                INSERT INTO character_need_states (
+                    character_entity_id,
+                    need_type,
+                    debt_score,
+                    last_evaluated_at,
+                    metadata
+                )
+                SELECT NEW.entity_id,
+                       need_type::character_need_type,
+                       0,
+                       anchor_world_time,
+                       '{"initialized_by": "character_trigger"}'::jsonb
+                FROM (
+                    VALUES
+                        ('sleep'),
+                        ('hunger'),
+                        ('thirst'),
+                        ('socialize'),
+                        ('intimacy')
+                ) AS needs(need_type)
+                ON CONFLICT (character_entity_id, need_type) DO NOTHING;
+
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+            """
+        )
+    conn.commit()
+
+
+def _backfill_need_states(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            WITH clock AS (
+                SELECT COALESCE(MAX(world_time), now()) AS world_time
+                FROM chunk_metadata
+            ),
+            needs(need_type) AS (
+                VALUES ('socialize'), ('intimacy')
+            )
+            INSERT INTO character_need_states (
+                character_entity_id,
+                need_type,
+                debt_score,
+                last_evaluated_at,
+                metadata
+            )
+            SELECT c.entity_id,
+                   needs.need_type::character_need_type,
+                   0,
+                   clock.world_time,
+                   '{"backfilled_by": "migration_032"}'::jsonb
+            FROM characters c
+            JOIN entities e ON e.id = c.entity_id
+            CROSS JOIN needs
+            CROSS JOIN clock
+            WHERE c.entity_id IS NOT NULL
+              AND e.kind = 'character'
+              AND e.is_active = true
+            ON CONFLICT (character_entity_id, need_type) DO NOTHING
+            """
+        )
+    conn.commit()

--- a/migrations/032_orrery_interpersonal_needs.py
+++ b/migrations/032_orrery_interpersonal_needs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from psycopg2 import sql
+
 
 NEED_TYPES = ("socialize", "intimacy")
 
@@ -162,13 +164,37 @@ def run(conn) -> None:
     _backfill_need_states(conn)
 
 
-def _extend_need_type_enum(conn) -> None:
+def _enum_value_exists(conn, type_name: str, value: str) -> bool:
     with conn.cursor() as cur:
-        for need_type in NEED_TYPES:
+        cur.execute(
+            """
+            SELECT 1
+            FROM pg_enum
+            WHERE enumtypid = %s::regtype
+              AND enumlabel = %s
+            """,
+            (type_name, value),
+        )
+        return cur.fetchone() is not None
+
+
+def _extend_need_type_enum(conn) -> None:
+    """Add character_need_type enum values needed by interpersonal needs.
+
+    Keep the one-value-per-commit pattern used by earlier enum-extension
+    migrations so new values are usable before later seed/backfill statements.
+    """
+
+    for need_type in NEED_TYPES:
+        if _enum_value_exists(conn, "character_need_type", need_type):
+            continue
+        with conn.cursor() as cur:
             cur.execute(
-                f"ALTER TYPE character_need_type ADD VALUE IF NOT EXISTS '{need_type}'"
+                sql.SQL("ALTER TYPE character_need_type ADD VALUE {}").format(
+                    sql.Literal(need_type)
+                )
             )
-    conn.commit()
+        conn.commit()
 
 
 def _seed_durable_tags(conn) -> None:

--- a/nexus.toml
+++ b/nexus.toml
@@ -177,8 +177,8 @@ candidate_pool_multiplier = 4
 provider = "local"
 
 [orrery.sunhelm]
-accrual_rates = { sleep = 1.0, hunger = 1.0, thirst = 1.0 }
-priorities = { sleep = 25, thirst = 24, hunger = 22 }
+accrual_rates = { sleep = 1.0, hunger = 1.0, thirst = 1.0, socialize = 1.0, intimacy = 1.0 }
+priorities = { sleep = 25, thirst = 24, hunger = 22, socialize = 18, intimacy = 16 }
 
 [orrery.sunhelm.severity_thresholds.sleep]
 mild = 16.0
@@ -197,6 +197,18 @@ mild = 4.0
 moderate = 8.0
 severe = 16.0
 critical = 24.0
+
+[orrery.sunhelm.severity_thresholds.socialize]
+mild = 24.0
+moderate = 72.0
+severe = 168.0
+critical = 336.0
+
+[orrery.sunhelm.severity_thresholds.intimacy]
+mild = 72.0
+moderate = 168.0
+severe = 336.0
+critical = 720.0
 
 [orrery.sunhelm.pressure]
 min_severity_level = 2

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -82,6 +82,10 @@ _register(
     lambda m: f"{_slot(m.group('slot'))} has `{m.group('tag')}` ephemeral",
 )
 _register(
+    r"has_any_intimacy_suppressor\(@(?P<slot>\w+)\)",
+    lambda m: f"{_slot(m.group('slot'))} has an intimacy suppressor",
+)
+_register(
     r"has_severity_tag\((?P<prefix>[^@()]+)@(?P<slot>\w+)\)",
     lambda m: f"{_slot(m.group('slot'))} has `{m.group('prefix')}` severity",
 )
@@ -125,6 +129,10 @@ _register(
         + (f" with `{m.group('ephemeral')}` ephemeral" if m.group("ephemeral") else "")
         + f" co-located with {_slot(m.group('slot'))}"
     ),
+)
+_register(
+    r"has_established_partner_co_located\(@(?P<slot>\w+)\)",
+    lambda m: f"{_slot(m.group('slot'))} has an established partner co-located",
 )
 
 # Trust predicates

--- a/nexus/agents/orrery/needs.py
+++ b/nexus/agents/orrery/needs.py
@@ -10,11 +10,13 @@ from typing import Any, Mapping, Optional
 
 
 class NeedType(str, Enum):
-    """Basic physiological needs tracked by the Sunhelm substrate."""
+    """Need types tracked by the Orrery timestamp-plus-debt substrate."""
 
     SLEEP = "sleep"
     HUNGER = "hunger"
     THIRST = "thirst"
+    SOCIALIZE = "socialize"
+    INTIMACY = "intimacy"
 
 
 NEED_TYPES: tuple[str, ...] = tuple(item.value for item in NeedType)
@@ -22,6 +24,8 @@ NEED_SEVERITY_PREFIX: Mapping[str, str] = {
     NeedType.SLEEP.value: "sleep_deprived",
     NeedType.HUNGER.value: "hungry",
     NeedType.THIRST.value: "thirsty",
+    NeedType.SOCIALIZE.value: "under_socialized",
+    NeedType.INTIMACY.value: "intimacy_starved",
 }
 NEED_SEVERITY_LEVELS: tuple[tuple[int, str], ...] = (
     (4, "critical"),
@@ -33,6 +37,8 @@ DEFAULT_NEED_ACCRUAL_RATES: Mapping[str, float] = {
     NeedType.SLEEP.value: 1.0,
     NeedType.HUNGER.value: 1.0,
     NeedType.THIRST.value: 1.0,
+    NeedType.SOCIALIZE.value: 1.0,
+    NeedType.INTIMACY.value: 1.0,
 }
 DEFAULT_NEED_SEVERITY_THRESHOLDS: Mapping[str, Mapping[str, float]] = {
     NeedType.SLEEP.value: {
@@ -53,11 +59,25 @@ DEFAULT_NEED_SEVERITY_THRESHOLDS: Mapping[str, Mapping[str, float]] = {
         "severe": 16.0,
         "critical": 24.0,
     },
+    NeedType.SOCIALIZE.value: {
+        "mild": 24.0,
+        "moderate": 72.0,
+        "severe": 168.0,
+        "critical": 336.0,
+    },
+    NeedType.INTIMACY.value: {
+        "mild": 72.0,
+        "moderate": 168.0,
+        "severe": 336.0,
+        "critical": 720.0,
+    },
 }
 DEFAULT_NEED_PRIORITIES: Mapping[str, int] = {
     NeedType.SLEEP.value: 25,
     NeedType.THIRST.value: 24,
     NeedType.HUNGER.value: 22,
+    NeedType.SOCIALIZE.value: 18,
+    NeedType.INTIMACY.value: 16,
 }
 
 

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -1015,12 +1015,14 @@ def _need_pressure_stub(
             "friction, relief at being seen, or the pull toward company, but "
             "Orrery does not decide what {actor} does in scene."
         )
-    return (
-        "{actor} is carrying "
-        f"{label} ({debt_score:.1f}). You may render wanting, suppression, "
-        "privacy-seeking, or deferral with appropriate restraint, but Orrery "
-        "does not decide what {actor} does in scene or who they choose."
-    )
+    if need_type == "intimacy":
+        return (
+            "{actor} is carrying "
+            f"{label} ({debt_score:.1f}). You may render wanting, suppression, "
+            "privacy-seeking, or deferral with appropriate restraint, but Orrery "
+            "does not decide what {actor} does in scene or who they choose."
+        )
+    raise ValueError(f"Unhandled Orrery need pressure type: {need_type!r}")
 
 
 def _render_bound_text(

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -12,6 +12,7 @@ from sqlalchemy import text
 from nexus.agents.orrery.substrate import (
     Bindings,
     EventRecord,
+    INTIMACY_SUPPRESSOR_TAGS,
     PresentTargetPolicy,
     Resolution,
     Slot,
@@ -907,6 +908,8 @@ def _present_need_pressure_specs(
     specs: list[dict[str, Any]] = []
     for actor_id in sorted(present_actor_ids):
         for need_type, prefix in NEED_SEVERITY_PREFIX.items():
+            if _present_need_pressure_suppressed(state, actor_id, need_type):
+                continue
             debt_score = state.need_debt_scores.get((actor_id, need_type), 0.0)
             severity = severity_for_debt(
                 need_type,
@@ -929,6 +932,21 @@ def _present_need_pressure_specs(
                 }
             )
     return tuple(specs)
+
+
+def _present_need_pressure_suppressed(
+    state: WorldState,
+    actor_id: int,
+    need_type: str,
+) -> bool:
+    """Return whether a present-character need should stay out of prompt pressure."""
+
+    if need_type != "intimacy":
+        return False
+    actor_tags = state.tags.get(actor_id, frozenset()) | state.ephemeral_tags.get(
+        actor_id, frozenset()
+    )
+    return bool(INTIMACY_SUPPRESSOR_TAGS & actor_tags)
 
 
 def _scene_pressure_from_need_spec(

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -983,11 +983,25 @@ def _need_pressure_stub(
             "irritability, or interest in food, but Orrery does not decide "
             "what {actor} does in scene."
         )
+    if need_type == "thirst":
+        return (
+            "{actor} is carrying "
+            f"{label} ({debt_score:.1f}). You may render thirst, discomfort, "
+            "or urgency around water, but Orrery does not decide what {actor} "
+            "does in scene."
+        )
+    if need_type == "socialize":
+        return (
+            "{actor} is carrying "
+            f"{label} ({debt_score:.1f}). You may render loneliness, social "
+            "friction, relief at being seen, or the pull toward company, but "
+            "Orrery does not decide what {actor} does in scene."
+        )
     return (
         "{actor} is carrying "
-        f"{label} ({debt_score:.1f}). You may render thirst, discomfort, "
-        "or urgency around water, but Orrery does not decide what {actor} "
-        "does in scene."
+        f"{label} ({debt_score:.1f}). You may render wanting, suppression, "
+        "privacy-seeking, or deferral with appropriate restraint, but Orrery "
+        "does not decide what {actor} does in scene or who they choose."
     )
 
 

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -42,6 +42,27 @@ class PresentTargetPolicy(str, Enum):
 Bindings = Dict[Slot, Any]
 Condition = Callable[["WorldState", Bindings], bool]
 
+INTIMACY_SUPPRESSOR_TAGS: frozenset[str] = frozenset(
+    {
+        "closeted",
+        "vow_of_celibacy",
+        "religiously_abstinent",
+        "grieving_recent_partner",
+        "recently_traumatized_intimate",
+        "focus_committed",
+        "libido_absent",
+    }
+)
+ESTABLISHED_PARTNER_RELATIONSHIP_TYPES: frozenset[str] = frozenset(
+    {
+        "romantic",
+        "spouse",
+        "lover",
+        "partner",
+        "romantic_partner",
+    }
+)
+
 
 @dataclass(frozen=True, slots=True)
 class EventRecord:
@@ -134,6 +155,27 @@ def has_ephemeral(tag: str, slot: Slot = Slot.ACTOR) -> Condition:
         )
 
     return _named(_condition, f"has_ephemeral({tag}@{slot.value})")
+
+
+def has_any_intimacy_suppressor(slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound entity carries an intimacy suppressor.
+
+    Suppressors may be durable identity/context tags or ephemeral conditions.
+    The predicate intentionally treats ``libido_absent`` as a suppressor so
+    intimacy rows can exist without forcing intimacy behavior for characters
+    whose identity makes the need inapplicable.
+    """
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        tags = state.tags.get(entity_id, frozenset()) | state.ephemeral_tags.get(
+            entity_id, frozenset()
+        )
+        return bool(INTIMACY_SUPPRESSOR_TAGS & tags)
+
+    return _named(_condition, f"has_any_intimacy_suppressor(@{slot.value})")
 
 
 def has_severity_tag(prefix: str, slot: Slot = Slot.ACTOR) -> Condition:
@@ -297,6 +339,34 @@ def count_co_located(
         filters.append(f"ephemeral={with_ephemeral}")
     suffix = "," + ",".join(filters) if filters else ""
     return _named(_condition, f"count_co_located({minimum}@{slot.value}{suffix})")
+
+
+def has_established_partner_co_located(slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether the actor is co-located with an established partner.
+
+    This intentionally reads existing relationship rows rather than deriving
+    intimate compatibility. Orrery may notice an established relationship and
+    shared place; it does not choose a new partner.
+    """
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        location_id = state.locations.get(entity_id)
+        if location_id is None:
+            return False
+        for (source, target), relationship_types in state.relationship_types.items():
+            if entity_id not in (source, target):
+                continue
+            if not (ESTABLISHED_PARTNER_RELATIONSHIP_TYPES & relationship_types):
+                continue
+            partner_id = target if source == entity_id else source
+            if state.locations.get(partner_id) == location_id:
+                return True
+        return False
+
+    return _named(_condition, f"has_established_partner_co_located(@{slot.value})")
 
 
 def trust_at_least(

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -13,8 +13,10 @@ from nexus.agents.orrery.substrate import (
     Template,
     co_located,
     count_co_located,
+    has_any_intimacy_suppressor,
     has_any_tag,
     has_ephemeral,
+    has_established_partner_co_located,
     has_need_debt_at_or_above,
     has_relationship_of_type,
     has_symmetric_relationship_of_type,
@@ -1926,6 +1928,298 @@ EAT = Template(
 )
 
 
+SOCIALIZE = Template(
+    id="socialize",
+    priority=18,
+    blurb="The need for the company of others, on whatever terms a character can have it.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        has_need_debt_at_or_above("socialize", 24),
+        since_last_event_at_least("socialized", minimum_ticks=4),
+        since_last_event_at_least("socialized_alone", minimum_ticks=4),
+        NOT(has_ephemeral("under_active_pursuit")),
+        NOT(has_ephemeral("bereaved")),
+        NOT(has_ephemeral("wounded")),
+    ),
+    branches=(
+        Branch(
+            label="Seek company after extended isolation",
+            conditions=has_need_debt_at_or_above("socialize", 168),
+            narrative_stub=(
+                "{actor} feels the particular pressure that comes from going "
+                "too long without other people in their life, and moves "
+                "toward somewhere there will be voices, even if those voices "
+                "are not for them."
+            ),
+            state_delta={
+                "character.current_activity": "seeking company after isolation",
+                "need.fulfill": {
+                    "type": "socialize",
+                    "quality": "sought_company_after_isolation",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="socialized",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.54,
+        ),
+        Branch(
+            label="Engage with company already present",
+            conditions=count_co_located(1),
+            narrative_stub=(
+                "{actor} spends real attention on the people around them — "
+                "not transactional attention, the other kind — for long "
+                "enough that the social need is briefly met without anyone "
+                "naming it as such."
+            ),
+            state_delta={
+                "character.current_activity": "engaging with present company",
+                "need.fulfill": {
+                    "type": "socialize",
+                    "quality": "present_company",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="socialized",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.22,
+        ),
+        Branch(
+            label="Go where people are",
+            conditions=OR(
+                in_location_class("tavern"),
+                in_location_class("teahouse"),
+                in_location_class("market"),
+                in_location_class("town_square"),
+                in_location_class("public_space"),
+                in_location_class("general_social_venue"),
+            ),
+            narrative_stub=(
+                "{actor} goes to one of the places built around the fact "
+                "that people gather there, and stays long enough to become "
+                "part of the room's ordinary texture."
+            ),
+            state_delta={
+                "character.current_activity": "passing time in a populated place",
+                "need.fulfill": {
+                    "type": "socialize",
+                    "quality": "public_company",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="socialized",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.20,
+        ),
+        Branch(
+            label="Reach out to a contact for no urgent reason",
+            conditions=has_tag("contacts_available"),
+            narrative_stub=(
+                "{actor} thinks of someone they have not spoken with in too "
+                "long and reaches out for no urgent reason, which is its "
+                "own kind of reason."
+            ),
+            state_delta={
+                "character.current_activity": "reconnecting with a contact",
+                "need.fulfill": {
+                    "type": "socialize",
+                    "quality": "remote_contact",
+                    "discharge_debt": 72,
+                },
+            },
+            event_type="socialized",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.24,
+        ),
+        Branch(
+            label="Practice parasocial company",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} spends an hour with the voice of a stranger — a "
+                "book, a serial, a recording — which is not the same as "
+                "company but is enough like company to take the worst edge "
+                "off."
+            ),
+            state_delta={
+                "character.current_activity": "spending time with a stranger's voice",
+                "need.fulfill": {
+                    "type": "socialize",
+                    "quality": "parasocial",
+                    "discharge_debt": 12,
+                },
+            },
+            event_type="socialized_alone",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.16,
+        ),
+    ),
+)
+
+
+INTIMACY = Template(
+    id="intimacy",
+    priority=16,
+    blurb="The body asks for the kind of connection that is not conversation.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        has_need_debt_at_or_above("intimacy", 72),
+        NOT(has_any_intimacy_suppressor()),
+        since_last_event_at_least("intimacy_fulfilled", minimum_ticks=8),
+        since_last_event_at_least("intimacy_pursued", minimum_ticks=8),
+        since_last_event_at_least("intimacy_partial", minimum_ticks=8),
+        since_last_event_at_least("intimacy_deferred", minimum_ticks=8),
+        NOT(has_ephemeral("under_active_pursuit")),
+        NOT(has_ephemeral("wounded")),
+        NOT(has_ephemeral("bereaved")),
+    ),
+    branches=(
+        Branch(
+            label="Spend private time with an established partner",
+            conditions=AND(
+                in_location_class("home"),
+                has_established_partner_co_located(),
+            ),
+            narrative_stub=(
+                "{actor} closes the door on the day and lets private time "
+                "with an established partner answer a need the public world "
+                "has no claim on."
+            ),
+            state_delta={
+                "character.current_activity": "spending private time with partner",
+                "need.fulfill": {
+                    "type": "intimacy",
+                    "quality": "established_partner",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="intimacy_fulfilled",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.32,
+        ),
+        Branch(
+            label="Visit a place where compatible company gathers",
+            conditions=AND(
+                in_location_class("intimate_social_venue"),
+                has_need_debt_at_or_above("intimacy", 168),
+                NOT(has_tag("partnered_exclusively")),
+            ),
+            narrative_stub=(
+                "{actor} goes to the kind of place where someone like them "
+                "might meet someone they would want to meet, alert to the "
+                "possibility without presuming the outcome."
+            ),
+            state_delta={
+                "character.current_activity": "seeking compatible company",
+                "need.fulfill": {
+                    "type": "intimacy",
+                    "quality": "pursued_possibility",
+                    "discharge_debt": 24,
+                },
+            },
+            event_type="intimacy_pursued",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.48,
+        ),
+        Branch(
+            label="Engage contracted intimate company",
+            conditions=AND(
+                in_location_class("intimate_services_establishment"),
+                has_tag("contacts_available"),
+                NOT(has_tag("partnered_exclusively")),
+                NOT(
+                    has_any_tag(
+                        "vow_of_celibacy",
+                        "religiously_abstinent",
+                        "ethically_opposed_to_contracted_intimacy",
+                    )
+                ),
+            ),
+            narrative_stub=(
+                "{actor} arranges what can be arranged, in one of the places "
+                "where the transaction is understood by everyone involved "
+                "and made ordinary by that clarity."
+            ),
+            state_delta={
+                "character.current_activity": "engaging contracted intimate company",
+                "need.fulfill": {
+                    "type": "intimacy",
+                    "quality": "contracted_companion",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="intimacy_fulfilled",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.28,
+        ),
+        Branch(
+            label="Attend to the need in private",
+            conditions=AND(
+                OR(in_location_class("home"), in_location_class("private_quarters")),
+                NOT(count_co_located(1)),
+            ),
+            narrative_stub=(
+                "{actor} attends to the body's quieter demands in private — "
+                "an unremarkable hour the rest of the world has no business "
+                "knowing about."
+            ),
+            state_delta={
+                "character.current_activity": "private personal time",
+                "need.fulfill": {
+                    "type": "intimacy",
+                    "quality": "private_solo",
+                    "discharge_debt": 48,
+                },
+            },
+            event_type="intimacy_partial",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.06,
+        ),
+        Branch(
+            label="Let the want stay where it is",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} does not pursue what the body is asking for — the "
+                "wrong company, the wrong hour, the wrong life — and the "
+                "want stays where it has been for a while now."
+            ),
+            state_delta={
+                "character.current_activity": "carrying an unaddressed want",
+            },
+            event_type="intimacy_deferred",
+            changed_fields=("character.current_activity",),
+            magnitude=0.10,
+        ),
+    ),
+)
+
+
 BUILTIN_TEMPLATES = (
     EVADE_PURSUERS,
     PROTECT_KIN,
@@ -1944,5 +2238,7 @@ BUILTIN_TEMPLATES = (
     SLEEP,
     DRINK,
     EAT,
+    SOCIALIZE,
+    INTIMACY,
     MAINTAIN_COVER,
 )

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -2145,7 +2145,7 @@ INTIMACY = Template(
             label="Engage contracted intimate company",
             conditions=AND(
                 in_location_class("intimate_services_establishment"),
-                has_tag("contacts_available"),
+                has_tag("intimate_services_contact"),
                 NOT(has_tag("partnered_exclusively")),
                 NOT(
                     has_any_tag(

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -303,11 +303,17 @@ class OrreryPromoteSettings(BaseModel):
 
 
 def _default_need_accrual_rates() -> Dict[str, float]:
-    return {"sleep": 1.0, "hunger": 1.0, "thirst": 1.0}
+    return {
+        "sleep": 1.0,
+        "hunger": 1.0,
+        "thirst": 1.0,
+        "socialize": 1.0,
+        "intimacy": 1.0,
+    }
 
 
 def _default_need_priorities() -> Dict[str, int]:
-    return {"sleep": 25, "thirst": 24, "hunger": 22}
+    return {"sleep": 25, "thirst": 24, "hunger": 22, "socialize": 18, "intimacy": 16}
 
 
 def _default_need_severity_thresholds() -> Dict[str, "OrreryNeedThresholdSettings"]:
@@ -329,6 +335,18 @@ def _default_need_severity_thresholds() -> Dict[str, "OrreryNeedThresholdSetting
             moderate=8.0,
             severe=16.0,
             critical=24.0,
+        ),
+        "socialize": OrreryNeedThresholdSettings(
+            mild=24.0,
+            moderate=72.0,
+            severe=168.0,
+            critical=336.0,
+        ),
+        "intimacy": OrreryNeedThresholdSettings(
+            mild=72.0,
+            moderate=168.0,
+            severe=336.0,
+            critical=720.0,
         ),
     }
 
@@ -380,7 +398,7 @@ class OrrerySunhelmSettings(BaseModel):
 
     @model_validator(mode="after")
     def _validate_need_keys(self) -> "OrrerySunhelmSettings":
-        required = {"sleep", "hunger", "thirst"}
+        required = {"sleep", "hunger", "thirst", "socialize", "intimacy"}
         for field_name, mapping in (
             ("accrual_rates", self.accrual_rates),
             ("severity_thresholds", self.severity_thresholds),

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -20,11 +20,17 @@ def test_orrery_settings_resolve_model_reference() -> None:
         "sleep": 1.0,
         "hunger": 1.0,
         "thirst": 1.0,
+        "socialize": 1.0,
+        "intimacy": 1.0,
     }
     assert settings.orrery.sunhelm.severity_thresholds["sleep"].moderate == 30.0
+    assert settings.orrery.sunhelm.severity_thresholds["socialize"].severe == 168.0
+    assert settings.orrery.sunhelm.severity_thresholds["intimacy"].critical == 720.0
     assert settings.orrery.sunhelm.priorities == {
         "sleep": 25,
         "thirst": 24,
         "hunger": 22,
+        "socialize": 18,
+        "intimacy": 16,
     }
     assert settings.orrery.sunhelm.pressure.min_severity_level == 2

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -183,3 +183,18 @@ def test_interpersonal_need_migration_extends_need_vocab() -> None:
         event_type
         for event_type, _category, _severity, _description in migration.EVENT_TYPES
     }
+
+
+def test_interpersonal_need_migration_uses_safe_enum_extension_pattern() -> None:
+    """Migration 032 keeps enum extension compatible with earlier migrations."""
+
+    migration_source = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "032_orrery_interpersonal_needs.py"
+    ).read_text()
+
+    assert "def _enum_value_exists" in migration_source
+    assert "ALTER TYPE character_need_type ADD VALUE {}" in migration_source
+    assert "sql.Literal(need_type)" in migration_source
+    assert "ADD VALUE IF NOT EXISTS" not in migration_source

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -151,3 +151,35 @@ def test_slot2_semantic_vocab_documents_new_faction_categories() -> None:
         "power_posture",
         "hidden_agenda_class",
     } <= documented
+
+
+def test_interpersonal_need_migration_extends_need_vocab() -> None:
+    """Migration 032 seeds the interpersonal need vocabulary."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "032_orrery_interpersonal_needs.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+
+    assert migration.NEED_TYPES == ("socialize", "intimacy")
+    assert {
+        "under_socialized_1_mild",
+        "under_socialized_4_critical",
+        "intimacy_starved_1_mild",
+        "intimacy_starved_4_critical",
+        "closeted",
+        "libido_absent",
+    } <= {tag for tag, _category, _description in migration.SEVERITY_TAGS}
+    assert {
+        "socialized",
+        "socialized_alone",
+        "intimacy_fulfilled",
+        "intimacy_pursued",
+        "intimacy_partial",
+        "intimacy_deferred",
+    } <= {
+        event_type
+        for event_type, _category, _severity, _description in migration.EVENT_TYPES
+    }

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -170,6 +170,7 @@ def test_interpersonal_need_migration_extends_need_vocab() -> None:
         "intimacy_starved_1_mild",
         "intimacy_starved_4_critical",
         "closeted",
+        "intimate_services_contact",
         "libido_absent",
     } <= {tag for tag, _category, _description in migration.SEVERITY_TAGS}
     assert {

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -324,6 +324,144 @@ def test_resolve_dry_run_fires_sunhelm_need_template() -> None:
     assert proposal.resolutions[0].state_delta["need.fulfill"]["type"] == "sleep"
 
 
+def test_resolve_dry_run_fires_socialize_need_template() -> None:
+    """Interpersonal need debt can resolve through SOCIALIZE."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            need_debt_rows=[
+                {
+                    "character_entity_id": 1,
+                    "need_type": "socialize",
+                    "debt_score": 200,
+                    "last_evaluated_at": datetime(
+                        2073, 10, 31, 12, tzinfo=timezone.utc
+                    ),
+                }
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "socialize"
+    assert proposal.resolutions[0].branch_label == (
+        "Seek company after extended isolation"
+    )
+    assert proposal.resolutions[0].state_delta["need.fulfill"]["type"] == "socialize"
+
+
+def test_resolve_dry_run_fires_intimacy_need_template_without_pairing() -> None:
+    """INTIMACY records pressure relief without selecting a partner target."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            location_class_rows=[
+                {"id": 10, "location_class": "home", "is_primary": True}
+            ],
+            need_debt_rows=[
+                {
+                    "character_entity_id": 1,
+                    "need_type": "intimacy",
+                    "debt_score": 100,
+                    "last_evaluated_at": datetime(
+                        2073, 10, 31, 12, tzinfo=timezone.utc
+                    ),
+                }
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "intimacy"
+    assert proposal.resolutions[0].branch_label == "Attend to the need in private"
+    assert proposal.resolutions[0].bindings == {"actor": 1}
+    assert proposal.resolutions[0].state_delta["need.fulfill"]["type"] == "intimacy"
+
+
+def test_intimacy_partner_branch_requires_partner_relationship() -> None:
+    """Established-partner intimacy uses relationship-aware co-location."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            location_rows=[
+                {"entity_id": 1, "current_location": 10},
+                {"entity_id": 2, "current_location": 10},
+            ],
+            location_class_rows=[
+                {"id": 10, "location_class": "home", "is_primary": True}
+            ],
+            relationship_rows=[
+                {
+                    "source_entity_id": 1,
+                    "target_entity_id": 2,
+                    "relationship_type": "romantic",
+                    "valence_magnitude": 3,
+                }
+            ],
+            need_debt_rows=[
+                {
+                    "character_entity_id": 1,
+                    "need_type": "intimacy",
+                    "debt_score": 100,
+                    "last_evaluated_at": datetime(
+                        2073, 10, 31, 12, tzinfo=timezone.utc
+                    ),
+                }
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "intimacy"
+    assert proposal.resolutions[0].branch_label == (
+        "Spend private time with an established partner"
+    )
+
+
+def test_intimacy_suppressor_blocks_intimacy_template() -> None:
+    """Named suppressors close the INTIMACY gate without deleting need debt."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            tag_rows=[
+                {
+                    "entity_id": 1,
+                    "tag": "closeted",
+                    "is_ephemeral": False,
+                }
+            ],
+            location_class_rows=[
+                {"id": 10, "location_class": "home", "is_primary": True}
+            ],
+            need_debt_rows=[
+                {
+                    "character_entity_id": 1,
+                    "need_type": "intimacy",
+                    "debt_score": 100,
+                    "last_evaluated_at": datetime(
+                        2073, 10, 31, 12, tzinfo=timezone.utc
+                    ),
+                }
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "maintain_cover"
+
+
 def test_hydrate_world_state_populates_trust_from_valence_magnitude() -> None:
     """Orrery trust reads the SQL-derived relationship valence magnitude."""
 

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -7,6 +7,7 @@ import pytest
 from nexus.agents.lore.utils.turn_context import TurnContext
 from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
 from nexus.agents.orrery.resolver import (
+    _need_pressure_stub,
     compose_actor_target_bindings,
     hydrate_world_state,
     resolve_dry_run,
@@ -180,6 +181,9 @@ def test_resolve_dry_run_returns_inspectable_proposal() -> None:
     assert proposal.actor_count == 1
     assert proposal.resolution_count == 1
     assert proposal.resolutions[0].template_id == "maintain_cover"
+    assert not any(
+        resolution.template_id == "intimacy" for resolution in proposal.resolutions
+    )
     assert proposal.resolutions[0].bindings == {"actor": 1}
 
 
@@ -876,6 +880,13 @@ def test_resolve_dry_run_routes_present_need_debt_to_scene_pressure() -> None:
     assert pressure.bindings == {"actor": 1, "resource": "sleep"}
     assert "Mara is carrying moderate sleep debt" in pressure.prompt_text
     assert "Orrery does not decide what Mara does" in pressure.prompt_text
+
+
+def test_need_pressure_stub_rejects_unhandled_need_types() -> None:
+    """Need prompt-pressure copy must not silently reuse intimacy wording."""
+
+    with pytest.raises(ValueError, match="Unhandled Orrery need pressure type"):
+        _need_pressure_stub("wanderlust", severity_name="moderate", debt_score=1)
 
 
 def test_resolve_dry_run_routes_present_intimacy_debt_to_scene_pressure() -> None:

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -878,6 +878,82 @@ def test_resolve_dry_run_routes_present_need_debt_to_scene_pressure() -> None:
     assert "Orrery does not decide what Mara does" in pressure.prompt_text
 
 
+def test_resolve_dry_run_routes_present_intimacy_debt_to_scene_pressure() -> None:
+    """Unsuppressed on-screen intimacy pressure can reach the Storyteller."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[{"entity_id": 1}],
+            present_actor_rows=[{"entity_id": 1}],
+            tag_rows=[
+                {"entity_id": 1, "tag": "libido_moderate", "is_ephemeral": False},
+            ],
+            need_debt_rows=[
+                {
+                    "character_entity_id": 1,
+                    "need_type": "intimacy",
+                    "debt_score": 168,
+                    "last_evaluated_at": datetime(
+                        2073, 10, 31, 12, tzinfo=timezone.utc
+                    ),
+                }
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 0
+    assert proposal.pressure_count == 1
+    pressure = proposal.scene_pressures[0]
+    assert pressure.template_id == "intimacy_need_pressure"
+    assert pressure.bindings == {"actor": 1, "resource": "intimacy"}
+    assert "Mara is carrying moderate intimacy debt" in pressure.prompt_text
+    assert "Orrery does not decide what Mara does" in pressure.prompt_text
+
+
+@pytest.mark.parametrize(
+    ("tag", "is_ephemeral"),
+    [
+        ("closeted", False),
+        ("libido_absent", False),
+        ("focus_committed", True),
+    ],
+)
+def test_resolve_dry_run_suppresses_present_intimacy_pressure(
+    tag: str,
+    is_ephemeral: bool,
+) -> None:
+    """Intimacy suppressors keep prompt pressure out of active scenes."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[{"entity_id": 1}],
+            present_actor_rows=[{"entity_id": 1}],
+            tag_rows=[
+                {"entity_id": 1, "tag": tag, "is_ephemeral": is_ephemeral},
+            ],
+            need_debt_rows=[
+                {
+                    "character_entity_id": 1,
+                    "need_type": "intimacy",
+                    "debt_score": 720,
+                    "last_evaluated_at": datetime(
+                        2073, 10, 31, 12, tzinfo=timezone.utc
+                    ),
+                }
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 0
+    assert proposal.pressure_count == 0
+
+
 def test_resolve_dry_run_uses_configured_present_need_pressure_tuning() -> None:
     """Present-character need pressure uses config thresholds and priorities."""
 

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -17,6 +17,8 @@ from nexus.agents.orrery.substrate import (
     binding_hash,
     count_co_located,
     evaluate_stack,
+    has_any_intimacy_suppressor,
+    has_established_partner_co_located,
     has_need_debt_at_or_above,
     has_severity_tag_at_or_above,
     has_symmetric_relationship_of_type,
@@ -292,6 +294,23 @@ def test_count_co_located_condition_filters_by_tag() -> None:
     assert not count_co_located(2, with_tag="pursuer")(state, {Slot.ACTOR: 1})
 
 
+def test_established_partner_co_location_uses_relationships() -> None:
+    """Partner co-location does not treat arbitrary co-presence as intimacy."""
+
+    predicate = has_established_partner_co_located()
+    partnered_state = WorldState(
+        relationship_types={(1, 2): frozenset({"romantic"})},
+        locations={1: 10, 2: 10, 3: 10},
+    )
+    bystander_state = WorldState(
+        relationship_types={(1, 2): frozenset({"romantic"})},
+        locations={1: 10, 2: 11, 3: 10},
+    )
+
+    assert predicate(partnered_state, {Slot.ACTOR: 1})
+    assert not predicate(bystander_state, {Slot.ACTOR: 1})
+
+
 def test_need_debt_condition_reads_world_state_scores() -> None:
     """Sunhelm gates read effective need debt from hydrated world state."""
 
@@ -336,6 +355,29 @@ def test_severity_tag_threshold_parses_level_prefix() -> None:
 
     assert has_severity_tag_at_or_above("sleep_deprived", 2)(state, {Slot.ACTOR: 1})
     assert not has_severity_tag_at_or_above("sleep_deprived", 4)(state, {Slot.ACTOR: 1})
+
+
+def test_intimacy_suppressor_reads_durable_and_ephemeral_tags() -> None:
+    """Intimacy gates can honor named suppressors without generic tags."""
+
+    predicate = has_any_intimacy_suppressor()
+
+    assert predicate(
+        WorldState(tags={1: frozenset({"closeted"})}),
+        {Slot.ACTOR: 1},
+    )
+    assert predicate(
+        WorldState(ephemeral_tags={1: frozenset({"focus_committed"})}),
+        {Slot.ACTOR: 1},
+    )
+    assert predicate(
+        WorldState(tags={1: frozenset({"libido_absent"})}),
+        {Slot.ACTOR: 1},
+    )
+    assert not predicate(
+        WorldState(tags={1: frozenset({"libido_moderate"})}),
+        {Slot.ACTOR: 1},
+    )
 
 
 def test_recent_event_can_filter_by_changed_fields() -> None:

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -306,8 +306,13 @@ def test_established_partner_co_location_uses_relationships() -> None:
         relationship_types={(1, 2): frozenset({"romantic"})},
         locations={1: 10, 2: 11, 3: 10},
     )
+    reverse_partnered_state = WorldState(
+        relationship_types={(2, 1): frozenset({"romantic"})},
+        locations={1: 10, 2: 10},
+    )
 
     assert predicate(partnered_state, {Slot.ACTOR: 1})
+    assert predicate(reverse_partnered_state, {Slot.ACTOR: 1})
     assert not predicate(bystander_state, {Slot.ACTOR: 1})
 
 


### PR DESCRIPTION
## Summary

Adds the Orrery interpersonal need layer on top of the existing timestamp-plus-debt substrate:

- extends `character_need_type`, `NeedType`, config tuning, and present-character pressure wording for `socialize` and `intimacy`
- seeds controlled vocabulary for under-socialization, intimacy starvation, intimacy suppressors/modulators, place affordances, and interpersonal event types
- adds conservative `SOCIALIZE` and `INTIMACY` templates that record pressure/fulfillment conditions without autonomous pairing or Storyteller-owned scene decisions
- tightens catalog rendering for the new predicates and regenerates `docs/orrery_packages.md`
- updates `docs/orrery_design_plan.md` status for the current Orrery build path

## Design notes

`INTIMACY` intentionally remains single-slot. It can notice established-partner co-location through existing relationship rows, and it can route to private/venue/deferred branches, but it does not compute compatibility, bind a new partner target, or decide relationship outcomes.

The migration also replaces the character need-state initializer so new characters receive `sleep`, `hunger`, `thirst`, `socialize`, and `intimacy` rows.

## Validation

- `poetry run pytest tests/test_orrery tests/config -q`
- `poetry run pytest tests/test_api/test_lore_adapter.py tests/test_lore/test_turn_cycle.py -q`
- `poetry run python -m nexus.agents.orrery.catalog --check`
- `poetry run python -m py_compile nexus/agents/orrery/needs.py nexus/agents/orrery/substrate.py nexus/agents/orrery/templates.py nexus/agents/orrery/resolver.py nexus/agents/orrery/catalog.py migrations/032_orrery_interpersonal_needs.py tests/test_orrery/test_resolver.py tests/test_orrery/test_substrate.py`
- `git diff --check`
- `poetry run python scripts/migrate.py --all` applied migration 032 to `NEXUS_template` and unlocked slots 2-5; slot 1 remained locked
- rollback-only live probes:
  - slot 5 forced `SOCIALIZE` and `INTIMACY` against a small-story actor after temporarily making one present reference off-screen in-transaction
  - slot 2 forced `SOCIALIZE` and `INTIMACY` against Victor Sato, then rolled back
  - natural slot 2 full dry-run still resolves cleanly: 18 actors, 18 resolutions, 2 pressures
