### PR TITLE
Add trait compiler audit CLI

### DIFF
--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -890,68 +890,69 @@ def run_trait_audit(args: argparse.Namespace) -> Dict[str, Any]:
     """
 
     try:
-        from nexus.api.db_pool import get_connection
-        from nexus.api.new_story_cache import read_cache
-        from nexus.api.new_story_schemas import CharacterCreationState
-        from nexus.api.slot_utils import slot_dbname
-        from nexus.api.trait_compiler import compile_character_traits
-        from nexus.api.trait_compiler_schemas import TraitCompileInputs
-
-        dbname = slot_dbname(args.slot)
-        cache = read_cache(dbname)
-        if cache is None:
-            return {
-                "success": False,
-                "error": f"Slot {args.slot} has no new-story wizard cache.",
-            }
-
-        character_draft = cache.get_character_dict()
-        if character_draft is None:
-            return {
-                "success": False,
-                "error": (
-                    f"Slot {args.slot} does not have a complete character draft "
-                    "to audit."
-                ),
-            }
-
         trait_inputs_payload = _load_trait_inputs(args.trait_inputs)
-        trait_inputs = (
-            TraitCompileInputs.model_validate(trait_inputs_payload)
-            if trait_inputs_payload is not None
-            else None
-        )
-        character_state = CharacterCreationState.model_validate(character_draft)
-        character = character_state.to_character_sheet()
-
-        with get_connection(dbname) as conn:
-            with conn.cursor() as cur:
-                result = compile_character_traits(
-                    cur,
-                    character=character,
-                    character_id=args.character_id,
-                    character_entity_id=args.character_entity_id,
-                    trait_compile_inputs=trait_inputs,
-                    dry_run=True,
-                )
-
-        audit = result.model_dump(mode="json")
-        remainder_count = audit["counters"]["prose_only_remainders"]
-        failed_policy = bool(args.fail_on_remainders and remainder_count)
-        return {
-            "success": True,
-            "message": f"Trait compiler audit for slot {args.slot} (dry run).",
-            "slot": args.slot,
-            "dbname": dbname,
-            "character_name": character.name,
-            "traits": [trait.name for trait in character.get_trait_entries()],
-            "trait_audit": audit,
-            "failed_policy": failed_policy,
-        }
     except json.JSONDecodeError as e:
         return {"success": False, "error": f"Invalid --trait-inputs JSON: {e}"}
-    except Exception as e:
+    except ValueError as e:
         return {"success": False, "error": str(e)}
+
+    from nexus.api.db_pool import get_connection
+    from nexus.api.new_story_cache import read_cache
+    from nexus.api.new_story_schemas import CharacterCreationState
+    from nexus.api.slot_utils import slot_dbname
+    from nexus.api.trait_compiler import compile_character_traits
+    from nexus.api.trait_compiler_schemas import TraitCompileInputs
+
+    dbname = slot_dbname(args.slot)
+    cache = read_cache(dbname)
+    if cache is None:
+        return {
+            "success": False,
+            "error": f"Slot {args.slot} has no new-story wizard cache.",
+        }
+
+    character_draft = cache.get_character_dict()
+    if character_draft is None:
+        return {
+            "success": False,
+            "error": (
+                f"Slot {args.slot} does not have a complete character draft "
+                "to audit."
+            ),
+        }
+
+    trait_inputs = (
+        TraitCompileInputs.model_validate(trait_inputs_payload)
+        if trait_inputs_payload is not None
+        else None
+    )
+    character_state = CharacterCreationState.model_validate(character_draft)
+    character = character_state.to_character_sheet()
+
+    with get_connection(dbname) as conn:
+        with conn.cursor() as cur:
+            result = compile_character_traits(
+                cur,
+                character=character,
+                character_id=args.character_id,
+                character_entity_id=args.character_entity_id,
+                trait_compile_inputs=trait_inputs,
+                dry_run=True,
+            )
+
+    audit = result.model_dump(mode="json")
+    remainder_count = audit["counters"]["prose_only_remainders"]
+    failed_policy = bool(args.fail_on_remainders and remainder_count)
+    return {
+        "success": True,
+        "message": f"Trait compiler audit for slot {args.slot} (dry run).",
+        "slot": args.slot,
+        "dbname": dbname,
+        "character_name": character.name,
+        "traits": [trait.name for trait in character.get_trait_entries()],
+        "trait_audit": audit,
+        "failed_policy": failed_policy,
+    }
 
 
 def run_lock(args: argparse.Namespace) -> Dict[str, Any]:
@@ -1144,7 +1145,10 @@ Examples:
     trait_audit_parser.add_argument(
         "--fail-on-remainders",
         action="store_true",
-        help="Exit with status 1 if any trait falls back to prose-only storage",
+        help=(
+            "Exit with status 1 if any trait falls back to prose-only storage; "
+            "JSON callers should check the exit code or failed_policy"
+        ),
     )
 
     # lock command

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -7,6 +7,7 @@ Commands:
     nexus undo --slot N         Revert the last action
     nexus regenerate --slot N   Regenerate the last storyteller turn
     nexus model --slot N        Get or set the model for a slot
+    nexus trait-audit --slot N  Dry-run new-story trait compiler audit
 
 The CLI is slot-centric: only --slot N is required. The backend resolves
 all other state (wizard phase, current chunk, thread ID) automatically.
@@ -127,6 +128,89 @@ def _print_artifact(
             _print_value(key, value, indent=2, truncate=truncate)
 
 
+def _print_trait_audit(payload: Dict[str, Any]) -> None:
+    """Print a dry-run trait compiler audit in a compact CLI format."""
+
+    audit = payload.get("trait_audit") or {}
+    counters = audit.get("counters") or {}
+    traits = payload.get("traits") or []
+
+    character_name = payload.get("character_name")
+    if character_name:
+        print(f"Character: {character_name}")
+    if traits:
+        print(f"Traits: {', '.join(traits)}")
+
+    print()
+    print("Counters:")
+    for key in (
+        "applied_single_entity_tags",
+        "applied_pair_tags",
+        "created_entities",
+        "created_relationships",
+        "prose_only_remainders",
+    ):
+        print(f"  {key}: {counters.get(key, 0)}")
+
+    single_tags = audit.get("applied_single_entity_tags") or []
+    if single_tags:
+        print()
+        print("Applied single-entity tags:")
+        for item in single_tags:
+            print(
+                "  - "
+                f"{item['trait']}: {item['category']}:{item['tag']} "
+                f"on entity {item['entity_id']}"
+            )
+
+    pair_tags = audit.get("applied_pair_tags") or []
+    if pair_tags:
+        print()
+        print("Applied pair tags:")
+        for item in pair_tags:
+            print(
+                "  - "
+                f"{item['trait']}: {item['tag']} "
+                f"{item['subject_entity_id']} -> {item['object_entity_id']}"
+            )
+
+    created_entities = audit.get("created_entities") or []
+    if created_entities:
+        print()
+        print("Created entities:")
+        for item in created_entities:
+            name = f" ({item['name']})" if item.get("name") else ""
+            print(
+                "  - "
+                f"{item['trait']}: {item['entity_kind']} "
+                f"entity {item['entity_id']}{name}"
+            )
+
+    created_relationships = audit.get("created_relationships") or []
+    if created_relationships:
+        print()
+        print("Created relationships:")
+        for item in created_relationships:
+            print(
+                "  - "
+                f"{item['trait']}: character {item['character1_id']} -> "
+                f"{item['character2_id']} "
+                f"({item['relationship_type']}, {item['emotional_valence']})"
+            )
+
+    remainders = audit.get("prose_only_remainders") or []
+    if remainders:
+        print()
+        print("Prose-only remainders:")
+        for item in remainders:
+            print(f"  - {item['trait']}: {item['reason_code']}")
+            print(f"    {item['message']}")
+
+    if payload.get("failed_policy"):
+        print()
+        print("Policy: failed because --fail-on-remainders was set.")
+
+
 def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) -> None:
     """Emit payload to stdout in JSON or human-readable format."""
     if as_json:
@@ -142,6 +226,10 @@ def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) 
     message = payload.get("message") or payload.get("storyteller_text")
     if message:
         print(message)
+        print()
+
+    if payload.get("trait_audit"):
+        _print_trait_audit(payload)
         print()
 
     # Get display elements
@@ -234,7 +322,10 @@ def run_load(args: argparse.Namespace) -> Dict[str, Any]:
         if data.get("is_empty"):
             return {
                 "success": True,
-                "message": f"Slot {args.slot} is empty. Use 'nexus continue --slot {args.slot}' to initialize.",
+                "message": (
+                    f"Slot {args.slot} is empty. "
+                    f"Use 'nexus continue --slot {args.slot}' to initialize."
+                ),
                 "is_empty": True,
             }
 
@@ -289,7 +380,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
 
         if state.get("is_empty"):
             # Initialize via setup/start endpoint
-            # Use CLI-provided model, slot's configured model, or let backend use default
+            # Use CLI-provided model, slot's configured model, or backend default.
             setup_url = f"{get_api_url()}/api/story/new/setup/start"
             setup_payload = {"slot": args.slot}
             model_to_use = getattr(args, "model", None) or state.get("model")
@@ -346,7 +437,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                 # Check if we're in trait selection mode
                 trait_menu = state.get("trait_menu")
 
-                # Map --accept-fate to --choice 0 in trait mode when confirmation is available
+                # Map --accept-fate to --choice 0 when confirmation is available.
                 if trait_menu and args.accept_fate and state.get("can_confirm"):
                     args.choice = 0  # Treat as confirm
 
@@ -354,7 +445,10 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                     if args.dev:
                         return {
                             "success": False,
-                            "error": "Dev mode is not supported for trait selection toggles.",
+                            "error": (
+                                "Dev mode is not supported for trait selection "
+                                "toggles."
+                            ),
                         }
                     # Trait toggle/confirm mode: choice 0 = confirm, 1-10 = toggle
                     if args.choice == 0:
@@ -366,14 +460,18 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                     elif not (1 <= args.choice <= 10):
                         return {
                             "success": False,
-                            "error": f"Choice {args.choice} out of range (0-10 for trait selection)",
+                            "error": (
+                                f"Choice {args.choice} out of range "
+                                "(0-10 for trait selection)"
+                            ),
                         }
 
                     payload = {
                         "slot": args.slot,
                         "message": "",
                         "trait_choice": args.choice,
-                        "current_phase": "character",  # Required for trait toggle handler
+                        # Required for trait toggle handler.
+                        "current_phase": "character",
                     }
                     if model_to_use:
                         payload["model"] = model_to_use
@@ -382,14 +480,18 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                     response.raise_for_status()
                     data = response.json()
 
-                    # Check if subphase completed (traits confirmed → need wildcard intro)
+                    # Check if confirmed traits need a wildcard intro.
                     if data.get("subphase_complete"):
                         next_subphase = data.get("subphase")  # Should be "wildcard"
                         if next_subphase:
                             # Request Skald intro for next subphase
                             intro_payload = {
                                 "slot": args.slot,
-                                "message": f"[SYSTEM] Phase character subphase traits complete. Proceeding to {next_subphase}. Please introduce the next subphase.",
+                                "message": (
+                                    "[SYSTEM] Phase character subphase traits "
+                                    f"complete. Proceeding to {next_subphase}. "
+                                    "Please introduce the next subphase."
+                                ),
                                 "current_phase": "character",
                             }
                             if model_to_use:
@@ -409,7 +511,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                                     "subphase": next_subphase,
                                 }
 
-                    # Return for non-completing operations (toggles) or if intro request failed
+                    # Return for toggles or if the intro request failed.
                     return {
                         "success": True,
                         "message": data.get("message", ""),
@@ -429,7 +531,10 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                     else:
                         return {
                             "success": False,
-                            "error": f"Choice {args.choice} out of range (1-{len(choices)})",
+                            "error": (
+                                f"Choice {args.choice} out of range "
+                                f"(1-{len(choices)})"
+                            ),
                         }
 
                 payload = {
@@ -475,7 +580,11 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                         # Send transition message to get next phase intro
                         transition_payload = {
                             "slot": args.slot,
-                            "message": f"[SYSTEM] Phase {current_phase} complete. Proceeding to {next_phase}. Please introduce the next phase.",
+                            "message": (
+                                f"[SYSTEM] Phase {current_phase} complete. "
+                                f"Proceeding to {next_phase}. "
+                                "Please introduce the next phase."
+                            ),
                             "current_phase": next_phase,
                         }
                         if model_to_use:
@@ -486,7 +595,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                         )
                         if intro_response.ok:
                             intro_data = intro_response.json()
-                            # Append intro to result (artifact stays, intro message added)
+                            # Append intro to result, preserving the artifact.
                             result["next_phase_intro"] = intro_data.get("message")
                             result["choices"] = intro_data.get("choices", [])
                             result["phase"] = intro_data.get("phase") or next_phase
@@ -543,7 +652,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
             # Wait for generation to complete and fetch result
             session_id = data.get("session_id")
             if session_id:
-                # Poll for completion (simplified - real implementation would use websocket)
+                # Poll for completion; websocket is intentionally not used here.
                 for _ in range(GENERATION_POLL_SECONDS):
                     status_url = f"{get_api_url()}/api/narrative/status/{session_id}"
                     status_response = requests.get(
@@ -760,6 +869,91 @@ def run_clear(args: argparse.Namespace) -> Dict[str, Any]:
         return {"success": False, "error": str(e)}
 
 
+def _load_trait_inputs(raw_value: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Parse optional trait compiler input overrides from a JSON string."""
+
+    if not raw_value:
+        return None
+    value = json.loads(raw_value)
+    if not isinstance(value, dict):
+        raise ValueError("--trait-inputs must be a JSON object")
+    return value
+
+
+def run_trait_audit(args: argparse.Namespace) -> Dict[str, Any]:
+    """
+    Dry-run the trait compiler against the current new-story wizard cache.
+
+    This command is intentionally opt-in: normal wizard and React UI flows keep
+    minimizing confirmation screens, while test loops can inspect the mechanical
+    fallout before bootstrap.
+    """
+
+    try:
+        from nexus.api.db_pool import get_connection
+        from nexus.api.new_story_cache import read_cache
+        from nexus.api.new_story_schemas import CharacterCreationState
+        from nexus.api.slot_utils import slot_dbname
+        from nexus.api.trait_compiler import compile_character_traits
+        from nexus.api.trait_compiler_schemas import TraitCompileInputs
+
+        dbname = slot_dbname(args.slot)
+        cache = read_cache(dbname)
+        if cache is None:
+            return {
+                "success": False,
+                "error": f"Slot {args.slot} has no new-story wizard cache.",
+            }
+
+        character_draft = cache.get_character_dict()
+        if character_draft is None:
+            return {
+                "success": False,
+                "error": (
+                    f"Slot {args.slot} does not have a complete character draft "
+                    "to audit."
+                ),
+            }
+
+        trait_inputs_payload = _load_trait_inputs(args.trait_inputs)
+        trait_inputs = (
+            TraitCompileInputs.model_validate(trait_inputs_payload)
+            if trait_inputs_payload is not None
+            else None
+        )
+        character_state = CharacterCreationState.model_validate(character_draft)
+        character = character_state.to_character_sheet()
+
+        with get_connection(dbname) as conn:
+            with conn.cursor() as cur:
+                result = compile_character_traits(
+                    cur,
+                    character=character,
+                    character_id=args.character_id,
+                    character_entity_id=args.character_entity_id,
+                    trait_compile_inputs=trait_inputs,
+                    dry_run=True,
+                )
+
+        audit = result.model_dump(mode="json")
+        remainder_count = audit["counters"]["prose_only_remainders"]
+        failed_policy = bool(args.fail_on_remainders and remainder_count)
+        return {
+            "success": True,
+            "message": f"Trait compiler audit for slot {args.slot} (dry run).",
+            "slot": args.slot,
+            "dbname": dbname,
+            "character_name": character.name,
+            "traits": [trait.name for trait in character.get_trait_entries()],
+            "trait_audit": audit,
+            "failed_policy": failed_policy,
+        }
+    except json.JSONDecodeError as e:
+        return {"success": False, "error": f"Invalid --trait-inputs JSON: {e}"}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
 def run_lock(args: argparse.Namespace) -> Dict[str, Any]:
     """
     Lock a slot to prevent modifications.
@@ -829,6 +1023,7 @@ Examples:
   nexus clear --slot 5          Clear slot (reset wizard state)
   nexus lock --slot 1           Lock slot to prevent modifications
   nexus unlock --slot 2         Unlock slot to allow modifications
+  nexus trait-audit --slot 5    Dry-run trait compiler audit
 """,
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON output")
@@ -872,7 +1067,10 @@ Examples:
     )
     continue_parser.add_argument(
         "--model",
-        help="Override model for this request (use a registry ID; see /api/config/models)",
+        help=(
+            "Override model for this request "
+            "(use a registry ID; see /api/config/models)"
+        ),
     )
 
     # undo command
