### PR TITLE
Add entity_pair_tags substrate: schema + writer + tests

### DIFF
--- a/migrations/042_orrery_entity_pair_tags.py
+++ b/migrations/042_orrery_entity_pair_tags.py
@@ -126,7 +126,11 @@ def run(conn: connection) -> None:
     """Create the entity_pair_tags substrate and seed the 12 settled relations."""
 
     with conn.cursor() as cur:
-        # Registry of relation types (analog of `tags` but with kind validation columns)
+        # Registry of relation types (analog of `tags` but with kind validation columns).
+        # Empty-array CHECK uses `cardinality(...) >= 1` rather than `array_length(...) >= 1`:
+        # PostgreSQL's `array_length('{}', 1)` returns NULL, and CHECK treats NULL as
+        # passing — so array_length would silently admit empty arrays. `cardinality`
+        # returns 0 for empty arrays, making the check NULL-safe.
         cur.execute(
             """
             CREATE TABLE IF NOT EXISTS pair_tags (
@@ -142,8 +146,8 @@ def run(conn: connection) -> None:
                 description          text,
                 created_at           timestamptz NOT NULL DEFAULT now(),
                 CHECK (is_ephemeral = (clearance_kind IS NOT NULL)),
-                CHECK (array_length(subject_kinds, 1) >= 1),
-                CHECK (array_length(object_kinds, 1) >= 1),
+                CHECK (cardinality(subject_kinds) >= 1),
+                CHECK (cardinality(object_kinds) >= 1),
                 CHECK (btrim(tag) <> '')
             )
             """
@@ -171,8 +175,37 @@ def run(conn: connection) -> None:
             "COMMENT ON COLUMN pair_tags.is_ephemeral IS "
             "'TRUE for relations that get cleared by world events (e.g., `pursuing`); FALSE for durable relations.'"
         )
+        cur.execute(
+            "COMMENT ON COLUMN pair_tags.clearance_kind IS "
+            "'For ephemeral relations: the mode of clearance (e.g. `semantic`). NULL for durable relations. Enforced equal to (is_ephemeral) by check constraint.'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN pair_tags.reapplication_policy IS "
+            "'How the relation behaves if reapplied after clearance. NULL = no special policy.'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN pair_tags.clear_on IS "
+            "'Optional JSONB describing world_event types or conditions that auto-clear instances of this relation. Shape mirrors tags.clear_on.'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN pair_tags.deprecated IS "
+            "'TRUE marks the relation as no longer accepted for new bestowals; lookup intentionally filters deprecated rows.'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN pair_tags.description IS "
+            "'Human-readable description of the relation semantics.'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN pair_tags.created_at IS "
+            "'When the relation type was registered.'"
+        )
 
-        # Application table — actual edges between entities
+        # Application table — actual edges between entities.
+        # Uniqueness is enforced by the partial index `ix_entity_pair_tags_current`
+        # below (one active row per directed triple). No `UNIQUE (subject, object,
+        # pair_tag, applied_at)` constraint is needed: `applied_at = now()` advances
+        # per-statement so two writes from different transactions never share a value,
+        # making such a constraint dead weight.
         cur.execute(
             """
             CREATE TABLE IF NOT EXISTS entity_pair_tags (
@@ -186,9 +219,7 @@ def run(conn: connection) -> None:
                 cleared_at            timestamptz,
                 clear_on_override     jsonb,
                 template_id           text,
-                CHECK (subject_entity_id <> object_entity_id),
-                CONSTRAINT entity_pair_tags_unique_event UNIQUE
-                    (subject_entity_id, object_entity_id, pair_tag_id, applied_at)
+                CHECK (subject_entity_id <> object_entity_id)
             )
             """
         )
@@ -212,8 +243,28 @@ def run(conn: connection) -> None:
             "'FK to pair_tags — the relation type.'"
         )
         cur.execute(
+            "COMMENT ON COLUMN entity_pair_tags.applied_at IS "
+            "'Real-world wall-clock time the row was inserted (DEFAULT now()).'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN entity_pair_tags.applied_at_world_time IS "
+            "'In-story world time when the relation became active. NULL if no world_time was provided by the caller.'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN entity_pair_tags.source_kind IS "
+            "'Provenance: `skald_inline` for runtime bestowals, `llm_generated` for offline backfills (same enum as entity_tags.source_kind).'"
+        )
+        cur.execute(
             "COMMENT ON COLUMN entity_pair_tags.cleared_at IS "
             "'When set, the relation is no longer active (analogous to entity_tags.cleared_at).'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN entity_pair_tags.clear_on_override IS "
+            "'Optional per-row override of the relation type''s clear_on policy (analogous to entity_tags.clear_on).'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN entity_pair_tags.template_id IS "
+            "'Optional bestowal-template identifier for downstream traceability (analogous to entity_tags.template_id).'"
         )
 
         # Indexes

