### PR TITLE
Make Orrery Bleed deterministic

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -132,7 +132,7 @@ The proposal is a Bethesda-inspired off-screen behavior subsystem: a pipeline (`
 | **Clear** (Stage 3) | Local-LLM (batched) + deterministic | Event-based clearance runs in the commit transaction; semantic clearance runs post-commit, async, results available for next tick | Commit (event) + post-commit (semantic) |
 | **Promote** (Stage 4) | Local-LLM (batched) | Decide which resolutions deserve frontier prose | Post-commit |
 | **Narrate** (Stage 5) | Frontier-LLM, async via durable outbox | Generate prose for promoted resolutions; persist into `offscreen_narrations` (separate from `narrative_chunks`) | Async after commit; durable across process restart |
-| **Bleed** (Stage 6) | Local-LLM at storyteller-time, hard 2s budget | Filter recent narrated resolutions for perceptibility; produce optional menu | LORE Phase 5 (`payload_assembly`), each player turn |
+| **Bleed** (Stage 6) | Deterministic storyteller-time selection | Offer a bounded menu from already-filtered, succeeded narrations | LORE Phase 5 (`payload_assembly`), each player turn |
 | **Stage 7 (deferred)** | — | Middle-tier journalistic prose | Metric-gated; see "Deferred — Orrery Stage 7" |
 
 **Cost shape (load-bearing):** Resolve is free and runs at full breadth. Each downstream stage is more expensive per call but operates on a smaller surface. Frontier prose only generates for resolutions that survived two earlier gates.
@@ -489,13 +489,13 @@ CREATE TABLE offscreen_narrations (
 
 ### Bleed Selector
 
-**Local LLM produces a menu, never a decision.** Perceptibility filtering only: given the player's current location, time, activity — which recent narrated off-screen events could plausibly register at all? Output is a curated list of N candidates (typically N ≤ 3), each annotated with sensory channel (auditory, news fragment, secondhand mention, faction graffiti) and a thin perceptual descriptor — *not* the narrator's full prose.
+**Bleed offers a menu, never a decision.** Perceptibility filtering happens before narration promotion and in the candidate query; storyteller-time Bleed now chooses deterministically from eligible narrated events. Output is a bounded list of N candidates (typically N ≤ 3), each annotated with sensory channel (auditory, news fragment, secondhand mention, faction graffiti) and a thin perceptual descriptor — *not* the narrator's full prose.
 
 **Hook point.** Bleed runs at the start of LORE Phase 5 (`assemble_context_payload`, `nexus/agents/lore/utils/turn_cycle.py:489`). Its output populates `turn_context.bleed_menu`, which `assemble_context_payload` then reads when building the payload. Concretely, the Bleed entry point is a new method on `TurnCycleManager` invoked from `assemble_context_payload` before payload assembly proper begins.
 
-**Latency budget: hard 2-second cap, enforced via an async local-LLM request timeout.** If the local-LLM call exceeds budget, the bleed menu for this turn is empty and the overrun logged loudly. Empty bleed is a valid outcome.
+**No inference budget.** Bleed no longer makes a storyteller-time model call; empty bleed remains a valid outcome when no eligible narration exists.
 
-**Candidate query is typed**: reads from `orrery_resolutions` JOIN `world_events` JOIN `offscreen_narrations` with filters on age, location proximity, sensory plausibility, surfacing history. The local LLM call uses `LocalLLMManager.structured_query(prompt, response_model)` (`nexus/agents/lore/utils/local_llm.py:642`) — signature is `(prompt, response_model, *, temperature=None, max_tokens=None, system_prompt=None)`. The existing helper handles SDK-vs-fallback parsing; no new structured-output plumbing required.
+**Candidate query is typed**: reads from `orrery_resolutions` JOIN `world_events` JOIN `offscreen_narrations` with filters on age, location proximity, sensory plausibility, and surfacing history. Selection is deterministic from the SQL ordering, capped by `[orrery.bleed] max_candidates`; Storyteller remains free to adapt, delay, or ignore the offered peripherals.
 
 **Surfacing bookkeeping** prevents nag (Codex): `last_offered_chunk_id`, `offer_count`, `first_surfaced_chunk_id` (on `orrery_resolutions`). Distinguish "offered to storyteller" from "actually surfaced" — only the latter creates a visible-world surfacing record.
 
@@ -510,7 +510,7 @@ CREATE TABLE offscreen_narrations (
 - **Clear (semantic)** runs post-commit, async, batched, filtered to entities with recent relevant events.
 - **Promote** runs post-commit, async, batched per tick.
 - **Narrate** is async via durable outbox. Bleed reads only `state='succeeded'` narrations + deterministic briefs.
-- **Bleed** runs synchronously at storyteller-time (LORE Phase 5) with hard latency budget.
+- **Bleed** runs synchronously at storyteller-time (LORE Phase 5) without inference.
 
 ### World Time Denormalization
 
@@ -580,7 +580,6 @@ provider = "anthropic"
 model_ref = "@anthropic.default"                        # resolved via [global.model.api_models]
 
 [orrery.bleed]
-latency_budget_ms = 2000
 max_candidates = 3
 candidate_pool_multiplier = 4
 
@@ -727,7 +726,7 @@ Revisit when: fourth real entity kind appears, compatibility view becomes write 
 - `nexus/agents/lore/lore.py:289` — `process_turn`; new LORE Phase 4.5 inserts here
 - `nexus/agents/lore/utils/turn_context.py:12-41` — `TurnPhase` enum (add `ORRERY_RESOLVE`) and `TurnContext` dataclass (add `orrery_proposal`, `bleed_menu`)
 - `nexus/agents/lore/utils/turn_cycle.py:489` — `assemble_context_payload` (LORE Phase 5); Bleed selector hooks at the start
-- `nexus/agents/lore/utils/local_llm.py:642` — `structured_query(prompt, response_model, *, temperature=None, max_tokens=None, system_prompt=None)` — used by Promote, Clear (semantic), Bleed
+- `nexus/agents/lore/utils/local_llm.py:642` — `structured_query(prompt, response_model, *, temperature=None, max_tokens=None, system_prompt=None)` — used by Promote and Clear (semantic)
 
 **Commit path (production = sync)**
 - `nexus/api/narrative.py:281` — existing `BackgroundTasks` pattern to mirror
@@ -785,7 +784,7 @@ Verification should use live NEXUS flows where the feature touches LORE, LOGON, 
 1. **Hook seams corrected.** `CommitOrreryTick` hooks the *transaction-wrapping* functions (`commit_incubator_to_database` L320 async; `commit_incubator_to_database_sync` L233 sync) at Step 8.5, not the `apply_state_updates*` workers at L223/L451.
 2. **Sync path called out as production.** Only `narrative.py:407` calls a commit function in production code, and it calls the sync variant. Async kept in parity for tests.
 3. **`chunk_workflow.py` removed from PR 0 audit.** It is not on the commit path; replaced with an audit of `narrative.py::_approve_narrative_impl` (L387).
-4. **Bleed hook point named.** Runs at the start of LORE Phase 5 (`assemble_context_payload`, `turn_cycle.py:489`); 2s budget enforced by the async local-LLM request timeout.
+4. **Bleed hook point named.** Runs at the start of LORE Phase 5 (`assemble_context_payload`, `turn_cycle.py:489`); current implementation is deterministic and inference-free.
 5. **Pipeline stages renamed.** "Phase N" reserved for LORE turn cycle; Orrery pipeline uses "Stage N". Deferred "Phase 7" → "Orrery Stage 7".
 6. **`TurnContext` extension spelled out.** Two new dataclass fields + one new `TurnPhase` enum value.
 7. **`world_layer_type` precondition.** Postgres ENUM not in tracked migrations; PR 0 confirms or PR 1 declares.
@@ -793,7 +792,7 @@ Verification should use live NEXUS flows where the feature touches LORE, LOGON, 
 9. **`source_kind` enum gains `'auto_registered'`** to satisfy the Vocabulary Growth contract.
 10. **Backfill pattern spelled out.** `NOT VALID → batch backfill → VALIDATE → CONCURRENTLY UNIQUE INDEX → SET NOT NULL`. Migration becomes Python, not SQL, because `scripts/migrate.py` is single-transaction-per-file.
 11. **`world_events.source` and `world_event_entities.role` promoted to real enums** (`event_source_kind`, `event_role_kind`), consistent with the rest of the controlled vocabulary.
-12. **`LocalLLMManager.structured_query` signature noted.** Existing API at `local_llm.py:642`; no new structured-output plumbing needed.
+12. **`LocalLLMManager.structured_query` signature noted.** Existing API at `local_llm.py:642`; no new structured-output plumbing needed for the remaining Promote/Clear paths.
 13. **`BackgroundTasks` pattern cross-referenced** to existing call sites (`narrative.py:281`, `storyteller.py:561, 666`).
 14. **`tick_chunk_id` timing clarified.** Not known during Resolve (Stage 1); stamped during CommitOrreryTick (Stage 2) after `insert_narrative_chunk` returns the new chunk's id. The UNIQUE idempotency constraint fires at write time.
 15. **MEMNON safety claim sharpened.** `get_recent_chunks` is already safe; real audit target is `query_memory` / `SearchManager`.

--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -495,6 +495,8 @@ CREATE TABLE offscreen_narrations (
 
 **No inference budget.** Bleed no longer makes a storyteller-time model call; empty bleed remains a valid outcome when no eligible narration exists.
 
+Older configs may still include `[orrery.bleed] latency_budget_ms` or `candidate_pool_multiplier`; the settings model accepts those keys as deprecated/ignored so existing slots keep booting.
+
 **Candidate query is typed**: reads from `orrery_resolutions` JOIN `world_events` JOIN `offscreen_narrations` with filters on age, location proximity, sensory plausibility, and surfacing history. Selection is deterministic from the SQL ordering, capped by `[orrery.bleed] max_candidates`; Storyteller remains free to adapt, delay, or ignore the offered peripherals.
 
 **Surfacing bookkeeping** prevents nag (Codex): `last_offered_chunk_id`, `offer_count`, `first_surfaced_chunk_id` (on `orrery_resolutions`). Distinguish "offered to storyteller" from "actually surfaced" — only the latter creates a visible-world surfacing record.
@@ -581,7 +583,6 @@ model_ref = "@anthropic.default"                        # resolved via [global.m
 
 [orrery.bleed]
 max_candidates = 3
-candidate_pool_multiplier = 4
 
 [orrery.promote]
 provider = "local"

--- a/nexus.toml
+++ b/nexus.toml
@@ -176,7 +176,6 @@ provider = "anthropic"
 model_ref = "@anthropic.default"
 
 [orrery.bleed]
-latency_budget_ms = 2000
 max_candidates = 3
 candidate_pool_multiplier = 4
 

--- a/nexus.toml
+++ b/nexus.toml
@@ -177,7 +177,6 @@ model_ref = "@anthropic.default"
 
 [orrery.bleed]
 max_candidates = 3
-candidate_pool_multiplier = 4
 
 [orrery.promote]
 provider = "local"

--- a/nexus/agents/lore/lore.py
+++ b/nexus/agents/lore/lore.py
@@ -212,8 +212,8 @@ class LORE:
         self.token_manager = TokenBudgetManager(self.settings)
         self.turn_manager = TurnCycleManager(self)
         logger.info(
-            "LORE turn cycle uses deterministic retrieval planning; local LLM "
-            "manager will be initialized on demand for legacy retrieval tools."
+            "LORE turn cycle uses deterministic retrieval planning and direct "
+            "MEMNON search."
         )
 
         # MEMNON is REQUIRED
@@ -247,19 +247,6 @@ class LORE:
         )
 
         logger.info("Component initialization complete")
-
-    def _ensure_local_llm_manager(self):
-        """Initialize the legacy local LLM manager on demand."""
-        if self.llm_manager is None:
-            from utils.local_llm import LocalLLMManager
-
-            settings_path = (
-                self.settings_path if hasattr(self, "settings_path") else None
-            )
-            self.llm_manager = LocalLLMManager(
-                self.settings, settings_path, self.system_prompt
-            )
-        return self.llm_manager
 
     def _initialize_memnon(self):
         """Initialize MEMNON utility for memory retrieval"""
@@ -404,20 +391,6 @@ class LORE:
             if failed_phase == TurnPhase.APEX_GENERATION:
                 raise
             return f"Error processing turn: {str(e)}"
-
-        finally:
-            # Clean up legacy local-LLM resources if they were initialized by
-            # deprecated retrieval tools during this process.
-            if (
-                self.llm_manager
-                and self.llm_manager.unload_on_exit  # allow --keep-model to disable
-                and self.settings.get("Agent Settings", {})
-                .get("LORE", {})
-                .get("llm", {})
-                .get("unload_after_turn", True)
-            ):
-                logger.debug("Unloading model after turn cycle to free resources")
-                self.llm_manager.unload_model()
 
     async def retrieve_context(
         self,
@@ -649,15 +622,7 @@ class LORE:
             "components": {
                 "memnon": "available" if self.memnon else "unavailable",
                 "logon": "available" if self.logon else "unavailable",
-                "llm": (
-                    "not initialized"
-                    if self.llm_manager is None
-                    else (
-                        "available"
-                        if self.llm_manager.is_available()
-                        else "unavailable"
-                    )
-                ),
+                "retrieval": "direct_memnon",
             },
         }
 
@@ -668,9 +633,7 @@ class LORE:
             "components": {
                 "memnon": self.memnon is not None,
                 "logon": self.logon is not None,
-                "local_llm": (
-                    self.llm_manager.is_available() if self.llm_manager else False
-                ),
+                "retrieval": "direct_memnon",
                 "token_manager": self.token_manager is not None,
                 "turn_manager": self.turn_manager is not None,
                 "memory_manager": self.memory_manager is not None,

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -836,13 +836,6 @@ class TurnCycleManager:
         if not self.lore.memnon:
             raise RuntimeError("Orrery bleed requires MEMNON database access")
 
-        llm_manager = self.lore.llm_manager
-        if llm_manager is None and hasattr(self.lore, "_ensure_local_llm_manager"):
-            llm_manager = self.lore._ensure_local_llm_manager()
-        if not llm_manager:
-            raise RuntimeError("Orrery bleed requires local LLM access")
-
-        latency_budget_ms = int(bleed_settings.get("latency_budget_ms", 2000))
         with self.lore.memnon.Session() as session:
             if turn_context.orrery_proposal is not None:
                 anchor_chunk_id = turn_context.orrery_proposal.anchor_chunk_id
@@ -858,13 +851,9 @@ class TurnCycleManager:
 
             result = await select_bleed_menu_async(
                 session,
-                llm_manager=llm_manager,
                 anchor_chunk_id=anchor_chunk_id,
-                user_input=turn_context.user_input,
-                warm_slice=turn_context.warm_slice,
                 max_candidates=max_candidates,
                 candidate_pool_multiplier=candidate_pool_multiplier,
-                latency_budget_ms=latency_budget_ms,
             )
 
         turn_context.bleed_menu = result.selected

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -29,7 +29,7 @@ try:
     from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
     from nexus.agents.orrery.bleed import (
         record_bleed_offers,
-        select_bleed_menu_async,
+        select_bleed_menu,
     )
     from nexus.config.settings_models import LORERetrievalSettings
     from nexus.util.authorial_directives import normalize_authorial_directives
@@ -52,7 +52,7 @@ except ImportError:
     from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
     from nexus.agents.orrery.bleed import (
         record_bleed_offers,
-        select_bleed_menu_async,
+        select_bleed_menu,
     )
     from nexus.config.settings_models import LORERetrievalSettings
     from nexus.util.authorial_directives import normalize_authorial_directives
@@ -822,9 +822,6 @@ class TurnCycleManager:
 
         bleed_settings = orrery_settings.get("bleed", {})
         max_candidates = int(bleed_settings.get("max_candidates", 3))
-        candidate_pool_multiplier = int(
-            bleed_settings.get("candidate_pool_multiplier", 4)
-        )
         if max_candidates <= 0:
             turn_context.phase_states["orrery_bleed"] = {
                 "enabled": True,
@@ -849,11 +846,10 @@ class TurnCycleManager:
                 }
                 return
 
-            result = await select_bleed_menu_async(
+            result = select_bleed_menu(
                 session,
                 anchor_chunk_id=anchor_chunk_id,
                 max_candidates=max_candidates,
-                candidate_pool_multiplier=candidate_pool_multiplier,
             )
 
         turn_context.bleed_menu = result.selected
@@ -862,7 +858,6 @@ class TurnCycleManager:
             "anchor_chunk_id": anchor_chunk_id,
             "candidate_count": result.candidates_considered,
             "selected_count": len(result.selected),
-            "timed_out": result.timed_out,
             "offers_recorded": 0,
         }
 

--- a/nexus/agents/orrery/bleed.py
+++ b/nexus/agents/orrery/bleed.py
@@ -48,7 +48,6 @@ class BleedSelectorResult(BaseModel):
 
     candidates_considered: int = 0
     selected: list[BleedCandidate] = Field(default_factory=list)
-    timed_out: bool = False
 
 
 def load_bleed_candidates(
@@ -110,12 +109,11 @@ def load_bleed_candidates(
     return [_candidate_from_row(row) for row in rows]
 
 
-async def select_bleed_menu_async(
+def select_bleed_menu(
     session: Any,
     *,
     anchor_chunk_id: int,
     max_candidates: int,
-    candidate_pool_multiplier: int,
 ) -> BleedSelectorResult:
     """Select a deterministic ambient Bleed menu from eligible candidates."""
 
@@ -125,7 +123,7 @@ async def select_bleed_menu_async(
     candidate_pool = load_bleed_candidates(
         session,
         anchor_chunk_id=anchor_chunk_id,
-        limit=max_candidates * max(1, candidate_pool_multiplier),
+        limit=max_candidates,
     )
     if not candidate_pool:
         return BleedSelectorResult()

--- a/nexus/agents/orrery/bleed.py
+++ b/nexus/agents/orrery/bleed.py
@@ -2,24 +2,15 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from decimal import Decimal
 from typing import Any, Mapping, Optional
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field
 from sqlalchemy import text
 
 logger = logging.getLogger("nexus.orrery.bleed")
-
-
-BLEED_SYSTEM_PROMPT = (
-    "You are the Orrery Bleed selector. Choose only off-screen narrations that "
-    "could plausibly be perceived as ambient peripheral texture in the current "
-    "scene. Prefer sensory, social, or digital traces. Ignore candidates that "
-    "would spoil hidden information or force the Storyteller to use them."
-)
 
 
 class BleedCandidate(BaseModel):
@@ -50,13 +41,6 @@ class BleedCandidate(BaseModel):
             "target_name": self.target_name,
             "magnitude": self.magnitude,
         }
-
-
-class BleedSelection(BaseModel):
-    """Structured local-LLM verdict for Bleed candidates."""
-
-    selected_resolution_ids: list[int] = Field(default_factory=list)
-    reasoning: str = ""
 
 
 class BleedSelectorResult(BaseModel):
@@ -129,15 +113,11 @@ def load_bleed_candidates(
 async def select_bleed_menu_async(
     session: Any,
     *,
-    llm_manager: Any,
     anchor_chunk_id: int,
-    user_input: str,
-    warm_slice: list[dict[str, Any]],
     max_candidates: int,
     candidate_pool_multiplier: int,
-    latency_budget_ms: int,
 ) -> BleedSelectorResult:
-    """Select a spoiler-safe ambient Bleed menu under a hard latency budget."""
+    """Select a deterministic ambient Bleed menu from eligible candidates."""
 
     if max_candidates <= 0:
         return BleedSelectorResult()
@@ -150,35 +130,9 @@ async def select_bleed_menu_async(
     if not candidate_pool:
         return BleedSelectorResult()
 
-    prompt = _build_bleed_prompt(
-        candidate_pool,
-        user_input=user_input,
-        warm_slice=warm_slice,
-        max_candidates=max_candidates,
-    )
-
-    try:
-        async with asyncio.timeout(latency_budget_ms / 1000):
-            selected = await _select_candidates_async(
-                llm_manager,
-                prompt,
-                candidate_pool,
-                max_candidates,
-                latency_budget_ms / 1000,
-            )
-    except (TimeoutError, asyncio.TimeoutError):
-        logger.error(
-            "Orrery Bleed selector exceeded %sms latency budget",
-            latency_budget_ms,
-        )
-        return BleedSelectorResult(
-            candidates_considered=len(candidate_pool),
-            timed_out=True,
-        )
-
     return BleedSelectorResult(
         candidates_considered=len(candidate_pool),
-        selected=selected,
+        selected=candidate_pool[:max_candidates],
     )
 
 
@@ -250,87 +204,3 @@ def _float_or_none(value: Any) -> Optional[float]:
     if isinstance(value, Decimal):
         return float(value)
     return float(value)
-
-
-def _build_bleed_prompt(
-    candidates: list[BleedCandidate],
-    *,
-    user_input: str,
-    warm_slice: list[dict[str, Any]],
-    max_candidates: int,
-) -> str:
-    recent_lines = []
-    for chunk in warm_slice[-3:]:
-        text_value = chunk.get("text") or chunk.get("full_text") or ""
-        if text_value:
-            recent_lines.append(" ".join(str(text_value).split())[:500])
-
-    candidate_payload = [
-        {
-            "resolution_id": candidate.resolution_id,
-            "template_id": candidate.template_id,
-            "event_type": candidate.event_type,
-            "actor_name": candidate.actor_name,
-            "target_name": candidate.target_name,
-            "channel": candidate.channel,
-            "summary": candidate.summary,
-            "brief": candidate.brief,
-            # Full narration text is only for selector-side spoiler judgment.
-            # Storyteller injection must use BleedCandidate.to_prompt_dict().
-            "text": candidate.text,
-            "magnitude": candidate.magnitude,
-        }
-        for candidate in candidates
-    ]
-
-    return (
-        "Select ambient Orrery Bleed candidates for the next Storyteller turn.\n\n"
-        f"User input: {user_input}\n\n"
-        "Recent scene excerpts:\n"
-        + "\n".join(f"- {line}" for line in recent_lines)
-        + "\n\nCandidates:\n"
-        + json.dumps(candidate_payload, sort_keys=True)
-        + "\n\nReturn at most "
-        + str(max_candidates)
-        + " selected_resolution_ids. Select none if no candidate is safely "
-        "perceptible from the current scene."
-    )
-
-
-async def _select_candidates_async(
-    llm_manager: Any,
-    prompt: str,
-    candidates: list[BleedCandidate],
-    max_candidates: int,
-    timeout_seconds: float,
-) -> list[BleedCandidate]:
-    raw = await llm_manager.structured_query_async(
-        prompt,
-        BleedSelection,
-        temperature=0.1,
-        max_tokens=512,
-        system_prompt=BLEED_SYSTEM_PROMPT,
-        timeout=timeout_seconds,
-    )
-    try:
-        selection = (
-            raw
-            if isinstance(raw, BleedSelection)
-            else BleedSelection.model_validate(raw)
-        )
-    except ValidationError as exc:
-        raise ValueError(f"Malformed Orrery Bleed selection: {raw}") from exc
-
-    candidates_by_id = {candidate.resolution_id: candidate for candidate in candidates}
-    selected: list[BleedCandidate] = []
-    unknown_ids = [
-        resolution_id
-        for resolution_id in selection.selected_resolution_ids
-        if resolution_id not in candidates_by_id
-    ]
-    if unknown_ids:
-        raise ValueError(f"Orrery Bleed selected unknown resolutions: {unknown_ids}")
-
-    for resolution_id in selection.selected_resolution_ids[:max_candidates]:
-        selected.append(candidates_by_id[resolution_id])
-    return selected

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -315,8 +315,19 @@ class OrreryBleedSettings(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    latency_budget_ms: Optional[int] = Field(
+        default=None,
+        ge=1,
+        exclude=True,
+        description="Deprecated and ignored; Bleed selection is deterministic.",
+    )
+    candidate_pool_multiplier: Optional[int] = Field(
+        default=None,
+        ge=1,
+        exclude=True,
+        description="Deprecated and ignored; Bleed fetches max_candidates.",
+    )
     max_candidates: int = Field(default=3, ge=0)
-    candidate_pool_multiplier: int = Field(default=4, ge=1)
 
 
 class OrreryPromoteSettings(BaseModel):

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -315,7 +315,6 @@ class OrreryBleedSettings(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    latency_budget_ms: int = Field(default=2000, ge=1)
     max_candidates: int = Field(default=3, ge=0)
     candidate_pool_multiplier: int = Field(default=4, ge=1)
 

--- a/tests/test_orrery/test_bleed.py
+++ b/tests/test_orrery/test_bleed.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from decimal import Decimal
 from types import SimpleNamespace
 
@@ -11,7 +10,6 @@ import pytest
 from nexus.agents.lore.utils.turn_context import TurnContext
 from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
 from nexus.agents.orrery.bleed import (
-    BleedSelection,
     load_bleed_candidates,
     select_bleed_menu_async,
 )
@@ -65,34 +63,6 @@ class FakeSession:
         self.commits += 1
 
 
-class FakeLLM:
-    """Local LLM stand-in returning one Bleed selection."""
-
-    def __init__(self, selection):
-        self.selection = selection
-        self.prompts = []
-
-    async def structured_query_async(self, prompt, response_model, **_kwargs):
-        self.prompts.append((prompt, response_model))
-        return self.selection
-
-
-class SlowLLM(FakeLLM):
-    """Local LLM stand-in that exceeds the latency budget."""
-
-    def __init__(self, selection):
-        super().__init__(selection)
-        self.cancelled = False
-
-    async def structured_query_async(self, prompt, response_model, **kwargs):
-        try:
-            await asyncio.sleep(0.05)
-        except asyncio.CancelledError:
-            self.cancelled = True
-            raise
-        return await super().structured_query_async(prompt, response_model, **kwargs)
-
-
 class FakeMemnon:
     """Minimal MEMNON stand-in exposing the Session factory."""
 
@@ -132,21 +102,17 @@ class FakeLore:
     token_manager = None
     enable_logon = True
 
-    def __init__(self, settings, session, llm_manager, logon=None):
+    def __init__(self, settings, session, logon=None):
         self.settings = settings
         self.memnon = FakeMemnon(session)
-        self.llm_manager = llm_manager
-        self.lazy_llm_manager = llm_manager
-        self.ensure_llm_calls = 0
+        self.llm_manager = None
         self.logon = logon or FakeLogon()
 
     def ensure_logon(self):
         return None
 
     def _ensure_local_llm_manager(self):
-        self.ensure_llm_calls += 1
-        self.llm_manager = self.lazy_llm_manager
-        return self.llm_manager
+        raise AssertionError("Orrery Bleed must not initialize a local LLM")
 
 
 def _candidate_row():
@@ -169,12 +135,18 @@ def _candidate_row():
     }
 
 
+def _candidate_row_with_id(resolution_id: int):
+    row = dict(_candidate_row())
+    row["resolution_id"] = resolution_id
+    row["narration_id"] = 500 + resolution_id
+    return row
+
+
 def _settings():
     return {
         "orrery": {
             "enabled": True,
             "bleed": {
-                "latency_budget_ms": 2000,
                 "max_candidates": 3,
                 "candidate_pool_multiplier": 4,
             },
@@ -199,21 +171,18 @@ def test_load_bleed_candidates_coerces_descriptor() -> None:
 
 
 @pytest.mark.asyncio
-async def test_select_bleed_menu_returns_selected_without_recording_offers() -> None:
+async def test_select_bleed_menu_returns_top_candidate_without_recording_offers() -> (
+    None
+):
     """Selection is pure; offer bookkeeping waits until generation succeeds."""
 
     session = FakeSession(candidate_rows=[_candidate_row()])
-    llm = FakeLLM(BleedSelection(selected_resolution_ids=[10], reasoning="apt"))
 
     result = await select_bleed_menu_async(
         session,
-        llm_manager=llm,
         anchor_chunk_id=100,
-        user_input="Continue.",
-        warm_slice=[{"text": "Rain ticks against the transit glass."}],
         max_candidates=3,
         candidate_pool_multiplier=4,
-        latency_budget_ms=2000,
     )
 
     assert result.candidates_considered == 1
@@ -226,70 +195,43 @@ async def test_select_bleed_menu_returns_selected_without_recording_offers() -> 
 
 @pytest.mark.asyncio
 async def test_select_bleed_menu_returns_empty_without_candidates() -> None:
-    """No candidates means no local LLM call and no bookkeeping writes."""
+    """No candidates means no bookkeeping writes."""
 
     session = FakeSession(candidate_rows=[])
-    llm = FakeLLM(BleedSelection(selected_resolution_ids=[10], reasoning="unused"))
 
     result = await select_bleed_menu_async(
         session,
-        llm_manager=llm,
         anchor_chunk_id=100,
-        user_input="Continue.",
-        warm_slice=[],
         max_candidates=3,
         candidate_pool_multiplier=4,
-        latency_budget_ms=2000,
     )
 
     assert result.candidates_considered == 0
     assert result.selected == []
-    assert llm.prompts == []
     assert session.commits == 0
 
 
 @pytest.mark.asyncio
-async def test_select_bleed_menu_timeout_returns_empty() -> None:
-    """Latency overruns produce an empty menu and no offer bookkeeping."""
+async def test_select_bleed_menu_caps_deterministic_selection() -> None:
+    """Deterministic Bleed preserves SQL ordering and max-candidate caps."""
 
-    session = FakeSession(candidate_rows=[_candidate_row()])
-    llm = SlowLLM(BleedSelection(selected_resolution_ids=[10]))
+    session = FakeSession(
+        candidate_rows=[
+            _candidate_row_with_id(10),
+            _candidate_row_with_id(11),
+        ]
+    )
 
     result = await select_bleed_menu_async(
         session,
-        llm_manager=llm,
         anchor_chunk_id=100,
-        user_input="Continue.",
-        warm_slice=[],
-        max_candidates=3,
+        max_candidates=1,
         candidate_pool_multiplier=4,
-        latency_budget_ms=1,
     )
 
-    assert result.timed_out is True
-    assert result.selected == []
-    assert llm.cancelled is True
-    assert session.commits == 0
-
-
-@pytest.mark.asyncio
-async def test_select_bleed_menu_rejects_unknown_resolution_ids() -> None:
-    """Hallucinated structured IDs fail loudly instead of silently disappearing."""
-
-    session = FakeSession(candidate_rows=[_candidate_row()])
-
-    with pytest.raises(ValueError, match="unknown resolutions"):
-        await select_bleed_menu_async(
-            session,
-            llm_manager=FakeLLM(BleedSelection(selected_resolution_ids=[9999])),
-            anchor_chunk_id=100,
-            user_input="Continue.",
-            warm_slice=[],
-            max_candidates=3,
-            candidate_pool_multiplier=4,
-            latency_budget_ms=2000,
-        )
-
+    assert result.timed_out is False
+    assert result.candidates_considered == 2
+    assert [candidate.resolution_id for candidate in result.selected] == [10]
     assert session.commits == 0
 
 
@@ -298,13 +240,7 @@ async def test_assemble_context_payload_includes_bleed_menu() -> None:
     """LORE payload assembly injects selected ambient Orrery peripherals."""
 
     session = FakeSession(candidate_rows=[_candidate_row()])
-    manager = TurnCycleManager(
-        FakeLore(
-            _settings(),
-            session,
-            FakeLLM(BleedSelection(selected_resolution_ids=[10], reasoning="apt")),
-        )
-    )
+    manager = TurnCycleManager(FakeLore(_settings(), session))
     context = TurnContext(
         turn_id="t1",
         user_input="Continue.",
@@ -321,13 +257,11 @@ async def test_assemble_context_payload_includes_bleed_menu() -> None:
 
 
 @pytest.mark.asyncio
-async def test_assemble_context_payload_initializes_bleed_llm_lazily() -> None:
-    """Orrery Bleed may still opt into the legacy local manager on demand."""
+async def test_assemble_context_payload_does_not_initialize_bleed_llm() -> None:
+    """Orrery Bleed should not summon local inference during turn assembly."""
 
     session = FakeSession(candidate_rows=[_candidate_row()])
-    llm = FakeLLM(BleedSelection(selected_resolution_ids=[10], reasoning="apt"))
-    lore = FakeLore(_settings(), session, llm)
-    lore.llm_manager = None
+    lore = FakeLore(_settings(), session)
     manager = TurnCycleManager(lore)
     context = TurnContext(
         turn_id="t1",
@@ -338,8 +272,7 @@ async def test_assemble_context_payload_initializes_bleed_llm_lazily() -> None:
 
     await manager.assemble_context_payload(context)
 
-    assert lore.ensure_llm_calls == 1
-    assert lore.llm_manager is llm
+    assert lore.llm_manager is None
     assert context.phase_states["orrery_bleed"]["selected_count"] == 1
 
 
@@ -348,13 +281,7 @@ async def test_assemble_context_payload_reuses_orrery_proposal_anchor() -> None:
     """Bleed uses the existing resolve anchor instead of recomputing max chunk."""
 
     session = FakeSession(candidate_rows=[_candidate_row()])
-    manager = TurnCycleManager(
-        FakeLore(
-            _settings(),
-            session,
-            FakeLLM(BleedSelection(selected_resolution_ids=[10], reasoning="apt")),
-        )
-    )
+    manager = TurnCycleManager(FakeLore(_settings(), session))
     context = TurnContext(
         turn_id="t1",
         user_input="Continue.",
@@ -379,9 +306,7 @@ async def test_call_apex_ai_records_bleed_offers_after_generation_success() -> N
     """Surfacing bookkeeping is written only after LOGON returns a response."""
 
     session = FakeSession()
-    manager = TurnCycleManager(
-        FakeLore(_settings(), session, FakeLLM(BleedSelection()), logon=FakeLogon())
-    )
+    manager = TurnCycleManager(FakeLore(_settings(), session, logon=FakeLogon()))
     context = TurnContext(turn_id="t1", user_input="Continue.", start_time=0)
     context.context_payload = {"user_input": "Continue."}
     context.bleed_menu = load_bleed_candidates(
@@ -414,9 +339,7 @@ async def test_call_apex_ai_does_not_record_bleed_offers_on_generation_failure()
     """Failed LOGON generation does not consume a Bleed opportunity."""
 
     session = FakeSession()
-    manager = TurnCycleManager(
-        FakeLore(_settings(), session, FakeLLM(BleedSelection()), logon=FailingLogon())
-    )
+    manager = TurnCycleManager(FakeLore(_settings(), session, logon=FailingLogon()))
     context = TurnContext(turn_id="t1", user_input="Continue.", start_time=0)
     context.context_payload = {"user_input": "Continue."}
     context.bleed_menu = load_bleed_candidates(

--- a/tests/test_orrery/test_bleed.py
+++ b/tests/test_orrery/test_bleed.py
@@ -11,7 +11,7 @@ from nexus.agents.lore.utils.turn_context import TurnContext
 from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
 from nexus.agents.orrery.bleed import (
     load_bleed_candidates,
-    select_bleed_menu_async,
+    select_bleed_menu,
 )
 
 
@@ -52,7 +52,7 @@ class FakeSession:
         if "/* orrery:bleed_candidates */" in sql:
             assert "r.tick_chunk_id <= :anchor_chunk_id" in sql
             assert "r.offer_count < 3" in sql
-            return FakeResult(self.candidate_rows)
+            return FakeResult(self.candidate_rows[: params["limit"]])
         if "/* orrery:record_bleed_offers */" in sql:
             return FakeResult([])
         if "SELECT max(id) AS max_id" in sql:
@@ -111,9 +111,6 @@ class FakeLore:
     def ensure_logon(self):
         return None
 
-    def _ensure_local_llm_manager(self):
-        raise AssertionError("Orrery Bleed must not initialize a local LLM")
-
 
 def _candidate_row():
     return {
@@ -148,7 +145,6 @@ def _settings():
             "enabled": True,
             "bleed": {
                 "max_candidates": 3,
-                "candidate_pool_multiplier": 4,
             },
         }
     }
@@ -170,19 +166,15 @@ def test_load_bleed_candidates_coerces_descriptor() -> None:
     assert candidates[0].magnitude == 0.72
 
 
-@pytest.mark.asyncio
-async def test_select_bleed_menu_returns_top_candidate_without_recording_offers() -> (
-    None
-):
+def test_select_bleed_menu_returns_top_candidate_without_recording_offers() -> None:
     """Selection is pure; offer bookkeeping waits until generation succeeds."""
 
     session = FakeSession(candidate_rows=[_candidate_row()])
 
-    result = await select_bleed_menu_async(
+    result = select_bleed_menu(
         session,
         anchor_chunk_id=100,
         max_candidates=3,
-        candidate_pool_multiplier=4,
     )
 
     assert result.candidates_considered == 1
@@ -193,17 +185,15 @@ async def test_select_bleed_menu_returns_top_candidate_without_recording_offers(
     )
 
 
-@pytest.mark.asyncio
-async def test_select_bleed_menu_returns_empty_without_candidates() -> None:
+def test_select_bleed_menu_returns_empty_without_candidates() -> None:
     """No candidates means no bookkeeping writes."""
 
     session = FakeSession(candidate_rows=[])
 
-    result = await select_bleed_menu_async(
+    result = select_bleed_menu(
         session,
         anchor_chunk_id=100,
         max_candidates=3,
-        candidate_pool_multiplier=4,
     )
 
     assert result.candidates_considered == 0
@@ -211,8 +201,7 @@ async def test_select_bleed_menu_returns_empty_without_candidates() -> None:
     assert session.commits == 0
 
 
-@pytest.mark.asyncio
-async def test_select_bleed_menu_caps_deterministic_selection() -> None:
+def test_select_bleed_menu_caps_deterministic_selection() -> None:
     """Deterministic Bleed preserves SQL ordering and max-candidate caps."""
 
     session = FakeSession(
@@ -222,15 +211,13 @@ async def test_select_bleed_menu_caps_deterministic_selection() -> None:
         ]
     )
 
-    result = await select_bleed_menu_async(
+    result = select_bleed_menu(
         session,
         anchor_chunk_id=100,
         max_candidates=1,
-        candidate_pool_multiplier=4,
     )
 
-    assert result.timed_out is False
-    assert result.candidates_considered == 2
+    assert result.candidates_considered == 1
     assert [candidate.resolution_id for candidate in result.selected] == [10]
     assert session.commits == 0
 

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -1,6 +1,7 @@
 """Tests for Orrery configuration loading."""
 
 from nexus.config import load_settings
+from nexus.config.settings_models import OrreryBleedSettings
 
 
 def test_orrery_settings_resolve_model_reference() -> None:
@@ -13,7 +14,6 @@ def test_orrery_settings_resolve_model_reference() -> None:
     assert settings.orrery.binding.window_chunks == 30
     expected_model = settings.global_.model.api_models["anthropic"].roles["default"]
     assert settings.orrery.narration.model_ref == expected_model
-    assert settings.orrery.bleed.candidate_pool_multiplier == 4
     assert settings.orrery.promote.provider == "local"
     assert settings.orrery.sunhelm.accrual_rates == {
         "sleep": 1.0,
@@ -33,3 +33,17 @@ def test_orrery_settings_resolve_model_reference() -> None:
         "intimacy": 16,
     }
     assert settings.orrery.sunhelm.pressure.min_severity_level == 2
+
+
+def test_orrery_bleed_accepts_deprecated_selection_keys() -> None:
+    """Old Bleed config keys should still validate but stay out of dumps."""
+
+    settings = OrreryBleedSettings(
+        latency_budget_ms=2000,
+        candidate_pool_multiplier=4,
+    )
+
+    assert settings.max_candidates == 3
+    dumped = settings.model_dump()
+    assert "latency_budget_ms" not in dumped
+    assert "candidate_pool_multiplier" not in dumped

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -13,7 +13,6 @@ def test_orrery_settings_resolve_model_reference() -> None:
     assert settings.orrery.binding.window_chunks == 30
     expected_model = settings.global_.model.api_models["anthropic"].roles["default"]
     assert settings.orrery.narration.model_ref == expected_model
-    assert settings.orrery.bleed.latency_budget_ms == 2000
     assert settings.orrery.bleed.candidate_pool_multiplier == 4
     assert settings.orrery.promote.provider == "local"
     assert settings.orrery.sunhelm.accrual_rates == {


### PR DESCRIPTION
## Summary
- replace Storyteller-time Orrery Bleed inference with deterministic selection from the already-filtered SQL candidate ordering
- remove the Bleed structured-selection prompt, timeout path, and LORE local-manager initialization path
- remove the now-unused Bleed latency config and update the Orrery design notes

## Tests
- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery/test_bleed.py tests/test_orrery/test_config.py -q`
- `PYTHONPATH=$PWD poetry run pytest tests/test_lore/test_turn_cycle.py tests/test_lore/test_logon_lazy_init.py -q`
- `PYTHONPATH=$PWD poetry run pytest tests/test_lore -q`
- `PYTHONPATH=$PWD poetry run pytest tests/test_orrery -q`
- `PYTHONPATH=$PWD poetry run pytest tests/test_api/test_lore_adapter.py -q`