### PR TITLE
Refine Orrery concealment and contact packages

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -19,9 +19,15 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 **Gate:**
 
-- **OR:**
-  - actor has `under_active_pursuit` ephemeral
-  - recent `compliance_alert` event targeting actor in last 5 ticks
+- **AND:**
+  - **OR:**
+    - actor has `under_active_pursuit` ephemeral
+    - recent `compliance_alert` event targeting actor in last 5 ticks
+  - **NOT:** actor is constrained or immobilized
+  - **OR:**
+    - actor is in `the_roots` place affordance
+    - actor has `contacts_available` tag
+    - actor can plausibly move through public flow
 
 ### Branch 1 — Go to ground in flooded tunnels  *(mag 0.72)*
 
@@ -47,12 +53,21 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 3 — Keep moving, blend into public flow  *(mag 0.42)*
 
-**When:** *(always)*
+**When:** actor can plausibly move through public flow
 
 **Does:** activity → "blending into public flow"
 **Event:** `evade_pursuit`
 
 > {actor} joins the densest pedestrian current nearby, never stopping long enough to make a clean pattern.
+
+### Branch 4 — Break line of sight without a clean route  *(mag 0.28)*
+
+**When:** *(always)*
+
+**Does:** activity → "breaking pursuit pattern"
+**Event:** `evade_pursuit`
+
+> {actor} cannot rely on a clean public path, so they buy seconds instead: doors, stairwells, service gaps, and any angle that keeps the pursuit from becoming certain.
 
 ---
 
@@ -279,6 +294,84 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ---
 
+## HIDE — priority 84
+
+> Steady-state concealment for people who are already living out of sight.
+
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor has enough hydrated context
+  - actor is hidden or off-grid
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+  - **NOT:** actor is constrained or immobilized
+  - ≥ 6 ticks since last `hideout_maintained` event for actor
+  - ≥ 6 ticks since last `signal_exposure_reduced` event for actor
+  - ≥ 6 ticks since last `counter_surveillance_sweep` event for actor
+
+### Branch 1 — Harden or sanitize a safehouse  *(mag 0.4)*
+
+**When:**
+
+- **AND:**
+  - actor is in `safe_house` place affordance
+  - actor has any current tag of [`contacts_available`, `fixer`, `route_familiar`, `safehouse_operator`, `survivalist`]
+
+**Does:** activity → "hardening a safehouse"
+**Event:** `hideout_maintained`
+
+> {actor} spends the turn making the safe place safer: cleaning traces, changing habits, checking exits, and removing the small comforts that become evidence.
+
+### Branch 2 — Go dark and reduce signal exposure  *(mag 0.36)*
+
+**When:** actor has any current tag of [`contacts_available`, `ghostprint_active`, `hacker`, `off_grid`, `paranoid`, `signal_operator`]
+
+**Does:** activity → "reducing signal exposure"
+**Event:** `signal_exposure_reduced`
+
+> {actor} trims their signal down to almost nothing — no unnecessary pings, no sentimental check-ins, no pattern that would let a watcher say yes, there.
+
+### Branch 3 — Run a counter-surveillance sweep  *(mag 0.34)*
+
+**When:**
+
+- **OR:**
+  - actor has any current tag of [`combat_trained`, `hacker`, `informant_handler`, `paranoid`, `scout`, `surveillance_capable`]
+  - recent `compliance_alert` event targeting actor in last 8 ticks
+
+**Does:** activity → "running counter-surveillance"
+**Event:** `counter_surveillance_sweep`
+
+> {actor} checks whether anyone has learned the shape of their absence: doubled-back routes, watcher positions, unusual queries, and the tiny repetitions that turn hiding into a map.
+
+### Branch 4 — Shift a mobile route without surfacing  *(mag 0.3)*
+
+**When:**
+
+- **AND:**
+  - **OR:**
+    - actor is in transit
+    - actor has a planned travel destination
+  - actor has any current tag of [`fugitive`, `route_familiar`, `travel_ready`, `wanted`]
+
+**Does:** activity → "shifting concealed route"
+**Event:** `hideout_maintained`
+
+> {actor} changes the route without making the change look like a change, letting timing and terrain do what panic would ruin.
+
+### Branch 5 — Preserve the silence another day  *(mag 0.22)*
+
+**When:** *(always)*
+
+**Does:** activity → "preserving concealment"
+**Event:** `hideout_maintained`
+
+> {actor} does the unglamorous work of staying missing: small routines, smaller footprints, and the discipline not to reach toward the people who would make the silence easier to bear.
+
+---
+
 ## HONOR_DEBT — priority 80
 
 > A binding obligation surfaces from the blank years.
@@ -348,7 +441,11 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 1 — Reach the ally face-to-face before the word gets out  *(mag 0.66)*
 
-**When:** actor and target are co-located
+**When:**
+
+- **AND:**
+  - actor and target are co-located
+  - **NOT:** direct contact actor→target is dramatic
 
 **Does:** activity → "delivering urgent warning in person"; adds `forewarned` to target
 **Event:** `warning_delivered`
@@ -361,7 +458,9 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 2 — Send word through whatever channel will reach them quickest  *(mag 0.52)*
 
-**When:** *(always)*
+**When:**
+
+- **NOT:** direct contact actor→target is dramatic
 
 **Does:** activity → "sending urgent warning"; adds `forewarned` to target
 **Event:** `warning_delivered`
@@ -371,6 +470,19 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
 
 > {actor} has sent {target} an urgent warning by remote means. The scene may show this as an incoming message, a vague disturbance, a half-heard signal, or it may not land in time.
+
+### Branch 3 — Leak the warning without breaking cover  *(mag 0.4)*
+
+**When:** *(always)*
+
+**Does:** activity → "leaking urgent warning"; adds `forewarned` to target
+**Event:** `warning_delivered`
+
+> {actor} still sends the warning, but strips their own hand from it: a proxy, a coded leak, an anonymous ping, something that can reach {target} without making contact itself the story.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} has sent {target} an indirect warning. It may appear as a leak, proxy message, coded signal, or not land in time; Orrery is not deciding how {target} responds.
 
 ---
 
@@ -608,6 +720,115 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ---
 
+## SURVEIL — priority 48
+
+> Watching from afar without turning observation into contact.
+
+**Slots:** ACTOR, TARGET
+**Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
+
+**Gate:**
+
+- **AND:**
+  - actor has enough hydrated context
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:** actor has `under_active_pursuit` ephemeral
+  - **NOT:** actor has `grudge_active` ephemeral
+  - **OR:**
+    - actor is hidden or off-grid
+    - actor has any current tag of [`broker`, `contacts_available`, `hacker`, `informant_handler`, `intelligence_asset_active`, `paranoid`, `researcher`, `signal_operator`, `surveillance_capable`]
+    - actor has `captor` relationship to target
+    - actor has `guardian` relationship to target
+    - actor has `handler` relationship to target
+    - trust actor→target < -2
+    - recent `threat_issued` event targeting target in last 8 ticks
+  - ≥ 6 ticks since last `surveillance_performed` event for (actor, target) pair
+  - ≥ 6 ticks since last `intel_reviewed` event for (actor, target) pair
+
+### Branch 1 — Keep tabs from a distance  *(mag 0.44)*
+
+**When:**
+
+- **OR:**
+  - actor is hidden or off-grid
+  - trust actor→target < -2
+
+**Does:** activity → "keeping tabs from a distance"
+**Event:** `surveillance_performed`
+
+> {actor} keeps tabs on {target} without touching the line between them: a pattern noticed, a channel checked, a small confirmation that does not become contact.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is keeping tabs on {target} from off-screen. Treat this as possible pressure, unease, traces, or delayed setup; do not turn it into automatic contact or control of {target}'s choices.
+
+### Branch 2 — Intercept signal traffic  *(mag 0.48)*
+
+**When:** actor has any current tag of [`ghostprint_active`, `hacker`, `researcher`, `signal_operator`, `surveillance_capable`]
+
+**Does:** activity → "intercepting target signals"
+**Event:** `surveillance_performed`
+
+> {actor} watches the signal field around {target}: not the person directly, not yet, but the traffic and absences that make a life legible to someone patient enough.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} may be reading signal traffic around {target}'s current scene. Use it as optional pressure or atmosphere, not as a canonical breach unless the scene earns it.
+
+### Branch 3 — Collect a proxy watcher report  *(mag 0.38)*
+
+**When:** actor has any current tag of [`broker`, `contacts_available`, `fixer`, `informant_handler`]
+
+**Does:** activity → "collecting a proxy watcher report"
+**Event:** `surveillance_performed`
+
+> {actor} does not go near {target}. They let someone else look, then read the report for what the watcher understood and what they were too ordinary to notice.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} has someone off-screen watching for signs around {target}. This can surface as a watcher, rumor, false alarm, or nothing at all.
+
+### Branch 4 — Review accumulated intel  *(mag 0.34)*
+
+**When:** actor has any current tag of [`academic`, `intelligence_asset_active`, `paranoid`, `researcher`]
+
+**Does:** activity → "reviewing accumulated intel"
+**Event:** `intel_reviewed`
+
+> {actor} stops gathering and starts reading: old logs, half-useful reports, fragments whose meaning only appears after the same question has been asked too many times.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is reviewing accumulated intel related to {target}. If useful, let the scene feel watched or anticipated; the review itself does not force new facts into canon.
+
+### Branch 5 — Follow the public pattern  *(mag 0.3)*
+
+**When:** target can plausibly move through public flow
+
+**Does:** activity → "following target public pattern"
+**Event:** `surveillance_performed`
+
+> {actor} follows the public shape of {target}'s life: where they appear, what routes repeat, which absences look chosen and which look imposed.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} may have mapped the public pattern around {target}. Use this only as Storyteller-controlled scene pressure or a future setup.
+
+### Branch 6 — Keep the target in view without contact  *(mag 0.24)*
+
+**When:** *(always)*
+
+**Does:** activity → "surveilling without contact"
+**Event:** `surveillance_performed`
+
+> {actor} keeps {target} in view at the lowest useful resolution, choosing continued uncertainty over the kind of move that would make the watching visible.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is watching around {target} but has not made contact. The Storyteller may adapt, delay, ignore, or incorporate that pressure without letting Orrery decide what {target} does.
+
+---
+
 ## REACH_OUT_TO_KIN — priority 40
 
 > A small thread of contact between people who hold each other.
@@ -623,8 +844,13 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
     - actor and target share `romantic` relationship (either direction)
     - actor and target share `chosen_kin` relationship (either direction)
     - actor and target share `comrade` relationship (either direction)
+  - **OR:**
+    - actor and target have mutual warm trust
+    - directional trust actor↔target differs by 3+ or is loaded
+    - direct contact actor→target is dramatic
   - ≥ 8 ticks since last `contact_made` event for (actor, target) pair
   - ≥ 8 ticks since last `kin_visit` event for (actor, target) pair
+  - ≥ 8 ticks since last `contact_deferred` event for (actor, target) pair
   - **NOT:** actor has `under_active_pursuit` ephemeral
   - **NOT:** actor has `grudge_active` ephemeral
 
@@ -634,6 +860,8 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 - **AND:**
   - actor and target are co-located
+  - actor and target have mutual warm trust
+  - **NOT:** direct contact actor→target is dramatic
   - ≥ 5 ticks since last `kin_visit` event for (actor, target) pair
 
 **Does:** activity → "spending real time with kin"
@@ -647,7 +875,11 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 2 — Send a message that says less than it means  *(mag 0.16)*
 