--- a/migrations/042_orrery_entity_pair_tags.py
+++ b/migrations/042_orrery_entity_pair_tags.py
@@ -1,0 +1,270 @@
+"""Add the entity_pair_tags substrate for multi-entity (relational) tags.
+
+Single-entity tags live in `entity_tags` (and their vocabulary in `tags`); this
+migration introduces the parallel `entity_pair_tags` table for directed binary
+relations between entities, with their vocabulary in a new `pair_tags`
+registry.
+
+Seeds the 12 multi-entity relations settled in
+`temp/orrery/orrery_vocabulary.md` ("Multi-Entity Tags — Settled, 12 total"):
+
+- Place-bound (6): `knows_location`, `can_access`, `claims`, `resides_at`,
+  `operates_from`, `originates_from`
+- Character/faction relations (6): `pursuing`, `handles`, `obligation`,
+  `authority_over`, `protects`, `mentors`
+
+`pursuing` is the only seeded ephemeral relation; the rest are durable.
+
+The companion writer lives in `nexus.agents.orrery.tag_writer`
+(`apply_pair_tag_bestowal`, `clear_pair_tag`). Read predicates
+(`has_pair_tag`, `inbound_pair_tag_subjects`, `outbound_pair_tag_objects`) and
+the binding-composer extension will be added in a follow-up PR.
+
+Design rationale: scope-bound status, fame as detection radius, package
+self-awareness (issue #282) all depend on this substrate.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from psycopg2.extensions import connection
+
+
+# (tag, subject_kinds, object_kinds, is_ephemeral, description)
+PAIR_TAG_SEED: Sequence[tuple[str, list[str], list[str], bool, str]] = (
+    # Place-bound (durable)
+    (
+        "knows_location",
+        ["character"],
+        ["place"],
+        False,
+        "Subject knows of the place's existence and how to find it.",
+    ),
+    (
+        "can_access",
+        ["character", "faction"],
+        ["place"],
+        False,
+        "Subject has permission to enter the place (direct individual or group-mediated).",
+    ),
+    (
+        "claims",
+        ["faction"],
+        ["place"],
+        False,
+        "Subject (faction) asserts a territorial claim on the place; contestation emerges from row cardinality.",
+    ),
+    (
+        "resides_at",
+        ["character"],
+        ["place"],
+        False,
+        "Subject's habitual residence. Multi-residence is supported via multiple rows.",
+    ),
+    (
+        "operates_from",
+        ["faction"],
+        ["place"],
+        False,
+        "Faction's operational base. Distinct from `claims` — claim is territorial, operates_from is functional.",
+    ),
+    (
+        "originates_from",
+        ["character"],
+        ["place"],
+        False,
+        "Character's origin or hometown.",
+    ),
+    # Character / faction relations
+    (
+        "pursuing",
+        ["character", "faction"],
+        ["character"],
+        True,
+        "Subject is actively hunting the target. Ephemeral; also confers narrow targeted detection sensitivity for that target (see issue #282).",
+    ),
+    (
+        "handles",
+        ["character"],
+        ["character"],
+        False,
+        "Subject is the operational handler of the target (covert / espionage / criminal flavor).",
+    ),
+    (
+        "obligation",
+        ["character", "faction"],
+        ["character", "faction"],
+        False,
+        "Subject owes a debt / oath / loyalty to the target. Kind inferable from establishing event.",
+    ),
+    (
+        "authority_over",
+        ["character", "faction"],
+        ["character", "faction"],
+        False,
+        "Subject holds institutional or positional power over the target.",
+    ),
+    (
+        "protects",
+        ["character", "faction"],
+        ["character"],
+        False,
+        "Subject is in an active protective relationship with the target. Durable.",
+    ),
+    (
+        "mentors",
+        ["character"],
+        ["character"],
+        False,
+        "Subject teaches or trains the target.",
+    ),
+)
+
+
+def run(conn: connection) -> None:
+    """Create the entity_pair_tags substrate and seed the 12 settled relations."""
+
+    with conn.cursor() as cur:
+        # Registry of relation types (analog of `tags` but with kind validation columns)
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS pair_tags (
+                id                   bigserial PRIMARY KEY,
+                tag                  text UNIQUE NOT NULL,
+                subject_kinds        text[] NOT NULL,
+                object_kinds         text[] NOT NULL,
+                is_ephemeral         boolean NOT NULL DEFAULT FALSE,
+                clearance_kind       entity_tag_clearance_kind,
+                reapplication_policy entity_tag_reapplication_policy,
+                clear_on             jsonb,
+                deprecated           boolean NOT NULL DEFAULT FALSE,
+                description          text,
+                created_at           timestamptz NOT NULL DEFAULT now(),
+                CHECK (is_ephemeral = (clearance_kind IS NOT NULL)),
+                CHECK (array_length(subject_kinds, 1) >= 1),
+                CHECK (array_length(object_kinds, 1) >= 1),
+                CHECK (btrim(tag) <> '')
+            )
+            """
+        )
+
+        cur.execute(
+            """
+            COMMENT ON TABLE pair_tags IS
+                'Registry of multi-entity (directed binary) relation types. The vocabulary for entity_pair_tags. Analog of `tags` for edges between entities.';
+            """
+        )
+        cur.execute(
+            "COMMENT ON COLUMN pair_tags.tag IS "
+            "'Relation name (snake_case). May embed a level via the colon convention, e.g. `status:senior`.'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN pair_tags.subject_kinds IS "
+            "'Allowed entity_kind values for the subject (source) of this relation. Polymorphism (e.g. character|faction) is expressed via array membership.'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN pair_tags.object_kinds IS "
+            "'Allowed entity_kind values for the object (target) of this relation.'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN pair_tags.is_ephemeral IS "
+            "'TRUE for relations that get cleared by world events (e.g., `pursuing`); FALSE for durable relations.'"
+        )
+
+        # Application table — actual edges between entities
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS entity_pair_tags (
+                id                    bigserial PRIMARY KEY,
+                subject_entity_id     bigint NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+                object_entity_id      bigint NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+                pair_tag_id           bigint NOT NULL REFERENCES pair_tags(id),
+                applied_at            timestamptz NOT NULL DEFAULT now(),
+                applied_at_world_time timestamptz,
+                source_kind           entity_tag_source_kind NOT NULL,
+                cleared_at            timestamptz,
+                clear_on_override     jsonb,
+                template_id           text,
+                CHECK (subject_entity_id <> object_entity_id),
+                CONSTRAINT entity_pair_tags_unique_event UNIQUE
+                    (subject_entity_id, object_entity_id, pair_tag_id, applied_at)
+            )
+            """
+        )
+
+        cur.execute(
+            """
+            COMMENT ON TABLE entity_pair_tags IS
+                'Directed binary tag (relation) edge from subject to object. The application table for multi-entity tags; analog of entity_tags.';
+            """
+        )
+        cur.execute(
+            "COMMENT ON COLUMN entity_pair_tags.subject_entity_id IS "
+            "'The source endpoint of the directed relation (FK entities).'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN entity_pair_tags.object_entity_id IS "
+            "'The target endpoint of the directed relation (FK entities). Must differ from subject_entity_id.'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN entity_pair_tags.pair_tag_id IS "
+            "'FK to pair_tags — the relation type.'"
+        )
+        cur.execute(
+            "COMMENT ON COLUMN entity_pair_tags.cleared_at IS "
+            "'When set, the relation is no longer active (analogous to entity_tags.cleared_at).'"
+        )
+
+        # Indexes
+        cur.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS ix_entity_pair_tags_current
+                ON entity_pair_tags (subject_entity_id, object_entity_id, pair_tag_id)
+                WHERE cleared_at IS NULL
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS ix_entity_pair_tags_subject_current
+                ON entity_pair_tags (subject_entity_id, pair_tag_id)
+                WHERE cleared_at IS NULL
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS ix_entity_pair_tags_object_current
+                ON entity_pair_tags (object_entity_id, pair_tag_id)
+                WHERE cleared_at IS NULL
+            """
+        )
+
+        # Seed the 12 settled multi-entity relations
+        for tag, subject_kinds, object_kinds, is_ephemeral, description in PAIR_TAG_SEED:
+            clearance_kind = "semantic" if is_ephemeral else None
+            cur.execute(
+                """
+                INSERT INTO pair_tags (
+                    tag, subject_kinds, object_kinds,
+                    is_ephemeral, clearance_kind, description
+                ) VALUES (
+                    %s, %s, %s, %s, %s::entity_tag_clearance_kind, %s
+                )
+                ON CONFLICT (tag) DO UPDATE SET
+                    subject_kinds = EXCLUDED.subject_kinds,
+                    object_kinds  = EXCLUDED.object_kinds,
+                    is_ephemeral  = EXCLUDED.is_ephemeral,
+                    clearance_kind = EXCLUDED.clearance_kind,
+                    description   = EXCLUDED.description
+                """,
+                (
+                    tag,
+                    subject_kinds,
+                    object_kinds,
+                    is_ephemeral,
+                    clearance_kind,
+                    description,
+                ),
+            )
+
+    conn.commit()

