### PR TITLE
Canonicalize Orrery grief state

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -998,7 +998,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **Gate:**
 
 - **AND:**
-  - actor has `bereaved` ephemeral
+  - actor has `grieving` ephemeral
   - ≥ 3 ticks since last `mourning_act` event for actor
   - **NOT:** actor has `under_active_pursuit` ephemeral
 
@@ -1013,7 +1013,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 2 — Sit with others who carry the same loss  *(mag 0.38)*
 
-**When:** 1+ other entities with `bereaved` ephemeral co-located with actor
+**When:** 1+ other entities with `grieving` ephemeral co-located with actor
 
 **Does:** activity → "gathering with co-mourners"
 **Event:** `mourning_act`
@@ -1257,7 +1257,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
     - actor is in transit
     - actor has a planned travel destination
   - **NOT:** actor has `wounded` ephemeral
-  - **NOT:** actor has `bereaved` ephemeral
+  - **NOT:** actor has `grieving` ephemeral
 
 ### Branch 1 — Arrive at the planned destination  *(mag 0.34)*
 
@@ -1338,7 +1338,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
   - ≥ 4 ticks since last `socialized` event for actor
   - ≥ 4 ticks since last `socialized_alone` event for actor
   - **NOT:** actor has `under_active_pursuit` ephemeral
-  - **NOT:** actor has `bereaved` ephemeral
+  - **NOT:** actor has `grieving` ephemeral
   - **NOT:** actor has `wounded` ephemeral
 
 ### Branch 1 — Seek company after extended isolation  *(mag 0.54)*
@@ -1413,7 +1413,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
   - ≥ 8 ticks since last `intimacy_deferred` event for actor
   - **NOT:** actor has `under_active_pursuit` ephemeral
   - **NOT:** actor has `wounded` ephemeral
-  - **NOT:** actor has `bereaved` ephemeral
+  - **NOT:** actor has `grieving` ephemeral
 
 ### Branch 1 — Spend private time with an established partner  *(mag 0.32)*
 
@@ -1496,7 +1496,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
   - ≥ 4 ticks since last `craft_tended` event for actor
   - **NOT:** actor has `under_active_pursuit` ephemeral
   - **NOT:** actor has `wounded` ephemeral
-  - **NOT:** actor has `bereaved` ephemeral
+  - **NOT:** actor has `grieving` ephemeral
 
 ### Branch 1 — Make the weapon ready for what comes next  *(mag 0.18)*
 
@@ -1601,7 +1601,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
   - ≥ 4 ticks since last `household_work_performed` event for actor
   - **NOT:** actor has `under_active_pursuit` ephemeral
   - **NOT:** actor has `wounded` ephemeral
-  - **NOT:** actor has `bereaved` ephemeral
+  - **NOT:** actor has `grieving` ephemeral
 
 ### Branch 1 — Work a public-facing shift  *(mag 0.18)*
 
@@ -1826,11 +1826,11 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 
 ### Tags queried as ephemeral (via `has_ephemeral`)
 
-- `bereaved`
 - `captive`
 - `cns_stimulated`
 - `debt_pulse_active`
 - `dying`
+- `grieving`
 - `grudge_active`
 - `unconscious`
 - `under_active_pursuit`

