### PR TITLE
Add Orrery tag expiry substrate

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1769,6 +1769,8 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/042_orrery_entity_pair_tags.py`
 - `migrations/043_orrery_category_refactor_phase1.py`
 - `migrations/048_orrery_hunting_pair_tag.py`
+- `migrations/049_orrery_entity_tag_expiry_substrate.py`
+- `migrations/050_orrery_state_clearance_event_types.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 

--- a/docs/orrery_state_vocabulary.md
+++ b/docs/orrery_state_vocabulary.md
@@ -36,7 +36,7 @@ Most affective states are pressure material → binary. `wounded`/`sick` are the
 One hard substrate fact constrains this: `ix_entity_tags_current` is `UNIQUE (entity_id, tag_id) WHERE cleared_at IS NULL`, so **any single `tag_id` is singular** — only one open row per tag per entity. Implications:
 
 - Distinct tags coexist freely (different `tag_id`s): `intoxicated:stimulant` + `intoxicated:depressant` is fine.
-- A re-apply of the **same** tag raises a unique violation — it does not silently stack or extend. The pharmacologic cluster's additive-timer behavior therefore requires an **extend-on-conflict** branch in the application writer (see open issue / migration debts).
+- A re-apply of the **same** tag is policy-dispatched by the application writer: most tags keep idempotent `new_row` behavior, duration-bearing tags can `extend_expiry`, and refresh-style tags can `replace` the active row.
 - Graduated-severity tracks are mutually exclusive within track by construction (one tier tag at a time), which the needs maintenance pass already enforces by clearing sibling tiers on re-tier.
 
 ---
