### PR TITLE
[codex] Add faction table migration audit

### DIFF
--- a/docs/orrery_faction_vocabulary.md
+++ b/docs/orrery_faction_vocabulary.md
@@ -313,6 +313,13 @@ Keep as columns:
 - `primary_location`
 - `created_at`, `updated_at`, `extra_data`
 
+Preflight command:
+
+- `nexus faction-audit --slot N` performs a read-only dry run over the legacy
+  faction columns, existing `claims` / `operates_from` pair-tags, and legacy
+  faction tag categories. Review its JSON output before any destructive data
+  rewrite or column-drop migration.
+
 ---
 
 ## Mechanical Implications

--- a/nexus/api/faction_table_audit.py
+++ b/nexus/api/faction_table_audit.py
@@ -1,0 +1,912 @@
+"""Read-only audit for migrating legacy faction columns into Orrery substrate."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from decimal import Decimal
+import re
+from typing import Any, Mapping, Optional
+
+
+LEGACY_FACTION_COLUMNS = (
+    "ideology",
+    "history",
+    "current_activity",
+    "hidden_agenda",
+    "territory",
+    "power_level",
+    "resources",
+)
+KEEP_FACTION_COLUMNS = (
+    "id",
+    "name",
+    "entity_id",
+    "summary",
+    "primary_location",
+    "created_at",
+    "updated_at",
+    "extra_data",
+)
+LEGACY_TAG_CATEGORIES = ("operational_secrecy", "state")
+RUNTIME_WRITE_SURFACES = (
+    "nexus/api/db_converters.py::create_new_faction",
+    "nexus/api/commit_handler_sync.py::create_new_faction_sync",
+    "nexus/api/commit_handler.py::commit_state_updates",
+    "nexus/api/commit_handler_sync.py::commit_state_updates_sync",
+    "nexus/agents/logon/apex_schema.py::NewFaction",
+    "nexus/agents/logon/apex_schema.py::FactionStateUpdate",
+    "nexus/api/lore_adapter.py::extract_state_updates",
+)
+
+IDEOLOGY_TAGS = frozenset(
+    {
+        "authoritarian",
+        "egalitarian",
+        "traditionalist",
+        "progressive",
+        "theocratic",
+        "secularist",
+        "nationalist",
+        "cosmopolitan",
+        "imperial",
+        "communalist",
+        "mercantilist",
+        "technocratic",
+        "revolutionary",
+        "restorationist",
+        "isolationist",
+    }
+)
+RESOURCE_BASE_TAGS = frozenset(
+    {
+        "capital",
+        "force",
+        "information",
+        "faith",
+        "industry",
+        "labor",
+        "territory",
+        "patronage",
+        "bureaucracy",
+        "technology",
+        "specialized_knowledge",
+        "criminal_network",
+        "supply_lines",
+        "mobility",
+    }
+)
+OPERATIONAL_MODE_TAGS = frozenset({"overt", "covert", "hybrid"})
+POWER_STATUS_TAGS = frozenset(
+    {
+        "dominant",
+        "ascending",
+        "stable",
+        "pressured",
+        "declining",
+        "fragile",
+        "collapsed",
+    }
+)
+AGENDA_TAGS = frozenset(
+    {
+        "expand_control",
+        "consolidate_control",
+        "infiltrate",
+        "seize_leadership",
+        "settle_succession",
+        "recover_losses",
+        "negotiate",
+        "mobilize",
+        "investigate",
+        "recruit",
+        "extract_resources",
+        "sabotage",
+        "suppress_dissent",
+        "conceal_exposure",
+        "reform_internal",
+        "secure_alliance",
+        "enforce_claim",
+        "protect_asset",
+        "retaliate",
+    }
+)
+LEGACY_AGENDA_ALIASES = {
+    "revanchist": "recover_losses",
+    "infiltration": "infiltrate",
+    "coup": "seize_leadership",
+    "succession": "settle_succession",
+    "expansion": "expand_control",
+    "consolidation": "consolidate_control",
+}
+OPERATIONAL_MODE_ALIASES = {
+    "hidden": "covert",
+    "secretive": "covert",
+    "secret": "covert",
+    "underground": "covert",
+    "compartmented": "covert",
+    "cellular_clandestine": "covert",
+    "public": "overt",
+    "open": "overt",
+}
+RESOURCE_KEYWORDS = {
+    "capital": (
+        "capital",
+        "money",
+        "credit",
+        "wealth",
+        "finance",
+        "cash",
+        "funding",
+    ),
+    "force": (
+        "force",
+        "fighters",
+        "guards",
+        "troops",
+        "enforcers",
+        "weapons",
+        "military",
+        "soldiers",
+    ),
+    "information": (
+        "information",
+        "intelligence",
+        "intel",
+        "archives",
+        "surveillance",
+        "secrets",
+        "informants",
+    ),
+    "faith": ("faith", "religious", "ritual", "sacred", "pilgrim", "donor"),
+    "industry": (
+        "industry",
+        "workshops",
+        "factories",
+        "production",
+        "craft",
+        "manufacturing",
+    ),
+    "labor": ("labor", "workers", "volunteers", "conscripts", "members"),
+    "territory": (
+        "territory",
+        "land",
+        "estate",
+        "district",
+        "region",
+        "holdings",
+    ),
+    "patronage": ("patronage", "sponsors", "donors", "backers", "subsidy"),
+    "bureaucracy": ("bureaucracy", "records", "offices", "permits"),
+    "technology": ("technology", "machines", "infrastructure", "engineered"),
+    "specialized_knowledge": (
+        "knowledge",
+        "scholarship",
+        "lore",
+        "expertise",
+        "doctrine",
+        "trade secrets",
+    ),
+    "criminal_network": (
+        "criminal",
+        "smuggling",
+        "black market",
+        "fences",
+        "racket",
+        "illicit",
+    ),
+    "supply_lines": (
+        "supply",
+        "logistics",
+        "warehousing",
+        "transport",
+        "food",
+        "fuel",
+    ),
+    "mobility": (
+        "ships",
+        "vehicles",
+        "mounts",
+        "portals",
+        "couriers",
+        "roads",
+        "fleet",
+    ),
+}
+NETWORK_AMBIGUOUS_RESOURCE_TAGS = (
+    "criminal_network",
+    "information",
+    "patronage",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FactionMappingCandidate:
+    """One proposed destination for a legacy faction datum."""
+
+    source_column: str
+    source_value: Optional[str]
+    target_kind: str
+    target_category: Optional[str] = None
+    target_tag: Optional[str] = None
+    target_pair_tag: Optional[str] = None
+    confidence: str = "manual_review"
+    review_required: bool = True
+    reason: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyTagRow:
+    """Existing legacy tag row relevant to faction migration."""
+
+    faction_id: int
+    faction_name: str
+    entity_id: int
+    category: str
+    tag: str
+
+
+@dataclass(slots=True)
+class FactionAuditEntry:
+    """Audit result for one faction row."""
+
+    faction_id: int
+    faction_name: str
+    entity_id: Optional[int]
+    obsolete_columns: dict[str, Any]
+    existing_pair_tags: dict[str, int] = field(default_factory=dict)
+    legacy_tags: list[LegacyTagRow] = field(default_factory=list)
+    mapping_candidates: list[FactionMappingCandidate] = field(default_factory=list)
+
+    @property
+    def review_required(self) -> bool:
+        """Return True when any candidate must be inspected by a human."""
+
+        return any(candidate.review_required for candidate in self.mapping_candidates)
+
+
+def build_faction_table_audit(cur: Any) -> dict[str, Any]:
+    """Build a read-only dry-run audit for legacy faction table cleanup."""
+
+    faction_rows = _fetch_faction_rows(cur)
+    pair_counts = _fetch_pair_tag_counts(cur)
+    legacy_tags = _fetch_legacy_tag_rows(cur)
+    legacy_tags_by_entity = _group_legacy_tags_by_entity(legacy_tags)
+
+    entries: list[FactionAuditEntry] = []
+    non_null_counts = {column: 0 for column in LEGACY_FACTION_COLUMNS}
+    for row in faction_rows:
+        obsolete_values = _obsolete_values(row)
+        for column, value in obsolete_values.items():
+            if _has_value(value):
+                non_null_counts[column] += 1
+        entity_id = _coerce_optional_int(_row_value(row, "entity_id"))
+        entry = audit_faction_row(
+            row,
+            existing_pair_tags=pair_counts.get(entity_id or -1, {}),
+            legacy_tags=legacy_tags_by_entity.get(entity_id or -1, []),
+        )
+        entries.append(entry)
+
+    counters = _build_counters(entries, non_null_counts, legacy_tags)
+    return {
+        "dry_run": True,
+        "source_columns": list(LEGACY_FACTION_COLUMNS),
+        "keep_columns": list(KEEP_FACTION_COLUMNS),
+        "runtime_write_surfaces": list(RUNTIME_WRITE_SURFACES),
+        "counters": counters,
+        "non_null_counts": non_null_counts,
+        "legacy_tag_rows": [asdict(row) for row in legacy_tags],
+        "factions": [_entry_to_dict(entry) for entry in entries],
+    }
+
+
+def audit_faction_row(
+    row: Mapping[str, Any],
+    *,
+    existing_pair_tags: Mapping[str, int],
+    legacy_tags: list[LegacyTagRow],
+) -> FactionAuditEntry:
+    """Map one faction row into reviewable migration candidates."""
+
+    obsolete_values = _obsolete_values(row)
+    entry = FactionAuditEntry(
+        faction_id=int(_row_value(row, "id")),
+        faction_name=str(_row_value(row, "name") or ""),
+        entity_id=_coerce_optional_int(_row_value(row, "entity_id")),
+        obsolete_columns={
+            key: _json_safe(value) for key, value in obsolete_values.items()
+        },
+        existing_pair_tags=dict(existing_pair_tags),
+        legacy_tags=legacy_tags,
+    )
+    entry.mapping_candidates.extend(_map_ideology(obsolete_values["ideology"]))
+    entry.mapping_candidates.extend(_map_history(obsolete_values["history"]))
+    entry.mapping_candidates.extend(
+        _map_agenda_text(
+            "current_activity",
+            obsolete_values["current_activity"],
+            fallback_reason=(
+                "Current activity is free prose. It may become agenda when it "
+                "names an active campaign; otherwise preserve it as prose."
+            ),
+        )
+    )
+    entry.mapping_candidates.extend(
+        _map_agenda_text(
+            "hidden_agenda",
+            obsolete_values["hidden_agenda"],
+            fallback_reason=(
+                "Hidden agenda is narrative prose unless it matches an accepted "
+                "agenda anchor."
+            ),
+        )
+    )
+    entry.mapping_candidates.extend(
+        _map_territory(obsolete_values["territory"], existing_pair_tags)
+    )
+    entry.mapping_candidates.extend(_map_power_level(obsolete_values["power_level"]))
+    entry.mapping_candidates.extend(_map_resources(obsolete_values["resources"]))
+    for tag_row in legacy_tags:
+        entry.mapping_candidates.extend(_map_legacy_tag_row(tag_row))
+    return entry
+
+
+def _fetch_faction_rows(cur: Any) -> list[Mapping[str, Any]]:
+    cur.execute(
+        """
+        SELECT
+            id,
+            name,
+            entity_id,
+            ideology,
+            history,
+            current_activity,
+            hidden_agenda,
+            territory,
+            primary_location,
+            power_level,
+            resources
+        FROM factions
+        ORDER BY id
+        """
+    )
+    return list(cur.fetchall())
+
+
+def _fetch_pair_tag_counts(cur: Any) -> dict[int, dict[str, int]]:
+    cur.execute(
+        """
+        SELECT
+            ept.subject_entity_id AS entity_id,
+            pt.tag,
+            COUNT(*)::int AS active_count
+        FROM entity_pair_tags ept
+        JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+        WHERE ept.cleared_at IS NULL
+          AND pt.tag = ANY(%s)
+          AND NOT pt.deprecated
+        GROUP BY ept.subject_entity_id, pt.tag
+        """,
+        (["claims", "operates_from"],),
+    )
+    counts: dict[int, dict[str, int]] = {}
+    for row in cur.fetchall():
+        entity_id = int(_row_value(row, "entity_id"))
+        tag = str(_row_value(row, "tag"))
+        active_count = int(_row_value(row, "active_count"))
+        counts.setdefault(entity_id, {})[tag] = active_count
+    return counts
+
+
+def _fetch_legacy_tag_rows(cur: Any) -> list[LegacyTagRow]:
+    cur.execute(
+        """
+        SELECT
+            f.id AS faction_id,
+            f.name AS faction_name,
+            f.entity_id,
+            etc.category,
+            etc.tag
+        FROM entity_tags_current etc
+        JOIN factions f ON f.entity_id = etc.entity_id
+        WHERE etc.entity_kind = 'faction'
+          AND etc.category = ANY(%s)
+        ORDER BY f.id, etc.category, etc.tag
+        """,
+        (list(LEGACY_TAG_CATEGORIES),),
+    )
+    return [
+        LegacyTagRow(
+            faction_id=int(_row_value(row, "faction_id")),
+            faction_name=str(_row_value(row, "faction_name")),
+            entity_id=int(_row_value(row, "entity_id")),
+            category=str(_row_value(row, "category")),
+            tag=str(_row_value(row, "tag")),
+        )
+        for row in cur.fetchall()
+    ]
+
+
+def _group_legacy_tags_by_entity(
+    rows: list[LegacyTagRow],
+) -> dict[int, list[LegacyTagRow]]:
+    grouped: dict[int, list[LegacyTagRow]] = {}
+    for row in rows:
+        grouped.setdefault(row.entity_id, []).append(row)
+    return grouped
+
+
+def _build_counters(
+    entries: list[FactionAuditEntry],
+    non_null_counts: Mapping[str, int],
+    legacy_tags: list[LegacyTagRow],
+) -> dict[str, int]:
+    manual_review_items = 0
+    ambiguous_resource_values = 0
+    entity_tag_candidates = 0
+    pair_tag_candidates = 0
+    prose_remainders = 0
+    for entry in entries:
+        for candidate in entry.mapping_candidates:
+            if candidate.review_required:
+                manual_review_items += 1
+            if candidate.target_kind == "entity_tag":
+                entity_tag_candidates += 1
+            elif candidate.target_kind == "pair_tag":
+                pair_tag_candidates += 1
+            elif candidate.target_kind in {
+                "world_event_or_prose",
+                "structured_remainder",
+            }:
+                prose_remainders += 1
+        if any(
+            candidate.source_column == "resources"
+            and candidate.confidence == "ambiguous"
+            for candidate in entry.mapping_candidates
+        ):
+            ambiguous_resource_values += 1
+
+    return {
+        "factions_scanned": len(entries),
+        "factions_with_legacy_values": sum(
+            1
+            for entry in entries
+            if any(_has_value(value) for value in entry.obsolete_columns.values())
+        ),
+        "non_null_legacy_values": sum(non_null_counts.values()),
+        "candidate_entity_tags": entity_tag_candidates,
+        "candidate_pair_tags": pair_tag_candidates,
+        "prose_or_remainder_items": prose_remainders,
+        "manual_review_items": manual_review_items,
+        "ambiguous_resource_values": ambiguous_resource_values,
+        "active_claim_edges": sum(
+            entry.existing_pair_tags.get("claims", 0) for entry in entries
+        ),
+        "active_operates_from_edges": sum(
+            entry.existing_pair_tags.get("operates_from", 0) for entry in entries
+        ),
+        "legacy_operational_secrecy_tags": sum(
+            1 for row in legacy_tags if row.category == "operational_secrecy"
+        ),
+        "legacy_faction_state_tags": sum(
+            1 for row in legacy_tags if row.category == "state"
+        ),
+    }
+
+
+def _map_ideology(value: Any) -> list[FactionMappingCandidate]:
+    text = _clean_text(value)
+    if text is None:
+        return []
+    matched = _match_controlled_values(text, IDEOLOGY_TAGS)
+    if matched:
+        return [
+            FactionMappingCandidate(
+                source_column="ideology",
+                source_value=text,
+                target_kind="entity_tag",
+                target_category="ideology",
+                target_tag=tag,
+                confidence=(
+                    "deterministic" if _normalize_token(text) == tag else "suggested"
+                ),
+                review_required=_normalize_token(text) != tag,
+                reason="Legacy ideology matches accepted faction ideology vocabulary.",
+            )
+            for tag in matched
+        ]
+    return [
+        FactionMappingCandidate(
+            source_column="ideology",
+            source_value=text,
+            target_kind="structured_remainder",
+            target_category="ideology",
+            confidence="manual_review",
+            review_required=True,
+            reason="Legacy ideology is free text and needs vocabulary review.",
+        )
+    ]
+
+
+def _map_history(value: Any) -> list[FactionMappingCandidate]:
+    text = _clean_text(value)
+    if text is None:
+        return []
+    return [
+        FactionMappingCandidate(
+            source_column="history",
+            source_value=text,
+            target_kind="world_event_or_prose",
+            confidence="manual_review",
+            review_required=True,
+            reason=(
+                "Faction history should become world_events or summary prose, "
+                "not tags."
+            ),
+        )
+    ]
+
+
+def _map_agenda_text(
+    source_column: str,
+    value: Any,
+    *,
+    fallback_reason: str,
+) -> list[FactionMappingCandidate]:
+    text = _clean_text(value)
+    if text is None:
+        return []
+    normalized = _normalize_token(text)
+    tag = LEGACY_AGENDA_ALIASES.get(normalized, normalized)
+    if tag in AGENDA_TAGS:
+        return [
+            FactionMappingCandidate(
+                source_column=source_column,
+                source_value=text,
+                target_kind="entity_tag",
+                target_category="agenda",
+                target_tag=tag,
+                confidence="deterministic" if normalized == tag else "suggested",
+                review_required=normalized != tag,
+                reason="Legacy value matches an accepted agenda anchor.",
+            )
+        ]
+
+    matched = _match_controlled_values(text, AGENDA_TAGS)
+    if matched:
+        return [
+            FactionMappingCandidate(
+                source_column=source_column,
+                source_value=text,
+                target_kind="entity_tag",
+                target_category="agenda",
+                target_tag=tag,
+                confidence="suggested",
+                review_required=True,
+                reason="Legacy prose contains an accepted agenda anchor.",
+            )
+            for tag in matched
+        ]
+
+    return [
+        FactionMappingCandidate(
+            source_column=source_column,
+            source_value=text,
+            target_kind="structured_remainder",
+            target_category="agenda",
+            confidence="manual_review",
+            review_required=True,
+            reason=fallback_reason,
+        )
+    ]
+
+
+def _map_territory(
+    value: Any, existing_pair_tags: Mapping[str, int]
+) -> list[FactionMappingCandidate]:
+    text = _clean_text(value)
+    candidates: list[FactionMappingCandidate] = []
+    claim_count = int(existing_pair_tags.get("claims", 0))
+    if claim_count:
+        candidates.append(
+            FactionMappingCandidate(
+                source_column="territory",
+                source_value=text,
+                target_kind="entity_tag",
+                target_category="resource_base",
+                target_tag="territory",
+                confidence="deterministic",
+                review_required=False,
+                reason=(
+                    "Faction already has active claims(...) edges; "
+                    "resource_base:territory can be seeded from substrate."
+                ),
+            )
+        )
+    if text is None:
+        return candidates
+
+    candidates.append(
+        FactionMappingCandidate(
+            source_column="territory",
+            source_value=text,
+            target_kind="pair_tag",
+            target_pair_tag="claims",
+            confidence="manual_review",
+            review_required=True,
+            reason=(
+                "Territory prose must be resolved to concrete place targets "
+                "before claims(faction -> place) can be written."
+            ),
+        )
+    )
+    candidates.append(
+        FactionMappingCandidate(
+            source_column="territory",
+            source_value=text,
+            target_kind="pair_tag",
+            target_pair_tag="operates_from",
+            confidence="manual_review",
+            review_required=True,
+            reason=(
+                "Territory prose may describe bases or reach; review before "
+                "writing operates_from(faction -> place)."
+            ),
+        )
+    )
+    if _mentions_territorial_capacity(text) and claim_count == 0:
+        candidates.append(
+            FactionMappingCandidate(
+                source_column="territory",
+                source_value=text,
+                target_kind="entity_tag",
+                target_category="resource_base",
+                target_tag="territory",
+                confidence="suggested",
+                review_required=True,
+                reason=(
+                    "Legacy column explicitly names territorial control, but "
+                    "no active claims(...) edge exists yet."
+                ),
+            )
+        )
+    return candidates
+
+
+def _map_power_level(value: Any) -> list[FactionMappingCandidate]:
+    if value is None:
+        return []
+    numeric = float(value)
+    if numeric >= 0.85:
+        tag = "dominant"
+    elif numeric >= 0.70:
+        tag = "ascending"
+    elif numeric >= 0.45:
+        tag = "stable"
+    elif numeric >= 0.30:
+        tag = "pressured"
+    elif numeric > 0.10:
+        tag = "declining"
+    elif numeric > 0.0:
+        tag = "fragile"
+    else:
+        tag = "collapsed"
+    return [
+        FactionMappingCandidate(
+            source_column="power_level",
+            source_value=str(value),
+            target_kind="entity_tag",
+            target_category="power_status",
+            target_tag=tag,
+            confidence="suggested",
+            review_required=True,
+            reason=(
+                "Numeric power_level lacks trajectory; suggested power_status "
+                "is rank-only and should be reviewed before migration."
+            ),
+        )
+    ]
+
+
+def _map_resources(value: Any) -> list[FactionMappingCandidate]:
+    text = _clean_text(value)
+    if text is None:
+        return []
+    normalized = _normalize_token(text)
+    if normalized in RESOURCE_BASE_TAGS:
+        return [
+            FactionMappingCandidate(
+                source_column="resources",
+                source_value=text,
+                target_kind="entity_tag",
+                target_category="resource_base",
+                target_tag=normalized,
+                confidence="deterministic",
+                review_required=False,
+                reason=(
+                    "Legacy resources value matches accepted resource_base "
+                    "vocabulary."
+                ),
+            )
+        ]
+    if "network" in _tokens(text):
+        return [
+            FactionMappingCandidate(
+                source_column="resources",
+                source_value=text,
+                target_kind="entity_tag",
+                target_category="resource_base",
+                target_tag=tag,
+                confidence="ambiguous",
+                review_required=True,
+                reason=(
+                    "Legacy 'network' is overloaded; choose the specific "
+                    "resource_base reading manually."
+                ),
+            )
+            for tag in NETWORK_AMBIGUOUS_RESOURCE_TAGS
+        ]
+
+    matched = [
+        tag
+        for tag, keywords in RESOURCE_KEYWORDS.items()
+        if any(_contains_phrase(text, keyword) for keyword in keywords)
+    ]
+    if matched:
+        return [
+            FactionMappingCandidate(
+                source_column="resources",
+                source_value=text,
+                target_kind="entity_tag",
+                target_category="resource_base",
+                target_tag=tag,
+                confidence="suggested",
+                review_required=True,
+                reason="Legacy resources prose contains resource_base keywords.",
+            )
+            for tag in sorted(set(matched))
+        ]
+    return [
+        FactionMappingCandidate(
+            source_column="resources",
+            source_value=text,
+            target_kind="structured_remainder",
+            target_category="resource_base",
+            confidence="manual_review",
+            review_required=True,
+            reason="Legacy resources are free text and need vocabulary review.",
+        )
+    ]
+
+
+def _map_legacy_tag_row(row: LegacyTagRow) -> list[FactionMappingCandidate]:
+    if row.category == "operational_secrecy":
+        normalized = _normalize_token(row.tag)
+        tag = OPERATIONAL_MODE_ALIASES.get(normalized, normalized)
+        if tag in OPERATIONAL_MODE_TAGS:
+            return [
+                FactionMappingCandidate(
+                    source_column="entity_tags_current.operational_secrecy",
+                    source_value=row.tag,
+                    target_kind="entity_tag",
+                    target_category="operational_mode",
+                    target_tag=tag,
+                    confidence="deterministic" if normalized == tag else "suggested",
+                    review_required=normalized != tag,
+                    reason=(
+                        "Legacy operational_secrecy tag maps to " "operational_mode."
+                    ),
+                )
+            ]
+        return [
+            FactionMappingCandidate(
+                source_column="entity_tags_current.operational_secrecy",
+                source_value=row.tag,
+                target_kind="structured_remainder",
+                target_category="operational_mode",
+                confidence="manual_review",
+                review_required=True,
+                reason="Unknown operational_secrecy value needs manual mapping.",
+            )
+        ]
+    if row.category == "state":
+        return [
+            FactionMappingCandidate(
+                source_column="entity_tags_current.state",
+                source_value=row.tag,
+                target_kind="structured_remainder",
+                confidence="manual_review",
+                review_required=True,
+                reason=(
+                    "Faction-only state has no canonical replacement; "
+                    "decompose into power_status, agenda, pair-tags, events, "
+                    "or prose."
+                ),
+            )
+        ]
+    return []
+
+
+def _obsolete_values(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {column: _row_value(row, column) for column in LEGACY_FACTION_COLUMNS}
+
+
+def _entry_to_dict(entry: FactionAuditEntry) -> dict[str, Any]:
+    payload = asdict(entry)
+    payload["review_required"] = entry.review_required
+    payload["manual_review_items"] = sum(
+        1 for candidate in entry.mapping_candidates if candidate.review_required
+    )
+    return payload
+
+
+def _row_value(row: Mapping[str, Any], key: str) -> Any:
+    return row[key]
+
+
+def _clean_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = " ".join(str(value).split())
+    return text or None
+
+
+def _has_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return float(value)
+    return value
+
+
+def _coerce_optional_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    return int(value)
+
+
+def _normalize_token(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.strip().lower()).strip("_")
+
+
+def _tokens(value: str) -> set[str]:
+    return set(re.findall(r"[a-z0-9_]+", value.lower()))
+
+
+def _contains_phrase(text: str, phrase: str) -> bool:
+    pattern = r"(?<![a-z0-9_])" + re.escape(phrase.lower()) + r"(?![a-z0-9_])"
+    return re.search(pattern, text.lower()) is not None
+
+
+def _match_controlled_values(text: str, allowed: frozenset[str]) -> list[str]:
+    normalized = _normalize_token(text)
+    if normalized in allowed:
+        return [normalized]
+    matches = [tag for tag in allowed if _contains_phrase(text, tag.replace("_", " "))]
+    matches.extend(tag for tag in allowed if _contains_phrase(text, tag))
+    return sorted(set(matches))
+
+
+def _mentions_territorial_capacity(text: str) -> bool:
+    terms = (
+        "controls",
+        "controlled",
+        "claims",
+        "claimed",
+        "holds",
+        "held",
+        "rules",
+        "territory",
+        "land",
+        "district",
+        "estate",
+        "region",
+        "zone",
+    )
+    return any(_contains_phrase(text, term) for term in terms)

--- a/nexus/api/faction_table_audit.py
+++ b/nexus/api/faction_table_audit.py
@@ -4,9 +4,24 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from decimal import Decimal
+import importlib
 import re
 from typing import Any, Mapping, Optional
 
+
+_CATEGORY_REFACTOR = importlib.import_module(
+    "migrations.043_orrery_category_refactor_phase1"
+)
+LEGACY_CATEGORY_REPLACEMENTS: dict[str, tuple[str, ...]] = {
+    legacy_category: tuple(replacement_categories or ())
+    for (
+        legacy_category,
+        entity_kind,
+        replacement_categories,
+    ) in _CATEGORY_REFACTOR.DEPRECATED_CATEGORY_REPLACEMENTS
+    if entity_kind == "faction"
+}
+LEGACY_TAG_CATEGORIES = tuple(LEGACY_CATEGORY_REPLACEMENTS)
 
 LEGACY_FACTION_COLUMNS = (
     "ideology",
@@ -27,17 +42,9 @@ KEEP_FACTION_COLUMNS = (
     "updated_at",
     "extra_data",
 )
-LEGACY_TAG_CATEGORIES = ("operational_secrecy", "state")
-RUNTIME_WRITE_SURFACES = (
-    "nexus/api/db_converters.py::create_new_faction",
-    "nexus/api/commit_handler_sync.py::create_new_faction_sync",
-    "nexus/api/commit_handler.py::commit_state_updates",
-    "nexus/api/commit_handler_sync.py::commit_state_updates_sync",
-    "nexus/agents/logon/apex_schema.py::NewFaction",
-    "nexus/agents/logon/apex_schema.py::FactionStateUpdate",
-    "nexus/api/lore_adapter.py::extract_state_updates",
-)
 
+# Tag values mirror docs/orrery_faction_vocabulary.md. Migration 043 owns the
+# category registry, but the faction tag-value bank is still a design document.
 IDEOLOGY_TAGS = frozenset(
     {
         "authoritarian",
@@ -76,6 +83,17 @@ RESOURCE_BASE_TAGS = frozenset(
     }
 )
 OPERATIONAL_MODE_TAGS = frozenset({"overt", "covert", "hybrid"})
+LEGITIMACY_TAGS = frozenset(
+    {
+        "state_recognized",
+        "customary",
+        "tolerated",
+        "shadow_legal",
+        "underground",
+        "outlaw",
+        "contested",
+    }
+)
 POWER_STATUS_TAGS = frozenset(
     {
         "dominant",
@@ -110,6 +128,45 @@ AGENDA_TAGS = frozenset(
         "retaliate",
     }
 )
+# Hand-curated from docs/orrery_faction_vocabulary.md plus the observed slot-2
+# legacy scan on 2026-05-26. Aliases stay reviewable unless already canonical.
+LEGACY_IDEOLOGY_ALIASES = {
+    "anarchist_collective": ("egalitarian", "communalist"),
+    "esoteric_metaphysical": ("theocratic",),
+    "mutual_aid_norms": ("communalist", "egalitarian"),
+    "transhumanist_program": ("technocratic", "progressive"),
+}
+LEGACY_LEGITIMACY_ALIASES = {
+    "recognized": ("state_recognized",),
+    "sanctioned": ("state_recognized",),
+    "chartered": ("state_recognized",),
+    "legal": ("state_recognized",),
+    "custom": ("customary",),
+    "customary": ("customary",),
+    "tolerated": ("tolerated",),
+    "gray_legal": ("shadow_legal",),
+    "grey_legal": ("shadow_legal",),
+    "shadow": ("shadow_legal",),
+    "shadow_legal": ("shadow_legal",),
+    "criminal_underground": ("outlaw",),
+    "proscribed": ("outlaw",),
+    "outlawed": ("outlaw",),
+    "outlaw": ("outlaw",),
+    "underground": ("underground",),
+    "contested": ("contested",),
+}
+LEGACY_RESOURCE_ALIASES = {
+    "barter_economy": ("capital",),
+    "information_intensive": ("information",),
+    "materiel_stockpile": ("force", "supply_lines"),
+    "patron_dependent": ("patronage",),
+    "salvage_economy": ("industry", "supply_lines"),
+}
+LEGACY_HIDDEN_AGENDA_ALIASES = {
+    "covert_loyalty_play": ("infiltrate", "secure_alliance"),
+    "expansionist_ambition": ("expand_control",),
+    "schismatic_internal_threat": ("suppress_dissent", "settle_succession"),
+}
 LEGACY_AGENDA_ALIASES = {
     "revanchist": "recover_losses",
     "infiltration": "infiltrate",
@@ -292,10 +349,8 @@ def build_faction_table_audit(cur: Any) -> dict[str, Any]:
         "dry_run": True,
         "source_columns": list(LEGACY_FACTION_COLUMNS),
         "keep_columns": list(KEEP_FACTION_COLUMNS),
-        "runtime_write_surfaces": list(RUNTIME_WRITE_SURFACES),
         "counters": counters,
         "non_null_counts": non_null_counts,
-        "legacy_tag_rows": [asdict(row) for row in legacy_tags],
         "factions": [_entry_to_dict(entry) for entry in entries],
     }
 
@@ -446,6 +501,7 @@ def _build_counters(
     entity_tag_candidates = 0
     pair_tag_candidates = 0
     prose_remainders = 0
+    no_replacement_items = 0
     for entry in entries:
         for candidate in entry.mapping_candidates:
             if candidate.review_required:
@@ -459,6 +515,8 @@ def _build_counters(
                 "structured_remainder",
             }:
                 prose_remainders += 1
+            elif candidate.target_kind == "no_replacement":
+                no_replacement_items += 1
         if any(
             candidate.source_column == "resources"
             and candidate.confidence == "ambiguous"
@@ -477,6 +535,7 @@ def _build_counters(
         "candidate_entity_tags": entity_tag_candidates,
         "candidate_pair_tags": pair_tag_candidates,
         "prose_or_remainder_items": prose_remainders,
+        "no_replacement_items": no_replacement_items,
         "manual_review_items": manual_review_items,
         "ambiguous_resource_values": ambiguous_resource_values,
         "active_claim_edges": sum(
@@ -485,11 +544,27 @@ def _build_counters(
         "active_operates_from_edges": sum(
             entry.existing_pair_tags.get("operates_from", 0) for entry in entries
         ),
+        "legacy_tag_rows": len(legacy_tags),
+        "legacy_ideology_axis_tags": sum(
+            1 for row in legacy_tags if row.category == "ideology_axis"
+        ),
+        "legacy_power_posture_tags": sum(
+            1 for row in legacy_tags if row.category == "power_posture"
+        ),
+        "legacy_legitimacy_status_tags": sum(
+            1 for row in legacy_tags if row.category == "legitimacy_status"
+        ),
         "legacy_operational_secrecy_tags": sum(
             1 for row in legacy_tags if row.category == "operational_secrecy"
         ),
-        "legacy_faction_state_tags": sum(
-            1 for row in legacy_tags if row.category == "state"
+        "legacy_resource_class_tags": sum(
+            1 for row in legacy_tags if row.category == "resource_class"
+        ),
+        "legacy_hidden_agenda_class_tags": sum(
+            1 for row in legacy_tags if row.category == "hidden_agenda_class"
+        ),
+        "legacy_history_class_tags": sum(
+            1 for row in legacy_tags if row.category == "history_class"
         ),
     }
 
@@ -685,7 +760,7 @@ def _map_power_level(value: Any) -> list[FactionMappingCandidate]:
         tag = "stable"
     elif numeric >= 0.30:
         tag = "pressured"
-    elif numeric > 0.10:
+    elif numeric >= 0.10:
         tag = "declining"
     elif numeric > 0.0:
         tag = "fragile"
@@ -729,24 +804,6 @@ def _map_resources(value: Any) -> list[FactionMappingCandidate]:
                 ),
             )
         ]
-    if "network" in _tokens(text):
-        return [
-            FactionMappingCandidate(
-                source_column="resources",
-                source_value=text,
-                target_kind="entity_tag",
-                target_category="resource_base",
-                target_tag=tag,
-                confidence="ambiguous",
-                review_required=True,
-                reason=(
-                    "Legacy 'network' is overloaded; choose the specific "
-                    "resource_base reading manually."
-                ),
-            )
-            for tag in NETWORK_AMBIGUOUS_RESOURCE_TAGS
-        ]
-
     matched = [
         tag
         for tag, keywords in RESOURCE_KEYWORDS.items()
@@ -766,6 +823,23 @@ def _map_resources(value: Any) -> list[FactionMappingCandidate]:
             )
             for tag in sorted(set(matched))
         ]
+    if normalized == "network":
+        return [
+            FactionMappingCandidate(
+                source_column="resources",
+                source_value=text,
+                target_kind="entity_tag",
+                target_category="resource_base",
+                target_tag=tag,
+                confidence="ambiguous",
+                review_required=True,
+                reason=(
+                    "Legacy 'network' is overloaded; choose the specific "
+                    "resource_base reading manually."
+                ),
+            )
+            for tag in NETWORK_AMBIGUOUS_RESOURCE_TAGS
+        ]
     return [
         FactionMappingCandidate(
             source_column="resources",
@@ -780,51 +854,174 @@ def _map_resources(value: Any) -> list[FactionMappingCandidate]:
 
 
 def _map_legacy_tag_row(row: LegacyTagRow) -> list[FactionMappingCandidate]:
+    if row.category == "ideology_axis":
+        return _map_controlled_legacy_tag_row(
+            row,
+            target_category="ideology",
+            allowed_tags=IDEOLOGY_TAGS,
+            aliases=LEGACY_IDEOLOGY_ALIASES,
+            unknown_reason=(
+                "Legacy ideology_axis tag has no direct canonical ideology "
+                "reading; review before migration."
+            ),
+        )
+    if row.category == "power_posture":
+        return _map_controlled_legacy_tag_row(
+            row,
+            target_category="power_status",
+            allowed_tags=POWER_STATUS_TAGS,
+            aliases={},
+            unknown_reason=(
+                "Legacy power_posture tag is not an accepted power_status "
+                "value; review trajectory and capacity before migration."
+            ),
+        )
+    if row.category == "legitimacy_status":
+        return _map_controlled_legacy_tag_row(
+            row,
+            target_category="legitimacy",
+            allowed_tags=LEGITIMACY_TAGS,
+            aliases=LEGACY_LEGITIMACY_ALIASES,
+            unknown_reason=(
+                "Legacy legitimacy_status tag needs manual legitimacy review."
+            ),
+        )
     if row.category == "operational_secrecy":
-        normalized = _normalize_token(row.tag)
-        tag = OPERATIONAL_MODE_ALIASES.get(normalized, normalized)
-        if tag in OPERATIONAL_MODE_TAGS:
-            return [
-                FactionMappingCandidate(
-                    source_column="entity_tags_current.operational_secrecy",
-                    source_value=row.tag,
-                    target_kind="entity_tag",
-                    target_category="operational_mode",
-                    target_tag=tag,
-                    confidence="deterministic" if normalized == tag else "suggested",
-                    review_required=normalized != tag,
-                    reason=(
-                        "Legacy operational_secrecy tag maps to " "operational_mode."
-                    ),
-                )
-            ]
+        return _map_controlled_legacy_tag_row(
+            row,
+            target_category="operational_mode",
+            allowed_tags=OPERATIONAL_MODE_TAGS,
+            aliases=OPERATIONAL_MODE_ALIASES,
+            unknown_reason="Unknown operational_secrecy value needs manual mapping.",
+        )
+    if row.category == "resource_class":
+        return _map_controlled_legacy_tag_row(
+            row,
+            target_category="resource_base",
+            allowed_tags=RESOURCE_BASE_TAGS,
+            aliases=LEGACY_RESOURCE_ALIASES,
+            unknown_reason=(
+                "Legacy resource_class tag needs manual resource_base review."
+            ),
+        )
+    if row.category == "hidden_agenda_class":
+        return _map_controlled_legacy_tag_row(
+            row,
+            target_category="agenda",
+            allowed_tags=AGENDA_TAGS,
+            aliases=LEGACY_HIDDEN_AGENDA_ALIASES,
+            unknown_reason="Legacy hidden_agenda_class tag needs agenda review.",
+        )
+    if row.category == "history_class":
         return [
             FactionMappingCandidate(
-                source_column="entity_tags_current.operational_secrecy",
+                source_column="entity_tags_current.history_class",
                 source_value=row.tag,
-                target_kind="structured_remainder",
-                target_category="operational_mode",
-                confidence="manual_review",
-                review_required=True,
-                reason="Unknown operational_secrecy value needs manual mapping.",
-            )
-        ]
-    if row.category == "state":
-        return [
-            FactionMappingCandidate(
-                source_column="entity_tags_current.state",
-                source_value=row.tag,
-                target_kind="structured_remainder",
+                target_kind="no_replacement",
                 confidence="manual_review",
                 review_required=True,
                 reason=(
-                    "Faction-only state has no canonical replacement; "
-                    "decompose into power_status, agenda, pair-tags, events, "
-                    "or prose."
+                    "Migration 043 marks history_class with no replacement; "
+                    "preserve useful detail as world_events or prose before "
+                    "dropping the legacy tag."
                 ),
             )
         ]
-    return []
+    return [
+        FactionMappingCandidate(
+            source_column=f"entity_tags_current.{row.category}",
+            source_value=row.tag,
+            target_kind="structured_remainder",
+            confidence="manual_review",
+            review_required=True,
+            reason="Unrecognized legacy faction tag category needs manual review.",
+        )
+    ]
+
+
+def _map_controlled_legacy_tag_row(
+    row: LegacyTagRow,
+    *,
+    target_category: str,
+    allowed_tags: frozenset[str],
+    aliases: Mapping[str, str | tuple[str, ...]],
+    unknown_reason: str,
+) -> list[FactionMappingCandidate]:
+    source_column = f"entity_tags_current.{row.category}"
+    normalized = _normalize_token(row.tag)
+    alias = aliases.get(normalized)
+    alias_tags: tuple[str, ...]
+    if isinstance(alias, str):
+        alias_tags = (alias,)
+    else:
+        alias_tags = alias or ()
+
+    valid_alias_tags = tuple(tag for tag in alias_tags if tag in allowed_tags)
+    if valid_alias_tags:
+        return [
+            FactionMappingCandidate(
+                source_column=source_column,
+                source_value=row.tag,
+                target_kind="entity_tag",
+                target_category=target_category,
+                target_tag=tag,
+                confidence="deterministic" if normalized == tag else "suggested",
+                review_required=normalized != tag,
+                reason=(
+                    f"Legacy {row.category} tag maps to {target_category}; "
+                    "review alias-derived readings before migration."
+                ),
+            )
+            for tag in valid_alias_tags
+        ]
+
+    if normalized in allowed_tags:
+        return [
+            FactionMappingCandidate(
+                source_column=source_column,
+                source_value=row.tag,
+                target_kind="entity_tag",
+                target_category=target_category,
+                target_tag=normalized,
+                confidence="deterministic",
+                review_required=False,
+                reason=(
+                    f"Legacy {row.category} tag already matches accepted "
+                    f"{target_category} vocabulary."
+                ),
+            )
+        ]
+
+    matched = _match_controlled_values(row.tag, allowed_tags)
+    if matched:
+        return [
+            FactionMappingCandidate(
+                source_column=source_column,
+                source_value=row.tag,
+                target_kind="entity_tag",
+                target_category=target_category,
+                target_tag=tag,
+                confidence="suggested",
+                review_required=True,
+                reason=(
+                    f"Legacy {row.category} text contains accepted "
+                    f"{target_category} vocabulary."
+                ),
+            )
+            for tag in matched
+        ]
+
+    return [
+        FactionMappingCandidate(
+            source_column=source_column,
+            source_value=row.tag,
+            target_kind="structured_remainder",
+            target_category=target_category,
+            confidence="manual_review",
+            review_required=True,
+            reason=unknown_reason,
+        )
+    ]
 
 
 def _obsolete_values(row: Mapping[str, Any]) -> dict[str, Any]:
@@ -875,10 +1072,6 @@ def _normalize_token(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "_", value.strip().lower()).strip("_")
 
 
-def _tokens(value: str) -> set[str]:
-    return set(re.findall(r"[a-z0-9_]+", value.lower()))
-
-
 def _contains_phrase(text: str, phrase: str) -> bool:
     pattern = r"(?<![a-z0-9_])" + re.escape(phrase.lower()) + r"(?![a-z0-9_])"
     return re.search(pattern, text.lower()) is not None
@@ -888,6 +1081,8 @@ def _match_controlled_values(text: str, allowed: frozenset[str]) -> list[str]:
     normalized = _normalize_token(text)
     if normalized in allowed:
         return [normalized]
+    # Match both prose spelling ("criminal network") and canonical spelling
+    # ("criminal_network") so old free text can still point at tag anchors.
     matches = [tag for tag in allowed if _contains_phrase(text, tag.replace("_", " "))]
     matches.extend(tag for tag in allowed if _contains_phrase(text, tag))
     return sorted(set(matches))

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -8,6 +8,7 @@ Commands:
     nexus regenerate --slot N   Regenerate the last storyteller turn
     nexus model --slot N        Get or set the model for a slot
     nexus trait-audit --slot N  Dry-run new-story trait compiler audit
+    nexus faction-audit --slot N  Dry-run legacy faction column migration audit
 
 The CLI is slot-centric: only --slot N is required. The backend resolves
 all other state (wizard phase, current chunk, thread ID) automatically.
@@ -211,6 +212,58 @@ def _print_trait_audit(payload: Dict[str, Any]) -> None:
         print("Policy: failed because --fail-on-remainders was set.")
 
 
+def _print_faction_audit(payload: Dict[str, Any]) -> None:
+    """Print a dry-run faction table migration audit in a compact CLI format."""
+
+    audit = payload.get("faction_audit") or {}
+    counters = audit.get("counters") or {}
+    non_null_counts = audit.get("non_null_counts") or {}
+    factions = audit.get("factions") or []
+
+    print("Counters:")
+    for key in (
+        "factions_scanned",
+        "factions_with_legacy_values",
+        "non_null_legacy_values",
+        "candidate_entity_tags",
+        "candidate_pair_tags",
+        "prose_or_remainder_items",
+        "manual_review_items",
+        "ambiguous_resource_values",
+        "active_claim_edges",
+        "legacy_operational_secrecy_tags",
+        "legacy_faction_state_tags",
+    ):
+        print(f"  {key}: {counters.get(key, 0)}")
+
+    if non_null_counts:
+        print()
+        print("Legacy column values:")
+        for column, count in non_null_counts.items():
+            print(f"  {column}: {count}")
+
+    review_factions = [item for item in factions if item.get("review_required")]
+    if review_factions:
+        print()
+        print("Manual review:")
+        for item in review_factions[:10]:
+            print(
+                "  - "
+                f"{item['faction_name']} "
+                f"(id {item['faction_id']}): "
+                f"{item.get('manual_review_items', 0)} item(s)"
+            )
+        if len(review_factions) > 10:
+            print(f"  ...{len(review_factions) - 10} more")
+
+    write_surfaces = audit.get("runtime_write_surfaces") or []
+    if write_surfaces:
+        print()
+        print("Known runtime write surfaces still requiring cleanup:")
+        for surface in write_surfaces:
+            print(f"  - {surface}")
+
+
 def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) -> None:
     """Emit payload to stdout in JSON or human-readable format."""
     if as_json:
@@ -230,6 +283,10 @@ def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) 
 
     if payload.get("trait_audit"):
         _print_trait_audit(payload)
+        print()
+
+    if payload.get("faction_audit"):
+        _print_faction_audit(payload)
         print()
 
     # Get display elements
@@ -955,6 +1012,28 @@ def run_trait_audit(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
+def run_faction_audit(args: argparse.Namespace) -> Dict[str, Any]:
+    """Dry-run the legacy faction table to Orrery substrate migration."""
+
+    from nexus.api.db_pool import get_connection
+    from nexus.api.faction_table_audit import build_faction_table_audit
+    from nexus.api.slot_utils import slot_dbname
+
+    dbname = slot_dbname(args.slot)
+    with get_connection(dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SET TRANSACTION READ ONLY")
+            audit = build_faction_table_audit(cur)
+
+    return {
+        "success": True,
+        "message": f"Faction table audit for slot {args.slot} (dry run).",
+        "slot": args.slot,
+        "dbname": dbname,
+        "faction_audit": audit,
+    }
+
+
 def run_lock(args: argparse.Namespace) -> Dict[str, Any]:
     """
     Lock a slot to prevent modifications.
