### PR TITLE
[codex] Batch MEMNON cross-encoder scoring

### DIFF
--- a/nexus/agents/memnon/utils/cross_encoder.py
+++ b/nexus/agents/memnon/utils/cross_encoder.py
@@ -181,8 +181,10 @@ class CrossEncoderReranker:
 
             return [self._normalize_score(score) for score in score_values]
         except Exception as e:
-            logger.error(f"Error scoring batch: {e}")
-            return [0.0 for _ in passages]
+            logger.error(
+                f"Error scoring batch: {e}; falling back to per-passage scoring"
+            )
+            return [self.score_pair(query, passage) for passage in passages]
 
     def score_pair_with_sliding_window(self, query: str, passage: str) -> float:
         """

--- a/nexus/agents/memnon/utils/cross_encoder.py
+++ b/nexus/agents/memnon/utils/cross_encoder.py
@@ -130,7 +130,7 @@ class CrossEncoderReranker:
             if flattened.size == 0:
                 return 0.0
             score = flattened[0]
-        elif isinstance(raw_score, (list, tuple)):
+        elif isinstance(raw_score, list):
             if not raw_score:
                 return 0.0
             score = raw_score[0]
@@ -162,29 +162,29 @@ class CrossEncoderReranker:
         if not passages:
             return []
 
+        pairs = [(query, passage) for passage in passages]
         try:
-            pairs = [(query, passage) for passage in passages]
             raw_scores = self.model.predict(pairs, batch_size=batch_size)
-
-            if isinstance(raw_scores, np.ndarray):
-                score_values = raw_scores.reshape(-1).tolist()
-            elif isinstance(raw_scores, list):
-                score_values = raw_scores
-            else:
-                score_values = [raw_scores]
-
-            if len(score_values) != len(passages):
-                raise ValueError(
-                    "CrossEncoder returned "
-                    f"{len(score_values)} scores for {len(passages)} passages"
-                )
-
-            return [self._normalize_score(score) for score in score_values]
         except Exception as e:
             logger.error(
                 f"Error scoring batch: {e}; falling back to per-passage scoring"
             )
             return [self.score_pair(query, passage) for passage in passages]
+
+        if isinstance(raw_scores, np.ndarray):
+            score_values = raw_scores.reshape(-1).tolist()
+        elif isinstance(raw_scores, list):
+            score_values = raw_scores
+        else:
+            score_values = [raw_scores]
+
+        if len(score_values) != len(passages):
+            raise ValueError(
+                "CrossEncoder returned "
+                f"{len(score_values)} scores for {len(passages)} passages"
+            )
+
+        return [self._normalize_score(score) for score in score_values]
 
     def score_pair_with_sliding_window(self, query: str, passage: str) -> float:
         """

--- a/nexus/agents/memnon/utils/cross_encoder.py
+++ b/nexus/agents/memnon/utils/cross_encoder.py
@@ -118,23 +118,71 @@ class CrossEncoderReranker:
         try:
             # Use sentence-transformers CrossEncoder predict method
             scores = self.model.predict([(query, passage)])
-            
-            # CrossEncoder might return a single score as a numpy array or list
-            if isinstance(scores, np.ndarray):
-                score = scores[0]
-            elif isinstance(scores, list):
-                score = scores[0]
-            else:
-                score = scores
-                
-            # Normalize to 0-1 range with sigmoid if needed
-            if score < 0 or score > 1:
-                score = 1 / (1 + np.exp(-score))  # Sigmoid
-                
-            return float(score)
+            return self._normalize_score(scores)
         except Exception as e:
             logger.error(f"Error scoring pair: {e}")
             return 0.0
