### PR TITLE
[codex] Add faction migration manifest dry run

### DIFF
--- a/docs/orrery_faction_vocabulary.md
+++ b/docs/orrery_faction_vocabulary.md
@@ -319,6 +319,12 @@ Preflight command:
   faction columns, existing `claims` / `operates_from` pair-tags, and legacy
   faction tag categories. Review its JSON output before any destructive data
   rewrite or column-drop migration.
+- `nexus faction-manifest --slot N` folds the audit into a read-only migration
+  manifest with stable operation IDs. It separates deterministic entity-tag
+  inserts from review-required tag candidates, pair-tag target resolution,
+  prose/world-event preservation, structured remainders, and no-replacement
+  legacy tag drops. The manifest is a review/apply contract for a later script;
+  it does not authorize destructive mutations by itself.
 
 ---
 

--- a/nexus/api/faction_table_audit.py
+++ b/nexus/api/faction_table_audit.py
@@ -1107,12 +1107,9 @@ def _manifest_operation(
 ) -> dict[str, Any]:
     target_kind = str(candidate.get("target_kind") or "manual_review")
     if target_kind == "entity_tag":
-        operation_type = (
-            "insert_entity_tag"
-            if _candidate_is_apply_ready(candidate)
-            else "review_entity_tag"
-        )
-        status = "ready" if _candidate_is_apply_ready(candidate) else "review_required"
+        apply_ready = _candidate_is_apply_ready(candidate)
+        operation_type = "insert_entity_tag" if apply_ready else "review_entity_tag"
+        status = "ready" if apply_ready else "review_required"
         target = {
             "entity_kind": "faction",
             "entity_id": faction.get("entity_id"),
@@ -1158,7 +1155,7 @@ def _manifest_operation(
         },
         "target": target,
         "confidence": candidate.get("confidence"),
-        "review_required": bool(candidate.get("review_required", True)),
+        "review_required": status != "ready",
         "reason": candidate.get("reason") or "",
     }
     return operation

--- a/nexus/api/faction_table_audit.py
+++ b/nexus/api/faction_table_audit.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from decimal import Decimal
+import hashlib
 import importlib
 import re
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Sequence
 
 
+FACTION_MANIFEST_SCHEMA_VERSION = "faction-migration-manifest.v1"
 _CATEGORY_REFACTOR = importlib.import_module(
     "migrations.043_orrery_category_refactor_phase1"
 )
@@ -352,6 +354,81 @@ def build_faction_table_audit(cur: Any) -> dict[str, Any]:
         "counters": counters,
         "non_null_counts": non_null_counts,
         "factions": [_entry_to_dict(entry) for entry in entries],
+    }
+
+
+def build_faction_migration_manifest(
+    audit: Mapping[str, Any],
+    *,
+    slot: Optional[int] = None,
+    dbname: Optional[str] = None,
+) -> dict[str, Any]:
+    """Convert a faction audit into explicit review/apply operations.
+
+    The manifest is intentionally read-only: it names what a later migration
+    could do, but never mutates tags, pair-tags, prose, or legacy columns.
+    """
+
+    operations: list[dict[str, Any]] = []
+    factions: list[dict[str, Any]] = []
+    for faction in audit.get("factions", []):
+        faction_operations: list[dict[str, Any]] = []
+        for candidate in faction.get("mapping_candidates", []):
+            operation = _manifest_operation(faction, candidate)
+            operations.append(operation)
+            faction_operations.append(operation)
+
+        factions.append(
+            {
+                "faction_id": faction.get("faction_id"),
+                "faction_name": faction.get("faction_name"),
+                "entity_id": faction.get("entity_id"),
+                "operation_ids": [
+                    operation["operation_id"] for operation in faction_operations
+                ],
+                "ready_operations": sum(
+                    1
+                    for operation in faction_operations
+                    if operation["status"] == "ready"
+                ),
+                "review_required_operations": sum(
+                    1
+                    for operation in faction_operations
+                    if operation["status"] != "ready"
+                ),
+            }
+        )
+
+    counters = _build_manifest_counters(operations)
+    return {
+        "schema_version": FACTION_MANIFEST_SCHEMA_VERSION,
+        "dry_run": True,
+        "source": {
+            "slot": slot,
+            "dbname": dbname,
+            "audit_counters": dict(audit.get("counters") or {}),
+            "source_columns": list(audit.get("source_columns") or []),
+            "keep_columns": list(audit.get("keep_columns") or []),
+        },
+        "review_policy": {
+            "ready": (
+                "Only deterministic entity-tag candidates that require no review "
+                "are apply-ready."
+            ),
+            "review_required": (
+                "Suggested, ambiguous, prose, pair-tag, structured remainder, "
+                "and no-replacement operations need human review before any "
+                "apply script consumes them."
+            ),
+            "destructive_mutations": (
+                "This manifest performs no writes and does not authorize column "
+                "drops; destructive work needs a later migration with backup or "
+                "test-slot scoping."
+            ),
+        },
+        "counters": counters,
+        "factions": factions,
+        "operations": operations,
     }
 
 