-**When:** *(always)*
+**When:**
+
+- **AND:**
+  - actor and target have mutual warm trust
+  - **NOT:** direct contact actor→target is dramatic
 
 **Does:** activity → "keeping kin contact warm"
 **Event:** `contact_made`
@@ -657,6 +889,36 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
 
 > {actor} has sent {target} a small affectionate message. Treat as ambient relationship-warmth — possibly an incoming notification, possibly not surfaced at all.
+
+### Branch 3 — Draft the message and leave it unsent  *(mag 0.18)*
+
+**When:**
+
+- **OR:**
+  - directional trust actor↔target differs by 3+ or is loaded
+  - direct contact actor→target is dramatic
+
+**Does:** activity → "drafting unsent kin contact"
+**Event:** `contact_deferred`
+
+> {actor} writes the message anyway, or composes the call in their head, and then does not send it. The wanting is real; so is the cost of turning it into contact.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is holding back a loaded attempt to reach {target}. Use this as optional emotional pressure or a future story beat; Orrery has not made contact happen.
+
+### Branch 4 — Let the silence stand for now  *(mag 0.08)*
+
+**When:** *(always)*
+
+**Does:** activity → "deferring kin contact"
+**Event:** `contact_deferred`
+
+> {actor} lets the thread remain unpulled. Whatever exists between them and {target}, it is not made warmer by forcing the wrong kind of contact today.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is choosing not to contact {target} for now. Treat this as optional subtext, not as a visible scene event.
 
 ---
 
@@ -1403,29 +1665,73 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ## MAINTAIN_COVER — priority 0
 
-> Baseline activity that keeps the behavioral ledger plausible.
+> Specific public-cover maintenance, not a universal fallback.
 
 **Slots:** ACTOR
 
-**Gate:** *(always)*
+**Gate:**
+
+- **AND:**
+  - actor has enough hydrated context
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:** actor is hidden or off-grid
+  - **NOT:** actor is in transit
+  - **OR:**
+    - actor has any current tag of [`broker`, `cover_identity`, `deep_cover`, `fixer`, `operative`, `public_role`, `undercover`]
+    - actor is in `the_glow` place affordance
+    - actor is in `market` place affordance
+    - actor is in `transit_hub` place affordance
+    - recent `maintain_cover` event with actor=actor in last 10 ticks
+  - ≥ 6 ticks since last `maintain_cover` event for actor
 
 ### Branch 1 — Run a low-level courier job  *(mag 0.16)*
 
-**When:** actor is in `the_glow` place affordance
+**When:**
+
+- **AND:**
+  - actor is in `the_glow` place affordance
+  - actor can plausibly move through public flow
 
 **Does:** activity → "running low-level cover work"
 **Event:** `maintain_cover`
 
 > {actor} picks up a benign data packet, walks it across the district, and earns just enough to register as ordinary.
 
-### Branch 2 — Drift through public space  *(mag 0.1)*
+### Branch 2 — Maintain a specific cover identity  *(mag 0.14)*
 
-**When:** *(always)*
+**When:** actor has any current tag of [`cover_identity`, `deep_cover`, `public_role`, `undercover`]
+
+**Does:** activity → "maintaining cover identity"
+**Event:** `maintain_cover`
+
+> {actor} services the identity that keeps questions from forming: one believable errand, one ordinary exchange, one small proof that the mask has a life of its own.
+
+### Branch 3 — Keep a public role legible  *(mag 0.12)*
+
+**When:** actor has any current tag of [`broker`, `fixer`, `operative`]
+
+**Does:** activity → "keeping public role legible"
+**Event:** `maintain_cover`
+
+> {actor} keeps their visible role legible to the people who expect to see it — enough routine, enough responsiveness, enough plausible friction to look like a life.
+
+### Branch 4 — Drift through public space  *(mag 0.1)*
+
+**When:** actor can plausibly move through public flow
 
 **Does:** activity → "maintaining public cover"
 **Event:** `maintain_cover`
 
 > {actor} moves through public space at the pace of someone with somewhere to be, generating forgettable civilian noise.
+
+### Branch 5 — Keep the ledger plausible from a fixed post  *(mag 0.08)*
+
+**When:** *(always)*
+
+**Does:** activity → "maintaining fixed cover"
+**Event:** `maintain_cover`
+
+> {actor} makes no dramatic move. They answer what must be answered, neglect what can be neglected, and keep their visible life plausible without pretending to be free of it.
 
 ---
 
@@ -1444,6 +1750,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/031_orrery_slot2_semantic_tag_vocab.py`
 - `migrations/032_orrery_interpersonal_needs.py`
 - `migrations/033_orrery_travel_work.py`
+- `migrations/034_orrery_concealment_surveillance_vocab.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 
@@ -1453,11 +1760,14 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `artisan`
 - `artist`
 - `athlete`
+- `broker`
 - `cares_for_household`
 - `combat_trained`
 - `contacts_available`
 - `contemplative`
+- `cover_identity`
 - `dancer`
+- `deep_cover`
 - `devout`
 - `domestic_role`
 - `engineer`
@@ -1466,12 +1776,15 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `field_worker`
 - `fighter`
 - `first_aid_trained`
+- `fixer`
 - `forager`
+- `fugitive`
 - `ghostprint_active`
 - `hacker`
 - `hunter`
 - `informant_handler`
 - `innkeeper`
+- `intelligence_asset_active`
 - `intimate_services_contact`
 - `keeps_shop`
 - `loremaster`
@@ -1484,29 +1797,38 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `merchant`
 - `monk`
 - `musician`
+- `off_grid`
+- `operative`
+- `paranoid`
 - `parent`
 - `partnered_exclusively`
 - `patriarch`
 - `performer`
+- `public_role`
 - `ranger`
 - `religiously_abstinent`
 - `researcher`
 - `ritual_practitioner`
 - `route_familiar`
+- `safehouse_operator`
 - `scholar`
 - `scout`
 - `seeking_identity`
+- `signal_operator`
 - `soldier`
 - `surgical_training`
+- `surveillance_capable`
 - `survivalist`
 - `tinkerer`
 - `trader`
 - `travel_provisioned`
 - `travel_ready`
 - `under_active_pursuit`
+- `undercover`
 - `vendetta_holder`
 - `violent_history`
 - `vow_of_celibacy`
+- `wanted`
 - `warrior`
 - `work_obligation`
 - `writer`
@@ -1528,8 +1850,6 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `at_vigil`
 - `distressed`
 - `forewarned`
-- `intelligence_asset_active`
-- `off_grid`
 - `recently_drained`
 - `recently_protective`
 - `recently_tended`
@@ -1542,16 +1862,20 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 
 - `ate`
 - `compliance_alert`
+- `contact_deferred`
 - `contact_made`
+- `counter_surveillance_sweep`
 - `craft_tended`
 - `drank`
 - `encoded_message`
 - `evade_pursuit`
 - `faction_realignment`
+- `hideout_maintained`
 - `honor_debt`
 - `household_work_performed`
 - `informant_contact`
 - `intel_acquired`
+- `intel_reviewed`
 - `intimacy_deferred`
 - `intimacy_fulfilled`
 - `intimacy_partial`
@@ -1564,9 +1888,11 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `retaliation_attempted`
 - `retaliation_executed`
 - `rival_consulted`
+- `signal_exposure_reduced`
 - `slept`
 - `socialized`
 - `socialized_alone`
+- `surveillance_performed`
 - `tended_wound`
 - `threat_issued`
 - `travel_arrived`

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -745,7 +745,20 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
   - ≥ 6 ticks since last `surveillance_performed` event for (actor, target) pair
   - ≥ 6 ticks since last `intel_reviewed` event for (actor, target) pair
 
-### Branch 1 — Keep tabs from a distance  *(mag 0.44)*
+### Branch 1 — Intercept signal traffic  *(mag 0.48)*
+
+**When:** actor has any current tag of [`ghostprint_active`, `hacker`, `researcher`, `signal_operator`, `surveillance_capable`]
+
+**Does:** activity → "intercepting target signals"
+**Event:** `surveillance_performed`
+
+> {actor} watches the signal field around {target}: not the person directly, not yet, but the traffic and absences that make a life legible to someone patient enough.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} may be reading signal traffic around {target}'s current scene. Use it as optional pressure or atmosphere, not as a canonical breach unless the scene earns it.
+
+### Branch 2 — Keep tabs from a distance  *(mag 0.44)*
 
 **When:**
 
@@ -761,19 +774,6 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
 
 > {actor} is keeping tabs on {target} from off-screen. Treat this as possible pressure, unease, traces, or delayed setup; do not turn it into automatic contact or control of {target}'s choices.
-
-### Branch 2 — Intercept signal traffic  *(mag 0.48)*
-
-**When:** actor has any current tag of [`ghostprint_active`, `hacker`, `researcher`, `signal_operator`, `surveillance_capable`]
-
-**Does:** activity → "intercepting target signals"
-**Event:** `surveillance_performed`
-
-> {actor} watches the signal field around {target}: not the person directly, not yet, but the traffic and absences that make a life legible to someone patient enough.
-
-**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
-
-> {actor} may be reading signal traffic around {target}'s current scene. Use it as optional pressure or atmosphere, not as a canonical breach unless the scene earns it.
 
 ### Branch 3 — Collect a proxy watcher report  *(mag 0.38)*
 
@@ -1677,11 +1677,10 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
   - **NOT:** actor is hidden or off-grid
   - **NOT:** actor is in transit
   - **OR:**
-    - actor has any current tag of [`broker`, `cover_identity`, `deep_cover`, `fixer`, `operative`, `public_role`, `undercover`]
+    - actor has any current tag of [`broker`, `cover_identity`, `fixer`, `operative`, `public_role`, `undercover`]
     - actor is in `the_glow` place affordance
     - actor is in `market` place affordance
     - actor is in `transit_hub` place affordance
-    - recent `maintain_cover` event with actor=actor in last 10 ticks
   - ≥ 6 ticks since last `maintain_cover` event for actor
 
 ### Branch 1 — Run a low-level courier job  *(mag 0.16)*
@@ -1699,7 +1698,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 2 — Maintain a specific cover identity  *(mag 0.14)*
 
-**When:** actor has any current tag of [`cover_identity`, `deep_cover`, `public_role`, `undercover`]
+**When:** actor has any current tag of [`cover_identity`, `public_role`, `undercover`]
 
 **Does:** activity → "maintaining cover identity"
 **Event:** `maintain_cover`
@@ -1760,14 +1759,11 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `artisan`
 - `artist`
 - `athlete`
-- `broker`
 - `cares_for_household`
 - `combat_trained`
 - `contacts_available`
 - `contemplative`
-- `cover_identity`
 - `dancer`
-- `deep_cover`
 - `devout`
 - `domestic_role`
 - `engineer`
@@ -1776,15 +1772,12 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `field_worker`
 - `fighter`
 - `first_aid_trained`
-- `fixer`
 - `forager`
-- `fugitive`
 - `ghostprint_active`
 - `hacker`
 - `hunter`
 - `informant_handler`
 - `innkeeper`
-- `intelligence_asset_active`
 - `intimate_services_contact`
 - `keeps_shop`
 - `loremaster`
@@ -1797,38 +1790,29 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `merchant`
 - `monk`
 - `musician`
-- `off_grid`
-- `operative`
-- `paranoid`
 - `parent`
 - `partnered_exclusively`
 - `patriarch`
 - `performer`
-- `public_role`
 - `ranger`
 - `religiously_abstinent`
 - `researcher`
 - `ritual_practitioner`
 - `route_familiar`
-- `safehouse_operator`
 - `scholar`
 - `scout`
 - `seeking_identity`
-- `signal_operator`
 - `soldier`
 - `surgical_training`
