### PR TITLE
[codex] Fix bootstrap prompt plumbing

### DIFF
--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -8,7 +8,7 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional
 
 import psycopg2
 
@@ -28,6 +28,53 @@ from nexus.config.loader import get_provider_for_model
 logger = logging.getLogger("nexus.lore.logon")
 
 
+def _coerce_mapping(value: Any) -> Dict[str, Any]:
+    """Return a JSON-like mapping from DB or model payloads."""
+
+    if value is None:
+        return {}
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse mapping JSON for prompt context: %r", value)
+            return {}
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="json", exclude_none=True)
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _string_value(value: Any) -> str:
+    """Render a scalar prompt value, keeping empty values out of prompts."""
+
+    if value is None or value == "":
+        return ""
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, set):
+        return ", ".join(
+            str(item) for item in sorted(value, key=str) if item not in (None, "")
+        )
+    if isinstance(value, (list, tuple)):
+        return ", ".join(str(item) for item in value if item not in (None, ""))
+    if isinstance(value, Mapping):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return str(value)
+
+
+def _labeled_lines(rows: list[tuple[str, Any]]) -> list[str]:
+    """Render label/value rows, omitting absent values."""
+
+    lines: list[str] = []
+    for label, value in rows:
+        rendered = _string_value(value)
+        if rendered:
+            lines.append(f"- {label}: {rendered}")
+    return lines
+
+
 class LogonUtility:
     """Wrapper for Apex AI API calls using existing providers"""
 
@@ -39,6 +86,7 @@ class LogonUtility:
         settings: Dict[str, Any],
         dbname: Optional[str] = None,
         model_override: Optional[str] = None,
+        bootstrap_mode: bool = False,
     ):
         """
         Initialize LOGON utility with configured provider.
@@ -49,27 +97,28 @@ class LogonUtility:
                     If not provided, uses NEXUS_SLOT env var.
             model_override: Optional model to use instead of settings/slot config.
                            If None, will check slot's configured model first.
+            bootstrap_mode: Whether this LOGON instance is generating chunk #1.
         """
         self.settings = settings
         self.dbname = dbname
         self.model_override = model_override
+        self.bootstrap_mode = bootstrap_mode
         self.provider: Optional[object] = None
         self._system_prompt: Optional[str] = None
+        self._provider_bootstrap_mode: Optional[bool] = None
 
-    def _load_system_prompt(self) -> str:
-        """Load and combine the storyteller core prompt with setting context."""
+    def _load_system_prompt(self, is_bootstrap: Optional[bool] = None) -> str:
+        """Load and combine storyteller instructions with live slot context."""
         from nexus.api.slot_utils import require_slot_dbname
 
+        is_bootstrap = self.bootstrap_mode if is_bootstrap is None else is_bootstrap
+
         # Load storyteller core prompt
-        core_prompt_path = (
-            Path(__file__).parent.parent.parent.parent
-            / "prompts"
-            / "storyteller_core.md"
-        )
+        prompts_dir = Path(__file__).parent.parent.parent.parent / "prompts"
+        core_prompt_path = prompts_dir / "storyteller_core.md"
 
         try:
-            with open(core_prompt_path, "r") as f:
-                core_prompt = f.read()
+            core_prompt = core_prompt_path.read_text()
             logger.info(f"Loaded storyteller core prompt ({len(core_prompt)} chars)")
         except FileNotFoundError:
             logger.warning(
@@ -77,12 +126,29 @@ class LogonUtility:
             )
             core_prompt = "You are a narrative intelligence system generating interactive fiction."
 
+        system_prompt = core_prompt
+        if is_bootstrap:
+            bootstrap_path = prompts_dir / "storyteller_bootstrap.md"
+            try:
+                bootstrap_content = bootstrap_path.read_text()
+                system_prompt = f"{system_prompt}\n\n---\n\n{bootstrap_content}"
+                logger.info(
+                    "Appended storyteller bootstrap supplement (%s chars)",
+                    len(bootstrap_content),
+                )
+            except FileNotFoundError:
+                logger.warning(
+                    "Bootstrap supplement not found at %s, using core prompt only",
+                    bootstrap_path,
+                )
+
         # Query setting from global_variables
         try:
             db = require_slot_dbname(dbname=self.dbname)
             try:
                 tag_library_prompt = format_tag_library_for_prompt(db)