--- a/migrations/046_canonical_grieving_state.py
+++ b/migrations/046_canonical_grieving_state.py
@@ -18,7 +18,9 @@ def run(conn) -> None:
                 deprecated, description
             ) VALUES (
                 'grieving', 'state', TRUE,
-                'event', NULL, '{"event_types": ["mourning_completed"]}'::jsonb,
+                'event',
+                'extend_expiry'::entity_tag_reapplication_policy,
+                '{"event_types": ["mourning_completed"]}'::jsonb,
                 FALSE,
                 'Actor is grieving a consequential loss. Long-lived; gates '
                 'MOURN_LOSS and suppresses incompatible routine/social/intimacy '

--- a/migrations/046_canonical_grieving_state.py
+++ b/migrations/046_canonical_grieving_state.py
@@ -1,0 +1,97 @@
+"""Canonicalize grief vocabulary around the ``grieving`` state tag."""
+
+from __future__ import annotations
+
+
+LEGACY_TAGS = ("bereaved", "grieving_recent_partner")
+
+
+def run(conn) -> None:
+    """Seed ``grieving`` and migrate legacy grief tags to the canonical row."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO tags (
+                tag, category, is_ephemeral,
+                clearance_kind, reapplication_policy, clear_on,
+                deprecated, description
+            ) VALUES (
+                'grieving', 'state', TRUE,
+                'event', NULL, '{"event_types": ["mourning_completed"]}'::jsonb,
+                FALSE,
+                'Actor is grieving a consequential loss. Long-lived; gates '
+                'MOURN_LOSS and suppresses incompatible routine/social/intimacy '
+                'branches until cleared by mourning_completed.'
+            )
+            ON CONFLICT (tag) DO UPDATE SET
+                category = EXCLUDED.category,
+                is_ephemeral = EXCLUDED.is_ephemeral,
+                clearance_kind = EXCLUDED.clearance_kind,
+                reapplication_policy = EXCLUDED.reapplication_policy,
+                clear_on = EXCLUDED.clear_on,
+                deprecated = FALSE,
+                synonym_for = NULL,
+                description = EXCLUDED.description
+            RETURNING id
+            """
+        )
+        canonical_id = cur.fetchone()[0]
+
+        cur.execute(
+            """
+            SELECT id
+            FROM tags
+            WHERE tag = ANY(%s)
+            """,
+            (list(LEGACY_TAGS),),
+        )
+        legacy_ids = [row[0] for row in cur.fetchall()]
+
+        for legacy_id in legacy_ids:
+            cur.execute(
+                """
+                INSERT INTO entity_tags (
+                    entity_id, tag_id, applied_at, applied_at_world_time,
+                    clear_on_override, template_id, source_kind
+                )
+                SELECT et.entity_id,
+                       %s,
+                       et.applied_at,
+                       et.applied_at_world_time,
+                       et.clear_on_override,
+                       et.template_id,
+                       et.source_kind
+                FROM entity_tags et
+                WHERE et.tag_id = %s
+                  AND et.cleared_at IS NULL
+                ON CONFLICT (entity_id, tag_id)
+                  WHERE cleared_at IS NULL
+                  DO NOTHING
+                """,
+                (canonical_id, legacy_id),
+            )
+            cur.execute(
+                """
+                UPDATE entity_tags
+                SET cleared_at = now()
+                WHERE tag_id = %s
+                  AND cleared_at IS NULL
+                """,
+                (legacy_id,),
+            )
+
+        cur.execute(
+            """
+            UPDATE tags
+            SET deprecated = TRUE,
+                synonym_for = %s,
+                description = COALESCE(description, '')
+                    || ' Deprecated alias of grieving.'
+            WHERE tag = ANY(%s)
+              AND id <> %s
+            """,
+            (canonical_id, list(LEGACY_TAGS), canonical_id),
+        )
+
+    conn.commit()

