### PR TITLE
[codex] Add Retrograde vocabulary and weird-dial config

### DIFF
--- a/docs/trait_menu.md
+++ b/docs/trait_menu.md
@@ -33,13 +33,15 @@ Not choosing a trait does not mean the character is bereft of it; rather, this s
 ## Power & Position
 
 ### Status
-- formal standing recognized by a specific institution or social structure
-- examples: military commission, guild journeyman, corporate board seat
+- standing within a specific institution, faction, community, or social scene
+- can be formal rank or informal local esteem/clout
+- use this when you are known within that group, even if obscure elsewhere
+- examples: military commission, guild journeyman, corporate board seat, respected neighborhood fixer
 
-### Reputation
-- how widely you're known
-- what for
-- for better or worse
+### Reputation (Fame)
+- how broadly you're recognized beyond any one specific group
+- what the wider world recognizes you for, for better or worse
+- use Status instead when the recognition is limited to one faction, institution, community, or subculture
 - may or may not confer influence
 
 ## Assets & Territory

--- a/migrations/010_add_traits_table.sql
+++ b/migrations/010_add_traits_table.sql
@@ -58,14 +58,16 @@ INSERT INTO assets.traits (id, name, description, is_selected, rationale) VALUES
 
 -- Power & Position
 (5, 'status', ARRAY[
-    'formal standing recognized by a specific institution or social structure',
-    'examples: military commission, guild journeyman, corporate board seat'
+    'standing within a specific institution, faction, community, or social scene',
+    'can be formal rank or informal local esteem/clout',
+    'use this when you are known within that group, even if obscure elsewhere',
+    'examples: military commission, guild journeyman, corporate board seat, respected neighborhood fixer'
 ], FALSE, NULL),
 
 (6, 'reputation', ARRAY[
-    'how widely you''re known',
-    'what for',
-    'for better or worse',
+    'Fame: how broadly you''re recognized beyond any one specific group',
+    'what the wider world recognizes you for, for better or worse',
+    'use Status instead when recognition is limited to one faction, institution, community, or subculture',
     'may or may not confer influence'
 ], FALSE, NULL),
 