-- `surveillance_capable`
 - `survivalist`
 - `tinkerer`
 - `trader`
 - `travel_provisioned`
 - `travel_ready`
 - `under_active_pursuit`
-- `undercover`
 - `vendetta_holder`
 - `violent_history`
 - `vow_of_celibacy`
-- `wanted`
 - `warrior`
 - `work_obligation`
 - `writer`
@@ -1844,6 +1828,34 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `unconscious`
 - `under_active_pursuit`
 - `wounded`
+
+### Tags queried as current durable-or-ephemeral state (via `has_any_current_tag`)
+
+- `academic`
+- `broker`
+- `combat_trained`
+- `contacts_available`
+- `cover_identity`
+- `fixer`
+- `fugitive`
+- `ghostprint_active`
+- `hacker`
+- `informant_handler`
+- `intelligence_asset_active`
+- `off_grid`
+- `operative`
+- `paranoid`
+- `public_role`
+- `researcher`
+- `route_familiar`
+- `safehouse_operator`
+- `scout`
+- `signal_operator`
+- `surveillance_capable`
+- `survivalist`
+- `travel_ready`
+- `undercover`
+- `wanted`
 
 ### Tags applied by branch effects (durable vs ephemeral classification per migration)
 

--- a/migrations/034_orrery_concealment_surveillance_vocab.py
+++ b/migrations/034_orrery_concealment_surveillance_vocab.py
@@ -1,0 +1,268 @@
+"""Seed Orrery concealment, surveillance, and contact-risk vocabulary."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from psycopg2.extensions import connection
+
+
+# (tag, category, description)
+DURABLE_TAGS: Sequence[tuple[str, str, str]] = (
+    (
+        "cover_identity",
+        "orrery_cover",
+        "Character maintains a specific cover identity that needs routine upkeep.",
+    ),
+    (
+        "undercover",
+        "orrery_cover",
+        "Character is operating under an assumed role or hidden affiliation.",
+    ),
+    (
+        "deep_cover",
+        "orrery_cover",
+        "Character's assumed identity is load-bearing enough that direct contact "
+        "can become a major story beat.",
+    ),
+    (
+        "public_role",
+        "orrery_cover",
+        "Character has a visible public role whose routine can sustain cover.",
+    ),
+    (
+        "operative",
+        "profession_lite",
+        "Character performs covert, paramilitary, intelligence, or field work.",
+    ),
+    (
+        "presumed_dead",
+        "orrery_concealment",
+        "Character is broadly believed dead or unavailable in a way that makes "
+        "direct contact dramatically loaded.",
+    ),
+    (
+        "presumed_dead_by_some",
+        "orrery_concealment",
+        "Some important parties believe the character is dead or gone.",
+    ),
+    (
+        "long_hidden",
+        "orrery_concealment",
+        "Character has remained hidden for a long stretch of narrative time.",
+    ),
+    (
+        "long_absent",
+        "orrery_concealment",
+        "Character has been away long enough that contact carries accumulated "
+        "dramatic weight.",
+    ),
+    (
+        "long_estranged",
+        "relationship_risk",
+        "A relationship has been estranged long enough that ordinary warmth is "
+        "not safe to infer from the relationship type.",
+    ),
+    (
+        "hidden_identity",
+        "orrery_concealment",
+        "Character's current identity or survival depends on staying unrevealed.",
+    ),
+    (
+        "wanted",
+        "orrery_concealment",
+        "Character is sought by authorities, enemies, or other organized forces.",
+    ),
+    (
+        "signal_operator",
+        "capacity",
+        "Character can monitor, intercept, or manipulate communication signals.",
+    ),
+    (
+        "surveillance_capable",
+        "capacity",
+        "Character can perform competent observation, tailing, or remote watching.",
+    ),
+    (
+        "safehouse_operator",
+        "profession_lite",
+        "Character knows how to provision, sanitize, or rotate safe locations.",
+    ),
+)
+
+
+# (tag, category, clearance_kind, clear_on_json, description)
+EPHEMERAL_TAGS: Sequence[tuple[str, str, str, str | None, str]] = (
+    (
+        "contained",
+        "state",
+        "semantic",
+        '{"description": "cleared when the containment condition ends"}',
+        "Entity is physically, socially, or operationally contained.",
+    ),
+    (
+        "immobile",
+        "state",
+        "semantic",
+        '{"description": "cleared when the entity regains meaningful mobility"}',
+        "Entity cannot currently move enough for public-flow packages to apply.",
+    ),
+)
+
+
+# (tag, description)
+PLACE_AFFORDANCE_TAGS: Sequence[tuple[str, str]] = (
+    (
+        "street",
+        "Place supports ordinary public movement through streets, roads, or paths.",
+    ),
+)
+
+
+# (event_type, category, severity, description)
+EVENT_TYPES: Sequence[tuple[str, str, str, str]] = (
+    (
+        "hideout_maintained",
+        "concealment",
+        "minor",
+        "Actor preserves a steady-state hidden life, safehouse, or route.",
+    ),
+    (
+        "signal_exposure_reduced",
+        "concealment",
+        "minor",
+        "Actor reduces their observable communications or digital footprint.",
+    ),
+    (
+        "counter_surveillance_sweep",
+        "concealment",
+        "minor",
+        "Actor checks whether their hiding pattern has become visible.",
+    ),
+    (
+        "surveillance_performed",
+        "intelligence",
+        "minor",
+        "Actor watches, monitors, or keeps tabs on a target without contact.",
+    ),
+    (
+        "intel_reviewed",
+        "intelligence",
+        "minor",
+        "Actor reviews accumulated intelligence instead of gathering new contact.",
+    ),
+    (
+        "contact_deferred",
+        "interpersonal",
+        "minor",
+        "Actor considers relational contact but deliberately withholds it.",
+    ),
+)
+
+
+def run(conn: connection) -> None:
+    """Apply concealment/surveillance package vocabulary."""
+
+    _seed_durable_tags(conn)
+    _seed_ephemeral_tags(conn)
+    _seed_place_affordance_tags(conn)
+    _seed_event_types(conn)
+
+
+def _seed_durable_tags(conn: connection) -> None:
+    with conn.cursor() as cur:
+        for tag, category, description in DURABLE_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, %s, FALSE,
+                    NULL, NULL,
+                    NULL, %s
+                )
+                ON CONFLICT (tag) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    is_ephemeral = EXCLUDED.is_ephemeral,
+                    clearance_kind = EXCLUDED.clearance_kind,
+                    reapplication_policy = EXCLUDED.reapplication_policy,
+                    clear_on = EXCLUDED.clear_on,
+                    description = EXCLUDED.description
+                """,
+                (tag, category, description),
+            )
+    conn.commit()
+
+
+def _seed_ephemeral_tags(conn: connection) -> None:
+    with conn.cursor() as cur:
+        for tag, category, clearance_kind, clear_on_json, description in EPHEMERAL_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, %s, TRUE,
+                    %s::entity_tag_clearance_kind,
+                    'extend_expiry'::entity_tag_reapplication_policy,
+                    %s::jsonb, %s
+                )
+                ON CONFLICT (tag) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    is_ephemeral = EXCLUDED.is_ephemeral,
+                    clearance_kind = EXCLUDED.clearance_kind,
+                    reapplication_policy = EXCLUDED.reapplication_policy,
+                    clear_on = EXCLUDED.clear_on,
+                    description = EXCLUDED.description
+                """,
+                (tag, category, clearance_kind, clear_on_json, description),
+            )
+    conn.commit()
+
+
+def _seed_place_affordance_tags(conn: connection) -> None:
+    with conn.cursor() as cur:
+        for tag, description in PLACE_AFFORDANCE_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, 'place_affordance', FALSE,
+                    NULL, NULL,
+                    NULL, %s
+                )
+                ON CONFLICT (tag) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    is_ephemeral = EXCLUDED.is_ephemeral,
+                    clearance_kind = EXCLUDED.clearance_kind,
+                    reapplication_policy = EXCLUDED.reapplication_policy,
+                    clear_on = EXCLUDED.clear_on,
+                    description = EXCLUDED.description
+                """,
+                (tag, description),
+            )
+    conn.commit()
+
+
+def _seed_event_types(conn: connection) -> None:
+    with conn.cursor() as cur:
+        for event_type, category, severity, description in EVENT_TYPES:
+            cur.execute(
+                """
+                INSERT INTO event_types (
+                    type, category, severity, description
+                ) VALUES (
+                    %s, %s, %s::event_severity_kind, %s
+                )
+                ON CONFLICT (type) DO NOTHING
+                """,
+                (event_type, category, severity, description),
+            )
+    conn.commit()

--- a/migrations/034_orrery_concealment_surveillance_vocab.py
+++ b/migrations/034_orrery_concealment_surveillance_vocab.py
@@ -36,6 +36,12 @@ DURABLE_TAGS: Sequence[tuple[str, str, str]] = (
         "Character performs covert, paramilitary, intelligence, or field work.",
     ),
     (
+        "off_grid",
+        "orrery_state",
+        "Entity has reduced their observable footprint for concealment; this "
+        "is durable until narrative action or semantic review removes it.",
+    ),
+    (
         "presumed_dead",
         "orrery_concealment",
         "Character is broadly believed dead or unavailable in a way that makes "
@@ -261,7 +267,10 @@ def _seed_event_types(conn: connection) -> None:
                 ) VALUES (
                     %s, %s, %s::event_severity_kind, %s
                 )
