### PR TITLE
[codex] Add Orrery location class category shim

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1756,6 +1756,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/039_new_story_character_orrery_tags.py`
 - `migrations/041_orrery_authority_model.sql`
 - `migrations/042_orrery_entity_pair_tags.py`
+- `migrations/043_orrery_category_refactor_phase1.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 

--- a/migrations/043_orrery_category_refactor_phase1.py
+++ b/migrations/043_orrery_category_refactor_phase1.py
@@ -84,10 +84,13 @@ NEW_CATEGORY_REGISTRY: Sequence[tuple[str, str, int, str]] = (
     ),
 )
 
-# (legacy_category, replacement_categories)
-DEPRECATED_CATEGORY_REPLACEMENTS: Sequence[tuple[str, Optional[tuple[str, ...]]]] = (
+# (legacy_category, entity_kind, replacement_categories)
+DEPRECATED_CATEGORY_REPLACEMENTS: Sequence[
+    tuple[str, str, Optional[tuple[str, ...]]]
+] = (
     (
         "place_affordance",
+        "place",
         (
             "place_function",
             "place_visibility",
@@ -96,15 +99,15 @@ DEPRECATED_CATEGORY_REPLACEMENTS: Sequence[tuple[str, Optional[tuple[str, ...]]]
             "place_threat",
         ),
     ),
-    ("profession_lite", ("role",)),
-    ("orrery_signal", ("state",)),
-    ("ideology_axis", ("ideology",)),
-    ("power_posture", ("power_status",)),
-    ("legitimacy_status", ("legitimacy",)),
-    ("operational_secrecy", ("operational_mode",)),
-    ("resource_class", ("resource_base",)),
-    ("hidden_agenda_class", ("agenda",)),
-    ("history_class", None),
+    ("profession_lite", "character", ("role",)),
+    ("orrery_signal", "character", ("state",)),
+    ("ideology_axis", "faction", ("ideology",)),
+    ("power_posture", "faction", ("power_status",)),
+    ("legitimacy_status", "faction", ("legitimacy",)),
+    ("operational_secrecy", "faction", ("operational_mode",)),
+    ("resource_class", "faction", ("resource_base",)),
+    ("hidden_agenda_class", "faction", ("agenda",)),
+    ("history_class", "faction", None),
 )
 
 
@@ -158,17 +161,23 @@ def run(conn: connection) -> None:
                 (category, entity_kind, prompt_order, description),
             )
 
-        for legacy_category, replacement_categories in DEPRECATED_CATEGORY_REPLACEMENTS:
+        for (
+            legacy_category,
+            entity_kind,
+            replacement_categories,
+        ) in DEPRECATED_CATEGORY_REPLACEMENTS:
             cur.execute(
                 """
                 UPDATE tag_category_registry
                 SET deprecated = TRUE,
                     replacement_categories = %s
                 WHERE category = %s
+                  AND entity_kind = %s::entity_kind
                 """,
                 (
                     list(replacement_categories) if replacement_categories else None,
                     legacy_category,
+                    entity_kind,
                 ),
             )
     conn.commit()

--- a/migrations/043_orrery_category_refactor_phase1.py
+++ b/migrations/043_orrery_category_refactor_phase1.py
@@ -1,0 +1,174 @@
+"""Phase 1 compatibility metadata for the Orrery category refactor.
+
+The vocabulary design splits broad legacy categories such as
+``place_affordance`` into narrower axes. This migration records that cutover
+metadata and registers the new category names without rewriting existing tags
+or entity_tags rows. Runtime compatibility is handled by the resolver shim
+that hydrates old and new place categories into ``WorldState.location_classes``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from psycopg2.extensions import connection
+
+
+# (category, entity_kind, prompt_order, description)
+NEW_CATEGORY_REGISTRY: Sequence[tuple[str, str, int, str]] = (
+    (
+        "place_function",
+        "place",
+        10,
+        "Functional role a place serves for package gates.",
+    ),
+    (
+        "place_visibility",
+        "place",
+        20,
+        "Whether a place is broadly known or hidden.",
+    ),
+    (
+        "place_access",
+        "place",
+        30,
+        "Whether a place is open or restricted.",
+    ),
+    (
+        "place_environment",
+        "place",
+        40,
+        "Physical or geographic environment of a place.",
+    ),
+    (
+        "place_threat",
+        "place",
+        50,
+        "Current safety or danger posture of a place.",
+    ),
+    (
+        "ideology",
+        "faction",
+        10,
+        "Faction worldview, political, or metaphysical orientation.",
+    ),
+    (
+        "power_status",
+        "faction",
+        20,
+        "Current faction strength or momentum.",
+    ),
+    (
+        "agenda",
+        "faction",
+        30,
+        "Active faction goals, schemes, or pressure vectors.",
+    ),
+    (
+        "resource_base",
+        "faction",
+        40,
+        "Material, economic, institutional, or informational resources.",
+    ),
+    (
+        "legitimacy",
+        "faction",
+        50,
+        "Public, legal, or underworld legitimacy posture.",
+    ),
+    (
+        "operational_mode",
+        "faction",
+        60,
+        "Whether faction action is overt, covert, or hybrid.",
+    ),
+)
+
+# (legacy_category, replacement_categories)
+DEPRECATED_CATEGORY_REPLACEMENTS: Sequence[tuple[str, Optional[tuple[str, ...]]]] = (
+    (
+        "place_affordance",
+        (
+            "place_function",
+            "place_visibility",
+            "place_access",
+            "place_environment",
+            "place_threat",
+        ),
+    ),
+    ("profession_lite", ("role",)),
+    ("orrery_signal", ("state",)),
+    ("ideology_axis", ("ideology",)),
+    ("power_posture", ("power_status",)),
+    ("legitimacy_status", ("legitimacy",)),
+    ("operational_secrecy", ("operational_mode",)),
+    ("resource_class", ("resource_base",)),
+    ("hidden_agenda_class", ("agenda",)),
+    ("history_class", None),
+)
+
+
+def run(conn: connection) -> None:
+    """Register new categories and mark legacy categories as deprecated."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            ALTER TABLE tag_category_registry
+            ADD COLUMN IF NOT EXISTS deprecated boolean NOT NULL DEFAULT false
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE tag_category_registry
+            ADD COLUMN IF NOT EXISTS replacement_categories text[]
+            """
+        )
+        cur.execute(
+            """
+            COMMENT ON COLUMN tag_category_registry.deprecated IS
+                'Category-level cutover marker; existing tag rows remain live '
+                || 'until a data migration rewrites them.';
+            """
+        )
+        cur.execute(
+            """
+            COMMENT ON COLUMN tag_category_registry.replacement_categories IS
+                'Preferred successor categories for deprecated category rows, '
+                || 'when any exist.';
+            """
+        )
+
+        for category, entity_kind, prompt_order, description in NEW_CATEGORY_REGISTRY:
+            cur.execute(
+                """
+                INSERT INTO tag_category_registry (
+                    category, entity_kind, prompt_order, description,
+                    deprecated, replacement_categories
+                ) VALUES (
+                    %s, %s::entity_kind, %s, %s,
+                    FALSE, NULL
+                )
+                ON CONFLICT (category, entity_kind) DO UPDATE SET
+                    prompt_order = EXCLUDED.prompt_order,
+                    description = EXCLUDED.description,
+                    deprecated = FALSE,
+                    replacement_categories = NULL
+                """,
+                (category, entity_kind, prompt_order, description),
+            )
+
+        for legacy_category, replacement_categories in DEPRECATED_CATEGORY_REPLACEMENTS:
+            cur.execute(
+                """
+                UPDATE tag_category_registry
+                SET deprecated = TRUE,
+                    replacement_categories = %s
+                WHERE category = %s
+                """,
+                (
+                    list(replacement_categories) if replacement_categories else None,
+                    legacy_category,
+                ),
+            )
+    conn.commit()

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -38,6 +38,7 @@ LOCATION_CLASS_TAG_CATEGORIES: tuple[str, ...] = (
     "place_environment",
     "place_threat",
 )
+# Safe: assembled only from hardcoded LOCATION_CLASS_TAG_CATEGORIES values.
 _LOCATION_CLASS_CATEGORY_SQL = ", ".join(
     f"'{category}'" for category in LOCATION_CLASS_TAG_CATEGORIES
 )

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -30,6 +30,18 @@ from nexus.agents.orrery.needs import (
     severity_for_debt,
 )
 
+LOCATION_CLASS_TAG_CATEGORIES: tuple[str, ...] = (
+    "place_affordance",
+    "place_function",
+    "place_visibility",
+    "place_access",
+    "place_environment",
+    "place_threat",
+)
+_LOCATION_CLASS_CATEGORY_SQL = ", ".join(
+    f"'{category}'" for category in LOCATION_CLASS_TAG_CATEGORIES
+)
+
 
 def _proposal_id(template_id: str, binding_hash_value: str) -> str:
     """Return the stable public identifier for one tick proposal."""
@@ -260,7 +272,7 @@ def hydrate_world_state(
     location_classes: dict[int, set[str]] = {}
     for row in session.execute(
         text(
-            """
+            f"""
             /* orrery:location_classes */
             SELECT p.id, p.type::text AS location_class, true AS is_primary
             FROM places p
@@ -270,7 +282,7 @@ def hydrate_world_state(
             FROM places p
             JOIN entity_tags_current etc ON etc.entity_id = p.entity_id
             WHERE etc.entity_kind = 'place'
-              AND etc.category = 'place_affordance'
+              AND etc.category IN ({_LOCATION_CLASS_CATEGORY_SQL})
             """
         )
     ).mappings():