--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -257,3 +257,140 @@ def _row_value(row: Any, key: str, index: int) -> Any:
     if hasattr(row, "get"):
         return row[key]
     return row[index]
+
+
+# ---------------------------------------------------------------------------
+# Multi-entity (pair) tag writer
+# ---------------------------------------------------------------------------
+#
+# `entity_pair_tags` is the application table for directed binary relations
+# between entities; `pair_tags` is the corresponding vocabulary registry (see
+# migration 042). This section adds writer helpers analogous to the single-
+# entity tag writer above: `apply_pair_tag_bestowal` for inserts (idempotent
+# against the unique partial index on active rows) and `clear_pair_tag` for
+# retiring an ephemeral relation.
+#
+# Predicates (`has_pair_tag`, inbound/outbound subject lookups) and the
+# binding-composer extension live in a separate module to keep the writer
+# focused on writes.
+
+
+def apply_pair_tag_bestowal(
+    cur: Any,
+    *,
+    subject_entity_id: int,
+    object_entity_id: int,
+    subject_kind: str,
+    object_kind: str,
+    tag: str,
+    source_kind: str = "skald_inline",
+    world_time: Optional[datetime] = None,
+) -> bool:
+    """Apply a directed multi-entity tag (relation) from subject to object.
+
+    Looks up the pair_tag by name, validates that ``subject_kind`` /
+    ``object_kind`` are members of the relation's allowed-kinds arrays, and
+    inserts a row into ``entity_pair_tags``. Idempotent via ``ON CONFLICT``
+    against ``ix_entity_pair_tags_current`` (the unique partial index covering
+    active rows).
+
+    Caller owns the transaction; no commits here.
+
+    Returns ``True`` if a new active row was inserted, ``False`` if an active
+    row for ``(subject, object, pair_tag)`` already existed (silently
+    suppressed).
+
+    Raises ``ValueError`` for:
+    - subject_entity_id == object_entity_id (self-loop)
+    - unknown / deprecated ``tag``
+    - ``subject_kind`` not in the tag's allowed subject_kinds
+    - ``object_kind`` not in the tag's allowed object_kinds
+    """
+
+    if subject_entity_id == object_entity_id:
+        raise ValueError(
+            f"pair_tag {tag!r} requires distinct subject and object; "
+            f"got subject_entity_id == object_entity_id == {subject_entity_id}"
+        )
+
+    cur.execute(
+        """
+        SELECT id, subject_kinds, object_kinds
+        FROM pair_tags
+        WHERE tag = %s AND NOT deprecated
+        """,
+        (tag,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"Unknown or deprecated pair_tag {tag!r}")
+
+    pair_tag_id = _row_value(row, "id", 0)
+    subject_kinds = _row_value(row, "subject_kinds", 1)
+    object_kinds = _row_value(row, "object_kinds", 2)
+
+    if subject_kind not in subject_kinds:
+        raise ValueError(
+            f"pair_tag {tag!r} does not allow subject_kind={subject_kind!r}; "
+            f"allowed: {sorted(subject_kinds)}"
+        )
+    if object_kind not in object_kinds:
+        raise ValueError(
+            f"pair_tag {tag!r} does not allow object_kind={object_kind!r}; "
+            f"allowed: {sorted(object_kinds)}"
+        )
+
+    if world_time is None:
+        cur.execute("SELECT max(world_time) AS world_time FROM chunk_metadata")
+        chunk_row = cur.fetchone()
+        if chunk_row is not None:
+            world_time = _row_value(chunk_row, "world_time", 0)
+
+    cur.execute(
+        """
+        INSERT INTO entity_pair_tags (
+            subject_entity_id, object_entity_id, pair_tag_id,
+            applied_at_world_time, source_kind
+        )
+        VALUES (%s, %s, %s, %s, %s::entity_tag_source_kind)
+        ON CONFLICT (subject_entity_id, object_entity_id, pair_tag_id)
+          WHERE cleared_at IS NULL
+          DO NOTHING
+        """,
+        (subject_entity_id, object_entity_id, pair_tag_id, world_time, source_kind),
+    )
+    return bool(cur.rowcount)
+
+
+def clear_pair_tag(
+    cur: Any,
+    *,
+    subject_entity_id: int,
+    object_entity_id: int,
+    tag: str,
+) -> bool:
+    """Mark an active multi-entity tag as cleared (UPDATE cleared_at = now()).
+
+    Used to retire ephemeral relations when their establishing context no
+    longer holds (e.g., a `pursuing` relation when the pursuers give up).
+    Durable relations can also be cleared if narrative or substrate updates
+    require it.
+
+    Returns ``True`` if a row was cleared, ``False`` if no active row existed
+    for ``(subject, object, pair_tag)``.
+    """
+
+    cur.execute(
+        """
+        UPDATE entity_pair_tags ept
+        SET cleared_at = now()
+        FROM pair_tags pt
+        WHERE ept.pair_tag_id = pt.id
+          AND pt.tag = %s
+          AND ept.subject_entity_id = %s
+          AND ept.object_entity_id = %s
+          AND ept.cleared_at IS NULL
+        """,
+        (tag, subject_entity_id, object_entity_id),
+    )
+    return bool(cur.rowcount)

--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -305,6 +305,13 @@ def apply_pair_tag_bestowal(
     - unknown / deprecated ``tag``
     - ``subject_kind`` not in the tag's allowed subject_kinds
     - ``object_kind`` not in the tag's allowed object_kinds
+
+    Note: ``subject_kind`` / ``object_kind`` are validated against the
+    pair_tag's allowed-kinds arrays only — they are NOT cross-checked against
+    the actual ``entities.kind`` values of the supplied entity IDs. Callers
+    must ensure ``subject_kind`` and ``object_kind`` correctly describe the
+    underlying entities; passing mismatched kind labels is undefined behavior
+    that this function will silently accept.
     """
 
     if subject_entity_id == object_entity_id:
@@ -378,6 +385,13 @@ def clear_pair_tag(
 
     Returns ``True`` if a row was cleared, ``False`` if no active row existed
     for ``(subject, object, pair_tag)``.
+
+    Note: unknown or deprecated ``tag`` names silently return ``False``
+    rather than raising — this is the inverse of ``apply_pair_tag_bestowal``,
+    which raises ``ValueError`` for unknown tags. The asymmetry is deliberate:
+    clearing a relation that doesn't exist is a no-op, so an unknown tag is
+    indistinguishable from a missing row. Callers should not interpret
+    ``False`` as "previously cleared" versus "tag doesn't exist."
     """
 
     cur.execute(

--- a/tests/test_orrery/test_pair_tag_writer.py
+++ b/tests/test_orrery/test_pair_tag_writer.py
@@ -1,0 +1,343 @@
+"""Real-DB integration tests for the entity_pair_tags writer.
+
+Exercises ``apply_pair_tag_bestowal`` and ``clear_pair_tag`` against a live
+slot database (``save_05`` by default). Verifies that the migration-042
+substrate works end-to-end: insert, idempotent re-insert, kind validation,
+self-loop rejection, clear-then-reinsert cycle.
+
+These tests are guarded by the ``requires_postgres`` marker; activate with
+``NEXUS_RUN_POSTGRES=1`` to run them. Cleanup runs in the fixture both
+pre- and post-yield so a failed run never leaves pair tags behind in the
+slot.
+"""
+
+from __future__ import annotations
+
+from typing import Generator
+
+import psycopg2
+import pytest
+
+from nexus.agents.orrery.tag_writer import (
+    apply_pair_tag_bestowal,
+    clear_pair_tag,
+)
+
+
+pytestmark = pytest.mark.requires_postgres
+
+
+TEST_DBNAME = "save_05"
+
+
+# Two pre-existing character entity IDs in save_05. If save_05 is rebuilt and
+# these IDs change, the fixture's pre-yield cleanup still works (it scopes by
+# subject/object pair) — but the tests will fail FK validation. In that case,
+# look up two character entities via ``SELECT id FROM entities WHERE kind =
+# 'character' LIMIT 2``.
+TEST_SUBJECT_ENTITY_ID = 1
+TEST_OBJECT_ENTITY_ID = 3
+
+
+@pytest.fixture
+def slot_connection() -> Generator[psycopg2.extensions.connection, None, None]:
+    """Yield a save_05 connection; clean any test pair tags before and after."""
+
+    conn = psycopg2.connect(
+        dbname=TEST_DBNAME,
+        user="pythagor",
+        host="localhost",
+        port=5432,
+    )
+    try:
+        _purge_test_rows(conn)
+        yield conn
+    finally:
+        _purge_test_rows(conn)
+        conn.close()
+
+
+def _purge_test_rows(conn: psycopg2.extensions.connection) -> None:
+    """Delete any entity_pair_tags rows between the two test entity IDs (both directions)."""
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                DELETE FROM entity_pair_tags
+                WHERE (subject_entity_id = %s AND object_entity_id = %s)
+                   OR (subject_entity_id = %s AND object_entity_id = %s)
+                """,
+                (
+                    TEST_SUBJECT_ENTITY_ID,
+                    TEST_OBJECT_ENTITY_ID,
+                    TEST_OBJECT_ENTITY_ID,
+                    TEST_SUBJECT_ENTITY_ID,
+                ),
+            )
+
+
+def _count_active_pair_tags(
+    conn: psycopg2.extensions.connection,
+    *,
+    subject_id: int,
+    object_id: int,
+    tag: str,
+) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT count(*)
+            FROM entity_pair_tags ept
+            JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+            WHERE ept.subject_entity_id = %s
+              AND ept.object_entity_id = %s
+              AND pt.tag = %s
+              AND ept.cleared_at IS NULL
+            """,
+            (subject_id, object_id, tag),
+        )
+        return cur.fetchone()[0]
+
+
+def test_insert_durable_pair_tag(
+    slot_connection: psycopg2.extensions.connection,
+) -> None:
+    """A fresh insert succeeds and creates exactly one active row."""
+
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            inserted = apply_pair_tag_bestowal(
+                cur,
+                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
+                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                subject_kind="character",
+                object_kind="character",
+                tag="mentors",
+            )
+            assert inserted is True
+
+    assert (
+        _count_active_pair_tags(
+            slot_connection,
+            subject_id=TEST_SUBJECT_ENTITY_ID,
+            object_id=TEST_OBJECT_ENTITY_ID,
+            tag="mentors",
+        )
+        == 1
+    )
+
+
+def test_insert_is_idempotent(
+    slot_connection: psycopg2.extensions.connection,
+) -> None:
+    """Inserting the same (subject, object, tag) twice yields exactly one active row."""
+
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            first = apply_pair_tag_bestowal(
+                cur,
+                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
+                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                subject_kind="character",
+                object_kind="character",
+                tag="mentors",
+            )
+            second = apply_pair_tag_bestowal(
+                cur,
+                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
+                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                subject_kind="character",
+                object_kind="character",
+                tag="mentors",
+            )
+            assert first is True
+            assert second is False  # Duplicate suppressed by unique partial index
+
+    assert (
+        _count_active_pair_tags(
+            slot_connection,
+            subject_id=TEST_SUBJECT_ENTITY_ID,
+            object_id=TEST_OBJECT_ENTITY_ID,
+            tag="mentors",
+        )
+        == 1
+    )
+
+
+def test_insert_rejects_self_loop(
+    slot_connection: psycopg2.extensions.connection,
+) -> None:
+    """A pair tag from an entity to itself is rejected before SQL is issued."""
+
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            with pytest.raises(ValueError, match="distinct subject and object"):
+                apply_pair_tag_bestowal(
+                    cur,
+                    subject_entity_id=TEST_SUBJECT_ENTITY_ID,
+                    object_entity_id=TEST_SUBJECT_ENTITY_ID,
+                    subject_kind="character",
+                    object_kind="character",
+                    tag="mentors",
+                )
+
+
+def test_insert_rejects_unknown_tag(
+    slot_connection: psycopg2.extensions.connection,
+) -> None:
+    """An unknown pair_tag raises ValueError without issuing an INSERT."""
+
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            with pytest.raises(ValueError, match="Unknown or deprecated pair_tag"):
+                apply_pair_tag_bestowal(
+                    cur,
+                    subject_entity_id=TEST_SUBJECT_ENTITY_ID,
+                    object_entity_id=TEST_OBJECT_ENTITY_ID,
+                    subject_kind="character",
+                    object_kind="character",
+                    tag="this_tag_does_not_exist",
+                )
+
+
+def test_insert_rejects_invalid_subject_kind(
+    slot_connection: psycopg2.extensions.connection,
+) -> None:
+    """A subject_kind not in the tag's allowed list raises ValueError."""
+
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            # `mentors` requires both subject and object to be `character`
+            with pytest.raises(ValueError, match="does not allow subject_kind"):
+                apply_pair_tag_bestowal(
+                    cur,
+                    subject_entity_id=TEST_SUBJECT_ENTITY_ID,
+                    object_entity_id=TEST_OBJECT_ENTITY_ID,
+                    subject_kind="faction",  # not allowed for mentors
+                    object_kind="character",
+                    tag="mentors",
+                )
+
+
+def test_insert_rejects_invalid_object_kind(
+    slot_connection: psycopg2.extensions.connection,
+) -> None:
+    """An object_kind not in the tag's allowed list raises ValueError."""
+
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            # `mentors` requires both subject and object to be `character`
+            with pytest.raises(ValueError, match="does not allow object_kind"):
+                apply_pair_tag_bestowal(
+                    cur,
+                    subject_entity_id=TEST_SUBJECT_ENTITY_ID,
+                    object_entity_id=TEST_OBJECT_ENTITY_ID,
+                    subject_kind="character",
+                    object_kind="place",  # not allowed for mentors
+                    tag="mentors",
+                )
+
+
+def test_clear_then_reinsert_cycle(
+    slot_connection: psycopg2.extensions.connection,
+) -> None:
+    """Clearing an active row allows a fresh insert (active count goes 1 → 0 → 1)."""
+
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            apply_pair_tag_bestowal(
+                cur,
+                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
+                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                subject_kind="character",
+                object_kind="character",
+                tag="mentors",
+            )
+            assert (
+                _count_active_pair_tags(
+                    slot_connection,
+                    subject_id=TEST_SUBJECT_ENTITY_ID,
+                    object_id=TEST_OBJECT_ENTITY_ID,
+                    tag="mentors",
+                )
+                == 1
+            )
+
+            cleared = clear_pair_tag(
+                cur,
+                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
+                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                tag="mentors",
+            )
+            assert cleared is True
+
+    assert (
+        _count_active_pair_tags(
+            slot_connection,
+            subject_id=TEST_SUBJECT_ENTITY_ID,
+            object_id=TEST_OBJECT_ENTITY_ID,
+            tag="mentors",
+        )
+        == 0
+    )
+
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            reinserted = apply_pair_tag_bestowal(
+                cur,
+                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
+                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                subject_kind="character",
+                object_kind="character",
+                tag="mentors",
+            )
+            assert reinserted is True
+
+    assert (
+        _count_active_pair_tags(
+            slot_connection,
+            subject_id=TEST_SUBJECT_ENTITY_ID,
+            object_id=TEST_OBJECT_ENTITY_ID,
+            tag="mentors",
+        )
+        == 1
+    )
+
+
+def test_clear_returns_false_when_no_active_row(
+    slot_connection: psycopg2.extensions.connection,
+) -> None:
+    """Clearing a relation that isn't active returns False without raising."""
+
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            cleared = clear_pair_tag(
+                cur,
+                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
+                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                tag="mentors",
+            )
+            assert cleared is False
+
+
+def test_polymorphic_subject_kind_accepted(
+    slot_connection: psycopg2.extensions.connection,
+) -> None:
+    """A pair_tag with multiple allowed subject_kinds accepts each of them."""
+
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            # `obligation` allows both character and faction as subject; verify
+            # the character path goes through (we use TEST_OBJECT for the faction
+            # slot conceptually, but it's a character — kind validation is
+            # type-only and doesn't check entity_id↔kind consistency at this
+            # layer; that's the caller's responsibility).
+            inserted = apply_pair_tag_bestowal(
+                cur,
+                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
+                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                subject_kind="character",
+                object_kind="character",
+                tag="obligation",
+            )
+            assert inserted is True

--- a/tests/test_orrery/test_pair_tag_writer.py
+++ b/tests/test_orrery/test_pair_tag_writer.py
@@ -3,17 +3,27 @@
 Exercises ``apply_pair_tag_bestowal`` and ``clear_pair_tag`` against a live
 slot database (``save_05`` by default). Verifies that the migration-042
 substrate works end-to-end: insert, idempotent re-insert, kind validation,
-self-loop rejection, clear-then-reinsert cycle.
+self-loop rejection, clear-then-reinsert cycle, polymorphic acceptance.
 
 These tests are guarded by the ``requires_postgres`` marker; activate with
-``NEXUS_RUN_POSTGRES=1`` to run them. Cleanup runs in the fixture both
-pre- and post-yield so a failed run never leaves pair tags behind in the
-slot.
+``NEXUS_RUN_POSTGRES=1`` to run them.
+
+**Cleanup scoping (data-safety guarantee):** the fixture snapshots the IDs of
+all ``entity_pair_tags`` rows that already exist for the chosen test entity
+pair before the test runs, then on teardown deletes only rows whose IDs are
+NOT in that snapshot. This preserves any legitimate pre-existing relations
+between the chosen entities — the fixture only removes rows that the test
+itself created.
+
+**Entity selection:** the fixture queries ``entities`` at setup time for
+character/faction IDs rather than hardcoding sentinel values. If insufficient
+characters exist (e.g., a freshly reset save_05), the test is skipped rather
+than failing on FK violations.
 """
 
 from __future__ import annotations
 
-from typing import Generator
+from typing import Generator, Optional
 
 import psycopg2
 import pytest
@@ -22,6 +32,7 @@ from nexus.agents.orrery.tag_writer import (
     apply_pair_tag_bestowal,
     clear_pair_tag,
 )
+from nexus.api.slot_utils import get_slot_db_url
 
 
 pytestmark = pytest.mark.requires_postgres
@@ -30,50 +41,97 @@ pytestmark = pytest.mark.requires_postgres
 TEST_DBNAME = "save_05"
 
 
-# Two pre-existing character entity IDs in save_05. If save_05 is rebuilt and
-# these IDs change, the fixture's pre-yield cleanup still works (it scopes by
-# subject/object pair) — but the tests will fail FK validation. In that case,
-# look up two character entities via ``SELECT id FROM entities WHERE kind =
-# 'character' LIMIT 2``.
-TEST_SUBJECT_ENTITY_ID = 1
-TEST_OBJECT_ENTITY_ID = 3
+class _TestEntities:
+    """Container for resolved test entity IDs and the row-ID snapshots used for
+    surgical cleanup."""
+
+    def __init__(
+        self,
+        *,
+        char_a: int,
+        char_b: int,
+        faction: Optional[int],
+        preexisting_ids: set[int],
+    ):
+        self.char_a = char_a
+        self.char_b = char_b
+        self.faction = faction
+        self.preexisting_ids = preexisting_ids
 
 
 @pytest.fixture
 def slot_connection() -> Generator[psycopg2.extensions.connection, None, None]:
-    """Yield a save_05 connection; clean any test pair tags before and after."""
+    """Yield a save_05 connection (no entity setup; resolved by `test_entities`)."""
 
-    conn = psycopg2.connect(
-        dbname=TEST_DBNAME,
-        user="pythagor",
-        host="localhost",
-        port=5432,
-    )
+    conn = psycopg2.connect(get_slot_db_url(dbname=TEST_DBNAME))
     try:
-        _purge_test_rows(conn)
         yield conn
     finally:
-        _purge_test_rows(conn)
         conn.close()
 
 
-def _purge_test_rows(conn: psycopg2.extensions.connection) -> None:
-    """Delete any entity_pair_tags rows between the two test entity IDs (both directions)."""
-    with conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                DELETE FROM entity_pair_tags
-                WHERE (subject_entity_id = %s AND object_entity_id = %s)
-                   OR (subject_entity_id = %s AND object_entity_id = %s)
-                """,
-                (
-                    TEST_SUBJECT_ENTITY_ID,
-                    TEST_OBJECT_ENTITY_ID,
-                    TEST_OBJECT_ENTITY_ID,
-                    TEST_SUBJECT_ENTITY_ID,
-                ),
+@pytest.fixture
+def test_entities(
+    slot_connection: psycopg2.extensions.connection,
+) -> Generator[_TestEntities, None, None]:
+    """Resolve two character entity IDs (and optionally a faction) for the test
+    suite, snapshot any pre-existing pair_tags rows between them, yield, then
+    on teardown remove only rows the test created."""
+
+    with slot_connection.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM entities WHERE kind = 'character' ORDER BY id LIMIT 2"
+        )
+        char_rows = cur.fetchall()
+        if len(char_rows) < 2:
+            pytest.skip(
+                f"{TEST_DBNAME} has fewer than 2 character entities; "
+                "cannot exercise pair-tag writer."
             )
+        char_a, char_b = char_rows[0][0], char_rows[1][0]
+
+        cur.execute("SELECT id FROM entities WHERE kind = 'faction' ORDER BY id LIMIT 1")
+        faction_row = cur.fetchone()
+        faction = faction_row[0] if faction_row else None
+
+        # Snapshot pre-existing row IDs between the chosen entities so cleanup
+        # can be surgical (delete only test-created rows).
+        ids_in_scope = [char_a, char_b]
+        if faction is not None:
+            ids_in_scope.append(faction)
+        cur.execute(
+            """
+            SELECT id FROM entity_pair_tags
+            WHERE subject_entity_id = ANY(%s) AND object_entity_id = ANY(%s)
+            """,
+            (ids_in_scope, ids_in_scope),
+        )
+        preexisting_ids = {row[0] for row in cur.fetchall()}
+
+    entities = _TestEntities(
+        char_a=char_a,
+        char_b=char_b,
+        faction=faction,
+        preexisting_ids=preexisting_ids,
+    )
+
+    try:
+        yield entities
+    finally:
+        with slot_connection:
+            with slot_connection.cursor() as cur:
+                ids_in_scope = [char_a, char_b]
+                if faction is not None:
+                    ids_in_scope.append(faction)
+                cur.execute(
+                    """
+                    DELETE FROM entity_pair_tags
+                    WHERE subject_entity_id = ANY(%s)
+                      AND object_entity_id = ANY(%s)
+                      AND NOT (id = ANY(%s))
+                    """,
+                    (ids_in_scope, ids_in_scope, list(entities.preexisting_ids)),
+                )
 
 
 def _count_active_pair_tags(
@@ -101,6 +159,7 @@ def _count_active_pair_tags(
 
 def test_insert_durable_pair_tag(
     slot_connection: psycopg2.extensions.connection,
+    test_entities: _TestEntities,
 ) -> None:
     """A fresh insert succeeds and creates exactly one active row."""
 
@@ -108,8 +167,8 @@ def test_insert_durable_pair_tag(
         with slot_connection.cursor() as cur:
             inserted = apply_pair_tag_bestowal(
                 cur,
-                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
-                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                subject_entity_id=test_entities.char_a,
+                object_entity_id=test_entities.char_b,
                 subject_kind="character",
                 object_kind="character",
                 tag="mentors",
@@ -119,8 +178,8 @@ def test_insert_durable_pair_tag(
     assert (
         _count_active_pair_tags(
             slot_connection,
-            subject_id=TEST_SUBJECT_ENTITY_ID,
-            object_id=TEST_OBJECT_ENTITY_ID,
+            subject_id=test_entities.char_a,
+            object_id=test_entities.char_b,
             tag="mentors",
         )
         == 1
@@ -129,6 +188,7 @@ def test_insert_durable_pair_tag(
 
 def test_insert_is_idempotent(
     slot_connection: psycopg2.extensions.connection,
+    test_entities: _TestEntities,
 ) -> None:
     """Inserting the same (subject, object, tag) twice yields exactly one active row."""
 
@@ -136,16 +196,16 @@ def test_insert_is_idempotent(
         with slot_connection.cursor() as cur:
             first = apply_pair_tag_bestowal(
                 cur,
-                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
-                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                subject_entity_id=test_entities.char_a,
+                object_entity_id=test_entities.char_b,
                 subject_kind="character",
                 object_kind="character",
                 tag="mentors",
             )
             second = apply_pair_tag_bestowal(
                 cur,
-                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
-                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                subject_entity_id=test_entities.char_a,
+                object_entity_id=test_entities.char_b,
                 subject_kind="character",
                 object_kind="character",
                 tag="mentors",
@@ -156,8 +216,8 @@ def test_insert_is_idempotent(
     assert (
         _count_active_pair_tags(
             slot_connection,
-            subject_id=TEST_SUBJECT_ENTITY_ID,
-            object_id=TEST_OBJECT_ENTITY_ID,
+            subject_id=test_entities.char_a,
+            object_id=test_entities.char_b,
             tag="mentors",
         )
         == 1
@@ -166,6 +226,7 @@ def test_insert_is_idempotent(
 
 def test_insert_rejects_self_loop(
     slot_connection: psycopg2.extensions.connection,
+    test_entities: _TestEntities,
 ) -> None:
     """A pair tag from an entity to itself is rejected before SQL is issued."""
 
@@ -174,8 +235,8 @@ def test_insert_rejects_self_loop(
             with pytest.raises(ValueError, match="distinct subject and object"):
                 apply_pair_tag_bestowal(
                     cur,
-                    subject_entity_id=TEST_SUBJECT_ENTITY_ID,
-                    object_entity_id=TEST_SUBJECT_ENTITY_ID,
+                    subject_entity_id=test_entities.char_a,
+                    object_entity_id=test_entities.char_a,
                     subject_kind="character",
                     object_kind="character",
                     tag="mentors",
@@ -184,6 +245,7 @@ def test_insert_rejects_self_loop(
 
 def test_insert_rejects_unknown_tag(
     slot_connection: psycopg2.extensions.connection,
+    test_entities: _TestEntities,
 ) -> None:
     """An unknown pair_tag raises ValueError without issuing an INSERT."""
 
@@ -192,8 +254,8 @@ def test_insert_rejects_unknown_tag(
             with pytest.raises(ValueError, match="Unknown or deprecated pair_tag"):
                 apply_pair_tag_bestowal(
                     cur,
-                    subject_entity_id=TEST_SUBJECT_ENTITY_ID,
-                    object_entity_id=TEST_OBJECT_ENTITY_ID,
+                    subject_entity_id=test_entities.char_a,
+                    object_entity_id=test_entities.char_b,
                     subject_kind="character",
                     object_kind="character",
                     tag="this_tag_does_not_exist",
@@ -202,6 +264,7 @@ def test_insert_rejects_unknown_tag(
 
 def test_insert_rejects_invalid_subject_kind(
     slot_connection: psycopg2.extensions.connection,
+    test_entities: _TestEntities,
 ) -> None:
     """A subject_kind not in the tag's allowed list raises ValueError."""
 
@@ -211,8 +274,8 @@ def test_insert_rejects_invalid_subject_kind(
             with pytest.raises(ValueError, match="does not allow subject_kind"):
                 apply_pair_tag_bestowal(
                     cur,
-                    subject_entity_id=TEST_SUBJECT_ENTITY_ID,
-                    object_entity_id=TEST_OBJECT_ENTITY_ID,
+                    subject_entity_id=test_entities.char_a,
+                    object_entity_id=test_entities.char_b,
                     subject_kind="faction",  # not allowed for mentors
                     object_kind="character",
                     tag="mentors",
@@ -221,6 +284,7 @@ def test_insert_rejects_invalid_subject_kind(
 
 def test_insert_rejects_invalid_object_kind(
     slot_connection: psycopg2.extensions.connection,
+    test_entities: _TestEntities,
 ) -> None:
     """An object_kind not in the tag's allowed list raises ValueError."""
 
@@ -230,8 +294,8 @@ def test_insert_rejects_invalid_object_kind(
             with pytest.raises(ValueError, match="does not allow object_kind"):
                 apply_pair_tag_bestowal(
                     cur,
-                    subject_entity_id=TEST_SUBJECT_ENTITY_ID,
-                    object_entity_id=TEST_OBJECT_ENTITY_ID,
+                    subject_entity_id=test_entities.char_a,
+                    object_entity_id=test_entities.char_b,
                     subject_kind="character",
                     object_kind="place",  # not allowed for mentors
                     tag="mentors",
@@ -240,6 +304,7 @@ def test_insert_rejects_invalid_object_kind(
 
 def test_clear_then_reinsert_cycle(
     slot_connection: psycopg2.extensions.connection,
+    test_entities: _TestEntities,
 ) -> None:
     """Clearing an active row allows a fresh insert (active count goes 1 → 0 → 1)."""
 
@@ -247,8 +312,8 @@ def test_clear_then_reinsert_cycle(
         with slot_connection.cursor() as cur:
             apply_pair_tag_bestowal(
                 cur,
-                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
-                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                subject_entity_id=test_entities.char_a,
+                object_entity_id=test_entities.char_b,
                 subject_kind="character",
                 object_kind="character",
                 tag="mentors",
@@ -256,8 +321,8 @@ def test_clear_then_reinsert_cycle(
             assert (
                 _count_active_pair_tags(
                     slot_connection,
-                    subject_id=TEST_SUBJECT_ENTITY_ID,
-                    object_id=TEST_OBJECT_ENTITY_ID,
+                    subject_id=test_entities.char_a,
+                    object_id=test_entities.char_b,
                     tag="mentors",
                 )
                 == 1
@@ -265,8 +330,8 @@ def test_clear_then_reinsert_cycle(
 
             cleared = clear_pair_tag(
                 cur,
-                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
-                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                subject_entity_id=test_entities.char_a,
+                object_entity_id=test_entities.char_b,
                 tag="mentors",
             )
             assert cleared is True
@@ -274,8 +339,8 @@ def test_clear_then_reinsert_cycle(
     assert (
         _count_active_pair_tags(
             slot_connection,
-            subject_id=TEST_SUBJECT_ENTITY_ID,
-            object_id=TEST_OBJECT_ENTITY_ID,
+            subject_id=test_entities.char_a,
+            object_id=test_entities.char_b,
             tag="mentors",
         )
         == 0
@@ -285,8 +350,8 @@ def test_clear_then_reinsert_cycle(
         with slot_connection.cursor() as cur:
             reinserted = apply_pair_tag_bestowal(
                 cur,
-                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
-                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                subject_entity_id=test_entities.char_a,
+                object_entity_id=test_entities.char_b,
                 subject_kind="character",
                 object_kind="character",
                 tag="mentors",
@@ -296,8 +361,8 @@ def test_clear_then_reinsert_cycle(
     assert (
         _count_active_pair_tags(
             slot_connection,
-            subject_id=TEST_SUBJECT_ENTITY_ID,
-            object_id=TEST_OBJECT_ENTITY_ID,
+            subject_id=test_entities.char_a,
+            object_id=test_entities.char_b,
             tag="mentors",
         )
         == 1
@@ -306,6 +371,7 @@ def test_clear_then_reinsert_cycle(
 
 def test_clear_returns_false_when_no_active_row(
     slot_connection: psycopg2.extensions.connection,
+    test_entities: _TestEntities,
 ) -> None:
     """Clearing a relation that isn't active returns False without raising."""
 
@@ -313,31 +379,54 @@ def test_clear_returns_false_when_no_active_row(
         with slot_connection.cursor() as cur:
             cleared = clear_pair_tag(
                 cur,
-                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
-                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                subject_entity_id=test_entities.char_a,
+                object_entity_id=test_entities.char_b,
                 tag="mentors",
             )
             assert cleared is False
 
 
-def test_polymorphic_subject_kind_accepted(
+def test_polymorphic_subject_kind_character_path(
     slot_connection: psycopg2.extensions.connection,
+    test_entities: _TestEntities,
 ) -> None:
-    """A pair_tag with multiple allowed subject_kinds accepts each of them."""
+    """A pair_tag with polymorphic subject_kinds accepts the character path."""
 
     with slot_connection:
         with slot_connection.cursor() as cur:
-            # `obligation` allows both character and faction as subject; verify
-            # the character path goes through (we use TEST_OBJECT for the faction
-            # slot conceptually, but it's a character — kind validation is
-            # type-only and doesn't check entity_id↔kind consistency at this
-            # layer; that's the caller's responsibility).
             inserted = apply_pair_tag_bestowal(
                 cur,
-                subject_entity_id=TEST_SUBJECT_ENTITY_ID,
-                object_entity_id=TEST_OBJECT_ENTITY_ID,
+                subject_entity_id=test_entities.char_a,
+                object_entity_id=test_entities.char_b,
                 subject_kind="character",
                 object_kind="character",
+                tag="obligation",
+            )
+            assert inserted is True
+
+
+def test_polymorphic_object_kind_faction_path(
+    slot_connection: psycopg2.extensions.connection,
+    test_entities: _TestEntities,
+) -> None:
+    """A pair_tag with polymorphic object_kinds accepts the faction path.
+
+    ``obligation`` allows ``character|faction`` on both ends — this case
+    exercises the faction object path that the character-only test above does
+    not. Skipped if save_05 has no faction entities.
+    """
+
+    if test_entities.faction is None:
+        pytest.skip(f"{TEST_DBNAME} has no faction entities; skipping faction polymorphism case.")
+
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            inserted = apply_pair_tag_bestowal(
+                cur,
+                subject_entity_id=test_entities.char_a,
+                object_entity_id=test_entities.faction,
+                subject_kind="character",
+                object_kind="faction",
                 tag="obligation",
             )
             assert inserted is True


### PR DESCRIPTION
## Summary

Introduces the foundational substrate for multi-entity (relational) Orrery tags. The in-progress role taxonomy refactor depends on this layer for scope-bound status (`status:<level>(char → faction)`), the fame-PRNG runtime semantics, and package self-awareness (issue #282).

This PR ships the **substrate-only** layer: schema + writer + tests. Predicate functions (`has_pair_tag`, `inbound_pair_tag_subjects`, `outbound_pair_tag_objects`) and the binding-composer extension are the natural follow-up PR for clarity of review.

## What landed

**Migration `042_orrery_entity_pair_tags.py`:**

- `pair_tags` — registry table for relation types. Analog of `tags` but with `subject_kinds` / `object_kinds` arrays expressing polymorphism (e.g., `obligation` allows `character|faction` on both ends). Uses existing `entity_tag_clearance_kind` / `entity_tag_reapplication_policy` enums.
- `entity_pair_tags` — application table. Subject + object FK `entities(id)` with `ON DELETE CASCADE`. Unique partial index `ix_entity_pair_tags_current` on `(subject, object, pair_tag_id) WHERE cleared_at IS NULL` enforces one active edge per directed triple. Inbound/outbound helper indexes for predicate lookups. CHECK rejects self-loops at the schema level.
- Seeds 12 multi-entity relations settled in `temp/orrery/orrery_vocabulary.md`: `knows_location`, `can_access`, `claims`, `resides_at`, `operates_from`, `originates_from`, `pursuing`, `handles`, `obligation`, `authority_over`, `protects`, `mentors`. `pursuing` is ephemeral; rest are durable.

**Writer additions in `nexus/agents/orrery/tag_writer.py`:**

- `apply_pair_tag_bestowal(cur, *, subject_entity_id, object_entity_id, subject_kind, object_kind, tag, source_kind, world_time)` — idempotent insert via `ON CONFLICT DO NOTHING` against the unique partial index. Validates kinds against the registry's `subject_kinds`/`object_kinds` arrays. Raises `ValueError` for self-loops, unknown/deprecated tags, and kind-mismatch violations. Returns whether a new active row was inserted.
- `clear_pair_tag(cur, *, subject_entity_id, object_entity_id, tag)` — sets `cleared_at = now()` for the active row, if one exists. Returns whether a clear happened.
- Caller owns the transaction (consistent with existing `apply_tag_bestowal` convention).

**Tests (`tests/test_orrery/test_pair_tag_writer.py`):**

Nine real-DB integration tests against `save_05`, guarded by `requires_postgres` marker. Coverage:

- Durable insert produces exactly one active row
- Idempotent re-insert (second returns `False`; row count stays 1)
- Self-loop rejection (`ValueError` before SQL issued)
- Unknown-tag rejection
- Invalid subject_kind / object_kind rejection
- Clear-then-reinsert cycle: 1 → 0 → 1
- No-op clear when no active row exists
- Polymorphic subject_kind acceptance

Fixture purges test pair tags both pre- and post-yield so a failed test never leaves residue in the slot.

## Test results

```
NEXUS_RUN_POSTGRES=1 poetry run pytest tests/test_orrery/test_pair_tag_writer.py -v
======================== 9 passed in 0.47s ========================

poetry run pytest tests/test_orrery/test_tag_writer.py -v
======================== 13 passed in 0.12s =======================  (no regression in existing single-entity writer tests)
```

## Schema deployment

Migration applied to `save_05` (dev slot) for verification. Template database and other slots will receive the migration via the standard `scripts/migrate.py --all` (or `--template`) post-merge workflow.

## What's NOT in this PR

Tracked for follow-up:

- **Predicates** (`has_pair_tag`, `inbound_pair_tag_subjects`, `outbound_pair_tag_objects`) — natural next PR, will live in a new `pair_tag_predicates.py` module
- **Binding composer extension** (`compose_actor_destination_bindings` consuming multi-entity tags) — pairs with predicates
- **Vocabulary refactor doc** (role section rewrite + multi-entity tag list extension + Reference Taggings refactor in `temp/orrery/orrery_vocabulary.md`)
- **Trait → tag compiler** (`nexus/api/new_story_db_mapper.py::finalize_narrative_bootstrap()` extension)
- **`trait_menu.md` update** (broaden Status, rename Reputation→Fame)

All sequenced per the plan at `~/.claude/plans/luminous-sparking-rossum.md`.

## Test plan

- [ ] Visual review of migration 042 (table shape, indexes, seed data, CHECK constraints)
- [ ] Visual review of `apply_pair_tag_bestowal` / `clear_pair_tag` (kind validation, ON CONFLICT clause, raises)
- [ ] Run integration tests with `NEXUS_RUN_POSTGRES=1 poetry run pytest tests/test_orrery/test_pair_tag_writer.py`
- [ ] Confirm no regression in existing `tests/test_orrery/test_tag_writer.py` (still 13 passing)
- [ ] Sanity-check that `\d+ pair_tags` / `\d+ entity_pair_tags` in `save_05` shows the expected shape and column comments
- [ ] Apply migration to template + other unlocked slots post-merge via `python scripts/migrate.py --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)