### PR TITLE
[codex] Replace contact availability with kinded pair-tags

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -126,7 +126,7 @@ Current mechanical surface:
 - `Resources` → exclusive `role.resources:<level>` single-entity tag.
 - `Fame` / legacy `Reputation` → exclusive `role.fame:<level>` single-entity tag.
 - `Status` → `status:<level>(character → faction)` pair-tag.
-- `Allies`, `Contacts`, `Enemies` → `character_relationships` rows from structured targets, with optional pair-tags (`ally`, `contact`, `hostile_to`) only when a package gate explicitly needs the binary edge.
+- `Allies`, `Contacts`, `Enemies` → `character_relationships` rows from structured targets, with optional pair-tags (`ally`, `contact:<kind>`, `hostile_to`) only when a package gate explicitly needs the binary edge.
 
 Current prose-only surface: `Domain`, `Patron`, `Dependents`, and `Obligations` return `UnresolvedTrait` entries in `TraitCompileResult.prose_only_remainders` when they are selected and their typed compilers have not landed. The required wildcard is persisted separately in `characters.extra_data.wildcard` and can carry Skald-bestowed `orrery_tags`; it is not part of the selected-trait compiler loop yet.
 

--- a/docs/orrery_needs.md
+++ b/docs/orrery_needs.md
@@ -290,7 +290,7 @@ Three names were live for the same concept: `bereaved` (gate-blocker in SOCIALIZ
 
 ### R3. `contacts_available` → Derive from `contact` Pair-Tag with Kind Qualifier
 
-The single-entity `contacts_available` tag was overloaded across three templates with three meanings (SLEEP: lodging-providing; SOCIALIZE: reach-out target; INTIMACY: contracted-intimacy access). **Resolved**: drop the overloaded tag. Per-gate predicates filter the actor's outbound `contact:<kind>(char → other_char)` data by relationship kind — `has_contact_of_kind('lodging')` / `'social'` / `'intimate'`. The trait compiler's Contacts MVP writes `character_relationships` rows by default; optional pair-tag writes now require a kind-qualified `contact:<kind>` edge, not the deprecated bare `contact` pair-tag.
+The single-entity `contacts_available` tag was overloaded across three templates with three meanings (SLEEP: lodging-providing; SOCIALIZE: reach-out target; INTIMACY: contracted-intimacy access). **Resolved**: drop the overloaded tag. Per-gate predicates filter the actor's outbound `contact:<kind>(char → other_char)` data by relationship kind — `has_contact_of_kind('lodging')` / `'social'` / `'intimate'`. The trait compiler's Contacts MVP writes `character_relationships` rows by default; optional pair-tag writes now require a kind-qualified `contact:<kind>` edge, not the deprecated bare `contact` pair-tag. The old public-mobility affordance is preserved narrowly through `contact:social`; lodging and intimate contacts do not imply general public-flow movement.
 
 ### R4. Affective Severity — Hybrid (Graduated Where Packages Gate; Flat Otherwise)
 

--- a/docs/orrery_needs.md
+++ b/docs/orrery_needs.md
@@ -290,7 +290,7 @@ Three names were live for the same concept: `bereaved` (gate-blocker in SOCIALIZ
 
 ### R3. `contacts_available` → Derive from `contact` Pair-Tag with Kind Qualifier
 
-The single-entity `contacts_available` tag was overloaded across three templates with three meanings (SLEEP: lodging-providing; SOCIALIZE: reach-out target; INTIMACY: contracted-intimacy access). **Resolved**: drop the overloaded tag. Per-gate predicates should filter the actor's outbound `contact(char → other_char)` data by relationship kind — `has_contact_of_kind('lodging')` / `'social'` / `'intimate'`. Implementation is tracked by issue #317. Important boundary: the trait compiler's Contacts MVP writes `character_relationships` rows by default and only writes the bare `contact` pair-tag when explicitly requested for a package gate; #317 must define where the kind qualifier lives before the needs templates consume it.
+The single-entity `contacts_available` tag was overloaded across three templates with three meanings (SLEEP: lodging-providing; SOCIALIZE: reach-out target; INTIMACY: contracted-intimacy access). **Resolved**: drop the overloaded tag. Per-gate predicates filter the actor's outbound `contact:<kind>(char → other_char)` data by relationship kind — `has_contact_of_kind('lodging')` / `'social'` / `'intimate'`. The trait compiler's Contacts MVP writes `character_relationships` rows by default; optional pair-tag writes now require a kind-qualified `contact:<kind>` edge, not the deprecated bare `contact` pair-tag.
 
 ### R4. Affective Severity — Hybrid (Graduated Where Packages Gate; Flat Otherwise)
 
@@ -329,7 +329,7 @@ The basic-needs templates fire for every character every game-day, producing pot
 
 ### 5. ~~`contacts_available` Ambiguity~~ — Resolved
 
-See R3 above. Decision: derive from `contact` data with a relationship-kind qualifier. Implementation is tracked by issue #317.
+See R3 above. Decision: derive from `contact:<kind>` data with a relationship-kind qualifier.
 
 ### 6. Setting-Tag Vocabulary for `in_preference_compatible_setting`
 
@@ -356,6 +356,5 @@ The architecture intentionally does not include a CONNECT template. Deep emotion
   - **#233** — Sunhelm basic-needs implementation
   - **#243** — Interpersonal needs implementation
 - **Open implementation issues**:
-  - **#317** — Replace `contacts_available` overload with kind-qualified contact predicates
   - **#318** — Replace `under_active_pursuit` ephemeral with inbound `hunting` pair-tag predicate
 - **Drafting record (gitignored)**: `temp/orrery/sunhelm_update_draft.md`, `temp/orrery/orrery_interpersonal_update_draft.md` — full design conversation including multi-model input per open question. Useful for understanding *why* a particular decision was made; not authoritative for *what* shipped (this doc is).

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -26,7 +26,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
   - **NOT:** actor is constrained or immobilized
   - **OR:**
     - actor is in `the_roots` place affordance
-    - actor has `contacts_available` tag
+    - actor has outbound `contact:lodging` pair tag
     - actor can plausibly move through public flow
 
 ### Branch 1 — Go to ground in flooded tunnels  *(mag 0.72)*
@@ -44,7 +44,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 2 — Reach a safe house through contacts  *(mag 0.58)*
 
-**When:** actor has `contacts_available` tag
+**When:** actor has outbound `contact:lodging` pair tag
 
 **Does:** activity → "relocating through safe contacts"
 **Event:** `evade_pursuit`
@@ -114,7 +114,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **When:**
 
 - **AND:**
-  - actor has `contacts_available` tag
+  - actor has outbound `contact:social` pair tag
   - **NOT:** actor and target are co-located
 
 **Does:** activity → "moving to reach kin in danger"
@@ -196,7 +196,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 **When:**
 
 - **AND:**
-  - actor has `contacts_available` tag
+  - actor has outbound `contact:social` pair tag
   - actor is in `the_glow` place affordance
 
 **Does:** activity → "running a reputation attack"; adds `reputation_compromised` to target
@@ -317,7 +317,9 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 - **AND:**
   - actor is in `safe_house` place affordance
-  - actor has any current tag of [`contacts_available`, `fixer`, `route_familiar`, `safehouse_operator`, `survivalist`]
+  - **OR:**
+    - actor has outbound `contact:lodging` pair tag
+    - actor has any current tag of [`fixer`, `route_familiar`, `safehouse_operator`, `survivalist`]
 
 **Does:** activity → "hardening a safehouse"
 **Event:** `hideout_maintained`
@@ -326,7 +328,11 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 2 — Go dark and reduce signal exposure  *(mag 0.36)*
 
-**When:** actor has any current tag of [`contacts_available`, `ghostprint_active`, `hacker`, `off_grid`, `paranoid`, `signal_operator`]
+**When:**
+
+- **OR:**
+  - actor has outbound `contact:social` pair tag
+  - actor has any current tag of [`ghostprint_active`, `hacker`, `off_grid`, `paranoid`, `signal_operator`]
 
 **Does:** activity → "reducing signal exposure"
 **Event:** `signal_exposure_reduced`
@@ -399,7 +405,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 2 — Fulfill obligation through a dead-drop  *(mag 0.5)*
 
-**When:** actor has `contacts_available` tag
+**When:** actor has outbound `contact:social` pair tag
 
 **Does:** activity → "servicing an old debt"
 **Event:** `honor_debt`
@@ -736,7 +742,8 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
   - **NOT:** actor has `grudge_active` ephemeral
   - **OR:**
     - actor is hidden or off-grid
-    - actor has any current tag of [`broker`, `contacts_available`, `hacker`, `informant_handler`, `intelligence_asset_active`, `paranoid`, `researcher`, `signal_operator`, `surveillance_capable`]
+    - actor has outbound `contact:social` pair tag
+    - actor has any current tag of [`broker`, `hacker`, `informant_handler`, `intelligence_asset_active`, `paranoid`, `researcher`, `signal_operator`, `surveillance_capable`]
     - actor has `captor` relationship to target
     - actor has `guardian` relationship to target
     - actor has `handler` relationship to target
@@ -777,7 +784,11 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 3 — Collect a proxy watcher report  *(mag 0.38)*
 
-**When:** actor has any current tag of [`broker`, `contacts_available`, `fixer`, `informant_handler`]
+**When:**
+
+- **OR:**
+  - actor has outbound `contact:social` pair tag
+  - actor has any current tag of [`broker`, `fixer`, `informant_handler`]
 
 **Does:** activity → "collecting a proxy watcher report"
 **Event:** `surveillance_performed`
@@ -963,7 +974,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 2 — Send a carefully-worded message through indirect channels  *(mag 0.48)*
 
-**When:** actor has `contacts_available` tag
+**When:** actor has outbound `contact:social` pair tag
 
 **Does:** activity → "reaching out to a rival via intermediary"
 **Event:** `rival_consulted`
@@ -1082,6 +1093,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 - **OR:**
   - actor is in `lodgings` place affordance
   - actor is in `safe_house` place affordance
+  - actor has outbound `contact:lodging` pair tag
 
 **Does:** activity → "sleeping in safe lodgings"; fulfills `sleep` need, quality `adequate`, discharge 7
 **Event:** `slept`
@@ -1378,7 +1390,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ### Branch 4 — Reach out to a contact for no urgent reason  *(mag 0.24)*
 
-**When:** actor has `contacts_available` tag
+**When:** actor has outbound `contact:social` pair tag
 
 **Does:** activity → "reconnecting with a contact"; fulfills `socialize` need, quality `remote_contact`, discharge 72
 **Event:** `socialized`
@@ -1448,7 +1460,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 - **AND:**
   - actor is in `intimate_services_establishment` place affordance
-  - actor has `intimate_services_contact` tag
+  - actor has outbound `contact:intimate` pair tag
   - **NOT:** actor has `partnered_exclusively` tag
   - **NOT:** actor has any of [`vow_of_celibacy`, `religiously_abstinent`, `ethically_opposed_to_contracted_intimacy`]
 
@@ -1768,7 +1780,6 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `athlete`
 - `cares_for_household`
 - `combat_trained`
-- `contacts_available`
 - `contemplative`
 - `dancer`
 - `devout`
@@ -1785,7 +1796,6 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `hunter`
 - `informant_handler`
 - `innkeeper`
-- `intimate_services_contact`
 - `keeps_shop`
 - `loremaster`
 - `magical_healing`
@@ -1841,7 +1851,6 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `academic`
 - `broker`
 - `combat_trained`
-- `contacts_available`
 - `cover_identity`
 - `fixer`
 - `fugitive`
@@ -1876,6 +1885,12 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `recently_violent`
 - `reputation_compromised`
 - `under_truce`
+
+### Pair tags queried by directed predicates
+
+- `contact:intimate`
+- `contact:lodging`
+- `contact:social`
 
 ### Event types
 

--- a/docs/orrery_tag_vocabulary.md
+++ b/docs/orrery_tag_vocabulary.md
@@ -668,21 +668,25 @@ Status-family reads and writes go through `nexus.agents.orrery.status_family` / 
 
 ### Trait-Compiler Relationship Pair Tags
 
-Migration 045 registers three additional character ↔ character multi-entity tags for trait-compiler and future package-gate use.
+Migration 045 registered the first trait-compiler relationship tags. Migration 047 deprecates the bare `contact` pair-tag for new gates and registers the kind-qualified contact family.
 
 **Important per #303**: these tags' existence in the registry does NOT mean the compiler instantiates them automatically at trait selection. Per the functional-vs-affective principle (Pair Tags vs. `character_relationships` Source-of-Truth Rule below), affective traits (Allies, Contacts, Enemies) compile primarily to `character_relationships` rows. The pair-tags below exist for *future* package gates that may need a binary mechanical edge; the compiler adds them per-package, not by default at trait selection time.
 
 | Tag | Subject | Object | Purpose |
 |---|---|---|---|
 | `ally` | character | character | Will actively help when it matters; takes risks for the other |
-| `contact` | character | character | Lower-intensity transactional relationship; information / favor pipeline |
+| `contact:lodging` | character | character | Contact can provide lodging, shelter, or safe-house access |
+| `contact:social` | character | character | Contact can provide ordinary social connection, favors, messages, or indirect channels |
+| `contact:intimate` | character | character | Contact can provide contracted-intimacy access where the setting supports it |
 | `hostile_to` | character \| faction | character \| faction | Active opposition; willing to expend energy thwarting the other. **Durable** — captures simmering enmity (the Enemies trait is a durable character feature, not an acute episode). Distinct from `hunting` (which is *ephemeral, purposeful, acute* targeted pursuit). A character can be `hostile_to` someone without currently `hunting` them; conversely a hunt may fire without antecedent hostility. |
 
 All cardinalities multi-valued. Polymorphic subjects/objects collapse what would otherwise be ~30 separate tags.
 
+The bare `contact` pair-tag was registered by migration 045 but is deprecated by migration 047. Use `contact:<kind>` for package gates; generic contact flavor belongs in `character_relationships`.
+
 ### Pair Tags vs. `character_relationships` — Source-of-Truth Rule
 
-The `ally`, `contact`, and `hostile_to` tags (and their compiler-planned siblings) sit alongside the existing `character_relationships` table. Both layers can describe what looks like "the same" relationship — but they answer different questions and must not drift.
+The `ally`, `contact:<kind>`, and `hostile_to` tags (and their future siblings) sit alongside the existing `character_relationships` table. Both layers can describe what looks like "the same" relationship — but they answer different questions and must not drift.
 
 - **`pair_tag`** = typed mechanical edge that packages gate on. Binary: exists or it doesn't, plus the tag name. Cheap to query; deterministic. Example: a HIDE package gating on "does the acting character have any `hunting(other → self)` edges?"
 - **`character_relationships`** = affective / historical / valence layer that Skald and social-logic read. Multi-state; evolves continuously over time; carries trust, valence, history, sub-states. Example: Skald composing prose that reflects "Alex and Emilia were close, then there was a falling-out, then a partial reconciliation."
@@ -691,7 +695,7 @@ The `ally`, `contact`, and `hostile_to` tags (and their compiler-planned sibling
 
 The compiler writes both layers within a single transaction *when both are warranted*. Reconciliation invariants:
 
-- Every `ally` / `contact` / `hostile_to` pair tag MUST have a corresponding `character_relationships` row (these tags carry intrinsic affective content)
+- Every `ally` / `contact:<kind>` / `hostile_to` pair tag MUST have a corresponding `character_relationships` row (these tags carry intrinsic affective content)
 - The converse does NOT hold uniformly — a `character_relationships` row need not have a parallel pair-tag unless a package needs the gate
 
 Drift between paired rows is a bug. Issue #291 codified the rule and added the reconciliation surface in `nexus/api/trait_compiler.py::reconcile_trait_relationship_pair_tags`.
@@ -713,7 +717,7 @@ Compiler surfaces:
 | `Fame` / legacy `Reputation` | Writes `role.fame:<level>` when typed input supplies `obscure`, `known`, `renowned`, or `legendary`. Legacy `reputation` input aliases to `fame`. | Rename landed in migration 045; `reputation` remains accepted as a compatibility alias. |
 | `Resources` | Writes `role.resources:<level>` when typed input supplies `destitute`, `poor`, `comfortable`, `wealthy`, or `magnate`. | `comfortable` is the default/ordinary tier; absence of typed input is reported, not guessed. |
 | `Allies` | Writes `character_relationships` rows from structured targets. No pair-tag by default; optional `apply_pair_tag=True` writes `ally(char → char)` in the same transaction. | Per #303, affective relationship row first; pair-tag only when a package gate needs the binary edge. |
-| `Contacts` | Writes `character_relationships` rows from structured targets. No pair-tag by default; optional `apply_pair_tag=True` writes `contact(char → char)`. | Kind-qualified contact gates for needs are still open (#317); do not use the base `contact` pair-tag as a lodging/social/intimate catch-all. |
+| `Contacts` | Writes `character_relationships` rows from structured targets. No pair-tag by default; optional `apply_pair_tag=True` requires `contact_kind` (`lodging`, `social`, or `intimate`) or an explicit `contact:<kind>` pair-tag. | The bare `contact` pair-tag is deprecated as a package gate. Needs templates consume `has_contact_of_kind(...)` predicates. |
 | `Enemies` | Writes `character_relationships` rows from structured targets. Optional `apply_pair_tag=True` can write `hostile_to`; target-to-protagonist direction is supported. | Active pursuit remains the `pursuing`/future-`hunting` pair-tag track, not default `hostile_to` (#318). |
 | `Domain` | Current MVP returns a prose-only remainder. | Target design: create/identify a place entity and write `claims(char → place)`; registry polymorphism is ready, compiler input/schema is not. |
 | `Patron` | Current MVP returns a prose-only remainder. | Target design: one `character_relationships` row for the patron-client bond; package-specific pair-tags later as needed. This preserves the #305 resolution: patron is not decomposed into a default OR/AND bundle of mentor, sponsor, protector, and authority edges. |
@@ -721,7 +725,7 @@ Compiler surfaces:
 | `Obligations` | Current MVP returns a prose-only remainder. | Target design: `obligation(char → target)` when a structured target exists. |
 | `Wildcard` | Outside the current selected-trait compiler loop. The wizard persists prose in `characters.extra_data.wildcard`, and any Skald-bestowed `orrery_tags` apply through the ordinary tag bestowal surface. | Future wildcard decomposition may only use registered vocabulary. It cannot mint tags; novel mechanics remain prose/`extra_data` until a compiler surface exists. There is no planned `items` table; inanimate artifacts stay prose/`extra_data` unless/until project scope changes. |
 
-**Migration 045 landed the substrate portion**: `role.resources`, `role.fame`, the status pair-tag family, `ally`, `contact`, `hostile_to`, the `claims` subject-kind extension, the `assets.traits` `reputation` → `fame` rename, and the `trait_compile_result` cache column. The compiler code owns only the current MVP rows above; the table is deliberately split so future docs do not confuse registry readiness with compiler readiness.
+**Migration 045 landed the trait-compiler substrate portion**: `role.resources`, `role.fame`, the status pair-tag family, `ally`, `contact`, `hostile_to`, the `claims` subject-kind extension, the `assets.traits` `reputation` → `fame` rename, and the `trait_compile_result` cache column. **Migration 047 refines contacts** by deprecating bare `contact`, adding `contact:lodging` / `contact:social` / `contact:intimate`, and deprecating the old single-entity contact flags. The compiler code owns only the current MVP rows above; the table is deliberately split so future docs do not confuse registry readiness with compiler readiness.
 
 ---
 
@@ -748,7 +752,7 @@ Compiler surfaces:
 3. **Clearance vocabulary for ephemerals.** What `world_event` types clear which ephemeral tags? Needs enumeration per ephemeral tag (single-entity and multi-entity).
 4. **Genre tag set.** Settle the values for `genre:*` informational tags on the story slot. Sample: `fantasy`, `science_fiction`, `horror`, `noir`, `romance`, etc. + subgenres as composable tags.
 5. **Cardinality column on `tags` registry.** Migration to add `cardinality enum('exclusive', 'multi')`.
-6. **`entity_pair_tags` substrate** — mostly landed. PR #283 shipped the migration (`042_orrery_entity_pair_tags.py`), the `pair_tags` registry, the `entity_pair_tags` table, and the writer functions (`apply_pair_tag_bestowal`, `clear_pair_tag`). PR #284 shipped the DB-level predicates (`pair_tag_exists`, `lookup_pair_tag_subjects`, `lookup_pair_tag_objects`). PR #285 shipped WorldState hydration + Condition-shape predicates (`has_pair_tag` over hydrated state). Follow-up work is now specific: `under_active_pursuit` → inbound `hunting` (#318), kind-qualified contact gates (#317), and any future pair-tag-derived binding composers demanded by package implementations.
+6. **`entity_pair_tags` substrate** — mostly landed. PR #283 shipped the migration (`042_orrery_entity_pair_tags.py`), the `pair_tags` registry, the `entity_pair_tags` table, and the writer functions (`apply_pair_tag_bestowal`, `clear_pair_tag`). PR #284 shipped the DB-level predicates (`pair_tag_exists`, `lookup_pair_tag_subjects`, `lookup_pair_tag_objects`). PR #285 shipped WorldState hydration + Condition-shape predicates (`has_pair_tag` over hydrated state). Follow-up work is now specific: `under_active_pursuit` → inbound `hunting` (#318), and any future pair-tag-derived binding composers demanded by package implementations.
 7. **Audit pass on existing slot 2 vocabulary.** Per-tag classification: keep (in new categories), rename, drop, or convert to multi-entity tag.
 8. **Template rewrite.** `NEXUS_template` schema/seed updates downstream of vocabulary lock-in.
 9. **Slot 2 backfill data plan.** Re-apply settled tags to existing slot 2 entities; deferred until the full vocabulary draft and data-rewrite plan tracked by issue #326 are ready.
@@ -761,17 +765,18 @@ Compiler surfaces:
 - `docs/orrery_design_plan.md` — broader Orrery system design.
 - `migrations/042_orrery_entity_pair_tags.py` — source-of-truth for seeded multi-entity tags (registry rows in `pair_tags`).
 - `migrations/045_trait_compiler_substrate.py` — trait-compiler registry additions, `claims` subject-kind extension, `reputation` → `fame` data update, and audit cache column.
+- `migrations/047_kind_qualified_contact_pair_tags.py` — `contact:<kind>` registry additions plus deprecation of `contacts_available`, `intimate_services_contact`, and bare `contact`.
 - Issue #275 / PR #276 — Skald sovereignty (adjudication) model. *Merged.*
 - Issue #282 — Package self-awareness architectural pattern (three-stage gating: entry → branch → outcome; `pursuing` / future-`hunting` tags confer targeted detection sensitivity). *Open.*
 - PR #283 — `entity_pair_tags` substrate (migration 042 + writer functions). *Merged.*
 - PR #284 — DB-level multi-entity tag predicates (`pair_tag_exists`, inbound/outbound subject lookups). *Merged.*
 - Issue #290 / PR #323 — structured trait-compiler audit and opt-in `nexus trait-audit` CLI. *Merged.*
 - Issue #291 — pair-tag-vs-`character_relationships` reconciliation. *Closed.*
+- Issue #317 — Replace `contacts_available` overload with kind-qualified contact pair-tag predicates.
 
 ### Implementation Contracts (Open)
 
 These are the downstream mechanical pre-requisites surfaced during the design-doc review. Each is tracked as its own issue so substrate work can be sequenced independently of further doc edits.
 
 - Issue #292 — Place/faction tag subcategory refactor + resolver adapter for `in_location_class()` gates.
-- Issue #317 — Replace `contacts_available` overload with kind-qualified contact pair-tag predicates.
 - Issue #318 — Replace `under_active_pursuit` ephemeral with inbound `hunting` pair-tag predicate.

--- a/migrations/047_kind_qualified_contact_pair_tags.py
+++ b/migrations/047_kind_qualified_contact_pair_tags.py
@@ -1,0 +1,110 @@
+"""Seed kind-qualified contact pair-tags and retire contact flags."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+CONTACT_PAIR_TAGS: Sequence[tuple[str, str]] = (
+    (
+        "contact:lodging",
+        "Subject can reach a contact who can provide lodging, shelter, "
+        "or safe-house access.",
+    ),
+    (
+        "contact:social",
+        "Subject can reach a contact for ordinary social connection, favors, "
+        "messages, or indirect channels.",
+    ),
+    (
+        "contact:intimate",
+        "Subject can reach a contact for contracted intimacy access "
+        "where the setting supports it.",
+    ),
+)
+
+LEGACY_CONTACT_TAGS: Sequence[tuple[str, str]] = (
+    (
+        "contacts_available",
+        "Replaced by kind-qualified contact pair-tags: contact:lodging, "
+        "contact:social, and contact:intimate.",
+    ),
+    (
+        "intimate_services_contact",
+        "Replaced by the contact:intimate pair-tag.",
+    ),
+)
+LEGACY_CONTACT_PAIR_TAGS: Sequence[tuple[str, str]] = (
+    (
+        "contact",
+        "Replaced by kind-qualified contact pair-tags: contact:lodging, "
+        "contact:social, and contact:intimate.",
+    ),
+)
+
+
+def run(conn) -> None:
+    """Apply the issue #317 contact-kind vocabulary update."""
+
+    with conn.cursor() as cur:
+        for tag, description in CONTACT_PAIR_TAGS:
+            cur.execute(
+                """
+                INSERT INTO pair_tags (
+                    tag, subject_kinds, object_kinds,
+                    is_ephemeral, clearance_kind, description, deprecated
+                ) VALUES (
+                    %s,
+                    ARRAY['character'],
+                    ARRAY['character'],
+                    FALSE,
+                    NULL,
+                    %s,
+                    FALSE
+                )
+                ON CONFLICT (tag) DO UPDATE SET
+                    subject_kinds = EXCLUDED.subject_kinds,
+                    object_kinds = EXCLUDED.object_kinds,
+                    is_ephemeral = EXCLUDED.is_ephemeral,
+                    clearance_kind = EXCLUDED.clearance_kind,
+                    description = EXCLUDED.description,
+                    deprecated = FALSE
+                """,
+                (tag, description),
+            )
+
+        for tag, replacement_note in LEGACY_CONTACT_TAGS:
+            cur.execute(
+                """
+                UPDATE tags
+                SET deprecated = TRUE,
+                    description = CASE
+                        WHEN description IS NULL OR description = ''
+                            THEN %s
+                        WHEN description LIKE '%%Replaced by%%'
+                            THEN description
+                        ELSE description || ' ' || %s
+                    END
+                WHERE tag = %s
+                """,
+                (replacement_note, replacement_note, tag),
+            )
+
+        for tag, replacement_note in LEGACY_CONTACT_PAIR_TAGS:
+            cur.execute(
+                """
+                UPDATE pair_tags
+                SET deprecated = TRUE,
+                    description = CASE
+                        WHEN description IS NULL OR description = ''
+                            THEN %s
+                        WHEN description LIKE '%%Replaced by%%'
+                            THEN description
+                        ELSE description || ' ' || %s
+                    END
+                WHERE tag = %s
+                """,
+                (replacement_note, replacement_note, tag),
+            )
+
+    conn.commit()

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -108,6 +108,13 @@ _register(
     ),
 )
 _register(
+    r"has_contact_of_kind\((?P<kind>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('slot'))} has outbound "
+        f"`contact:{m.group('kind')}` pair tag"
+    ),
+)
+_register(
     r"has_ephemeral\((?P<tag>[^@()]+)@(?P<slot>\w+)\)",
     lambda m: f"{_slot(m.group('slot'))} has `{m.group('tag')}` ephemeral",
 )
@@ -514,6 +521,7 @@ _VOCAB_PATTERNS: List[Tuple[str, re.Pattern]] = [
     ("pair_tag", re.compile(r"has_pair_tag\(([^@()]+)@")),
     ("pair_tag", re.compile(r"lacks_pair_tag\(([^@()]+)@")),
     ("pair_tag_list", re.compile(r"has_any_pair_tag\(([^@()]+)@")),
+    ("contact_kind", re.compile(r"has_contact_of_kind\(([^@()]+)@")),
     ("event_type", re.compile(r"recent_event\(([^,*()]+),")),
     ("event_type", re.compile(r"since_last_event_at_least\(([^,()]+),")),
     ("place_affordance", re.compile(r"in_location_class\(([^@()]+)@")),
@@ -573,6 +581,8 @@ def _collect_vocabulary(
             elif kind == "pair_tag_list":
                 for tag in captured.split(","):
                     pair_tags.add(tag.strip())
+            elif kind == "contact_kind":
+                pair_tags.add(f"contact:{captured}")
             elif kind == "event_type":
                 events.add(captured)
             elif kind == "place_affordance":

--- a/nexus/agents/orrery/demo.py
+++ b/nexus/agents/orrery/demo.py
@@ -42,8 +42,9 @@ def build_presets() -> Dict[str, WorldState]:
     }
     return {
         "hunted": WorldState(
-            tags={ACTOR_ID: frozenset({"seeking_identity", "contacts_available"})},
+            tags={ACTOR_ID: frozenset({"seeking_identity"})},
             ephemeral_tags={ACTOR_ID: frozenset({"under_active_pursuit"})},
+            pair_tags={(ACTOR_ID, TARGET_ID): frozenset({"contact:lodging"})},
             locations=common_locations,
             location_class=location_classes,
             recent_events=(
@@ -58,11 +59,8 @@ def build_presets() -> Dict[str, WorldState]:
             current_tick=100,
         ),
         "fragment": WorldState(
-            tags={
-                ACTOR_ID: frozenset(
-                    {"seeking_identity", "contacts_available", "ghostprint_active"}
-                )
-            },
+            tags={ACTOR_ID: frozenset({"seeking_identity", "ghostprint_active"})},
+            pair_tags={(ACTOR_ID, TARGET_ID): frozenset({"contact:social"})},
             locations=common_locations,
             location_class=location_classes,
             time_of_day="evening",
@@ -70,8 +68,9 @@ def build_presets() -> Dict[str, WorldState]:
             current_tick=100,
         ),
         "debt": WorldState(
-            tags={ACTOR_ID: frozenset({"seeking_identity", "contacts_available"})},
+            tags={ACTOR_ID: frozenset({"seeking_identity"})},
             ephemeral_tags={ACTOR_ID: frozenset({"debt_pulse_active"})},
+            pair_tags={(ACTOR_ID, TARGET_ID): frozenset({"contact:social"})},
             locations={ACTOR_ID: STACKS_PLACE_ID},
             location_class=location_classes,
             recent_events=(

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -41,6 +41,7 @@ class PresentTargetPolicy(str, Enum):
 
 Bindings = Dict[Slot, Any]
 Condition = Callable[["WorldState", Bindings], bool]
+ContactKind = Literal["lodging", "social", "intimate"]
 
 INTIMACY_SUPPRESSOR_TAGS: frozenset[str] = frozenset(
     {
@@ -88,7 +89,6 @@ HIDDEN_TAGS: frozenset[str] = frozenset(
 PUBLIC_MOBILITY_TAGS: frozenset[str] = frozenset(
     {
         "broker",
-        "contacts_available",
         "courier",
         "field_worker",
         "fixer",
@@ -114,6 +114,11 @@ DRAMATIC_CONTACT_TAGS: frozenset[str] = HIDDEN_TAGS | frozenset(
         "long_estranged",
     }
 )
+CONTACT_PAIR_TAGS: Mapping[ContactKind, str] = {
+    "lodging": "contact:lodging",
+    "social": "contact:social",
+    "intimate": "contact:intimate",
+}
 LOADED_TRUST_FORWARD_MIN = 2
 LOADED_TRUST_REVERSE_MAX = -1
 
@@ -290,6 +295,32 @@ def has_any_pair_tag(
         _condition,
         f"has_any_pair_tag({','.join(tags)}@{subject_slot.value}->{object_slot.value})",
     )
+
+
+def contact_pair_tag_for_kind(kind: ContactKind) -> str:
+    """Return the pair-tag name for a kind-qualified contact edge."""
+
+    try:
+        return CONTACT_PAIR_TAGS[kind]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported contact kind: {kind!r}") from exc
+
+
+def has_contact_of_kind(kind: ContactKind, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound entity has any outbound contact of ``kind``."""
+
+    pair_tag = contact_pair_tag_for_kind(kind)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        return any(
+            subject_id == entity_id and pair_tag in tags
+            for (subject_id, _object_id), tags in state.pair_tags.items()
+        )
+
+    return _named(_condition, f"has_contact_of_kind({kind}@{slot.value})")
 
 
 def has_any_current_tag(*tags: str, slot: Slot = Slot.ACTOR) -> Condition:
@@ -832,7 +863,8 @@ def has_relationship_of_type(
 
     return _named(
         _condition,
-        f"has_relationship_of_type({relationship_type},{slot_from.value}->{slot_to.value})",
+        "has_relationship_of_type("
+        f"{relationship_type},{slot_from.value}->{slot_to.value})",
     )
 
 
@@ -857,7 +889,8 @@ def has_symmetric_relationship_of_type(
 
     return _named(
         _condition,
-        f"has_symmetric_relationship_of_type({relationship_type},{slot_a.value}<->{slot_b.value})",
+        "has_symmetric_relationship_of_type("
+        f"{relationship_type},{slot_a.value}<->{slot_b.value})",
     )
 
 

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -199,6 +199,13 @@ def _is_in_transit(state: WorldState, entity_id: int) -> bool:
     return bool(travel_state and travel_state.is_in_transit)
 
 
+def _has_outbound_pair_tag(state: WorldState, entity_id: int, pair_tag: str) -> bool:
+    return any(
+        subject_id == entity_id and pair_tag in tags
+        for (subject_id, _object_id), tags in state.pair_tags.items()
+    )
+
+
 def has_tag(tag: str, slot: Slot = Slot.ACTOR) -> Condition:
     """Return whether a slot-bound entity has a durable tag."""
 
@@ -315,10 +322,7 @@ def has_contact_of_kind(kind: ContactKind, slot: Slot = Slot.ACTOR) -> Condition
         entity_id = _slot_entity(bindings, slot)
         if entity_id is None:
             return False
-        return any(
-            subject_id == entity_id and pair_tag in tags
-            for (subject_id, _object_id), tags in state.pair_tags.items()
-        )
+        return _has_outbound_pair_tag(state, entity_id, pair_tag)
 
     return _named(_condition, f"has_contact_of_kind({kind}@{slot.value})")
 
@@ -416,6 +420,8 @@ def can_move_publicly(slot: Slot = Slot.ACTOR) -> Condition:
         if CONSTRAINED_TAGS & current_tags:
             return False
         if PUBLIC_MOBILITY_TAGS & current_tags:
+            return True
+        if _has_outbound_pair_tag(state, entity_id, CONTACT_PAIR_TAGS["social"]):
             return True
         location_id = state.locations.get(entity_id)
         if location_id is None:

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -18,6 +18,7 @@ from nexus.agents.orrery.substrate import (
     has_any_intimacy_suppressor,
     has_any_current_tag,
     has_any_tag,
+    has_contact_of_kind,
     has_ephemeral,
     has_established_partner_co_located,
     has_minimal_context,
@@ -57,7 +58,7 @@ EVADE_PURSUERS = Template(
         NOT(is_constrained()),
         OR(
             in_location_class("the_roots"),
-            has_tag("contacts_available"),
+            has_contact_of_kind("lodging"),
             can_move_publicly(),
         ),
     ),
@@ -79,7 +80,7 @@ EVADE_PURSUERS = Template(
         ),
         Branch(
             label="Reach a safe house through contacts",
-            conditions=has_tag("contacts_available"),
+            conditions=has_contact_of_kind("lodging"),
             narrative_stub=(
                 "{actor} pings a broker through a low-bandwidth dead-drop and "
                 "takes a four-hop route to a safe house."
@@ -139,12 +140,14 @@ HIDE = Template(
             label="Harden or sanitize a safehouse",
             conditions=AND(
                 in_location_class("safe_house"),
-                has_any_current_tag(
-                    "contacts_available",
-                    "fixer",
-                    "route_familiar",
-                    "safehouse_operator",
-                    "survivalist",
+                OR(
+                    has_contact_of_kind("lodging"),
+                    has_any_current_tag(
+                        "fixer",
+                        "route_familiar",
+                        "safehouse_operator",
+                        "survivalist",
+                    ),
                 ),
             ),
             narrative_stub=(
@@ -161,13 +164,15 @@ HIDE = Template(
         ),
         Branch(
             label="Go dark and reduce signal exposure",
-            conditions=has_any_current_tag(
-                "contacts_available",
-                "ghostprint_active",
-                "hacker",
-                "off_grid",
-                "paranoid",
-                "signal_operator",
+            conditions=OR(
+                has_contact_of_kind("social"),
+                has_any_current_tag(
+                    "ghostprint_active",
+                    "hacker",
+                    "off_grid",
+                    "paranoid",
+                    "signal_operator",
+                ),
             ),
             narrative_stub=(
                 "{actor} trims their signal down to almost nothing — no "
@@ -279,7 +284,7 @@ HONOR_DEBT = Template(
         ),
         Branch(
             label="Fulfill obligation through a dead-drop",
-            conditions=has_tag("contacts_available"),
+            conditions=has_contact_of_kind("social"),
             narrative_stub=(
                 "{actor} tucks an encoded microdrive behind a loose ceramic "
                 "tile and leaves a mark for the recipient."
@@ -543,7 +548,7 @@ EXTRACT_VENGEANCE = Template(
         Branch(
             label="Surface a reputation attack in the right channels",
             conditions=AND(
-                has_tag("contacts_available"),
+                has_contact_of_kind("social"),
                 in_location_class("the_glow"),
             ),
             narrative_stub=(
@@ -646,7 +651,7 @@ PROTECT_KIN = Template(
         Branch(
             label="Travel toward the target's last known location",
             conditions=AND(
-                has_tag("contacts_available"),
+                has_contact_of_kind("social"),
                 NOT(co_located(Slot.ACTOR, Slot.TARGET)),
             ),
             narrative_stub=(
@@ -724,9 +729,9 @@ SURVEIL = Template(
         NOT(has_ephemeral("grudge_active")),
         OR(
             is_hidden(),
+            has_contact_of_kind("social"),
             has_any_current_tag(
                 "broker",
-                "contacts_available",
                 "hacker",
                 "informant_handler",
                 "intelligence_asset_active",
@@ -798,11 +803,13 @@ SURVEIL = Template(
         ),
         Branch(
             label="Collect a proxy watcher report",
-            conditions=has_any_current_tag(
-                "broker",
-                "contacts_available",
-                "fixer",
-                "informant_handler",
+            conditions=OR(
+                has_contact_of_kind("social"),
+                has_any_current_tag(
+                    "broker",
+                    "fixer",
+                    "informant_handler",
+                ),
             ),
             narrative_stub=(
                 "{actor} does not go near {target}. They let someone else "
@@ -1351,7 +1358,10 @@ KEEP_VIGIL = Template(
 TRAVEL = Template(
     id="travel",
     priority=21,
-    blurb="A character moves between meaningful places without pretending the road is a room.",
+    blurb=(
+        "A character moves between meaningful places without pretending the "
+        "road is a room."
+    ),
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
         OR(is_in_transit(), has_travel_destination()),
@@ -1475,7 +1485,10 @@ TRAVEL = Template(
 WORK = Template(
     id="work",
     priority=14,
-    blurb="The recurring work that keeps a life, household, or organization functioning.",
+    blurb=(
+        "The recurring work that keeps a life, household, or organization "
+        "functioning."
+    ),
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
         OR(
@@ -2216,7 +2229,7 @@ CONSULT_RIVAL = Template(
         ),
         Branch(
             label="Send a carefully-worded message through indirect channels",
-            conditions=has_tag("contacts_available"),
+            conditions=has_contact_of_kind("social"),
             narrative_stub=(
                 "{actor} sends {target} a message routed through an "
                 "intermediary they both trust slightly more than they "
@@ -2226,7 +2239,9 @@ CONSULT_RIVAL = Template(
                 "ignore it."
             ),
             state_delta={
-                "character.current_activity": "reaching out to a rival via intermediary",
+                "character.current_activity": (
+                    "reaching out to a rival via intermediary"
+                ),
             },
             event_type="rival_consulted",
             changed_fields=("character.current_activity",),
@@ -2239,7 +2254,7 @@ CONSULT_RIVAL = Template(
             ),
         ),
         Branch(
-            label="Leave a sign the rival will recognize and a door they can open",
+            label=("Leave a sign the rival will recognize and a door they can open"),
             conditions=ALWAYS,
             narrative_stub=(
                 "{actor} doesn't quite reach out — but they place a sign "
@@ -2249,7 +2264,9 @@ CONSULT_RIVAL = Template(
                 "begun. If they don't, it hasn't."
             ),
             state_delta={
-                "character.current_activity": "leaving a tentative overture for a rival",
+                "character.current_activity": (
+                    "leaving a tentative overture for a rival"
+                ),
             },
             event_type="contact_made",
             changed_fields=("character.current_activity",),
@@ -2334,6 +2351,7 @@ SLEEP = Template(
             conditions=OR(
                 in_location_class("lodgings"),
                 in_location_class("safe_house"),
+                has_contact_of_kind("lodging"),
             ),
             narrative_stub=(
                 "{actor} finds a place secure enough to become temporary "
@@ -2495,7 +2513,10 @@ DRINK = Template(
 EAT = Template(
     id="eat",
     priority=22,
-    blurb="The body asks for fuel; what it gets matters more than the cookbook suggests.",
+    blurb=(
+        "The body asks for fuel; what it gets matters more than the cookbook "
+        "suggests."
+    ),
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
         has_need_debt_at_or_above("hunger", 4),
@@ -2656,7 +2677,10 @@ EAT = Template(
 SOCIALIZE = Template(
     id="socialize",
     priority=18,
-    blurb="The need for the company of others, on whatever terms a character can have it.",
+    blurb=(
+        "The need for the company of others, on whatever terms a character "
+        "can have it."
+    ),
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
         has_need_debt_at_or_above("socialize", 24),
@@ -2747,7 +2771,7 @@ SOCIALIZE = Template(
         ),
         Branch(
             label="Reach out to a contact for no urgent reason",
-            conditions=has_tag("contacts_available"),
+            conditions=has_contact_of_kind("social"),
             narrative_stub=(
                 "{actor} thinks of someone they have not spoken with in too "
                 "long and reaches out for no urgent reason, which is its "
@@ -2870,7 +2894,7 @@ INTIMACY = Template(
             label="Engage contracted intimate company",
             conditions=AND(
                 in_location_class("intimate_services_establishment"),
-                has_tag("intimate_services_contact"),
+                has_contact_of_kind("intimate"),
                 NOT(has_tag("partnered_exclusively")),
                 NOT(
                     has_any_tag(

--- a/nexus/api/trait_compiler.py
+++ b/nexus/api/trait_compiler.py
@@ -9,6 +9,7 @@ from nexus.agents.orrery.status_family import (
     normalize_status_level,
     status_tag_for_level,
 )
+from nexus.agents.orrery.substrate import CONTACT_PAIR_TAGS, contact_pair_tag_for_kind
 from nexus.agents.orrery.tag_writer import (
     apply_exclusive_tag_bestowal,
     apply_pair_tag_bestowal,
@@ -53,7 +54,10 @@ RELATIONSHIP_DEFAULTS = {
     },
 }
 
-PAIR_TAG_RELATIONSHIP_TYPES = frozenset({"ally", "contact", "hostile_to"})
+PAIR_TAG_RELATIONSHIP_TYPES = frozenset({"ally", "hostile_to"}) | frozenset(
+    CONTACT_PAIR_TAGS.values()
+)
+CONTACT_KIND_BY_PAIR_TAG = {tag: kind for kind, tag in CONTACT_PAIR_TAGS.items()}
 
 
 def compile_character_traits(
@@ -493,6 +497,17 @@ def _compile_relationship_target(
     emotional_valence = target.emotional_valence or defaults["emotional_valence"]
     pair_tag = target.pair_tag or defaults["pair_tag"]
 
+    contact_kind = target.contact_kind if canonical_trait == "contacts" else None
+    if target.apply_pair_tag and canonical_trait == "contacts":
+        resolved_contact = _resolve_contact_pair_tag(
+            result,
+            trait=trait,
+            target=target,
+        )
+        if resolved_contact is None:
+            return
+        pair_tag, contact_kind = resolved_contact
+
     if target.apply_pair_tag and target.character_entity_id is None:
         _add_remainder(
             result,
@@ -559,6 +574,7 @@ def _compile_relationship_target(
             pair_tag_direction=(
                 target.pair_tag_direction if target.apply_pair_tag else None
             ),
+            contact_kind=contact_kind,
         )
     result.created_relationships.append(
         CreatedRelationship(
@@ -568,9 +584,65 @@ def _compile_relationship_target(
             relationship_type=relationship_type,
             emotional_valence=emotional_valence,
             pair_tag=pair_tag if target.apply_pair_tag else None,
+            contact_kind=contact_kind,
             dry_run=dry_run,
         )
     )
+
+
+def _resolve_contact_pair_tag(
+    result: TraitCompileResult,
+    *,
+    trait: str,
+    target: RelationshipTargetInput,
+) -> Optional[tuple[str, str]]:
+    if target.contact_kind is not None:
+        kind_pair_tag = contact_pair_tag_for_kind(target.contact_kind)
+        if target.pair_tag is not None and target.pair_tag != kind_pair_tag:
+            _add_remainder(
+                result,
+                trait=trait,
+                reason_code=TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT,
+                message=(
+                    "Contacts pair-tag input must not disagree with contact_kind."
+                ),
+                details={
+                    "name": target.name,
+                    "contact_kind": target.contact_kind,
+                    "pair_tag": target.pair_tag,
+                    "expected_pair_tag": kind_pair_tag,
+                },
+            )
+            return None
+        return kind_pair_tag, target.contact_kind
+
+    if target.pair_tag is not None and target.pair_tag in CONTACT_KIND_BY_PAIR_TAG:
+        return target.pair_tag, CONTACT_KIND_BY_PAIR_TAG[target.pair_tag]
+
+    if target.pair_tag is not None and target.pair_tag.startswith("contact:"):
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT,
+            message=(
+                "Contacts pair-tag input must use a registered contact kind "
+                "(lodging, social, intimate)."
+            ),
+            details={"name": target.name, "pair_tag": target.pair_tag},
+        )
+        return None
+
+    _add_remainder(
+        result,
+        trait=trait,
+        reason_code=TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT,
+        message=(
+            "Contacts pair-tag input requires contact_kind "
+            "(lodging, social, intimate) or an explicit contact:<kind> pair_tag."
+        ),
+        details={"name": target.name, "pair_tag": target.pair_tag or "contact"},
+    )
+    return None
 
 
 def _upsert_character_relationship(
@@ -586,6 +658,7 @@ def _upsert_character_relationship(
     trait: str,
     pair_tag: Optional[str],
     pair_tag_direction: Optional[str],
+    contact_kind: Optional[str],
 ) -> None:
     extra_data: dict[str, Any] = {
         "source": "trait_compiler",
@@ -595,6 +668,8 @@ def _upsert_character_relationship(
         extra_data["trait_compiler_pair_tag"] = pair_tag
     if pair_tag_direction is not None:
         extra_data["trait_compiler_pair_tag_direction"] = pair_tag_direction
+    if contact_kind is not None:
+        extra_data["trait_compiler_contact_kind"] = contact_kind
     cur.execute(
         """
         INSERT INTO character_relationships (

--- a/nexus/api/trait_compiler_schemas.py
+++ b/nexus/api/trait_compiler_schemas.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field
 ResourceLevel = Literal["destitute", "poor", "comfortable", "wealthy", "magnate"]
 FameLevel = Literal["obscure", "known", "renowned", "legendary"]
 PairTagDirection = Literal["protagonist_to_target", "target_to_protagonist"]
+ContactKind = Literal["lodging", "social", "intimate"]
 
 
 def canonical_trait_name(trait_name: str) -> str:
@@ -96,6 +97,12 @@ class RelationshipTargetInput(BaseModel):
         "protagonist_to_target",
         description="Direction for the pair-tag edge when apply_pair_tag is true.",
     )
+    contact_kind: Optional[ContactKind] = Field(
+        None,
+        description=(
+            "Kind qualifier for Contacts pair-tags: lodging, social, or intimate."
+        ),
+    )
 
 
 class RelationshipTraitInput(BaseModel):
@@ -165,6 +172,7 @@ class CreatedRelationship(BaseModel):
     relationship_type: str
     emotional_valence: str
     pair_tag: Optional[str] = None
+    contact_kind: Optional[ContactKind] = None
     dry_run: bool = False
 
 

--- a/nexus/api/trait_compiler_schemas.py
+++ b/nexus/api/trait_compiler_schemas.py
@@ -7,11 +7,12 @@ from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from nexus.agents.orrery.substrate import ContactKind
+
 
 ResourceLevel = Literal["destitute", "poor", "comfortable", "wealthy", "magnate"]
 FameLevel = Literal["obscure", "known", "renowned", "legendary"]
 PairTagDirection = Literal["protagonist_to_target", "target_to_protagonist"]
-ContactKind = Literal["lodging", "social", "intimate"]
 
 
 def canonical_trait_name(trait_name: str) -> str:

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -1,6 +1,7 @@
 """Tests for migration discovery around Orrery's Python migration."""
 
 from pathlib import Path
+from typing import Any, Iterable
 
 import psycopg2
 import pytest
@@ -536,6 +537,127 @@ def test_kind_qualified_contact_migration_deprecates_contact_flags() -> None:
 
 
 @pytest.mark.requires_postgres
+def test_kind_qualified_contact_migration_executes_against_slot_db() -> None:
+    """Migration 047 seeds kinded contacts and deprecates legacy rows."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "047_kind_qualified_contact_pair_tags.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    contact_pair_tags = [tag for tag, _description in migration.CONTACT_PAIR_TAGS]
+    legacy_pair_tags = [tag for tag, _note in migration.LEGACY_CONTACT_PAIR_TAGS]
+    legacy_tags = [tag for tag, _note in migration.LEGACY_CONTACT_TAGS]
+
+    try:
+        conn = psycopg2.connect(get_slot_db_url(dbname="save_05"))
+    except psycopg2.Error as exc:
+        pytest.skip(f"save_05 PostgreSQL test database unavailable: {exc}")
+
+    pair_tag_names = [*contact_pair_tags, *legacy_pair_tags]
+    pair_tag_snapshot = _snapshot_pair_tags(conn, pair_tag_names)
+    tag_snapshot = _snapshot_tags(conn, legacy_tags)
+
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                for tag in legacy_pair_tags:
+                    cur.execute(
+                        """
+                        INSERT INTO pair_tags (
+                            tag, subject_kinds, object_kinds,
+                            is_ephemeral, clearance_kind, description, deprecated
+                        ) VALUES (
+                            %s,
+                            ARRAY['character'],
+                            ARRAY['character'],
+                            FALSE,
+                            NULL,
+                            'legacy contact pair-tag test seed.',
+                            FALSE
+                        )
+                        ON CONFLICT (tag) DO UPDATE SET
+                            subject_kinds = EXCLUDED.subject_kinds,
+                            object_kinds = EXCLUDED.object_kinds,
+                            is_ephemeral = FALSE,
+                            clearance_kind = NULL,
+                            description = EXCLUDED.description,
+                            deprecated = FALSE
+                        """,
+                        (tag,),
+                    )
+                for tag in legacy_tags:
+                    cur.execute(
+                        """
+                        INSERT INTO tags (
+                            tag, category, is_ephemeral, clearance_kind,
+                            synonym_for, deprecated, description
+                        ) VALUES (
+                            %s,
+                            'orrery_state',
+                            FALSE,
+                            NULL,
+                            NULL,
+                            FALSE,
+                            'legacy contact tag test seed.'
+                        )
+                        ON CONFLICT (tag) DO UPDATE SET
+                            category = EXCLUDED.category,
+                            is_ephemeral = FALSE,
+                            clearance_kind = NULL,
+                            synonym_for = NULL,
+                            deprecated = FALSE,
+                            description = EXCLUDED.description
+                        """,
+                        (tag,),
+                    )
+
+        migration.run(conn)
+        migration.run(conn)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT tag, subject_kinds, object_kinds, is_ephemeral,
+                       deprecated, description
+                FROM pair_tags
+                WHERE tag = ANY(%s)
+                """,
+                (pair_tag_names,),
+            )
+            pair_rows = {row[0]: row[1:] for row in cur.fetchall()}
+            for tag in contact_pair_tags:
+                assert pair_rows[tag][0] == ["character"]
+                assert pair_rows[tag][1] == ["character"]
+                assert pair_rows[tag][2] is False
+                assert pair_rows[tag][3] is False
+
+            for tag in legacy_pair_tags:
+                description = pair_rows[tag][4]
+                assert pair_rows[tag][3] is True
+                assert description.count("Replaced by") == 1
+
+            cur.execute(
+                """
+                SELECT tag, deprecated, description
+                FROM tags
+                WHERE tag = ANY(%s)
+                """,
+                (legacy_tags,),
+            )
+            tag_rows = {row[0]: row[1:] for row in cur.fetchall()}
+            for tag in legacy_tags:
+                assert tag_rows[tag][0] is True
+                assert tag_rows[tag][1].count("Replaced by") == 1
+    finally:
+        conn.rollback()
+        _restore_pair_tags(conn, pair_tag_snapshot, pair_tag_names)
+        _restore_tags(conn, tag_snapshot, legacy_tags)
+        conn.close()
+
+
+@pytest.mark.requires_postgres
 def test_canonical_grieving_migration_executes_against_slot_db() -> None:
     """Migration 046 moves active legacy rows and preserves grief reapply policy."""
 
@@ -646,3 +768,99 @@ def test_canonical_grieving_migration_executes_against_slot_db() -> None:
                         )
         finally:
             conn.close()
+
+
+def _snapshot_pair_tags(
+    conn: Any,
+    tag_names: Iterable[str],
+) -> dict[str, tuple[Any, ...]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT tag, subject_kinds, object_kinds, is_ephemeral,
+                   clearance_kind::text, reapplication_policy::text,
+                   clear_on::text, deprecated, description
+            FROM pair_tags
+            WHERE tag = ANY(%s)
+            """,
+            (list(tag_names),),
+        )
+        return {row[0]: row[1:] for row in cur.fetchall()}
+
+
+def _restore_pair_tags(
+    conn: Any,
+    snapshot: dict[str, tuple[Any, ...]],
+    tag_names: Iterable[str],
+) -> None:
+    with conn:
+        with conn.cursor() as cur:
+            for tag in tag_names:
+                row = snapshot.get(tag)
+                if row is None:
+                    cur.execute("DELETE FROM pair_tags WHERE tag = %s", (tag,))
+                    continue
+                cur.execute(
+                    """
+                    UPDATE pair_tags
+                    SET subject_kinds = %s,
+                        object_kinds = %s,
+                        is_ephemeral = %s,
+                        clearance_kind = %s::entity_tag_clearance_kind,
+                        reapplication_policy =
+                            %s::entity_tag_reapplication_policy,
+                        clear_on = %s::jsonb,
+                        deprecated = %s,
+                        description = %s
+                    WHERE tag = %s
+                    """,
+                    (*row, tag),
+                )
+
+
+def _snapshot_tags(
+    conn: Any,
+    tag_names: Iterable[str],
+) -> dict[str, tuple[Any, ...]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT tag, category, is_ephemeral, clearance_kind::text,
+                   reapplication_policy::text, clear_on::text, synonym_for,
+                   deprecated, description
+            FROM tags
+            WHERE tag = ANY(%s)
+            """,
+            (list(tag_names),),
+        )
+        return {row[0]: row[1:] for row in cur.fetchall()}
+
+
+def _restore_tags(
+    conn: Any,
+    snapshot: dict[str, tuple[Any, ...]],
+    tag_names: Iterable[str],
+) -> None:
+    with conn:
+        with conn.cursor() as cur:
+            for tag in tag_names:
+                row = snapshot.get(tag)
+                if row is None:
+                    cur.execute("DELETE FROM tags WHERE tag = %s", (tag,))
+                    continue
+                cur.execute(
+                    """
+                    UPDATE tags
+                    SET category = %s,
+                        is_ephemeral = %s,
+                        clearance_kind = %s::entity_tag_clearance_kind,
+                        reapplication_policy =
+                            %s::entity_tag_reapplication_policy,
+                        clear_on = %s::jsonb,
+                        synonym_for = %s,
+                        deprecated = %s,
+                        description = %s
+                    WHERE tag = %s
+                    """,
+                    (*row, tag),
+                )

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -507,6 +507,34 @@ def test_canonical_grieving_migration_aliases_legacy_grief_tags() -> None:
     assert "synonym_for = %s" in migration_source
 
 
+def test_kind_qualified_contact_migration_deprecates_contact_flags() -> None:
+    """Migration 047 replaces overloaded contact flags with pair-tag kinds."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "047_kind_qualified_contact_pair_tags.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    migration_source = migration_path.read_text()
+
+    assert {"contact:lodging", "contact:social", "contact:intimate"} == {
+        tag for tag, _description in migration.CONTACT_PAIR_TAGS
+    }
+    assert {"contacts_available", "intimate_services_contact"} == {
+        tag for tag, _replacement_note in migration.LEGACY_CONTACT_TAGS
+    }
+    assert migration.LEGACY_CONTACT_PAIR_TAGS == (
+        (
+            "contact",
+            "Replaced by kind-qualified contact pair-tags: contact:lodging, "
+            "contact:social, and contact:intimate.",
+        ),
+    )
+    assert "INSERT INTO pair_tags" in migration_source
+    assert "SET deprecated = TRUE" in migration_source
+
+
 @pytest.mark.requires_postgres
 def test_canonical_grieving_migration_executes_against_slot_db() -> None:
     """Migration 046 moves active legacy rows and preserves grief reapply policy."""
@@ -581,9 +609,7 @@ def test_canonical_grieving_migration_executes_against_slot_db() -> None:
             assert {
                 tag: (is_deprecated, alias_target)
                 for tag, is_deprecated, alias_target in cur.fetchall()
-            } == {
-                tag: (True, grieving_id) for tag in migration.LEGACY_TAGS
-            }
+            } == {tag: (True, grieving_id) for tag in migration.LEGACY_TAGS}
 
             cur.execute(
                 """

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -259,11 +259,11 @@ def test_resolve_dry_run_excludes_anchor_present_characters() -> None:
         ),
         (
             FakeSession(
-                tag_rows=[
+                pair_tag_rows=[
                     {
-                        "entity_id": 1,
-                        "tag": "contacts_available",
-                        "is_ephemeral": False,
+                        "subject_entity_id": 1,
+                        "object_entity_id": 2,
+                        "tag": "contact:social",
                     }
                 ],
                 event_rows=[
@@ -408,12 +408,18 @@ def test_active_pursuit_beats_hide() -> None:
         FakeSession(
             tag_rows=[
                 {"entity_id": 1, "tag": "off_grid", "is_ephemeral": False},
-                {"entity_id": 1, "tag": "contacts_available", "is_ephemeral": False},
                 {
                     "entity_id": 1,
                     "tag": "under_active_pursuit",
                     "is_ephemeral": True,
                 },
+            ],
+            pair_tag_rows=[
+                {
+                    "subject_entity_id": 1,
+                    "object_entity_id": 2,
+                    "tag": "contact:lodging",
+                }
             ],
             location_class_rows=[
                 {"id": 10, "location_class": "safe_house", "is_primary": True}

--- a/tests/test_orrery/test_slot2_tag_backfill.py
+++ b/tests/test_orrery/test_slot2_tag_backfill.py
@@ -25,7 +25,7 @@ def test_slot2_tag_backfill_filters_and_canonicalizes_proposals() -> None:
                 "registered_tag_proposals": [
                     {"tag": "safe_house", "confidence": "high"},
                     {"tag": "sleep_deprived_1_mild", "confidence": "high"},
-                    {"tag": "contacts_available", "confidence": "low"},
+                    {"tag": "low_confidence_anchor", "confidence": "low"},
                 ],
                 "unregistered_tag_candidates": [
                     {"tag": "found_family_anchor", "confidence": "high"},
@@ -45,7 +45,7 @@ def test_slot2_tag_backfill_filters_and_canonicalizes_proposals() -> None:
         ]
     }
     tags = {
-        "contacts_available": TagDefinition(
+        "low_confidence_anchor": TagDefinition(
             id=1, category="orrery_state", is_ephemeral=False
         ),
         "corporate_exile": TagDefinition(id=2, category="state", is_ephemeral=False),
@@ -99,7 +99,7 @@ def test_slot2_tag_backfill_skips_existing_and_missing_entities() -> None:
                 "entity_kind": "character",
                 "entity_name": "Alex",
                 "registered_tag_proposals": [
-                    {"tag": "contacts_available", "confidence": "high"},
+                    {"tag": "quiet_retreat", "confidence": "high"},
                 ],
             },
             {
@@ -107,14 +107,14 @@ def test_slot2_tag_backfill_skips_existing_and_missing_entities() -> None:
                 "entity_kind": "character",
                 "entity_name": "Ghost",
                 "registered_tag_proposals": [
-                    {"tag": "contacts_available", "confidence": "high"},
+                    {"tag": "quiet_retreat", "confidence": "high"},
                     {"tag": "off_grid", "confidence": "medium"},
                 ],
             },
         ]
     }
     tags = {
-        "contacts_available": TagDefinition(
+        "quiet_retreat": TagDefinition(
             id=1, category="orrery_state", is_ephemeral=False
         ),
         "off_grid": TagDefinition(id=2, category="orrery_state", is_ephemeral=False),
@@ -145,7 +145,7 @@ def test_slot2_tag_backfill_rejects_manifest_entity_kind_mismatch() -> None:
                 "entity_kind": "character",
                 "entity_name": "Dynacorp",
                 "registered_tag_proposals": [
-                    {"tag": "contacts_available", "confidence": "high"},
+                    {"tag": "quiet_retreat", "confidence": "high"},
                 ],
             }
         ]
@@ -155,7 +155,7 @@ def test_slot2_tag_backfill_rejects_manifest_entity_kind_mismatch() -> None:
         _build_candidates(
             manifest,
             tags={
-                "contacts_available": TagDefinition(
+                "quiet_retreat": TagDefinition(
                     id=1, category="orrery_state", is_ephemeral=False
                 )
             },
@@ -166,9 +166,7 @@ def test_slot2_tag_backfill_rejects_manifest_entity_kind_mismatch() -> None:
         )
 
 
-def test_slot2_tag_backfill_insert_candidates_counts_rows_without_mutating_current() -> (
-    None
-):
+def test_slot2_tag_backfill_insert_counts_rows_without_mutating_current() -> None:
     """The insert helper counts DB rowcount and keeps caller state unchanged."""
 
     cursor = FakeInsertCursor(conflicting={(2, 20)})

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -19,10 +19,12 @@ from nexus.agents.orrery.substrate import (
     can_move_publicly,
     co_located,
     count_co_located,
+    contact_pair_tag_for_kind,
     direct_contact_is_dramatic,
     evaluate_stack,
     has_any_pair_tag,
     has_any_intimacy_suppressor,
+    has_contact_of_kind,
     has_established_partner_co_located,
     has_minimal_context,
     has_need_debt_at_or_above,
@@ -245,6 +247,31 @@ def test_pair_tag_predicates_are_direction_sensitive() -> None:
     assert has_any_pair_tag("claims", "protects")(state, bindings)
     assert not has_pair_tag("mentors")(state, reversed_bindings)
     assert not has_pair_tag("pursuing")(state, bindings)
+
+
+def test_contact_kind_predicate_reads_outbound_kind_specific_edges() -> None:
+    """Contact-kind gates match outbound contact:<kind> pair-tags only."""
+
+    state = WorldState(
+        pair_tags={
+            (1, 2): frozenset({"contact:social"}),
+            (2, 1): frozenset({"contact:lodging"}),
+            (1, 3): frozenset({"ally"}),
+        }
+    )
+
+    assert has_contact_of_kind("social")(state, {Slot.ACTOR: 1})
+    assert not has_contact_of_kind("lodging")(state, {Slot.ACTOR: 1})
+    assert has_contact_of_kind("lodging")(state, {Slot.ACTOR: 2})
+    assert not has_contact_of_kind("intimate")(state, {Slot.ACTOR: 1})
+    assert not has_contact_of_kind("social")(state, {Slot.TARGET: 1})
+
+
+def test_contact_pair_tag_for_kind_rejects_unknown_kind() -> None:
+    """Contact-kind helpers fail loudly instead of inventing vocabulary."""
+
+    with pytest.raises(ValueError, match="Unsupported contact kind"):
+        contact_pair_tag_for_kind("medical")  # type: ignore[arg-type]
 
 
 def test_lacks_pair_tag_is_inverse_for_bound_slots() -> None:

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -328,6 +328,15 @@ def test_public_mobility_requires_public_context_and_freedom() -> None:
     assert not can_move_publicly()(captive_state, {Slot.ACTOR: 1})
 
 
+def test_public_mobility_can_use_social_contact_channel() -> None:
+    """A social contact preserves the old contacts_available mobility affordance."""
+
+    state = WorldState(pair_tags={(1, 2): frozenset({"contact:social"})})
+
+    assert can_move_publicly()(state, {Slot.ACTOR: 1})
+    assert not can_move_publicly()(state, {Slot.ACTOR: 2})
+
+
 def test_relationship_contact_predicates_capture_asymmetry() -> None:
     """Kin/contact templates can distinguish warmth from loaded contact."""
 

--- a/tests/test_trait_compiler.py
+++ b/tests/test_trait_compiler.py
@@ -54,6 +54,21 @@ class TraitCompilerCursor:
                 "subject_kinds": ["character"],
                 "object_kinds": ["character"],
             },
+            "contact:lodging": {
+                "id": 104,
+                "subject_kinds": ["character"],
+                "object_kinds": ["character"],
+            },
+            "contact:social": {
+                "id": 105,
+                "subject_kinds": ["character"],
+                "object_kinds": ["character"],
+            },
+            "contact:intimate": {
+                "id": 106,
+                "subject_kinds": ["character"],
+                "object_kinds": ["character"],
+            },
             "hostile_to": {
                 "id": 103,
                 "subject_kinds": ["character", "faction"],
@@ -406,9 +421,9 @@ def test_no_typed_inputs_returns_structured_remainders() -> None:
         "status",
         "allies",
     }
-    assert {
-        item.reason_code for item in result.prose_only_remainders
-    } == {TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT}
+    assert {item.reason_code for item in result.prose_only_remainders} == {
+        TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT
+    }
 
 
 def test_resources_and_reputation_compile_to_single_entity_tags() -> None:
@@ -513,6 +528,133 @@ def test_explicit_ally_pair_tag_writes_both_layers() -> None:
     assert result.created_relationships[0].pair_tag == "ally"
     assert len(cur.entity_pair_tags) == 1
     assert len(cur.character_relationships) == 1
+
+
+def test_contacts_pair_tag_requires_kind() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        contacts=RelationshipTraitInput(
+            targets=[
+                RelationshipTargetInput(
+                    character_id=2,
+                    character_entity_id=502,
+                    dynamic="A contact without a known gate kind.",
+                    apply_pair_tag=True,
+                )
+            ]
+        )
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("contacts", "resources", "domain", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert result.applied_pair_tags == []
+    assert cur.entity_pair_tags == []
+    assert result.prose_only_remainders[0].reason_code == (
+        TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT
+    )
+    assert "contact_kind" in result.prose_only_remainders[0].message
+
+
+def test_contact_kind_pair_tag_writes_kind_specific_edge() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        contacts=RelationshipTraitInput(
+            targets=[
+                RelationshipTargetInput(
+                    character_id=2,
+                    character_entity_id=502,
+                    dynamic="A lodging contact for safe-house access.",
+                    apply_pair_tag=True,
+                    contact_kind="lodging",
+                )
+            ]
+        )
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("contacts", "resources", "domain", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert result.applied_pair_tags[0].tag == "contact:lodging"
+    assert result.created_relationships[0].pair_tag == "contact:lodging"
+    assert result.created_relationships[0].contact_kind == "lodging"
+    assert cur.entity_pair_tags[0]["pair_tag_id"] == 104
+    assert (
+        '"trait_compiler_contact_kind": "lodging"'
+        in cur.character_relationships[0]["extra_data"]
+    )
+
+
+def test_explicit_contact_pair_tag_infers_contact_kind_metadata() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        contacts=RelationshipTraitInput(
+            targets=[
+                RelationshipTargetInput(
+                    character_id=2,
+                    character_entity_id=502,
+                    dynamic="A social contact for messages and favors.",
+                    apply_pair_tag=True,
+                    pair_tag="contact:social",
+                )
+            ]
+        )
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("contacts", "resources", "domain", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert result.applied_pair_tags[0].tag == "contact:social"
+    assert result.created_relationships[0].pair_tag == "contact:social"
+    assert result.created_relationships[0].contact_kind == "social"
+    assert cur.entity_pair_tags[0]["pair_tag_id"] == 105
+    assert (
+        '"trait_compiler_contact_kind": "social"'
+        in cur.character_relationships[0]["extra_data"]
+    )
+
+
+def test_unknown_contact_pair_tag_is_structured_remainder() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        contacts=RelationshipTraitInput(
+            targets=[
+                RelationshipTargetInput(
+                    character_id=2,
+                    character_entity_id=502,
+                    dynamic="A contact with an unsupported gate kind.",
+                    apply_pair_tag=True,
+                    pair_tag="contact:trade",
+                )
+            ]
+        )
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("contacts", "resources", "domain", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert result.applied_pair_tags == []
+    assert cur.entity_pair_tags == []
+    assert result.prose_only_remainders[0].reason_code == (
+        TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT
+    )
+    assert result.prose_only_remainders[0].details["pair_tag"] == "contact:trade"
 
 
 def test_enemy_pair_tag_can_point_from_target_to_protagonist() -> None:
@@ -624,6 +766,30 @@ def test_reconciliation_reports_relationship_without_pair_tag() -> None:
     assert len(drift) == 1
     assert drift[0].drift_kind == "missing_pair_tag"
     assert drift[0].pair_tag == "ally"
+
+
+def test_reconciliation_ignores_deprecated_bare_contact_pair_tag() -> None:
+    cur = TraitCompilerCursor()
+    cur.character_relationships.append(
+        {
+            "character1_id": 1,
+            "character2_id": 2,
+            "relationship_type": "contact",
+            "emotional_valence": "+1|favorable",
+            "dynamic": "Legacy compiler-authored contact relationship.",
+            "recent_events": "",
+            "history": "",
+            "extra_data": json.dumps(
+                {
+                    "source": "trait_compiler",
+                    "trait": "contacts",
+                    "trait_compiler_pair_tag": "contact",
+                }
+            ),
+        }
+    )
+
+    assert reconcile_trait_relationship_pair_tags(cur) == []
 
 
 def test_persist_trait_compile_result_requires_wizard_cache_row() -> None:


### PR DESCRIPTION
## Summary

- Add migration 047 to seed `contact:lodging`, `contact:social`, and `contact:intimate`, while deprecating the overloaded `contacts_available`, `intimate_services_contact`, and bare `contact` registry entries.
- Add `has_contact_of_kind(...)` to Orrery substrate/catalog and move package gates, demos, generated package docs, and vocabulary docs onto kind-qualified contact predicates.
- Update the trait compiler so Contacts pair-tag writes require a `contact_kind` or valid explicit `contact:<kind>` tag, infer contact-kind audit metadata, and avoid reconciling deprecated bare `contact` as a live pair-tag.

Closes #317.

## Validation

- `poetry run pytest tests/test_orrery tests/test_trait_compiler.py -q`
- `poetry run flake8 nexus/agents/orrery/substrate.py nexus/agents/orrery/templates.py nexus/agents/orrery/catalog.py nexus/agents/orrery/demo.py nexus/api/trait_compiler.py nexus/api/trait_compiler_schemas.py migrations/047_kind_qualified_contact_pair_tags.py tests/test_trait_compiler.py tests/test_orrery/test_substrate.py tests/test_orrery/test_resolver.py tests/test_orrery/test_migrate.py tests/test_orrery/test_slot2_tag_backfill.py`
- `git diff --check`

## Data Impact

Migration 047 adds non-ephemeral character→character pair-tag registry rows and marks legacy contact tags deprecated. It does not delete existing rows; active legacy entity-tag rows stop hydrating through the current non-deprecated tag views once the migration is applied.