### PR TITLE
Harden live retrieval setup

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -114,6 +114,9 @@ enable_streaming = true
 debug = true
 agentic_sql = true  # Enable agent to generate SQL queries dynamically
 
+[lore.retrieval]
+fallback_query = "Recent narrative events"
+
 [lore.token_budget]
 # Context window limits for APEX generation
 apex_context_window = 75_000  # Total tokens available for APEX (includes prompt + context)

--- a/nexus/agents/lore/utils/local_llm.py
+++ b/nexus/agents/lore/utils/local_llm.py
@@ -177,6 +177,11 @@ class LocalLLMManager:
         # user explicitly opts out. This avoids re-loading 70B+/120B models on
         # every turn, which can add 45-90 seconds of startup latency.
         self.unload_on_exit: bool = bool(self.llm_config.get("unload_on_exit", False))
+        self.fallback_retrieval_query: str = (
+            settings.get("lore", {})
+            .get("retrieval", {})
+            .get("fallback_query", "Recent narrative events")
+        )
 
         if LMS_SDK_AVAILABLE:
             self._initialize_sdk_client()
@@ -583,7 +588,8 @@ Each query should be a complete question or search phrase."""
             )
 
             response = _extract_final_channel_text(response)
-            queries = _sanitize_retrieval_queries(response.splitlines())
+            query_candidates = list(response.splitlines())
+            queries = _sanitize_retrieval_queries(query_candidates)
 
             # Ensure we have between 3-5 queries
             if len(queries) < 3:
@@ -596,15 +602,11 @@ Each query should be a complete question or search phrase."""
                     fallback_candidates.append(f"What happened with {characters[0]}?")
                 if locations:
                     fallback_candidates.append(f"Past events at {locations[0]}")
-                queries.extend(_sanitize_retrieval_queries(fallback_candidates))
-
-            queries = _sanitize_retrieval_queries(queries)
-
-            # Limit to 5 queries
-            queries = queries[:5]
+                query_candidates.extend(fallback_candidates)
+                queries = _sanitize_retrieval_queries(query_candidates)
 
             logger.info(f"Generated {len(queries)} retrieval queries via text parsing")
-            return queries or ["Recent narrative events"]
+            return queries or [self.fallback_retrieval_query]
 
         except Exception as e:
             logger.error(f"Failed to generate retrieval queries: {e}")
@@ -620,7 +622,7 @@ Each query should be a complete question or search phrase."""
 
             # Ensure at least one query
             if not fallback_queries:
-                fallback_queries = ["Recent narrative events"]
+                fallback_queries = [self.fallback_retrieval_query]
 
             return fallback_queries
     

--- a/nexus/agents/lore/utils/local_llm.py
+++ b/nexus/agents/lore/utils/local_llm.py
@@ -7,6 +7,8 @@ Handles initialization and interaction with local language models via LM Studio 
 import logging
 import requests
 import json
+import re
+import unicodedata
 from typing import Optional, Dict, Any, List, Type, Union
 from typing import Literal
 from pathlib import Path
@@ -19,6 +21,42 @@ except ImportError:
     LMS_SDK_AVAILABLE = False
 
 logger = logging.getLogger("nexus.lore.local_llm")
+
+_LM_FINAL_CHANNEL_MARKERS = (
+    "<|channel|>final<|message|>",
+    "<|start_header_id|>assistant<|end_header_id|>",
+)
+_LM_CONTROL_TOKEN_RE = re.compile(r"<\|[^>]+?\|>")
+_QUERY_PREFIX_RE = re.compile(
+    r"^(?:query\s*)?(?:\d+[\.)]|[-*•])\s*|^query\s*\d*\s*:\s*",
+    re.IGNORECASE,
+)
+_META_QUERY_PREFIXES = (
+    "analysis ",
+    "based on the current narrative context",
+    "context analysis",
+    "each query should",
+    "format:",
+    "generate ",
+    "here are",
+    "key entities",
+    "let's ",
+    "locations:",
+    "no numbering",
+    "output exactly",
+    "the user wants",
+    "thus produce",
+    "user input",
+    "we need",
+    "we should",
+)
+_META_QUERY_FRAGMENTS = (
+    "complete question or search phrase",
+    "generate retrieval queries",
+    "generate queries",
+    "one per line",
+    "retrieval queries to search",
+)
 
 
 # Pydantic models for structured responses
@@ -51,6 +89,64 @@ class RetrievalQueries(BaseModel):
         max_length=5,
         description="Retrieval queries for finding relevant narrative context"
     )
+
+
+def _extract_final_channel_text(response: str) -> str:
+    """Prefer assistant final-channel text when a local model leaks chat markers."""
+    for marker in _LM_FINAL_CHANNEL_MARKERS:
+        if marker in response:
+            return response.rsplit(marker, 1)[-1]
+    return response
+
+
+def _clean_retrieval_query(query: Any) -> Optional[str]:
+    """Normalize one candidate retrieval query and reject instruction/meta text."""
+    if not isinstance(query, str):
+        return None
+
+    cleaned = unicodedata.normalize("NFKD", query)
+    cleaned = cleaned.replace("\xa0", " ").replace("…", "...")
+    cleaned = _LM_CONTROL_TOKEN_RE.sub(" ", cleaned)
+    cleaned = " ".join(cleaned.split()).strip()
+    cleaned = _QUERY_PREFIX_RE.sub("", cleaned).strip(" \"'`")
+
+    if len(cleaned) <= 10:
+        return None
+
+    lowered = cleaned.lower()
+    if lowered.startswith(_META_QUERY_PREFIXES):
+        return None
+    if any(fragment in lowered for fragment in _META_QUERY_FRAGMENTS):
+        return None
+    if not any(character.isalpha() for character in cleaned):
+        return None
+    if len(re.findall(r"[A-Za-z0-9]+", cleaned)) < 3:
+        return None
+
+    return cleaned
+
+
+def _sanitize_retrieval_queries(queries: List[Any], limit: int = 5) -> List[str]:
+    """Return deduplicated, MEMNON-safe retrieval queries."""
+    valid_queries: List[str] = []
+    seen: set[str] = set()
+
+    for query in queries:
+        cleaned = _clean_retrieval_query(query)
+        if not cleaned:
+            continue
+
+        key = cleaned.casefold()
+        if key in seen:
+            continue
+
+        valid_queries.append(cleaned)
+        seen.add(key)
+
+        if len(valid_queries) >= limit:
+            break
+
+    return valid_queries
 
 
 class LocalLLMManager:
@@ -445,20 +541,7 @@ Each query should be a complete search phrase that captures what information you
                 logger.debug(f"Structured output result type: {type(result)}")
                 logger.debug(f"Parsed queries: {queries}")
 
-                # Clean up and validate queries
-                import unicodedata
-                valid_queries = []
-                for q in queries:
-                    if q:
-                        # Clean up non-breaking spaces and other Unicode artifacts
-                        cleaned = unicodedata.normalize('NFKD', q)
-                        cleaned = cleaned.replace('\xa0', ' ')  # Replace non-breaking spaces
-                        cleaned = cleaned.replace('…', '...')  # Replace ellipsis character
-                        cleaned = ' '.join(cleaned.split())  # Normalize whitespace
-
-                        # Check if the cleaned query is valid
-                        if len(cleaned.strip()) > 10:  # Minimum meaningful query length
-                            valid_queries.append(cleaned)
+                valid_queries = _sanitize_retrieval_queries(queries)
 
                 if valid_queries:
                     logger.info(f"Generated {len(valid_queries)} valid retrieval queries via structured output")
@@ -499,38 +582,29 @@ Each query should be a complete question or search phrase."""
                 system_prompt=system_prompt
             )
 
-            # Parse the response into individual queries
-            queries = []
-            for line in response.split('\n'):
-                line = line.strip()
-                # Skip empty lines, numbering, and bullets
-                if not line:
-                    continue
-                # Remove common numbering/bullet formats
-                if line and line[0].isdigit() and (line[1] == '.' or line[1] == ')'):
-                    line = line[2:].strip()
-                elif line.startswith('-') or line.startswith('*'):
-                    line = line[1:].strip()
-
-                if line and len(line) > 10:  # Minimum meaningful query length
-                    queries.append(line)
+            response = _extract_final_channel_text(response)
+            queries = _sanitize_retrieval_queries(response.splitlines())
 
             # Ensure we have between 3-5 queries
             if len(queries) < 3:
                 # Fallback: add generic queries based on user input
                 logger.warning(f"Only generated {len(queries)} queries, adding fallbacks")
+                fallback_candidates = []
                 if user_input:
-                    queries.append(user_input)
+                    fallback_candidates.append(user_input)
                 if characters:
-                    queries.append(f"What happened with {characters[0]}?")
+                    fallback_candidates.append(f"What happened with {characters[0]}?")
                 if locations:
-                    queries.append(f"Past events at {locations[0]}")
+                    fallback_candidates.append(f"Past events at {locations[0]}")
+                queries.extend(_sanitize_retrieval_queries(fallback_candidates))
+
+            queries = _sanitize_retrieval_queries(queries)
 
             # Limit to 5 queries
             queries = queries[:5]
 
             logger.info(f"Generated {len(queries)} retrieval queries via text parsing")
-            return queries
+            return queries or ["Recent narrative events"]
 
         except Exception as e:
             logger.error(f"Failed to generate retrieval queries: {e}")
@@ -542,6 +616,7 @@ Each query should be a complete question or search phrase."""
                 fallback_queries.append(f"Past events involving {characters[0]}")
             if locations:
                 fallback_queries.append(f"History of {locations[0]}")
+            fallback_queries = _sanitize_retrieval_queries(fallback_queries)
 
             # Ensure at least one query
             if not fallback_queries:

--- a/nexus/agents/lore/utils/local_llm.py
+++ b/nexus/agents/lore/utils/local_llm.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 
 try:
     import lmstudio as lms
+
     LMS_SDK_AVAILABLE = True
 except ImportError:
     LMS_SDK_AVAILABLE = False
@@ -62,15 +63,23 @@ _META_QUERY_FRAGMENTS = (
 # Pydantic models for structured responses
 class NarrativeAnalysis(BaseModel):
     """Structured analysis of narrative context"""
+
     characters: List[str] = Field(description="Character names mentioned or relevant")
     locations: List[str] = Field(description="Locations mentioned or relevant")
-    context_type: str = Field(description="Type of narrative context: dialogue/action/exploration/transition")
-    entities_for_retrieval: List[str] = Field(description="Key entities needing deeper context retrieval")
-    confidence_score: float = Field(default=0.8, description="Confidence in the analysis")
+    context_type: str = Field(
+        description="Type of narrative context: dialogue/action/exploration/transition"
+    )
+    entities_for_retrieval: List[str] = Field(
+        description="Key entities needing deeper context retrieval"
+    )
+    confidence_score: float = Field(
+        default=0.8, description="Confidence in the analysis"
+    )
 
 
 class QAResponse(BaseModel):
     """Structured Q&A response for LORE synthesis"""
+
     answer: str
     reasoning: str
     cited_chunk_ids: List[int] = Field(default_factory=list)
@@ -78,16 +87,18 @@ class QAResponse(BaseModel):
 
 class SQLStep(BaseModel):
     """Structured planner step for agentic SQL."""
+
     action: Literal["sql", "final"]
     sql: Optional[str] = None
 
 
 class RetrievalQueries(BaseModel):
     """Structured retrieval query generation for Phase 4"""
+
     queries: List[str] = Field(
         min_length=3,
         max_length=5,
-        description="Retrieval queries for finding relevant narrative context"
+        description="Retrieval queries for finding relevant narrative context",
     )
 
 
@@ -97,6 +108,39 @@ def _extract_final_channel_text(response: str) -> str:
         if marker in response:
             return response.rsplit(marker, 1)[-1]
     return response
+
+
+def _parse_structured_json_text(response: str) -> Optional[Dict[str, Any]]:
+    """Extract a JSON object from local-model text, including leaked chat wrappers."""
+    final_text = _extract_final_channel_text(response).strip()
+    if not final_text:
+        return None
+
+    decoder = json.JSONDecoder()
+    candidates = [final_text]
+    candidates.append(_LM_CONTROL_TOKEN_RE.sub(" ", final_text).strip())
+
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            return parsed
+
+        for index, character in enumerate(candidate):
+            if character != "{":
+                continue
+            try:
+                parsed, _end = decoder.raw_decode(candidate[index:])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                return parsed
+
+    return None
 
 
 def _clean_retrieval_query(query: Any) -> Optional[str]:
@@ -151,27 +195,36 @@ def _sanitize_retrieval_queries(queries: List[Any], limit: int = 5) -> List[str]
 
 class LocalLLMManager:
     """Manages local LLM for LORE's reasoning capabilities via LM Studio SDK"""