@@ -89,7 +89,7 @@ Replaces the vague `intoxicated` with one tag per **pharmacological class**, usi
 
 **Kinetics model — duration at application, sweeper-cleared.** Every dose carries a duration set **at application** (default per class, overridable by the establishing event / Skald when the substance warrants it — espresso vs combat-drug). Clearance is by elapsed world-time, via the **expiry sweeper** (#328), *not* by any event — so these are the one cluster that names a **duration**, not a clearing event type. The clearance-event enumeration below intentionally does not include any `metabolized` type; it doesn't exist.
 
-**Polypharmacy.** Multi-valued: different classes are distinct `tag_id`s and coexist (`intoxicated:stimulant` + `intoxicated:depressant` is a specific, recognizable state, and the suppression/impairment effects compose). Same-class re-dose is *not* a second row — the unique index forbids it — so the writer must **extend the open row's expiry** on conflict. **Substrate prerequisite:** the `tags.reapplication_policy` column already exists (migration 023, enum `new_row` / `extend_expiry` / `replace`) and several existing tags already declare `extend_expiry`. What's missing is (1) the `entity_tags.expires_at_world_time` column for the sweeper to read, and (2) writer-side dispatch on `reapplication_policy` (currently `ON CONFLICT DO NOTHING` at `tag_writer.py:268`, ignoring the template field). Tracked in #329, sibling to #328.
+**Polypharmacy.** Multi-valued: different classes are distinct `tag_id`s and coexist (`intoxicated:stimulant` + `intoxicated:depressant` is a specific, recognizable state, and the suppression/impairment effects compose). Same-class re-dose is *not* a second row — the unique index forbids it — so the writer must **extend the open row's expiry** on conflict. Migration 049 provides the `entity_tags.expires_at_world_time` column plus writer dispatch on the existing `tags.reapplication_policy` enum (`new_row` / `extend_expiry` / `replace`). The remaining runtime prerequisite is the expiry sweeper (#328).
 
 **On the kinetics framing.** Additive-timer is a *narrative-modeling convenience*, not pharmacological accuracy — only ethanol is genuinely zero-order at narrative-relevant doses; stimulants, opioids, hallucinogens, and dissociatives are first-order in reality. We favor legibility (more dose = lasts longer, in a way the writer can reason about) over verisimilitude. A per-class `expires_at` cap is a one-line knob if runaway re-dosing ever matters; probably unnecessary for narrative purposes.
 
@@ -119,20 +119,20 @@ These passed the membership test in earlier passes but belong to none of the fir
 
 **Where clearance config lives.** Per-tag-template fields declare *which* event types clear *this* state — clearance is a property of the state, not of the event. The runtime mechanism is `_clear_event_tags_sync` / `_clear_event_tags_async` (`nexus/agents/orrery/events.py:3030+`), which queries `t.clear_on -> 'event_types' ? <event_type>` against the `tags` table's `clear_on` JSONB column. Adding a new event type doesn't require enumerating every state it could clear; each tag template declares its own clearance contract. The event registry below lists *names referenced from the state side*; whether each currently exists in the `event_types` table is independent of whether any state has actually wired it up. A state whose clearance config names a nonexistent event type does not no-op — it applies and **never clears, silently** — so the event vocabulary cannot lag the state vocabulary.
 
-The table marks each row's registry status against the live `event_types` table. Registration of the new rows is tracked by #330.
+The table marks each row's registry status against the live `event_types` table. Migration 050 registers the new rows required by this draft.
 
 | Clearing event type(s) | Registry status | Clears |
 |---|---|---|
 | `tended_wound`, `wound_healed` | **existing** | `wounded` |
-| `recovered_from_illness`, `cured` | **register** | `sick` |
+| `recovered_from_illness`, `cured` | **existing** | `sick` |
 | `captivity_ended` | **existing** | `restrained` (release variant), `imprisoned` |
-| `escaped` | **register** | `restrained`, `imprisoned` (escape variant — distinct from `captivity_ended` because the actor's agency matters narratively) |
-| `revealed`, `discovered` | **register** | `concealed` |
-| `unmasked`, `exposed` | **register** | `disguised` |
-| `threat_removed` | **register** | `afraid` |
+| `escaped` | **existing** | `restrained`, `imprisoned` (escape variant — distinct from `captivity_ended` because the actor's agency matters narratively) |
+| `revealed`, `discovered` | **existing** | `concealed` |
+| `unmasked`, `exposed` | **existing** | `disguised` |
+| `threat_removed` | **existing** | `afraid` |
 | `retaliation_executed` | **existing** | `enraged` (vengeance variant — uses the existing retaliation event-type from the contact/hostility cluster) |
-| `confrontation_resolved` | **register** | `enraged` (alternate path — confronted-and-de-escalated without retaliation) |
-| `circumstance_reversed` | **register** | `despairing` |
+| `confrontation_resolved` | **existing** | `enraged` (alternate path — confronted-and-de-escalated without retaliation) |
+| `circumstance_reversed` | **existing** | `despairing` |
 | `mourning_completed` | **existing** | `grieving` (authored fallback — the sweeper handles the primary time-decay path) |
 | *(none — time-cleared via sweeper)* | sweeper #328 | `grieving` (primary), all `intoxicated:*` |
 
@@ -146,13 +146,11 @@ Several alignments with existing vocab dropped synonymous proposals: `tended`/`h
 
 1. **`under_active_pursuit` → inbound `hunting` pair-tag — resolved.** Migration 048 renames live `pursuing` pair-tag rows to `hunting`, deprecates the legacy single-entity signal, and templates now gate on `has_inbound_pair_tag("hunting", ...)`. This closes the category-error state debt; remaining `hunting` behavior belongs to package self-awareness (#282), not the `state` vocabulary.
 2. **Grief vocabulary — resolved.** PR #320 collapsed three competing names (`bereaved`, `grieving_recent_partner`, the earlier-proposed `grieving`) to the canonical `grieving`. The INTIMACY suppressor row for `grieving_recent_partner` was removed; general `grieving` covers it. This doc adopts that resolution; no further work required.
-3. **`cns_stimulated` → `intoxicated:stimulant` alias.** Alias via `CANONICAL_TAGS` + SLEEP-gate rewrite, as in Cluster 3. Implementation surface: `nexus/agents/orrery/tag_constants.py` (add alias) and `nexus/agents/orrery/templates.py:2298` (rewrite the gate predicate). Small enough to land alongside the substrate enrichment in #329, or as its own micro-PR.
+3. **`cns_stimulated` → `intoxicated:stimulant` alias.** Alias via `CANONICAL_TAGS` + SLEEP-gate rewrite, as in Cluster 3. Implementation surface: `nexus/agents/orrery/tag_constants.py` (add alias) and `nexus/agents/orrery/templates.py:2298` (rewrite the gate predicate). This remains a small follow-up once the pharmacologic tags themselves are ready to ship.
 4. **`contacts_available` overload — resolved.** PR #327 (migration 047) shipped the kind-qualified `contact:<lodging|social|intimate>` pair-tag family, replacing the overloaded `contacts_available` ephemeral and closing #317. Not a `state` issue — noted only for cross-reference; the substrate fix applies cleanly to needs templates per `orrery_needs.md` R3.
-5. **`entity_tags` substrate enrichment for additive-timer pharmacologics.** The pharmacologic cluster's same-class re-dose behavior requires two substrate additions:
-   - `entity_tags.expires_at_world_time` column (currently absent — the table has `cleared_at` for actual clearance, but no scheduled-expiry field for the sweeper to read).
-   - `_insert_entity_tag`'s `ON CONFLICT ... DO NOTHING` becomes policy-dispatched: `new_row` / `extend_expiry` / `replace`, declared on the tag template via the existing `reapplication_policy` field.
+5. **`entity_tags` substrate enrichment for additive-timer pharmacologics — resolved.** Migration 049 adds `entity_tags.expires_at_world_time` and the expiring-row index, and `_insert_entity_tag` now dispatches `new_row` / `extend_expiry` / `replace` from each tag's existing `reapplication_policy` field.
    
-   Tracked in **#329**; sibling to **#328** (sweeper). The pharmacologic cluster blocks on both — neither shipping in isolation gives you a working `intoxicated:*` tag.
+   The remaining sibling is **#328** (sweeper). The pharmacologic cluster still needs the sweeper before `intoxicated:*` becomes a fully working time-cleared state family.
 
 ---
 

--- a/migrations/049_orrery_entity_tag_expiry_substrate.py
+++ b/migrations/049_orrery_entity_tag_expiry_substrate.py
@@ -1,0 +1,26 @@
+"""Add scheduled-expiry substrate for Orrery entity tags."""
+
+from __future__ import annotations
+
+
+def run(conn) -> None:
+    """Add ``expires_at_world_time`` and an index for expiry sweeps."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            ALTER TABLE entity_tags
+                ADD COLUMN IF NOT EXISTS expires_at_world_time timestamptz;
+
+            COMMENT ON COLUMN entity_tags.expires_at_world_time IS
+                'World-time deadline for scheduled tag expiry. NULL means the '
+                'tag does not expire by elapsed world time.';
+
+            CREATE INDEX IF NOT EXISTS ix_entity_tags_expiring
+                ON entity_tags (expires_at_world_time)
+                WHERE cleared_at IS NULL
+                  AND expires_at_world_time IS NOT NULL;
+            """
+        )
+
+    conn.commit()

--- a/migrations/050_orrery_state_clearance_event_types.py
+++ b/migrations/050_orrery_state_clearance_event_types.py
@@ -1,0 +1,96 @@
+"""Register clearance event types for the drafted Orrery state vocabulary."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+EVENT_TYPES: Sequence[tuple[str, str, str, str]] = (
+    (
+        "recovered_from_illness",
+        "care",
+        "moderate",
+        "A character recovers from sickness without implying a specific cure.",
+    ),
+    (
+        "cured",
+        "care",
+        "moderate",
+        "A sickness state is actively cured by treatment, magic, or intervention.",
+    ),
+    (
+        "escaped",
+        "movement",
+        "moderate",
+        "A character escapes restraint or imprisonment through their own agency.",
+    ),
+    (
+        "revealed",
+        "revelation",
+        "moderate",
+        "A concealed character or fact becomes visible to relevant observers.",
+    ),
+    (
+        "discovered",
+        "revelation",
+        "moderate",
+        "An observer discovers a previously concealed character or fact.",
+    ),
+    (
+        "unmasked",
+        "revelation",
+        "moderate",
+        "A disguised character is recognized as other than their presented identity.",
+    ),
+    (
+        "exposed",
+        "revelation",
+        "moderate",
+        "A disguise, cover, or hidden condition is exposed.",
+    ),
+    (
+        "threat_removed",
+        "threat",
+        "moderate",
+        "The immediate threat sustaining fear is removed or neutralized.",
+    ),
+    (
+        "confrontation_resolved",
+        "interpersonal",
+        "moderate",
+        "A confrontation resolves without requiring retaliation as the clearing beat.",
+    ),
+    (
+        "circumstance_reversed",
+        "circumstance",
+        "moderate",
+        "The circumstance sustaining despair is reversed or materially transformed.",
+    ),
+)
+
+
+def run(conn) -> None:
+    """Seed state-clearance event types idempotently."""
+
+    with conn.cursor() as cur:
+        for event_type, category, severity, description in EVENT_TYPES:
+            cur.execute(
+                """
+                INSERT INTO event_types (
+                    type, category, severity, description,
+                    deprecated, synonym_for
+                ) VALUES (
+                    %s, %s, %s::event_severity_kind, %s,
+                    FALSE, NULL
+                )
+                ON CONFLICT (type) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    severity = EXCLUDED.severity,
+                    description = EXCLUDED.description,
+                    deprecated = FALSE,
+                    synonym_for = NULL
+                """,
+                (event_type, category, severity, description),
+            )
+
+    conn.commit()

--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -12,14 +12,16 @@ The shared insert path stamps rows with the supplied ``source_kind`` (typically
 ``llm_generated``). Operates within the caller's transaction — no commits here.
 
 Depends on migration 036 making ``ix_entity_tags_current`` UNIQUE so the
-``ON CONFLICT`` clause in ``_insert_entity_tag`` matches a unique index, and on
+``ON CONFLICT`` clause in ``_insert_entity_tag`` matches a unique index,
 migration 037 seeding ``tag_category_registry`` so runtime bestowals know which
-tag categories may be applied to each entity kind.
+tag categories may be applied to each entity kind, and migration 049 adding the
+scheduled-expiry column used by duration-bearing tags.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import Any, Optional
 
 from nexus.agents.orrery.status_family import STATUS_TAGS, status_tag_for_level
@@ -30,6 +32,13 @@ from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
 
 # Split the retired source-kind literal so grep checks catch live usage sites.
 _DISALLOWED_SOURCE_KINDS = frozenset({"auto_" "registered"})
+_REAPPLICATION_POLICIES = frozenset({"new_row", "extend_expiry", "replace"})
+
+
+@dataclass(frozen=True)
+class _TagApplication:
+    tag_id: int
+    reapplication_policy: Optional[str]
 
 
 def apply_tag_bestowal(
@@ -40,6 +49,7 @@ def apply_tag_bestowal(
     bestowal: Optional[OrreryTagBestowal],
     source_kind: str = "skald_inline",
     world_time: Optional[datetime] = None,
+    duration_override: Optional[timedelta] = None,
 ) -> dict[str, int]:
     """Apply a closed-vocabulary tag bestowal to the database.
 
@@ -51,6 +61,8 @@ def apply_tag_bestowal(
     Requires migration 037's ``tag_category_registry`` rows for the target
     ``entity_kind``; missing registry data is treated as a slot-migration error.
     Unknown, deprecated, or entity-kind-incompatible tags raise ``ValueError``.
+    ``duration_override`` sets ``entity_tags.expires_at_world_time`` for
+    duration-bearing applications and drives ``extend_expiry`` reapplications.
 
     Returns counter dict suitable for logging:
     ``{"applied", "cleared"}``.
@@ -80,7 +92,7 @@ def apply_tag_bestowal(
     if world_time is None:
         world_time = _load_world_time(cur)
 
-    tags_to_apply: list[int] = []
+    tags_to_apply: list[_TagApplication] = []
     for tag_name in bestowal.applied_tags:
         canonical_name, tag_row = _lookup_canonical_tag(cur, tag_name)
         category = _row_value(tag_row, "category", 1)
@@ -90,7 +102,12 @@ def apply_tag_bestowal(
             tag_name=canonical_name,
             entity_kind=entity_kind,
         )
-        tags_to_apply.append(_row_value(tag_row, "id", 0))
+        tags_to_apply.append(
+            _TagApplication(
+                tag_id=_row_value(tag_row, "id", 0),
+                reapplication_policy=_row_value(tag_row, "reapplication_policy", 3),
+            )
+        )
 
     tags_to_clear: list[int] = []
     for clear_name in bestowal.tags_to_clear:
@@ -105,13 +122,15 @@ def apply_tag_bestowal(
         tags_to_clear.append(_row_value(tag_row, "id", 0))
 
     # 1. apply registered tags to the entity
-    for tag_id in tags_to_apply:
+    for tag_application in tags_to_apply:
         applied = _insert_entity_tag(
             cur,
             entity_id=entity_id,
-            tag_id=tag_id,
+            tag_id=tag_application.tag_id,
             source_kind=source_kind,
             world_time=world_time,
+            duration_override=duration_override,
+            reapplication_policy=tag_application.reapplication_policy,
         )
         if applied:
             counters["applied"] += 1
@@ -132,6 +151,7 @@ def apply_exclusive_tag_bestowal(
     tag: str,
     source_kind: str = "skald_inline",
     world_time: Optional[datetime] = None,
+    duration_override: Optional[timedelta] = None,
 ) -> bool:
     """Replace the active tag within a single-entity exclusive category.
 
@@ -143,6 +163,7 @@ def apply_exclusive_tag_bestowal(
 
     Returns ``True`` if the new tag row was inserted, ``False`` if it was
     already active. Sibling rows are cleared either way.
+    ``duration_override`` has the same meaning as in ``apply_tag_bestowal``.
     """
 
     _validate_source_kind(source_kind)
@@ -167,6 +188,7 @@ def apply_exclusive_tag_bestowal(
         entity_kind=entity_kind,
     )
     tag_id = _row_value(tag_row, "id", 0)
+    reapplication_policy = _row_value(tag_row, "reapplication_policy", 3)
 
     if world_time is None:
         world_time = _load_world_time(cur)
@@ -183,6 +205,8 @@ def apply_exclusive_tag_bestowal(
         tag_id=tag_id,
         source_kind=source_kind,
         world_time=world_time,
+        duration_override=duration_override,
+        reapplication_policy=reapplication_policy,
     )
 
 
@@ -201,7 +225,7 @@ def _lookup_allowed_categories(cur: Any, entity_kind: str) -> set[str]:
 def _lookup_tag(cur: Any, tag_name: str) -> Optional[Any]:
     cur.execute(
         """
-        SELECT id, category, is_ephemeral
+        SELECT id, category, is_ephemeral, reapplication_policy
         FROM tags
         WHERE tag = %s AND NOT deprecated AND synonym_for IS NULL
         """,
@@ -260,18 +284,99 @@ def _insert_entity_tag(
     tag_id: int,
     source_kind: str,
     world_time: Optional[datetime],
+    duration_override: Optional[timedelta],
+    reapplication_policy: Optional[str],
 ) -> bool:
+    reapplication_policy = reapplication_policy or "new_row"
+    if reapplication_policy not in _REAPPLICATION_POLICIES:
+        raise ValueError(
+            f"Unsupported entity tag reapplication_policy={reapplication_policy!r}"
+        )
+
+    expires_at_world_time = _compute_expires_at_world_time(
+        world_time=world_time,
+        duration_override=duration_override,
+    )
+
+    if reapplication_policy == "replace":
+        cur.execute(
+            """
+            INSERT INTO entity_tags (
+                entity_id, tag_id, applied_at_world_time,
+                expires_at_world_time, source_kind
+            )
+            VALUES (%s, %s, %s, %s, %s::entity_tag_source_kind)
+            ON CONFLICT (entity_id, tag_id)
+              WHERE cleared_at IS NULL
+              DO UPDATE SET
+                applied_at = now(),
+                applied_at_world_time = EXCLUDED.applied_at_world_time,
+                expires_at_world_time = EXCLUDED.expires_at_world_time,
+                source_kind = EXCLUDED.source_kind
+            """,
+            (entity_id, tag_id, world_time, expires_at_world_time, source_kind),
+        )
+        return bool(cur.rowcount)
+
+    if reapplication_policy == "extend_expiry" and duration_override is not None:
+        cur.execute(
+            """
+            INSERT INTO entity_tags (
+                entity_id, tag_id, applied_at_world_time,
+                expires_at_world_time, source_kind
+            )
+            VALUES (%s, %s, %s, %s, %s::entity_tag_source_kind)
+            ON CONFLICT (entity_id, tag_id)
+              WHERE cleared_at IS NULL
+              DO UPDATE SET
+                applied_at = now(),
+                applied_at_world_time = EXCLUDED.applied_at_world_time,
+                expires_at_world_time = GREATEST(
+                    COALESCE(
+                        entity_tags.expires_at_world_time,
+                        EXCLUDED.applied_at_world_time
+                    ),
+                    EXCLUDED.applied_at_world_time
+                ) + %s,
+                source_kind = EXCLUDED.source_kind
+            """,
+            (
+                entity_id,
+                tag_id,
+                world_time,
+                expires_at_world_time,
+                source_kind,
+                duration_override,
+            ),
+        )
+        return bool(cur.rowcount)
+
     cur.execute(
         """
-        INSERT INTO entity_tags (entity_id, tag_id, applied_at_world_time, source_kind)
-        VALUES (%s, %s, %s, %s::entity_tag_source_kind)
+        INSERT INTO entity_tags (
+            entity_id, tag_id, applied_at_world_time,
+            expires_at_world_time, source_kind
+        )
+        VALUES (%s, %s, %s, %s, %s::entity_tag_source_kind)
         ON CONFLICT (entity_id, tag_id)
           WHERE cleared_at IS NULL
           DO NOTHING
         """,
-        (entity_id, tag_id, world_time, source_kind),
+        (entity_id, tag_id, world_time, expires_at_world_time, source_kind),
     )
     return bool(cur.rowcount)
+
+
+def _compute_expires_at_world_time(
+    *,
+    world_time: Optional[datetime],
+    duration_override: Optional[timedelta],
+) -> Optional[datetime]:
+    if duration_override is None:
+        return None
+    if world_time is None:
+        raise ValueError("duration_override requires a known Orrery world_time")
+    return world_time + duration_override
 
 
 def _clear_entity_tag_siblings(

--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any, Literal, Optional, TypeAlias
 
 from nexus.agents.orrery.status_family import STATUS_TAGS, status_tag_for_level
 from nexus.agents.orrery.tag_constants import CANONICAL_TAGS
@@ -33,12 +33,13 @@ from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
 # Split the retired source-kind literal so grep checks catch live usage sites.
 _DISALLOWED_SOURCE_KINDS = frozenset({"auto_" "registered"})
 _REAPPLICATION_POLICIES = frozenset({"new_row", "extend_expiry", "replace"})
+ReapplicationPolicy: TypeAlias = Literal["new_row", "extend_expiry", "replace"]
 
 
 @dataclass(frozen=True)
 class _TagApplication:
     tag_id: int
-    reapplication_policy: Optional[str]
+    reapplication_policy: Optional[ReapplicationPolicy]
 
 
 def apply_tag_bestowal(
@@ -285,12 +286,16 @@ def _insert_entity_tag(
     source_kind: str,
     world_time: Optional[datetime],
     duration_override: Optional[timedelta],
-    reapplication_policy: Optional[str],
+    reapplication_policy: Optional[ReapplicationPolicy],
 ) -> bool:
     reapplication_policy = reapplication_policy or "new_row"
     if reapplication_policy not in _REAPPLICATION_POLICIES:
         raise ValueError(
             f"Unsupported entity tag reapplication_policy={reapplication_policy!r}"
+        )
+    if reapplication_policy == "extend_expiry" and duration_override is None:
+        raise ValueError(
+            "reapplication_policy='extend_expiry' requires duration_override"
         )
 
     expires_at_world_time = _compute_expires_at_world_time(
@@ -318,7 +323,7 @@ def _insert_entity_tag(
         )
         return bool(cur.rowcount)
 
-    if reapplication_policy == "extend_expiry" and duration_override is not None:
+    if reapplication_policy == "extend_expiry":
         cur.execute(
             """
             INSERT INTO entity_tags (
@@ -349,6 +354,8 @@ def _insert_entity_tag(
                 duration_override,
             ),
         )
+        # A truthy result means the active row changed: either inserted fresh or
+        # conflict-updated. For replace/extend, "applied" is broader than insert.
         return bool(cur.rowcount)
 
     cur.execute(

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -604,6 +604,86 @@ def test_state_clearance_event_type_migration_registers_new_events() -> None:
 
 
 @pytest.mark.requires_postgres
+def test_entity_tag_expiry_substrate_migration_executes_against_slot_db() -> None:
+    """Migration 049 DDL is idempotent against a real slot schema."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "049_orrery_entity_tag_expiry_substrate.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    try:
+        conn = psycopg2.connect(get_slot_db_url(dbname="save_05"))
+    except psycopg2.Error as exc:
+        pytest.skip(f"save_05 PostgreSQL test database unavailable: {exc}")
+
+    column_existed = _column_exists(conn, "entity_tags", "expires_at_world_time")
+    index_definition_before = _index_definition(conn, "ix_entity_tags_expiring")
+    try:
+        migration.run(conn)
+        migration.run(conn)
+
+        assert _column_exists(conn, "entity_tags", "expires_at_world_time")
+        index_definition = _index_definition(conn, "ix_entity_tags_expiring")
+        assert index_definition is not None
+        assert "expires_at_world_time" in index_definition
+        assert "cleared_at IS NULL" in index_definition
+        assert "expires_at_world_time IS NOT NULL" in index_definition
+    finally:
+        with conn:
+            with conn.cursor() as cur:
+                if index_definition_before is None:
+                    cur.execute("DROP INDEX IF EXISTS ix_entity_tags_expiring")
+                if not column_existed:
+                    cur.execute(
+                        "ALTER TABLE entity_tags "
+                        "DROP COLUMN IF EXISTS expires_at_world_time"
+                    )
+        conn.close()
+
+
+@pytest.mark.requires_postgres
+def test_state_clearance_event_type_migration_executes_against_slot_db() -> None:
+    """Migration 050 event-type seeding is idempotent against a real slot."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "050_orrery_state_clearance_event_types.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    event_types = [event_type for event_type, *_rest in migration.EVENT_TYPES]
+    try:
+        conn = psycopg2.connect(get_slot_db_url(dbname="save_05"))
+    except psycopg2.Error as exc:
+        pytest.skip(f"save_05 PostgreSQL test database unavailable: {exc}")
+
+    snapshot = _snapshot_event_types(conn, event_types)
+    try:
+        migration.run(conn)
+        migration.run(conn)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT type, category, severity::text, deprecated, synonym_for
+                FROM event_types
+                WHERE type = ANY(%s)
+                """,
+                (event_types,),
+            )
+            rows = {row[0]: row[1:] for row in cur.fetchall()}
+
+        assert set(rows) == set(event_types)
+        assert all(row[2] is False for row in rows.values())
+        assert all(row[3] is None for row in rows.values())
+    finally:
+        _restore_event_types(conn, snapshot, event_types)
+        conn.close()
+
+
+@pytest.mark.requires_postgres
 def test_kind_qualified_contact_migration_executes_against_slot_db() -> None:
     """Migration 047 seeds kinded contacts and deprecates legacy rows."""
 
@@ -835,6 +915,81 @@ def test_canonical_grieving_migration_executes_against_slot_db() -> None:
                         )
         finally:
             conn.close()
+
+
+def _column_exists(conn: Any, table_name: str, column_name: str) -> bool:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = %s
+              AND column_name = %s
+            """,
+            (table_name, column_name),
+        )
+        return cur.fetchone() is not None
+
+
+def _index_definition(conn: Any, index_name: str) -> str | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT indexdef
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname = %s
+            """,
+            (index_name,),
+        )
+        row = cur.fetchone()
+        return row[0] if row is not None else None
+
+
+def _snapshot_event_types(
+    conn: Any,
+    event_types: Iterable[str],
+) -> dict[str, tuple[Any, ...]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT type, category, severity::text, description,
+                   deprecated, synonym_for
+            FROM event_types
+            WHERE type = ANY(%s)
+            """,
+            (list(event_types),),
+        )
+        return {row[0]: row[1:] for row in cur.fetchall()}
+
+
+def _restore_event_types(
+    conn: Any,
+    snapshot: dict[str, tuple[Any, ...]],
+    event_types: Iterable[str],
+) -> None:
+    with conn:
+        with conn.cursor() as cur:
+            for event_type in event_types:
+                row = snapshot.get(event_type)
+                if row is None:
+                    cur.execute(
+                        "DELETE FROM event_types WHERE type = %s", (event_type,)
+                    )
+                    continue
+                cur.execute(
+                    """
+                    UPDATE event_types
+                    SET category = %s,
+                        severity = %s::event_severity_kind,
+                        description = %s,
+                        deprecated = %s,
+                        synonym_for = %s
+                    WHERE type = %s
+                    """,
+                    (*row, event_type),
+                )
 
 
 def _snapshot_pair_tags(

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -556,6 +556,53 @@ def test_hunting_pair_tag_migration_retires_pursuit_vocabulary() -> None:
     assert "WHERE tag = 'under_active_pursuit'" in migration_source
 
 
+def test_entity_tag_expiry_substrate_migration_adds_expiry_column() -> None:
+    """Migration 049 adds the scheduled-expiry column and sweeper index."""
+
+    migration_source = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "049_orrery_entity_tag_expiry_substrate.py"
+    ).read_text()
+
+    assert "ADD COLUMN IF NOT EXISTS expires_at_world_time timestamptz" in (
+        migration_source
+    )
+    assert "ix_entity_tags_expiring" in migration_source
+    assert "WHERE cleared_at IS NULL" in migration_source
+    assert "expires_at_world_time IS NOT NULL" in migration_source
+
+
+def test_state_clearance_event_type_migration_registers_new_events() -> None:
+    """Migration 050 registers event types named by state clear_on contracts."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "050_orrery_state_clearance_event_types.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    migration_source = migration_path.read_text()
+
+    assert {
+        "recovered_from_illness",
+        "cured",
+        "escaped",
+        "revealed",
+        "discovered",
+        "unmasked",
+        "exposed",
+        "threat_removed",
+        "confrontation_resolved",
+        "circumstance_reversed",
+    } == {
+        event_type
+        for event_type, _category, _severity, _description in migration.EVENT_TYPES
+    }
+    assert "ON CONFLICT (type) DO UPDATE SET" in migration_source
+    assert "synonym_for = NULL" in migration_source
+
+
 @pytest.mark.requires_postgres
 def test_kind_qualified_contact_migration_executes_against_slot_db() -> None:
     """Migration 047 seeds kinded contacts and deprecates legacy rows."""

--- a/tests/test_orrery/test_tag_writer.py
+++ b/tests/test_orrery/test_tag_writer.py
@@ -10,7 +10,7 @@ in Phase 2/3 of the Skald-tag-bestowal plan.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
 import pytest
@@ -64,7 +64,7 @@ class FakeCursor:
     ):
         self.tags = dict(
             tags or {}
-        )  # name → {id, category, is_ephemeral, deprecated, synonym_for}
+        )  # name -> {id, category, is_ephemeral, reapplication_policy, ...}
         self.entity_tags = list(entity_tags or [])
         self.category_registry = category_registry or _default_category_registry()
         self.world_time = world_time
@@ -127,6 +127,7 @@ class FakeCursor:
                 "id": tag_id,
                 "category": category,
                 "is_ephemeral": is_ephemeral,
+                "reapplication_policy": None,
                 "clearance_kind": clearance_kind,
                 "deprecated": False,
                 "synonym_for": None,
@@ -158,25 +159,51 @@ class FakeCursor:
                     "id": row["id"],
                     "category": row["category"],
                     "is_ephemeral": row["is_ephemeral"],
+                    "reapplication_policy": row.get("reapplication_policy"),
                 },
-                ["id", "category", "is_ephemeral"],
+                ["id", "category", "is_ephemeral", "reapplication_policy"],
             )
             self.rowcount = 1
             return
         if sql_upper.startswith("INSERT INTO ENTITY_TAGS"):
-            entity_id, tag_id, world_time, source_kind = params
+            if len(params) == 4:
+                entity_id, tag_id, world_time, source_kind = params
+                expires_at_world_time = None
+                duration_override = None
+            else:
+                entity_id, tag_id, world_time, expires_at_world_time, source_kind = (
+                    params[:5]
+                )
+                duration_override = params[5] if len(params) > 5 else None
             for row in self.entity_tags:
                 if (
                     row["entity_id"] == entity_id
                     and row["tag_id"] == tag_id
                     and row["cleared_at"] is None
                 ):
+                    if "GREATEST" in sql_upper:
+                        base = max(
+                            row.get("expires_at_world_time") or world_time,
+                            world_time,
+                        )
+                        row["applied_at_world_time"] = world_time
+                        row["expires_at_world_time"] = base + duration_override
+                        row["source_kind"] = source_kind
+                        self.rowcount = 1
+                        return
+                    if "DO UPDATE SET" in sql_upper:
+                        row["applied_at_world_time"] = world_time
+                        row["expires_at_world_time"] = expires_at_world_time
+                        row["source_kind"] = source_kind
+                        self.rowcount = 1
+                        return
                     self.rowcount = 0
                     return
             new_row = {
                 "entity_id": entity_id,
                 "tag_id": tag_id,
                 "applied_at_world_time": world_time,
+                "expires_at_world_time": expires_at_world_time,
                 "source_kind": source_kind,
                 "cleared_at": None,
             }
@@ -254,11 +281,16 @@ def _registered(*entries):
     """Quick helper to build the vocabulary dict for the fake cursor."""
     table = {}
     for entry in entries:
-        name, category, ephemeral = entry
+        if len(entry) == 3:
+            name, category, ephemeral = entry
+            reapplication_policy = None
+        else:
+            name, category, ephemeral, reapplication_policy = entry
         table[name] = {
             "id": hash(name) & 0xFFFFFF,
             "category": category,
             "is_ephemeral": ephemeral,
+            "reapplication_policy": reapplication_policy,
             "clearance_kind": "semantic" if ephemeral else None,
             "deprecated": False,
             "synonym_for": None,
@@ -326,6 +358,130 @@ def test_idempotent_when_open_row_exists():
     )
     assert counters["applied"] == 0
     assert len(cur.inserted_entity_tag_rows) == 0
+
+
+def test_duration_override_sets_expiry_on_insert():
+    cur = FakeCursor(tags=_registered(("intoxicated:stimulant", "state", True)))
+
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=42,
+        entity_kind="character",
+        bestowal=OrreryTagBestowal(applied_tags=["intoxicated:stimulant"]),
+        duration_override=timedelta(hours=2),
+        world_time=_WORLD_TIME,
+    )
+
+    assert counters["applied"] == 1
+    assert cur.inserted_entity_tag_rows[0]["expires_at_world_time"] == (
+        _WORLD_TIME + timedelta(hours=2)
+    )
+
+
+def test_new_row_policy_preserves_existing_open_row_on_reapply():
+    tag_id = hash("intoxicated:stimulant") & 0xFFFFFF
+    original_expiry = _WORLD_TIME + timedelta(minutes=30)
+    cur = FakeCursor(
+        tags=_registered(
+            ("intoxicated:stimulant", "state", True, "new_row"),
+        ),
+        entity_tags=[
+            {
+                "entity_id": 42,
+                "tag_id": tag_id,
+                "applied_at_world_time": _WORLD_TIME,
+                "expires_at_world_time": original_expiry,
+                "source_kind": "skald_inline",
+                "cleared_at": None,
+            }
+        ],
+    )
+
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=42,
+        entity_kind="character",
+        bestowal=OrreryTagBestowal(applied_tags=["intoxicated:stimulant"]),
+        duration_override=timedelta(hours=2),
+        world_time=_WORLD_TIME + timedelta(minutes=10),
+    )
+
+    assert counters["applied"] == 0
+    assert cur.entity_tags[0]["expires_at_world_time"] == original_expiry
+
+
+def test_extend_expiry_policy_extends_from_later_of_expiry_or_world_time():
+    tag_id = hash("intoxicated:stimulant") & 0xFFFFFF
+    original_expiry = _WORLD_TIME + timedelta(minutes=30)
+    cur = FakeCursor(
+        tags=_registered(
+            ("intoxicated:stimulant", "state", True, "extend_expiry"),
+        ),
+        entity_tags=[
+            {
+                "entity_id": 42,
+                "tag_id": tag_id,
+                "applied_at_world_time": _WORLD_TIME,
+                "expires_at_world_time": original_expiry,
+                "source_kind": "skald_inline",
+                "cleared_at": None,
+            }
+        ],
+    )
+
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=42,
+        entity_kind="character",
+        bestowal=OrreryTagBestowal(applied_tags=["intoxicated:stimulant"]),
+        duration_override=timedelta(hours=1),
+        world_time=_WORLD_TIME + timedelta(minutes=10),
+        source_kind="system",
+    )
+
+    assert counters["applied"] == 1
+    assert cur.entity_tags[0]["expires_at_world_time"] == (
+        original_expiry + timedelta(hours=1)
+    )
+    assert cur.entity_tags[0]["applied_at_world_time"] == (
+        _WORLD_TIME + timedelta(minutes=10)
+    )
+    assert cur.entity_tags[0]["source_kind"] == "system"
+
+
+def test_replace_policy_restamps_existing_open_row():
+    tag_id = hash("disguised") & 0xFFFFFF
+    cur = FakeCursor(
+        tags=_registered(("disguised", "state", True, "replace")),
+        entity_tags=[
+            {
+                "entity_id": 42,
+                "tag_id": tag_id,
+                "applied_at_world_time": _WORLD_TIME,
+                "expires_at_world_time": _WORLD_TIME + timedelta(hours=1),
+                "source_kind": "skald_inline",
+                "cleared_at": None,
+            }
+        ],
+    )
+    new_world_time = _WORLD_TIME + timedelta(days=1)
+
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=42,
+        entity_kind="character",
+        bestowal=OrreryTagBestowal(applied_tags=["disguised"]),
+        duration_override=timedelta(hours=3),
+        world_time=new_world_time,
+        source_kind="system",
+    )
+
+    assert counters["applied"] == 1
+    assert cur.entity_tags[0]["applied_at_world_time"] == new_world_time
+    assert cur.entity_tags[0]["expires_at_world_time"] == (
+        new_world_time + timedelta(hours=3)
+    )
+    assert cur.entity_tags[0]["source_kind"] == "system"
 
 
 def test_closed_bestowal_schema_rejects_runtime_vocabulary_growth_field():

--- a/tests/test_orrery/test_tag_writer.py
+++ b/tests/test_orrery/test_tag_writer.py
@@ -449,6 +449,25 @@ def test_extend_expiry_policy_extends_from_later_of_expiry_or_world_time():
     assert cur.entity_tags[0]["source_kind"] == "system"
 
 
+def test_extend_expiry_policy_requires_duration_override():
+    cur = FakeCursor(
+        tags=_registered(
+            ("intoxicated:stimulant", "state", True, "extend_expiry"),
+        )
+    )
+
+    with pytest.raises(ValueError, match="extend_expiry.*duration_override"):
+        apply_tag_bestowal(
+            cur,
+            entity_id=42,
+            entity_kind="character",
+            bestowal=OrreryTagBestowal(applied_tags=["intoxicated:stimulant"]),
+            world_time=_WORLD_TIME,
+        )
+
+    assert cur.entity_tags == []
+
+
 def test_replace_policy_restamps_existing_open_row():
     tag_id = hash("disguised") & 0xFFFFFF
     cur = FakeCursor(

--- a/tests/test_trait_compiler.py
+++ b/tests/test_trait_compiler.py
@@ -131,7 +131,7 @@ class TraitCompilerCursor:
             (tag,) = params
             row = self.tags.get(tag)
             self._next_row = (
-                (row["id"], row["category"], False) if row is not None else None
+                (row["id"], row["category"], False, None) if row is not None else None
             )
             self.rowcount = 1 if row else 0
             return
@@ -185,7 +185,12 @@ class TraitCompilerCursor:
             return
 
         if normalized.startswith("INSERT INTO ENTITY_TAGS"):
-            entity_id, tag_id, _world_time, source_kind = params
+            if len(params) == 4:
+                entity_id, tag_id, _world_time, source_kind = params
+            else:
+                entity_id, tag_id, _world_time, _expires_at_world_time, source_kind = (
+                    params[:5]
+                )
             active = [
                 row
                 for row in self.entity_tags


### PR DESCRIPTION
## Summary
- add entity_tags.expires_at_world_time plus an expiring-row partial index for the future sweeper
- dispatch single-entity tag reapplications through tags.reapplication_policy (new_row, extend_expiry, replace) with duration override support
- register the state-clearance event types drafted in docs/orrery_state_vocabulary.md
- refresh Orrery docs/catalog and update fake cursors for the expanded tag lookup shape

Closes #329.
Closes #330.

## Verification
- poetry run pytest tests/test_orrery/test_tag_writer.py tests/test_orrery/test_migrate.py -q
- poetry run flake8 migrations/049_orrery_entity_tag_expiry_substrate.py migrations/050_orrery_state_clearance_event_types.py nexus/agents/orrery/tag_writer.py tests/test_orrery/test_tag_writer.py tests/test_orrery/test_migrate.py tests/test_trait_compiler.py
- poetry run pytest tests/test_orrery -q
- poetry run pytest -q