### PR TITLE
Persist Storyteller authorial directives

### DIFF
--- a/migrations/040_storyteller_authorial_directives.sql
+++ b/migrations/040_storyteller_authorial_directives.sql
@@ -1,0 +1,45 @@
+-- 040_storyteller_authorial_directives.sql
+--
+-- Persist Storyteller-authored retrieval priorities so each committed chunk can
+-- steer the next turn's MEMNON retrieval, matching storyteller_core.md.
+
+ALTER TABLE narrative_chunks
+ADD COLUMN IF NOT EXISTS authorial_directives JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE incubator
+ADD COLUMN IF NOT EXISTS authorial_directives JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN narrative_chunks.authorial_directives IS
+    'Storyteller-authored retrieval directives for the successor turn.';
+
+COMMENT ON COLUMN incubator.authorial_directives IS
+    'Provisional Storyteller-authored retrieval directives to persist when accepted.';
+
+DROP VIEW IF EXISTS incubator_view;
+CREATE VIEW incubator_view AS
+SELECT
+    i.chunk_id,
+    i.parent_chunk_id,
+    nc.raw_text AS parent_chunk_text,
+    i.user_text,
+    i.storyteller_text,
+    i.choice_object,
+    i.choice_text,
+    i.authorial_directives,
+    i.orrery_proposal,
+    i.metadata_updates -> 'chronology' ->> 'episode_transition' AS episode_transition,
+    i.metadata_updates -> 'chronology' ->> 'time_delta_description' AS time_delta,
+    i.metadata_updates ->> 'world_layer' AS world_layer,
+    i.metadata_updates ->> 'pacing' AS pacing,
+    COALESCE(jsonb_array_length(i.entity_updates -> 'characters'), 0)
+        + COALESCE(jsonb_array_length(i.entity_updates -> 'locations'), 0)
+        + COALESCE(jsonb_array_length(i.entity_updates -> 'factions'), 0)
+        AS entity_update_count,
+    i.entity_updates AS entity_changes,
+    i.reference_updates AS "references",
+    i.status,
+    i.session_id,
+    i.created_at
+FROM incubator i
+LEFT JOIN narrative_chunks nc ON nc.id = i.parent_chunk_id
+WHERE i.id = TRUE;

--- a/nexus.toml
+++ b/nexus.toml
@@ -115,6 +115,7 @@ debug = true
 agentic_sql = true  # Enable agent to generate SQL queries dynamically
 
 [lore.retrieval]
+max_deep_queries = 5
 fallback_query = "Recent narrative events"
 
 [lore.token_budget]

--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -20,6 +20,10 @@ from typing import List, Optional, Dict, Any, Union, Literal
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 from datetime import datetime
 