@@ -1022,6 +1099,117 @@ def _map_controlled_legacy_tag_row(
             reason=unknown_reason,
         )
     ]
+
+
+def _manifest_operation(
+    faction: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+) -> dict[str, Any]:
+    target_kind = str(candidate.get("target_kind") or "manual_review")
+    if target_kind == "entity_tag":
+        operation_type = (
+            "insert_entity_tag"
+            if _candidate_is_apply_ready(candidate)
+            else "review_entity_tag"
+        )
+        status = "ready" if _candidate_is_apply_ready(candidate) else "review_required"
+        target = {
+            "entity_kind": "faction",
+            "entity_id": faction.get("entity_id"),
+            "category": candidate.get("target_category"),
+            "tag": candidate.get("target_tag"),
+        }
+    elif target_kind == "pair_tag":
+        operation_type = "resolve_pair_tag_target"
+        status = "review_required"
+        target = {
+            "subject_entity_kind": "faction",
+            "subject_entity_id": faction.get("entity_id"),
+            "pair_tag": candidate.get("target_pair_tag"),
+            "object_entity_id": None,
+        }
+    elif target_kind == "world_event_or_prose":
+        operation_type = "preserve_prose"
+        status = "review_required"
+        target = {"destination": "world_event_or_summary_prose"}
+    elif target_kind == "no_replacement":
+        operation_type = "drop_legacy_tag_after_review"
+        status = "review_required"
+        target = {"replacement": None}
+    elif target_kind == "structured_remainder":
+        operation_type = "classify_structured_remainder"
+        status = "review_required"
+        target = {"target_category": candidate.get("target_category")}
+    else:
+        operation_type = "manual_review"
+        status = "review_required"
+        target = {}
+
+    operation = {
+        "operation_id": _manifest_operation_id(faction, candidate),
+        "operation_type": operation_type,
+        "status": status,
+        "faction_id": faction.get("faction_id"),
+        "faction_name": faction.get("faction_name"),
+        "entity_id": faction.get("entity_id"),
+        "source": {
+            "column": candidate.get("source_column"),
+            "value": candidate.get("source_value"),
+        },
+        "target": target,
+        "confidence": candidate.get("confidence"),
+        "review_required": bool(candidate.get("review_required", True)),
+        "reason": candidate.get("reason") or "",
+    }
+    return operation
+
+
+def _candidate_is_apply_ready(candidate: Mapping[str, Any]) -> bool:
+    return (
+        candidate.get("target_kind") == "entity_tag"
+        and candidate.get("confidence") == "deterministic"
+        and not bool(candidate.get("review_required", True))
+        and bool(candidate.get("target_category"))
+        and bool(candidate.get("target_tag"))
+    )
+
+
+def _manifest_operation_id(
+    faction: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+) -> str:
+    parts = (
+        str(faction.get("faction_id") or ""),
+        str(faction.get("entity_id") or ""),
+        str(candidate.get("source_column") or ""),
+        str(candidate.get("source_value") or ""),
+        str(candidate.get("target_kind") or ""),
+        str(candidate.get("target_category") or ""),
+        str(candidate.get("target_tag") or ""),
+        str(candidate.get("target_pair_tag") or ""),
+    )
+    digest = hashlib.sha1("\x1f".join(parts).encode("utf-8")).hexdigest()[:12]
+    return f"faction-migration-{digest}"
+
+
+def _build_manifest_counters(
+    operations: Sequence[Mapping[str, Any]],
+) -> dict[str, int]:
+    counters = {
+        "operation_items": len(operations),
+        "ready_operations": 0,
+        "review_required_operations": 0,
+    }
+    for operation in operations:
+        operation_type = str(operation["operation_type"])
+        counters[f"{operation_type}_operations"] = (
+            counters.get(f"{operation_type}_operations", 0) + 1
+        )
+        if operation["status"] == "ready":
+            counters["ready_operations"] += 1
+        else:
+            counters["review_required_operations"] += 1
+    return counters
 
 
 def _obsolete_values(row: Mapping[str, Any]) -> dict[str, Any]:

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -9,6 +9,7 @@ Commands:
     nexus model --slot N        Get or set the model for a slot
     nexus trait-audit --slot N  Dry-run new-story trait compiler audit
     nexus faction-audit --slot N  Dry-run legacy faction column migration audit
