### PR TITLE
Align LORE QA TUI with direct retrieval

### DIFF
--- a/nexus/agents/lore/lore_qa_tui.py
+++ b/nexus/agents/lore/lore_qa_tui.py
@@ -61,7 +61,12 @@ def format_retrieval_context(result: Dict[str, Any]) -> str:
     )
 
 
-def collect_directive_field(result: Dict[str, Any], field_name: str) -> List[Any]:
+def collect_directive_field(
+    result: Dict[str, Any],
+    field_name: str,
+    *,
+    include_scalars: bool = True,
+) -> List[Any]:
     """Collect per-directive retrieval metadata into one flat list."""
 
     collected: List[Any] = []
@@ -75,9 +80,25 @@ def collect_directive_field(result: Dict[str, Any], field_name: str) -> List[Any
         value = payload.get(field_name)
         if isinstance(value, list):
             collected.extend(value)
-        elif value:
+        elif include_scalars and value:
             collected.append(value)
     return collected
+
+
+def format_reasoning_metadata(result: Dict[str, Any]) -> str:
+    """Format top-level or per-directive reasoning metadata for export."""
+
+    reasoning_items = collect_directive_field(result, "reasoning")
+    if not reasoning_items:
+        return str(result.get("reasoning", "")).strip()
+
+    rendered = []
+    for item in reasoning_items:
+        if isinstance(item, (dict, list)):
+            rendered.append(json.dumps(item, indent=2, sort_keys=True))
+        else:
+            rendered.append(str(item))
+    return "\n\n".join(rendered)
 
 
 class StatusBar(Static):
@@ -383,7 +404,9 @@ class LoreQATerminal(App[None]):
             conversation.add_lore(format_retrieval_context(result))
 
             # Citations
-            sources = result.get("sources") or []
+            sources = result.get("sources") or collect_directive_field(
+                result, "sources", include_scalars=False
+            )
             if sources:
                 conversation.write("[dim]citations:[/]")
                 for cid in sources[:10]:
@@ -411,7 +434,7 @@ class LoreQATerminal(App[None]):
             # Search progress
             progress_table.clear(columns=False)
             sp = result.get("search_progress") or collect_directive_field(
-                result, "search_progress"
+                result, "search_progress", include_scalars=False
             )
             for idx, item in enumerate(sp, start=1):
                 if isinstance(item, dict):
@@ -423,7 +446,7 @@ class LoreQATerminal(App[None]):
             # SQL attempts
             sql_table.clear(columns=False)
             attempts = result.get("sql_attempts") or collect_directive_field(
-                result, "sql_attempts"
+                result, "sql_attempts", include_scalars=False
             )
             for i, att in enumerate(attempts, start=1):
                 if isinstance(att, dict):
@@ -518,22 +541,19 @@ if __name__ == "__main__":
                     elapsed_ms = int((time.time() - start) * 1000)
                     print(f"\nRetrieved context:\n{format_retrieval_context(result)}\n")
 
-                    sources = result.get("sources") or []
+                    sources = result.get("sources") or collect_directive_field(
+                        result, "sources", include_scalars=False
+                    )
                     if sources:
                         print("Citations:")
                         for cid in sources[:10]:
                             print(f"- chunk_id:{cid}")
                         print()
 
-                    reasoning_items = collect_directive_field(result, "reasoning")
-                    reasoning_text = str(result.get("reasoning", "")).strip()
-                    if reasoning_items or reasoning_text:
+                    reasoning_text = format_reasoning_metadata(result)
+                    if reasoning_text:
                         print("Reasoning:")
-                        if reasoning_items:
-                            for item in reasoning_items:
-                                print(item)
-                        else:
-                            print(reasoning_text)
+                        print(reasoning_text)
                         print()
 
                     queries = result.get("queries") or []
@@ -545,7 +565,7 @@ if __name__ == "__main__":
                         print()
 
                     attempts = result.get("sql_attempts") or collect_directive_field(
-                        result, "sql_attempts"
+                        result, "sql_attempts", include_scalars=False
                     )
                     if attempts:
                         print("SQL attempts:")
@@ -592,18 +612,16 @@ if __name__ == "__main__":
                     try:
                         out_md = Path(args.save_md)
                         out_md.parent.mkdir(parents=True, exist_ok=True)
+                        sources = result.get("sources") or collect_directive_field(
+                            result, "sources", include_scalars=False
+                        )
                         lines = [
                             f"# LORE Q&A\n",
                             f"Question: {args.qa}\n\n",
                             f"Retrieved context:\n\n{format_retrieval_context(result)}\n\n",
                             "Citations:\n"
-                            + "\n".join(
-                                [
-                                    f"- chunk_id:{cid}"
-                                    for cid in (result.get("sources") or [])
-                                ]
-                            ),
-                            "\n\nReasoning:\n\n" + str(result.get("reasoning", "")),
+                            + "\n".join([f"- chunk_id:{cid}" for cid in sources]),
+                            "\n\nReasoning:\n\n" + format_reasoning_metadata(result),
                             f"\n\nElapsed: {int(elapsed*1000)} ms\n",
                         ]
                         out_md.write_text("".join(lines))

--- a/nexus/agents/lore/lore_qa_tui.py
+++ b/nexus/agents/lore/lore_qa_tui.py
@@ -1,14 +1,11 @@
 """
-LORE Q&A Retrofuturistic TUI (Scaffold)
-
-Stage 1: App/screen/layout/theme only, no backend wiring yet.
+LORE Q&A Retrofuturistic TUI.
 
 Run:
   python nexus/agents/lore/lore_qa_tui.py
 
-Planned wiring in next stages:
-  - On submit, dispatch background `run_qa(question)`
-  - Populate telemetry and conversation from LORE.answer_question payload
+The legacy Q&A helper now returns direct MEMNON retrieval context rather than a
+local-model synthesized answer.
 """
 
 from __future__ import annotations
@@ -39,20 +36,70 @@ COLOR_ERROR = "#FF33FF"
 COLOR_ERROR_ALT = "#FF6633"
 
 
-class StatusBar(Static):
-    """Header status bar showing product, model, db, and hints."""
+def format_retrieval_context(result: Dict[str, Any]) -> str:
+    """Format direct MEMNON retrieval results for human-facing displays."""
 
-    model_name: reactive[str] = reactive("(model: unknown)")
+    answer = str(result.get("answer", "")).strip()
+    if answer:
+        return answer
+
+    directives = result.get("directives") or {}
+    if not isinstance(directives, dict):
+        return "No relevant information found in the available story data."
+
+    parts: list[str] = []
+    for directive, payload in directives.items():
+        if not isinstance(payload, dict):
+            continue
+        context = str(payload.get("retrieved_context", "")).strip()
+        if context:
+            parts.append(f"{directive}\n\n{context}")
+
+    return (
+        "\n\n---\n\n".join(parts)
+        or "No relevant information found in the available story data."
+    )
+
+
+def collect_directive_field(result: Dict[str, Any], field_name: str) -> List[Any]:
+    """Collect per-directive retrieval metadata into one flat list."""
+
+    collected: List[Any] = []
+    directives = result.get("directives") or {}
+    if not isinstance(directives, dict):
+        return collected
+
+    for payload in directives.values():
+        if not isinstance(payload, dict):
+            continue
+        value = payload.get(field_name)
+        if isinstance(value, list):
+            collected.extend(value)
+        elif value:
+            collected.append(value)
+    return collected
+
+
+class StatusBar(Static):
+    """Header status bar showing product, retrieval mode, db, and hints."""
+
+    retrieval_mode: reactive[str] = reactive("(retrieval: direct)")
     db_health: reactive[str] = reactive("DB: ?")
     latency_ms: reactive[str] = reactive("— ms")
     token_info: reactive[str] = reactive("tokens: —")
-    hint_text: reactive[str] = reactive("Ctrl+Q: Quit  Ctrl+C: Clear  Ctrl+S: Save  ↑/↓: History")
+    hint_text: reactive[str] = reactive(
+        "Ctrl+Q: Quit  Ctrl+C: Clear  Ctrl+S: Save  ↑/↓: History"
+    )
 
     def render(self) -> str:
-        left = f"LORE Q&A  {self.model_name}  {self.db_health}  {self.token_info}"
+        left = f"LORE Q&A  {self.retrieval_mode}  {self.db_health}  {self.token_info}"
         right = f"⏱ {self.latency_ms}   {self.hint_text}"
         # Simple two-column feel by padding; Textual's Static render returns str
-        return f"[bold {COLOR_SYSTEM}]{left}[/]" + " " * 4 + f"[bold {COLOR_SYSTEM}]{right}[/]"
+        return (
+            f"[bold {COLOR_SYSTEM}]{left}[/]"
+            + " " * 4
+            + f"[bold {COLOR_SYSTEM}]{right}[/]"
+        )
 
 
 class ConversationView(Log):
@@ -75,14 +122,14 @@ class ConversationView(Log):
 
 
 class ReasoningLog(Log):
-    """Live reasoning stream (LLM trace)."""
+    """Direct retrieval trace."""
 
     def on_mount(self) -> None:  # type: ignore[override]
-        self.write(f"[bold {COLOR_SYSTEM}]Reasoning stream initialized…[/]")
+        self.write(f"[bold {COLOR_SYSTEM}]Retrieval trace initialized...[/]")
 
 
 class QueryList(DataTable):
-    """Generated queries table."""
+    """Retrieval queries table."""
 
     def on_mount(self) -> None:  # type: ignore[override]
         self.cursor_type = "row"
@@ -111,7 +158,7 @@ class TelemetryPanel(Vertical):
     def compose(self) -> ComposeResult:  # type: ignore[override]
         yield Static(f"[bold {COLOR_SYSTEM}]Reasoning[/]")
         yield ReasoningLog(id="reasoning")
-        yield Static(f"[bold {COLOR_SYSTEM}]Generated Queries[/]")
+        yield Static(f"[bold {COLOR_SYSTEM}]Retrieval Queries[/]")
         yield QueryList(id="queries")
         yield Static(f"[bold {COLOR_SYSTEM}]Search Progress[/]")
         yield SearchProgress(id="progress")
@@ -212,7 +259,7 @@ class LoreQATerminal(App[None]):
     def on_mount(self) -> None:  # type: ignore[override]
         # Seed placeholder values in the header
         status = self.query_one(StatusBar)
-        status.model_name = "(model: pending)"
+        status.retrieval_mode = "(retrieval: direct)"
         status.db_health = "DB: pending"
         status.latency_ms = "—"
         status.token_info = "tokens: —"
@@ -239,7 +286,9 @@ class LoreQATerminal(App[None]):
 
     def action_save_transcript(self) -> None:
         # Placeholder: stage 4 will implement save/load
-        self.query_one(ConversationView).add_lore("[save placeholder] Transcript saving will be implemented in a later stage.")
+        self.query_one(ConversationView).add_lore(
+            "[save placeholder] Transcript saving will be implemented in a later stage."
+        )
 
     def action_history_up(self) -> None:
         if not self.input_history:
@@ -252,7 +301,6 @@ class LoreQATerminal(App[None]):
             return
         self.history_index = min(len(self.input_history) - 1, self.history_index + 1)
         self.query_one(Input).value = self.input_history[self.history_index]
-
 
     async def on_input_submitted(self, event: Input.Submitted) -> None:  # type: ignore[override]
         question = (event.value or "").strip()
@@ -271,7 +319,9 @@ class LoreQATerminal(App[None]):
         self._set_status_busy()
 
         # Give immediate feedback
-        self.query_one(ReasoningLog).write(f"[dim]{time.strftime('%H:%M:%S')}[/] [bold {COLOR_SYSTEM}]queued[/] {question}")
+        self.query_one(ReasoningLog).write(
+            f"[dim]{time.strftime('%H:%M:%S')}[/] [bold {COLOR_SYSTEM}]queued[/] {question}"
+        )
 
         # Run in background to keep UI responsive
         asyncio.create_task(self._run_qa_flow(question))
@@ -292,7 +342,7 @@ class LoreQATerminal(App[None]):
             status = self.query_one(StatusBar)
             s = lore.get_status()  # type: ignore[attr-defined]
             comp = s.get("components", {}) if isinstance(s, dict) else {}
-            status.model_name = "(model: local)" if comp.get("local_llm") else "(model: unavailable)"
+            status.retrieval_mode = "(retrieval: direct)"
             status.db_health = "DB: ok" if comp.get("memnon") else "DB: unavailable"
         except Exception:
             pass
@@ -302,9 +352,12 @@ class LoreQATerminal(App[None]):
             return
         try:
             from nexus.agents.lore.lore import LORE  # Lazy import
+
             self.lore = LORE()
         except Exception as e:
-            self.query_one(ConversationView).add_error(f"Failed to initialize LORE: {e}")
+            self.query_one(ConversationView).add_error(
+                f"Failed to initialize LORE: {e}"
+            )
             raise
 
     async def _run_qa_flow(self, question: str) -> None:
@@ -326,9 +379,8 @@ class LoreQATerminal(App[None]):
             # Call backend
             result: Dict[str, Any] = await lore.answer_question(question)  # type: ignore[attr-defined]
 
-            # Populate conversation
-            answer = str(result.get("answer", "")).strip()
-            conversation.add_lore(answer or "I don't know based on the available story data.")
+            # Populate conversation with direct retrieval context.
+            conversation.add_lore(format_retrieval_context(result))
 
             # Citations
             sources = result.get("sources") or []
@@ -339,8 +391,12 @@ class LoreQATerminal(App[None]):
 
             # Reasoning
             reasoning.clear()
-            if result.get("reasoning"):
-                reasoning.write(result["reasoning"])  # type: ignore[index]
+            reasoning_items = collect_directive_field(result, "reasoning")
+            if reasoning_items:
+                for item in reasoning_items:
+                    reasoning.write(str(item))
+            elif result.get("reasoning"):
+                reasoning.write(str(result["reasoning"]))  # type: ignore[index]
             else:
                 reasoning.write("[dim]No reasoning trace provided.[/]")
 
@@ -354,7 +410,9 @@ class LoreQATerminal(App[None]):
 
             # Search progress
             progress_table.clear(columns=False)
-            sp = result.get("search_progress") or []
+            sp = result.get("search_progress") or collect_directive_field(
+                result, "search_progress"
+            )
             for idx, item in enumerate(sp, start=1):
                 if isinstance(item, dict):
                     q = str(item.get("query", ""))
@@ -364,7 +422,9 @@ class LoreQATerminal(App[None]):
 
             # SQL attempts
             sql_table.clear(columns=False)
-            attempts = result.get("sql_attempts") or []
+            attempts = result.get("sql_attempts") or collect_directive_field(
+                result, "sql_attempts"
+            )
             for i, att in enumerate(attempts, start=1):
                 if isinstance(att, dict):
                     sql = str(att.get("sql", "")).replace("\n", " ")
@@ -384,22 +444,36 @@ class LoreQATerminal(App[None]):
             except Exception:
                 pass
 
+
 if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="LORE Q&A TUI or headless CLI")
