### PR TITLE
Make Orrery worker promotion deterministic

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -1,6 +1,6 @@
 # Off-Screen Behavior Resolver — Orrery Design Plan
 
-**Status:** The Orrery build path is now past foundation and into route realism. Main has landed the identity spine and schema, dry-run resolver, accepted-chunk commit path, narration outbox, Bleed selector, retrieval-boundary hardening, relationship-trust hydration, semantic-clearance worker/status surface, Sunhelm needs, place affordance semantics, slot 2 semantic tag seeding, deterministic review orchestration, interpersonal needs (`SOCIALIZE` and `INTIMACY`), Work + Travel, concealment/contact package tuning, and authored travel edges. The runtime pipeline remains disabled by default (`orrery.enabled = false`). The active slice is **routing phase 3**: local OSM-derived graph routing before falling back to authored edges and coarse estimates.
+**Status:** The Orrery build path is now past foundation and into route realism. Main has landed the identity spine and schema, dry-run resolver, accepted-chunk commit path, narration outbox, Bleed selector, retrieval-boundary hardening, relationship-trust hydration, semantic-clearance status surface, Sunhelm needs, place affordance semantics, slot 2 semantic tag seeding, deterministic review orchestration, interpersonal needs (`SOCIALIZE` and `INTIMACY`), Work + Travel, concealment/contact package tuning, and authored travel edges. The runtime pipeline remains disabled by default (`orrery.enabled = false`). The active slice is **routing phase 3**: local OSM-derived graph routing before falling back to authored edges and coarse estimates.
 
 **Originating artifacts:** `temp/orrery/off_screen_resolver_spec.md`, `temp/orrery/behavior_substrate.py`, `temp/orrery/package_simulator.jsx`
 **Review trace:** `temp/orrery/design_plan_edited.md` (round 1: GPT-5.5-Pro, Codex, separate-Claude, Gemini) + `temp/orrery/super_table_question.md` (round 2: GPT-5.5-Pro, Claude Opus 4.7 chat) + v4 grounding pass against current `main` (claude-opus-4-7).
@@ -85,7 +85,7 @@ PR #222 adds deterministic review orchestration so newly opened PRs can schedule
 ### Landed After PR #222
 
 - PR #223 expands the package library with round-2 care, craft, and contact templates.
-- PR #224 adds batched post-commit semantic clearance for ephemeral tags and exposes `python -m nexus.agents.orrery.worker --slot N --status` as a compact operational snapshot for pending Orrery background work.
+- PR #224 added a semantic-clearance/status surface; the live semantic-clearance worker now stays conservative and performs no clears until a non-local clearance signal exists. `python -m nexus.agents.orrery.worker --slot N --status` remains the compact operational snapshot for pending Orrery background work.
 - The Sunhelm phase adds `character_need_states`, timestamp-plus-debt need tracking, and SLEEP/DRINK/EAT packages.
 - The location phase adds place-affordance semantics used by need and package gates.
 - PR #237 applies slot 2 semantic tag seeding so mature-state dry runs have real package vocabulary to work with.
@@ -117,7 +117,7 @@ Package authors can contribute now. The cleanest contribution format is a small 
 
 NEXUS today asks the storyteller LLM to confabulate off-stage character activity each turn, with heuristic instructions about narrative debt and ambient texture. There is no architectural guarantee that any specific character gets updated, no continuity beyond the context window, and no provenance — distant sirens in the prose are decoration, not the audible signature of a real package execution sitting in the database.
 
-The proposal is a Bethesda-inspired off-screen behavior subsystem: a pipeline (`Resolve → Commit → Promote → Narrate → Bleed`) that simulates what every tracked entity does between player turns. Most state changes resolve deterministically in pure Python; a small subset is promoted to local-LLM judgment, then to frontier-model prose, then offered to the storyteller as an optional menu of perceivable ambient peripherals.
+The proposal is a Bethesda-inspired off-screen behavior subsystem: a pipeline (`Resolve → Commit → Promote → Narrate → Bleed`) that simulates what every tracked entity does between player turns. Most state changes resolve deterministically in pure Python; a small salient subset is promoted by deterministic policy to frontier-model prose, then offered to the storyteller as an optional menu of perceivable ambient peripherals.
 
 **Motivating test case:** an NPC the player forcefully interrogated fifty chunks ago protested that their life was over. Behind the scenes, a package on that NPC ticks through fifty chunks of pure state resolution. Eventually a branch fires that's high-magnitude enough to promote: the retaliation. Prose generated, persisted, never surfaced. Two chunks later the player is in an intimacy scene in an entirely different part of the city and the storyteller has the option of hearing sirens in the distance — or not. If they do, MEMNON has substrate for retrieval. If they don't, the dramatic irony lives in the database, available to inform any future scene where it matters.
 