+
+    def _normalize_score(self, raw_score: Any) -> float:
+        """Normalize a CrossEncoder score to the 0-1 relevance range."""
+        if isinstance(raw_score, np.ndarray):
+            flattened = raw_score.reshape(-1)
+            if flattened.size == 0:
+                return 0.0
+            score = flattened[0]
+        elif isinstance(raw_score, (list, tuple)):
+            if not raw_score:
+                return 0.0
+            score = raw_score[0]
+        else:
+            score = raw_score
+
+        score = float(score)
+        if score < 0 or score > 1:
+            score = 1 / (1 + np.exp(-score))  # Sigmoid
+        return float(score)
+
+    def score_batch(
+        self,
+        query: str,
+        passages: List[str],
+        batch_size: int = 8,
+    ) -> List[float]:
+        """
+        Score query-passage pairs with true CrossEncoder batched inference.
+
+        Args:
+            query: The search query
+            passages: Passages to score
+            batch_size: Batch size for model inference
+
+        Returns:
+            Relevance scores between 0 and 1, one per passage
+        """
+        if not passages:
+            return []
+
+        try:
+            pairs = [(query, passage) for passage in passages]
+            raw_scores = self.model.predict(pairs, batch_size=batch_size)
+
+            if isinstance(raw_scores, np.ndarray):
+                score_values = raw_scores.reshape(-1).tolist()
+            elif isinstance(raw_scores, list):
+                score_values = raw_scores
+            else:
+                score_values = [raw_scores]
+
+            if len(score_values) != len(passages):
+                raise ValueError(
+                    "CrossEncoder returned "
+                    f"{len(score_values)} scores for {len(passages)} passages"
+                )
+
+            return [self._normalize_score(score) for score in score_values]
+        except Exception as e:
+            logger.error(f"Error scoring batch: {e}")
+            return [0.0 for _ in passages]
 
     def score_pair_with_sliding_window(self, query: str, passage: str) -> float:
         """
@@ -235,19 +283,41 @@ class CrossEncoderReranker:
         Returns:
             List of relevance scores for each passage
         """
+        if not passages:
+            return []
+
         scores = []
 
         # Process in batches
         for i in range(0, len(passages), batch_size):
             batch_passages = passages[i:i+batch_size]
-            batch_scores = []
 
-            for passage in batch_passages:
-                if use_sliding_window:
-                    score = self.score_pair_with_sliding_window(query, passage)
+            if not use_sliding_window:
+                scores.extend(
+                    self.score_batch(query, batch_passages, batch_size=batch_size)
+                )
+                continue
+
+            batch_scores = [0.0 for _ in batch_passages]
+            short_passage_indexes = []
+            short_passages = []
+
+            for batch_index, passage in enumerate(batch_passages):
+                if len(passage) < self.max_length * 4:
+                    short_passage_indexes.append(batch_index)
+                    short_passages.append(passage)
                 else:
-                    score = self.score_pair(query, passage)
-                batch_scores.append(score)
+                    batch_scores[batch_index] = self.score_pair_with_sliding_window(
+                        query, passage
+                    )
+
+            short_scores = self.score_batch(
+                query,
+                short_passages,
+                batch_size=batch_size,
+            )
+            for batch_index, score in zip(short_passage_indexes, short_scores):
+                batch_scores[batch_index] = score
 
             scores.extend(batch_scores)
 

--- a/tests/test_memnon_cross_encoder.py
+++ b/tests/test_memnon_cross_encoder.py
@@ -35,6 +35,15 @@ class BatchFailingCrossEncoderModel(FakeCrossEncoderModel):
         return np.array([len(passage) / 10])
 
 
+class WrongScoreCountCrossEncoderModel(FakeCrossEncoderModel):
+    """Fake that violates the CrossEncoder score-count contract."""
+
+    def predict(self, pairs, batch_size=None):
+        pairs = list(pairs)
+        self.calls.append({"pairs": pairs, "batch_size": batch_size})
+        return np.array([0.1])
+
+
 def make_reranker(model, max_length=512):
     """Build a reranker around a fake model without running __init__."""
     reranker = CrossEncoderReranker.__new__(CrossEncoderReranker)
@@ -68,6 +77,7 @@ def test_rerank_batch_batches_short_passages_in_sliding_window_mode():
         "query",
         ["a", "bb", "ccc"],
         batch_size=3,
+        use_sliding_window=True,
     )
 
     assert scores == pytest.approx([0.1, 0.2, 0.3])
@@ -103,6 +113,32 @@ def test_rerank_batch_preserves_order_when_long_passages_use_sliding_window():
     assert model.calls[0]["pairs"] == [("query", "aa"), ("query", "bbb")]
 
 