-    
-    def __init__(self, settings: Dict[str, Any], settings_path: Optional[Path] = None, system_prompt: Optional[str] = None):
+
+    def __init__(
+        self,
+        settings: Dict[str, Any],
+        settings_path: Optional[Path] = None,
+        system_prompt: Optional[str] = None,
+    ):
         """Initialize with LLM configuration from settings"""
         self.settings = settings
         self.settings_path = settings_path
-        self.llm_config = settings.get("Agent Settings", {}).get("LORE", {}).get("llm", {})
+        self.llm_config = (
+            settings.get("Agent Settings", {}).get("LORE", {}).get("llm", {})
+        )
         self.system_prompt = system_prompt  # Store the system prompt for use in queries
-        
+
         # LM Studio configuration
         self.base_url = self.llm_config.get("lmstudio_url", "http://localhost:1234/v1")
         self.model_name = self.llm_config.get("model_name", "local-model")
-        self.required_model = self.llm_config.get("required_model", None)  # Specific model to load if needed
-        
+        self.required_model = self.llm_config.get(
+            "required_model", None
+        )  # Specific model to load if needed
+
         # Model path for reference (models stored in ~/.lmstudio/models)
         self.models_dir = Path.home() / ".lmstudio" / "models"
-        
+
         # Initialize LM Studio client if SDK available
         self.client = None
         self.model = None
         self.loaded_model_id = None
-        
+
         # Whether to unload model on object deletion
         # During active development we keep the local model resident unless the
         # user explicitly opts out. This avoids re-loading 70B+/120B models on
@@ -188,7 +241,7 @@ class LocalLLMManager:
         else:
             logger.warning("LM Studio SDK not available, falling back to HTTP requests")
             self._verify_connection()
-    
+
     def _initialize_sdk_client(self):
         """Initialize LM Studio SDK client - FAILS HARD if not available"""
         try:
@@ -199,32 +252,41 @@ class LocalLLMManager:
                 .replace("/v1", "")
                 .strip("/")
             )
-            
+
             # Configure default client (idempotent)
             try:
                 lms.configure_default_client(host)
             except Exception as e:
                 if "Default client is already created" in str(e):
-                    logger.debug("Default LM Studio client already configured; reusing existing client")
+                    logger.debug(
+                        "Default LM Studio client already configured; reusing existing client"
+                    )
                 else:
                     raise
-            
+
             # Use model manager to ensure correct model is loaded
             from nexus.llm import ModelManager
-            manager = ModelManager(self.settings_path, unload_on_exit=self.unload_on_exit)
+
+            manager = ModelManager(
+                self.settings_path, unload_on_exit=self.unload_on_exit
+            )
             model_id = manager.ensure_default_model()
-            
+
             # Get the model handle - already loaded by manager
             self.model = lms.llm()
             self.loaded_model_id = model_id
-            
-            logger.info(f"LM Studio SDK initialized successfully with model: {self.loaded_model_id}")
-            
+
+            logger.info(
+                f"LM Studio SDK initialized successfully with model: {self.loaded_model_id}"
+            )
+
         except Exception as e:
-            raise RuntimeError(f"FATAL: Cannot initialize LM Studio SDK!\n"
-                             f"Error: {e}\n"
-                             f"ACTION REQUIRED: Start LM Studio and ensure a model is available")
-    
+            raise RuntimeError(
+                f"FATAL: Cannot initialize LM Studio SDK!\n"
+                f"Error: {e}\n"
+                f"ACTION REQUIRED: Start LM Studio and ensure a model is available"
+            )
+
     def _verify_connection(self):
         """Verify connection to LM Studio API - FAILS HARD if not available (fallback method)"""
         if not LMS_SDK_AVAILABLE:
@@ -233,42 +295,60 @@ class LocalLLMManager:
                 if response.status_code == 200:
                     models = response.json().get("data", [])
                     if not models:
-                        raise RuntimeError(f"LM Studio is running but NO MODELS are loaded! Load a model in LM Studio first.")
-                    logger.info(f"Connected to LM Studio (HTTP). Available models: {[m['id'] for m in models]}")
+                        raise RuntimeError(
+                            f"LM Studio is running but NO MODELS are loaded! Load a model in LM Studio first."
+                        )
+                    logger.info(
+                        f"Connected to LM Studio (HTTP). Available models: {[m['id'] for m in models]}"
+                    )
                     return True
                 else:
-                    raise RuntimeError(f"LM Studio API returned status {response.status_code}. Is the server running?")
+                    raise RuntimeError(
+                        f"LM Studio API returned status {response.status_code}. Is the server running?"
+                    )
             except requests.exceptions.RequestException as e:
-                raise RuntimeError(f"FATAL: Cannot connect to LM Studio API at {self.base_url}!\n"
-                                 f"Error: {e}\n"
-                                 f"ACTION REQUIRED: Start LM Studio and enable the local server on port 1234")
+                raise RuntimeError(
+                    f"FATAL: Cannot connect to LM Studio API at {self.base_url}!\n"
+                    f"Error: {e}\n"
+                    f"ACTION REQUIRED: Start LM Studio and enable the local server on port 1234"
+                )
         return True
-    
-    def query(self, 
-              prompt: str, 
-              temperature: Optional[float] = None, 
-              max_tokens: Optional[int] = None,
-              system_prompt: Optional[str] = None) -> str:
+
+    def query(
+        self,
+        prompt: str,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        system_prompt: Optional[str] = None,
+    ) -> str:
         """
         Query the local LLM via LM Studio SDK or API.
         FAILS HARD if LM Studio is not available.
-        
+
         Args:
             prompt: The prompt to send to the LLM
             temperature: Optional temperature override
             max_tokens: Optional max tokens override
             system_prompt: Optional system prompt
-            
+
         Returns:
             LLM response as string
-        
+
         Raises:
             RuntimeError: If LM Studio is not available or query fails
         """
         # Use provided parameters or fall back to config
-        temp = temperature if temperature is not None else self.llm_config.get("temperature", 0.7)
-        max_tok = max_tokens if max_tokens is not None else self.llm_config.get("max_tokens", 2048)
-        
+        temp = (
+            temperature
+            if temperature is not None
+            else self.llm_config.get("temperature", 0.7)
+        )
+        max_tok = (
+            max_tokens
+            if max_tokens is not None
+            else self.llm_config.get("max_tokens", 2048)
+        )
+
         if LMS_SDK_AVAILABLE and self.model:
             # Use SDK for cleaner API
             try:
@@ -278,78 +358,88 @@ class LocalLLMManager:
                 elif self.system_prompt:
                     effective_prompt = self.system_prompt
                 else:
-                    raise RuntimeError("FATAL: No system prompt available for LLM query!")
+                    raise RuntimeError(
+                        "FATAL: No system prompt available for LLM query!"
+                    )
                 chat = lms.Chat(effective_prompt)
                 chat.add_user_message(prompt)
-                
+
                 config = {
                     "temperature": temp,
                     "maxTokens": max_tok,
                     "topP": self.llm_config.get("top_p", 0.9),
-                    "contextLength": self.llm_config.get("context_window", 65536)
+                    "contextLength": self.llm_config.get("context_window", 65536),
                 }
-                
+
                 # Add reasoning effort for GPT-OSS models
                 if "gpt-oss" in str(self.loaded_model_id).lower():
                     # Get reasoning effort from settings or use high for Q&A
                     reasoning_effort = self.llm_config.get("reasoning_effort", "high")
                     config["reasoning"] = {"effort": reasoning_effort}
-                    logger.debug(f"Using {reasoning_effort} reasoning effort for GPT-OSS model")
-                
+                    logger.debug(
+                        f"Using {reasoning_effort} reasoning effort for GPT-OSS model"
+                    )
+
                 # Debug log the config being sent
                 logger.debug(f"LLM query config: {config}")
                 logger.debug(f"Prompt length: {len(prompt)} chars")
-                
+
                 result = self.model.respond(chat, config=config)
-                
+
                 return result.content.strip()
-                
+
             except Exception as e:
-                raise RuntimeError(f"FATAL: LM Studio SDK query failed!\nError: {e}\nPrompt was: {prompt[:100]}...")
-        
+                raise RuntimeError(
+                    f"FATAL: LM Studio SDK query failed!\nError: {e}\nPrompt was: {prompt[:100]}..."
+                )
+
         else:
             # Fallback to HTTP requests
             messages = []
             if system_prompt:
                 messages.append({"role": "system", "content": system_prompt})
             messages.append({"role": "user", "content": prompt})
-            
+
             payload = {
                 "model": self.model_name,
                 "messages": messages,
                 "temperature": temp,
                 "max_tokens": max_tok,
                 "top_p": self.llm_config.get("top_p", 0.9),
-                "stream": False
+                "stream": False,
             }
-            
+
             try:
                 response = requests.post(
                     f"{self.base_url}/chat/completions",
                     json=payload,
                     headers={"Content-Type": "application/json"},
-                    timeout=60
+                    timeout=60,
                 )
-                
+
                 if response.status_code == 200:
                     result = response.json()
                     return result["choices"][0]["message"]["content"].strip()
                 else:
-                    raise RuntimeError(f"LM Studio API error {response.status_code}: {response.text}")
-                    
+                    raise RuntimeError(
+                        f"LM Studio API error {response.status_code}: {response.text}"
+                    )
+
             except requests.exceptions.RequestException as e:
