### PR TITLE
Implement trait compiler pipeline

### DIFF
--- a/docs/trait_menu.md
+++ b/docs/trait_menu.md
@@ -38,7 +38,7 @@ Not choosing a trait does not mean the character is bereft of it; rather, this s
 - use this when you are known within that group, even if obscure elsewhere
 - examples: military commission, guild journeyman, corporate board seat, respected neighborhood fixer
 
-### Reputation (Fame)
+### Fame (formerly Reputation)
 - how broadly you're recognized beyond any one specific group
 - what the wider world recognizes you for, for better or worse
 - use Status instead when the recognition is limited to one faction, institution, community, or subculture

--- a/migrations/045_trait_compiler_substrate.py
+++ b/migrations/045_trait_compiler_substrate.py
@@ -1,0 +1,182 @@
+"""Seed trait-compiler substrate vocabulary and audit storage."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+ROLE_CATEGORIES: Sequence[tuple[str, int, str]] = (
+    (
+        "role.resources",
+        30,
+        "Exclusive character wealth/resource tier used by the Resources trait.",
+    ),
+    (
+        "role.fame",
+        40,
+        "Exclusive ambient recognition radius used by the Fame trait.",
+    ),
+)
+
+
+ROLE_TAGS: Sequence[tuple[str, str, str]] = (
+    ("destitute", "role.resources", "Resource tier: destitute."),
+    ("poor", "role.resources", "Resource tier: poor."),
+    ("comfortable", "role.resources", "Resource tier: comfortable/default."),
+    ("wealthy", "role.resources", "Resource tier: wealthy."),
+    ("magnate", "role.resources", "Resource tier: magnate."),
+    ("obscure", "role.fame", "Fame tier: obscure/default."),
+    ("known", "role.fame", "Fame tier: known."),
+    ("renowned", "role.fame", "Fame tier: renowned."),
+    ("legendary", "role.fame", "Fame tier: legendary."),
+)
+
+
+PAIR_TAGS: Sequence[tuple[str, list[str], list[str], bool, str]] = (
+    (
+        "ally",
+        ["character"],
+        ["character"],
+        False,
+        "Affective relationship gate: willing to help and take risks.",
+    ),
+    (
+        "contact",
+        ["character"],
+        ["character"],
+        False,
+        "Affective relationship gate: information/favor pipeline.",
+    ),
+    (
+        "hostile_to",
+        ["character", "faction"],
+        ["character", "faction"],
+        False,
+        "Durable active opposition distinct from acute pursuit.",
+    ),
+)
+
+
+STATUS_PAIR_TAGS: Sequence[tuple[str, list[str], list[str], bool, str]] = tuple(
+    (
+        f"status:{level}",
+        ["character", "faction"],
+        ["faction"],
+        False,
+        f"Scope-bound status level: {level}.",
+    )
+    for level in (
+        "junior",
+        "senior",
+        "executive",
+        "sovereign",
+        "respected",
+        "elite",
+        "outcast",
+        "pariah",
+        "enslaved",
+    )
+)
+
+
+def run(conn) -> None:
+    """Apply trait-compiler substrate changes."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            ALTER TABLE IF EXISTS assets.new_story_creator
+            ADD COLUMN IF NOT EXISTS trait_compile_result jsonb
+            """
+        )
+        cur.execute(
+            """
+            COMMENT ON COLUMN assets.new_story_creator.trait_compile_result IS
+                'Dry-run or final trait compiler audit result for debugging.';
+            """
+        )
+
+        for category, prompt_order, description in ROLE_CATEGORIES:
+            cur.execute(
+                """
+                INSERT INTO tag_category_registry (
+                    category, entity_kind, prompt_order, description,
+                    deprecated, replacement_categories
+                ) VALUES (
+                    %s, 'character'::entity_kind, %s, %s,
+                    FALSE, NULL
+                )
+                ON CONFLICT (category, entity_kind) DO UPDATE SET
+                    prompt_order = EXCLUDED.prompt_order,
+                    description = EXCLUDED.description,
+                    deprecated = FALSE,
+                    replacement_categories = NULL
+                """,
+                (category, prompt_order, description),
+            )
+
+        for tag, category, description in ROLE_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy,
+                    clear_on, deprecated, description
+                ) VALUES (
+                    %s, %s, FALSE,
+                    NULL, NULL,
+                    NULL, FALSE, %s
+                )
+                ON CONFLICT (tag) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    is_ephemeral = EXCLUDED.is_ephemeral,
+                    clearance_kind = EXCLUDED.clearance_kind,
+                    reapplication_policy = EXCLUDED.reapplication_policy,
+                    clear_on = EXCLUDED.clear_on,
+                    deprecated = FALSE,
+                    description = EXCLUDED.description
+                """,
+                (tag, category, description),
+            )
+
+        for tag, subject_kinds, object_kinds, is_ephemeral, description in (
+            PAIR_TAGS + STATUS_PAIR_TAGS
+        ):
+            cur.execute(
+                """
+                INSERT INTO pair_tags (
+                    tag, subject_kinds, object_kinds,
+                    is_ephemeral, clearance_kind, description, deprecated
+                ) VALUES (
+                    %s, %s, %s,
+                    %s, NULL, %s, FALSE
+                )
+                ON CONFLICT (tag) DO UPDATE SET
+                    subject_kinds = EXCLUDED.subject_kinds,
+                    object_kinds = EXCLUDED.object_kinds,
+                    is_ephemeral = EXCLUDED.is_ephemeral,
+                    clearance_kind = EXCLUDED.clearance_kind,
+                    description = EXCLUDED.description,
+                    deprecated = FALSE
+                """,
+                (tag, subject_kinds, object_kinds, is_ephemeral, description),
+            )
+
+        cur.execute(
+            """
+            UPDATE pair_tags
+            SET subject_kinds = ARRAY['character', 'faction']
+            WHERE tag = 'claims'
+            """
+        )
+
+        cur.execute(
+            """
+            UPDATE assets.traits
+            SET name = 'fame'
+            WHERE id = 6
+              AND name = 'reputation'
+            """
+        )
+
+    conn.commit()