-                core_prompt = f"{core_prompt}\n\n---\n\n{tag_library_prompt}"
+                if tag_library_prompt:
+                    system_prompt = f"{system_prompt}\n\n---\n\n{tag_library_prompt}"
             except Exception as e:
                 logger.warning(
                     "Failed to load Orrery tag library for storyteller prompt: %s",
@@ -95,15 +161,15 @@ class LogonUtility:
                 result = cur.fetchone()
 
                 if result and result[0]:
-                    setting_data = result[0]
-                    # Extract the markdown content from the JSON
-                    setting_content = setting_data.get("content", "")
-                    setting_title = setting_data.get("title", "Setting Context")
+                    setting_content = self._format_setting_context(result[0])
+                    if not setting_content:
+                        logger.warning(
+                            "Setting data found in global_variables but no promptable fields were present"
+                        )
+                        return system_prompt
 
                     # Combine core prompt with setting
-                    combined_prompt = (
-                        f"{core_prompt}\n\n## {setting_title}\n\n{setting_content}"
-                    )
+                    combined_prompt = f"{system_prompt}\n\n{setting_content}"
                     logger.info(
                         f"Combined prompt with setting context ({len(setting_content)} chars)"
                     )
@@ -112,14 +178,55 @@ class LogonUtility:
                     logger.warning(
                         "No setting data found in global_variables, using core prompt only"
                     )
-                    return core_prompt
+                    return system_prompt
 
         except Exception as e:
             logger.error(f"Failed to load setting from database: {e}")
-            return core_prompt
+            return system_prompt
         finally:
             if "conn" in locals():
                 conn.close()
+
+    @staticmethod
+    def _format_setting_context(setting_data: Any) -> str:
+        """Render persisted SettingCard JSON into system-prompt context."""
+
+        setting = _coerce_mapping(setting_data)
+        if not setting:
+            return ""
+
+        legacy_content = _string_value(setting.get("content"))
+        if legacy_content:
+            legacy_title = _string_value(setting.get("title")) or "Setting Context"
+            return f"## {legacy_title}\n\n{legacy_content}"
+
+        world_name = _string_value(setting.get("world_name")) or "Setting Context"
+        lines = [f"## Setting Context: {world_name}"]
+
+        diegetic_artifact = _string_value(setting.get("diegetic_artifact"))
+        if diegetic_artifact:
+            lines.extend(["", "### Diegetic Artifact", diegetic_artifact])
+
+        field_rows = [
+            ("Genre", setting.get("genre")),
+            ("Secondary Genres", setting.get("secondary_genres")),
+            ("Tone", setting.get("tone")),
+            ("Time Period", setting.get("time_period")),
+            ("Technology Level", setting.get("tech_level")),
+            ("Geographic Scope", setting.get("geographic_scope")),
+            ("Themes", setting.get("themes")),
+            ("Magic Exists", setting.get("magic_exists")),
+            ("Magic Description", setting.get("magic_description")),
+            ("Political Structure", setting.get("political_structure")),
+            ("Major Conflict", setting.get("major_conflict")),
+            ("Cultural Notes", setting.get("cultural_notes")),
+            ("Language Notes", setting.get("language_notes")),
+        ]
+        structured_lines = _labeled_lines(field_rows)
+        if structured_lines:
+            lines.extend(["", "### Structured Setting Card", *structured_lines])
+
+        return "\n".join(lines)
 
     def _get_slot_model(self) -> Optional[str]:
         """Get the model configured for the current slot from global_variables."""
@@ -139,9 +246,12 @@ class LogonUtility:
             logger.warning(f"Failed to get slot model: {e}")
             return None
 
-    def _initialize_provider(self) -> None:
+    def _initialize_provider(self, is_bootstrap: Optional[bool] = None) -> None:
         """Initialize the appropriate API provider based on settings and slot config."""
         apex_settings = self.settings.get("API Settings", {}).get("apex", {})
+        provider_bootstrap_mode = (
+            self.bootstrap_mode if is_bootstrap is None else is_bootstrap
+        )
 
         # Model priority: override > slot config > settings
         model = self.model_override
@@ -163,7 +273,9 @@ class LogonUtility:
             logger.info(f"TEST model: routing to mock server at {base_url}")
 
         # Load system prompt
-        system_prompt = self._load_system_prompt()
+        system_prompt = self._load_system_prompt(provider_bootstrap_mode)
+        self._system_prompt = system_prompt
+        self._provider_bootstrap_mode = provider_bootstrap_mode
 
         if provider_type in {"openai", "test"}:
             self.provider = OpenAIProvider(
@@ -191,19 +303,33 @@ class LogonUtility:
         )
         logger.info(f"System prompt loaded: {len(system_prompt)} chars")
 
-    def _ensure_provider(self) -> None:
+    def _ensure_provider(
+        self, context_payload: Optional[Dict[str, Any]] = None
+    ) -> None:
         """Ensure the provider is initialized before use."""
+        desired_bootstrap_mode = (
+            self._is_bootstrap_context(context_payload)
+            if context_payload is not None
+            else self.bootstrap_mode
+        )
+
         if self.provider is None:
-            self._initialize_provider()
+            self._initialize_provider(desired_bootstrap_mode)
             return
 
         resolved_model = self.model_override or self._get_slot_model()
-        if resolved_model and getattr(self.provider, "model", None) != resolved_model:
+        model_changed = bool(
+            resolved_model and getattr(self.provider, "model", None) != resolved_model
+        )
+        bootstrap_changed = self._provider_bootstrap_mode != desired_bootstrap_mode
+        if model_changed or bootstrap_changed:
             logger.info(
-                "Model override detected. Reinitializing provider for model %s",
-                resolved_model,
+                "LOGON provider context changed. Reinitializing provider for model %s "
+                "(bootstrap=%s)",
+                resolved_model or getattr(self.provider, "model", None),
+                desired_bootstrap_mode,
             )
-            self._initialize_provider()
+            self._initialize_provider(desired_bootstrap_mode)
 
     def ensure_provider(self) -> None:
         """Public wrapper for provider initialization."""
@@ -211,7 +337,7 @@ class LogonUtility:
 
     def generate_narrative(self, context_payload: Dict[str, Any]) -> StoryTurnResponse:
         """Generate narrative from context payload with structured output."""
-        self._ensure_provider()
+        self._ensure_provider(context_payload)
         # Format the context into a prompt
         prompt = self._format_context_prompt(context_payload)
         schema_model = self._select_response_schema(context_payload)
@@ -236,7 +362,7 @@ class LogonUtility:
         self, context_payload: Dict[str, Any]
     ) -> StoryTurnResponse:
         """Generate narrative from context payload without blocking the event loop."""