--- a/migrations/042_orrery_entity_pair_tags.py
+++ b/migrations/042_orrery_entity_pair_tags.py
@@ -26,99 +26,10 @@ self-awareness (issue #282) all depend on this substrate.
 
 from __future__ import annotations
 
-from typing import Sequence
-
 from psycopg2.extensions import connection
 
-
-# (tag, subject_kinds, object_kinds, is_ephemeral, description)
-PAIR_TAG_SEED: Sequence[tuple[str, list[str], list[str], bool, str]] = (
-    # Place-bound (durable)
-    (
-        "knows_location",
-        ["character"],
-        ["place"],
-        False,
-        "Subject knows of the place's existence and how to find it.",
-    ),
-    (
-        "can_access",
-        ["character", "faction"],
-        ["place"],
-        False,
-        "Subject has permission to enter the place (direct individual or group-mediated).",
-    ),
-    (
-        "claims",
-        ["faction"],
-        ["place"],
-        False,
-        "Subject (faction) asserts a territorial claim on the place; contestation emerges from row cardinality.",
-    ),
-    (
-        "resides_at",
-        ["character"],
-        ["place"],
-        False,
-        "Subject's habitual residence. Multi-residence is supported via multiple rows.",
-    ),
-    (
-        "operates_from",
-        ["faction"],
-        ["place"],
-        False,
-        "Faction's operational base. Distinct from `claims` — claim is territorial, operates_from is functional.",
-    ),
-    (
-        "originates_from",
-        ["character"],
-        ["place"],
-        False,
-        "Character's origin or hometown.",
-    ),
-    # Character / faction relations
-    (
-        "pursuing",
-        ["character", "faction"],
-        ["character"],
-        True,
-        "Subject is actively hunting the target. Ephemeral; also confers narrow targeted detection sensitivity for that target (see issue #282).",
-    ),
-    (
-        "handles",
-        ["character"],
-        ["character"],
-        False,
-        "Subject is the operational handler of the target (covert / espionage / criminal flavor).",
-    ),
-    (
-        "obligation",
-        ["character", "faction"],
-        ["character", "faction"],
-        False,
-        "Subject owes a debt / oath / loyalty to the target. Kind inferable from establishing event.",
-    ),
-    (
-        "authority_over",
-        ["character", "faction"],
-        ["character", "faction"],
-        False,
-        "Subject holds institutional or positional power over the target.",
-    ),
-    (
-        "protects",
-        ["character", "faction"],
-        ["character"],
-        False,
-        "Subject is in an active protective relationship with the target. Durable.",
-    ),
-    (
-        "mentors",
-        ["character"],
-        ["character"],
-        False,
-        "Subject teaches or trains the target.",
-    ),
+from nexus.agents.orrery.pair_tag_registry import (
+    PAIR_TAG_SEED,
 )
 
 
@@ -126,11 +37,11 @@ def run(conn: connection) -> None:
     """Create the entity_pair_tags substrate and seed the 12 settled relations."""
 
     with conn.cursor() as cur:
-        # Registry of relation types (analog of `tags` but with kind validation columns).
-        # Empty-array CHECK uses `cardinality(...) >= 1` rather than `array_length(...) >= 1`:
-        # PostgreSQL's `array_length('{}', 1)` returns NULL, and CHECK treats NULL as
-        # passing — so array_length would silently admit empty arrays. `cardinality`
-        # returns 0 for empty arrays, making the check NULL-safe.
+        # Registry of relation types (analog of `tags` but with kind validation
+        # columns). Empty-array CHECK uses `cardinality(...) >= 1` rather than
+        # `array_length(...) >= 1`: PostgreSQL's `array_length('{}', 1)` returns
+        # NULL, and CHECK treats NULL as passing. `cardinality` returns 0 for
+        # empty arrays, making the check NULL-safe.
         cur.execute(
             """
             CREATE TABLE IF NOT EXISTS pair_tags (
@@ -156,16 +67,20 @@ def run(conn: connection) -> None:
         cur.execute(
             """
             COMMENT ON TABLE pair_tags IS
-                'Registry of multi-entity (directed binary) relation types. The vocabulary for entity_pair_tags. Analog of `tags` for edges between entities.';
+                'Registry of multi-entity (directed binary) relation types.
+                The vocabulary for entity_pair_tags. Analog of `tags` for
+                edges between entities.';
             """
         )
         cur.execute(
             "COMMENT ON COLUMN pair_tags.tag IS "
-            "'Relation name (snake_case). May embed a level via the colon convention, e.g. `status:senior`.'"
+            "'Relation name (snake_case). May embed a level via the colon "
+            "convention, e.g. `status:senior`.'"
         )
         cur.execute(
             "COMMENT ON COLUMN pair_tags.subject_kinds IS "
-            "'Allowed entity_kind values for the subject (source) of this relation. Polymorphism (e.g. character|faction) is expressed via array membership.'"
+            "'Allowed entity_kind values for the subject (source) of this "
+            "relation. Polymorphism is expressed via array membership.'"
         )
         cur.execute(
             "COMMENT ON COLUMN pair_tags.object_kinds IS "
@@ -173,23 +88,28 @@ def run(conn: connection) -> None:
         )
         cur.execute(
             "COMMENT ON COLUMN pair_tags.is_ephemeral IS "
-            "'TRUE for relations that get cleared by world events (e.g., `pursuing`); FALSE for durable relations.'"
+            "'TRUE for relations that get cleared by world events; FALSE "
+            "for durable relations.'"
         )
         cur.execute(
             "COMMENT ON COLUMN pair_tags.clearance_kind IS "
-            "'For ephemeral relations: the mode of clearance (e.g. `semantic`). NULL for durable relations. Enforced equal to (is_ephemeral) by check constraint.'"
+            "'For ephemeral relations: the mode of clearance. NULL for "
+            "durable relations. Enforced equal to is_ephemeral by check.'"
         )
         cur.execute(
             "COMMENT ON COLUMN pair_tags.reapplication_policy IS "
-            "'How the relation behaves if reapplied after clearance. NULL = no special policy.'"
+            "'How the relation behaves if reapplied after clearance. "
+            "NULL = no special policy.'"
         )
         cur.execute(
             "COMMENT ON COLUMN pair_tags.clear_on IS "
-            "'Optional JSONB describing world_event types or conditions that auto-clear instances of this relation. Shape mirrors tags.clear_on.'"
+            "'Optional JSONB describing world_event types or conditions "
+            "that auto-clear relation instances. Shape mirrors tags.clear_on.'"
         )
         cur.execute(
             "COMMENT ON COLUMN pair_tags.deprecated IS "
-            "'TRUE marks the relation as no longer accepted for new bestowals; lookup intentionally filters deprecated rows.'"
+            "'TRUE marks the relation as no longer accepted for new "
+            "bestowals; lookup intentionally filters deprecated rows.'"
         )
         cur.execute(
             "COMMENT ON COLUMN pair_tags.description IS "
@@ -210,8 +130,10 @@ def run(conn: connection) -> None:
             """
             CREATE TABLE IF NOT EXISTS entity_pair_tags (
                 id                    bigserial PRIMARY KEY,
-                subject_entity_id     bigint NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
-                object_entity_id      bigint NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+                subject_entity_id     bigint NOT NULL
+                                      REFERENCES entities(id) ON DELETE CASCADE,
+                object_entity_id      bigint NOT NULL
+                                      REFERENCES entities(id) ON DELETE CASCADE,
                 pair_tag_id           bigint NOT NULL REFERENCES pair_tags(id),
                 applied_at            timestamptz NOT NULL DEFAULT now(),
                 applied_at_world_time timestamptz,
@@ -227,7 +149,9 @@ def run(conn: connection) -> None:
         cur.execute(
             """
             COMMENT ON TABLE entity_pair_tags IS
-                'Directed binary tag (relation) edge from subject to object. The application table for multi-entity tags; analog of entity_tags.';
+                'Directed binary tag (relation) edge from subject to object.
+                The application table for multi-entity tags; analog of
+                entity_tags.';
             """
         )
         cur.execute(
@@ -236,7 +160,8 @@ def run(conn: connection) -> None:
         )
         cur.execute(
             "COMMENT ON COLUMN entity_pair_tags.object_entity_id IS "
-            "'The target endpoint of the directed relation (FK entities). Must differ from subject_entity_id.'"
+            "'The target endpoint of the directed relation (FK entities). "
+            "Must differ from subject_entity_id.'"
         )
         cur.execute(
             "COMMENT ON COLUMN entity_pair_tags.pair_tag_id IS "
@@ -248,23 +173,28 @@ def run(conn: connection) -> None:
         )
         cur.execute(
             "COMMENT ON COLUMN entity_pair_tags.applied_at_world_time IS "
-            "'In-story world time when the relation became active. NULL if no world_time was provided by the caller.'"
+            "'In-story world time when the relation became active. NULL if "
+            "no world_time was provided by the caller.'"
         )
         cur.execute(
             "COMMENT ON COLUMN entity_pair_tags.source_kind IS "
-            "'Provenance: `skald_inline` for runtime bestowals, `llm_generated` for offline backfills (same enum as entity_tags.source_kind).'"
+            "'Provenance: `skald_inline` for runtime bestowals, "
+            "`llm_generated` for offline backfills.'"
         )
         cur.execute(
             "COMMENT ON COLUMN entity_pair_tags.cleared_at IS "
-            "'When set, the relation is no longer active (analogous to entity_tags.cleared_at).'"
+            "'When set, the relation is no longer active, analogous to "
+            "entity_tags.cleared_at.'"
         )
         cur.execute(
             "COMMENT ON COLUMN entity_pair_tags.clear_on_override IS "
-            "'Optional per-row override of the relation type''s clear_on policy (analogous to entity_tags.clear_on).'"
+            "'Optional per-row override of the relation type''s clear_on "
+            "policy, analogous to entity_tags.clear_on.'"
         )
         cur.execute(
             "COMMENT ON COLUMN entity_pair_tags.template_id IS "
-            "'Optional bestowal-template identifier for downstream traceability (analogous to entity_tags.template_id).'"
+            "'Optional bestowal-template identifier for downstream "
+            "traceability, analogous to entity_tags.template_id.'"
         )
 
         # Indexes
@@ -291,7 +221,13 @@ def run(conn: connection) -> None:
         )
 
         # Seed the 12 settled multi-entity relations
-        for tag, subject_kinds, object_kinds, is_ephemeral, description in PAIR_TAG_SEED:
+        for (
+            tag,
+            subject_kinds,
+            object_kinds,
+            is_ephemeral,
+            description,
+        ) in PAIR_TAG_SEED:
             clearance_kind = "semantic" if is_ephemeral else None
             cur.execute(
                 """

--- a/migrations/044_disambiguate_status_reputation_traits.sql
+++ b/migrations/044_disambiguate_status_reputation_traits.sql
@@ -1,0 +1,25 @@
+-- Migration 044: Disambiguate Status from broad Reputation/Fame in the wizard.
+--
+-- The trait enum/storage value remains `reputation` until the broader Fame
+-- rename lands. This copy update makes the wizard distinction explicit now:
+-- Status is scoped standing inside a group; Reputation is ambient recognition.
+
+UPDATE assets.traits
+SET description = ARRAY[
+    'standing within a specific institution, faction, community, or social scene',
+    'can be formal rank or informal local esteem/clout',
+    'use this when you are known within that group, even if obscure elsewhere',
+    'examples: military commission, guild journeyman, corporate board seat, respected neighborhood fixer'
+]
+WHERE id = 5
+  AND name = 'status';
+
+UPDATE assets.traits
+SET description = ARRAY[
+    'Fame: how broadly you''re recognized beyond any one specific group',
+    'what the wider world recognizes you for, for better or worse',
+    'use Status instead when recognition is limited to one faction, institution, community, or subculture',
+    'may or may not confer influence'
+]
+WHERE id = 6
+  AND name IN ('reputation', 'fame');

--- a/nexus.toml
+++ b/nexus.toml
@@ -188,6 +188,85 @@ magnitude_base = 0.35
 magnitude_per_level = 0.10
 magnitude_cap = 0.85
 
+[orrery.retrograde.weird]
+# Player-facing Retrograde strangeness is low/medium/high. Each genre remaps
+# those labels onto the raw calibration float below, so "medium" means
+# medium-for-that-genre rather than a universal numeric value.
+default_level = "medium"
+
+[orrery.retrograde.weird.dev]
+# Future calibration CLI surface, MidJourney-style: --weird <float>.
+# Runtime/player UI should keep using the coarse level labels above.
+cli_flag = "--weird"
+min = 0.0
+max = 1.0
+default = 0.5
+
+[orrery.retrograde.weird.bands_by_genre.fantasy]
+low = { min = 0.12, max = 0.28 }
+medium = { min = 0.28, max = 0.55 }
+high = { min = 0.55, max = 0.82 }
+
+[orrery.retrograde.weird.bands_by_genre.scifi]
+low = { min = 0.18, max = 0.34 }
+medium = { min = 0.34, max = 0.62 }
+high = { min = 0.62, max = 0.90 }
+
+[orrery.retrograde.weird.bands_by_genre.horror]
+low = { min = 0.10, max = 0.26 }
+medium = { min = 0.26, max = 0.54 }
+high = { min = 0.54, max = 0.88 }
+
+[orrery.retrograde.weird.bands_by_genre.mystery]
+low = { min = 0.04, max = 0.16 }
+medium = { min = 0.16, max = 0.34 }
+high = { min = 0.34, max = 0.58 }
+
+[orrery.retrograde.weird.bands_by_genre.historical]
+low = { min = 0.02, max = 0.12 }
+medium = { min = 0.12, max = 0.28 }
+high = { min = 0.28, max = 0.48 }
+
+[orrery.retrograde.weird.bands_by_genre.contemporary]
+low = { min = 0.03, max = 0.14 }
+medium = { min = 0.14, max = 0.32 }
+high = { min = 0.32, max = 0.52 }
+
+[orrery.retrograde.weird.bands_by_genre.postapocalyptic]
+low = { min = 0.14, max = 0.30 }
+medium = { min = 0.30, max = 0.58 }
+high = { min = 0.58, max = 0.84 }
+
+[orrery.retrograde.weird.bands_by_genre.cyberpunk]
+low = { min = 0.18, max = 0.36 }
+medium = { min = 0.36, max = 0.66 }
+high = { min = 0.66, max = 0.92 }
+
+[orrery.retrograde.weird.bands_by_genre.steampunk]
+low = { min = 0.14, max = 0.30 }
+medium = { min = 0.30, max = 0.56 }
+high = { min = 0.56, max = 0.82 }
+
+[orrery.retrograde.weird.bands_by_genre.urban_fantasy]
+low = { min = 0.12, max = 0.28 }
+medium = { min = 0.28, max = 0.54 }
+high = { min = 0.54, max = 0.80 }
+
+[orrery.retrograde.weird.bands_by_genre.space_opera]
+low = { min = 0.22, max = 0.40 }
+medium = { min = 0.40, max = 0.70 }
+high = { min = 0.70, max = 0.96 }
+
+[orrery.retrograde.weird.bands_by_genre.noir]
+low = { min = 0.08, max = 0.22 }
+medium = { min = 0.22, max = 0.45 }
+high = { min = 0.45, max = 0.70 }
+
+[orrery.retrograde.weird.bands_by_genre.thriller]
+low = { min = 0.06, max = 0.20 }
+medium = { min = 0.20, max = 0.44 }
+high = { min = 0.44, max = 0.68 }
+
 # =============================================================================
 # MEMNON Agent Settings (Memory & Retrieval)
 # =============================================================================

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -615,6 +615,12 @@ def _collect_vocabulary(
     }
 
 
+def collect_template_vocabulary(templates: Iterable[Template]) -> dict:
+    """Return package-facing vocabulary referenced by Orrery templates."""
+
+    return _collect_vocabulary(templates)
+
+
 def _discover_orrery_migrations() -> List[str]:
     """Find every migration file in migrations/ whose name mentions orrery.
 

--- a/nexus/agents/orrery/pair_tag_registry.py
+++ b/nexus/agents/orrery/pair_tag_registry.py
@@ -1,0 +1,105 @@
+"""Canonical built-in pair-tag registry rows shared by migrations and readers."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+PairTagSeedRow = tuple[str, list[str], list[str], bool, str]
+
+
+# (tag, subject_kinds, object_kinds, is_ephemeral, description)
+PAIR_TAG_SEED: Sequence[PairTagSeedRow] = (
+    # Place-bound (durable)
+    (
+        "knows_location",
+        ["character"],
+        ["place"],
+        False,
+        "Subject knows of the place's existence and how to find it.",
+    ),
+    (
+        "can_access",
+        ["character", "faction"],
+        ["place"],
+        False,
+        "Subject has permission to enter the place "
+        "(direct individual or group-mediated).",
+    ),
+    (
+        "claims",
+        ["faction"],
+        ["place"],
+        False,
+        "Subject (faction) asserts a territorial claim on the place; "
+        "contestation emerges from row cardinality.",
+    ),
+    (
+        "resides_at",
+        ["character"],
+        ["place"],
+        False,
+        "Subject's habitual residence. Multi-residence is supported via multiple rows.",
+    ),
+    (
+        "operates_from",
+        ["faction"],
+        ["place"],
+        False,
+        "Faction's operational base. Distinct from `claims` — claim is "
+        "territorial, operates_from is functional.",
+    ),
+    (
+        "originates_from",
+        ["character"],
+        ["place"],
+        False,
+        "Character's origin or hometown.",
+    ),
+    # Character / faction relations
+    (
+        "pursuing",
+        ["character", "faction"],
+        ["character"],
+        True,
+        "Subject is actively hunting the target. Ephemeral; also confers "
+        "narrow targeted detection sensitivity for that target (see issue #282).",
+    ),
+    (
+        "handles",
+        ["character"],
+        ["character"],
+        False,
+        "Subject is the operational handler of the target "
+        "(covert / espionage / criminal flavor).",
+    ),
+    (
+        "obligation",
+        ["character", "faction"],
+        ["character", "faction"],
+        False,
+        "Subject owes a debt / oath / loyalty to the target. Kind inferable "
+        "from establishing event.",
+    ),
+    (
+        "authority_over",
+        ["character", "faction"],
+        ["character", "faction"],
+        False,
+        "Subject holds institutional or positional power over the target.",
+    ),
+    (
+        "protects",
+        ["character", "faction"],
+        ["character"],
+        False,
+        "Subject is in an active protective relationship with the target. Durable.",
+    ),
+    (
+        "mentors",
+        ["character"],
+        ["character"],
+        False,
+        "Subject teaches or trains the target.",
+    ),
+)

--- a/nexus/agents/orrery/retrograde_vocabulary.py
+++ b/nexus/agents/orrery/retrograde_vocabulary.py
@@ -1,0 +1,108 @@
+"""Seed-eligible Orrery vocabulary enumeration for Retrograde generation."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import TypedDict
+
+from nexus.agents.orrery.catalog import _collect_vocabulary
+from nexus.agents.orrery.substrate import EntityKind, Slot
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+
+
+class PairTagPrimitive(TypedDict):
+    """One registered multi-entity tag family with kind constraints."""
+
+    tag: str
+    subject_kinds: list[str]
+    object_kinds: list[str]
+    is_ephemeral: bool
+
+
+class SeedEligibleVocabulary(TypedDict):
+    """Primitive vocabulary Retrograde may use for substrate-legal seeds."""
+
+    entity_kinds: list[str]
+    slots: list[str]
+    single_entity_tag_anchors: list[str]
+    durable_tags: list[str]
+    ephemeral_tags: list[str]
+    current_tags: list[str]
+    applied_tags: list[str]
+    multi_entity_tag_families: list[str]
+    multi_entity_tag_definitions: list[PairTagPrimitive]
+    event_types: list[str]
+    place_affordances: list[str]
+    relationship_types: list[str]
+
+
+def enumerate_seed_eligible_vocabulary() -> SeedEligibleVocabulary:
+    """Return the current substrate-legal primitive set for Retrograde seeds.
+
+    The enumeration is read from the same Python sources the forward Orrery
+    already uses: built-in templates for package-facing tags/events/relations,
+    substrate enums for typed entities and slots, and the pair-tag migration's
+    seed registry for directed multi-entity tag families.
+    """
+
+    template_vocab = _collect_vocabulary(BUILTIN_TEMPLATES)
+    single_entity_tags = sorted(
+        set(template_vocab["durable_tags"])
+        | set(template_vocab["ephemeral_tags"])
+        | set(template_vocab["current_tags"])
+        | set(template_vocab["applied_tags"])
+    )
+    pair_tag_definitions = _load_pair_tag_definitions()
+
+    return {
+        "entity_kinds": sorted(kind.value for kind in EntityKind),
+        "slots": sorted(slot.value for slot in Slot),
+        "single_entity_tag_anchors": single_entity_tags,
+        "durable_tags": list(template_vocab["durable_tags"]),
+        "ephemeral_tags": list(template_vocab["ephemeral_tags"]),
+        "current_tags": list(template_vocab["current_tags"]),
+        "applied_tags": list(template_vocab["applied_tags"]),
+        "multi_entity_tag_families": [item["tag"] for item in pair_tag_definitions],
+        "multi_entity_tag_definitions": pair_tag_definitions,
+        "event_types": list(template_vocab["event_types"]),
+        "place_affordances": list(template_vocab["place_affordances"]),
+        "relationship_types": list(template_vocab["relationship_types"]),
+    }
+
+
+def _load_pair_tag_definitions() -> list[PairTagPrimitive]:
+    """Load pair-tag seed definitions from their existing migration registry."""
+
+    migration = _load_python_module(
+        Path(__file__).resolve().parents[3]
+        / "migrations"
+        / "042_orrery_entity_pair_tags.py"
+    )
+    seed_rows = getattr(migration, "PAIR_TAG_SEED")
+    definitions: list[PairTagPrimitive] = []
+    for tag, subject_kinds, object_kinds, is_ephemeral, _description in seed_rows:
+        definitions.append(
+            {
+                "tag": str(tag),
+                "subject_kinds": [str(kind) for kind in subject_kinds],
+                "object_kinds": [str(kind) for kind in object_kinds],
+                "is_ephemeral": bool(is_ephemeral),
+            }
+        )
+    return sorted(definitions, key=lambda item: item["tag"])
+
+
+def _load_python_module(path: Path) -> ModuleType:
+    """Load a Python file by path without requiring importable package names."""
+
+    spec = importlib.util.spec_from_file_location(
+        f"nexus_orrery_retrograde_{path.stem}",
+        path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load Orrery registry module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/nexus/agents/orrery/retrograde_vocabulary.py
+++ b/nexus/agents/orrery/retrograde_vocabulary.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType
 from typing import TypedDict
 
-from nexus.agents.orrery.catalog import _collect_vocabulary
+from nexus.agents.orrery.catalog import collect_template_vocabulary
+from nexus.agents.orrery.pair_tag_registry import PAIR_TAG_SEED
 from nexus.agents.orrery.substrate import EntityKind, Slot
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 
@@ -43,11 +41,11 @@ def enumerate_seed_eligible_vocabulary() -> SeedEligibleVocabulary:
 
     The enumeration is read from the same Python sources the forward Orrery
     already uses: built-in templates for package-facing tags/events/relations,
-    substrate enums for typed entities and slots, and the pair-tag migration's
-    seed registry for directed multi-entity tag families.
+    substrate enums for typed entities and slots, and the shared pair-tag
+    registry for directed multi-entity tag families.
     """
 
-    template_vocab = _collect_vocabulary(BUILTIN_TEMPLATES)
+    template_vocab = collect_template_vocabulary(BUILTIN_TEMPLATES)
     single_entity_tags = sorted(
         set(template_vocab["durable_tags"])
         | set(template_vocab["ephemeral_tags"])
@@ -60,29 +58,23 @@ def enumerate_seed_eligible_vocabulary() -> SeedEligibleVocabulary:
         "entity_kinds": sorted(kind.value for kind in EntityKind),
         "slots": sorted(slot.value for slot in Slot),
         "single_entity_tag_anchors": single_entity_tags,
-        "durable_tags": list(template_vocab["durable_tags"]),
-        "ephemeral_tags": list(template_vocab["ephemeral_tags"]),
-        "current_tags": list(template_vocab["current_tags"]),
-        "applied_tags": list(template_vocab["applied_tags"]),
+        "durable_tags": _sorted_strings(template_vocab["durable_tags"]),
+        "ephemeral_tags": _sorted_strings(template_vocab["ephemeral_tags"]),
+        "current_tags": _sorted_strings(template_vocab["current_tags"]),
+        "applied_tags": _sorted_strings(template_vocab["applied_tags"]),
         "multi_entity_tag_families": [item["tag"] for item in pair_tag_definitions],
         "multi_entity_tag_definitions": pair_tag_definitions,
-        "event_types": list(template_vocab["event_types"]),
-        "place_affordances": list(template_vocab["place_affordances"]),
-        "relationship_types": list(template_vocab["relationship_types"]),
+        "event_types": _sorted_strings(template_vocab["event_types"]),
+        "place_affordances": _sorted_strings(template_vocab["place_affordances"]),
+        "relationship_types": _sorted_strings(template_vocab["relationship_types"]),
     }
 
 
 def _load_pair_tag_definitions() -> list[PairTagPrimitive]:
-    """Load pair-tag seed definitions from their existing migration registry."""
+    """Load pair-tag seed definitions from the shared built-in registry."""
 
-    migration = _load_python_module(
-        Path(__file__).resolve().parents[3]
-        / "migrations"
-        / "042_orrery_entity_pair_tags.py"
-    )
-    seed_rows = getattr(migration, "PAIR_TAG_SEED")
     definitions: list[PairTagPrimitive] = []
-    for tag, subject_kinds, object_kinds, is_ephemeral, _description in seed_rows:
+    for tag, subject_kinds, object_kinds, is_ephemeral, _description in PAIR_TAG_SEED:
         definitions.append(
             {
                 "tag": str(tag),
@@ -94,15 +86,7 @@ def _load_pair_tag_definitions() -> list[PairTagPrimitive]:
     return sorted(definitions, key=lambda item: item["tag"])
 
 
-def _load_python_module(path: Path) -> ModuleType:
-    """Load a Python file by path without requiring importable package names."""
+def _sorted_strings(values: object) -> list[str]:
+    """Return stable string ordering for a vocabulary bucket."""
 
-    spec = importlib.util.spec_from_file_location(
-        f"nexus_orrery_retrograde_{path.stem}",
-        path,
-    )
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"Unable to load Orrery registry module: {path}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    return sorted(str(value) for value in values)

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -302,7 +302,10 @@ class OrreryPromoteSettings(BaseModel):
     perceptual_summary_max_chars: int = Field(
         default=240,
         ge=1,
-        description="Maximum characters copied from a resolution brief into the promotion summary.",
+        description=(
+            "Maximum characters copied from a resolution brief into the "
+            "promotion summary."
+        ),
     )
     provider: Optional[Literal["local"]] = Field(
         default=None,
@@ -422,6 +425,103 @@ class OrrerySunhelmSettings(BaseModel):
         return self
 
 
+class OrreryRetrogradeWeirdBandSettings(BaseModel):
+    """Inclusive raw-float interval for one player-facing weirdness level."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    min: float = Field(..., ge=0.0)
+    max: float = Field(..., ge=0.0)
+
+    @model_validator(mode="after")
+    def _validate_order(self) -> "OrreryRetrogradeWeirdBandSettings":
+        if self.min > self.max:
+            raise ValueError("Weird band min must be less than or equal to max")
+        return self
+
+
+class OrreryRetrogradeWeirdGenreBands(BaseModel):
+    """Per-genre remapping from coarse player level to raw weirdness band."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    low: OrreryRetrogradeWeirdBandSettings
+    medium: OrreryRetrogradeWeirdBandSettings
+    high: OrreryRetrogradeWeirdBandSettings
+
+    @model_validator(mode="after")
+    def _validate_monotonic(self) -> "OrreryRetrogradeWeirdGenreBands":
+        if not (
+            self.low.min
+            <= self.low.max
+            <= self.medium.min
+            <= self.medium.max
+            <= self.high.min
+            <= self.high.max
+        ):
+            raise ValueError(
+                "Weird genre bands must be monotonic: "
+                "low <= medium <= high without overlap"
+            )
+        return self
+
+
+class OrreryRetrogradeWeirdDevSettings(BaseModel):
+    """Developer-facing raw weirdness float surface for calibration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    cli_flag: str = Field(
+        default="--weird",
+        description="Future calibration CLI flag for raw weirdness overrides.",
+    )
+    min: float = Field(default=0.0, ge=0.0)
+    max: float = Field(default=1.0, ge=0.0)
+    default: float = Field(default=0.5, ge=0.0)
+
+    @model_validator(mode="after")
+    def _validate_range(self) -> "OrreryRetrogradeWeirdDevSettings":
+        if self.min > self.max:
+            raise ValueError("Retrograde weird dev min must be <= max")
+        if not self.min <= self.default <= self.max:
+            raise ValueError("Retrograde weird dev default must be within range")
+        return self
+
+
+class OrreryRetrogradeWeirdSettings(BaseModel):
+    """Entropy/coherence control for Retrograde seed generation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    default_level: Literal["low", "medium", "high"] = "medium"
+    dev: OrreryRetrogradeWeirdDevSettings = Field(
+        default_factory=OrreryRetrogradeWeirdDevSettings
+    )
+    bands_by_genre: Dict[str, OrreryRetrogradeWeirdGenreBands] = Field(
+        default_factory=dict
+    )
+
+    @model_validator(mode="after")
+    def _validate_bands_within_dev_range(self) -> "OrreryRetrogradeWeirdSettings":
+        for genre, bands in self.bands_by_genre.items():
+            for level in ("low", "medium", "high"):
+                band = getattr(bands, level)
+                if band.min < self.dev.min or band.max > self.dev.max:
+                    raise ValueError(
+                        f"orrery.retrograde.weird band {genre}.{level} "
+                        "must stay within the dev raw range"
+                    )
+        return self
+
+
+class OrreryRetrogradeSettings(BaseModel):
+    """Retrograde deep-history generation settings."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    weird: OrreryRetrogradeWeirdSettings
+
+
 class OrrerySettings(BaseModel):
     """Orrery off-screen behavior subsystem settings."""
 
@@ -436,6 +536,7 @@ class OrrerySettings(BaseModel):
     bleed: OrreryBleedSettings = Field(default_factory=OrreryBleedSettings)
     promote: OrreryPromoteSettings = Field(default_factory=OrreryPromoteSettings)
     sunhelm: OrrerySunhelmSettings = Field(default_factory=OrrerySunhelmSettings)
+    retrograde: OrreryRetrogradeSettings
 
 
 # =============================================================================
@@ -558,7 +659,8 @@ class RerankerCandidate(BaseModel):
     """One reranker model entry in the bakeoff candidate registry.
 
     `api_type` selects the inference path in ``cross_encoder.rerank_results``:
-      - "cross_encoder": standard SequenceClassification (DeBERTa-v3, mxbai, BGE-v2, etc.)
+      - "cross_encoder": standard SequenceClassification (DeBERTa-v3,
+        mxbai, BGE-v2, etc.)
       - "qwen3_lm": Qwen3-Reranker causal-LM with yes/no logit head
 
     Note: the production reranker is selected by the top-level
@@ -739,10 +841,15 @@ class IREvalJudgmentConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    model: str = Field(..., description="LLM model identifier for relevance judgments")
+    model: str = Field(
+        ...,
+        description="LLM model identifier for relevance judgments",
+    )
     reasoning_effort: str = Field(
         default="high",
-        description="Reasoning effort for the judgment model (e.g. minimal/medium/high)",
+        description=(
+            "Reasoning effort for the judgment model " "(e.g. minimal/medium/high)"
+        ),
     )
 
 
@@ -872,9 +979,9 @@ class Settings(BaseModel):
 
     def model_dump(self, **kwargs) -> dict:
         """
-        Convert settings to dict, preserving dict-style access for backward compatibility.
+        Convert settings to dict, preserving dict-style access.
 
-        This ensures that existing code using settings.get("key", default) continues to work.
+        This keeps existing settings.get("key", default) callers working.
         """
         return super().model_dump(by_alias=True, **kwargs)
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -425,6 +425,25 @@ class OrrerySunhelmSettings(BaseModel):
         return self
 
 
+RETROGRADE_SUPPORTED_GENRES = frozenset(
+    {
+        "fantasy",
+        "scifi",
+        "horror",
+        "mystery",
+        "historical",
+        "contemporary",
+        "postapocalyptic",
+        "cyberpunk",
+        "steampunk",
+        "urban_fantasy",
+        "space_opera",
+        "noir",
+        "thriller",
+    }
+)
+
+
 class OrreryRetrogradeWeirdBandSettings(BaseModel):
     """Inclusive raw-float interval for one player-facing weirdness level."""
 
@@ -462,6 +481,14 @@ class OrreryRetrogradeWeirdGenreBands(BaseModel):
             raise ValueError(
                 "Weird genre bands must be monotonic: "
                 "low <= medium <= high without overlap"
+            )
+        if not (
+            _same_float_boundary(self.low.max, self.medium.min)
+            and _same_float_boundary(self.medium.max, self.high.min)
+        ):
+            raise ValueError(
+                "Weird genre bands must be contiguous: "
+                "low.max == medium.min and medium.max == high.min"
             )
         return self
 
@@ -503,6 +530,15 @@ class OrreryRetrogradeWeirdSettings(BaseModel):
 
     @model_validator(mode="after")
     def _validate_bands_within_dev_range(self) -> "OrreryRetrogradeWeirdSettings":
+        configured = set(self.bands_by_genre)
+        if configured != RETROGRADE_SUPPORTED_GENRES:
+            missing = sorted(RETROGRADE_SUPPORTED_GENRES - configured)
+            unknown = sorted(configured - RETROGRADE_SUPPORTED_GENRES)
+            raise ValueError(
+                "orrery.retrograde.weird.bands_by_genre must define exactly "
+                f"{sorted(RETROGRADE_SUPPORTED_GENRES)}; "
+                f"missing={missing}, unknown={unknown}"
+            )
         for genre, bands in self.bands_by_genre.items():
             for level in ("low", "medium", "high"):
                 band = getattr(bands, level)
@@ -514,6 +550,10 @@ class OrreryRetrogradeWeirdSettings(BaseModel):
         return self
 
 
+def _same_float_boundary(left: float, right: float) -> bool:
+    return abs(left - right) <= 1e-9
+
+
 class OrreryRetrogradeSettings(BaseModel):
     """Retrograde deep-history generation settings."""
 
@@ -523,7 +563,11 @@ class OrreryRetrogradeSettings(BaseModel):
 
 
 class OrrerySettings(BaseModel):
-    """Orrery off-screen behavior subsystem settings."""
+    """Orrery off-screen behavior settings.
+
+    Retrograde config is intentionally required so every slot has explicit
+    weird-dial genre remapping before generation code starts reading it.
+    """
 
     model_config = ConfigDict(extra="forbid")
 

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -1,5 +1,7 @@
 """Tests for Orrery configuration loading."""
 
+from copy import deepcopy
+
 import pytest
 from pydantic import ValidationError
 
@@ -93,17 +95,32 @@ def test_orrery_retrograde_weird_rejects_overlapping_bands() -> None:
         )
 
 
+def test_orrery_retrograde_weird_rejects_non_contiguous_bands() -> None:
+    """Genre remaps should cover a continuous raw-float band per genre."""
+
+    with pytest.raises(ValidationError, match="must be contiguous"):
+        OrreryRetrogradeWeirdGenreBands(
+            low={"min": 0.0, "max": 0.3},
+            medium={"min": 0.4, "max": 0.7},
+            high={"min": 0.7, "max": 1.0},
+        )
+
+
+def test_orrery_retrograde_weird_rejects_unknown_genre_keys() -> None:
+    """Typos in per-genre weird bands should fail at config load time."""
+
+    payload = deepcopy(load_settings("nexus.toml").orrery.retrograde.weird.model_dump())
+    payload["bands_by_genre"]["sci_fi"] = payload["bands_by_genre"].pop("scifi")
+
+    with pytest.raises(ValidationError, match="must define exactly"):
+        OrreryRetrogradeWeirdSettings(**payload)
+
+
 def test_orrery_retrograde_weird_rejects_bands_outside_dev_range() -> None:
     """Per-genre raw bands must stay within the configured dev float surface."""
 
+    payload = deepcopy(load_settings("nexus.toml").orrery.retrograde.weird.model_dump())
+    payload["dev"]["min"] = 0.2
+
     with pytest.raises(ValidationError, match="within the dev raw range"):
-        OrreryRetrogradeWeirdSettings(
-            dev={"cli_flag": "--weird", "min": 0.2, "max": 0.8, "default": 0.5},
-            bands_by_genre={
-                "fantasy": {
-                    "low": {"min": 0.1, "max": 0.2},
-                    "medium": {"min": 0.2, "max": 0.5},
-                    "high": {"min": 0.5, "max": 0.8},
-                }
-            },
-        )
+        OrreryRetrogradeWeirdSettings(**payload)

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -1,7 +1,16 @@
 """Tests for Orrery configuration loading."""
 
+import pytest
+from pydantic import ValidationError
+
 from nexus.config import load_settings
-from nexus.config.settings_models import OrreryBleedSettings, OrreryPromoteSettings
+from nexus.api.new_story_schemas import Genre
+from nexus.config.settings_models import (
+    OrreryBleedSettings,
+    OrreryPromoteSettings,
+    OrreryRetrogradeWeirdGenreBands,
+    OrreryRetrogradeWeirdSettings,
+)
 
 
 def test_orrery_settings_resolve_model_reference() -> None:
@@ -36,6 +45,14 @@ def test_orrery_settings_resolve_model_reference() -> None:
         "intimacy": 16,
     }
     assert settings.orrery.sunhelm.pressure.min_severity_level == 2
+    weird = settings.orrery.retrograde.weird
+    assert weird.default_level == "medium"
+    assert weird.dev.cli_flag == "--weird"
+    assert weird.dev.min == 0.0
+    assert weird.dev.max == 1.0
+    assert set(weird.bands_by_genre) == {genre.value for genre in Genre}
+    assert weird.bands_by_genre["cyberpunk"].medium.min == 0.36
+    assert weird.bands_by_genre["historical"].medium.min == 0.12
 
 
 def test_orrery_bleed_accepts_deprecated_selection_keys() -> None:
@@ -63,3 +80,30 @@ def test_orrery_promote_accepts_deprecated_provider_key() -> None:
     assert dumped["magnitude_threshold"] == 0.5
     assert dumped["perceptual_summary_max_chars"] == 240
     assert "provider" not in dumped
+
+
+def test_orrery_retrograde_weird_rejects_overlapping_bands() -> None:
+    """Genre remaps must preserve low -> medium -> high ordering."""
+
+    with pytest.raises(ValidationError, match="low <= medium <= high"):
+        OrreryRetrogradeWeirdGenreBands(
+            low={"min": 0.0, "max": 0.5},
+            medium={"min": 0.4, "max": 0.7},
+            high={"min": 0.7, "max": 1.0},
+        )
+
+
+def test_orrery_retrograde_weird_rejects_bands_outside_dev_range() -> None:
+    """Per-genre raw bands must stay within the configured dev float surface."""
+
+    with pytest.raises(ValidationError, match="within the dev raw range"):
+        OrreryRetrogradeWeirdSettings(
+            dev={"cli_flag": "--weird", "min": 0.2, "max": 0.8, "default": 0.5},
+            bands_by_genre={
+                "fantasy": {
+                    "low": {"min": 0.1, "max": 0.2},
+                    "medium": {"min": 0.2, "max": 0.5},
+                    "high": {"min": 0.5, "max": 0.8},
+                }
+            },
+        )

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -398,6 +398,22 @@ def test_category_refactor_phase1_migration_marks_cutover_categories() -> None:
     assert "AND entity_kind = %s::entity_kind" in migration_source
 
 
+def test_status_reputation_disambiguation_migration_updates_wizard_copy() -> None:
+    """Migration 044 clarifies scoped Status vs broad Reputation/Fame."""
+
+    migration_source = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "044_disambiguate_status_reputation_traits.sql"
+    ).read_text()
+
+    assert "known within that group" in migration_source
+    assert "broadly you''re recognized beyond any one specific group" in (
+        migration_source
+    )
+    assert "use Status instead when recognition is limited" in migration_source
+
+
 def test_tag_baseline_reconciliation_migration_closes_slot_drift() -> None:
     """Migration 038 keeps template clones and existing slots on one vocab set."""
 

--- a/tests/test_orrery/test_retrograde_vocabulary.py
+++ b/tests/test_orrery/test_retrograde_vocabulary.py
@@ -1,0 +1,51 @@
+"""Tests for Retrograde seed-eligible vocabulary enumeration."""
+
+from __future__ import annotations
+
+from nexus.agents.orrery.retrograde_vocabulary import (
+    enumerate_seed_eligible_vocabulary,
+)
+
+
+def test_seed_eligible_vocabulary_includes_template_primitives() -> None:
+    """The enumerator reflects tags, events, places, and relations in templates."""
+
+    vocabulary = enumerate_seed_eligible_vocabulary()
+
+    assert {"character", "faction", "place"} <= set(vocabulary["entity_kinds"])
+    assert {"actor", "target", "location"} <= set(vocabulary["slots"])
+    assert "vendetta_holder" in vocabulary["single_entity_tag_anchors"]
+    assert "grudge_active" in vocabulary["single_entity_tag_anchors"]
+    assert "reputation_compromised" in vocabulary["single_entity_tag_anchors"]
+    assert "retaliation_executed" in vocabulary["event_types"]
+    assert "evade_pursuit" in vocabulary["event_types"]
+    assert "home" in vocabulary["place_affordances"]
+    assert "wilderness" in vocabulary["place_affordances"]
+    assert "family" in vocabulary["relationship_types"]
+    assert "handler" in vocabulary["relationship_types"]
+
+
+def test_seed_eligible_vocabulary_includes_pair_tag_kind_constraints() -> None:
+    """Multi-entity tag families include subject/object polymorphism."""
+
+    vocabulary = enumerate_seed_eligible_vocabulary()
+    definitions = {
+        item["tag"]: item for item in vocabulary["multi_entity_tag_definitions"]
+    }
+
+    assert "claims" in vocabulary["multi_entity_tag_families"]
+    assert definitions["claims"]["subject_kinds"] == ["faction"]
+    assert definitions["claims"]["object_kinds"] == ["place"]
+    assert definitions["pursuing"]["subject_kinds"] == ["character", "faction"]
+    assert definitions["pursuing"]["object_kinds"] == ["character"]
+    assert definitions["pursuing"]["is_ephemeral"] is True
+
+
+def test_seed_eligible_pair_tags_are_sorted() -> None:
+    """Stable ordering keeps snapshots and future prompt generation deterministic."""
+
+    vocabulary = enumerate_seed_eligible_vocabulary()
+
+    assert vocabulary["multi_entity_tag_families"] == sorted(
+        vocabulary["multi_entity_tag_families"]
+    )

--- a/tests/test_orrery/test_retrograde_vocabulary.py
+++ b/tests/test_orrery/test_retrograde_vocabulary.py
@@ -45,7 +45,19 @@ def test_seed_eligible_pair_tags_are_sorted() -> None:
     """Stable ordering keeps snapshots and future prompt generation deterministic."""
 
     vocabulary = enumerate_seed_eligible_vocabulary()
-
-    assert vocabulary["multi_entity_tag_families"] == sorted(
-        vocabulary["multi_entity_tag_families"]
+    list_keys = (
+        "entity_kinds",
+        "slots",
+        "single_entity_tag_anchors",
+        "durable_tags",
+        "ephemeral_tags",
+        "current_tags",
+        "applied_tags",
+        "multi_entity_tag_families",
+        "event_types",
+        "place_affordances",
+        "relationship_types",
     )
+
+    for key in list_keys:
+        assert vocabulary[key] == sorted(vocabulary[key])

--- a/tests/test_trait_menu_docs.py
+++ b/tests/test_trait_menu_docs.py
@@ -1,0 +1,16 @@
+"""Tests for player-facing trait menu guidance."""
+
+from pathlib import Path
+
+
+def test_trait_menu_disambiguates_status_from_reputation() -> None:
+    """Wizard trait reference must separate scoped standing from broad fame."""
+
+    trait_menu = (
+        Path(__file__).resolve().parents[1] / "docs" / "trait_menu.md"
+    ).read_text()
+
+    assert "standing within a specific institution, faction, community" in trait_menu
+    assert "known within that group" in trait_menu
+    assert "how broadly you're recognized beyond any one specific group" in trait_menu
+    assert "use Status instead when the recognition is limited" in trait_menu


### PR DESCRIPTION
## Summary

- Add `enumerate_seed_eligible_vocabulary()` for Retrograde Stage R1, sourcing template vocabulary, substrate enums, and pair-tag definitions from the existing Orrery registries.
- Add `[orrery.retrograde.weird]` config with a raw dev `--weird` float surface and per-supported-genre low/medium/high remapping.
- Clarify wizard Status vs Reputation/Fame copy in `docs/trait_menu.md`, fresh-slot trait seeds, and migration 044 for existing slots.
- Resolve #302 separately by closing the issue with the existing real-call retrieval bake-off writeup and go/no-go disposition.

## Validation

- `PYTHONPATH=. poetry run pytest tests/test_orrery tests/config tests/test_trait_menu_docs.py`
- `PYTHONPATH=. poetry run pytest tests/test_orrery/test_catalog.py`
- `poetry run flake8 nexus/agents/orrery/retrograde_vocabulary.py nexus/config/settings_models.py tests/test_orrery/test_config.py tests/test_orrery/test_migrate.py tests/test_orrery/test_retrograde_vocabulary.py tests/test_trait_menu_docs.py`
- `git diff --check`
- `poetry run python scripts/migrate.py --all --dry-run`

## Schema / Config Impact

- Adds migration `044_disambiguate_status_reputation_traits.sql`; dry-run confirms it is discoverable after 043.
- Adds new `orrery.retrograde.weird` config required by the Pydantic settings loader.

Closes #297
Closes #298
Closes #309
