### PR TITLE
[codex] Add Orrery proposal adjudication

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -70,6 +70,16 @@
 
 PR #219 implements PR 4: Bleed selection at Storyteller time. It selects a bounded menu of previously narrated off-screen events, records surfacing bookkeeping only after successful generation, and injects optional ambient peripherals into the LOGON prompt without advancing chronology or promoting off-screen narrations into warm-slice memory.
 
+### Authority Model for Issue #275
+
+- Skald is sovereign. Current-tick Orrery resolutions enter the storyteller payload as `orrery_imminent_activity`, each with a stable `proposal_id`.
+- Absence of an `orrery_adjudications` entry means ratify: accepted commits materialize the proposal as before.
+- `defer` skips materialization this tick and logs the decision; persistent substrate pressure can reappear on later ticks if the underlying state still warrants it.
+- `void` skips materialization and logs that Skald considers the proposal definitively wrong or no longer true.
+- `replace` skips the original proposal. If Skald provides `replacement_state_delta`, commit materializes that limited Orrery-compatible delta instead; if not, commit assumes Skald handled the replacement through normal structured `state_updates` or prose. Replacement deltas only emit canonical world events when Skald also provides `replacement_event_type`.
+- Commit also infers `replace` without prose parsing when Skald's structured character `state_updates` touch the same actor/field that an Orrery proposal would change. This prevents Orrery from overwriting ordinary authoritative state writes such as `current_activity` or movement-related `current_location`.
+- All explicit and inferred decisions write `orrery_adjudication_log`. Bleed remains cross-turn ambient surfacing, not the path for current-tick proposals.
+
 ### Landed in PR #220
 
 PR #220 closes the retrieval-boundary audit: warm slices and normal MEMNON search remain accepted-narrative surfaces only, while explicit read-only SQL may still inspect public Orrery tables such as `offscreen_narrations`.
@@ -706,6 +716,7 @@ This section is now mostly historical. The active queue has moved past the found
 ### PR 4 — Bleed Selector + Storyteller Integration (implemented in PR #219)
 
 - Bleed selector wired into LORE Phase 5 (`assemble_context_payload`, `turn_cycle.py:489`); reads `turn_context.bleed_menu` populated by a new selector method invoked at the start of that phase.