-        self._ensure_provider()
+        self._ensure_provider(context_payload)
         prompt = self._format_context_prompt(context_payload)
         schema_model = self._select_response_schema(context_payload)
 
@@ -260,15 +386,22 @@ class LogonUtility:
         self, context_payload: Dict[str, Any]
     ) -> type[StorytellerResponseBootstrap] | type[StorytellerResponseExtended]:
         """Select the structured output schema for the current narrative context."""
+        if self._is_bootstrap_context(context_payload):
+            return StorytellerResponseBootstrap
+
+        return StorytellerResponseExtended
+
+    @staticmethod
+    def _is_bootstrap_context(context_payload: Optional[Mapping[str, Any]]) -> bool:
+        """Return whether a context payload is for the opening bootstrap chunk."""
+
+        if not isinstance(context_payload, Mapping):
+            return False
         metadata = context_payload.get("metadata", {})
         metadata_bootstrap = (
             metadata.get("is_bootstrap", False) if isinstance(metadata, dict) else False
         )
-
-        if context_payload.get("is_bootstrap", False) or metadata_bootstrap:
-            return StorytellerResponseBootstrap
-
-        return StorytellerResponseExtended
+        return bool(context_payload.get("is_bootstrap", False) or metadata_bootstrap)
 
     def _format_context_prompt(self, context: Dict) -> str:
         """Format context payload into a prompt for the Apex AI"""
@@ -279,6 +412,12 @@ class LogonUtility:
             sections.append("=== RECENT NARRATIVE ===")
             for chunk in context["warm_slice"]["chunks"]:
                 sections.append(chunk.get("text", ""))