-                ON CONFLICT (type) DO NOTHING
+                ON CONFLICT (type) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    severity = EXCLUDED.severity,
+                    description = EXCLUDED.description
                 """,
                 (event_type, category, severity, description),
             )

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -487,7 +487,7 @@ _VOCAB_PATTERNS: List[Tuple[str, re.Pattern]] = [
     ("durable_tag", re.compile(r"has_tag\(([^@()]+)@")),
     ("durable_tag", re.compile(r"lacks_tag\(([^@()]+)@")),
     ("durable_tag_list", re.compile(r"has_any_tag\(([^@()]+)@")),
-    ("durable_tag_list", re.compile(r"has_any_current_tag\(([^@()]+)@")),
+    ("current_tag_list", re.compile(r"has_any_current_tag\(([^@()]+)@")),
     ("ephemeral_tag", re.compile(r"has_ephemeral\(([^@()]+)@")),
     ("event_type", re.compile(r"recent_event\(([^,*()]+),")),
     ("event_type", re.compile(r"since_last_event_at_least\(([^,()]+),")),
@@ -515,6 +515,7 @@ def _collect_vocabulary(
 
     durable: set[str] = set()
     ephemeral: set[str] = set()
+    current: set[str] = set()
     applied: set[str] = set()
     events: set[str] = set()
     place_affordances: set[str] = set()
@@ -536,6 +537,9 @@ def _collect_vocabulary(
             elif kind == "durable_tag_list":
                 for tag in captured.split(","):
                     durable.add(tag.strip())
+            elif kind == "current_tag_list":
+                for tag in captured.split(","):
+                    current.add(tag.strip())
             elif kind == "ephemeral_tag":
                 ephemeral.add(captured)
             elif kind == "event_type":
@@ -566,10 +570,12 @@ def _collect_vocabulary(
     # duplicated; classification by query wins.
     applied -= durable
     applied -= ephemeral
+    applied -= current
 
     return {
         "durable_tags": sorted(durable),
         "ephemeral_tags": sorted(ephemeral),
+        "current_tags": sorted(current),
         "applied_tags": sorted(applied),
         "event_types": sorted(events),
         "place_affordances": sorted(place_affordances),
@@ -612,6 +618,11 @@ def _render_vocabulary_appendix(templates: Iterable[Template]) -> List[str]:
         (
             "Tags queried as ephemeral (via `has_ephemeral`)",
             vocab["ephemeral_tags"],
+        ),
+        (
+            "Tags queried as current durable-or-ephemeral state "
+            "(via `has_any_current_tag`)",
+            vocab["current_tags"],
         ),
         (
             "Tags applied by branch effects (durable vs ephemeral "

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -78,8 +78,32 @@ _register(
     ),
 )
 _register(
+    r"has_any_current_tag\((?P<tags>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('slot'))} has any current tag of ["
+        + ", ".join(f"`{t}`" for t in m.group("tags").split(","))
+        + "]"
+    ),
+)
+_register(
     r"has_ephemeral\((?P<tag>[^@()]+)@(?P<slot>\w+)\)",
     lambda m: f"{_slot(m.group('slot'))} has `{m.group('tag')}` ephemeral",
+)
+_register(
+    r"has_minimal_context\(@(?P<slot>\w+)\)",
+    lambda m: f"{_slot(m.group('slot'))} has enough hydrated context",
+)
+_register(
+    r"is_constrained\(@(?P<slot>\w+)\)",
+    lambda m: f"{_slot(m.group('slot'))} is constrained or immobilized",
+)
+_register(
+    r"is_hidden\(@(?P<slot>\w+)\)",
+    lambda m: f"{_slot(m.group('slot'))} is hidden or off-grid",
+)
+_register(
+    r"can_move_publicly\(@(?P<slot>\w+)\)",
+    lambda m: f"{_slot(m.group('slot'))} can plausibly move through public flow",
 )
 _register(
     r"has_any_intimacy_suppressor\(@(?P<slot>\w+)\)",
@@ -165,6 +189,25 @@ _register(
     r"trust_below\((?P<thresh>-?\d+),(?P<a>\w+)->(?P<b>\w+)\)",
     lambda m: (
         f"trust {_slot(m.group('a'))}→{_slot(m.group('b'))} < {m.group('thresh')}"
+    ),
+)
+_register(
+    r"relationship_is_mutual_warm\((?P<a>\w+)<->(?P<b>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('a'))} and {_slot(m.group('b'))} have mutual warm trust"
+    ),
+)
+_register(
+    r"relationship_is_asymmetric\((?P<thresh>\d+),(?P<a>\w+)<->(?P<b>\w+)\)",
+    lambda m: (
+        f"directional trust {_slot(m.group('a'))}↔{_slot(m.group('b'))} "
+        f"differs by {m.group('thresh')}+ or is loaded"
+    ),
+)
+_register(
+    r"direct_contact_is_dramatic\((?P<a>\w+)->(?P<b>\w+)\)",
+    lambda m: (
+        f"direct contact {_slot(m.group('a'))}→{_slot(m.group('b'))} is dramatic"
     ),
 )
 
@@ -444,6 +487,7 @@ _VOCAB_PATTERNS: List[Tuple[str, re.Pattern]] = [
     ("durable_tag", re.compile(r"has_tag\(([^@()]+)@")),
     ("durable_tag", re.compile(r"lacks_tag\(([^@()]+)@")),
     ("durable_tag_list", re.compile(r"has_any_tag\(([^@()]+)@")),
+    ("durable_tag_list", re.compile(r"has_any_current_tag\(([^@()]+)@")),
     ("ephemeral_tag", re.compile(r"has_ephemeral\(([^@()]+)@")),
     ("event_type", re.compile(r"recent_event\(([^,*()]+),")),
     ("event_type", re.compile(r"since_last_event_at_least\(([^,()]+),")),

--- a/nexus/agents/orrery/demo.py
+++ b/nexus/agents/orrery/demo.py
@@ -93,6 +93,14 @@ def build_presets() -> Dict[str, WorldState]:
             weather="clear",
             current_tick=100,
         ),
+        "hiding": WorldState(
+            tags={ACTOR_ID: frozenset({"off_grid"})},
+            locations={ACTOR_ID: ROOTS_PLACE_ID},
+            location_class=location_classes,
+            time_of_day="night",
+            weather="clear",
+            current_tick=100,
+        ),
         # Round-2 solo presets
         "mourning": WorldState(
             ephemeral_tags={ACTOR_ID: frozenset({"bereaved"})},
@@ -166,6 +174,17 @@ def build_multi_slot_presets() -> Dict[str, dict]:
             ),
             "bindings": {Slot.ACTOR: ACTOR_ID, Slot.TARGET: TARGET_ID},
         },
+        "surveillance": {
+            "state": WorldState(
+                tags={ACTOR_ID: frozenset({"signal_operator"})},
+                locations={ACTOR_ID: GLOW_PLACE_ID, TARGET_ID: ROOTS_PLACE_ID},
+                location_class=location_classes,
+                time_of_day="night",
+                weather="clear",
+                current_tick=100,
+            ),
+            "bindings": {Slot.ACTOR: ACTOR_ID, Slot.TARGET: TARGET_ID},
+        },
         # Round-2 multi-slot presets
         "wounded_healing": {
             "state": WorldState(
@@ -224,6 +243,7 @@ def build_multi_slot_presets() -> Dict[str, dict]:
         "kin_visit": {
             "state": WorldState(
                 relationship_types={(ACTOR_ID, TARGET_ID): frozenset({"family"})},
+                trust={(ACTOR_ID, TARGET_ID): 3, (TARGET_ID, ACTOR_ID): 2},
                 locations={ACTOR_ID: GLOW_PLACE_ID, TARGET_ID: GLOW_PLACE_ID},
                 location_class=location_classes,
                 time_of_day="afternoon",

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -62,6 +62,59 @@ ESTABLISHED_PARTNER_RELATIONSHIP_TYPES: frozenset[str] = frozenset(
         "romantic_partner",
     }
 )
+CONSTRAINED_TAGS: frozenset[str] = frozenset(
+    {
+        "captive",
+        "contained",
+        "dying",
+        "immobile",
+        "sandboxed",
+        "unconscious",
+        "wounded",
+    }
+)
+HIDDEN_TAGS: frozenset[str] = frozenset(
+    {
+        "fugitive",
+        "hidden_identity",
+        "long_absent",
+        "long_hidden",
+        "off_grid",
+        "presumed_dead",
+        "presumed_dead_by_some",
+        "wanted",
+    }
+)
+PUBLIC_MOBILITY_TAGS: frozenset[str] = frozenset(
+    {
+        "broker",
+        "contacts_available",
+        "courier",
+        "field_worker",
+        "fixer",
+        "public_role",
+        "route_familiar",
+        "scout",
+        "travel_ready",
+    }
+)
+PUBLIC_PLACE_AFFORDANCES: frozenset[str] = frozenset(
+    {
+        "market",
+        "public_space",
+        "street",
+        "the_glow",
+        "the_roots",
+        "transit_hub",
+        "workplace",
+    }
+)
+DRAMATIC_CONTACT_TAGS: frozenset[str] = HIDDEN_TAGS | frozenset(
+    {
+        "deep_cover",
+        "long_estranged",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -173,6 +226,23 @@ def has_any_tag(*tags: str, slot: Slot = Slot.ACTOR) -> Condition:
     return _named(_condition, f"has_any_tag({','.join(tags)}@{slot.value})")
 
 
+def has_any_current_tag(*tags: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound entity has any durable or ephemeral tag."""
+
+    candidates = frozenset(tags)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        current_tags = state.tags.get(
+            entity_id, frozenset()
+        ) | state.ephemeral_tags.get(entity_id, frozenset())
+        return bool(candidates & current_tags)
+
+    return _named(_condition, f"has_any_current_tag({','.join(tags)}@{slot.value})")
+
+
 def has_ephemeral(tag: str, slot: Slot = Slot.ACTOR) -> Condition:
     """Return whether a slot-bound entity has a current ephemeral tag."""
 
@@ -183,6 +253,83 @@ def has_ephemeral(tag: str, slot: Slot = Slot.ACTOR) -> Condition:
         )
 
     return _named(_condition, f"has_ephemeral({tag}@{slot.value})")