-                raise RuntimeError(f"FATAL: LM Studio query failed!\nError: {e}\nPrompt was: {prompt[:100]}...")
-    
-    def analyze_narrative_context(self, 
-                                  warm_slice: List[Dict], 
-                                  user_input: str) -> Dict[str, Any]:
+                raise RuntimeError(
+                    f"FATAL: LM Studio query failed!\nError: {e}\nPrompt was: {prompt[:100]}..."
+                )
+
+    def analyze_narrative_context(
+        self, warm_slice: List[Dict], user_input: str
+    ) -> Dict[str, Any]:
         """
         Analyze narrative context to identify entities and context type.
-        
+
         Args:
             warm_slice: List of recent narrative chunks
             user_input: User's input
-            
+
         Returns:
             Analysis results dictionary
         """
@@ -358,30 +448,34 @@ class LocalLLMManager:
 
         # REQUIRE the system prompt - fail hard if not loaded
         if not self.system_prompt:
-            raise RuntimeError("FATAL: LORE system prompt not loaded! Cannot perform narrative analysis without proper instructions.")
+            raise RuntimeError(
+                "FATAL: LORE system prompt not loaded! Cannot perform narrative analysis without proper instructions."
+            )
         system_prompt = self.system_prompt
-        
+
         if LMS_SDK_AVAILABLE and self.model:
             # Use structured output for clean parsing
             try:
                 chat = lms.Chat(system_prompt)
-                chat.add_user_message(f"""Analyze the following narrative context and user input.
+                chat.add_user_message(
+                    f"""Analyze the following narrative context and user input.
 
 Recent narrative:
 {warm_text}
 
 User input: {user_input}
 
-Provide a structured analysis of characters, locations, context type, and entities needing retrieval.""")
-                
+Provide a structured analysis of characters, locations, context type, and entities needing retrieval."""
+                )
+
                 result = self.model.respond(
                     chat,
                     response_format=NarrativeAnalysis,
                     config={
                         "temperature": 0.3,
                         "maxTokens": 500,
-                        "contextLength": self.llm_config.get("context_window", 65536)
-                    }
+                        "contextLength": self.llm_config.get("context_window", 65536),
+                    },
                 )
 
                 # Convert structured output to dict safely
@@ -394,25 +488,37 @@ Provide a structured analysis of characters, locations, context type, and entiti
                                 "characters": analysis.get("characters", []),
                                 "locations": analysis.get("locations", []),
                                 "context_type": analysis.get("context_type", "unknown"),
-                                "entities_for_retrieval": analysis.get("entities_for_retrieval", []),
-                                "confidence_score": analysis.get("confidence_score", 0.8),
+                                "entities_for_retrieval": analysis.get(
+                                    "entities_for_retrieval", []
+                                ),
+                                "confidence_score": analysis.get(
+                                    "confidence_score", 0.8
+                                ),
                             }
                         else:
                             return {
                                 "characters": getattr(analysis, "characters", []),
                                 "locations": getattr(analysis, "locations", []),
-                                "context_type": getattr(analysis, "context_type", "unknown"),
-                                "entities_for_retrieval": getattr(analysis, "entities_for_retrieval", []),
-                                "confidence_score": getattr(analysis, "confidence_score", 0.8),
+                                "context_type": getattr(
+                                    analysis, "context_type", "unknown"
+                                ),
+                                "entities_for_retrieval": getattr(
+                                    analysis, "entities_for_retrieval", []
+                                ),
+                                "confidence_score": getattr(
+                                    analysis, "confidence_score", 0.8
+                                ),
                             }
                 except Exception as e:
                     logger.error(f"Error processing structured analysis: {e}")
                     # Fall through to text parsing
-                
+
             except Exception as e:
-                logger.error(f"SDK structured analysis failed: {e}, falling back to text parsing")
+                logger.error(
+                    f"SDK structured analysis failed: {e}, falling back to text parsing"
+                )
                 # Fall through to text parsing
-        
+
         # Fallback to text parsing (for non-SDK or if structured output fails)
         prompt = f"""Analyze the following narrative context and user input.
 
@@ -428,21 +534,23 @@ Identify:
 4. KEY_ENTITIES: [Entities needing deeper context retrieval]
 
 Response format - use exact headers:"""
-        
-        response = self.query(prompt, temperature=0.3, max_tokens=500, system_prompt=system_prompt)
-        
+
+        response = self.query(
+            prompt, temperature=0.3, max_tokens=500, system_prompt=system_prompt
+        )
+
         # Parse the response
         result = {
             "characters": [],
             "locations": [],
             "context_type": "unknown",
-            "entities_for_retrieval": []
+            "entities_for_retrieval": [],
         }
-        
+
         try:
-            lines = response.split('\n')
+            lines = response.split("\n")
             current_section = None
-            
+
             for line in lines:
                 line = line.strip()
                 if "CHARACTER:" in line:
@@ -463,12 +571,12 @@ Response format - use exact headers:"""
                         result[current_section].append(line)
         except Exception as e:
             logger.error(f"Error parsing LLM analysis: {e}")
-        
+
         return result
-    
-    def generate_retrieval_queries(self,
-                                   context_analysis: Dict[str, Any],
-                                   user_input: str) -> List[str]:
+
+    def generate_retrieval_queries(
+        self, context_analysis: Dict[str, Any], user_input: str
+    ) -> List[str]:
         """
         Generate targeted retrieval queries based on context analysis.
 
@@ -491,14 +599,17 @@ Response format - use exact headers:"""
         # Build a prompt for query generation
         # REQUIRE the system prompt - fail hard if not loaded
         if not self.system_prompt:
-            raise RuntimeError("FATAL: LORE system prompt not loaded! Cannot generate retrieval queries without proper instructions.")
+            raise RuntimeError(
+                "FATAL: LORE system prompt not loaded! Cannot generate retrieval queries without proper instructions."
+            )
         system_prompt = self.system_prompt
 
         if LMS_SDK_AVAILABLE and self.model:
             # Use structured output for clean, validated queries
             try:
                 chat = lms.Chat(system_prompt)
-                chat.add_user_message(f"""Generate retrieval queries to search for relevant past events, character history, or world information.
+                chat.add_user_message(
+                    f"""Generate retrieval queries to search for relevant past events, character history, or world information.
 
 User input: {user_input}
 
@@ -514,7 +625,8 @@ Generate 3-5 specific queries that would retrieve:
 3. Character relationships and interactions
 4. Background information on key entities
 
-Each query should be a complete search phrase that captures what information you're looking for.""")
+Each query should be a complete search phrase that captures what information you're looking for."""
+                )
 
                 result = self.model.respond(
                     chat,
@@ -524,8 +636,8 @@ Each query should be a complete search phrase that captures what information you
                         "maxTokens": 300,
                         "topP": 0.9,
                         "contextLength": 65536,
-                        "reasoning": {"effort": "high"}
-                    }
+                        "reasoning": {"effort": "high"},
+                    },
                 )
 
                 # Access the parsed result correctly
@@ -549,14 +661,20 @@ Each query should be a complete search phrase that captures what information you
                 valid_queries = _sanitize_retrieval_queries(queries)
 
                 if valid_queries:
-                    logger.info(f"Generated {len(valid_queries)} valid retrieval queries via structured output")
+                    logger.info(
+                        f"Generated {len(valid_queries)} valid retrieval queries via structured output"
+                    )
                     return valid_queries
                 else:
-                    logger.warning("Structured output returned only empty/invalid queries, falling back to text parsing")
+                    logger.warning(
+                        "Structured output returned only empty/invalid queries, falling back to text parsing"
+                    )
                     raise ValueError("Invalid structured output")
 
             except Exception as e:
-                logger.warning(f"SDK structured output failed: {e}, falling back to text parsing")
+                logger.warning(
+                    f"SDK structured output failed: {e}, falling back to text parsing"
+                )
                 # Fall through to text parsing approach
 
         # Fallback: Use text parsing with the regular query method
@@ -583,8 +701,8 @@ Each query should be a complete question or search phrase."""
             response = self.query(
                 prompt=prompt,
                 temperature=0.5,  # Moderate creativity
-                max_tokens=300,   # Keep it concise
-                system_prompt=system_prompt
+                max_tokens=300,  # Keep it concise
+                system_prompt=system_prompt,
             )
 
             response = _extract_final_channel_text(response)
@@ -594,7 +712,9 @@ Each query should be a complete question or search phrase."""
             # Ensure we have between 3-5 queries
             if len(queries) < 3:
                 # Fallback: add generic queries based on user input
-                logger.warning(f"Only generated {len(queries)} queries, adding fallbacks")
+                logger.warning(
+                    f"Only generated {len(queries)} queries, adding fallbacks"
+                )
                 fallback_candidates = []
                 if user_input:
                     fallback_candidates.append(user_input)
@@ -625,89 +745,102 @@ Each query should be a complete question or search phrase."""
                 fallback_queries = [self.fallback_retrieval_query]
 
             return fallback_queries
-    
+
     def is_available(self) -> bool:
         """Check if local LLM is available via LM Studio"""
         if LMS_SDK_AVAILABLE and self.model:
             return True
         return self._verify_connection()
-    
+
     def _check_and_manage_loaded_model(self):
         """Check what model is loaded and manage lifecycle"""
         try:
             import requests
+
             response = requests.get(f"{self.base_url}/models", timeout=5)
             if response.status_code == 200:
                 models = response.json().get("data", [])
                 if not models:
                     raise RuntimeError("No models loaded in LM Studio!")
-                
+
                 # Get currently loaded model
                 current_model = models[0]["id"] if models else None
                 self.loaded_model_id = current_model
-                
+
                 # Check if we need a specific model
                 if self.required_model and current_model != self.required_model:
-                    logger.info(f"Current model {current_model} != required {self.required_model}")
+                    logger.info(
+                        f"Current model {current_model} != required {self.required_model}"
+                    )
                     # In production, we could unload and load the right model
                     # For now, just log the mismatch
-                    logger.warning(f"Required model {self.required_model} not loaded, using {current_model}")
-                
+                    logger.warning(
+                        f"Required model {self.required_model} not loaded, using {current_model}"
+                    )
+
                 logger.info(f"Using loaded model: {current_model}")
-                
+
         except Exception as e:
             logger.error(f"Failed to check loaded models: {e}")
             raise
-    
+
     def unload_model(self):
         """Unload the current model to free resources"""
         if LMS_SDK_AVAILABLE and self.model:
             try:
                 # Use model manager for proper unloading
                 from nexus.llm import ModelManager
-                manager = ModelManager(self.settings_path, unload_on_exit=self.unload_on_exit)
+
+                manager = ModelManager(
+                    self.settings_path, unload_on_exit=self.unload_on_exit
+                )
                 if manager.unload_model():
                     logger.info(f"Unloaded model: {self.loaded_model_id}")
                 else:
                     logger.warning("Model unload may have failed")
-                    
+
                 self.model = None
                 self.loaded_model_id = None
-                
+
             except Exception as e:
                 logger.error(f"Failed to unload model: {e}")
-    
+
     def ensure_model_loaded(self):
         """Ensure the required model is loaded"""
         if self.required_model and self.loaded_model_id != self.required_model:
-            logger.warning(f"Model mismatch! Expected {self.required_model} but {self.loaded_model_id} is loaded.")
-            logger.warning(f"Please load {self.required_model} in LM Studio before proceeding.")
+            logger.warning(
+                f"Model mismatch! Expected {self.required_model} but {self.loaded_model_id} is loaded."
+            )
+            logger.warning(
+                f"Please load {self.required_model} in LM Studio before proceeding."
+            )
             # In production, we'd fail hard here, but for testing we continue
             # raise RuntimeError(f"Wrong model loaded! Please load {self.required_model} in LM Studio")
-    
+
     def __del__(self):
         """Cleanup on deletion - unload any loaded models"""
-        if self.unload_on_exit and hasattr(self, 'model') and self.model:
+        if self.unload_on_exit and hasattr(self, "model") and self.model:
             try:
                 self.unload_model()
             except:
                 pass  # Best effort cleanup
-    
+
     def __enter__(self):
         """Context manager entry - ensure model is loaded"""
         self.ensure_model_loaded()
         return self
-    
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Context manager exit - clean up resources"""
         if self.unload_on_exit:
             self.unload_model()
         return False
