### PR TITLE
Seed Orrery faction tag vocabulary

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -9,11 +9,11 @@ Orrery's shape borrows openly from two reference points:
 - **Bethesda's Radiant AI** (Skyrim, Fallout): NPCs have schedules, dispositions, and faction-affiliated routines that run independent of player presence. Off-screen state isn't fiction; it's the canonical answer to "what is this NPC doing right now?"
 - **Dwarf Fortress**: autonomous agents with needs, relationships, and emergent off-screen events that produce historical record. The world simulates regardless of where attention is currently pointed.
 
-What distinguishes Orrery from either of those is LLM-native integration: deterministic resolution feeds prose generation, prose feeds a *curated bleed menu*, and the storyteller (Skald) retains full authorial latitude over what makes it into the actual narrative chunk. The deterministic substrate decides what's *true*; the storyteller decides what's *said*.
+What distinguishes Orrery from either of those is LLM-native integration: deterministic resolution feeds Skald a structured proposal stream, Skald retains full authorial authority over current-tick proposals, and accepted off-screen outcomes can later feed narration plus a *curated bleed menu*. The deterministic substrate creates pressure and defaults; Skald decides what becomes canonical for the visible story.
 
 ## Motivating Example
 
-An NPC the player interrogated fifty chunks ago protested that their life was over. Behind the scenes, packages on that NPC tick through fifty chunks of deterministic state resolution. Eventually a high-magnitude branch fires — say, the NPC's retaliation against the player's faction. Prose is generated, persisted into `offscreen_narrations`, never directly surfaced. Two chunks later the player is in an intimacy scene in an entirely different part of the city, and the storyteller has the option of having a character hear distant sirens. If they do, MEMNON has substrate for retrieval and the moment connects to the long-ago interrogation. If they don't, the dramatic irony lives quietly in the database, available for any future scene that wants it.
+An NPC the player interrogated fifty chunks ago protested that their life was over. Behind the scenes, packages on that NPC tick through fifty chunks of deterministic state resolution. Eventually a high-magnitude branch fires — say, the NPC's retaliation against the player's faction. Orrery surfaces the proposal to Skald as imminent activity; if Skald ignores it, the proposal is ratified and committed. Prose is generated, persisted into `offscreen_narrations`, never directly surfaced. Two chunks later the player is in an intimacy scene in an entirely different part of the city, and the storyteller has the option of having a character hear distant sirens. If they do, MEMNON has substrate for retrieval and the moment connects to the long-ago interrogation. If they don't, the dramatic irony lives quietly in the database, available for any future scene that wants it.
 
 This is the shape: the world ticks for everyone, the dramatic salience filter is deterministic, the authorial choice is LLM-authored.
 
@@ -39,12 +39,12 @@ This is the shape: the world ticks for everyone, the dramatic salience filter is
 |---|---|---|---|
 | **Resolve** (Stage 1) | Free (pure Python) | Evaluate templates against per-entity bindings; produce an `OrreryTickProposal` (no writes) | In-cycle, during LORE Phase 4.5 |
 | **Commit** (Stage 2) | Free (SQL) | Stamp `tick_chunk_id`, materialize the proposal into canonical tables, enqueue narration jobs | Inside the accepted-chunk commit transaction |
-| **Clear** (Stage 3) | Deterministic | Event-based clearance runs in the commit transaction; semantic clearance currently no-op | Commit (event-driven) |
+| **Clear** (Stage 3) | Deterministic | Event-based clearance and scheduled-expiry sweeps run in the commit transaction; semantic clearance currently no-op | Commit (event/time-driven) |
 | **Promote** (Stage 4) | Deterministic | Decide which resolutions deserve frontier prose | Post-commit |
 | **Narrate** (Stage 5) | Frontier LLM, async via durable outbox | Generate prose for promoted resolutions; persist into `offscreen_narrations` | Async after commit; durable across process restart |
 | **Bleed** (Stage 6) | Deterministic, storyteller-time | Offer a bounded menu from already-filtered succeeded narrations | LORE Phase 5 (`payload_assembly`), each player turn |
 
-**Cost shape (load-bearing):** Resolve is free and runs at full breadth. Each downstream stage is more expensive per call but operates on a smaller surface. Frontier prose only generates for resolutions that survive two earlier gates — salience-based promotion, then optional bleed selection. The only LLM call in the Orrery path is the Narration step; Promote and Bleed are both deterministic.
+**Cost shape (load-bearing):** Resolve is free and runs at full breadth. Each downstream stage is more expensive per call but operates on a smaller surface. Frontier prose only generates for resolutions that survive promotion. Skald adjudication happens inside the ordinary storyteller call; there is no separate local-LLM adjudicator. The only Orrery-owned frontier call is Narrate; Promote and Bleed are deterministic.
 
 ---
 
