### PR TITLE
[codex] Add pair-tag WorldState hydration

### DIFF
--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -86,6 +86,28 @@ _register(
     ),
 )
 _register(
+    r"has_pair_tag\((?P<tag>[^@()]+)@(?P<subj>\w+)->(?P<obj>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('subj'))} has `{m.group('tag')}` pair tag "
+        f"to {_slot(m.group('obj'))}"
+    ),
+)
+_register(
+    r"lacks_pair_tag\((?P<tag>[^@()]+)@(?P<subj>\w+)->(?P<obj>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('subj'))} lacks `{m.group('tag')}` pair tag "
+        f"to {_slot(m.group('obj'))}"
+    ),
+)
+_register(
+    r"has_any_pair_tag\((?P<tags>[^@()]+)@(?P<subj>\w+)->(?P<obj>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('subj'))} has any of ["
+        + ", ".join(f"`{t}`" for t in m.group("tags").split(","))
+        + f"] pair tags to {_slot(m.group('obj'))}"
+    ),
+)
+_register(
     r"has_ephemeral\((?P<tag>[^@()]+)@(?P<slot>\w+)\)",
     lambda m: f"{_slot(m.group('slot'))} has `{m.group('tag')}` ephemeral",
 )
@@ -489,6 +511,9 @@ _VOCAB_PATTERNS: List[Tuple[str, re.Pattern]] = [
     ("durable_tag_list", re.compile(r"has_any_tag\(([^@()]+)@")),
     ("current_tag_list", re.compile(r"has_any_current_tag\(([^@()]+)@")),
     ("ephemeral_tag", re.compile(r"has_ephemeral\(([^@()]+)@")),
+    ("pair_tag", re.compile(r"has_pair_tag\(([^@()]+)@")),
+    ("pair_tag", re.compile(r"lacks_pair_tag\(([^@()]+)@")),
+    ("pair_tag_list", re.compile(r"has_any_pair_tag\(([^@()]+)@")),
     ("event_type", re.compile(r"recent_event\(([^,*()]+),")),
     ("event_type", re.compile(r"since_last_event_at_least\(([^,()]+),")),
     ("place_affordance", re.compile(r"in_location_class\(([^@()]+)@")),
@@ -517,6 +542,7 @@ def _collect_vocabulary(
     ephemeral: set[str] = set()
     current: set[str] = set()
     applied: set[str] = set()
+    pair_tags: set[str] = set()
     events: set[str] = set()
     place_affordances: set[str] = set()
     relationships: set[str] = set()
@@ -542,6 +568,11 @@ def _collect_vocabulary(
                     current.add(tag.strip())
             elif kind == "ephemeral_tag":
                 ephemeral.add(captured)
+            elif kind == "pair_tag":
+                pair_tags.add(captured)
+            elif kind == "pair_tag_list":
+                for tag in captured.split(","):
+                    pair_tags.add(tag.strip())
             elif kind == "event_type":
                 events.add(captured)
             elif kind == "place_affordance":
@@ -577,6 +608,7 @@ def _collect_vocabulary(
         "ephemeral_tags": sorted(ephemeral),
         "current_tags": sorted(current),
         "applied_tags": sorted(applied),
+        "pair_tags": sorted(pair_tags),
         "event_types": sorted(events),
         "place_affordances": sorted(place_affordances),
         "relationship_types": sorted(relationships),
@@ -629,6 +661,7 @@ def _render_vocabulary_appendix(templates: Iterable[Template]) -> List[str]:
             "classification per migration)",
             vocab["applied_tags"],
         ),
+        ("Pair tags queried by directed predicates", vocab["pair_tags"]),
         ("Event types", vocab["event_types"]),
         (
             "Place affordances queried by location predicates",

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -322,6 +322,28 @@ def hydrate_world_state(
             if _should_replace_trust_magnitude(trust.get(key), valence_magnitude):
                 trust[key] = valence_magnitude
 
+    pair_tags: dict[tuple[int, int], set[str]] = {}
+    for row in session.execute(
+        text(
+            """
+            /* orrery:pair_tags */
+            SELECT ept.subject_entity_id,
+                   ept.object_entity_id,
+                   pt.tag
+            FROM entity_pair_tags ept
+            JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+            JOIN entities subject_entity ON subject_entity.id = ept.subject_entity_id
+            JOIN entities object_entity ON object_entity.id = ept.object_entity_id
+            WHERE ept.cleared_at IS NULL
+              AND NOT pt.deprecated
+              AND subject_entity.is_active = true
+              AND object_entity.is_active = true
+            """
+        )
+    ).mappings():
+        key = (row["subject_entity_id"], row["object_entity_id"])
+        pair_tags.setdefault(key, set()).add(row["tag"])
+
     faction_memberships: dict[int, set[int]] = {}
     for row in session.execute(
         text(
@@ -369,6 +391,7 @@ def hydrate_world_state(
         relationship_types={
             key: frozenset(values) for key, values in relationship_types.items()
         },
+        pair_tags={key: frozenset(values) for key, values in pair_tags.items()},
         faction_memberships={
             entity_id: frozenset(values)
             for entity_id, values in faction_memberships.items()

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -166,6 +166,7 @@ class WorldState:
     relationship_types: Mapping[Tuple[int, int], frozenset[str]] = field(
         default_factory=dict
     )
+    pair_tags: Mapping[Tuple[int, int], frozenset[str]] = field(default_factory=dict)
     faction_memberships: Mapping[int, frozenset[int]] = field(default_factory=dict)
     location_class: Mapping[int, str] = field(default_factory=dict)
     location_classes: Mapping[int, frozenset[str]] = field(default_factory=dict)
@@ -225,6 +226,70 @@ def has_any_tag(*tags: str, slot: Slot = Slot.ACTOR) -> Condition:
         return bool(candidates & state.tags.get(entity_id, frozenset()))
 
     return _named(_condition, f"has_any_tag({','.join(tags)}@{slot.value})")
+
+
+def has_pair_tag(
+    tag: str,
+    subject_slot: Slot = Slot.ACTOR,
+    object_slot: Slot = Slot.TARGET,
+) -> Condition:
+    """Return whether a directed pair tag exists between two slot-bound entities."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        subject_id = _slot_entity(bindings, subject_slot)
+        object_id = _slot_entity(bindings, object_slot)
+        if subject_id is None or object_id is None:
+            return False
+        return tag in state.pair_tags.get((subject_id, object_id), frozenset())
+
+    return _named(
+        _condition,
+        f"has_pair_tag({tag}@{subject_slot.value}->{object_slot.value})",
+    )
+
+
+def lacks_pair_tag(
+    tag: str,
+    subject_slot: Slot = Slot.ACTOR,
+    object_slot: Slot = Slot.TARGET,
+) -> Condition:
+    """Return whether a directed pair tag is absent between slot-bound entities."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        subject_id = _slot_entity(bindings, subject_slot)
+        object_id = _slot_entity(bindings, object_slot)
+        if subject_id is None or object_id is None:
+            return True
+        return tag not in state.pair_tags.get((subject_id, object_id), frozenset())
+
+    return _named(
+        _condition,
+        f"lacks_pair_tag({tag}@{subject_slot.value}->{object_slot.value})",
+    )
+
+
+def has_any_pair_tag(
+    *tags: str,
+    subject_slot: Slot = Slot.ACTOR,
+    object_slot: Slot = Slot.TARGET,
+) -> Condition:
+    """Return whether any directed pair tag exists between slot-bound entities."""
+
+    candidates = frozenset(tags)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        subject_id = _slot_entity(bindings, subject_slot)
+        object_id = _slot_entity(bindings, object_slot)
+        if subject_id is None or object_id is None:
+            return False
+        return bool(
+            candidates & state.pair_tags.get((subject_id, object_id), frozenset())
+        )
+
+    return _named(
+        _condition,
+        f"has_any_pair_tag({','.join(tags)}@{subject_slot.value}->{object_slot.value})",
+    )
 
 
 def has_any_current_tag(*tags: str, slot: Slot = Slot.ACTOR) -> Condition:

--- a/tests/test_orrery/test_catalog.py
+++ b/tests/test_orrery/test_catalog.py
@@ -111,6 +111,18 @@ def test_render_predicate_name_handles_known_predicates() -> None:
             "actor and target share `family` relationship (either direction)",
         ),
         (
+            "has_pair_tag(mentors@actor->target)",
+            "actor has `mentors` pair tag to target",
+        ),
+        (
+            "lacks_pair_tag(pursuing@target->actor)",
+            "target lacks `pursuing` pair tag to actor",
+        ),
+        (
+            "has_any_pair_tag(claims,protects@actor->target)",
+            "actor has any of [`claims`, `protects`] pair tags to target",
+        ),
+        (
             "since_last_event_at_least(informant_contact,4@actor,target=target)",
             "≥ 4 ticks since last `informant_contact` event for "
             "(actor, target) pair",
@@ -149,6 +161,30 @@ def test_render_catalog_accepts_a_generator() -> None:
     assert "vendetta_holder" in content
     assert "grudge_active" in content
     assert "retaliation_executed" in content
+
+
+def test_pair_tag_predicates_populate_vocabulary_appendix() -> None:
+    """Pair-tag predicates render as prose and populate the appendix."""
+
+    from nexus.agents.orrery.substrate import Branch, Slot, Template, has_pair_tag
+
+    template = Template(
+        id="pair_tag_catalog_fixture",
+        priority=1,
+        blurb="Catalog fixture.",
+        required_slots=(Slot.ACTOR, Slot.TARGET),
+        package_gate=has_pair_tag("mentors"),
+        branches=(
+            Branch("fallback", lambda _state, _bindings: True, "{actor} waits."),
+        ),
+    )
+
+    content = render_catalog((template,))
+    vocab = _collect_vocabulary((template,))
+
+    assert "actor has `mentors` pair tag to target" in content
+    assert "Pair tags queried by directed predicates" in content
+    assert "mentors" in vocab["pair_tags"]
 
 
 def test_orrery_packages_md_is_up_to_date() -> None:

--- a/tests/test_orrery/test_pair_tag_substrate.py
+++ b/tests/test_orrery/test_pair_tag_substrate.py
@@ -1,0 +1,308 @@
+"""Real-DB integration tests for pair-tag WorldState hydration and predicates.
+
+Exercises the Orrery Condition layer against a live ``save_05`` database.
+Activated by ``NEXUS_RUN_POSTGRES=1``. Tests create fresh bare entity rows and
+delete them on teardown; ``entity_pair_tags`` uses ON DELETE CASCADE for those
+endpoints, so no user narrative data is touched.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import psycopg2
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from nexus.agents.orrery.resolver import hydrate_world_state
+from nexus.agents.orrery.substrate import (
+    Slot,
+    has_pair_tag,
+    lacks_pair_tag,
+)
+from nexus.agents.orrery.tag_writer import (
+    apply_pair_tag_bestowal,
+    clear_pair_tag,
+)
+from nexus.api.slot_utils import get_slot_db_url
+
+
+pytestmark = pytest.mark.requires_postgres
+
+
+TEST_DBNAME = "save_05"
+
+
+class _TestEntities:
+    """Container for freshly-created test entity IDs."""
+
+    def __init__(self, *, char_a: int, char_b: int, all_ids: list[int]):
+        self.char_a = char_a
+        self.char_b = char_b
+        self.all_ids = all_ids
+
+
+@pytest.fixture
+def slot_connection() -> Generator[psycopg2.extensions.connection, None, None]:
+    conn = psycopg2.connect(get_slot_db_url(dbname=TEST_DBNAME))
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def sqlalchemy_session() -> Generator[Session, None, None]:
+    engine = create_engine(get_slot_db_url(dbname=TEST_DBNAME), future=True)
+    SessionFactory = sessionmaker(bind=engine, future=True)
+    try:
+        with SessionFactory() as session:
+            yield session
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def test_entities(
+    slot_connection: psycopg2.extensions.connection,
+) -> Generator[_TestEntities, None, None]:
+    """Create fresh bare character entities for isolated pair-tag tests."""
+
+    required_tags = ("mentors", "protects")
+    try:
+        with slot_connection.cursor() as cur:
+            cur.execute(
+                "SELECT tag FROM pair_tags WHERE NOT deprecated AND tag = ANY(%s)",
+                (list(required_tags),),
+            )
+            registered = {row[0] for row in cur.fetchall()}
+    except psycopg2.errors.UndefinedTable:
+        slot_connection.rollback()
+        pytest.skip(f"{TEST_DBNAME}.pair_tags is missing; run migration 042 first.")
+
+    missing_tags = set(required_tags) - registered
+    if missing_tags:
+        pytest.skip(
+            f"{TEST_DBNAME}.pair_tags is missing {sorted(missing_tags)}; "
+            "substrate tests require migration 042's seed vocabulary."
+        )
+
+    created_ids: list[int] = []
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            for _ in range(2):
+                cur.execute(
+                    "INSERT INTO entities (kind, is_active) "
+                    "VALUES ('character', true) RETURNING id"
+                )
+                created_ids.append(cur.fetchone()[0])
+
+    entities = _TestEntities(
+        char_a=created_ids[0],
+        char_b=created_ids[1],
+        all_ids=created_ids,
+    )
+    try:
+        yield entities
+    finally:
+        with slot_connection:
+            with slot_connection.cursor() as cur:
+                cur.execute("DELETE FROM entities WHERE id = ANY(%s)", (created_ids,))
+
+
+def _bestow(
+    cur,
+    *,
+    subject: int,
+    obj: int,
+    tag: str,
+) -> None:
+    apply_pair_tag_bestowal(
+        cur,
+        subject_entity_id=subject,
+        object_entity_id=obj,
+        subject_kind="character",
+        object_kind="character",
+        tag=tag,
+    )
+
+
+def test_hydrate_world_state_loads_active_pair_tags(
+    slot_connection: psycopg2.extensions.connection,
+    sqlalchemy_session: Session,
+    test_entities: _TestEntities,
+) -> None:
+    """WorldState hydration exposes active directed pair tags."""
+
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            _bestow(
+                cur,
+                subject=test_entities.char_a,
+                obj=test_entities.char_b,
+                tag="mentors",
+            )
+
+    state = hydrate_world_state(
+        sqlalchemy_session,
+        anchor_chunk_id=None,
+        window_chunks=1,
+    )
+
+    assert state.pair_tags[(test_entities.char_a, test_entities.char_b)] == frozenset(
+        {"mentors"}
+    )
+
+
+def test_pair_tag_conditions_are_direction_and_tag_sensitive(
+    slot_connection: psycopg2.extensions.connection,
+    sqlalchemy_session: Session,
+    test_entities: _TestEntities,
+) -> None:
+    """Condition predicates read directed pair tags from hydrated state."""
+
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            _bestow(
+                cur,
+                subject=test_entities.char_a,
+                obj=test_entities.char_b,
+                tag="mentors",
+            )
+
+    state = hydrate_world_state(
+        sqlalchemy_session,
+        anchor_chunk_id=None,
+        window_chunks=1,
+    )
+
+    bindings = {Slot.ACTOR: test_entities.char_a, Slot.TARGET: test_entities.char_b}
+    reversed_bindings = {
+        Slot.ACTOR: test_entities.char_b,
+        Slot.TARGET: test_entities.char_a,
+    }
+
+    assert has_pair_tag("mentors")(state, bindings)
+    assert not has_pair_tag("mentors")(state, reversed_bindings)
+    assert not has_pair_tag("protects")(state, bindings)
+    assert not lacks_pair_tag("mentors")(state, bindings)
+    assert lacks_pair_tag("mentors")(state, reversed_bindings)
+    assert lacks_pair_tag("protects")(state, bindings)
+
+
+def test_cleared_pair_tags_do_not_hydrate(
+    slot_connection: psycopg2.extensions.connection,
+    sqlalchemy_session: Session,
+    test_entities: _TestEntities,
+) -> None:
+    """Rows cleared through the writer are absent from WorldState pair_tags."""
+
+    with slot_connection:
+        with slot_connection.cursor() as cur:
+            _bestow(
+                cur,
+                subject=test_entities.char_a,
+                obj=test_entities.char_b,
+                tag="mentors",
+            )
+            clear_pair_tag(
+                cur,
+                subject_entity_id=test_entities.char_a,
+                object_entity_id=test_entities.char_b,
+                tag="mentors",
+            )
+
+    state = hydrate_world_state(
+        sqlalchemy_session,
+        anchor_chunk_id=None,
+        window_chunks=1,
+    )
+
+    assert "mentors" not in state.pair_tags.get(
+        (test_entities.char_a, test_entities.char_b),
+        frozenset(),
+    )
+
+
+def test_deprecated_pair_tags_do_not_hydrate(
+    slot_connection: psycopg2.extensions.connection,
+    sqlalchemy_session: Session,
+    test_entities: _TestEntities,
+) -> None:
+    """Hydration filters active rows whose pair_tag definition is deprecated."""
+
+    deprecated_tag_id: int | None = None
+    deprecated_tag_name = "_test_deprecated_relation_substrate"
+
+    try:
+        with slot_connection:
+            with slot_connection.cursor() as cur:
+                cur.execute(
+                    """
+                    DELETE FROM entity_pair_tags
+                    WHERE pair_tag_id IN (
+                        SELECT id FROM pair_tags WHERE tag = %s
+                    )
+                    """,
+                    (deprecated_tag_name,),
+                )
+                cur.execute(
+                    "DELETE FROM pair_tags WHERE tag = %s",
+                    (deprecated_tag_name,),
+                )
+                cur.execute(
+                    """
+                    INSERT INTO pair_tags (
+                        tag, subject_kinds, object_kinds,
+                        is_ephemeral, deprecated, description
+                    ) VALUES (
+                        %s, %s, %s, false, true, %s
+                    )
+                    RETURNING id
+                    """,
+                    (
+                        deprecated_tag_name,
+                        ["character"],
+                        ["character"],
+                        "Test fixture only; exercises hydration deprecation filter.",
+                    ),
+                )
+                deprecated_tag_id = cur.fetchone()[0]
+                cur.execute(
+                    """
+                    INSERT INTO entity_pair_tags (
+                        subject_entity_id,
+                        object_entity_id,
+                        pair_tag_id,
+                        source_kind
+                    ) VALUES (%s, %s, %s, 'skald_inline'::entity_tag_source_kind)
+                    """,
+                    (
+                        test_entities.char_a,
+                        test_entities.char_b,
+                        deprecated_tag_id,
+                    ),
+                )
+
+        state = hydrate_world_state(
+            sqlalchemy_session,
+            anchor_chunk_id=None,
+            window_chunks=1,
+        )
+
+        assert deprecated_tag_name not in state.pair_tags.get(
+            (test_entities.char_a, test_entities.char_b),
+            frozenset(),
+        )
+    finally:
+        if deprecated_tag_id is not None:
+            with slot_connection:
+                with slot_connection.cursor() as cur:
+                    cur.execute(
+                        "DELETE FROM entity_pair_tags WHERE pair_tag_id = %s",
+                        (deprecated_tag_id,),
+                    )
+                    cur.execute(
+                        "DELETE FROM pair_tags WHERE id = %s", (deprecated_tag_id,)
+                    )

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -52,6 +52,7 @@ class FakeSession:
         location_class_rows=None,
         activity_rows=None,
         relationship_rows=None,
+        pair_tag_rows=None,
         faction_rows=None,
         event_rows=None,
         chunk_ref_actor_rows=None,
@@ -75,6 +76,7 @@ class FakeSession:
             {"entity_id": 1, "current_activity": "idle"}
         ]
         self.relationship_rows = relationship_rows or []
+        self.pair_tag_rows = pair_tag_rows or []
         self.faction_rows = faction_rows or []
         self.event_rows = event_rows or []
         self.chunk_ref_actor_rows = chunk_ref_actor_rows or [{"entity_id": 1}]
@@ -115,6 +117,10 @@ class FakeSession:
         if "/* orrery:relationship_types */" in sql:
             assert "valence_magnitude" in sql
             return FakeResult(self.relationship_rows)
+        if "/* orrery:pair_tags */" in sql:
+            assert "ept.cleared_at IS NULL" in sql
+            assert "NOT pt.deprecated" in sql
+            return FakeResult(self.pair_tag_rows)
         if "/* orrery:faction_memberships */" in sql:
             return FakeResult(self.faction_rows)
         if "/* orrery:recent_events */" in sql:
@@ -747,6 +753,32 @@ def test_hydrate_world_state_uses_stable_trust_magnitude_for_duplicate_pairs() -
     assert state.trust[(2, 1)] == -3
     assert state.relationship_types[(1, 2)] == frozenset({"comrade", "enemy"})
     assert state.relationship_types[(2, 1)] == frozenset({"ally", "rival"})
+
+
+def test_hydrate_world_state_loads_pair_tags() -> None:
+    """Orrery snapshots hydrate active directed pair tags."""
+
+    state = hydrate_world_state(
+        FakeSession(
+            pair_tag_rows=[
+                {
+                    "subject_entity_id": 1,
+                    "object_entity_id": 2,
+                    "tag": "mentors",
+                },
+                {
+                    "subject_entity_id": 2,
+                    "object_entity_id": 1,
+                    "tag": "protects",
+                },
+            ]
+        ),
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert state.pair_tags[(1, 2)] == frozenset({"mentors"})
+    assert state.pair_tags[(2, 1)] == frozenset({"protects"})
 
 
 def test_hydrate_world_state_loads_travel_states() -> None:

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -21,16 +21,19 @@ from nexus.agents.orrery.substrate import (
     count_co_located,
     direct_contact_is_dramatic,
     evaluate_stack,
+    has_any_pair_tag,
     has_any_intimacy_suppressor,
     has_established_partner_co_located,
     has_minimal_context,
     has_need_debt_at_or_above,
+    has_pair_tag,
     has_severity_tag_at_or_above,
     has_symmetric_relationship_of_type,
     in_location,
     in_location_class,
     is_constrained,
     is_hidden,
+    lacks_pair_tag,
     recent_event,
     relationship_is_asymmetric,
     relationship_is_mutual_warm,
@@ -229,6 +232,30 @@ def test_has_symmetric_relationship_of_type_matches_either_direction() -> None:
     assert predicate(forward_state, bindings)
     assert predicate(reverse_state, bindings)
     assert not predicate(empty_state, bindings)
+
+
+def test_pair_tag_predicates_are_direction_sensitive() -> None:
+    """Directed pair-tag helpers read WorldState pair tags without symmetrizing."""
+
+    state = WorldState(pair_tags={(1, 2): frozenset({"mentors", "protects"})})
+    bindings = {Slot.ACTOR: 1, Slot.TARGET: 2}
+    reversed_bindings = {Slot.ACTOR: 2, Slot.TARGET: 1}
+
+    assert has_pair_tag("mentors")(state, bindings)
+    assert has_any_pair_tag("claims", "protects")(state, bindings)
+    assert not has_pair_tag("mentors")(state, reversed_bindings)
+    assert not has_pair_tag("pursuing")(state, bindings)
+
+
+def test_lacks_pair_tag_is_inverse_for_bound_slots() -> None:
+    """lacks_pair_tag is true for wrong direction, wrong tag, or missing slots."""
+
+    state = WorldState(pair_tags={(1, 2): frozenset({"mentors"})})
+
+    assert not lacks_pair_tag("mentors")(state, {Slot.ACTOR: 1, Slot.TARGET: 2})
+    assert lacks_pair_tag("mentors")(state, {Slot.ACTOR: 2, Slot.TARGET: 1})
+    assert lacks_pair_tag("protects")(state, {Slot.ACTOR: 1, Slot.TARGET: 2})
+    assert lacks_pair_tag("mentors")(state, {Slot.ACTOR: 1})
 
 
 def test_context_and_constraint_predicates_read_current_tags() -> None:


### PR DESCRIPTION
## Summary
- Add `WorldState.pair_tags` for active directed multi-entity tag rows.
- Hydrate pair tags from `entity_pair_tags` joined to non-deprecated `pair_tags` definitions and active entity endpoints.
- Add Condition-shape helpers: `has_pair_tag`, `lacks_pair_tag`, and `has_any_pair_tag`.
- Cover the substrate with fast unit tests plus real-DB `save_05` integration tests for active, cleared, deprecated, wrong-tag, and reverse-direction cases.

## Validation
- `PYTHONPATH=/Users/pythagor/nexus-codex-substrate poetry run pytest tests/test_orrery/test_substrate.py tests/test_orrery/test_resolver.py`
- `PYTHONPATH=/Users/pythagor/nexus-codex-substrate poetry run pytest tests/test_orrery/test_pair_tag_substrate.py`
- `PYTHONPATH=/Users/pythagor/nexus-codex-substrate NEXUS_RUN_POSTGRES=1 poetry run pytest tests/test_orrery/test_pair_tag_substrate.py`
- `git diff --check`

## Notes
- No new migration in this PR; it reads the schema introduced by #283 and predicates introduced by #284.
- `CODEX_HANDOFF.md` remains local handoff material and is not part of this PR.