@@ -129,8 +129,8 @@ The proposal is a Bethesda-inspired off-screen behavior subsystem: a pipeline (`
 |---|---|---|---|
 | **Resolve** (Stage 1) | Free (pure Python) | Evaluate templates against per-entity bindings; produce an `OrreryTickProposal` (no writes, no `tick_chunk_id` yet) | In-cycle, during a new LORE Phase 4.5 (between `DEEP_QUERIES` and `PAYLOAD_ASSEMBLY`) |
 | **Commit** (Stage 2) | Free (SQL transaction) | Stamp `tick_chunk_id`, then atomically materialize the proposal into canonical tables (entity deltas, tag mutations, `world_events`, `orrery_resolutions`, enqueue narration jobs) | Inside the same transaction as accepted-chunk commit |
-| **Clear** (Stage 3) | Local-LLM (batched) + deterministic | Event-based clearance runs in the commit transaction; semantic clearance runs post-commit, async, results available for next tick | Commit (event) + post-commit (semantic) |
-| **Promote** (Stage 4) | Local-LLM (batched) | Decide which resolutions deserve frontier prose | Post-commit |
+| **Clear** (Stage 3) | Deterministic | Event-based clearance runs in the commit transaction; semantic clearance is intentionally disabled until a non-local clearance signal exists | Commit (event) |
+| **Promote** (Stage 4) | Deterministic | Decide which resolutions deserve frontier prose | Post-commit |
 | **Narrate** (Stage 5) | Frontier-LLM, async via durable outbox | Generate prose for promoted resolutions; persist into `offscreen_narrations` (separate from `narrative_chunks`) | Async after commit; durable across process restart |
 | **Bleed** (Stage 6) | Deterministic storyteller-time selection | Offer a bounded menu from already-filtered, succeeded narrations | LORE Phase 5 (`payload_assembly`), each player turn |
 | **Stage 7 (deferred)** | — | Middle-tier journalistic prose | Metric-gated; see "Deferred — Orrery Stage 7" |
@@ -509,7 +509,7 @@ Older configs may still include `[orrery.bleed] latency_budget_ms` or `candidate
 - **Resolve runs in-cycle** during a new **LORE Phase 4.5**, inserted between `DEEP_QUERIES` (Phase 4) and `PAYLOAD_ASSEMBLY` (Phase 5). Pure Python; produces `OrreryTickProposal` carried on `TurnContext.orrery_proposal`; no writes.
 - **CommitOrreryTick** runs as Step 8.5 inside `commit_incubator_to_database` (L320) / `commit_incubator_to_database_sync` (L233), between the existing `apply_state_updates*` call and `clear_incubator`. All canonical writes happen here.
 - **Clear (event)** runs in the same commit transaction as the triggering event.
-- **Clear (semantic)** runs post-commit, async, batched, filtered to entities with recent relevant events.
+- **Clear (semantic)** is currently a conservative no-op; event/authored clearance remains canonical until a non-local semantic-clearance signal exists.
 - **Promote** runs post-commit, async, batched per tick.
 - **Narrate** is async via durable outbox. Bleed reads only `state='succeeded'` narrations + deterministic briefs.
 - **Bleed** runs synchronously at storyteller-time (LORE Phase 5) without inference.
@@ -583,9 +583,6 @@ model_ref = "@anthropic.default"                        # resolved via [global.m
 
 [orrery.bleed]
 max_candidates = 3
-
-[orrery.promote]
-provider = "local"
 ```
 
 Every model reference uses the `@provider.role` syntax that the existing config loader resolves against `[global.model.api_models]` — never a hardcoded ID in runtime code (per `CLAUDE.md` "Testing Defaults").
@@ -692,14 +689,14 @@ This section is now mostly historical. The active queue has moved past the found
 
 - **`CommitOrreryTick` writer**: Step 8.5 inside `commit_incubator_to_database_sync` (L233 — the production path; insert between `apply_state_updates_sync` at L415 and incubator clear at L418) and parity inside `commit_incubator_to_database` (L320 — async, test-only; insert between `apply_state_updates` at L420 and `clear_incubator` at L423). Both call into the unified event writer in `nexus/agents/orrery/events.py`.
 - **Stamp `tick_chunk_id`** on every proposal row at this step, after `insert_narrative_chunk` returns the new chunk id.
-- Promote discriminator: `LocalLLMManager.structured_query(prompt, PromotionVerdict)` (existing API at `local_llm.py:642`). Fail loudly on malformed local-model output.
+- Promote discriminator: deterministic salience policy over `priority`, `magnitude`, `state_delta`, `event_ids`, and `brief`. No local inference required.
 - Deterministic brief generator → `orrery_resolutions.brief`.
 - Frontier narration via durable outbox; trigger drain via `BackgroundTasks` from `_approve_narrative_impl` after commit returns; standalone CLI worker for catch-up.
 - Narrator persistence to `offscreen_narrations` (not `narrative_chunks`); embedding pipeline shared with MEMNON.
-- Clear (event) in commit transaction; Clear (semantic) post-commit async, batched, filtered, and logged through `tag_clearance_log`.
+- Clear (event) in commit transaction; Clear (semantic) remains disabled as a conservative no-op until a non-local clearance path exists.
 - `tag_clearance_log` rows with justification.
 - Instrumented counters for the Orrery Stage 7 trigger metrics.
-- Verification: engineered fifty-chunk scenario (motivating test case), idempotency, incubator rejection, warm-slice contamination, local-LLM failure, async-worker state transitions.
+- Verification: engineered fifty-chunk scenario (motivating test case), idempotency, incubator rejection, warm-slice contamination, deterministic promotion behavior, async-worker state transitions.
 
 ### PR 4 — Bleed Selector + Storyteller Integration (implemented in PR #219)
 
@@ -727,7 +724,7 @@ Revisit when: fourth real entity kind appears, compatibility view becomes write 
 - `nexus/agents/lore/lore.py:289` — `process_turn`; new LORE Phase 4.5 inserts here
 - `nexus/agents/lore/utils/turn_context.py:12-41` — `TurnPhase` enum (add `ORRERY_RESOLVE`) and `TurnContext` dataclass (add `orrery_proposal`, `bleed_menu`)
 - `nexus/agents/lore/utils/turn_cycle.py:489` — `assemble_context_payload` (LORE Phase 5); Bleed selector hooks at the start
-- `nexus/agents/lore/utils/local_llm.py:642` — `structured_query(prompt, response_model, *, temperature=None, max_tokens=None, system_prompt=None)` — used by Promote and Clear (semantic)
+- `nexus/agents/orrery/worker.py` — deterministic Promote policy, durable narration outbox drain, and conservative semantic-clearance no-op
 
 **Commit path (production = sync)**
 - `nexus/api/narrative.py:281` — existing `BackgroundTasks` pattern to mirror
@@ -759,7 +756,7 @@ Revisit when: fourth real entity kind appears, compatibility view becomes write 
 - Mirror in `_approve_narrative_impl` post-commit to drain the narration outbox
 
 **Config + system prompt**
-- `nexus.toml` — new `[orrery]`, `[orrery.binding]`, `[orrery.narration]`, `[orrery.bleed]`, `[orrery.promote]` sections; use `@provider.role` syntax per `[global.model.api_models]` registry
+- `nexus.toml` — new `[orrery]`, `[orrery.binding]`, `[orrery.narration]`, and `[orrery.bleed]` sections; use `@provider.role` syntax per `[global.model.api_models]` registry
 - `nexus/agents/lore/logon_utility.py::_format_context_prompt` — PR 4 Bleed prompt framing
 
 **New artifacts**
@@ -775,8 +772,8 @@ Verification should use live NEXUS flows where the feature touches LORE, LOGON, 
 - **PR 0/1 foundation (#210):** Substrate demo runs against four presets; migration applies cleanly via `scripts/migrate.py --template` and unlocked slots; entity spine backfill validated; kind-enforcement triggers tested; compatibility views return expected unions; MEMNON whitelist updated and tested; `world_layer_type` confirmed or created in template.
 - **Retrieval-boundary hardening:** Regression tests assert warm-slice retrieval, text search, and vector-search collection routing remain disjoint from `offscreen_narrations`; `execute_readonly_sql` can SELECT from public Orrery tables and cannot select internal queue/raw tag tables.
 - **PR 2 (#211):** Dry-pass against slot 5 and slot 2; proposal contents inspected; zero writes observed; `TurnContext.orrery_proposal` carries no `tick_chunk_id` at this phase. Optional full-turn acceptance before PR 3: enable Orrery for a live LORE pass and confirm the storyteller payload remains unaffected while the proposal is attached only to the turn context.
-- **PR 3 (#214):** Engineered fifty-chunk motivating scenario (interrogated NPC → fifty ticks → retaliation prose persisted to `offscreen_narrations`, never surfaced); idempotency (regeneration cannot double-write — UNIQUE key fires); rejection (incubator rejection rolls everything back, including the Step 8.5 writes); warm-slice contamination (none); local-LLM failure (Promote fails loud); async-worker state transitions (`queued → leased → succeeded|failed`).
-- **PR 4:** Apt-bleed (ambient peripheral surfaces in the Storyteller payload); null-bleed (no candidates produces empty menu and no local-LLM call); chronology/surfacing boundary (only accepted prior narrated resolutions are eligible); latency-budget overrun produces empty menu and logs loudly.
+- **PR 3 (#214):** Engineered fifty-chunk motivating scenario (interrogated NPC → fifty ticks → retaliation prose persisted to `offscreen_narrations`, never surfaced); idempotency (regeneration cannot double-write — UNIQUE key fires); rejection (incubator rejection rolls everything back, including the Step 8.5 writes); warm-slice contamination (none); deterministic promotion; async-worker state transitions (`queued → leased → succeeded|failed`).
+- **PR 4:** Apt-bleed (ambient peripheral surfaces in the Storyteller payload); null-bleed (no candidates produces empty menu and no inference call); chronology/surfacing boundary (only accepted prior narrated resolutions are eligible); latency-budget overrun produces empty menu and logs loudly.
 
 ---
 
@@ -793,7 +790,7 @@ Verification should use live NEXUS flows where the feature touches LORE, LOGON, 
 9. **`source_kind` enum gains `'auto_registered'`** to satisfy the Vocabulary Growth contract.
 10. **Backfill pattern spelled out.** `NOT VALID → batch backfill → VALIDATE → CONCURRENTLY UNIQUE INDEX → SET NOT NULL`. Migration becomes Python, not SQL, because `scripts/migrate.py` is single-transaction-per-file.
 11. **`world_events.source` and `world_event_entities.role` promoted to real enums** (`event_source_kind`, `event_role_kind`), consistent with the rest of the controlled vocabulary.
-12. **`LocalLLMManager.structured_query` signature noted.** Existing API at `local_llm.py:642`; no new structured-output plumbing needed for the remaining Promote/Clear paths.
+12. **Live Orrery worker path is inference-free except narration.** Promote is deterministic, Bleed is deterministic, and semantic Clear is a conservative no-op until a non-local clearance signal exists.
 13. **`BackgroundTasks` pattern cross-referenced** to existing call sites (`narrative.py:281`, `storyteller.py:561, 666`).
 14. **`tick_chunk_id` timing clarified.** Not known during Resolve (Stage 1); stamped during CommitOrreryTick (Stage 2) after `insert_narrative_chunk` returns the new chunk's id. The UNIQUE idempotency constraint fires at write time.
 15. **MEMNON safety claim sharpened.** `get_recent_chunks` is already safe; real audit target is `query_memory` / `SearchManager`.

--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -583,6 +583,11 @@ model_ref = "@anthropic.default"                        # resolved via [global.m
 
 [orrery.bleed]
 max_candidates = 3
+
+[orrery.promote]
+priority_threshold = 50.0
+magnitude_threshold = 0.5
+perceptual_summary_max_chars = 240
 ```
 
 Every model reference uses the `@provider.role` syntax that the existing config loader resolves against `[global.model.api_models]` — never a hardcoded ID in runtime code (per `CLAUDE.md` "Testing Defaults").
@@ -689,7 +694,7 @@ This section is now mostly historical. The active queue has moved past the found
 
 - **`CommitOrreryTick` writer**: Step 8.5 inside `commit_incubator_to_database_sync` (L233 — the production path; insert between `apply_state_updates_sync` at L415 and incubator clear at L418) and parity inside `commit_incubator_to_database` (L320 — async, test-only; insert between `apply_state_updates` at L420 and `clear_incubator` at L423). Both call into the unified event writer in `nexus/agents/orrery/events.py`.
 - **Stamp `tick_chunk_id`** on every proposal row at this step, after `insert_narrative_chunk` returns the new chunk id.
-- Promote discriminator: deterministic salience policy over `priority`, `magnitude`, `state_delta`, `event_ids`, and `brief`. No local inference required.
+- Promote discriminator: deterministic salience policy over `priority`, `magnitude`, `state_delta`, `event_ids`, and `brief`, tuned through `[orrery.promote]`. No local inference required.
 - Deterministic brief generator → `orrery_resolutions.brief`.
 - Frontier narration via durable outbox; trigger drain via `BackgroundTasks` from `_approve_narrative_impl` after commit returns; standalone CLI worker for catch-up.
 - Narrator persistence to `offscreen_narrations` (not `narrative_chunks`); embedding pipeline shared with MEMNON.
@@ -756,7 +761,7 @@ Revisit when: fourth real entity kind appears, compatibility view becomes write 
 - Mirror in `_approve_narrative_impl` post-commit to drain the narration outbox
 
 **Config + system prompt**
-- `nexus.toml` — new `[orrery]`, `[orrery.binding]`, `[orrery.narration]`, and `[orrery.bleed]` sections; use `@provider.role` syntax per `[global.model.api_models]` registry
+- `nexus.toml` — new `[orrery]`, `[orrery.binding]`, `[orrery.narration]`, `[orrery.bleed]`, and `[orrery.promote]` sections; use `@provider.role` syntax per `[global.model.api_models]` registry
 - `nexus/agents/lore/logon_utility.py::_format_context_prompt` — PR 4 Bleed prompt framing
 
 **New artifacts**

--- a/nexus.toml
+++ b/nexus.toml
@@ -178,9 +178,6 @@ model_ref = "@anthropic.default"
 [orrery.bleed]
 max_candidates = 3
 
-[orrery.promote]
-provider = "local"
-
 [orrery.sunhelm]
 accrual_rates = { sleep = 1.0, hunger = 1.0, thirst = 1.0, socialize = 1.0, intimacy = 1.0 }
 priorities = { sleep = 25, thirst = 24, hunger = 22, socialize = 18, intimacy = 16 }

--- a/nexus.toml
+++ b/nexus.toml
@@ -178,6 +178,11 @@ model_ref = "@anthropic.default"
 [orrery.bleed]
 max_candidates = 3
 
+[orrery.promote]
+priority_threshold = 50.0
+magnitude_threshold = 0.5
+perceptual_summary_max_chars = 240
+
 [orrery.sunhelm]
 accrual_rates = { sleep = 1.0, hunger = 1.0, thirst = 1.0, socialize = 1.0, intimacy = 1.0 }
 priorities = { sleep = 25, thirst = 24, hunger = 22, socialize = 18, intimacy = 16 }

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -13,6 +13,7 @@ from psycopg2.extras import RealDictCursor
 from pydantic import BaseModel, Field
 
 from nexus.config import load_settings_as_dict
+from nexus.config.settings_models import OrreryPromoteSettings
 
 logger = logging.getLogger("nexus.orrery.worker")
 
@@ -23,8 +24,6 @@ DEFAULT_SEMANTIC_CLEARANCE_LIMIT = 20
 DEFAULT_SEMANTIC_CLEARANCE_RECENT_CHUNKS = 10
 DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_CHUNKS = 5
 DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_EVENTS = 6
-DEFAULT_PROMOTION_PRIORITY_THRESHOLD = 50.0
-DEFAULT_PROMOTION_MAGNITUDE_THRESHOLD = 0.5
 
 NARRATION_SYSTEM_PROMPT = (
     "You write concise off-screen narrative records for NEXUS. The prose is "
@@ -86,7 +85,6 @@ def process_orrery_outbox_sync(
         DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_EVENTS
     ),
     settings: Optional[Mapping[str, Any]] = None,
-    llm_manager: Optional[Any] = None,
     narration_provider: Optional[Any] = None,
 ) -> OrreryWorkerResult:
     """Drain pending Orrery background work."""
@@ -95,7 +93,6 @@ def process_orrery_outbox_sync(
         slot,
         limit=promotion_limit,
         settings=settings,
-        llm_manager=llm_manager,
     )
     narrated, failed = drain_narration_outbox_sync(
         slot,
@@ -110,7 +107,6 @@ def process_orrery_outbox_sync(
         evidence_chunk_limit=semantic_clearance_evidence_chunks,
         evidence_event_limit=semantic_clearance_evidence_events,
         settings=settings,
-        llm_manager=llm_manager,
     )
     return OrreryWorkerResult(
         promoted=promoted,
@@ -126,13 +122,9 @@ def promote_pending_resolutions_sync(
     *,
     limit: int = 20,
     settings: Optional[Mapping[str, Any]] = None,
-    llm_manager: Optional[Any] = None,
     conn: Optional[Any] = None,
 ) -> tuple[int, int]:
-    """Mark pending resolutions promoted or skipped with deterministic criteria.
-
-    ``llm_manager`` is accepted for compatibility with older callers and ignored.
-    """
+    """Mark pending resolutions promoted or skipped with deterministic criteria."""
 
     owns_conn = conn is None
     conn = conn or _connect_for_slot(slot)
@@ -166,11 +158,12 @@ def promote_pending_resolutions_sync(
                 if not rows:
                     return (0, 0)
 
+                promotion_settings = _promotion_settings(settings_dict)
                 promoted = 0
                 skipped = 0
                 slot_label = _slot_label(slot)
                 for row in rows:
-                    verdict = _promotion_verdict(row)
+                    verdict = _promotion_verdict(row, promotion_settings)
                     if verdict.promote:
                         _mark_promoted(cur, row, verdict, slot_label, settings_dict)
                         promoted += 1
@@ -287,7 +280,6 @@ def clear_semantic_tags_sync(
     evidence_chunk_limit: int = DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_CHUNKS,
     evidence_event_limit: int = DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_EVENTS,
     settings: Optional[Mapping[str, Any]] = None,
-    llm_manager: Optional[Any] = None,
     conn: Optional[Any] = None,
 ) -> int:
     """Return no semantic clears until a non-local clearance signal exists.
@@ -491,35 +483,46 @@ def _mark_narration_failed(
     )
 
 
-def _promotion_verdict(row: Mapping[str, Any]) -> PromotionVerdict:
+def _promotion_verdict(
+    row: Mapping[str, Any], settings: OrreryPromoteSettings
+) -> PromotionVerdict:
     priority = _numeric_or_zero(row.get("priority"))
     magnitude = _numeric_or_zero(row.get("magnitude"))
     state_delta = row.get("state_delta") or {}
     event_ids = row.get("event_ids") or []
     brief = str(row.get("brief") or "").strip()
-    has_canonical_signal = bool(brief) and bool(state_delta or event_ids)
+    has_resolution_content = bool(brief or state_delta or event_ids)
     is_salient = (
-        priority >= DEFAULT_PROMOTION_PRIORITY_THRESHOLD
-        or magnitude >= DEFAULT_PROMOTION_MAGNITUDE_THRESHOLD
+        priority >= settings.priority_threshold
+        or magnitude >= settings.magnitude_threshold
     )
 
-    if has_canonical_signal and is_salient:
+    if has_resolution_content and is_salient:
         return PromotionVerdict(
             promote=True,
             reason=(
                 "Deterministic promotion: priority "
-                f"{priority:g}, magnitude {magnitude:g}, "
+                f"{priority:g}/{settings.priority_threshold:g}, magnitude "
+                f"{magnitude:g}/{settings.magnitude_threshold:g}, "
                 f"state_delta={bool(state_delta)}, event_ids={len(event_ids)}."
             ),
-            perceptual_summary=brief[:240],
+            perceptual_summary=brief[: settings.perceptual_summary_max_chars] or None,
         )
     return PromotionVerdict(
         promote=False,
         reason=(
-            "Deterministic skip: resolution lacks both a durable canonical "
-            "signal and salience threshold."
+            "Deterministic skip: resolution lacks content or salience threshold "
+            f"(priority {priority:g}/{settings.priority_threshold:g}, "
+            f"magnitude {magnitude:g}/{settings.magnitude_threshold:g})."
         ),
     )
+
+
+def _promotion_settings(settings: Mapping[str, Any]) -> OrreryPromoteSettings:
+    raw_settings = (settings.get("orrery") or {}).get("promote") or {}
+    if isinstance(raw_settings, OrreryPromoteSettings):
+        return raw_settings
+    return OrreryPromoteSettings.model_validate(raw_settings)
 
 
 def _mark_promoted(

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -6,17 +6,12 @@ import argparse
 import json
 import logging
 import os
-import re
 from typing import Any, Mapping, Optional
 
 import psycopg2
 from psycopg2.extras import RealDictCursor
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field
 
-from nexus.agents.lore.utils.local_llm import (
-    LocalLLMManager,
-    _parse_structured_json_text,
-)
 from nexus.config import load_settings_as_dict
 
 logger = logging.getLogger("nexus.orrery.worker")
@@ -28,13 +23,8 @@ DEFAULT_SEMANTIC_CLEARANCE_LIMIT = 20
 DEFAULT_SEMANTIC_CLEARANCE_RECENT_CHUNKS = 10
 DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_CHUNKS = 5
 DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_EVENTS = 6
-
-PROMOTION_SYSTEM_PROMPT = (
-    "You are the Orrery promotion discriminator. Decide whether an off-screen "
-    "resolution deserves durable prose. Promote only events that create future "
-    "retrieval value, dramatic irony, concrete world change, or a perceivable "
-    "ambient consequence. Do not promote routine maintenance."
-)
+DEFAULT_PROMOTION_PRIORITY_THRESHOLD = 50.0
+DEFAULT_PROMOTION_MAGNITUDE_THRESHOLD = 0.5
 
 NARRATION_SYSTEM_PROMPT = (
     "You write concise off-screen narrative records for NEXUS. The prose is "
@@ -42,16 +32,9 @@ NARRATION_SYSTEM_PROMPT = (
     "where useful, and free of second-person address."
 )
 
-SEMANTIC_CLEARANCE_SYSTEM_PROMPT = (
-    "You are the Orrery semantic tag-clearance judge. Decide whether an "
-    "ephemeral off-screen state tag is no longer active based only on the "
-    "recent canonical narrative and Orrery events provided. Clear tags only "
-    "when the evidence is concrete; uncertainty means keep the tag."
-)
-
 
 class PromotionVerdict(BaseModel):
-    """Structured local-LLM promotion verdict for an Orrery resolution."""
+    """Deterministic promotion verdict for an Orrery resolution."""
 
     promote: bool
     reason: str = Field(min_length=1)
@@ -63,13 +46,6 @@ class PromotionVerdict(BaseModel):
         default=None,
         description="Short spoiler-safe cue a later Bleed selector could inspect.",
     )
-
-
-class SemanticClearanceVerdict(BaseModel):
-    """Structured local-LLM verdict for semantic ephemeral-tag clearance."""
-
-    clear: bool
-    reason: str = Field(min_length=1)
 
 
 class OrreryWorkerResult(BaseModel):
@@ -113,7 +89,7 @@ def process_orrery_outbox_sync(
     llm_manager: Optional[Any] = None,
     narration_provider: Optional[Any] = None,
 ) -> OrreryWorkerResult:
-    """Promote, narrate, and clear pending Orrery background work."""
+    """Drain pending Orrery background work."""
 
     promoted, skipped = promote_pending_resolutions_sync(
         slot,
@@ -153,7 +129,10 @@ def promote_pending_resolutions_sync(
     llm_manager: Optional[Any] = None,
     conn: Optional[Any] = None,
 ) -> tuple[int, int]:
-    """Use the local LLM to mark pending resolutions promoted or skipped."""
+    """Mark pending resolutions promoted or skipped with deterministic criteria.
+
+    ``llm_manager`` is accepted for compatibility with older callers and ignored.
+    """
 
     owns_conn = conn is None
     conn = conn or _connect_for_slot(slot)
@@ -187,12 +166,11 @@ def promote_pending_resolutions_sync(
                 if not rows:
                     return (0, 0)
 
-                manager = llm_manager or LocalLLMManager(settings_dict)
                 promoted = 0
                 skipped = 0
                 slot_label = _slot_label(slot)
                 for row in rows:
-                    verdict = _promotion_verdict(manager, row)
+                    verdict = _promotion_verdict(row)
                     if verdict.promote:
                         _mark_promoted(cur, row, verdict, slot_label, settings_dict)
                         promoted += 1
@@ -312,53 +290,12 @@ def clear_semantic_tags_sync(
     llm_manager: Optional[Any] = None,
     conn: Optional[Any] = None,
 ) -> int:
-    """Use the local LLM to clear stale semantic ephemeral tags."""
+    """Return no semantic clears until a non-local clearance signal exists.
 
-    if (
-        limit <= 0
-        or recent_chunk_window <= 0
-        or evidence_chunk_limit <= 0
-        or evidence_event_limit <= 0
-    ):
-        return 0
+    Arguments are accepted for compatibility with older callers.
+    """
 
-    owns_conn = conn is None
-    conn = conn or _connect_for_slot(slot)
-    settings_dict = dict(settings or load_settings_as_dict())
-    try:
-        rows = _semantic_clearance_candidates_sync(
-            conn,
-            limit=limit,
-            recent_chunk_window=recent_chunk_window,
-        )
-        if not rows:
-            return 0
-
-        manager = llm_manager or LocalLLMManager(settings_dict)
-        cleared = 0
-        for row in rows:
-            with conn:
-                with conn.cursor(cursor_factory=RealDictCursor) as cur:
-                    evidence = _semantic_clearance_evidence_sync(
-                        cur,
-                        entity_id=int(row["entity_id"]),
-                        chunk_limit=evidence_chunk_limit,
-                        event_limit=evidence_event_limit,
-                    )
-            verdict = _semantic_clearance_verdict(manager, row, evidence)
-            if verdict.clear:
-                did_clear = _mark_semantic_tag_cleared_sync(
-                    conn,
-                    row=row,
-                    verdict=verdict,
-                    source_chunk_id=_latest_evidence_chunk_id(evidence),
-                )
-                if did_clear:
-                    cleared += 1
-        return cleared
-    finally:
-        if owns_conn:
-            conn.close()
+    return 0
 
 
 def load_orrery_status_sync(
@@ -554,112 +491,35 @@ def _mark_narration_failed(
     )
 
 
-def _promotion_verdict(manager: Any, row: Mapping[str, Any]) -> PromotionVerdict:
-    prompt = (
-        "Evaluate this off-screen resolution for durable narration.\n\n"
-        f"Template: {row['template_id']}\n"
-        f"Actor: {row.get('actor_name') or row.get('actor_entity_id')}\n"
-        f"Priority: {row['priority']}\n"
-        f"Magnitude: {row.get('magnitude')}\n"
-        f"Brief: {row.get('brief')}\n"
-        f"State delta: {json.dumps(row.get('state_delta') or {}, sort_keys=True)}\n\n"
-        "Return promote=true only if this deserves off-screen prose."
+def _promotion_verdict(row: Mapping[str, Any]) -> PromotionVerdict:
+    priority = _numeric_or_zero(row.get("priority"))
+    magnitude = _numeric_or_zero(row.get("magnitude"))
+    state_delta = row.get("state_delta") or {}
+    event_ids = row.get("event_ids") or []
+    brief = str(row.get("brief") or "").strip()
+    has_canonical_signal = bool(brief) and bool(state_delta or event_ids)
+    is_salient = (
+        priority >= DEFAULT_PROMOTION_PRIORITY_THRESHOLD
+        or magnitude >= DEFAULT_PROMOTION_MAGNITUDE_THRESHOLD
     )
-    raw = manager.structured_query(
-        prompt,
-        PromotionVerdict,
-        temperature=0.1,
-        max_tokens=512,
-        system_prompt=PROMOTION_SYSTEM_PROMPT,
-    )
-    return _coerce_promotion_verdict(raw)
 
-
-def _structured_payload_from_raw(raw: Any) -> Any:
-    """Recover structured JSON when a local model leaks chat text wrappers."""
-    if isinstance(raw, Mapping):
-        answer = raw.get("answer")
-        if isinstance(answer, str):
-            parsed = _parse_structured_json_text(answer)
-            if parsed is not None:
-                return parsed
-    elif isinstance(raw, str):
-        parsed = _parse_structured_json_text(raw)
-        if parsed is not None:
-            return parsed
-    return raw
-
-
-def _markdown_bool_payload_from_raw(
-    raw: Any, field_name: str
-) -> Optional[dict[str, Any]]:
-    """Recover simple markdown/text boolean verdicts from local LLM fallbacks."""
-    text: Optional[str] = None
-    reason: Optional[str] = None
-
-    if isinstance(raw, Mapping):
-        answer = raw.get("answer")
-        if isinstance(answer, str):
-            text = answer
-        for reason_key in ("reason", "reasoning"):
-            value = raw.get(reason_key)
-            if isinstance(value, str) and value.strip():
-                reason = value.strip()
-                break
-    elif isinstance(raw, str):
-        text = raw
-
-    if not text:
-        return None
-
-    verdict_match = re.search(
-        rf"^\s*(?:[-*+]\s*)?(?:\*\*)?\s*{re.escape(field_name)}\s*"
-        r"(?:\*\*)?\s*[:=]\s*(?:\*\*)?\s*(true|false)\b",
-        text,
-        re.IGNORECASE | re.MULTILINE,
-    )
-    if not verdict_match:
-        return None
-
-    if reason is None:
-        reason_match = re.search(
-            r"^\s*(?:[-*+]\s*)?(?:\*\*)?\s*reason\s*" r"(?:\*\*)?\s*[:=]\s*(.+)$",
-            text,
-            re.IGNORECASE | re.MULTILINE,
-        )
-        if reason_match:
-            reason = reason_match.group(1).strip()
-
-    return {
-        field_name: verdict_match.group(1).lower() == "true",
-        "reason": reason or "Local model returned a text boolean verdict.",
-    }
-
-
-def _coerce_promotion_verdict(raw: Any) -> PromotionVerdict:
-    """Return a conservative promotion verdict from noisy local-model output."""
-    try:
-        if isinstance(raw, PromotionVerdict):
-            return raw
-        payload = _structured_payload_from_raw(raw)
-        if not (isinstance(payload, Mapping) and "promote" in payload):
-            payload = _markdown_bool_payload_from_raw(payload, "promote") or payload
-        if isinstance(payload, Mapping) and "promote" in payload:
-            payload = dict(payload)
-            payload.setdefault(
-                "reason", "Local model returned a bare promotion decision."
-            )
-        return PromotionVerdict.model_validate(payload)
-    except ValidationError as exc:
-        logger.warning(
-            "Malformed Orrery promotion verdict; skipping conservatively: %s",
-            raw,
-            exc_info=True,
-        )
+    if has_canonical_signal and is_salient:
         return PromotionVerdict(
-            promote=False,
-            reason="Malformed local promotion verdict; skipped conservatively.",
+            promote=True,
+            reason=(
+                "Deterministic promotion: priority "
+                f"{priority:g}, magnitude {magnitude:g}, "
+                f"state_delta={bool(state_delta)}, event_ids={len(event_ids)}."
+            ),
+            perceptual_summary=brief[:240],
         )
+    return PromotionVerdict(
+        promote=False,
+        reason=(
+            "Deterministic skip: resolution lacks both a durable canonical "
+            "signal and salience threshold."
+        ),
+    )
 
 
 def _mark_promoted(
@@ -705,255 +565,17 @@ def _mark_skipped(cur: Any, row: Mapping[str, Any], verdict: PromotionVerdict) -
     )
 
 
-def _semantic_clearance_candidates_sync(
-    conn: Any,
-    *,
-    limit: int,
-    recent_chunk_window: int,
-) -> list[Mapping[str, Any]]:
-    """Load semantic tag candidates without holding row locks across inference."""
-
-    with conn:
-        with conn.cursor(cursor_factory=RealDictCursor) as cur:
-            cur.execute(
-                """
-                WITH recent_ticks AS (
-                    SELECT id
-                    FROM narrative_chunks
-                    ORDER BY id DESC
-                    LIMIT %s
-                )
-                SELECT
-                    et.id AS entity_tag_id,
-                    et.entity_id,
-                    et.applied_at,
-                    et.applied_at_world_time,
-                    et.template_id,
-                    t.tag,
-                    t.category,
-                    t.description,
-                    n.name AS entity_name
-                FROM entity_tags et
-                JOIN tags t ON t.id = et.tag_id
-                LEFT JOIN entity_names_v n ON n.id = et.entity_id
-                WHERE et.cleared_at IS NULL
-                  AND t.deprecated = false
-                  AND t.is_ephemeral = true
-                  AND t.clearance_kind = 'semantic'
-                  AND (
-                      EXISTS (
-                          SELECT 1
-                          FROM chunk_entity_references_v cer
-                          JOIN recent_ticks rt ON rt.id = cer.chunk_id
-                          WHERE cer.entity_id = et.entity_id
-                      )
-                      OR EXISTS (
-                          SELECT 1
-                          FROM world_events we
-                          JOIN recent_ticks rt ON rt.id = we.tick_chunk_id
-                          WHERE we.actor_entity_id = et.entity_id
-                             OR we.target_entity_id = et.entity_id
-                             OR EXISTS (
-                                  SELECT 1
-                                  FROM world_event_entities wee
-                                  WHERE wee.event_id = we.id
-                                    AND wee.entity_id = et.entity_id
-                             )
-                      )
-                  )
-                ORDER BY et.applied_at, et.id
-                LIMIT %s
-                """,
-                (recent_chunk_window, limit),
-            )
-            return list(cur.fetchall())
-
-
-def _semantic_clearance_evidence_sync(
-    cur: Any,
-    *,
-    entity_id: int,
-    chunk_limit: int = DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_CHUNKS,
-    event_limit: int = DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_EVENTS,
-) -> dict[str, Any]:
-    """Load bounded canonical evidence, not only the candidate trigger window."""
-
-    cur.execute(
-        """
-        SELECT nc.id, left(nc.raw_text, 1200) AS text
-        FROM chunk_entity_references_v cer
-        JOIN narrative_chunks nc ON nc.id = cer.chunk_id
-        WHERE cer.entity_id = %s
-        ORDER BY nc.id DESC
-        LIMIT %s
-        """,
-        (entity_id, chunk_limit),
-    )
-    chunks = [
-        {"chunk_id": row["id"], "text": row.get("text")} for row in cur.fetchall()
-    ]
-
-    cur.execute(
-        """
-        SELECT
-            we.id,
-            we.tick_chunk_id,
-            we.event_type,
-            we.changed_fields,
-            we.magnitude,
-            we.payload
-        FROM world_events we
-        WHERE we.actor_entity_id = %s
-           OR we.target_entity_id = %s
-           OR EXISTS (
-                SELECT 1
-                FROM world_event_entities wee
-                WHERE wee.event_id = we.id
-                  AND wee.entity_id = %s
-           )
-        ORDER BY we.tick_chunk_id DESC, we.id DESC
-        LIMIT %s
-        """,
-        (entity_id, entity_id, entity_id, event_limit),
-    )
-    events = [
-        {
-            "event_id": row["id"],
-            "tick_chunk_id": row["tick_chunk_id"],
-            "event_type": row["event_type"],
-            "changed_fields": list(row.get("changed_fields") or ()),
-            "magnitude": _json_scalar(row.get("magnitude")),
-            "payload": row.get("payload") or {},
-        }
-        for row in cur.fetchall()
-    ]
-    return {"recent_chunks": chunks, "recent_events": events}
-
-
-def _semantic_clearance_verdict(
-    manager: Any, row: Mapping[str, Any], evidence: Mapping[str, Any]
-) -> SemanticClearanceVerdict:
-    prompt = (
-        "Evaluate whether this semantic ephemeral Orrery tag should be cleared.\n\n"
-        f"Entity: {row.get('entity_name') or row['entity_id']}\n"
-        f"Tag: {row['tag']}\n"
-        f"Category: {row.get('category')}\n"
-        f"Description: {row.get('description')}\n"
-        f"Applied at: {row.get('applied_at')}\n"
-        f"Applied world time: {row.get('applied_at_world_time')}\n"
-        f"Template source: {row.get('template_id')}\n\n"
-        "Evidence:\n"
-        f"{json.dumps(evidence, sort_keys=True, default=str)}\n\n"
-        "Return clear=true only if the tag is now stale, resolved, or no "
-        "longer active. Return clear=false when evidence is missing, weak, "
-        "ambiguous, or the state still plausibly applies."
-    )
-    raw = manager.structured_query(
-        prompt,
-        SemanticClearanceVerdict,
-        temperature=0.1,
-        max_tokens=512,
-        system_prompt=SEMANTIC_CLEARANCE_SYSTEM_PROMPT,
-    )
-    return _coerce_semantic_clearance_verdict(raw)
-
-
-def _coerce_semantic_clearance_verdict(raw: Any) -> SemanticClearanceVerdict:
-    """Keep semantic tags when local clearance output is malformed."""
-    try:
-        if isinstance(raw, SemanticClearanceVerdict):
-            return raw
-        payload = _structured_payload_from_raw(raw)
-        if not (isinstance(payload, Mapping) and "clear" in payload):
-            payload = _markdown_bool_payload_from_raw(payload, "clear") or payload
-        if isinstance(payload, Mapping) and "clear" in payload:
-            payload = dict(payload)
-            payload.setdefault(
-                "reason", "Local model returned a bare semantic-clearance decision."
-            )
-        return SemanticClearanceVerdict.model_validate(payload)
-    except ValidationError as exc:
-        logger.warning(
-            "Malformed Orrery semantic clearance verdict; keeping tag: %s",
-            raw,
-            exc_info=True,
-        )
-        return SemanticClearanceVerdict(
-            clear=False,
-            reason="Malformed local semantic-clearance verdict; kept conservatively.",
-        )
-
-
-def _mark_semantic_tag_cleared_sync(
-    conn: Any,
-    *,
-    row: Mapping[str, Any],
-    verdict: SemanticClearanceVerdict,
-    source_chunk_id: Optional[int],
-) -> bool:
-    with conn:
-        with conn.cursor(cursor_factory=RealDictCursor) as cur:
-            cur.execute(
-                """
-                UPDATE entity_tags et
-                SET cleared_at = now()
-                FROM tags t
-                WHERE et.id = %s
-                  AND t.id = et.tag_id
-                  AND et.cleared_at IS NULL
-                  AND t.deprecated = false
-                  AND t.is_ephemeral = true
-                  AND t.clearance_kind = 'semantic'
-                RETURNING et.id
-                """,
-                (row["entity_tag_id"],),
-            )
-            updated = cur.fetchone()
-            if not updated:
-                return False
-            cur.execute(
-                """
-                INSERT INTO tag_clearance_log (
-                    entity_tag_id, mechanism, justification, source_chunk_id
-                ) VALUES (%s, 'semantic', %s::jsonb, %s)
-                """,
-                (
-                    row["entity_tag_id"],
-                    json.dumps(
-                        {
-                            "tag": row["tag"],
-                            "reason": verdict.reason,
-                        }
-                    ),
-                    source_chunk_id,
-                ),
-            )
-            return True
-
-
-def _latest_evidence_chunk_id(evidence: Mapping[str, Any]) -> Optional[int]:
-    chunk_ids: list[int] = []
-    for chunk in evidence.get("recent_chunks") or ():
-        chunk_id = chunk.get("chunk_id")
-        if chunk_id is not None:
-            chunk_ids.append(int(chunk_id))
-    for event in evidence.get("recent_events") or ():
-        chunk_id = event.get("tick_chunk_id")
-        if chunk_id is not None:
-            chunk_ids.append(int(chunk_id))
-    return max(chunk_ids) if chunk_ids else None
-
-
 def _count_sync(cur: Any, sql: str) -> int:
     cur.execute(sql)
     row = cur.fetchone()
     return int((row or {}).get("count") or 0)
 
 
-def _json_scalar(value: Any) -> Any:
-    if hasattr(value, "as_tuple"):
+def _numeric_or_zero(value: Any) -> float:
+    try:
         return float(value)
-    return value
+    except (TypeError, ValueError):
+        return 0.0
 
 
 def _generate_narration(provider: Any, row: Mapping[str, Any]) -> str:
@@ -1071,25 +693,25 @@ def main(argv: Optional[list[str]] = None) -> int:
         "--semantic-clearance-limit",
         type=int,
         default=DEFAULT_SEMANTIC_CLEARANCE_LIMIT,
-        help="Maximum semantic ephemeral tags to evaluate in this run.",
+        help="Deprecated; semantic clearance is currently disabled.",
     )
     parser.add_argument(
         "--semantic-clearance-recent-chunks",
         type=int,
         default=DEFAULT_SEMANTIC_CLEARANCE_RECENT_CHUNKS,
-        help="Recent chunk window used to find relevant semantic tag evidence.",
+        help="Deprecated; semantic clearance is currently disabled.",
     )
     parser.add_argument(
         "--semantic-clearance-evidence-chunks",
         type=int,
         default=DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_CHUNKS,
-        help="Maximum recent narrative chunks included per semantic tag verdict.",
+        help="Deprecated; semantic clearance is currently disabled.",
     )
     parser.add_argument(
         "--semantic-clearance-evidence-events",
         type=int,
         default=DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_EVENTS,
-        help="Maximum recent Orrery events included per semantic tag verdict.",
+        help="Deprecated; semantic clearance is currently disabled.",
     )
     args = parser.parse_args(argv)
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -331,11 +331,15 @@ class OrreryBleedSettings(BaseModel):
 
 
 class OrreryPromoteSettings(BaseModel):
-    """Promotion discriminator settings for Orrery resolutions."""
+    """Deprecated promotion discriminator settings for Orrery resolutions."""
 
     model_config = ConfigDict(extra="forbid")
 
-    provider: Literal["local"] = "local"
+    provider: Optional[Literal["local"]] = Field(
+        default=None,
+        exclude=True,
+        description="Deprecated and ignored; promotion is deterministic.",
+    )
 
 
 def _default_need_accrual_rates() -> Dict[str, float]:

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -331,10 +331,25 @@ class OrreryBleedSettings(BaseModel):
 
 
 class OrreryPromoteSettings(BaseModel):
-    """Deprecated promotion discriminator settings for Orrery resolutions."""
+    """Deterministic promotion discriminator settings for Orrery resolutions."""
 
     model_config = ConfigDict(extra="forbid")
 
+    priority_threshold: float = Field(
+        default=50.0,
+        ge=0.0,
+        description="Promote resolutions whose priority is at or above this value.",
+    )
+    magnitude_threshold: float = Field(
+        default=0.5,
+        ge=0.0,
+        description="Promote resolutions whose magnitude is at or above this value.",
+    )
+    perceptual_summary_max_chars: int = Field(
+        default=240,
+        ge=1,
+        description="Maximum characters copied from a resolution brief into the promotion summary.",
+    )
     provider: Optional[Literal["local"]] = Field(
         default=None,
         exclude=True,

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -15,6 +15,9 @@ def test_orrery_settings_resolve_model_reference() -> None:
     expected_model = settings.global_.model.api_models["anthropic"].roles["default"]
     assert settings.orrery.narration.model_ref == expected_model
     assert settings.orrery.promote.provider is None
+    assert settings.orrery.promote.priority_threshold == 50.0
+    assert settings.orrery.promote.magnitude_threshold == 0.5
+    assert settings.orrery.promote.perceptual_summary_max_chars == 240
     assert settings.orrery.sunhelm.accrual_rates == {
         "sleep": 1.0,
         "hunger": 1.0,
@@ -55,4 +58,8 @@ def test_orrery_promote_accepts_deprecated_provider_key() -> None:
     settings = OrreryPromoteSettings(provider="local")
 
     assert settings.provider == "local"
-    assert "provider" not in settings.model_dump()
+    dumped = settings.model_dump()
+    assert dumped["priority_threshold"] == 50.0
+    assert dumped["magnitude_threshold"] == 0.5
+    assert dumped["perceptual_summary_max_chars"] == 240
+    assert "provider" not in dumped

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -1,7 +1,7 @@
 """Tests for Orrery configuration loading."""
 
 from nexus.config import load_settings
-from nexus.config.settings_models import OrreryBleedSettings
+from nexus.config.settings_models import OrreryBleedSettings, OrreryPromoteSettings
 
 
 def test_orrery_settings_resolve_model_reference() -> None:
@@ -14,7 +14,7 @@ def test_orrery_settings_resolve_model_reference() -> None:
     assert settings.orrery.binding.window_chunks == 30
     expected_model = settings.global_.model.api_models["anthropic"].roles["default"]
     assert settings.orrery.narration.model_ref == expected_model
-    assert settings.orrery.promote.provider == "local"
+    assert settings.orrery.promote.provider is None
     assert settings.orrery.sunhelm.accrual_rates == {
         "sleep": 1.0,
         "hunger": 1.0,
@@ -47,3 +47,12 @@ def test_orrery_bleed_accepts_deprecated_selection_keys() -> None:
     dumped = settings.model_dump()
     assert "latency_budget_ms" not in dumped
     assert "candidate_pool_multiplier" not in dumped
+
+
+def test_orrery_promote_accepts_deprecated_provider_key() -> None:
+    """Old promotion config should validate but stay out of dumps."""
+
+    settings = OrreryPromoteSettings(provider="local")
+
+    assert settings.provider == "local"
+    assert "provider" not in settings.model_dump()

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -7,10 +7,6 @@ import json
 import pytest
 
 from nexus.agents.orrery.worker import (
-    PromotionVerdict,
-    SemanticClearanceVerdict,
-    _coerce_promotion_verdict,
-    _coerce_semantic_clearance_verdict,
     clear_semantic_tags_sync,
     drain_narration_outbox_sync,
     load_orrery_status_sync,
@@ -27,16 +23,10 @@ class WorkerCursor:
         *,
         promotion_rows=None,
         job_rows=None,
-        semantic_rows=None,
-        semantic_chunk_rows=None,
-        semantic_event_rows=None,
         count_rows=None,
     ):
         self.promotion_rows = promotion_rows or []
         self.job_rows = job_rows or []
-        self.semantic_rows = semantic_rows or []
-        self.semantic_chunk_rows = semantic_chunk_rows or []
-        self.semantic_event_rows = semantic_event_rows or []
         self.count_rows = list(count_rows or [])
         self.executed = []
         self._fetchall = []
@@ -59,18 +49,8 @@ class WorkerCursor:
             self._fetchall = self.promotion_rows
         elif "FROM orrery_narration_jobs j" in normalized:
             self._fetchall = self.job_rows
-        elif (
-            "WITH recent_ticks AS" in normalized and "FROM entity_tags et" in normalized
-        ):
-            self._fetchall = self.semantic_rows
-        elif "FROM chunk_entity_references_v cer" in normalized:
-            self._fetchall = self.semantic_chunk_rows
-        elif "FROM world_events we" in normalized:
-            self._fetchall = self.semantic_event_rows
         elif "INSERT INTO offscreen_narrations" in normalized:
             self._fetchone = {"id": 501}
-        elif "UPDATE entity_tags et SET cleared_at = now()" in normalized:
-            self._fetchone = {"id": params[0]}
 
     def fetchall(self):
         return self._fetchall
@@ -97,18 +77,6 @@ class WorkerConn:
 
     def close(self):
         self.closed = True
-
-
-class FakeLLM:
-    """Local LLM stand-in returning one structured verdict."""
-
-    def __init__(self, verdict):
-        self.verdicts = list(verdict) if isinstance(verdict, list) else [verdict]
-        self.prompts = []
-
-    def structured_query(self, prompt, response_model, **_kwargs):
-        self.prompts.append((prompt, response_model))
-        return self.verdicts.pop(0)
 
 
 class FakeProviderResponse:
@@ -185,67 +153,15 @@ def _job_row():
     }
 
 
-def _semantic_tag_row():
-    return {
-        "entity_tag_id": 700,
-        "entity_id": 1,
-        "entity_name": "Mara",
-        "applied_at": "2073-10-31T18:00:00+00:00",
-        "applied_at_world_time": None,
-        "template_id": "evade_pursuers",
-        "tag": "wounded",
-        "category": "state",
-        "description": "Entity has a recent physical injury.",
-    }
-
-
-def _semantic_tag_row_2():
-    row = dict(_semantic_tag_row())
-    row.update(
-        {
-            "entity_tag_id": 701,
-            "entity_id": 2,
-            "entity_name": "Toma",
-            "tag": "recently_violent",
-            "description": "Actor has executed violence in the recent past.",
-        }
-    )
-    return row
-
-
-def _semantic_chunk_row():
-    return {
-        "id": 105,
-        "text": "Mara limps at first, then steadies herself and keeps moving.",
-    }
-
-
-def _semantic_event_row():
-    return {
-        "id": 20,
-        "tick_chunk_id": 104,
-        "event_type": "evade_pursuit",
-        "changed_fields": ["character.current_activity"],
-        "magnitude": 0.72,
-        "payload": {"branch_label": "Go to ground"},
-    }
-
-
 def test_promote_pending_resolutions_queues_narration_job() -> None:
     """Promoted resolutions are marked and placed into the durable outbox."""
 
     cursor = WorkerCursor(promotion_rows=[_promotion_row()])
-    verdict = PromotionVerdict(
-        promote=True,
-        reason="It creates future retrieval value.",
-        perceptual_channel="digital",
-        perceptual_summary="street cameras briefly lose Mara",
-    )
 
     promoted, skipped = promote_pending_resolutions_sync(
         slot=5,
         settings=_settings(),
-        llm_manager=FakeLLM(verdict),
+        llm_manager=object(),
         conn=WorkerConn(cursor),
     )
 
@@ -258,77 +174,33 @@ def test_promote_pending_resolutions_queues_narration_job() -> None:
     assert "INSERT INTO orrery_narration_jobs" in statements
 
 
-def test_promote_pending_resolutions_skips_malformed_llm_output() -> None:
-    """Malformed local-LLM promotion data is skipped conservatively."""
+def test_promote_pending_resolutions_skips_low_signal_rows() -> None:
+    """Low-salience rows stay skipped without asking a local model."""
 
-    cursor = WorkerCursor(promotion_rows=[_promotion_row()])
+    row = dict(
+        _promotion_row(),
+        priority=10,
+        magnitude=0.1,
+        state_delta={},
+        event_ids=[],
+    )
+    cursor = WorkerCursor(promotion_rows=[row])
 
     promoted, skipped = promote_pending_resolutions_sync(
         slot=5,
         settings=_settings(),
-        llm_manager=FakeLLM({"answer": "sure"}),
+        llm_manager=object(),
         conn=WorkerConn(cursor),
     )
 
     verdict = json.loads(cursor.executed[-1][1][0])
+    statements = "\n".join(sql for sql, _params in cursor.executed)
 
     assert promoted == 0
     assert skipped == 1
     assert verdict["promote"] is False
-    assert "Malformed local promotion verdict" in verdict["reason"]
-
-
-def test_promote_pending_resolutions_recovers_bare_final_channel_json() -> None:
-    """Leaked final-channel JSON with no reason gets a durable skip reason."""
-
-    cursor = WorkerCursor(promotion_rows=[_promotion_row()])
-    raw = {
-        "answer": (
-            "<|channel|>analysis<|message|>routine maintenance\n"
-            '<|channel|>final<|message|>{"promote": false}'
-        ),
-        "reasoning": "unstructured",
-    }
-
-    promoted, skipped = promote_pending_resolutions_sync(
-        slot=5,
-        settings=_settings(),
-        llm_manager=FakeLLM(raw),
-        conn=WorkerConn(cursor),
-    )
-
-    verdict = json.loads(cursor.executed[-1][1][0])
-
-    assert promoted == 0
-    assert skipped == 1
-    assert verdict["promote"] is False
-    assert verdict["reason"] == "Local model returned a bare promotion decision."
-
-
-def test_coerce_promotion_verdict_recovers_markdown_boolean() -> None:
-    """Markdown-ish local fallback text should not become malformed noise."""
-
-    verdict = _coerce_promotion_verdict(
-        {"answer": "**promote:** false", "reasoning": "Routine maintenance."}
-    )
-
-    assert verdict.promote is False
-    assert verdict.reason == "Routine maintenance."
-
-
-def test_coerce_promotion_verdict_prefers_structured_field_over_answer() -> None:
-    """Structured verdict fields should not be shadowed by markdown answer text."""
-
-    verdict = _coerce_promotion_verdict(
-        {
-            "promote": False,
-            "answer": "**promote:** true",
-            "reason": "Structured field wins.",
-        }
-    )
-
-    assert verdict.promote is False
-    assert verdict.reason == "Structured field wins."
+    assert "Deterministic skip" in verdict["reason"]
+    assert "INSERT INTO orrery_narration_jobs" not in statements
 
 
 def test_drain_narration_outbox_persists_offscreen_narration() -> None:
@@ -415,152 +287,24 @@ def test_drain_narration_outbox_marks_terminal_after_max_attempts() -> None:
     assert "narration_status = 'failed'" in statements
 
 
-def test_clear_semantic_tags_clears_when_verdict_true() -> None:
-    """Semantic ephemeral tags clear only after a structured positive verdict."""
+def test_clear_semantic_tags_is_conservative_noop_without_local_inference() -> None:
+    """Semantic clearance performs no writes without a non-local clearance signal."""
 
-    cursor = WorkerCursor(
-        semantic_rows=[_semantic_tag_row()],
-        semantic_chunk_rows=[_semantic_chunk_row()],
-        semantic_event_rows=[_semantic_event_row()],
-    )
-    verdict = SemanticClearanceVerdict(clear=True, reason="Mara recovered.")
-    llm = FakeLLM(verdict)
+    cursor = WorkerCursor()
 
     cleared = clear_semantic_tags_sync(
         slot=5,
         settings=_settings(),
-        llm_manager=llm,
+        llm_manager=object(),
         conn=WorkerConn(cursor),
     )
-
-    statements = "\n".join(sql for sql, _params in cursor.executed)
-
-    assert cleared == 1
-    assert "WITH recent_ticks AS" in statements
-    assert "FOR UPDATE OF et SKIP LOCKED" not in statements
-    assert "UPDATE entity_tags et" in statements
-    assert "SET cleared_at = now()" in statements
-    assert "INSERT INTO tag_clearance_log" in statements
-    assert "VALUES (%s, 'semantic', %s::jsonb, %s)" in statements
-    assert cursor.executed[-1][1][2] == 105
-    assert llm.prompts[0][1] is SemanticClearanceVerdict
-    assert "Tag: wounded" in llm.prompts[0][0]
-    assert "Mara limps at first" in llm.prompts[0][0]
-
-
-def test_clear_semantic_tags_keeps_when_verdict_false() -> None:
-    """A negative semantic verdict leaves the current tag untouched."""
-
-    cursor = WorkerCursor(
-        semantic_rows=[_semantic_tag_row()],
-        semantic_chunk_rows=[_semantic_chunk_row()],
-        semantic_event_rows=[_semantic_event_row()],
-    )
-    verdict = SemanticClearanceVerdict(clear=False, reason="Recovery is ambiguous.")
-
-    cleared = clear_semantic_tags_sync(
-        slot=5,
-        settings=_settings(),
-        llm_manager=FakeLLM(verdict),
-        conn=WorkerConn(cursor),
-    )
-
-    statements = "\n".join(sql for sql, _params in cursor.executed)
 
     assert cleared == 0
-    assert "UPDATE entity_tags SET cleared_at" not in statements
-    assert "INSERT INTO tag_clearance_log" not in statements
-
-
-def test_clear_semantic_tags_keeps_on_malformed_llm_output() -> None:
-    """Malformed semantic-clearance data keeps the tag without losing prior commits."""
-
-    cursor = WorkerCursor(
-        semantic_rows=[_semantic_tag_row(), _semantic_tag_row_2()],
-        semantic_chunk_rows=[_semantic_chunk_row()],
-        semantic_event_rows=[_semantic_event_row()],
-    )
-    llm = FakeLLM(
-        [
-            SemanticClearanceVerdict(clear=True, reason="Mara recovered."),
-            {"answer": "maybe"},
-        ]
-    )
-
-    cleared = clear_semantic_tags_sync(
-        slot=5,
-        settings=_settings(),
-        llm_manager=llm,
-        conn=WorkerConn(cursor),
-    )
-
-    statements = "\n".join(sql for sql, _params in cursor.executed)
-
-    assert cleared == 1
-    assert statements.count("UPDATE entity_tags et") == 1
-    assert statements.count("INSERT INTO tag_clearance_log") == 1
-
-
-def test_coerce_semantic_clearance_verdict_recovers_markdown_boolean() -> None:
-    """Markdown-ish local fallback text should produce a normal keep verdict."""
-
-    verdict = _coerce_semantic_clearance_verdict(
-        {"answer": "**clear:** false", "reasoning": "Evidence still supports tag."}
-    )
-
-    assert verdict.clear is False
-    assert verdict.reason == "Evidence still supports tag."
-
-
-def test_coerce_semantic_clearance_prefers_structured_field_over_answer() -> None:
-    """Structured clearance fields should not be shadowed by markdown answer text."""
-
-    verdict = _coerce_semantic_clearance_verdict(
-        {
-            "clear": False,
-            "answer": "**clear:** true",
-            "reason": "Structured field wins.",
-        }
-    )
-
-    assert verdict.clear is False
-    assert verdict.reason == "Structured field wins."
-
-
-def test_coerce_semantic_clearance_ignores_incidental_markdown_boolean() -> None:
-    """Incidental prose should not clear tags by pretending to be a verdict."""
-
-    verdict = _coerce_semantic_clearance_verdict(
-        "This is noisy prose. To be clear: true, the evidence is mixed."
-    )
-
-    assert verdict.clear is False
-    assert (
-        verdict.reason
-        == "Malformed local semantic-clearance verdict; kept conservatively."
-    )
-
-
-def test_coerce_promotion_verdict_recovers_bulleted_markdown_boolean() -> None:
-    """Explicit bullet key/value verdicts should still parse."""
-
-    verdict = _coerce_promotion_verdict("- **promote:** true\n- reason: Enough proof.")
-
-    assert verdict.promote is True
-    assert verdict.reason == "Enough proof."
-
-
-def test_coerce_semantic_clearance_uses_default_reason_for_bare_text() -> None:
-    """Bare string verdicts without a reason should get a durable default reason."""
-
-    verdict = _coerce_semantic_clearance_verdict("clear: false")
-
-    assert verdict.clear is False
-    assert verdict.reason == "Local model returned a text boolean verdict."
+    assert cursor.executed == []
 
 
 def test_process_orrery_outbox_includes_semantic_clearance(monkeypatch) -> None:
-    """The background entry point drains semantic clearance with other work."""
+    """The background entry point keeps the semantic-clearance compatibility call."""
 
     calls = []
 

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -109,7 +109,12 @@ def _settings():
             "narration": {
                 "provider": "anthropic",
                 "model_ref": "claude-sonnet-4-6",
-            }
+            },
+            "promote": {
+                "priority_threshold": 50.0,
+                "magnitude_threshold": 0.5,
+                "perceptual_summary_max_chars": 240,
+            },
         }
     }
 
@@ -161,7 +166,6 @@ def test_promote_pending_resolutions_queues_narration_job() -> None:
     promoted, skipped = promote_pending_resolutions_sync(
         slot=5,
         settings=_settings(),
-        llm_manager=object(),
         conn=WorkerConn(cursor),
     )
 
@@ -189,7 +193,6 @@ def test_promote_pending_resolutions_skips_low_signal_rows() -> None:
     promoted, skipped = promote_pending_resolutions_sync(
         slot=5,
         settings=_settings(),
-        llm_manager=object(),
         conn=WorkerConn(cursor),
     )
 
@@ -201,6 +204,59 @@ def test_promote_pending_resolutions_skips_low_signal_rows() -> None:
     assert verdict["promote"] is False
     assert "Deterministic skip" in verdict["reason"]
     assert "INSERT INTO orrery_narration_jobs" not in statements
+
+
+def test_promote_pending_resolutions_uses_state_signal_without_brief() -> None:
+    """A salient state/event resolution should not require a generated brief."""
+
+    row = dict(
+        _promotion_row(),
+        priority=80,
+        magnitude=0.1,
+        brief="",
+        state_delta={"character.current_activity": "recovering"},
+        event_ids=[],
+    )
+    cursor = WorkerCursor(promotion_rows=[row])
+
+    promoted, skipped = promote_pending_resolutions_sync(
+        slot=5,
+        settings=_settings(),
+        conn=WorkerConn(cursor),
+    )
+
+    verdict = json.loads(cursor.executed[1][1][0])
+
+    assert promoted == 1
+    assert skipped == 0
+    assert verdict["promote"] is True
+    assert verdict["perceptual_summary"] is None
+
+
+def test_promote_pending_resolutions_uses_configured_thresholds() -> None:
+    """Promotion salience should be tuned through Orrery promote config."""
+
+    row = dict(_promotion_row(), priority=80, magnitude=0.7)
+    settings = _settings()
+    settings["orrery"]["promote"] = {
+        "priority_threshold": 90.0,
+        "magnitude_threshold": 0.9,
+        "perceptual_summary_max_chars": 16,
+    }
+    cursor = WorkerCursor(promotion_rows=[row])
+
+    promoted, skipped = promote_pending_resolutions_sync(
+        slot=5,
+        settings=settings,
+        conn=WorkerConn(cursor),
+    )
+
+    verdict = json.loads(cursor.executed[-1][1][0])
+
+    assert promoted == 0
+    assert skipped == 1
+    assert verdict["promote"] is False
+    assert "80/90" in verdict["reason"]
 
 
 def test_drain_narration_outbox_persists_offscreen_narration() -> None:
@@ -295,7 +351,6 @@ def test_clear_semantic_tags_is_conservative_noop_without_local_inference() -> N
     cleared = clear_semantic_tags_sync(
         slot=5,
         settings=_settings(),
-        llm_manager=object(),
         conn=WorkerConn(cursor),
     )
 


### PR DESCRIPTION
## Summary
- remove the Orrery worker's local-LLM promotion and semantic-clearance paths
- replace promotion with a conservative deterministic salience policy over priority, magnitude, state_delta, event_ids, and brief
- keep old promote/semantic-clearance call/config surfaces compatible while documenting that semantic clearance is now a no-op until a non-local signal exists

## Validation
- PYTHONPATH=$PWD poetry run pytest tests/test_orrery/test_worker.py tests/test_orrery/test_config.py
- PYTHONPATH=$PWD poetry run pytest tests/test_orrery
- PYTHONPATH=$PWD poetry run pytest tests/test_lore
- PYTHONPATH=$PWD poetry run pytest tests/test_api/test_lore_adapter.py
