### PR TITLE
Add Orrery entity tag clear helper

### DIFF
--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -307,9 +307,13 @@ def clear_entity_tag(cur: Any, *, entity_id: int, tag: str) -> bool:
     than raising — this is the inverse of ``apply_tag_bestowal``, which raises
     ``ValueError`` for unknown tags. The asymmetry matches ``clear_pair_tag``:
     clearing a tag that doesn't exist is a no-op, so an unknown tag is
-    indistinguishable from a missing row.
+    indistinguishable from a missing row. Alias names in ``CANONICAL_TAGS``
+    resolve to their canonical tag before clearing. Deprecated registry rows
+    are intentionally treated as absent; clearing pre-deprecation active rows is
+    a data-cleanup concern for a migration or id-based maintenance helper.
     """
 
+    canonical_name = CANONICAL_TAGS.get(tag, tag)
     cur.execute(
         """
         UPDATE entity_tags et
@@ -322,7 +326,7 @@ def clear_entity_tag(cur: Any, *, entity_id: int, tag: str) -> bool:
           AND t.synonym_for IS NULL
           AND et.cleared_at IS NULL
         """,
-        (entity_id, tag),
+        (entity_id, canonical_name),
     )
     return bool(cur.rowcount)
 

--- a/tests/test_orrery/test_tag_writer.py
+++ b/tests/test_orrery/test_tag_writer.py
@@ -379,7 +379,7 @@ def test_clear_entity_tag_marks_known_active_tag_cleared():
     assert cur.cleared_keys == [(11, tag_id)]
 
 
-def test_clear_entity_tag_returns_false_when_no_active_row():
+def test_clear_entity_tag_is_idempotent():
     tag_id = hash("scrying_target") & 0xFFFFFF
     cur = FakeCursor(
         tags=_registered(("scrying_target", "orrery_state", True)),
@@ -396,6 +396,33 @@ def test_clear_entity_tag_returns_false_when_no_active_row():
 
     assert clear_entity_tag(cur, entity_id=11, tag="scrying_target") is True
     assert clear_entity_tag(cur, entity_id=11, tag="scrying_target") is False
+
+
+def test_clear_entity_tag_returns_false_when_no_active_row():
+    cur = FakeCursor(tags=_registered(("scrying_target", "orrery_state", True)))
+
+    assert clear_entity_tag(cur, entity_id=11, tag="scrying_target") is False
+
+
+def test_clear_entity_tag_resolves_canonical_alias():
+    tag_id = hash("corporate_exile") & 0xFFFFFF
+    cur = FakeCursor(
+        tags=_registered(("corporate_exile", "state", False)),
+        entity_tags=[
+            {
+                "entity_id": 42,
+                "tag_id": tag_id,
+                "applied_at_world_time": _WORLD_TIME,
+                "source_kind": "skald_inline",
+                "cleared_at": None,
+            }
+        ],
+    )
+
+    cleared = clear_entity_tag(cur, entity_id=42, tag="corporate_defector")
+
+    assert cleared is True
+    assert cur.entity_tags[0]["cleared_at"] == "now"
 
 
 def test_clear_entity_tag_unknown_or_deprecated_tag_is_noop():


### PR DESCRIPTION
## Summary
- Add public `clear_entity_tag` for event-driven single-entity tag clearance by tag name.
- Keep clear semantics no-op for missing, inactive, unknown, or deprecated tag names.
- Fix migration 043 `COMMENT ON COLUMN` syntax so 043 and queued 044 can apply.

## Validation
- `poetry run flake8 nexus/agents/orrery/tag_writer.py tests/test_orrery/test_tag_writer.py migrations/043_orrery_category_refactor_phase1.py tests/test_orrery/test_migrate.py`
- `git diff --check`
- `poetry run pytest tests/test_orrery/test_tag_writer.py tests/test_orrery/test_migrate.py`
- `poetry run python scripts/migrate.py --all`
- `psql -d save_02 -Atc "SELECT ... col_description(...) ..."`
- `poetry run pytest tests/test_orrery`
- `poetry run pytest`

## Schema / Config / Data
- Schema migration 043 is fixed in place because it was unapplied before this branch.
- Local migration run applied 043 and 044 to `NEXUS_template` and `save_02` through `save_05`; locked `save_01` was skipped as expected.
- No settings/config changes.

Closes #313
Closes #314