### PR TITLE
[codex] Prefer authored Orrery travel edges

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -1,6 +1,6 @@
 # Off-Screen Behavior Resolver — Orrery Design Plan
 
-**Status:** The Orrery build path is now past foundation and into package-library depth. Main has landed the identity spine and schema, dry-run resolver, accepted-chunk commit path, narration outbox, Bleed selector, retrieval-boundary hardening, relationship-trust hydration, semantic-clearance worker/status surface, Sunhelm needs, place affordance semantics, slot 2 semantic tag seeding, deterministic review orchestration, and the interpersonal need layer (`SOCIALIZE` and `INTIMACY`). The runtime pipeline remains disabled by default (`orrery.enabled = false`). The active slice is **Work + Travel**: routine livelihood packages plus additive in-transit state that preserves `characters.current_location` as the semantic place anchor.
+**Status:** The Orrery build path is now past foundation and into package-library depth. Main has landed the identity spine and schema, dry-run resolver, accepted-chunk commit path, narration outbox, Bleed selector, retrieval-boundary hardening, relationship-trust hydration, semantic-clearance worker/status surface, Sunhelm needs, place affordance semantics, slot 2 semantic tag seeding, deterministic review orchestration, interpersonal needs (`SOCIALIZE` and `INTIMACY`), Work + Travel, and concealment/contact package tuning. The runtime pipeline remains disabled by default (`orrery.enabled = false`). The active slice is **routing phase 2**: using authored travel edges before falling back to coarse local distance estimates.
 
 **Originating artifacts:** `temp/orrery/off_screen_resolver_spec.md`, `temp/orrery/behavior_substrate.py`, `temp/orrery/package_simulator.jsx`
 **Review trace:** `temp/orrery/design_plan_edited.md` (round 1: GPT-5.5-Pro, Codex, separate-Claude, Gemini) + `temp/orrery/super_table_question.md` (round 2: GPT-5.5-Pro, Claude Opus 4.7 chat) + v4 grounding pass against current `main` (claude-opus-4-7).
@@ -91,16 +91,18 @@ PR #222 adds deterministic review orchestration so newly opened PRs can schedule
 - PR #237 applies slot 2 semantic tag seeding so mature-state dry runs have real package vocabulary to work with.
 - PR #236/#238 tighten deterministic review orchestration so fix commits do not trigger duplicate review windows.
 - PR #243 extends `character_need_states` from physiological needs into interpersonal pressure by adding `socialize` and `intimacy` need types, controlled severity/suppressor vocabulary, conservative SOCIALIZE and INTIMACY templates, and catalog coverage.
+- PR #244 adds additive WORK and TRAVEL state: `characters.current_location` remains the readable place anchor, while `character_travel_states` records planned/in-transit movement and route estimates.
+- PR #247 tunes concealment, surveillance, and cautious contact packages around hidden or relationship-loaded actors so mature-slot resolutions are less narratively blunt.
 
 ### Current Slice
 
-The current slice adds **WORK** and **TRAVEL**. `WORK` models routine livelihood, duty, household labor, maintenance, and organizational obligations without displacing specialist packages like `TEND_CRAFT`. `TRAVEL` models off-screen movement at turn granularity: planned destination, departure, route progress, delay, arrival, travel mode, and route risk.
+The current slice is **routing phase 2** for TRAVEL. Travel starts now prefer explicit `orrery_travel_edges` when a compatible authored edge exists, including deliberately bidirectional reverse traversal. Worlds without authored routing data still fall back to the local coordinate-distance estimate introduced with PR #244.
 
-The database change is intentionally additive. `characters.current_location` remains the readable `places(id)` anchor used by existing LORE/LOGON/MEMNON/Orrery callers. `character_travel_states` records whether a character is at a place, planning travel, or in transit; while in transit, location predicates treat the anchor as non-physical so the resolver does not pretend the character is still co-located there. `orrery_travel_edges` gives future authored/OSM routing somewhere to live, while the first implementation uses local coordinate distance plus mode-specific detour and speed estimates.
+The database posture remains additive. `characters.current_location` is still the `places(id)` anchor used by existing LORE/LOGON/MEMNON/Orrery callers. `character_travel_states` records whether a character is at a place, planning travel, or in transit; while in transit, location predicates treat the anchor as non-physical so the resolver does not pretend the character is still co-located there. `orrery_travel_edges` is now active for authored route selection, while `route_method = osm_graph` remains reserved for a later offline routing pass.
 
 ### Next Planned Slice
 
-After Work + Travel, the next useful slice is package-library tuning on top of the new movement substrate: packages that create or consume travel intent, work obligations that interact with relationship and faction pressure, and route realism improvements if estimated travel starts producing bad narrative beats. Richer routing should plug into the existing route-method seam (`authored_edge` or `osm_graph`) rather than replacing the additive travel state.
+After authored route edges, the next useful routing slice is phase 3: an offline OSM-backed route graph that can populate or supplement route edges without adding a map API or inference dependency to normal Orrery ticks. Package-library tuning remains an ongoing parallel lane: new packages should create or consume travel intent through the additive travel state rather than mutating `characters.current_location` directly.
 
 ### Package Author Checkpoint
 
@@ -641,7 +643,7 @@ The alias-oriented hybrid remains the right future escape hatch if that pain app
 
 ## Phased Delivery
 