-    parser.add_argument("--qa", help="Run headless Q&A with the given question (no TUI)")
-    parser.add_argument("--repl", action="store_true", help="Run interactive headless CLI (no TUI)")
-    parser.add_argument("--agentic-sql", action="store_true", help="Enable agentic SQL (default: ON via settings.json)")
-    parser.add_argument("--settings", default="settings.json", help="Path to settings.json for LORE (default: settings.json)")
-    parser.add_argument("--debug", action="store_true", help="Enable debug logging for headless mode")
-    parser.add_argument("--save-json", help="Path to save JSON transcript (headless mode)")
-    parser.add_argument("--save-md", help="Path to save Markdown summary (headless mode)")
-    parser.add_argument("--keep-model", action="store_true", help="Keep LM Studio model loaded (headless mode)")
+    parser.add_argument(
+        "--qa", help="Run headless Q&A with the given question (no TUI)"
+    )
+    parser.add_argument(
+        "--repl", action="store_true", help="Run interactive headless CLI (no TUI)"
+    )
+    parser.add_argument(
+        "--settings",
+        default="settings.json",
+        help="Path to settings.json for LORE (default: settings.json)",
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="Enable debug logging for headless mode"
+    )
+    parser.add_argument(
+        "--save-json", help="Path to save JSON transcript (headless mode)"
+    )
+    parser.add_argument(
+        "--save-md", help="Path to save Markdown summary (headless mode)"
+    )
 
     args = parser.parse_args()
 
     if args.repl:
