### PR TITLE
Filter stuttered retrieval queries

### DIFF
--- a/nexus/agents/lore/utils/local_llm.py
+++ b/nexus/agents/lore/utils/local_llm.py
@@ -46,6 +46,7 @@ _META_QUERY_PREFIXES = (
     "no numbering",
     "the user wants",
     "thus produce",
+    "thus we ",
     "user input",
     "we need",
     "we must",
@@ -70,6 +71,7 @@ _META_QUERY_FRAGMENTS = (
 _GENERIC_RETRIEVAL_QUERIES = {
     "background info on key entities",
     "character relationships and interactions",
+    "character relationships and interactions among them",
     "past events at",
     "relevant past events involving these characters",
 }
@@ -79,6 +81,20 @@ _TEMPLATE_PLACEHOLDER_QUERY_PREFIXES = (
     "so there is a scene where someone maybe",
 )
 _MIN_RETRIEVAL_QUERIES = 3
+_QUERY_STUTTER_STOPWORDS = {
+    "about",
+    "after",
+    "among",
+    "and",
+    "from",
+    "history",
+    "into",
+    "past",
+    "that",
+    "the",
+    "them",
+    "with",
+}
 
 
 # Pydantic models for structured responses
@@ -195,6 +211,30 @@ def _has_well_formed_double_quotes(query: str) -> bool:
     return True
 
 
+def _normalized_query_terms(query: str) -> list[str]:
+    """Return content-ish query terms for lightweight quality checks."""
+    terms: list[str] = []
+    for token in re.findall(r"[A-Za-z0-9]+", query.casefold()):
+        if len(token) < 4 or token in _QUERY_STUTTER_STOPWORDS:
+            continue
+        if len(token) > 4 and token.endswith("ies"):
+            token = f"{token[:-3]}y"
+        elif len(token) > 4 and token.endswith("s"):
+            token = token[:-1]
+        terms.append(token)
+    return terms
+
+
+def _has_adjacent_duplicate_query_terms(query: str) -> bool:
+    """Return whether a candidate looks like local-model keyword stutter."""
+    previous: Optional[str] = None
+    for term in _normalized_query_terms(query):
+        if term == previous:
+            return True
+        previous = term
+    return False
+
+
 def _clean_retrieval_query(query: Any) -> Optional[str]:
     """Normalize one candidate retrieval query and reject instruction/meta text."""
     if not isinstance(query, str):
@@ -231,6 +271,8 @@ def _clean_retrieval_query(query: Any) -> Optional[str]:
     if not any(character.isalpha() for character in cleaned):
         return None
     if len(re.findall(r"[A-Za-z0-9]+", cleaned)) < 3:
+        return None
+    if _has_adjacent_duplicate_query_terms(cleaned):
         return None
     if not _has_well_formed_double_quotes(cleaned):
         return None

--- a/nexus/agents/lore/utils/local_llm.py
+++ b/nexus/agents/lore/utils/local_llm.py
@@ -211,24 +211,30 @@ def _has_well_formed_double_quotes(query: str) -> bool:
     return True
 
 
-def _normalized_query_terms(query: str) -> list[str]:
-    """Return content-ish query terms for lightweight quality checks."""
-    terms: list[str] = []
-    for token in re.findall(r"[A-Za-z0-9]+", query.casefold()):
-        if len(token) < 4 or token in _QUERY_STUTTER_STOPWORDS:
-            continue
-        if len(token) > 4 and token.endswith("ies"):
-            token = f"{token[:-3]}y"
-        elif len(token) > 4 and token.endswith("s"):
-            token = token[:-1]
-        terms.append(token)
-    return terms
+def _normalized_query_term(token: str) -> Optional[str]:
+    """Return a comparable content term, preserving ignored tokens as boundaries."""
+    token = token.casefold()
+    if len(token) < 4 or token in _QUERY_STUTTER_STOPWORDS:
+        return None
+    if len(token) > 4 and token.endswith("ies"):
+        return f"{token[:-3]}y"
+    if (
+        len(token) > 4
+        and token.endswith("s")
+        and not token.endswith(("ss", "is", "os", "us"))
+    ):
+        return token[:-1]
+    return token
 
 
 def _has_adjacent_duplicate_query_terms(query: str) -> bool:
     """Return whether a candidate looks like local-model keyword stutter."""
     previous: Optional[str] = None
-    for term in _normalized_query_terms(query):
+    for token in re.findall(r"[A-Za-z0-9]+", query):
+        term = _normalized_query_term(token)
+        if term is None:
+            previous = None
+            continue
         if term == previous:
             return True
         previous = term

--- a/tests/test_lore/test_local_llm.py
+++ b/tests/test_lore/test_local_llm.py
@@ -18,7 +18,9 @@ sys.path.insert(0, str(nexus_root))
 
 from nexus.agents.lore.utils.local_llm import (
     _extract_final_channel_text,
+    _has_adjacent_duplicate_query_terms,
     _has_complete_retrieval_query_set,
+    _normalized_query_term,
     _parse_structured_json_text,
     _sanitize_retrieval_queries,
     LocalLLMManager,
@@ -279,6 +281,52 @@ class TestQueryGeneration:
             "Lantern Court laundry crate inspector search",
             "Ledger concealment near the service hatch",
         ]
+
+    def test_sanitize_retrieval_queries_preserves_non_adjacent_repeats(self):
+        """Repeated terms separated by real boundaries can still be useful."""
+        queries = _sanitize_retrieval_queries(
+            [
+                "Orrel ledgers in ledger archive",
+                "Inspector warrants and inspector protocols",
+            ]
+        )
+
+        assert queries == [
+            "Orrel ledgers in ledger archive",
+            "Inspector warrants and inspector protocols",
+        ]
+
+    @pytest.mark.parametrize(
+        ("token", "expected"),
+        [
+            ("inspectors", "inspector"),
+            ("ledgers", "ledger"),
+            ("batteries", "battery"),
+            ("them", None),
+            ("front", "front"),
+            ("chaos", "chaos"),
+            ("focus", "focus"),
+        ],
+    )
+    def test_normalized_query_term_documents_stutter_comparison(self, token, expected):
+        """Query stutter normalization should stay small and predictable."""
+        assert _normalized_query_term(token) == expected
+
+    @pytest.mark.parametrize(
+        ("query", "has_stutter"),
+        [
+            ("front front the drains laundry", True),
+            ("Orrel ledger ledgers ledgers", True),
+            ("inspectors inspector misdirection tactics", True),
+            ("Orrel ledgers in ledger archive", False),
+            ("Inspector warrants and inspector protocols", False),
+        ],
+    )
+    def test_has_adjacent_duplicate_query_terms_preserves_boundaries(
+        self, query, has_stutter
+    ):
+        """Ignored words should break adjacency instead of collapsing repeats."""
+        assert _has_adjacent_duplicate_query_terms(query) is has_stutter
 
     def test_retrieval_query_set_requires_three_queries(self):
         """Structured output should fall back when too few valid queries survive."""

--- a/tests/test_lore/test_local_llm.py
+++ b/tests/test_lore/test_local_llm.py
@@ -259,6 +259,27 @@ class TestQueryGeneration:
             "East Span Crown wardline pursuit",
         ]
 
+    def test_sanitize_retrieval_queries_rejects_live_keyword_stutter(self):
+        """Live local models can emit keyword stutter instead of useful queries."""
+        queries = _sanitize_retrieval_queries(
+            [
+                "Character relationships and interactions among them.",
+                "Thus we can propose queries like:",
+                'Orrel "misdirect" inspectors inspector misdirection tactics',
+                "front front the drains laundry?",
+                "Orrel ledger ledgers ledgers",
+                "Orrel misdirect inspectors through laundry chaos",
+                "Lantern Court laundry crate inspector search",
+                "Ledger concealment near the service hatch",
+            ]
+        )
+
+        assert queries == [
+            "Orrel misdirect inspectors through laundry chaos",
+            "Lantern Court laundry crate inspector search",
+            "Ledger concealment near the service hatch",
+        ]
+
     def test_retrieval_query_set_requires_three_queries(self):
         """Structured output should fall back when too few valid queries survive."""
         assert not _has_complete_retrieval_query_set(["Sella sour bite"])


### PR DESCRIPTION
## Summary
- reject exact generic relationship queries that leaked during slot 5 stress testing
- filter adjacent duplicate query-term stutter such as `front front`, `ledger ledgers ledgers`, and `inspectors inspector`
- keep specific generic-looking openers intact so useful entity/location queries survive

## Verification
- `PYTHONPATH=/Users/pythagor/nexus poetry run pytest tests/test_lore/test_local_llm.py -q`
- `PYTHONPATH=/Users/pythagor/nexus poetry run pytest tests/test_lore/test_local_llm.py tests/test_lore/test_local_llm_integration.py tests/test_lore/test_turn_cycle.py -q`
- `poetry run black --check nexus/agents/lore/utils/local_llm.py tests/test_lore/test_local_llm.py`

## Live Evidence
Observed during slot 5 stress advancement around chunks 47-49: `Character relationships and interactions among them.`, `front front the drains laundry?`, `Orrel ledger ledgers ledgers`, `Orrel "misdirect" inspectors inspector misdirection tactics`, and `Thus we can propose queries like:` reached MEMNON as retrieval queries.