@@ -1025,6 +1104,7 @@ Examples:
   nexus lock --slot 1           Lock slot to prevent modifications
   nexus unlock --slot 2         Unlock slot to allow modifications
   nexus trait-audit --slot 5    Dry-run trait compiler audit
+  nexus faction-audit --slot 2  Dry-run faction column migration audit
 """,
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON output")
@@ -1151,6 +1231,15 @@ Examples:
         ),
     )
 
+    # faction-audit command
+    faction_audit_parser = subparsers.add_parser(
+        "faction-audit",
+        help="Dry-run legacy faction column migration into Orrery substrate",
+    )
+    faction_audit_parser.add_argument(
+        "--slot", type=int, required=True, help="Slot number (1-5)"
+    )
+
     # lock command
     lock_parser = subparsers.add_parser(
         "lock", help="Lock a slot to prevent modifications"
@@ -1183,6 +1272,7 @@ def main() -> int:
         "regenerate",
         "clear",
         "trait-audit",
+        "faction-audit",
         "lock",
         "unlock",
     ):
@@ -1213,6 +1303,8 @@ def main() -> int:
         result = run_clear(args)
     elif args.command == "trait-audit":
         result = run_trait_audit(args)
+    elif args.command == "faction-audit":
+        result = run_faction_audit(args)
     elif args.command == "lock":
         result = run_lock(args)
     elif args.command == "unlock":

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -228,12 +228,19 @@ def _print_faction_audit(payload: Dict[str, Any]) -> None:
         "candidate_entity_tags",
         "candidate_pair_tags",
         "prose_or_remainder_items",
+        "no_replacement_items",
         "manual_review_items",
         "ambiguous_resource_values",
         "active_claim_edges",
         "active_operates_from_edges",
+        "legacy_tag_rows",
+        "legacy_ideology_axis_tags",
+        "legacy_power_posture_tags",
+        "legacy_legitimacy_status_tags",
         "legacy_operational_secrecy_tags",
-        "legacy_faction_state_tags",
+        "legacy_resource_class_tags",
+        "legacy_hidden_agenda_class_tags",
+        "legacy_history_class_tags",
     ):
         print(f"  {key}: {counters.get(key, 0)}")
 
@@ -256,13 +263,6 @@ def _print_faction_audit(payload: Dict[str, Any]) -> None:
             )
         if len(review_factions) > 10:
             print(f"  ...{len(review_factions) - 10} more")
-
-    write_surfaces = audit.get("runtime_write_surfaces") or []
-    if write_surfaces:
-        print()
-        print("Known runtime write surfaces still requiring cleanup:")
-        for surface in write_surfaces:
-            print(f"  - {surface}")
 
 
 def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) -> None:

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -231,6 +231,7 @@ def _print_faction_audit(payload: Dict[str, Any]) -> None:
         "manual_review_items",
         "ambiguous_resource_values",
         "active_claim_edges",
+        "active_operates_from_edges",
         "legacy_operational_secrecy_tags",
         "legacy_faction_state_tags",
     ):

--- a/tests/test_faction_table_audit.py
+++ b/tests/test_faction_table_audit.py
@@ -3,104 +3,37 @@
 from __future__ import annotations
 
 from argparse import Namespace
+from dataclasses import asdict
 from decimal import Decimal
+import json
 from typing import Any
 
+import psycopg2  # type: ignore[import-untyped]
+import pytest
+
 from nexus import cli
+from nexus.api.db_pool import close_pool, get_connection
 from nexus.api.faction_table_audit import (
+    LEGACY_TAG_CATEGORIES,
     LegacyTagRow,
     audit_faction_row,
     build_faction_table_audit,
 )
 
 
-class FakeFactionAuditConnection:
-    """Context-manager connection double for faction audit CLI tests."""
-
-    def __enter__(self) -> "FakeFactionAuditConnection":
-        """Enter connection context."""
-
-        return self
-
-    def __exit__(self, *args: Any) -> None:
-        """Exit connection context."""
-
-        return None
-
-    def cursor(self) -> "FakeFactionAuditCursor":
-        """Return a context-manager cursor double."""
-
-        return FakeFactionAuditCursor()
+TEST_DBNAME = "save_02"
 
 
-class FakeFactionAuditCursor:
-    """Cursor double for the read-only faction audit query sequence."""
-
-    def __init__(self) -> None:
-        self._result: list[dict[str, Any]] = []
-        self.executed_sql: list[str] = []
-
-    def __enter__(self) -> "FakeFactionAuditCursor":
-        """Enter cursor context."""
-
-        return self
-
-    def __exit__(self, *args: Any) -> None:
-        """Exit cursor context."""
-
-        return None
-
-    def execute(self, sql: str, params: Any = None) -> None:
-        """Return canned rows for each audit query."""
-
-        del params
-        self.executed_sql.append(sql)
-        if "SET TRANSACTION READ ONLY" in sql:
-            self._result = []
-        elif "FROM factions" in sql and "entity_tags_current" not in sql:
-            self._result = [
-                {
-                    "id": 1,
-                    "name": "Canal League",
-                    "entity_id": 101,
-                    "ideology": "mercantilist",
-                    "history": "Founded after the river war.",
-                    "current_activity": "expansion",
-                    "hidden_agenda": "network",
-                    "territory": "controls the canal district",
-                    "primary_location": 44,
-                    "power_level": Decimal("0.72"),
-                    "resources": "network",
-                }
-            ]
-        elif "FROM entity_pair_tags" in sql:
-            self._result = [
-                {"entity_id": 101, "tag": "claims", "active_count": 2},
-            ]
-        elif "FROM entity_tags_current" in sql:
-            self._result = [
-                {
-                    "faction_id": 1,
-                    "faction_name": "Canal League",
-                    "entity_id": 101,
-                    "category": "operational_secrecy",
-                    "tag": "hidden",
-                },
-                {
-                    "faction_id": 1,
-                    "faction_name": "Canal League",
-                    "entity_id": 101,
-                    "category": "state",
-                    "tag": "mobilized",
-                },
-            ]
-        else:
-            raise AssertionError(f"Unexpected SQL: {sql}")
-
-    def fetchall(self) -> list[dict[str, Any]]:
-        """Return rows from the most recent execute call."""
-
-        return self._result
+def _slot2_faction_audit() -> dict[str, Any]:
+    try:
+        with get_connection(TEST_DBNAME, dict_cursor=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute("SET TRANSACTION READ ONLY")
+                return build_faction_table_audit(cur)
+    except psycopg2.Error as exc:
+        pytest.skip(f"{TEST_DBNAME} PostgreSQL test database unavailable: {exc}")
+    finally:
+        close_pool(TEST_DBNAME)
 
 
 def test_audit_faction_row_flags_network_resource_ambiguity() -> None:
@@ -137,19 +70,88 @@ def test_audit_faction_row_flags_network_resource_ambiguity() -> None:
     assert all(item.confidence == "ambiguous" for item in resource_candidates)
 
 
-def test_build_faction_table_audit_reports_legacy_tag_and_claim_counts() -> None:
-    """Audit counters should expose dry-run work and review pressure."""
+def test_audit_faction_row_maps_specific_network_resource() -> None:
+    """Specific network prose should reach the keyword matcher."""
 
-    audit = build_faction_table_audit(FakeFactionAuditCursor())
+    entry = audit_faction_row(
+        {
+            "id": 8,
+            "name": "Ledger Ring",
+            "entity_id": 808,
+            "ideology": None,
+            "history": None,
+            "current_activity": None,
+            "hidden_agenda": None,
+            "territory": None,
+            "primary_location": None,
+            "power_level": None,
+            "resources": "information network",
+        },
+        existing_pair_tags={},
+        legacy_tags=[],
+    )
+
+    resource_candidates = [
+        item for item in entry.mapping_candidates if item.source_column == "resources"
+    ]
+
+    assert [(item.target_tag, item.confidence) for item in resource_candidates] == [
+        ("information", "suggested")
+    ]
+
+
+def test_power_level_point_one_maps_to_declining() -> None:
+    """The 0.10 band edge should not collapse the faction."""
+
+    entry = audit_faction_row(
+        {
+            "id": 9,
+            "name": "Thin Crown",
+            "entity_id": 909,
+            "ideology": None,
+            "history": None,
+            "current_activity": None,
+            "hidden_agenda": None,
+            "territory": None,
+            "primary_location": None,
+            "power_level": Decimal("0.10"),
+            "resources": None,
+        },
+        existing_pair_tags={},
+        legacy_tags=[],
+    )
+
+    candidates = [
+        item for item in entry.mapping_candidates if item.source_column == "power_level"
+    ]
+
+    assert candidates[0].target_tag == "declining"
+
+
+@pytest.mark.requires_postgres
+def test_build_faction_table_audit_reads_slot2_legacy_tag_categories() -> None:
+    """The audit should cover every legacy faction category present in slot 2."""
+
+    audit = _slot2_faction_audit()
+    counters = audit["counters"]
+    factions = audit["factions"]
+    legacy_categories = {
+        tag["category"] for faction in factions for tag in faction["legacy_tags"]
+    }
+    candidate_sources = {
+        candidate["source_column"]
+        for faction in factions
+        for candidate in faction["mapping_candidates"]
+    }
 
     assert audit["dry_run"] is True
-    assert audit["non_null_counts"]["resources"] == 1
-    assert audit["counters"]["factions_scanned"] == 1
-    assert audit["counters"]["active_claim_edges"] == 2
-    assert audit["counters"]["legacy_operational_secrecy_tags"] == 1
-    assert audit["counters"]["legacy_faction_state_tags"] == 1
-    assert audit["counters"]["ambiguous_resource_values"] == 1
-    assert audit["factions"][0]["review_required"] is True
+    assert "legacy_tag_rows" not in audit
+    assert counters["factions_scanned"] >= 1
+    assert counters["legacy_tag_rows"] >= len(legacy_categories)
+    assert legacy_categories <= set(LEGACY_TAG_CATEGORIES)
+    assert "state" not in legacy_categories
+    for category in legacy_categories:
+        assert f"entity_tags_current.{category}" in candidate_sources
 
 
 def test_operational_secrecy_hidden_maps_to_operational_mode_covert() -> None:
@@ -232,24 +234,139 @@ def test_operational_secrecy_cellular_maps_to_reviewable_covert() -> None:
     assert candidates[0].review_required is True
 
 
-def test_cli_faction_audit_returns_dry_run_payload(monkeypatch) -> None:
-    """The faction audit CLI should resolve the slot and keep the DB read-only."""
+def test_legitimacy_status_gray_legal_maps_to_shadow_legal() -> None:
+    """Legacy legitimacy rows should point at the new legitimacy category."""
 
-    from nexus.api import db_pool
-
-    monkeypatch.setattr(
-        db_pool,
-        "get_connection",
-        lambda *args, **kwargs: FakeFactionAuditConnection(),
+    entry = audit_faction_row(
+        {
+            "id": 5,
+            "name": "Licensed Knives",
+            "entity_id": 505,
+            "ideology": None,
+            "history": None,
+            "current_activity": None,
+            "hidden_agenda": None,
+            "territory": None,
+            "primary_location": None,
+            "power_level": None,
+            "resources": None,
+        },
+        existing_pair_tags={},
+        legacy_tags=[
+            LegacyTagRow(
+                faction_id=5,
+                faction_name="Licensed Knives",
+                entity_id=505,
+                category="legitimacy_status",
+                tag="gray_legal",
+            )
+        ],
     )
 
-    result = cli.run_faction_audit(Namespace(slot=2))
+    candidates = [
+        item
+        for item in entry.mapping_candidates
+        if item.source_column == "entity_tags_current.legitimacy_status"
+    ]
+
+    assert candidates[0].target_category == "legitimacy"
+    assert candidates[0].target_tag == "shadow_legal"
+    assert candidates[0].review_required is True
+
+
+def test_history_class_is_explicit_no_replacement() -> None:
+    """No-replacement legacy categories should be visible in dry-run output."""
+
+    entry = audit_faction_row(
+        {
+            "id": 6,
+            "name": "Old Compact",
+            "entity_id": 606,
+            "ideology": None,
+            "history": None,
+            "current_activity": None,
+            "hidden_agenda": None,
+            "territory": None,
+            "primary_location": None,
+            "power_level": None,
+            "resources": None,
+        },
+        existing_pair_tags={},
+        legacy_tags=[
+            LegacyTagRow(
+                faction_id=6,
+                faction_name="Old Compact",
+                entity_id=606,
+                category="history_class",
+                tag="ancient_continuous",
+            )
+        ],
+    )
+
+    candidates = [
+        item
+        for item in entry.mapping_candidates
+        if item.source_column == "entity_tags_current.history_class"
+    ]
+
+    assert candidates[0].target_kind == "no_replacement"
+    assert candidates[0].review_required is True
+
+
+@pytest.mark.requires_postgres
+def test_cli_faction_audit_returns_live_slot2_payload() -> None:
+    """The faction audit CLI should resolve slot 2 against the real database."""
+
+    try:
+        result = cli.run_faction_audit(Namespace(slot=2))
+    except psycopg2.Error as exc:
+        pytest.skip(f"{TEST_DBNAME} PostgreSQL test database unavailable: {exc}")
+    finally:
+        close_pool(TEST_DBNAME)
 
     assert result["success"] is True
     assert result["slot"] == 2
     assert result["dbname"] == "save_02"
     assert result["faction_audit"]["dry_run"] is True
-    assert result["faction_audit"]["counters"]["factions_scanned"] == 1
+    assert result["faction_audit"]["counters"]["factions_scanned"] >= 1
+
+
+def test_cli_faction_audit_json_output_handles_decimal_payload(capsys) -> None:
+    """Faction audit JSON output should round-trip Decimal-origin values."""
+
+    entry = audit_faction_row(
+        {
+            "id": 10,
+            "name": "Measured Guild",
+            "entity_id": 1010,
+            "ideology": None,
+            "history": None,
+            "current_activity": None,
+            "hidden_agenda": None,
+            "territory": None,
+            "primary_location": None,
+            "power_level": Decimal("0.10"),
+            "resources": None,
+        },
+        existing_pair_tags={},
+        legacy_tags=[],
+    )
+    payload = {
+        "message": "Faction table audit for slot 2 (dry run).",
+        "faction_audit": {
+            "counters": {},
+            "non_null_counts": {"power_level": 1},
+            "factions": [asdict(entry)],
+        },
+    }
+
+    cli.emit_output(payload, as_json=True)
+    decoded = json.loads(capsys.readouterr().out)
+
+    assert (
+        decoded["faction_audit"]["factions"][0]["obsolete_columns"]["power_level"]
+        == 0.1
+    )
 
 
 def test_cli_prints_all_pair_edge_counters(capsys) -> None:
@@ -265,7 +382,6 @@ def test_cli_prints_all_pair_edge_counters(capsys) -> None:
                 },
                 "non_null_counts": {},
                 "factions": [],
-                "runtime_write_surfaces": [],
             },
         },
         as_json=False,

--- a/tests/test_faction_table_audit.py
+++ b/tests/test_faction_table_audit.py
@@ -250,3 +250,28 @@ def test_cli_faction_audit_returns_dry_run_payload(monkeypatch) -> None:
     assert result["dbname"] == "save_02"
     assert result["faction_audit"]["dry_run"] is True
     assert result["faction_audit"]["counters"]["factions_scanned"] == 1
+
+
+def test_cli_prints_all_pair_edge_counters(capsys) -> None:
+    """Human faction audit output should include both relation edge counters."""
+
+    cli.emit_output(
+        {
+            "message": "Faction table audit for slot 2 (dry run).",
+            "faction_audit": {
+                "counters": {
+                    "active_claim_edges": 2,
+                    "active_operates_from_edges": 3,
+                },
+                "non_null_counts": {},
+                "factions": [],
+                "runtime_write_surfaces": [],
+            },
+        },
+        as_json=False,
+    )
+
+    output = capsys.readouterr().out
+
+    assert "active_claim_edges: 2" in output
+    assert "active_operates_from_edges: 3" in output

--- a/tests/test_faction_table_audit.py
+++ b/tests/test_faction_table_audit.py
@@ -1,0 +1,252 @@
+"""Tests for faction table migration dry-run audit helpers."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from decimal import Decimal
+from typing import Any
+
+from nexus import cli
+from nexus.api.faction_table_audit import (
+    LegacyTagRow,
+    audit_faction_row,
+    build_faction_table_audit,
+)
+
+
+class FakeFactionAuditConnection:
+    """Context-manager connection double for faction audit CLI tests."""
+
+    def __enter__(self) -> "FakeFactionAuditConnection":
+        """Enter connection context."""
+
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Exit connection context."""
+
+        return None
+
+    def cursor(self) -> "FakeFactionAuditCursor":
+        """Return a context-manager cursor double."""
+
+        return FakeFactionAuditCursor()
+
+
+class FakeFactionAuditCursor:
+    """Cursor double for the read-only faction audit query sequence."""
+
+    def __init__(self) -> None:
+        self._result: list[dict[str, Any]] = []
+        self.executed_sql: list[str] = []
+
+    def __enter__(self) -> "FakeFactionAuditCursor":
+        """Enter cursor context."""
+
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Exit cursor context."""
+
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        """Return canned rows for each audit query."""
+
+        del params
+        self.executed_sql.append(sql)
+        if "SET TRANSACTION READ ONLY" in sql:
+            self._result = []
+        elif "FROM factions" in sql and "entity_tags_current" not in sql:
+            self._result = [
+                {
+                    "id": 1,
+                    "name": "Canal League",
+                    "entity_id": 101,
+                    "ideology": "mercantilist",
+                    "history": "Founded after the river war.",
+                    "current_activity": "expansion",
+                    "hidden_agenda": "network",
+                    "territory": "controls the canal district",
+                    "primary_location": 44,
+                    "power_level": Decimal("0.72"),
+                    "resources": "network",
+                }
+            ]
+        elif "FROM entity_pair_tags" in sql:
+            self._result = [
+                {"entity_id": 101, "tag": "claims", "active_count": 2},
+            ]
+        elif "FROM entity_tags_current" in sql:
+            self._result = [
+                {
+                    "faction_id": 1,
+                    "faction_name": "Canal League",
+                    "entity_id": 101,
+                    "category": "operational_secrecy",
+                    "tag": "hidden",
+                },
+                {
+                    "faction_id": 1,
+                    "faction_name": "Canal League",
+                    "entity_id": 101,
+                    "category": "state",
+                    "tag": "mobilized",
+                },
+            ]
+        else:
+            raise AssertionError(f"Unexpected SQL: {sql}")
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        """Return rows from the most recent execute call."""
+
+        return self._result
+
+
+def test_audit_faction_row_flags_network_resource_ambiguity() -> None:
+    """The overloaded legacy network value should not silently pick one tag."""
+
+    entry = audit_faction_row(
+        {
+            "id": 7,
+            "name": "Quiet Hand",
+            "entity_id": 707,
+            "ideology": None,
+            "history": None,
+            "current_activity": None,
+            "hidden_agenda": None,
+            "territory": None,
+            "primary_location": None,
+            "power_level": None,
+            "resources": "network",
+        },
+        existing_pair_tags={},
+        legacy_tags=[],
+    )
+
+    resource_candidates = [
+        item for item in entry.mapping_candidates if item.source_column == "resources"
+    ]
+
+    assert entry.review_required is True
+    assert {item.target_tag for item in resource_candidates} == {
+        "criminal_network",
+        "information",
+        "patronage",
+    }
+    assert all(item.confidence == "ambiguous" for item in resource_candidates)
+
+
+def test_build_faction_table_audit_reports_legacy_tag_and_claim_counts() -> None:
+    """Audit counters should expose dry-run work and review pressure."""
+
+    audit = build_faction_table_audit(FakeFactionAuditCursor())
+
+    assert audit["dry_run"] is True
+    assert audit["non_null_counts"]["resources"] == 1
+    assert audit["counters"]["factions_scanned"] == 1
+    assert audit["counters"]["active_claim_edges"] == 2
+    assert audit["counters"]["legacy_operational_secrecy_tags"] == 1
+    assert audit["counters"]["legacy_faction_state_tags"] == 1
+    assert audit["counters"]["ambiguous_resource_values"] == 1
+    assert audit["factions"][0]["review_required"] is True
+
+
+def test_operational_secrecy_hidden_maps_to_operational_mode_covert() -> None:
+    """Legacy operational_secrecy rows should seed operational_mode candidates."""
+
+    entry = audit_faction_row(
+        {
+            "id": 3,
+            "name": "Veiled Office",
+            "entity_id": 303,
+            "ideology": None,
+            "history": None,
+            "current_activity": None,
+            "hidden_agenda": None,
+            "territory": None,
+            "primary_location": None,
+            "power_level": None,
+            "resources": None,
+        },
+        existing_pair_tags={},
+        legacy_tags=[
+            LegacyTagRow(
+                faction_id=3,
+                faction_name="Veiled Office",
+                entity_id=303,
+                category="operational_secrecy",
+                tag="hidden",
+            )
+        ],
+    )
+
+    candidates = [
+        item
+        for item in entry.mapping_candidates
+        if item.source_column == "entity_tags_current.operational_secrecy"
+    ]
+
+    assert len(candidates) == 1
+    assert candidates[0].target_category == "operational_mode"
+    assert candidates[0].target_tag == "covert"
+
+
+def test_operational_secrecy_cellular_maps_to_reviewable_covert() -> None:
+    """Old structure-flavored secrecy tags should still point at covert mode."""
+
+    entry = audit_faction_row(
+        {
+            "id": 4,
+            "name": "Cell Office",
+            "entity_id": 404,
+            "ideology": None,
+            "history": None,
+            "current_activity": None,
+            "hidden_agenda": None,
+            "territory": None,
+            "primary_location": None,
+            "power_level": None,
+            "resources": None,
+        },
+        existing_pair_tags={},
+        legacy_tags=[
+            LegacyTagRow(
+                faction_id=4,
+                faction_name="Cell Office",
+                entity_id=404,
+                category="operational_secrecy",
+                tag="cellular_clandestine",
+            )
+        ],
+    )
+
+    candidates = [
+        item
+        for item in entry.mapping_candidates
+        if item.source_column == "entity_tags_current.operational_secrecy"
+    ]
+
+    assert candidates[0].target_category == "operational_mode"
+    assert candidates[0].target_tag == "covert"
+    assert candidates[0].review_required is True
+
+
+def test_cli_faction_audit_returns_dry_run_payload(monkeypatch) -> None:
+    """The faction audit CLI should resolve the slot and keep the DB read-only."""
+
+    from nexus.api import db_pool
+
+    monkeypatch.setattr(
+        db_pool,
+        "get_connection",
+        lambda *args, **kwargs: FakeFactionAuditConnection(),
+    )
+
+    result = cli.run_faction_audit(Namespace(slot=2))
+
+    assert result["success"] is True
+    assert result["slot"] == 2
+    assert result["dbname"] == "save_02"
+    assert result["faction_audit"]["dry_run"] is True
+    assert result["faction_audit"]["counters"]["factions_scanned"] == 1


### PR DESCRIPTION
## Summary
- add a read-only `nexus faction-audit --slot N` dry run for legacy `factions` column migration
- map legacy faction columns and old faction tag categories into reviewable Orrery tag, pair-tag, event/prose, or remainder candidates
- document the preflight command in the faction vocabulary cleanup section

## Validation
- `poetry run pytest tests/test_faction_table_audit.py tests/test_cli.py -q`
- `poetry run flake8 nexus/api/faction_table_audit.py nexus/cli.py tests/test_faction_table_audit.py`
- `poetry run mypy nexus/api/faction_table_audit.py tests/test_faction_table_audit.py`
- `poetry run python -m nexus.cli faction-audit --slot 2`
- `poetry run python -m nexus.cli faction-audit --slot 5`

## Data impact
- Read-only audit only; no data rewrite, schema migration, or runtime write-surface cleanup yet.
- Slot 2 dry run reports 9 factions scanned, 57 non-null legacy values, 28 entity-tag candidates, 16 pair-tag candidates, and 79 manual-review items.
- Slot 5 dry run reports 4 factions scanned, 4 non-null legacy values, and 6 manual-review items.

Refs #337