+    nexus faction-manifest --slot N  Build reviewed faction migration manifest
 
 The CLI is slot-centric: only --slot N is required. The backend resolves
 all other state (wizard phase, current chunk, thread ID) automatically.
@@ -265,6 +266,49 @@ def _print_faction_audit(payload: Dict[str, Any]) -> None:
             print(f"  ...{len(review_factions) - 10} more")
 
 
+def _print_faction_manifest(payload: Dict[str, Any]) -> None:
+    """Print a faction migration manifest summary."""
+
+    manifest = payload.get("faction_manifest") or {}
+    counters = manifest.get("counters") or {}
+    factions = manifest.get("factions") or []
+
+    print("Manifest:")
+    print(f"  schema_version: {manifest.get('schema_version')}")
+    print(f"  dry_run: {manifest.get('dry_run')}")
+
+    print()
+    print("Counters:")
+    for key in (
+        "operation_items",
+        "ready_operations",
+        "review_required_operations",
+        "insert_entity_tag_operations",
+        "review_entity_tag_operations",
+        "resolve_pair_tag_target_operations",
+        "preserve_prose_operations",
+        "classify_structured_remainder_operations",
+        "drop_legacy_tag_after_review_operations",
+    ):
+        print(f"  {key}: {counters.get(key, 0)}")
+
+    review_factions = [
+        item for item in factions if item.get("review_required_operations", 0)
+    ]
+    if review_factions:
+        print()
+        print("Manual review:")
+        for item in review_factions[:10]:
+            print(
+                "  - "
+                f"{item['faction_name']} "
+                f"(id {item['faction_id']}): "
+                f"{item.get('review_required_operations', 0)} item(s)"
+            )
+        if len(review_factions) > 10:
+            print(f"  ...{len(review_factions) - 10} more")
+
+
 def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) -> None:
     """Emit payload to stdout in JSON or human-readable format."""
     if as_json:
@@ -288,6 +332,10 @@ def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) 
 
     if payload.get("faction_audit"):
         _print_faction_audit(payload)
+        print()
+
+    if payload.get("faction_manifest"):
+        _print_faction_manifest(payload)
         print()
 
     # Get display elements