+
         async def _run_repl() -> int:
             """Run an interactive headless REPL for LORE Q&A.
 
@@ -410,23 +484,16 @@ if __name__ == "__main__":
                 from nexus.agents.lore.lore import LORE
 
                 lore = LORE(settings_path=args.settings, debug=args.debug)
-                # Agentic SQL is ON by default in settings.json; flag forces ON if provided
-                if args.agentic_sql:
-                    lore.settings.setdefault("Agent Settings", {}).setdefault("LORE", {}).setdefault("agentic_sql", True)
-                if args.keep_model and getattr(lore, "llm_manager", None):
-                    try:
-                        lore.llm_manager.unload_on_exit = False  # type: ignore[attr-defined]
-                    except Exception:
-                        pass
 
                 print("LORE Q&A CLI — type 'exit' or Ctrl+D to quit.\n")
                 # Best-effort status line
                 try:
                     status = lore.get_status()  # type: ignore[attr-defined]
-                    comps = status.get("components", {}) if isinstance(status, dict) else {}
-                    model = "local" if comps.get("local_llm") else "unavailable"
+                    comps = (
+                        status.get("components", {}) if isinstance(status, dict) else {}
+                    )
                     db = "ok" if comps.get("memnon") else "unavailable"
-                    print(f"Status: model={model}; db={db}\n")
+                    print(f"Status: retrieval=direct; db={db}\n")
                 except Exception:
                     pass
 
@@ -449,8 +516,7 @@ if __name__ == "__main__":
                         continue
 
                     elapsed_ms = int((time.time() - start) * 1000)
-                    answer = str(result.get("answer", "")).strip()
-                    print(f"\nAnswer:\n{answer}\n")
+                    print(f"\nRetrieved context:\n{format_retrieval_context(result)}\n")
 
                     sources = result.get("sources") or []
                     if sources:
@@ -459,21 +525,28 @@ if __name__ == "__main__":
                             print(f"- chunk_id:{cid}")
                         print()
 
+                    reasoning_items = collect_directive_field(result, "reasoning")
                     reasoning_text = str(result.get("reasoning", "")).strip()
-                    if reasoning_text:
+                    if reasoning_items or reasoning_text:
                         print("Reasoning:")
-                        print(reasoning_text)
+                        if reasoning_items:
+                            for item in reasoning_items:
+                                print(item)
+                        else:
+                            print(reasoning_text)
                         print()
 
                     queries = result.get("queries") or []
                     if queries:
-                        print("Generated queries:")
+                        print("Retrieval queries:")
                         for i, q in enumerate(queries, start=1):
                             q_text = str(q)
                             print(f" {i}. {q_text}")
                         print()
 
-                    attempts = result.get("sql_attempts") or []
+                    attempts = result.get("sql_attempts") or collect_directive_field(
+                        result, "sql_attempts"
+                    )
                     if attempts:
                         print("SQL attempts:")
                         for i, att in enumerate(attempts, start=1):
@@ -493,18 +566,12 @@ if __name__ == "__main__":
 
         raise SystemExit(asyncio.run(_run_repl()))
     elif args.qa:
+
         async def _run_headless() -> int:
             try:
                 from nexus.agents.lore.lore import LORE
+
                 lore = LORE(settings_path=args.settings, debug=args.debug)
-                # Apply runtime options immediately so they affect the run
-                if args.keep_model and getattr(lore, "llm_manager", None):
-                    try:
-                        lore.llm_manager.unload_on_exit = False  # type: ignore[attr-defined]
-                    except Exception:
-                        pass
-                if args.agentic_sql:
-                    lore.settings.setdefault("Agent Settings", {}).setdefault("LORE", {}).setdefault("agentic_sql", True)
                 start = time.time()
                 result: Dict[str, Any] = await lore.answer_question(args.qa)
                 elapsed = time.time() - start
@@ -528,8 +595,14 @@ if __name__ == "__main__":
                         lines = [
                             f"# LORE Q&A\n",
                             f"Question: {args.qa}\n\n",
-                            f"Answer:\n\n{result.get('answer','')}\n\n",
-                            "Citations:\n" + "\n".join([f"- chunk_id:{cid}" for cid in (result.get('sources') or [])]),
+                            f"Retrieved context:\n\n{format_retrieval_context(result)}\n\n",
+                            "Citations:\n"
+                            + "\n".join(
+                                [
+                                    f"- chunk_id:{cid}"
+                                    for cid in (result.get("sources") or [])
+                                ]
+                            ),
                             "\n\nReasoning:\n\n" + str(result.get("reasoning", "")),
                             f"\n\nElapsed: {int(elapsed*1000)} ms\n",
                         ]
@@ -538,7 +611,6 @@ if __name__ == "__main__":
                         pass
                 # Print to stdout
                 print(json.dumps(result, indent=2))
-                # keep-model already applied before run
                 return 0
             except Exception as e:
                 print(json.dumps({"error": str(e)}))
@@ -547,5 +619,3 @@ if __name__ == "__main__":
         raise SystemExit(asyncio.run(_run_headless()))
     else:
         LoreQATerminal().run()
-
-

--- a/tests/test_lore/test_lore_qa_tui.py
+++ b/tests/test_lore/test_lore_qa_tui.py
@@ -10,6 +10,7 @@ pytest.importorskip("textual")
 
 from nexus.agents.lore.lore_qa_tui import (  # noqa: E402
     collect_directive_field,
+    format_reasoning_metadata,
     format_retrieval_context,
 )
 
@@ -36,6 +37,19 @@ def test_format_retrieval_context_uses_directive_payloads() -> None:
     assert "What does Emilia know?" in rendered
 
 
+def test_format_retrieval_context_preserves_answer_fast_path() -> None:
+    """Legacy answer-shaped payloads should not duplicate directive context."""
+
+    result: Dict[str, Any] = {
+        "answer": "Victor is still hidden.",
+        "directives": {
+            "Where is Victor?": {"retrieved_context": "Duplicate context."},
+        },
+    }
+
+    assert format_retrieval_context(result) == "Victor is still hidden."
+
+
 def test_collect_directive_field_flattens_per_directive_metadata() -> None:
     """Telemetry tables consume direct retrieval metadata from each directive."""
 
@@ -50,3 +64,34 @@ def test_collect_directive_field_flattens_per_directive_metadata() -> None:
         {"query": "alpha", "result_count": 1},
         {"query": "beta", "result_count": 2},
     ]
+
+
+def test_collect_directive_field_can_exclude_scalars_for_list_fields() -> None:
+    """List-oriented table paths should not receive scalar metadata by accident."""
+
+    result: Dict[str, Any] = {
+        "directives": {
+            "a": {"search_progress": "not-a-progress-row"},
+            "b": {"search_progress": [{"query": "beta", "result_count": 2}]},
+        }
+    }
+
+    assert collect_directive_field(
+        result, "search_progress", include_scalars=False
+    ) == [{"query": "beta", "result_count": 2}]
+
+
+def test_format_reasoning_metadata_uses_directive_reasoning() -> None:
+    """Markdown exports should include reasoning from directive payloads."""
+
+    result: Dict[str, Any] = {
+        "directives": {
+            "a": {"reasoning": {"mode": "direct_memnon_retrieval", "query_count": 1}},
+            "b": {"reasoning": {"mode": "direct_memnon_retrieval", "query_count": 2}},
+        }
+    }
+
+    rendered = format_reasoning_metadata(result)
+
+    assert '"query_count": 1' in rendered
+    assert '"query_count": 2' in rendered

--- a/tests/test_lore/test_lore_qa_tui.py
+++ b/tests/test_lore/test_lore_qa_tui.py
@@ -1,0 +1,52 @@
+"""Tests for LORE Q&A display helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+pytest.importorskip("textual")
+
+from nexus.agents.lore.lore_qa_tui import (  # noqa: E402
+    collect_directive_field,
+    format_retrieval_context,
+)
+
+
+def test_format_retrieval_context_uses_directive_payloads() -> None:
+    """Direct retrieval payloads should render useful text without an answer."""
+
+    result: Dict[str, Any] = {
+        "directives": {
+            "Where is Victor?": {
+                "retrieved_context": "Retrieval directive: Where is Victor?\n\n[Source 1] ...",
+            },
+            "What does Emilia know?": {
+                "retrieved_context": "Retrieval directive: What does Emilia know?\n\n[Source 2] ...",
+            },
+        }
+    }
+
+    rendered = format_retrieval_context(result)
+
+    assert "Where is Victor?" in rendered
+    assert "[Source 1]" in rendered
+    assert "---" in rendered
+    assert "What does Emilia know?" in rendered
+
+
+def test_collect_directive_field_flattens_per_directive_metadata() -> None:
+    """Telemetry tables consume direct retrieval metadata from each directive."""
+
+    result: Dict[str, Any] = {
+        "directives": {
+            "a": {"search_progress": [{"query": "alpha", "result_count": 1}]},
+            "b": {"search_progress": [{"query": "beta", "result_count": 2}]},
+        }
+    }
+
+    assert collect_directive_field(result, "search_progress") == [
+        {"query": "alpha", "result_count": 1},
+        {"query": "beta", "result_count": 2},
+    ]


### PR DESCRIPTION
## Summary
- update the LORE QA TUI/headless display path to render direct MEMNON retrieval context instead of expecting a local-LLM synthesized answer
- remove stale `--agentic-sql` and `--keep-model` affordances from the QA TUI CLI
- add helper coverage for directive-shaped retrieval payload formatting

## Tests
- `PYTHONPATH=$PWD poetry run pytest tests/test_lore/test_lore_qa_tui.py tests/test_lore/test_lore_retrieve_context.py -q`
- `PYTHONPATH=$PWD poetry run pytest tests/test_lore/test_turn_cycle.py tests/test_lore/test_logon_lazy_init.py -q`
- `PYTHONPATH=$PWD poetry run pytest tests/test_lore -q`
- `PYTHONPATH=$PWD poetry run pytest tests/test_api/test_lore_adapter.py -q`
- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery/test_bleed.py -q`
- `PYTHONPATH=$PWD poetry run python nexus/agents/lore/lore_qa_tui.py --help`