+- Current-tick proposals are no longer treated as Bleed. They enter Phase 5 as `orrery_imminent_activity` and are finalized by commit according to Skald's optional `orrery_adjudications`.
 - Typed candidate query over `orrery_resolutions` ⋈ `world_events` ⋈ `offscreen_narrations`.
 - Hard 2-second latency budget enforced via `asyncio.wait_for`; overrun = empty menu + loud log.
 - Surfacing bookkeeping increments.

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1754,6 +1754,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/037_orrery_tag_category_registry.py`
 - `migrations/038_orrery_tag_baseline_reconciliation.py`
 - `migrations/039_new_story_character_orrery_tags.py`
+- `migrations/041_orrery_authority_model.sql`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 

--- a/migrations/041_orrery_authority_model.sql
+++ b/migrations/041_orrery_authority_model.sql
@@ -1,0 +1,68 @@
+-- 041_orrery_authority_model.sql
+--
+-- Persist Skald's structured adjudication of current-tick Orrery proposals.
+-- Absence of an adjudication ratifies the proposal; explicit rows record
+-- defer/void/replace decisions for auditability.
+
+ALTER TABLE incubator
+ADD COLUMN IF NOT EXISTS orrery_adjudications JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN incubator.orrery_adjudications IS
+    'Skald-authored defer/replace/void rulings for Orrery proposals in the provisional chunk.';
+
+CREATE TABLE IF NOT EXISTS orrery_adjudication_log (
+    id                       bigserial PRIMARY KEY,
+    tick_chunk_id            bigint NOT NULL REFERENCES narrative_chunks(id),
+    proposal_id              text NOT NULL,
+    template_id              text NOT NULL,
+    binding_hash             text NOT NULL,
+    action                   text NOT NULL
+        CHECK (action IN ('defer', 'replace', 'void')),
+    adjudication_source      text NOT NULL DEFAULT 'explicit'
+        CHECK (adjudication_source IN ('explicit', 'structured_state_update')),
+    skald_note               text,
+    original_state_delta     jsonb NOT NULL DEFAULT '{}'::jsonb,
+    replacement_state_delta  jsonb,
+    replacement_event_type   text REFERENCES event_types(type),
+    applied_resolution_id    bigint REFERENCES orrery_resolutions(id),
+    created_at               timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ix_orrery_adjudication_log_tick_chunk_id
+    ON orrery_adjudication_log (tick_chunk_id);
+
+CREATE INDEX IF NOT EXISTS ix_orrery_adjudication_log_proposal_id
+    ON orrery_adjudication_log (proposal_id);
+
+CREATE INDEX IF NOT EXISTS ix_orrery_adjudication_log_action
+    ON orrery_adjudication_log (action);
+
+DROP VIEW IF EXISTS incubator_view;
+CREATE VIEW incubator_view AS
+SELECT
+    i.chunk_id,
+    i.parent_chunk_id,
+    nc.raw_text AS parent_chunk_text,
+    i.user_text,
+    i.storyteller_text,
+    i.choice_object,
+    i.choice_text,
+    i.authorial_directives,
+    i.orrery_proposal,
+    i.orrery_adjudications,
+    i.metadata_updates -> 'chronology' ->> 'episode_transition' AS episode_transition,
+    i.metadata_updates -> 'chronology' ->> 'time_delta_description' AS time_delta,
+    i.metadata_updates ->> 'world_layer' AS world_layer,
+    i.metadata_updates ->> 'pacing' AS pacing,
+    COALESCE(jsonb_array_length(i.entity_updates -> 'characters'), 0)
+        + COALESCE(jsonb_array_length(i.entity_updates -> 'locations'), 0)
+        + COALESCE(jsonb_array_length(i.entity_updates -> 'factions'), 0)
+        AS entity_update_count,
+    i.entity_updates AS entity_changes,
+    i.reference_updates AS "references",
+    i.status,
+    i.session_id,
+    i.created_at
+FROM incubator i
+LEFT JOIN narrative_chunks nc ON nc.id = i.parent_chunk_id
+WHERE i.id = TRUE;

--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -753,6 +753,79 @@ class StateUpdates(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class OrreryReplacementStateDelta(BaseModel):
+    """
+    Limited Orrery state delta Skald may substitute for a proposed resolution.
+
+    Field names are Skald-facing aliases. The commit layer maps them to the
+    canonical dotted Orrery keys after schema validation.
+    """
+
+    character_current_activity: Optional[str] = Field(
+        default=None,
+        description="Replacement for the actor's character.current_activity delta",
+    )
+    entity_tags_add: List[str] = Field(
+        default_factory=list,
+        description="Replacement actor tags to add",
+    )
+    entity_tags_remove: List[str] = Field(
+        default_factory=list,
+        description="Replacement actor tags to clear",
+    )
+    entity_tags_target_add: List[str] = Field(
+        default_factory=list,
+        description="Replacement target tags to add",
+    )
+    entity_tags_target_remove: List[str] = Field(
+        default_factory=list,
+        description="Replacement target tags to clear",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class OrreryAdjudication(BaseModel):
+    """
+    Skald's optional ruling for one current-tick Orrery proposal.
+
+    Omit an adjudication to ratify the proposal at commit time. Use defer to
+    leave the pressure unresolved for a later tick, void when the proposal is
+    definitively false, and replace when Skald has supplied a story-truer
+    state update or replacement delta.
+    """
+
+    proposal_id: str = Field(
+        min_length=1,
+        description="Exact proposal_id from orrery_imminent_activity",
+    )
+    action: Literal["defer", "replace", "void"] = Field(
+        description="Structured authority decision for this proposal"
+    )
+    note: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        description="Brief reason or replacement summary for audit/debugging",
+    )
+    replacement_state_delta: Optional[OrreryReplacementStateDelta] = Field(
+        default=None,
+        description=(
+            "Optional limited Orrery delta to commit instead of the proposal. "
+            "If omitted for replace, commit assumes Skald handled the replacement "
+            "through normal state_updates or prose."
+        ),
+    )
+    replacement_event_type: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional registered event type for a replacement_state_delta. "
+            "Leave unset unless the replacement should emit a canonical world_event."
+        ),
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
 # ============================================================================
 # Operations
 # ============================================================================
@@ -858,6 +931,10 @@ class StorytellerResponseMinimal(AuthorialDirectivesMixin):
     referenced_entities: Optional[ReferencedEntities] = Field(
         default=None, description="Entities referenced in narrative"
     )
+    orrery_adjudications: List[OrreryAdjudication] = Field(
+        default_factory=list,
+        description="Optional defer/replace/void rulings for Orrery proposals",
+    )
 
     model_config = ConfigDict(extra="forbid")
 
@@ -877,6 +954,10 @@ class StorytellerResponseStandard(AuthorialDirectivesMixin):
     )
     state_updates: Optional[StateUpdates] = Field(
         default=None, description="State changes for entities"
+    )
+    orrery_adjudications: List[OrreryAdjudication] = Field(
+        default_factory=list,
+        description="Optional defer/replace/void rulings for Orrery proposals",
     )
 
     model_config = ConfigDict(extra="forbid")
@@ -898,6 +979,10 @@ class StorytellerResponseExtended(AuthorialDirectivesMixin):
     state_updates: StateUpdates = Field(description="Comprehensive state updates")
     operations: Optional[Operations] = Field(
         default=None, description="Special operations or requests"
+    )
+    orrery_adjudications: List[OrreryAdjudication] = Field(
+        default_factory=list,
+        description="Optional defer/replace/void rulings for Orrery proposals",
     )
     reasoning: Optional[str] = Field(
         default=None, description="Storyteller's reasoning (debug mode only)"

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -555,6 +555,26 @@ class LogonUtility:
                     f"[Score: {passage.get('score', 0):.2f}] {passage.get('text', '')}"
                 )
 
+        imminent_activity = context.get("orrery_imminent_activity") or []
+        if imminent_activity:
+            sections.append("\n=== ORRERY IMMINENT ACTIVITY ===")
+            sections.append(
+                "These are current-tick Orrery proposals. If you omit a proposal "
+                "from orrery_adjudications, commit will ratify it. You remain "
+                "sovereign: use defer to leave pressure unresolved, void when a "
+                "proposal is definitively false, and replace when your structured "
+                "state_updates or replacement_state_delta supersede it. A replacement "
+                "only emits a world_event if you provide replacement_event_type. "
+                "Refer only to proposal_id; do not rely on prose parsing."
+            )
+            for proposal in imminent_activity[:5]:
+                if not isinstance(proposal, dict):
+                    continue
+                proposal_id = proposal.get("proposal_id")
+                label = proposal.get("branch_label") or proposal.get("template_id")
+                state_delta = proposal.get("state_delta") or {}
+                sections.append(f"- {proposal_id} [{label}]: state_delta={state_delta}")
+
         scene_pressures = context.get("orrery_scene_pressures") or []
         if scene_pressures:
             sections.append("\n=== ORRERY SCENE PRESSURE ===")

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -775,6 +775,12 @@ class TurnCycleManager:
         if turn_context.note:
             turn_context.context_payload["note"] = turn_context.note
 
+        proposal: Any = turn_context.orrery_proposal
+        if proposal and getattr(proposal, "resolution_count", 0):
+            turn_context.context_payload["orrery_imminent_activity"] = [
+                draft.to_dict() for draft in proposal.resolutions
+            ]
+
         if turn_context.orrery_proposal and turn_context.orrery_proposal.pressure_count:
             turn_context.context_payload["orrery_scene_pressures"] = [
                 pressure.to_dict()

--- a/nexus/agents/orrery/__init__.py
+++ b/nexus/agents/orrery/__init__.py
@@ -24,7 +24,10 @@ from nexus.agents.orrery.resolver import (
     OrreryScenePressureDraft,
     OrreryTickProposal,
 )
-from nexus.agents.orrery.events import CommitOrreryTickResult, OrreryAdjudication
+from nexus.agents.orrery.events import (
+    CommitOrreryTickResult,
+    OrreryAdjudicationDecision,
+)
 from nexus.agents.orrery.bleed import BleedCandidate, BleedSelectorResult
 
 __all__ = [
@@ -43,7 +46,7 @@ __all__ = [
     "Template",
     "WorldState",
     "CommitOrreryTickResult",
-    "OrreryAdjudication",
+    "OrreryAdjudicationDecision",
     "BleedCandidate",
     "BleedSelectorResult",
     "OrreryResolutionDraft",

--- a/nexus/agents/orrery/__init__.py
+++ b/nexus/agents/orrery/__init__.py
@@ -24,7 +24,7 @@ from nexus.agents.orrery.resolver import (
     OrreryScenePressureDraft,
     OrreryTickProposal,
 )
-from nexus.agents.orrery.events import CommitOrreryTickResult
+from nexus.agents.orrery.events import CommitOrreryTickResult, OrreryAdjudication
 from nexus.agents.orrery.bleed import BleedCandidate, BleedSelectorResult
 
 __all__ = [
@@ -43,6 +43,7 @@ __all__ = [
     "Template",
     "WorldState",
     "CommitOrreryTickResult",
+    "OrreryAdjudication",
     "BleedCandidate",
     "BleedSelectorResult",
     "OrreryResolutionDraft",

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -7,7 +7,7 @@ only place that materializes those proposals into canonical Orrery tables.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import timedelta
 import json
 from typing import Any, Mapping, Optional
@@ -46,6 +46,20 @@ SUPPORTED_STATE_DELTA_KEYS = frozenset(
         "travel.delay",
     }
 )
+ADJUDICATION_ACTIONS = frozenset({"defer", "replace", "void"})
+ADJUDICATION_SOURCES = frozenset({"explicit", "structured_state_update"})
+REPLACEMENT_STATE_DELTA_ALIASES = {
+    "character_current_activity": "character.current_activity",
+    "entity_tags_add": "entity_tags.add",
+    "entity_tags_remove": "entity_tags.remove",
+    "entity_tags_target_add": "entity_tags_target.add",
+    "entity_tags_target_remove": "entity_tags_target.remove",
+    "need_fulfill": "need.fulfill",
+    "travel_start": "travel.start",
+    "travel_advance": "travel.advance",
+    "travel_arrive": "travel.arrive",
+    "travel_delay": "travel.delay",
+}
 
 TRAVEL_MODE_DETOUR_FACTOR = {
     "walking": 1.35,
@@ -77,6 +91,28 @@ class CommitOrreryTickResult:
     tag_mutation_count: int = 0
     cleared_tag_count: int = 0
     skipped_existing_count: int = 0
+    adjudication_count: int = 0
+    deferred_count: int = 0
+    voided_count: int = 0
+    replaced_count: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class OrreryAdjudication:
+    """Skald's structured ruling for one Orrery proposal."""
+
+    proposal_id: str
+    action: str
+    note: Optional[str] = None
+    replacement_state_delta: Optional[Mapping[str, Any]] = None
+    replacement_event_type: Optional[str] = None
+
+
+@dataclass(frozen=True, slots=True)
+class StateUpdateIndex:
+    """Structured Storyteller state writes indexed by Orrery entity id."""
+
+    character_fields_by_entity: Mapping[int, frozenset[str]]
 
 
 def coerce_proposal(proposal: Any) -> Optional[OrreryTickProposal]:
@@ -93,6 +129,95 @@ def coerce_proposal(proposal: Any) -> Optional[OrreryTickProposal]:
     raise TypeError(f"Unsupported Orrery proposal payload: {type(proposal).__name__}")
 
 
+def coerce_adjudications(adjudications: Any) -> dict[str, OrreryAdjudication]:
+    """Coerce Skald adjudications into a proposal-id keyed mapping."""
+
+    if adjudications is None:
+        return {}
+    if isinstance(adjudications, str):
+        adjudications = json.loads(adjudications)
+    if hasattr(adjudications, "model_dump"):
+        adjudications = adjudications.model_dump(mode="json", exclude_none=True)
+    if isinstance(adjudications, Mapping):
+        if "orrery_adjudications" in adjudications:
+            adjudications = adjudications["orrery_adjudications"]
+        elif "adjudications" in adjudications:
+            adjudications = adjudications["adjudications"]
+        else:
+            adjudications = [adjudications]
+    if not isinstance(adjudications, Iterable) or isinstance(
+        adjudications, (str, bytes)
+    ):
+        raise TypeError(
+            "Orrery adjudications must be a list of structured adjudication objects"
+        )
+
+    coerced: dict[str, OrreryAdjudication] = {}
+    for item in adjudications:
+        adjudication = _coerce_adjudication(item)
+        if adjudication.proposal_id in coerced:
+            raise ValueError(
+                f"Duplicate Orrery adjudication for {adjudication.proposal_id!r}"
+            )
+        coerced[adjudication.proposal_id] = adjudication
+    return coerced
+
+
+def _coerce_adjudication(item: Any) -> OrreryAdjudication:
+    if hasattr(item, "model_dump"):
+        item = item.model_dump(mode="json", exclude_none=True)
+    if not isinstance(item, Mapping):
+        raise TypeError("Orrery adjudication entries must be objects")
+
+    proposal_id = str(item.get("proposal_id") or "").strip()
+    if not proposal_id:
+        raise ValueError("Orrery adjudication is missing proposal_id")
+    action = str(item.get("action") or "").strip()
+    if action not in ADJUDICATION_ACTIONS:
+        raise ValueError(
+            "Orrery adjudication action must be one of "
+            f"{', '.join(sorted(ADJUDICATION_ACTIONS))}"
+        )
+
+    note = item.get("note")
+    replacement_state_delta = _normalize_replacement_state_delta(
+        item.get("replacement_state_delta")
+    )
+    replacement_event_type = item.get("replacement_event_type")
+    return OrreryAdjudication(
+        proposal_id=proposal_id,
+        action=action,
+        note=str(note).strip() if note else None,
+        replacement_state_delta=replacement_state_delta or None,
+        replacement_event_type=(
+            str(replacement_event_type).strip() if replacement_event_type else None
+        ),
+    )
+
+
+def _normalize_replacement_state_delta(raw: Any) -> dict[str, Any]:
+    """Map Skald-facing replacement delta field names to canonical Orrery keys."""
+
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        raw = json.loads(raw)
+    if hasattr(raw, "model_dump"):
+        raw = raw.model_dump(mode="json", exclude_none=True)
+    if not isinstance(raw, Mapping):
+        raise TypeError("replacement_state_delta must be an object")
+
+    normalized: dict[str, Any] = {}
+    for key, value in raw.items():
+        if value is None or value == [] or value == {}:
+            continue
+        canonical_key = REPLACEMENT_STATE_DELTA_ALIASES.get(str(key), str(key))
+        if canonical_key not in SUPPORTED_STATE_DELTA_KEYS:
+            raise ValueError(f"Unsupported Orrery replacement_state_delta key: {key!r}")
+        normalized[canonical_key] = value
+    return normalized
+
+
 def commit_orrery_tick_sync(
     conn: Any,
     proposal: Any,
@@ -101,6 +226,8 @@ def commit_orrery_tick_sync(
     slot: Optional[int] = None,
     world_layer: Optional[str] = "primary",
     sunhelm_settings: Optional[Any] = None,
+    adjudications: Any = None,
+    storyteller_state_updates: Any = None,
 ) -> CommitOrreryTickResult:
     """Materialize a preview proposal inside the accepted-chunk transaction."""
 
@@ -108,26 +235,95 @@ def commit_orrery_tick_sync(
     if coerced is None or not coerced.resolutions:
         return CommitOrreryTickResult()
 
+    adjudication_map = coerce_adjudications(adjudications)
     need_tuning = coerce_need_tuning(sunhelm_settings)
     _validate_proposal(coerced)
+    _validate_adjudications(coerced, adjudication_map)
     with conn.cursor() as cur:
         entity_ids = _entity_ids_from_proposal(coerced)
         _validate_entity_ids_sync(cur, entity_ids)
         entity_names = _entity_names_sync(cur, entity_ids)
+        state_update_index = _state_update_index_sync(cur, storyteller_state_updates)
 
         resolution_count = 0
         event_count = 0
         tag_mutation_count = 0
         cleared_tag_count = 0
         skipped_existing_count = 0
+        adjudication_count = 0
+        deferred_count = 0
+        voided_count = 0
+        replaced_count = 0
 
         for draft in coerced.resolutions:
+            adjudication = adjudication_map.get(draft.proposal_id)
+            adjudication_source = "explicit"
+            if adjudication is None and _replaced_by_storyteller_state(
+                draft, state_update_index
+            ):
+                adjudication = OrreryAdjudication(
+                    proposal_id=draft.proposal_id,
+                    action="replace",
+                    note=(
+                        "Storyteller state_updates touched the same "
+                        "character field; skipped the original Orrery delta."
+                    ),
+                )
+                adjudication_source = "structured_state_update"
+
             actor_entity_id = _scalar_entity_binding(draft.bindings, "actor")
             target_entity_id = _scalar_entity_binding(draft.bindings, "target")
-            brief = _render_brief(draft, entity_names)
+            draft_to_commit = draft
+            brief = _render_brief(draft_to_commit, entity_names)
+
+            if adjudication is not None:
+                adjudication_count += 1
+                if adjudication.action == "defer":
+                    deferred_count += 1
+                    _insert_adjudication_log_sync(
+                        cur,
+                        draft,
+                        adjudication,
+                        tick_chunk_id=tick_chunk_id,
+                        adjudication_source=adjudication_source,
+                    )
+                    continue
+                if adjudication.action == "void":
+                    voided_count += 1
+                    _insert_adjudication_log_sync(
+                        cur,
+                        draft,
+                        adjudication,
+                        tick_chunk_id=tick_chunk_id,
+                        adjudication_source=adjudication_source,
+                    )
+                    continue
+                if adjudication.action == "replace":
+                    replaced_count += 1
+                    if not adjudication.replacement_state_delta:
+                        _insert_adjudication_log_sync(
+                            cur,
+                            draft,
+                            adjudication,
+                            tick_chunk_id=tick_chunk_id,
+                            adjudication_source=adjudication_source,
+                        )
+                        continue
+                    draft_to_commit = replace(
+                        draft,
+                        state_delta=dict(adjudication.replacement_state_delta),
+                        changed_fields=tuple(
+                            adjudication.replacement_state_delta.keys()
+                        ),
+                        event_type=adjudication.replacement_event_type,
+                    )
+                    brief = adjudication.note or _render_brief(
+                        draft_to_commit, entity_names
+                    )
+
             resolution_id = _insert_resolution_sync(
                 cur,
-                draft,
+                draft_to_commit,
                 tick_chunk_id=tick_chunk_id,
                 actor_entity_id=actor_entity_id,
                 brief=brief,
@@ -136,10 +332,20 @@ def commit_orrery_tick_sync(
                 skipped_existing_count += 1
                 continue
 
+            if adjudication is not None:
+                _insert_adjudication_log_sync(
+                    cur,
+                    draft,
+                    adjudication,
+                    tick_chunk_id=tick_chunk_id,
+                    adjudication_source=adjudication_source,
+                    applied_resolution_id=resolution_id,
+                )
+
             resolution_count += 1
             tag_mutation_count += _apply_state_delta_sync(
                 cur,
-                draft,
+                draft_to_commit,
                 actor_entity_id=actor_entity_id,
                 target_entity_id=target_entity_id,
                 source_chunk_id=tick_chunk_id,
@@ -147,7 +353,7 @@ def commit_orrery_tick_sync(
             )
             event_id = _emit_world_event_sync(
                 cur,
-                draft,
+                draft_to_commit,
                 tick_chunk_id=tick_chunk_id,
                 resolution_id=resolution_id,
                 actor_entity_id=actor_entity_id,
@@ -161,7 +367,7 @@ def commit_orrery_tick_sync(
                     cleared_tag_count += _clear_event_tags_sync(
                         cur,
                         entity_id=actor_entity_id,
-                        event_type=str(draft.event_type),
+                        event_type=str(draft_to_commit.event_type),
                         triggering_event_id=event_id,
                         source_chunk_id=tick_chunk_id,
                     )
@@ -172,6 +378,10 @@ def commit_orrery_tick_sync(
         tag_mutation_count=tag_mutation_count,
         cleared_tag_count=cleared_tag_count,
         skipped_existing_count=skipped_existing_count,
+        adjudication_count=adjudication_count,
+        deferred_count=deferred_count,
+        voided_count=voided_count,
+        replaced_count=replaced_count,
     )
 
 
@@ -183,6 +393,8 @@ async def commit_orrery_tick_async(
     slot: Optional[int] = None,
     world_layer: Optional[str] = "primary",
     sunhelm_settings: Optional[Any] = None,
+    adjudications: Any = None,
+    storyteller_state_updates: Any = None,
 ) -> CommitOrreryTickResult:
     """Async parity wrapper for tests and non-production commit callers."""
 
@@ -190,25 +402,94 @@ async def commit_orrery_tick_async(
     if coerced is None or not coerced.resolutions:
         return CommitOrreryTickResult()
 
+    adjudication_map = coerce_adjudications(adjudications)
     need_tuning = coerce_need_tuning(sunhelm_settings)
     _validate_proposal(coerced)
+    _validate_adjudications(coerced, adjudication_map)
     entity_ids = _entity_ids_from_proposal(coerced)
     await _validate_entity_ids_async(conn, entity_ids)
     entity_names = await _entity_names_async(conn, entity_ids)
+    state_update_index = await _state_update_index_async(
+        conn, storyteller_state_updates
+    )
 
     resolution_count = 0
     event_count = 0
     tag_mutation_count = 0
     cleared_tag_count = 0
     skipped_existing_count = 0
+    adjudication_count = 0
+    deferred_count = 0
+    voided_count = 0
+    replaced_count = 0
 
     for draft in coerced.resolutions:
+        adjudication = adjudication_map.get(draft.proposal_id)
+        adjudication_source = "explicit"
+        if adjudication is None and _replaced_by_storyteller_state(
+            draft, state_update_index
+        ):
+            adjudication = OrreryAdjudication(
+                proposal_id=draft.proposal_id,
+                action="replace",
+                note=(
+                    "Storyteller state_updates touched the same "
+                    "character field; skipped the original Orrery delta."
+                ),
+            )
+            adjudication_source = "structured_state_update"
+
         actor_entity_id = _scalar_entity_binding(draft.bindings, "actor")
         target_entity_id = _scalar_entity_binding(draft.bindings, "target")
-        brief = _render_brief(draft, entity_names)
+        draft_to_commit = draft
+        brief = _render_brief(draft_to_commit, entity_names)
+
+        if adjudication is not None:
+            adjudication_count += 1
+            if adjudication.action == "defer":
+                deferred_count += 1
+                await _insert_adjudication_log_async(
+                    conn,
+                    draft,
+                    adjudication,
+                    tick_chunk_id=tick_chunk_id,
+                    adjudication_source=adjudication_source,
+                )
+                continue
+            if adjudication.action == "void":
+                voided_count += 1
+                await _insert_adjudication_log_async(
+                    conn,
+                    draft,
+                    adjudication,
+                    tick_chunk_id=tick_chunk_id,
+                    adjudication_source=adjudication_source,
+                )
+                continue
+            if adjudication.action == "replace":
+                replaced_count += 1
+                if not adjudication.replacement_state_delta:
+                    await _insert_adjudication_log_async(
+                        conn,
+                        draft,
+                        adjudication,
+                        tick_chunk_id=tick_chunk_id,
+                        adjudication_source=adjudication_source,
+                    )
+                    continue
+                draft_to_commit = replace(
+                    draft,
+                    state_delta=dict(adjudication.replacement_state_delta),
+                    changed_fields=tuple(adjudication.replacement_state_delta.keys()),
+                    event_type=adjudication.replacement_event_type,
+                )
+                brief = adjudication.note or _render_brief(
+                    draft_to_commit, entity_names
+                )
+
         resolution_id = await _insert_resolution_async(
             conn,
-            draft,
+            draft_to_commit,
             tick_chunk_id=tick_chunk_id,
             actor_entity_id=actor_entity_id,
             brief=brief,
@@ -217,10 +498,20 @@ async def commit_orrery_tick_async(
             skipped_existing_count += 1
             continue
 
+        if adjudication is not None:
+            await _insert_adjudication_log_async(
+                conn,
+                draft,
+                adjudication,
+                tick_chunk_id=tick_chunk_id,
+                adjudication_source=adjudication_source,
+                applied_resolution_id=resolution_id,
+            )
+
         resolution_count += 1
         tag_mutation_count += await _apply_state_delta_async(
             conn,
-            draft,
+            draft_to_commit,
             actor_entity_id=actor_entity_id,
             target_entity_id=target_entity_id,
             source_chunk_id=tick_chunk_id,
@@ -228,7 +519,7 @@ async def commit_orrery_tick_async(
         )
         event_id = await _emit_world_event_async(
             conn,
-            draft,
+            draft_to_commit,
             tick_chunk_id=tick_chunk_id,
             resolution_id=resolution_id,
             actor_entity_id=actor_entity_id,
@@ -242,7 +533,7 @@ async def commit_orrery_tick_async(
                 cleared_tag_count += await _clear_event_tags_async(
                     conn,
                     entity_id=actor_entity_id,
-                    event_type=str(draft.event_type),
+                    event_type=str(draft_to_commit.event_type),
                     triggering_event_id=event_id,
                     source_chunk_id=tick_chunk_id,
                 )
@@ -253,6 +544,10 @@ async def commit_orrery_tick_async(
         tag_mutation_count=tag_mutation_count,
         cleared_tag_count=cleared_tag_count,
         skipped_existing_count=skipped_existing_count,
+        adjudication_count=adjudication_count,
+        deferred_count=deferred_count,
+        voided_count=voided_count,
+        replaced_count=replaced_count,
     )
 
 
@@ -264,6 +559,121 @@ def _validate_proposal(proposal: OrreryTickProposal) -> None:
                 "Unsupported Orrery state_delta keys for "
                 f"{draft.template_id}: {', '.join(sorted(unsupported))}"
             )
+
+
+def _validate_adjudications(
+    proposal: OrreryTickProposal,
+    adjudications: Mapping[str, OrreryAdjudication],
+) -> None:
+    proposal_ids = {draft.proposal_id for draft in proposal.resolutions}
+    unknown = set(adjudications) - proposal_ids
+    if unknown:
+        raise ValueError(
+            "Orrery adjudication references unknown proposal_id(s): "
+            + ", ".join(sorted(unknown))
+        )
+
+
+def _coerce_state_updates_payload(raw: Any) -> Mapping[str, Any]:
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        raw = json.loads(raw)
+    if hasattr(raw, "model_dump"):
+        raw = raw.model_dump(mode="json", exclude_none=True)
+    if isinstance(raw, Mapping):
+        return raw
+    raise TypeError("Storyteller state_updates must be a structured object")
+
+
+def _character_state_touches(raw: Any) -> dict[int, set[str]]:
+    payload = _coerce_state_updates_payload(raw)
+    touches: dict[int, set[str]] = {}
+    for item in payload.get("characters") or ():
+        if hasattr(item, "model_dump"):
+            item = item.model_dump(mode="json", exclude_none=True)
+        if not isinstance(item, Mapping) or not item.get("character_id"):
+            continue
+        character_id = _coerce_int(item["character_id"], label="character_id")
+        fields = touches.setdefault(character_id, set())
+        if item.get("current_activity"):
+            fields.add("current_activity")
+        if item.get("current_location"):
+            fields.add("current_location")
+    return touches
+
+
+def _state_update_index_sync(cur: Any, raw_state_updates: Any) -> StateUpdateIndex:
+    touches_by_character_id = _character_state_touches(raw_state_updates)
+    if not touches_by_character_id:
+        return StateUpdateIndex(character_fields_by_entity={})
+
+    cur.execute(
+        "SELECT id, entity_id FROM characters WHERE id = ANY(%s)",
+        (sorted(touches_by_character_id),),
+    )
+    character_to_entity = {
+        _row_get(row, "id", 0): _row_get(row, "entity_id", 1) for row in cur.fetchall()
+    }
+    touches_by_entity: dict[int, frozenset[str]] = {}
+    for character_id, fields in touches_by_character_id.items():
+        entity_id = character_to_entity.get(character_id)
+        if entity_id is not None:
+            touches_by_entity[int(entity_id)] = frozenset(fields)
+    return StateUpdateIndex(character_fields_by_entity=touches_by_entity)
+
+
+async def _state_update_index_async(
+    conn: Any, raw_state_updates: Any
+) -> StateUpdateIndex:
+    touches_by_character_id = _character_state_touches(raw_state_updates)
+    if not touches_by_character_id:
+        return StateUpdateIndex(character_fields_by_entity={})
+
+    rows = await conn.fetch(
+        "SELECT id, entity_id FROM characters WHERE id = ANY($1::bigint[])",
+        sorted(touches_by_character_id),
+    )
+    character_to_entity = {
+        _row_get(row, "id", 0): _row_get(row, "entity_id", 1) for row in rows
+    }
+    touches_by_entity: dict[int, frozenset[str]] = {}
+    for character_id, fields in touches_by_character_id.items():
+        entity_id = character_to_entity.get(character_id)
+        if entity_id is not None:
+            touches_by_entity[int(entity_id)] = frozenset(fields)
+    return StateUpdateIndex(character_fields_by_entity=touches_by_entity)
+
+
+def _replaced_by_storyteller_state(
+    draft: OrreryResolutionDraft,
+    state_update_index: StateUpdateIndex,
+) -> bool:
+    actor_entity_id = _scalar_entity_binding(draft.bindings, "actor")
+    if actor_entity_id is None:
+        return False
+    touched_fields = state_update_index.character_fields_by_entity.get(
+        actor_entity_id, frozenset()
+    )
+    if not touched_fields:
+        return False
+
+    delta_keys = set(draft.state_delta)
+    changed_fields = set(draft.changed_fields)
+    touches_travel_state = any(key.startswith("travel.") for key in delta_keys) or any(
+        field.startswith("character_travel_states.") for field in changed_fields
+    )
+    if "current_activity" in touched_fields and (
+        "character.current_activity" in delta_keys
+        or "character.current_activity" in changed_fields
+        or touches_travel_state
+    ):
+        return True
+    if "current_location" in touched_fields and (
+        "character.current_location" in changed_fields or touches_travel_state
+    ):
+        return True
+    return False
 
 
 def _entity_ids_from_proposal(proposal: OrreryTickProposal) -> set[int]:
@@ -364,6 +774,86 @@ def _entity_label(value: Any, entity_names: Mapping[int, str]) -> str:
     except (TypeError, ValueError):
         return str(value)
     return entity_names.get(entity_id, f"entity {entity_id}")
+
+
+def _insert_adjudication_log_sync(
+    cur: Any,
+    draft: OrreryResolutionDraft,
+    adjudication: OrreryAdjudication,
+    *,
+    tick_chunk_id: int,
+    adjudication_source: str,
+    applied_resolution_id: Optional[int] = None,
+) -> None:
+    if adjudication_source not in ADJUDICATION_SOURCES:
+        raise ValueError(
+            f"Unsupported Orrery adjudication source {adjudication_source!r}"
+        )
+    cur.execute(
+        """
+        INSERT INTO orrery_adjudication_log (
+            tick_chunk_id, proposal_id, template_id, binding_hash, action,
+            adjudication_source, skald_note, original_state_delta,
+            replacement_state_delta, replacement_event_type, applied_resolution_id
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s)
+        """,
+        (
+            tick_chunk_id,
+            adjudication.proposal_id,
+            draft.template_id,
+            draft.binding_hash,
+            adjudication.action,
+            adjudication_source,
+            adjudication.note,
+            json.dumps(draft.state_delta),
+            (
+                json.dumps(adjudication.replacement_state_delta)
+                if adjudication.replacement_state_delta
+                else None
+            ),
+            adjudication.replacement_event_type,
+            applied_resolution_id,
+        ),
+    )
+
+
+async def _insert_adjudication_log_async(
+    conn: Any,
+    draft: OrreryResolutionDraft,
+    adjudication: OrreryAdjudication,
+    *,
+    tick_chunk_id: int,
+    adjudication_source: str,
+    applied_resolution_id: Optional[int] = None,
+) -> None:
+    if adjudication_source not in ADJUDICATION_SOURCES:
+        raise ValueError(
+            f"Unsupported Orrery adjudication source {adjudication_source!r}"
+        )
+    await conn.execute(
+        """
+        INSERT INTO orrery_adjudication_log (
+            tick_chunk_id, proposal_id, template_id, binding_hash, action,
+            adjudication_source, skald_note, original_state_delta,
+            replacement_state_delta, replacement_event_type, applied_resolution_id
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9::jsonb, $10, $11)
+        """,
+        tick_chunk_id,
+        adjudication.proposal_id,
+        draft.template_id,
+        draft.binding_hash,
+        adjudication.action,
+        adjudication_source,
+        adjudication.note,
+        json.dumps(draft.state_delta),
+        (
+            json.dumps(adjudication.replacement_state_delta)
+            if adjudication.replacement_state_delta
+            else None
+        ),
+        adjudication.replacement_event_type,
+        applied_resolution_id,
+    )
 
 
 def _insert_resolution_sync(
@@ -474,24 +964,23 @@ def _apply_state_delta_sync(
             delta_key="entity_tags.remove",
         )
 
-    if (
-        draft.state_delta.get("entity_tags_target.add")
-        or draft.state_delta.get("entity_tags_target.remove")
-    ) and target_entity_id is None:
-        raise ValueError(f"Orrery draft {draft.template_id} has no target binding")
-
-    for tag in draft.state_delta.get("entity_tags_target.add", ()) or ():
-        if _add_entity_tag_sync(cur, target_entity_id, str(tag), draft.template_id):
-            tag_mutations += 1
-    for tag in draft.state_delta.get("entity_tags_target.remove", ()) or ():
-        tag_mutations += _remove_entity_tag_sync(
-            cur,
-            target_entity_id,
-            str(tag),
-            draft.template_id,
-            source_chunk_id=source_chunk_id,
-            delta_key="entity_tags_target.remove",
-        )
+    target_tag_adds = draft.state_delta.get("entity_tags_target.add", ()) or ()
+    target_tag_removes = draft.state_delta.get("entity_tags_target.remove", ()) or ()
+    if target_tag_adds or target_tag_removes:
+        if target_entity_id is None:
+            raise ValueError(f"Orrery draft {draft.template_id} has no target binding")
+        for tag in target_tag_adds:
+            if _add_entity_tag_sync(cur, target_entity_id, str(tag), draft.template_id):
+                tag_mutations += 1
+        for tag in target_tag_removes:
+            tag_mutations += _remove_entity_tag_sync(
+                cur,
+                target_entity_id,
+                str(tag),
+                draft.template_id,
+                source_chunk_id=source_chunk_id,
+                delta_key="entity_tags_target.remove",
+            )
     if "need.fulfill" in draft.state_delta:
         tag_mutations += _apply_need_fulfillment_sync(
             cur,
@@ -578,26 +1067,25 @@ async def _apply_state_delta_async(
             delta_key="entity_tags.remove",
         )
 
-    if (
-        draft.state_delta.get("entity_tags_target.add")
-        or draft.state_delta.get("entity_tags_target.remove")
-    ) and target_entity_id is None:
-        raise ValueError(f"Orrery draft {draft.template_id} has no target binding")
-
-    for tag in draft.state_delta.get("entity_tags_target.add", ()) or ():
-        if await _add_entity_tag_async(
-            conn, target_entity_id, str(tag), draft.template_id
-        ):
-            tag_mutations += 1
-    for tag in draft.state_delta.get("entity_tags_target.remove", ()) or ():
-        tag_mutations += await _remove_entity_tag_async(
-            conn,
-            target_entity_id,
-            str(tag),
-            draft.template_id,
-            source_chunk_id=source_chunk_id,
-            delta_key="entity_tags_target.remove",
-        )
+    target_tag_adds = draft.state_delta.get("entity_tags_target.add", ()) or ()
+    target_tag_removes = draft.state_delta.get("entity_tags_target.remove", ()) or ()
+    if target_tag_adds or target_tag_removes:
+        if target_entity_id is None:
+            raise ValueError(f"Orrery draft {draft.template_id} has no target binding")
+        for tag in target_tag_adds:
+            if await _add_entity_tag_async(
+                conn, target_entity_id, str(tag), draft.template_id
+            ):
+                tag_mutations += 1
+        for tag in target_tag_removes:
+            tag_mutations += await _remove_entity_tag_async(
+                conn,
+                target_entity_id,
+                str(tag),
+                draft.template_id,
+                source_chunk_id=source_chunk_id,
+                delta_key="entity_tags_target.remove",
+            )
     if "need.fulfill" in draft.state_delta:
         tag_mutations += await _apply_need_fulfillment_async(
             conn,
@@ -1615,6 +2103,7 @@ def _emit_world_event_sync(
     _ensure_event_type_sync(cur, draft.event_type)
     location_id = _actor_location_sync(cur, actor_entity_id)
     payload = {
+        "proposal_id": draft.proposal_id,
         "template_id": draft.template_id,
         "binding_hash": draft.binding_hash,
         "bindings": dict(draft.bindings),
@@ -1681,6 +2170,7 @@ async def _emit_world_event_async(
     await _ensure_event_type_async(conn, draft.event_type)
     location_id = await _actor_location_async(conn, actor_entity_id)
     payload = {
+        "proposal_id": draft.proposal_id,
         "template_id": draft.template_id,
         "binding_hash": draft.binding_hash,
         "bindings": dict(draft.bindings),

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -54,11 +54,6 @@ REPLACEMENT_STATE_DELTA_ALIASES = {
     "entity_tags_remove": "entity_tags.remove",
     "entity_tags_target_add": "entity_tags_target.add",
     "entity_tags_target_remove": "entity_tags_target.remove",
-    "need_fulfill": "need.fulfill",
-    "travel_start": "travel.start",
-    "travel_advance": "travel.advance",
-    "travel_arrive": "travel.arrive",
-    "travel_delay": "travel.delay",
 }
 
 TRAVEL_MODE_DETOUR_FACTOR = {
@@ -98,7 +93,7 @@ class CommitOrreryTickResult:
 
 
 @dataclass(frozen=True, slots=True)
-class OrreryAdjudication:
+class OrreryAdjudicationDecision:
     """Skald's structured ruling for one Orrery proposal."""
 
     proposal_id: str
@@ -115,6 +110,16 @@ class StateUpdateIndex:
     character_fields_by_entity: Mapping[int, frozenset[str]]
 
 
+@dataclass(frozen=True, slots=True)
+class AdjudicatedDraft:
+    """Pure adjudication result before sync/async commit writes diverge."""
+
+    adjudication: Optional[OrreryAdjudicationDecision]
+    adjudication_source: str
+    draft_to_commit: Optional[OrreryResolutionDraft]
+    brief: str
+
+
 def coerce_proposal(proposal: Any) -> Optional[OrreryTickProposal]:
     """Coerce incubator JSONB data into an Orrery proposal."""
 
@@ -129,7 +134,7 @@ def coerce_proposal(proposal: Any) -> Optional[OrreryTickProposal]:
     raise TypeError(f"Unsupported Orrery proposal payload: {type(proposal).__name__}")
 
 
-def coerce_adjudications(adjudications: Any) -> dict[str, OrreryAdjudication]:
+def coerce_adjudications(adjudications: Any) -> dict[str, OrreryAdjudicationDecision]:
     """Coerce Skald adjudications into a proposal-id keyed mapping."""
 
     if adjudications is None:
@@ -144,7 +149,7 @@ def coerce_adjudications(adjudications: Any) -> dict[str, OrreryAdjudication]:
         elif "adjudications" in adjudications:
             adjudications = adjudications["adjudications"]
         else:
-            adjudications = [adjudications]
+            raise TypeError("Orrery adjudications must be a list")
     if not isinstance(adjudications, Iterable) or isinstance(
         adjudications, (str, bytes)
     ):
@@ -152,7 +157,7 @@ def coerce_adjudications(adjudications: Any) -> dict[str, OrreryAdjudication]:
             "Orrery adjudications must be a list of structured adjudication objects"
         )
 
-    coerced: dict[str, OrreryAdjudication] = {}
+    coerced: dict[str, OrreryAdjudicationDecision] = {}
     for item in adjudications:
         adjudication = _coerce_adjudication(item)
         if adjudication.proposal_id in coerced:
@@ -163,7 +168,7 @@ def coerce_adjudications(adjudications: Any) -> dict[str, OrreryAdjudication]:
     return coerced
 
 
-def _coerce_adjudication(item: Any) -> OrreryAdjudication:
+def _coerce_adjudication(item: Any) -> OrreryAdjudicationDecision:
     if hasattr(item, "model_dump"):
         item = item.model_dump(mode="json", exclude_none=True)
     if not isinstance(item, Mapping):
@@ -184,7 +189,7 @@ def _coerce_adjudication(item: Any) -> OrreryAdjudication:
         item.get("replacement_state_delta")
     )
     replacement_event_type = item.get("replacement_event_type")
-    return OrreryAdjudication(
+    return OrreryAdjudicationDecision(
         proposal_id=proposal_id,
         action=action,
         note=str(note).strip() if note else None,
@@ -256,96 +261,81 @@ def commit_orrery_tick_sync(
         replaced_count = 0
 
         for draft in coerced.resolutions:
-            adjudication = adjudication_map.get(draft.proposal_id)
-            adjudication_source = "explicit"
-            if adjudication is None and _replaced_by_storyteller_state(
-                draft, state_update_index
-            ):
-                adjudication = OrreryAdjudication(
-                    proposal_id=draft.proposal_id,
-                    action="replace",
-                    note=(
-                        "Storyteller state_updates touched the same "
-                        "character field; skipped the original Orrery delta."
-                    ),
-                )
-                adjudication_source = "structured_state_update"
-
+            adjudicated = _adjudicate_draft(
+                draft,
+                adjudication_map,
+                state_update_index,
+                entity_names,
+            )
             actor_entity_id = _scalar_entity_binding(draft.bindings, "actor")
             target_entity_id = _scalar_entity_binding(draft.bindings, "target")
-            draft_to_commit = draft
-            brief = _render_brief(draft_to_commit, entity_names)
 
-            if adjudication is not None:
+            if adjudicated.adjudication is not None:
                 adjudication_count += 1
-                if adjudication.action == "defer":
+                if adjudicated.adjudication.action == "defer":
                     deferred_count += 1
                     _insert_adjudication_log_sync(
                         cur,
                         draft,
-                        adjudication,
+                        adjudicated.adjudication,
                         tick_chunk_id=tick_chunk_id,
-                        adjudication_source=adjudication_source,
+                        adjudication_source=adjudicated.adjudication_source,
                     )
                     continue
-                if adjudication.action == "void":
+                if adjudicated.adjudication.action == "void":
                     voided_count += 1
                     _insert_adjudication_log_sync(
                         cur,
                         draft,
-                        adjudication,
+                        adjudicated.adjudication,
                         tick_chunk_id=tick_chunk_id,
-                        adjudication_source=adjudication_source,
+                        adjudication_source=adjudicated.adjudication_source,
                     )
                     continue
-                if adjudication.action == "replace":
+                if (
+                    adjudicated.adjudication.action == "replace"
+                    and adjudicated.draft_to_commit is None
+                ):
                     replaced_count += 1
-                    if not adjudication.replacement_state_delta:
-                        _insert_adjudication_log_sync(
-                            cur,
-                            draft,
-                            adjudication,
-                            tick_chunk_id=tick_chunk_id,
-                            adjudication_source=adjudication_source,
-                        )
-                        continue
-                    draft_to_commit = replace(
+                    _insert_adjudication_log_sync(
+                        cur,
                         draft,
-                        state_delta=dict(adjudication.replacement_state_delta),
-                        changed_fields=tuple(
-                            adjudication.replacement_state_delta.keys()
-                        ),
-                        event_type=adjudication.replacement_event_type,
+                        adjudicated.adjudication,
+                        tick_chunk_id=tick_chunk_id,
+                        adjudication_source=adjudicated.adjudication_source,
                     )
-                    brief = adjudication.note or _render_brief(
-                        draft_to_commit, entity_names
-                    )
+                    continue
+
+            if adjudicated.draft_to_commit is None:
+                raise RuntimeError("Orrery adjudication produced no draft to commit")
 
             resolution_id = _insert_resolution_sync(
                 cur,
-                draft_to_commit,
+                adjudicated.draft_to_commit,
                 tick_chunk_id=tick_chunk_id,
                 actor_entity_id=actor_entity_id,
-                brief=brief,
+                brief=adjudicated.brief,
             )
             if resolution_id is None:
                 skipped_existing_count += 1
                 continue
 
-            if adjudication is not None:
+            if adjudicated.adjudication is not None:
+                if adjudicated.adjudication.action == "replace":
+                    replaced_count += 1
                 _insert_adjudication_log_sync(
                     cur,
                     draft,
-                    adjudication,
+                    adjudicated.adjudication,
                     tick_chunk_id=tick_chunk_id,
-                    adjudication_source=adjudication_source,
+                    adjudication_source=adjudicated.adjudication_source,
                     applied_resolution_id=resolution_id,
                 )
 
             resolution_count += 1
             tag_mutation_count += _apply_state_delta_sync(
                 cur,
-                draft_to_commit,
+                adjudicated.draft_to_commit,
                 actor_entity_id=actor_entity_id,
                 target_entity_id=target_entity_id,
                 source_chunk_id=tick_chunk_id,
@@ -353,7 +343,7 @@ def commit_orrery_tick_sync(
             )
             event_id = _emit_world_event_sync(
                 cur,
-                draft_to_commit,
+                adjudicated.draft_to_commit,
                 tick_chunk_id=tick_chunk_id,
                 resolution_id=resolution_id,
                 actor_entity_id=actor_entity_id,
@@ -367,7 +357,7 @@ def commit_orrery_tick_sync(
                     cleared_tag_count += _clear_event_tags_sync(
                         cur,
                         entity_id=actor_entity_id,
-                        event_type=str(draft_to_commit.event_type),
+                        event_type=str(adjudicated.draft_to_commit.event_type),
                         triggering_event_id=event_id,
                         source_chunk_id=tick_chunk_id,
                     )
@@ -424,94 +414,81 @@ async def commit_orrery_tick_async(
     replaced_count = 0
 
     for draft in coerced.resolutions:
-        adjudication = adjudication_map.get(draft.proposal_id)
-        adjudication_source = "explicit"
-        if adjudication is None and _replaced_by_storyteller_state(
-            draft, state_update_index
-        ):
-            adjudication = OrreryAdjudication(
-                proposal_id=draft.proposal_id,
-                action="replace",
-                note=(
-                    "Storyteller state_updates touched the same "
-                    "character field; skipped the original Orrery delta."
-                ),
-            )
-            adjudication_source = "structured_state_update"
-
+        adjudicated = _adjudicate_draft(
+            draft,
+            adjudication_map,
+            state_update_index,
+            entity_names,
+        )
         actor_entity_id = _scalar_entity_binding(draft.bindings, "actor")
         target_entity_id = _scalar_entity_binding(draft.bindings, "target")
-        draft_to_commit = draft
-        brief = _render_brief(draft_to_commit, entity_names)
 
-        if adjudication is not None:
+        if adjudicated.adjudication is not None:
             adjudication_count += 1
-            if adjudication.action == "defer":
+            if adjudicated.adjudication.action == "defer":
                 deferred_count += 1
                 await _insert_adjudication_log_async(
                     conn,
                     draft,
-                    adjudication,
+                    adjudicated.adjudication,
                     tick_chunk_id=tick_chunk_id,
-                    adjudication_source=adjudication_source,
+                    adjudication_source=adjudicated.adjudication_source,
                 )
                 continue
-            if adjudication.action == "void":
+            if adjudicated.adjudication.action == "void":
                 voided_count += 1
                 await _insert_adjudication_log_async(
                     conn,
                     draft,
-                    adjudication,
+                    adjudicated.adjudication,
                     tick_chunk_id=tick_chunk_id,
-                    adjudication_source=adjudication_source,
+                    adjudication_source=adjudicated.adjudication_source,
                 )
                 continue
-            if adjudication.action == "replace":
+            if (
+                adjudicated.adjudication.action == "replace"
+                and adjudicated.draft_to_commit is None
+            ):
                 replaced_count += 1
-                if not adjudication.replacement_state_delta:
-                    await _insert_adjudication_log_async(
-                        conn,
-                        draft,
-                        adjudication,
-                        tick_chunk_id=tick_chunk_id,
-                        adjudication_source=adjudication_source,
-                    )
-                    continue
-                draft_to_commit = replace(
+                await _insert_adjudication_log_async(
+                    conn,
                     draft,
-                    state_delta=dict(adjudication.replacement_state_delta),
-                    changed_fields=tuple(adjudication.replacement_state_delta.keys()),
-                    event_type=adjudication.replacement_event_type,
+                    adjudicated.adjudication,
+                    tick_chunk_id=tick_chunk_id,
+                    adjudication_source=adjudicated.adjudication_source,
                 )
-                brief = adjudication.note or _render_brief(
-                    draft_to_commit, entity_names
-                )
+                continue
+
+        if adjudicated.draft_to_commit is None:
+            raise RuntimeError("Orrery adjudication produced no draft to commit")
 
         resolution_id = await _insert_resolution_async(
             conn,
-            draft_to_commit,
+            adjudicated.draft_to_commit,
             tick_chunk_id=tick_chunk_id,
             actor_entity_id=actor_entity_id,
-            brief=brief,
+            brief=adjudicated.brief,
         )
         if resolution_id is None:
             skipped_existing_count += 1
             continue
 
-        if adjudication is not None:
+        if adjudicated.adjudication is not None:
+            if adjudicated.adjudication.action == "replace":
+                replaced_count += 1
             await _insert_adjudication_log_async(
                 conn,
                 draft,
-                adjudication,
+                adjudicated.adjudication,
                 tick_chunk_id=tick_chunk_id,
-                adjudication_source=adjudication_source,
+                adjudication_source=adjudicated.adjudication_source,
                 applied_resolution_id=resolution_id,
             )
 
         resolution_count += 1
         tag_mutation_count += await _apply_state_delta_async(
             conn,
-            draft_to_commit,
+            adjudicated.draft_to_commit,
             actor_entity_id=actor_entity_id,
             target_entity_id=target_entity_id,
             source_chunk_id=tick_chunk_id,
@@ -519,7 +496,7 @@ async def commit_orrery_tick_async(
         )
         event_id = await _emit_world_event_async(
             conn,
-            draft_to_commit,
+            adjudicated.draft_to_commit,
             tick_chunk_id=tick_chunk_id,
             resolution_id=resolution_id,
             actor_entity_id=actor_entity_id,
@@ -533,7 +510,7 @@ async def commit_orrery_tick_async(
                 cleared_tag_count += await _clear_event_tags_async(
                     conn,
                     entity_id=actor_entity_id,
-                    event_type=str(draft_to_commit.event_type),
+                    event_type=str(adjudicated.draft_to_commit.event_type),
                     triggering_event_id=event_id,
                     source_chunk_id=tick_chunk_id,
                 )
@@ -563,7 +540,7 @@ def _validate_proposal(proposal: OrreryTickProposal) -> None:
 
 def _validate_adjudications(
     proposal: OrreryTickProposal,
-    adjudications: Mapping[str, OrreryAdjudication],
+    adjudications: Mapping[str, OrreryAdjudicationDecision],
 ) -> None:
     proposal_ids = {draft.proposal_id for draft in proposal.resolutions}
     unknown = set(adjudications) - proposal_ids
@@ -572,6 +549,67 @@ def _validate_adjudications(
             "Orrery adjudication references unknown proposal_id(s): "
             + ", ".join(sorted(unknown))
         )
+
+
+def _adjudicate_draft(
+    draft: OrreryResolutionDraft,
+    adjudication_map: Mapping[str, OrreryAdjudicationDecision],
+    state_update_index: StateUpdateIndex,
+    entity_names: Mapping[int, str],
+) -> AdjudicatedDraft:
+    """Resolve Skald's authority decision without performing database writes."""
+
+    adjudication = adjudication_map.get(draft.proposal_id)
+    adjudication_source = "explicit"
+    if adjudication is None and _replaced_by_storyteller_state(
+        draft, state_update_index
+    ):
+        adjudication = OrreryAdjudicationDecision(
+            proposal_id=draft.proposal_id,
+            action="replace",
+            note=(
+                "Storyteller state_updates touched the same "
+                "character field; skipped the original Orrery delta."
+            ),
+        )
+        adjudication_source = "structured_state_update"
+
+    brief = _render_brief(draft, entity_names)
+    if adjudication is None:
+        return AdjudicatedDraft(
+            adjudication=None,
+            adjudication_source=adjudication_source,
+            draft_to_commit=draft,
+            brief=brief,
+        )
+    if adjudication.action in {"defer", "void"}:
+        return AdjudicatedDraft(
+            adjudication=adjudication,
+            adjudication_source=adjudication_source,
+            draft_to_commit=None,
+            brief=brief,
+        )
+    if adjudication.action == "replace":
+        if not adjudication.replacement_state_delta:
+            return AdjudicatedDraft(
+                adjudication=adjudication,
+                adjudication_source=adjudication_source,
+                draft_to_commit=None,
+                brief=brief,
+            )
+        draft_to_commit = replace(
+            draft,
+            state_delta=dict(adjudication.replacement_state_delta),
+            changed_fields=tuple(adjudication.replacement_state_delta.keys()),
+            event_type=adjudication.replacement_event_type,
+        )
+        return AdjudicatedDraft(
+            adjudication=adjudication,
+            adjudication_source=adjudication_source,
+            draft_to_commit=draft_to_commit,
+            brief=adjudication.note or _render_brief(draft_to_commit, entity_names),
+        )
+    raise ValueError(f"Unsupported Orrery adjudication action {adjudication.action!r}")
 
 
 def _coerce_state_updates_payload(raw: Any) -> Mapping[str, Any]:
@@ -666,7 +704,6 @@ def _replaced_by_storyteller_state(
     if "current_activity" in touched_fields and (
         "character.current_activity" in delta_keys
         or "character.current_activity" in changed_fields
-        or touches_travel_state
     ):
         return True
     if "current_location" in touched_fields and (
@@ -779,7 +816,7 @@ def _entity_label(value: Any, entity_names: Mapping[int, str]) -> str:
 def _insert_adjudication_log_sync(
     cur: Any,
     draft: OrreryResolutionDraft,
-    adjudication: OrreryAdjudication,
+    adjudication: OrreryAdjudicationDecision,
     *,
     tick_chunk_id: int,
     adjudication_source: str,
@@ -820,7 +857,7 @@ def _insert_adjudication_log_sync(
 async def _insert_adjudication_log_async(
     conn: Any,
     draft: OrreryResolutionDraft,
-    adjudication: OrreryAdjudication,
+    adjudication: OrreryAdjudicationDecision,
     *,
     tick_chunk_id: int,
     adjudication_source: str,

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -31,6 +31,12 @@ from nexus.agents.orrery.needs import (
 )
 
 
+def _proposal_id(template_id: str, binding_hash_value: str) -> str:
+    """Return the stable public identifier for one tick proposal."""
+
+    return f"{template_id}:{binding_hash_value}"
+
+
 @dataclass(frozen=True, slots=True)
 class OrreryResolutionDraft:
     """Serializable dry-run result for one actor-bound package resolution."""
@@ -46,10 +52,17 @@ class OrreryResolutionDraft:
     changed_fields: Tuple[str, ...] = ()
     magnitude: float = 0.0
 
+    @property
+    def proposal_id(self) -> str:
+        """Stable identifier Skald can use to adjudicate this proposal."""
+
+        return _proposal_id(self.template_id, self.binding_hash)
+
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable representation of this draft."""
 
         return {
+            "proposal_id": self.proposal_id,
             "template_id": self.template_id,
             "priority": self.priority,
             "binding_hash": self.binding_hash,
@@ -66,10 +79,23 @@ class OrreryResolutionDraft:
     def from_dict(cls, data: Mapping[str, Any]) -> "OrreryResolutionDraft":
         """Hydrate a draft from incubator JSONB data."""
 
+        template_id = str(data["template_id"])
+        binding_hash_value = str(data["binding_hash"])
+        expected_proposal_id = _proposal_id(template_id, binding_hash_value)
+        stored_proposal_id = data.get("proposal_id")
+        if (
+            stored_proposal_id is not None
+            and str(stored_proposal_id) != expected_proposal_id
+        ):
+            raise ValueError(
+                "Orrery proposal_id does not match template_id/binding_hash: "
+                f"{stored_proposal_id!r} != {expected_proposal_id!r}"
+            )
+
         return cls(
-            template_id=str(data["template_id"]),
+            template_id=template_id,
             priority=int(data["priority"]),
-            binding_hash=str(data["binding_hash"]),
+            binding_hash=binding_hash_value,
             bindings=dict(data.get("bindings") or {}),
             branch_label=str(data["branch_label"]),
             narrative_stub=str(data["narrative_stub"]),

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -54,6 +54,7 @@ async def fetch_incubator_data(
         """
         SELECT chunk_id, parent_chunk_id, user_text, storyteller_text,
                choice_object, choice_text, orrery_proposal,
+               COALESCE(orrery_adjudications, '[]'::jsonb) AS orrery_adjudications,
                COALESCE(authorial_directives, '[]'::jsonb) AS authorial_directives,
                metadata_updates, entity_updates, reference_updates,
                llm_response_id, status
@@ -448,17 +449,28 @@ async def commit_incubator_to_database(
                 tick_chunk_id=chunk_id,
                 slot=slot,
                 world_layer=world_layer,
+                adjudications=incubator.get("orrery_adjudications"),
+                storyteller_state_updates=incubator.get("entity_updates"),
             )
-            if orrery_result.resolution_count or orrery_result.skipped_existing_count:
+            if (
+                orrery_result.resolution_count
+                or orrery_result.skipped_existing_count
+                or orrery_result.adjudication_count
+            ):
                 logger.info(
                     "Committed Orrery tick for chunk %s: %s resolutions, %s events, "
-                    "%s tag mutations, %s cleared tags, %s existing skipped",
+                    "%s tag mutations, %s cleared tags, %s existing skipped, "
+                    "%s adjudications (%s deferred, %s voided, %s replaced)",
                     chunk_id,
                     orrery_result.resolution_count,
                     orrery_result.event_count,
                     orrery_result.tag_mutation_count,
                     orrery_result.cleared_tag_count,
                     orrery_result.skipped_existing_count,
+                    orrery_result.adjudication_count,
+                    orrery_result.deferred_count,
+                    orrery_result.voided_count,
+                    orrery_result.replaced_count,
                 )
 
             # Step 9: Clear incubator

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -331,6 +331,8 @@ def commit_incubator_to_database_sync(
                     """
                     SELECT chunk_id, parent_chunk_id, user_text, storyteller_text,
                            choice_object, choice_text, orrery_proposal,
+                           COALESCE(orrery_adjudications, '[]'::jsonb)
+                               AS orrery_adjudications,
                            COALESCE(authorial_directives, '[]'::jsonb) AS authorial_directives,
                            metadata_updates, entity_updates, reference_updates,
                            llm_response_id, status
@@ -540,17 +542,28 @@ def commit_incubator_to_database_sync(
                 tick_chunk_id=chunk_id,
                 slot=slot,
                 world_layer=world_layer,
+                adjudications=incubator.get("orrery_adjudications"),
+                storyteller_state_updates=incubator.get("entity_updates"),
             )
-            if orrery_result.resolution_count or orrery_result.skipped_existing_count:
+            if (
+                orrery_result.resolution_count
+                or orrery_result.skipped_existing_count
+                or orrery_result.adjudication_count
+            ):
                 logger.info(
                     "Committed Orrery tick for chunk %s: %s resolutions, %s events, "
-                    "%s tag mutations, %s cleared tags, %s existing skipped",
+                    "%s tag mutations, %s cleared tags, %s existing skipped, "
+                    "%s adjudications (%s deferred, %s voided, %s replaced)",
                     chunk_id,
                     orrery_result.resolution_count,
                     orrery_result.event_count,
                     orrery_result.tag_mutation_count,
                     orrery_result.cleared_tag_count,
                     orrery_result.skipped_existing_count,
+                    orrery_result.adjudication_count,
+                    orrery_result.deferred_count,
+                    orrery_result.voided_count,
+                    orrery_result.replaced_count,
                 )
 
             # Step 9: Clear incubator

--- a/nexus/api/lore_adapter.py
+++ b/nexus/api/lore_adapter.py
@@ -103,6 +103,18 @@ def extract_authorial_directives(response: StoryTurnResponse) -> List[str]:
     return normalize_authorial_directives(directives)
 
 
+def extract_orrery_adjudications(response: StoryTurnResponse) -> List[Dict[str, Any]]:
+    """Extract optional Skald rulings for current-tick Orrery proposals."""
+
+    adjudications = getattr(response, "orrery_adjudications", None) or []
+    serialized = []
+    for adjudication in adjudications:
+        data = _model_to_json_dict(adjudication)
+        if data:
+            serialized.append(data)
+    return serialized
+
+
 def response_to_incubator(
     response: StoryTurnResponse,
     parent_chunk_id: int,
@@ -149,6 +161,7 @@ def response_to_incubator(
         "reference_updates": extract_reference_updates(response),
         "authorial_directives": extract_authorial_directives(response),
         "orrery_proposal": _serialize_orrery_proposal(orrery_proposal),
+        "orrery_adjudications": extract_orrery_adjudications(response),
         "session_id": session_id,
         "llm_response_id": getattr(response, "response_id", None),
         "status": "provisional",

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -272,10 +272,10 @@ async def write_to_incubator(conn, data: Dict[str, Any]):
             id, chunk_id, parent_chunk_id, user_text, storyteller_text,
             choice_object, choice_text,
             metadata_updates, entity_updates, reference_updates,
-            authorial_directives, orrery_proposal,
+            authorial_directives, orrery_proposal, orrery_adjudications,
             session_id, llm_response_id, status
         ) VALUES (
-            TRUE, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+            TRUE, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
         )
         """
 
@@ -301,6 +301,7 @@ async def write_to_incubator(conn, data: Dict[str, Any]):
                     if data.get("orrery_proposal")
                     else None
                 ),
+                json.dumps(data.get("orrery_adjudications", [])),
                 data["session_id"],
                 data["llm_response_id"],
                 data["status"],
@@ -503,6 +504,7 @@ async def generate_bootstrap_narrative(
             "factions": [],
         },
         "authorial_directives": extract_authorial_directives(story_response),
+        "orrery_adjudications": [],
         "session_id": session_id,
         "llm_response_id": f"bootstrap_{uuid.uuid4().hex[:8]}",
         "status": "provisional",

--- a/tests/test_lore/test_apex_schema.py
+++ b/tests/test_lore/test_apex_schema.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from nexus.agents.logon.apex_schema import (
     FactionStateUpdate,
     NewPlace,
+    OrreryAdjudication,
     PlaceType,
     StorytellerResponseBootstrap,
     StorytellerResponseExtended,
@@ -73,6 +74,27 @@ def test_faction_state_update_accepts_current_activity() -> None:
     )
 
     assert update.current_activity == "Watching the station exits."
+
+
+def test_orrery_adjudication_schema_accepts_replace_delta() -> None:
+    """Storyteller responses can rule on Orrery proposals without prose parsing."""
+
+    adjudication = OrreryAdjudication(
+        proposal_id="sleep_pressure:abc123",
+        action="replace",
+        replacement_state_delta={
+            "character_current_activity": "nodding off mid-sentence",
+        },
+        replacement_event_type="sleep_need",
+    )
+
+    assert adjudication.proposal_id == "sleep_pressure:abc123"
+    assert adjudication.replacement_state_delta is not None
+    assert (
+        adjudication.replacement_state_delta.character_current_activity
+        == "nodding off mid-sentence"
+    )
+    assert adjudication.replacement_event_type == "sleep_need"
 
 
 def test_extended_response_accepts_partial_new_character_context() -> None:

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -220,6 +220,35 @@ def test_context_prompt_includes_orrery_scene_pressure_controls() -> None:
     assert "Travel toward the target's last known location: Mara is moving" in prompt
 
 
+def test_context_prompt_includes_orrery_imminent_activity_controls() -> None:
+    """Current-tick proposals are framed as ratifiable but Skald-sovereign."""
+
+    prompt = LogonUtility({})._format_context_prompt(
+        {
+            "user_input": "Continue.",
+            "orrery_imminent_activity": [
+                {
+                    "proposal_id": "sleep_pressure:sleepy-1",
+                    "template_id": "sleep_pressure",
+                    "branch_label": "Nod off",
+                    "state_delta": {
+                        "character.current_activity": "sleeping",
+                    },
+                }
+            ],
+        }
+    )
+
+    assert "=== ORRERY IMMINENT ACTIVITY ===" in prompt
+    assert "If you omit a proposal from orrery_adjudications" in prompt
+    assert "defer to leave pressure unresolved" in prompt
+    assert "void when a proposal is definitively false" in prompt
+    assert "replace when your structured state_updates" in prompt
+    assert "replacement_event_type" in prompt
+    assert "Refer only to proposal_id" in prompt
+    assert "sleep_pressure:sleepy-1 [Nod off]" in prompt
+
+
 def test_context_prompt_includes_orrery_bleed_menu_controls() -> None:
     """Selected Bleed peripherals are framed as optional ambient texture."""
 

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -40,6 +40,7 @@ class RecordingCursor:
         route_graph_edges=None,
         authored_route_edges=None,
         travel_state_update_rowcount=1,
+        character_entity_ids=None,
     ):
         self.duplicate_resolution = duplicate_resolution
         self.known_tags = {"off_grid": 77} if known_tags is None else known_tags
@@ -56,6 +57,9 @@ class RecordingCursor:
         self.route_graph_edges = list(route_graph_edges or [])
         self.authored_route_edges = list(authored_route_edges or [])
         self.travel_state_update_rowcount = travel_state_update_rowcount
+        self.character_entity_ids = (
+            {11: 1} if character_entity_ids is None else character_entity_ids
+        )
         self.executed = []
         self.rowcount = 1
         self._fetchone = None
@@ -76,6 +80,16 @@ class RecordingCursor:
         if "FROM entities WHERE id = ANY" in normalized:
             entity_ids = params[0]
             self._fetchall = [{"id": entity_id} for entity_id in entity_ids]
+        elif "FROM characters WHERE id = ANY" in normalized:
+            character_ids = params[0]
+            self._fetchall = [
+                {
+                    "id": character_id,
+                    "entity_id": self.character_entity_ids[character_id],
+                }
+                for character_id in character_ids
+                if character_id in self.character_entity_ids
+            ]
         elif "FROM entity_names_v WHERE id = ANY" in normalized:
             names = {1: "Mara", 2: "Vale"}
             self._fetchall = [
@@ -415,8 +429,10 @@ def test_proposal_round_trips_through_json_shape() -> None:
     """Commit can hydrate the exact proposal shape stored in incubator JSONB."""
 
     proposal = _proposal()
+    payload = proposal.to_dict()
 
-    assert OrreryTickProposal.from_dict(proposal.to_dict()) == proposal
+    assert payload["resolutions"][0]["proposal_id"] == "evade_pursuers:abc123"
+    assert OrreryTickProposal.from_dict(payload) == proposal
 
 
 def test_proposal_round_trips_scene_pressures_without_state_delta() -> None:
@@ -446,6 +462,35 @@ def test_response_to_incubator_serializes_orrery_proposal() -> None:
         "evade_pursuers"
     )
     assert incubator_data["orrery_proposal"]["scene_pressures"] == []
+
+
+def test_response_to_incubator_serializes_orrery_adjudications() -> None:
+    """Skald's structured Orrery rulings ride the incubator handoff."""
+
+    class ResponseWithAdjudication(MinimalStoryResponse):
+        orrery_adjudications = [
+            {
+                "proposal_id": "evade_pursuers:abc123",
+                "action": "defer",
+                "note": "Hold for the next beat.",
+            }
+        ]
+
+    incubator_data = response_to_incubator(
+        ResponseWithAdjudication(),
+        parent_chunk_id=99,
+        user_text="Continue.",
+        session_id="session-1",
+        orrery_proposal=_proposal(),
+    )
+
+    assert incubator_data["orrery_adjudications"] == [
+        {
+            "proposal_id": "evade_pursuers:abc123",
+            "action": "defer",
+            "note": "Hold for the next beat.",
+        }
+    ]
 
 
 def test_commit_orrery_tick_ignores_scene_pressures() -> None:
@@ -503,6 +548,168 @@ def test_commit_orrery_tick_materializes_resolution_event_and_tags() -> None:
     assert "INSERT INTO world_event_entities" in statements
     assert "INSERT INTO tag_clearance_log" in statements
     assert resolution_params[-1] == "Mara vanishes into a maintenance corridor."
+
+
+def test_commit_orrery_tick_defers_explicit_adjudication() -> None:
+    """Defer preserves pressure by skipping materialization this tick."""
+
+    cursor = RecordingCursor()
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _proposal(),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+        adjudications=[
+            {
+                "proposal_id": "evade_pursuers:abc123",
+                "action": "defer",
+                "note": "Not during this exchange.",
+            }
+        ],
+    )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+
+    assert result.resolution_count == 0
+    assert result.event_count == 0
+    assert result.adjudication_count == 1
+    assert result.deferred_count == 1
+    assert "INSERT INTO orrery_adjudication_log" in statements
+    assert "INSERT INTO orrery_resolutions" not in statements
+    assert "UPDATE characters SET current_activity" not in statements
+
+
+def test_commit_orrery_tick_voids_explicit_adjudication() -> None:
+    """Void records a definitive Skald cancellation without side effects."""
+
+    cursor = RecordingCursor()
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _proposal(),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+        adjudications=[
+            {
+                "proposal_id": "evade_pursuers:abc123",
+                "action": "void",
+                "note": "The pursuit no longer exists.",
+            }
+        ],
+    )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+
+    assert result.resolution_count == 0
+    assert result.adjudication_count == 1
+    assert result.voided_count == 1
+    assert "INSERT INTO orrery_adjudication_log" in statements
+    assert "INSERT INTO world_events" not in statements
+
+
+def test_commit_orrery_tick_replaces_from_structured_state_update() -> None:
+    """Structured Skald writes to the same entity/field beat Orrery proposals."""
+
+    cursor = RecordingCursor()
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _proposal(),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+        storyteller_state_updates={
+            "characters": [
+                {"character_id": 11, "current_activity": "arguing in the room"}
+            ]
+        },
+    )
+
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+    audit_params = next(
+        params
+        for sql, params in cursor.executed
+        if "INSERT INTO orrery_adjudication_log" in sql
+    )
+
+    assert result.resolution_count == 0
+    assert result.adjudication_count == 1
+    assert result.replaced_count == 1
+    assert audit_params[5] == "structured_state_update"
+    assert "INSERT INTO orrery_resolutions" not in statements
+    assert "UPDATE characters SET current_activity" not in statements
+
+
+def test_commit_orrery_tick_replaces_with_explicit_delta() -> None:
+    """Replace can commit a Skald-authored Orrery-compatible delta."""
+
+    cursor = RecordingCursor()
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _proposal(),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+        adjudications=[
+            {
+                "proposal_id": "evade_pursuers:abc123",
+                "action": "replace",
+                "note": "Mara stays engaged instead of vanishing.",
+                "replacement_state_delta": {
+                    "character_current_activity": "arguing in the room"
+                },
+            }
+        ],
+    )
+
+    activity_params = next(
+        params
+        for sql, params in cursor.executed
+        if "UPDATE characters SET current_activity" in sql
+    )
+    audit_params = next(
+        params
+        for sql, params in cursor.executed
+        if "INSERT INTO orrery_adjudication_log" in sql
+    )
+
+    assert result.resolution_count == 1
+    assert result.event_count == 0
+    assert result.adjudication_count == 1
+    assert result.replaced_count == 1
+    assert activity_params == ("arguing in the room", 1)
+    assert audit_params[5] == "explicit"
+    assert not any("INSERT INTO world_events" in sql for sql, _ in cursor.executed)
+
+
+def test_commit_orrery_tick_replacement_event_type_is_explicit() -> None:
+    """Replacement deltas only emit canonical events when Skald names the event."""
+
+    cursor = RecordingCursor()
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _proposal(),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+        adjudications=[
+            {
+                "proposal_id": "evade_pursuers:abc123",
+                "action": "replace",
+                "replacement_state_delta": {
+                    "character_current_activity": "ducking out of sight"
+                },
+                "replacement_event_type": "evade_pursuit",
+            }
+        ],
+    )
+
+    event_params = next(
+        params for sql, params in cursor.executed if "INSERT INTO world_events" in sql
+    )
+
+    assert result.event_count == 1
+    assert event_params[0] == "evade_pursuit"
 
 
 def test_commit_orrery_tick_skips_existing_resolution_without_double_writes() -> None:

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -10,7 +10,7 @@ from typing import Any
 import pytest
 
 import nexus.agents.orrery.events as orrery_events
-from nexus.agents.orrery.events import commit_orrery_tick_sync
+from nexus.agents.orrery.events import coerce_adjudications, commit_orrery_tick_sync
 from nexus.agents.orrery.resolver import (
     OrreryResolutionDraft,
     OrreryScenePressureDraft,
@@ -710,6 +710,92 @@ def test_commit_orrery_tick_replacement_event_type_is_explicit() -> None:
 
     assert result.event_count == 1
     assert event_params[0] == "evade_pursuit"
+
+
+def test_coerce_adjudications_rejects_bare_mapping() -> None:
+    """Adjudications must be a list or wrapper object, not guessed from a dict."""
+
+    with pytest.raises(TypeError, match="must be a list"):
+        coerce_adjudications(
+            {
+                "proposal_id": "evade_pursuers:abc123",
+                "action": "defer",
+            }
+        )
+
+
+def test_commit_orrery_tick_does_not_cancel_travel_for_activity_only_update() -> None:
+    """A current_activity write alone does not supersede unrelated travel state."""
+
+    draft = OrreryResolutionDraft(
+        template_id="travel",
+        priority=21,
+        binding_hash="travel-state-only",
+        bindings={"actor": 1},
+        branch_label="Depart toward the planned destination",
+        narrative_stub="{actor} starts the journey.",
+        state_delta={
+            "travel.start": {
+                "destination_place_id": 42,
+                "mode": "vehicle",
+                "initial_progress": 0.1,
+            },
+        },
+        event_type="travel_departed",
+        changed_fields=("character_travel_states.status",),
+        magnitude=0.28,
+    )
+    proposal = OrreryTickProposal(
+        anchor_chunk_id=99,
+        actor_count=1,
+        resolutions=(draft,),
+        generated_at="2073-10-31T18:00:00+00:00",
+    )
+    cursor = RecordingCursor()
+
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        proposal,
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+        storyteller_state_updates={
+            "characters": [
+                {"character_id": 11, "current_activity": "reading in the room"}
+            ]
+        },
+    )
+
+    assert result.resolution_count == 1
+    assert result.replaced_count == 0
+    assert any(
+        "INSERT INTO character_travel_states" in sql for sql, _ in cursor.executed
+    )
+
+
+def test_commit_orrery_tick_does_not_count_duplicate_replacement() -> None:
+    """Replacement metrics describe applied or handled replacements, not duplicates."""
+
+    cursor = RecordingCursor(duplicate_resolution=True)
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        _proposal(),
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+        adjudications=[
+            {
+                "proposal_id": "evade_pursuers:abc123",
+                "action": "replace",
+                "replacement_state_delta": {
+                    "character_current_activity": "arguing in the room"
+                },
+            }
+        ],
+    )
+
+    assert result.skipped_existing_count == 1
+    assert result.replaced_count == 0
 
 
 def test_commit_orrery_tick_skips_existing_resolution_without_double_writes() -> None:


### PR DESCRIPTION
## Summary

Implements the Orrery authority model from #275: current-tick proposals now surface to Skald with stable `proposal_id`s, and Skald can explicitly `defer`, `void`, or `replace` them through structured `orrery_adjudications`. Omitted adjudications still ratify proposals at commit time.

## What changed

- Added `orrery_imminent_activity` payload surfacing and prompt framing that keeps Skald sovereign.
- Added structured LOGON schema and incubator persistence for Orrery adjudications.
- Added commit-time adjudication handling plus `orrery_adjudication_log` migration.
- Added structured-state conflict detection so Skald `state_updates` touching the same character/field automatically supersede Orrery without prose parsing.
- Added replacement delta support, with `replacement_event_type` required before replacement deltas emit canonical world events.
- Updated Orrery design/package docs and tests.

## Validation

- `poetry run pytest` -> 404 passed, 32 skipped
- `git diff --check` -> clean
- `poetry run flake8` -> unavailable in this Poetry env (`Command not found: flake8`)
- Targeted `mypy` still fails on existing repo typing/stub debt outside this slice.