@@ -1035,6 +1083,36 @@ def run_faction_audit(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
+def run_faction_manifest(args: argparse.Namespace) -> Dict[str, Any]:
+    """Build a read-only faction migration manifest from the audit output."""
+
+    from nexus.api.db_pool import get_connection
+    from nexus.api.faction_table_audit import (
+        build_faction_migration_manifest,
+        build_faction_table_audit,
+    )
+    from nexus.api.slot_utils import slot_dbname
+
+    dbname = slot_dbname(args.slot)
+    with get_connection(dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SET TRANSACTION READ ONLY")
+            audit = build_faction_table_audit(cur)
+
+    manifest = build_faction_migration_manifest(
+        audit,
+        slot=args.slot,
+        dbname=dbname,
+    )
+    return {
+        "success": True,
+        "message": f"Faction migration manifest for slot {args.slot} (dry run).",
+        "slot": args.slot,
+        "dbname": dbname,
+        "faction_manifest": manifest,
+    }
+
+
 def run_lock(args: argparse.Namespace) -> Dict[str, Any]:
     """
     Lock a slot to prevent modifications.
@@ -1106,6 +1184,7 @@ Examples:
   nexus unlock --slot 2         Unlock slot to allow modifications
   nexus trait-audit --slot 5    Dry-run trait compiler audit
   nexus faction-audit --slot 2  Dry-run faction column migration audit
+  nexus faction-manifest --slot 2  Build faction migration manifest
 """,
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON output")
@@ -1241,6 +1320,15 @@ Examples:
         "--slot", type=int, required=True, help="Slot number (1-5)"
     )
 
+    # faction-manifest command
+    faction_manifest_parser = subparsers.add_parser(
+        "faction-manifest",
+        help="Build read-only faction migration manifest from audit output",
+    )
+    faction_manifest_parser.add_argument(
+        "--slot", type=int, required=True, help="Slot number (1-5)"
+    )
+
     # lock command
     lock_parser = subparsers.add_parser(
         "lock", help="Lock a slot to prevent modifications"
@@ -1274,6 +1362,7 @@ def main() -> int:
         "clear",
         "trait-audit",
         "faction-audit",
+        "faction-manifest",
         "lock",
         "unlock",
     ):
@@ -1306,6 +1395,8 @@ def main() -> int:
         result = run_trait_audit(args)
     elif args.command == "faction-audit":
         result = run_faction_audit(args)
+    elif args.command == "faction-manifest":
+        result = run_faction_manifest(args)
     elif args.command == "lock":
         result = run_lock(args)
     elif args.command == "unlock":

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -279,6 +279,7 @@ def _print_faction_manifest(payload: Dict[str, Any]) -> None:
 
     print()
     print("Counters:")
+    printed_counters = set()
     for key in (
         "operation_items",
         "ready_operations",
@@ -291,6 +292,9 @@ def _print_faction_manifest(payload: Dict[str, Any]) -> None:
         "drop_legacy_tag_after_review_operations",
     ):
         print(f"  {key}: {counters.get(key, 0)}")
+        printed_counters.add(key)
+    for key in sorted(key for key in counters if key not in printed_counters):
+        print(f"  {key}: {counters[key]}")
 
     review_factions = [
         item for item in factions if item.get("review_required_operations", 0)
@@ -1071,7 +1075,7 @@ def run_faction_audit(args: argparse.Namespace) -> Dict[str, Any]:
     dbname = slot_dbname(args.slot)
     with get_connection(dbname, dict_cursor=True) as conn:
         with conn.cursor() as cur:
-            cur.execute("SET TRANSACTION READ ONLY")
+            cur.execute("BEGIN READ ONLY")
             audit = build_faction_table_audit(cur)
 
     return {
@@ -1096,7 +1100,7 @@ def run_faction_manifest(args: argparse.Namespace) -> Dict[str, Any]:
     dbname = slot_dbname(args.slot)
     with get_connection(dbname, dict_cursor=True) as conn:
         with conn.cursor() as cur:
-            cur.execute("SET TRANSACTION READ ONLY")
+            cur.execute("BEGIN READ ONLY")
             audit = build_faction_table_audit(cur)
 
     manifest = build_faction_migration_manifest(

--- a/tests/test_faction_table_audit.py
+++ b/tests/test_faction_table_audit.py
@@ -17,6 +17,7 @@ from nexus.api.faction_table_audit import (
     LEGACY_TAG_CATEGORIES,
     LegacyTagRow,
     audit_faction_row,
+    build_faction_migration_manifest,
     build_faction_table_audit,
 )
 
@@ -391,3 +392,115 @@ def test_cli_prints_all_pair_edge_counters(capsys) -> None:
 
     assert "active_claim_edges: 2" in output
     assert "active_operates_from_edges: 3" in output
+
+
+def test_faction_migration_manifest_classifies_operations() -> None:
+    """The manifest should separate ready writes from review-only work."""
+
+    entry = audit_faction_row(
+        {
+            "id": 11,
+            "name": "Canal League",
+            "entity_id": 1111,
+            "ideology": "mercantilist",
+            "history": "Founded after the river war.",
+            "current_activity": None,
+            "hidden_agenda": None,
+            "territory": "controls the canal district",
+            "primary_location": None,
+            "power_level": None,
+            "resources": "network",
+        },
+        existing_pair_tags={},
+        legacy_tags=[
+            LegacyTagRow(
+                faction_id=11,
+                faction_name="Canal League",
+                entity_id=1111,
+                category="history_class",
+                tag="ancient_continuous",
+            )
+        ],
+    )
+    audit = {
+        "counters": {},
+        "source_columns": ["ideology", "history", "territory", "resources"],
+        "keep_columns": ["id", "name"],
+        "factions": [asdict(entry)],
+    }
+
+    manifest = build_faction_migration_manifest(
+        audit,
+        slot=2,
+        dbname="save_02",
+    )
+    operation_types = {
+        operation["operation_type"] for operation in manifest["operations"]
+    }
+
+    assert manifest["schema_version"] == "faction-migration-manifest.v1"
+    assert manifest["dry_run"] is True
+    assert manifest["source"]["slot"] == 2
+    assert manifest["counters"]["ready_operations"] == 1
+    assert manifest["counters"]["insert_entity_tag_operations"] == 1
+    assert "review_entity_tag" in operation_types
+    assert "resolve_pair_tag_target" in operation_types
+    assert "preserve_prose" in operation_types
+    assert "drop_legacy_tag_after_review" in operation_types
+    assert all(
+        operation["operation_id"].startswith("faction-migration-")
+        for operation in manifest["operations"]
+    )
+
+
+@pytest.mark.requires_postgres
+def test_cli_faction_manifest_returns_live_slot2_payload() -> None:
+    """The faction manifest CLI should build from the real slot 2 audit."""
+
+    try:
+        result = cli.run_faction_manifest(Namespace(slot=2))
+    except psycopg2.Error as exc:
+        pytest.skip(f"{TEST_DBNAME} PostgreSQL test database unavailable: {exc}")
+    finally:
+        close_pool(TEST_DBNAME)
+
+    manifest = result["faction_manifest"]
+
+    assert result["success"] is True
+    assert result["slot"] == 2
+    assert manifest["dry_run"] is True
+    assert manifest["counters"]["operation_items"] >= 1
+    assert manifest["counters"]["operation_items"] == len(manifest["operations"])
+
+
+def test_cli_prints_faction_manifest_summary(capsys) -> None:
+    """Human faction manifest output should show operation counters."""
+
+    cli.emit_output(
+        {
+            "message": "Faction migration manifest for slot 2 (dry run).",
+            "faction_manifest": {
+                "schema_version": "faction-migration-manifest.v1",
+                "dry_run": True,
+                "counters": {
+                    "operation_items": 2,
+                    "ready_operations": 1,
+                    "review_required_operations": 1,
+                },
+                "factions": [
+                    {
+                        "faction_id": 11,
+                        "faction_name": "Canal League",
+                        "review_required_operations": 1,
+                    }
+                ],
+            },
+        },
+        as_json=False,
+    )
+
+    output = capsys.readouterr().out
+
+    assert "operation_items: 2" in output
+    assert "ready_operations: 1" in output
+    assert "Canal League (id 11): 1 item(s)" in output

--- a/tests/test_faction_table_audit.py
+++ b/tests/test_faction_table_audit.py
@@ -451,6 +451,10 @@ def test_faction_migration_manifest_classifies_operations() -> None:
         operation["operation_id"].startswith("faction-migration-")
         for operation in manifest["operations"]
     )
+    assert all(
+        operation["review_required"] == (operation["status"] != "ready")
+        for operation in manifest["operations"]
+    )
 
 
 @pytest.mark.requires_postgres
@@ -486,6 +490,7 @@ def test_cli_prints_faction_manifest_summary(capsys) -> None:
                     "operation_items": 2,
                     "ready_operations": 1,
                     "review_required_operations": 1,
+                    "manual_review_operations": 1,
                 },
                 "factions": [
                     {
@@ -503,4 +508,5 @@ def test_cli_prints_faction_manifest_summary(capsys) -> None:
 
     assert "operation_items: 2" in output
     assert "ready_operations: 1" in output
+    assert "manual_review_operations: 1" in output
     assert "Canal League (id 11): 1 item(s)" in output


### PR DESCRIPTION
## Summary
- add a read-only faction migration manifest layer over the existing faction audit
- expose nexus faction-manifest --slot N with JSON and human summaries plus stable operation IDs
- document the manifest as the review/apply contract before destructive faction-column migration

## Validation
- poetry run black nexus/api/faction_table_audit.py nexus/cli.py tests/test_faction_table_audit.py
- poetry run flake8 nexus/api/faction_table_audit.py nexus/cli.py tests/test_faction_table_audit.py
- poetry run mypy nexus/api/faction_table_audit.py tests/test_faction_table_audit.py
- poetry run pytest tests/test_faction_table_audit.py tests/test_cli.py -q
- NEXUS_RUN_POSTGRES=1 poetry run pytest tests/test_faction_table_audit.py -q
- poetry run python -m nexus.cli faction-manifest --slot 2
- poetry run python -m nexus.cli --json faction-manifest --slot 2

## Notes
- Refs #337; this is the manifest-first dry-run slice, not the destructive data rewrite or schema cleanup.
- No database mutations are performed by this command.