+from nexus.util.authorial_directives import (
+    normalize_authorial_directives as normalize_directive_list,
+)
+
 # Import all database ENUMs
 from nexus.agents.logon.apex_enums import (
     AgentType,
@@ -823,11 +827,7 @@ class AuthorialDirectivesMixin(BaseModel):
     def normalize_authorial_directives(cls, directives: List[str]) -> List[str]:
         """Trim empty directive strings before persistence and prompt echoing."""
 
-        normalized = [
-            directive.strip()
-            for directive in directives
-            if isinstance(directive, str) and directive.strip()
-        ]
+        normalized = normalize_directive_list(directives)
         if not normalized:
             raise ValueError("authorial_directives must include at least one directive")
         return normalized

--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -805,7 +805,35 @@ class Operations(BaseModel):
 # ============================================================================
 
 
-class StorytellerResponseBootstrap(BaseModel):
+class AuthorialDirectivesMixin(BaseModel):
+    """Fields shared by Storyteller response schemas."""
+
+    authorial_directives: List[str] = Field(
+        min_length=1,
+        max_length=5,
+        description=(
+            "Focused retrieval priorities for the next Storyteller turn. "
+            "Use concrete people, places, factions, objects, unresolved questions, "
+            "or continuity facts that should be easy for MEMNON to retrieve."
+        ),
+    )
+
+    @field_validator("authorial_directives")
+    @classmethod
+    def normalize_authorial_directives(cls, directives: List[str]) -> List[str]:
+        """Trim empty directive strings before persistence and prompt echoing."""
+
+        normalized = [
+            directive.strip()
+            for directive in directives
+            if isinstance(directive, str) and directive.strip()
+        ]
+        if not normalized:
+            raise ValueError("authorial_directives must include at least one directive")
+        return normalized
+
+
+class StorytellerResponseBootstrap(AuthorialDirectivesMixin):
     """Bootstrap response for first-chunk narrative generation."""
 
     narrative: str = Field(description="The opening narrative prose")
@@ -818,7 +846,7 @@ class StorytellerResponseBootstrap(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class StorytellerResponseMinimal(BaseModel):
+class StorytellerResponseMinimal(AuthorialDirectivesMixin):
     """Minimal response for quick narrative generation."""
 
     narrative: str = Field(description="The narrative prose (500-1500 words)")
@@ -834,7 +862,7 @@ class StorytellerResponseMinimal(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class StorytellerResponseStandard(BaseModel):
+class StorytellerResponseStandard(AuthorialDirectivesMixin):
     """Standard response with narrative and essential metadata."""
 
     narrative: str = Field(description="The narrative prose (500-1500 words)")
@@ -854,7 +882,7 @@ class StorytellerResponseStandard(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class StorytellerResponseExtended(BaseModel):
+class StorytellerResponseExtended(AuthorialDirectivesMixin):
     """Extended response with all features including operations."""
 
     narrative: str = Field(description="The narrative prose (500-1500 words)")
@@ -991,6 +1019,9 @@ def create_minimal_response(narrative_text: str) -> StorytellerResponseMinimal:
     """
     return StorytellerResponseMinimal(
         narrative=narrative_text,
+        authorial_directives=[
+            "Preserve the immediate scene continuity and unresolved player choice."
+        ],
         choices=[
             "Continue.",
             "Wait and observe.",

--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -43,6 +43,7 @@ class TurnContext:
     token_counts: Dict[str, int] = field(default_factory=dict)
     memory_state: Dict[str, Any] = field(default_factory=dict)
     authorial_directives: List[str] = field(default_factory=list)
+    generated_authorial_directives: List[str] = field(default_factory=list)
     target_chunk_id: Optional[int] = None
     # Soft author's note / suggestion for the storyteller.
     note: Optional[str] = None

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -5,6 +5,7 @@ Handles the execution of individual turn cycle phases.
 """
 
 import logging
+import json
 import time
 from typing import Dict, List, Any, Optional, Union, Iterable
 from datetime import datetime
@@ -80,6 +81,25 @@ def _sorted_chunk_ids(chunk_ids: Iterable[Any]) -> List[Any]:
             return (1, str(chunk_id))
 
     return sorted(chunk_ids, key=sort_key)
+
+
+def _coerce_authorial_directives(raw_directives: Any) -> List[str]:
+    """Normalize authorial directives loaded from JSONB or structured responses."""
+
+    if isinstance(raw_directives, str):
+        try:
+            raw_directives = json.loads(raw_directives)
+        except json.JSONDecodeError:
+            raw_directives = [raw_directives]
+
+    if not isinstance(raw_directives, list):
+        return []
+
+    return [
+        directive.strip()
+        for directive in raw_directives
+        if isinstance(directive, str) and directive.strip()
+    ]
 
 
 class TurnCycleManager:
@@ -162,6 +182,9 @@ class TurnCycleManager:
                     if not target_entry.get("text") and target_entry.get("full_text"):
                         target_entry["text"] = target_entry["full_text"]
                     target_entry["is_target"] = True
+                    turn_context.authorial_directives = _coerce_authorial_directives(
+                        target_entry.get("authorial_directives")
+                    )
                     warm_slice_chunks.append(target_entry)
                     logger.info(
                         f"Anchored warm slice to requested chunk {target_chunk_id}"
@@ -187,6 +210,14 @@ class TurnCycleManager:
                 # Get most recent chunks directly
                 recent_chunks = self.lore.memnon.get_recent_chunks(limit=initial_chunks)
                 recent_list = recent_chunks.get("results", [])
+                if (
+                    not turn_context.authorial_directives
+                    and target_chunk_id is None
+                    and recent_list
+                ):
+                    turn_context.authorial_directives = _coerce_authorial_directives(
+                        recent_list[0].get("authorial_directives")
+                    )
 
                 if target_chunk_id is not None:
                     recent_list = [
@@ -234,6 +265,7 @@ class TurnCycleManager:
         turn_context.phase_states["warm_analysis"] = {
             "analysis": analysis,
             "chunk_count": len(turn_context.warm_slice),
+            "authorial_directive_count": len(turn_context.authorial_directives),
         }
 
     async def query_entity_states(self, turn_context: TurnContext):
@@ -482,24 +514,40 @@ class TurnCycleManager:
                 "Cannot proceed with deep queries without narrative context analysis."
             )
 
-        # LLM generates queries from scratch based on what information
-        # would help continue the narrative
-        llm_queries = self.lore.llm_manager.generate_retrieval_queries(
-            analysis, turn_context.user_input
+        incoming_directives = _coerce_authorial_directives(
+            turn_context.authorial_directives
         )
 
-        if not llm_queries:
+        if getattr(self.lore, "memory_manager", None):
+            self.lore.memory_manager.reset_pass1_queries()
+
+        # Storyteller-authored directives are first-line retrieval input. The
+        # local LLM fills any remaining query budget from the current analysis.
+        queries = []
+        for directive in incoming_directives[:5]:
+            queries.append(
+                {
+                    "text": directive,
+                    "type": "general",
+                    "source": "authorial_directive",
+                }
+            )
+
+        remaining_query_slots = max(0, 5 - len(queries))
+        llm_queries = []
+        if remaining_query_slots:
+            llm_queries = self.lore.llm_manager.generate_retrieval_queries(
+                analysis, turn_context.user_input
+            )
+
+        if not queries and not llm_queries:
             raise RuntimeError(
                 "FATAL: LLM failed to generate any retrieval queries. "
                 "This should not happen - check LLM configuration."
             )
 
-        if getattr(self.lore, "memory_manager", None):
-            self.lore.memory_manager.reset_pass1_queries()
-
-        # Step 2: Classify each generated query with MEMNON's QueryAnalyzer
-        queries = []
-        for q_text in llm_queries:
+        # Step 2: Classify local generated queries with MEMNON's QueryAnalyzer
+        for q_text in llm_queries[:remaining_query_slots]:
             query_type = "general"
             if self.query_analyzer:
                 query_info = self.query_analyzer.analyze_query(q_text)
@@ -561,6 +609,14 @@ class TurnCycleManager:
         turn_context.phase_states["deep_queries"] = {
             "queries_executed": len(queries),
             "query_types": query_type_counts,
+            "query_sources": {
+                "authorial_directive": sum(
+                    1 for query in queries if query["source"] == "authorial_directive"
+                ),
+                "llm_generated": sum(
+                    1 for query in queries if query["source"] == "llm_generated"
+                ),
+            },
             "results_retrieved": len(unique_results),
         }
 
@@ -855,6 +911,9 @@ class TurnCycleManager:
 
             # Store the full structured response
             turn_context.apex_response = story_response
+            turn_context.generated_authorial_directives = _coerce_authorial_directives(
+                getattr(story_response, "authorial_directives", [])
+            )
 
             # Extract narrative text for backward compatibility
             narrative_text = story_response.narrative
@@ -868,6 +927,9 @@ class TurnCycleManager:
                 "has_metadata": chunk_metadata is not None,
                 "has_entities": referenced_entities is not None,
                 "has_state_updates": state_updates is not None,
+                "authorial_directive_count": len(
+                    turn_context.generated_authorial_directives
+                ),
                 "narrative_length": len(narrative_text),
             }
 
@@ -917,6 +979,13 @@ class TurnCycleManager:
         }
 
         if structured_response is not None:
+            turn_context.generated_authorial_directives = _coerce_authorial_directives(
+                getattr(
+                    structured_response,
+                    "authorial_directives",
+                    turn_context.generated_authorial_directives,
+                )
+            )
             turn_context.phase_states["integration"][
                 "structured_response"
             ] = structured_response.model_dump()
@@ -929,7 +998,8 @@ class TurnCycleManager:
                     retrieved_passages=turn_context.retrieved_passages,
                     token_usage=turn_context.token_counts,
                     assembled_context=turn_context.context_payload,
-                    authorial_directives=turn_context.authorial_directives,
+                    authorial_directives=turn_context.generated_authorial_directives,
+                    execute_authorial_directives=False,
                 )
                 transition = self.lore.memory_manager.context_state.transition
                 baseline_snapshot = {

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -5,7 +5,6 @@ Handles the execution of individual turn cycle phases.
 """
 
 import logging
-import json
 import time
 from typing import Dict, List, Any, Optional, Union, Iterable
 from datetime import datetime
@@ -32,6 +31,8 @@ try:
         record_bleed_offers,
         select_bleed_menu_async,
     )
+    from nexus.config.settings_models import LORERetrievalSettings
+    from nexus.util.authorial_directives import normalize_authorial_directives
 except ImportError:
     # If relative import fails, try absolute
     from nexus.agents.lore.utils.turn_context import TurnContext, TurnPhase
@@ -53,6 +54,8 @@ except ImportError:
         record_bleed_offers,
         select_bleed_menu_async,
     )
+    from nexus.config.settings_models import LORERetrievalSettings
+    from nexus.util.authorial_directives import normalize_authorial_directives
 
 try:
     from nexus.agents.memnon.utils.query_analysis import QueryAnalyzer
@@ -86,20 +89,7 @@ def _sorted_chunk_ids(chunk_ids: Iterable[Any]) -> List[Any]:
 def _coerce_authorial_directives(raw_directives: Any) -> List[str]:
     """Normalize authorial directives loaded from JSONB or structured responses."""
 
-    if isinstance(raw_directives, str):
-        try:
-            raw_directives = json.loads(raw_directives)
-        except json.JSONDecodeError:
-            raw_directives = [raw_directives]
-
-    if not isinstance(raw_directives, list):
-        return []
-
-    return [
-        directive.strip()
-        for directive in raw_directives
-        if isinstance(directive, str) and directive.strip()
-    ]
+    return normalize_authorial_directives(raw_directives, allow_json_string=True)
 
 
 class TurnCycleManager:
@@ -120,6 +110,21 @@ class TurnCycleManager:
         if MEMNON_ANALYZER_AVAILABLE:
             memnon_settings = self.settings.get("Agent Settings", {}).get("MEMNON", {})
             self.query_analyzer = QueryAnalyzer(memnon_settings)
+
+    def _max_deep_queries(self) -> int:
+        """Resolve the configured deep-query budget for one turn."""
+
+        retrieval_settings = self.settings.get("lore", {}).get("retrieval") or (
+            self.settings.get("Agent Settings", {}).get("LORE", {}).get("retrieval", {})
+        )
+        default_budget = LORERetrievalSettings().max_deep_queries
+        budget = retrieval_settings.get("max_deep_queries", default_budget)
+        try:
+            return max(1, int(budget))
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"Invalid LORE retrieval max_deep_queries setting: {budget!r}"
+            ) from exc
 
     async def process_user_input(self, turn_context: TurnContext):
         """
@@ -514,17 +519,15 @@ class TurnCycleManager:
                 "Cannot proceed with deep queries without narrative context analysis."
             )
 
-        incoming_directives = _coerce_authorial_directives(
-            turn_context.authorial_directives
-        )
-
         if getattr(self.lore, "memory_manager", None):
             self.lore.memory_manager.reset_pass1_queries()
 
         # Storyteller-authored directives are first-line retrieval input. The
         # local LLM fills any remaining query budget from the current analysis.
+        max_deep_queries = self._max_deep_queries()
+        incoming_directives = turn_context.authorial_directives
         queries = []
-        for directive in incoming_directives[:5]:
+        for directive in incoming_directives[:max_deep_queries]:
             queries.append(
                 {
                     "text": directive,
@@ -533,7 +536,7 @@ class TurnCycleManager:
                 }
             )
 
-        remaining_query_slots = max(0, 5 - len(queries))
+        remaining_query_slots = max(0, max_deep_queries - len(queries))
         llm_queries = []
         if remaining_query_slots:
             llm_queries = self.lore.llm_manager.generate_retrieval_queries(
@@ -562,7 +565,7 @@ class TurnCycleManager:
         all_results = []
         query_type_counts = {}
 
-        for query_obj in queries[:5]:  # Limit to 5 queries
+        for query_obj in queries[:max_deep_queries]:
             if getattr(self.lore, "memory_manager", None):
                 self.lore.memory_manager.record_pass1_query(query_obj["text"])
             try:
@@ -611,10 +614,12 @@ class TurnCycleManager:
             "query_types": query_type_counts,
             "query_sources": {
                 "authorial_directive": sum(
-                    1 for query in queries if query["source"] == "authorial_directive"
+                    1
+                    for query in queries
+                    if query.get("source") == "authorial_directive"
                 ),
                 "llm_generated": sum(
-                    1 for query in queries if query["source"] == "llm_generated"
+                    1 for query in queries if query.get("source") == "llm_generated"
                 ),
             },
             "results_retrieved": len(unique_results),

--- a/nexus/agents/memnon/memnon.py
+++ b/nexus/agents/memnon/memnon.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 import sqlalchemy as sa
 from sqlalchemy import create_engine, Column, Table, MetaData, text, inspect, func, or_
-from sqlalchemy.dialects.postgresql import UUID, BYTEA, ARRAY
+from sqlalchemy.dialects.postgresql import UUID, BYTEA, ARRAY, JSONB
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
 # Import utility modules
@@ -175,6 +175,9 @@ class NarrativeChunk(Base):
 
     id = Column(sa.BigInteger, primary_key=True)
     raw_text = Column(sa.Text, nullable=False)
+    authorial_directives = Column(
+        JSONB, nullable=False, server_default=sa.text("'[]'::jsonb")
+    )
     created_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now())
 
 
@@ -1656,6 +1659,7 @@ class MEMNON:
                     SELECT 
                         nc.id,
                         nc.raw_text,
+                        COALESCE(nc.authorial_directives, '[]'::jsonb) AS authorial_directives,
                         cm.season,
                         cm.episode,
                         cm.scene,
@@ -1671,6 +1675,7 @@ class MEMNON:
                     GROUP BY
                         nc.id,
                         nc.raw_text,
+                        nc.authorial_directives,
                         cm.season,
                         cm.episode,
                         cm.scene,
@@ -1692,6 +1697,10 @@ class MEMNON:
                     return {
                         "id": result.id,
                         "text": result.raw_text,
+                        "authorial_directives": getattr(
+                            result, "authorial_directives", []
+                        )
+                        or [],
                         "header": header,
                         "full_text": header + "\n" + result.raw_text,
                     }
@@ -1715,7 +1724,9 @@ class MEMNON:
             with self.Session() as session:
                 query = text(
                     """
-                    SELECT nc.id, nc.raw_text, cm.season, cm.episode, cm.scene AS scene_number,
+                    SELECT nc.id, nc.raw_text,
+                           COALESCE(nc.authorial_directives, '[]'::jsonb) AS authorial_directives,
+                           cm.season, cm.episode, cm.scene AS scene_number,
                            cm.world_layer
                     FROM narrative_chunks nc
                     LEFT JOIN chunk_metadata cm ON nc.id = cm.chunk_id
@@ -1732,6 +1743,10 @@ class MEMNON:
                         {
                             "id": result.id,
                             "text": result.raw_text,
+                            "authorial_directives": getattr(
+                                result, "authorial_directives", []
+                            )
+                            or [],
                             "metadata": {
                                 "season": result.season,
                                 "episode": result.episode,

--- a/nexus/agents/memnon/utils/db_schema.py
+++ b/nexus/agents/memnon/utils/db_schema.py
@@ -8,7 +8,7 @@ import logging
 from typing import Dict, Any, Optional
 import sqlalchemy as sa
 from sqlalchemy import create_engine, Column, Table, MetaData, text, inspect
-from sqlalchemy.dialects.postgresql import UUID, BYTEA, ARRAY
+from sqlalchemy.dialects.postgresql import UUID, BYTEA, ARRAY, JSONB
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
 logger = logging.getLogger("nexus.memnon.db_schema")
@@ -23,6 +23,9 @@ class NarrativeChunk(Base):
 
     id = Column(sa.BigInteger, primary_key=True)
     raw_text = Column(sa.Text, nullable=False)
+    authorial_directives = Column(
+        JSONB, nullable=False, server_default=sa.text("'[]'::jsonb")
+    )
     created_at = Column(sa.DateTime(timezone=True), server_default=sa.func.now())
 
 

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -54,6 +54,7 @@ async def fetch_incubator_data(
         """
         SELECT chunk_id, parent_chunk_id, user_text, storyteller_text,
                choice_object, choice_text, orrery_proposal,
+               COALESCE(authorial_directives, '[]'::jsonb) AS authorial_directives,
                metadata_updates, entity_updates, reference_updates,
                llm_response_id, status
         FROM incubator
@@ -100,6 +101,7 @@ async def insert_narrative_chunk(
     storyteller_text: Optional[str],
     choice_object: Optional[Dict[str, Any]],
     choice_text: Optional[str],
+    authorial_directives: Optional[List[str]],
 ) -> int:
     """
     Insert a new narrative chunk and return its ID.
@@ -109,15 +111,17 @@ async def insert_narrative_chunk(
     chunk_id = await conn.fetchval(
         """
         INSERT INTO narrative_chunks (
-            raw_text, storyteller_text, choice_object, choice_text
+            raw_text, storyteller_text, choice_object, choice_text,
+            authorial_directives
         )
-        VALUES ($1, $2, $3::jsonb, $4)
+        VALUES ($1, $2, $3::jsonb, $4, $5::jsonb)
         RETURNING id
         """,
         raw_text,
         storyteller_text,
         json.dumps(choice_object) if choice_object else None,
         choice_text,
+        json.dumps(authorial_directives or []),
     )
     logger.info(f"Created narrative chunk {chunk_id}")
     return chunk_id
@@ -411,6 +415,7 @@ async def commit_incubator_to_database(
                 storyteller_text=storyteller_text,
                 choice_object=choice_object,
                 choice_text=choice_text,
+                authorial_directives=incubator.get("authorial_directives"),
             )
             if chunk_id is None:
                 raise ValueError("Failed to obtain chunk_id after insert")

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -331,6 +331,7 @@ def commit_incubator_to_database_sync(
                     """
                     SELECT chunk_id, parent_chunk_id, user_text, storyteller_text,
                            choice_object, choice_text, orrery_proposal,
+                           COALESCE(authorial_directives, '[]'::jsonb) AS authorial_directives,
                            metadata_updates, entity_updates, reference_updates,
                            llm_response_id, status
                     FROM incubator
@@ -432,9 +433,10 @@ def commit_incubator_to_database_sync(
                 cur.execute(
                     """
                     INSERT INTO narrative_chunks (
-                        raw_text, storyteller_text, choice_object, choice_text
+                        raw_text, storyteller_text, choice_object, choice_text,
+                        authorial_directives
                     )
-                    VALUES (%s, %s, %s, %s)
+                    VALUES (%s, %s, %s, %s, %s)
                     RETURNING id
                 """,
                     (
@@ -442,6 +444,7 @@ def commit_incubator_to_database_sync(
                         storyteller_text,
                         json.dumps(choice_object) if choice_object else None,
                         choice_text,
+                        json.dumps(incubator.get("authorial_directives") or []),
                     ),
                 )
                 chunk_id = cur.fetchone()[0]

--- a/nexus/api/lore_adapter.py
+++ b/nexus/api/lore_adapter.py
@@ -95,6 +95,17 @@ def compute_raw_text(
     return f"{storyteller_text.rstrip()}\n\n{resolved_choice_text}"
 
 
+def extract_authorial_directives(response: StoryTurnResponse) -> List[str]:
+    """Extract normalized next-turn retrieval directives from a response."""
+
+    directives = getattr(response, "authorial_directives", None) or []
+    return [
+        directive.strip()
+        for directive in directives
+        if isinstance(directive, str) and directive.strip()
+    ]
+
+
 def response_to_incubator(
     response: StoryTurnResponse,
     parent_chunk_id: int,
@@ -139,6 +150,7 @@ def response_to_incubator(
         "metadata_updates": extract_metadata_updates(response),
         "entity_updates": extract_entity_updates(response),
         "reference_updates": extract_reference_updates(response),
+        "authorial_directives": extract_authorial_directives(response),
         "orrery_proposal": _serialize_orrery_proposal(orrery_proposal),
         "session_id": session_id,
         "llm_response_id": getattr(response, "response_id", None),
@@ -319,6 +331,7 @@ def validate_incubator_data(incubator_data: Dict[str, Any]) -> bool:
         "metadata_updates",
         "entity_updates",
         "reference_updates",
+        "authorial_directives",
         "session_id",
         "status",
     ]

--- a/nexus/api/lore_adapter.py
+++ b/nexus/api/lore_adapter.py
@@ -14,6 +14,7 @@ from nexus.api.choice_handling import (
     normalize_choice_object,
     selected_text_from_choice_object,
 )
+from nexus.util.authorial_directives import normalize_authorial_directives
 
 logger = logging.getLogger("nexus.api.lore_adapter")
 
@@ -99,11 +100,7 @@ def extract_authorial_directives(response: StoryTurnResponse) -> List[str]:
     """Extract normalized next-turn retrieval directives from a response."""
 
     directives = getattr(response, "authorial_directives", None) or []
-    return [
-        directive.strip()
-        for directive in directives
-        if isinstance(directive, str) and directive.strip()
-    ]
+    return normalize_authorial_directives(directives)
 
 
 def response_to_incubator(

--- a/nexus/api/mock_openai.py
+++ b/nexus/api/mock_openai.py
@@ -39,10 +39,11 @@ def _parse_pg_array(value: Any) -> List[str]:
         return []
     if isinstance(value, list):
         return value
-    if isinstance(value, str) and value.startswith('{') and value.endswith('}'):
+    if isinstance(value, str) and value.startswith("{") and value.endswith("}"):
         inner = value[1:-1]
-        return inner.split(',') if inner else []
+        return inner.split(",") if inner else []
     return []
+
 
 app = FastAPI(title="NEXUS Mock OpenAI")
 
@@ -70,7 +71,8 @@ def query_wizard_cache() -> Dict[str, Any]:
     """Query wizard cache from mock.assets.new_story_creator."""
     with get_mock_connection() as conn:
         with conn.cursor() as cur:
-            cur.execute("""
+            cur.execute(
+                """
                 SELECT
                     -- Setting
                     setting_genre, setting_secondary_genres, setting_world_name,
@@ -92,7 +94,8 @@ def query_wizard_cache() -> Dict[str, Any]:
                     initial_location
                 FROM assets.new_story_creator
                 WHERE id = TRUE
-            """)
+            """
+            )
             return cur.fetchone() or {}
 
 
@@ -100,11 +103,13 @@ def query_traits() -> List[Dict[str, Any]]:
     """Query all traits from mock.assets.traits."""
     with get_mock_connection() as conn:
         with conn.cursor() as cur:
-            cur.execute("""
+            cur.execute(
+                """
                 SELECT id, name, description, is_selected, rationale
                 FROM assets.traits
                 ORDER BY id
-            """)
+            """
+            )
             return list(cur.fetchall())
 
 
@@ -112,15 +117,20 @@ def query_bootstrap_narrative() -> Dict[str, Any]:
     """Query bootstrap narrative from mock.incubator."""
     with get_mock_connection() as conn:
         with conn.cursor() as cur:
-            cur.execute("""
-                SELECT storyteller_text, choice_object, metadata_updates, reference_updates
+            cur.execute(
+                """
+                SELECT storyteller_text, choice_object, metadata_updates,
+                       reference_updates, authorial_directives
                 FROM incubator
                 WHERE id = TRUE
-            """)
+            """
+            )
             return cur.fetchone() or {}
 
 
-def get_cached_phase_response(phase: str, subphase: Optional[str] = None) -> Dict[str, Any]:
+def get_cached_phase_response(
+    phase: str, subphase: Optional[str] = None
+) -> Dict[str, Any]:
     """
     Get cached response for a wizard phase from mock database.
 
@@ -145,7 +155,9 @@ def get_cached_phase_response(phase: str, subphase: Optional[str] = None) -> Dic
                 "language_notes": cache.get("setting_language_notes"),
                 "major_conflict": cache.get("setting_major_conflict"),
                 "geographic_scope": cache.get("setting_geographic_scope"),
-                "secondary_genres": _parse_pg_array(cache.get("setting_secondary_genres")),
+                "secondary_genres": _parse_pg_array(
+                    cache.get("setting_secondary_genres")
+                ),
                 "political_structure": cache.get("setting_political_structure"),
                 "diegetic_artifact": cache.get("setting_diegetic_artifact"),
             },
@@ -155,12 +167,18 @@ def get_cached_phase_response(phase: str, subphase: Optional[str] = None) -> Dic
     elif phase == "character":
         # Query traits from assets.traits table
         traits = query_traits()
-        selected_traits = [t for t in traits if t.get("is_selected") and t.get("id") <= 10]
+        selected_traits = [
+            t for t in traits if t.get("is_selected") and t.get("id") <= 10
+        ]
         wildcard = next((t for t in traits if t.get("id") == 11), None)
 
         # Build trait names and rationales from selected traits
         selected_names = [t.get("name") for t in selected_traits]
-        trait_rationales = {t.get("name"): t.get("rationale") for t in selected_traits if t.get("rationale")}
+        trait_rationales = {
+            t.get("name"): t.get("rationale")
+            for t in selected_traits
+            if t.get("rationale")
+        }
 
         if subphase == "concept":
             # For concept submission, suggest 3 traits if none are selected yet
@@ -215,8 +233,12 @@ def get_cached_phase_response(phase: str, subphase: Optional[str] = None) -> Dic
                             "selected_traits": selected_names,
                         },
                         "wildcard": {
-                            "wildcard_name": wildcard.get("name") if wildcard else "wildcard",
-                            "wildcard_description": wildcard.get("rationale") if wildcard else None,
+                            "wildcard_name": (
+                                wildcard.get("name") if wildcard else "wildcard"
+                            ),
+                            "wildcard_description": (
+                                wildcard.get("rationale") if wildcard else None
+                            ),
                         },
                     },
                 },
@@ -278,25 +300,18 @@ def get_cached_phase_response(phase: str, subphase: Optional[str] = None) -> Dic
 
     return {"data": {}, "message": "[TEST MODE] Unknown phase"}
 
+
 # Archetype choices for character intro
-ARCHETYPE_CHOICES = [
-    "The Amnesiac Courier",
-    "The Double Agent",
-    "The Memory Architect"
-]
+ARCHETYPE_CHOICES = ["The Amnesiac Courier", "The Double Agent", "The Memory Architect"]
 
 # Wildcard choices
-WILDCARD_CHOICES = [
-    "Ghostprint Key",
-    "Neural Echo",
-    "Dead Man's Archive"
-]
+WILDCARD_CHOICES = ["Ghostprint Key", "Neural Echo", "Dead Man's Archive"]
 
 # Seed type choices
 SEED_CHOICES = [
     "The Job You Already Took",
     "The Message That Found You",
-    "The Face You Used to Wear"
+    "The Face You Used to Wear",
 ]
 
 
@@ -343,7 +358,9 @@ def get_forced_tool(tool_choice: Any) -> Optional[str]:
     return None
 
 
-def detect_phase_from_tools(tools: Optional[List[Dict[str, Any]]]) -> tuple[str, Optional[str]]:
+def detect_phase_from_tools(
+    tools: Optional[List[Dict[str, Any]]],
+) -> tuple[str, Optional[str]]:
     """
     Detect wizard phase and subphase from the tools array in the request.
     """
@@ -380,10 +397,12 @@ def build_respond_with_choices(message: str, choices: List[str]) -> Dict[str, An
                 "type": "function",
                 "function": {
                     "name": "respond_with_choices",
-                    "arguments": json.dumps({
-                        "message": message,
-                        "choices": choices,
-                    }),
+                    "arguments": json.dumps(
+                        {
+                            "message": message,
+                            "choices": choices,
+                        }
+                    ),
                 },
             }
         ],
@@ -476,7 +495,9 @@ async def chat_completions(request: ChatCompletionRequest):
     if phase == "setting":
         # Setting phase goes straight to artifact (no intro conversation)
         cached = get_cached_phase_response("setting", None)
-        message = build_artifact_response("submit_world_document", cached.get("data", {}))
+        message = build_artifact_response(
+            "submit_world_document", cached.get("data", {})
+        )
         logger.info("[MOCK] Returning setting artifact")
 
     # === CHARACTER PHASE ===
@@ -491,14 +512,18 @@ async def chat_completions(request: ChatCompletionRequest):
             else:
                 # Any input (choice selection, accept_fate, or freeform) → advance
                 cached = get_cached_phase_response("character", "concept")
-                message = build_artifact_response("submit_character_concept", cached.get("data", {}))
+                message = build_artifact_response(
+                    "submit_character_concept", cached.get("data", {})
+                )
                 logger.info("[MOCK] Returning character concept artifact")
 
         # Subphase: Traits
         elif subphase == "traits":
             # Trait selection is handled by the UI - just return the artifact
             cached = get_cached_phase_response("character", "traits")
-            message = build_artifact_response("submit_trait_selection", cached.get("data", {}))
+            message = build_artifact_response(
+                "submit_trait_selection", cached.get("data", {})
+            )
             logger.info("[MOCK] Returning trait selection artifact")
 
         # Subphase: Wildcard
@@ -510,15 +535,23 @@ async def chat_completions(request: ChatCompletionRequest):
             else:
                 # Any input (choice selection, accept_fate, or freeform) → advance
                 cached = get_cached_phase_response("character", "wildcard")
-                wildcard_data = cached.get("data", {}).get("character_state", {}).get("wildcard", {})
-                message = build_artifact_response("submit_wildcard_trait", wildcard_data)
+                wildcard_data = (
+                    cached.get("data", {})
+                    .get("character_state", {})
+                    .get("wildcard", {})
+                )
+                message = build_artifact_response(
+                    "submit_wildcard_trait", wildcard_data
+                )
                 logger.info("[MOCK] Returning wildcard trait artifact")
 
         # Subphase: Character Sheet (all subphases complete)
         elif subphase == "sheet":
             # Return the final character sheet
             cached = get_cached_phase_response("character", "wildcard")
-            message = build_artifact_response("submit_character_sheet", cached.get("data", {}))
+            message = build_artifact_response(
+                "submit_character_sheet", cached.get("data", {})
+            )
             logger.info("[MOCK] Returning final character sheet artifact")
 
     # === SEED PHASE ===
@@ -530,16 +563,20 @@ async def chat_completions(request: ChatCompletionRequest):
         else:
             # Any input (choice selection, accept_fate, or freeform) → advance
             cached = get_cached_phase_response("seed", None)
-            message = build_artifact_response("submit_starting_scenario", cached.get("data", {}))
+            message = build_artifact_response(
+                "submit_starting_scenario", cached.get("data", {})
+            )
             logger.info("[MOCK] Returning seed artifact")
 
     # Fallback
     if message is None:
         message = build_respond_with_choices(
             f"[TEST MODE] Unexpected state: phase={phase}, subphase={subphase}",
-            ["Continue", "Go back"]
+            ["Continue", "Go back"],
         )
-        logger.warning(f"[MOCK] Fallback response for phase={phase}, subphase={subphase}")
+        logger.warning(
+            f"[MOCK] Fallback response for phase={phase}, subphase={subphase}"
+        )
 
     return {
         "id": f"chatcmpl-mock-{uuid.uuid4().hex[:8]}",
@@ -568,6 +605,7 @@ async def chat_completions(request: ChatCompletionRequest):
 
 class ResponsesRequest(BaseModel):
     """Request format for /v1/responses endpoint."""
+
     model: str
     input: List[Dict[str, Any]]
     max_output_tokens: Optional[int] = None
@@ -587,7 +625,11 @@ def get_cached_bootstrap_narrative() -> Dict[str, Any]:
 
     if not row:
         logger.warning("[MOCK] No bootstrap narrative found in mock.incubator")
-        return {"narrative": "[TEST MODE] No mock data available", "choices": ["Continue", "Wait"]}
+        return {
+            "narrative": "[TEST MODE] No mock data available",
+            "choices": ["Continue", "Wait"],
+            "authorial_directives": ["Retrieve the immediate prior scene."],
+        }
 
     # Extract choices from choice_object
     choice_obj = row.get("choice_object") or {}
@@ -604,6 +646,8 @@ def get_cached_bootstrap_narrative() -> Dict[str, Any]:
     return {
         "narrative": row.get("storyteller_text", ""),
         "choices": choices,
+        "authorial_directives": row.get("authorial_directives")
+        or ["Retrieve the immediate prior scene."],
         # ChunkMetadataUpdate: has chronology (nested) and world_layer
         "chunk_metadata": {
             "chronology": {
@@ -641,7 +685,7 @@ def get_cached_bootstrap_narrative() -> Dict[str, Any]:
             "factions": [],
         },
         "operations": None,
-        "reasoning": "[TEST MODE] Returning cached bootstrap narrative"
+        "reasoning": "[TEST MODE] Returning cached bootstrap narrative",
     }
 
 
@@ -663,9 +707,10 @@ async def responses_create(request: ResponsesRequest):
         if isinstance(content, str):
             input_text += content
 
-    is_narrative = any(kw in input_text.lower() for kw in [
-        "narrative", "story", "protagonist", "bootstrap", "user input"
-    ])
+    is_narrative = any(
+        kw in input_text.lower()
+        for kw in ["narrative", "story", "protagonist", "bootstrap", "user input"]
+    )
 
     if is_narrative:
         logger.info("[MOCK] Detected narrative request, returning cached bootstrap")

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -18,6 +18,7 @@ from psycopg2.extras import RealDictCursor
 
 from nexus.agents.lore.lore import LORE
 from nexus.api.lore_adapter import (
+    extract_authorial_directives,
     response_to_incubator,
     validate_incubator_data,
 )
@@ -270,10 +271,11 @@ async def write_to_incubator(conn, data: Dict[str, Any]):
         INSERT INTO incubator (
             id, chunk_id, parent_chunk_id, user_text, storyteller_text,
             choice_object, choice_text,
-            metadata_updates, entity_updates, reference_updates, orrery_proposal,
+            metadata_updates, entity_updates, reference_updates,
+            authorial_directives, orrery_proposal,
             session_id, llm_response_id, status
         ) VALUES (
-            TRUE, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+            TRUE, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
         )
         """
 
@@ -293,6 +295,7 @@ async def write_to_incubator(conn, data: Dict[str, Any]):
                 json.dumps(data["metadata_updates"]),
                 json.dumps(data["entity_updates"]),
                 json.dumps(data["reference_updates"]),
+                json.dumps(data.get("authorial_directives", [])),
                 (
                     json.dumps(data.get("orrery_proposal"))
                     if data.get("orrery_proposal")
@@ -455,6 +458,7 @@ async def generate_bootstrap_narrative(
             "places": [],
             "factions": [],
         },
+        "authorial_directives": extract_authorial_directives(story_response),
         "session_id": session_id,
         "llm_response_id": f"bootstrap_{uuid.uuid4().hex[:8]}",
         "status": "provisional",

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -254,6 +254,11 @@ class LORERetrievalSettings(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    max_deep_queries: int = Field(
+        default=5,
+        ge=1,
+        description="Maximum MEMNON queries to execute during LORE deep-query pass",
+    )
     fallback_query: str = Field(
         default="Recent narrative events",
         min_length=1,

--- a/nexus/memory/manager.py
+++ b/nexus/memory/manager.py
@@ -105,7 +105,10 @@ class Pass2Update:
     def to_dict(self) -> Dict[str, Any]:
         return {
             "divergence": self.divergence.to_dict(),
-            "retrieved_chunk_ids": [chunk.get("chunk_id") or chunk.get("id") for chunk in self.retrieved_chunks],
+            "retrieved_chunk_ids": [
+                chunk.get("chunk_id") or chunk.get("id")
+                for chunk in self.retrieved_chunks
+            ],
             "tokens_used": self.tokens_used,
             "baseline_available": self.baseline_available,
             "llm_unavailable": self.llm_unavailable,
@@ -128,20 +131,33 @@ class ContextMemoryManager:
         memory_settings = settings.get("memory", {})
 
         # Phase 2 configuration
-        self.phase2_fraction = float(memory_settings.get("phase2_fraction", 0.1))  # 10% of apex window
-        self.raw_search_k = int(memory_settings.get("raw_search_k", 30))  # Overretrieve for curation
-        self.skip_simple_choices = bool(memory_settings.get("skip_simple_choices", True))
+        self.phase2_fraction = float(
+            memory_settings.get("phase2_fraction", 0.1)
+        )  # 10% of apex window
+        self.raw_search_k = int(
+            memory_settings.get("raw_search_k", 30)
+        )  # Overretrieve for curation
+        self.skip_simple_choices = bool(
+            memory_settings.get("skip_simple_choices", True)
+        )
 
         # Calculate actual Phase 2 budget from apex window
-        apex_context_window = settings.get("Agent Settings", {}).get("LORE", {}).get(
-            "token_budget", {}
-        ).get("apex_context_window", 75000)
+        apex_context_window = (
+            settings.get("Agent Settings", {})
+            .get("LORE", {})
+            .get("token_budget", {})
+            .get("apex_context_window", 75000)
+        )
         self.phase2_budget = int(apex_context_window * self.phase2_fraction)
-        logger.info(f"Phase 2 budget: {self.phase2_budget} tokens ({self.phase2_fraction * 100:.0f}% of {apex_context_window})")
+        logger.info(
+            f"Phase 2 budget: {self.phase2_budget} tokens ({self.phase2_fraction * 100:.0f}% of {apex_context_window})"
+        )
 
         # Legacy settings (kept for compatibility but may be deprecated)
         self.pass2_reserve = float(memory_settings.get("pass2_budget_reserve", 0.25))
-        self.divergence_threshold = float(memory_settings.get("divergence_threshold", 0.7))
+        self.divergence_threshold = float(
+            memory_settings.get("divergence_threshold", 0.7)
+        )
         self.warm_slice_default = bool(memory_settings.get("warm_slice_default", True))
         self.max_sql_iterations = int(memory_settings.get("max_sql_iterations", 5))
 
@@ -156,13 +172,16 @@ class ContextMemoryManager:
         self.entity_detector = None
 
         if use_llm_requested and not llm_manager:
-            self.degraded_mode_reason = "LLM manager not available - using entity-based fallback detector"
+            self.degraded_mode_reason = (
+                "LLM manager not available - using entity-based fallback detector"
+            )
             logger.warning(
-                "\n" + "="*80 +
-                "\n⚠️  DEGRADED MODE WARNING: LLM-based divergence detection unavailable!\n" +
-                "    Falling back to entity-based detector with reduced capabilities.\n" +
-                "    Narrative callbacks and references may not be detected properly.\n" +
-                "="*80
+                "\n"
+                + "=" * 80
+                + "\n⚠️  DEGRADED MODE WARNING: LLM-based divergence detection unavailable!\n"
+                + "    Falling back to entity-based detector with reduced capabilities.\n"
+                + "    Narrative callbacks and references may not be detected properly.\n"
+                + "=" * 80
             )
             use_llm_requested = False
 
@@ -174,27 +193,35 @@ class ContextMemoryManager:
                 use_local_llm=use_local,
             )
             self.using_llm_detector = True
-            logger.info("✅ Using LLM-based divergence detector (threshold=%.2f)", self.divergence_threshold)
+            logger.info(
+                "✅ Using LLM-based divergence detector (threshold=%.2f)",
+                self.divergence_threshold,
+            )
         else:
             # Import and use high-specificity entity detector as fallback
             from .entity_detector import HighSpecificityEntityDetector
 
             # Try to get database connection from memnon
             db_connection = None
-            if self.memnon and hasattr(self.memnon, 'db'):
+            if self.memnon and hasattr(self.memnon, "db"):
                 db_connection = self.memnon.db
 
             self.entity_detector = HighSpecificityEntityDetector(db_connection)
-            self.divergence_detector = DivergenceDetector(threshold=self.divergence_threshold)
+            self.divergence_detector = DivergenceDetector(
+                threshold=self.divergence_threshold
+            )
 
             if not self.degraded_mode_reason:
-                self.degraded_mode_reason = "LLM divergence detection disabled - using entity-based fallback"
+                self.degraded_mode_reason = (
+                    "LLM divergence detection disabled - using entity-based fallback"
+                )
 
             logger.warning(
-                "\n" + "="*80 +
-                "\n⚠️  DEGRADED MODE: Using entity-based detector as fallback\n" +
-                "    Limited to known entities from database, may miss narrative references\n" +
-                "="*80
+                "\n"
+                + "=" * 80
+                + "\n⚠️  DEGRADED MODE: Using entity-based detector as fallback\n"
+                + "    Limited to known entities from database, may miss narrative references\n"
+                + "=" * 80
             )
 
         self.incremental = IncrementalRetriever(
@@ -209,12 +236,13 @@ class ContextMemoryManager:
 
         # Initialize LLM curator for Phase 2
         from .llm_curator import LLMContextCurator
+
         self.llm_curator = None
         if llm_manager:
             self.llm_curator = LLMContextCurator(
                 llm_manager=llm_manager,
                 phase2_budget=self.phase2_budget,
-                use_local_llm=True
+                use_local_llm=True,
             )
             logger.info("LLM Context Curator initialized for Phase 2 management")
 
@@ -236,25 +264,45 @@ class ContextMemoryManager:
 
         if current_package:
             pass1_usage = {
-                "baseline_tokens": current_package.token_usage.get("baseline_tokens", 0),
-                "reserved_for_pass2": current_package.token_usage.get("reserved_for_pass2", 0),
+                "baseline_tokens": current_package.token_usage.get(
+                    "baseline_tokens", 0
+                ),
+                "reserved_for_pass2": current_package.token_usage.get(
+                    "reserved_for_pass2", 0
+                ),
             }
             pass2_usage = {
-                "reserve_shortfall": current_package.token_usage.get("reserve_shortfall", 0),
+                "reserve_shortfall": current_package.token_usage.get(
+                    "reserve_shortfall", 0
+                ),
                 "remaining_budget": self.context_state.get_remaining_budget(),
             }
         return {
             "pass1": {
-                "baseline_chunks": len(current_package.baseline_chunks) if current_package else 0,
-                "baseline_themes": current_package.baseline_themes if current_package else [],
-                "authorial_directives": current_package.authorial_directives if current_package else [],
-                "structured_passages": current_package.structured_passages if current_package else [],
+                "baseline_chunks": (
+                    len(current_package.baseline_chunks) if current_package else 0
+                ),
+                "baseline_themes": (
+                    current_package.baseline_themes if current_package else []
+                ),
+                "authorial_directives": (
+                    current_package.authorial_directives if current_package else []
+                ),
+                "structured_passages": (
+                    current_package.structured_passages if current_package else []
+                ),
                 "token_usage": pass1_usage,
             },
             "pass2": {
-                "divergence_detected": current_package.divergence_detected if current_package else False,
-                "divergence_confidence": current_package.divergence_confidence if current_package else 0.0,
-                "additional_chunks": len(current_package.additional_chunks) if current_package else 0,
+                "divergence_detected": (
+                    current_package.divergence_detected if current_package else False
+                ),
+                "divergence_confidence": (
+                    current_package.divergence_confidence if current_package else 0.0
+                ),
+                "additional_chunks": (
+                    len(current_package.additional_chunks) if current_package else 0
+                ),
                 "token_reserve_percent": int(self.pass2_reserve * 100),
                 "usage": pass2_usage,
             },
@@ -264,8 +312,8 @@ class ContextMemoryManager:
             },
             "settings": {
                 "divergence_threshold": self.divergence_threshold,
-                "warm_slice_default": self.warm_slice_default
-            }
+                "warm_slice_default": self.warm_slice_default,
+            },
         }
 
     # ------------------------------------------------------------------
@@ -279,6 +327,7 @@ class ContextMemoryManager:
         token_usage: Optional[Dict[str, int]] = None,
         assembled_context: Optional[Dict[str, Any]] = None,
         authorial_directives: Optional[Iterable[str]] = None,
+        execute_authorial_directives: bool = True,
     ) -> ContextPackage:
         """Run Pass 1 analysis and store baseline context for the next turn."""
 
@@ -301,7 +350,7 @@ class ContextMemoryManager:
         existing_ids: Set[int] = set()
         structured_passages: List[Dict[str, Any]] = []
 
-        for collection in (warm_slice or []):
+        for collection in warm_slice or []:
             normalized = dict(collection)
             chunk_id = self._coerce_chunk_id(normalized)
             if chunk_id is None:
@@ -313,7 +362,7 @@ class ContextMemoryManager:
             chunk_details.append({"chunk_id": chunk_id, **normalized})
 
         chunk_retrievals: List[Dict[str, Any]] = []
-        for passage in (retrieved_passages or []):
+        for passage in retrieved_passages or []:
             normalized = dict(passage)
             chunk_id = self._coerce_chunk_id(normalized)
             if chunk_id is None:
@@ -325,20 +374,30 @@ class ContextMemoryManager:
 
         directive_chunks: List[Dict[str, Any]] = []
         directive_structured: List[Dict[str, Any]] = []
-        if directives:
-            directive_chunks, directive_structured = self._execute_authorial_directives(directives, existing_ids)
+        if directives and execute_authorial_directives:
+            directive_chunks, directive_structured = self._execute_authorial_directives(
+                directives, existing_ids
+            )
             if directive_chunks:
                 chunk_retrievals.extend(directive_chunks)
             if directive_structured:
                 structured_passages.extend(directive_structured)
             if assembled_context is not None:
                 if directive_chunks:
-                    retrieval_section = assembled_context.setdefault("retrieved_passages", {})
+                    retrieval_section = assembled_context.setdefault(
+                        "retrieved_passages", {}
+                    )
                     retrieval_results = retrieval_section.setdefault("results", [])
-                    retrieval_results.extend(dict(result) for result in directive_chunks)
+                    retrieval_results.extend(
+                        dict(result) for result in directive_chunks
+                    )
                 if directive_structured:
-                    structured_section = assembled_context.setdefault("structured_passages", [])
-                    structured_section.extend(dict(result) for result in directive_structured)
+                    structured_section = assembled_context.setdefault(
+                        "structured_passages", []
+                    )
+                    structured_section.extend(
+                        dict(result) for result in directive_structured
+                    )
 
         if assembled_context is not None:
             structured_section = assembled_context.setdefault("structured_passages", [])
@@ -353,7 +412,8 @@ class ContextMemoryManager:
 
         token_usage = token_usage or {}
         baseline_tokens = sum(
-            token_usage.get(key, 0) for key in ("warm_slice", "structured", "augmentation")
+            token_usage.get(key, 0)
+            for key in ("warm_slice", "structured", "augmentation")
         )
         total_available = token_usage.get("total_available", 0)
         reserved_for_pass2 = max(0, int(total_available * self.pass2_reserve))
@@ -421,16 +481,21 @@ class ContextMemoryManager:
 
         # Strip whitespace and common punctuation
         import re
+
         # Remove leading/trailing whitespace and punctuation
-        cleaned = user_input.strip().strip('.,!?;:')
+        cleaned = user_input.strip().strip(".,!?;:")
 
         # Pattern: single digit, or single letter (upper/lower)
         # After stripping, should just be the choice character
-        pattern = r'^[1-9]$|^[A-Za-z]$'
+        pattern = r"^[1-9]$|^[A-Za-z]$"
 
         is_simple = bool(re.match(pattern, cleaned))
         if is_simple:
-            logger.info("Simple choice detected: '%s' -> '%s' - skipping Phase 2 retrieval", user_input, cleaned)
+            logger.info(
+                "Simple choice detected: '%s' -> '%s' - skipping Phase 2 retrieval",
+                user_input,
+                cleaned,
+            )
 
         return is_simple
 
@@ -464,7 +529,9 @@ class ContextMemoryManager:
 
         return DivergenceResult(False, 0.0, {}, set(), set())
 
-    def _compute_available_phase2_budget(self, token_counts: Optional[Dict[str, int]]) -> int:
+    def _compute_available_phase2_budget(
+        self, token_counts: Optional[Dict[str, int]]
+    ) -> int:
         """Determine the usable Phase 2 budget for this turn."""
 
         remaining_budget = self.context_state.get_remaining_budget()
@@ -473,7 +540,8 @@ class ContextMemoryManager:
             total_available = token_counts.get("total_available")
             if total_available is not None:
                 baseline_tokens = sum(
-                    token_counts.get(key, 0) for key in ("warm_slice", "structured", "augmentation")
+                    token_counts.get(key, 0)
+                    for key in ("warm_slice", "structured", "augmentation")
                 )
                 actual_remaining = max(0, int(total_available) - int(baseline_tokens))
                 if actual_remaining != remaining_budget:
@@ -524,7 +592,9 @@ class ContextMemoryManager:
         if not context or not transition:
             logger.debug("No baseline context available; skipping Phase 2")
             return Pass2Update(
-                divergence, [], 0,
+                divergence,
+                [],
+                0,
                 baseline_available=False,
                 llm_unavailable=not self.llm_curator,
                 degraded_mode_reason=degraded_reason,
@@ -536,19 +606,23 @@ class ContextMemoryManager:
         if self.skip_simple_choices and self._is_simple_choice(user_input):
             logger.info("📌 Phase 2 skipped: Simple choice detected")
             return Pass2Update(
-                divergence, [], 0,
+                divergence,
+                [],
+                0,
                 baseline_available=True,
                 llm_unavailable=not self.llm_curator,
-                degraded_mode_reason=degraded_reason
+                degraded_mode_reason=degraded_reason,
             )
 
         if available_budget <= 0:
             logger.info("📉 Phase 2 skipped: No remaining token budget available")
             return Pass2Update(
-                divergence, [], 0,
+                divergence,
+                [],
+                0,
                 baseline_available=True,
                 llm_unavailable=not self.llm_curator,
-                degraded_mode_reason=degraded_reason
+                degraded_mode_reason=degraded_reason,
             )
 
         # STEP 2: Always run raw vector search (unless simple choice)
@@ -556,23 +630,29 @@ class ContextMemoryManager:
         raw_search_results, raw_tokens = self.incremental.retrieve_from_raw_input(
             user_input,
             budget=available_budget,
-            k=self.raw_search_k  # Overretrieve (default 30)
+            k=self.raw_search_k,  # Overretrieve (default 30)
         )
 
         if not raw_search_results:
             logger.info("No results from raw vector search - Phase 2 complete")
             return Pass2Update(
-                divergence, [], 0,
+                divergence,
+                [],
+                0,
                 baseline_available=True,
                 llm_unavailable=not self.llm_curator,
-                degraded_mode_reason=degraded_reason
+                degraded_mode_reason=degraded_reason,
             )
 
-        logger.info(f"Raw search retrieved {len(raw_search_results)} chunks (~{raw_tokens} tokens)")
+        logger.info(
+            f"Raw search retrieved {len(raw_search_results)} chunks (~{raw_tokens} tokens)"
+        )
 
         # STEP 3: Use LLM curator to decide what to keep (if available)
         if not self.llm_curator:
-            logger.warning("No LLM curator available - keeping first chunks that fit budget")
+            logger.warning(
+                "No LLM curator available - keeping first chunks that fit budget"
+            )
             # Simple fallback: keep chunks that fit in budget
             kept_chunks = []
             total_tokens = 0
@@ -591,10 +671,12 @@ class ContextMemoryManager:
                     total_tokens,
                 )
             return Pass2Update(
-                divergence, kept_chunks, total_tokens,
+                divergence,
+                kept_chunks,
+                total_tokens,
                 baseline_available=True,
                 llm_unavailable=True,
-                degraded_mode_reason=degraded_reason
+                degraded_mode_reason=degraded_reason,
             )
 
         logger.info("🤖 Phase 2 Step 2: LLM curation of results")
@@ -606,7 +688,7 @@ class ContextMemoryManager:
         curation = self.llm_curator.curate(
             user_input=user_input,
             raw_search_results=raw_search_results,
-            storyteller_context=storyteller_context
+            storyteller_context=storyteller_context,
         )
 
         # STEP 4: Process curation decision
@@ -626,7 +708,9 @@ class ContextMemoryManager:
         # STEP 5: Execute additional queries suggested by LLM
         remaining_budget = max(0, available_budget - final_tokens)
         if curation.additional_queries and remaining_budget > 0:
-            logger.info(f"🔍 Phase 2 Step 3: Executing {len(curation.additional_queries)} additional queries")
+            logger.info(
+                f"🔍 Phase 2 Step 3: Executing {len(curation.additional_queries)} additional queries"
+            )
 
             for query_spec in curation.additional_queries:
                 query_type = query_spec.get("type", "vector")
@@ -640,10 +724,12 @@ class ContextMemoryManager:
                     try:
                         add_chunks, add_tokens = self.incremental.retrieve_gap_context(
                             {query_text: "LLM-requested targeted retrieval"},
-                            remaining_budget
+                            remaining_budget,
                         )
                         if add_chunks:
-                            logger.info(f"Vector query '{query_text[:50]}...' retrieved {len(add_chunks)} chunks")
+                            logger.info(
+                                f"Vector query '{query_text[:50]}...' retrieved {len(add_chunks)} chunks"
+                            )
                             final_chunks.extend(add_chunks)
                             final_tokens += add_tokens
                             remaining_budget -= add_tokens
@@ -652,7 +738,9 @@ class ContextMemoryManager:
 
                 elif query_type == "sql":
                     # SQL queries could be implemented here if needed
-                    logger.info(f"SQL queries not yet implemented: {query_text[:50]}...")
+                    logger.info(
+                        f"SQL queries not yet implemented: {query_text[:50]}..."
+                    )
 
                 if remaining_budget <= 0:
                     logger.info("Phase 2 budget exhausted")
@@ -671,10 +759,12 @@ class ContextMemoryManager:
             logger.info("Phase 2 complete: No chunks retained after curation")
 
         return Pass2Update(
-            divergence, final_chunks, final_tokens,
+            divergence,
+            final_chunks,
+            final_tokens,
             baseline_available=True,
             llm_unavailable=not self.llm_curator,
-            degraded_mode_reason=degraded_reason
+            degraded_mode_reason=degraded_reason,
         )
 
     # ------------------------------------------------------------------
@@ -707,13 +797,19 @@ class ContextMemoryManager:
                 continue
 
             if self.query_memory.has_run(directive_text):
-                logger.debug("Skipping duplicate authorial directive: %s", directive_text)
+                logger.debug(
+                    "Skipping duplicate authorial directive: %s", directive_text
+                )
                 continue
 
             try:
-                payload = memnon.query_memory(query=directive_text, k=6, use_hybrid=True)
+                payload = memnon.query_memory(
+                    query=directive_text, k=6, use_hybrid=True
+                )
             except Exception as exc:  # pragma: no cover - defensive logging
-                logger.error("Authorial directive query failed for '%s': %s", directive_text, exc)
+                logger.error(
+                    "Authorial directive query failed for '%s': %s", directive_text, exc
+                )
                 continue
 
             for result in payload.get("results", []):
@@ -747,7 +843,9 @@ class ContextMemoryManager:
         except (TypeError, ValueError):
             return None
 
-    def augment_warm_slice(self, warm_slice: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def augment_warm_slice(
+        self, warm_slice: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
         """Merge existing warm slice chunks with any incremental additions."""
 
         if not warm_slice:
@@ -832,7 +930,9 @@ class ContextMemoryManager:
                         canonical = self.user_character_name.lower()
                         if canonical not in self.alias_lookup:
                             self.alias_lookup[canonical] = [self.user_character_name]
-                            self.canonical_name_map[canonical] = self.user_character_name
+                            self.canonical_name_map[canonical] = (
+                                self.user_character_name
+                            )
                         for alias in self.alias_lookup[canonical]:
                             self.alias_inverse[alias.lower()] = canonical
                         for pronoun in ("you", "your", "yours", "yourself"):
@@ -900,7 +1000,13 @@ class ContextMemoryManager:
         """Lightweight heuristic analysis of storyteller output."""
         text = narrative or ""
         if not text.strip():
-            return {"characters": [], "locations": [], "keywords": [], "themes": [], "expected": []}
+            return {
+                "characters": [],
+                "locations": [],
+                "keywords": [],
+                "themes": [],
+                "expected": [],
+            }
 
         character_candidates = re.findall(r"([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)", text)
         characters: List[str] = []
@@ -964,6 +1070,3 @@ class ContextMemoryManager:
             "themes": themes,
             "expected": expected,
         }
-
-
-    

--- a/nexus/util/authorial_directives.py
+++ b/nexus/util/authorial_directives.py
@@ -1,0 +1,32 @@
+"""Shared helpers for Storyteller-authored retrieval directives."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, List
+
+
+def normalize_authorial_directives(
+    raw_directives: Any, *, allow_json_string: bool = False
+) -> List[str]:
+    """Return trimmed, non-empty authorial directives.
+
+    Runtime DB paths may receive JSONB values as decoded lists or as serialized
+    JSON strings depending on driver boundaries. Structured response paths pass
+    lists directly and should leave JSON-string coercion disabled.
+    """
+
+    if isinstance(raw_directives, str) and allow_json_string:
+        try:
+            raw_directives = json.loads(raw_directives)
+        except json.JSONDecodeError:
+            raw_directives = [raw_directives]
+
+    if not isinstance(raw_directives, list):
+        return []
+
+    return [
+        directive.strip()
+        for directive in raw_directives
+        if isinstance(directive, str) and directive.strip()
+    ]

--- a/scripts/create_incubator_table.sql
+++ b/scripts/create_incubator_table.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS incubator (
     entity_updates JSONB DEFAULT '{}',                      -- Character/place/faction state changes
     reference_updates JSONB DEFAULT '{}',                   -- Entity references (present/mentioned)
     authorial_directives JSONB DEFAULT '[]',                -- Retrieval directives for the next turn
+    orrery_proposal JSONB,                                  -- No-write Orrery proposal awaiting approval
     session_id UUID NOT NULL DEFAULT gen_random_uuid(),     -- Track generation attempts
     llm_response_id TEXT,                                   -- API response ID for debugging
     status TEXT DEFAULT 'provisional',                      -- provisional -> approved -> committed
@@ -32,6 +33,7 @@ COMMENT ON COLUMN incubator.metadata_updates IS 'JSON: {episode_transition, time
 COMMENT ON COLUMN incubator.entity_updates IS 'JSON object of entity state changes: {characters: [], locations: [], factions: []}';
 COMMENT ON COLUMN incubator.reference_updates IS 'JSON: {character_present: [], character_referenced: [], place_referenced: []}';
 COMMENT ON COLUMN incubator.authorial_directives IS 'Storyteller-authored retrieval directives for the successor turn';
+COMMENT ON COLUMN incubator.orrery_proposal IS 'No-write OrreryTickProposal generated during preview; stamped into canonical Orrery tables only when the incubator chunk is accepted.';
 COMMENT ON COLUMN incubator.session_id IS 'UUID for tracking regeneration attempts';
 COMMENT ON COLUMN incubator.llm_response_id IS 'OpenAI or LM Studio response ID for debugging';
 COMMENT ON COLUMN incubator.status IS 'Status: provisional (pending approval), approved (ready to commit), committed (written to main tables)';
@@ -47,6 +49,7 @@ SELECT
     i.choice_object,
     i.choice_text,
     i.authorial_directives,
+    i.orrery_proposal,
     i.metadata_updates -> 'chronology' ->> 'episode_transition' AS episode_transition,
     i.metadata_updates -> 'chronology' ->> 'time_delta_description' AS time_delta,
     i.metadata_updates ->> 'world_layer' AS world_layer,

--- a/scripts/create_incubator_table.sql
+++ b/scripts/create_incubator_table.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS incubator (
     metadata_updates JSONB DEFAULT '{}',                    -- Time delta, episode transition, etc
     entity_updates JSONB DEFAULT '{}',                      -- Character/place/faction state changes
     reference_updates JSONB DEFAULT '{}',                   -- Entity references (present/mentioned)
+    authorial_directives JSONB DEFAULT '[]',                -- Retrieval directives for the next turn
     session_id UUID NOT NULL DEFAULT gen_random_uuid(),     -- Track generation attempts
     llm_response_id TEXT,                                   -- API response ID for debugging
     status TEXT DEFAULT 'provisional',                      -- provisional -> approved -> committed
@@ -30,6 +31,7 @@ COMMENT ON COLUMN incubator.choice_text IS 'Resolved user response text for the 
 COMMENT ON COLUMN incubator.metadata_updates IS 'JSON: {episode_transition, time_delta_seconds, time_delta_description, world_layer, pacing}';
 COMMENT ON COLUMN incubator.entity_updates IS 'JSON object of entity state changes: {characters: [], locations: [], factions: []}';
 COMMENT ON COLUMN incubator.reference_updates IS 'JSON: {character_present: [], character_referenced: [], place_referenced: []}';
+COMMENT ON COLUMN incubator.authorial_directives IS 'Storyteller-authored retrieval directives for the successor turn';
 COMMENT ON COLUMN incubator.session_id IS 'UUID for tracking regeneration attempts';
 COMMENT ON COLUMN incubator.llm_response_id IS 'OpenAI or LM Studio response ID for debugging';
 COMMENT ON COLUMN incubator.status IS 'Status: provisional (pending approval), approved (ready to commit), committed (written to main tables)';
@@ -44,6 +46,7 @@ SELECT
     i.storyteller_text,
     i.choice_object,
     i.choice_text,
+    i.authorial_directives,
     i.metadata_updates -> 'chronology' ->> 'episode_transition' AS episode_transition,
     i.metadata_updates -> 'chronology' ->> 'time_delta_description' AS time_delta,
     i.metadata_updates ->> 'world_layer' AS world_layer,

--- a/tests/test_api/test_lore_adapter.py
+++ b/tests/test_api/test_lore_adapter.py
@@ -1,6 +1,9 @@
 """Tests for adapting LOGON responses into incubator payloads."""
 
-from nexus.agents.logon.apex_schema import ReferencedEntities, StorytellerResponseExtended
+from nexus.agents.logon.apex_schema import (
+    ReferencedEntities,
+    StorytellerResponseExtended,
+)
 from nexus.api.lore_adapter import response_to_incubator
 
 
@@ -10,6 +13,9 @@ def test_response_to_incubator_serializes_current_reference_schema() -> None:
     response = StorytellerResponseExtended(
         narrative="Jonas waits beneath the pharmacy sign.",
         choices=["Follow Jonas.", "Answer the phone."],
+        authorial_directives=[
+            "Retrieve Jonas Vale's prior interactions with Eleanor Voss."
+        ],
         chunk_metadata={
             "chronology": {
                 "episode_transition": "continue",
@@ -60,6 +66,9 @@ def test_response_to_incubator_serializes_current_reference_schema() -> None:
     )
 
     assert incubator["metadata_updates"]["chronology"]["time_delta_minutes"] == 1
+    assert incubator["authorial_directives"] == [
+        "Retrieve Jonas Vale's prior interactions with Eleanor Voss."
+    ]
     reference_updates = incubator["reference_updates"]
     assert reference_updates["characters"][0]["character_name"] == "Eleanor Voss"
     assert reference_updates["characters"][1]["new_character"]["name"] == "Jonas Vale"
@@ -69,8 +78,7 @@ def test_response_to_incubator_serializes_current_reference_schema() -> None:
         == "transit stop"
     )
     assert (
-        reference_updates["factions"][0]["new_faction"]["name"]
-        == "Project Palimpsest"
+        reference_updates["factions"][0]["new_faction"]["name"] == "Project Palimpsest"
     )
 
     # The commit path reparses this JSONB payload into the current schema.

--- a/tests/test_lore/test_apex_schema.py
+++ b/tests/test_lore/test_apex_schema.py
@@ -13,21 +13,26 @@ from nexus.agents.logon.apex_schema import (
 )
 
 
-def test_bootstrap_response_schema_only_accepts_narrative_and_choices() -> None:
-    """Bootstrap responses should not request entity metadata."""
+def test_bootstrap_response_schema_accepts_directives_but_not_metadata() -> None:
+    """Bootstrap responses should include successor directives, not entity metadata."""
 
     response = StorytellerResponseBootstrap(
         narrative="The story begins.",
         choices=["Step forward.", "Look around."],
+        authorial_directives=["Retrieve the starting room and visible companion."],
     )
 
     assert response.narrative == "The story begins."
     assert response.choices == ["Step forward.", "Look around."]
+    assert response.authorial_directives == [
+        "Retrieve the starting room and visible companion."
+    ]
 
     with pytest.raises(ValidationError):
         StorytellerResponseBootstrap(
             narrative="The story begins.",
             choices=["Step forward.", "Look around."],
+            authorial_directives=["Retrieve the starting room."],
             referenced_entities={"characters": []},
         )
 
@@ -41,6 +46,9 @@ def test_create_minimal_response_includes_valid_choices() -> None:
     assert response.choices == [
         "Continue.",
         "Wait and observe.",
+    ]
+    assert response.authorial_directives == [
+        "Preserve the immediate scene continuity and unresolved player choice."
     ]
 
 
@@ -73,6 +81,9 @@ def test_extended_response_accepts_partial_new_character_context() -> None:
     response = StorytellerResponseExtended(
         narrative="The watcher steps into the pharmacy light.",
         choices=["Ask his name.", "Step back."],
+        authorial_directives=[
+            "Retrieve Adrian Vale's prior appearances and brass token references."
+        ],
         chunk_metadata={
             "chronology": {
                 "episode_transition": "continue",

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -53,6 +53,9 @@ class _DummyProvider:
     def _response(self, prompt: str) -> StorytellerResponseMinimal:
         return StorytellerResponseMinimal(
             narrative=f"dummy:{prompt[:20]}",
+            authorial_directives=[
+                "Retrieve the immediate prior scene and unresolved player choice."
+            ],
             choices=[
                 "Continue.",
                 "Wait and observe.",

--- a/tests/test_lore/test_memory_manager.py
+++ b/tests/test_lore/test_memory_manager.py
@@ -36,7 +36,9 @@ class DummyMemnon:
         self.queries: List[str] = []
         self.recent_calls: List[int] = []
 
-    def query_memory(self, query: str, k: int = 5, use_hybrid: bool = True) -> Dict[str, object]:
+    def query_memory(
+        self, query: str, k: int = 5, use_hybrid: bool = True
+    ) -> Dict[str, object]:
         self.queries.append(query)
         # Return a deep copy so downstream mutations don't affect subsequent checks
         return {"results": copy.deepcopy(self._gap_results)}
@@ -53,16 +55,12 @@ def dummy_memnon() -> DummyMemnon:
 
 @pytest.fixture
 def baseline_inputs() -> Dict[str, object]:
-    narrative = (
-        "Alex and Emilia secure the Crystal Orb inside the sealed vault while Pete monitors the perimeter."
-    )
+    narrative = "Alex and Emilia secure the Crystal Orb inside the sealed vault while Pete monitors the perimeter."
     warm_slice = [
         {"chunk_id": 101, "text": "Setup: extraction plan finalised."},
         {"chunk_id": 102, "text": "Alex briefs Emilia on the vault sequence."},
     ]
-    retrieved = [
-        {"id": 201, "text": "Intel dossier on Dynacorp vault design."}
-    ]
+    retrieved = [{"id": 201, "text": "Intel dossier on Dynacorp vault design."}]
     token_usage = {
         "total_available": 1200,
         "warm_slice": 360,
@@ -77,7 +75,9 @@ def baseline_inputs() -> Dict[str, object]:
     }
 
 
-def test_pass1_baseline_tracks_chunks_and_budget(minimal_settings, dummy_memnon, baseline_inputs):
+def test_pass1_baseline_tracks_chunks_and_budget(
+    minimal_settings, dummy_memnon, baseline_inputs
+):
     manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
 
     package = manager.handle_storyteller_response(
@@ -103,7 +103,9 @@ def test_pass1_baseline_tracks_chunks_and_budget(minimal_settings, dummy_memnon,
     assert "Emilia" in package.baseline_entities.get("characters", [])
 
 
-def test_pass1_records_reserve_shortfall(minimal_settings, dummy_memnon, baseline_inputs):
+def test_pass1_records_reserve_shortfall(
+    minimal_settings, dummy_memnon, baseline_inputs
+):
     manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
 
     tight_tokens = {
@@ -129,7 +131,9 @@ def test_pass1_records_reserve_shortfall(minimal_settings, dummy_memnon, baselin
     assert transition.remaining_budget == max(0, 1000 - 940)
 
 
-def test_pass2_divergence_triggers_incremental_retrieval(minimal_settings, dummy_memnon, baseline_inputs):
+def test_pass2_divergence_triggers_incremental_retrieval(
+    minimal_settings, dummy_memnon, baseline_inputs
+):
     manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
 
     manager.handle_storyteller_response(
@@ -163,12 +167,19 @@ def test_pass2_divergence_triggers_incremental_retrieval(minimal_settings, dummy
     assert post_budget == max(0, pre_budget - update.tokens_used)
     assert manager.context_state.context.gap_analysis == update.divergence.gaps
 
-    reserve = int(token_counts["total_available"] * minimal_settings["memory"]["pass2_budget_reserve"])
+    reserve = int(
+        token_counts["total_available"]
+        * minimal_settings["memory"]["pass2_budget_reserve"]
+    )
     assert manager.context_state.context.token_usage["reserved_for_pass2"] == reserve
-    assert manager.context_state.context.token_usage["reserve_shortfall"] == max(0, reserve - post_budget)
+    assert manager.context_state.context.token_usage["reserve_shortfall"] == max(
+        0, reserve - post_budget
+    )
 
 
-def test_pass1_stores_authorial_directives(minimal_settings, dummy_memnon, baseline_inputs):
+def test_pass1_stores_authorial_directives(
+    minimal_settings, dummy_memnon, baseline_inputs
+):
     manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
 
     directives = [
@@ -200,7 +211,30 @@ def test_pass1_stores_authorial_directives(minimal_settings, dummy_memnon, basel
     assert history["pass2"] == []
 
 
-def test_pass1_separates_structured_passages(minimal_settings, dummy_memnon, baseline_inputs):
+def test_pass1_can_store_authorial_directives_without_executing_queries(
+    minimal_settings, dummy_memnon, baseline_inputs
+):
+    manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
+
+    package = manager.handle_storyteller_response(
+        narrative=baseline_inputs["narrative"],
+        warm_slice=baseline_inputs["warm_slice"],
+        retrieved_passages=baseline_inputs["retrieved"],
+        token_usage=baseline_inputs["token_usage"],
+        authorial_directives=["Retrieve next-turn context."],
+        execute_authorial_directives=False,
+    )
+
+    assert package.authorial_directives == ["Retrieve next-turn context."]
+    assert dummy_memnon.queries == []
+
+    history = manager.query_memory.snapshot()
+    assert history["pass1"] == ["Retrieve next-turn context."]
+
+
+def test_pass1_separates_structured_passages(
+    minimal_settings, dummy_memnon, baseline_inputs
+):
     manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
 
     structured = {
@@ -208,7 +242,10 @@ def test_pass1_separates_structured_passages(minimal_settings, dummy_memnon, bas
         "name": "Alex Navarro",
         "summary": "Lead infiltrator, tracking The Ghost",
     }
-    retrieved = baseline_inputs["retrieved"] + [structured, {"chunk_id": 305, "text": "Bridge diagnostics memo."}]
+    retrieved = baseline_inputs["retrieved"] + [
+        structured,
+        {"chunk_id": 305, "text": "Bridge diagnostics memo."},
+    ]
 
     package = manager.handle_storyteller_response(
         narrative=baseline_inputs["narrative"],
@@ -227,7 +264,9 @@ def test_pass1_separates_structured_passages(minimal_settings, dummy_memnon, bas
     assert all(entry.get("chunk_id") is not None for entry in chunk_details)
 
 
-def test_pass2_warm_slice_expansion_without_divergence(minimal_settings, dummy_memnon, baseline_inputs):
+def test_pass2_warm_slice_expansion_without_divergence(
+    minimal_settings, dummy_memnon, baseline_inputs
+):
     manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
 
     manager.handle_storyteller_response(
@@ -254,7 +293,9 @@ def test_pass2_warm_slice_expansion_without_divergence(minimal_settings, dummy_m
     assert 501 in manager.context_state.context.additional_chunks
 
 
-def test_augment_warm_slice_merges_incremental_additions(minimal_settings, dummy_memnon, baseline_inputs):
+def test_augment_warm_slice_merges_incremental_additions(
+    minimal_settings, dummy_memnon, baseline_inputs
+):
     manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
 
     manager.handle_storyteller_response(
@@ -264,25 +305,31 @@ def test_augment_warm_slice_merges_incremental_additions(minimal_settings, dummy
         token_usage=baseline_inputs["token_usage"],
     )
 
-    manager.divergence_detector.detect = lambda text, context, transition: DivergenceResult(
-        detected=True,
-        confidence=1.0,
-        gaps={"Data Shard": "Reference not present"},
-        unmatched_entities={"Data Shard"},
-        references_seen={"Data Shard"},
+    manager.divergence_detector.detect = (
+        lambda text, context, transition: DivergenceResult(
+            detected=True,
+            confidence=1.0,
+            gaps={"Data Shard": "Reference not present"},
+            unmatched_entities={"Data Shard"},
+            references_seen={"Data Shard"},
+        )
     )
 
     manager.handle_user_input("Need the Data Shard briefing.")
 
-    augmented = manager.augment_warm_slice([
-        {"chunk_id": 101, "text": "Setup: extraction plan finalised."},
-    ])
+    augmented = manager.augment_warm_slice(
+        [
+            {"chunk_id": 101, "text": "Setup: extraction plan finalised."},
+        ]
+    )
 
     chunk_ids = {chunk["chunk_id"] for chunk in augmented if "chunk_id" in chunk}
     assert {101, 501}.issubset(chunk_ids)
 
 
-def test_get_memory_summary_reports_state(minimal_settings, dummy_memnon, baseline_inputs):
+def test_get_memory_summary_reports_state(
+    minimal_settings, dummy_memnon, baseline_inputs
+):
     manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
 
     manager.handle_storyteller_response(

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -25,6 +25,27 @@ class DummyLore:
         self.llm_manager = None
 
 
+class DummyLLMManager:
+    """Local LLM stub with deterministic warm analysis and query generation."""
+
+    def __init__(self) -> None:
+        self.generated_query_calls = 0
+
+    def is_available(self) -> bool:
+        return True
+
+    def analyze_narrative_context(
+        self, warm_slice: list[Dict[str, Any]], user_input: str
+    ) -> Dict[str, Any]:
+        return {"themes": ["testing"], "user_input": user_input}
+
+    def generate_retrieval_queries(
+        self, analysis: Dict[str, Any], user_input: str
+    ) -> list[str]:
+        self.generated_query_calls += 1
+        return ["Local query A", "Local query B", "Local query C"]
+
+
 @pytest.fixture()
 def turn_manager() -> TurnCycleManager:
     return TurnCycleManager(DummyLore())
@@ -57,7 +78,7 @@ def _stub_baseline(
     return package
 
 
-def test_integrate_response_passes_authorial_directives(
+def test_integrate_response_passes_generated_authorial_directives(
     turn_manager: TurnCycleManager, monkeypatch: pytest.MonkeyPatch
 ):
     ctx = TurnContext(
@@ -65,7 +86,11 @@ def test_integrate_response_passes_authorial_directives(
         user_input="Test input",
         start_time=time.time(),
     )
-    ctx.authorial_directives = ["Directive A", "Directive B"]
+    ctx.authorial_directives = ["Incoming directive"]
+    ctx.generated_authorial_directives = [
+        "Generated directive A",
+        "Generated directive B",
+    ]
     ctx.warm_slice = [{"chunk_id": 999, "text": "Recent narrative."}]
     ctx.retrieved_passages = []
     ctx.token_counts = {
@@ -79,6 +104,9 @@ def test_integrate_response_passes_authorial_directives(
 
     def fake_handle_storyteller_response(**kwargs):
         captured["authorial_directives"] = kwargs.get("authorial_directives")
+        captured["execute_authorial_directives"] = kwargs.get(
+            "execute_authorial_directives"
+        )
         return _stub_baseline(
             turn_manager.lore.memory_manager,
             kwargs.get("narrative", ""),
@@ -95,10 +123,94 @@ def test_integrate_response_passes_authorial_directives(
 
     asyncio.run(turn_manager.integrate_response(ctx, "Story chunk text"))
 
-    assert captured["authorial_directives"] == ctx.authorial_directives
+    assert captured["authorial_directives"] == ctx.generated_authorial_directives
+    assert captured["execute_authorial_directives"] is False
     baseline_snapshot = ctx.memory_state["pass1"]
-    assert baseline_snapshot["authorial_directives"] == ctx.authorial_directives
+    assert (
+        baseline_snapshot["authorial_directives"] == ctx.generated_authorial_directives
+    )
     assert baseline_snapshot["structured_passages"] == []
+
+
+def test_warm_analysis_loads_parent_authorial_directives(
+    turn_manager: TurnCycleManager,
+):
+    class DummyMemnon:
+        def get_chunk_by_id(self, chunk_id: int) -> Dict[str, Any]:
+            return {
+                "id": chunk_id,
+                "text": "Parent scene.",
+                "authorial_directives": [
+                    "Retrieve the missing ledger and ash-boiler escape route."
+                ],
+            }
+
+        def get_recent_chunks(self, limit: int) -> Dict[str, Any]:
+            return {"results": []}
+
+    turn_manager.lore.memnon = DummyMemnon()
+    turn_manager.lore.llm_manager = DummyLLMManager()
+    ctx = TurnContext(
+        turn_id="turn_parent_directives",
+        user_input="Continue.",
+        start_time=time.time(),
+        target_chunk_id=42,
+    )
+
+    asyncio.run(turn_manager.perform_warm_analysis(ctx))
+
+    assert ctx.authorial_directives == [
+        "Retrieve the missing ledger and ash-boiler escape route."
+    ]
+    assert ctx.phase_states["warm_analysis"]["authorial_directive_count"] == 1
+
+
+def test_deep_queries_use_authorial_directives_before_local_llm(
+    turn_manager: TurnCycleManager,
+):
+    class DummyMemnon:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+
+        def query_memory(
+            self, query: str, k: int, use_hybrid: bool
+        ) -> Dict[str, list[Dict[str, Any]]]:
+            self.queries.append(query)
+            return {
+                "results": [
+                    {
+                        "id": len(self.queries),
+                        "score": 1.0,
+                        "text": f"Result for {query}",
+                    }
+                ]
+            }
+
+    memnon = DummyMemnon()
+    llm_manager = DummyLLMManager()
+    turn_manager.lore.memnon = memnon
+    turn_manager.lore.llm_manager = llm_manager
+
+    ctx = TurnContext(
+        turn_id="turn_deep_directives",
+        user_input="Continue.",
+        start_time=time.time(),
+    )
+    ctx.authorial_directives = [
+        "Directive query A",
+        "Directive query B",
+    ]
+    ctx.phase_states["warm_analysis"] = {"analysis": {"themes": ["testing"]}}
+
+    asyncio.run(turn_manager.execute_deep_queries(ctx))
+
+    assert memnon.queries[:2] == ["Directive query A", "Directive query B"]
+    assert memnon.queries[2:] == ["Local query A", "Local query B", "Local query C"]
+    assert llm_manager.generated_query_calls == 1
+    assert ctx.phase_states["deep_queries"]["query_sources"] == {
+        "authorial_directive": 2,
+        "llm_generated": 3,
+    }
 
 
 def test_integrate_response_sorts_mixed_chunk_id_payloads(

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -213,6 +213,59 @@ def test_deep_queries_use_authorial_directives_before_local_llm(
     }
 
 
+def test_deep_queries_obey_configured_query_budget(
+    turn_manager: TurnCycleManager,
+):
+    """The deep-query budget should come from LORE retrieval settings."""
+
+    class DummyMemnon:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+
+        def query_memory(
+            self, query: str, k: int, use_hybrid: bool
+        ) -> Dict[str, list[Dict[str, Any]]]:
+            self.queries.append(query)
+            return {
+                "results": [
+                    {
+                        "id": len(self.queries),
+                        "score": 1.0,
+                        "text": f"Result for {query}",
+                    }
+                ]
+            }
+
+    memnon = DummyMemnon()
+    llm_manager = DummyLLMManager()
+    turn_manager.lore.memnon = memnon
+    turn_manager.lore.llm_manager = llm_manager
+    turn_manager.lore.settings["lore"] = {"retrieval": {"max_deep_queries": 3}}
+
+    ctx = TurnContext(
+        turn_id="turn_deep_budget",
+        user_input="Continue.",
+        start_time=time.time(),
+    )
+    ctx.authorial_directives = [
+        "Directive query A",
+        "Directive query B",
+    ]
+    ctx.phase_states["warm_analysis"] = {"analysis": {"themes": ["testing"]}}
+
+    asyncio.run(turn_manager.execute_deep_queries(ctx))
+
+    assert memnon.queries == [
+        "Directive query A",
+        "Directive query B",
+        "Local query A",
+    ]
+    assert ctx.phase_states["deep_queries"]["query_sources"] == {
+        "authorial_directive": 2,
+        "llm_generated": 1,
+    }
+
+
 def test_integrate_response_sorts_mixed_chunk_id_payloads(
     turn_manager: TurnCycleManager, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add structured Storyteller authorial directives to LOGON response schemas
- persist directives on incubator and narrative chunks, including commit and MEMNON reads
- feed parent-chunk directives into next-turn deep retrieval before local LLM query generation
- store generated directives for the next turn without running post-response MEMNON queries in FastAPI integration

## Validation
- PYTHONPATH=$PWD poetry run pytest tests/test_lore -q
- PYTHONPATH=$PWD poetry run pytest tests/test_api -q
- PYTHONPATH=$PWD poetry run pytest tests/test_lore/test_apex_schema.py tests/test_api/test_lore_adapter.py tests/test_lore/test_turn_cycle.py tests/test_lore/test_logon_lazy_init.py tests/test_lore/test_memory_manager.py tests/test_lore/test_pass2_chunk1369.py tests/test_api/test_narrative_generation.py tests/test_api/test_choice_promotion.py tests/test_logon_mock_integration.py -q
- PYTHONPATH=$PWD poetry run black --check <edited Python files>
- git diff --check
- Live slot 5: chunk 52 directives were committed, chunk 53 used those directives for deep queries, chunk 54 generated with five new directives, and patched integration completed without post-response directive query execution.