@@ -950,7 +962,8 @@ def _classify_weather(raw_weather: str) -> str:
 def _draft_from_resolution(resolution: Resolution) -> OrreryResolutionDraft:
     if resolution.branch_label is None or resolution.narrative_stub is None:
         raise RuntimeError(
-            f"Orrery resolution {resolution.template_id!r} passed gate but lacks branch data"
+            f"Orrery resolution {resolution.template_id!r} passed gate but lacks "
+            "branch data"
         )
     return OrreryResolutionDraft(
         template_id=resolution.template_id,

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -361,7 +361,12 @@ def test_category_refactor_phase1_migration_marks_cutover_categories() -> None:
             migration.NEW_CATEGORY_REGISTRY
         )
     }
-    deprecated = dict(migration.DEPRECATED_CATEGORY_REPLACEMENTS)
+    deprecated = {
+        (category, entity_kind): replacements
+        for category, entity_kind, replacements in (
+            migration.DEPRECATED_CATEGORY_REPLACEMENTS
+        )
+    }
 
     assert {
         ("place_function", "place"),
@@ -376,20 +381,21 @@ def test_category_refactor_phase1_migration_marks_cutover_categories() -> None:
         ("legitimacy", "faction"),
         ("operational_mode", "faction"),
     } <= registered