@@ -916,6 +1114,39 @@ Examples:
         "--slot", type=int, required=True, help="Slot number (1-5)"
     )
 
+    # trait-audit command
+    trait_audit_parser = subparsers.add_parser(
+        "trait-audit",
+        help="Dry-run the new-story trait compiler against wizard cache",
+    )
+    trait_audit_parser.add_argument(
+        "--slot", type=int, required=True, help="Slot number (1-5)"
+    )
+    trait_audit_parser.add_argument(
+        "--trait-inputs",
+        help=(
+            "Optional TraitCompileInputs JSON object for this dry run "
+            "(does not mutate wizard cache)"
+        ),
+    )
+    trait_audit_parser.add_argument(
+        "--character-id",
+        type=int,
+        default=0,
+        help="Placeholder character id to use in dry-run relationship output",
+    )
+    trait_audit_parser.add_argument(
+        "--character-entity-id",
+        type=int,
+        default=0,
+        help="Placeholder entity id to use in dry-run tag output",
+    )
+    trait_audit_parser.add_argument(
+        "--fail-on-remainders",
+        action="store_true",
+        help="Exit with status 1 if any trait falls back to prose-only storage",
+    )
+
     # lock command
     lock_parser = subparsers.add_parser(
         "lock", help="Lock a slot to prevent modifications"
@@ -941,7 +1172,16 @@ def main() -> int:
     args = parser.parse_args()
 
     # Validate slot for commands that require it
-    if args.command in ("load", "continue", "undo", "regenerate", "clear", "lock", "unlock"):
+    if args.command in (
+        "load",
+        "continue",
+        "undo",
+        "regenerate",
+        "clear",
+        "trait-audit",
+        "lock",
+        "unlock",
+    ):
         if args.slot < 1 or args.slot > 5:
             emit_error("Slot must be between 1 and 5", args.json)
             return 1
@@ -967,6 +1207,8 @@ def main() -> int:
         result = run_model(args)
     elif args.command == "clear":
         result = run_clear(args)
+    elif args.command == "trait-audit":
+        result = run_trait_audit(args)
     elif args.command == "lock":
         result = run_lock(args)
     elif args.command == "unlock":
@@ -981,6 +1223,8 @@ def main() -> int:
         return 1
 
     emit_output(result, args.json, truncate=args.truncate)
+    if result.get("failed_policy"):
+        return 1
     return 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for the NEXUS CLI helpers."""
 
+import sys
 from argparse import Namespace
 from typing import Any
 
@@ -99,3 +100,169 @@ def test_continue_posts_choice_to_backend_without_preapproving(
     assert payload["choice"] == 1
     assert payload["accept_fate"] is False
     assert payload["user_text"] == ""
+
+
+class FakeWizardCache:
+    """Wizard cache double with a complete character draft."""
+
+    def get_character_dict(self) -> dict[str, Any]:
+        """Return enough character data to assemble a CharacterSheet."""
+
+        return {
+            "concept": {
+                "name": "Mara",
+                "archetype": "wary operator with complicated loyalties",
+                "background": (
+                    "Mara has survived by cultivating favors and avoiding "
+                    "easy debts in a city that records every promise."
+                ),
+                "appearance": (
+                    "Lean, watchful, and dressed for quick departures from "
+                    "dangerous rooms."
+                ),
+                "suggested_traits": ["resources", "status", "allies"],
+                "trait_rationales": {
+                    "resources": "Her money opens doors but paints a target.",
+                    "status": "Her badge matters in one narrow hierarchy.",
+                    "allies": "Her old crew still answers when she calls.",
+                },
+            },
+            "trait_selection": {
+                "selected_traits": ["resources", "status", "allies"],
+                "trait_rationales": {
+                    "resources": "Her money opens doors but paints a target.",
+                    "status": "Her badge matters in one narrow hierarchy.",
+                    "allies": "Her old crew still answers when she calls.",
+                },
+                "suggested_by_llm": ["resources", "status", "allies"],
+            },
+            "wildcard": {
+                "wildcard_name": "Storm Marked",
+                "wildcard_description": (
+                    "Lightning follows her in ways nobody can explain, "
+                    "turning quiet rooms into omens."
+                ),
+            },
+        }
+
+
+class FakeConnection:
+    """Context-manager connection double for dry-run compiler tests."""
+
+    def __enter__(self) -> "FakeConnection":
+        """Enter connection context."""
+
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Exit connection context."""
+
+        return None
+
+    def cursor(self) -> "FakeCursor":
+        """Return a context-manager cursor double."""
+
+        return FakeCursor()
+
+
+class FakeCursor:
+    """Cursor double; missing compiler inputs do not require SQL."""
+
+    def __enter__(self) -> "FakeCursor":
+        """Enter cursor context."""
+
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Exit cursor context."""
+
+        return None
+
+
+def test_trait_audit_reports_prose_only_remainders(monkeypatch) -> None:
+    """The CLI audit should expose dry-run compiler remainders from cache."""
+
+    from nexus.api import db_pool, new_story_cache
+
+    monkeypatch.setattr(new_story_cache, "read_cache", lambda dbname: FakeWizardCache())
+    monkeypatch.setattr(db_pool, "get_connection", lambda dbname: FakeConnection())
+
+    result = cli.run_trait_audit(
+        Namespace(
+            slot=5,
+            trait_inputs=None,
+            character_id=0,
+            character_entity_id=0,
+            fail_on_remainders=False,
+        )
+    )
+
+    assert result["success"] is True
+    assert result["character_name"] == "Mara"
+    assert result["traits"] == ["resources", "status", "allies"]
+    assert result["trait_audit"]["dry_run"] is True
+    assert result["trait_audit"]["counters"]["prose_only_remainders"] == 3
+    assert result["failed_policy"] is False
+
+
+def test_trait_audit_fail_on_remainders_sets_policy_failure(monkeypatch) -> None:
+    """Automation loops can request a nonzero status on prose-only fallback."""
+
+    from nexus.api import db_pool, new_story_cache
+
+    monkeypatch.setattr(new_story_cache, "read_cache", lambda dbname: FakeWizardCache())
+    monkeypatch.setattr(db_pool, "get_connection", lambda dbname: FakeConnection())
+
+    result = cli.run_trait_audit(
+        Namespace(
+            slot=5,
+            trait_inputs=None,
+            character_id=0,
+            character_entity_id=0,
+            fail_on_remainders=True,
+        )
+    )
+
+    assert result["success"] is True
+    assert result["failed_policy"] is True
+
+
+def test_main_trait_audit_policy_failure_keeps_output(monkeypatch, capsys) -> None:
+    """Policy failures should still print the audit payload for callers."""
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["nexus", "trait-audit", "--slot", "5", "--fail-on-remainders"],
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_trait_audit",
+        lambda args: {
+            "success": True,
+            "message": "Trait compiler audit for slot 5 (dry run).",
+            "traits": ["resources"],
+            "trait_audit": {
+                "counters": {
+                    "applied_single_entity_tags": 0,
+                    "applied_pair_tags": 0,
+                    "created_entities": 0,
+                    "created_relationships": 0,
+                    "prose_only_remainders": 1,
+                },
+                "prose_only_remainders": [
+                    {
+                        "trait": "resources",
+                        "reason_code": "missing_structured_trait_input",
+                        "message": "Missing input.",
+                    }
+                ],
+            },
+            "failed_policy": True,
+        },
+    )
+
+    assert cli.main() == 1
+    captured = capsys.readouterr()
+    assert "Trait compiler audit for slot 5" in captured.out
+    assert "resources: missing_structured_trait_input" in captured.out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,7 +166,10 @@ class FakeConnection:
 
 
 class FakeCursor:
-    """Cursor double; missing compiler inputs do not require SQL."""
+    """Cursor double for remainder-only compiler paths."""
+
+    # All traits in FakeWizardCache hit remainder paths before SQL. If that
+    # changes, this double needs an execute() stub or a real trait cursor fake.
 
     def __enter__(self) -> "FakeCursor":
         """Enter cursor context."""
@@ -203,6 +206,23 @@ def test_trait_audit_reports_prose_only_remainders(monkeypatch) -> None:
     assert result["trait_audit"]["dry_run"] is True
     assert result["trait_audit"]["counters"]["prose_only_remainders"] == 3
     assert result["failed_policy"] is False
+
+
+def test_trait_audit_rejects_non_object_trait_inputs() -> None:
+    """Trait input overrides must be a JSON object."""
+
+    result = cli.run_trait_audit(
+        Namespace(
+            slot=5,
+            trait_inputs="[1, 2, 3]",
+            character_id=0,
+            character_entity_id=0,
+            fail_on_remainders=False,
+        )
+    )
+
+    assert result["success"] is False
+    assert "--trait-inputs must be a JSON object" in result["error"]
 
 
 def test_trait_audit_fail_on_remainders_sets_policy_failure(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add `nexus trait-audit --slot N` as an opt-in dry-run surface for new-story trait compiler audits
- render applied writes and prose-only remainders in human output while preserving full JSON via global `--json`
- support `--trait-inputs`, placeholder IDs, and `--fail-on-remainders` for testing loops

## Validation
- `poetry run black --check nexus/cli.py tests/test_cli.py`
- `poetry run flake8 nexus/cli.py tests/test_cli.py`
- `poetry run pytest tests/test_trait_compiler.py tests/test_cli.py`
- `poetry run nexus trait-audit --help`
- `poetry run nexus --json trait-audit --slot 5` (expected local result: no wizard cache on slot 5)

## Data Impact
- No schema/config changes. The command reads wizard cache and runs the compiler with `dry_run=True`; it does not mutate slot data.

Closes #290