### PR TITLE
[codex] Add mock Orrery adjudication fixture

### DIFF
--- a/nexus/api/mock_openai.py
+++ b/nexus/api/mock_openai.py
@@ -15,6 +15,7 @@ Usage:
 
 import json
 import logging
+import re
 import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -607,11 +608,171 @@ class ResponsesRequest(BaseModel):
     """Request format for /v1/responses endpoint."""
 
     model: str
-    input: List[Dict[str, Any]]
+    input: Any
     max_output_tokens: Optional[int] = None
     temperature: Optional[float] = None
     reasoning: Optional[Dict[str, Any]] = None
     text_format: Optional[Any] = None  # Pydantic schema for structured output
+
+
+def _collect_text(value: Any) -> str:
+    """Flatten OpenAI Responses input variants into searchable prompt text."""
+
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "\n".join(part for item in value if (part := _collect_text(item)))
+    if isinstance(value, dict):
+        text_parts: List[str] = []
+        for key in ("content", "text", "input", "message"):
+            if key in value:
+                text = _collect_text(value[key])
+                if text:
+                    text_parts.append(text)
+        if text_parts:
+            return "\n".join(text_parts)
+        return "\n".join(
+            part for item in value.values() if (part := _collect_text(item))
+        )
+    return ""
+
+
+def _extract_orrery_proposal_ids(prompt: str) -> List[str]:
+    """Extract proposal IDs from LogonUtility's prompt-facing Orrery list."""
+
+    proposal_ids: List[str] = []
+    seen: set[str] = set()
+    patterns = (
+        re.compile(r"^-\s+(?P<id>[^\s\[]+)\s+\[", re.MULTILINE),
+        re.compile(r'"proposal_id"\s*:\s*"(?P<id>[^"]+)"'),
+    )
+    for pattern in patterns:
+        for match in pattern.finditer(prompt):
+            proposal_id = match.group("id").strip()
+            if ":" not in proposal_id or proposal_id in seen:
+                continue
+            seen.add(proposal_id)
+            proposal_ids.append(proposal_id)
+    return proposal_ids
+
+
+def _mock_orrery_adjudications(prompt: str) -> List[Dict[str, Any]]:
+    """Return deterministic defer/void/replace decisions for Orrery tests."""
+
+    proposal_ids = _extract_orrery_proposal_ids(prompt)
+    adjudications: List[Dict[str, Any]] = []
+    for index, proposal_id in enumerate(proposal_ids[:3]):
+        if index == 0:
+            adjudications.append(
+                {
+                    "proposal_id": proposal_id,
+                    "action": "defer",
+                    "note": "[TEST MODE] Deferred so pressure can remain live.",
+                }
+            )
+        elif index == 1:
+            adjudications.append(
+                {
+                    "proposal_id": proposal_id,
+                    "action": "void",
+                    "note": "[TEST MODE] Voided as definitively untrue this tick.",
+                }
+            )
+        else:
+            adjudications.append(
+                {
+                    "proposal_id": proposal_id,
+                    "action": "replace",
+                    "note": "[TEST MODE] Replaced with a story-truer activity.",
+                    "replacement_state_delta": {
+                        "character_current_activity": (
+                            "following the mock-server replacement beat"
+                        )
+                    },
+                }
+            )
+    return adjudications
+
+
+def _mock_storyteller_response(prompt: str) -> Dict[str, Any]:
+    """Build a schema-valid deterministic narrative response for TEST mode."""
+
+    adjudications = _mock_orrery_adjudications(prompt)
+    return {
+        "narrative": (
+            "[TEST MODE] The scene advances under deterministic mock control. "
+            "Orrery pressure is acknowledged structurally, while the prose remains "
+            "simple enough for integration tests to inspect."
+        ),
+        "choices": [
+            "Continue following the immediate lead.",
+            "Pause and reassess the pressure around the scene.",
+            "Shift attention to the quieter off-screen consequence.",
+        ],
+        "authorial_directives": [
+            "Retrieve the immediate prior scene and unresolved Orrery pressure."
+        ],
+        "chunk_metadata": {
+            "chronology": {
+                "episode_transition": "continue",
+                "time_delta_minutes": 5,
+                "time_delta_hours": None,
+                "time_delta_days": None,
+                "time_delta_description": "A few focused minutes pass.",
+            },
+            "world_layer": "primary",
+        },
+        "referenced_entities": {
+            "characters": [],
+            "places": [],
+            "factions": [],
+        },
+        "state_updates": {
+            "characters": [],
+            "relationships": [],
+            "locations": [],
+            "factions": [],
+        },
+        "operations": None,
+        "orrery_adjudications": adjudications,
+        "reasoning": "[TEST MODE] Deterministic mock storyteller response.",
+    }
+
+
+def _responses_payload(output_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Format structured JSON as an OpenAI Responses-compatible payload."""
+
+    output_json = json.dumps(output_data)
+    return {
+        "id": f"resp-mock-{uuid.uuid4().hex[:8]}",
+        "object": "response",
+        "created_at": int(datetime.now().timestamp()),
+        "model": "TEST",
+        "status": "completed",
+        "output": [
+            {
+                "type": "message",
+                "id": f"msg-mock-{uuid.uuid4().hex[:8]}",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": output_json,
+                        "annotations": [],
+                    }
+                ],
+            }
+        ],
+        "output_text": output_json,
+        "usage": {
+            "input_tokens": 1000,
+            "output_tokens": 800,
+            "total_tokens": 1800,
+        },
+    }
 
 
 def get_cached_bootstrap_narrative() -> Dict[str, Any]:
@@ -701,52 +862,24 @@ async def responses_create(request: ResponsesRequest):
 
     # Check if this is a bootstrap/narrative request (vs wizard)
     # by looking for storyteller-related content in the messages
-    input_text = ""
-    for msg in request.input:
-        content = msg.get("content", "")
-        if isinstance(content, str):
-            input_text += content
+    input_text = _collect_text(request.input)
+    proposal_ids = _extract_orrery_proposal_ids(input_text)
 
     is_narrative = any(
         kw in input_text.lower()
         for kw in ["narrative", "story", "protagonist", "bootstrap", "user input"]
     )
 
+    if proposal_ids:
+        logger.info(
+            "[MOCK] Detected %d Orrery proposals, returning adjudication fixture",
+            len(proposal_ids),
+        )
+        return _responses_payload(_mock_storyteller_response(input_text))
+
     if is_narrative:
         logger.info("[MOCK] Detected narrative request, returning cached bootstrap")
-        cached = get_cached_bootstrap_narrative()
-        output_json = json.dumps(cached)
-
-        # Format as OpenAI responses API structured output
-        # content must be an array of content blocks, not a raw string
-        return {
-            "id": f"resp-mock-{uuid.uuid4().hex[:8]}",
-            "object": "response",
-            "created_at": int(datetime.now().timestamp()),
-            "model": "TEST",
-            "status": "completed",
-            "output": [
-                {
-                    "type": "message",
-                    "id": f"msg-mock-{uuid.uuid4().hex[:8]}",
-                    "status": "completed",
-                    "role": "assistant",
-                    "content": [
-                        {
-                            "type": "output_text",
-                            "text": output_json,
-                            "annotations": [],
-                        }
-                    ],
-                }
-            ],
-            "output_text": output_json,
-            "usage": {
-                "input_tokens": 1000,
-                "output_tokens": 800,
-                "total_tokens": 1800,
-            },
-        }
+        return _responses_payload(get_cached_bootstrap_narrative())
 
     # Default fallback for non-narrative requests
     logger.warning(f"[MOCK] Unknown responses request type")

--- a/nexus/api/mock_openai.py
+++ b/nexus/api/mock_openai.py
@@ -616,7 +616,11 @@ class ResponsesRequest(BaseModel):
 
 
 def _collect_text(value: Any) -> str:
-    """Flatten OpenAI Responses input variants into searchable prompt text."""
+    """Flatten OpenAI Responses input variants into searchable prompt text.
+
+    When a dict has multiple prompt-like keys, use the first known Responses API
+    shape instead of concatenating siblings that may duplicate the same content.
+    """
 
     if value is None:
         return ""
@@ -625,14 +629,11 @@ def _collect_text(value: Any) -> str:
     if isinstance(value, list):
         return "\n".join(part for item in value if (part := _collect_text(item)))
     if isinstance(value, dict):
-        text_parts: List[str] = []
         for key in ("content", "text", "input", "message"):
             if key in value:
                 text = _collect_text(value[key])
                 if text:
-                    text_parts.append(text)
-        if text_parts:
-            return "\n".join(text_parts)
+                    return text
         return "\n".join(
             part for item in value.values() if (part := _collect_text(item))
         )
@@ -640,13 +641,18 @@ def _collect_text(value: Any) -> str:
 
 
 def _extract_orrery_proposal_ids(prompt: str) -> List[str]:
-    """Extract proposal IDs from LogonUtility's prompt-facing Orrery list."""
+    """Extract proposal IDs from LogonUtility's prompt-facing Orrery list.
+
+    Orrery proposal IDs are generated as ``template_id:binding_hash`` in
+    ``nexus.agents.orrery.resolver``. Requiring the colon keeps generic markdown
+    bullets from being mistaken for proposal IDs.
+    """
 
     proposal_ids: List[str] = []
     seen: set[str] = set()
     patterns = (
-        re.compile(r"^-\s+(?P<id>[^\s\[]+)\s+\[", re.MULTILINE),
-        re.compile(r'"proposal_id"\s*:\s*"(?P<id>[^"]+)"'),
+        re.compile(r"^-\s+(?P<id>[^:\s\[]+:[^\s\[]+)\s+\[", re.MULTILINE),
+        re.compile(r'"proposal_id"\s*:\s*"(?P<id>[^":]+:[^"]+)"'),
     )
     for pattern in patterns:
         for match in pattern.finditer(prompt):
@@ -686,6 +692,7 @@ def _mock_orrery_adjudications(prompt: str) -> List[Dict[str, Any]]:
                     "proposal_id": proposal_id,
                     "action": "replace",
                     "note": "[TEST MODE] Replaced with a story-truer activity.",
+                    "replacement_event_type": "mock_replacement",
                     "replacement_state_delta": {
                         "character_current_activity": (
                             "following the mock-server replacement beat"

--- a/tests/test_mock_openai.py
+++ b/tests/test_mock_openai.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 from nexus.agents.logon.apex_schema import StorytellerResponseExtended
-from nexus.api.mock_openai import ResponsesRequest, responses_create
+from nexus.api.mock_openai import ResponsesRequest, _collect_text, responses_create
 
 
 @pytest.mark.asyncio
@@ -36,11 +36,39 @@ async def test_mock_responses_returns_orrery_adjudication_fixture() -> None:
     assert parsed.orrery_adjudications[1].proposal_id == "hide:bbb"
     replacement = parsed.orrery_adjudications[2]
     assert replacement.proposal_id == "tend_craft:ccc"
+    assert replacement.replacement_event_type == "mock_replacement"
     assert replacement.replacement_state_delta is not None
     assert (
         replacement.replacement_state_delta.character_current_activity
         == "following the mock-server replacement beat"
     )
+
+
+@pytest.mark.asyncio
+async def test_mock_responses_single_orrery_proposal_only_defers() -> None:
+    """A one-proposal prompt returns a schema-valid partial adjudication list."""
+
+    response = await responses_create(
+        ResponsesRequest(
+            model="TEST",
+            input=[
+                {
+                    "role": "user",
+                    "content": (
+                        "=== ORRERY IMMINENT ACTIVITY ===\n"
+                        "- sleep_pressure:aaa [Doze off]: "
+                        "state_delta={'character.current_activity': 'sleeping'}"
+                    ),
+                }
+            ],
+        )
+    )
+
+    payload = json.loads(response["output_text"])
+    parsed = StorytellerResponseExtended.model_validate(payload)
+
+    assert [item.action for item in parsed.orrery_adjudications] == ["defer"]
+    assert parsed.orrery_adjudications[0].proposal_id == "sleep_pressure:aaa"
 
 
 @pytest.mark.asyncio
@@ -67,3 +95,42 @@ async def test_mock_responses_parses_nested_responses_input_content() -> None:
 
     payload = json.loads(response["output_text"])
     assert payload["orrery_adjudications"][0]["proposal_id"] == "drink:aaa"
+
+
+@pytest.mark.asyncio
+async def test_mock_responses_prioritizes_orrery_fixture_over_cached_story() -> None:
+    """Orrery proposal prompts use the adjudication fixture even if narrative-like."""
+
+    response = await responses_create(
+        ResponsesRequest(
+            model="TEST",
+            input=[
+                {
+                    "role": "user",
+                    "content": (
+                        "Continue the protagonist story.\n"
+                        "=== ORRERY IMMINENT ACTIVITY ===\n"
+                        "- honor_debt:aaa [Repay debt]: state_delta={}"
+                    ),
+                }
+            ],
+        )
+    )
+
+    payload = json.loads(response["output_text"])
+    assert payload["narrative"].startswith("[TEST MODE]")
+    assert payload["orrery_adjudications"][0]["proposal_id"] == "honor_debt:aaa"
+
+
+def test_collect_text_uses_first_prompt_like_key() -> None:
+    """Sibling text fields do not duplicate or alter higher-priority content."""
+
+    assert (
+        _collect_text(
+            {
+                "content": "canonical prompt with drink:aaa",
+                "text": "ignored sibling with hide:bbb",
+            }
+        )
+        == "canonical prompt with drink:aaa"
+    )

--- a/tests/test_mock_openai.py
+++ b/tests/test_mock_openai.py
@@ -1,0 +1,69 @@
+"""Tests for the local TEST-mode OpenAI impersonator."""
+
+import json
+
+import pytest
+
+from nexus.agents.logon.apex_schema import StorytellerResponseExtended
+from nexus.api.mock_openai import ResponsesRequest, responses_create
+
+
+@pytest.mark.asyncio
+async def test_mock_responses_returns_orrery_adjudication_fixture() -> None:
+    """TEST mode can force defer, void, and replace without live API calls."""
+
+    prompt = """
+=== ORRERY IMMINENT ACTIVITY ===
+- drink:aaa [Drink routinely]: state_delta={'character.current_activity': 'drinking'}
+- hide:bbb [Go dark]: state_delta={'character.current_activity': 'hiding'}
+- tend_craft:ccc [Tend craft]: state_delta={'character.current_activity': 'tending'}
+- evade_pursuers:ddd [Evade]: state_delta={'character.current_activity': 'moving'}
+"""
+
+    response = await responses_create(
+        ResponsesRequest(model="TEST", input=[{"role": "user", "content": prompt}])
+    )
+
+    payload = json.loads(response["output_text"])
+    parsed = StorytellerResponseExtended.model_validate(payload)
+
+    assert [item.action for item in parsed.orrery_adjudications] == [
+        "defer",
+        "void",
+        "replace",
+    ]
+    assert parsed.orrery_adjudications[0].proposal_id == "drink:aaa"
+    assert parsed.orrery_adjudications[1].proposal_id == "hide:bbb"
+    replacement = parsed.orrery_adjudications[2]
+    assert replacement.proposal_id == "tend_craft:ccc"
+    assert replacement.replacement_state_delta is not None
+    assert (
+        replacement.replacement_state_delta.character_current_activity
+        == "following the mock-server replacement beat"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mock_responses_parses_nested_responses_input_content() -> None:
+    """Pydantic AI style nested content still exposes Orrery proposal IDs."""
+
+    response = await responses_create(
+        ResponsesRequest(
+            model="TEST",
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "Story turn"},
+                        {
+                            "type": "input_text",
+                            "text": '- "proposal_id": "drink:aaa"',
+                        },
+                    ],
+                }
+            ],
+        )
+    )
+
+    payload = json.loads(response["output_text"])
+    assert payload["orrery_adjudications"][0]["proposal_id"] == "drink:aaa"


### PR DESCRIPTION
## Summary
- Teach the local mock OpenAI Responses endpoint to flatten current Responses API input shapes.
- Return deterministic Orrery adjudication fixtures when proposal IDs are present: first `defer`, second `void`, third `replace`, with omitted proposals left for ratification.
- Add mock-server tests covering schema-valid adjudications and nested Pydantic-AI-style content extraction.

## Validation
- `poetry run pytest tests/test_mock_openai.py tests/test_lore/test_apex_schema.py::test_orrery_adjudication_schema_accepts_replace_delta tests/test_orrery/test_events.py -k 'adjudication or defer or void or replacement or replace'`
- `git diff --check main..HEAD`

## Notes
- No schema, settings, or data migration impact.
- Branch was rebased onto current `main` before opening, so the PR contains only the mock-server fixture work.