+
+
+def has_minimal_context(slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether Orrery has enough substrate to reason about an entity."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        if state.tags.get(entity_id) or state.ephemeral_tags.get(entity_id):
+            return True
+        if entity_id in state.locations or entity_id in state.activities:
+            return True
+        if entity_id in state.travel_states:
+            return True
+        return any(
+            event.actor_entity_id == entity_id or event.target_entity_id == entity_id
+            for event in state.recent_events
+        )
+
+    return _named(_condition, f"has_minimal_context(@{slot.value})")
+
+
+def is_constrained(slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound entity is not free to act off-screen."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        current_tags = state.tags.get(
+            entity_id, frozenset()
+        ) | state.ephemeral_tags.get(entity_id, frozenset())
+        return bool(CONSTRAINED_TAGS & current_tags)
+
+    return _named(_condition, f"is_constrained(@{slot.value})")
+
+
+def is_hidden(slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound entity is living under concealment."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        current_tags = state.tags.get(
+            entity_id, frozenset()
+        ) | state.ephemeral_tags.get(entity_id, frozenset())
+        return bool(HIDDEN_TAGS & current_tags)
+
+    return _named(_condition, f"is_hidden(@{slot.value})")
+
+
+def can_move_publicly(slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether public-flow movement is plausible for the entity."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None or _is_in_transit(state, entity_id):
+            return False
+        current_tags = state.tags.get(
+            entity_id, frozenset()
+        ) | state.ephemeral_tags.get(entity_id, frozenset())
+        if CONSTRAINED_TAGS & current_tags:
+            return False
+        if PUBLIC_MOBILITY_TAGS & current_tags:
+            return True
+        location_id = state.locations.get(entity_id)
+        if location_id is None:
+            return False
+        semantic_classes = state.location_classes.get(location_id, frozenset())
+        if PUBLIC_PLACE_AFFORDANCES & semantic_classes:
+            return True
+        location_class = state.location_class.get(location_id)
+        return bool(location_class and location_class in PUBLIC_PLACE_AFFORDANCES)
+
+    return _named(_condition, f"can_move_publicly(@{slot.value})")
 
 
 def has_any_intimacy_suppressor(slot: Slot = Slot.ACTOR) -> Condition:
@@ -511,6 +658,81 @@ def trust_below(
 
     return _named(
         _condition, f"trust_below({threshold},{slot_from.value}->{slot_to.value})"
+    )
+
+
+def relationship_is_mutual_warm(
+    slot_a: Slot = Slot.ACTOR,
+    slot_b: Slot = Slot.TARGET,
+) -> Condition:
+    """Return whether two entities have enough mutual trust for warm contact."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        source = _slot_entity(bindings, slot_a)
+        target = _slot_entity(bindings, slot_b)
+        if source is None or target is None:
+            return False
+        return (
+            state.trust.get((source, target), 0) >= 2
+            and state.trust.get((target, source), 0) >= 1
+        )
+
+    return _named(
+        _condition,
+        f"relationship_is_mutual_warm({slot_a.value}<->{slot_b.value})",
+    )
+
+
+def relationship_is_asymmetric(
+    threshold: int = 3,
+    slot_a: Slot = Slot.ACTOR,
+    slot_b: Slot = Slot.TARGET,
+) -> Condition:
+    """Return whether directional trust is dramatically lopsided."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        source = _slot_entity(bindings, slot_a)
+        target = _slot_entity(bindings, slot_b)
+        if source is None or target is None:
+            return False
+        forward = state.trust.get((source, target), 0)
+        reverse = state.trust.get((target, source), 0)
+        return abs(forward - reverse) >= threshold or (forward >= 2 and reverse <= -1)
+
+    return _named(
+        _condition,
+        f"relationship_is_asymmetric({threshold},{slot_a.value}<->{slot_b.value})",
+    )
+
+
+def direct_contact_is_dramatic(
+    slot_from: Slot = Slot.ACTOR,
+    slot_to: Slot = Slot.TARGET,
+) -> Condition:
+    """Return whether direct contact should be treated as a story beat."""
+
+    asymmetric = relationship_is_asymmetric(slot_a=slot_from, slot_b=slot_to)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        source = _slot_entity(bindings, slot_from)
+        target = _slot_entity(bindings, slot_to)
+        if source is None or target is None:
+            return False
+        source_tags = state.tags.get(source, frozenset()) | state.ephemeral_tags.get(
+            source, frozenset()
+        )
+        target_tags = state.tags.get(target, frozenset()) | state.ephemeral_tags.get(
+            target, frozenset()
+        )
+        if DRAMATIC_CONTACT_TAGS & (source_tags | target_tags):
+            return True
+        if state.trust.get((target, source), 0) <= -2:
+            return True
+        return asymmetric(state, bindings)
+
+    return _named(
+        _condition,
+        f"direct_contact_is_dramatic({slot_from.value}->{slot_to.value})",
     )
 
 

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -70,11 +70,11 @@ CONSTRAINED_TAGS: frozenset[str] = frozenset(
         "immobile",
         "sandboxed",
         "unconscious",
-        "wounded",
     }
 )
 HIDDEN_TAGS: frozenset[str] = frozenset(
     {
+        "deep_cover",
         "fugitive",
         "hidden_identity",
         "long_absent",
@@ -111,10 +111,11 @@ PUBLIC_PLACE_AFFORDANCES: frozenset[str] = frozenset(
 )
 DRAMATIC_CONTACT_TAGS: frozenset[str] = HIDDEN_TAGS | frozenset(
     {
-        "deep_cover",
         "long_estranged",
     }
 )
+LOADED_TRUST_FORWARD_MIN = 2
+LOADED_TRUST_REVERSE_MAX = -1
 
 
 @dataclass(frozen=True, slots=True)
@@ -697,7 +698,7 @@ def relationship_is_asymmetric(
             return False
         forward = state.trust.get((source, target), 0)
         reverse = state.trust.get((target, source), 0)
-        return abs(forward - reverse) >= threshold or (forward >= 2 and reverse <= -1)
+        return _trust_values_are_asymmetric(forward, reverse, threshold)
 
     return _named(
         _condition,
@@ -710,8 +711,6 @@ def direct_contact_is_dramatic(
     slot_to: Slot = Slot.TARGET,
 ) -> Condition:
     """Return whether direct contact should be treated as a story beat."""
-
-    asymmetric = relationship_is_asymmetric(slot_a=slot_from, slot_b=slot_to)
 
     def _condition(state: WorldState, bindings: Bindings) -> bool:
         source = _slot_entity(bindings, slot_from)
@@ -726,13 +725,27 @@ def direct_contact_is_dramatic(
         )
         if DRAMATIC_CONTACT_TAGS & (source_tags | target_tags):
             return True
-        if state.trust.get((target, source), 0) <= -2:
+        forward = state.trust.get((source, target), 0)
+        reverse = state.trust.get((target, source), 0)
+        if reverse <= -2:
             return True
-        return asymmetric(state, bindings)
+        return _trust_values_are_asymmetric(forward, reverse)
 
     return _named(
         _condition,
         f"direct_contact_is_dramatic({slot_from.value}->{slot_to.value})",
+    )
+
+
+def _trust_values_are_asymmetric(
+    forward: int,
+    reverse: int,
+    threshold: int = 3,
+) -> bool:
+    """Return whether trust values are lopsided or one-sided warm/resentful."""
+
+    return abs(forward - reverse) >= threshold or (
+        forward >= LOADED_TRUST_FORWARD_MIN and reverse <= LOADED_TRUST_REVERSE_MAX
     )
 
 

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -11,21 +11,29 @@ from nexus.agents.orrery.substrate import (
     PresentTargetPolicy,
     Slot,
     Template,
+    can_move_publicly,
     co_located,
     count_co_located,
+    direct_contact_is_dramatic,
     has_any_intimacy_suppressor,
+    has_any_current_tag,
     has_any_tag,
     has_ephemeral,
     has_established_partner_co_located,
+    has_minimal_context,
     has_need_debt_at_or_above,
     has_relationship_of_type,
     has_symmetric_relationship_of_type,
     has_tag,
     has_travel_destination,
     in_location_class,
+    is_constrained,
+    is_hidden,
     is_in_transit,
     lacks_tag,
     recent_event,
+    relationship_is_asymmetric,
+    relationship_is_mutual_warm,
     since_last_event_at_least,
     time_of_day_in,
     travel_progress_at_or_above,
@@ -41,9 +49,17 @@ EVADE_PURSUERS = Template(
     priority=100,
     blurb="When the city is closing in.",
     required_slots=(Slot.ACTOR,),
-    package_gate=OR(
-        has_ephemeral("under_active_pursuit"),
-        recent_event("compliance_alert", within_ticks=5, target_slot=Slot.ACTOR),
+    package_gate=AND(
+        OR(
+            has_ephemeral("under_active_pursuit"),
+            recent_event("compliance_alert", within_ticks=5, target_slot=Slot.ACTOR),
+        ),
+        NOT(is_constrained()),
+        OR(
+            in_location_class("the_roots"),
+            has_tag("contacts_available"),
+            can_move_publicly(),
+        ),
     ),
     branches=(
         Branch(
@@ -77,7 +93,7 @@ EVADE_PURSUERS = Template(
         ),
         Branch(
             label="Keep moving, blend into public flow",
-            conditions=ALWAYS,
+            conditions=can_move_publicly(),
             narrative_stub=(
                 "{actor} joins the densest pedestrian current nearby, never "
                 "stopping long enough to make a clean pattern."
@@ -86,6 +102,150 @@ EVADE_PURSUERS = Template(
             event_type="evade_pursuit",
             changed_fields=("character.current_activity",),
             magnitude=0.42,
+        ),
+        Branch(
+            label="Break line of sight without a clean route",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} cannot rely on a clean public path, so they buy "
+                "seconds instead: doors, stairwells, service gaps, and any "
+                "angle that keeps the pursuit from becoming certain."
+            ),
+            state_delta={"character.current_activity": "breaking pursuit pattern"},
+            event_type="evade_pursuit",
+            changed_fields=("character.current_activity",),
+            magnitude=0.28,
+        ),
+    ),
+)
+
+
+HIDE = Template(
+    id="hide",
+    priority=84,
+    blurb="Steady-state concealment for people who are already living out of sight.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        has_minimal_context(),
+        is_hidden(),
+        NOT(has_ephemeral("under_active_pursuit")),
+        NOT(is_constrained()),
+        since_last_event_at_least("hideout_maintained", minimum_ticks=6),
+        since_last_event_at_least("signal_exposure_reduced", minimum_ticks=6),
+        since_last_event_at_least("counter_surveillance_sweep", minimum_ticks=6),
+    ),
+    branches=(
+        Branch(
+            label="Harden or sanitize a safehouse",
+            conditions=AND(
+                in_location_class("safe_house"),
+                has_any_current_tag(
+                    "contacts_available",
+                    "fixer",
+                    "route_familiar",
+                    "safehouse_operator",
+                    "survivalist",
+                ),
+            ),
+            narrative_stub=(
+                "{actor} spends the turn making the safe place safer: "
+                "cleaning traces, changing habits, checking exits, and "
+                "removing the small comforts that become evidence."
+            ),
+            state_delta={
+                "character.current_activity": "hardening a safehouse",
+            },
+            event_type="hideout_maintained",
+            changed_fields=("character.current_activity",),
+            magnitude=0.40,
+        ),
+        Branch(
+            label="Go dark and reduce signal exposure",
+            conditions=has_any_current_tag(
+                "contacts_available",
+                "ghostprint_active",
+                "hacker",
+                "off_grid",
+                "paranoid",
+                "signal_operator",
+            ),
+            narrative_stub=(
+                "{actor} trims their signal down to almost nothing — no "
+                "unnecessary pings, no sentimental check-ins, no pattern "
+                "that would let a watcher say yes, there."
+            ),
+            state_delta={
+                "character.current_activity": "reducing signal exposure",
+            },
+            event_type="signal_exposure_reduced",
+            changed_fields=("character.current_activity",),
+            magnitude=0.36,
+        ),
+        Branch(
+            label="Run a counter-surveillance sweep",
+            conditions=OR(
+                has_any_current_tag(
+                    "combat_trained",
+                    "hacker",
+                    "informant_handler",
+                    "paranoid",
+                    "scout",
+                    "surveillance_capable",
+                ),
+                recent_event(
+                    "compliance_alert",
+                    within_ticks=8,
+                    target_slot=Slot.ACTOR,
+                ),
+            ),
+            narrative_stub=(
+                "{actor} checks whether anyone has learned the shape of their "
+                "absence: doubled-back routes, watcher positions, unusual "
+                "queries, and the tiny repetitions that turn hiding into a map."
+            ),
+            state_delta={
+                "character.current_activity": "running counter-surveillance",
+            },
+            event_type="counter_surveillance_sweep",
+            changed_fields=("character.current_activity",),
+            magnitude=0.34,
+        ),
+        Branch(
+            label="Shift a mobile route without surfacing",
+            conditions=AND(
+                OR(is_in_transit(), has_travel_destination()),
+                has_any_current_tag(
+                    "fugitive",
+                    "route_familiar",
+                    "travel_ready",
+                    "wanted",
+                ),
+            ),
+            narrative_stub=(
+                "{actor} changes the route without making the change look like "
+                "a change, letting timing and terrain do what panic would ruin."
+            ),
+            state_delta={
+                "character.current_activity": "shifting concealed route",
+            },
+            event_type="hideout_maintained",
+            changed_fields=("character.current_activity",),
+            magnitude=0.30,
+        ),
+        Branch(
+            label="Preserve the silence another day",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} does the unglamorous work of staying missing: small "
+                "routines, smaller footprints, and the discipline not to reach "
+                "toward the people who would make the silence easier to bear."
+            ),
+            state_delta={
+                "character.current_activity": "preserving concealment",
+            },
+            event_type="hideout_maintained",
+            changed_fields=("character.current_activity",),
+            magnitude=0.22,
         ),
     ),
 )
@@ -200,13 +360,34 @@ PURSUE_GHOST_LEAD = Template(
 MAINTAIN_COVER = Template(
     id="maintain_cover",
     priority=0,
-    blurb="Baseline activity that keeps the behavioral ledger plausible.",
+    blurb="Specific public-cover maintenance, not a universal fallback.",
     required_slots=(Slot.ACTOR,),
-    package_gate=ALWAYS,
+    package_gate=AND(
+        has_minimal_context(),
+        NOT(is_constrained()),
+        NOT(is_hidden()),
+        NOT(is_in_transit()),
+        OR(
+            has_any_current_tag(
+                "broker",
+                "cover_identity",
+                "deep_cover",
+                "fixer",
+                "operative",
+                "public_role",
+                "undercover",
+            ),
+            in_location_class("the_glow"),
+            in_location_class("market"),
+            in_location_class("transit_hub"),
+            recent_event("maintain_cover", within_ticks=10, actor_slot=Slot.ACTOR),
+        ),
+        since_last_event_at_least("maintain_cover", minimum_ticks=6),
+    ),
     branches=(
         Branch(
             label="Run a low-level courier job",
-            conditions=in_location_class("the_glow"),
+            conditions=AND(in_location_class("the_glow"), can_move_publicly()),
             narrative_stub=(
                 "{actor} picks up a benign data packet, walks it across the "
                 "district, and earns just enough to register as ordinary."
@@ -217,8 +398,39 @@ MAINTAIN_COVER = Template(
             magnitude=0.16,
         ),
         Branch(
+            label="Maintain a specific cover identity",
+            conditions=has_any_current_tag(
+                "cover_identity",
+                "deep_cover",
+                "public_role",
+                "undercover",
+            ),
+            narrative_stub=(
+                "{actor} services the identity that keeps questions from "
+                "forming: one believable errand, one ordinary exchange, one "
+                "small proof that the mask has a life of its own."
+            ),
+            state_delta={"character.current_activity": "maintaining cover identity"},
+            event_type="maintain_cover",
+            changed_fields=("character.current_activity",),
+            magnitude=0.14,
+        ),
+        Branch(
+            label="Keep a public role legible",
+            conditions=has_any_current_tag("broker", "fixer", "operative"),
+            narrative_stub=(
+                "{actor} keeps their visible role legible to the people who "
+                "expect to see it — enough routine, enough responsiveness, "
+                "enough plausible friction to look like a life."
+            ),
+            state_delta={"character.current_activity": "keeping public role legible"},
+            event_type="maintain_cover",
+            changed_fields=("character.current_activity",),
+            magnitude=0.12,
+        ),
+        Branch(
             label="Drift through public space",
-            conditions=ALWAYS,
+            conditions=can_move_publicly(),
             narrative_stub=(
                 "{actor} moves through public space at the pace of someone "
                 "with somewhere to be, generating forgettable civilian noise."
@@ -227,6 +439,19 @@ MAINTAIN_COVER = Template(
             event_type="maintain_cover",
             changed_fields=("character.current_activity",),
             magnitude=0.1,
+        ),
+        Branch(
+            label="Keep the ledger plausible from a fixed post",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} makes no dramatic move. They answer what must be "
+                "answered, neglect what can be neglected, and keep their "
+                "visible life plausible without pretending to be free of it."
+            ),
+            state_delta={"character.current_activity": "maintaining fixed cover"},
+            event_type="maintain_cover",
+            changed_fields=("character.current_activity",),
+            magnitude=0.08,
         ),
     ),
 )
@@ -483,6 +708,185 @@ PROTECT_KIN = Template(
                 "{actor} is monitoring {target}'s danger from off-screen. This "
                 "is emotional and logistical pressure, not a command to change "
                 "what {target} does in the scene."
+            ),
+        ),
+    ),
+    present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
+)
+
+
+SURVEIL = Template(
+    id="surveil",
+    priority=48,
+    blurb="Watching from afar without turning observation into contact.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    package_gate=AND(
+        has_minimal_context(),
+        NOT(is_constrained()),
+        NOT(has_ephemeral("under_active_pursuit")),
+        NOT(has_ephemeral("grudge_active")),
+        OR(
+            is_hidden(),
+            has_any_current_tag(
+                "broker",
+                "contacts_available",
+                "hacker",
+                "informant_handler",
+                "intelligence_asset_active",
+                "paranoid",
+                "researcher",
+                "signal_operator",
+                "surveillance_capable",
+            ),
+            has_relationship_of_type("captor", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("guardian", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("handler", Slot.ACTOR, Slot.TARGET),
+            trust_below(-2),
+            recent_event("threat_issued", within_ticks=8, target_slot=Slot.TARGET),
+        ),
+        since_last_event_at_least(
+            "surveillance_performed", minimum_ticks=6, target_slot=Slot.TARGET
+        ),
+        since_last_event_at_least(
+            "intel_reviewed", minimum_ticks=6, target_slot=Slot.TARGET
+        ),
+    ),
+    branches=(
+        Branch(
+            label="Keep tabs from a distance",
+            conditions=OR(is_hidden(), trust_below(-2)),
+            narrative_stub=(
+                "{actor} keeps tabs on {target} without touching the line "
+                "between them: a pattern noticed, a channel checked, a "
+                "small confirmation that does not become contact."
+            ),
+            state_delta={
+                "character.current_activity": "keeping tabs from a distance",
+            },
+            event_type="surveillance_performed",
+            changed_fields=("character.current_activity",),
+            magnitude=0.44,
+            scene_pressure_stub=(
+                "{actor} is keeping tabs on {target} from off-screen. Treat "
+                "this as possible pressure, unease, traces, or delayed setup; "
+                "do not turn it into automatic contact or control of "
+                "{target}'s choices."
+            ),
+        ),
+        Branch(
+            label="Intercept signal traffic",
+            conditions=has_any_current_tag(
+                "ghostprint_active",
+                "hacker",
+                "researcher",
+                "signal_operator",
+                "surveillance_capable",
+            ),
+            narrative_stub=(
+                "{actor} watches the signal field around {target}: not the "
+                "person directly, not yet, but the traffic and absences that "
+                "make a life legible to someone patient enough."
+            ),
+            state_delta={
+                "character.current_activity": "intercepting target signals",
+            },
+            event_type="surveillance_performed",
+            changed_fields=("character.current_activity",),
+            magnitude=0.48,
+            scene_pressure_stub=(
+                "{actor} may be reading signal traffic around {target}'s "
+                "current scene. Use it as optional pressure or atmosphere, "
+                "not as a canonical breach unless the scene earns it."
+            ),
+        ),
+        Branch(
+            label="Collect a proxy watcher report",
+            conditions=has_any_current_tag(
+                "broker",
+                "contacts_available",
+                "fixer",
+                "informant_handler",
+            ),
+            narrative_stub=(
+                "{actor} does not go near {target}. They let someone else "
+                "look, then read the report for what the watcher understood "
+                "and what they were too ordinary to notice."
+            ),
+            state_delta={
+                "character.current_activity": "collecting a proxy watcher report",
+            },
+            event_type="surveillance_performed",
+            changed_fields=("character.current_activity",),
+            magnitude=0.38,
+            scene_pressure_stub=(
+                "{actor} has someone off-screen watching for signs around "
+                "{target}. This can surface as a watcher, rumor, false alarm, "
+                "or nothing at all."
+            ),
+        ),
+        Branch(
+            label="Review accumulated intel",
+            conditions=has_any_current_tag(
+                "academic",
+                "intelligence_asset_active",
+                "paranoid",
+                "researcher",
+            ),
+            narrative_stub=(
+                "{actor} stops gathering and starts reading: old logs, "
+                "half-useful reports, fragments whose meaning only appears "
+                "after the same question has been asked too many times."
+            ),
+            state_delta={
+                "character.current_activity": "reviewing accumulated intel",
+            },
+            event_type="intel_reviewed",
+            changed_fields=("character.current_activity",),
+            magnitude=0.34,
+            scene_pressure_stub=(
+                "{actor} is reviewing accumulated intel related to {target}. "
+                "If useful, let the scene feel watched or anticipated; the "
+                "review itself does not force new facts into canon."
+            ),
+        ),
+        Branch(
+            label="Follow the public pattern",
+            conditions=can_move_publicly(slot=Slot.TARGET),
+            narrative_stub=(
+                "{actor} follows the public shape of {target}'s life: where "
+                "they appear, what routes repeat, which absences look chosen "
+                "and which look imposed."
+            ),
+            state_delta={
+                "character.current_activity": "following target public pattern",
+            },
+            event_type="surveillance_performed",
+            changed_fields=("character.current_activity",),
+            magnitude=0.30,
+            scene_pressure_stub=(
+                "{actor} may have mapped the public pattern around {target}. "
+                "Use this only as Storyteller-controlled scene pressure or a "
+                "future setup."
+            ),
+        ),
+        Branch(
+            label="Keep the target in view without contact",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} keeps {target} in view at the lowest useful "
+                "resolution, choosing continued uncertainty over the kind of "
+                "move that would make the watching visible."
+            ),
+            state_delta={
+                "character.current_activity": "surveilling without contact",
+            },
+            event_type="surveillance_performed",
+            changed_fields=("character.current_activity",),
+            magnitude=0.24,
+            scene_pressure_stub=(
+                "{actor} is watching around {target} but has not made contact. "
+                "The Storyteller may adapt, delay, ignore, or incorporate that "
+                "pressure without letting Orrery decide what {target} does."
             ),
         ),
     ),
@@ -1459,7 +1863,10 @@ WARN_ALLY = Template(
     branches=(
         Branch(
             label="Reach the ally face-to-face before the word gets out",
-            conditions=co_located(Slot.ACTOR, Slot.TARGET),
+            conditions=AND(
+                co_located(Slot.ACTOR, Slot.TARGET),
+                NOT(direct_contact_is_dramatic()),
+            ),
             narrative_stub=(
                 "{actor} catches {target} before they have time to "
                 "compose themselves and tells them quickly, in a voice "
@@ -1482,7 +1889,7 @@ WARN_ALLY = Template(
         ),
         Branch(
             label="Send word through whatever channel will reach them quickest",
-            conditions=ALWAYS,
+            conditions=NOT(direct_contact_is_dramatic()),
             narrative_stub=(
                 "{actor} sends the warning through whatever channel will "
                 "reach {target} fastest — a call, a runner, a sealed "
@@ -1502,6 +1909,28 @@ WARN_ALLY = Template(
                 "means. The scene may show this as an incoming message, "
                 "a vague disturbance, a half-heard signal, or it may not "
                 "land in time."
+            ),
+        ),
+        Branch(
+            label="Leak the warning without breaking cover",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} still sends the warning, but strips their own hand "
+                "from it: a proxy, a coded leak, an anonymous ping, something "
+                "that can reach {target} without making contact itself the "
+                "story."
+            ),
+            state_delta={
+                "character.current_activity": "leaking urgent warning",
+                "entity_tags_target.add": ["forewarned"],
+            },
+            event_type="warning_delivered",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.40,
+            scene_pressure_stub=(
+                "{actor} has sent {target} an indirect warning. It may appear "
+                "as a leak, proxy message, coded signal, or not land in time; "
+                "Orrery is not deciding how {target} responds."
             ),
         ),
     ),
@@ -1610,11 +2039,19 @@ REACH_OUT_TO_KIN = Template(
             has_symmetric_relationship_of_type("chosen_kin"),
             has_symmetric_relationship_of_type("comrade"),
         ),
+        OR(
+            relationship_is_mutual_warm(),
+            relationship_is_asymmetric(),
+            direct_contact_is_dramatic(),
+        ),
         since_last_event_at_least(
             "contact_made", minimum_ticks=8, target_slot=Slot.TARGET
         ),
         since_last_event_at_least(
             "kin_visit", minimum_ticks=8, target_slot=Slot.TARGET
+        ),
+        since_last_event_at_least(
+            "contact_deferred", minimum_ticks=8, target_slot=Slot.TARGET
         ),
         NOT(has_ephemeral("under_active_pursuit")),
         NOT(has_ephemeral("grudge_active")),
@@ -1624,6 +2061,8 @@ REACH_OUT_TO_KIN = Template(
             label="Find the moment for a real face-to-face conversation",
             conditions=AND(
                 co_located(Slot.ACTOR, Slot.TARGET),
+                relationship_is_mutual_warm(),
+                NOT(direct_contact_is_dramatic()),
                 since_last_event_at_least(
                     "kin_visit", minimum_ticks=5, target_slot=Slot.TARGET
                 ),
@@ -1649,7 +2088,10 @@ REACH_OUT_TO_KIN = Template(
         ),
         Branch(
             label="Send a message that says less than it means",
-            conditions=ALWAYS,
+            conditions=AND(
+                relationship_is_mutual_warm(),
+                NOT(direct_contact_is_dramatic()),
+            ),
             narrative_stub=(
                 "{actor} sends {target} the small message that means "
                 "more than the words it contains — a check-in, a shared "
@@ -1666,6 +2108,45 @@ REACH_OUT_TO_KIN = Template(
                 "{actor} has sent {target} a small affectionate message. "
                 "Treat as ambient relationship-warmth — possibly an "
                 "incoming notification, possibly not surfaced at all."
+            ),
+        ),
+        Branch(
+            label="Draft the message and leave it unsent",
+            conditions=OR(relationship_is_asymmetric(), direct_contact_is_dramatic()),
+            narrative_stub=(
+                "{actor} writes the message anyway, or composes the call in "
+                "their head, and then does not send it. The wanting is real; "
+                "so is the cost of turning it into contact."
+            ),
+            state_delta={
+                "character.current_activity": "drafting unsent kin contact",
+            },
+            event_type="contact_deferred",
+            changed_fields=("character.current_activity",),
+            magnitude=0.18,
+            scene_pressure_stub=(
+                "{actor} is holding back a loaded attempt to reach {target}. "
+                "Use this as optional emotional pressure or a future story "
+                "beat; Orrery has not made contact happen."
+            ),
+        ),
+        Branch(
+            label="Let the silence stand for now",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} lets the thread remain unpulled. Whatever exists "
+                "between them and {target}, it is not made warmer by forcing "
+                "the wrong kind of contact today."
+            ),
+            state_delta={
+                "character.current_activity": "deferring kin contact",
+            },
+            event_type="contact_deferred",
+            changed_fields=("character.current_activity",),
+            magnitude=0.08,
+            scene_pressure_stub=(
+                "{actor} is choosing not to contact {target} for now. Treat "
+                "this as optional subtext, not as a visible scene event."
             ),
         ),
     ),
@@ -2472,8 +2953,10 @@ BUILTIN_TEMPLATES = (
     PROTECT_KIN,
     EXTRACT_VENGEANCE,
     TEND_WOUNDED,
+    HIDE,
     HONOR_DEBT,
     WARN_ALLY,
+    SURVEIL,
     PURSUE_GHOST_LEAD,
     CHECK_ON_DEPENDENT,
     CULTIVATE_INFORMANT,

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -371,7 +371,6 @@ MAINTAIN_COVER = Template(
             has_any_current_tag(
                 "broker",
                 "cover_identity",
-                "deep_cover",
                 "fixer",
                 "operative",
                 "public_role",
@@ -380,7 +379,6 @@ MAINTAIN_COVER = Template(
             in_location_class("the_glow"),
             in_location_class("market"),
             in_location_class("transit_hub"),
-            recent_event("maintain_cover", within_ticks=10, actor_slot=Slot.ACTOR),
         ),
         since_last_event_at_least("maintain_cover", minimum_ticks=6),
     ),
@@ -401,7 +399,6 @@ MAINTAIN_COVER = Template(
             label="Maintain a specific cover identity",
             conditions=has_any_current_tag(
                 "cover_identity",
-                "deep_cover",
                 "public_role",
                 "undercover",
             ),
@@ -753,27 +750,6 @@ SURVEIL = Template(
     ),
     branches=(
         Branch(
-            label="Keep tabs from a distance",
-            conditions=OR(is_hidden(), trust_below(-2)),
-            narrative_stub=(
-                "{actor} keeps tabs on {target} without touching the line "
-                "between them: a pattern noticed, a channel checked, a "
-                "small confirmation that does not become contact."
-            ),
-            state_delta={
-                "character.current_activity": "keeping tabs from a distance",
-            },
-            event_type="surveillance_performed",
-            changed_fields=("character.current_activity",),
-            magnitude=0.44,
-            scene_pressure_stub=(
-                "{actor} is keeping tabs on {target} from off-screen. Treat "
-                "this as possible pressure, unease, traces, or delayed setup; "
-                "do not turn it into automatic contact or control of "
-                "{target}'s choices."
-            ),
-        ),
-        Branch(
             label="Intercept signal traffic",
             conditions=has_any_current_tag(
                 "ghostprint_active",
@@ -797,6 +773,27 @@ SURVEIL = Template(
                 "{actor} may be reading signal traffic around {target}'s "
                 "current scene. Use it as optional pressure or atmosphere, "
                 "not as a canonical breach unless the scene earns it."
+            ),
+        ),
+        Branch(
+            label="Keep tabs from a distance",
+            conditions=OR(is_hidden(), trust_below(-2)),
+            narrative_stub=(
+                "{actor} keeps tabs on {target} without touching the line "
+                "between them: a pattern noticed, a channel checked, a "
+                "small confirmation that does not become contact."
+            ),
+            state_delta={
+                "character.current_activity": "keeping tabs from a distance",
+            },
+            event_type="surveillance_performed",
+            changed_fields=("character.current_activity",),
+            magnitude=0.44,
+            scene_pressure_stub=(
+                "{actor} is keeping tabs on {target} from off-screen. Treat "
+                "this as possible pressure, unease, traces, or delayed setup; "
+                "do not turn it into automatic contact or control of "
+                "{target}'s choices."
             ),
         ),
         Branch(

--- a/tests/test_orrery/test_catalog.py
+++ b/tests/test_orrery/test_catalog.py
@@ -76,6 +76,7 @@ def test_catalog_vocabulary_appendix_collects_referenced_terms() -> None:
     # Sanity checks against known-present vocabulary from the templates:
     assert "vendetta_holder" in vocab["durable_tags"]
     assert "grudge_active" in vocab["ephemeral_tags"]
+    assert "intelligence_asset_active" in vocab["current_tags"]
     assert "retaliation_executed" in vocab["event_types"]
     assert "home" in vocab["place_affordances"]
     assert "wilderness" in vocab["place_affordances"]

--- a/tests/test_orrery/test_catalog.py
+++ b/tests/test_orrery/test_catalog.py
@@ -98,6 +98,14 @@ def test_render_predicate_name_handles_known_predicates() -> None:
             "actor and target are co-located",
         ),
         (
+            "can_move_publicly(@actor)",
+            "actor can plausibly move through public flow",
+        ),
+        (
+            "relationship_is_asymmetric(3,actor<->target)",
+            "directional trust actor↔target differs by 3+ or is loaded",
+        ),
+        (
             "has_symmetric_relationship_of_type(family,actor<->target)",
             "actor and target share `family` relationship (either direction)",
         ),

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -277,6 +277,7 @@ def test_concealment_surveillance_migration_seeds_package_vocab() -> None:
 
     assert {
         "cover_identity",
+        "off_grid",
         "undercover",
         "presumed_dead",
         "presumed_dead_by_some",
@@ -302,3 +303,5 @@ def test_concealment_surveillance_migration_seeds_package_vocab() -> None:
         event_type
         for event_type, _category, _severity, _description in migration.EVENT_TYPES
     }
+    migration_source = migration_path.read_text()
+    assert "ON CONFLICT (type) DO UPDATE SET" in migration_source

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -263,3 +263,42 @@ def test_travel_work_migration_seeds_work_travel_vocab() -> None:
         event_type
         for event_type, _category, _severity, _description in migration.EVENT_TYPES
     }
+
+
+def test_concealment_surveillance_migration_seeds_package_vocab() -> None:
+    """Migration 034 registers tags/events for HIDE, SURVEIL, and contact risk."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "034_orrery_concealment_surveillance_vocab.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+
+    assert {
+        "cover_identity",
+        "undercover",
+        "presumed_dead",
+        "presumed_dead_by_some",
+        "long_hidden",
+        "long_absent",
+        "hidden_identity",
+        "wanted",
+        "signal_operator",
+        "surveillance_capable",
+        "safehouse_operator",
+    } <= {tag for tag, _category, _description in migration.DURABLE_TAGS}
+    ephemeral_tags = {row[0] for row in migration.EPHEMERAL_TAGS}
+    assert {"contained", "immobile"} <= ephemeral_tags
+    assert {"street"} <= {tag for tag, _description in migration.PLACE_AFFORDANCE_TAGS}
+    assert {
+        "hideout_maintained",
+        "signal_exposure_reduced",
+        "counter_surveillance_sweep",
+        "surveillance_performed",
+        "intel_reviewed",
+        "contact_deferred",
+    } <= {
+        event_type
+        for event_type, _category, _severity, _description in migration.EVENT_TYPES
+    }

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -173,8 +173,8 @@ class FakeLore:
         self.memnon = FakeMemnon(session)
 
 
-def test_resolve_dry_run_returns_inspectable_proposal() -> None:
-    """Dry-run resolution hydrates, binds, and produces no-write drafts."""
+def test_resolve_dry_run_allows_null_resolution() -> None:
+    """Dry-run resolution can skip under-specified actors without fallback noise."""
 
     proposal = resolve_dry_run(
         FakeSession(),
@@ -185,12 +185,8 @@ def test_resolve_dry_run_returns_inspectable_proposal() -> None:
 
     assert proposal.anchor_chunk_id == 100
     assert proposal.actor_count == 1
-    assert proposal.resolution_count == 1
-    assert proposal.resolutions[0].template_id == "maintain_cover"
-    assert not any(
-        resolution.template_id == "intimacy" for resolution in proposal.resolutions
-    )
-    assert proposal.resolutions[0].bindings == {"actor": 1}
+    assert proposal.resolution_count == 0
+    assert proposal.pressure_count == 0
 
 
 def test_resolve_dry_run_excludes_anchor_present_characters() -> None:
@@ -202,6 +198,10 @@ def test_resolve_dry_run_excludes_anchor_present_characters() -> None:
             event_actor_rows=[{"entity_id": 3}],
             ephemeral_actor_rows=[{"entity_id": 4}],
             present_actor_rows=[{"entity_id": 1}, {"entity_id": 3}],
+            tag_rows=[
+                {"entity_id": 2, "tag": "cover_identity", "is_ephemeral": False},
+                {"entity_id": 4, "tag": "cover_identity", "is_ephemeral": False},
+            ],
             location_rows=[
                 {"entity_id": 1, "current_location": 10},
                 {"entity_id": 2, "current_location": 10},
@@ -305,6 +305,212 @@ def test_resolve_dry_run_exercises_priority_packages(
     assert proposal.resolution_count == 1
     assert proposal.resolutions[0].template_id == template_id
     assert proposal.resolutions[0].branch_label == branch_label
+
+
+def test_maintain_cover_requires_positive_cover_context() -> None:
+    """MAINTAIN_COVER is not a generic fallback for every quiet actor."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            tag_rows=[{"entity_id": 1, "tag": "cover_identity", "is_ephemeral": False}],
+            location_class_rows=[
+                {"id": 10, "location_class": "fixed_location", "is_primary": True}
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "maintain_cover"
+    assert proposal.resolutions[0].branch_label == "Maintain a specific cover identity"
+
+
+def test_maintain_cover_skips_constrained_actor() -> None:
+    """Captive/sandboxed actors should not drift through public cover."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            tag_rows=[
+                {"entity_id": 1, "tag": "cover_identity", "is_ephemeral": False},
+                {"entity_id": 1, "tag": "sandboxed", "is_ephemeral": True},
+            ],
+            location_class_rows=[
+                {"id": 10, "location_class": "the_glow", "is_primary": True}
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 0
+
+
+def test_evade_pursuers_skips_captive_public_flow() -> None:
+    """Active-pursuit fallback cannot make a captive actor blend into crowds."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            tag_rows=[
+                {
+                    "entity_id": 1,
+                    "tag": "under_active_pursuit",
+                    "is_ephemeral": True,
+                },
+                {"entity_id": 1, "tag": "captive", "is_ephemeral": True},
+            ],
+            location_class_rows=[
+                {"id": 10, "location_class": "blacksite", "is_primary": True}
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 0
+
+
+def test_hide_handles_steady_state_concealment() -> None:
+    """Off-grid concealment resolves through HIDE rather than cover fallback."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            tag_rows=[{"entity_id": 1, "tag": "off_grid", "is_ephemeral": False}],
+            location_class_rows=[
+                {"id": 10, "location_class": "safe_house", "is_primary": True}
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "hide"
+    assert proposal.resolutions[0].branch_label == "Go dark and reduce signal exposure"
+
+
+def test_active_pursuit_beats_hide() -> None:
+    """EVADE owns hot pursuit while HIDE owns chronic concealment."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            tag_rows=[
+                {"entity_id": 1, "tag": "off_grid", "is_ephemeral": False},
+                {"entity_id": 1, "tag": "contacts_available", "is_ephemeral": False},
+                {
+                    "entity_id": 1,
+                    "tag": "under_active_pursuit",
+                    "is_ephemeral": True,
+                },
+            ],
+            location_class_rows=[
+                {"id": 10, "location_class": "safe_house", "is_primary": True}
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "evade_pursuers"
+    assert proposal.resolutions[0].branch_label == "Reach a safe house through contacts"
+
+
+def test_surveillance_offscreen_target_commits_resolution() -> None:
+    """SURVEIL keeps tabs without creating contact."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[{"entity_id": 1}],
+            tag_rows=[
+                {"entity_id": 1, "tag": "signal_operator", "is_ephemeral": False}
+            ],
+            actor_target_relationship_rows=[
+                {"source_entity_id": 1, "target_entity_id": 2},
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    surveil = [
+        draft for draft in proposal.resolutions if draft.template_id == "surveil"
+    ]
+    assert len(surveil) == 1
+    assert surveil[0].branch_label == "Intercept signal traffic"
+    assert surveil[0].event_type == "surveillance_performed"
+    assert not any(draft.event_type == "contact_made" for draft in proposal.resolutions)
+
+
+def test_surveillance_present_target_becomes_scene_pressure() -> None:
+    """SURVEIL may pressure an on-screen target but cannot commit it."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[{"entity_id": 1}],
+            present_actor_rows=[{"entity_id": 2}],
+            tag_rows=[
+                {"entity_id": 1, "tag": "signal_operator", "is_ephemeral": False}
+            ],
+            actor_target_relationship_rows=[
+                {"source_entity_id": 1, "target_entity_id": 2},
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert not any(draft.template_id == "surveil" for draft in proposal.resolutions)
+    assert proposal.pressure_count == 1
+    assert proposal.scene_pressures[0].template_id == "surveil"
+    assert "not as a canonical breach" in proposal.scene_pressures[0].prompt_text
+
+
+def test_asymmetric_kin_defers_contact_instead_of_affectionate_message() -> None:
+    """Kinship alone no longer implies ordinary warm contact."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[{"entity_id": 1}],
+            relationship_rows=[
+                {
+                    "source_entity_id": 1,
+                    "target_entity_id": 2,
+                    "relationship_type": "family",
+                    "valence_magnitude": 5,
+                },
+                {
+                    "source_entity_id": 2,
+                    "target_entity_id": 1,
+                    "relationship_type": "family",
+                    "valence_magnitude": -3,
+                },
+            ],
+            actor_target_relationship_rows=[
+                {"source_entity_id": 1, "target_entity_id": 2},
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    kin = [
+        draft
+        for draft in proposal.resolutions
+        if draft.template_id == "reach_out_to_kin"
+    ]
+    assert len(kin) == 1
+    assert kin[0].branch_label == "Draft the message and leave it unsent"
+    assert kin[0].event_type == "contact_deferred"
+    assert not any(draft.event_type == "contact_made" for draft in proposal.resolutions)
 
 
 def test_resolve_dry_run_fires_sunhelm_need_template() -> None:
@@ -438,7 +644,7 @@ def test_intimacy_partner_branch_requires_partner_relationship() -> None:
 
 
 def test_intimacy_suppressor_blocks_intimacy_template() -> None:
-    """Named suppressors close the INTIMACY gate without deleting need debt."""
+    """Named suppressors close INTIMACY without falling into cover noise."""
 
     proposal = resolve_dry_run(
         FakeSession(
@@ -468,8 +674,7 @@ def test_intimacy_suppressor_blocks_intimacy_template() -> None:
         window_chunks=30,
     )
 
-    assert proposal.resolution_count == 1
-    assert proposal.resolutions[0].template_id == "maintain_cover"
+    assert proposal.resolution_count == 0
 
 
 def test_hydrate_world_state_populates_trust_from_valence_magnitude() -> None:
@@ -738,8 +943,7 @@ def test_work_template_uses_one_global_work_cooldown() -> None:
         window_chunks=30,
     )
 
-    assert proposal.resolution_count == 1
-    assert proposal.resolutions[0].template_id == "maintain_cover"
+    assert proposal.resolution_count == 0
 
 
 @pytest.mark.parametrize(
@@ -830,7 +1034,7 @@ async def test_resolve_orrery_attaches_proposal_when_enabled() -> None:
 
     assert context.orrery_proposal is not None
     assert context.orrery_proposal.anchor_chunk_id == 100
-    assert context.phase_states["orrery_resolve"]["resolution_count"] == 1
+    assert context.phase_states["orrery_resolve"]["resolution_count"] == 0
     assert context.context_payload == {}
 
 

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -16,17 +16,24 @@ from nexus.agents.orrery.substrate import (
     TravelState,
     WorldState,
     binding_hash,
+    can_move_publicly,
     co_located,
     count_co_located,
+    direct_contact_is_dramatic,
     evaluate_stack,
     has_any_intimacy_suppressor,
     has_established_partner_co_located,
+    has_minimal_context,
     has_need_debt_at_or_above,
     has_severity_tag_at_or_above,
     has_symmetric_relationship_of_type,
     in_location,
     in_location_class,
+    is_constrained,
+    is_hidden,
     recent_event,
+    relationship_is_asymmetric,
+    relationship_is_mutual_warm,
     since_last_event_at_least,
     validate_always_fallbacks,
 )
@@ -130,6 +137,7 @@ def test_storyteller_pressure_templates_require_pressure_stubs() -> None:
         ("fragment", "pursue_ghost_lead", "Recon a hideout their body remembers"),
         ("debt", "honor_debt", "Fulfill obligation through a dead-drop"),
         ("quiet", "maintain_cover", "Run a low-level courier job"),
+        ("hiding", "hide", "Go dark and reduce signal exposure"),
         (
             "vengeance",
             "extract_vengeance",
@@ -144,6 +152,11 @@ def test_storyteller_pressure_templates_require_pressure_stubs() -> None:
             "informant",
             "cultivate_informant",
             "Routine contact to maintain the relationship",
+        ),
+        (
+            "surveillance",
+            "surveil",
+            "Intercept signal traffic",
         ),
         # Round-2 templates
         (
@@ -216,6 +229,63 @@ def test_has_symmetric_relationship_of_type_matches_either_direction() -> None:
     assert predicate(forward_state, bindings)
     assert predicate(reverse_state, bindings)
     assert not predicate(empty_state, bindings)
+
+
+def test_context_and_constraint_predicates_read_current_tags() -> None:
+    """Package guards can distinguish hydrated actors from constrained ones."""
+
+    assert has_minimal_context()(
+        WorldState(tags={1: frozenset({"off_grid"})}), {Slot.ACTOR: 1}
+    )
+    assert has_minimal_context()(WorldState(locations={1: 10}), {Slot.ACTOR: 1})
+    assert not has_minimal_context()(WorldState(), {Slot.ACTOR: 1})
+    assert is_constrained()(
+        WorldState(ephemeral_tags={1: frozenset({"sandboxed"})}), {Slot.ACTOR: 1}
+    )
+    assert is_hidden()(
+        WorldState(tags={1: frozenset({"presumed_dead"})}), {Slot.ACTOR: 1}
+    )
+
+
+def test_public_mobility_requires_public_context_and_freedom() -> None:
+    """Public-flow package branches should not fire inside blacksites."""
+
+    public_state = WorldState(
+        locations={1: 10},
+        location_classes={10: frozenset({"market"})},
+    )
+    private_state = WorldState(
+        locations={1: 11},
+        location_classes={11: frozenset({"blacksite"})},
+    )
+    captive_state = WorldState(
+        tags={1: frozenset({"route_familiar"})},
+        ephemeral_tags={1: frozenset({"captive"})},
+        locations={1: 10},
+        location_classes={10: frozenset({"market"})},
+    )
+
+    assert can_move_publicly()(public_state, {Slot.ACTOR: 1})
+    assert not can_move_publicly()(private_state, {Slot.ACTOR: 1})
+    assert not can_move_publicly()(captive_state, {Slot.ACTOR: 1})
+
+
+def test_relationship_contact_predicates_capture_asymmetry() -> None:
+    """Kin/contact templates can distinguish warmth from loaded contact."""
+
+    warm_state = WorldState(trust={(1, 2): 3, (2, 1): 2})
+    estranged_state = WorldState(trust={(1, 2): 5, (2, 1): -3})
+    hidden_state = WorldState(
+        tags={1: frozenset({"presumed_dead"})},
+        trust={(1, 2): 3, (2, 1): 2},
+    )
+    bindings = {Slot.ACTOR: 1, Slot.TARGET: 2}
+
+    assert relationship_is_mutual_warm()(warm_state, bindings)
+    assert not relationship_is_mutual_warm()(estranged_state, bindings)
+    assert relationship_is_asymmetric()(estranged_state, bindings)
+    assert direct_contact_is_dramatic()(estranged_state, bindings)
+    assert direct_contact_is_dramatic()(hidden_state, bindings)
 
 
 def test_since_last_event_at_least_target_slot_scopes_cooldown() -> None:

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -242,9 +242,13 @@ def test_context_and_constraint_predicates_read_current_tags() -> None:
     assert is_constrained()(
         WorldState(ephemeral_tags={1: frozenset({"sandboxed"})}), {Slot.ACTOR: 1}
     )
+    assert not is_constrained()(
+        WorldState(ephemeral_tags={1: frozenset({"wounded"})}), {Slot.ACTOR: 1}
+    )
     assert is_hidden()(
         WorldState(tags={1: frozenset({"presumed_dead"})}), {Slot.ACTOR: 1}
     )
+    assert is_hidden()(WorldState(tags={1: frozenset({"deep_cover"})}), {Slot.ACTOR: 1})
 
 
 def test_public_mobility_requires_public_context_and_freedom() -> None:


### PR DESCRIPTION
## Summary
- narrow MAINTAIN_COVER so null resolution is valid for under-specified or constrained actors
- add steady-state HIDE and first-class SURVEIL packages with present-target scene-pressure routing
- make kin/warning contact respect asymmetric trust and dramatic direct-contact risk
- seed concealment/surveillance/contact-risk vocabulary and regenerate the package catalog

Closes #239.
Closes #240.
Closes #241.
Closes #242.

## Validation
- PYTHONPATH=$PWD poetry run pytest tests/test_orrery
- PYTHONPATH=$PWD poetry run pytest tests/test_api/test_lore_adapter.py tests/test_lore/test_logon_prompt_formatting.py
- git diff --check