--- a/nexus/agents/orrery/demo.py
+++ b/nexus/agents/orrery/demo.py
@@ -103,7 +103,7 @@ def build_presets() -> Dict[str, WorldState]:
         ),
         # Round-2 solo presets
         "mourning": WorldState(
-            ephemeral_tags={ACTOR_ID: frozenset({"bereaved"})},
+            ephemeral_tags={ACTOR_ID: frozenset({"grieving"})},
             locations={ACTOR_ID: REMEMBRANCE_PLACE_ID},
             location_class=location_classes,
             time_of_day="evening",

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -47,7 +47,7 @@ INTIMACY_SUPPRESSOR_TAGS: frozenset[str] = frozenset(
         "closeted",
         "vow_of_celibacy",
         "religiously_abstinent",
-        "grieving_recent_partner",
+        "grieving",
         "recently_traumatized_intimate",
         "focus_committed",
         "libido_absent",

--- a/nexus/agents/orrery/tag_constants.py
+++ b/nexus/agents/orrery/tag_constants.py
@@ -11,6 +11,7 @@ from typing import Mapping
 
 
 CANONICAL_TAGS: Mapping[str, str] = {
+    "bereaved": "grieving",
     "bridge_linked": "bridge_aware",
     "captive_subject": "captive",
     "collapse_survivor": "trauma_survivor",
@@ -22,6 +23,7 @@ CANONICAL_TAGS: Mapping[str, str] = {
     "ex_corporate": "corporate_exile",
     "found_family_anchor": "extended_household",
     "found_family_member": "extended_household",
+    "grieving_recent_partner": "grieving",
     "shadow_broker": "broker",
     "trauma_history": "trauma_survivor",
 }

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -1033,7 +1033,7 @@ CULTIVATE_INFORMANT = Template(
 #     (which reads `wounded` but had no template emitting `wound_healed`
 #     until now).
 #
-#   * `bereaved` / `dying` / `unconscious` ephemerals are seeded with
+#   * `grieving` / `dying` / `unconscious` ephemerals are seeded with
 #     event-based clearance pointing at `mourning_completed` / `death_recorded`
 #     / `regained_consciousness`. These events are authored externally
 #     (CommitOrreryTick or future world-state systems); MOURN_LOSS and
@@ -1164,7 +1164,7 @@ MOURN_LOSS = Template(
     blurb="A loss settles into the body across many quiet days.",
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
-        has_ephemeral("bereaved"),
+        has_ephemeral("grieving"),
         since_last_event_at_least("mourning_act", minimum_ticks=3),
         NOT(has_ephemeral("under_active_pursuit")),
     ),
@@ -1187,7 +1187,7 @@ MOURN_LOSS = Template(
         ),
         Branch(
             label="Sit with others who carry the same loss",
-            conditions=count_co_located(1, with_ephemeral="bereaved"),
+            conditions=count_co_located(1, with_ephemeral="grieving"),
             narrative_stub=(
                 "{actor} finds the others who knew the dead and sits with "
                 "them — wordlessly, mostly. The presence of someone else "
@@ -1356,7 +1356,7 @@ TRAVEL = Template(
     package_gate=AND(
         OR(is_in_transit(), has_travel_destination()),
         NOT(has_ephemeral("wounded")),
-        NOT(has_ephemeral("bereaved")),
+        NOT(has_ephemeral("grieving")),
     ),
     branches=(
         Branch(
@@ -1501,7 +1501,7 @@ WORK = Template(
         since_last_event_at_least("household_work_performed", minimum_ticks=4),
         NOT(has_ephemeral("under_active_pursuit")),
         NOT(has_ephemeral("wounded")),
-        NOT(has_ephemeral("bereaved")),
+        NOT(has_ephemeral("grieving")),
     ),
     branches=(
         Branch(
@@ -1648,7 +1648,7 @@ TEND_CRAFT = Template(
         since_last_event_at_least("craft_tended", minimum_ticks=4),
         NOT(has_ephemeral("under_active_pursuit")),
         NOT(has_ephemeral("wounded")),
-        NOT(has_ephemeral("bereaved")),
+        NOT(has_ephemeral("grieving")),
     ),
     branches=(
         Branch(
@@ -2663,7 +2663,7 @@ SOCIALIZE = Template(
         since_last_event_at_least("socialized", minimum_ticks=4),
         since_last_event_at_least("socialized_alone", minimum_ticks=4),
         NOT(has_ephemeral("under_active_pursuit")),
-        NOT(has_ephemeral("bereaved")),
+        NOT(has_ephemeral("grieving")),
         NOT(has_ephemeral("wounded")),
     ),
     branches=(
@@ -2810,7 +2810,7 @@ INTIMACY = Template(
         since_last_event_at_least("intimacy_deferred", minimum_ticks=8),
         NOT(has_ephemeral("under_active_pursuit")),
         NOT(has_ephemeral("wounded")),
-        NOT(has_ephemeral("bereaved")),
+        NOT(has_ephemeral("grieving")),
     ),
     branches=(
         Branch(

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -2,9 +2,11 @@
 
 from pathlib import Path
 
+import psycopg2
 import pytest
 
 import scripts.migrate as migrate
+from nexus.api.slot_utils import get_slot_db_url
 
 
 def test_discover_migrations_includes_python_and_skips_seed_script(
@@ -500,5 +502,121 @@ def test_canonical_grieving_migration_aliases_legacy_grief_tags() -> None:
 
     assert migration.LEGACY_TAGS == ("bereaved", "grieving_recent_partner")
     assert "'grieving', 'state', TRUE" in migration_source
+    assert "'extend_expiry'::entity_tag_reapplication_policy" in migration_source
     assert "ON CONFLICT (entity_id, tag_id)" in migration_source
     assert "synonym_for = %s" in migration_source
+
+
+@pytest.mark.requires_postgres
+def test_canonical_grieving_migration_executes_against_slot_db() -> None:
+    """Migration 046 moves active legacy rows and preserves grief reapply policy."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "046_canonical_grieving_state.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    try:
+        conn = psycopg2.connect(get_slot_db_url(dbname="save_05"))
+    except psycopg2.Error as exc:
+        pytest.skip(f"save_05 PostgreSQL test database unavailable: {exc}")
+
+    created_entity_ids: list[int] = []
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT tag, id
+                    FROM tags
+                    WHERE tag = ANY(%s)
+                    """,
+                    (list(migration.LEGACY_TAGS),),
+                )
+                legacy_ids = {tag: tag_id for tag, tag_id in cur.fetchall()}
+                missing = set(migration.LEGACY_TAGS) - set(legacy_ids)
+                if missing:
+                    pytest.skip(f"Missing legacy grief tags: {sorted(missing)}")
+
+                for tag in migration.LEGACY_TAGS:
+                    cur.execute(
+                        "INSERT INTO entities (kind, is_active) "
+                        "VALUES ('character', true) RETURNING id"
+                    )
+                    entity_id = cur.fetchone()[0]
+                    created_entity_ids.append(entity_id)
+                    cur.execute(
+                        """
+                        INSERT INTO entity_tags (entity_id, tag_id, source_kind)
+                        VALUES (%s, %s, 'skald_inline')
+                        """,
+                        (entity_id, legacy_ids[tag]),
+                    )
+
+        migration.run(conn)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, reapplication_policy, deprecated, synonym_for
+                FROM tags
+                WHERE tag = 'grieving'
+                """
+            )
+            grieving_id, reapply, deprecated, synonym_for = cur.fetchone()
+            assert reapply == "extend_expiry"
+            assert deprecated is False
+            assert synonym_for is None
+
+            cur.execute(
+                """
+                SELECT t.tag, t.deprecated, t.synonym_for
+                FROM tags t
+                WHERE t.tag = ANY(%s)
+                ORDER BY t.tag
+                """,
+                (list(migration.LEGACY_TAGS),),
+            )
+            assert {
+                tag: (is_deprecated, alias_target)
+                for tag, is_deprecated, alias_target in cur.fetchall()
+            } == {
+                tag: (True, grieving_id) for tag in migration.LEGACY_TAGS
+            }
+
+            cur.execute(
+                """
+                SELECT e.id, active.tag, legacy.tag
+                FROM entities e
+                JOIN entity_tags et
+                  ON et.entity_id = e.id
+                 AND et.cleared_at IS NULL
+                JOIN tags active ON active.id = et.tag_id
+                LEFT JOIN entity_tags old_et
+                  ON old_et.entity_id = e.id
+                 AND old_et.tag_id = ANY(%s)
+                 AND old_et.cleared_at IS NULL
+                LEFT JOIN tags legacy ON legacy.id = old_et.tag_id
+                WHERE e.id = ANY(%s)
+                ORDER BY e.id
+                """,
+                (
+                    [legacy_ids[tag] for tag in migration.LEGACY_TAGS],
+                    created_entity_ids,
+                ),
+            )
+            assert cur.fetchall() == [
+                (entity_id, "grieving", None) for entity_id in created_entity_ids
+            ]
+    finally:
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    if created_entity_ids:
+                        cur.execute(
+                            "DELETE FROM entities WHERE id = ANY(%s)",
+                            (created_entity_ids,),
+                        )
+        finally:
+            conn.close()

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -485,3 +485,20 @@ def test_trait_compiler_substrate_migration_seeds_required_contracts() -> None:
     assert "trait_compile_result jsonb" in migration_source
     assert "SET subject_kinds = ARRAY['character', 'faction']" in migration_source
     assert "SET name = 'fame'" in migration_source
+
+
+def test_canonical_grieving_migration_aliases_legacy_grief_tags() -> None:
+    """Migration 046 collapses bereaved and partner grief into grieving."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "046_canonical_grieving_state.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    migration_source = migration_path.read_text()
+
+    assert migration.LEGACY_TAGS == ("bereaved", "grieving_recent_partner")
+    assert "'grieving', 'state', TRUE" in migration_source
+    assert "ON CONFLICT (entity_id, tag_id)" in migration_source
+    assert "synonym_for = %s" in migration_source

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -504,6 +504,10 @@ def test_intimacy_suppressor_reads_durable_and_ephemeral_tags() -> None:
         {Slot.ACTOR: 1},
     )
     assert predicate(
+        WorldState(ephemeral_tags={1: frozenset({"grieving"})}),
+        {Slot.ACTOR: 1},
+    )
+    assert predicate(
         WorldState(ephemeral_tags={1: frozenset({"focus_committed"})}),
         {Slot.ACTOR: 1},
     )


### PR DESCRIPTION
## Summary
- Canonicalize Orrery grief vocabulary on `grieving`, with `bereaved` and `grieving_recent_partner` routed through `CANONICAL_TAGS`.
- Add migration 046 to seed the canonical `grieving` state, move active legacy `entity_tags` rows onto it, and mark legacy tag rows as deprecated synonyms.
- Update package gates, intimacy suppressors, demo presets, and regenerated `docs/orrery_packages.md` to read `grieving`.

Closes #319.

## Data / Migration Impact
- Adds migration `046_canonical_grieving_state.py`.
- Ran `PYTHONPATH=. poetry run python scripts/migrate.py --all`: applied to `NEXUS_template` and `save_02` through `save_05`; `save_01` was locked and skipped by the migration runner.

## Validation
- `PYTHONPATH=. poetry run pytest tests/test_orrery/test_substrate.py tests/test_orrery/test_resolver.py tests/test_orrery/test_catalog.py tests/test_orrery/test_migrate.py`
- `poetry run flake8 migrations/046_canonical_grieving_state.py tests/test_orrery/test_substrate.py tests/test_orrery/test_migrate.py nexus/agents/orrery/tag_constants.py nexus/agents/orrery/demo.py`
- `git diff --check`