--- a/nexus/api/new_story_cache.py
+++ b/nexus/api/new_story_cache.py
@@ -29,6 +29,8 @@ VALID_TRAITS = frozenset(
         "patron",
         "dependents",
         "status",
+        "fame",
+        # Backward-compatible during the Reputation -> Fame rename.
         "reputation",
         "resources",
         "domain",
@@ -127,6 +129,7 @@ class CharacterData:
     wildcard_name: Optional[str] = None  # from traits.name where id=11
     wildcard_rationale: Optional[str] = None  # from traits.rationale where id=11
     orrery_tags: Optional[Dict[str, Any]] = None  # from new_story_creator JSONB
+    trait_compile_result: Optional[Dict[str, Any]] = None
 
     def has_concept(self) -> bool:
         """Check if concept subphase is complete."""
@@ -445,6 +448,7 @@ def _row_to_cache(
             wildcard_name=wildcard_row.get("name") if wildcard_row else None,
             wildcard_rationale=wildcard_row.get("rationale") if wildcard_row else None,
             orrery_tags=_parse_json_object(row.get("character_orrery_tags")),
+            trait_compile_result=_parse_json_object(row.get("trait_compile_result")),
         ),
         seed=SeedData(
             seed_type=row.get("seed_type"),
@@ -898,7 +902,8 @@ def clear_cache(dbname: Optional[str] = None) -> None:
             cur.execute(
                 """
                 UPDATE assets.new_story_creator
-                SET character_orrery_tags = NULL
+                SET character_orrery_tags = NULL,
+                    trait_compile_result = NULL
                 WHERE id = TRUE
                 """
             )

--- a/nexus/api/new_story_cache.py
+++ b/nexus/api/new_story_cache.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from nexus.api.db_pool import get_connection
+from nexus.api.trait_compiler_schemas import canonical_trait_name
 
 logger = logging.getLogger("nexus.api.new_story_cache")
 
@@ -40,14 +41,6 @@ VALID_TRAITS = frozenset(
 )
 
 
-def _canonical_trait_name(trait_name: str) -> str:
-    """Return the database storage name for accepted trait aliases."""
-
-    if trait_name == "reputation":
-        return "fame"
-    return trait_name
-
-
 def _ensure_trait_update_matched(
     cur: Any,
     *,
@@ -61,6 +54,22 @@ def _ensure_trait_update_matched(
             f"Trait {trait_name!r} resolved to {storage_name!r}, "
             "but no assets.traits row was updated."
         )
+
+
+def _trait_rationale(
+    rationales: Dict[str, str],
+    *,
+    trait_name: str,
+    storage_name: str,
+) -> str:
+    """Resolve rationales across canonical trait names and legacy aliases."""
+
+    return (
+        rationales.get(trait_name)
+        or rationales.get(storage_name)
+        or (rationales.get("reputation") if storage_name == "fame" else None)
+        or ""
+    )
 
 
 def _parse_pg_array(value: Any) -> List[str]:
@@ -602,7 +611,7 @@ def toggle_trait(dbname: Optional[str], trait_name: str) -> bool:
         raise ValueError(
             f"Invalid trait: {trait_name}. Must be one of {sorted(VALID_TRAITS)}"
         )
-    storage_name = _canonical_trait_name(trait_name)
+    storage_name = canonical_trait_name(trait_name)
 
     with get_connection(dbname) as conn:
         with conn.cursor() as cur:
@@ -788,7 +797,7 @@ def write_suggested_traits(
                         f"Invalid trait: {trait_name}. "
                         f"Must be one of {sorted(VALID_TRAITS)}"
                     )
-                storage_name = _canonical_trait_name(trait_name)
+                storage_name = canonical_trait_name(trait_name)
                 cur.execute(
                     """
                     UPDATE assets.traits
@@ -940,14 +949,6 @@ def clear_cache(dbname: Optional[str] = None) -> None:
     """
     with get_connection(dbname) as conn:
         with conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE assets.new_story_creator
-                SET character_orrery_tags = NULL,
-                    trait_compile_result = NULL
-                WHERE id = TRUE
-                """
-            )
             cur.execute("DELETE FROM assets.new_story_creator WHERE id = TRUE")
             # Reset traits: deselect optional traits, clear rationales, reset wildcard name
             cur.execute(
@@ -1013,6 +1014,7 @@ def clear_character_phase(dbname: Optional[str] = None) -> None:
                     character_background = NULL,
                     character_appearance = NULL,
                     character_orrery_tags = NULL,
+                    trait_compile_result = NULL,
                     traits_confirmed = FALSE,
                     -- Seed columns (also clear downstream)
                     seed_type = NULL,
@@ -1081,6 +1083,7 @@ def clear_setting_phase(dbname: Optional[str] = None) -> None:
                     character_background = NULL,
                     character_appearance = NULL,
                     character_orrery_tags = NULL,
+                    trait_compile_result = NULL,
                     -- Seed columns
                     seed_type = NULL,
                     seed_title = NULL,
@@ -1242,8 +1245,12 @@ def write_cache(
                             "UPDATE assets.traits SET is_selected = FALSE, rationale = NULL WHERE id <= 10"
                         )
                         for trait_name in selected:
-                            storage_name = _canonical_trait_name(trait_name)
-                            rationale = rationales.get(trait_name, "")
+                            storage_name = canonical_trait_name(trait_name)
+                            rationale = _trait_rationale(
+                                rationales,
+                                trait_name=trait_name,
+                                storage_name=storage_name,
+                            )
                             cur.execute(
                                 """
                                 UPDATE assets.traits

--- a/nexus/api/new_story_cache.py
+++ b/nexus/api/new_story_cache.py
@@ -40,6 +40,29 @@ VALID_TRAITS = frozenset(
 )
 
 
+def _canonical_trait_name(trait_name: str) -> str:
+    """Return the database storage name for accepted trait aliases."""
+
+    if trait_name == "reputation":
+        return "fame"
+    return trait_name
+
+
+def _ensure_trait_update_matched(
+    cur: Any,
+    *,
+    trait_name: str,
+    storage_name: str,
+) -> None:
+    """Fail fast if a selected trait alias did not match an assets row."""
+
+    if getattr(cur, "rowcount", None) == 0:
+        raise RuntimeError(
+            f"Trait {trait_name!r} resolved to {storage_name!r}, "
+            "but no assets.traits row was updated."
+        )
+
+
 def _parse_pg_array(value: Any) -> List[str]:
     """Parse PostgreSQL array literal to Python list.
 
@@ -579,6 +602,7 @@ def toggle_trait(dbname: Optional[str], trait_name: str) -> bool:
         raise ValueError(
             f"Invalid trait: {trait_name}. Must be one of {sorted(VALID_TRAITS)}"
         )
+    storage_name = _canonical_trait_name(trait_name)
 
     with get_connection(dbname) as conn:
         with conn.cursor() as cur:
@@ -589,10 +613,15 @@ def toggle_trait(dbname: Optional[str], trait_name: str) -> bool:
                 WHERE name = %s
                 RETURNING is_selected
                 """,
-                (trait_name,),
+                (storage_name,),
             )
             result = cur.fetchone()
-            new_state = result[0] if result else False
+            if result is None:
+                raise RuntimeError(
+                    f"Trait {trait_name!r} resolved to {storage_name!r}, "
+                    "but no assets.traits row was toggled."
+                )
+            new_state = result[0]
     logger.info("Toggled trait %s to %s in %s", trait_name, new_state, dbname)
     return new_state
 
@@ -753,13 +782,25 @@ def write_suggested_traits(
 
             # Select and set rationale for each suggested trait
             for suggestion in suggestions:
+                trait_name = suggestion["trait"]
+                if trait_name not in VALID_TRAITS:
+                    raise ValueError(
+                        f"Invalid trait: {trait_name}. "
+                        f"Must be one of {sorted(VALID_TRAITS)}"
+                    )
+                storage_name = _canonical_trait_name(trait_name)
                 cur.execute(
                     """
                     UPDATE assets.traits
                     SET is_selected = TRUE, rationale = %s
                     WHERE name = %s
                     """,
-                    (suggestion["rationale"], suggestion["trait"]),
+                    (suggestion["rationale"], storage_name),
+                )
+                _ensure_trait_update_matched(
+                    cur,
+                    trait_name=trait_name,
+                    storage_name=storage_name,
                 )
     logger.info(
         "Wrote %d suggested traits to %s",
@@ -1201,6 +1242,7 @@ def write_cache(
                             "UPDATE assets.traits SET is_selected = FALSE, rationale = NULL WHERE id <= 10"
                         )
                         for trait_name in selected:
+                            storage_name = _canonical_trait_name(trait_name)
                             rationale = rationales.get(trait_name, "")
                             cur.execute(
                                 """
@@ -1208,7 +1250,12 @@ def write_cache(
                                 SET is_selected = TRUE, rationale = %s
                                 WHERE name = %s
                                 """,
-                                (rationale, trait_name),
+                                (rationale, storage_name),
+                            )
+                            _ensure_trait_update_matched(
+                                cur,
+                                trait_name=trait_name,
+                                storage_name=storage_name,
                             )
                         logger.info(
                             "Wrote 3 selected traits to assets.traits in %s", dbname

--- a/nexus/api/new_story_db_mapper.py
+++ b/nexus/api/new_story_db_mapper.py
@@ -24,6 +24,10 @@ from nexus.api.new_story_schemas import (
 )
 from nexus.api.db_pool import get_connection
 from nexus.api.new_story_cache import clear_cache
+from nexus.api.trait_compiler import (
+    apply_character_trait_compilation,
+    persist_trait_compile_result,
+)
 from nexus.agents.orrery.tag_writer import apply_tag_bestowal
 
 logger = logging.getLogger("nexus.api.new_story_db_mapper")
@@ -541,8 +545,9 @@ class NewStoryDatabaseMapper:
         3. Saves story seed to global_variables
         4. Creates protagonist character
         5. Creates complete location hierarchy (layer -> zone -> place)
-        6. Sets base timestamp
-        7. Clears the wizard cache (mode is derived from data presence)
+        6. Applies typed trait compilation and persists the audit result
+        7. Sets base timestamp
+        8. Clears the wizard cache (mode is derived from data presence)
 
         Args:
             transition_data: Complete transition data package
@@ -657,6 +662,16 @@ class NewStoryDatabaseMapper:
                         current_activity=initial_activity,
                     )
                     logger.debug(f"Created protagonist with ID {character_id}")
+                    cur.execute(
+                        "SELECT entity_id FROM characters WHERE id = %s",
+                        (character_id,),
+                    )
+                    character_entity_row = cur.fetchone()
+                    if character_entity_row is None:
+                        raise ValueError(
+                            f"Character ID {character_id} was not found after insert"
+                        )
+                    character_entity_id = character_entity_row[0]
 
                     # Create complete location hierarchy (using shared cursor)
                     location_ids = self.create_location_hierarchy(
@@ -667,6 +682,23 @@ class NewStoryDatabaseMapper:
                         cursor=cur,
                     )
                     logger.debug(f"Created location hierarchy: {location_ids}")
+
+                    trait_compile_result = apply_character_trait_compilation(
+                        cur,
+                        character=transition_data.character,
+                        character_id=character_id,
+                        character_entity_id=character_entity_id,
+                    )
+                    persist_trait_compile_result(
+                        cur,
+                        character_id=character_id,
+                        result=trait_compile_result,
+                    )
+                    logger.info(
+                        "Trait compilation for %s: %s",
+                        transition_data.character.name,
+                        trait_compile_result.counters.model_dump(),
+                    )
 
                     # Set base timestamp (already a datetime from TransitionData)
                     cur.execute(
@@ -696,6 +728,13 @@ class NewStoryDatabaseMapper:
                     f"All database changes rolled back (no partial data)."
                 )
                 raise
+
+    def finalize_narrative_bootstrap(
+        self, transition_data: TransitionData
+    ) -> Dict[str, int]:
+        """Finalize setup into narrative mode, including trait compilation."""
+
+        return self.perform_transition(transition_data)
 
     def _build_character_extra_data(self, character: CharacterSheet) -> Dict[str, Any]:
         """

--- a/nexus/api/new_story_db_mapper.py
+++ b/nexus/api/new_story_db_mapper.py
@@ -729,13 +729,6 @@ class NewStoryDatabaseMapper:
                 )
                 raise
 
-    def finalize_narrative_bootstrap(
-        self, transition_data: TransitionData
-    ) -> Dict[str, int]:
-        """Finalize setup into narrative mode, including trait compilation."""
-
-        return self.perform_transition(transition_data)
-
     def _build_character_extra_data(self, character: CharacterSheet) -> Dict[str, Any]:
         """
         Build extra_data JSONB from CharacterSheet traits.

--- a/nexus/api/new_story_schemas.py
+++ b/nexus/api/new_story_schemas.py
@@ -14,6 +14,7 @@ from enum import Enum
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 
 from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
+from nexus.api.trait_compiler_schemas import TraitCompileInputs
 
 LEGACY_ORRERY_PROPOSAL_KEY = "new_tag_proposals"
 
@@ -141,6 +142,7 @@ TraitName = Literal[
     "patron",
     "dependents",
     "status",
+    "fame",
     "reputation",
     "resources",
     "domain",
@@ -229,6 +231,13 @@ class CharacterSheet(BaseModel):
         default=None,
         description="Semantic Orrery tags bestowed by Skald during the wizard wildcard step.",
     )
+    trait_compile_inputs: Optional[TraitCompileInputs] = Field(
+        default=None,
+        description=(
+            "Optional typed inputs for deterministic trait-to-Orrery compilation. "
+            "Traits without structured inputs remain prose-only remainders."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_unique_traits(self) -> "CharacterSheet":
@@ -284,8 +293,11 @@ class TraitRationales(BaseModel):
     status: Optional[str] = Field(
         None, description="Why status trait fits this character"
     )
+    fame: Optional[str] = Field(
+        None, description="Why fame trait fits this character"
+    )
     reputation: Optional[str] = Field(
-        None, description="Why reputation trait fits this character"
+        None, description="Why reputation/fame trait fits this character"
     )
     resources: Optional[str] = Field(
         None, description="Why resources trait fits this character"
@@ -452,7 +464,10 @@ class TraitSelection(BaseModel):
         ...,
         min_length=3,
         max_length=3,
-        description="Exactly 3 trait names from: allies, contacts, patron, dependents, status, reputation, resources, domain, enemies, obligations",
+        description=(
+            "Exactly 3 trait names from: allies, contacts, patron, dependents, "
+            "status, fame, reputation, resources, domain, enemies, obligations"
+        ),
     )
     trait_rationales: TraitRationales = Field(
         ...,
@@ -520,6 +535,12 @@ class CharacterCreationState(BaseModel):
     concept: Optional[CharacterConcept] = None
     trait_selection: Optional[TraitSelection] = None
     wildcard: Optional[WildcardTrait] = None
+    trait_compile_inputs: Optional[TraitCompileInputs] = Field(
+        default=None,
+        description=(
+            "Optional typed inputs gathered for deterministic trait compilation."
+        ),
+    )
 
     # Fleshed-out trait descriptions (filled in during trait development dialog)
     trait_details: Dict[str, str] = Field(
@@ -595,6 +616,7 @@ class CharacterCreationState(BaseModel):
             trait_2=trait_entries[1],
             trait_3=trait_entries[2],
             orrery_tags=self.wildcard.orrery_tags,
+            trait_compile_inputs=self.trait_compile_inputs,
         )
 
 

--- a/nexus/api/trait_compiler.py
+++ b/nexus/api/trait_compiler.py
@@ -28,6 +28,7 @@ from nexus.api.trait_compiler_schemas import (
     TraitCompileResult,
     TraitRelationshipDrift,
     UnresolvedTrait,
+    canonical_trait_name,
 )
 
 
@@ -80,7 +81,7 @@ def compile_character_traits(
 
     for trait in character.get_trait_entries():
         trait_name = str(trait.name)
-        canonical_trait = _canonical_trait_name(trait_name)
+        canonical_trait = canonical_trait_name(trait_name)
         if canonical_trait == "resources":
             _compile_single_entity_level(
                 cur,
@@ -182,6 +183,8 @@ def persist_trait_compile_result(
         """,
         (json.dumps({"trait_compile_result": payload}), character_id),
     )
+    if getattr(cur, "rowcount", None) == 0:
+        raise RuntimeError(f"Character {character_id} was not updated.")
     cur.execute(
         """
         UPDATE assets.new_story_creator
@@ -191,6 +194,8 @@ def persist_trait_compile_result(
         """,
         (json.dumps(payload),),
     )
+    if getattr(cur, "rowcount", None) == 0:
+        raise RuntimeError("assets.new_story_creator row was not updated.")
 
 
 def reconcile_trait_relationship_pair_tags(cur: Any) -> list[TraitRelationshipDrift]:
@@ -658,6 +663,7 @@ def _lookup_faction_entity_id(cur: Any, faction_name: str) -> Optional[int]:
         SELECT entity_id
         FROM factions
         WHERE name = %s
+        ORDER BY entity_id
         LIMIT 1
         """,
         (faction_name,),
@@ -676,12 +682,6 @@ def _coerce_inputs(
     if isinstance(value, TraitCompileInputs):
         return value
     return TraitCompileInputs.model_validate(value)
-
-
-def _canonical_trait_name(trait_name: str) -> str:
-    if trait_name == "reputation":
-        return "fame"
-    return trait_name
 
 
 def _add_remainder(

--- a/nexus/api/trait_compiler.py
+++ b/nexus/api/trait_compiler.py
@@ -209,8 +209,14 @@ def reconcile_trait_relationship_pair_tags(cur: Any) -> list[TraitRelationshipDr
         LEFT JOIN characters c1 ON c1.entity_id = ept.subject_entity_id
         LEFT JOIN characters c2 ON c2.entity_id = ept.object_entity_id
         LEFT JOIN character_relationships cr
-               ON cr.character1_id = c1.id
-              AND cr.character2_id = c2.id
+               ON (
+                   cr.character1_id = c1.id
+                   AND cr.character2_id = c2.id
+               )
+               OR (
+                   cr.character1_id = c2.id
+                   AND cr.character2_id = c1.id
+               )
         WHERE ept.cleared_at IS NULL
           AND NOT pt.deprecated
           AND pt.tag = ANY(%s)
@@ -246,11 +252,25 @@ def reconcile_trait_relationship_pair_tags(cur: Any) -> list[TraitRelationshipDr
               SELECT 1
               FROM entity_pair_tags ept
               JOIN pair_tags pt ON pt.id = ept.pair_tag_id
-              WHERE ept.subject_entity_id = c1.entity_id
-                AND ept.object_entity_id = c2.entity_id
-                AND ept.cleared_at IS NULL
+              WHERE ept.cleared_at IS NULL
                 AND NOT pt.deprecated
                 AND pt.tag = cr.extra_data->>'trait_compiler_pair_tag'
+                AND (
+                    (
+                        COALESCE(
+                            cr.extra_data->>'trait_compiler_pair_tag_direction',
+                            'protagonist_to_target'
+                        ) = 'protagonist_to_target'
+                        AND ept.subject_entity_id = c1.entity_id
+                        AND ept.object_entity_id = c2.entity_id
+                    )
+                    OR (
+                        cr.extra_data->>'trait_compiler_pair_tag_direction'
+                            = 'target_to_protagonist'
+                        AND ept.subject_entity_id = c2.entity_id
+                        AND ept.object_entity_id = c1.entity_id
+                    )
+                )
           )
         ORDER BY c1.entity_id, c2.entity_id, pair_tag
         """,
@@ -531,6 +551,9 @@ def _compile_relationship_target(
             history=target.history,
             trait=trait,
             pair_tag=pair_tag if target.apply_pair_tag else None,
+            pair_tag_direction=(
+                target.pair_tag_direction if target.apply_pair_tag else None
+            ),
         )
     result.created_relationships.append(
         CreatedRelationship(
@@ -557,6 +580,7 @@ def _upsert_character_relationship(
     history: str,
     trait: str,
     pair_tag: Optional[str],
+    pair_tag_direction: Optional[str],
 ) -> None:
     extra_data: dict[str, Any] = {
         "source": "trait_compiler",
@@ -564,6 +588,8 @@ def _upsert_character_relationship(
     }
     if pair_tag is not None:
         extra_data["trait_compiler_pair_tag"] = pair_tag
+    if pair_tag_direction is not None:
+        extra_data["trait_compiler_pair_tag_direction"] = pair_tag_direction
     cur.execute(
         """
         INSERT INTO character_relationships (

--- a/nexus/api/trait_compiler.py
+++ b/nexus/api/trait_compiler.py
@@ -1,0 +1,692 @@
+"""Compile new-story character traits into deterministic Orrery writes."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable, Optional
+
+from nexus.agents.orrery.status_family import (
+    normalize_status_level,
+    status_tag_for_level,
+)
+from nexus.agents.orrery.tag_writer import (
+    apply_exclusive_tag_bestowal,
+    apply_pair_tag_bestowal,
+    apply_status_pair_tag_bestowal,
+)
+from nexus.api.new_story_schemas import CharacterSheet
+from nexus.api.trait_compiler_schemas import (
+    AppliedPairTag,
+    AppliedTag,
+    CreatedRelationship,
+    RelationshipTargetInput,
+    SingleEntityTraitInput,
+    StatusTraitInput,
+    TraitCompileCounters,
+    TraitCompileInputs,
+    TraitCompileReasonCode,
+    TraitCompileResult,
+    TraitRelationshipDrift,
+    UnresolvedTrait,
+)
+
+
+RESOURCE_TAGS = frozenset({"destitute", "poor", "comfortable", "wealthy", "magnate"})
+FAME_TAGS = frozenset({"obscure", "known", "renowned", "legendary"})
+
+RELATIONSHIP_DEFAULTS = {
+    "allies": {
+        "relationship_type": "ally",
+        "emotional_valence": "+3|trusting",
+        "pair_tag": "ally",
+    },
+    "contacts": {
+        "relationship_type": "contact",
+        "emotional_valence": "+1|favorable",
+        "pair_tag": "contact",
+    },
+    "enemies": {
+        "relationship_type": "enemy",
+        "emotional_valence": "-4|hostile",
+        "pair_tag": "hostile_to",
+    },
+}
+
+PAIR_TAG_RELATIONSHIP_TYPES = frozenset({"ally", "contact", "hostile_to"})
+
+
+def compile_character_traits(
+    cur: Any,
+    *,
+    character: CharacterSheet,
+    character_id: int,
+    character_entity_id: int,
+    trait_compile_inputs: Optional[TraitCompileInputs | dict[str, Any]] = None,
+    dry_run: bool = True,
+) -> TraitCompileResult:
+    """Compile selected character traits without owning commits.
+
+    Every selected trait produces either deterministic mechanical output or a
+    structured prose-only remainder. ``dry_run=True`` validates registry rows
+    and reports what would be written without mutating the database.
+    """
+
+    inputs = _coerce_inputs(trait_compile_inputs or character.trait_compile_inputs)
+    result = TraitCompileResult(
+        character_id=character_id,
+        character_entity_id=character_entity_id,
+        dry_run=dry_run,
+    )
+
+    for trait in character.get_trait_entries():
+        trait_name = str(trait.name)
+        canonical_trait = _canonical_trait_name(trait_name)
+        if canonical_trait == "resources":
+            _compile_single_entity_level(
+                cur,
+                result=result,
+                trait=trait_name,
+                entity_id=character_entity_id,
+                entity_kind="character",
+                typed_input=inputs.resources,
+                category="role.resources",
+                allowed_levels=RESOURCE_TAGS,
+                dry_run=dry_run,
+            )
+        elif canonical_trait == "fame":
+            _compile_single_entity_level(
+                cur,
+                result=result,
+                trait=trait_name,
+                entity_id=character_entity_id,
+                entity_kind="character",
+                typed_input=inputs.fame or inputs.reputation,
+                category="role.fame",
+                allowed_levels=FAME_TAGS,
+                dry_run=dry_run,
+            )
+        elif canonical_trait == "status":
+            _compile_status(
+                cur,
+                result=result,
+                trait=trait_name,
+                character_entity_id=character_entity_id,
+                typed_input=inputs.status,
+                dry_run=dry_run,
+            )
+        elif canonical_trait in RELATIONSHIP_DEFAULTS:
+            _compile_relationship_trait(
+                cur,
+                result=result,
+                trait=trait_name,
+                canonical_trait=canonical_trait,
+                character_id=character_id,
+                character_entity_id=character_entity_id,
+                typed_input=getattr(inputs, canonical_trait),
+                dry_run=dry_run,
+            )
+        else:
+            _add_remainder(
+                result,
+                trait=trait_name,
+                reason_code=TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT,
+                message=(
+                    "This trait has no typed compiler input in the current MVP; "
+                    "its prose remains in character.extra_data."
+                ),
+            )
+
+    _refresh_counters(result)
+    return result
+
+
+def apply_character_trait_compilation(
+    cur: Any,
+    *,
+    character: CharacterSheet,
+    character_id: int,
+    character_entity_id: int,
+    trait_compile_inputs: Optional[TraitCompileInputs | dict[str, Any]] = None,
+) -> TraitCompileResult:
+    """Apply trait compilation inside a savepoint owned by the caller transaction."""
+
+    cur.execute("SAVEPOINT trait_compile_apply")
+    try:
+        result = compile_character_traits(
+            cur,
+            character=character,
+            character_id=character_id,
+            character_entity_id=character_entity_id,
+            trait_compile_inputs=trait_compile_inputs,
+            dry_run=False,
+        )
+        cur.execute("RELEASE SAVEPOINT trait_compile_apply")
+        return result
+    except Exception:
+        cur.execute("ROLLBACK TO SAVEPOINT trait_compile_apply")
+        cur.execute("RELEASE SAVEPOINT trait_compile_apply")
+        raise
+
+
+def persist_trait_compile_result(
+    cur: Any, *, character_id: int, result: TraitCompileResult
+) -> None:
+    """Persist compile output to durable character extra_data and wizard cache."""
+
+    payload = result.model_dump(mode="json")
+    cur.execute(
+        """
+        UPDATE characters
+        SET extra_data = COALESCE(extra_data, '{}'::jsonb) || %s::jsonb
+        WHERE id = %s
+        """,
+        (json.dumps({"trait_compile_result": payload}), character_id),
+    )
+    cur.execute(
+        """
+        UPDATE assets.new_story_creator
+        SET trait_compile_result = %s::jsonb,
+            updated_at = NOW()
+        WHERE id = TRUE
+        """,
+        (json.dumps(payload),),
+    )
+
+
+def reconcile_trait_relationship_pair_tags(cur: Any) -> list[TraitRelationshipDrift]:
+    """Report drift for pair-tags that carry intrinsic relationship meaning."""
+
+    drift: list[TraitRelationshipDrift] = []
+    cur.execute(
+        """
+        SELECT ept.subject_entity_id,
+               ept.object_entity_id,
+               pt.tag,
+               c1.id AS character1_id,
+               c2.id AS character2_id
+        FROM entity_pair_tags ept
+        JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+        LEFT JOIN characters c1 ON c1.entity_id = ept.subject_entity_id
+        LEFT JOIN characters c2 ON c2.entity_id = ept.object_entity_id
+        LEFT JOIN character_relationships cr
+               ON cr.character1_id = c1.id
+              AND cr.character2_id = c2.id
+        WHERE ept.cleared_at IS NULL
+          AND NOT pt.deprecated
+          AND pt.tag = ANY(%s)
+          AND cr.character1_id IS NULL
+        ORDER BY ept.subject_entity_id, ept.object_entity_id, pt.tag
+        """,
+        (sorted(PAIR_TAG_RELATIONSHIP_TYPES),),
+    )
+    for row in cur.fetchall():
+        drift.append(
+            TraitRelationshipDrift(
+                drift_kind="missing_relationship",
+                subject_entity_id=_row_value(row, "subject_entity_id", 0),
+                object_entity_id=_row_value(row, "object_entity_id", 1),
+                pair_tag=_row_value(row, "tag", 2),
+                character1_id=_row_value(row, "character1_id", 3),
+                character2_id=_row_value(row, "character2_id", 4),
+            )
+        )
+
+    cur.execute(
+        """
+        SELECT c1.entity_id AS subject_entity_id,
+               c2.entity_id AS object_entity_id,
+               cr.extra_data->>'trait_compiler_pair_tag' AS pair_tag,
+               cr.character1_id,
+               cr.character2_id
+        FROM character_relationships cr
+        JOIN characters c1 ON c1.id = cr.character1_id
+        JOIN characters c2 ON c2.id = cr.character2_id
+        WHERE cr.extra_data->>'trait_compiler_pair_tag' = ANY(%s)
+          AND NOT EXISTS (
+              SELECT 1
+              FROM entity_pair_tags ept
+              JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+              WHERE ept.subject_entity_id = c1.entity_id
+                AND ept.object_entity_id = c2.entity_id
+                AND ept.cleared_at IS NULL
+                AND NOT pt.deprecated
+                AND pt.tag = cr.extra_data->>'trait_compiler_pair_tag'
+          )
+        ORDER BY c1.entity_id, c2.entity_id, pair_tag
+        """,
+        (sorted(PAIR_TAG_RELATIONSHIP_TYPES),),
+    )
+    for row in cur.fetchall():
+        drift.append(
+            TraitRelationshipDrift(
+                drift_kind="missing_pair_tag",
+                subject_entity_id=_row_value(row, "subject_entity_id", 0),
+                object_entity_id=_row_value(row, "object_entity_id", 1),
+                pair_tag=_row_value(row, "pair_tag", 2),
+                character1_id=_row_value(row, "character1_id", 3),
+                character2_id=_row_value(row, "character2_id", 4),
+            )
+        )
+
+    return drift
+
+
+def _compile_single_entity_level(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    entity_id: int,
+    entity_kind: str,
+    typed_input: Optional[SingleEntityTraitInput],
+    category: str,
+    allowed_levels: Iterable[str],
+    dry_run: bool,
+) -> None:
+    if typed_input is None:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT,
+            message="Trait has no structured level input.",
+        )
+        return
+
+    tag = typed_input.level
+    if tag not in set(allowed_levels) or not _registered_tag_exists(cur, tag, category):
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.REGISTRY_MISSING_TAG,
+            message=f"No active registered tag for {category}:{tag}.",
+            details={"tag": tag, "category": category},
+        )
+        return
+
+    inserted: Optional[bool] = None
+    if not dry_run:
+        inserted = apply_exclusive_tag_bestowal(
+            cur,
+            entity_id=entity_id,
+            entity_kind=entity_kind,
+            tag=tag,
+            source_kind="skald_inline",
+        )
+    result.applied_single_entity_tags.append(
+        AppliedTag(
+            trait=trait,
+            entity_id=entity_id,
+            tag=tag,
+            category=category,
+            inserted=inserted,
+            dry_run=dry_run,
+        )
+    )
+
+
+def _compile_status(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    character_entity_id: int,
+    typed_input: Optional[StatusTraitInput],
+    dry_run: bool,
+) -> None:
+    if typed_input is None:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT,
+            message="Status has no structured scope faction and level input.",
+        )
+        return
+    try:
+        level = normalize_status_level(typed_input.level)
+    except ValueError:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.UNKNOWN_STATUS_LEVEL,
+            message=f"Unknown status level {typed_input.level!r}.",
+            details={"level": typed_input.level},
+        )
+        return
+
+    scope_faction_entity_id = typed_input.scope_faction_entity_id
+    if scope_faction_entity_id is None and typed_input.scope_faction_name:
+        scope_faction_entity_id = _lookup_faction_entity_id(
+            cur, typed_input.scope_faction_name
+        )
+        if scope_faction_entity_id is None:
+            _add_remainder(
+                result,
+                trait=trait,
+                reason_code=TraitCompileReasonCode.UNKNOWN_SCOPE_FACTION,
+                message=f"Unknown scope faction {typed_input.scope_faction_name!r}.",
+                details={"scope_faction_name": typed_input.scope_faction_name},
+            )
+            return
+    if scope_faction_entity_id is None:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.AMBIGUOUS_TARGET,
+            message="Status requires a scope faction entity id or name.",
+        )
+        return
+
+    tag = status_tag_for_level(level)
+    if not _registered_pair_tag_exists(cur, tag):
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.REGISTRY_MISSING_PAIR_TAG,
+            message=f"No active registered pair_tag for {tag}.",
+            details={"pair_tag": tag},
+        )
+        return
+
+    inserted: Optional[bool] = None
+    if not dry_run:
+        inserted = apply_status_pair_tag_bestowal(
+            cur,
+            subject_entity_id=character_entity_id,
+            scope_faction_entity_id=scope_faction_entity_id,
+            subject_kind="character",
+            level=level,
+            source_kind="skald_inline",
+        )
+    result.applied_pair_tags.append(
+        AppliedPairTag(
+            trait=trait,
+            subject_entity_id=character_entity_id,
+            object_entity_id=scope_faction_entity_id,
+            tag=tag,
+            inserted=inserted,
+            dry_run=dry_run,
+        )
+    )
+
+
+def _compile_relationship_trait(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    canonical_trait: str,
+    character_id: int,
+    character_entity_id: int,
+    typed_input: Any,
+    dry_run: bool,
+) -> None:
+    if typed_input is None or not typed_input.targets:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT,
+            message="Relationship trait has no structured targets.",
+        )
+        return
+
+    for target in typed_input.targets:
+        _compile_relationship_target(
+            cur,
+            result=result,
+            trait=trait,
+            canonical_trait=canonical_trait,
+            character_id=character_id,
+            character_entity_id=character_entity_id,
+            target=target,
+            dry_run=dry_run,
+        )
+
+
+def _compile_relationship_target(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    canonical_trait: str,
+    character_id: int,
+    character_entity_id: int,
+    target: RelationshipTargetInput,
+    dry_run: bool,
+) -> None:
+    if target.character_id is None:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.AMBIGUOUS_TARGET,
+            message="Relationship target requires an existing character_id.",
+            details={"name": target.name},
+        )
+        return
+
+    defaults = RELATIONSHIP_DEFAULTS[canonical_trait]
+    relationship_type = target.relationship_type or defaults["relationship_type"]
+    emotional_valence = target.emotional_valence or defaults["emotional_valence"]
+    pair_tag = target.pair_tag or defaults["pair_tag"]
+
+    if target.apply_pair_tag and target.character_entity_id is None:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.AMBIGUOUS_TARGET,
+            message="Pair-tagged relationship target requires character_entity_id.",
+            details={"name": target.name, "pair_tag": pair_tag},
+        )
+        return
+    if target.apply_pair_tag and not _registered_pair_tag_exists(cur, pair_tag):
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.REGISTRY_MISSING_PAIR_TAG,
+            message=f"No active registered pair_tag for {pair_tag}.",
+            details={"pair_tag": pair_tag},
+        )
+        return
+
+    inserted_pair_tag: Optional[bool] = None
+    if target.apply_pair_tag:
+        target_entity_id = target.character_entity_id
+        if target_entity_id is None:
+            raise AssertionError("pair-tag target entity id was validated above")
+        pair_subject_entity_id = character_entity_id
+        pair_object_entity_id = target_entity_id
+        if target.pair_tag_direction == "target_to_protagonist":
+            pair_subject_entity_id = target_entity_id
+            pair_object_entity_id = character_entity_id
+
+        if not dry_run:
+            inserted_pair_tag = apply_pair_tag_bestowal(
+                cur,
+                subject_entity_id=pair_subject_entity_id,
+                object_entity_id=pair_object_entity_id,
+                subject_kind="character",
+                object_kind="character",
+                tag=pair_tag,
+                source_kind="skald_inline",
+            )
+        result.applied_pair_tags.append(
+            AppliedPairTag(
+                trait=trait,
+                subject_entity_id=pair_subject_entity_id,
+                object_entity_id=pair_object_entity_id,
+                tag=pair_tag,
+                inserted=inserted_pair_tag,
+                dry_run=dry_run,
+            )
+        )
+
+    if not dry_run:
+        _upsert_character_relationship(
+            cur,
+            character1_id=character_id,
+            character2_id=target.character_id,
+            relationship_type=relationship_type,
+            emotional_valence=emotional_valence,
+            dynamic=target.dynamic,
+            recent_events=target.recent_events,
+            history=target.history,
+            trait=trait,
+            pair_tag=pair_tag if target.apply_pair_tag else None,
+        )
+    result.created_relationships.append(
+        CreatedRelationship(
+            trait=trait,
+            character1_id=character_id,
+            character2_id=target.character_id,
+            relationship_type=relationship_type,
+            emotional_valence=emotional_valence,
+            pair_tag=pair_tag if target.apply_pair_tag else None,
+            dry_run=dry_run,
+        )
+    )
+
+
+def _upsert_character_relationship(
+    cur: Any,
+    *,
+    character1_id: int,
+    character2_id: int,
+    relationship_type: str,
+    emotional_valence: str,
+    dynamic: str,
+    recent_events: str,
+    history: str,
+    trait: str,
+    pair_tag: Optional[str],
+) -> None:
+    extra_data: dict[str, Any] = {
+        "source": "trait_compiler",
+        "trait": trait,
+    }
+    if pair_tag is not None:
+        extra_data["trait_compiler_pair_tag"] = pair_tag
+    cur.execute(
+        """
+        INSERT INTO character_relationships (
+            character1_id, character2_id, relationship_type, emotional_valence,
+            dynamic, recent_events, history, extra_data
+        ) VALUES (
+            %s, %s, %s, %s,
+            %s, %s, %s, %s::jsonb
+        )
+        ON CONFLICT (character1_id, character2_id) DO UPDATE SET
+            relationship_type = EXCLUDED.relationship_type,
+            emotional_valence = EXCLUDED.emotional_valence,
+            dynamic = EXCLUDED.dynamic,
+            recent_events = EXCLUDED.recent_events,
+            history = EXCLUDED.history,
+            extra_data = COALESCE(character_relationships.extra_data, '{}'::jsonb)
+                         || EXCLUDED.extra_data,
+            updated_at = NOW()
+        """,
+        (
+            character1_id,
+            character2_id,
+            relationship_type,
+            emotional_valence,
+            dynamic,
+            recent_events,
+            history,
+            json.dumps(extra_data),
+        ),
+    )
+
+
+def _registered_tag_exists(cur: Any, tag: str, category: str) -> bool:
+    cur.execute(
+        """
+        SELECT 1
+        FROM tags
+        WHERE tag = %s
+          AND category = %s
+          AND NOT deprecated
+          AND synonym_for IS NULL
+        LIMIT 1
+        """,
+        (tag, category),
+    )
+    return cur.fetchone() is not None
+
+
+def _registered_pair_tag_exists(cur: Any, tag: str) -> bool:
+    cur.execute(
+        """
+        SELECT 1
+        FROM pair_tags
+        WHERE tag = %s
+          AND NOT deprecated
+        LIMIT 1
+        """,
+        (tag,),
+    )
+    return cur.fetchone() is not None
+
+
+def _lookup_faction_entity_id(cur: Any, faction_name: str) -> Optional[int]:
+    cur.execute(
+        """
+        SELECT entity_id
+        FROM factions
+        WHERE name = %s
+        LIMIT 1
+        """,
+        (faction_name,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    return _row_value(row, "entity_id", 0)
+
+
+def _coerce_inputs(
+    value: Optional[TraitCompileInputs | dict[str, Any]],
+) -> TraitCompileInputs:
+    if value is None:
+        return TraitCompileInputs()
+    if isinstance(value, TraitCompileInputs):
+        return value
+    return TraitCompileInputs.model_validate(value)
+
+
+def _canonical_trait_name(trait_name: str) -> str:
+    if trait_name == "reputation":
+        return "fame"
+    return trait_name
+
+
+def _add_remainder(
+    result: TraitCompileResult,
+    *,
+    trait: str,
+    reason_code: TraitCompileReasonCode,
+    message: str,
+    details: Optional[dict[str, Any]] = None,
+) -> None:
+    result.prose_only_remainders.append(
+        UnresolvedTrait(
+            trait=trait,
+            reason_code=reason_code,
+            message=message,
+            details=details or {},
+        )
+    )
+
+
+def _refresh_counters(result: TraitCompileResult) -> None:
+    result.counters = TraitCompileCounters(
+        applied_single_entity_tags=len(result.applied_single_entity_tags),
+        applied_pair_tags=len(result.applied_pair_tags),
+        created_entities=len(result.created_entities),
+        created_relationships=len(result.created_relationships),
+        prose_only_remainders=len(result.prose_only_remainders),
+    )
+
+
+def _row_value(row: Any, key: str, index: int) -> Any:
+    if hasattr(row, "get"):
+        return row[key]
+    return row[index]

--- a/nexus/api/trait_compiler_schemas.py
+++ b/nexus/api/trait_compiler_schemas.py
@@ -13,6 +13,14 @@ FameLevel = Literal["obscure", "known", "renowned", "legendary"]
 PairTagDirection = Literal["protagonist_to_target", "target_to_protagonist"]
 
 
+def canonical_trait_name(trait_name: str) -> str:
+    """Return the canonical storage name for accepted trait aliases."""
+
+    if trait_name == "reputation":
+        return "fame"
+    return trait_name
+
+
 class TraitCompileReasonCode(str, Enum):
     """Reason a selected trait did not produce mechanical writes."""
 

--- a/nexus/api/trait_compiler_schemas.py
+++ b/nexus/api/trait_compiler_schemas.py
@@ -1,0 +1,204 @@
+"""Schemas for compiling new-story traits into Orrery substrate facts."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+ResourceLevel = Literal["destitute", "poor", "comfortable", "wealthy", "magnate"]
+FameLevel = Literal["obscure", "known", "renowned", "legendary"]
+PairTagDirection = Literal["protagonist_to_target", "target_to_protagonist"]
+
+
+class TraitCompileReasonCode(str, Enum):
+    """Reason a selected trait did not produce mechanical writes."""
+
+    MISSING_STRUCTURED_TRAIT_INPUT = "missing_structured_trait_input"
+    AMBIGUOUS_TARGET = "ambiguous_target"
+    UNKNOWN_SCOPE_FACTION = "unknown_scope_faction"
+    UNKNOWN_STATUS_LEVEL = "unknown_status_level"
+    UNSUPPORTED_WILDCARD_DECOMPOSITION = "unsupported_wildcard_decomposition"
+    REGISTRY_MISSING_TAG = "registry_missing_tag"
+    REGISTRY_MISSING_PAIR_TAG = "registry_missing_pair_tag"
+
+
+class SingleEntityTraitInput(BaseModel):
+    """Typed input for a single-entity trait level."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    level: str = Field(..., description="Closed-vocabulary level anchor.")
+
+
+class StatusTraitInput(BaseModel):
+    """Typed input for scope-bound status compilation."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    level: str = Field(..., description="Closed status level, e.g. senior.")
+    scope_faction_entity_id: Optional[int] = Field(
+        None, description="Existing faction entity_id for the status scope."
+    )
+    scope_faction_name: Optional[str] = Field(
+        None, description="Existing faction name if entity_id is not known."
+    )
+
+
+class RelationshipTargetInput(BaseModel):
+    """Typed input for one trait-declared character relationship."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    character_id: Optional[int] = Field(
+        None, description="Existing target character row id."
+    )
+    character_entity_id: Optional[int] = Field(
+        None, description="Existing target character entity_id."
+    )
+    name: Optional[str] = Field(None, description="Human-readable target name.")
+    relationship_type: Optional[str] = Field(
+        None, description="character_relationships.relationship_type override."
+    )
+    emotional_valence: Optional[str] = Field(
+        None, description="character_relationships.emotional_valence override."
+    )
+    dynamic: str = Field(
+        "",
+        description="Current relationship state written to character_relationships.",
+    )
+    recent_events: str = Field(
+        "",
+        description="Recent events summary written to character_relationships.",
+    )
+    history: str = Field(
+        "",
+        description="History summary written to character_relationships.",
+    )
+    apply_pair_tag: bool = Field(
+        False,
+        description="Whether this relationship also needs a binary pair-tag gate.",
+    )
+    pair_tag: Optional[str] = Field(
+        None, description="Pair-tag to apply when apply_pair_tag is true."
+    )
+    pair_tag_direction: PairTagDirection = Field(
+        "protagonist_to_target",
+        description="Direction for the pair-tag edge when apply_pair_tag is true.",
+    )
+
+
+class RelationshipTraitInput(BaseModel):
+    """Typed input for a relationship-bearing trait."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    targets: List[RelationshipTargetInput] = Field(default_factory=list)
+
+
+class TraitCompileInputs(BaseModel):
+    """Optional typed mechanical inputs collected during the wizard."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    resources: Optional[SingleEntityTraitInput] = None
+    fame: Optional[SingleEntityTraitInput] = None
+    reputation: Optional[SingleEntityTraitInput] = Field(
+        default=None,
+        description="Backward-compatible alias for fame during transition.",
+    )
+    status: Optional[StatusTraitInput] = None
+    allies: Optional[RelationshipTraitInput] = None
+    contacts: Optional[RelationshipTraitInput] = None
+    enemies: Optional[RelationshipTraitInput] = None
+
+
+class AppliedTag(BaseModel):
+    """Single-entity tag that was or would be applied."""
+
+    trait: str
+    entity_id: int
+    tag: str
+    category: str
+    inserted: Optional[bool] = None
+    dry_run: bool = False
+
+
+class AppliedPairTag(BaseModel):
+    """Pair-tag that was or would be applied."""
+
+    trait: str
+    subject_entity_id: int
+    object_entity_id: int
+    tag: str
+    inserted: Optional[bool] = None
+    dry_run: bool = False
+
+
+class CreatedEntity(BaseModel):
+    """Entity created by trait compilation."""
+
+    trait: str
+    entity_kind: str
+    entity_id: int
+    row_id: Optional[int] = None
+    name: Optional[str] = None
+    dry_run: bool = False
+
+
+class CreatedRelationship(BaseModel):
+    """character_relationships row that was or would be written."""
+
+    trait: str
+    character1_id: int
+    character2_id: int
+    relationship_type: str
+    emotional_valence: str
+    pair_tag: Optional[str] = None
+    dry_run: bool = False
+
+
+class UnresolvedTrait(BaseModel):
+    """Selected trait that remains prose-only for a structured reason."""
+
+    trait: str
+    reason_code: TraitCompileReasonCode
+    message: str
+    details: Dict[str, Any] = Field(default_factory=dict)
+
+
+class TraitCompileCounters(BaseModel):
+    """Summary counts for logs/UI."""
+
+    applied_single_entity_tags: int = 0
+    applied_pair_tags: int = 0
+    created_entities: int = 0
+    created_relationships: int = 0
+    prose_only_remainders: int = 0
+
+
+class TraitCompileResult(BaseModel):
+    """Complete result of compiling selected traits for one character."""
+
+    character_id: int
+    character_entity_id: int
+    dry_run: bool
+    applied_single_entity_tags: List[AppliedTag] = Field(default_factory=list)
+    applied_pair_tags: List[AppliedPairTag] = Field(default_factory=list)
+    created_entities: List[CreatedEntity] = Field(default_factory=list)
+    created_relationships: List[CreatedRelationship] = Field(default_factory=list)
+    prose_only_remainders: List[UnresolvedTrait] = Field(default_factory=list)
+    counters: TraitCompileCounters = Field(default_factory=TraitCompileCounters)
+
+
+class TraitRelationshipDrift(BaseModel):
+    """Detected drift between pair-tag and character_relationships layers."""
+
+    drift_kind: Literal["missing_relationship", "missing_pair_tag"]
+    subject_entity_id: int
+    object_entity_id: int
+    pair_tag: str
+    character1_id: Optional[int] = None
+    character2_id: Optional[int] = None

--- a/nexus/api/wizard_agent.py
+++ b/nexus/api/wizard_agent.py
@@ -34,6 +34,7 @@ from nexus.api.new_story_schemas import (
     WizardResponse,
 )
 from nexus.api.slot_utils import slot_dbname
+from nexus.api.trait_compiler_schemas import canonical_trait_name
 from nexus.agents.orrery.tag_library import format_tag_library_for_prompt
 
 logger = logging.getLogger("nexus.api.wizard_agent")
@@ -347,13 +348,17 @@ async def _submit_concept_impl(
         {**creation_state.model_dump(), "concept": concept_data.model_dump()}
     )
 
-    suggestions = [
-        {
-            "trait": trait,
-            "rationale": concept_data.trait_rationales.to_dict().get(trait, ""),
-        }
-        for trait in concept_data.suggested_traits
-    ]
+    rationales = concept_data.trait_rationales.to_dict()
+    suggestions = []
+    for trait in concept_data.suggested_traits:
+        storage_name = canonical_trait_name(trait)
+        rationale = (
+            rationales.get(trait)
+            or rationales.get(storage_name)
+            or (rationales.get("reputation") if storage_name == "fame" else None)
+            or ""
+        )
+        suggestions.append({"trait": trait, "rationale": rationale})
     if suggestions:
         write_suggested_traits(slot_dbname(ctx.deps.slot), suggestions)
 

--- a/tests/test_new_story_cache.py
+++ b/tests/test_new_story_cache.py
@@ -48,6 +48,10 @@ def test_row_to_cache_reads_character_orrery_tags() -> None:
         "applied_tags": ["ritualist"],
         "tags_to_clear": [],
     }
+    compile_result = {
+        "dry_run": False,
+        "counters": {"prose_only_remainders": 1},
+    }
 
     cache = _row_to_cache(
         {
@@ -56,6 +60,7 @@ def test_row_to_cache_reads_character_orrery_tags() -> None:
             "character_background": "Raised in a sealed archive.",
             "character_appearance": "Ink-stained hands and observant eyes.",
             "character_orrery_tags": bestowal,
+            "trait_compile_result": compile_result,
         },
         selected_traits=[
             SuggestedTrait("contacts", "Archivists trade favors."),
@@ -72,6 +77,7 @@ def test_row_to_cache_reads_character_orrery_tags() -> None:
     )
 
     assert cache.character.orrery_tags == bestowal
+    assert cache.character.trait_compile_result == compile_result
     assert cache.get_character_dict()["wildcard"]["orrery_tags"] == bestowal
 
 

--- a/tests/test_new_story_cache.py
+++ b/tests/test_new_story_cache.py
@@ -9,6 +9,42 @@ from nexus.api.new_story_cache import (
 import nexus.api.new_story_cache as cache_module
 
 
+class FakeCursor:
+    def __init__(self) -> None:
+        self.calls = []
+        self.rowcount = 1
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def execute(self, sql, params=None):
+        self.calls.append((sql, params))
+        self.rowcount = 1
+
+
+class FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_obj = FakeCursor()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def cursor(self):
+        return self.cursor_obj
+
+
+def _install_fake_connection(monkeypatch) -> FakeConnection:
+    fake_conn = FakeConnection()
+    monkeypatch.setattr(cache_module, "get_connection", lambda _dbname: fake_conn)
+    return fake_conn
+
+
 def test_character_dict_preserves_wildcard_orrery_tags() -> None:
     """Cached protagonist tags must survive through transition assembly."""
 
@@ -84,34 +120,7 @@ def test_row_to_cache_reads_character_orrery_tags() -> None:
 def test_write_cache_marks_three_selected_traits_confirmed(monkeypatch) -> None:
     """Structured trait submissions should advance slot-state phase detection."""
 
-    class FakeCursor:
-        def __init__(self) -> None:
-            self.calls = []
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_exc):
-            return False
-
-        def execute(self, sql, params=None):
-            self.calls.append((sql, params))
-
-    class FakeConnection:
-        def __init__(self) -> None:
-            self.cursor_obj = FakeCursor()
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_exc):
-            return False
-
-        def cursor(self):
-            return self.cursor_obj
-
-    fake_conn = FakeConnection()
-    monkeypatch.setattr(cache_module, "get_connection", lambda _dbname: fake_conn)
+    fake_conn = _install_fake_connection(monkeypatch)
 
     cache_module.write_cache(
         dbname="save_05",
@@ -135,36 +144,7 @@ def test_write_cache_marks_three_selected_traits_confirmed(monkeypatch) -> None:
 def test_write_cache_canonicalizes_legacy_reputation_trait(monkeypatch) -> None:
     """The Fame rename should not make legacy reputation selections vanish."""
 
-    class FakeCursor:
-        def __init__(self) -> None:
-            self.calls = []
-            self.rowcount = 1
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_exc):
-            return False
-
-        def execute(self, sql, params=None):
-            self.calls.append((sql, params))
-            self.rowcount = 1
-
-    class FakeConnection:
-        def __init__(self) -> None:
-            self.cursor_obj = FakeCursor()
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_exc):
-            return False
-
-        def cursor(self):
-            return self.cursor_obj
-
-    fake_conn = FakeConnection()
-    monkeypatch.setattr(cache_module, "get_connection", lambda _dbname: fake_conn)
+    fake_conn = _install_fake_connection(monkeypatch)
 
     cache_module.write_cache(
         dbname="save_05",
@@ -186,41 +166,39 @@ def test_write_cache_canonicalizes_legacy_reputation_trait(monkeypatch) -> None:
     )
 
 
+def test_write_cache_preserves_rationale_across_fame_alias(
+    monkeypatch,
+) -> None:
+    """Rationale lookup should tolerate Fame/Reputation transition skew."""
+
+    fake_conn = _install_fake_connection(monkeypatch)
+
+    cache_module.write_cache(
+        dbname="save_05",
+        character_draft={
+            "trait_selection": {
+                "selected_traits": ["contacts", "fame", "resources"],
+                "trait_rationales": {
+                    "contacts": "Informants keep her aware.",
+                    "reputation": "Her name has started to travel.",
+                    "resources": "She has liquid reserves.",
+                },
+            }
+        },
+    )
+
+    assert any(
+        params == ("Her name has started to travel.", "fame")
+        for _sql, params in fake_conn.cursor_obj.calls
+    )
+
+
 def test_write_suggested_traits_canonicalizes_legacy_reputation(
     monkeypatch,
 ) -> None:
     """Concept suggestions should also write the Fame storage row."""
 
-    class FakeCursor:
-        def __init__(self) -> None:
-            self.calls = []
-            self.rowcount = 1
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_exc):
-            return False
-
-        def execute(self, sql, params=None):
-            self.calls.append((sql, params))
-            self.rowcount = 1
-
-    class FakeConnection:
-        def __init__(self) -> None:
-            self.cursor_obj = FakeCursor()
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_exc):
-            return False
-
-        def cursor(self):
-            return self.cursor_obj
-
-    fake_conn = FakeConnection()
-    monkeypatch.setattr(cache_module, "get_connection", lambda _dbname: fake_conn)
+    fake_conn = _install_fake_connection(monkeypatch)
 
     cache_module.write_suggested_traits(
         "save_05",
@@ -236,34 +214,7 @@ def test_write_suggested_traits_canonicalizes_legacy_reputation(
 def test_write_cache_creates_row_before_wildcard_tags(monkeypatch) -> None:
     """First legacy cache writes must not drop wildcard Orrery tag payloads."""
 
-    class FakeCursor:
-        def __init__(self) -> None:
-            self.calls = []
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_exc):
-            return False
-
-        def execute(self, sql, params=None):
-            self.calls.append((sql, params))
-
-    class FakeConnection:
-        def __init__(self) -> None:
-            self.cursor_obj = FakeCursor()
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_exc):
-            return False
-
-        def cursor(self):
-            return self.cursor_obj
-
-    fake_conn = FakeConnection()
-    monkeypatch.setattr(cache_module, "get_connection", lambda _dbname: fake_conn)
+    fake_conn = _install_fake_connection(monkeypatch)
 
     cache_module.write_cache(
         dbname="save_05",
@@ -292,3 +243,27 @@ def test_write_cache_creates_row_before_wildcard_tags(monkeypatch) -> None:
     )
 
     assert row_insert_index < tag_update_index
+
+
+def test_phase_resets_clear_trait_compile_result(monkeypatch) -> None:
+    fake_conn = _install_fake_connection(monkeypatch)
+
+    cache_module.clear_character_phase("save_05")
+    cache_module.clear_setting_phase("save_05")
+
+    reset_sql = "\n".join(sql for sql, _params in fake_conn.cursor_obj.calls)
+    assert reset_sql.count("trait_compile_result = NULL") == 2
+
+
+def test_clear_cache_deletes_without_dead_trait_compile_update(monkeypatch) -> None:
+    fake_conn = _install_fake_connection(monkeypatch)
+
+    cache_module.clear_cache("save_05")
+
+    calls = [sql for sql, _params in fake_conn.cursor_obj.calls]
+    assert "DELETE FROM assets.new_story_creator WHERE id = TRUE" in calls
+    assert not any(
+        "trait_compile_result = NULL" in sql
+        and "UPDATE assets.new_story_creator" in sql
+        for sql in calls
+    )

--- a/tests/test_new_story_cache.py
+++ b/tests/test_new_story_cache.py
@@ -132,6 +132,107 @@ def test_write_cache_marks_three_selected_traits_confirmed(monkeypatch) -> None:
     )
 
 
+def test_write_cache_canonicalizes_legacy_reputation_trait(monkeypatch) -> None:
+    """The Fame rename should not make legacy reputation selections vanish."""
+
+    class FakeCursor:
+        def __init__(self) -> None:
+            self.calls = []
+            self.rowcount = 1
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def execute(self, sql, params=None):
+            self.calls.append((sql, params))
+            self.rowcount = 1
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.cursor_obj = FakeCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def cursor(self):
+            return self.cursor_obj
+
+    fake_conn = FakeConnection()
+    monkeypatch.setattr(cache_module, "get_connection", lambda _dbname: fake_conn)
+
+    cache_module.write_cache(
+        dbname="save_05",
+        character_draft={
+            "trait_selection": {
+                "selected_traits": ["contacts", "reputation", "resources"],
+                "trait_rationales": {
+                    "contacts": "Informants keep her aware.",
+                    "reputation": "Her name has started to travel.",
+                    "resources": "She has liquid reserves.",
+                },
+            }
+        },
+    )
+
+    assert any(
+        params == ("Her name has started to travel.", "fame")
+        for _sql, params in fake_conn.cursor_obj.calls
+    )
+
+
+def test_write_suggested_traits_canonicalizes_legacy_reputation(
+    monkeypatch,
+) -> None:
+    """Concept suggestions should also write the Fame storage row."""
+
+    class FakeCursor:
+        def __init__(self) -> None:
+            self.calls = []
+            self.rowcount = 1
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def execute(self, sql, params=None):
+            self.calls.append((sql, params))
+            self.rowcount = 1
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.cursor_obj = FakeCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def cursor(self):
+            return self.cursor_obj
+
+    fake_conn = FakeConnection()
+    monkeypatch.setattr(cache_module, "get_connection", lambda _dbname: fake_conn)
+
+    cache_module.write_suggested_traits(
+        "save_05",
+        [{"trait": "reputation", "rationale": "People know the name."}],
+    )
+
+    assert any(
+        params == ("People know the name.", "fame")
+        for _sql, params in fake_conn.cursor_obj.calls
+    )
+
+
 def test_write_cache_creates_row_before_wildcard_tags(monkeypatch) -> None:
     """First legacy cache writes must not drop wildcard Orrery tag payloads."""
 

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -442,3 +442,46 @@ def test_new_story_character_orrery_tags_migration_adds_cache_column() -> None:
 
     assert "character_orrery_tags jsonb" in migration_source
     assert "OrreryTagBestowal JSON" in migration_source
+
+
+def test_trait_compiler_substrate_migration_seeds_required_contracts() -> None:
+    """Migration 045 owns the closed vocab and audit storage for issue #295."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "045_trait_compiler_substrate.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    migration_source = migration_path.read_text()
+
+    assert {"role.resources", "role.fame"} == {
+        category for category, _order, _description in migration.ROLE_CATEGORIES
+    }
+    assert {
+        "destitute",
+        "poor",
+        "comfortable",
+        "wealthy",
+        "magnate",
+    } <= {tag for tag, _category, _description in migration.ROLE_TAGS}
+    assert {"obscure", "known", "renowned", "legendary"} <= {
+        tag for tag, _category, _description in migration.ROLE_TAGS
+    }
+    assert {"ally", "contact", "hostile_to"} <= {
+        tag for tag, *_rest in migration.PAIR_TAGS
+    }
+    assert {
+        "status:junior",
+        "status:senior",
+        "status:executive",
+        "status:sovereign",
+        "status:respected",
+        "status:elite",
+        "status:outcast",
+        "status:pariah",
+        "status:enslaved",
+    } == {tag for tag, *_rest in migration.STATUS_PAIR_TAGS}
+    assert "trait_compile_result jsonb" in migration_source
+    assert "SET subject_kinds = ARRAY['character', 'faction']" in migration_source
+    assert "SET name = 'fame'" in migration_source

--- a/tests/test_trait_compiler.py
+++ b/tests/test_trait_compiler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from copy import deepcopy
 from typing import Any, Optional
 
@@ -11,6 +12,7 @@ from nexus.api.new_story_schemas import CharacterSheet, CharacterTrait
 from nexus.api.trait_compiler import (
     apply_character_trait_compilation,
     compile_character_traits,
+    persist_trait_compile_result,
     reconcile_trait_relationship_pair_tags,
 )
 from nexus.api.trait_compiler_schemas import (
@@ -20,6 +22,7 @@ from nexus.api.trait_compiler_schemas import (
     StatusTraitInput,
     TraitCompileInputs,
     TraitCompileReasonCode,
+    TraitCompileResult,
 )
 
 
@@ -298,8 +301,57 @@ class TraitCompilerCursor:
             return
 
         if "CR.EXTRA_DATA->>'TRAIT_COMPILER_PAIR_TAG' = ANY" in normalized:
-            self._next_rows = []
-            self.rowcount = 0
+            tags = set(params[0])
+            rows = []
+            character_to_entity = {
+                character_id: row["entity_id"]
+                for character_id, row in self.characters.items()
+            }
+            tag_by_id = {row["id"]: tag for tag, row in self.pair_tags.items()}
+            active_pair_keys = {
+                (
+                    row["subject_entity_id"],
+                    row["object_entity_id"],
+                    tag_by_id[row["pair_tag_id"]],
+                )
+                for row in self.entity_pair_tags
+                if row["cleared_at"] is None
+            }
+            for row in self.character_relationships:
+                extra_data = row["extra_data"]
+                if isinstance(extra_data, str):
+                    extra_data = json.loads(extra_data)
+                pair_tag = extra_data.get("trait_compiler_pair_tag")
+                if pair_tag not in tags:
+                    continue
+                character1_entity_id = character_to_entity[row["character1_id"]]
+                character2_entity_id = character_to_entity[row["character2_id"]]
+                pair_key = (
+                    character1_entity_id,
+                    character2_entity_id,
+                    pair_tag,
+                )
+                if (
+                    extra_data.get("trait_compiler_pair_tag_direction")
+                    == "target_to_protagonist"
+                ):
+                    pair_key = (
+                        character2_entity_id,
+                        character1_entity_id,
+                        pair_tag,
+                    )
+                if pair_key not in active_pair_keys:
+                    rows.append(
+                        (
+                            character1_entity_id,
+                            character2_entity_id,
+                            pair_tag,
+                            row["character1_id"],
+                            row["character2_id"],
+                        )
+                    )
+            self._next_rows = rows
+            self.rowcount = len(rows)
             return
 
         raise AssertionError(f"Unhandled SQL: {sql.strip()[:120]}")
@@ -544,3 +596,54 @@ def test_reconciliation_reports_pair_tag_without_relationship() -> None:
     assert len(drift) == 1
     assert drift[0].drift_kind == "missing_relationship"
     assert drift[0].pair_tag == "ally"
+
+
+def test_reconciliation_reports_relationship_without_pair_tag() -> None:
+    cur = TraitCompilerCursor()
+    cur.character_relationships.append(
+        {
+            "character1_id": 1,
+            "character2_id": 2,
+            "relationship_type": "ally",
+            "emotional_valence": "+3|trusting",
+            "dynamic": "A compiler-authored ally relationship.",
+            "recent_events": "",
+            "history": "",
+            "extra_data": json.dumps(
+                {
+                    "source": "trait_compiler",
+                    "trait": "allies",
+                    "trait_compiler_pair_tag": "ally",
+                }
+            ),
+        }
+    )
+
+    drift = reconcile_trait_relationship_pair_tags(cur)
+
+    assert len(drift) == 1
+    assert drift[0].drift_kind == "missing_pair_tag"
+    assert drift[0].pair_tag == "ally"
+
+
+def test_persist_trait_compile_result_requires_wizard_cache_row() -> None:
+    class PersistCursor:
+        def __init__(self) -> None:
+            self.rowcounts = [1, 0]
+            self.rowcount = 0
+
+        def execute(self, _sql, _params=None):
+            self.rowcount = self.rowcounts.pop(0)
+
+    result = TraitCompileResult(
+        character_id=1,
+        character_entity_id=501,
+        dry_run=False,
+    )
+
+    with pytest.raises(RuntimeError, match="new_story_creator"):
+        persist_trait_compile_result(
+            PersistCursor(),
+            character_id=1,
+            result=result,
+        )

--- a/tests/test_trait_compiler.py
+++ b/tests/test_trait_compiler.py
@@ -271,6 +271,10 @@ class TraitCompilerCursor:
                 (row["character1_id"], row["character2_id"])
                 for row in self.character_relationships
             }
+            relationship_keys |= {
+                (character2_id, character1_id)
+                for character1_id, character2_id in relationship_keys
+            }
             for row in self.entity_pair_tags:
                 tag = tag_by_id[row["pair_tag_id"]]
                 character1_id = entity_to_character.get(row["subject_entity_id"])
@@ -490,6 +494,11 @@ def test_enemy_pair_tag_can_point_from_target_to_protagonist() -> None:
     assert cur.entity_pair_tags[0]["object_entity_id"] == 501
     assert cur.character_relationships[0]["character1_id"] == 1
     assert cur.character_relationships[0]["character2_id"] == 2
+    assert (
+        '"trait_compiler_pair_tag_direction": "target_to_protagonist"'
+        in cur.character_relationships[0]["extra_data"]
+    )
+    assert reconcile_trait_relationship_pair_tags(cur) == []
 
 
 def test_failed_relationship_write_rolls_back_pair_tag_savepoint() -> None:

--- a/tests/test_trait_compiler.py
+++ b/tests/test_trait_compiler.py
@@ -1,0 +1,537 @@
+"""Tests for deterministic trait-to-Orrery compilation."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Optional
+
+import pytest
+
+from nexus.api.new_story_schemas import CharacterSheet, CharacterTrait
+from nexus.api.trait_compiler import (
+    apply_character_trait_compilation,
+    compile_character_traits,
+    reconcile_trait_relationship_pair_tags,
+)
+from nexus.api.trait_compiler_schemas import (
+    RelationshipTargetInput,
+    RelationshipTraitInput,
+    SingleEntityTraitInput,
+    StatusTraitInput,
+    TraitCompileInputs,
+    TraitCompileReasonCode,
+)
+
+
+class TraitCompilerCursor:
+    """Fake psycopg cursor for the compiler and Orrery writer SQL shapes."""
+
+    def __init__(self, *, fail_relationship: bool = False):
+        self.tags = {
+            "wealthy": {"id": 10, "category": "role.resources"},
+            "known": {"id": 11, "category": "role.fame"},
+            "poor": {"id": 12, "category": "role.resources"},
+        }
+        self.category_registry = {
+            "character": {"role.resources", "role.fame"},
+        }
+        self.pair_tags = {
+            "status:senior": {
+                "id": 100,
+                "subject_kinds": ["character", "faction"],
+                "object_kinds": ["faction"],
+            },
+            "ally": {
+                "id": 101,
+                "subject_kinds": ["character"],
+                "object_kinds": ["character"],
+            },
+            "contact": {
+                "id": 102,
+                "subject_kinds": ["character"],
+                "object_kinds": ["character"],
+            },
+            "hostile_to": {
+                "id": 103,
+                "subject_kinds": ["character", "faction"],
+                "object_kinds": ["character", "faction"],
+            },
+        }
+        self.characters = {
+            1: {"entity_id": 501},
+            2: {"entity_id": 502},
+        }
+        self.factions = {"The Guild": 900}
+        self.entity_tags: list[dict[str, Any]] = []
+        self.entity_pair_tags: list[dict[str, Any]] = []
+        self.character_relationships: list[dict[str, Any]] = []
+        self.fail_relationship = fail_relationship
+        self.rowcount = 0
+        self._next_row: Optional[Any] = None
+        self._next_rows: list[Any] = []
+        self._savepoints: list[tuple[list[dict[str, Any]], list[dict[str, Any]]]] = []
+
+    def execute(self, sql: str, params: Optional[tuple] = None) -> None:
+        params = params or ()
+        normalized = " ".join(sql.strip().upper().split())
+
+        if normalized.startswith("SAVEPOINT"):
+            self._savepoints.append(
+                (
+                    deepcopy(self.entity_pair_tags),
+                    deepcopy(self.character_relationships),
+                )
+            )
+            self.rowcount = 0
+            return
+        if normalized.startswith("ROLLBACK TO SAVEPOINT"):
+            self.entity_pair_tags, self.character_relationships = deepcopy(
+                self._savepoints[-1]
+            )
+            self.rowcount = 0
+            return
+        if normalized.startswith("RELEASE SAVEPOINT"):
+            self._savepoints.pop()
+            self.rowcount = 0
+            return
+
+        if normalized.startswith("SELECT MAX(WORLD_TIME)"):
+            self._next_row = (None,)
+            self.rowcount = 1
+            return
+
+        if "FROM TAG_CATEGORY_REGISTRY" in normalized:
+            (entity_kind,) = params
+            self._next_rows = [
+                (category,)
+                for category in self.category_registry.get(entity_kind, set())
+            ]
+            self.rowcount = len(self._next_rows)
+            return
+
+        if normalized.startswith("SELECT ID, CATEGORY, IS_EPHEMERAL"):
+            (tag,) = params
+            row = self.tags.get(tag)
+            self._next_row = (
+                (row["id"], row["category"], False) if row is not None else None
+            )
+            self.rowcount = 1 if row else 0
+            return
+
+        if normalized.startswith("SELECT 1 FROM TAGS"):
+            tag, category = params
+            row = self.tags.get(tag)
+            self._next_row = (1,) if row and row["category"] == category else None
+            self.rowcount = 1 if self._next_row else 0
+            return
+
+        if normalized.startswith("SELECT 1 FROM PAIR_TAGS"):
+            (tag,) = params
+            self._next_row = (1,) if tag in self.pair_tags else None
+            self.rowcount = 1 if self._next_row else 0
+            return
+
+        if normalized.startswith("SELECT ID, SUBJECT_KINDS, OBJECT_KINDS"):
+            (tag,) = params
+            row = self.pair_tags.get(tag)
+            self._next_row = (
+                (row["id"], row["subject_kinds"], row["object_kinds"])
+                if row is not None
+                else None
+            )
+            self.rowcount = 1 if row else 0
+            return
+
+        if normalized.startswith("SELECT ENTITY_ID FROM FACTIONS"):
+            (name,) = params
+            entity_id = self.factions.get(name)
+            self._next_row = (entity_id,) if entity_id is not None else None
+            self.rowcount = 1 if entity_id is not None else 0
+            return
+
+        if normalized.startswith("UPDATE ENTITY_TAGS ET"):
+            entity_id, category, keep_tag_id = params
+            tag_by_id = {row["id"]: row for row in self.tags.values()}
+            cleared = 0
+            for row in self.entity_tags:
+                tag_row = tag_by_id[row["tag_id"]]
+                if (
+                    row["entity_id"] == entity_id
+                    and row["tag_id"] != keep_tag_id
+                    and tag_row["category"] == category
+                    and row["cleared_at"] is None
+                ):
+                    row["cleared_at"] = "now"
+                    cleared += 1
+            self.rowcount = cleared
+            return
+
+        if normalized.startswith("INSERT INTO ENTITY_TAGS"):
+            entity_id, tag_id, _world_time, source_kind = params
+            active = [
+                row
+                for row in self.entity_tags
+                if row["entity_id"] == entity_id
+                and row["tag_id"] == tag_id
+                and row["cleared_at"] is None
+            ]
+            if active:
+                self.rowcount = 0
+                return
+            self.entity_tags.append(
+                {
+                    "entity_id": entity_id,
+                    "tag_id": tag_id,
+                    "source_kind": source_kind,
+                    "cleared_at": None,
+                }
+            )
+            self.rowcount = 1
+            return
+
+        if normalized.startswith("UPDATE ENTITY_PAIR_TAGS EPT"):
+            subject_id, object_id, tags = params
+            tag_by_id = {row["id"]: tag for tag, row in self.pair_tags.items()}
+            cleared = 0
+            for row in self.entity_pair_tags:
+                tag = tag_by_id[row["pair_tag_id"]]
+                if (
+                    row["subject_entity_id"] == subject_id
+                    and row["object_entity_id"] == object_id
+                    and tag in tags
+                    and row["cleared_at"] is None
+                ):
+                    row["cleared_at"] = "now"
+                    cleared += 1
+            self.rowcount = cleared
+            return
+
+        if normalized.startswith("INSERT INTO ENTITY_PAIR_TAGS"):
+            subject_id, object_id, pair_tag_id, _world_time, source_kind = params
+            active = [
+                row
+                for row in self.entity_pair_tags
+                if row["subject_entity_id"] == subject_id
+                and row["object_entity_id"] == object_id
+                and row["pair_tag_id"] == pair_tag_id
+                and row["cleared_at"] is None
+            ]
+            if active:
+                self.rowcount = 0
+                return
+            self.entity_pair_tags.append(
+                {
+                    "subject_entity_id": subject_id,
+                    "object_entity_id": object_id,
+                    "pair_tag_id": pair_tag_id,
+                    "source_kind": source_kind,
+                    "cleared_at": None,
+                }
+            )
+            self.rowcount = 1
+            return
+
+        if normalized.startswith("INSERT INTO CHARACTER_RELATIONSHIPS"):
+            if self.fail_relationship:
+                raise RuntimeError("relationship write failed")
+            (
+                character1_id,
+                character2_id,
+                relationship_type,
+                emotional_valence,
+                dynamic,
+                recent_events,
+                history,
+                extra_data,
+            ) = params
+            self.character_relationships.append(
+                {
+                    "character1_id": character1_id,
+                    "character2_id": character2_id,
+                    "relationship_type": relationship_type,
+                    "emotional_valence": emotional_valence,
+                    "dynamic": dynamic,
+                    "recent_events": recent_events,
+                    "history": history,
+                    "extra_data": extra_data,
+                }
+            )
+            self.rowcount = 1
+            return
+
+        if "AND CR.CHARACTER1_ID IS NULL" in normalized:
+            tags = set(params[0])
+            rows = []
+            tag_by_id = {row["id"]: tag for tag, row in self.pair_tags.items()}
+            entity_to_character = {
+                row["entity_id"]: character_id
+                for character_id, row in self.characters.items()
+            }
+            relationship_keys = {
+                (row["character1_id"], row["character2_id"])
+                for row in self.character_relationships
+            }
+            for row in self.entity_pair_tags:
+                tag = tag_by_id[row["pair_tag_id"]]
+                character1_id = entity_to_character.get(row["subject_entity_id"])
+                character2_id = entity_to_character.get(row["object_entity_id"])
+                if (
+                    tag in tags
+                    and row["cleared_at"] is None
+                    and (character1_id, character2_id) not in relationship_keys
+                ):
+                    rows.append(
+                        (
+                            row["subject_entity_id"],
+                            row["object_entity_id"],
+                            tag,
+                            character1_id,
+                            character2_id,
+                        )
+                    )
+            self._next_rows = rows
+            self.rowcount = len(rows)
+            return
+
+        if "CR.EXTRA_DATA->>'TRAIT_COMPILER_PAIR_TAG' = ANY" in normalized:
+            self._next_rows = []
+            self.rowcount = 0
+            return
+
+        raise AssertionError(f"Unhandled SQL: {sql.strip()[:120]}")
+
+    def fetchone(self):
+        row = self._next_row
+        self._next_row = None
+        return row
+
+    def fetchall(self):
+        rows = self._next_rows
+        self._next_rows = []
+        return rows
+
+
+def _character(
+    *trait_names: str,
+    inputs: TraitCompileInputs | None = None,
+) -> CharacterSheet:
+    traits = [
+        CharacterTrait(name=trait_name, description=f"{trait_name} description")
+        for trait_name in trait_names
+    ]
+    return CharacterSheet(
+        name="Mara",
+        summary="A wary operator with ties across the city.",
+        appearance="Lean, watchful, and dressed for quick departures.",
+        background="Mara has survived by cultivating favors and avoiding easy debts.",
+        personality="Careful, loyal to a fault, and slow to trust strangers.",
+        wildcard_name="Storm Marked",
+        wildcard_description="Lightning follows her in ways nobody can explain.",
+        trait_1=traits[0],
+        trait_2=traits[1],
+        trait_3=traits[2],
+        trait_compile_inputs=inputs,
+    )
+
+
+def test_no_typed_inputs_returns_structured_remainders() -> None:
+    cur = TraitCompilerCursor()
+    result = compile_character_traits(
+        cur,
+        character=_character("resources", "status", "allies"),
+        character_id=1,
+        character_entity_id=501,
+        dry_run=True,
+    )
+
+    assert result.counters.prose_only_remainders == 3
+    assert {item.trait for item in result.prose_only_remainders} == {
+        "resources",
+        "status",
+        "allies",
+    }
+    assert {
+        item.reason_code for item in result.prose_only_remainders
+    } == {TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT}
+
+
+def test_resources_and_reputation_compile_to_single_entity_tags() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        resources=SingleEntityTraitInput(level="wealthy"),
+        reputation=SingleEntityTraitInput(level="known"),
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("resources", "reputation", "domain", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert {
+        (item.trait, item.tag, item.category)
+        for item in result.applied_single_entity_tags
+    } == {
+        ("resources", "wealthy", "role.resources"),
+        ("reputation", "known", "role.fame"),
+    }
+    assert {row["tag_id"] for row in cur.entity_tags} == {10, 11}
+    assert result.counters.prose_only_remainders == 1
+
+
+def test_status_compiles_to_scoped_pair_tag() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        status=StatusTraitInput(scope_faction_entity_id=900, level="senior")
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("status", "resources", "domain", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert result.applied_pair_tags[0].tag == "status:senior"
+    assert cur.entity_pair_tags == [
+        {
+            "subject_entity_id": 501,
+            "object_entity_id": 900,
+            "pair_tag_id": 100,
+            "source_kind": "skald_inline",
+            "cleared_at": None,
+        }
+    ]
+
+
+def test_allies_default_to_relationship_without_pair_tag() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        allies=RelationshipTraitInput(
+            targets=[
+                RelationshipTargetInput(
+                    character_id=2,
+                    character_entity_id=502,
+                    dynamic="A trusted ally from before the story opens.",
+                )
+            ]
+        )
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("allies", "resources", "domain", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert result.created_relationships[0].relationship_type == "ally"
+    assert result.applied_pair_tags == []
+    assert cur.entity_pair_tags == []
+
+
+def test_explicit_ally_pair_tag_writes_both_layers() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        allies=RelationshipTraitInput(
+            targets=[
+                RelationshipTargetInput(
+                    character_id=2,
+                    character_entity_id=502,
+                    dynamic="A package gate explicitly needs this ally edge.",
+                    apply_pair_tag=True,
+                )
+            ]
+        )
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("allies", "resources", "domain", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert result.applied_pair_tags[0].tag == "ally"
+    assert result.created_relationships[0].pair_tag == "ally"
+    assert len(cur.entity_pair_tags) == 1
+    assert len(cur.character_relationships) == 1
+
+
+def test_enemy_pair_tag_can_point_from_target_to_protagonist() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        enemies=RelationshipTraitInput(
+            targets=[
+                RelationshipTargetInput(
+                    character_id=2,
+                    character_entity_id=502,
+                    dynamic="The enemy is hunting for payback.",
+                    apply_pair_tag=True,
+                    pair_tag_direction="target_to_protagonist",
+                )
+            ]
+        )
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("enemies", "resources", "domain", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert result.applied_pair_tags[0].tag == "hostile_to"
+    assert result.applied_pair_tags[0].subject_entity_id == 502
+    assert result.applied_pair_tags[0].object_entity_id == 501
+    assert result.created_relationships[0].relationship_type == "enemy"
+    assert cur.entity_pair_tags[0]["subject_entity_id"] == 502
+    assert cur.entity_pair_tags[0]["object_entity_id"] == 501
+    assert cur.character_relationships[0]["character1_id"] == 1
+    assert cur.character_relationships[0]["character2_id"] == 2
+
+
+def test_failed_relationship_write_rolls_back_pair_tag_savepoint() -> None:
+    cur = TraitCompilerCursor(fail_relationship=True)
+    inputs = TraitCompileInputs(
+        allies=RelationshipTraitInput(
+            targets=[
+                RelationshipTargetInput(
+                    character_id=2,
+                    character_entity_id=502,
+                    apply_pair_tag=True,
+                )
+            ]
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="relationship write failed"):
+        apply_character_trait_compilation(
+            cur,
+            character=_character("allies", "resources", "domain", inputs=inputs),
+            character_id=1,
+            character_entity_id=501,
+        )
+
+    assert cur.entity_pair_tags == []
+    assert cur.character_relationships == []
+
+
+def test_reconciliation_reports_pair_tag_without_relationship() -> None:
+    cur = TraitCompilerCursor()
+    cur.entity_pair_tags.append(
+        {
+            "subject_entity_id": 501,
+            "object_entity_id": 502,
+            "pair_tag_id": 101,
+            "source_kind": "skald_inline",
+            "cleared_at": None,
+        }
+    )
+
+    drift = reconcile_trait_relationship_pair_tags(cur)
+
+    assert len(drift) == 1
+    assert drift[0].drift_kind == "missing_relationship"
+    assert drift[0].pair_tag == "ally"


### PR DESCRIPTION
## Summary
- Add a testable trait compiler module with dry-run/apply modes, structured result schemas, reason-coded prose-only remainders, transactional savepoint application, and relationship/pair-tag reconciliation reporting.
- Seed the compiler substrate with migration 045: `role.resources`, `role.fame`, status pair-tags, `ally`/`contact`/`hostile_to`, `claims` subject-kind widening, `trait_compile_result`, and the Reputation -> Fame transition row update.
- Wire bootstrap to apply the compiler after protagonist/location creation, persist the audit result to `characters.extra_data` and the wizard cache, and keep relationship pair-tags explicit/selective per the current vocabulary design.

Closes #295.

## Notes
- Relationship traits write `character_relationships` by default. They dual-write `ally`/`contact`/`hostile_to` pair-tags when typed input explicitly requests a package-gate edge.
- Enemy pair-tags support typed direction, so `hostile_to` can point either protagonist -> target or target -> protagonist.
- Existing `reputation` remains accepted as a compatibility alias while the forward trait name is `fame`.

## Data / Migration Impact
- Ran migration 045 locally with `poetry run python scripts/migrate.py --all`: applied to `NEXUS_template` and `save_02` through `save_05`; `save_01` was locked and skipped by the migration runner.
- Spot-checked `save_02` for new pair-tags, role categories, seeded role tags, `assets.traits.id=6` renamed to `fame`, and `assets.new_story_creator.trait_compile_result`.

## Validation
- `PYTHONPATH=. poetry run pytest` (448 passed, 60 skipped)
- `PYTHONPATH=. poetry run mypy nexus/api/trait_compiler.py nexus/api/trait_compiler_schemas.py`
- `poetry run flake8 nexus/api/trait_compiler.py nexus/api/trait_compiler_schemas.py tests/test_trait_compiler.py migrations/045_trait_compiler_substrate.py tests/test_orrery/test_migrate.py`
- `git diff --check`

Repo-wide `poetry run flake8` still reports pre-existing violations across unrelated legacy files, so validation here is scoped to the new compiler/migration slice.