-    
+
     def list_available_models(self) -> List[str]:
         """List models available in LM Studio"""
         try:
             import requests
+
             response = requests.get(f"{self.base_url}/models", timeout=5)
             if response.status_code == 200:
                 models = response.json().get("data", [])
@@ -730,22 +863,34 @@ Each query should be a complete question or search phrase."""
         Falls back to plain text JSON parsing with `query()` when SDK structured mode is unavailable.
         """
         if LMS_SDK_AVAILABLE and self.model:
-            chat = lms.Chat(system_prompt or "You are LORE, a narrative intelligence system.")
+            chat = lms.Chat(
+                system_prompt or "You are LORE, a narrative intelligence system."
+            )
             chat.add_user_message(prompt)
             try:
                 config = {
-                    "temperature": temperature if temperature is not None else self.llm_config.get("temperature", 0.3),
-                    "maxTokens": max_tokens if max_tokens is not None else self.llm_config.get("max_tokens", 1024),
+                    "temperature": (
+                        temperature
+                        if temperature is not None
+                        else self.llm_config.get("temperature", 0.3)
+                    ),
+                    "maxTokens": (
+                        max_tokens
+                        if max_tokens is not None
+                        else self.llm_config.get("max_tokens", 1024)
+                    ),
                     "topP": self.llm_config.get("top_p", 0.9),
-                    "contextLength": self.llm_config.get("context_window", 65536)
+                    "contextLength": self.llm_config.get("context_window", 65536),
                 }
-                
+
                 # Add reasoning effort for GPT-OSS models in structured queries too
                 if "gpt-oss" in str(self.loaded_model_id).lower():
                     reasoning_effort = self.llm_config.get("reasoning_effort", "high")
                     config["reasoning"] = {"effort": reasoning_effort}
-                    logger.debug(f"Using {reasoning_effort} reasoning effort for structured query")
-                
+                    logger.debug(
+                        f"Using {reasoning_effort} reasoning effort for structured query"
+                    )
+
                 result = self.model.respond(
                     chat,
                     response_format=response_model,
@@ -754,16 +899,26 @@ Each query should be a complete question or search phrase."""
                 if hasattr(result, "parsed") and result.parsed is not None:
                     return result.parsed
             except Exception as e:
-                logger.error(f"SDK structured_query failed: {e}; falling back to JSON parsing")
+                logger.error(
+                    f"SDK structured_query failed: {e}; falling back to JSON parsing"
+                )
 
         # Fallback: call plain query with JSON instructions and parse
-        raw = self.query(prompt, temperature=temperature, max_tokens=max_tokens, system_prompt=system_prompt)
-        try:
-            data = json.loads(raw)
+        raw = self.query(
+            prompt,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            system_prompt=system_prompt,
+        )
+        data = _parse_structured_json_text(raw)
+        if data is not None:
             return data
-        except Exception:
-            # Return raw content in a dict-like shape
-            return {"answer": raw, "reasoning": "unstructured"}
+
+        # Return raw content in a dict-like shape
+        return {
+            "answer": _extract_final_channel_text(raw).strip(),
+            "reasoning": "unstructured",
+        }
 
     async def structured_query_async(
         self,
@@ -795,12 +950,16 @@ Each query should be a complete question or search phrase."""
                 },
                 {"role": "user", "content": prompt_with_schema},
             ],