-    assert deprecated["place_affordance"] == (
+    assert deprecated[("place_affordance", "place")] == (
         "place_function",
         "place_visibility",
         "place_access",
         "place_environment",
         "place_threat",
     )
-    assert deprecated["profession_lite"] == ("role",)
-    assert deprecated["orrery_signal"] == ("state",)
-    assert deprecated["history_class"] is None
+    assert deprecated[("profession_lite", "character")] == ("role",)
+    assert deprecated[("orrery_signal", "character")] == ("state",)
+    assert deprecated[("history_class", "faction")] is None
 
     migration_source = migration_path.read_text()
     assert "ADD COLUMN IF NOT EXISTS deprecated" in migration_source
     assert "ADD COLUMN IF NOT EXISTS replacement_categories" in migration_source
+    assert "AND entity_kind = %s::entity_kind" in migration_source
 
 
 def test_tag_baseline_reconciliation_migration_closes_slot_drift() -> None:

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -346,6 +346,52 @@ def test_tag_category_registry_migration_covers_current_vocab_categories() -> No
     assert "tag_category_registry" in migration_path.read_text()
 
 
+def test_category_refactor_phase1_migration_marks_cutover_categories() -> None:
+    """Migration 043 records new category axes without rewriting live tags."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "043_orrery_category_refactor_phase1.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    registered = {
+        (category, entity_kind)
+        for category, entity_kind, _order, _description in (
+            migration.NEW_CATEGORY_REGISTRY
+        )
+    }
+    deprecated = dict(migration.DEPRECATED_CATEGORY_REPLACEMENTS)
+
+    assert {
+        ("place_function", "place"),
+        ("place_visibility", "place"),
+        ("place_access", "place"),
+        ("place_environment", "place"),
+        ("place_threat", "place"),
+        ("ideology", "faction"),
+        ("power_status", "faction"),
+        ("agenda", "faction"),
+        ("resource_base", "faction"),
+        ("legitimacy", "faction"),
+        ("operational_mode", "faction"),
+    } <= registered
+    assert deprecated["place_affordance"] == (
+        "place_function",
+        "place_visibility",
+        "place_access",
+        "place_environment",
+        "place_threat",
+    )
+    assert deprecated["profession_lite"] == ("role",)
+    assert deprecated["orrery_signal"] == ("state",)
+    assert deprecated["history_class"] is None
+
+    migration_source = migration_path.read_text()
+    assert "ADD COLUMN IF NOT EXISTS deprecated" in migration_source
+    assert "ADD COLUMN IF NOT EXISTS replacement_categories" in migration_source
+
+
 def test_tag_baseline_reconciliation_migration_closes_slot_drift() -> None:
     """Migration 038 keeps template clones and existing slots on one vocab set."""
 

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -1439,7 +1439,7 @@ def test_resolve_dry_run_uses_configured_present_need_pressure_tuning() -> None:
     assert pressure.magnitude == pytest.approx(0.3)
 
 
-def test_resolve_dry_run_keeps_default_templates_offscreen_only_for_present_targets():
+def test_default_templates_keep_present_targets_offscreen_only() -> None:
     """Default multi-slot templates cannot pressure an on-screen target."""
 
     default_template = Template(

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -7,6 +7,7 @@ import pytest
 from nexus.agents.lore.utils.turn_context import TurnContext
 from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
 from nexus.agents.orrery.resolver import (
+    LOCATION_CLASS_TAG_CATEGORIES,
     _need_pressure_stub,
     compose_actor_target_bindings,
     hydrate_world_state,
@@ -110,7 +111,8 @@ class FakeSession:
         if "/* orrery:character_locations */" in sql:
             return FakeResult(self.location_rows)
         if "/* orrery:location_classes */" in sql:
-            assert "place_affordance" in sql
+            for category in LOCATION_CLASS_TAG_CATEGORIES:
+                assert category in sql
             return FakeResult(self.location_class_rows)
         if "/* orrery:character_activities */" in sql:
             return FakeResult(self.activity_rows)
@@ -839,6 +841,37 @@ def test_hydrate_world_state_loads_semantic_place_affordances() -> None:
     )
 
 
+def test_hydrate_world_state_loads_new_place_category_classes() -> None:
+    """Cutover category rows also feed legacy in_location_class() gates."""
+
+    state = hydrate_world_state(
+        FakeSession(
+            location_class_rows=[
+                {"id": 10, "location_class": "dwelling", "is_primary": False},
+                {"id": 10, "location_class": "hidden", "is_primary": False},
+                {"id": 10, "location_class": "restricted", "is_primary": False},
+                {"id": 10, "location_class": "subterranean", "is_primary": False},
+                {"id": 10, "location_class": "contested", "is_primary": False},
+                {"id": 10, "location_class": "fixed_location", "is_primary": True},
+            ],
+        ),
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert state.location_class[10] == "fixed_location"
+    assert state.location_classes[10] == frozenset(
+        {
+            "fixed_location",
+            "dwelling",
+            "hidden",
+            "restricted",
+            "subterranean",
+            "contested",
+        }
+    )
+
+
 def test_hydrate_world_state_computes_effective_need_debt() -> None:
     """Need debt accrues from last_evaluated_at without resolver writes."""
 
@@ -1406,9 +1439,7 @@ def test_resolve_dry_run_uses_configured_present_need_pressure_tuning() -> None:
     assert pressure.magnitude == pytest.approx(0.3)
 
 
-def test_resolve_dry_run_keeps_default_templates_offscreen_only_for_present_targets() -> (
-    None
-):
+def test_resolve_dry_run_keeps_default_templates_offscreen_only_for_present_targets():
     """Default multi-slot templates cannot pressure an on-screen target."""
 
     default_template = Template(


### PR DESCRIPTION
## Summary

- adds Phase 1 category-refactor migration metadata for #292 without rewriting existing tag rows
- registers new place category axes and safe non-shared faction category names in `tag_category_registry`
- marks legacy category rows deprecated with replacement-category metadata while leaving existing slots operational
- hydrates old `place_affordance` rows and new place category rows into `WorldState.location_classes` so existing `in_location_class()` gates keep working during cutover
- refreshes the generated Orrery package catalog migration list

Refs #292. This intentionally does not close the issue; Phase 2 still needs the data migration/template audit/removal of the resolver shim.

## Validation

- `poetry run black nexus/agents/orrery/resolver.py migrations/043_orrery_category_refactor_phase1.py tests/test_orrery/test_resolver.py tests/test_orrery/test_migrate.py`
- `poetry run pytest tests/test_orrery/test_resolver.py tests/test_orrery/test_migrate.py tests/test_orrery/test_substrate.py tests/test_orrery/test_tag_library.py`
- `poetry run pytest tests/test_orrery`
- `poetry run flake8 nexus/agents/orrery/resolver.py migrations/043_orrery_category_refactor_phase1.py tests/test_orrery/test_resolver.py tests/test_orrery/test_migrate.py`
- `git diff --check`

## Notes

- The deprecated category marker is metadata-only in this PR. Writers and prompt-library reads are not changed to reject old categories yet, because old slots and wizard prompts still depend on legacy tag rows until the Phase 2 data/vocabulary migration lands.
- I did not register faction `state` as a new faction category here. The current registry is category-level, so registering shared `state` for factions would make existing character-state tags faction-valid. That belongs with the later vocabulary/data migration, not this compatibility shim.