### PR TITLE
Add Orrery entity tag expiry sweeper

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1771,6 +1771,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/048_orrery_hunting_pair_tag.py`
 - `migrations/049_orrery_entity_tag_expiry_substrate.py`
 - `migrations/050_orrery_state_clearance_event_types.py`
+- `migrations/051_orrery_time_tag_clearance_kind.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 

--- a/docs/orrery_state_vocabulary.md
+++ b/docs/orrery_state_vocabulary.md
@@ -134,11 +134,11 @@ The table marks each row's registry status against the live `event_types` table.
 | `confrontation_resolved` | **existing** | `enraged` (alternate path — confronted-and-de-escalated without retaliation) |
 | `circumstance_reversed` | **existing** | `despairing` |
 | `mourning_completed` | **existing** | `grieving` (authored fallback — the sweeper handles the primary time-decay path) |
-| *(none — time-cleared via sweeper)* | sweeper #328 | `grieving` (primary), all `intoxicated:*` |
+| *(none — time-cleared via sweeper)* | **existing** | `grieving` (primary), all `intoxicated:*` |
 
 Several alignments with existing vocab dropped synonymous proposals: `tended`/`healed` collapse to the existing `tended_wound` + `wound_healed` pair; `released` collapses to `captivity_ended`; `vengeance_taken` collapses to `retaliation_executed`. The remaining new-registrations are anchors that don't currently have an event-type partner in the live registry.
 
-**Substrate gap on `clearance_kind`.** The per-cluster tables above use `time` and `time + authored` in the Clearance kind column. The live `entity_tag_clearance_kind` enum only has `{event, semantic, authored}` (migration 023) — no `time` value. Adding `time` is implicitly bundled with the sweeper work in #328; without it, migrations for time-cleared tags will fail with a cast error. The enum extension should land before any tag template references `'time'::entity_tag_clearance_kind`.
+**Substrate note on `clearance_kind`.** Migration 051 adds `time` to the live `entity_tag_clearance_kind` enum so `tag_clearance_log` can distinguish elapsed-time sweeps from event, semantic, and authored clearances. Time-cleared tag templates can now use `'time'::entity_tag_clearance_kind` once their vocabulary rows ship.
 
 ---
 
