### PR TITLE
Seed deep retrieval with raw chunk text

### DIFF
--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -92,6 +92,13 @@ def _coerce_authorial_directives(raw_directives: Any) -> List[str]:
     return normalize_authorial_directives(raw_directives, allow_json_string=True)
 
 
+def _chunk_text(chunk: Dict[str, Any]) -> str:
+    """Return the best available narrative text from a warm-slice chunk."""
+
+    text = chunk.get("text") or chunk.get("full_text") or chunk.get("raw_text") or ""
+    return text.strip() if isinstance(text, str) else ""
+
+
 class TurnCycleManager:
     """Manages the execution of turn cycle phases"""
 
@@ -125,6 +132,19 @@ class TurnCycleManager:
             raise RuntimeError(
                 f"Invalid LORE retrieval max_deep_queries setting: {budget!r}"
             ) from exc
+
+    def _raw_chunk_retrieval_query(self, turn_context: TurnContext) -> Optional[str]:
+        """Resolve the current/parent chunk text to use as a baseline query."""
+
+        for chunk in turn_context.warm_slice:
+            if chunk.get("is_target"):
+                text = _chunk_text(chunk)
+                if text:
+                    return text
+
+        if turn_context.warm_slice:
+            return _chunk_text(turn_context.warm_slice[0]) or None
+        return None
 
     async def process_user_input(self, turn_context: TurnContext):
         """
@@ -522,12 +542,23 @@ class TurnCycleManager:
         if getattr(self.lore, "memory_manager", None):
             self.lore.memory_manager.reset_pass1_queries()
 
-        # Storyteller-authored directives are first-line retrieval input. The
-        # local LLM fills any remaining query budget from the current analysis.
+        # Full chunk text is the first-line retrieval baseline. Storyteller
+        # directives add targeted continuity, and local LLM queries fill any
+        # remaining budget from the current analysis.
         max_deep_queries = self._max_deep_queries()
         incoming_directives = turn_context.authorial_directives
         queries = []
-        for directive in incoming_directives[:max_deep_queries]:
+        raw_chunk_query = self._raw_chunk_retrieval_query(turn_context)
+        if raw_chunk_query:
+            queries.append(
+                {
+                    "text": raw_chunk_query,
+                    "type": "general",
+                    "source": "raw_chunk",
+                }
+            )
+
+        for directive in incoming_directives[: max_deep_queries - len(queries)]:
             queries.append(
                 {
                     "text": directive,
@@ -613,6 +644,9 @@ class TurnCycleManager:
             "queries_executed": len(queries),
             "query_types": query_type_counts,
             "query_sources": {
+                "raw_chunk": sum(
+                    1 for query in queries if query.get("source") == "raw_chunk"
+                ),
                 "authorial_directive": sum(
                     1
                     for query in queries

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -95,7 +95,7 @@ def _coerce_authorial_directives(raw_directives: Any) -> List[str]:
 def _chunk_text(chunk: Dict[str, Any]) -> str:
     """Return the best available narrative text from a warm-slice chunk."""
 
-    text = chunk.get("text") or chunk.get("full_text") or chunk.get("raw_text") or ""
+    text = chunk.get("text") or chunk.get("full_text") or ""
     return text.strip() if isinstance(text, str) else ""
 
 
@@ -141,10 +141,18 @@ class TurnCycleManager:
                 text = _chunk_text(chunk)
                 if text:
                     return text
-
-        if turn_context.warm_slice:
-            return _chunk_text(turn_context.warm_slice[0]) or None
         return None
+
+    def _classify_query_type(self, query_text: str) -> str:
+        """Classify a MEMNON query for phase-state accounting."""
+
+        if not self.query_analyzer:
+            return "general"
+
+        query_info = self.query_analyzer.analyze_query(query_text)
+        query_type = query_info.get("type", "general")
+        logger.debug(f"Query '{query_text[:50]}...' classified as '{query_type}'")
+        return query_type
 
     async def process_user_input(self, turn_context: TurnContext):
         """