@@ -178,7 +178,13 @@ The existing six triplicate relationship/reference tables (`chunk_character_refe
 
 ```sql
 CREATE TYPE entity_tag_source_kind AS ENUM (
-  'authored', 'llm_generated', 'system', 'template', 'auto_registered', 'skald_inline'
+  'authored', 'llm_generated', 'system', 'template',
+  'auto_registered', -- retired legacy literal; writers reject it
+  'skald_inline'
+);
+
+CREATE TYPE entity_tag_clearance_kind AS ENUM (
+  'event', 'semantic', 'authored', 'time'
 );
 
 CREATE TABLE tags (
@@ -202,6 +208,7 @@ CREATE TABLE entity_tags (
   tag_id                 bigint NOT NULL REFERENCES tags(id),
   applied_at             timestamp NOT NULL DEFAULT now(),
   applied_at_world_time  timestamptz,
+  expires_at_world_time  timestamptz,
   clear_on_override      jsonb,
   cleared_at             timestamp,                   -- NULL means current
   template_id            text,                        -- if applied by a template
@@ -209,10 +216,15 @@ CREATE TABLE entity_tags (
   UNIQUE (entity_id, tag_id, applied_at)
 );
 
+CREATE UNIQUE INDEX ix_entity_tags_current
+  ON entity_tags (entity_id, tag_id)
+  WHERE cleared_at IS NULL;
+
 CREATE VIEW entity_tags_current AS
   SELECT et.id AS entity_tag_id, et.entity_id, e.kind AS entity_kind,
          t.tag, t.category, t.is_ephemeral, t.clearance_kind,
-         et.applied_at, et.applied_at_world_time, et.source_kind, et.template_id
+         et.applied_at, et.applied_at_world_time, et.expires_at_world_time,
+         et.source_kind, et.template_id
   FROM entity_tags et
   JOIN entities e ON e.id = et.entity_id
   JOIN tags t ON t.id = et.tag_id
@@ -238,8 +250,59 @@ Design constraints:
 - Surrogate `entity_tags.id` (not composite key); allows multiple historical applications.
 - Single FK to `entities(id)`, no discriminator column.
 - `cleared_at` column for cheap current-view reads.
-- Three clearance kinds: `event` / `semantic` / `authored`. No clock-based expiry.
-- `source_kind` as a real PG enum. `'auto_registered'` satisfies the Vocabulary Growth contract; `'skald_inline'` is the runtime path from Skald tagging during structured-output entity registration.
+- Four clearance kinds: `event` / `semantic` / `authored` / `time`. `semantic` remains a conservative no-op until a non-local clearance signal exists; `time` records scheduled-expiry sweeps.
+- `entity_tags.expires_at_world_time` supports duration-bearing states. The accepted-tick commit path clears expired rows and records `tag_clearance_log.mechanism = 'time'`.
+- `source_kind` is a real PG enum. `skald_inline` is the runtime path from Skald tagging during structured-output entity registration. `auto_registered` remains an old enum literal for migration compatibility only; closed-vocabulary writers reject it.
+- Runtime tag bestowal is closed-vocabulary: unknown, deprecated, or entity-kind-incompatible tags raise.
+
+### Pair Tag System
+
+Multi-entity tags are directed binary relations between rows in the entity
+spine. They live in `entity_pair_tags`, with vocabulary and endpoint-kind
+constraints in `pair_tags`.
+
+```sql
+CREATE TABLE pair_tags (
+  id                   bigserial PRIMARY KEY,
+  tag                  text UNIQUE NOT NULL,
+  subject_kinds        text[] NOT NULL,
+  object_kinds         text[] NOT NULL,
+  is_ephemeral         boolean NOT NULL DEFAULT false,
+  clearance_kind       entity_tag_clearance_kind,
+  reapplication_policy entity_tag_reapplication_policy,
+  clear_on             jsonb,
+  deprecated           boolean NOT NULL DEFAULT false,
+  description          text,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  CHECK (is_ephemeral = (clearance_kind IS NOT NULL)),
+  CHECK (cardinality(subject_kinds) >= 1),
+  CHECK (cardinality(object_kinds) >= 1)
+);
+
+CREATE TABLE entity_pair_tags (
+  id                    bigserial PRIMARY KEY,
+  subject_entity_id     bigint NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  object_entity_id      bigint NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  pair_tag_id           bigint NOT NULL REFERENCES pair_tags(id),
+  applied_at            timestamptz NOT NULL DEFAULT now(),
+  applied_at_world_time timestamptz,
+  source_kind           entity_tag_source_kind NOT NULL,
+  cleared_at            timestamptz,
+  clear_on_override     jsonb,
+  template_id           text,
+  CHECK (subject_entity_id <> object_entity_id)
+);
+
+CREATE UNIQUE INDEX ix_entity_pair_tags_current
+  ON entity_pair_tags (subject_entity_id, object_entity_id, pair_tag_id)
+  WHERE cleared_at IS NULL;
+```
+
+Design constraints:
+- Pair tags are not rich relationship rows. They are package-facing facts such as `claims(faction -> place)`, `knows_location(character -> place)`, `hunting(faction -> character)`, or `status:senior(character -> faction)`.
+- Endpoint polymorphism is declared in `pair_tags.subject_kinds` and `pair_tags.object_kinds`; writers validate against the entity spine before inserting.
+- The active-edge uniqueness index gives one current row per `(subject, object, pair_tag)`, while historical cleared rows remain available for audit.
+- Seeded families now include the original relation set (migration 042), trait/status additions and `claims` subject-kind extension (migration 045), kind-qualified `contact:<kind>` rows (migration 047), and the `pursuing` -> `hunting` rename (migration 048).
 
 ### Event Stream
 
@@ -383,6 +446,7 @@ Storyteller-time Bleed chooses deterministically from these eligible narrated ev
 - **Resolve runs in-cycle** during LORE Phase 4.5 (`TurnPhase.ORRERY_RESOLVE`), between `DEEP_QUERIES` and `PAYLOAD_ASSEMBLY`. Pure Python; no writes.
 - **CommitOrreryTick** runs as Step 8.5 inside `commit_incubator_to_database{,_sync}`. All canonical writes happen here.
 - **Clear (event)** runs in the same commit transaction as the triggering event.
+- **Clear (time)** sweeps open `entity_tags` rows whose `expires_at_world_time` is at or before the accepted tick's world time, recording `tag_clearance_log` rows with mechanism `time`.
 - **Clear (semantic)** is currently a conservative no-op until a non-local clearance signal exists.
 - **Promote** runs post-commit, deterministically, batched per tick.
 - **Narrate** is async via durable outbox. Bleed reads only `state='succeeded'` narrations + deterministic briefs.
@@ -429,11 +493,14 @@ Postgres FKs enforce existence; `EntityRef` is a typed read-side convenience tha
 
 ## Invariants and Contracts
 
-### Vocabulary Growth Contract
+### Closed Vocabulary Contract
 
 When a tag or `event_type` is referenced that the registry hasn't seen:
 - **Resolver-sourced**: fail loudly. Templates must register their vocabulary before use.
-- **Apex/Skald-sourced**: auto-register with `source_kind='auto_registered'` or `'skald_inline'` and `description='AUTO: pending review'`. Surfaces in periodic curation.
+- **Apex/Skald-sourced tags**: fail loudly. Skald may bestow only registered, non-deprecated tags allowed for the target entity kind. `skald_inline` is provenance, not a vocabulary-growth loophole.
+- **Event types**: fail loudly for authored templates and structured replacement events. Register event vocabulary in migrations before a template or adjudication contract depends on it.
+
+`auto_registered` remains in the PostgreSQL enum because enum-value removal is not worth the migration risk, but runtime code treats it as disallowed.
 
 ### ALWAYS-Fallback Invariant
 
@@ -508,7 +575,7 @@ Every model reference uses the `@provider.role` syntax that the config loader re
 - `nexus/agents/orrery/substrate.py` — package primitive (`Template`, `Branch`, predicates, `evaluate`, `evaluate_stack`)
 - `nexus/agents/orrery/templates.py` — package catalog
 - `nexus/agents/orrery/resolver.py` — `resolve_dry_run` + binding composers
-- `nexus/agents/orrery/events.py` — canonical event writer (`emit_state_updates_events`, `emit_event`)
+- `nexus/agents/orrery/events.py` — canonical event writer (`emit_state_updates_events`, `emit_event`), event tag clearance, and scheduled-expiry sweeps
 - `nexus/agents/orrery/bleed.py` — bleed candidate query + offer bookkeeping
 - `nexus/agents/orrery/worker.py` — Promote / narration outbox drain
 - `nexus/api/trait_compiler.py` — new-story trait → Orrery compiler, final apply, dry-run compile, and pair-tag/relationship drift reconciliation
@@ -521,6 +588,8 @@ Every model reference uses the `@provider.role` syntax that the config loader re
 - `docs/orrery_needs.md` — design rationale for the physiological and interpersonal need packages (SLEEP, EAT, DRINK, SOCIALIZE, INTIMACY): the substrate-vs-storyteller principle, the graduated severity pattern, the stimulant gate-suppression pattern, modulator tags, intimacy suppressors, the Pete worked example, and open questions. Companion to the mechanical catalog at `docs/orrery_packages.md`.
 - `docs/orrery_retrograde_spec.md` — design spec for deep-history generation (Orrery run backward at wizard-time and per-entity stub maturation at runtime). Phase 3+ work.
 - `docs/orrery_tag_vocabulary.md` — registry-level closed-vocabulary specification for tag categories (single-entity tags, multi-entity pair tags, place / faction categories, trait_menu alignment).
+- `docs/orrery_state_vocabulary.md` — state-tag vocabulary, clearance contracts, pharmacologic/time-cleared states, and current substrate debts.
+- `docs/orrery_faction_vocabulary.md` — faction tag vocabulary seeded by migration 052, legacy category mapping, and faction-table cleanup implications.
 
 ---
 

--- a/docs/orrery_faction_vocabulary.md
+++ b/docs/orrery_faction_vocabulary.md
@@ -1,6 +1,6 @@
 # Orrery Faction Vocabulary
 
-**Status:** draft design spec for faction single-entity tag categories. Companion to `docs/orrery_tag_vocabulary.md`; downstream implementation is expected to seed these tags, rewrite legacy Slot 2 faction tags, and update any faction table cleanup plan.
+**Status:** draft design spec for faction single-entity tag categories. Companion to `docs/orrery_tag_vocabulary.md`; migration 052 seeds the 65 tag anchors. Legacy Slot 2 faction tag rewrite, faction-table cleanup, and clearance-event collapse remain separate follow-up work.
 
 ---
 
@@ -197,6 +197,8 @@ The replacement names are longer, but they are easier to guess without peeking a
 
 Faction ephemerals need a clearance/replacement plan before they ship as seeded tags. The state vocabulary's rule applies here too: clearance belongs to the tag row's `clear_on`, not to a central event table. Event names below are design targets unless a migration already registers them.
 
+Migration 052 seeds `power_status` and `agenda` rows with `clearance_kind='semantic'`, `reapplication_policy='replace'`, and per-row `clear_on.description` text so runtime bestowal can begin without duration overrides or unregistered event dependencies. A later clearance migration can promote specific rows to event clearance after the event names are collapsed and registered.
+
 ### `power_status`
 
 `power_status` should usually be replaced rather than cleared to absence. A faction without an active power row is "unknown," not necessarily stable.
@@ -330,7 +332,7 @@ Preflight command:
 
 ## Mechanical Implications
 
-1. **Registry categories.** Migration 043 already registers the six categories used here. The draft intentionally avoids adding faction `state`, so a future seeding migration can stay within that surface unless review admits a seventh category.
+1. **Registry categories.** Migration 043 registers the six categories used here, and migration 052 seeds the 65 canonical tag rows. The draft intentionally avoids adding faction `state`; any future seventh category needs a separate category-registration migration.
 2. **Cardinality enforcement.** `legitimacy`, `operational_mode`, and `power_status` are exclusive design categories. Until the `tags.cardinality` column ships, application writers must clear sibling rows explicitly, as with current exclusive character categories.
 3. **Slot 2 backfill.** Existing faction tags should be classified as keep/rename/drop/convert-to-pair-tag. Ambiguous `resource_class:network` rows need manual review because "network" may mean information, patronage, criminal logistics, or membership.
 4. **Package gates.** Packages should prefer category-specific predicates when they care about the axis. A gate that cares whether a faction is public should read `operational_mode`, not `legitimacy`; a gate that cares whether public association is risky should read `legitimacy`.

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1772,6 +1772,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/049_orrery_entity_tag_expiry_substrate.py`
 - `migrations/050_orrery_state_clearance_event_types.py`
 - `migrations/051_orrery_time_tag_clearance_kind.py`
+- `migrations/052_orrery_faction_tag_vocab.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 

--- a/docs/orrery_tag_vocabulary.md
+++ b/docs/orrery_tag_vocabulary.md
@@ -584,7 +584,9 @@ Compositions: Hong Kong is `urban_dense` + `coastal`; a castle in the Alps is `m
 
 ## Faction Categories
 
-Draft companion: `docs/orrery_faction_vocabulary.md`.
+Companion: `docs/orrery_faction_vocabulary.md`. Migration 052 seeds the 65
+faction tag anchors; Slot 2 data rewrite, faction table cleanup, and
+clearance-event collapse remain follow-up work.
 
 Faction categories describe group-level actors: institutions, movements,
 corporations, gangs, churches, polities, guilds, scenes, families, and other
@@ -593,7 +595,7 @@ by migration 043 and does not add a generic faction `state` category; passive
 faction conditions decompose into `power_status`, `agenda`, pair-tags, event
 history, or prose.
 
-| Category | Cardinality | Ephemerality | Draft tags |
+| Category | Cardinality | Ephemerality | Seeded tags |
 |---|---|---|---|
 | `ideology` | Multi-valued | Durable | `authoritarian`, `egalitarian`, `traditionalist`, `progressive`, `theocratic`, `secularist`, `nationalist`, `cosmopolitan`, `imperial`, `communalist`, `mercantilist`, `technocratic`, `revolutionary`, `restorationist`, `isolationist` |
 | `resource_base` | Multi-valued | Durable | `capital`, `force`, `information`, `faith`, `industry`, `labor`, `territory`, `patronage`, `bureaucracy`, `technology`, `specialized_knowledge`, `criminal_network`, `supply_lines`, `mobility` |
@@ -607,7 +609,7 @@ Legacy sample values rename for clarity: `revanchist` -> `recover_losses`,
 `infiltration` -> `infiltrate`, `expansion` -> `expand_control`, and
 `consolidation` -> `consolidate_control`.
 
-### `factions` Table Cleanup (in Scope for the Migration)
+### `factions` Table Cleanup (Future Data Migration Scope)
 
 **Drop columns (move to tags):**
 - `ideology` → tag category `ideology`
@@ -759,7 +761,7 @@ Compiler surfaces:
 ## Open Items
 
 1. **Character category values.** `bodyform`, `disposition`, `capacity`, and the role split (`role.function`, `role.resources`, `role.fame`, scope-bound `status`) are settled. `role.resources`, `role.fame`, and `status:*` have substrate support via migration 045 and compiler MVP support where typed inputs exist. The `state` category vocabulary is now specified in `docs/orrery_state_vocabulary.md`; implementation remains coupled to clearance-event vocabulary (item 3) and the substrate debts named there.
-2. **Faction category values.** Drafted in `docs/orrery_faction_vocabulary.md`; still needs review, seeding migration, Slot 2 mapping, and clearance-event collapse.
+2. **Faction category values.** Drafted in `docs/orrery_faction_vocabulary.md`; migration 052 seeds the closed 65-anchor tag vocabulary. Remaining work: Slot 2 mapping, faction-table cleanup, and clearance-event collapse.
 3. **Clearance vocabulary for ephemerals.** What `world_event` types clear which ephemeral tags? Needs enumeration per ephemeral tag (single-entity and multi-entity).
 4. **Genre tag set.** Settle the values for `genre:*` informational tags on the story slot. Sample: `fantasy`, `science_fiction`, `horror`, `noir`, `romance`, etc. + subgenres as composable tags.
 5. **Cardinality column on `tags` registry.** Migration to add `cardinality enum('exclusive', 'multi')`.
@@ -775,12 +777,13 @@ Compiler surfaces:
 - `docs/trait_menu.md` — player-facing trait selection system; alignment documented above.
 - `docs/orrery_design_plan.md` — broader Orrery system design.
 - `docs/orrery_state_vocabulary.md` — authoritative spec for the `state` category; kept separate from this registry overview because it carries clearance contracts, substrate debts, and state-specific open decisions.
-- `docs/orrery_faction_vocabulary.md` — draft spec for faction tag categories, legacy category mapping, and faction table cleanup implications.
+- `docs/orrery_faction_vocabulary.md` — draft spec for faction tag categories, legacy category mapping, seeded anchors, and faction table cleanup implications.
 - `migrations/043_orrery_category_refactor_phase1.py` — registers the six faction category names (`ideology`, `power_status`, `agenda`, `resource_base`, `legitimacy`, `operational_mode`) and records the legacy-to-replacement mappings.
 - `migrations/042_orrery_entity_pair_tags.py` — source-of-truth for seeded multi-entity tags (registry rows in `pair_tags`).
 - `migrations/045_trait_compiler_substrate.py` — trait-compiler registry additions, `claims` subject-kind extension, `reputation` → `fame` data update, and audit cache column.
 - `migrations/047_kind_qualified_contact_pair_tags.py` — `contact:<kind>` registry additions plus deprecation of `contacts_available`, `intimate_services_contact`, and bare `contact`.
 - `migrations/048_orrery_hunting_pair_tag.py` — `pursuing` → `hunting` pair-tag rename plus deprecation of `under_active_pursuit`.
+- `migrations/052_orrery_faction_tag_vocab.py` — seeds the 65 faction tag anchors across `ideology`, `resource_base`, `legitimacy`, `operational_mode`, `power_status`, and `agenda`.
 - Issue #275 / PR #276 — Skald sovereignty (adjudication) model. *Merged.*
 - Issue #282 — Package self-awareness architectural pattern (three-stage gating: entry → branch → outcome; `hunting` tags confer targeted detection sensitivity). *Open.*
 - PR #283 — `entity_pair_tags` substrate (migration 042 + writer functions). *Merged.*

--- a/migrations/052_orrery_faction_tag_vocab.py
+++ b/migrations/052_orrery_faction_tag_vocab.py
@@ -1,0 +1,557 @@
+"""Seed Orrery faction tag vocabulary anchors."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Sequence
+
+from psycopg2.extensions import connection
+
+
+# (tag, category, description)
+DURABLE_TAGS: Sequence[tuple[str, str, str]] = (
+    (
+        "authoritarian",
+        "ideology",
+        "Faction legitimizes hierarchy, command, obedience, and coercive order.",
+    ),
+    (
+        "egalitarian",
+        "ideology",
+        "Faction legitimizes equal standing, distributed rights, or anti-elite "
+        "politics.",
+    ),
+    (
+        "traditionalist",
+        "ideology",
+        "Faction legitimizes inherited custom, lineage, ritual, or precedent.",
+    ),
+    (
+        "progressive",
+        "ideology",
+        "Faction legitimizes deliberate reform, novelty, or future-oriented change.",
+    ),
+    (
+        "theocratic",
+        "ideology",
+        "Faction grounds authority in sacred law, divine mandate, or priesthood.",
+    ),
+    (
+        "secularist",
+        "ideology",
+        "Faction grounds authority outside priestly or sacred institutions.",
+    ),
+    (
+        "nationalist",
+        "ideology",
+        "Faction organizes around a people, homeland, nation, tribe, or civic "
+        "identity.",
+    ),
+    (
+        "cosmopolitan",
+        "ideology",
+        "Faction organizes around cross-border, cross-culture, or universalist "
+        "belonging.",
+    ),
+    (
+        "imperial",
+        "ideology",
+        "Faction legitimizes expansion, dominion, tributary hierarchy, or "
+        "civilizing mission.",
+    ),
+    (
+        "communalist",
+        "ideology",
+        "Faction prioritizes local commons, mutual obligation, or community survival.",
+    ),
+    (
+        "mercantilist",
+        "ideology",
+        "Faction prioritizes trade advantage, market control, profit, or commerce.",
+    ),
+    (
+        "technocratic",
+        "ideology",
+        "Faction legitimizes expert rule, optimization, planning, or technical "
+        "competence.",
+    ),
+    (
+        "revolutionary",
+        "ideology",
+        "Faction legitimizes overthrow of the present order and rupture with "
+        "authority.",
+    ),
+    (
+        "restorationist",
+        "ideology",
+        "Faction legitimizes return to a prior order, lost dynasty, or old law.",
+    ),
+    (
+        "isolationist",
+        "ideology",
+        "Faction prioritizes boundary maintenance and protection from outside control.",
+    ),
+    (
+        "capital",
+        "resource_base",
+        "Faction can mobilize money, credit, stored wealth, or financial leverage.",
+    ),
+    (
+        "force",
+        "resource_base",
+        "Faction can mobilize fighters, guards, troops, weapons, or coercive capacity.",
+    ),
+    (
+        "information",
+        "resource_base",
+        "Faction can mobilize intelligence, archives, surveillance, secrets, or "
+        "analysis.",
+    ),
+    (
+        "faith",
+        "resource_base",
+        "Faction can mobilize religious devotion, ritual authority, or sacred "
+        "legitimacy.",
+    ),
+    (
+        "industry",
+        "resource_base",
+        "Faction can mobilize workshops, factories, craft, or production capacity.",
+    ),
+    (
+        "labor",
+        "resource_base",
+        "Faction can mobilize workers, volunteers, conscripts, members, or retainers.",
+    ),
+    (
+        "territory",
+        "resource_base",
+        "Faction draws operational capacity from land or resource control.",
+    ),
+    (
+        "patronage",
+        "resource_base",
+        "Faction can mobilize sponsors, donors, backers, parent bodies, or subsidies.",
+    ),
+    (
+        "bureaucracy",
+        "resource_base",
+        "Faction can mobilize records, offices, permits, administrators, or procedure.",
+    ),
+    (
+        "technology",
+        "resource_base",
+        "Faction can mobilize advanced tools, machines, infrastructure, or systems.",
+    ),
+    (
+        "specialized_knowledge",
+        "resource_base",
+        "Faction can mobilize rare expertise, scholarship, lore, or trade secrets.",
+    ),
+    (
+        "criminal_network",
+        "resource_base",
+        "Faction can mobilize smuggling, black markets, fences, or illicit logistics.",
+    ),
+    (
+        "supply_lines",
+        "resource_base",
+        "Faction can mobilize logistics, transport, warehousing, or material "
+        "throughput.",
+    ),
+    (
+        "mobility",
+        "resource_base",
+        "Faction can mobilize ships, vehicles, mounts, portals, couriers, or roads.",
+    ),
+    (
+        "state_recognized",
+        "legitimacy",
+        "Faction is formally recognized by the dominant legal or political order.",
+    ),
+    (
+        "customary",
+        "legitimacy",
+        "Faction is locally accepted by tradition or community practice.",
+    ),
+    (
+        "tolerated",
+        "legitimacy",
+        "Faction is known and allowed to operate without strong formal recognition.",
+    ),
+    (
+        "shadow_legal",
+        "legitimacy",
+        "Faction is partly legal, deniable, gray-market, or protected by loopholes.",
+    ),
+    (
+        "underground",
+        "legitimacy",
+        "Faction is hidden or unofficial; exposure changes its risk profile.",
+    ),
+    (
+        "outlaw",
+        "legitimacy",
+        "Faction is known and proscribed; public association is dangerous or "
+        "criminalized.",
+    ),
+    (
+        "contested",
+        "legitimacy",
+        "Faction recognition is unstable or disputed by competing authorities.",
+    ),
+    (
+        "overt",
+        "operational_mode",
+        "Faction acts openly under its own name; public footprint is normal.",
+    ),
+    (
+        "covert",
+        "operational_mode",
+        "Faction acts through secrecy, fronts, cells, aliases, or deniable agents.",
+    ),
+    (
+        "hybrid",
+        "operational_mode",
+        "Faction maintains both public and hidden operating surfaces.",
+    ),
+)
+
+# (tag, category, clear_on_json, description)
+EPHEMERAL_TAGS: Sequence[tuple[str, str, str, str]] = (
+    (
+        "dominant",
+        "power_status",
+        '{"description": "replace when strength or trajectory changes"}',
+        "Faction sets terms locally; rivals react to it.",
+    ),
+    (
+        "ascending",
+        "power_status",
+        '{"description": "replace when gains consolidate or reverse"}',
+        "Faction is gaining power, territory, members, resources, or legitimacy.",
+    ),
+    (
+        "stable",
+        "power_status",
+        '{"description": "replace when a major event changes faction trajectory"}',
+        "Faction is operationally steady; neither surging nor collapsing.",
+    ),
+    (
+        "pressured",
+        "power_status",
+        '{"description": "replace when pressure resolves or worsens"}',
+        "Faction is under meaningful stress without yet losing the overall position.",
+    ),
+    (
+        "declining",
+        "power_status",
+        '{"description": "replace when recovery, collapse, or restructure changes it"}',
+        "Faction is losing ground, influence, cohesion, resources, or legitimacy.",
+    ),
+    (
+        "fragile",
+        "power_status",
+        '{"description": "replace when recovery, collapse, or rescue changes it"}',
+        "Faction can still act, but one shock could break its position.",
+    ),
+    (
+        "collapsed",
+        "power_status",
+        '{"description": "clear or replace when it dissolves, refounds, or revives"}',
+        "Faction is no longer coherent as an actor, though remnants may persist.",
+    ),
+    (
+        "expand_control",
+        "agenda",
+        '{"description": "clear when expansion succeeds, fails, or is abandoned"}',
+        "Faction is trying to acquire territory, influence, markets, offices, "
+        "or reach.",
+    ),
+    (
+        "consolidate_control",
+        "agenda",
+        '{"description": "clear when control consolidates, realigns, or fails"}',
+        "Faction is trying to secure gains, normalize rule, or stabilize holdings.",
+    ),
+    (
+        "infiltrate",
+        "agenda",
+        '{"description": "clear when infiltration succeeds, is exposed, or fails"}',
+        "Faction is trying to place agents or influence inside a target.",
+    ),
+    (
+        "seize_leadership",
+        "agenda",
+        '{"description": "clear when leadership changes or seizure fails"}',
+        "Faction is trying to take control of a faction, office, throne, or command.",
+    ),
+    (
+        "settle_succession",
+        "agenda",
+        '{"description": "clear when succession settles or deepens"}',
+        "Faction is trying to resolve contested leadership or inheritance.",
+    ),
+    (
+        "recover_losses",
+        "agenda",
+        '{"description": "clear when losses recover, settle, or are abandoned"}',
+        "Faction is trying to retake lost assets, territory, status, members, "
+        "or rights.",
+    ),
+    (
+        "negotiate",
+        "agenda",
+        '{"description": "clear when agreement is reached or talks fail"}',
+        "Faction is seeking settlement, alliance, treaty, contract, ransom, or "
+        "accommodation.",
+    ),
+    (
+        "mobilize",
+        "agenda",
+        '{"description": "clear when mobilization completes or stands down"}',
+        "Faction is preparing forces, members, resources, or logistics for "
+        "imminent action.",
+    ),
+    (
+        "investigate",
+        "agenda",
+        '{"description": "clear when investigation resolves, blocks, or is abandoned"}',
+        "Faction is trying to discover facts, identify actors, audit records, "
+        "or locate causes.",
+    ),
+    (
+        "recruit",
+        "agenda",
+        '{"description": "clear when recruitment completes, disrupts, or stops"}',
+        "Faction is trying to grow membership, hire agents, convert, or enlist.",
+    ),
+    (
+        "extract_resources",
+        "agenda",
+        '{"description": "clear when extraction completes, disrupts, or loses target"}',
+        "Faction is trying to draw value from people, territory, infrastructure, "
+        "or debt.",
+    ),
+    (
+        "sabotage",
+        "agenda",
+        '{"description": "clear when sabotage completes, fails, or is exposed"}',
+        "Faction is trying to disrupt a rival operation, infrastructure, "
+        "reputation, or supply.",
+    ),
+    (
+        "suppress_dissent",
+        "agenda",
+        '{"description": "clear when dissent is suppressed, fails, or settles"}',
+        "Faction is trying to silence, coerce, appease, or eliminate internal "
+        "opposition.",
+    ),
+    (
+        "conceal_exposure",
+        "agenda",
+        '{"description": "clear when scandal is contained, exposed, or resolved"}',
+        "Faction is trying to contain scandal, leak, investigation, identity, "
+        "or evidence.",
+    ),
+    (
+        "reform_internal",
+        "agenda",
+        '{"description": "clear when reform completes, fails, or is superseded"}',
+        "Faction is trying to change doctrine, governance, membership rules, or "
+        "methods.",
+    ),
+    (
+        "secure_alliance",
+        "agenda",
+        '{"description": "clear when alliance brokers, fails, breaks, or stops"}',
+        "Faction is trying to build or preserve alliance, patronage, clientage, "
+        "or coalition.",
+    ),
+    (
+        "enforce_claim",
+        "agenda",
+        '{"description": "clear when claim enforces, fails, or is abandoned"}',
+        "Faction is trying to turn a claim into practical control or punish "
+        "its violation.",
+    ),
+    (
+        "protect_asset",
+        "agenda",
+        '{"description": "clear when asset secures, is lost, or guard ends"}',
+        "Faction is trying to guard a person, place, object, secret, route, or "
+        "institution.",
+    ),
+    (
+        "retaliate",
+        "agenda",
+        '{"description": "clear when retaliation executes, truces, or stops"}',
+        "Faction is trying to punish injury, betrayal, insult, attack, default, "
+        "or trespass.",
+    ),
+)
+
+
+def run(conn: connection) -> None:
+    """Seed faction vocabulary tag rows idempotently."""
+
+    with conn.cursor() as cur:
+        _assert_no_cross_category_conflicts(cur)
+        for tag, category, description in DURABLE_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy, clear_on,
+                    synonym_for, deprecated, description
+                ) VALUES (
+                    %s, %s, FALSE,
+                    NULL, NULL, NULL,
+                    NULL, FALSE, %s
+                )
+                ON CONFLICT (tag) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    is_ephemeral = EXCLUDED.is_ephemeral,
+                    clearance_kind = EXCLUDED.clearance_kind,
+                    reapplication_policy = EXCLUDED.reapplication_policy,
+                    clear_on = EXCLUDED.clear_on,
+                    synonym_for = NULL,
+                    deprecated = FALSE,
+                    description = EXCLUDED.description
+                """,
+                (tag, category, description),
+            )
+
+        for tag, category, clear_on_json, description in EPHEMERAL_TAGS:
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral,
+                    clearance_kind, reapplication_policy, clear_on,
+                    synonym_for, deprecated, description
+                ) VALUES (
+                    %s, %s, TRUE,
+                    'semantic'::entity_tag_clearance_kind,
+                    'replace'::entity_tag_reapplication_policy,
+                    %s::jsonb,
+                    NULL, FALSE, %s
+                )
+                ON CONFLICT (tag) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    is_ephemeral = EXCLUDED.is_ephemeral,
+                    clearance_kind = EXCLUDED.clearance_kind,
+                    reapplication_policy = EXCLUDED.reapplication_policy,
+                    clear_on = EXCLUDED.clear_on,
+                    synonym_for = NULL,
+                    deprecated = FALSE,
+                    description = EXCLUDED.description
+                """,
+                (tag, category, clear_on_json, description),
+            )
+
+        _assert_seeded_tags(cur)
+    conn.commit()
+
+
+def _assert_no_cross_category_conflicts(cur: Any) -> None:
+    expected_categories = _expected_categories()
+    cur.execute(
+        """
+        SELECT tag, category
+        FROM tags
+        WHERE tag = ANY(%s)
+        ORDER BY tag
+        """,
+        (list(expected_categories),),
+    )
+    conflicts = {
+        tag: category
+        for tag, category in cur.fetchall()
+        if category != expected_categories[tag]
+    }
+    if conflicts:
+        detail = ", ".join(
+            f"{tag}={actual_category} (expected {expected_categories[tag]})"
+            for tag, actual_category in conflicts.items()
+        )
+        raise RuntimeError(f"Faction tag vocabulary name collisions: {detail}")
+
+
+def _assert_seeded_tags(cur: Any) -> None:
+    expected = {
+        tag: (category, False, None, None, None, False, description)
+        for tag, category, description in DURABLE_TAGS
+    }
+    expected.update(
+        {
+            tag: (
+                category,
+                True,
+                "semantic",
+                "replace",
+                _normalize_clear_on(clear_on_json),
+                False,
+                description,
+            )
+            for tag, category, clear_on_json, description in EPHEMERAL_TAGS
+        }
+    )
+    cur.execute(
+        """
+        SELECT tag,
+               category,
+               is_ephemeral,
+               clearance_kind::text,
+               reapplication_policy::text,
+               clear_on,
+               deprecated,
+               description
+        FROM tags
+        WHERE tag = ANY(%s)
+        ORDER BY tag
+        """,
+        (list(expected),),
+    )
+    actual = {}
+    for (
+        tag,
+        category,
+        is_ephemeral,
+        clearance_kind,
+        reapplication_policy,
+        clear_on,
+        deprecated,
+        description,
+    ) in cur.fetchall():
+        actual[tag] = (
+            category,
+            is_ephemeral,
+            clearance_kind,
+            reapplication_policy,
+            _normalize_clear_on(clear_on),
+            deprecated,
+            description,
+        )
+    missing = sorted(set(expected) - set(actual))
+    mismatched = sorted(
+        f"{tag}={actual[tag]}"
+        for tag in set(expected) & set(actual)
+        if actual[tag] != expected[tag]
+    )
+    if missing or mismatched:
+        message = "Orrery faction vocabulary seed mismatch"
+        if missing:
+            message += f"; missing={missing}"
+        if mismatched:
+            message += f"; mismatched={mismatched}"
+        raise RuntimeError(message)
+
+
+def _expected_categories() -> dict[str, str]:
+    return {tag: category for tag, category, *_rest in (*DURABLE_TAGS, *EPHEMERAL_TAGS)}
+
+
+def _normalize_clear_on(value: Any) -> Any:
+    if isinstance(value, str):
+        return json.loads(value)
+    return value

--- a/migrations/052_orrery_faction_tag_vocab.py
+++ b/migrations/052_orrery_faction_tag_vocab.py
@@ -534,7 +534,7 @@ def _assert_seeded_tags(cur: Any) -> None:
         )
     missing = sorted(set(expected) - set(actual))
     mismatched = sorted(
-        f"{tag}={actual[tag]}"
+        f"{tag}: expected={expected[tag]!r}, got={actual[tag]!r}"
         for tag in set(expected) & set(actual)
         if actual[tag] != expected[tag]
     )
@@ -552,6 +552,8 @@ def _expected_categories() -> dict[str, str]:
 
 
 def _normalize_clear_on(value: Any) -> Any:
+    # psycopg2 normally decodes JSONB to dicts on read. The string path covers
+    # Python-side fixture literals and any custom connection that returns text.
     if isinstance(value, str):
         return json.loads(value)
     return value

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -618,6 +618,44 @@ def test_time_clearance_kind_migration_extends_tag_clearance_enum() -> None:
     assert 'sql.Literal("time")' in migration_source
 
 
+def test_faction_tag_vocab_migration_seeds_closed_anchor_set() -> None:
+    """Migration 052 seeds the closed faction vocabulary from the doc draft."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "052_orrery_faction_tag_vocab.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    durable_tags = {
+        (tag, category) for tag, category, _description in migration.DURABLE_TAGS
+    }
+    ephemeral_tags = {
+        (tag, category)
+        for tag, category, _clear_on_json, _description in migration.EPHEMERAL_TAGS
+    }
+    tag_names = {tag for tag, _category in durable_tags | ephemeral_tags}
+
+    assert len(tag_names) == 65
+    assert len(migration.DURABLE_TAGS) == 39
+    assert len(migration.EPHEMERAL_TAGS) == 26
+    assert {
+        "ideology",
+        "resource_base",
+        "legitimacy",
+        "operational_mode",
+    } == {category for _tag, category in durable_tags}
+    assert {"power_status", "agenda"} == {category for _tag, category in ephemeral_tags}
+    assert {
+        "stable",
+        "capital",
+        "territory",
+        "underground",
+        "retaliate",
+    } <= tag_names
+    assert "'replace'::entity_tag_reapplication_policy" in migration_path.read_text()
+
+
 @pytest.mark.requires_postgres
 def test_entity_tag_expiry_substrate_migration_executes_against_slot_db() -> None:
     """Migration 049 DDL is idempotent against a real slot schema."""
@@ -655,6 +693,78 @@ def test_entity_tag_expiry_substrate_migration_executes_against_slot_db() -> Non
                         "ALTER TABLE entity_tags "
                         "DROP COLUMN IF EXISTS expires_at_world_time"
                     )
+        conn.close()
+
+
+@pytest.mark.requires_postgres
+def test_faction_tag_vocab_migration_executes_against_slot_db() -> None:
+    """Migration 052 seeds all faction anchors idempotently against a real slot."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "052_orrery_faction_tag_vocab.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    durable = {
+        tag: (category, description)
+        for tag, category, description in migration.DURABLE_TAGS
+    }
+    ephemeral = {
+        tag: (category, description)
+        for tag, category, _clear_on_json, description in migration.EPHEMERAL_TAGS
+    }
+    faction_tags = [*durable, *ephemeral]
+
+    try:
+        conn = psycopg2.connect(get_slot_db_url(dbname="save_05"))
+    except psycopg2.Error as exc:
+        pytest.skip(f"save_05 PostgreSQL test database unavailable: {exc}")
+
+    snapshot = _snapshot_tags(conn, faction_tags)
+    try:
+        migration.run(conn)
+        migration.run(conn)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT tag, category, is_ephemeral, clearance_kind::text,
+                       reapplication_policy::text, clear_on IS NOT NULL,
+                       deprecated, synonym_for, description
+                FROM tags
+                WHERE tag = ANY(%s)
+                """,
+                (faction_tags,),
+            )
+            rows = {row[0]: row[1:] for row in cur.fetchall()}
+
+        assert set(rows) == set(faction_tags)
+        for tag, (category, description) in durable.items():
+            assert rows[tag] == (
+                category,
+                False,
+                None,
+                None,
+                False,
+                False,
+                None,
+                description,
+            )
+        for tag, (category, description) in ephemeral.items():
+            assert rows[tag] == (
+                category,
+                True,
+                "semantic",
+                "replace",
+                True,
+                False,
+                None,
+                description,
+            )
+    finally:
+        conn.rollback()
+        _restore_tags(conn, snapshot, faction_tags)
         conn.close()
 
 

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -1,5 +1,6 @@
 """Tests for migration discovery around Orrery's Python migration."""
 
+import json
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -711,8 +712,8 @@ def test_faction_tag_vocab_migration_executes_against_slot_db() -> None:
         for tag, category, description in migration.DURABLE_TAGS
     }
     ephemeral = {
-        tag: (category, description)
-        for tag, category, _clear_on_json, description in migration.EPHEMERAL_TAGS
+        tag: (category, json.loads(clear_on_json), description)
+        for tag, category, clear_on_json, description in migration.EPHEMERAL_TAGS
     }
     faction_tags = [*durable, *ephemeral]
 
@@ -730,14 +731,26 @@ def test_faction_tag_vocab_migration_executes_against_slot_db() -> None:
             cur.execute(
                 """
                 SELECT tag, category, is_ephemeral, clearance_kind::text,
-                       reapplication_policy::text, clear_on IS NOT NULL,
+                       reapplication_policy::text, clear_on,
                        deprecated, synonym_for, description
                 FROM tags
                 WHERE tag = ANY(%s)
                 """,
                 (faction_tags,),
             )
-            rows = {row[0]: row[1:] for row in cur.fetchall()}
+            rows = {
+                row[0]: (
+                    row[1],
+                    row[2],
+                    row[3],
+                    row[4],
+                    _normalize_jsonb(row[5]),
+                    row[6],
+                    row[7],
+                    row[8],
+                )
+                for row in cur.fetchall()
+            }
 
         assert set(rows) == set(faction_tags)
         for tag, (category, description) in durable.items():
@@ -746,18 +759,18 @@ def test_faction_tag_vocab_migration_executes_against_slot_db() -> None:
                 False,
                 None,
                 None,
-                False,
+                None,
                 False,
                 None,
                 description,
             )
-        for tag, (category, description) in ephemeral.items():
+        for tag, (category, clear_on, description) in ephemeral.items():
             assert rows[tag] == (
                 category,
                 True,
                 "semantic",
                 "replace",
-                True,
+                clear_on,
                 False,
                 None,
                 description,
@@ -1070,6 +1083,12 @@ def _index_definition(conn: Any, index_name: str) -> str | None:
         )
         row = cur.fetchone()
         return row[0] if row is not None else None
+
+
+def _normalize_jsonb(value: Any) -> Any:
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
 
 
 def _snapshot_event_types(


### PR DESCRIPTION
## Summary
- add migration 052 to seed the 65 faction vocabulary anchors across ideology, resource_base, legitimacy, operational_mode, power_status, and agenda
- seed durable faction axes as non-ephemeral tags and strategic axes as semantic ephemerals with replace reapplication
- update Orrery vocabulary/package docs and migration tests for the seeded substrate

Refs #337.

## Validation
- poetry run flake8 migrations/052_orrery_faction_tag_vocab.py tests/test_orrery/test_migrate.py
- poetry run pytest -q tests/test_orrery/test_migrate.py
- NEXUS_RUN_POSTGRES=1 poetry run pytest -q tests/test_orrery/test_migrate.py::test_faction_tag_vocab_migration_executes_against_slot_db

## Schema / data impact
- Non-destructive tag registry seed only: no entity_tags backfill, no faction column writes, and no column drops.
- Existing same-name tags in another category raise a migration error instead of being silently repurposed.