+def test_rerank_batch_handles_all_long_passages_in_sliding_window_mode():
+    model = FakeCrossEncoderModel()
+    reranker = make_reranker(model, max_length=2)
+    long_passage_calls = []
+
+    def fake_sliding_window_score(query, passage):
+        long_passage_calls.append((query, passage))
+        return len(long_passage_calls) / 10
+
+    reranker.score_pair_with_sliding_window = fake_sliding_window_score
+
+    scores = reranker.rerank_batch(
+        "query",
+        ["first long passage", "second long passage"],
+        batch_size=2,
+        use_sliding_window=True,
+    )
+
+    assert scores == pytest.approx([0.1, 0.2])
+    assert long_passage_calls == [
+        ("query", "first long passage"),
+        ("query", "second long passage"),
+    ]
+    assert model.calls == []
+
+
 def test_rerank_batch_normalizes_raw_logits_like_score_pair():
     model = FakeCrossEncoderModel(scores=[-2.0, 0.25])
     reranker = make_reranker(model)
@@ -136,3 +172,16 @@ def test_rerank_batch_falls_back_to_per_passage_on_batch_error():
         [("query", "bad")],
         [("query", "cccc")],
     ]
+
+
+def test_rerank_batch_raises_when_cross_encoder_returns_wrong_score_count():
+    model = WrongScoreCountCrossEncoderModel()
+    reranker = make_reranker(model)
+
+    with pytest.raises(ValueError, match="returned 1 scores for 2 passages"):
+        reranker.rerank_batch(
+            "query",
+            ["first", "second"],
+            batch_size=2,
+            use_sliding_window=False,
+        )

--- a/tests/test_memnon_cross_encoder.py
+++ b/tests/test_memnon_cross_encoder.py
@@ -1,0 +1,103 @@
+"""Unit tests for MEMNON cross-encoder reranking helpers."""
+
+import numpy as np
+import pytest
+
+from nexus.agents.memnon.utils.cross_encoder import CrossEncoderReranker
+
+
+class FakeCrossEncoderModel:
+    """Small fake that records predict calls without loading a real model."""
+
+    def __init__(self, scores=None):
+        self.calls = []
+        self.scores = scores
+
+    def predict(self, pairs, batch_size=None):
+        pairs = list(pairs)
+        self.calls.append({"pairs": pairs, "batch_size": batch_size})
+        if self.scores is not None:
+            return np.array(self.scores[: len(pairs)])
+        return np.array([len(passage) / 10 for _query, passage in pairs])
+
+
+def make_reranker(model, max_length=512):
+    """Build a reranker around a fake model without running __init__."""
+    reranker = CrossEncoderReranker.__new__(CrossEncoderReranker)
+    reranker.model = model
+    reranker.max_length = max_length
+    reranker.sliding_window_overlap = 128
+    return reranker
+
+
+def test_rerank_batch_uses_predict_batches_for_direct_scoring():
+    model = FakeCrossEncoderModel()
+    reranker = make_reranker(model)
+
+    scores = reranker.rerank_batch(
+        "query",
+        ["a", "bb", "ccc", "dddd"],
+        batch_size=2,
+        use_sliding_window=False,
+    )
+
+    assert scores == pytest.approx([0.1, 0.2, 0.3, 0.4])
+    assert [call["batch_size"] for call in model.calls] == [2, 2]
+    assert [len(call["pairs"]) for call in model.calls] == [2, 2]
+
+
+def test_rerank_batch_batches_short_passages_in_sliding_window_mode():
+    model = FakeCrossEncoderModel()
+    reranker = make_reranker(model)
+
+    scores = reranker.rerank_batch(
+        "query",
+        ["a", "bb", "ccc"],
+        batch_size=3,
+    )
+
+    assert scores == pytest.approx([0.1, 0.2, 0.3])
+    assert len(model.calls) == 1
+    assert model.calls[0]["batch_size"] == 3
+    assert model.calls[0]["pairs"] == [
+        ("query", "a"),
+        ("query", "bb"),
+        ("query", "ccc"),
+    ]
+
+
+def test_rerank_batch_preserves_order_when_long_passages_use_sliding_window():
+    model = FakeCrossEncoderModel()
+    reranker = make_reranker(model, max_length=2)
+    long_passage_calls = []
+
+    def fake_sliding_window_score(query, passage):
+        long_passage_calls.append((query, passage))
+        return 0.9
+
+    reranker.score_pair_with_sliding_window = fake_sliding_window_score
+
+    scores = reranker.rerank_batch(
+        "query",
+        ["aa", "this passage is long", "bbb"],
+        batch_size=3,
+    )
+
+    assert scores == pytest.approx([0.2, 0.9, 0.3])
+    assert long_passage_calls == [("query", "this passage is long")]
+    assert len(model.calls) == 1
+    assert model.calls[0]["pairs"] == [("query", "aa"), ("query", "bbb")]
+
+
+def test_rerank_batch_normalizes_raw_logits_like_score_pair():
+    model = FakeCrossEncoderModel(scores=[-2.0, 0.25])
+    reranker = make_reranker(model)
+
+    scores = reranker.rerank_batch(
+        "query",
+        ["first", "second"],
+        batch_size=2,
+        use_sliding_window=False,
+    )
+
+    assert scores == pytest.approx([1 / (1 + np.exp(2.0)), 0.25])

