### PR TITLE
Harden retrieval query quality

### DIFF
--- a/nexus/agents/lore/utils/local_llm.py
+++ b/nexus/agents/lore/utils/local_llm.py
@@ -43,6 +43,7 @@ _META_QUERY_PREFIXES = (
     "key entities",
     "let's ",
     "locations:",
+    "make sure",
     "no numbering",
     "output exactly",
     "the user wants",
@@ -55,6 +56,8 @@ _META_QUERY_FRAGMENTS = (
     "complete question or search phrase",
     "generate retrieval queries",
     "generate queries",
+    "no bullet",
+    "query phrase",
     "one per line",
     "retrieval queries to search",
 )
@@ -63,6 +66,7 @@ _GENERIC_RETRIEVAL_QUERIES = {
     "character relationships and interactions",
     "relevant past events involving these characters",
 }
+_MIN_RETRIEVAL_QUERIES = 3
 
 
 # Pydantic models for structured responses
@@ -180,6 +184,10 @@ def _clean_retrieval_query(query: Any) -> Optional[str]:
         return None
     if len(re.findall(r"[A-Za-z0-9]+", cleaned)) < 3:
         return None
+    if cleaned.count('"') % 2 == 1:
+        return None
+    if cleaned.count('"') >= 4:
+        return None
 
     return cleaned
 
@@ -205,6 +213,11 @@ def _sanitize_retrieval_queries(queries: List[Any], limit: int = 5) -> List[str]
             break
 
     return valid_queries
+
+
+def _has_complete_retrieval_query_set(queries: List[str]) -> bool:
+    """Return whether a generated query set is complete enough for deep search."""
+    return len(queries) >= _MIN_RETRIEVAL_QUERIES
 
 
 class LocalLLMManager:
@@ -674,14 +687,14 @@ Each query should be a complete search phrase that captures what information you
 
                 valid_queries = _sanitize_retrieval_queries(queries)
 
-                if valid_queries:
+                if _has_complete_retrieval_query_set(valid_queries):
                     logger.info(
                         f"Generated {len(valid_queries)} valid retrieval queries via structured output"
                     )
                     return valid_queries
                 else:
                     logger.warning(
-                        "Structured output returned only empty/invalid queries, falling back to text parsing"
+                        "Structured output returned fewer than 3 valid queries, falling back to text parsing"
                     )
                     raise ValueError("Invalid structured output")
 

--- a/nexus/agents/lore/utils/local_llm.py
+++ b/nexus/agents/lore/utils/local_llm.py
@@ -43,7 +43,6 @@ _META_QUERY_PREFIXES = (
     "key entities",
     "let's ",
     "locations:",
-    "make sure",
     "no numbering",
     "output exactly",
     "the user wants",
@@ -56,6 +55,7 @@ _META_QUERY_FRAGMENTS = (
     "complete question or search phrase",
     "generate retrieval queries",
     "generate queries",
+    "make sure",
     "no bullet",
     "query phrase",
     "one per line",
@@ -152,6 +152,37 @@ def _parse_structured_json_text(response: str) -> Optional[Dict[str, Any]]:
     return None
 
 
+def _has_well_formed_double_quotes(query: str) -> bool:
+    """Return whether double quotes look like balanced phrase delimiters."""
+    quote_positions = [match.start() for match in re.finditer('"', query)]
+    if not quote_positions:
+        return True
+    if len(quote_positions) % 2 == 1:
+        return False
+
+    for pair_index, quote_index in enumerate(quote_positions):
+        previous_char = query[quote_index - 1] if quote_index > 0 else ""
+        next_char = query[quote_index + 1] if quote_index + 1 < len(query) else ""
+        is_opening = pair_index % 2 == 0
+
+        if is_opening:
+            if (
+                previous_char
+                and not previous_char.isspace()
+                and previous_char not in "([{:"
+            ):
+                return False
+            if not next_char or next_char.isspace():
+                return False
+        else:
+            if not previous_char or previous_char.isspace():
+                return False
+            if next_char and not next_char.isspace() and next_char not in ".,;:)]}":
+                return False
+
+    return True
+
+
 def _clean_retrieval_query(query: Any) -> Optional[str]:
     """Normalize one candidate retrieval query and reject instruction/meta text."""
     if not isinstance(query, str):
@@ -161,7 +192,7 @@ def _clean_retrieval_query(query: Any) -> Optional[str]:
     cleaned = cleaned.replace("\xa0", " ").replace("…", "...")
     cleaned = _LM_CONTROL_TOKEN_RE.sub(" ", cleaned)
     cleaned = " ".join(cleaned.split()).strip()
-    cleaned = _QUERY_PREFIX_RE.sub("", cleaned).strip(" \"'`")
+    cleaned = _QUERY_PREFIX_RE.sub("", cleaned).strip().strip("`")
 
     if len(cleaned) <= 10:
         return None
@@ -184,9 +215,7 @@ def _clean_retrieval_query(query: Any) -> Optional[str]:
         return None
     if len(re.findall(r"[A-Za-z0-9]+", cleaned)) < 3:
         return None
-    if cleaned.count('"') % 2 == 1:
-        return None
-    if cleaned.count('"') >= 4:
+    if not _has_well_formed_double_quotes(cleaned):
         return None
 
     return cleaned
@@ -687,6 +716,8 @@ Each query should be a complete search phrase that captures what information you
 
                 valid_queries = _sanitize_retrieval_queries(queries)
 
+                # Sanitization can drop generic or malformed items even when the
+                # Pydantic response had the requested list length.
                 if _has_complete_retrieval_query_set(valid_queries):
                     logger.info(
                         f"Generated {len(valid_queries)} valid retrieval queries via structured output"
@@ -694,7 +725,7 @@ Each query should be a complete search phrase that captures what information you
                     return valid_queries
                 else:
                     logger.warning(
-                        "Structured output returned fewer than 3 valid queries, falling back to text parsing"
+                        f"Structured output returned fewer than {_MIN_RETRIEVAL_QUERIES} valid queries, falling back to text parsing"
                     )
                     raise ValueError("Invalid structured output")
 
@@ -737,10 +768,10 @@ Each query should be a complete question or search phrase."""
             queries = _sanitize_retrieval_queries(query_candidates)
 
             # Ensure we have between 3-5 queries
-            if len(queries) < 3:
+            if not _has_complete_retrieval_query_set(queries):
                 # Fallback: add generic queries based on user input
                 logger.warning(
-                    f"Only generated {len(queries)} queries, adding fallbacks"
+                    f"Only generated {len(queries)} queries; need {_MIN_RETRIEVAL_QUERIES}, adding fallbacks"
                 )
                 fallback_candidates = []
                 if user_input:

--- a/tests/test_lore/test_local_llm.py
+++ b/tests/test_lore/test_local_llm.py
@@ -237,6 +237,7 @@ class TestQueryGeneration:
                 "Make sure each line is a query phrase. No bullet points.",
                 'Ganrow?" "stated*" "delay',
                 'Sella" "clause splinter" history of location "Rema',
+                'history of "Lantern Court" alliance with "Remainder Chamber"',
                 "Sella sour bite Remainder Chamber poisoning",
                 "Lantern Court healer living remainder",
                 "East Span Crown wardline pursuit",
@@ -244,6 +245,7 @@ class TestQueryGeneration:
         )
 
         assert queries == [
+            'history of "Lantern Court" alliance with "Remainder Chamber"',
             "Sella sour bite Remainder Chamber poisoning",
             "Lantern Court healer living remainder",
             "East Span Crown wardline pursuit",

--- a/tests/test_lore/test_local_llm.py
+++ b/tests/test_lore/test_local_llm.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(nexus_root))
 
 from nexus.agents.lore.utils.local_llm import (
     _extract_final_channel_text,
+    _has_complete_retrieval_query_set,
     _parse_structured_json_text,
     _sanitize_retrieval_queries,
     LocalLLMManager,
@@ -228,6 +229,36 @@ class TestQueryGeneration:
         )
 
         assert queries == ["Lantern Court trapdoor history"]
+
+    def test_sanitize_retrieval_queries_rejects_instruction_and_quote_junk(self):
+        """Live local models can leak instructions or malformed quote fragments."""
+        queries = _sanitize_retrieval_queries(
+            [
+                "Make sure each line is a query phrase. No bullet points.",
+                'Ganrow?" "stated*" "delay',
+                'Sella" "clause splinter" history of location "Rema',
+                "Sella sour bite Remainder Chamber poisoning",
+                "Lantern Court healer living remainder",
+                "East Span Crown wardline pursuit",
+            ]
+        )
+
+        assert queries == [
+            "Sella sour bite Remainder Chamber poisoning",
+            "Lantern Court healer living remainder",
+            "East Span Crown wardline pursuit",
+        ]
+
+    def test_retrieval_query_set_requires_three_queries(self):
+        """Structured output should fall back when too few valid queries survive."""
+        assert not _has_complete_retrieval_query_set(["Sella sour bite"])
+        assert _has_complete_retrieval_query_set(
+            [
+                "Sella sour bite Remainder Chamber poisoning",
+                "Lantern Court healer living remainder",
+                "East Span Crown wardline pursuit",
+            ]
+        )
 
     def test_parse_structured_json_text_uses_final_channel_json(self):
         """Structured fallback parsing should recover JSON from leaked transcripts."""


### PR DESCRIPTION
## Summary
- require at least three sanitized retrieval queries before accepting structured local-LLM output
- reject live-observed instruction/meta lines and malformed quote fragments before MEMNON search
- add regression coverage for the new sanitizer behavior and minimum-query completeness check

## Validation
- `PYTHONPATH=$PWD poetry run pytest tests/test_lore/test_local_llm.py -q`
- `poetry run black --check nexus/agents/lore/utils/local_llm.py tests/test_lore/test_local_llm.py`
- `PYTHONPATH=$PWD poetry run pytest tests/test_lore/test_local_llm.py tests/test_lore/test_local_llm_integration.py tests/test_lore/test_turn_cycle.py -q`
- live slot 5 stress reached committed chunk 30 with chunk 31 incubated; this patch addresses retrieval-query quality issues observed during that run