@@ -150,7 +150,7 @@ Several alignments with existing vocab dropped synonymous proposals: `tended`/`h
 4. **`contacts_available` overload — resolved.** PR #327 (migration 047) shipped the kind-qualified `contact:<lodging|social|intimate>` pair-tag family, replacing the overloaded `contacts_available` ephemeral and closing #317. Not a `state` issue — noted only for cross-reference; the substrate fix applies cleanly to needs templates per `orrery_needs.md` R3.
 5. **`entity_tags` substrate enrichment for additive-timer pharmacologics — resolved.** Migration 049 adds `entity_tags.expires_at_world_time` and the expiring-row index, and `_insert_entity_tag` now dispatches `new_row` / `extend_expiry` / `replace` from each tag's existing `reapplication_policy` field.
    
-   The remaining sibling is **#328** (sweeper). The pharmacologic cluster still needs the sweeper before `intoxicated:*` becomes a fully working time-cleared state family.
+   The sweeper is resolved by #328: accepted ticks now clear open rows whose `expires_at_world_time` has passed and record `tag_clearance_log` rows with mechanism `time`.
 
 ---
 

--- a/migrations/051_orrery_time_tag_clearance_kind.py
+++ b/migrations/051_orrery_time_tag_clearance_kind.py
@@ -1,0 +1,17 @@
+"""Add time-based tag clearance mechanism for expiry sweeps."""
+
+from __future__ import annotations
+
+from psycopg2 import sql
+
+
+def run(conn) -> None:
+    """Allow ``tag_clearance_log.mechanism`` to record elapsed-time sweeps."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL(
+                "ALTER TYPE entity_tag_clearance_kind ADD VALUE IF NOT EXISTS {}"
+            ).format(sql.Literal("time"))
+        )
+    conn.commit()

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -247,7 +247,6 @@ def commit_orrery_tick_sync(
         _validate_adjudications(coerced, adjudication_map)
     else:
         adjudication_map = {}
-        need_tuning = coerce_need_tuning(sunhelm_settings)
 
     with conn.cursor() as cur:
         expired_tag_count = _sweep_expired_entity_tags_sync(
@@ -410,7 +409,6 @@ async def commit_orrery_tick_async(
         _validate_adjudications(coerced, adjudication_map)
     else:
         adjudication_map = {}
-        need_tuning = coerce_need_tuning(sunhelm_settings)
 
     expired_tag_count = await _sweep_expired_entity_tags_async(
         conn,

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -239,14 +239,25 @@ def commit_orrery_tick_sync(
     """Materialize a preview proposal inside the accepted-chunk transaction."""
 
     coerced = coerce_proposal(proposal)
-    if coerced is None or not coerced.resolutions:
-        return CommitOrreryTickResult()
+    has_resolutions = coerced is not None and bool(coerced.resolutions)
+    if has_resolutions:
+        adjudication_map = coerce_adjudications(adjudications)
+        need_tuning = coerce_need_tuning(sunhelm_settings)
+        _validate_proposal(coerced)
+        _validate_adjudications(coerced, adjudication_map)
+    else:
+        adjudication_map = {}
+        need_tuning = coerce_need_tuning(sunhelm_settings)
 
-    adjudication_map = coerce_adjudications(adjudications)
-    need_tuning = coerce_need_tuning(sunhelm_settings)
-    _validate_proposal(coerced)
-    _validate_adjudications(coerced, adjudication_map)
     with conn.cursor() as cur:
+        expired_tag_count = _sweep_expired_entity_tags_sync(
+            cur,
+            source_chunk_id=tick_chunk_id,
+        )
+        if not has_resolutions:
+            return CommitOrreryTickResult(cleared_tag_count=expired_tag_count)
+
+        assert coerced is not None
         entity_ids = _entity_ids_from_proposal(coerced)
         _validate_entity_ids_sync(cur, entity_ids)
         entity_names = _entity_names_sync(cur, entity_ids)
@@ -255,7 +266,7 @@ def commit_orrery_tick_sync(
         resolution_count = 0
         event_count = 0
         tag_mutation_count = 0
-        cleared_tag_count = 0
+        cleared_tag_count = expired_tag_count
         skipped_existing_count = 0
         adjudication_count = 0
         deferred_count = 0
@@ -391,13 +402,24 @@ async def commit_orrery_tick_async(
     """Async parity wrapper for tests and non-production commit callers."""
 
     coerced = coerce_proposal(proposal)
-    if coerced is None or not coerced.resolutions:
-        return CommitOrreryTickResult()
+    has_resolutions = coerced is not None and bool(coerced.resolutions)
+    if has_resolutions:
+        adjudication_map = coerce_adjudications(adjudications)
+        need_tuning = coerce_need_tuning(sunhelm_settings)
+        _validate_proposal(coerced)
+        _validate_adjudications(coerced, adjudication_map)
+    else:
+        adjudication_map = {}
+        need_tuning = coerce_need_tuning(sunhelm_settings)
 
-    adjudication_map = coerce_adjudications(adjudications)
-    need_tuning = coerce_need_tuning(sunhelm_settings)
-    _validate_proposal(coerced)
-    _validate_adjudications(coerced, adjudication_map)
+    expired_tag_count = await _sweep_expired_entity_tags_async(
+        conn,
+        source_chunk_id=tick_chunk_id,
+    )
+    if not has_resolutions:
+        return CommitOrreryTickResult(cleared_tag_count=expired_tag_count)
+
+    assert coerced is not None
     entity_ids = _entity_ids_from_proposal(coerced)
     await _validate_entity_ids_async(conn, entity_ids)
     entity_names = await _entity_names_async(conn, entity_ids)
@@ -408,7 +430,7 @@ async def commit_orrery_tick_async(
     resolution_count = 0
     event_count = 0
     tag_mutation_count = 0
-    cleared_tag_count = 0
+    cleared_tag_count = expired_tag_count
     skipped_existing_count = 0
     adjudication_count = 0
     deferred_count = 0
@@ -3136,6 +3158,55 @@ def _clear_event_tags_sync(
     return len(tag_ids)
 
 
+def _sweep_expired_entity_tags_sync(
+    cur: Any,
+    *,
+    source_chunk_id: int,
+) -> int:
+    world_time = _tick_world_time_sync(cur, source_chunk_id)
+    cur.execute(
+        """
+        SELECT et.id, et.expires_at_world_time
+        FROM entity_tags et
+        WHERE et.cleared_at IS NULL
+          AND et.expires_at_world_time IS NOT NULL
+          AND et.expires_at_world_time <= %s
+        """,
+        (world_time,),
+    )
+    rows = cur.fetchall()
+    for row in rows:
+        entity_tag_id = _row_get(row, "id", 0)
+        expires_at_world_time = _row_get(row, "expires_at_world_time", 1)
+        cur.execute(
+            "UPDATE entity_tags SET cleared_at = now() WHERE id = %s",
+            (entity_tag_id,),
+        )
+        cur.execute(
+            """
+            INSERT INTO tag_clearance_log (
+                entity_tag_id, cleared_at_world_time, mechanism,
+                triggering_event_id, justification, source_chunk_id
+            ) VALUES (%s, %s, 'time', NULL, %s::jsonb, %s)
+            """,
+            (
+                entity_tag_id,
+                world_time,
+                json.dumps(
+                    {
+                        "expires_at_world_time": (
+                            str(expires_at_world_time)
+                            if expires_at_world_time is not None
+                            else None
+                        )
+                    }
+                ),
+                source_chunk_id,
+            ),
+        )
+    return len(rows)
+
+
 async def _clear_event_tags_async(
     conn: Any,
     *,
@@ -3177,6 +3248,52 @@ async def _clear_event_tags_async(
             source_chunk_id,
         )
     return len(tag_ids)
+
+
+async def _sweep_expired_entity_tags_async(
+    conn: Any,
+    *,
+    source_chunk_id: int,
+) -> int:
+    world_time = await _tick_world_time_async(conn, source_chunk_id)
+    rows = await conn.fetch(
+        """
+        SELECT et.id, et.expires_at_world_time
+        FROM entity_tags et
+        WHERE et.cleared_at IS NULL
+          AND et.expires_at_world_time IS NOT NULL
+          AND et.expires_at_world_time <= $1
+        """,
+        world_time,
+    )
+    for row in rows:
+        entity_tag_id = _row_get(row, "id", 0)
+        expires_at_world_time = _row_get(row, "expires_at_world_time", 1)
+        await conn.execute(
+            "UPDATE entity_tags SET cleared_at = now() WHERE id = $1",
+            entity_tag_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO tag_clearance_log (
+                entity_tag_id, cleared_at_world_time, mechanism,
+                triggering_event_id, justification, source_chunk_id
+            ) VALUES ($1, $2, 'time', NULL, $3::jsonb, $4)
+            """,
+            entity_tag_id,
+            world_time,
+            json.dumps(
+                {
+                    "expires_at_world_time": (
+                        str(expires_at_world_time)
+                        if expires_at_world_time is not None
+                        else None
+                    )
+                }
+            ),
+            source_chunk_id,
+        )
+    return len(rows)
 
 
 def _scalar_entity_binding(bindings: Mapping[str, Any], slot: str) -> Optional[int]:

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -456,6 +456,7 @@ async def commit_incubator_to_database(
                 orrery_result.resolution_count
                 or orrery_result.skipped_existing_count
                 or orrery_result.adjudication_count
+                or orrery_result.cleared_tag_count
             ):
                 logger.info(
                     "Committed Orrery tick for chunk %s: %s resolutions, %s events, "

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -549,6 +549,7 @@ def commit_incubator_to_database_sync(
                 orrery_result.resolution_count
                 or orrery_result.skipped_existing_count
                 or orrery_result.adjudication_count
+                or orrery_result.cleared_tag_count
             ):
                 logger.info(
                     "Committed Orrery tick for chunk %s: %s resolutions, %s events, "

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -43,6 +43,7 @@ class RecordingCursor:
         travel_state_update_rowcount=1,
         character_entity_ids=None,
         inbound_pair_tag_clear_count=0,
+        expired_entity_tags=None,
     ):
         self.duplicate_resolution = duplicate_resolution
         self.known_tags = {"off_grid": 77} if known_tags is None else known_tags
@@ -63,6 +64,7 @@ class RecordingCursor:
             {11: 1} if character_entity_ids is None else character_entity_ids
         )
         self.inbound_pair_tag_clear_count = inbound_pair_tag_clear_count
+        self.expired_entity_tags = list(expired_entity_tags or [])
         self.executed = []
         self.rowcount = 1
         self._fetchone = None
@@ -288,6 +290,15 @@ class RecordingCursor:
             self._fetchone = {"id": 20}
         elif "SELECT et.id FROM entity_tags et JOIN tags t" in normalized:
             self._fetchall = [{"id": tag_id} for tag_id in self.clear_tag_ids]
+        elif "SELECT et.id, et.expires_at_world_time FROM entity_tags et" in (
+            normalized
+        ):
+            (world_time,) = params
+            self._fetchall = [
+                row
+                for row in self.expired_entity_tags
+                if row["expires_at_world_time"] <= world_time
+            ]
         elif "SELECT et.id FROM entity_tags et WHERE" in normalized:
             entity_id, tag_id = params
             tags_by_id = {value: key for key, value in self.known_tags.items()}
@@ -499,7 +510,7 @@ def test_response_to_incubator_serializes_orrery_adjudications() -> None:
 
 
 def test_commit_orrery_tick_ignores_scene_pressures() -> None:
-    """Prompt-only pressures do not materialize canonical Orrery writes."""
+    """Prompt-only pressures do not materialize resolution/event writes."""
 
     proposal = OrreryTickProposal(
         anchor_chunk_id=99,
@@ -521,7 +532,48 @@ def test_commit_orrery_tick_ignores_scene_pressures() -> None:
     assert result.resolution_count == 0
     assert result.event_count == 0
     assert result.tag_mutation_count == 0
-    assert cursor.executed == []
+    statements = "\n".join(sql for sql, _params in cursor.executed)
+    assert "INSERT INTO orrery_resolutions" not in statements
+    assert "INSERT INTO world_events" not in statements
+
+
+def test_commit_orrery_tick_sweeps_expired_entity_tags_without_resolution() -> None:
+    """Accepted ticks clear elapsed-time tags even when no package commits."""
+
+    expired_at = datetime(2073, 10, 31, 17, tzinfo=timezone.utc)
+    future_at = datetime(2073, 10, 31, 19, tzinfo=timezone.utc)
+    cursor = RecordingCursor(
+        expired_entity_tags=[
+            {"id": 501, "expires_at_world_time": expired_at},
+            {"id": 502, "expires_at_world_time": future_at},
+        ]
+    )
+
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        None,
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    clearance_logs = [
+        params
+        for sql, params in cursor.executed
+        if "INSERT INTO tag_clearance_log" in sql
+    ]
+
+    assert result.resolution_count == 0
+    assert result.event_count == 0
+    assert result.cleared_tag_count == 1
+    assert clearance_logs == [
+        (
+            501,
+            cursor.world_time,
+            json.dumps({"expires_at_world_time": str(expired_at)}),
+            100,
+        )
+    ]
 
 
 def test_commit_orrery_tick_materializes_resolution_event_and_tags() -> None:

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -562,10 +562,16 @@ def test_commit_orrery_tick_sweeps_expired_entity_tags_without_resolution() -> N
         for sql, params in cursor.executed
         if "INSERT INTO tag_clearance_log" in sql
     ]
+    update_stmts = [
+        params
+        for sql, params in cursor.executed
+        if "UPDATE entity_tags SET cleared_at" in sql
+    ]
 
     assert result.resolution_count == 0
     assert result.event_count == 0
     assert result.cleared_tag_count == 1
+    assert update_stmts == [(501,)]
     assert clearance_logs == [
         (
             501,

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -603,6 +603,21 @@ def test_state_clearance_event_type_migration_registers_new_events() -> None:
     assert "synonym_for = NULL" in migration_source
 
 
+def test_time_clearance_kind_migration_extends_tag_clearance_enum() -> None:
+    """Migration 051 adds the time mechanism used by expiry sweeps."""
+
+    migration_source = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "051_orrery_time_tag_clearance_kind.py"
+    ).read_text()
+
+    assert "ALTER TYPE entity_tag_clearance_kind ADD VALUE IF NOT EXISTS" in (
+        migration_source
+    )
+    assert 'sql.Literal("time")' in migration_source
+
+
 @pytest.mark.requires_postgres
 def test_entity_tag_expiry_substrate_migration_executes_against_slot_db() -> None:
     """Migration 049 DDL is idempotent against a real slot schema."""


### PR DESCRIPTION
## Summary
- add `time` as an `entity_tag_clearance_kind` so elapsed-time clearances can be audited distinctly
- sweep expired `entity_tags.expires_at_world_time` rows on every accepted Orrery commit tick, including no-resolution ticks
- log time clearances to `tag_clearance_log` with NULL `triggering_event_id` and the accepted tick's world time
- refresh Orrery docs/catalog to mark the sweeper substrate as present

Closes #328.

## Verification
- `poetry run pytest tests/test_orrery/test_events.py tests/test_orrery/test_migrate.py -q`
- `poetry run flake8 nexus/agents/orrery/events.py tests/test_orrery/test_events.py tests/test_orrery/test_migrate.py migrations/051_orrery_time_tag_clearance_kind.py`
- `poetry run pytest tests/test_orrery -q`
- `poetry run pytest -q`

Note: whole-file flake8 on `nexus/api/commit_handler*.py` still reports pre-existing legacy line-length/unused-import issues unrelated to this diff; the touched logging condition is covered by full pytest.