--- a/tests/test_memnon_cross_encoder.py
+++ b/tests/test_memnon_cross_encoder.py
@@ -21,6 +21,20 @@ class FakeCrossEncoderModel:
         return np.array([len(passage) / 10 for _query, passage in pairs])
 
 
+class BatchFailingCrossEncoderModel(FakeCrossEncoderModel):
+    """Fake that models a batch-level failure plus one bad passage."""
+
+    def predict(self, pairs, batch_size=None):
+        pairs = list(pairs)
+        self.calls.append({"pairs": pairs, "batch_size": batch_size})
+        if len(pairs) > 1:
+            raise RuntimeError("batch failed")
+        _query, passage = pairs[0]
+        if passage == "bad":
+            raise RuntimeError("single failed")
+        return np.array([len(passage) / 10])
+
+
 def make_reranker(model, max_length=512):
     """Build a reranker around a fake model without running __init__."""
     reranker = CrossEncoderReranker.__new__(CrossEncoderReranker)
@@ -101,3 +115,24 @@ def test_rerank_batch_normalizes_raw_logits_like_score_pair():
     )
 
     assert scores == pytest.approx([1 / (1 + np.exp(2.0)), 0.25])
+
+
+def test_rerank_batch_falls_back_to_per_passage_on_batch_error():
+    model = BatchFailingCrossEncoderModel()
+    reranker = make_reranker(model)
+
+    scores = reranker.rerank_batch(
+        "query",
+        ["aa", "bad", "cccc"],
+        batch_size=3,
+        use_sliding_window=False,
+    )
+
+    assert scores == pytest.approx([0.2, 0.0, 0.4])
+    assert [call["batch_size"] for call in model.calls] == [3, None, None, None]
+    assert [call["pairs"] for call in model.calls] == [
+        [("query", "aa"), ("query", "bad"), ("query", "cccc")],
+        [("query", "aa")],
+        [("query", "bad")],
+        [("query", "cccc")],
+    ]


### PR DESCRIPTION
## Summary

Closes #324.

- Added a true batch scoring helper for the standard MEMNON `CrossEncoderReranker` path so short/default passages call `CrossEncoder.predict(pairs, batch_size=batch_size)` once per configured batch.
- Routed direct reranking and short passages in sliding-window mode through the batched helper, while preserving the existing long-passage max-over-windows behavior.
- Added fake-model unit coverage proving `batch_size` reduces `predict()` calls and preserving score normalization/order behavior.

## Validation

- `poetry run pytest tests/test_memnon_cross_encoder.py -q`
- `poetry run pytest tests/test_memnon_cross_encoder.py tests/test_memnon_cross_encoder_dependencies.py -q`
- `poetry run pytest -q`
- `poetry run flake8 tests/test_memnon_cross_encoder.py`
- `poetry run black --check tests/test_memnon_cross_encoder.py`
- `poetry run flake8 nexus/agents/memnon/utils/cross_encoder.py` currently fails on pre-existing whole-file style debt (`F401`, `E302`, `W293`, `E501`, `F841`, `F541`); this PR avoids broad formatting churn.

## Data / config impact

No schema, migration, settings, or data changes.
