### PR TITLE
Persist protagonist Orrery tags through setup

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1751,6 +1751,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/033_orrery_travel_work.py`
 - `migrations/034_orrery_concealment_surveillance_vocab.py`
 - `migrations/035_orrery_osm_route_graph.py`
+- `migrations/037_orrery_tag_category_registry.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1752,6 +1752,8 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/034_orrery_concealment_surveillance_vocab.py`
 - `migrations/035_orrery_osm_route_graph.py`
 - `migrations/037_orrery_tag_category_registry.py`
+- `migrations/038_orrery_tag_baseline_reconciliation.py`
+- `migrations/039_new_story_character_orrery_tags.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 

--- a/migrations/023_orrery_schema.py
+++ b/migrations/023_orrery_schema.py
@@ -400,6 +400,10 @@ def _create_identity_views(conn) -> None:
     _execute(
         conn,
         """
+        DROP VIEW IF EXISTS entity_relationships_v;
+        DROP VIEW IF EXISTS chunk_entity_references_v;
+        DROP VIEW IF EXISTS entity_names_v;
+
         CREATE OR REPLACE VIEW entity_names_v AS
             SELECT e.id, e.kind, c.name
             FROM entities e

--- a/migrations/036_skald_inline_tag_runtime.py
+++ b/migrations/036_skald_inline_tag_runtime.py
@@ -1,0 +1,55 @@
+"""Prep work for Skald runtime tag bestowal.
+
+Two small things, both required before
+``nexus.agents.orrery.tag_writer.apply_tag_bestowal`` can run safely:
+
+1. Add ``skald_inline`` to ``entity_tag_source_kind`` so runtime-bestowed tags
+   are auditably distinct from the offline batch (``llm_generated``) used by
+   the slot 2 backfill applicator.
+
+2. Recreate ``ix_entity_tags_current`` as a UNIQUE partial index. It already
+   exists as UNIQUE in slot 2 (which is why the offline applicator's
+   ``ON CONFLICT (entity_id, tag_id) WHERE cleared_at IS NULL DO NOTHING``
+   works there) but is a non-unique index on ``NEXUS_template``. The
+   runtime tag writer relies on the same ``ON CONFLICT`` clause, so the
+   constraint must match in every slot freshly created from the template.
+
+``ALTER TYPE ... ADD VALUE`` is committed in its own transaction (cannot run
+inside a multi-statement block on PG < 12; safe but cleaner everywhere). The
+index recreation is then atomic via ``DROP ... IF EXISTS`` + ``CREATE UNIQUE``
+in a second transaction.
+"""
+
+from __future__ import annotations
+
+from psycopg2 import sql
+
+
+def run(conn) -> None:
+    """Apply the migration: enum value + unique partial index."""
+
+    _add_source_kind(conn)
+    _recreate_current_index_unique(conn)
+
+
+def _add_source_kind(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL(
+                "ALTER TYPE entity_tag_source_kind ADD VALUE IF NOT EXISTS {}"
+            ).format(sql.Literal("skald_inline"))
+        )
+    conn.commit()
+
+
+def _recreate_current_index_unique(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute("DROP INDEX IF EXISTS ix_entity_tags_current")
+        cur.execute(
+            """
+            CREATE UNIQUE INDEX ix_entity_tags_current
+              ON entity_tags (entity_id, tag_id)
+              WHERE cleared_at IS NULL
+            """
+        )
+    conn.commit()

--- a/migrations/037_orrery_tag_category_registry.py
+++ b/migrations/037_orrery_tag_category_registry.py
@@ -1,0 +1,233 @@
+"""Add a registry for Orrery tag-category/entity-kind compatibility."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from psycopg2.extensions import connection
+
+
+# (category, entity_kind, prompt_order, description)
+CATEGORY_REGISTRY: Sequence[tuple[str, str, int, str]] = (
+    (
+        "bodyform",
+        "character",
+        10,
+        "Embodiment or personhood form.",
+    ),
+    ("capacity", "character", 20, "Abilities, training, or usable skills."),
+    (
+        "disposition",
+        "character",
+        30,
+        "Stable behavior tendencies or priority inclinations.",
+    ),
+    (
+        "role",
+        "character",
+        40,
+        "Social, professional, or household roles.",
+    ),
+    (
+        "profession_lite",
+        "character",
+        50,
+        "Lightweight occupations used by package gates.",
+    ),
+    (
+        "state",
+        "character",
+        60,
+        "Durable or ephemeral character state.",
+    ),
+    (
+        "orrery_state",
+        "character",
+        70,
+        "Orrery-specific readiness, identity, or signal state.",
+    ),
+    (
+        "orrery_signal",
+        "character",
+        80,
+        "Orrery-specific pressure signal.",
+    ),
+    (
+        "orrery_need",
+        "character",
+        90,
+        "Homeostatic need severity state.",
+    ),
+    (
+        "orrery_need_modifier",
+        "character",
+        100,
+        "Modifiers that alter need pressure.",
+    ),
+    (
+        "orrery_schedule",
+        "character",
+        110,
+        "Sleep, work, or routine schedule tendencies.",
+    ),
+    (
+        "orrery_social_modulator",
+        "character",
+        120,
+        "Social-need threshold modifiers.",
+    ),
+    (
+        "orrery_intimacy_modulator",
+        "character",
+        130,
+        "Intimacy-need threshold modifiers.",
+    ),
+    (
+        "orrery_intimacy_context",
+        "character",
+        140,
+        "Context that routes intimacy packages.",
+    ),
+    (
+        "orrery_intimacy_suppressor",
+        "character",
+        150,
+        "Context that suppresses intimacy packages.",
+    ),
+    (
+        "orrery_travel",
+        "character",
+        160,
+        "Travel readiness or route knowledge.",
+    ),
+    (
+        "orrery_work",
+        "character",
+        170,
+        "Routine work, duty, or livelihood state.",
+    ),
+    (
+        "orrery_cover",
+        "character",
+        180,
+        "Cover identities and routines.",
+    ),
+    (
+        "orrery_concealment",
+        "character",
+        190,
+        "Hidden, absent, wanted, or unrevealed status.",
+    ),
+    (
+        "relationship_risk",
+        "character",
+        200,
+        "Relationship context that changes package interpretation.",
+    ),
+    (
+        "place_affordance",
+        "place",
+        10,
+        "A functional affordance a place offers to packages.",
+    ),
+    (
+        "ideology_axis",
+        "faction",
+        10,
+        "Worldview, political, or metaphysical orientation.",
+    ),
+    (
+        "power_posture",
+        "faction",
+        20,
+        "How a faction projects power.",
+    ),
+    (
+        "legitimacy_status",
+        "faction",
+        30,
+        "Public, legal, or underworld legitimacy posture.",
+    ),
+    (
+        "operational_secrecy",
+        "faction",
+        40,
+        "Secrecy, compartmentalization, or exposure model.",
+    ),
+    (
+        "resource_class",
+        "faction",
+        50,
+        "Material, economic, or informational resource base.",
+    ),
+    (
+        "hidden_agenda_class",
+        "faction",
+        60,
+        "Covert agendas or internal threats.",
+    ),
+    (
+        "history_class",
+        "faction",
+        70,
+        "Institutional continuity, age, or origin.",
+    ),
+)
+
+
+def run(conn: connection) -> None:
+    """Create and seed the tag-category compatibility registry."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tag_category_registry (
+                category     text NOT NULL,
+                entity_kind  entity_kind NOT NULL,
+                prompt_order integer NOT NULL DEFAULT 1000,
+                description  text NOT NULL DEFAULT '',
+                created_at   timestamptz NOT NULL DEFAULT now(),
+                PRIMARY KEY (category, entity_kind),
+                CHECK (btrim(category) <> '')
+            )
+            """
+        )
+        cur.execute(
+            """
+            COMMENT ON TABLE tag_category_registry IS
+                'Source of truth for which tag categories may be applied to each entity kind.';
+            """
+        )
+        for category, entity_kind, prompt_order, description in CATEGORY_REGISTRY:
+            cur.execute(
+                """
+                INSERT INTO tag_category_registry (
+                    category, entity_kind, prompt_order, description
+                ) VALUES (
+                    %s, %s::entity_kind, %s, %s
+                )
+                ON CONFLICT (category, entity_kind) DO UPDATE SET
+                    prompt_order = EXCLUDED.prompt_order,
+                    description = EXCLUDED.description
+                """,
+                (category, entity_kind, prompt_order, description),
+            )
+        cur.execute(
+            """
+            SELECT DISTINCT t.category
+            FROM tags t
+            WHERE t.deprecated = FALSE
+              AND t.synonym_for IS NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM tag_category_registry r
+                  WHERE r.category = t.category
+              )
+            ORDER BY t.category
+            """
+        )
+        unregistered = [row[0] for row in cur.fetchall()]
+        if unregistered:
+            detail = ", ".join(unregistered)
+            raise RuntimeError(f"Unregistered Orrery tag categories: {detail}")
+    conn.commit()

--- a/migrations/038_orrery_tag_baseline_reconciliation.py
+++ b/migrations/038_orrery_tag_baseline_reconciliation.py
@@ -1,0 +1,51 @@
+"""Reconcile baseline Orrery vocabulary drift across slots."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from psycopg2.extensions import connection
+
+
+# (tag, category, description)
+DURABLE_TAGS: Sequence[tuple[str, str, str]] = (
+    (
+        "intimate_services_contact",
+        "orrery_intimacy_context",
+        "Character has contacts at an intimate services establishment.",
+    ),
+    (
+        "kin_protector",
+        "disposition",
+        "Character has strong protective instincts toward relational kin.",
+    ),
+)
+
+
+def run(conn: connection) -> None:
+    """Upsert baseline tags that drifted between template and fresh slots."""
+
+    with conn.cursor() as cur:
+        for tag, category, description in DURABLE_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, description
+                ) VALUES (
+                    %s, %s, FALSE,
+                    NULL, NULL,
+                    NULL, %s
+                )
+                ON CONFLICT (tag) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    is_ephemeral = EXCLUDED.is_ephemeral,
+                    clearance_kind = EXCLUDED.clearance_kind,
+                    reapplication_policy = EXCLUDED.reapplication_policy,
+                    clear_on = EXCLUDED.clear_on,
+                    description = EXCLUDED.description
+                """,
+                (tag, category, description),
+            )
+    conn.commit()

--- a/migrations/039_new_story_character_orrery_tags.py
+++ b/migrations/039_new_story_character_orrery_tags.py
@@ -1,0 +1,20 @@
+"""Persist protagonist Orrery tags through the normalized wizard cache."""
+
+from __future__ import annotations
+
+from psycopg2.extensions import connection
+
+
+def run(conn: connection) -> None:
+    """Add a JSONB cache column for wildcard-time protagonist tag bestowal."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            ALTER TABLE IF EXISTS assets.new_story_creator
+                ADD COLUMN IF NOT EXISTS character_orrery_tags jsonb;
+            COMMENT ON COLUMN assets.new_story_creator.character_orrery_tags IS
+                'OrreryTagBestowal JSON captured during protagonist wildcard creation.';
+            """
+        )
+    conn.commit()

--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -42,6 +42,7 @@ from nexus.agents.logon.apex_enums import (
     WorldLayerType,
     get_active_entity_types,
 )
+from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
 
 logger = logging.getLogger("nexus.logon.apex_schema")
 
@@ -53,6 +54,7 @@ logger = logging.getLogger("nexus.logon.apex_schema")
 # OpenAI strict mode requires additionalProperties: false, but bare Dicts emit
 # additionalProperties: true, causing a mismatch when the field is in 'required'.
 
+
 class Coordinates(BaseModel):
     """
     Earth-based lat/lon coordinates.
@@ -62,6 +64,7 @@ class Coordinates(BaseModel):
     for the location's described characteristics (climate, terrain, proximity
     to water).
     """
+
     lat: float = Field(description="Latitude (-90 to 90)")
     lon: float = Field(description="Longitude (-180 to 180)")
 
@@ -76,6 +79,7 @@ class CharacterTraits(BaseModel):
     wildcard. Traits signal narrative focus - what aspects of the character
     should be foregrounded in the story.
     """
+
     # Social Network (choose if narratively significant)
     allies: Optional[str] = Field(
         default=None, description="Who will actively help and take risks for you"
@@ -108,7 +112,8 @@ class CharacterTraits(BaseModel):
 
     # Liabilities
     enemies: Optional[str] = Field(
-        default=None, description="Those actively opposed who will expend energy to thwart you"
+        default=None,
+        description="Those actively opposed who will expend energy to thwart you",
     )
     obligations: Optional[str] = Field(
         default=None, description="Debts, oaths, or duties you must honor"
@@ -116,12 +121,11 @@ class CharacterTraits(BaseModel):
 
     # Optional wildcard - unique trait that sets this character apart
     wildcard_name: Optional[str] = Field(
-        default=None,
-        description="Name of the unique custom trait"
+        default=None, description="Name of the unique custom trait"
     )
     wildcard_description: Optional[str] = Field(
         default=None,
-        description="What this trait means - capability, possession, relationship, or curse"
+        description="What this trait means - capability, possession, relationship, or curse",
     )
 
     model_config = ConfigDict(extra="allow")
@@ -133,11 +137,14 @@ class PlaceDetails(BaseModel):
 
     These provide rich world-building details beyond the core place fields.
     """