-This section is now mostly historical. The active queue has moved past the foundation, Bleed, needs, place semantics, semantic tag seeding, and interpersonal layers into **Work + Travel packages plus additive in-transit state**. The PR 0-4 headings below are preserved as landing notes for the foundation, resolver, commit pipeline, and Bleed integration rather than as the current forward plan.
+This section is now mostly historical. The active queue has moved past the foundation, Bleed, needs, place semantics, semantic tag seeding, interpersonal layers, Work + Travel, and package-quality tuning into **route realism**. The PR 0-4 headings below are preserved as landing notes for the foundation, resolver, commit pipeline, and Bleed integration rather than as the current forward plan.
 
 ### PR 0 — Seam Audit & Invariants (Foundation Subset in PR #210)
 

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -811,13 +811,14 @@ def _apply_travel_start_sync(
     if origin_place_id is None or destination_place_id is None:
         raise ValueError("travel.start requires origin and destination places")
 
-    estimate = _estimate_route_sync(
+    route = _select_route_sync(
         cur,
         origin_place_id=int(origin_place_id),
         destination_place_id=int(destination_place_id),
         mode=mode,
+        risk=risk,
     )
-    eta = _eta(world_time, estimate["duration_minutes"])
+    eta = _eta(world_time, route["duration_minutes"])
     progress = float(data.get("initial_progress", 0.0))
     cur.execute(
         """
@@ -831,7 +832,8 @@ def _apply_travel_start_sync(
         ) VALUES (
             %s, 'in_transit', %s,
             %s, %s,
-            'estimated', %s::orrery_travel_mode, %s::orrery_travel_risk, %s,
+            %s::orrery_travel_route_method,
+            %s::orrery_travel_mode, %s::orrery_travel_risk, %s,
             %s, %s,
             %s, %s, %s,
             %s::jsonb
@@ -858,15 +860,16 @@ def _apply_travel_start_sync(
             origin_place_id,
             origin_place_id,
             destination_place_id,
-            mode,
-            risk,
+            route["route_method"],
+            route["travel_mode"],
+            route["risk"],
             progress,
-            estimate["distance_m"],
-            estimate["duration_minutes"],
+            route["distance_m"],
+            route["duration_minutes"],
             world_time,
             world_time,
             eta,
-            json.dumps(estimate["metadata"]),
+            json.dumps(route["metadata"]),
         ),
     )
 
@@ -893,13 +896,14 @@ async def _apply_travel_start_async(
     if origin_place_id is None or destination_place_id is None:
         raise ValueError("travel.start requires origin and destination places")
 
-    estimate = await _estimate_route_async(
+    route = await _select_route_async(
         conn,
         origin_place_id=int(origin_place_id),
         destination_place_id=int(destination_place_id),
         mode=mode,
+        risk=risk,
     )
-    eta = _eta(world_time, estimate["duration_minutes"])
+    eta = _eta(world_time, route["duration_minutes"])
     progress = float(data.get("initial_progress", 0.0))
     await conn.execute(
         """
@@ -913,10 +917,11 @@ async def _apply_travel_start_async(
         ) VALUES (
             $1, 'in_transit', $2,
             $3, $4,
-            'estimated', $5::orrery_travel_mode, $6::orrery_travel_risk, $7,
-            $8, $9,
-            $10, $11, $12,
-            $13::jsonb
+            $5::orrery_travel_route_method,
+            $6::orrery_travel_mode, $7::orrery_travel_risk, $8,
+            $9, $10,
+            $11, $12, $13,
+            $14::jsonb
         )
         ON CONFLICT (character_entity_id) DO UPDATE SET
             status = EXCLUDED.status,
@@ -939,15 +944,16 @@ async def _apply_travel_start_async(
         origin_place_id,
         origin_place_id,
         destination_place_id,
-        mode,
-        risk,
+        route["route_method"],
+        route["travel_mode"],
+        route["risk"],
         progress,
-        estimate["distance_m"],
-        estimate["duration_minutes"],
+        route["distance_m"],
+        route["duration_minutes"],
         world_time,
         world_time,
         eta,
-        json.dumps(estimate["metadata"]),
+        json.dumps(route["metadata"]),
     )
 
 
@@ -1820,12 +1826,255 @@ async def _current_travel_progress_async(conn: Any, actor_entity_id: int) -> flo
     return float(progress or 0.0)
 
 
+def _select_route_sync(
+    cur: Any,
+    *,
+    origin_place_id: int,
+    destination_place_id: int,
+    mode: str,
+    risk: str,
+) -> dict[str, Any]:
+    edge = _authored_route_edge_sync(
+        cur,
+        origin_place_id=origin_place_id,
+        destination_place_id=destination_place_id,
+        mode=mode,
+    )
+    if edge is not None:
+        row, reversed_edge = edge
+        return _route_from_authored_edge(
+            row,
+            origin_place_id=origin_place_id,
+            destination_place_id=destination_place_id,
+            requested_mode=mode,
+            reversed_edge=reversed_edge,
+        )
+    return _estimate_route_sync(
+        cur,
+        origin_place_id=origin_place_id,
+        destination_place_id=destination_place_id,
+        mode=mode,
+        risk=risk,
+    )
+
+
+async def _select_route_async(
+    conn: Any,
+    *,
+    origin_place_id: int,
+    destination_place_id: int,
+    mode: str,
+    risk: str,
+) -> dict[str, Any]:
+    edge = await _authored_route_edge_async(
+        conn,
+        origin_place_id=origin_place_id,
+        destination_place_id=destination_place_id,
+        mode=mode,
+    )
+    if edge is not None:
+        row, reversed_edge = edge
+        return _route_from_authored_edge(
+            row,
+            origin_place_id=origin_place_id,
+            destination_place_id=destination_place_id,
+            requested_mode=mode,
+            reversed_edge=reversed_edge,
+        )
+    return await _estimate_route_async(
+        conn,
+        origin_place_id=origin_place_id,
+        destination_place_id=destination_place_id,
+        mode=mode,
+        risk=risk,
+    )
+
+
+def _authored_route_edge_sync(
+    cur: Any,
+    *,
+    origin_place_id: int,
+    destination_place_id: int,
+    mode: str,
+) -> Optional[tuple[Any, bool]]:
+    cur.execute(
+        """
+        SELECT id,
+               from_place_id,
+               to_place_id,
+               route_method::text AS route_method,
+               travel_mode::text AS travel_mode,
+               risk::text AS risk,
+               bidirectional,
+               distance_m,
+               duration_minutes,
+               ST_AsGeoJSON(route_geometry) AS route_geometry_geojson,
+               source,
+               metadata
+        FROM orrery_travel_edges
+        WHERE from_place_id = %s
+          AND to_place_id = %s
+          AND route_method = 'authored_edge'
+          AND travel_mode = %s::orrery_travel_mode
+        ORDER BY id
+        LIMIT 1
+        """,
+        (origin_place_id, destination_place_id, mode),
+    )
+    row = cur.fetchone()
+    if row is not None:
+        return row, False
+
+    cur.execute(
+        """
+        SELECT id,
+               from_place_id,
+               to_place_id,
+               route_method::text AS route_method,
+               travel_mode::text AS travel_mode,
+               risk::text AS risk,
+               bidirectional,
+               distance_m,
+               duration_minutes,
+               ST_AsGeoJSON(route_geometry) AS route_geometry_geojson,
+               source,
+               metadata
+        FROM orrery_travel_edges
+        WHERE from_place_id = %s
+          AND to_place_id = %s
+          AND route_method = 'authored_edge'
+          AND travel_mode = %s::orrery_travel_mode
+          AND bidirectional = true
+        ORDER BY id
+        LIMIT 1
+        """,
+        (destination_place_id, origin_place_id, mode),
+    )
+    row = cur.fetchone()
+    if row is not None:
+        return row, True
+    return None
+
+
+async def _authored_route_edge_async(
+    conn: Any,
+    *,
+    origin_place_id: int,
+    destination_place_id: int,
+    mode: str,
+) -> Optional[tuple[Any, bool]]:
+    row = await conn.fetchrow(
+        """
+        SELECT id,
+               from_place_id,
+               to_place_id,
+               route_method::text AS route_method,
+               travel_mode::text AS travel_mode,
+               risk::text AS risk,
+               bidirectional,
+               distance_m,
+               duration_minutes,
+               ST_AsGeoJSON(route_geometry) AS route_geometry_geojson,
+               source,
+               metadata
+        FROM orrery_travel_edges
+        WHERE from_place_id = $1
+          AND to_place_id = $2
+          AND route_method = 'authored_edge'
+          AND travel_mode = $3::orrery_travel_mode
+        ORDER BY id
+        LIMIT 1
+        """,
+        origin_place_id,
+        destination_place_id,
+        mode,
+    )
+    if row is not None:
+        return row, False
+
+    row = await conn.fetchrow(
+        """
+        SELECT id,
+               from_place_id,
+               to_place_id,
+               route_method::text AS route_method,
+               travel_mode::text AS travel_mode,
+               risk::text AS risk,
+               bidirectional,
+               distance_m,
+               duration_minutes,
+               ST_AsGeoJSON(route_geometry) AS route_geometry_geojson,
+               source,
+               metadata
+        FROM orrery_travel_edges
+        WHERE from_place_id = $1
+          AND to_place_id = $2
+          AND route_method = 'authored_edge'
+          AND travel_mode = $3::orrery_travel_mode
+          AND bidirectional = true
+        ORDER BY id
+        LIMIT 1
+        """,
+        destination_place_id,
+        origin_place_id,
+        mode,
+    )
+    if row is not None:
+        return row, True
+    return None
+
+
+def _route_from_authored_edge(
+    row: Any,
+    *,
+    origin_place_id: int,
+    destination_place_id: int,
+    requested_mode: str,
+    reversed_edge: bool,
+) -> dict[str, Any]:
+    edge_id = int(_row_get(row, "id", 0))
+    edge_from_place_id = int(_row_get(row, "from_place_id", 1))
+    edge_to_place_id = int(_row_get(row, "to_place_id", 2))
+    travel_mode = str(_row_get(row, "travel_mode", 4))
+    risk = str(_row_get(row, "risk", 5))
+    route_geometry = _decode_json_value(
+        _row_get_optional(row, "route_geometry_geojson", 9)
+    )
+    metadata = {
+        "route_method": "authored_edge",
+        "origin_place_id": origin_place_id,
+        "destination_place_id": destination_place_id,
+        "requested_travel_mode": requested_mode,
+        "travel_mode": travel_mode,
+        "risk": risk,
+        "route_edge_id": edge_id,
+        "edge_from_place_id": edge_from_place_id,
+        "edge_to_place_id": edge_to_place_id,
+        "bidirectional": bool(_row_get(row, "bidirectional", 6)),
+        "reversed": reversed_edge,
+        "source": _row_get_optional(row, "source", 10),
+        "edge_metadata": _decode_json_value(_row_get_optional(row, "metadata", 11))
+        or {},
+    }
+    if route_geometry is not None:
+        metadata["route_geometry"] = route_geometry
+    return {
+        "route_method": "authored_edge",
+        "travel_mode": travel_mode,
+        "risk": risk,
+        "distance_m": _float_or_none(_row_get(row, "distance_m", 7)),
+        "duration_minutes": _float_or_none(_row_get(row, "duration_minutes", 8)),
+        "metadata": metadata,
+    }
+
+
 def _estimate_route_sync(
     cur: Any,
     *,
     origin_place_id: int,
     destination_place_id: int,
     mode: str,
+    risk: str,
 ) -> dict[str, Any]:
     cur.execute(
         """
@@ -1845,6 +2094,7 @@ def _estimate_route_sync(
         origin_place_id=origin_place_id,
         destination_place_id=destination_place_id,
         mode=mode,
+        risk=risk,
     )
 
 
@@ -1854,6 +2104,7 @@ async def _estimate_route_async(
     origin_place_id: int,
     destination_place_id: int,
     mode: str,
+    risk: str,
 ) -> dict[str, Any]:
     geodesic_distance_m = await conn.fetchval(
         """
@@ -1872,6 +2123,7 @@ async def _estimate_route_async(
         origin_place_id=origin_place_id,
         destination_place_id=destination_place_id,
         mode=mode,
+        risk=risk,
     )
 
 
@@ -1881,6 +2133,7 @@ def _route_estimate_from_distance(
     origin_place_id: int,
     destination_place_id: int,
     mode: str,
+    risk: str,
 ) -> dict[str, Any]:
     detour_factor = TRAVEL_MODE_DETOUR_FACTOR[mode]
     speed_kmh = TRAVEL_MODE_SPEED_KMH[mode]
@@ -1895,6 +2148,7 @@ def _route_estimate_from_distance(
         "origin_place_id": origin_place_id,
         "destination_place_id": destination_place_id,
         "travel_mode": mode,
+        "risk": risk,
         "geodesic_distance_m": (
             float(geodesic_distance_m) if geodesic_distance_m is not None else None
         ),
@@ -1902,6 +2156,9 @@ def _route_estimate_from_distance(
         "speed_kmh": speed_kmh,
     }
     return {
+        "route_method": "estimated",
+        "travel_mode": mode,
+        "risk": risk,
         "distance_m": distance_m,
         "duration_minutes": duration_minutes,
         "metadata": metadata,
@@ -2039,6 +2296,28 @@ def _row_get(row: Any, key: str, index: int) -> Any:
     if isinstance(row, Mapping):
         return row[key]
     return row[index]
+
+
+def _row_get_optional(row: Any, key: str, index: int, default: Any = None) -> Any:
+    try:
+        return _row_get(row, key, index)
+    except (KeyError, IndexError):
+        return default
+
+
+def _float_or_none(value: Any) -> Optional[float]:
+    return None if value is None else float(value)
+
+
+def _decode_json_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return value
 
 
 def _affected_count(status: str) -> int:

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -1841,13 +1841,13 @@ def _select_route_sync(
         mode=mode,
     )
     if edge is not None:
-        row, reversed_edge = edge
+        # Authored edges own their stored risk; caller risk only applies to
+        # coordinate-estimate fallback routes.
         return _route_from_authored_edge(
-            row,
+            edge,
             origin_place_id=origin_place_id,
             destination_place_id=destination_place_id,
             requested_mode=mode,
-            reversed_edge=reversed_edge,
         )
     return _estimate_route_sync(
         cur,
@@ -1873,13 +1873,13 @@ async def _select_route_async(
         mode=mode,
     )
     if edge is not None:
-        row, reversed_edge = edge
+        # Authored edges own their stored risk; caller risk only applies to
+        # coordinate-estimate fallback routes.
         return _route_from_authored_edge(
-            row,
+            edge,
             origin_place_id=origin_place_id,
             destination_place_id=destination_place_id,
             requested_mode=mode,
-            reversed_edge=reversed_edge,
         )
     return await _estimate_route_async(
         conn,
@@ -1896,7 +1896,7 @@ def _authored_route_edge_sync(
     origin_place_id: int,
     destination_place_id: int,
     mode: str,
-) -> Optional[tuple[Any, bool]]:
+) -> Optional[Any]:
     cur.execute(
         """
         SELECT id,
@@ -1910,50 +1910,30 @@ def _authored_route_edge_sync(
                duration_minutes,
                ST_AsGeoJSON(route_geometry) AS route_geometry_geojson,
                source,
-               metadata
+               metadata,
+               (from_place_id = %s AND to_place_id = %s) AS is_direct
         FROM orrery_travel_edges
-        WHERE from_place_id = %s
-          AND to_place_id = %s
-          AND route_method = 'authored_edge'
-          AND travel_mode = %s::orrery_travel_mode
-        ORDER BY id
+        WHERE route_method = 'authored_edge'
+          AND travel_mode IN (%s::orrery_travel_mode, 'mixed'::orrery_travel_mode)
+          AND (
+            (from_place_id = %s AND to_place_id = %s)
+            OR (from_place_id = %s AND to_place_id = %s AND bidirectional = true)
+          )
+        ORDER BY (travel_mode = %s::orrery_travel_mode) DESC, is_direct DESC, id
         LIMIT 1
         """,
-        (origin_place_id, destination_place_id, mode),
+        (
+            origin_place_id,
+            destination_place_id,
+            mode,
+            origin_place_id,
+            destination_place_id,
+            destination_place_id,
+            origin_place_id,
+            mode,
+        ),
     )
-    row = cur.fetchone()
-    if row is not None:
-        return row, False
-
-    cur.execute(
-        """
-        SELECT id,
-               from_place_id,
-               to_place_id,
-               route_method::text AS route_method,
-               travel_mode::text AS travel_mode,
-               risk::text AS risk,
-               bidirectional,
-               distance_m,
-               duration_minutes,
-               ST_AsGeoJSON(route_geometry) AS route_geometry_geojson,
-               source,
-               metadata
-        FROM orrery_travel_edges
-        WHERE from_place_id = %s
-          AND to_place_id = %s
-          AND route_method = 'authored_edge'
-          AND travel_mode = %s::orrery_travel_mode
-          AND bidirectional = true
-        ORDER BY id
-        LIMIT 1
-        """,
-        (destination_place_id, origin_place_id, mode),
-    )
-    row = cur.fetchone()
-    if row is not None:
-        return row, True
-    return None
+    return cur.fetchone()
 
 
 async def _authored_route_edge_async(
@@ -1962,7 +1942,7 @@ async def _authored_route_edge_async(
     origin_place_id: int,
     destination_place_id: int,
     mode: str,
-) -> Optional[tuple[Any, bool]]:
+) -> Optional[Any]:
     row = await conn.fetchrow(
         """
         SELECT id,
@@ -1976,52 +1956,23 @@ async def _authored_route_edge_async(
                duration_minutes,
                ST_AsGeoJSON(route_geometry) AS route_geometry_geojson,
                source,
-               metadata
+               metadata,
+               (from_place_id = $1 AND to_place_id = $2) AS is_direct
         FROM orrery_travel_edges
-        WHERE from_place_id = $1
-          AND to_place_id = $2
-          AND route_method = 'authored_edge'
-          AND travel_mode = $3::orrery_travel_mode
-        ORDER BY id
+        WHERE route_method = 'authored_edge'
+          AND travel_mode IN ($3::orrery_travel_mode, 'mixed'::orrery_travel_mode)
+          AND (
+            (from_place_id = $1 AND to_place_id = $2)
+            OR (from_place_id = $2 AND to_place_id = $1 AND bidirectional = true)
+          )
+        ORDER BY (travel_mode = $3::orrery_travel_mode) DESC, is_direct DESC, id
         LIMIT 1
         """,
         origin_place_id,
         destination_place_id,
         mode,
     )
-    if row is not None:
-        return row, False
-
-    row = await conn.fetchrow(
-        """
-        SELECT id,
-               from_place_id,
-               to_place_id,
-               route_method::text AS route_method,
-               travel_mode::text AS travel_mode,
-               risk::text AS risk,
-               bidirectional,
-               distance_m,
-               duration_minutes,
-               ST_AsGeoJSON(route_geometry) AS route_geometry_geojson,
-               source,
-               metadata
-        FROM orrery_travel_edges
-        WHERE from_place_id = $1
-          AND to_place_id = $2
-          AND route_method = 'authored_edge'
-          AND travel_mode = $3::orrery_travel_mode
-          AND bidirectional = true
-        ORDER BY id
-        LIMIT 1
-        """,
-        destination_place_id,
-        origin_place_id,
-        mode,
-    )
-    if row is not None:
-        return row, True
-    return None
+    return row
 
 
 def _route_from_authored_edge(
@@ -2030,22 +1981,24 @@ def _route_from_authored_edge(
     origin_place_id: int,
     destination_place_id: int,
     requested_mode: str,
-    reversed_edge: bool,
 ) -> dict[str, Any]:
     edge_id = int(_row_get(row, "id", 0))
     edge_from_place_id = int(_row_get(row, "from_place_id", 1))
     edge_to_place_id = int(_row_get(row, "to_place_id", 2))
-    travel_mode = str(_row_get(row, "travel_mode", 4))
+    edge_travel_mode = str(_row_get(row, "travel_mode", 4))
+    travel_mode = requested_mode if edge_travel_mode == "mixed" else edge_travel_mode
     risk = str(_row_get(row, "risk", 5))
     route_geometry = _decode_json_value(
         _row_get_optional(row, "route_geometry_geojson", 9)
     )
+    reversed_edge = not bool(_row_get(row, "is_direct", 12))
     metadata = {
         "route_method": "authored_edge",
         "origin_place_id": origin_place_id,
         "destination_place_id": destination_place_id,
         "requested_travel_mode": requested_mode,
         "travel_mode": travel_mode,
+        "edge_travel_mode": edge_travel_mode,
         "risk": risk,
         "route_edge_id": edge_id,
         "edge_from_place_id": edge_from_place_id,

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -137,19 +137,43 @@ class RecordingCursor:
         ):
             self._fetchone = {"progress_ratio": self.travel_progress}
         elif "FROM orrery_travel_edges" in normalized:
-            from_place_id, to_place_id, travel_mode = params
-            require_bidirectional = "AND bidirectional = true" in normalized
+            (
+                origin_place_id,
+                destination_place_id,
+                travel_mode,
+                _direct_from_place_id,
+                _direct_to_place_id,
+                reverse_from_place_id,
+                reverse_to_place_id,
+                _order_travel_mode,
+            ) = params
+            candidates = []
             for edge in self.authored_route_edges:
                 if edge.get("route_method", "authored_edge") != "authored_edge":
                     continue
-                if edge["from_place_id"] != from_place_id:
+                edge_travel_mode = edge.get("travel_mode", "mixed")
+                if edge_travel_mode not in {travel_mode, "mixed"}:
                     continue
-                if edge["to_place_id"] != to_place_id:
-                    continue
-                if edge.get("travel_mode", "mixed") != travel_mode:
-                    continue
-                if require_bidirectional and not edge.get("bidirectional", True):
-                    continue
+                is_direct = (
+                    edge["from_place_id"] == origin_place_id
+                    and edge["to_place_id"] == destination_place_id
+                )
+                is_reversible = (
+                    edge["from_place_id"] == reverse_from_place_id
+                    and edge["to_place_id"] == reverse_to_place_id
+                    and edge.get("bidirectional", False)
+                )
+                if is_direct or is_reversible:
+                    candidates.append(
+                        (
+                            edge_travel_mode != travel_mode,
+                            not is_direct,
+                            edge.get("id", 7),
+                            edge,
+                        )
+                    )
+            if candidates:
+                _is_mixed, _is_reverse, _edge_id, edge = sorted(candidates)[0]
                 self._fetchone = {
                     "id": edge.get("id", 7),
                     "from_place_id": edge["from_place_id"],
@@ -157,14 +181,17 @@ class RecordingCursor:
                     "route_method": edge.get("route_method", "authored_edge"),
                     "travel_mode": edge.get("travel_mode", "mixed"),
                     "risk": edge.get("risk", "low"),
-                    "bidirectional": edge.get("bidirectional", True),
+                    "bidirectional": edge.get("bidirectional", False),
                     "distance_m": edge.get("distance_m"),
                     "duration_minutes": edge.get("duration_minutes"),
                     "route_geometry_geojson": edge.get("route_geometry_geojson"),
                     "source": edge.get("source"),
                     "metadata": edge.get("metadata", {}),
+                    "is_direct": (
+                        edge["from_place_id"] == origin_place_id
+                        and edge["to_place_id"] == destination_place_id
+                    ),
                 }
-                break
         elif "SELECT ST_Distance(o.coordinates, d.coordinates)" in normalized:
             self._fetchone = {"geodesic_distance_m": self.geodesic_distance_m}
         elif "SELECT current_location FROM characters" in normalized:
@@ -638,9 +665,95 @@ def test_commit_orrery_tick_prefers_direct_authored_route_edge() -> None:
     assert route_metadata["route_method"] == "authored_edge"
     assert route_metadata["route_edge_id"] == 17
     assert route_metadata["reversed"] is False
+    assert route_metadata["bidirectional"] is False
+    assert route_metadata["travel_mode"] == "vehicle"
+    assert route_metadata["edge_travel_mode"] == "vehicle"
     assert route_metadata["source"] == "author:route-notes"
     assert route_metadata["edge_metadata"] == {"name": "checkpoint road"}
     assert route_metadata["route_geometry"]["type"] == "LineString"
+
+
+def test_commit_orrery_tick_uses_mixed_authored_edge_for_concrete_mode() -> None:
+    """Generic authored edges still serve concrete travel-mode requests."""
+
+    cursor = RecordingCursor(
+        current_location=99,
+        geodesic_distance_m=999999,
+        authored_route_edges=[
+            {
+                "id": 31,
+                "from_place_id": 99,
+                "to_place_id": 42,
+                "travel_mode": "mixed",
+                "risk": "moderate",
+                "distance_m": 15000,
+                "duration_minutes": 45,
+            }
+        ],
+    )
+
+    commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _travel_start_proposal(mode="vehicle"),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    travel_params = next(
+        params
+        for sql, params in cursor.executed
+        if "INSERT INTO character_travel_states" in sql
+    )
+    route_metadata = json.loads(travel_params[-1])
+
+    assert not any(
+        "ST_Distance(o.coordinates, d.coordinates)" in sql for sql, _ in cursor.executed
+    )
+    assert travel_params[4] == "authored_edge"
+    assert travel_params[5] == "vehicle"
+    assert route_metadata["route_edge_id"] == 31
+    assert route_metadata["travel_mode"] == "vehicle"
+    assert route_metadata["edge_travel_mode"] == "mixed"
+
+
+def test_commit_orrery_tick_allows_authored_route_without_duration() -> None:
+    """Incomplete authored estimates still preserve route provenance."""
+
+    cursor = RecordingCursor(
+        current_location=99,
+        authored_route_edges=[
+            {
+                "id": 19,
+                "from_place_id": 99,
+                "to_place_id": 42,
+                "travel_mode": "vehicle",
+                "distance_m": 12345,
+                "duration_minutes": None,
+            }
+        ],
+    )
+
+    commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _travel_start_proposal(mode="vehicle"),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    travel_params = next(
+        params
+        for sql, params in cursor.executed
+        if "INSERT INTO character_travel_states" in sql
+    )
+    route_metadata = json.loads(travel_params[-1])
+
+    assert travel_params[4] == "authored_edge"
+    assert travel_params[8] == pytest.approx(12345)
+    assert travel_params[9] is None
+    assert travel_params[12] is None
+    assert route_metadata["route_edge_id"] == 19
 
 
 def test_commit_orrery_tick_uses_bidirectional_authored_edge_in_reverse() -> None:
@@ -720,6 +833,10 @@ def test_commit_orrery_tick_rejects_non_bidirectional_reverse_edge() -> None:
     )
     route_metadata = json.loads(travel_params[-1])
 
+    route_queries = [
+        sql for sql, _ in cursor.executed if "FROM orrery_travel_edges" in sql
+    ]
+    assert len(route_queries) == 1
     assert any(
         "ST_Distance(o.coordinates, d.coordinates)" in sql for sql, _ in cursor.executed
     )

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -34,6 +34,7 @@ class RecordingCursor:
         active_destination=42,
         travel_progress=0.4,
         geodesic_distance_m=10000,
+        authored_route_edges=None,
         travel_state_update_rowcount=1,
     ):
         self.duplicate_resolution = duplicate_resolution
@@ -47,6 +48,7 @@ class RecordingCursor:
         self.active_destination = active_destination
         self.travel_progress = travel_progress
         self.geodesic_distance_m = geodesic_distance_m
+        self.authored_route_edges = list(authored_route_edges or [])
         self.travel_state_update_rowcount = travel_state_update_rowcount
         self.executed = []
         self.rowcount = 1
@@ -134,6 +136,35 @@ class RecordingCursor:
             and "status = 'in_transit'" in normalized
         ):
             self._fetchone = {"progress_ratio": self.travel_progress}
+        elif "FROM orrery_travel_edges" in normalized:
+            from_place_id, to_place_id, travel_mode = params
+            require_bidirectional = "AND bidirectional = true" in normalized
+            for edge in self.authored_route_edges:
+                if edge.get("route_method", "authored_edge") != "authored_edge":
+                    continue
+                if edge["from_place_id"] != from_place_id:
+                    continue
+                if edge["to_place_id"] != to_place_id:
+                    continue
+                if edge.get("travel_mode", "mixed") != travel_mode:
+                    continue
+                if require_bidirectional and not edge.get("bidirectional", True):
+                    continue
+                self._fetchone = {
+                    "id": edge.get("id", 7),
+                    "from_place_id": edge["from_place_id"],
+                    "to_place_id": edge["to_place_id"],
+                    "route_method": edge.get("route_method", "authored_edge"),
+                    "travel_mode": edge.get("travel_mode", "mixed"),
+                    "risk": edge.get("risk", "low"),
+                    "bidirectional": edge.get("bidirectional", True),
+                    "distance_m": edge.get("distance_m"),
+                    "duration_minutes": edge.get("duration_minutes"),
+                    "route_geometry_geojson": edge.get("route_geometry_geojson"),
+                    "source": edge.get("source"),
+                    "metadata": edge.get("metadata", {}),
+                }
+                break
         elif "SELECT ST_Distance(o.coordinates, d.coordinates)" in normalized:
             self._fetchone = {"geodesic_distance_m": self.geodesic_distance_m}
         elif "SELECT current_location FROM characters" in normalized:
@@ -220,6 +251,45 @@ def _scene_pressure() -> OrreryScenePressureDraft:
         pressure_stub="{actor} is moving toward {target}.",
         prompt_text="Mara is moving toward Vale.",
         magnitude=0.52,
+    )
+
+
+def _travel_start_proposal(
+    *,
+    destination_place_id: int = 42,
+    mode: str = "vehicle",
+    risk: str | None = None,
+) -> OrreryTickProposal:
+    travel_start = {
+        "destination_place_id": destination_place_id,
+        "mode": mode,
+        "initial_progress": 0.1,
+    }
+    if risk is not None:
+        travel_start["risk"] = risk
+    draft = OrreryResolutionDraft(
+        template_id="travel",
+        priority=21,
+        binding_hash=f"travel-start-{mode}-{destination_place_id}",
+        bindings={"actor": 1},
+        branch_label="Depart toward the planned destination",
+        narrative_stub="{actor} starts the journey.",
+        state_delta={
+            "character.current_activity": "departing toward destination",
+            "travel.start": travel_start,
+        },
+        event_type="travel_departed",
+        changed_fields=(
+            "character.current_activity",
+            "character_travel_states.status",
+        ),
+        magnitude=0.28,
+    )
+    return OrreryTickProposal(
+        anchor_chunk_id=99,
+        actor_count=1,
+        resolutions=(draft,),
+        generated_at="2073-10-31T18:00:00+00:00",
     )
 
 
@@ -506,14 +576,194 @@ def test_commit_orrery_tick_starts_estimated_travel_without_moving_actor() -> No
     assert result.event_count == 1
     assert "UPDATE characters SET current_location" not in statements
     assert travel_params[:4] == (1, 99, 99, 42)
-    assert travel_params[4] == "vehicle"
-    assert travel_params[6] == pytest.approx(0.1)
-    assert travel_params[7] > 10000
+    assert travel_params[4] == "estimated"
+    assert travel_params[5] == "vehicle"
+    assert travel_params[7] == pytest.approx(0.1)
+    assert travel_params[8] > 10000
     assert route_metadata["route_method"] == "estimated"
     assert route_metadata["origin_place_id"] == 99
     assert route_metadata["destination_place_id"] == 42
     assert route_metadata["travel_mode"] == "vehicle"
     assert route_metadata["detour_factor"] > 1
+
+
+def test_commit_orrery_tick_prefers_direct_authored_route_edge() -> None:
+    """An authored edge wins over the coarse coordinate estimate."""
+
+    cursor = RecordingCursor(
+        current_location=99,
+        geodesic_distance_m=999999,
+        authored_route_edges=[
+            {
+                "id": 17,
+                "from_place_id": 99,
+                "to_place_id": 42,
+                "travel_mode": "vehicle",
+                "risk": "high",
+                "distance_m": 12345,
+                "duration_minutes": 37.5,
+                "source": "author:route-notes",
+                "metadata": {"name": "checkpoint road"},
+                "route_geometry_geojson": (
+                    '{"type":"LineString","coordinates":[[0,0],[1,1]]}'
+                ),
+            }
+        ],
+    )
+
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _travel_start_proposal(mode="vehicle"),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    travel_params = next(
+        params
+        for sql, params in cursor.executed
+        if "INSERT INTO character_travel_states" in sql
+    )
+    route_metadata = json.loads(travel_params[-1])
+
+    assert result.resolution_count == 1
+    assert not any(
+        "ST_Distance(o.coordinates, d.coordinates)" in sql for sql, _ in cursor.executed
+    )
+    assert travel_params[4] == "authored_edge"
+    assert travel_params[5] == "vehicle"
+    assert travel_params[6] == "high"
+    assert travel_params[8] == pytest.approx(12345)
+    assert travel_params[9] == pytest.approx(37.5)
+    assert route_metadata["route_method"] == "authored_edge"
+    assert route_metadata["route_edge_id"] == 17
+    assert route_metadata["reversed"] is False
+    assert route_metadata["source"] == "author:route-notes"
+    assert route_metadata["edge_metadata"] == {"name": "checkpoint road"}
+    assert route_metadata["route_geometry"]["type"] == "LineString"
+
+
+def test_commit_orrery_tick_uses_bidirectional_authored_edge_in_reverse() -> None:
+    """Reverse traversal is allowed only when the authored edge opts in."""
+
+    cursor = RecordingCursor(
+        current_location=99,
+        authored_route_edges=[
+            {
+                "id": 23,
+                "from_place_id": 42,
+                "to_place_id": 99,
+                "travel_mode": "vehicle",
+                "risk": "moderate",
+                "bidirectional": True,
+                "distance_m": 8000,
+                "duration_minutes": 20,
+            }
+        ],
+    )
+
+    commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _travel_start_proposal(mode="vehicle"),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    travel_params = next(
+        params
+        for sql, params in cursor.executed
+        if "INSERT INTO character_travel_states" in sql
+    )
+    route_metadata = json.loads(travel_params[-1])
+
+    assert travel_params[4] == "authored_edge"
+    assert travel_params[6] == "moderate"
+    assert route_metadata["route_edge_id"] == 23
+    assert route_metadata["edge_from_place_id"] == 42
+    assert route_metadata["edge_to_place_id"] == 99
+    assert route_metadata["reversed"] is True
+
+
+def test_commit_orrery_tick_rejects_non_bidirectional_reverse_edge() -> None:
+    """One-way authored edges do not leak into reverse travel."""
+
+    cursor = RecordingCursor(
+        current_location=99,
+        geodesic_distance_m=10000,
+        authored_route_edges=[
+            {
+                "id": 23,
+                "from_place_id": 42,
+                "to_place_id": 99,
+                "travel_mode": "vehicle",
+                "risk": "moderate",
+                "bidirectional": False,
+                "distance_m": 8000,
+                "duration_minutes": 20,
+            }
+        ],
+    )
+
+    commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _travel_start_proposal(mode="vehicle"),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    travel_params = next(
+        params
+        for sql, params in cursor.executed
+        if "INSERT INTO character_travel_states" in sql
+    )
+    route_metadata = json.loads(travel_params[-1])
+
+    assert any(
+        "ST_Distance(o.coordinates, d.coordinates)" in sql for sql, _ in cursor.executed
+    )
+    assert travel_params[4] == "estimated"
+    assert route_metadata["route_method"] == "estimated"
+
+
+def test_commit_orrery_tick_falls_back_when_authored_edge_mode_incompatible() -> None:
+    """Edges for another travel mode are ignored instead of coerced."""
+
+    cursor = RecordingCursor(
+        current_location=99,
+        geodesic_distance_m=10000,
+        authored_route_edges=[
+            {
+                "id": 17,
+                "from_place_id": 99,
+                "to_place_id": 42,
+                "travel_mode": "rail",
+                "risk": "low",
+                "distance_m": 5000,
+                "duration_minutes": 12,
+            }
+        ],
+    )
+
+    commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _travel_start_proposal(mode="vehicle"),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    travel_params = next(
+        params
+        for sql, params in cursor.executed
+        if "INSERT INTO character_travel_states" in sql
+    )
+    route_metadata = json.loads(travel_params[-1])
+
+    assert travel_params[4] == "estimated"
+    assert route_metadata["route_method"] == "estimated"
+    assert route_metadata["travel_mode"] == "vehicle"
 
 
 def test_commit_orrery_tick_advances_travel_progress_without_moving_actor() -> None:


### PR DESCRIPTION
## Summary
- Prefer compatible authored `orrery_travel_edges` when committing `travel.start`, including bidirectional reverse traversal.
- Store selected route method, mode, risk, distance, duration, and route provenance metadata in `character_travel_states`.
- Update the Orrery design plan so the active slice points at routing phase 2 and phase 3 remains the next routing lane.

Closes #245.

## Validation
- `poetry run pytest tests/test_orrery/test_events.py -q`
- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery -q`
- `git diff --check`