### PR TITLE
Filter retrieval query meta leaks

### DIFF
--- a/nexus/agents/lore/utils/local_llm.py
+++ b/nexus/agents/lore/utils/local_llm.py
@@ -49,14 +49,21 @@ _META_QUERY_PREFIXES = (
     "thus produce",
     "user input",
     "we need",
+    "we must",
     "we should",
+    "we'll produce",
 )
 _META_QUERY_FRAGMENTS = (
     "complete question or search phrase",
+    "exactly 3-5",
     "generate retrieval queries",
     "generate queries",
     "make sure",
+    "need 3-5 queries",
     "no bullet",
+    "numbering or bullets",
+    "output exactly",
+    "produce 4 queries",
     "query phrase",
     "one per line",
     "retrieval queries to search",
@@ -64,8 +71,14 @@ _META_QUERY_FRAGMENTS = (
 _GENERIC_RETRIEVAL_QUERIES = {
     "background info on key entities",
     "character relationships and interactions",
+    "past events at",
     "relevant past events involving these characters",
 }
+_GENERIC_RETRIEVAL_PREFIXES = (
+    "background information on key entities",
+    "history of locations",
+    "so there is a scene",
+)
 _MIN_RETRIEVAL_QUERIES = 3
 
 
@@ -200,6 +213,10 @@ def _clean_retrieval_query(query: Any) -> Optional[str]:
     lowered = cleaned.lower()
     normalized_lowered = lowered.rstrip(" .:")
     if normalized_lowered in _GENERIC_RETRIEVAL_QUERIES:
+        return None
+    if lowered.endswith("..."):
+        return None
+    if normalized_lowered.startswith(_GENERIC_RETRIEVAL_PREFIXES):
         return None
     if cleaned.startswith(("{", "[")):
         return None

--- a/nexus/agents/lore/utils/local_llm.py
+++ b/nexus/agents/lore/utils/local_llm.py
@@ -44,7 +44,6 @@ _META_QUERY_PREFIXES = (
     "let's ",
     "locations:",
     "no numbering",
-    "output exactly",
     "the user wants",
     "thus produce",
     "user input",
@@ -74,10 +73,10 @@ _GENERIC_RETRIEVAL_QUERIES = {
     "past events at",
     "relevant past events involving these characters",
 }
-_GENERIC_RETRIEVAL_PREFIXES = (
-    "background information on key entities",
-    "history of locations",
-    "so there is a scene",
+_TEMPLATE_PLACEHOLDER_QUERY_PREFIXES = (
+    "background information on key entities (",
+    "history of locations (",
+    "so there is a scene where someone maybe",
 )
 _MIN_RETRIEVAL_QUERIES = 3
 
@@ -214,9 +213,10 @@ def _clean_retrieval_query(query: Any) -> Optional[str]:
     normalized_lowered = lowered.rstrip(" .:")
     if normalized_lowered in _GENERIC_RETRIEVAL_QUERIES:
         return None
+    # Use the raw lowered text: normalized_lowered strips the trailing dots.
     if lowered.endswith("..."):
         return None
-    if normalized_lowered.startswith(_GENERIC_RETRIEVAL_PREFIXES):
+    if normalized_lowered.startswith(_TEMPLATE_PLACEHOLDER_QUERY_PREFIXES):
         return None
     if cleaned.startswith(("{", "[")):
         return None

--- a/tests/test_lore/test_local_llm.py
+++ b/tests/test_lore/test_local_llm.py
@@ -235,6 +235,14 @@ class TestQueryGeneration:
         queries = _sanitize_retrieval_queries(
             [
                 "Make sure each line is a query phrase. No bullet points.",
+                "We must output exactly 3-5 lines, no numbering or bullets. Let's produce 4 queries.",
+                "But need 3-5 queries. Provide maybe four lines.",
+                "We'll produce something like:",
+                "So there is a scene where someone maybe climbs a dry pump throat.",
+                "History of locations (maybe Mercy Flue, ledger, Archivum).",
+                "Background information on key entities (Mercy Flue, ledger, Archivist).",
+                "Past events at",
+                "Past events at Lantern Lantern...",
                 'Ganrow?" "stated*" "delay',
                 'Sella" "clause splinter" history of location "Rema',
                 'history of "Lantern Court" alliance with "Remainder Chamber"',

--- a/tests/test_lore/test_local_llm.py
+++ b/tests/test_lore/test_local_llm.py
@@ -270,6 +270,22 @@ class TestQueryGeneration:
             ]
         )
 
+    def test_sanitize_retrieval_queries_keeps_specific_generic_openers(self):
+        """Specific entity/location queries should survive generic-looking openers."""
+        queries = _sanitize_retrieval_queries(
+            [
+                "Background information on key entities involved in the Lantern Court conspiracy",
+                "History of locations: Verdigris Scriptorium fire timeline",
+                "History of locations around Lantern Court and Door Six",
+            ]
+        )
+
+        assert queries == [
+            "Background information on key entities involved in the Lantern Court conspiracy",
+            "History of locations: Verdigris Scriptorium fire timeline",
+            "History of locations around Lantern Court and Door Six",
+        ]
+
     def test_parse_structured_json_text_uses_final_channel_json(self):
         """Structured fallback parsing should recover JSON from leaked transcripts."""
         raw = (


### PR DESCRIPTION
## Summary
- filter additional live-observed local-LLM retrieval-query meta chatter before MEMNON search
- reject incomplete/truncated generic queries such as `Past events at` and `Past events at Lantern Lantern...`
- extend sanitizer regression coverage with the exact shapes observed during slot 5 stress testing

## Validation
- `PYTHONPATH=$PWD poetry run pytest tests/test_lore/test_local_llm.py -q`
- `poetry run black --check nexus/agents/lore/utils/local_llm.py tests/test_lore/test_local_llm.py`
- `PYTHONPATH=$PWD poetry run pytest tests/test_lore/test_local_llm.py tests/test_lore/test_local_llm_integration.py tests/test_lore/test_turn_cycle.py -q`
- live slot 5 stress reached committed chunk 40 with chunk 41 incubated, embeddings through chunk 39, and Orrery events/resolutions through tick 40