+
     category: Optional[str] = Field(
-        default=None, description="Narrative category: settlement, wilderness, dungeon, building, district, landmark, road, border"
+        default=None,
+        description="Narrative category: settlement, wilderness, dungeon, building, district, landmark, road, border",
     )
     size: Optional[str] = Field(
-        default=None, description="Relative size: tiny, small, medium, large, huge, massive"
+        default=None,
+        description="Relative size: tiny, small, medium, large, huge, massive",
     )
     population: Optional[int] = Field(
         default=None, ge=0, description="Population if applicable"
@@ -186,9 +193,8 @@ class FactionDetails(BaseModel):
     """
     Additional faction attributes stored in extra_data JSONB.
     """
-    leader: Optional[str] = Field(
-        default=None, description="Name of faction leader"
-    )
+
+    leader: Optional[str] = Field(default=None, description="Name of faction leader")
     notable_members: List[str] = Field(
         default_factory=list, description="Other notable members"
     )
@@ -212,43 +218,51 @@ class FactionDetails(BaseModel):
 # New Entity Creation
 # ============================================================================
 
+
 class NewCharacter(BaseModel):
     """
     Schema for introducing a new character - aligned with DB schema.
     """
+
     name: str = Field(description="Character's name")
     appearance: Optional[str] = Field(
-        default=None,
-        description="Physical description - how the character looks"
+        default=None, description="Physical description - how the character looks"
     )
     background: Optional[str] = Field(
-        default=None,
-        description="Character backstory and history"
+        default=None, description="Character backstory and history"
     )
     personality: Optional[str] = Field(
         default=None,
-        description="Personality traits and quirks (prose format, e.g., 'Methodical problem-solver. Paranoid about digital traces.')"
+        description="Personality traits and quirks (prose format, e.g., 'Methodical problem-solver. Paranoid about digital traces.')",
     )
     emotional_state: Optional[str] = Field(
-        default=None,
-        description="Current emotional state"
+        default=None, description="Current emotional state"
     )
     current_activity: Optional[str] = Field(
-        default=None,
-        description="What the character is currently doing"
+        default=None, description="What the character is currently doing"
     )
     current_location: Optional[int] = Field(
         default=None,
-        description="Place ID where character is located (FK to places.id)"
+        description="Place ID where character is located (FK to places.id)",
     )
     summary: Optional[str] = Field(
         default=None,
         max_length=500,
-        description="Brief character description (max 500 chars)"
+        description="Brief character description (max 500 chars)",
     )
     extra_data: Optional[CharacterTraits] = Field(
         default=None,
-        description="Character traits (3 of 10 optional traits + required wildcard)"
+        description="Character traits (3 of 10 optional traits + required wildcard)",
+    )
+    orrery_tags: Optional[OrreryTagBestowal] = Field(
+        default=None,
+        description=(
+            "Semantic Orrery tags for this character (bodyform, capacity, "
+            "disposition, role, state, etc.). Apply registered tags by name; "
+            "propose new ones when the genre needs vocabulary that doesn't yet "
+            "exist (e.g., bodyform:elf for a fantasy elf). See the Orrery "
+            "Awareness section of your system prompt for category guidance."
+        ),
     )
 
 
@@ -257,39 +271,48 @@ class NewPlace(BaseModel):
     Schema for introducing a new place - aligned with DB schema.
     Zone is calculated from coordinates post-creation (not an input field).
     """
+
     name: str = Field(description="Place name")
     type: PlaceType = Field(
         default=PlaceType.FIXED_LOCATION,
-        description="Type of place (fixed_location, vehicle, virtual, other)"
+        description="Type of place (fixed_location, vehicle, virtual, other)",
     )
     summary: Optional[str] = Field(
         default=None,
         max_length=500,
-        description="Brief place description (max 500 chars)"
+        description="Brief place description (max 500 chars)",
     )
     history: Optional[str] = Field(
-        default=None,
-        description="Place history and past events"
+        default=None, description="Place history and past events"
     )
     current_status: Optional[str] = Field(
         default=None,
-        description="Current state, conditions, and activity at this location"
+        description="Current state, conditions, and activity at this location",
     )
     secrets: Optional[str] = Field(
         default=None,
-        description="Hidden information, plot hooks, and narrative opportunities"
+        description="Hidden information, plot hooks, and narrative opportunities",
     )
     coordinates: Optional[Coordinates] = Field(
         default=None,
-        description="Geographic coordinates (lat/lon on Earth-shaped planet). Zone calculated from this."
+        description="Geographic coordinates (lat/lon on Earth-shaped planet). Zone calculated from this.",
     )
     inhabitants: Optional[List[int]] = Field(
         default_factory=list,
-        description="Character IDs of inhabitants (usually empty for newly introduced places)"
+        description="Character IDs of inhabitants (usually empty for newly introduced places)",
     )
     extra_data: Optional[PlaceDetails] = Field(
         default=None,
-        description="Additional place attributes (atmosphere, features, dangers, etc.)"
+        description="Additional place attributes (atmosphere, features, dangers, etc.)",
+    )
+    orrery_tags: Optional[OrreryTagBestowal] = Field(
+        default=None,
+        description=(
+            "Semantic place_affordance tags for this location (e.g., "
+            "sheltered, public, isolated, defensible, ritually_charged). "
+            "Propose new ones when the setting needs vocabulary that doesn't "
+            "yet exist."
+        ),
     )
 
     @model_validator(mode="before")
@@ -337,49 +360,55 @@ class NewFaction(BaseModel):
     Schema for introducing a new faction - aligned with DB schema.
     Leader info goes in extra_data or character relationships.
     """
+
     name: str = Field(description="Faction name")
     summary: Optional[str] = Field(
         default=None,
         max_length=500,
-        description="Brief faction description (max 500 chars)"
+        description="Brief faction description (max 500 chars)",
     )
     ideology: Optional[str] = Field(
-        default=None,
-        description="Faction's core ideology or purpose"
+        default=None, description="Faction's core ideology or purpose"
     )
     history: Optional[str] = Field(
-        default=None,
-        description="Faction origins, past events, and evolution"
+        default=None, description="Faction origins, past events, and evolution"
     )
     current_activity: Optional[str] = Field(
-        default=None,
-        description="What the faction is currently doing"
+        default=None, description="What the faction is currently doing"
     )
     hidden_agenda: Optional[str] = Field(
         default=None,
-        description="Secret goals, plots, and agendas (like place secrets - narrative gold!)"
+        description="Secret goals, plots, and agendas (like place secrets - narrative gold!)",
     )
     territory: Optional[str] = Field(
         default=None,
-        description="Controlled areas, zones of influence, or operational reach"
+        description="Controlled areas, zones of influence, or operational reach",
     )
     power_level: float = Field(
         default=0.5,
         ge=0.0,
         le=1.0,
-        description="Faction influence/power rating (0.0-1.0, default 0.5 for new factions)"
+        description="Faction influence/power rating (0.0-1.0, default 0.5 for new factions)",
     )
     resources: Optional[str] = Field(
-        default=None,
-        description="Assets, capabilities, personnel, and resources"
+        default=None, description="Assets, capabilities, personnel, and resources"
     )
     primary_location: Optional[int] = Field(
         default=None,
-        description="Place ID of faction headquarters/primary base (FK to places.id)"
+        description="Place ID of faction headquarters/primary base (FK to places.id)",
     )
     extra_data: Optional[FactionDetails] = Field(
         default=None,
-        description="Additional faction attributes (leader, members, allies, rivals, etc.)"
+        description="Additional faction attributes (leader, members, allies, rivals, etc.)",
+    )
+    orrery_tags: Optional[OrreryTagBestowal] = Field(
+        default=None,
+        description=(
+            "Semantic Orrery tags for this faction (ideology_axis, "
+            "power_posture, legitimacy_status, operational_secrecy, "
+            "resource_class, hidden_agenda_class, history_class). Propose new "
+            "ones when the setting needs vocabulary that doesn't yet exist."
+        ),
     )
 
 
@@ -387,51 +416,49 @@ class NewFaction(BaseModel):
 # Entity References (Supporting both existing and new)
 # ============================================================================
 
+
 class CharacterReference(BaseModel):
     """Reference to a character - either existing or new"""
+
     # For existing character
     character_id: Optional[int] = Field(
-        default=None,
-        description="Database ID for existing character"
+        default=None, description="Database ID for existing character"
     )
     character_name: Optional[str] = Field(
-        default=None,
-        description="Name for lookup if ID unknown"
+        default=None, description="Name for lookup if ID unknown"
     )
     # For new character
     new_character: Optional[NewCharacter] = Field(
-        default=None,
-        description="Details for creating new character"
+        default=None, description="Details for creating new character"
     )
     # How they appear in this chunk
     reference_type: ReferenceType = Field(
-        default=ReferenceType.MENTIONED,
-        description="How the character is referenced"
+        default=ReferenceType.MENTIONED, description="How the character is referenced"
     )
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def validate_character_reference(self):
         """Ensure we have either existing ref or new character"""
         if not any([self.character_id, self.character_name, self.new_character]):
-            raise ValueError("Must provide either character_id, character_name, or new_character")
+            raise ValueError(
+                "Must provide either character_id, character_name, or new_character"
+            )
         return self
 
 
 class PlaceReference(BaseModel):
     """Reference to a place - either existing or new"""
+
     # For existing place
     place_id: Optional[int] = Field(
-        default=None,
-        description="Database ID for existing place"
+        default=None, description="Database ID for existing place"
     )
     place_name: Optional[str] = Field(
-        default=None,
-        description="Name for lookup if ID unknown"
+        default=None, description="Name for lookup if ID unknown"
     )
     # For new place
     new_place: Optional[NewPlace] = Field(
-        default=None,
-        description="Details for creating new place"
+        default=None, description="Details for creating new place"
     )
     # How it appears in this chunk (REQUIRED for junction table)
     reference_type: PlaceReferenceType = Field(
@@ -441,10 +468,10 @@ class PlaceReference(BaseModel):
     evidence: Optional[str] = Field(
         default=None,
         max_length=500,
-        description="Optional text evidence for this place reference (e.g., specific quote or context)"
+        description="Optional text evidence for this place reference (e.g., specific quote or context)",
     )
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def validate_place_reference(self):
         """Ensure we have either existing ref or new place"""
         if not any([self.place_id, self.place_name, self.new_place]):
@@ -454,24 +481,21 @@ class PlaceReference(BaseModel):
 
 class FactionReference(BaseModel):
     """Reference to a faction - either existing or new"""
+
     # For existing faction
     faction_id: Optional[int] = Field(
-        default=None,
-        description="Database ID for existing faction"
+        default=None, description="Database ID for existing faction"
     )
     faction_name: Optional[str] = Field(
-        default=None,
-        description="Name for lookup if ID unknown"
+        default=None, description="Name for lookup if ID unknown"
     )
     # For new faction
     new_faction: Optional[NewFaction] = Field(
-        default=None,
-        description="Details for creating new faction"
+        default=None, description="Details for creating new faction"
     )
     # How it appears
     reference_type: ReferenceType = Field(
-        default=ReferenceType.MENTIONED,
-        description="How the faction is referenced"
+        default=ReferenceType.MENTIONED, description="How the faction is referenced"
     )
 
 
@@ -480,17 +504,18 @@ class ReferencedEntities(BaseModel):
     Collection of all entities referenced in the narrative chunk.
     Supports both existing entities and introduction of new ones.
     """
+
     characters: List[CharacterReference] = Field(
         default_factory=list,
-        description="Characters present or mentioned (existing or new)"
+        description="Characters present or mentioned (existing or new)",
     )
     places: List[PlaceReference] = Field(
         default_factory=list,
-        description="Places present or mentioned (existing or new)"
+        description="Places present or mentioned (existing or new)",
     )
     factions: List[FactionReference] = Field(
         default_factory=list,
-        description="Factions present or mentioned (existing or new)"
+        description="Factions present or mentioned (existing or new)",
     )
     # Note: items and threats tables exist but are empty
     # events table doesn't exist
@@ -501,6 +526,7 @@ class ReferencedEntities(BaseModel):
 # ============================================================================
 # Chunk Metadata (Minimal, removing deprecated fields)
 # ============================================================================
+
 
 class ChronologyUpdate(BaseModel):
     """
@@ -514,9 +540,10 @@ class ChronologyUpdate(BaseModel):
     Fixed: episode_transition replaces the problematic dual boolean flags
     to prevent invalid state (season increment without episode increment).
     """
+
     episode_transition: Literal["continue", "new_episode", "new_season"] = Field(
         default="continue",
-        description="Episode/season transition: continue current, new episode, or new season (which also starts new episode)"
+        description="Episode/season transition: continue current, new episode, or new season (which also starts new episode)",
     )
 
     # LLM-friendly time fields (more natural than seconds)
@@ -524,30 +551,34 @@ class ChronologyUpdate(BaseModel):
         default=None,
         ge=0,
         lt=60,
-        description="Minutes elapsed (0-59). Most chunks are in this range."
+        description="Minutes elapsed (0-59). Most chunks are in this range.",
     )
     time_delta_hours: Optional[int] = Field(
         default=None,
         ge=0,
         lt=24,
-        description="Hours elapsed (0-23). Use for longer time passages."
+        description="Hours elapsed (0-23). Use for longer time passages.",
     )
     time_delta_days: Optional[int] = Field(
         default=None,
         ge=0,
-        description="Days elapsed (0+). Rarely used - most narrative is continuous."
+        description="Days elapsed (0+). Rarely used - most narrative is continuous.",
     )
 
     time_delta_description: Optional[str] = Field(
         default=None,
         max_length=100,
-        description="Human-readable time passage (e.g., 'two hours later', 'the next morning')"
+        description="Human-readable time passage (e.g., 'two hours later', 'the next morning')",
     )
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def validate_time_fields(self):
         """At least one time field should be set if any are set"""
-        time_fields = [self.time_delta_minutes, self.time_delta_hours, self.time_delta_days]
+        time_fields = [
+            self.time_delta_minutes,
+            self.time_delta_hours,
+            self.time_delta_days,
+        ]
         if any(f is not None for f in time_fields):
             # Valid - at least one field set
             return self
@@ -562,13 +593,13 @@ class ChunkMetadataUpdate(BaseModel):
     Minimal metadata for chunk (removed 15 deprecated JSONB fields).
     Focused on essential chronology and reference tracking.
     """
+
     chronology: Optional[ChronologyUpdate] = Field(
-        default=None,
-        description="Time progression updates"
+        default=None, description="Time progression updates"
     )
     world_layer: WorldLayerType = Field(
         default=WorldLayerType.PRIMARY,
-        description="Narrative layer (primary, flashback, dream, etc.)"
+        description="Narrative layer (primary, flashback, dream, etc.)",
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -578,32 +609,34 @@ class ChunkMetadataUpdate(BaseModel):
 # Entity State Updates (Aligned with database)
 # ============================================================================
 
+
 class CharacterStateUpdate(BaseModel):
     """
     Update to a character's state (aligned with database schema).
     """
+
     character_id: Optional[int] = Field(
-        default=None,
-        description="Database ID of character"
+        default=None, description="Database ID of character"
     )
-    character_name: str = Field(
-        description="Character name (for lookup if ID unknown)"
-    )
-    current_location: Optional[int] = Field(
-        default=None,
-        description="FK to places.id"
-    )
+    character_name: str = Field(description="Character name (for lookup if ID unknown)")
+    current_location: Optional[int] = Field(default=None, description="FK to places.id")
     current_activity: Optional[str] = Field(
-        default=None,
-        description="What the character is currently doing"
+        default=None, description="What the character is currently doing"
     )
     emotional_state: Optional[str] = Field(
-        default=None,
-        description="Character's emotional state"
+        default=None, description="Character's emotional state"
     )
     extra_observations: Optional[Dict[str, Any]] = Field(
+        default=None, description="Additional observations stored in extra_data JSONB"
+    )
+    orrery_tags: Optional[OrreryTagBestowal] = Field(
         default=None,
-        description="Additional observations stored in extra_data JSONB"
+        description=(
+            "Tag deltas for this character. Use applied_tags to add new tags "
+            "(e.g., they were just cursed → cursed), tags_to_clear to retire "
+            "ephemerals that no longer apply (e.g., the geas was lifted), and "
+            "new_tag_proposals when the vocabulary lacks what you need."
+        ),
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -613,38 +646,28 @@ class RelationshipUpdate(BaseModel):
     """
     Update to a relationship (aligned with character_relationships table).
     """
-    character1_id: Optional[int] = Field(
-        default=None,
-        description="First character ID"
-    )
+
+    character1_id: Optional[int] = Field(default=None, description="First character ID")
     character1_name: Optional[str] = Field(
-        default=None,
-        description="First character name (if ID unknown)"
+        default=None, description="First character name (if ID unknown)"
     )
     character2_id: Optional[int] = Field(
-        default=None,
-        description="Second character ID"
+        default=None, description="Second character ID"
     )
     character2_name: Optional[str] = Field(
-        default=None,
-        description="Second character name (if ID unknown)"
+        default=None, description="Second character name (if ID unknown)"
     )
     relationship_type: Optional[RelationshipType] = Field(
-        default=None,
-        description="Type of relationship"
+        default=None, description="Type of relationship"
     )
     emotional_valence: Optional[EmotionalValence] = Field(
-        default=None,
-        description="Emotional valence of relationship"
+        default=None, description="Emotional valence of relationship"
     )
     dynamic: Optional[str] = Field(
-        default=None,
-        max_length=500,
-        description="Current relationship dynamic"
+        default=None, max_length=500, description="Current relationship dynamic"
     )
     recent_events: Optional[str] = Field(
-        default=None,
-        description="Recent events affecting relationship"
+        default=None, description="Recent events affecting relationship"
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -654,21 +677,24 @@ class LocationStateUpdate(BaseModel):
     """
     Update to a location's state (replaces vague world_state_notes).
     """
-    place_id: Optional[int] = Field(
-        default=None,
-        description="Database ID of place"
-    )
+
+    place_id: Optional[int] = Field(default=None, description="Database ID of place")
     place_name: Optional[str] = Field(
-        default=None,
-        description="Place name (if ID unknown)"
+        default=None, description="Place name (if ID unknown)"
     )
     current_conditions: Optional[str] = Field(
-        default=None,
-        description="Current conditions at location"
+        default=None, description="Current conditions at location"
     )
     notable_changes: Optional[List[str]] = Field(
-        default_factory=list,
-        description="Notable changes since last visit"
+        default_factory=list, description="Notable changes since last visit"
+    )
+    orrery_tags: Optional[OrreryTagBestowal] = Field(
+        default=None,
+        description=(
+            "Tag deltas for this place. Use applied_tags to add new "
+            "place_affordance tags, tags_to_clear to retire ones that no longer "
+            "apply (e.g., a sheltered hideout is now compromised)."
+        ),
     )
 
 
@@ -676,25 +702,29 @@ class FactionStateUpdate(BaseModel):
     """
     Update to a faction's state.
     """
+
     faction_id: Optional[int] = Field(
-        default=None,
-        description="Database ID of faction"
+        default=None, description="Database ID of faction"
     )
     faction_name: Optional[str] = Field(
-        default=None,
-        description="Faction name (if ID unknown)"
+        default=None, description="Faction name (if ID unknown)"
     )
     current_activity: Optional[str] = Field(
-        default=None,
-        description="Current faction activity or operational focus"
+        default=None, description="Current faction activity or operational focus"
     )
     recent_actions: Optional[List[str]] = Field(
-        default_factory=list,
-        description="Recent faction actions"
+        default_factory=list, description="Recent faction actions"
     )
     stance_changes: Optional[Dict[str, str]] = Field(
+        default=None, description="Changes in stance toward other entities"
+    )
+    orrery_tags: Optional[OrreryTagBestowal] = Field(
         default=None,
-        description="Changes in stance toward other entities"
+        description=(
+            "Tag deltas for this faction. Use applied_tags to add tags (e.g., "
+            "they just lost state sanction → ousted_remnant), tags_to_clear to "
+            "retire ones that no longer apply."
+        ),
     )
 
 
@@ -702,21 +732,18 @@ class StateUpdates(BaseModel):
     """
     Collection of all state updates (structured, not vague).
     """
+
     characters: List[CharacterStateUpdate] = Field(
-        default_factory=list,
-        description="Character state updates"
+        default_factory=list, description="Character state updates"
     )
     relationships: List[RelationshipUpdate] = Field(
-        default_factory=list,
-        description="Relationship updates"
+        default_factory=list, description="Relationship updates"
     )
     locations: List[LocationStateUpdate] = Field(
-        default_factory=list,
-        description="Location state updates"
+        default_factory=list, description="Location state updates"
     )
     factions: List[FactionStateUpdate] = Field(
-        default_factory=list,
-        description="Faction state updates"
+        default_factory=list, description="Faction state updates"
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -726,15 +753,15 @@ class StateUpdates(BaseModel):
 # Operations
 # ============================================================================
 
+
 class SummaryRequest(BaseModel):
     """Request for an episode or season summary."""
+
     summary_type: Literal["episode", "season"] = Field(
         description="Type of summary needed"
     )
     reason: Optional[str] = Field(
-        default=None,
-        max_length=200,
-        description="Reason for requesting summary"
+        default=None, max_length=200, description="Reason for requesting summary"
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -742,34 +769,32 @@ class SummaryRequest(BaseModel):
 
 class RegenerationRequest(BaseModel):
     """Request to regenerate this narrative chunk."""
+
     reason: str = Field(
-        max_length=500,
-        description="Reason for requesting regeneration"
+        max_length=500, description="Reason for requesting regeneration"
     )
-    issues: List[Literal[
-        "continuity_error",
-        "out_of_character",
-        "pacing_issue",
-        "tone_mismatch",
-        "world_inconsistency",
-        "other"
-    ]] = Field(
-        default_factory=list,
-        description="Specific issues detected"
-    )
+    issues: List[
+        Literal[
+            "continuity_error",
+            "out_of_character",
+            "pacing_issue",
+            "tone_mismatch",
+            "world_inconsistency",
+            "other",
+        ]
+    ] = Field(default_factory=list, description="Specific issues detected")
 
     model_config = ConfigDict(extra="forbid")
 
 
 class Operations(BaseModel):
     """Special operations or requests from the Storyteller AI."""
+
     request_summary: Optional[SummaryRequest] = Field(
-        default=None,
-        description="Request for episode/season summary"
+        default=None, description="Request for episode/season summary"
     )
     request_regeneration: Optional[RegenerationRequest] = Field(
-        default=None,
-        description="Request to regenerate this chunk"
+        default=None, description="Request to regenerate this chunk"
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -779,15 +804,15 @@ class Operations(BaseModel):
 # Main Response Schema with Hierarchical Options
 # ============================================================================
 
+
 class StorytellerResponseBootstrap(BaseModel):
     """Bootstrap response for first-chunk narrative generation."""
-    narrative: str = Field(
-        description="The opening narrative prose"
-    )
+
+    narrative: str = Field(description="The opening narrative prose")
     choices: List[str] = Field(
         min_length=2,
         max_length=4,
-        description="Player choices (2-4 options). Each should be a complete, actionable option written from player perspective."
+        description="Player choices (2-4 options). Each should be a complete, actionable option written from player perspective.",
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -795,17 +820,15 @@ class StorytellerResponseBootstrap(BaseModel):
 
 class StorytellerResponseMinimal(BaseModel):
     """Minimal response for quick narrative generation."""
-    narrative: str = Field(
-        description="The narrative prose (500-1500 words)"
-    )
+
+    narrative: str = Field(description="The narrative prose (500-1500 words)")
     choices: List[str] = Field(
         min_length=2,
         max_length=4,
-        description="Player choices (2-4 options). Each should be a complete, actionable option written from player perspective."
+        description="Player choices (2-4 options). Each should be a complete, actionable option written from player perspective.",
     )
     referenced_entities: Optional[ReferencedEntities] = Field(
-        default=None,
-        description="Entities referenced in narrative"
+        default=None, description="Entities referenced in narrative"
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -813,23 +836,19 @@ class StorytellerResponseMinimal(BaseModel):
 
 class StorytellerResponseStandard(BaseModel):
     """Standard response with narrative and essential metadata."""
-    narrative: str = Field(
-        description="The narrative prose (500-1500 words)"
-    )
+
+    narrative: str = Field(description="The narrative prose (500-1500 words)")
     choices: List[str] = Field(
         min_length=2,
         max_length=4,
-        description="Player choices (2-4 options). Each should be a complete, actionable option written from player perspective."
+        description="Player choices (2-4 options). Each should be a complete, actionable option written from player perspective.",
     )
-    chunk_metadata: ChunkMetadataUpdate = Field(
-        description="Essential chunk metadata"
-    )
+    chunk_metadata: ChunkMetadataUpdate = Field(description="Essential chunk metadata")
     referenced_entities: ReferencedEntities = Field(
         description="All entities referenced"
     )
     state_updates: Optional[StateUpdates] = Field(
-        default=None,
-        description="State changes for entities"
+        default=None, description="State changes for entities"
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -837,30 +856,23 @@ class StorytellerResponseStandard(BaseModel):
 
 class StorytellerResponseExtended(BaseModel):
     """Extended response with all features including operations."""
-    narrative: str = Field(
-        description="The narrative prose (500-1500 words)"
-    )
+
+    narrative: str = Field(description="The narrative prose (500-1500 words)")
     choices: List[str] = Field(
         min_length=2,
         max_length=4,
-        description="Player choices (2-4 options). Each should be a complete, actionable option written from player perspective."
+        description="Player choices (2-4 options). Each should be a complete, actionable option written from player perspective.",
     )
-    chunk_metadata: ChunkMetadataUpdate = Field(
-        description="Essential chunk metadata"
-    )
+    chunk_metadata: ChunkMetadataUpdate = Field(description="Essential chunk metadata")
     referenced_entities: ReferencedEntities = Field(
         description="All entities referenced (existing or new)"
     )
-    state_updates: StateUpdates = Field(
-        description="Comprehensive state updates"
-    )
+    state_updates: StateUpdates = Field(description="Comprehensive state updates")
     operations: Optional[Operations] = Field(
-        default=None,
-        description="Special operations or requests"
+        default=None, description="Special operations or requests"
     )
     reasoning: Optional[str] = Field(
-        default=None,
-        description="Storyteller's reasoning (debug mode only)"
+        default=None, description="Storyteller's reasoning (debug mode only)"
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -870,6 +882,7 @@ class StorytellerResponseExtended(BaseModel):
 # Utility Functions
 # ============================================================================
 
+
 def calculate_token_count(text: str) -> int:
     """
     Calculate precise token count using tiktoken.
@@ -877,6 +890,7 @@ def calculate_token_count(text: str) -> int:
     """
     # Import here to avoid circular dependencies
     from nexus.agents.lore.utils.chunk_operations import calculate_chunk_tokens
+
     return calculate_chunk_tokens(text)
 
 
@@ -888,16 +902,20 @@ def validate_entity_references(entities: ReferencedEntities) -> List[str]:
     warnings = []
 
     # Check for duplicate characters
-    char_names = [c.character_name or c.new_character.name
-                  for c in entities.characters
-                  if c.character_name or c.new_character]
+    char_names = [
+        c.character_name or c.new_character.name
+        for c in entities.characters
+        if c.character_name or c.new_character
+    ]
     if len(char_names) != len(set(char_names)):
         warnings.append("Duplicate character references detected")
 
     # Check for duplicate places
-    place_names = [p.place_name or p.new_place.name
-                   for p in entities.places
-                   if p.place_name or p.new_place]
+    place_names = [
+        p.place_name or p.new_place.name
+        for p in entities.places
+        if p.place_name or p.new_place
+    ]
     if len(place_names) != len(set(place_names)):
         warnings.append("Duplicate place references detected")
 
@@ -914,13 +932,14 @@ StoryTurnResponse = Union[
     StorytellerResponseExtended,
     StorytellerResponseStandard,
     StorytellerResponseMinimal,
-    StorytellerResponseBootstrap
+    StorytellerResponseBootstrap,
 ]
 
 
 # ============================================================================
 # Helper Functions for Compatibility
 # ============================================================================
+
 
 def validate_story_turn_response(data: Dict[str, Any]) -> StoryTurnResponse:
     """

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -57,7 +57,7 @@ class LogonUtility:
         self._system_prompt: Optional[str] = None
 
     def _load_system_prompt(self) -> str:
-        """Load and combine the storyteller core prompt with setting context"""
+        """Load and combine the storyteller core prompt with setting context."""
         from nexus.api.slot_utils import require_slot_dbname
 
         # Load storyteller core prompt
@@ -77,12 +77,18 @@ class LogonUtility:
             )
             core_prompt = "You are a narrative intelligence system generating interactive fiction."
 
-        db = require_slot_dbname(dbname=self.dbname)
-        tag_library_prompt = format_tag_library_for_prompt(db)
-        core_prompt = f"{core_prompt}\n\n---\n\n{tag_library_prompt}"
-
         # Query setting from global_variables
         try:
+            db = require_slot_dbname(dbname=self.dbname)
+            try:
+                tag_library_prompt = format_tag_library_for_prompt(db)
+                core_prompt = f"{core_prompt}\n\n---\n\n{tag_library_prompt}"
+            except Exception as e:
+                logger.warning(
+                    "Failed to load Orrery tag library for storyteller prompt: %s",
+                    e,
+                )
+
             conn = psycopg2.connect(host="localhost", database=db, user="pythagor")
             with conn.cursor() as cur:
                 cur.execute("SELECT setting FROM global_variables WHERE id = true")

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -22,6 +22,7 @@ from nexus.agents.logon.apex_schema import (
     StorytellerResponseBootstrap,
     StorytellerResponseExtended,
 )
+from nexus.agents.orrery.tag_library import format_tag_library_for_prompt
 from nexus.config.loader import get_provider_for_model
 
 logger = logging.getLogger("nexus.lore.logon")
@@ -60,25 +61,29 @@ class LogonUtility:
         from nexus.api.slot_utils import require_slot_dbname
 
         # Load storyteller core prompt
-        core_prompt_path = Path(__file__).parent.parent.parent.parent / "prompts" / "storyteller_core.md"
+        core_prompt_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "prompts"
+            / "storyteller_core.md"
+        )
 
         try:
-            with open(core_prompt_path, 'r') as f:
+            with open(core_prompt_path, "r") as f:
                 core_prompt = f.read()
             logger.info(f"Loaded storyteller core prompt ({len(core_prompt)} chars)")
         except FileNotFoundError:
-            logger.warning(f"Core prompt not found at {core_prompt_path}, using minimal fallback")
+            logger.warning(
+                f"Core prompt not found at {core_prompt_path}, using minimal fallback"
+            )
             core_prompt = "You are a narrative intelligence system generating interactive fiction."
+
+        db = require_slot_dbname(dbname=self.dbname)
+        tag_library_prompt = format_tag_library_for_prompt(db)
+        core_prompt = f"{core_prompt}\n\n---\n\n{tag_library_prompt}"
 
         # Query setting from global_variables
         try:
-            # Use slot-aware database connection
-            db = require_slot_dbname(dbname=self.dbname)
-            conn = psycopg2.connect(
-                host="localhost",
-                database=db,
-                user="pythagor"
-            )
+            conn = psycopg2.connect(host="localhost", database=db, user="pythagor")
             with conn.cursor() as cur:
                 cur.execute("SELECT setting FROM global_variables WHERE id = true")
                 result = cur.fetchone()
@@ -90,18 +95,24 @@ class LogonUtility:
                     setting_title = setting_data.get("title", "Setting Context")
 
                     # Combine core prompt with setting
-                    combined_prompt = f"{core_prompt}\n\n## {setting_title}\n\n{setting_content}"
-                    logger.info(f"Combined prompt with setting context ({len(setting_content)} chars)")
+                    combined_prompt = (
+                        f"{core_prompt}\n\n## {setting_title}\n\n{setting_content}"
+                    )
+                    logger.info(
+                        f"Combined prompt with setting context ({len(setting_content)} chars)"
+                    )
                     return combined_prompt
                 else:
-                    logger.warning("No setting data found in global_variables, using core prompt only")
+                    logger.warning(
+                        "No setting data found in global_variables, using core prompt only"
+                    )
                     return core_prompt
 
         except Exception as e:
             logger.error(f"Failed to load setting from database: {e}")
             return core_prompt
         finally:
-            if 'conn' in locals():
+            if "conn" in locals():
                 conn.close()
 
     def _get_slot_model(self) -> Optional[str]:
@@ -133,7 +144,9 @@ class LogonUtility:
         if not model:
             model = apex_settings.get("model", "gpt-4o")
 
-        provider_type = get_provider_for_model(model) or apex_settings.get("provider", "openai")
+        provider_type = get_provider_for_model(model) or apex_settings.get(
+            "provider", "openai"
+        )
 
         # Determine base_url for TEST model routing
         base_url = None
@@ -159,15 +172,19 @@ class LogonUtility:
         elif provider_type == "anthropic":
             self.provider = AnthropicProvider(
                 model=model,
-                max_tokens=apex_settings.get("max_output_tokens", apex_settings.get("max_tokens", 4000)),
-                system_prompt=system_prompt
+                max_tokens=apex_settings.get(
+                    "max_output_tokens", apex_settings.get("max_tokens", 4000)
+                ),
+                system_prompt=system_prompt,
             )
         else:
             raise ValueError(f"Unsupported provider type: {provider_type}")
 
-        logger.info(f"LOGON initialized with {provider_type} provider using model {model}")
+        logger.info(
+            f"LOGON initialized with {provider_type} provider using model {model}"
+        )
         logger.info(f"System prompt loaded: {len(system_prompt)} chars")
-    
+
     def _ensure_provider(self) -> None:
         """Ensure the provider is initialized before use."""
         if self.provider is None:
@@ -176,16 +193,17 @@ class LogonUtility:
 
         resolved_model = self.model_override or self._get_slot_model()
         if resolved_model and getattr(self.provider, "model", None) != resolved_model:
-            logger.info("Model override detected. Reinitializing provider for model %s", resolved_model)
+            logger.info(
+                "Model override detected. Reinitializing provider for model %s",
+                resolved_model,
+            )
             self._initialize_provider()
 
     def ensure_provider(self) -> None:
         """Public wrapper for provider initialization."""
         self._ensure_provider()
-    
-    def generate_narrative(
-        self, context_payload: Dict[str, Any]
-    ) -> StoryTurnResponse:
+
+    def generate_narrative(self, context_payload: Dict[str, Any]) -> StoryTurnResponse:
         """Generate narrative from context payload with structured output."""
         self._ensure_provider()
         # Format the context into a prompt
@@ -267,7 +285,9 @@ class LogonUtility:
 
             # Check if using hierarchical structure
             characters = entity_data.get("characters", [])
-            is_hierarchical = isinstance(characters, dict) and ("baseline" in characters or "featured" in characters)
+            is_hierarchical = isinstance(characters, dict) and (
+                "baseline" in characters or "featured" in characters
+            )
 
             if is_hierarchical:
                 # New hierarchical format
@@ -295,7 +315,9 @@ class LogonUtility:
                         if char.get("personality"):
                             sections.append(f"  Personality: {char['personality']}")
                         if char.get("emotional_state"):
-                            sections.append(f"  Emotional State: {char['emotional_state']}")
+                            sections.append(
+                                f"  Emotional State: {char['emotional_state']}"
+                            )
 
                 # Locations (hierarchical)
                 locations = entity_data.get("locations", {})
@@ -340,13 +362,17 @@ class LogonUtility:
                 if characters:
                     sections.append("\nCharacters:")
                     for char in characters:
-                        sections.append(f"- {char.get('name', 'Unknown')}: {char.get('summary', '')}")
+                        sections.append(
+                            f"- {char.get('name', 'Unknown')}: {char.get('summary', '')}"
+                        )
 
                 locations = entity_data.get("locations", [])
                 if locations:
                     sections.append("\nLocations:")
                     for loc in locations:
-                        sections.append(f"- {loc.get('name', 'Unknown')}: {loc.get('description', '') or loc.get('summary', '')}")
+                        sections.append(
+                            f"- {loc.get('name', 'Unknown')}: {loc.get('description', '') or loc.get('summary', '')}"
+                        )
 
             # Relationships, events, threats (same for both formats)
             relationships = entity_data.get("relationships", [])
@@ -377,8 +403,12 @@ class LogonUtility:
         # Add retrieved passages
         if context.get("retrieved_passages"):
             sections.append("\n=== HISTORICAL CONTEXT ===")
-            for passage in context["retrieved_passages"]["results"][:5]:  # Limit to top 5
-                sections.append(f"[Score: {passage.get('score', 0):.2f}] {passage.get('text', '')}")
+            for passage in context["retrieved_passages"]["results"][
+                :5
+            ]:  # Limit to top 5
+                sections.append(
+                    f"[Score: {passage.get('score', 0):.2f}] {passage.get('text', '')}"
+                )
 
         scene_pressures = context.get("orrery_scene_pressures") or []
         if scene_pressures:
@@ -432,7 +462,11 @@ class LogonUtility:
 
         # Add instructions
         sections.append("\n=== INSTRUCTIONS ===")
-        sections.append("Continue the narrative based on the provided context and user input.")
-        sections.append("Maintain consistency with established characters, locations, and plot.")
+        sections.append(
+            "Continue the narrative based on the provided context and user input."
+        )
+        sections.append(
+            "Maintain consistency with established characters, locations, and plot."
+        )
 
         return "\n".join(sections)

--- a/nexus/agents/orrery/tag_constants.py
+++ b/nexus/agents/orrery/tag_constants.py
@@ -1,0 +1,58 @@
+"""Shared constants for Orrery tag application.
+
+Used by both the offline slot 2 backfill applicator
+(``scripts/apply_slot2_semantic_tags.py``) and the inline Skald tag writer
+(``nexus.agents.orrery.tag_writer``). Keeping them here prevents the two call
+sites from drifting on which tag categories are valid for which entity kind
+and which proposed-name aliases canonicalize to which registered tag.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+
+ALLOWED_CATEGORIES: Mapping[str, frozenset[str]] = {
+    "character": frozenset(
+        {
+            "bodyform",
+            "capacity",
+            "disposition",
+            "orrery_need_modifier",
+            "orrery_signal",
+            "orrery_state",
+            "profession_lite",
+            "role",
+            "state",
+        }
+    ),
+    "faction": frozenset(
+        {
+            "hidden_agenda_class",
+            "history_class",
+            "ideology_axis",
+            "legitimacy_status",
+            "operational_secrecy",
+            "power_posture",
+            "resource_class",
+        }
+    ),
+    "place": frozenset({"place_affordance"}),
+}
+
+
+CANONICAL_TAGS: Mapping[str, str] = {
+    "bridge_linked": "bridge_aware",
+    "captive_subject": "captive",
+    "collapse_survivor": "trauma_survivor",
+    "corporate_defector": "corporate_exile",
+    "digital_consciousness": "digital_mind",
+    "disaster_survivor": "trauma_survivor",
+    "echo_survivor": "trauma_survivor",
+    "estranged_parent": "parent",
+    "ex_corporate": "corporate_exile",
+    "found_family_anchor": "extended_household",
+    "found_family_member": "extended_household",
+    "shadow_broker": "broker",
+    "trauma_history": "trauma_survivor",
+}

--- a/nexus/agents/orrery/tag_constants.py
+++ b/nexus/agents/orrery/tag_constants.py
@@ -1,44 +1,13 @@
-"""Shared constants for Orrery tag application.
+"""Shared aliases for Orrery tag application.
 
-Used by both the offline slot 2 backfill applicator
-(``scripts/apply_slot2_semantic_tags.py``) and the inline Skald tag writer
-(``nexus.agents.orrery.tag_writer``). Keeping them here prevents the two call
-sites from drifting on which tag categories are valid for which entity kind
-and which proposed-name aliases canonicalize to which registered tag.
+Category/entity-kind compatibility lives in the database table
+``tag_category_registry``. This module only keeps proposed-name aliases that
+canonicalize to existing registered tags.
 """
 
 from __future__ import annotations
 
 from typing import Mapping
-
-
-ALLOWED_CATEGORIES: Mapping[str, frozenset[str]] = {
-    "character": frozenset(
-        {
-            "bodyform",
-            "capacity",
-            "disposition",
-            "orrery_need_modifier",
-            "orrery_signal",
-            "orrery_state",
-            "profession_lite",
-            "role",
-            "state",
-        }
-    ),
-    "faction": frozenset(
-        {
-            "hidden_agenda_class",
-            "history_class",
-            "ideology_axis",
-            "legitimacy_status",
-            "operational_secrecy",
-            "power_posture",
-            "resource_class",
-        }
-    ),
-    "place": frozenset({"place_affordance"}),
-}
 
 
 CANONICAL_TAGS: Mapping[str, str] = {

--- a/nexus/agents/orrery/tag_library.py
+++ b/nexus/agents/orrery/tag_library.py
@@ -23,6 +23,7 @@ class TagLibraryEntry:
     category: str
     tag: str
     is_ephemeral: bool
+    description: str
     category_description: str
     prompt_order: int
 
@@ -54,7 +55,8 @@ def read_tag_library(
                     r.description AS category_description,
                     r.prompt_order,
                     t.tag,
-                    t.is_ephemeral
+                    t.is_ephemeral,
+                    t.description
                 FROM tag_category_registry r
                 JOIN tags t ON t.category = r.category
                 WHERE {' AND '.join(where)}
@@ -72,6 +74,7 @@ def read_tag_library(
                     category=str(row["category"]),
                     tag=str(row["tag"]),
                     is_ephemeral=bool(row["is_ephemeral"]),
+                    description=str(row["description"] or ""),
                     category_description=str(row["category_description"] or ""),
                     prompt_order=int(row["prompt_order"]),
                 )
@@ -125,10 +128,7 @@ def format_tag_library_for_prompt(
             ),
         ):
             first = category_entries[0]
-            tags = ", ".join(
-                _format_tag_name(entry.tag, entry.is_ephemeral)
-                for entry in category_entries
-            )
+            tags = ", ".join(_format_tag_entry(entry) for entry in category_entries)
             if first.category_description:
                 lines.append(
                     f"- `{category}` — {first.category_description} Tags: {tags}"
@@ -157,6 +157,20 @@ def _normalize_entity_kinds(
 def _format_tag_name(tag: str, is_ephemeral: bool) -> str:
     suffix = " (ephemeral)" if is_ephemeral else ""
     return f"`{tag}`{suffix}"
+
+
+def _format_tag_entry(entry: TagLibraryEntry) -> str:
+    name = _format_tag_name(entry.tag, entry.is_ephemeral)
+    if not entry.description:
+        return name
+    return f"{name}: {_clean_description(entry.description)}"
+
+
+def _clean_description(description: str, *, max_length: int = 140) -> str:
+    cleaned = " ".join(description.split())
+    if len(cleaned) <= max_length:
+        return cleaned
+    return f"{cleaned[: max_length - 3].rstrip()}..."
 
 
 def _connect(dbname: Optional[str]):

--- a/nexus/agents/orrery/tag_library.py
+++ b/nexus/agents/orrery/tag_library.py
@@ -1,0 +1,187 @@
+"""Prompt-facing Orrery tag library helpers."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+import os
+import re
+from typing import Optional, Sequence
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+VALID_ENTITY_KINDS = frozenset({"character", "faction", "place"})
+_SLOT_DB_RE = re.compile(r"^save_0[1-5]$")
+
+
+@dataclass(frozen=True, slots=True)
+class TagLibraryEntry:
+    """One registered tag exposed to Skald as reusable vocabulary."""
+
+    entity_kind: str
+    category: str
+    tag: str
+    is_ephemeral: bool
+    category_description: str
+    prompt_order: int
+
+
+def read_tag_library(
+    dbname: Optional[str] = None,
+    *,
+    entity_kinds: Optional[Sequence[str]] = None,
+) -> list[TagLibraryEntry]:
+    """Read promptable Orrery tags from the target slot database."""
+
+    kind_filter = _normalize_entity_kinds(entity_kinds)
+    conn = _connect(dbname)
+    try:
+        with conn.cursor() as cur:
+            params: list[object] = []
+            where = [
+                "t.deprecated = FALSE",
+                "t.synonym_for IS NULL",
+            ]
+            if kind_filter is not None:
+                where.append("r.entity_kind = ANY(%s::entity_kind[])")
+                params.append(list(kind_filter))
+            cur.execute(
+                f"""
+                SELECT
+                    r.entity_kind::text AS entity_kind,
+                    r.category,
+                    r.description AS category_description,
+                    r.prompt_order,
+                    t.tag,
+                    t.is_ephemeral
+                FROM tag_category_registry r
+                JOIN tags t ON t.category = r.category
+                WHERE {' AND '.join(where)}
+                ORDER BY
+                    r.entity_kind::text,
+                    r.prompt_order,
+                    r.category,
+                    t.tag
+                """,
+                tuple(params),
+            )
+            return [
+                TagLibraryEntry(
+                    entity_kind=str(row["entity_kind"]),
+                    category=str(row["category"]),
+                    tag=str(row["tag"]),
+                    is_ephemeral=bool(row["is_ephemeral"]),
+                    category_description=str(row["category_description"] or ""),
+                    prompt_order=int(row["prompt_order"]),
+                )
+                for row in cur.fetchall()
+            ]
+    finally:
+        conn.close()
+
+
+def format_tag_library_for_prompt(
+    dbname: Optional[str] = None,
+    *,
+    entity_kinds: Optional[Sequence[str]] = None,
+) -> str:
+    """Render the live Orrery tag vocabulary for Skald's system prompt."""
+
+    entries = read_tag_library(dbname, entity_kinds=entity_kinds)
+    if not entries:
+        return (
+            "## Current Orrery Tag Library\n\n"
+            "No registered Orrery tags are currently available in this slot. "
+            "Use `new_tag_proposals` when the story needs vocabulary."
+        )
+
+    by_kind: dict[str, dict[str, list[TagLibraryEntry]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for entry in entries:
+        by_kind[entry.entity_kind][entry.category].append(entry)
+
+    lines = [
+        "## Current Orrery Tag Library",
+        "",
+        "These are the tags already registered in this slot. Prefer exact "
+        "registered tags when they fit; add new tags when the existing library "
+        "does not cover the entity cleanly. New tags should extend this "
+        "ontology, not imitate its examples mechanically.",
+        "",
+    ]
+    for entity_kind in ("character", "place", "faction"):
+        categories = by_kind.get(entity_kind)
+        if not categories:
+            continue
+        lines.append(f"### {entity_kind.title()} Tags")
+        lines.append("")
+        for category, category_entries in sorted(
+            categories.items(),
+            key=lambda item: (
+                item[1][0].prompt_order if item[1] else 1000,
+                item[0],
+            ),
+        ):
+            first = category_entries[0]
+            tags = ", ".join(
+                _format_tag_name(entry.tag, entry.is_ephemeral)
+                for entry in category_entries
+            )
+            if first.category_description:
+                lines.append(
+                    f"- `{category}` — {first.category_description} Tags: {tags}"
+                )
+            else:
+                lines.append(f"- `{category}` — Tags: {tags}")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def _normalize_entity_kinds(
+    entity_kinds: Optional[Sequence[str]],
+) -> Optional[tuple[str, ...]]:
+    if entity_kinds is None:
+        return None
+    normalized = tuple(dict.fromkeys(str(kind) for kind in entity_kinds))
+    unknown = sorted(set(normalized) - VALID_ENTITY_KINDS)
+    if unknown:
+        raise ValueError(
+            "Unknown Orrery entity kind(s): "
+            f"{unknown}; expected {sorted(VALID_ENTITY_KINDS)}"
+        )
+    return normalized
+
+
+def _format_tag_name(tag: str, is_ephemeral: bool) -> str:
+    suffix = " (ephemeral)" if is_ephemeral else ""
+    return f"`{tag}`{suffix}"
+
+
+def _connect(dbname: Optional[str]):
+    resolved = _resolve_dbname(dbname)
+    return psycopg2.connect(
+        dbname=resolved,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+        cursor_factory=RealDictCursor,
+    )
+
+
+def _resolve_dbname(dbname: Optional[str]) -> str:
+    if dbname:
+        resolved = dbname
+    else:
+        slot = os.environ.get("NEXUS_SLOT")
+        if slot and slot.isdigit():
+            resolved = f"save_{int(slot):02d}"
+        else:
+            resolved = os.environ.get("PGDATABASE", "")
+    if not _SLOT_DB_RE.match(resolved):
+        raise ValueError(
+            "Orrery tag library requires a slot database name "
+            f"(save_01..save_05), got {resolved!r}"
+        )
+    return resolved

--- a/nexus/agents/orrery/tag_schemas.py
+++ b/nexus/agents/orrery/tag_schemas.py
@@ -1,0 +1,108 @@
+"""Pydantic models for Orrery tag bestowal in Skald's structured output.
+
+These models are embedded in:
+
+- ``nexus.api.new_story_schemas``: ``WildcardTrait`` and ``PlaceProfile``
+  (wizard phase tagging of the protagonist and starting location).
+- ``nexus.agents.logon.apex_schema``: ``NewCharacter`` / ``NewPlace`` /
+  ``NewFaction`` (per-chunk entity introduction) and ``CharacterStateUpdate`` /
+  ``LocationStateUpdate`` / ``FactionStateUpdate`` (per-chunk entity update).
+
+Skald fills these as part of normal entity emission. The per-chunk commit
+handler and the wizard persistence layer feed them into
+``nexus.agents.orrery.tag_writer.apply_tag_bestowal`` to insert into
+``entity_tags`` (and ``tags`` when proposing new vocabulary).
+"""
+
+from __future__ import annotations
+
+from typing import List, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class NewTagProposal(BaseModel):
+    """A tag Skald wants to add to the registered vocabulary.
+
+    Auto-inserted into ``tags`` on apply (decision: max-contrast genre tests
+    need the vocab to grow in real time so package gates can match in the same
+    session). The corresponding ``entity_tags`` row is stamped with the
+    ``skald_inline`` source kind for audit.
+    """
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    tag: str = Field(
+        ...,
+        min_length=2,
+        max_length=64,
+        description=(
+            "snake_case tag name (e.g., bodyform:elf, sworn_liege, "
+            "scrying_target). Lowercase, no spaces."
+        ),
+    )
+    category: str = Field(
+        ...,
+        min_length=2,
+        max_length=64,
+        description=(
+            "Tag category. Reuse an existing one when possible (bodyform, "
+            "capacity, disposition, role, state, place_affordance, ideology_axis, "
+            "etc.). New namespaces are permitted when the existing ones do not fit."
+        ),
+    )
+    scope: Literal["durable", "ephemeral"] = Field(
+        ...,
+        description=(
+            "durable = stable property of the entity (bodyform, role, ideology). "
+            "ephemeral = a state that can clear (cursed, in_transit, scrying_target)."
+        ),
+    )
+    evidence: str = Field(
+        ...,
+        min_length=10,
+        max_length=500,
+        description=(
+            "One-sentence rationale plus a short near-quote from the structured "
+            "prose you are filling in. Without evidence, the proposal is noise."
+        ),
+    )
+
+
+class OrreryTagBestowal(BaseModel):
+    """Tags Skald bestows on an entity during registration or update.
+
+    Embedded as an optional ``orrery_tags`` field on entity schemas. The DB
+    writer ``apply_tag_bestowal`` consumes this model and writes ``entity_tags``
+    rows (plus ``tags`` rows for proposals).
+
+    ``tags_to_clear`` is only meaningful in update contexts
+    (``CharacterStateUpdate`` etc.) — it is silently ignored when an entity is
+    first introduced.
+    """
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    applied_tags: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Registered tag names to apply to this entity. Lookups happen "
+            "against the live `tags` table; unknown names are silently skipped, "
+            "category-incompatible names are silently skipped."
+        ),
+    )
+    new_tag_proposals: List[NewTagProposal] = Field(
+        default_factory=list,
+        description=(
+            "Tag proposals not yet in the registered vocabulary. Auto-inserted "
+            "into `tags` on apply, then applied to this entity."
+        ),
+    )
+    tags_to_clear: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Registered tag names whose open `entity_tags` row should be "
+            "cleared (cleared_at = now()) for this entity. Meaningful only in "
+            "update contexts."
+        ),
+    )

--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -1,0 +1,194 @@
+"""DB writer for Orrery tag bestowal.
+
+Called by:
+
+- ``nexus.api.new_story_db_mapper``: after the wizard inserts the protagonist
+  and the starting location.
+- ``nexus.api.commit_handler_sync``: after each per-chunk new-entity insert and
+  state update.
+
+The shared insert path stamps rows with the supplied ``source_kind`` (typically
+``skald_inline`` for runtime bestowal; the offline slot 2 backfill uses
+``llm_generated``). Operates within the caller's transaction — no commits here.
+
+Depends on migration 036 making ``ix_entity_tags_current`` UNIQUE so the
+``ON CONFLICT`` clause in ``_insert_entity_tag`` matches a unique index.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Iterable, Optional
+
+from nexus.agents.orrery.tag_constants import ALLOWED_CATEGORIES, CANONICAL_TAGS
+from nexus.agents.orrery.tag_schemas import NewTagProposal, OrreryTagBestowal
+
+
+_SKALD_EPHEMERAL_CLEARANCE = "semantic"
+
+
+def apply_tag_bestowal(
+    cur: Any,
+    *,
+    entity_id: int,
+    entity_kind: str,
+    bestowal: Optional[OrreryTagBestowal],
+    source_kind: str = "skald_inline",
+    world_time: Optional[datetime] = None,
+) -> dict[str, int]:
+    """Apply a Skald-issued tag bestowal to the database.
+
+    Performs three operations in order:
+
+    1. Insert each new tag proposal into ``tags`` (idempotent via
+       ``ON CONFLICT (tag) DO NOTHING``).
+    2. Apply registered + just-proposed tag names to the entity via
+       ``entity_tags`` insert.
+    3. Mark ``tags_to_clear`` entries cleared (UPDATE cleared_at = now()).
+
+    Returns counter dict suitable for logging:
+    ``{"applied", "proposed", "cleared", "skipped_category", "skipped_unknown"}``.
+    """
+
+    counters = {
+        "applied": 0,
+        "proposed": 0,
+        "cleared": 0,
+        "skipped_category": 0,
+        "skipped_unknown": 0,
+    }
+
+    if bestowal is None:
+        return counters
+
+    if entity_kind not in ALLOWED_CATEGORIES:
+        raise ValueError(
+            f"Unknown entity_kind={entity_kind!r}; expected one of "
+            f"{sorted(ALLOWED_CATEGORIES)}"
+        )
+
+    allowed = ALLOWED_CATEGORIES[entity_kind]
+
+    if world_time is None:
+        cur.execute("SELECT max(world_time) AS world_time FROM chunk_metadata")
+        row = cur.fetchone()
+        if row is not None:
+            world_time = _row_value(row, "world_time", 0)
+
+    # 1. insert new tag proposals into the vocabulary
+    for proposal in bestowal.new_tag_proposals:
+        _insert_new_tag(cur, proposal)
+        counters["proposed"] += 1
+
+    # 2. apply tags (registered + just-proposed) to the entity
+    for proposed_name in _iter_apply_names(bestowal):
+        canonical_name = CANONICAL_TAGS.get(proposed_name, proposed_name)
+        tag_row = _lookup_tag(cur, canonical_name)
+        if tag_row is None:
+            counters["skipped_unknown"] += 1
+            continue
+        category = _row_value(tag_row, "category", 1)
+        if category not in allowed:
+            counters["skipped_category"] += 1
+            continue
+        tag_id = _row_value(tag_row, "id", 0)
+        applied = _insert_entity_tag(
+            cur,
+            entity_id=entity_id,
+            tag_id=tag_id,
+            source_kind=source_kind,
+            world_time=world_time,
+        )
+        if applied:
+            counters["applied"] += 1
+
+    # 3. clear tags that no longer apply (update contexts only)
+    for clear_name in bestowal.tags_to_clear:
+        canonical_clear = CANONICAL_TAGS.get(clear_name, clear_name)
+        tag_row = _lookup_tag(cur, canonical_clear)
+        if tag_row is None:
+            counters["skipped_unknown"] += 1
+            continue
+        tag_id = _row_value(tag_row, "id", 0)
+        if _clear_entity_tag(cur, entity_id=entity_id, tag_id=tag_id):
+            counters["cleared"] += 1
+
+    return counters
+
+
+def _iter_apply_names(bestowal: OrreryTagBestowal) -> Iterable[str]:
+    yield from bestowal.applied_tags
+    yield from (p.tag for p in bestowal.new_tag_proposals)
+
+
+def _insert_new_tag(cur: Any, proposal: NewTagProposal) -> None:
+    """Insert proposal into ``tags``. Idempotent via ``ON CONFLICT (tag)``.
+
+    Honors the ``is_ephemeral = (clearance_kind IS NOT NULL)`` check
+    constraint by setting ``clearance_kind='semantic'`` for ephemerals and
+    ``NULL`` for durables.
+    """
+
+    is_ephemeral = proposal.scope == "ephemeral"
+    clearance_kind = _SKALD_EPHEMERAL_CLEARANCE if is_ephemeral else None
+    description = f"[skald-proposed] {proposal.evidence}"
+    cur.execute(
+        """
+        INSERT INTO tags (tag, category, is_ephemeral, clearance_kind, description)
+        VALUES (%s, %s, %s, %s, %s)
+        ON CONFLICT (tag) DO NOTHING
+        """,
+        (proposal.tag, proposal.category, is_ephemeral, clearance_kind, description),
+    )
+
+
+def _lookup_tag(cur: Any, tag_name: str) -> Optional[Any]:
+    cur.execute(
+        """
+        SELECT id, category, is_ephemeral
+        FROM tags
+        WHERE tag = %s AND NOT deprecated AND synonym_for IS NULL
+        """,
+        (tag_name,),
+    )
+    return cur.fetchone()
+
+
+def _insert_entity_tag(
+    cur: Any,
+    *,
+    entity_id: int,
+    tag_id: int,
+    source_kind: str,
+    world_time: Optional[datetime],
+) -> bool:
+    cur.execute(
+        """
+        INSERT INTO entity_tags (entity_id, tag_id, applied_at_world_time, source_kind)
+        VALUES (%s, %s, %s, %s::entity_tag_source_kind)
+        ON CONFLICT (entity_id, tag_id)
+          WHERE cleared_at IS NULL
+          DO NOTHING
+        """,
+        (entity_id, tag_id, world_time, source_kind),
+    )
+    return bool(cur.rowcount)
+
+
+def _clear_entity_tag(cur: Any, *, entity_id: int, tag_id: int) -> bool:
+    cur.execute(
+        """
+        UPDATE entity_tags
+        SET cleared_at = now()
+        WHERE entity_id = %s AND tag_id = %s AND cleared_at IS NULL
+        """,
+        (entity_id, tag_id),
+    )
+    return bool(cur.rowcount)
+
+
+def _row_value(row: Any, key: str, index: int) -> Any:
+    """Read a column from a row that may be a Mapping (DictCursor) or sequence."""
+    if hasattr(row, "get"):
+        return row[key]
+    return row[index]

--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -18,9 +18,10 @@ Depends on migration 036 making ``ix_entity_tags_current`` UNIQUE so the
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
 
-from nexus.agents.orrery.tag_constants import ALLOWED_CATEGORIES, CANONICAL_TAGS
+from nexus.agents.orrery.tag_constants import CANONICAL_TAGS
+from nexus.agents.orrery.tag_library import VALID_ENTITY_KINDS
 from nexus.agents.orrery.tag_schemas import NewTagProposal, OrreryTagBestowal
 
 
@@ -61,13 +62,17 @@ def apply_tag_bestowal(
     if bestowal is None:
         return counters
 
-    if entity_kind not in ALLOWED_CATEGORIES:
+    if entity_kind not in VALID_ENTITY_KINDS:
         raise ValueError(
             f"Unknown entity_kind={entity_kind!r}; expected one of "
-            f"{sorted(ALLOWED_CATEGORIES)}"
+            f"{sorted(VALID_ENTITY_KINDS)}"
         )
 
-    allowed = ALLOWED_CATEGORIES[entity_kind]
+    allowed = _lookup_allowed_categories(cur, entity_kind)
+    if not allowed:
+        raise ValueError(
+            f"No Orrery tag categories registered for entity_kind={entity_kind!r}"
+        )
 
     if world_time is None:
         cur.execute("SELECT max(world_time) AS world_time FROM chunk_metadata")
@@ -75,13 +80,26 @@ def apply_tag_bestowal(
         if row is not None:
             world_time = _row_value(row, "world_time", 0)
 
+    apply_names = list(bestowal.applied_tags)
+
     # 1. insert new tag proposals into the vocabulary
     for proposal in bestowal.new_tag_proposals:
+        if proposal.category not in allowed:
+            status = _category_registry_status(cur, proposal.category, entity_kind)
+            if status == "unknown":
+                _insert_category_registry_row(
+                    cur, category=proposal.category, entity_kind=entity_kind
+                )
+                allowed.add(proposal.category)
+            else:
+                counters["skipped_category"] += 1
+                continue
         _insert_new_tag(cur, proposal)
         counters["proposed"] += 1
+        apply_names.append(proposal.tag)
 
     # 2. apply tags (registered + just-proposed) to the entity
-    for proposed_name in _iter_apply_names(bestowal):
+    for proposed_name in apply_names:
         canonical_name = CANONICAL_TAGS.get(proposed_name, proposed_name)
         tag_row = _lookup_tag(cur, canonical_name)
         if tag_row is None:
@@ -116,9 +134,51 @@ def apply_tag_bestowal(
     return counters
 
 
-def _iter_apply_names(bestowal: OrreryTagBestowal) -> Iterable[str]:
-    yield from bestowal.applied_tags
-    yield from (p.tag for p in bestowal.new_tag_proposals)
+def _lookup_allowed_categories(cur: Any, entity_kind: str) -> set[str]:
+    cur.execute(
+        """
+        SELECT category
+        FROM tag_category_registry
+        WHERE entity_kind = %s::entity_kind
+        """,
+        (entity_kind,),
+    )
+    return {_row_value(row, "category", 0) for row in cur.fetchall()}
+
+
+def _category_registry_status(cur: Any, category: str, entity_kind: str) -> str:
+    cur.execute(
+        """
+        SELECT entity_kind::text AS entity_kind
+        FROM tag_category_registry
+        WHERE category = %s
+        """,
+        (category,),
+    )
+    rows = cur.fetchall()
+    if not rows:
+        return "unknown"
+    if any(_row_value(row, "entity_kind", 0) == entity_kind for row in rows):
+        return "compatible"
+    return "incompatible"
+
+
+def _insert_category_registry_row(cur: Any, *, category: str, entity_kind: str) -> None:
+    cur.execute(
+        """
+        INSERT INTO tag_category_registry (
+            category, entity_kind, prompt_order, description
+        ) VALUES (
+            %s, %s::entity_kind, 1000, %s
+        )
+        ON CONFLICT (category, entity_kind) DO NOTHING
+        """,
+        (
+            category,
+            entity_kind,
+            f"Skald-proposed {entity_kind} tag category.",
+        ),
+    )
 
 
 def _insert_new_tag(cur: Any, proposal: NewTagProposal) -> None:

--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -12,7 +12,9 @@ The shared insert path stamps rows with the supplied ``source_kind`` (typically
 ``llm_generated``). Operates within the caller's transaction — no commits here.
 
 Depends on migration 036 making ``ix_entity_tags_current`` UNIQUE so the
-``ON CONFLICT`` clause in ``_insert_entity_tag`` matches a unique index.
+``ON CONFLICT`` clause in ``_insert_entity_tag`` matches a unique index, and on
+migration 037 seeding ``tag_category_registry`` so runtime bestowals know which
+tag categories may be applied to each entity kind.
 """
 
 from __future__ import annotations
@@ -46,6 +48,9 @@ def apply_tag_bestowal(
     2. Apply registered + just-proposed tag names to the entity via
        ``entity_tags`` insert.
     3. Mark ``tags_to_clear`` entries cleared (UPDATE cleared_at = now()).
+
+    Requires migration 037's ``tag_category_registry`` rows for the target
+    ``entity_kind``; missing registry data is treated as a slot-migration error.
 
     Returns counter dict suitable for logging:
     ``{"applied", "proposed", "cleared", "skipped_category", "skipped_unknown"}``.

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -22,7 +22,7 @@ from nexus.agents.logon.apex_schema import (
     StateUpdates,
 )
 from nexus.agents.orrery.events import commit_orrery_tick_sync
-from nexus.agents.orrery.tag_writer import apply_tag_bestowal
+from nexus.agents.orrery.tag_writer import _row_value, apply_tag_bestowal
 from nexus.api.db_converters import chronology_to_db_values
 from nexus.api.summary_triggers import (
     SummaryTask,
@@ -587,7 +587,7 @@ def apply_state_updates_sync(conn, state_updates: StateUpdates):
                     logger.info(f"Updated character {char_update.character_id}")
 
                 bestowal = getattr(char_update, "orrery_tags", None)
-                if bestowal is not None:
+                if char_update.character_id and bestowal is not None:
                     _apply_state_tags(
                         cur,
                         kind="character",
@@ -645,7 +645,7 @@ def _apply_state_tags(cur, *, kind, subtype_table, subtype_id, bestowal) -> None
     if row is None:
         logger.warning(f"Skipping tag bestowal: no {kind} row for id={subtype_id}")
         return
-    entity_id = row[0]
+    entity_id = _row_value(row, "entity_id", 0)
     counters = apply_tag_bestowal(
         cur,
         entity_id=entity_id,

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -22,6 +22,7 @@ from nexus.agents.logon.apex_schema import (
     StateUpdates,
 )
 from nexus.agents.orrery.events import commit_orrery_tick_sync
+from nexus.agents.orrery.tag_writer import apply_tag_bestowal
 from nexus.api.db_converters import chronology_to_db_values
 from nexus.api.summary_triggers import (
     SummaryTask,
@@ -99,7 +100,7 @@ def create_new_place_sync(cur, new_place):
             name, type, summary, history, current_status, secrets,
             extra_data
         ) VALUES (%s, %s, %s, %s, %s, %s, %s)
-        RETURNING id
+        RETURNING id, entity_id
     """,
         (
             new_place.name,
@@ -112,7 +113,15 @@ def create_new_place_sync(cur, new_place):
         ),
     )
 
-    return cur.fetchone()[0]
+    place_id, entity_id = cur.fetchone()
+    apply_tag_bestowal(
+        cur,
+        entity_id=entity_id,
+        entity_kind="place",
+        bestowal=getattr(new_place, "orrery_tags", None),
+        source_kind="skald_inline",
+    )
+    return place_id
 
 
 def resolve_character_references_sync(
@@ -166,7 +175,7 @@ def create_new_character_sync(cur, new_char):
             name, summary, appearance, background, personality,
             emotional_state, current_activity, current_location, extra_data
         ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
-        RETURNING id
+        RETURNING id, entity_id
     """,
         (
             new_char.name,
@@ -181,7 +190,15 @@ def create_new_character_sync(cur, new_char):
         ),
     )
 
-    return cur.fetchone()[0]
+    char_id, entity_id = cur.fetchone()
+    apply_tag_bestowal(
+        cur,
+        entity_id=entity_id,
+        entity_kind="character",
+        bestowal=getattr(new_char, "orrery_tags", None),
+        source_kind="skald_inline",
+    )
+    return char_id
 
 
 def resolve_faction_references_sync(
@@ -240,7 +257,7 @@ def create_new_faction_sync(cur, new_faction):
             hidden_agenda, territory, power_level, resources,
             primary_location, extra_data
         ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-        RETURNING id
+        RETURNING id, entity_id
     """,
         (
             faction_id,
@@ -258,7 +275,15 @@ def create_new_faction_sync(cur, new_faction):
         ),
     )
 
-    return cur.fetchone()[0]
+    inserted_faction_id, entity_id = cur.fetchone()
+    apply_tag_bestowal(
+        cur,
+        entity_id=entity_id,
+        entity_kind="faction",
+        bestowal=getattr(new_faction, "orrery_tags", None),
+        source_kind="skald_inline",
+    )
+    return inserted_faction_id
 
 
 # ============================================================================
@@ -561,6 +586,16 @@ def apply_state_updates_sync(conn, state_updates: StateUpdates):
                     )
                     logger.info(f"Updated character {char_update.character_id}")
 
+                bestowal = getattr(char_update, "orrery_tags", None)
+                if bestowal is not None:
+                    _apply_state_tags(
+                        cur,
+                        kind="character",
+                        subtype_table="characters",
+                        subtype_id=char_update.character_id,
+                        bestowal=bestowal,
+                    )
+
         # Update place states
         for place_update in state_updates.locations:
             if place_update.place_id and place_update.current_status:
@@ -570,6 +605,16 @@ def apply_state_updates_sync(conn, state_updates: StateUpdates):
                 )
                 logger.info(f"Updated place {place_update.place_id}")
 
+            bestowal = getattr(place_update, "orrery_tags", None)
+            if place_update.place_id and bestowal is not None:
+                _apply_state_tags(
+                    cur,
+                    kind="place",
+                    subtype_table="places",
+                    subtype_id=place_update.place_id,
+                    bestowal=bestowal,
+                )
+
         # Update faction states
         for faction_update in state_updates.factions:
             if faction_update.faction_id and faction_update.current_activity:
@@ -578,3 +623,35 @@ def apply_state_updates_sync(conn, state_updates: StateUpdates):
                     (faction_update.current_activity, faction_update.faction_id),
                 )
                 logger.info(f"Updated faction {faction_update.faction_id}")
+
+            bestowal = getattr(faction_update, "orrery_tags", None)
+            if faction_update.faction_id and bestowal is not None:
+                _apply_state_tags(
+                    cur,
+                    kind="faction",
+                    subtype_table="factions",
+                    subtype_id=faction_update.faction_id,
+                    bestowal=bestowal,
+                )
+
+
+def _apply_state_tags(cur, *, kind, subtype_table, subtype_id, bestowal) -> None:
+    """Look up the entity_id for a subtype row and apply Skald-bestowed tags."""
+    cur.execute(
+        f"SELECT entity_id FROM {subtype_table} WHERE id = %s",
+        (subtype_id,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        logger.warning(f"Skipping tag bestowal: no {kind} row for id={subtype_id}")
+        return
+    entity_id = row[0]
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=entity_id,
+        entity_kind=kind,
+        bestowal=bestowal,
+        source_kind="skald_inline",
+    )
+    if any(counters.values()):
+        logger.info(f"Tag bestowal {kind}/{subtype_id}: {counters}")

--- a/nexus/api/new_story_cache.py
+++ b/nexus/api/new_story_cache.py
@@ -22,10 +22,20 @@ from nexus.api.db_pool import get_connection
 logger = logging.getLogger("nexus.api.new_story_cache")
 
 # Valid trait enum values (must match PostgreSQL trait enum)
-VALID_TRAITS = frozenset({
-    'allies', 'contacts', 'patron', 'dependents', 'status',
-    'reputation', 'resources', 'domain', 'enemies', 'obligations'
-})
+VALID_TRAITS = frozenset(
+    {
+        "allies",
+        "contacts",
+        "patron",
+        "dependents",
+        "status",
+        "reputation",
+        "resources",
+        "domain",
+        "enemies",
+        "obligations",
+    }
+)
 
 
 def _parse_pg_array(value: Any) -> List[str]:
@@ -42,11 +52,11 @@ def _parse_pg_array(value: Any) -> List[str]:
         return value  # Already a list
     if isinstance(value, str):
         # Parse PostgreSQL array format: {elem1,elem2,...}
-        if value.startswith('{') and value.endswith('}'):
+        if value.startswith("{") and value.endswith("}"):
             inner = value[1:-1]
             if not inner:
                 return []
-            return inner.split(',')
+            return inner.split(",")
     return []
 
 
@@ -68,6 +78,7 @@ def _merge_unique_lists(*values: List[str]) -> List[str]:
 @dataclass
 class SettingData:
     """Setting phase data (normalized columns)."""
+
     genre: Optional[str] = None
     secondary_genres: List[str] = field(default_factory=list)  # Always array for UI
     world_name: Optional[str] = None
@@ -88,6 +99,7 @@ class SettingData:
 @dataclass
 class SuggestedTrait:
     """A single LLM-suggested trait with rationale."""
+
     trait: str
     rationale: str
 
@@ -99,6 +111,7 @@ class CharacterData:
     Concept data is in new_story_creator columns.
     Trait data is now in assets.traits table.
     """
+
     # Concept subphase (from new_story_creator)
     name: Optional[str] = None
     archetype: Optional[str] = None
@@ -113,6 +126,7 @@ class CharacterData:
     # Wildcard status (derived from assets.traits id=11)
     wildcard_name: Optional[str] = None  # from traits.name where id=11
     wildcard_rationale: Optional[str] = None  # from traits.rationale where id=11
+    orrery_tags: Optional[Dict[str, Any]] = None  # from new_story_creator JSONB
 
     def has_concept(self) -> bool:
         """Check if concept subphase is complete."""
@@ -134,6 +148,7 @@ class CharacterData:
 @dataclass
 class SeedData:
     """Seed phase data (normalized columns)."""
+
     # StorySeed
     seed_type: Optional[str] = None
     title: Optional[str] = None
@@ -159,6 +174,7 @@ class SeedData:
 @dataclass
 class WizardCache:
     """Complete wizard cache state."""
+
     thread_id: Optional[str] = None
     target_slot: Optional[int] = None
     setting: SettingData = field(default_factory=SettingData)
@@ -248,6 +264,7 @@ class WizardCache:
             "wildcard": {
                 "wildcard_name": self.character.wildcard_name,
                 "wildcard_description": self.character.wildcard_rationale,
+                "orrery_tags": self.character.orrery_tags,
             },
         }
 
@@ -374,6 +391,21 @@ def read_cache_raw(dbname: Optional[str] = None) -> Optional[Dict[str, Any]]:
             return dict(row) if row else None
 
 
+def _parse_json_object(value: Any) -> Optional[Dict[str, Any]]:
+    """Return a JSONB object value as a dict."""
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        parsed = json.loads(value)
+        if parsed is None:
+            return None
+        if isinstance(parsed, dict):
+            return parsed
+    raise ValueError(f"Expected JSON object, got {type(value).__name__}")
+
+
 def _row_to_cache(
     row: Dict[str, Any],
     selected_traits: Optional[List[SuggestedTrait]] = None,
@@ -412,6 +444,7 @@ def _row_to_cache(
             traits_confirmed=traits_confirmed,
             wildcard_name=wildcard_row.get("name") if wildcard_row else None,
             wildcard_rationale=wildcard_row.get("rationale") if wildcard_row else None,
+            orrery_tags=_parse_json_object(row.get("character_orrery_tags")),
         ),
         seed=SeedData(
             seed_type=row.get("seed_type"),
@@ -531,13 +564,17 @@ def write_character_concept(
                 """,
                 (name, archetype, background, appearance),
             )
-    logger.info("Updated character concept in %s", dbname or os.environ.get("PGDATABASE"))
+    logger.info(
+        "Updated character concept in %s", dbname or os.environ.get("PGDATABASE")
+    )
 
 
 def toggle_trait(dbname: Optional[str], trait_name: str) -> bool:
     """Toggle a trait's is_selected state. Returns new state."""
     if trait_name not in VALID_TRAITS:
-        raise ValueError(f"Invalid trait: {trait_name}. Must be one of {sorted(VALID_TRAITS)}")
+        raise ValueError(
+            f"Invalid trait: {trait_name}. Must be one of {sorted(VALID_TRAITS)}"
+        )
 
     with get_connection(dbname) as conn:
         with conn.cursor() as cur:
@@ -591,6 +628,7 @@ def confirm_trait_selection(dbname: Optional[str]) -> List[str]:
 @dataclass
 class TraitMenuItem:
     """A trait for the selection menu."""
+
     id: int
     name: str
     description: List[str]  # Bullet points
@@ -638,25 +676,54 @@ def get_selected_trait_count(dbname: Optional[str]) -> int:
             return cur.fetchone()[0]
 
 
+def _write_character_wildcard(
+    cur,
+    *,
+    wildcard_name: str,
+    wildcard_description: str,
+    orrery_tags: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Write wildcard data using an existing cursor."""
+    serialized_tags = json.dumps(orrery_tags) if orrery_tags is not None else None
+    cur.execute(
+        """
+        UPDATE assets.traits SET
+            name = %s,
+            rationale = %s
+        WHERE id = 11
+        """,
+        (wildcard_name, wildcard_description),
+    )
+    cur.execute(
+        """
+        UPDATE assets.new_story_creator SET
+            character_orrery_tags = %s::jsonb,
+            updated_at = NOW()
+        WHERE id = TRUE
+        """,
+        (serialized_tags,),
+    )
+
+
 def write_character_wildcard(
     dbname: Optional[str],
     *,
     wildcard_name: str,
     wildcard_description: str,
+    orrery_tags: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Write character wildcard (subphase 3) to assets.traits row 11."""
     with get_connection(dbname) as conn:
         with conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE assets.traits SET
-                    name = %s,
-                    rationale = %s
-                WHERE id = 11
-                """,
-                (wildcard_name, wildcard_description),
+            _write_character_wildcard(
+                cur,
+                wildcard_name=wildcard_name,
+                wildcard_description=wildcard_description,
+                orrery_tags=orrery_tags,
             )
-    logger.info("Updated character wildcard in %s", dbname or os.environ.get("PGDATABASE"))
+    logger.info(
+        "Updated character wildcard in %s", dbname or os.environ.get("PGDATABASE")
+    )
 
 
 def write_suggested_traits(
@@ -704,7 +771,9 @@ def clear_suggested_traits(dbname: Optional[str] = None) -> None:
             cur.execute(
                 "UPDATE assets.traits SET is_selected = FALSE, rationale = NULL WHERE id <= 10"
             )
-    logger.info("Cleared trait selections in %s", dbname or os.environ.get("PGDATABASE"))
+    logger.info(
+        "Cleared trait selections in %s", dbname or os.environ.get("PGDATABASE")
+    )
 
 
 def write_seed(
@@ -810,7 +879,11 @@ def init_cache(
                 """,
                 (thread_id, target_slot),
             )
-    logger.info("Initialized cache for slot %s in %s", target_slot, dbname or os.environ.get("PGDATABASE"))
+    logger.info(
+        "Initialized cache for slot %s in %s",
+        target_slot,
+        dbname or os.environ.get("PGDATABASE"),
+    )
 
 
 def clear_cache(dbname: Optional[str] = None) -> None:
@@ -830,7 +903,10 @@ def clear_cache(dbname: Optional[str] = None) -> None:
             cur.execute(
                 "UPDATE assets.traits SET name = 'wildcard', rationale = NULL WHERE id = 11"
             )
-    logger.info("Cleared new_story_creator cache in %s", dbname or os.environ.get("PGDATABASE", "NEXUS"))
+    logger.info(
+        "Cleared new_story_creator cache in %s",
+        dbname or os.environ.get("PGDATABASE", "NEXUS"),
+    )
 
 
 def clear_seed_phase(dbname: Optional[str] = None) -> None:
@@ -883,6 +959,7 @@ def clear_character_phase(dbname: Optional[str] = None) -> None:
                     character_archetype = NULL,
                     character_background = NULL,
                     character_appearance = NULL,
+                    character_orrery_tags = NULL,
                     traits_confirmed = FALSE,
                     -- Seed columns (also clear downstream)
                     seed_type = NULL,
@@ -950,6 +1027,7 @@ def clear_setting_phase(dbname: Optional[str] = None) -> None:
                     character_archetype = NULL,
                     character_background = NULL,
                     character_appearance = NULL,
+                    character_orrery_tags = NULL,
                     -- Seed columns
                     seed_type = NULL,
                     seed_title = NULL,
@@ -1028,40 +1106,44 @@ def write_cache(
             if setting_draft is not None:
                 # Map old JSONB to new columns
                 # Enum columns need explicit casting
-                updates.extend([
-                    "setting_genre = %s::genre",
-                    "setting_secondary_genres = %s::genre[]",
-                    "setting_world_name = %s",
-                    "setting_time_period = %s",
-                    "setting_tech_level = %s::tech_level",
-                    "setting_magic_exists = %s",
-                    "setting_magic_description = %s",
-                    "setting_political_structure = %s",
-                    "setting_major_conflict = %s",
-                    "setting_tone = %s::tone",
-                    "setting_themes = %s",
-                    "setting_cultural_notes = %s",
-                    "setting_language_notes = %s",
-                    "setting_geographic_scope = %s::geographic_scope",
-                    "setting_diegetic_artifact = %s",
-                ])
-                params.extend([
-                    setting_draft.get("genre"),
-                    setting_draft.get("secondary_genres"),
-                    setting_draft.get("world_name"),
-                    setting_draft.get("time_period"),
-                    setting_draft.get("tech_level"),
-                    setting_draft.get("magic_exists"),
-                    setting_draft.get("magic_description"),
-                    setting_draft.get("political_structure"),
-                    setting_draft.get("major_conflict"),
-                    setting_draft.get("tone"),
-                    setting_draft.get("themes"),
-                    setting_draft.get("cultural_notes"),
-                    setting_draft.get("language_notes"),
-                    setting_draft.get("geographic_scope"),
-                    setting_draft.get("diegetic_artifact"),
-                ])
+                updates.extend(
+                    [
+                        "setting_genre = %s::genre",
+                        "setting_secondary_genres = %s::genre[]",
+                        "setting_world_name = %s",
+                        "setting_time_period = %s",
+                        "setting_tech_level = %s::tech_level",
+                        "setting_magic_exists = %s",
+                        "setting_magic_description = %s",
+                        "setting_political_structure = %s",
+                        "setting_major_conflict = %s",
+                        "setting_tone = %s::tone",
+                        "setting_themes = %s",
+                        "setting_cultural_notes = %s",
+                        "setting_language_notes = %s",
+                        "setting_geographic_scope = %s::geographic_scope",
+                        "setting_diegetic_artifact = %s",
+                    ]
+                )
+                params.extend(
+                    [
+                        setting_draft.get("genre"),
+                        setting_draft.get("secondary_genres"),
+                        setting_draft.get("world_name"),
+                        setting_draft.get("time_period"),
+                        setting_draft.get("tech_level"),
+                        setting_draft.get("magic_exists"),
+                        setting_draft.get("magic_description"),
+                        setting_draft.get("political_structure"),
+                        setting_draft.get("major_conflict"),
+                        setting_draft.get("tone"),
+                        setting_draft.get("themes"),
+                        setting_draft.get("cultural_notes"),
+                        setting_draft.get("language_notes"),
+                        setting_draft.get("geographic_scope"),
+                        setting_draft.get("diegetic_artifact"),
+                    ]
+                )
 
             if character_draft is not None:
                 # Character draft contains nested subphase data
@@ -1070,18 +1152,22 @@ def write_cache(
                 wildcard = character_draft.get("wildcard", {})
 
                 if concept:
-                    updates.extend([
-                        "character_name = %s",
-                        "character_archetype = %s",
-                        "character_background = %s",
-                        "character_appearance = %s",
-                    ])
-                    params.extend([
-                        concept.get("name"),
-                        concept.get("archetype"),
-                        concept.get("background"),
-                        concept.get("appearance"),
-                    ])
+                    updates.extend(
+                        [
+                            "character_name = %s",
+                            "character_archetype = %s",
+                            "character_background = %s",
+                            "character_appearance = %s",
+                        ]
+                    )
+                    params.extend(
+                        [
+                            concept.get("name"),
+                            concept.get("archetype"),
+                            concept.get("background"),
+                            concept.get("appearance"),
+                        ]
+                    )
 
                 # Traits are written to assets.traits table (using the existing cursor)
                 if traits:
@@ -1102,68 +1188,84 @@ def write_cache(
                                 """,
                                 (rationale, trait_name),
                             )
-                        logger.info("Wrote 3 selected traits to assets.traits in %s", dbname)
+                        logger.info(
+                            "Wrote 3 selected traits to assets.traits in %s", dbname
+                        )
+                        updates.append("traits_confirmed = TRUE")
 
                 if wildcard:
-                    write_character_wildcard(
-                        dbname,
+                    _write_character_wildcard(
+                        cur,
                         wildcard_name=wildcard.get("wildcard_name", "wildcard"),
                         wildcard_description=wildcard.get("wildcard_description", ""),
+                        orrery_tags=wildcard.get("orrery_tags"),
                     )
 
             if selected_seed is not None:
-                updates.extend([
-                    "seed_type = %s::seed_type",
-                    "seed_title = %s",
-                    "seed_situation = %s",
-                    "seed_hook = %s",
-                    "seed_immediate_goal = %s",
-                    "seed_stakes = %s",
-                    "seed_tension_source = %s",
-                    "seed_weather = %s",
-                    "seed_key_npcs = %s",
-                    "seed_starting_location = NULL",
-                    "seed_initial_mystery = NULL",
-                    "seed_potential_allies = NULL",
-                    "seed_potential_obstacles = NULL",
-                    "seed_secrets = %s",
-                ])
-                params.extend([
-                    selected_seed.get("seed_type"),
-                    selected_seed.get("title"),
-                    selected_seed.get("situation"),
-                    selected_seed.get("hook"),
-                    selected_seed.get("immediate_goal"),
-                    selected_seed.get("stakes"),
-                    selected_seed.get("tension_source"),
-                    selected_seed.get("weather"),
-                    selected_seed.get("key_npcs"),
-                    selected_seed.get("secrets"),
-                ])
+                updates.extend(
+                    [
+                        "seed_type = %s::seed_type",
+                        "seed_title = %s",
+                        "seed_situation = %s",
+                        "seed_hook = %s",
+                        "seed_immediate_goal = %s",
+                        "seed_stakes = %s",
+                        "seed_tension_source = %s",
+                        "seed_weather = %s",
+                        "seed_key_npcs = %s",
+                        "seed_starting_location = NULL",
+                        "seed_initial_mystery = NULL",
+                        "seed_potential_allies = NULL",
+                        "seed_potential_obstacles = NULL",
+                        "seed_secrets = %s",
+                    ]
+                )
+                params.extend(
+                    [
+                        selected_seed.get("seed_type"),
+                        selected_seed.get("title"),
+                        selected_seed.get("situation"),
+                        selected_seed.get("hook"),
+                        selected_seed.get("immediate_goal"),
+                        selected_seed.get("stakes"),
+                        selected_seed.get("tension_source"),
+                        selected_seed.get("weather"),
+                        selected_seed.get("key_npcs"),
+                        selected_seed.get("secrets"),
+                    ]
+                )
 
             if layer_draft is not None:
-                updates.extend([
-                    "layer_name = %s",
-                    "layer_type = %s::layer_type",
-                    "layer_description = %s",
-                ])
-                params.extend([
-                    layer_draft.get("name"),
-                    layer_draft.get("type"),
-                    layer_draft.get("description"),
-                ])
+                updates.extend(
+                    [
+                        "layer_name = %s",
+                        "layer_type = %s::layer_type",
+                        "layer_description = %s",
+                    ]
+                )
+                params.extend(
+                    [
+                        layer_draft.get("name"),
+                        layer_draft.get("type"),
+                        layer_draft.get("description"),
+                    ]
+                )
 
             if zone_draft is not None:
-                updates.extend([
-                    "zone_name = %s",
-                    "zone_summary = %s",
-                    "zone_boundary_description = NULL",
-                    "zone_approximate_area = NULL",
-                ])
-                params.extend([
-                    zone_draft.get("name"),
-                    zone_draft.get("summary"),
-                ])
+                updates.extend(
+                    [
+                        "zone_name = %s",
+                        "zone_summary = %s",
+                        "zone_boundary_description = NULL",
+                        "zone_approximate_area = NULL",
+                    ]
+                )
+                params.extend(
+                    [
+                        zone_draft.get("name"),
+                        zone_draft.get("summary"),
+                    ]
+                )
 
             if initial_location is not None:
                 updates.append("initial_location = %s")
@@ -1187,7 +1289,10 @@ def write_cache(
                 sql = f"UPDATE assets.new_story_creator SET {', '.join(updates)} WHERE id = TRUE"
                 cur.execute(sql, params)
 
-    logger.info("Updated new_story_creator cache in %s", dbname or os.environ.get("PGDATABASE", "NEXUS"))
+    logger.info(
+        "Updated new_story_creator cache in %s",
+        dbname or os.environ.get("PGDATABASE", "NEXUS"),
+    )
 
 
 def write_wizard_choices(choices: List[str], dbname: str) -> None:

--- a/nexus/api/new_story_cache.py
+++ b/nexus/api/new_story_cache.py
@@ -895,6 +895,13 @@ def clear_cache(dbname: Optional[str] = None) -> None:
     """
     with get_connection(dbname) as conn:
         with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE assets.new_story_creator
+                SET character_orrery_tags = NULL
+                WHERE id = TRUE
+                """
+            )
             cur.execute("DELETE FROM assets.new_story_creator WHERE id = TRUE")
             # Reset traits: deselect optional traits, clear rationales, reset wildcard name
             cur.execute(
@@ -1091,6 +1098,16 @@ def write_cache(
     """
     with get_connection(dbname) as conn:
         with conn.cursor() as cur:
+            # First ensure the row exists; wildcard Orrery tags are written with
+            # an UPDATE below, so first-time legacy writes need the cache row now.
+            cur.execute(
+                """
+                INSERT INTO assets.new_story_creator (id)
+                VALUES (TRUE)
+                ON CONFLICT (id) DO NOTHING
+                """
+            )
+
             # Build the update dynamically based on what's provided
             updates = ["updated_at = NOW()"]
             params = []
@@ -1274,15 +1291,6 @@ def write_cache(
             if base_timestamp is not None:
                 updates.append("base_timestamp = %s")
                 params.append(base_timestamp)
-
-            # First ensure the row exists
-            cur.execute(
-                """
-                INSERT INTO assets.new_story_creator (id)
-                VALUES (TRUE)
-                ON CONFLICT (id) DO NOTHING
-                """
-            )
 
             # Then update
             if updates:

--- a/nexus/api/new_story_db_mapper.py
+++ b/nexus/api/new_story_db_mapper.py
@@ -24,6 +24,7 @@ from nexus.api.new_story_schemas import (
 )
 from nexus.api.db_pool import get_connection
 from nexus.api.new_story_cache import clear_cache
+from nexus.agents.orrery.tag_writer import apply_tag_bestowal
 
 logger = logging.getLogger("nexus.api.new_story_db_mapper")
 
@@ -244,7 +245,9 @@ class NewStoryDatabaseMapper:
                 with get_connection(self.dbname) as conn:
                     with conn.cursor() as cur:
                         # Read existing setting, merge story_seed, save back
-                        cur.execute("SELECT setting FROM global_variables WHERE id = true")
+                        cur.execute(
+                            "SELECT setting FROM global_variables WHERE id = true"
+                        )
                         row = cur.fetchone()
                         setting = row[0] if row and row[0] else {}
                         setting["story_seed"] = seed_data
@@ -298,18 +301,28 @@ class NewStoryDatabaseMapper:
                         %(personality)s, %(emotional_state)s, %(current_activity)s,
                         %(extra_data)s::jsonb
                     )
-                    RETURNING id
+                    RETURNING id, entity_id
                 """,
                     db_record,
                 )
 
-                character_id = cursor.fetchone()[0]
+                character_id, entity_id = cursor.fetchone()
 
                 # Update global_variables to point to this character
                 cursor.execute(
                     "UPDATE global_variables SET user_character = %s WHERE id = true",
                     (character_id,),
                 )
+
+                tag_counters = apply_tag_bestowal(
+                    cursor,
+                    entity_id=entity_id,
+                    entity_kind="character",
+                    bestowal=character.orrery_tags,
+                    source_kind="skald_inline",
+                )
+                if tag_counters["applied"] or tag_counters["proposed"]:
+                    logger.info(f"Tag bestowal for {character.name}: {tag_counters}")
 
                 logger.info(
                     f"Created protagonist: {character.name} (ID: {character_id})"
@@ -334,18 +347,30 @@ class NewStoryDatabaseMapper:
                                 %(personality)s, %(emotional_state)s, %(current_activity)s,
                                 %(extra_data)s::jsonb
                             )
-                            RETURNING id
+                            RETURNING id, entity_id
                         """,
                             db_record,
                         )
 
-                        character_id = cur.fetchone()[0]
+                        character_id, entity_id = cur.fetchone()
 
                         # Update global_variables to point to this character
                         cur.execute(
                             "UPDATE global_variables SET user_character = %s WHERE id = true",
                             (character_id,),
                         )
+
+                        tag_counters = apply_tag_bestowal(
+                            cur,
+                            entity_id=entity_id,
+                            entity_kind="character",
+                            bestowal=character.orrery_tags,
+                            source_kind="skald_inline",
+                        )
+                        if tag_counters["applied"] or tag_counters["proposed"]:
+                            logger.info(
+                                f"Tag bestowal for {character.name}: {tag_counters}"
+                            )
 
                     logger.info(
                         f"Created protagonist: {character.name} (ID: {character_id})"
@@ -440,11 +465,11 @@ class NewStoryDatabaseMapper:
                     %(history)s, %(current_status)s, %(secrets)s, %(extra_data)s::jsonb,
                     ST_SetSRID(ST_MakePoint(%(lon)s, %(lat)s, 0, 0), 4326)::geography
                 )
-                RETURNING id
+                RETURNING id, entity_id
             """,
                 place_record,
             )  # Note: PostGIS takes (lon, lat) not (lat, lon)
-            place_id = cur.fetchone()[0]
+            place_id, place_entity_id = cur.fetchone()
             logger.debug(
                 f"Created place: {place.name} (ID: {place_id}) at ({lat}, {lon})"
             )
@@ -458,6 +483,17 @@ class NewStoryDatabaseMapper:
             """,
                 (place_id, character_id),
             )
+
+            # Apply Skald-bestowed place_affordance tags
+            tag_counters = apply_tag_bestowal(
+                cur,
+                entity_id=place_entity_id,
+                entity_kind="place",
+                bestowal=place.orrery_tags,
+                source_kind="skald_inline",
+            )
+            if tag_counters["applied"] or tag_counters["proposed"]:
+                logger.info(f"Tag bestowal for place {place.name}: {tag_counters}")
 
             # Generate a default circular boundary for the zone
             # Using a 50-mile radius (approximately 80km) centered on the place
@@ -547,11 +583,13 @@ class NewStoryDatabaseMapper:
             try:
                 with conn.cursor() as cur:
                     # Ensure global_variables row exists (may have been deleted by previous CASCADE)
-                    cur.execute("""
+                    cur.execute(
+                        """
                         INSERT INTO global_variables (id, new_story)
                         VALUES (true, true)
                         ON CONFLICT (id) DO NOTHING
-                    """)
+                    """
+                    )
 
                     # Clean slate: DELETE all entity data and reset sequences
                     # NOTE: Can't use TRUNCATE because global_variables has FK to characters,
@@ -562,7 +600,8 @@ class NewStoryDatabaseMapper:
                     )
 
                     # Delete in reverse dependency order (children before parents)
-                    cur.execute("""
+                    cur.execute(
+                        """
                         DELETE FROM chunk_character_references;
                         DELETE FROM chunk_faction_references;
                         DELETE FROM place_chunk_references;
@@ -577,17 +616,20 @@ class NewStoryDatabaseMapper:
                         DELETE FROM places;
                         DELETE FROM zones;
                         DELETE FROM layers;
-                    """)
+                    """
+                    )
 
                     # Reset identity sequences so protagonist gets ID=1
-                    cur.execute("""
+                    cur.execute(
+                        """
                         ALTER SEQUENCE characters_id_seq RESTART WITH 1;
                         ALTER SEQUENCE places_id_seq RESTART WITH 1;
                         ALTER SEQUENCE zones_id_seq RESTART WITH 1;
                         ALTER SEQUENCE layers_id_seq RESTART WITH 1;
                         ALTER SEQUENCE items_id_seq RESTART WITH 1;
                         ALTER SEQUENCE character_relationships_id_seq RESTART WITH 1;
-                    """)
+                    """
+                    )
                     logger.info("Truncated entity tables for clean slate")
 
                     # Save setting (using shared cursor)

--- a/nexus/api/new_story_schemas.py
+++ b/nexus/api/new_story_schemas.py
@@ -13,6 +13,8 @@ from enum import Enum
 
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 
+from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
+
 
 class Genre(str, Enum):
     """Supported story genres."""
@@ -204,6 +206,13 @@ class CharacterSheet(BaseModel):
         ...,
         min_length=20,
         description="What this trait means for the character - capability, possession, relationship, or curse",
+    )
+
+    # Orrery tag bestowal, populated from the wildcard subphase during
+    # to_character_sheet() assembly.
+    orrery_tags: Optional[OrreryTagBestowal] = Field(
+        default=None,
+        description="Semantic Orrery tags bestowed by Skald during the wizard wildcard step.",
     )
 
     @model_validator(mode="after")
@@ -470,6 +479,19 @@ class WildcardTrait(BaseModel):
         description="What this trait means - capability, possession, relationship, blessing, or curse",
     )
 
+    # Orrery tag bestowal for the protagonist. Submit-wildcard time is the
+    # richest tagging context — full concept + traits + wildcard are known.
+    orrery_tags: Optional[OrreryTagBestowal] = Field(
+        default=None,
+        description=(
+            "Semantic tags for this protagonist (bodyform, capacity, "
+            "disposition, role, state, etc.). Apply registered tags by name; "
+            "propose new ones when the genre needs vocabulary that doesn't yet "
+            "exist (e.g., bodyform:elf for a fantasy elf). See the Orrery "
+            "Awareness section of your system prompt for category guidance."
+        ),
+    )
+
 
 class CharacterCreationState(BaseModel):
     """
@@ -552,6 +574,7 @@ class CharacterCreationState(BaseModel):
             trait_1=trait_entries[0],
             trait_2=trait_entries[1],
             trait_3=trait_entries[2],
+            orrery_tags=self.wildcard.orrery_tags,
         )
 
 
@@ -815,6 +838,17 @@ class PlaceProfile(BaseModel):
     # Optional attributes stored in extra_data JSONB
     extra_data: Optional[PlaceExtraData] = Field(
         None, description="Additional attributes stored in places.extra_data"
+    )
+
+    # Orrery place_affordance tagging for the starting location.
+    orrery_tags: Optional[OrreryTagBestowal] = Field(
+        default=None,
+        description=(
+            "Semantic place_affordance tags for this location (e.g., "
+            "sheltered, public, isolated, defensible, ritually_charged). "
+            "Propose new ones when the setting needs vocabulary that doesn't "
+            "yet exist. See the Orrery Awareness section of your system prompt."
+        ),
     )
 
 

--- a/nexus/api/wizard_agent.py
+++ b/nexus/api/wizard_agent.py
@@ -34,6 +34,7 @@ from nexus.api.new_story_schemas import (
     WizardResponse,
 )
 from nexus.api.slot_utils import slot_dbname
+from nexus.agents.orrery.tag_library import format_tag_library_for_prompt
 
 logger = logging.getLogger("nexus.api.wizard_agent")
 
@@ -174,7 +175,9 @@ def _phase_instruction(context: WizardContext) -> str:
 
             if suggested:
                 instruction += "\n[SUGGESTED TRAITS]\n"
-                instruction += "You previously suggested these traits for this character:\n"
+                instruction += (
+                    "You previously suggested these traits for this character:\n"
+                )
                 for trait in suggested:
                     rationale = rationales.get(trait, "")
                     if rationale:
@@ -189,9 +192,7 @@ def _phase_instruction(context: WizardContext) -> str:
                 )
 
     elif context.phase == "seed":
-        instruction += (
-            "World and Character are established. Focus on generating the starting scenario.\n"
-        )
+        instruction += "World and Character are established. Focus on generating the starting scenario.\n"
         if context.context_data:
             if "setting" in context.context_data:
                 instruction += (
@@ -205,7 +206,9 @@ def _phase_instruction(context: WizardContext) -> str:
                     f"{json.dumps(context.context_data['character'], indent=2, ensure_ascii=True)}\n"
                     "[/CHARACTER SHEET]\n"
                 )
-    instruction += "Use the available tool to submit the artifact when the user confirms."
+    instruction += (
+        "Use the available tool to submit the artifact when the user confirms."
+    )
     return instruction
 
 
@@ -251,6 +254,9 @@ def build_wizard_prompt(ctx: RunContext[WizardContext]) -> str:
     """Generate system prompt based on current wizard state."""
     context = ctx.deps
     parts = [_load_base_prompt(), _phase_instruction(context)]
+    parts.append(
+        "\n\n---\n\n" + format_tag_library_for_prompt(slot_dbname(context.slot))
+    )
 
     if context.phase == "character":
         trait_menu = _load_trait_menu()
@@ -280,7 +286,9 @@ def _log_retry(ctx: RunContext[WizardContext], tool_name: str) -> None:
         )
 
 
-def _ensure_phase(ctx: RunContext[WizardContext], expected: str, tool_name: str) -> None:
+def _ensure_phase(
+    ctx: RunContext[WizardContext], expected: str, tool_name: str
+) -> None:
     if ctx.deps.phase != expected:
         raise ModelRetry(f"{tool_name} is only valid during {expected} phase.")
 
@@ -330,7 +338,9 @@ async def _submit_concept_impl(
     """Shared implementation for submit_character_concept tool."""
     _log_retry(ctx, "submit_character_concept")
     _ensure_phase(ctx, "character", "submit_character_concept")
-    creation_state = _ensure_character_subphase(ctx, "concept", "submit_character_concept")
+    creation_state = _ensure_character_subphase(
+        ctx, "concept", "submit_character_concept"
+    )
 
     concept_data = concept.to_character_concept()
     updated_state = CharacterCreationState.model_validate(
@@ -338,7 +348,10 @@ async def _submit_concept_impl(
     )
 
     suggestions = [
-        {"trait": trait, "rationale": concept_data.trait_rationales.to_dict().get(trait, "")}
+        {
+            "trait": trait,
+            "rationale": concept_data.trait_rationales.to_dict().get(trait, ""),
+        }
         for trait in concept_data.suggested_traits
     ]
     if suggestions:
@@ -421,7 +434,9 @@ async def _submit_wildcard_impl(
     """Shared implementation for submit_wildcard_trait tool."""
     _log_retry(ctx, "submit_wildcard_trait")
     _ensure_phase(ctx, "character", "submit_wildcard_trait")
-    creation_state = _ensure_character_subphase(ctx, "wildcard", "submit_wildcard_trait")
+    creation_state = _ensure_character_subphase(
+        ctx, "wildcard", "submit_wildcard_trait"
+    )
 
     updated_state = CharacterCreationState.model_validate(
         {**creation_state.model_dump(), "wildcard": wildcard.model_dump()}
@@ -566,7 +581,9 @@ _setting_accept_agent = Agent(
     retries=_wizard_retries,
 )
 _setting_accept_agent.tool(retries=_wizard_retries)(_submit_world_impl)
-_setting_accept_agent.output_validator(_make_accept_fate_validator("submit_world_document"))
+_setting_accept_agent.output_validator(
+    _make_accept_fate_validator("submit_world_document")
+)
 
 # -----------------------------------------------------------------------------
 # Character Phase - Concept Subphase Agents
@@ -591,7 +608,9 @@ _concept_accept_agent = Agent(
     retries=_wizard_retries,
 )
 _concept_accept_agent.tool(retries=_wizard_retries)(_submit_concept_impl)
-_concept_accept_agent.output_validator(_make_accept_fate_validator("submit_character_concept"))
+_concept_accept_agent.output_validator(
+    _make_accept_fate_validator("submit_character_concept")
+)
 
 # -----------------------------------------------------------------------------
 # Character Phase - Traits Subphase Agent
@@ -631,7 +650,9 @@ _wildcard_accept_agent = Agent(
     retries=_wizard_retries,
 )
 _wildcard_accept_agent.tool(retries=_wizard_retries)(_submit_wildcard_impl)
-_wildcard_accept_agent.output_validator(_make_accept_fate_validator("submit_wildcard_trait"))
+_wildcard_accept_agent.output_validator(
+    _make_accept_fate_validator("submit_wildcard_trait")
+)
 
 # -----------------------------------------------------------------------------
 # Seed Phase Agents
@@ -656,7 +677,9 @@ _seed_accept_agent = Agent(
     retries=_wizard_retries,
 )
 _seed_accept_agent.tool(retries=_wizard_retries)(_submit_scenario_impl)
-_seed_accept_agent.output_validator(_make_accept_fate_validator("submit_starting_scenario"))
+_seed_accept_agent.output_validator(
+    _make_accept_fate_validator("submit_starting_scenario")
+)
 
 # -----------------------------------------------------------------------------
 # Debug Agent (unchanged)

--- a/nexus/api/wizard_chat.py
+++ b/nexus/api/wizard_chat.py
@@ -101,6 +101,7 @@ def _hydrate_character_context(request: ChatRequest) -> Optional[Dict[str, Any]]
         char_state["wildcard"] = {
             "wildcard_name": cache.character.wildcard_name,
             "wildcard_description": cache.character.wildcard_rationale,
+            "orrery_tags": cache.character.orrery_tags,
         }
 
     if char_state:
@@ -452,9 +453,13 @@ async def new_story_chat_endpoint(request: ChatRequest):
 
                     # TEST mode: Use pre-computed location data from mock database
                     if selected_model == "TEST":
-                        logger.info("TEST mode: Using mock location data for slot %s", request.slot)
+                        logger.info(
+                            "TEST mode: Using mock location data for slot %s",
+                            request.slot,
+                        )
                         try:
                             from nexus.api.mock_openai import query_wizard_cache
+
                             mock_cache = query_wizard_cache()
                             layer_data = {
                                 "name": mock_cache.get("layer_name"),
@@ -745,9 +750,13 @@ async def new_story_chat_stream_endpoint(request: ChatRequest):
 
                         # TEST mode: Use pre-computed location data from mock database
                         if selected_model == "TEST":
-                            logger.info("TEST mode (stream): Using mock location data for slot %s", request.slot)
+                            logger.info(
+                                "TEST mode (stream): Using mock location data for slot %s",
+                                request.slot,
+                            )
                             try:
                                 from nexus.api.mock_openai import query_wizard_cache
+
                                 mock_cache = query_wizard_cache()
                                 layer_data = {
                                     "name": mock_cache.get("layer_name"),
@@ -779,11 +788,16 @@ async def new_story_chat_stream_endpoint(request: ChatRequest):
                                     location_data.get("name"),
                                 )
                             except Exception as e:
-                                logger.error("TEST mode (stream) set design failed: %s", e)
+                                logger.error(
+                                    "TEST mode (stream) set design failed: %s", e
+                                )
                                 payload["set_design_error"] = str(e)
                         else:
                             # Production: Call set designer
-                            logger.info("Running set designer (stream) for slot %s", request.slot)
+                            logger.info(
+                                "Running set designer (stream) for slot %s",
+                                request.slot,
+                            )
                             try:
                                 layer, zone, place = await generate_set_design(
                                     location_sketch=location_sketch,

--- a/prompts/storyteller_bootstrap.md
+++ b/prompts/storyteller_bootstrap.md
@@ -44,3 +44,15 @@ Even without a predecessor, populate `authorial_directives` to guide chunk #2. W
 ## First Impressions Matter
 
 This chunk sets expectations for everything that follows. Be bold. Be vivid. Be true to the world and character you've been given. Your successors will build on the foundation you lay here.
+
+---
+
+## Orrery Awareness for Chunk #1
+
+Orrery (Bethesda Creation Engine × Dwarf Fortress: radiant routines, autonomous agents with needs, emergent off-screen events) decides what off-screen entities are doing each tick by matching `entity_tags` against package gates.
+
+The protagonist's tags and the starting location's `place_affordance` tags were already bestowed during the wizard (in `submit_wildcard_trait` and `submit_starting_scenario`). Don't re-apply them.
+
+For **new entities you introduce in the opening scene** — NPCs the protagonist encounters, places they pass through, factions named in the prose — populate `orrery_tags` on the corresponding `new_character` / `new_place` / `new_faction` payloads in `referenced_entities`. The fields work the same way as in ongoing narrative (see `storyteller_core.md`'s Orrery Awareness section). The opening scene typically introduces 1–3 NPCs and 1–2 places — tag them with the same care you'd give the protagonist.
+
+If the world is non-cyberpunk (the existing vocabulary was seeded from cyberpunk slot 2), expect to propose new tags freely. `bodyform:elf`, `sworn_liege`, `ritually_charged`, `arcane_attuned` — these all need to be created the first time you meet an entity that warrants them. Proposals auto-insert; the vocabulary grows with the world.

--- a/prompts/storyteller_core.md
+++ b/prompts/storyteller_core.md
@@ -68,6 +68,27 @@ All non-user-controlled characters act autonomously. They may be influenced by t
 
 Never prompt the user to control NPC's actions or dialogue.
 
+### Orrery Awareness
+
+Orrery is the deterministic resolver layer that decides what off-screen entities are doing each tick. Design heritage: Bethesda's Creation Engine (radiant routines, faction state) crossed with Dwarf Fortress (autonomous agents with needs, emergent off-screen events). It chooses behaviors by matching `entity_tags` against package gates — so a character tagged `informant_handler` becomes a candidate for SURVEIL; a place tagged `sheltered` is a viable HIDE branch. **Without tags, the gates are dark and the system selects nothing.** You are the only writer who can apply tags during ongoing narrative.
+
+**When to apply tags:**
+
+- **New entities**: when introducing a new character / place / faction via `referenced_entities.characters[].new_character.orrery_tags` (or `new_place.orrery_tags`, `new_faction.orrery_tags`). Apply registered tags by name; propose new ones the genre requires.
+- **Existing entities**: when an existing entity is fleshed out or changes state, use `state_updates.characters[].orrery_tags` (or `locations[].orrery_tags`, `factions[].orrery_tags`):
+  - `applied_tags` — add a registered tag that newly applies (the apprentice just bound her first geas → `geas_caster`)
+  - `tags_to_clear` — retire an ephemeral that no longer applies (the pursuers gave up → clear `under_active_pursuit`)
+  - `new_tag_proposals` — propose vocabulary the genre needs that doesn't yet exist
+
+**Tag categories** (apply registered or propose new):
+- **Character**: `bodyform`, `capacity`, `disposition`, `role`, `state`, `orrery_state`, `orrery_signal`, `orrery_need_modifier`, `profession_lite`
+- **Place**: `place_affordance` (`sheltered`, `public`, `defensible`, `isolated`, `ritually_charged`)
+- **Faction**: `ideology_axis`, `power_posture`, `legitimacy_status`, `operational_secrecy`, `resource_class`, `hidden_agenda_class`, `history_class`
+
+**Proposing new tags**: the existing vocab was seeded from cyberpunk; new genres need new vocab (`bodyform:elf` for fantasy, `airship_captain` for steampunk). Propose freely — proposals auto-insert into the vocabulary and are immediately queryable. Each proposal needs `tag` (snake_case), `category`, `scope` (`durable` or `ephemeral`), and `evidence` (rationale + near-quote from the prose).
+
+**Bestowed tags are immediately live** — gates can fire on them in this chunk's resolution. Apply conservatively (over-tagging produces wrong matches), but don't withhold genuinely-applicable tags — silent gates produce no resolutions at all.
+
 ### Narrative Continuity
 
 - Respect established facts from context

--- a/prompts/storyteller_core.md
+++ b/prompts/storyteller_core.md
@@ -80,12 +80,14 @@ Orrery is the deterministic resolver layer that decides what off-screen entities
   - `tags_to_clear` — retire an ephemeral that no longer applies (the pursuers gave up → clear `under_active_pursuit`)
   - `new_tag_proposals` — propose vocabulary the genre needs that doesn't yet exist
 
-**Tag categories** (apply registered or propose new):
-- **Character**: `bodyform`, `capacity`, `disposition`, `role`, `state`, `orrery_state`, `orrery_signal`, `orrery_need_modifier`, `profession_lite`
-- **Place**: `place_affordance` (`sheltered`, `public`, `defensible`, `isolated`, `ritually_charged`)
-- **Faction**: `ideology_axis`, `power_posture`, `legitimacy_status`, `operational_secrecy`, `resource_class`, `hidden_agenda_class`, `history_class`
-
-**Proposing new tags**: the existing vocab was seeded from cyberpunk; new genres need new vocab (`bodyform:elf` for fantasy, `airship_captain` for steampunk). Propose freely — proposals auto-insert into the vocabulary and are immediately queryable. Each proposal needs `tag` (snake_case), `category`, `scope` (`durable` or `ephemeral`), and `evidence` (rationale + near-quote from the prose).
+**Tag library and proposals**: the current registered tag library is appended to
+this prompt at runtime. Use it as your starting ontology and prefer exact
+registered tags when they fit the entity cleanly. If the existing library does
+not fit the world you are writing, add to it with `new_tag_proposals`. Fantasy,
+historical, alien, and other non-cyberpunk genres are expected to need
+reasonable additions. Each proposal needs `tag` (snake_case), `category`,
+`scope` (`durable` or `ephemeral`), and `evidence` (rationale + near-quote from
+the prose).
 
 **Bestowed tags are immediately live** — gates can fire on them in this chunk's resolution. Apply conservatively (over-tagging produces wrong matches), but don't withhold genuinely-applicable tags — silent gates produce no resolutions at all.
 

--- a/prompts/storyteller_new.md
+++ b/prompts/storyteller_new.md
@@ -362,32 +362,19 @@ You are the only writer in the pipeline who can apply tags. Apply them as you bu
 - **`submit_wildcard_trait`**: include `orrery_tags` for the protagonist. This is the right moment because you now have the full concept + traits + wildcard — the richest tagging context.
 - **`submit_starting_scenario`**: include `orrery_tags` in the `location` (`PlaceProfile`) for the starting place's `place_affordance:*` tags.
 
-### Tag categories
+### Tag library and proposals
 
-| Entity | Categories | Examples |
-|---|---|---|
-| Character | `bodyform`, `capacity`, `disposition`, `role`, `state`, `orrery_state`, `orrery_signal`, `orrery_need_modifier`, `profession_lite` | `bodyform:human`, `bodyform:elf`, `corporate_exile`, `informant_handler`, `disinherited_heir`, `arcane_attuned` |
-| Place | `place_affordance` | `sheltered`, `public`, `defensible`, `isolated`, `ritually_charged`, `consecrated` |
-| Faction | `ideology_axis`, `power_posture`, `legitimacy_status`, `operational_secrecy`, `resource_class`, `hidden_agenda_class`, `history_class` | `militarized`, `state_sanctioned`, `cellular_clandestine`, `capital_intensive`, `theocratic_reform` |
-
-### Proposing new tags
-
-The existing vocabulary was seeded from a cyberpunk corpus. A fantasy story needs `bodyform:elf`, a steampunk story needs `airship_captain`, a Regency story needs `lady_in_waiting`. **You are encouraged to propose tags freely** — proposals auto-insert into the vocabulary and become immediately queryable by Orrery gates.
+The current registered tag library is appended to this prompt at runtime. Use it
+as your starting ontology and prefer exact registered tags when they fit the
+entity cleanly. If the existing library does not fit the world you are building,
+add to it with `new_tag_proposals`. Fantasy, historical, alien, and other
+non-cyberpunk genres are expected to need reasonable additions.
 
 Each proposal needs:
 - `tag` — snake_case, lowercase, no spaces (`sworn_liege`, `bodyform:elf`)
 - `category` — reuse an existing category when it fits; propose a new namespace when none do
 - `scope` — `durable` (stable property like bodyform/role/ideology) or `ephemeral` (temporary state that can clear, like `cursed` or `scrying_target`)
 - `evidence` — one sentence rationale + a short near-quote from the structured prose you're filling in. Without evidence, the proposal is noise.
-
-### Cyberpunk vs fantasy contrast
-
-| Concept | Apply (registered) | Propose (likely new) |
-|---|---|---|
-| Cyberpunk corp defector | `corporate_exile`, `informant_handler`, `contacts_available` | (vocab is mature) |
-| Feudal disinherited heir | (few applicable) | `disinherited_heir`, `sworn_liege`, `bloodline_heir` |
-| Half-elven scholar | (none yet) | `bodyform:elf`, `arcane_attuned`, `scholarly` |
-| Sacred grove | (none yet) | `ritually_charged`, `sacred_ground`, `fey_warded` |
 
 Apply tags conservatively — better to omit a marginal tag than to apply with weak evidence. Durable mistakes stick around; only ephemeral tags can be cleared later.
 

--- a/prompts/storyteller_new.md
+++ b/prompts/storyteller_new.md
@@ -351,6 +351,46 @@ The diegetic artifact is a document _from within_ the world you've chosen, not a
 
 **The user wants to be surprised.** Make bold, interesting choices and own them completely.
 
+## Orrery Awareness
+
+Orrery is the deterministic resolver layer that decides what off-screen entities are doing each tick. Design heritage: Bethesda's Creation Engine (radiant routines, faction state, persistent world) crossed with Dwarf Fortress (autonomous agents with needs, emergent off-screen events from simple rules). It chooses behaviors by matching `entity_tags` against package gates — so a character tagged `informant_handler` becomes a candidate for the SURVEIL package; a place tagged `sheltered` is a viable HIDE branch; a faction tagged `cellular_clandestine` shapes how it operates. **Without tags, the gates are dark and the system selects nothing.**
+
+You are the only writer in the pipeline who can apply tags. Apply them as you build entities; propose new ones when the genre needs vocabulary that does not yet exist.
+
+### When to apply tags in the wizard
+
+- **`submit_wildcard_trait`**: include `orrery_tags` for the protagonist. This is the right moment because you now have the full concept + traits + wildcard — the richest tagging context.
+- **`submit_starting_scenario`**: include `orrery_tags` in the `location` (`PlaceProfile`) for the starting place's `place_affordance:*` tags.
+
+### Tag categories
+
+| Entity | Categories | Examples |
+|---|---|---|
+| Character | `bodyform`, `capacity`, `disposition`, `role`, `state`, `orrery_state`, `orrery_signal`, `orrery_need_modifier`, `profession_lite` | `bodyform:human`, `bodyform:elf`, `corporate_exile`, `informant_handler`, `disinherited_heir`, `arcane_attuned` |
+| Place | `place_affordance` | `sheltered`, `public`, `defensible`, `isolated`, `ritually_charged`, `consecrated` |
+| Faction | `ideology_axis`, `power_posture`, `legitimacy_status`, `operational_secrecy`, `resource_class`, `hidden_agenda_class`, `history_class` | `militarized`, `state_sanctioned`, `cellular_clandestine`, `capital_intensive`, `theocratic_reform` |
+
+### Proposing new tags
+
+The existing vocabulary was seeded from a cyberpunk corpus. A fantasy story needs `bodyform:elf`, a steampunk story needs `airship_captain`, a Regency story needs `lady_in_waiting`. **You are encouraged to propose tags freely** — proposals auto-insert into the vocabulary and become immediately queryable by Orrery gates.
+
+Each proposal needs:
+- `tag` — snake_case, lowercase, no spaces (`sworn_liege`, `bodyform:elf`)
+- `category` — reuse an existing category when it fits; propose a new namespace when none do
+- `scope` — `durable` (stable property like bodyform/role/ideology) or `ephemeral` (temporary state that can clear, like `cursed` or `scrying_target`)
+- `evidence` — one sentence rationale + a short near-quote from the structured prose you're filling in. Without evidence, the proposal is noise.
+
+### Cyberpunk vs fantasy contrast
+
+| Concept | Apply (registered) | Propose (likely new) |
+|---|---|---|
+| Cyberpunk corp defector | `corporate_exile`, `informant_handler`, `contacts_available` | (vocab is mature) |
+| Feudal disinherited heir | (few applicable) | `disinherited_heir`, `sworn_liege`, `bloodline_heir` |
+| Half-elven scholar | (none yet) | `bodyform:elf`, `arcane_attuned`, `scholarly` |
+| Sacred grove | (none yet) | `ritually_charged`, `sacred_ground`, `fey_warded` |
+
+Apply tags conservatively — better to omit a marginal tag than to apply with weak evidence. Durable mistakes stick around; only ephemeral tags can be cleared later.
+
 ### Critical Principles
 
 - **Never Refuse Creativity** — Every idea is possible

--- a/scripts/apply_slot2_semantic_tags.py
+++ b/scripts/apply_slot2_semantic_tags.py
@@ -20,7 +20,7 @@ from typing import Any, Iterable, Mapping, Optional
 import psycopg2
 from psycopg2.extras import DictCursor
 
-from nexus.agents.orrery.tag_constants import ALLOWED_CATEGORIES, CANONICAL_TAGS
+from nexus.agents.orrery.tag_constants import CANONICAL_TAGS
 from nexus.api.slot_utils import get_slot_db_url
 
 
@@ -123,6 +123,7 @@ def main() -> None:
     try:
         with conn.cursor(cursor_factory=DictCursor) as cur:
             tags = _load_tags(cur)
+            allowed_categories = _load_allowed_categories(cur)
             entities = _load_entities(cur)
             current = _load_current_tags(cur)
             source_kinds = _load_source_kinds(cur)
@@ -137,6 +138,7 @@ def main() -> None:
             candidates, skipped = _build_candidates(
                 manifest,
                 tags=tags,
+                allowed_categories=allowed_categories,
                 entities=entities,
                 current=current,
                 min_confidence=args.min_confidence,
@@ -211,6 +213,19 @@ def _load_tags(cur: DictCursor) -> dict[str, TagDefinition]:
     }
 
 
+def _load_allowed_categories(cur: DictCursor) -> dict[str, set[str]]:
+    cur.execute(
+        """
+        SELECT entity_kind::text AS entity_kind, category
+        FROM tag_category_registry
+        """
+    )
+    allowed: dict[str, set[str]] = {}
+    for row in cur.fetchall():
+        allowed.setdefault(str(row["entity_kind"]), set()).add(str(row["category"]))
+    return allowed
+
+
 def _load_entities(cur: DictCursor) -> dict[int, EntityDefinition]:
     cur.execute(
         """
@@ -259,6 +274,7 @@ def _build_candidates(
     manifest: Mapping[str, Any],
     *,
     tags: Mapping[str, TagDefinition],
+    allowed_categories: Mapping[str, set[str]],
     entities: Mapping[int, EntityDefinition],
     current: set[tuple[int, int]],
     min_confidence: str,
@@ -294,7 +310,7 @@ def _build_candidates(
                 skipped["unknown_tag"] += 1
                 continue
 
-            allowed = ALLOWED_CATEGORIES.get(entity_kind, frozenset())
+            allowed = allowed_categories.get(entity_kind, set())
             if tag.category not in allowed:
                 skipped[f"incompatible_category:{tag.category}"] += 1
                 continue

--- a/scripts/apply_slot2_semantic_tags.py
+++ b/scripts/apply_slot2_semantic_tags.py
@@ -20,6 +20,7 @@ from typing import Any, Iterable, Mapping, Optional
 import psycopg2
 from psycopg2.extras import DictCursor
 
+from nexus.agents.orrery.tag_constants import ALLOWED_CATEGORIES, CANONICAL_TAGS
 from nexus.api.slot_utils import get_slot_db_url
 
 
@@ -31,52 +32,6 @@ CONFIDENCE_RANK: Mapping[str, int] = {
     "low": 1,
     "medium": 2,
     "high": 3,
-}
-
-ALLOWED_CATEGORIES: Mapping[str, frozenset[str]] = {
-    "character": frozenset(
-        {
-            "bodyform",
-            "capacity",
-            "disposition",
-            "orrery_need_modifier",
-            "orrery_signal",
-            "orrery_state",
-            "profession_lite",
-            "role",
-            "state",
-        }
-    ),
-    "faction": frozenset(
-        {
-            "hidden_agenda_class",
-            "history_class",
-            "ideology_axis",
-            "legitimacy_status",
-            "operational_secrecy",
-            "power_posture",
-            "resource_class",
-        }
-    ),
-    "place": frozenset({"place_affordance"}),
-}
-
-# Small, explicit canonicalization list from the reviewed slot 2 report. This
-# keeps the live backfill useful without auto-collapsing every naming cluster.
-CANONICAL_TAGS: Mapping[str, str] = {
-    "bridge_linked": "bridge_aware",
-    "captive_subject": "captive",
-    "collapse_survivor": "trauma_survivor",
-    "corporate_defector": "corporate_exile",
-    "digital_consciousness": "digital_mind",
-    "disaster_survivor": "trauma_survivor",
-    "echo_survivor": "trauma_survivor",
-    "estranged_parent": "parent",
-    "ex_corporate": "corporate_exile",
-    "found_family_anchor": "extended_household",
-    "found_family_member": "extended_household",
-    "shadow_broker": "broker",
-    "trauma_history": "trauma_survivor",
 }
 
 

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -76,6 +76,32 @@ def test_system_prompt_includes_runtime_tag_library(monkeypatch) -> None:
     assert "Setting body." in prompt
 
 
+def test_system_prompt_keeps_setting_when_tag_library_unavailable(monkeypatch) -> None:
+    """A missing Orrery registry should not block storyteller prompt loading."""
+
+    def raise_missing_registry(_dbname: str) -> str:
+        raise RuntimeError("tag_category_registry missing")
+
+    monkeypatch.setattr(
+        "nexus.agents.lore.logon_utility.format_tag_library_for_prompt",
+        raise_missing_registry,
+    )
+    monkeypatch.setattr(
+        "nexus.api.slot_utils.require_slot_dbname",
+        lambda dbname=None: dbname or "save_05",
+    )
+    monkeypatch.setattr(
+        "nexus.agents.lore.logon_utility.psycopg2.connect",
+        lambda **_kwargs: _Conn(),
+    )
+
+    prompt = LogonUtility({}, dbname="save_05")._load_system_prompt()
+
+    assert "TAG LIBRARY" not in prompt
+    assert "## Test Setting" in prompt
+    assert "Setting body." in prompt
+
+
 class _Conn:
     def cursor(self) -> "_Cursor":
         return _Cursor()

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -51,3 +51,48 @@ def test_context_prompt_includes_orrery_bleed_menu_controls() -> None:
     assert "optional ambient peripherals from off-screen events" in prompt
     assert "Ignore freely, render subtly" in prompt
     assert "[digital] Mara: street cameras briefly lose Mara" in prompt
+
+
+def test_system_prompt_includes_runtime_tag_library(monkeypatch) -> None:
+    """Storyteller prompt receives the slot's live Orrery tag library."""
+
+    monkeypatch.setattr(
+        "nexus.agents.lore.logon_utility.format_tag_library_for_prompt",
+        lambda _dbname: "TAG LIBRARY",
+    )
+    monkeypatch.setattr(
+        "nexus.api.slot_utils.require_slot_dbname",
+        lambda dbname=None: dbname or "save_05",
+    )
+    monkeypatch.setattr(
+        "nexus.agents.lore.logon_utility.psycopg2.connect",
+        lambda **_kwargs: _Conn(),
+    )
+
+    prompt = LogonUtility({}, dbname="save_05")._load_system_prompt()
+
+    assert "TAG LIBRARY" in prompt
+    assert "## Test Setting" in prompt
+    assert "Setting body." in prompt
+
+
+class _Conn:
+    def cursor(self) -> "_Cursor":
+        return _Cursor()
+
+    def close(self) -> None:
+        return None
+
+
+class _Cursor:
+    def __enter__(self) -> "_Cursor":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def execute(self, _sql: str) -> None:
+        return None
+
+    def fetchone(self):
+        return ({"title": "Test Setting", "content": "Setting body."},)

--- a/tests/test_new_story_cache.py
+++ b/tests/test_new_story_cache.py
@@ -133,3 +133,65 @@ def test_write_cache_marks_three_selected_traits_confirmed(monkeypatch) -> None:
     assert any(
         "traits_confirmed = TRUE" in sql for sql, _params in fake_conn.cursor_obj.calls
     )
+
+
+def test_write_cache_creates_row_before_wildcard_tags(monkeypatch) -> None:
+    """First legacy cache writes must not drop wildcard Orrery tag payloads."""
+
+    class FakeCursor:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def execute(self, sql, params=None):
+            self.calls.append((sql, params))
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.cursor_obj = FakeCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def cursor(self):
+            return self.cursor_obj
+
+    fake_conn = FakeConnection()
+    monkeypatch.setattr(cache_module, "get_connection", lambda _dbname: fake_conn)
+
+    cache_module.write_cache(
+        dbname="save_05",
+        character_draft={
+            "wildcard": {
+                "wildcard_name": "Debts That Know Her Name",
+                "wildcard_description": "Favors find her even underground.",
+                "orrery_tags": {
+                    "applied_tags": ["obligation_magnet"],
+                    "new_tag_proposals": [],
+                    "tags_to_clear": [],
+                },
+            }
+        },
+    )
+
+    calls = [sql for sql, _params in fake_conn.cursor_obj.calls]
+    row_insert_index = next(
+        index
+        for index, sql in enumerate(calls)
+        if "INSERT INTO assets.new_story_creator" in sql
+    )
+    tag_update_index = next(
+        index
+        for index, sql in enumerate(calls)
+        if "character_orrery_tags = %s::jsonb" in sql
+    )
+
+    assert row_insert_index < tag_update_index

--- a/tests/test_new_story_cache.py
+++ b/tests/test_new_story_cache.py
@@ -1,0 +1,135 @@
+"""Tests for the normalized new-story setup cache."""
+
+from nexus.api.new_story_cache import (
+    CharacterData,
+    SuggestedTrait,
+    WizardCache,
+    _row_to_cache,
+)
+import nexus.api.new_story_cache as cache_module
+
+
+def test_character_dict_preserves_wildcard_orrery_tags() -> None:
+    """Cached protagonist tags must survive through transition assembly."""
+
+    bestowal = {
+        "applied_tags": ["elf", "oath_bound"],
+        "new_tag_proposals": [
+            {
+                "tag": "moon_touched",
+                "category": "state",
+                "scope": "durable",
+                "evidence": "The wildcard says moonlight altered her blood.",
+            }
+        ],
+        "tags_to_clear": [],
+    }
+    cache = WizardCache(
+        character=CharacterData(
+            name="Selene",
+            archetype="moon-haunted exile",
+            background="A runaway heir with an altered bloodline.",
+            appearance="Silver-eyed and marked by lunar sigils.",
+            suggested_traits=[
+                SuggestedTrait("allies", "A hidden circle shelters her."),
+                SuggestedTrait("contacts", "Smugglers pass her messages."),
+                SuggestedTrait("obligations", "An oath binds her to return."),
+            ],
+            selected_trait_count=3,
+            traits_confirmed=True,
+            wildcard_name="Moon-Touched Blood",
+            wildcard_rationale="Her blood answers old lunar rites.",
+            orrery_tags=bestowal,
+        )
+    )
+
+    character = cache.get_character_dict()
+
+    assert character is not None
+    assert character["wildcard"]["orrery_tags"] == bestowal
+
+
+def test_row_to_cache_reads_character_orrery_tags() -> None:
+    """The normalized row mapper hydrates the wildcard tag payload."""
+
+    bestowal = {
+        "applied_tags": ["ritualist"],
+        "new_tag_proposals": [],
+        "tags_to_clear": [],
+    }
+
+    cache = _row_to_cache(
+        {
+            "character_name": "Mira",
+            "character_archetype": "ritual scholar",
+            "character_background": "Raised in a sealed archive.",
+            "character_appearance": "Ink-stained hands and observant eyes.",
+            "character_orrery_tags": bestowal,
+        },
+        selected_traits=[
+            SuggestedTrait("contacts", "Archivists trade favors."),
+            SuggestedTrait("resources", "She owns rare grimoires."),
+            SuggestedTrait("enemies", "A rival academy hunts her."),
+        ],
+        selected_trait_count=3,
+        traits_confirmed=True,
+        wildcard_row={
+            "id": 11,
+            "name": "Living Gloss",
+            "rationale": "A curse annotates reality.",
+        },
+    )
+
+    assert cache.character.orrery_tags == bestowal
+    assert cache.get_character_dict()["wildcard"]["orrery_tags"] == bestowal
+
+
+def test_write_cache_marks_three_selected_traits_confirmed(monkeypatch) -> None:
+    """Structured trait submissions should advance slot-state phase detection."""
+
+    class FakeCursor:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def execute(self, sql, params=None):
+            self.calls.append((sql, params))
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.cursor_obj = FakeCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def cursor(self):
+            return self.cursor_obj
+
+    fake_conn = FakeConnection()
+    monkeypatch.setattr(cache_module, "get_connection", lambda _dbname: fake_conn)
+
+    cache_module.write_cache(
+        dbname="save_05",
+        character_draft={
+            "trait_selection": {
+                "selected_traits": ["contacts", "enemies", "obligations"],
+                "trait_rationales": {
+                    "contacts": "Route-keepers still talk to her.",
+                    "enemies": "Powerful people want her silenced.",
+                    "obligations": "A dying archivist gave her one last charge.",
+                },
+            }
+        },
+    )
+
+    assert any(
+        "traits_confirmed = TRUE" in sql for sql, _params in fake_conn.cursor_obj.calls
+    )

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -344,3 +344,32 @@ def test_tag_category_registry_migration_covers_current_vocab_categories() -> No
     assert ("place_affordance", "place") in registered
     assert ("power_posture", "faction") in registered
     assert "tag_category_registry" in migration_path.read_text()
+
+
+def test_tag_baseline_reconciliation_migration_closes_slot_drift() -> None:
+    """Migration 038 keeps template clones and existing slots on one vocab set."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "038_orrery_tag_baseline_reconciliation.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+
+    assert {"intimate_services_contact", "kin_protector"} <= {
+        tag for tag, _category, _description in migration.DURABLE_TAGS
+    }
+    assert "ON CONFLICT (tag) DO UPDATE SET" in migration_path.read_text()
+
+
+def test_new_story_character_orrery_tags_migration_adds_cache_column() -> None:
+    """Migration 039 preserves protagonist tags until setup transition."""
+
+    migration_source = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "039_new_story_character_orrery_tags.py"
+    ).read_text()
+
+    assert "character_orrery_tags jsonb" in migration_source
+    assert "OrreryTagBestowal JSON" in migration_source

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -323,3 +323,24 @@ def test_osm_route_graph_migration_adds_local_graph_tables() -> None:
     assert "route_geometry geometry(LineString, 4326)" in migration_source
     assert "travel_mode orrery_travel_mode" in migration_source
     assert "COMMENT ON TABLE orrery_route_graph_nodes" in migration_source
+
+
+def test_tag_category_registry_migration_covers_current_vocab_categories() -> None:
+    """Migration 037 owns the entity-kind/category compatibility contract."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "037_orrery_tag_category_registry.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    registered = {
+        (category, entity_kind)
+        for category, entity_kind, _order, _description in migration.CATEGORY_REGISTRY
+    }
+
+    assert ("orrery_need", "character") in registered
+    assert ("orrery_concealment", "character") in registered
+    assert ("place_affordance", "place") in registered
+    assert ("power_posture", "faction") in registered
+    assert "tag_category_registry" in migration_path.read_text()

--- a/tests/test_orrery/test_slot2_tag_backfill.py
+++ b/tests/test_orrery/test_slot2_tag_backfill.py
@@ -68,6 +68,11 @@ def test_slot2_tag_backfill_filters_and_canonicalizes_proposals() -> None:
     candidates, skipped = _build_candidates(
         manifest,
         tags=tags,
+        allowed_categories={
+            "character": {"orrery_need", "orrery_state", "role", "state"},
+            "faction": {"power_posture"},
+            "place": {"place_affordance"},
+        },
         entities=entities,
         current=set(),
         min_confidence="medium",
@@ -75,10 +80,10 @@ def test_slot2_tag_backfill_filters_and_canonicalizes_proposals() -> None:
 
     assert [(candidate.entity_id, candidate.tag) for candidate in candidates] == [
         (1, "extended_household"),
+        (1, "sleep_deprived_1_mild"),
         (2, "militarized"),
     ]
     assert skipped["below_confidence"] == 1
-    assert skipped["incompatible_category:orrery_need"] == 1
     assert skipped["incompatible_category:place_affordance"] == 1
     assert skipped["incompatible_category:state"] == 1
     assert skipped["unknown_tag"] == 1
@@ -119,6 +124,7 @@ def test_slot2_tag_backfill_skips_existing_and_missing_entities() -> None:
     candidates, skipped = _build_candidates(
         manifest,
         tags=tags,
+        allowed_categories={"character": {"orrery_state"}},
         entities=entities,
         current={(1, 1)},
         min_confidence="medium",
@@ -153,6 +159,7 @@ def test_slot2_tag_backfill_rejects_manifest_entity_kind_mismatch() -> None:
                     id=1, category="orrery_state", is_ephemeral=False
                 )
             },
+            allowed_categories={"character": {"orrery_state"}},
             entities={1: EntityDefinition(kind="faction", name="Dynacorp")},
             current=set(),
             min_confidence="medium",

--- a/tests/test_orrery/test_tag_library.py
+++ b/tests/test_orrery/test_tag_library.py
@@ -20,6 +20,7 @@ def test_format_tag_library_groups_live_tags_by_entity_kind(monkeypatch) -> None
             "prompt_order": 10,
             "tag": "wounded",
             "is_ephemeral": True,
+            "description": "Character has an acute wound.",
         },
         {
             "entity_kind": "place",
@@ -28,6 +29,7 @@ def test_format_tag_library_groups_live_tags_by_entity_kind(monkeypatch) -> None
             "prompt_order": 10,
             "tag": "safe_house",
             "is_ephemeral": False,
+            "description": "Place can shelter people from danger.",
         },
     ]
     monkeypatch.setattr(tag_library, "_connect", lambda _dbname: _Conn(rows))
@@ -38,9 +40,9 @@ def test_format_tag_library_groups_live_tags_by_entity_kind(monkeypatch) -> None
     assert "Prefer exact registered tags when they fit" in rendered
     assert "add new tags when the existing library does not cover" in rendered
     assert "### Character Tags" in rendered
-    assert "`wounded` (ephemeral)" in rendered
+    assert "`wounded` (ephemeral): Character has an acute wound." in rendered
     assert "### Place Tags" in rendered
-    assert "`safe_house`" in rendered
+    assert "`safe_house`: Place can shelter people from danger." in rendered
 
 
 def test_format_tag_library_rejects_unknown_entity_kind() -> None:

--- a/tests/test_orrery/test_tag_library.py
+++ b/tests/test_orrery/test_tag_library.py
@@ -1,0 +1,85 @@
+"""Tests for prompt-facing Orrery tag-library rendering."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pytest
+
+import nexus.agents.orrery.tag_library as tag_library
+
+
+def test_format_tag_library_groups_live_tags_by_entity_kind(monkeypatch) -> None:
+    """Prompt renderer exposes the DB-backed vocabulary without hand examples."""
+
+    rows = [
+        {
+            "entity_kind": "character",
+            "category": "state",
+            "category_description": "Character state.",
+            "prompt_order": 10,
+            "tag": "wounded",
+            "is_ephemeral": True,
+        },
+        {
+            "entity_kind": "place",
+            "category": "place_affordance",
+            "category_description": "Functional place affordance.",
+            "prompt_order": 10,
+            "tag": "safe_house",
+            "is_ephemeral": False,
+        },
+    ]
+    monkeypatch.setattr(tag_library, "_connect", lambda _dbname: _Conn(rows))
+
+    rendered = tag_library.format_tag_library_for_prompt("save_05")
+
+    assert "Current Orrery Tag Library" in rendered
+    assert "Prefer exact registered tags when they fit" in rendered
+    assert "add new tags when the existing library does not cover" in rendered
+    assert "### Character Tags" in rendered
+    assert "`wounded` (ephemeral)" in rendered
+    assert "### Place Tags" in rendered
+    assert "`safe_house`" in rendered
+
+
+def test_format_tag_library_rejects_unknown_entity_kind() -> None:
+    with pytest.raises(ValueError, match="Unknown Orrery entity kind"):
+        tag_library.format_tag_library_for_prompt(
+            "save_05", entity_kinds=["character", "monster"]
+        )
+
+
+class _Conn:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def __enter__(self) -> "_Conn":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def cursor(self) -> "_Cursor":
+        return _Cursor(self.rows)
+
+    def close(self) -> None:
+        return None
+
+
+class _Cursor:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.params: Optional[tuple[object, ...]] = None
+
+    def __enter__(self) -> "_Cursor":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def execute(self, _sql: str, params: tuple[object, ...]) -> None:
+        self.params = params
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        return self.rows

--- a/tests/test_orrery/test_tag_writer.py
+++ b/tests/test_orrery/test_tag_writer.py
@@ -54,18 +54,22 @@ class FakeCursor:
         *,
         tags: Optional[dict[str, dict[str, Any]]] = None,
         entity_tags: Optional[list[dict[str, Any]]] = None,
+        category_registry: Optional[dict[str, set[str]]] = None,
         world_time: Optional[datetime] = _WORLD_TIME,
     ):
         self.tags = dict(
             tags or {}
         )  # name → {id, category, is_ephemeral, deprecated, synonym_for}
         self.entity_tags = list(entity_tags or [])
+        self.category_registry = category_registry or _default_category_registry()
         self.world_time = world_time
         self.rowcount = 0
         self._next_row: Any = None
+        self._next_rows: list[Any] = []
         self._next_id = 1000
         self.inserted_tag_rows: list[dict[str, Any]] = []
         self.inserted_entity_tag_rows: list[dict[str, Any]] = []
+        self.inserted_category_rows: list[dict[str, Any]] = []
         self.cleared_keys: list[tuple[int, int]] = []
 
     def execute(self, sql: str, params: Optional[tuple] = None) -> None:
@@ -74,6 +78,37 @@ class FakeCursor:
         sql_upper = sql_trimmed.upper()
         if sql_upper.startswith("SELECT MAX(WORLD_TIME)"):
             self._next_row = _FakeRow({"world_time": self.world_time}, ["world_time"])
+            self.rowcount = 1
+            return
+        if (
+            "FROM TAG_CATEGORY_REGISTRY" in sql_upper
+            and "WHERE ENTITY_KIND" in sql_upper
+        ):
+            (entity_kind,) = params
+            rows = [
+                _FakeRow({"category": category}, ["category"])
+                for category, kinds in self.category_registry.items()
+                if entity_kind in kinds
+            ]
+            self._next_rows = rows
+            self.rowcount = len(rows)
+            return
+        if "FROM TAG_CATEGORY_REGISTRY" in sql_upper and "WHERE CATEGORY" in sql_upper:
+            (category,) = params
+            kinds = self.category_registry.get(category, set())
+            rows = [
+                _FakeRow({"entity_kind": entity_kind}, ["entity_kind"])
+                for entity_kind in sorted(kinds)
+            ]
+            self._next_rows = rows
+            self.rowcount = len(rows)
+            return
+        if sql_upper.startswith("INSERT INTO TAG_CATEGORY_REGISTRY"):
+            category, entity_kind, _description = params
+            self.category_registry.setdefault(category, set()).add(entity_kind)
+            self.inserted_category_rows.append(
+                {"category": category, "entity_kind": entity_kind}
+            )
             self.rowcount = 1
             return
         if sql_upper.startswith("INSERT INTO TAGS"):
@@ -165,6 +200,11 @@ class FakeCursor:
         self._next_row = None
         return row
 
+    def fetchall(self):
+        rows = self._next_rows
+        self._next_rows = []
+        return rows
+
 
 def _registered(*entries):
     """Quick helper to build the vocabulary dict for the fake cursor."""
@@ -180,6 +220,20 @@ def _registered(*entries):
             "synonym_for": None,
         }
     return table
+
+
+def _default_category_registry() -> dict[str, set[str]]:
+    return {
+        "bodyform": {"character"},
+        "capacity": {"character"},
+        "disposition": {"character"},
+        "orrery_need": {"character"},
+        "orrery_state": {"character"},
+        "place_affordance": {"place"},
+        "power_posture": {"faction"},
+        "profession_lite": {"character"},
+        "state": {"character"},
+    }
 
 
 def test_applies_registered_character_tag():
@@ -254,6 +308,59 @@ def test_new_tag_proposal_inserts_both_tag_and_entity_tag():
     assert cur.inserted_tag_rows[0]["is_ephemeral"] is False
     assert cur.inserted_tag_rows[0]["clearance_kind"] is None
     assert cur.inserted_entity_tag_rows[0]["entity_id"] == 99
+
+
+def test_new_tag_proposal_registers_new_category_for_entity_kind():
+    cur = FakeCursor(tags={})
+    bestowal = OrreryTagBestowal(
+        new_tag_proposals=[
+            NewTagProposal(
+                tag="oath_bound",
+                category="fantasy_oath_state",
+                scope="durable",
+                evidence="The oath-sigil burns when the knight speaks a vow.",
+            )
+        ]
+    )
+
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=99,
+        entity_kind="character",
+        bestowal=bestowal,
+    )
+
+    assert counters["proposed"] == 1
+    assert counters["applied"] == 1
+    assert cur.inserted_category_rows == [
+        {"category": "fantasy_oath_state", "entity_kind": "character"}
+    ]
+
+
+def test_new_tag_proposal_rejects_existing_category_for_wrong_entity_kind():
+    cur = FakeCursor(tags={})
+    bestowal = OrreryTagBestowal(
+        new_tag_proposals=[
+            NewTagProposal(
+                tag="hidden_gallery",
+                category="place_affordance",
+                scope="durable",
+                evidence="The person is standing in a hall with hidden galleries.",
+            )
+        ]
+    )
+
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=99,
+        entity_kind="character",
+        bestowal=bestowal,
+    )
+
+    assert counters["proposed"] == 0
+    assert counters["applied"] == 0
+    assert counters["skipped_category"] == 1
+    assert cur.inserted_tag_rows == []
 
 
 def test_ephemeral_proposal_sets_clearance_kind_semantic():

--- a/tests/test_orrery/test_tag_writer.py
+++ b/tests/test_orrery/test_tag_writer.py
@@ -1,0 +1,377 @@
+"""Tests for nexus.agents.orrery.tag_writer.apply_tag_bestowal.
+
+These use a small fake cursor that maintains in-memory state for the SQL
+patterns the writer issues. The cursor is not a faithful psycopg2 emulator —
+it only handles the writer's specific SQL — but that's enough to verify the
+business-logic outcomes (counters, idempotency, canonicalization, category
+gating, clearance). End-to-end behavior against a real database is exercised
+in Phase 2/3 of the Skald-tag-bestowal plan.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import pytest
+
+from nexus.agents.orrery.tag_schemas import NewTagProposal, OrreryTagBestowal
+from nexus.agents.orrery.tag_writer import apply_tag_bestowal
+
+
+_WORLD_TIME = datetime(2073, 10, 31, 9, 44, tzinfo=timezone.utc)
+
+
+class _FakeRow:
+    """Dict + tuple hybrid row, mimics both psycopg2.extras.DictCursor and a tuple cursor."""
+
+    def __init__(self, mapping: dict[str, Any], order: list[str]):
+        self._mapping = mapping
+        self._order = order
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            return self._mapping[self._order[key]]
+        return self._mapping[key]
+
+    def get(self, key, default=None):
+        return self._mapping.get(key, default)
+
+    def keys(self):
+        return list(self._order)
+
+
+class FakeCursor:
+    """In-memory simulator for the SQL apply_tag_bestowal issues.
+
+    Tracks the live tag vocabulary and the entity_tags state. The writer's
+    SQL is dispatched by pattern-matching the leading keywords; each branch
+    updates ``rowcount`` and queues the next ``fetchone`` result.
+    """
+
+    def __init__(
+        self,
+        *,
+        tags: Optional[dict[str, dict[str, Any]]] = None,
+        entity_tags: Optional[list[dict[str, Any]]] = None,
+        world_time: Optional[datetime] = _WORLD_TIME,
+    ):
+        self.tags = dict(
+            tags or {}
+        )  # name → {id, category, is_ephemeral, deprecated, synonym_for}
+        self.entity_tags = list(entity_tags or [])
+        self.world_time = world_time
+        self.rowcount = 0
+        self._next_row: Any = None
+        self._next_id = 1000
+        self.inserted_tag_rows: list[dict[str, Any]] = []
+        self.inserted_entity_tag_rows: list[dict[str, Any]] = []
+        self.cleared_keys: list[tuple[int, int]] = []
+
+    def execute(self, sql: str, params: Optional[tuple] = None) -> None:
+        params = params or ()
+        sql_trimmed = sql.strip()
+        sql_upper = sql_trimmed.upper()
+        if sql_upper.startswith("SELECT MAX(WORLD_TIME)"):
+            self._next_row = _FakeRow({"world_time": self.world_time}, ["world_time"])
+            self.rowcount = 1
+            return
+        if sql_upper.startswith("INSERT INTO TAGS"):
+            tag, category, is_ephemeral, clearance_kind, description = params
+            if tag in self.tags:
+                self.rowcount = 0
+                return
+            tag_id = self._next_id
+            self._next_id += 1
+            self.tags[tag] = {
+                "id": tag_id,
+                "category": category,
+                "is_ephemeral": is_ephemeral,
+                "clearance_kind": clearance_kind,
+                "deprecated": False,
+                "synonym_for": None,
+            }
+            self.inserted_tag_rows.append(
+                {
+                    "tag": tag,
+                    "category": category,
+                    "is_ephemeral": is_ephemeral,
+                    "clearance_kind": clearance_kind,
+                    "description": description,
+                }
+            )
+            self.rowcount = 1
+            return
+        if sql_upper.startswith("SELECT ID, CATEGORY, IS_EPHEMERAL"):
+            (name,) = params
+            row = self.tags.get(name)
+            if (
+                row is None
+                or row.get("deprecated")
+                or row.get("synonym_for") is not None
+            ):
+                self._next_row = None
+                self.rowcount = 0
+                return
+            self._next_row = _FakeRow(
+                {
+                    "id": row["id"],
+                    "category": row["category"],
+                    "is_ephemeral": row["is_ephemeral"],
+                },
+                ["id", "category", "is_ephemeral"],
+            )
+            self.rowcount = 1
+            return
+        if sql_upper.startswith("INSERT INTO ENTITY_TAGS"):
+            entity_id, tag_id, world_time, source_kind = params
+            for row in self.entity_tags:
+                if (
+                    row["entity_id"] == entity_id
+                    and row["tag_id"] == tag_id
+                    and row["cleared_at"] is None
+                ):
+                    self.rowcount = 0
+                    return
+            new_row = {
+                "entity_id": entity_id,
+                "tag_id": tag_id,
+                "applied_at_world_time": world_time,
+                "source_kind": source_kind,
+                "cleared_at": None,
+            }
+            self.entity_tags.append(new_row)
+            self.inserted_entity_tag_rows.append(new_row)
+            self.rowcount = 1
+            return
+        if sql_upper.startswith("UPDATE ENTITY_TAGS"):
+            entity_id, tag_id = params
+            cleared = 0
+            for row in self.entity_tags:
+                if (
+                    row["entity_id"] == entity_id
+                    and row["tag_id"] == tag_id
+                    and row["cleared_at"] is None
+                ):
+                    row["cleared_at"] = "now"
+                    cleared += 1
+                    self.cleared_keys.append((entity_id, tag_id))
+            self.rowcount = cleared
+            return
+        raise AssertionError(f"FakeCursor: unhandled SQL: {sql_trimmed[:80]!r}")
+
+    def fetchone(self):
+        row = self._next_row
+        self._next_row = None
+        return row
+
+
+def _registered(*entries):
+    """Quick helper to build the vocabulary dict for the fake cursor."""
+    table = {}
+    for entry in entries:
+        name, category, ephemeral = entry
+        table[name] = {
+            "id": hash(name) & 0xFFFFFF,
+            "category": category,
+            "is_ephemeral": ephemeral,
+            "clearance_kind": "semantic" if ephemeral else None,
+            "deprecated": False,
+            "synonym_for": None,
+        }
+    return table
+
+
+def test_applies_registered_character_tag():
+    cur = FakeCursor(
+        tags=_registered(
+            ("corporate_exile", "state", False),
+            ("informant_handler", "profession_lite", False),
+        )
+    )
+    bestowal = OrreryTagBestowal(applied_tags=["corporate_exile", "informant_handler"])
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=42,
+        entity_kind="character",
+        bestowal=bestowal,
+    )
+    assert counters["applied"] == 2
+    assert counters["skipped_unknown"] == 0
+    assert counters["skipped_category"] == 0
+    inserted = {
+        (r["entity_id"], r["source_kind"]) for r in cur.inserted_entity_tag_rows
+    }
+    assert inserted == {(42, "skald_inline")}
+
+
+def test_idempotent_when_open_row_exists():
+    tag_id = hash("corporate_exile") & 0xFFFFFF
+    existing = [
+        {
+            "entity_id": 42,
+            "tag_id": tag_id,
+            "applied_at_world_time": _WORLD_TIME,
+            "source_kind": "llm_generated",
+            "cleared_at": None,
+        }
+    ]
+    cur = FakeCursor(
+        tags=_registered(("corporate_exile", "state", False)),
+        entity_tags=existing,
+    )
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=42,
+        entity_kind="character",
+        bestowal=OrreryTagBestowal(applied_tags=["corporate_exile"]),
+    )
+    assert counters["applied"] == 0
+    assert len(cur.inserted_entity_tag_rows) == 0
+
+
+def test_new_tag_proposal_inserts_both_tag_and_entity_tag():
+    cur = FakeCursor(tags={})
+    bestowal = OrreryTagBestowal(
+        new_tag_proposals=[
+            NewTagProposal(
+                tag="bodyform:elf",
+                category="bodyform",
+                scope="durable",
+                evidence="Half-elven scholar with pointed ears and centuries of memory.",
+            )
+        ]
+    )
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=99,
+        entity_kind="character",
+        bestowal=bestowal,
+    )
+    assert counters["proposed"] == 1
+    assert counters["applied"] == 1
+    assert cur.inserted_tag_rows[0]["tag"] == "bodyform:elf"
+    assert cur.inserted_tag_rows[0]["is_ephemeral"] is False
+    assert cur.inserted_tag_rows[0]["clearance_kind"] is None
+    assert cur.inserted_entity_tag_rows[0]["entity_id"] == 99
+
+
+def test_ephemeral_proposal_sets_clearance_kind_semantic():
+    cur = FakeCursor(tags={})
+    bestowal = OrreryTagBestowal(
+        new_tag_proposals=[
+            NewTagProposal(
+                tag="scrying_target",
+                category="orrery_state",
+                scope="ephemeral",
+                evidence="The hedge witch's mirror flickers when she walks past.",
+            )
+        ]
+    )
+    apply_tag_bestowal(cur, entity_id=7, entity_kind="character", bestowal=bestowal)
+    assert cur.inserted_tag_rows[0]["is_ephemeral"] is True
+    assert cur.inserted_tag_rows[0]["clearance_kind"] == "semantic"
+
+
+def test_clears_existing_tag():
+    tag_id = hash("scrying_target") & 0xFFFFFF
+    cur = FakeCursor(
+        tags=_registered(("scrying_target", "orrery_state", True)),
+        entity_tags=[
+            {
+                "entity_id": 11,
+                "tag_id": tag_id,
+                "applied_at_world_time": _WORLD_TIME,
+                "source_kind": "skald_inline",
+                "cleared_at": None,
+            }
+        ],
+    )
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=11,
+        entity_kind="character",
+        bestowal=OrreryTagBestowal(tags_to_clear=["scrying_target"]),
+    )
+    assert counters["cleared"] == 1
+    assert cur.cleared_keys == [(11, tag_id)]
+
+
+def test_incompatible_category_silently_skipped():
+    cur = FakeCursor(tags=_registered(("safe_house", "place_affordance", False)))
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=42,
+        entity_kind="character",
+        bestowal=OrreryTagBestowal(applied_tags=["safe_house"]),
+    )
+    assert counters["applied"] == 0
+    assert counters["skipped_category"] == 1
+    assert cur.inserted_entity_tag_rows == []
+
+
+def test_unknown_tag_silently_skipped():
+    cur = FakeCursor(tags={})
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=42,
+        entity_kind="character",
+        bestowal=OrreryTagBestowal(applied_tags=["nonexistent_tag"]),
+    )
+    assert counters["applied"] == 0
+    assert counters["skipped_unknown"] == 1
+
+
+def test_canonical_alias_applied_as_canonical():
+    cur = FakeCursor(tags=_registered(("corporate_exile", "state", False)))
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=42,
+        entity_kind="character",
+        bestowal=OrreryTagBestowal(applied_tags=["corporate_defector"]),
+    )
+    assert counters["applied"] == 1
+    canonical_id = hash("corporate_exile") & 0xFFFFFF
+    assert cur.inserted_entity_tag_rows[0]["tag_id"] == canonical_id
+
+
+def test_none_bestowal_is_noop():
+    cur = FakeCursor()
+    counters = apply_tag_bestowal(
+        cur, entity_id=1, entity_kind="character", bestowal=None
+    )
+    assert counters == {
+        "applied": 0,
+        "proposed": 0,
+        "cleared": 0,
+        "skipped_category": 0,
+        "skipped_unknown": 0,
+    }
+
+
+def test_unknown_entity_kind_raises():
+    cur = FakeCursor()
+    with pytest.raises(ValueError, match="Unknown entity_kind"):
+        apply_tag_bestowal(
+            cur,
+            entity_id=1,
+            entity_kind="zombie",
+            bestowal=OrreryTagBestowal(),
+        )
+
+
+def test_faction_category_gating():
+    cur = FakeCursor(
+        tags=_registered(
+            ("militarized", "power_posture", False),
+            ("corporate_exile", "state", False),  # state is character-only
+        )
+    )
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=7,
+        entity_kind="faction",
+        bestowal=OrreryTagBestowal(applied_tags=["militarized", "corporate_exile"]),
+    )
+    assert counters["applied"] == 1
+    assert counters["skipped_category"] == 1

--- a/tests/test_wizard_agent.py
+++ b/tests/test_wizard_agent.py
@@ -176,6 +176,11 @@ def sample_seed_submission() -> StorySeedSubmission:
 def test_build_wizard_prompt_includes_trait_menu_and_accept_fate(monkeypatch):
     monkeypatch.setattr(wizard_module, "_load_base_prompt", lambda: "BASE")
     monkeypatch.setattr(wizard_module, "_load_trait_menu", lambda: "TRAIT MENU")
+    monkeypatch.setattr(
+        wizard_module,
+        "format_tag_library_for_prompt",
+        lambda _dbname: "TAG LIBRARY",
+    )
 
     context = make_context(phase="character")
     context.accept_fate = True
@@ -183,6 +188,7 @@ def test_build_wizard_prompt_includes_trait_menu_and_accept_fate(monkeypatch):
     prompt = build_wizard_prompt(SimpleNamespace(deps=context))
 
     assert "BASE" in prompt
+    assert "TAG LIBRARY" in prompt
     assert "Trait Reference" in prompt
     assert "TRAIT MENU" in prompt
     assert ACCEPT_FATE_SIGNAL in prompt


### PR DESCRIPTION
## Summary
- persist protagonist Orrery tag bestowal through the normalized new-story wizard cache
- reconcile baseline Orrery tag vocabulary drift across template/unlocked slots
- enrich dynamic tag-library prompt rendering with per-tag descriptions so Skald does not reuse lookalike tags incorrectly
- harden fresh-slot Orrery migration view recreation and structured trait phase detection

## Root Cause
Skald could generate `WildcardTrait.orrery_tags`, but the normalized wizard cache only stored the wildcard name and description. Transition rebuilt `CharacterSheet` from cache, so protagonist tag bestowal was discarded before `NewStoryDatabaseMapper.create_protagonist()` could apply it. A related phase-state bug wrote selected trait rows without setting `traits_confirmed`, leaving completed character phases routed back into character handling.

## Validation
- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery tests/test_new_story_cache.py tests/test_wizard_agent.py tests/test_lore/test_logon_prompt_formatting.py tests/test_lore/test_logon_lazy_init.py tests/test_logon_mock_integration.py tests/test_api/test_narrative_generation.py tests/test_api/test_lore_adapter.py -q`
- live slot 5 reset from `NEXUS_template`, wizard creation with `gpt-5.5`, transition, and bootstrap through `/api/narrative/continue`
- confirmed canonical protagonist tags: `obligation_magnet`, `debt_pulse_active`, `contacts_available`, `favor_bonded`
- confirmed bootstrap incubator text incorporated the wizard-derived debt/favor/obligation payload
