### PR TITLE
Parse markdown Orrery verdicts

### DIFF
--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -613,18 +613,19 @@ def _markdown_bool_payload_from_raw(
         return None
 
     verdict_match = re.search(
-        rf"(?:\*\*)?\b{re.escape(field_name)}\b(?:\*\*)?\s*[:=]\s*(?:\*\*)?\s*(true|false)\b",
+        rf"^\s*(?:[-*+]\s*)?(?:\*\*)?\s*{re.escape(field_name)}\s*"
+        r"(?:\*\*)?\s*[:=]\s*(?:\*\*)?\s*(true|false)\b",
         text,
-        re.IGNORECASE,
+        re.IGNORECASE | re.MULTILINE,
     )
     if not verdict_match:
         return None
 
     if reason is None:
         reason_match = re.search(
-            r"(?:\*\*)?\breason\b(?:\*\*)?\s*[:=]\s*(.+)",
+            r"^\s*(?:[-*+]\s*)?(?:\*\*)?\s*reason\s*" r"(?:\*\*)?\s*[:=]\s*(.+)$",
             text,
-            re.IGNORECASE | re.DOTALL,
+            re.IGNORECASE | re.MULTILINE,
         )
         if reason_match:
             reason = reason_match.group(1).strip()
@@ -641,7 +642,8 @@ def _coerce_promotion_verdict(raw: Any) -> PromotionVerdict:
         if isinstance(raw, PromotionVerdict):
             return raw
         payload = _structured_payload_from_raw(raw)
-        payload = _markdown_bool_payload_from_raw(payload, "promote") or payload
+        if not (isinstance(payload, Mapping) and "promote" in payload):
+            payload = _markdown_bool_payload_from_raw(payload, "promote") or payload
         if isinstance(payload, Mapping) and "promote" in payload:
             payload = dict(payload)
             payload.setdefault(
@@ -862,7 +864,8 @@ def _coerce_semantic_clearance_verdict(raw: Any) -> SemanticClearanceVerdict:
         if isinstance(raw, SemanticClearanceVerdict):
             return raw
         payload = _structured_payload_from_raw(raw)
-        payload = _markdown_bool_payload_from_raw(payload, "clear") or payload
+        if not (isinstance(payload, Mapping) and "clear" in payload):
+            payload = _markdown_bool_payload_from_raw(payload, "clear") or payload
         if isinstance(payload, Mapping) and "clear" in payload:
             payload = dict(payload)
             payload.setdefault(

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import logging
 import os
+import re
 from typing import Any, Mapping, Optional
 
 import psycopg2
@@ -589,12 +590,58 @@ def _structured_payload_from_raw(raw: Any) -> Any:
     return raw
 
 
+def _markdown_bool_payload_from_raw(
+    raw: Any, field_name: str
+) -> Optional[dict[str, Any]]:
+    """Recover simple markdown/text boolean verdicts from local LLM fallbacks."""
+    text: Optional[str] = None
+    reason: Optional[str] = None
+
+    if isinstance(raw, Mapping):
+        answer = raw.get("answer")
+        if isinstance(answer, str):
+            text = answer
+        for reason_key in ("reason", "reasoning"):
+            value = raw.get(reason_key)
+            if isinstance(value, str) and value.strip():
+                reason = value.strip()
+                break
+    elif isinstance(raw, str):
+        text = raw
+
+    if not text:
+        return None
+
+    verdict_match = re.search(
+        rf"(?:\*\*)?\b{re.escape(field_name)}\b(?:\*\*)?\s*[:=]\s*(?:\*\*)?\s*(true|false)\b",
+        text,
+        re.IGNORECASE,
+    )
+    if not verdict_match:
+        return None
+
+    if reason is None:
+        reason_match = re.search(
+            r"(?:\*\*)?\breason\b(?:\*\*)?\s*[:=]\s*(.+)",
+            text,
+            re.IGNORECASE | re.DOTALL,
+        )
+        if reason_match:
+            reason = reason_match.group(1).strip()
+
+    return {
+        field_name: verdict_match.group(1).lower() == "true",
+        "reason": reason or "Local model returned a text boolean verdict.",
+    }
+
+
 def _coerce_promotion_verdict(raw: Any) -> PromotionVerdict:
     """Return a conservative promotion verdict from noisy local-model output."""
     try:
         if isinstance(raw, PromotionVerdict):
             return raw
         payload = _structured_payload_from_raw(raw)
+        payload = _markdown_bool_payload_from_raw(payload, "promote") or payload
         if isinstance(payload, Mapping) and "promote" in payload:
             payload = dict(payload)
             payload.setdefault(
@@ -815,6 +862,7 @@ def _coerce_semantic_clearance_verdict(raw: Any) -> SemanticClearanceVerdict:
         if isinstance(raw, SemanticClearanceVerdict):
             return raw
         payload = _structured_payload_from_raw(raw)
+        payload = _markdown_bool_payload_from_raw(payload, "clear") or payload
         if isinstance(payload, Mapping) and "clear" in payload:
             payload = dict(payload)
             payload.setdefault(

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -316,6 +316,21 @@ def test_coerce_promotion_verdict_recovers_markdown_boolean() -> None:
     assert verdict.reason == "Routine maintenance."
 
 
+def test_coerce_promotion_verdict_prefers_structured_field_over_answer() -> None:
+    """Structured verdict fields should not be shadowed by markdown answer text."""
+
+    verdict = _coerce_promotion_verdict(
+        {
+            "promote": False,
+            "answer": "**promote:** true",
+            "reason": "Structured field wins.",
+        }
+    )
+
+    assert verdict.promote is False
+    assert verdict.reason == "Structured field wins."
+
+
 def test_drain_narration_outbox_persists_offscreen_narration() -> None:
     """Queued narration jobs persist into offscreen_narrations."""
 
@@ -495,6 +510,53 @@ def test_coerce_semantic_clearance_verdict_recovers_markdown_boolean() -> None:
 
     assert verdict.clear is False
     assert verdict.reason == "Evidence still supports tag."
+
+
+def test_coerce_semantic_clearance_prefers_structured_field_over_answer() -> None:
+    """Structured clearance fields should not be shadowed by markdown answer text."""
+
+    verdict = _coerce_semantic_clearance_verdict(
+        {
+            "clear": False,
+            "answer": "**clear:** true",
+            "reason": "Structured field wins.",
+        }
+    )
+
+    assert verdict.clear is False
+    assert verdict.reason == "Structured field wins."
+
+
+def test_coerce_semantic_clearance_ignores_incidental_markdown_boolean() -> None:
+    """Incidental prose should not clear tags by pretending to be a verdict."""
+
+    verdict = _coerce_semantic_clearance_verdict(
+        "This is noisy prose. To be clear: true, the evidence is mixed."
+    )
+
+    assert verdict.clear is False
+    assert (
+        verdict.reason
+        == "Malformed local semantic-clearance verdict; kept conservatively."
+    )
+
+
+def test_coerce_promotion_verdict_recovers_bulleted_markdown_boolean() -> None:
+    """Explicit bullet key/value verdicts should still parse."""
+
+    verdict = _coerce_promotion_verdict("- **promote:** true\n- reason: Enough proof.")
+
+    assert verdict.promote is True
+    assert verdict.reason == "Enough proof."
+
+
+def test_coerce_semantic_clearance_uses_default_reason_for_bare_text() -> None:
+    """Bare string verdicts without a reason should get a durable default reason."""
+
+    verdict = _coerce_semantic_clearance_verdict("clear: false")
+
+    assert verdict.clear is False
+    assert verdict.reason == "Local model returned a text boolean verdict."
 
 
 def test_process_orrery_outbox_includes_semantic_clearance(monkeypatch) -> None:

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -9,6 +9,8 @@ import pytest
 from nexus.agents.orrery.worker import (
     PromotionVerdict,
     SemanticClearanceVerdict,
+    _coerce_promotion_verdict,
+    _coerce_semantic_clearance_verdict,
     clear_semantic_tags_sync,
     drain_narration_outbox_sync,
     load_orrery_status_sync,
@@ -303,6 +305,17 @@ def test_promote_pending_resolutions_recovers_bare_final_channel_json() -> None:
     assert verdict["reason"] == "Local model returned a bare promotion decision."
 
 
+def test_coerce_promotion_verdict_recovers_markdown_boolean() -> None:
+    """Markdown-ish local fallback text should not become malformed noise."""
+
+    verdict = _coerce_promotion_verdict(
+        {"answer": "**promote:** false", "reasoning": "Routine maintenance."}
+    )
+
+    assert verdict.promote is False
+    assert verdict.reason == "Routine maintenance."
+
+
 def test_drain_narration_outbox_persists_offscreen_narration() -> None:
     """Queued narration jobs persist into offscreen_narrations."""
 
@@ -471,6 +484,17 @@ def test_clear_semantic_tags_keeps_on_malformed_llm_output() -> None:
     assert cleared == 1
     assert statements.count("UPDATE entity_tags et") == 1
     assert statements.count("INSERT INTO tag_clearance_log") == 1
+
+
+def test_coerce_semantic_clearance_verdict_recovers_markdown_boolean() -> None:
+    """Markdown-ish local fallback text should produce a normal keep verdict."""
+
+    verdict = _coerce_semantic_clearance_verdict(
+        {"answer": "**clear:** false", "reasoning": "Evidence still supports tag."}
+    )
+
+    assert verdict.clear is False
+    assert verdict.reason == "Evidence still supports tag."
 
 
 def test_process_orrery_outbox_includes_semantic_clearance(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- recover simple markdown/text boolean Orrery verdicts such as `**clear:** false`
- reuse the recovery for promotion and semantic-clearance verdicts before falling back to malformed-output handling
- add worker tests for markdown promotion and semantic-clearance verdict coercion

## Validation
- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery/test_worker.py -q`
- `poetry run black --check nexus/agents/orrery/worker.py tests/test_orrery/test_worker.py`
- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery -q`
- live slot 5 stress reached committed chunk 45 with chunk 46 incubated; this patch addresses the markdown semantic-clearance verdict shape observed in that run