@@ -235,6 +243,8 @@ class TurnCycleManager:
                 # Get most recent chunks directly
                 recent_chunks = self.lore.memnon.get_recent_chunks(limit=initial_chunks)
                 recent_list = recent_chunks.get("results", [])
+                if target_chunk_id is None and recent_list:
+                    recent_list[0]["is_target"] = True
                 if (
                     not turn_context.authorial_directives
                     and target_chunk_id is None
@@ -553,12 +563,20 @@ class TurnCycleManager:
             queries.append(
                 {
                     "text": raw_chunk_query,
-                    "type": "general",
+                    "type": self._classify_query_type(raw_chunk_query),
                     "source": "raw_chunk",
                 }
             )
 
-        for directive in incoming_directives[: max_deep_queries - len(queries)]:
+        directive_budget = max(0, max_deep_queries - len(queries))
+        if incoming_directives and directive_budget <= 0:
+            logger.warning(
+                "raw_chunk query consumed full query budget (%d); "
+                "all authorial directives suppressed",
+                max_deep_queries,
+            )
+
+        for directive in incoming_directives[:directive_budget]:
             queries.append(
                 {
                     "text": directive,
@@ -582,14 +600,12 @@ class TurnCycleManager:
 
         # Step 2: Classify local generated queries with MEMNON's QueryAnalyzer
         for q_text in llm_queries[:remaining_query_slots]:
-            query_type = "general"
-            if self.query_analyzer:
-                query_info = self.query_analyzer.analyze_query(q_text)
-                query_type = query_info.get("type", "general")
-                logger.debug(f"Query '{q_text[:50]}...' classified as '{query_type}'")
-
             queries.append(
-                {"text": q_text, "type": query_type, "source": "llm_generated"}
+                {
+                    "text": q_text,
+                    "type": self._classify_query_type(q_text),
+                    "source": "llm_generated",
+                }
             )
 
         # Step 3: Execute queries with proper SearchManager configuration

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from typing import Any, Dict
 
@@ -251,7 +252,7 @@ def test_deep_queries_use_raw_chunk_before_targeted_queries(
         {
             "id": 10,
             "is_target": True,
-            "text": "Full parent chunk text with all the messy narrative details.",
+            "full_text": "Full parent chunk text with all the messy narrative details.",
         }
     ]
     ctx.authorial_directives = [
@@ -273,6 +274,63 @@ def test_deep_queries_use_raw_chunk_before_targeted_queries(
         "raw_chunk": 1,
         "authorial_directive": 2,
         "llm_generated": 2,
+    }
+
+
+def test_deep_queries_warn_when_raw_chunk_suppresses_directives(
+    turn_manager: TurnCycleManager,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A one-query budget should trace that raw text displaced directives."""
+
+    class DummyMemnon:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+
+        def query_memory(
+            self, query: str, k: int, use_hybrid: bool
+        ) -> Dict[str, list[Dict[str, Any]]]:
+            self.queries.append(query)
+            return {
+                "results": [
+                    {
+                        "id": len(self.queries),
+                        "score": 1.0,
+                        "text": f"Result for {query[:20]}",
+                    }
+                ]
+            }
+
+    memnon = DummyMemnon()
+    llm_manager = DummyLLMManager()
+    turn_manager.lore.memnon = memnon
+    turn_manager.lore.llm_manager = llm_manager
+    turn_manager.lore.settings["lore"] = {"retrieval": {"max_deep_queries": 1}}
+
+    ctx = TurnContext(
+        turn_id="turn_deep_raw_chunk_budget",
+        user_input="Continue.",
+        start_time=time.time(),
+    )
+    ctx.warm_slice = [
+        {
+            "id": 10,
+            "is_target": True,
+            "text": "Full parent chunk text.",
+        }
+    ]
+    ctx.authorial_directives = ["Directive query A"]
+    ctx.phase_states["warm_analysis"] = {"analysis": {"themes": ["testing"]}}
+
+    with caplog.at_level(logging.WARNING, logger="nexus.lore.turn_cycle"):
+        asyncio.run(turn_manager.execute_deep_queries(ctx))
+
+    assert memnon.queries == ["Full parent chunk text."]
+    assert "all authorial directives suppressed" in caplog.text
+    assert ctx.phase_states["deep_queries"]["query_sources"] == {
+        "raw_chunk": 1,
+        "authorial_directive": 0,
+        "llm_generated": 0,
     }
 
 

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -208,8 +208,71 @@ def test_deep_queries_use_authorial_directives_before_local_llm(
     assert memnon.queries[2:] == ["Local query A", "Local query B", "Local query C"]
     assert llm_manager.generated_query_calls == 1
     assert ctx.phase_states["deep_queries"]["query_sources"] == {
+        "raw_chunk": 0,
         "authorial_directive": 2,
         "llm_generated": 3,
+    }
+
+
+def test_deep_queries_use_raw_chunk_before_targeted_queries(
+    turn_manager: TurnCycleManager,
+):
+    """Full chunk text should seed retrieval before narrower query paths."""
+
+    class DummyMemnon:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+
+        def query_memory(
+            self, query: str, k: int, use_hybrid: bool
+        ) -> Dict[str, list[Dict[str, Any]]]:
+            self.queries.append(query)
+            return {
+                "results": [
+                    {
+                        "id": len(self.queries),
+                        "score": 1.0,
+                        "text": f"Result for {query[:20]}",
+                    }
+                ]
+            }
+
+    memnon = DummyMemnon()
+    llm_manager = DummyLLMManager()
+    turn_manager.lore.memnon = memnon
+    turn_manager.lore.llm_manager = llm_manager
+
+    ctx = TurnContext(
+        turn_id="turn_deep_raw_chunk",
+        user_input="Continue.",
+        start_time=time.time(),
+    )
+    ctx.warm_slice = [
+        {
+            "id": 10,
+            "is_target": True,
+            "text": "Full parent chunk text with all the messy narrative details.",
+        }
+    ]
+    ctx.authorial_directives = [
+        "Directive query A",
+        "Directive query B",
+    ]
+    ctx.phase_states["warm_analysis"] = {"analysis": {"themes": ["testing"]}}
+
+    asyncio.run(turn_manager.execute_deep_queries(ctx))
+
+    assert memnon.queries == [
+        "Full parent chunk text with all the messy narrative details.",
+        "Directive query A",
+        "Directive query B",
+        "Local query A",
+        "Local query B",
+    ]
+    assert ctx.phase_states["deep_queries"]["query_sources"] == {
+        "raw_chunk": 1,
+        "authorial_directive": 2,
+        "llm_generated": 2,
     }
 
 
@@ -261,6 +324,7 @@ def test_deep_queries_obey_configured_query_budget(
         "Local query A",
     ]
     assert ctx.phase_states["deep_queries"]["query_sources"] == {
+        "raw_chunk": 0,
         "authorial_directive": 2,
         "llm_generated": 1,
     }


### PR DESCRIPTION
## Summary
- seeds LORE deep retrieval with the raw current/parent chunk text when warm-slice text is available
- keeps Storyteller authorial directives as targeted follow-up queries within the configured budget
- leaves local LLM generated queries as gap-fillers only after raw text and directives

## Rationale
PR #261's live bake-off found raw full chunk text clearly stronger on future-oracle retrieval metrics while Skald/local targeted queries still had value for continuity coverage. This keeps both paths, but makes the cheap/high-recall raw query the baseline.

## Validation
- `PYTHONPATH=$PWD poetry run pytest tests/test_lore/test_turn_cycle.py -q`
- `PYTHONPATH=$PWD poetry run pytest tests/test_lore -q`
- `PYTHONPATH=$PWD poetry run black --check nexus/agents/lore/utils/turn_cycle.py tests/test_lore/test_turn_cycle.py`