+
+        bootstrap_sections = self._format_bootstrap_context(
+            context.get("bootstrap_data")
+        )
+        if bootstrap_sections:
+            sections.extend(bootstrap_sections)
 
         # Add user input
         sections.append("\n=== USER INPUT ===")
@@ -476,3 +615,101 @@ class LogonUtility:
         )
 
         return "\n".join(sections)
+
+    @staticmethod
+    def _format_bootstrap_context(bootstrap_data: Any) -> list[str]:
+        """Render new-story wizard output into chunk #1 user prompt context."""
+
+        data = _coerce_mapping(bootstrap_data)
+        if not data:
+            return []
+
+        sections = [
+            "\n=== BOOTSTRAP CONTEXT ===",
+            "Use this new-story context to write chunk #1. It is authoritative "
+            "for the opening scene.",
+        ]
+
+        setting = _coerce_mapping(data.get("setting"))
+        setting_lines = _labeled_lines(
+            [
+                ("World", setting.get("world_name")),
+                ("Genre", setting.get("genre")),
+                ("Tone", setting.get("tone")),
+                ("Themes", setting.get("themes")),
+                ("Time Period", setting.get("time_period")),
+                ("Technology Level", setting.get("tech_level")),
+                ("Magic Exists", setting.get("magic_exists")),
+                ("Magic Description", setting.get("magic_description")),
+                ("Political Structure", setting.get("political_structure")),
+                ("Major Conflict", setting.get("major_conflict")),
+                ("Cultural Notes", setting.get("cultural_notes")),
+                ("Language Notes", setting.get("language_notes")),
+                ("Geographic Scope", setting.get("geographic_scope")),
+                ("Diegetic Artifact", setting.get("diegetic_artifact")),
+            ]
+        )
+        if setting_lines:
+            sections.extend(["\n## Setting Snapshot", *setting_lines])
+
+        protagonist = _coerce_mapping(data.get("protagonist"))
+        protagonist_lines = _labeled_lines(
+            [
+                ("Name", protagonist.get("name")),
+                ("Summary", protagonist.get("summary")),
+                ("Appearance", protagonist.get("appearance")),
+                ("Background", protagonist.get("background")),
+                ("Personality", protagonist.get("personality")),
+                ("Emotional State", protagonist.get("emotional_state")),
+                ("Current Activity", protagonist.get("current_activity")),
+                ("Traits", protagonist.get("traits") or protagonist.get("extra_data")),
+            ]
+        )
+        if protagonist_lines:
+            sections.extend(["\n## Protagonist", *protagonist_lines])
+
+        location = _coerce_mapping(data.get("location"))
+        location_lines = _labeled_lines(
+            [
+                ("Name", location.get("name")),
+                ("Summary", location.get("summary")),
+                ("Current Status", location.get("current_status")),
+                ("Atmosphere", location.get("atmosphere")),
+                ("History", location.get("history")),
+                ("Inhabitants", location.get("inhabitants")),
+                ("Resources", location.get("resources")),
+                ("Dangers", location.get("dangers")),
+                ("Secrets", location.get("secrets")),
+            ]
+        )
+        if location_lines:
+            sections.extend(["\n## Starting Location", *location_lines])
+
+        seed = _coerce_mapping(data.get("story_seed"))
+        seed_title = _string_value(seed.get("title")) or "Story Seed"
+        seed_lines = _labeled_lines(
+            [
+                ("Seed Type", seed.get("seed_type")),
+                ("Situation", seed.get("situation")),
+                ("Hook", seed.get("hook")),
+                ("Immediate Goal", seed.get("immediate_goal")),
+                ("Stakes", seed.get("stakes")),
+                ("Tension Source", seed.get("tension_source")),
+                ("Weather", seed.get("weather")),
+                ("Key NPCs", seed.get("key_npcs")),
+            ]
+        )
+        if seed_lines:
+            sections.extend([f"\n## Story Seed: {seed_title}", *seed_lines])
+        seed_secrets = _string_value(seed.get("secrets"))
+        if seed_secrets:
+            sections.extend(
+                [
+                    "\n### LLM-Internal Secrets",
+                    "Use these for dramatic irony and continuity. Do not reveal "
+                    "them directly to the player unless the story earns it.",
+                    seed_secrets,
+                ]
+            )
+
+        return sections

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -349,20 +349,36 @@ async def generate_bootstrap_narrative(
 
         # Get character details
         cur.execute(
-            "SELECT name, appearance, background FROM characters WHERE id = %s",
+            """
+            SELECT name, summary, appearance, background, personality,
+                   emotional_state, current_activity, extra_data
+            FROM characters
+            WHERE id = %s
+            """,
             (character_id,),
         )
         char_row = cur.fetchone()
         character_name = char_row["name"] if char_row else "Unknown"
+        character_summary = char_row.get("summary", "") if char_row else ""
         character_appearance = char_row.get("appearance", "") if char_row else ""
         character_background = char_row.get("background", "") if char_row else ""
+        character_personality = char_row.get("personality", "") if char_row else ""
+        character_emotional_state = (
+            char_row.get("emotional_state", "") if char_row else ""
+        )
+        character_current_activity = (
+            char_row.get("current_activity", "") if char_row else ""
+        )
+        character_traits = (char_row.get("extra_data") or {}) if char_row else {}
 
         # Get starting location via FK chain:
         # global_variables.user_character → characters.current_location → places.id
         # Note: atmosphere is stored in extra_data JSONB
         cur.execute(
-            """SELECT p.name, p.summary,
-                      p.extra_data->>'atmosphere' as atmosphere
+            """SELECT p.name, p.summary, p.history, p.current_status, p.secrets,
+                      p.inhabitants,
+                      p.extra_data->>'atmosphere' as atmosphere,
+                      p.extra_data
                FROM global_variables g
                JOIN characters c ON c.id = g.user_character
                JOIN places p ON p.id = c.current_location
@@ -372,6 +388,13 @@ async def generate_bootstrap_narrative(
         location_name = place_row["name"] if place_row else "Unknown Location"
         location_summary = place_row.get("summary", "") if place_row else ""
         location_atmosphere = place_row.get("atmosphere", "") if place_row else ""
+        location_history = place_row.get("history", "") if place_row else ""
+        location_current_status = (
+            place_row.get("current_status", "") if place_row else ""
+        )
+        location_secrets = place_row.get("secrets", "") if place_row else ""
+        location_inhabitants = place_row.get("inhabitants", []) if place_row else []
+        location_extra_data = (place_row.get("extra_data") or {}) if place_row else {}
 
     # Extract story seed from setting
     story_seed = setting_data.get("story_seed", {})
@@ -386,9 +409,18 @@ async def generate_bootstrap_narrative(
                 "world_name": setting_data.get("world_name", "Unknown World"),
                 "tone": setting_data.get("tone", ""),
                 "genre": setting_data.get("genre", ""),
+                "secondary_genres": setting_data.get("secondary_genres", []),
                 "themes": setting_data.get("themes", []),
+                "time_period": setting_data.get("time_period", ""),
+                "tech_level": setting_data.get("tech_level", ""),
                 "magic_exists": setting_data.get("magic_exists", False),
                 "magic_description": setting_data.get("magic_description", ""),
+                "political_structure": setting_data.get("political_structure", ""),
+                "major_conflict": setting_data.get("major_conflict", ""),
+                "cultural_notes": setting_data.get("cultural_notes", ""),
+                "language_notes": setting_data.get("language_notes", ""),
+                "geographic_scope": setting_data.get("geographic_scope", ""),
+                "diegetic_artifact": setting_data.get("diegetic_artifact", ""),
             },
             "story_seed": {
                 "title": story_seed.get("title", ""),
@@ -400,16 +432,28 @@ async def generate_bootstrap_narrative(
                 "tension_source": story_seed.get("tension_source", ""),
                 "weather": story_seed.get("weather", ""),
                 "key_npcs": story_seed.get("key_npcs", []),
+                "secrets": story_seed.get("secrets", ""),
             },
             "protagonist": {
                 "name": character_name,
+                "summary": character_summary,
                 "appearance": character_appearance,
                 "background": character_background,
+                "personality": character_personality,
+                "emotional_state": character_emotional_state,
+                "current_activity": character_current_activity,
+                "traits": character_traits,
             },
             "location": {
                 "name": location_name,
                 "summary": location_summary,
                 "atmosphere": location_atmosphere,
+                "history": location_history,
+                "current_status": location_current_status,
+                "secrets": location_secrets,
+                "inhabitants": location_inhabitants,
+                "resources": location_extra_data.get("resources", []),
+                "dangers": location_extra_data.get("dangers", []),
             },
         },
         "entity_data": {},  # No entity data for bootstrap
@@ -424,7 +468,7 @@ async def generate_bootstrap_narrative(
     # Initialize LOGON and generate narrative
     settings = load_settings()
     dbname = require_slot_dbname(slot=slot)
-    logon = LogonUtility(settings, dbname=dbname)
+    logon = LogonUtility(settings, dbname=dbname, bootstrap_mode=True)
     story_response = await logon.generate_narrative_async(bootstrap_context)
 
     # Extract narrative text

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -99,9 +99,12 @@ def patched_provider(monkeypatch: pytest.MonkeyPatch) -> Dict[str, int]:
         def ensure_model_loaded(self) -> None:
             return None
 
-    def _fake_initialize(self: LogonUtility) -> None:
+    def _fake_initialize(self: LogonUtility, is_bootstrap: bool | None = None) -> None:
         init_calls["count"] += 1
         self.provider = _DummyProvider()
+        self._provider_bootstrap_mode = (
+            self.bootstrap_mode if is_bootstrap is None else is_bootstrap
+        )
 
     for target in (
         "nexus.agents.lore.logon_utility.LogonUtility._initialize_provider",
@@ -166,6 +169,7 @@ async def test_logon_async_generation_uses_structured_provider() -> None:
     provider = _DummyProvider()
     logon = LogonUtility({}, model_override="dummy-model")
     logon.provider = provider
+    logon._provider_bootstrap_mode = False
 
     response = await logon.generate_narrative_async(_minimal_payload())
 
@@ -183,6 +187,7 @@ async def test_logon_async_generation_uses_bootstrap_schema_for_bootstrap() -> N
     provider = _DummyProvider()
     logon = LogonUtility({}, model_override="dummy-model")
     logon.provider = provider
+    logon._provider_bootstrap_mode = True
 
     response = await logon.generate_narrative_async(_minimal_payload(is_bootstrap=True))
 
@@ -200,9 +205,35 @@ async def test_logon_structured_failure_does_not_call_plain_text_fallback() -> N
     provider = _FailingProvider()
     logon = LogonUtility({}, model_override="dummy-model")
     logon.provider = provider
+    logon._provider_bootstrap_mode = False
 
     with pytest.raises(RuntimeError, match="structured boom"):
         await logon.generate_narrative_async(_minimal_payload())
 
     assert provider.structured_calls == 1
     assert provider.completion_calls == 0
+
+
+def test_context_bootstrap_mode_does_not_mutate_logon_instance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bootstrap payload can re-prompt the provider without flipping the utility."""
+
+    initialized_modes: list[bool | None] = []
+
+    def _fake_initialize(self: LogonUtility, is_bootstrap: bool | None = None) -> None:
+        initialized_modes.append(is_bootstrap)
+        self.provider = _DummyProvider()
+        self._provider_bootstrap_mode = (
+            self.bootstrap_mode if is_bootstrap is None else is_bootstrap
+        )
+
+    monkeypatch.setattr(LogonUtility, "_initialize_provider", _fake_initialize)
+
+    logon = LogonUtility({}, model_override="dummy-model", bootstrap_mode=False)
+
+    logon.generate_narrative(_minimal_payload(is_bootstrap=True))
+
+    assert initialized_modes == [True]
+    assert logon.bootstrap_mode is False
+    assert logon._provider_bootstrap_mode is True

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -1,6 +1,196 @@
 """Tests for LOGON prompt formatting."""
 
+from pathlib import Path
+from typing import Any
+
+import pytest
+
 from nexus.agents.lore.logon_utility import LogonUtility
+
+
+PROMPTS_DIR = Path(__file__).parents[2] / "prompts"
+
+
+class _FakeCursor:
+    def __init__(self, row: Any) -> None:
+        self.row = row
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> bool:
+        return False
+
+    def execute(self, _sql: str) -> None:
+        return None
+
+    def fetchone(self) -> Any:
+        return self.row
+
+
+class _FakeConnection:
+    def __init__(self, row: Any) -> None:
+        self.row = row
+        self.closed = False
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self.row)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _patch_setting_row(monkeypatch: pytest.MonkeyPatch, row: Any) -> _FakeConnection:
+    fake_conn = _FakeConnection(row)
+    monkeypatch.setattr(
+        "nexus.api.slot_utils.require_slot_dbname",
+        lambda **_kwargs: "save_05",
+    )
+    monkeypatch.setattr(
+        "nexus.agents.lore.logon_utility.format_tag_library_for_prompt",
+        lambda _dbname: "",
+    )
+    monkeypatch.setattr(
+        "nexus.agents.lore.logon_utility.psycopg2.connect",
+        lambda **_kwargs: fake_conn,
+    )
+    return fake_conn
+
+
+def _setting_card() -> dict[str, Any]:
+    return {
+        "world_name": "Veyra",
+        "genre": "fantasy",
+        "secondary_genres": ["mystery"],
+        "tone": "dark",
+        "time_period": "Age of Ash",
+        "tech_level": "medieval",
+        "magic_exists": True,
+        "magic_description": "Oaths become weather.",
+        "political_structure": "Fractured baronies under a wounded crown.",
+        "major_conflict": "The bells name traitors before they act.",
+        "themes": ["loyalty", "guilt"],
+        "cultural_notes": "Hospitality is sworn at thresholds.",
+        "language_notes": "Names are formal in public.",
+        "geographic_scope": "regional",
+        "diegetic_artifact": "VERBATIM VEYRAN STYLE BIBLE",
+    }
+
+
+def test_load_system_prompt_renders_setting_card_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Persisted SettingCard JSON reaches the system prompt."""
+
+    fake_conn = _patch_setting_row(monkeypatch, (_setting_card(),))
+
+    prompt = LogonUtility({}, dbname="save_05")._load_system_prompt()
+
+    assert fake_conn.closed is True
+    assert "## Setting Context: Veyra" in prompt
+    assert "VERBATIM VEYRAN STYLE BIBLE" in prompt
+    assert "- Genre: fantasy" in prompt
+    assert "- Magic Description: Oaths become weather." in prompt
+    assert "- Major Conflict: The bells name traitors before they act." in prompt
+
+
+def test_load_system_prompt_without_setting_row_returns_core_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty slots still use the core storyteller prompt."""
+
+    _patch_setting_row(monkeypatch, None)
+    core_prompt = (PROMPTS_DIR / "storyteller_core.md").read_text()
+
+    prompt = LogonUtility({}, dbname="save_05")._load_system_prompt()
+
+    assert prompt == core_prompt
+    assert "Setting Context:" not in prompt
+
+
+def test_load_system_prompt_appends_bootstrap_supplement_only_for_bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Chunk #1 gets storyteller_bootstrap.md; normal chunks do not."""
+
+    _patch_setting_row(monkeypatch, None)
+
+    normal_prompt = LogonUtility({}, dbname="save_05")._load_system_prompt()
+    bootstrap_prompt = LogonUtility(
+        {}, dbname="save_05", bootstrap_mode=True
+    )._load_system_prompt()
+
+    assert "# Bootstrap Context (Chunk #1 Only)" not in normal_prompt
+    assert "# Bootstrap Context (Chunk #1 Only)" in bootstrap_prompt
+    assert "First Chunk Responsibilities" in bootstrap_prompt
+
+
+def test_context_prompt_renders_bootstrap_data() -> None:
+    """Opening chunk prompt carries protagonist, place, seed, and secrets."""
+
+    prompt = LogonUtility({})._format_context_prompt(
+        {
+            "user_input": "Begin the story.",
+            "bootstrap_data": {
+                "setting": {
+                    "world_name": "Veyra",
+                    "genre": "fantasy",
+                    "tone": "dark",
+                },
+                "protagonist": {
+                    "name": "Dame Varka",
+                    "appearance": "A scarred knight in a rain-dark cloak.",
+                    "background": "She broke the last oath she ever swore.",
+                    "traits": {"obligations": "Bound to the bell tower."},
+                },
+                "location": {
+                    "name": "Kestrelmark Keep",
+                    "atmosphere": "Wet stone, guttering rushlight, and iron bells.",
+                    "current_status": "The wardens are searching the lower gate.",
+                },
+                "story_seed": {
+                    "title": "The Bell That Names the Traitor",
+                    "situation": "The keep bell rings with Varka's true name.",
+                    "hook": "Someone has framed her before the court.",
+                    "immediate_goal": "Reach the bell tower before the second toll.",
+                    "stakes": "Her house will burn if she fails.",
+                    "tension_source": "The traitor is already in the keep.",
+                    "key_npcs": ["Brother Hal", "Mistress Rowan"],
+                    "secrets": "Brother Hal rang the bell to protect her.",
+                },
+            },
+        }
+    )
+
+    assert "=== BOOTSTRAP CONTEXT ===" in prompt
+    assert "## Setting Snapshot" in prompt
+    assert "- World: Veyra" in prompt
+    assert "## Protagonist" in prompt
+    assert "- Name: Dame Varka" in prompt
+    assert "## Starting Location" in prompt
+    assert "- Name: Kestrelmark Keep" in prompt
+    assert "## Story Seed: The Bell That Names the Traitor" in prompt
+    assert "### LLM-Internal Secrets" in prompt
+    assert "Do not reveal them directly to the player" in prompt
+    assert "Brother Hal rang the bell to protect her." in prompt
+    assert "=== USER INPUT ===\nBegin the story." in prompt
+
+
+def test_context_prompt_without_bootstrap_data_keeps_standard_shape() -> None:
+    """Non-bootstrap calls are unchanged when no bootstrap data is present."""
+
+    prompt = LogonUtility({})._format_context_prompt({"user_input": "Continue."})
+
+    assert "=== BOOTSTRAP CONTEXT ===" not in prompt
+    assert "\n=== USER INPUT ===\nContinue." in prompt
+    assert "\n=== INSTRUCTIONS ===" in prompt
+    assert (
+        "Continue the narrative based on the provided context and user input." in prompt
+    )
+    assert (
+        "Maintain consistency with established characters, locations, and plot."
+        in prompt
+    )
 
 
 def test_context_prompt_includes_orrery_scene_pressure_controls() -> None:


### PR DESCRIPTION
## Summary

Fixes the three bootstrap prompt regressions tagged by Claude Code:

- render persisted `SettingCard` fields from `global_variables.setting` instead of dead `content`/`title` keys
- append `prompts/storyteller_bootstrap.md` for chunk #1 bootstrap generations only
- render `bootstrap_data` into the LOGON user prompt so protagonist, starting location, story seed, and LLM-internal seed secrets reach the Storyteller
- pass richer bootstrap context from `generate_bootstrap_narrative`, including protagonist traits/personality, location status/history/secrets, and the setting diegetic artifact

Fixes #250
Fixes #251
Fixes #252

## Live Bootstrap Evidence

Ran a live slot 5 bootstrap generation without writing incubator rows. Transmission-side logs showed:

```
Loaded storyteller core prompt (14803 chars)
Appended storyteller bootstrap supplement (2211 chars)
Combined prompt with setting context (8894 chars)
System prompt loaded: 25917 chars
Using Pydantic AI structured output with model gpt-5.5 and schema StorytellerResponseBootstrap
```

Slot 5 source context was Veyr fantasy, Dame Varka Ash-Tusk, Kestrelmark Keep's Bell Hall, and seed `The Bell That Names the Traitor`. The generated chunk incorporated those anchors directly: corpse-bell, Veyran oath law, Dame Varka/Ash-Tusk, Kestrelmark Keep, Lady Ysmer, Ser Caldus, and the traitor-bell premise.

## Validation

- `poetry run pytest tests/test_lore/test_logon_prompt_formatting.py tests/test_lore/test_logon_lazy_init.py tests/test_api/test_narrative_generation.py tests/test_logon_mock_integration.py tests/test_lore/test_apex_schema.py tests/test_api/test_lore_adapter.py -q`
- `poetry run pytest tests/test_lore -q`
- `poetry run pytest tests/test_api/test_narrative_generation.py tests/test_api/test_lore_adapter.py -q`
- `git diff --check`
- `poetry run python -m py_compile nexus/agents/lore/logon_utility.py nexus/api/narrative_generation.py tests/test_lore/test_logon_prompt_formatting.py`