-            "temperature": temperature
-            if temperature is not None
-            else self.llm_config.get("temperature", 0.3),
-            "max_tokens": max_tokens
-            if max_tokens is not None
-            else self.llm_config.get("max_tokens", 1024),
+            "temperature": (
+                temperature
+                if temperature is not None
+                else self.llm_config.get("temperature", 0.3)
+            ),
+            "max_tokens": (
+                max_tokens
+                if max_tokens is not None
+                else self.llm_config.get("max_tokens", 1024)
+            ),
             "response_format": {
                 "type": "json_schema",
                 "json_schema": {

--- a/nexus/agents/lore/utils/local_llm.py
+++ b/nexus/agents/lore/utils/local_llm.py
@@ -58,6 +58,11 @@ _META_QUERY_FRAGMENTS = (
     "one per line",
     "retrieval queries to search",
 )
+_GENERIC_RETRIEVAL_QUERIES = {
+    "background info on key entities",
+    "character relationships and interactions",
+    "relevant past events involving these characters",
+}
 
 
 # Pydantic models for structured responses
@@ -158,6 +163,15 @@ def _clean_retrieval_query(query: Any) -> Optional[str]:
         return None
 
     lowered = cleaned.lower()
+    normalized_lowered = lowered.rstrip(" .:")
+    if normalized_lowered in _GENERIC_RETRIEVAL_QUERIES:
+        return None
+    if cleaned.startswith(("{", "[")):
+        return None
+    if lowered.startswith(("select ", "with ")):
+        return None
+    if '"action"' in lowered or '"sql"' in lowered:
+        return None
     if lowered.startswith(_META_QUERY_PREFIXES):
         return None
     if any(fragment in lowered for fragment in _META_QUERY_FRAGMENTS):

--- a/nexus/agents/memnon/utils/db_access.py
+++ b/nexus/agents/memnon/utils/db_access.py
@@ -803,9 +803,13 @@ def setup_database_indexes(db_url: str) -> bool:
 
                 # Create vector indexes for existing dimension-specific tables only.
                 for dim_table in _list_existing_embedding_tables(cursor):
+                    dimensions = parse_embedding_table_dimensions(dim_table)
+                    if dimensions is None:
+                        raise ValueError(
+                            f"Cannot parse dimensions from table name: {dim_table!r}"
+                        )
                     try:
-                        dimensions = parse_embedding_table_dimensions(dim_table)
-                        if dimensions and not supports_pgvector_ann_index(dimensions):
+                        if not supports_pgvector_ann_index(dimensions):
                             logger.info(
                                 "Skipping ANN vector index for %s: pgvector "
                                 "supports HNSW/IVFFlat indexes up to %sd "

--- a/nexus/agents/memnon/utils/db_access.py
+++ b/nexus/agents/memnon/utils/db_access.py
@@ -11,7 +11,12 @@ import psycopg2
 from typing import Dict, List, Tuple, Optional, Union, Any
 from urllib.parse import urlparse
 
-from .embedding_tables import resolve_dimension_table
+from .embedding_tables import (
+    PGVECTOR_ANN_INDEX_MAX_DIMENSIONS,
+    parse_embedding_table_dimensions,
+    resolve_dimension_table,
+    supports_pgvector_ann_index,
+)
 
 # Set up logging
 logger = logging.getLogger("nexus.memnon.db_access")
@@ -799,6 +804,17 @@ def setup_database_indexes(db_url: str) -> bool:
                 # Create vector indexes for existing dimension-specific tables only.
                 for dim_table in _list_existing_embedding_tables(cursor):
                     try:
+                        dimensions = parse_embedding_table_dimensions(dim_table)
+                        if dimensions and not supports_pgvector_ann_index(dimensions):
+                            logger.info(
+                                "Skipping ANN vector index for %s: pgvector "
+                                "supports HNSW/IVFFlat indexes up to %sd "
+                                "locally, and exact search remains available",
+                                dim_table,
+                                PGVECTOR_ANN_INDEX_MAX_DIMENSIONS,
+                            )
+                            continue
+
                         # Check for existing HNSW index
                         cursor.execute(
                             f"""

--- a/nexus/agents/memnon/utils/embedding_tables.py
+++ b/nexus/agents/memnon/utils/embedding_tables.py
@@ -9,6 +9,9 @@ from sqlalchemy import text
 from sqlalchemy.engine import Connection
 
 EMBEDDING_TABLE_PATTERN = re.compile(r"^chunk_embeddings_(?P<dimensions>\d+)d$")
+
+# pgvector 0.8.x caps HNSW/IVFFlat indexes at 2000 dimensions in this local
+# deployment. Higher-dimensional tables still support exact vector search.
 PGVECTOR_ANN_INDEX_MAX_DIMENSIONS = 2000
 
 # Historical dimensions that may exist in older slots. New dimensions should not

--- a/nexus/agents/memnon/utils/embedding_tables.py
+++ b/nexus/agents/memnon/utils/embedding_tables.py
@@ -9,6 +9,7 @@ from sqlalchemy import text
 from sqlalchemy.engine import Connection
 
 EMBEDDING_TABLE_PATTERN = re.compile(r"^chunk_embeddings_(?P<dimensions>\d+)d$")
+PGVECTOR_ANN_INDEX_MAX_DIMENSIONS = 2000
 
 # Historical dimensions that may exist in older slots. New dimensions should not
 # be added here; table names are generated from the model output dimensionality.
@@ -36,6 +37,11 @@ def parse_embedding_table_dimensions(table_name: str) -> Optional[int]:
     if not match:
         return None
     return int(match.group("dimensions"))
+
+
+def supports_pgvector_ann_index(dimensions: int) -> bool:
+    """Return whether pgvector ANN indexes support ``dimensions`` locally."""
+    return 0 < dimensions <= PGVECTOR_ANN_INDEX_MAX_DIMENSIONS
 
 
 def list_embedding_tables(connection: Connection) -> List[str]:

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -12,7 +12,10 @@ import psycopg2
 from psycopg2.extras import RealDictCursor
 from pydantic import BaseModel, Field, ValidationError
 
-from nexus.agents.lore.utils.local_llm import LocalLLMManager
+from nexus.agents.lore.utils.local_llm import (
+    LocalLLMManager,
+    _parse_structured_json_text,
+)
 from nexus.config import load_settings_as_dict
 
 logger = logging.getLogger("nexus.orrery.worker")
@@ -568,12 +571,46 @@ def _promotion_verdict(manager: Any, row: Mapping[str, Any]) -> PromotionVerdict
         max_tokens=512,
         system_prompt=PROMOTION_SYSTEM_PROMPT,
     )
+    return _coerce_promotion_verdict(raw)
+
+
+def _structured_payload_from_raw(raw: Any) -> Any:
+    """Recover structured JSON when a local model leaks chat text wrappers."""
+    if isinstance(raw, Mapping):
+        answer = raw.get("answer")
+        if isinstance(answer, str):
+            parsed = _parse_structured_json_text(answer)
+            if parsed is not None:
+                return parsed
+    elif isinstance(raw, str):
+        parsed = _parse_structured_json_text(raw)
+        if parsed is not None:
+            return parsed
+    return raw
+
+
+def _coerce_promotion_verdict(raw: Any) -> PromotionVerdict:
+    """Return a conservative promotion verdict from noisy local-model output."""
     try:
         if isinstance(raw, PromotionVerdict):
             return raw
-        return PromotionVerdict.model_validate(raw)
+        payload = _structured_payload_from_raw(raw)
+        if isinstance(payload, Mapping) and "promote" in payload:
+            payload = dict(payload)
+            payload.setdefault(
+                "reason", "Local model returned a bare promotion decision."
+            )
+        return PromotionVerdict.model_validate(payload)
     except ValidationError as exc:
-        raise ValueError(f"Malformed Orrery promotion verdict: {raw}") from exc
+        logger.warning(
+            "Malformed Orrery promotion verdict; skipping conservatively: %s",
+            raw,
+            exc_info=True,
+        )
+        return PromotionVerdict(
+            promote=False,
+            reason="Malformed local promotion verdict; skipped conservatively.",
+        )
 
 
 def _mark_promoted(
@@ -769,12 +806,31 @@ def _semantic_clearance_verdict(
         max_tokens=512,
         system_prompt=SEMANTIC_CLEARANCE_SYSTEM_PROMPT,
     )
+    return _coerce_semantic_clearance_verdict(raw)
+
+
+def _coerce_semantic_clearance_verdict(raw: Any) -> SemanticClearanceVerdict:
+    """Keep semantic tags when local clearance output is malformed."""
     try:
         if isinstance(raw, SemanticClearanceVerdict):
             return raw
-        return SemanticClearanceVerdict.model_validate(raw)
+        payload = _structured_payload_from_raw(raw)
+        if isinstance(payload, Mapping) and "clear" in payload:
+            payload = dict(payload)
+            payload.setdefault(
+                "reason", "Local model returned a bare semantic-clearance decision."
+            )
+        return SemanticClearanceVerdict.model_validate(payload)
     except ValidationError as exc:
-        raise ValueError(f"Malformed Orrery semantic clearance verdict: {raw}") from exc
+        logger.warning(
+            "Malformed Orrery semantic clearance verdict; keeping tag: %s",
+            raw,
+            exc_info=True,
+        )
+        return SemanticClearanceVerdict(
+            clear=False,
+            reason="Malformed local semantic-clearance verdict; kept conservatively.",
+        )
 
 
 def _mark_semantic_tag_cleared_sync(

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -74,7 +74,12 @@ def resolve_place_references_sync(
                 elif ref.new_place:
                     place_id = create_new_place_sync(cur, ref.new_place)
                 else:
-                    raise ValueError(f"Place '{ref.place_name}' not found in database")
+                    logger.warning(
+                        "Skipping unresolved place reference %r; provide place_id "
+                        "or new_place to persist place_chunk_references",
+                        ref.place_name,
+                    )
+                    continue
             elif ref.new_place:
                 # Create new place and get ID
                 place_id = create_new_place_sync(cur, ref.new_place)
@@ -146,7 +151,13 @@ def resolve_character_references_sync(
                 elif ref.new_character:
                     char_id = create_new_character_sync(cur, ref.new_character)
                 else:
-                    raise ValueError(f"Character '{ref.character_name}' not found")
+                    logger.warning(
+                        "Skipping unresolved character reference %r; provide "
+                        "character_id or new_character to persist "
+                        "chunk_character_references",
+                        ref.character_name,
+                    )
+                    continue
             elif ref.new_character:
                 char_id = create_new_character_sync(cur, ref.new_character)
 
@@ -223,7 +234,13 @@ def resolve_faction_references_sync(
                 elif ref.new_faction:
                     faction_id = create_new_faction_sync(cur, ref.new_faction)
                 else:
-                    raise ValueError(f"Faction '{ref.faction_name}' not found")
+                    logger.warning(
+                        "Skipping unresolved faction reference %r; provide "
+                        "faction_id or new_faction to persist "
+                        "chunk_faction_references",
+                        ref.faction_name,
+                    )
+                    continue
             elif ref.new_faction:
                 faction_id = create_new_faction_sync(cur, ref.new_faction)
 

--- a/nexus/api/db_converters.py
+++ b/nexus/api/db_converters.py
@@ -7,6 +7,7 @@ Handles time conversion, episode/season calculation, and entity resolution.
 """
 
 import json
+import logging
 from datetime import timedelta
 from typing import Optional, Tuple, List, Dict, Any
 import asyncpg
@@ -22,6 +23,8 @@ from nexus.agents.logon.apex_schema import (
     ReferenceType,
     ReferencedEntities
 )
+
+logger = logging.getLogger("nexus.api.db_converters")
 
 
 def _json_dumps_model(value: Any) -> Optional[str]:
@@ -164,7 +167,12 @@ async def resolve_place_references(
             if not place_id and ref.new_place:
                 place_id = await create_new_place(conn, ref.new_place)
             elif not place_id:
-                raise ValueError(f"Place '{ref.place_name}' not found in database")
+                logger.warning(
+                    "Skipping unresolved place reference %r; provide place_id "
+                    "or new_place to persist place_chunk_references",
+                    ref.place_name,
+                )
+                continue
         elif ref.new_place:
             # Create new place and get ID
             place_id = await create_new_place(conn, ref.new_place)
@@ -243,7 +251,13 @@ async def resolve_character_references(
             if not char_id and ref.new_character:
                 char_id = await create_new_character(conn, ref.new_character)
             elif not char_id:
-                raise ValueError(f"Character '{ref.character_name}' not found")
+                logger.warning(
+                    "Skipping unresolved character reference %r; provide "
+                    "character_id or new_character to persist "
+                    "chunk_character_references",
+                    ref.character_name,
+                )
+                continue
         elif ref.new_character:
             # Create new character
             char_id = await create_new_character(conn, ref.new_character)
@@ -331,7 +345,12 @@ async def resolve_faction_references(
             if not faction_id and ref.new_faction:
                 faction_id = await create_new_faction(conn, ref.new_faction)
             elif not faction_id:
-                raise ValueError(f"Faction '{ref.faction_name}' not found")
+                logger.warning(
+                    "Skipping unresolved faction reference %r; provide faction_id "
+                    "or new_faction to persist chunk_faction_references",
+                    ref.faction_name,
+                )
+                continue
         elif ref.new_faction:
             # Create new faction
             faction_id = await create_new_faction(conn, ref.new_faction)

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -249,6 +249,18 @@ class EntityInclusionConfig(BaseModel):
     max_total_threats: int = Field(..., ge=1)
 
 
+class LORERetrievalSettings(BaseModel):
+    """LORE retrieval query generation settings."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    fallback_query: str = Field(
+        default="Recent narrative events",
+        min_length=1,
+        description="Fallback MEMNON query when local query generation yields none",
+    )
+
+
 class LORESettings(BaseModel):
     """LORE agent configuration."""
 
@@ -259,6 +271,7 @@ class LORESettings(BaseModel):
     token_budget: TokenBudgetConfig
     payload_percent_budget: PayloadPercentBudget
     entity_inclusion: EntityInclusionConfig
+    retrieval: LORERetrievalSettings = Field(default_factory=LORERetrievalSettings)
 
 
 # =============================================================================

--- a/scripts/create_vector_index.py
+++ b/scripts/create_vector_index.py
@@ -22,7 +22,11 @@ logger = logging.getLogger("nexus.embeddings")
 # Add parent directory to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from nexus.agents.memnon.utils.embedding_tables import table_name_for_dimensions
+from nexus.agents.memnon.utils.embedding_tables import (
+    PGVECTOR_ANN_INDEX_MAX_DIMENSIONS,
+    supports_pgvector_ann_index,
+    table_name_for_dimensions,
+)
 
 # Try to load settings using centralized config loader
 try:
@@ -136,6 +140,15 @@ def create_vector_indexes(model_name: str, db_url: str = None):
             logger.warning("No embeddings found for this model!")
             return False
 
+        if not supports_pgvector_ann_index(dimensions):
+            logger.info(
+                "Skipping ANN vector index for %s: pgvector supports HNSW/IVFFlat "
+                "indexes up to %sd locally, and exact search remains available",
+                table_name,
+                PGVECTOR_ANN_INDEX_MAX_DIMENSIONS,
+            )
+            return True
+
         # Check for existing vector indexes
         index_sql = f"""
         SELECT indexname, indexdef
@@ -200,25 +213,6 @@ def create_vector_indexes(model_name: str, db_url: str = None):
                 except Exception as e2:
                     logger.error(f"Failed to create plain index: {e2}")
 
-        else:
-            # For super high dimensions, try but don't expect success
-            logger.warning(
-                f"Dimensions ({dimensions}) exceed 2000, vector indexes may not work"
-            )
-
-            try:
-                logger.info("Attempting to create plain vector index anyway...")
-                plain_sql = f"""
-                CREATE INDEX IF NOT EXISTS {table_name}_vector_idx
-                ON {table_name} (embedding vector_cosine_ops);
-                """
-                conn.execute(text(plain_sql))
-                logger.info("✓ Successfully created plain vector index")
-                success = True
-            except Exception as e:
-                logger.error(f"Failed to create vector index: {e}")
-                logger.info("Will use sequential scan for searches")
-
     return success
 
 
@@ -234,7 +228,7 @@ def main():
     try:
         success = create_vector_indexes(args.model, args.db_url)
         if success:
-            print("\nVector indexes created successfully!")
+            print("\nVector index setup completed.")
             return 0
         else:
             print("\nFailed to create vector indexes.")

--- a/scripts/regenerate_embeddings.py
+++ b/scripts/regenerate_embeddings.py
@@ -98,8 +98,10 @@ except ImportError:
 
 
 from nexus.agents.memnon.utils.embedding_tables import (
+    PGVECTOR_ANN_INDEX_MAX_DIMENSIONS,
     embedding_table_exists,
     ensure_embedding_table,
+    supports_pgvector_ann_index,
     table_name_for_dimensions,
 )
 
@@ -743,6 +745,15 @@ class EmbeddingRegenerator:
                 logger.error(f"Table {table_name} does not exist")
                 return False
 
+        if not supports_pgvector_ann_index(dimensions):
+            logger.info(
+                "Skipping ANN vector index for %s: pgvector supports HNSW/IVFFlat "
+                "indexes up to %sd locally, and exact search remains available",
+                table_name,
+                PGVECTOR_ANN_INDEX_MAX_DIMENSIONS,
+            )
+            return True
+
         # Now create specialized vector indexes in a separate transaction
         with self.engine.begin() as idx_conn:
             # First try HNSW index (preferred for performance)
@@ -964,7 +975,7 @@ class EmbeddingRegenerator:
             logger.info("Creating vector indexes now that data is loaded...")
             index_success = self.create_vector_indexes()
             if index_success:
-                logger.info("✅ Successfully created vector indexes")
+                logger.info("✅ Vector index setup completed")
             else:
                 logger.warning("⚠️ Failed to create vector indexes")
                 logger.info(

--- a/tests/test_commit_handler_sync.py
+++ b/tests/test_commit_handler_sync.py
@@ -1,0 +1,43 @@
+"""Unit tests for synchronous narrative commit helpers."""
+
+from nexus.agents.logon.apex_schema import CharacterReference, ReferenceType
+from nexus.api.commit_handler_sync import resolve_character_references_sync
+
+
+class MissingLookupCursor:
+    """Cursor stand-in whose name lookups find no rows."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def execute(self, *_args, **_kwargs):
+        return None
+
+    def fetchone(self):
+        return None
+
+
+class MissingLookupConnection:
+    """Connection stand-in for sync resolver tests."""
+
+    def cursor(self):
+        return MissingLookupCursor()
+
+
+def test_sync_unresolved_character_reference_is_skipped(caplog):
+    """Unresolved group labels should not block chunk commit."""
+    refs = resolve_character_references_sync(
+        [
+            CharacterReference(
+                character_name="Rectification officers",
+                reference_type=ReferenceType.PRESENT,
+            )
+        ],
+        MissingLookupConnection(),
+    )
+
+    assert refs == []
+    assert "Skipping unresolved character reference" in caplog.text

--- a/tests/test_db_converters.py
+++ b/tests/test_db_converters.py
@@ -6,12 +6,25 @@ from nexus.api.db_converters import (
     time_fields_to_interval,
     interval_to_time_fields,
     chronology_to_db_values,
+    resolve_character_references,
+    resolve_faction_references,
+    resolve_place_references,
 )
 from nexus.agents.logon.apex_schema import (
+    CharacterReference,
     ChronologyUpdate,
+    FactionReference,
     PlaceReference,
-    PlaceReferenceType
+    PlaceReferenceType,
+    ReferenceType,
 )
+
+
+class MissingLookupConnection:
+    """Async connection stand-in whose name lookups find no rows."""
+
+    async def fetchval(self, *_args, **_kwargs):
+        return None
 
 
 class TestTimeConversion:
@@ -149,6 +162,56 @@ class TestPlaceReference:
             PlaceReference(
                 reference_type=PlaceReferenceType.SETTING
             )
+
+
+class TestReferenceResolution:
+    """Test reference resolver tolerance for non-canonical extraction metadata."""
+
+    @pytest.mark.asyncio
+    async def test_unresolved_character_reference_is_skipped(self, caplog):
+        """Group labels should not block committing an otherwise valid chunk."""
+        refs = await resolve_character_references(
+            [
+                CharacterReference(
+                    character_name="Rectification officers",
+                    reference_type=ReferenceType.PRESENT,
+                )
+            ],
+            MissingLookupConnection(),
+        )
+
+        assert refs == []
+        assert "Skipping unresolved character reference" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_unresolved_place_reference_is_skipped(self, caplog):
+        refs = await resolve_place_references(
+            [
+                PlaceReference(
+                    place_name="Unresolved Threshold",
+                    reference_type=PlaceReferenceType.MENTIONED,
+                )
+            ],
+            MissingLookupConnection(),
+        )
+
+        assert refs == []
+        assert "Skipping unresolved place reference" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_unresolved_faction_reference_is_skipped(self, caplog):
+        refs = await resolve_faction_references(
+            [
+                FactionReference(
+                    faction_name="Unresolved Office",
+                    reference_type=ReferenceType.MENTIONED,
+                )
+            ],
+            MissingLookupConnection(),
+        )
+
+        assert refs == []
+        assert "Skipping unresolved faction reference" in caplog.text
 
 
 class TestTimeFieldValidation:

--- a/tests/test_ir_eval_v2/test_embedding_tables.py
+++ b/tests/test_ir_eval_v2/test_embedding_tables.py
@@ -5,6 +5,7 @@ import pytest
 from nexus.agents.memnon.utils.embedding_tables import (
     parse_embedding_table_dimensions,
     resolve_dimension_table,
+    supports_pgvector_ann_index,
     table_name_for_dimensions,
 )
 
@@ -36,3 +37,10 @@ def test_parse_embedding_table_dimensions() -> None:
     """Dimension parser recognizes canonical embedding table names only."""
     assert parse_embedding_table_dimensions("chunk_embeddings_1536d") == 1536
     assert parse_embedding_table_dimensions("chunk_embeddings_small") is None
+
+
+def test_pgvector_ann_index_dimension_limit() -> None:
+    """Local pgvector ANN indexes are only supported through 2000 dimensions."""
+    assert supports_pgvector_ann_index(2000)
+    assert not supports_pgvector_ann_index(2001)
+    assert not supports_pgvector_ann_index(2560)

--- a/tests/test_lore/test_local_llm.py
+++ b/tests/test_lore/test_local_llm.py
@@ -216,6 +216,19 @@ class TestQueryGeneration:
             "Hollow Choir obligation conflict",
         ]
 
+    def test_sanitize_retrieval_queries_rejects_structured_planner_leaks(self):
+        """Structured SQL/planner leakage should not become a MEMNON query."""
+        queries = _sanitize_retrieval_queries(
+            [
+                '{"action":"sql","sql":"SELECT * FROM events ..."}',
+                "Character relationships and interactions",
+                "Background info on key entities",
+                "Lantern Court trapdoor history",
+            ]
+        )
+
+        assert queries == ["Lantern Court trapdoor history"]
+
     def test_parse_structured_json_text_uses_final_channel_json(self):
         """Structured fallback parsing should recover JSON from leaked transcripts."""
         raw = (

--- a/tests/test_lore/test_local_llm.py
+++ b/tests/test_lore/test_local_llm.py
@@ -18,27 +18,28 @@ sys.path.insert(0, str(nexus_root))
 
 from nexus.agents.lore.utils.local_llm import (
     _extract_final_channel_text,
+    _parse_structured_json_text,
     _sanitize_retrieval_queries,
     LocalLLMManager,
     NarrativeAnalysis,
-    LMS_SDK_AVAILABLE
+    LMS_SDK_AVAILABLE,
 )
 
 
 class TestLocalLLMInitialization:
     """Test LLM manager initialization and configuration."""
-    
-    @patch('nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE', False)
+
+    @patch("nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE", False)
     def test_initialization_basic(self, settings, system_prompt):
         """Test basic initialization with settings."""
         # Mock the connection check
-        with patch('nexus.agents.lore.utils.local_llm.requests.get') as mock_get:
+        with patch("nexus.agents.lore.utils.local_llm.requests.get") as mock_get:
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_get.return_value = mock_response
-            
+
             manager = LocalLLMManager(settings, system_prompt=system_prompt)
-            
+
             assert manager.settings == settings
             expected_base = (
                 settings.get("Agent Settings", {})
@@ -54,35 +55,37 @@ class TestLocalLLMInitialization:
             )
             assert manager.base_url == expected_base
             assert manager.model_name == expected_model
-    
-    @patch('nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE', False)
+
+    @patch("nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE", False)
     def test_hard_failure_no_lm_studio(self, settings, system_prompt):
         """Test HARD FAILURE when LM Studio is not available (NO FALLBACKS)."""
-        with patch('nexus.agents.lore.utils.local_llm.requests.get') as mock_get:
+        with patch("nexus.agents.lore.utils.local_llm.requests.get") as mock_get:
             # Mock connection failure
-            mock_get.side_effect = requests.exceptions.ConnectionError("Connection refused")
-            
+            mock_get.side_effect = requests.exceptions.ConnectionError(
+                "Connection refused"
+            )
+
             # Should fail hard - no graceful fallback
             with pytest.raises(RuntimeError, match="Cannot connect to LM Studio API"):
                 LocalLLMManager(settings, system_prompt=system_prompt)
-    
-    @patch('nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE', False)
+
+    @patch("nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE", False)
     def test_is_available_method(self, settings, system_prompt):
         """Test the is_available method."""
-        with patch('nexus.agents.lore.utils.local_llm.requests.get') as mock_get:
+        with patch("nexus.agents.lore.utils.local_llm.requests.get") as mock_get:
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_get.return_value = mock_response
-            
+
             manager = LocalLLMManager(settings, system_prompt=system_prompt)
-            
+
             # Test availability check
             assert manager.is_available() == True
 
 
 class TestNarrativeAnalysis:
     """Test narrative analysis delegation to LLM."""
-    
+
     def test_narrative_analysis_model_structure(self):
         """Test the NarrativeAnalysis Pydantic model."""
         analysis = NarrativeAnalysis(
@@ -90,84 +93,90 @@ class TestNarrativeAnalysis:
             locations=["The Badlands"],
             context_type="action",
             entities_for_retrieval=["Wraith", "Rustborn"],
-            confidence_score=0.85
+            confidence_score=0.85,
         )
-        
+
         assert len(analysis.characters) == 2
         assert analysis.context_type == "action"
         assert analysis.confidence_score == 0.85
-        
+
         # Test serialization
         json_data = analysis.model_dump()
         assert json_data["characters"] == ["Alex", "Pete"]
-    
-    @patch('nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE', False)
+
+    @patch("nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE", False)
     def test_analyze_narrative_context_method_exists(self, settings, system_prompt):
         """Test that analyze_narrative_context method exists and delegates."""
-        with patch('nexus.agents.lore.utils.local_llm.requests.get') as mock_get:
+        with patch("nexus.agents.lore.utils.local_llm.requests.get") as mock_get:
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_get.return_value = mock_response
-            
+
             manager = LocalLLMManager(settings, system_prompt=system_prompt)
-            
+
             # Method should exist
-            assert hasattr(manager, 'analyze_narrative_context')
-            assert callable(getattr(manager, 'analyze_narrative_context'))
-    
-    @patch('nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE', False)
+            assert hasattr(manager, "analyze_narrative_context")
+            assert callable(getattr(manager, "analyze_narrative_context"))
+
+    @patch("nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE", False)
     def test_analyze_delegates_to_llm(self, settings, system_prompt):
         """Test that narrative analysis is delegated to LLM via HTTP."""
-        with patch('nexus.agents.lore.utils.local_llm.requests.get') as mock_get:
-            with patch('nexus.agents.lore.utils.local_llm.requests.post') as mock_post:
+        with patch("nexus.agents.lore.utils.local_llm.requests.get") as mock_get:
+            with patch("nexus.agents.lore.utils.local_llm.requests.post") as mock_post:
                 # Mock connection check
                 mock_get.return_value.status_code = 200
-                
+
                 # Mock LLM response
                 mock_llm_response = MagicMock()
                 mock_llm_response.status_code = 200
                 mock_llm_response.json.return_value = {
-                    "choices": [{
-                        "message": {
-                            "content": json.dumps({
-                                "characters": ["Alex"],
-                                "locations": ["Night City"],
-                                "themes": ["betrayal"]
-                            })
+                    "choices": [
+                        {
+                            "message": {
+                                "content": json.dumps(
+                                    {
+                                        "characters": ["Alex"],
+                                        "locations": ["Night City"],
+                                        "themes": ["betrayal"],
+                                    }
+                                )
+                            }
                         }
-                    }]
+                    ]
                 }
                 mock_post.return_value = mock_llm_response
-                
+
                 manager = LocalLLMManager(settings, system_prompt=system_prompt)
-                
+
                 # Call narrative analysis
                 warm_slice = [{"id": 1, "text": "Alex walked through Night City"}]
-                result = manager.analyze_narrative_context(warm_slice, "What should Alex do next?")
-                
+                result = manager.analyze_narrative_context(
+                    warm_slice, "What should Alex do next?"
+                )
+
                 # Should have called the LLM API
                 mock_post.assert_called()
-                
+
                 # Should return parsed result
                 assert isinstance(result, dict)
 
 
 class TestQueryGeneration:
     """Test natural language query generation."""
-    
-    @patch('nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE', False)
+
+    @patch("nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE", False)
     def test_generate_retrieval_queries_exists(self, settings, system_prompt):
         """Test that query generation method exists."""
-        with patch('nexus.agents.lore.utils.local_llm.requests.get') as mock_get:
+        with patch("nexus.agents.lore.utils.local_llm.requests.get") as mock_get:
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_get.return_value = mock_response
-            
+
             manager = LocalLLMManager(settings, system_prompt=system_prompt)
-            
+
             # Method should exist
-            assert hasattr(manager, 'generate_retrieval_queries')
-            assert callable(getattr(manager, 'generate_retrieval_queries'))
+            assert hasattr(manager, "generate_retrieval_queries")
+            assert callable(getattr(manager, "generate_retrieval_queries"))
 
     def test_sanitize_retrieval_queries_rejects_model_chatter(self):
         """Meta reasoning and prompt echoes should not become MEMNON queries."""
@@ -206,29 +215,42 @@ class TestQueryGeneration:
             "Past events at the Verdigris Scriptorium",
             "Hollow Choir obligation conflict",
         ]
-    
-    @patch('nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE', False)
+
+    def test_parse_structured_json_text_uses_final_channel_json(self):
+        """Structured fallback parsing should recover JSON from leaked transcripts."""
+        raw = (
+            "<|channel|>analysis<|message|>"
+            "We need to decide whether to promote.\n"
+            "<|channel|>final<|message|>"
+            '{"promote": false}<|end|>'
+        )
+
+        assert _parse_structured_json_text(raw) == {"promote": False}
+
+    @patch("nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE", False)
     def test_queries_are_natural_language(self, settings, system_prompt):
         """Test that queries are natural language, not keyword soup."""
-        with patch('nexus.agents.lore.utils.local_llm.requests.get') as mock_get:
-            with patch('nexus.agents.lore.utils.local_llm.requests.post') as mock_post:
+        with patch("nexus.agents.lore.utils.local_llm.requests.get") as mock_get:
+            with patch("nexus.agents.lore.utils.local_llm.requests.post") as mock_post:
                 # Mock connection check
                 mock_get.return_value.status_code = 200
-                
+
                 # Mock query generation response
                 mock_llm_response = MagicMock()
                 mock_llm_response.status_code = 200
                 mock_llm_response.json.return_value = {
-                    "choices": [{
-                        "message": {
-                            "content": "What happened when Victor betrayed Alex?\nTell me about the Dynacorp conspiracy."
+                    "choices": [
+                        {
+                            "message": {
+                                "content": "What happened when Victor betrayed Alex?\nTell me about the Dynacorp conspiracy."
+                            }
                         }
-                    }]
+                    ]
                 }
                 mock_post.return_value = mock_llm_response
-                
+
                 manager = LocalLLMManager(settings, system_prompt=system_prompt)
-                
+
                 # Generate queries
                 analysis = {
                     "characters": ["Victor"],
@@ -236,11 +258,13 @@ class TestQueryGeneration:
                     "entities_for_retrieval": ["Dynacorp"],
                     "context_type": "dialogue",
                 }
-                queries = manager.generate_retrieval_queries(analysis, "What happened with Victor?")
-                
+                queries = manager.generate_retrieval_queries(
+                    analysis, "What happened with Victor?"
+                )
+
                 # Should call LLM
                 mock_post.assert_called()
-                
+
                 # Should return natural language queries
                 assert isinstance(queries, list)
                 if len(queries) > 0:
@@ -253,51 +277,49 @@ class TestQueryGeneration:
 
 class TestSemanticDelegation:
     """Test that LORE never attempts semantic understanding itself."""
-    
-    @patch('nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE', False)
+
+    @patch("nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE", False)
     def test_no_hardcoded_understanding(self, settings, system_prompt):
         """Test that the manager doesn't have hardcoded narrative understanding."""
-        with patch('nexus.agents.lore.utils.local_llm.requests.get') as mock_get:
+        with patch("nexus.agents.lore.utils.local_llm.requests.get") as mock_get:
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_get.return_value = mock_response
-            
+
             manager = LocalLLMManager(settings, system_prompt=system_prompt)
-            
+
             # Manager should not have methods that imply local understanding
-            assert not hasattr(manager, 'extract_characters')
-            assert not hasattr(manager, 'understand_plot')
-            assert not hasattr(manager, 'interpret_dialogue')
-            assert not hasattr(manager, 'calculate_sentiment')
-            
+            assert not hasattr(manager, "extract_characters")
+            assert not hasattr(manager, "understand_plot")
+            assert not hasattr(manager, "interpret_dialogue")
+            assert not hasattr(manager, "calculate_sentiment")
+
             # Should have delegation methods
-            assert hasattr(manager, 'query')  # Generic LLM query
-            assert hasattr(manager, 'analyze_narrative_context')  # Delegates to LLM
-            assert hasattr(manager, 'generate_retrieval_queries')  # Delegates to LLM
-    
-    @patch('nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE', False)
+            assert hasattr(manager, "query")  # Generic LLM query
+            assert hasattr(manager, "analyze_narrative_context")  # Delegates to LLM
+            assert hasattr(manager, "generate_retrieval_queries")  # Delegates to LLM
+
+    @patch("nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE", False)
     def test_query_method_is_generic(self, settings, system_prompt):
         """Test that the query method is generic delegation, not specific understanding."""
-        with patch('nexus.agents.lore.utils.local_llm.requests.get') as mock_get:
-            with patch('nexus.agents.lore.utils.local_llm.requests.post') as mock_post:
+        with patch("nexus.agents.lore.utils.local_llm.requests.get") as mock_get:
+            with patch("nexus.agents.lore.utils.local_llm.requests.post") as mock_post:
                 # Mock connection check
                 mock_get.return_value.status_code = 200
-                
+
                 # Mock LLM response
                 mock_llm_response = MagicMock()
                 mock_llm_response.status_code = 200
                 mock_llm_response.json.return_value = {
-                    "choices": [{
-                        "message": {"content": "LLM response"}
-                    }]
+                    "choices": [{"message": {"content": "LLM response"}}]
                 }
                 mock_post.return_value = mock_llm_response
-                
+
                 manager = LocalLLMManager(settings, system_prompt=system_prompt)
-                
+
                 # Query method should accept any prompt
                 result = manager.query("Any semantic task", temperature=0.5)
-                
+
                 # Should delegate to LLM
                 mock_post.assert_called()
                 assert result is not None
@@ -305,47 +327,47 @@ class TestSemanticDelegation:
 
 class TestErrorHandling:
     """Test error handling and failure modes."""
-    
-    @patch('nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE', False)
+
+    @patch("nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE", False)
     def test_connection_failure_hard_error(self, settings, system_prompt):
         """Test that connection failures cause hard errors (NO FALLBACKS)."""
-        with patch('nexus.agents.lore.utils.local_llm.requests.get') as mock_get:
+        with patch("nexus.agents.lore.utils.local_llm.requests.get") as mock_get:
             # First call succeeds (initialization)
             # Second call fails (runtime)
             mock_get.side_effect = [
                 MagicMock(status_code=200),
-                requests.exceptions.ConnectionError("LM Studio disconnected")
+                requests.exceptions.ConnectionError("LM Studio disconnected"),
             ]
-            
+
             manager = LocalLLMManager(settings, system_prompt=system_prompt)
-            
+
             # Runtime connection failure should not be silently handled
             with pytest.raises(Exception):
                 manager.is_available()
-    
-    @patch('nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE', False)
+
+    @patch("nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE", False)
     def test_invalid_llm_response_handling(self, settings, system_prompt):
         """Test handling of malformed LLM responses."""
-        with patch('nexus.agents.lore.utils.local_llm.requests.get') as mock_get:
-            with patch('nexus.agents.lore.utils.local_llm.requests.post') as mock_post:
+        with patch("nexus.agents.lore.utils.local_llm.requests.get") as mock_get:
+            with patch("nexus.agents.lore.utils.local_llm.requests.post") as mock_post:
                 # Mock connection check
                 mock_get.return_value.status_code = 200
-                
+
                 # Mock invalid response
                 mock_llm_response = MagicMock()
                 mock_llm_response.status_code = 200
                 mock_llm_response.json.return_value = {
-                    "choices": [{
-                        "message": {"content": "Not valid JSON"}
-                    }]
+                    "choices": [{"message": {"content": "Not valid JSON"}}]
                 }
                 mock_post.return_value = mock_llm_response
-                
+
                 manager = LocalLLMManager(settings, system_prompt=system_prompt)
-                
+
                 # Should handle invalid JSON gracefully
                 warm_slice = [{"id": 1, "text": "Test narrative chunk"}]
-                result = manager.analyze_narrative_context(warm_slice, "Test user input")
-                
+                result = manager.analyze_narrative_context(
+                    warm_slice, "Test user input"
+                )
+
                 # Should return some result (even if empty/default)
                 assert result is not None

--- a/tests/test_lore/test_local_llm.py
+++ b/tests/test_lore/test_local_llm.py
@@ -17,6 +17,7 @@ nexus_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(nexus_root))
 
 from nexus.agents.lore.utils.local_llm import (
+    _sanitize_retrieval_queries,
     LocalLLMManager,
     NarrativeAnalysis,
     LMS_SDK_AVAILABLE
@@ -166,6 +167,67 @@ class TestQueryGeneration:
             # Method should exist
             assert hasattr(manager, 'generate_retrieval_queries')
             assert callable(getattr(manager, 'generate_retrieval_queries'))
+
+    def test_sanitize_retrieval_queries_rejects_model_chatter(self):
+        """Meta reasoning and prompt echoes should not become MEMNON queries."""
+        queries = _sanitize_retrieval_queries(
+            [
+                "<|channel|>analysis<|message|>The user wants retrieval queries",
+                "We need to output exactly 3-5 lines.",
+                "1. Mara Vey debt history with the Archivum",
+                "- Past events at the Verdigris Scriptorium",
+                "Query 3: Hollow Choir obligation conflict",
+                "Mara Vey debt history with the Archivum",
+            ]
+        )
+
+        assert queries == [
+            "Mara Vey debt history with the Archivum",
+            "Past events at the Verdigris Scriptorium",
+            "Hollow Choir obligation conflict",
+        ]
+
+    @patch('nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE', False)
+    def test_text_query_generation_prefers_final_channel(self, settings, system_prompt):
+        """Leaked analysis-channel text should be discarded when final text exists."""
+        with patch('nexus.agents.lore.utils.local_llm.requests.get') as mock_get:
+            with patch('nexus.agents.lore.utils.local_llm.requests.post') as mock_post:
+                mock_get.return_value.status_code = 200
+
+                mock_llm_response = MagicMock()
+                mock_llm_response.status_code = 200
+                mock_llm_response.json.return_value = {
+                    "choices": [{
+                        "message": {
+                            "content": (
+                                "<|channel|>analysis<|message|>"
+                                "We need to generate 3-5 retrieval queries.\n"
+                                "<|channel|>final<|message|>\n"
+                                "1. Mara Vey debt history with the Archivum\n"
+                                "2. Past events at the Verdigris Scriptorium\n"
+                                "3. Hollow Choir obligation conflict"
+                            )
+                        }
+                    }]
+                }
+                mock_post.return_value = mock_llm_response
+
+                manager = LocalLLMManager(settings, system_prompt=system_prompt)
+                queries = manager.generate_retrieval_queries(
+                    {
+                        "characters": ["Mara Vey"],
+                        "locations": ["Verdigris Scriptorium"],
+                        "entities_for_retrieval": ["Archivum"],
+                        "context_type": "exploration",
+                    },
+                    "Study the fruit ledger.",
+                )
+
+        assert queries == [
+            "Mara Vey debt history with the Archivum",
+            "Past events at the Verdigris Scriptorium",
+            "Hollow Choir obligation conflict",
+        ]
     
     @patch('nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE', False)
     def test_queries_are_natural_language(self, settings, system_prompt):

--- a/tests/test_lore/test_local_llm.py
+++ b/tests/test_lore/test_local_llm.py
@@ -17,6 +17,7 @@ nexus_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(nexus_root))
 
 from nexus.agents.lore.utils.local_llm import (
+    _extract_final_channel_text,
     _sanitize_retrieval_queries,
     LocalLLMManager,
     NarrativeAnalysis,
@@ -187,41 +188,18 @@ class TestQueryGeneration:
             "Hollow Choir obligation conflict",
         ]
 
-    @patch('nexus.agents.lore.utils.local_llm.LMS_SDK_AVAILABLE', False)
-    def test_text_query_generation_prefers_final_channel(self, settings, system_prompt):
+    def test_final_channel_text_feeds_query_sanitizer(self):
         """Leaked analysis-channel text should be discarded when final text exists."""
-        with patch('nexus.agents.lore.utils.local_llm.requests.get') as mock_get:
-            with patch('nexus.agents.lore.utils.local_llm.requests.post') as mock_post:
-                mock_get.return_value.status_code = 200
-
-                mock_llm_response = MagicMock()
-                mock_llm_response.status_code = 200
-                mock_llm_response.json.return_value = {
-                    "choices": [{
-                        "message": {
-                            "content": (
-                                "<|channel|>analysis<|message|>"
-                                "We need to generate 3-5 retrieval queries.\n"
-                                "<|channel|>final<|message|>\n"
-                                "1. Mara Vey debt history with the Archivum\n"
-                                "2. Past events at the Verdigris Scriptorium\n"
-                                "3. Hollow Choir obligation conflict"
-                            )
-                        }
-                    }]
-                }
-                mock_post.return_value = mock_llm_response
-
-                manager = LocalLLMManager(settings, system_prompt=system_prompt)
-                queries = manager.generate_retrieval_queries(
-                    {
-                        "characters": ["Mara Vey"],
-                        "locations": ["Verdigris Scriptorium"],
-                        "entities_for_retrieval": ["Archivum"],
-                        "context_type": "exploration",
-                    },
-                    "Study the fruit ledger.",
-                )
+        raw = (
+            "<|channel|>analysis<|message|>"
+            "We need to generate 3-5 retrieval queries.\n"
+            "<|channel|>final<|message|>\n"
+            "1. Mara Vey debt history with the Archivum\n"
+            "2. Past events at the Verdigris Scriptorium\n"
+            "3. Hollow Choir obligation conflict"
+        )
+        final_text = _extract_final_channel_text(raw)
+        queries = _sanitize_retrieval_queries(final_text.splitlines())
 
         assert queries == [
             "Mara Vey debt history with the Archivum",

--- a/tests/test_memnon_db_access.py
+++ b/tests/test_memnon_db_access.py
@@ -56,3 +56,19 @@ def test_setup_database_indexes_skips_ann_indexes_for_high_dimensions(monkeypatc
     assert "using hnsw" not in statements
     assert "using ivfflat" not in statements
     assert connection.closed
+
+
+def test_setup_database_indexes_fails_on_unparseable_embedding_table(monkeypatch):
+    """Malformed embedding table names should not fall through to ANN creation."""
+    cursor = FakeCursor()
+    connection = FakeConnection(cursor)
+
+    monkeypatch.setattr(db_access.psycopg2, "connect", lambda **_kwargs: connection)
+    monkeypatch.setattr(
+        db_access,
+        "_list_existing_embedding_tables",
+        lambda _cursor: ["chunk_embeddings_bad"],
+    )
+
+    assert not db_access.setup_database_indexes("postgresql://user:pass@localhost/NEXUS")
+    assert connection.closed

--- a/tests/test_memnon_db_access.py
+++ b/tests/test_memnon_db_access.py
@@ -1,0 +1,58 @@
+"""Unit tests for MEMNON database setup helpers."""
+
+from nexus.agents.memnon.utils import db_access
+
+
+class FakeCursor:
+    """Small cursor stand-in that records SQL issued by setup_database_indexes."""
+
+    def __init__(self):
+        self.statements = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def execute(self, statement, *_args, **_kwargs):
+        self.statements.append(str(statement))
+
+    def fetchone(self):
+        return (1,)
+
+
+class FakeConnection:
+    """Connection stand-in for setup_database_indexes."""
+
+    def __init__(self, cursor):
+        self.cursor_instance = cursor
+        self.autocommit = False
+        self.closed = False
+
+    def cursor(self):
+        return self.cursor_instance
+
+    def close(self):
+        self.closed = True
+
+
+def test_setup_database_indexes_skips_ann_indexes_for_high_dimensions(monkeypatch):
+    """2560d tables should keep model indexes without attempting unsupported ANN."""
+    cursor = FakeCursor()
+    connection = FakeConnection(cursor)
+
+    monkeypatch.setattr(db_access.psycopg2, "connect", lambda **_kwargs: connection)
+    monkeypatch.setattr(
+        db_access,
+        "_list_existing_embedding_tables",
+        lambda _cursor: ["chunk_embeddings_2560d"],
+    )
+
+    assert db_access.setup_database_indexes("postgresql://user:pass@localhost/NEXUS")
+
+    statements = "\n".join(cursor.statements).lower()
+    assert "chunk_embeddings_2560d_model_idx" in statements
+    assert "using hnsw" not in statements
+    assert "using ivfflat" not in statements
+    assert connection.closed

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from nexus.agents.orrery.worker import (
@@ -254,18 +256,51 @@ def test_promote_pending_resolutions_queues_narration_job() -> None:
     assert "INSERT INTO orrery_narration_jobs" in statements
 
 
-def test_promote_pending_resolutions_rejects_malformed_llm_output() -> None:
-    """Malformed local-LLM promotion data fails visibly."""
+def test_promote_pending_resolutions_skips_malformed_llm_output() -> None:
+    """Malformed local-LLM promotion data is skipped conservatively."""
 
     cursor = WorkerCursor(promotion_rows=[_promotion_row()])
 
-    with pytest.raises(ValueError, match="Malformed Orrery promotion verdict"):
-        promote_pending_resolutions_sync(
-            slot=5,
-            settings=_settings(),
-            llm_manager=FakeLLM({"answer": "sure"}),
-            conn=WorkerConn(cursor),
-        )
+    promoted, skipped = promote_pending_resolutions_sync(
+        slot=5,
+        settings=_settings(),
+        llm_manager=FakeLLM({"answer": "sure"}),
+        conn=WorkerConn(cursor),
+    )
+
+    verdict = json.loads(cursor.executed[-1][1][0])
+
+    assert promoted == 0
+    assert skipped == 1
+    assert verdict["promote"] is False
+    assert "Malformed local promotion verdict" in verdict["reason"]
+
+
+def test_promote_pending_resolutions_recovers_bare_final_channel_json() -> None:
+    """Leaked final-channel JSON with no reason gets a durable skip reason."""
+
+    cursor = WorkerCursor(promotion_rows=[_promotion_row()])
+    raw = {
+        "answer": (
+            "<|channel|>analysis<|message|>routine maintenance\n"
+            '<|channel|>final<|message|>{"promote": false}'
+        ),
+        "reasoning": "unstructured",
+    }
+
+    promoted, skipped = promote_pending_resolutions_sync(
+        slot=5,
+        settings=_settings(),
+        llm_manager=FakeLLM(raw),
+        conn=WorkerConn(cursor),
+    )
+
+    verdict = json.loads(cursor.executed[-1][1][0])
+
+    assert promoted == 0
+    assert skipped == 1
+    assert verdict["promote"] is False
+    assert verdict["reason"] == "Local model returned a bare promotion decision."
 
 
 def test_drain_narration_outbox_persists_offscreen_narration() -> None:
@@ -409,8 +444,8 @@ def test_clear_semantic_tags_keeps_when_verdict_false() -> None:
     assert "INSERT INTO tag_clearance_log" not in statements
 
 
-def test_clear_semantic_tags_rejects_malformed_llm_output() -> None:
-    """Malformed semantic-clearance data fails after prior row commits survive."""
+def test_clear_semantic_tags_keeps_on_malformed_llm_output() -> None:
+    """Malformed semantic-clearance data keeps the tag without losing prior commits."""
 
     cursor = WorkerCursor(
         semantic_rows=[_semantic_tag_row(), _semantic_tag_row_2()],
@@ -424,16 +459,16 @@ def test_clear_semantic_tags_rejects_malformed_llm_output() -> None:
         ]
     )
 
-    with pytest.raises(ValueError, match="Malformed Orrery semantic clearance verdict"):
-        clear_semantic_tags_sync(
-            slot=5,
-            settings=_settings(),
-            llm_manager=llm,
-            conn=WorkerConn(cursor),
-        )
+    cleared = clear_semantic_tags_sync(
+        slot=5,
+        settings=_settings(),
+        llm_manager=llm,
+        conn=WorkerConn(cursor),
+    )
 
     statements = "\n".join(sql for sql, _params in cursor.executed)
 
+    assert cleared == 1
     assert statements.count("UPDATE entity_tags et") == 1
     assert statements.count("INSERT INTO tag_clearance_log") == 1
 


### PR DESCRIPTION
## Summary
- sanitize local LLM retrieval query candidates before handing them to MEMNON, including leaked analysis-channel text and prompt echoes
- skip unsupported pgvector ANN index attempts for high-dimensional embedding tables while preserving exact search and model indexes
- align vector-index scripts with the same 2000d ANN limit

## Verification
- PYTHONPATH=$PWD poetry run pytest tests/test_lore/test_local_llm.py tests/test_ir_eval_v2/test_embedding_tables.py tests/test_memnon_db_access.py -q
- PYTHONPATH=$PWD poetry run pytest tests/test_orrery tests/test_lore/test_local_llm.py tests/test_ir_eval_v2/test_embedding_tables.py tests/test_memnon_db_access.py -q