### PR TITLE
[codex] Add faction manifest apply path

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -589,7 +589,7 @@ Every model reference uses the `@provider.role` syntax that the config loader re
 - `docs/orrery_retrograde_spec.md` — design spec for deep-history generation (Orrery run backward at wizard-time and per-entity stub maturation at runtime). Phase 3+ work.
 - `docs/orrery_tag_vocabulary.md` — registry-level closed-vocabulary specification for tag categories (single-entity tags, multi-entity pair tags, place / faction categories, trait_menu alignment).
 - `docs/orrery_state_vocabulary.md` — state-tag vocabulary, clearance contracts, pharmacologic/time-cleared states, and current substrate debts.
-- `docs/orrery_faction_vocabulary.md` — faction tag vocabulary seeded by migration 052, legacy category mapping, and faction-table cleanup implications.
+- `docs/orrery_faction_vocabulary.md` — faction tag vocabulary seeded by migration 052, deterministic `faction-apply` rewrite slice, legacy category mapping, and remaining faction-table cleanup implications.
 
 ---
 

--- a/docs/orrery_faction_vocabulary.md
+++ b/docs/orrery_faction_vocabulary.md
@@ -321,19 +321,19 @@ Preflight command:
   faction columns, existing `claims` / `operates_from` pair-tags, and legacy
   faction tag categories. Review its JSON output before any destructive data
   rewrite or column-drop migration.
-- `nexus faction-manifest --slot N` folds the audit into a read-only migration
-  manifest with stable operation IDs. It separates deterministic entity-tag
-  inserts from review-required tag candidates, pair-tag target resolution,
-  prose/world-event preservation, structured remainders, and no-replacement
-  legacy tag drops. The manifest is a review/apply contract for a later script;
-  it does not authorize destructive mutations by itself.
+- `nexus faction-manifest --slot N --output PATH` folds the audit into a
+  read-only migration manifest with stable operation IDs. It separates
+  deterministic entity-tag inserts from review-required tag candidates,
+  pair-tag target resolution, prose/world-event preservation, structured
+  remainders, and no-replacement legacy tag drops. The manifest is a
+  review/apply contract; it does not authorize destructive mutations by itself.
 - `nexus faction-apply --slot N` validates the same manifest and reports which
-  deterministic `insert_entity_tag` operations would write. Add `--execute` to
-  insert only those ready rows into `entity_tags` with `source_kind=system`.
-  Review-required operations, pair-tags, prose preservation, structured
-  remainders, legacy-tag drops, and existing exclusive-category conflicts are
-  skipped rather than inferred. This still does not clear legacy columns or
-  old tag rows.
+  deterministic `insert_entity_tag` operations would write. Add `--manifest
+  PATH --execute` to insert only the reviewed ready rows into `entity_tags` with
+  `source_kind=system`. Review-required operations, pair-tags, prose
+  preservation, structured remainders, legacy-tag drops, and existing
+  exclusive-category conflicts are skipped rather than inferred. This still
+  does not clear legacy columns or old tag rows.
 
 ---
 

--- a/docs/orrery_faction_vocabulary.md
+++ b/docs/orrery_faction_vocabulary.md
@@ -327,6 +327,13 @@ Preflight command:
   prose/world-event preservation, structured remainders, and no-replacement
   legacy tag drops. The manifest is a review/apply contract for a later script;
   it does not authorize destructive mutations by itself.
+- `nexus faction-apply --slot N` validates the same manifest and reports which
+  deterministic `insert_entity_tag` operations would write. Add `--execute` to
+  insert only those ready rows into `entity_tags` with `source_kind=system`.
+  Review-required operations, pair-tags, prose preservation, structured
+  remainders, legacy-tag drops, and existing exclusive-category conflicts are
+  skipped rather than inferred. This still does not clear legacy columns or
+  old tag rows.
 
 ---
 

--- a/docs/orrery_tag_vocabulary.md
+++ b/docs/orrery_tag_vocabulary.md
@@ -585,10 +585,10 @@ Compositions: Hong Kong is `urban_dense` + `coastal`; a castle in the Alps is `m
 ## Faction Categories
 
 Companion: `docs/orrery_faction_vocabulary.md`. Migration 052 seeds the 65
-faction tag anchors, and `nexus faction-apply --slot N [--execute]` covers the
-deterministic entity-tag rewrite slice. Review-required Slot 2 values, faction
-table API cleanup, column drops, and clearance-event collapse remain follow-up
-work.
+faction tag anchors, and `nexus faction-apply --slot N --manifest PATH
+[--execute]` covers the reviewed deterministic entity-tag rewrite slice.
+Review-required Slot 2 values, faction table API cleanup, column drops, and
+clearance-event collapse remain follow-up work.
 
 Faction categories describe group-level actors: institutions, movements,
 corporations, gangs, churches, polities, guilds, scenes, families, and other

--- a/docs/orrery_tag_vocabulary.md
+++ b/docs/orrery_tag_vocabulary.md
@@ -585,8 +585,10 @@ Compositions: Hong Kong is `urban_dense` + `coastal`; a castle in the Alps is `m
 ## Faction Categories
 
 Companion: `docs/orrery_faction_vocabulary.md`. Migration 052 seeds the 65
-faction tag anchors; Slot 2 data rewrite, faction table cleanup, and
-clearance-event collapse remain follow-up work.
+faction tag anchors, and `nexus faction-apply --slot N [--execute]` covers the
+deterministic entity-tag rewrite slice. Review-required Slot 2 values, faction
+table API cleanup, column drops, and clearance-event collapse remain follow-up
+work.
 
 Faction categories describe group-level actors: institutions, movements,
 corporations, gangs, churches, polities, guilds, scenes, families, and other

--- a/nexus/api/faction_table_audit.py
+++ b/nexus/api/faction_table_audit.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections import Counter
+from collections.abc import Mapping as MappingABC
 from dataclasses import asdict, dataclass, field
 from decimal import Decimal
 import hashlib
@@ -11,6 +13,15 @@ from typing import Any, Mapping, Optional, Sequence
 
 
 FACTION_MANIFEST_SCHEMA_VERSION = "faction-migration-manifest.v1"
+FACTION_APPLY_SCHEMA_VERSION = "faction-migration-apply.v1"
+FACTION_MIGRATION_SOURCE_KIND = "system"
+EXCLUSIVE_FACTION_CATEGORIES = frozenset(
+    {
+        "legitimacy",
+        "operational_mode",
+        "power_status",
+    }
+)
 _CATEGORY_REFACTOR = importlib.import_module(
     "migrations.043_orrery_category_refactor_phase1"
 )
@@ -429,6 +440,202 @@ def build_faction_migration_manifest(
         "counters": counters,
         "factions": factions,
         "operations": operations,
+    }
+
+
+def apply_faction_migration_manifest(
+    cur: Any,
+    manifest: Mapping[str, Any],
+    *,
+    dry_run: bool = True,
+    source_kind: str = FACTION_MIGRATION_SOURCE_KIND,
+) -> dict[str, Any]:
+    """Apply deterministic faction manifest operations to ``entity_tags``.
+
+    The apply phase intentionally consumes only ready ``insert_entity_tag``
+    operations. Pair-tags, prose preservation, legacy tag drops, structured
+    remainders, and any operation that still needs review are reported as
+    skipped. Destructive faction-column cleanup remains out of scope.
+    """
+
+    if manifest.get("schema_version") != FACTION_MANIFEST_SCHEMA_VERSION:
+        raise ValueError(
+            "Faction apply requires "
+            f"{FACTION_MANIFEST_SCHEMA_VERSION}; got "
+            f"{manifest.get('schema_version')!r}"
+        )
+
+    operations = list(manifest.get("operations") or [])
+    counters: Counter[str] = Counter()
+    counters["operation_items"] = len(operations)
+    applied_operations: list[dict[str, Any]] = []
+
+    _validate_entity_tag_source_kind(cur, source_kind)
+    allowed_categories = _load_faction_allowed_categories(cur)
+    if not allowed_categories:
+        raise ValueError("No Orrery tag categories registered for factions")
+    world_time = _load_current_world_time(cur)
+    planned_entity_tags: set[tuple[int, int]] = set()
+
+    for operation in operations:
+        operation_type = str(operation.get("operation_type") or "")
+        status = str(operation.get("status") or "")
+        if status != "ready" or bool(operation.get("review_required", True)):
+            counters["review_required_operations_skipped"] += 1
+            applied_operations.append(
+                _apply_operation_result(
+                    operation,
+                    status="skipped_review_required",
+                )
+            )
+            continue
+        if operation_type != "insert_entity_tag":
+            counters["non_entity_tag_operations_skipped"] += 1
+            applied_operations.append(
+                _apply_operation_result(
+                    operation,
+                    status="skipped_non_entity_tag_operation",
+                )
+            )
+            continue
+
+        counters["ready_entity_tag_operations"] += 1
+        target = _coerce_entity_tag_target(operation)
+        tag_row = _lookup_apply_tag(
+            cur,
+            tag=target["tag"],
+            category=target["category"],
+        )
+        tag_id = int(_row_value(tag_row, "id"))
+        category = str(_row_value(tag_row, "category"))
+        entity_id = int(target["entity_id"])
+
+        if category not in allowed_categories:
+            raise ValueError(
+                f"Orrery tag {target['tag']!r} has category {category!r}, "
+                "which is not registered for factions"
+            )
+        _validate_faction_entity(cur, entity_id)
+
+        entity_tag_key = (entity_id, tag_id)
+        base_result = _apply_operation_result(
+            operation,
+            entity_id=entity_id,
+            tag_id=tag_id,
+            category=category,
+            tag=target["tag"],
+        )
+        if entity_tag_key in planned_entity_tags:
+            counters["duplicate_ready_operations_skipped"] += 1
+            applied_operations.append(
+                {
+                    **base_result,
+                    "status": "skipped_duplicate_ready_operation",
+                }
+            )
+            continue
+
+        existing_entity_tag_id = _active_entity_tag_id(
+            cur,
+            entity_id=entity_id,
+            tag_id=tag_id,
+        )
+        if existing_entity_tag_id is not None:
+            counters["entity_tags_already_present"] += 1
+            planned_entity_tags.add(entity_tag_key)
+            applied_operations.append(
+                {
+                    **base_result,
+                    "status": "already_present",
+                    "entity_tag_id": existing_entity_tag_id,
+                }
+            )
+            continue
+
+        sibling_tags = _active_exclusive_sibling_tags(
+            cur,
+            entity_id=entity_id,
+            category=category,
+            tag_id=tag_id,
+        )
+        if sibling_tags:
+            counters["blocked_existing_sibling_operations"] += 1
+            applied_operations.append(
+                {
+                    **base_result,
+                    "status": "blocked_existing_sibling",
+                    "existing_sibling_tags": sibling_tags,
+                }
+            )
+            continue
+
+        planned_entity_tags.add(entity_tag_key)
+        if dry_run:
+            counters["entity_tags_would_insert"] += 1
+            applied_operations.append(
+                {
+                    **base_result,
+                    "status": "would_insert",
+                }
+            )
+            continue
+
+        inserted_id = _insert_entity_tag_operation(
+            cur,
+            entity_id=entity_id,
+            tag_id=tag_id,
+            world_time=world_time,
+            source_kind=source_kind,
+        )
+        if inserted_id is None:
+            counters["entity_tags_already_present"] += 1
+            applied_operations.append(
+                {
+                    **base_result,
+                    "status": "already_present",
+                }
+            )
+            continue
+        counters["entity_tags_inserted"] += 1
+        applied_operations.append(
+            {
+                **base_result,
+                "status": "inserted",
+                "entity_tag_id": inserted_id,
+            }
+        )
+
+    for key in (
+        "ready_entity_tag_operations",
+        "entity_tags_would_insert",
+        "entity_tags_inserted",
+        "entity_tags_already_present",
+        "duplicate_ready_operations_skipped",
+        "blocked_existing_sibling_operations",
+        "review_required_operations_skipped",
+        "non_entity_tag_operations_skipped",
+    ):
+        counters.setdefault(key, 0)
+
+    return {
+        "schema_version": FACTION_APPLY_SCHEMA_VERSION,
+        "manifest_schema_version": manifest.get("schema_version"),
+        "dry_run": dry_run,
+        "source_kind": source_kind,
+        "source": manifest.get("source") or {},
+        "policy": {
+            "scope": (
+                "Only deterministic ready insert_entity_tag operations are "
+                "eligible for writes."
+            ),
+            "exclusive_categories": sorted(EXCLUSIVE_FACTION_CATEGORIES),
+            "destructive_mutations": (
+                "This command never clears legacy tags, rewrites pair-tags, "
+                "edits faction prose columns, or drops schema columns."
+            ),
+        },
+        "counters": dict(counters),
+        "operations": applied_operations,
     }
 
 
@@ -1107,7 +1314,9 @@ def _manifest_operation(
 ) -> dict[str, Any]:
     target_kind = str(candidate.get("target_kind") or "manual_review")
     if target_kind == "entity_tag":
-        apply_ready = _candidate_is_apply_ready(candidate)
+        apply_ready = _candidate_is_apply_ready(candidate) and bool(
+            faction.get("entity_id")
+        )
         operation_type = "insert_entity_tag" if apply_ready else "review_entity_tag"
         status = "ready" if apply_ready else "review_required"
         target = {
@@ -1156,7 +1365,7 @@ def _manifest_operation(
         "target": target,
         "confidence": candidate.get("confidence"),
         "review_required": status != "ready",
-        "reason": candidate.get("reason") or "",
+        "reason": _manifest_operation_reason(faction, candidate, status=status),
     }
     return operation
 
@@ -1207,6 +1416,234 @@ def _build_manifest_counters(
         else:
             counters["review_required_operations"] += 1
     return counters
+
+
+def _manifest_operation_reason(
+    faction: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    *,
+    status: str,
+) -> str:
+    reason = str(candidate.get("reason") or "")
+    if (
+        status != "ready"
+        and candidate.get("target_kind") == "entity_tag"
+        and not faction.get("entity_id")
+    ):
+        suffix = "Faction row has no entity_id, so an entity_tag cannot be written."
+        return f"{reason} {suffix}".strip()
+    return reason
+
+
+def _apply_operation_result(
+    operation: Mapping[str, Any],
+    *,
+    status: str = "",
+    entity_id: Optional[int] = None,
+    tag_id: Optional[int] = None,
+    category: Optional[str] = None,
+    tag: Optional[str] = None,
+) -> dict[str, Any]:
+    result = {
+        "operation_id": operation.get("operation_id"),
+        "operation_type": operation.get("operation_type"),
+        "status": status,
+        "faction_id": operation.get("faction_id"),
+        "faction_name": operation.get("faction_name"),
+        "source": operation.get("source") or {},
+        "target": operation.get("target") or {},
+    }
+    if entity_id is not None:
+        result["entity_id"] = entity_id
+    if tag_id is not None:
+        result["tag_id"] = tag_id
+    if category is not None:
+        result["category"] = category
+    if tag is not None:
+        result["tag"] = tag
+    return result
+
+
+def _coerce_entity_tag_target(operation: Mapping[str, Any]) -> dict[str, Any]:
+    target = operation.get("target")
+    if not isinstance(target, MappingABC):
+        raise ValueError(
+            f"Operation {operation.get('operation_id')!r} has no target mapping"
+        )
+    if target.get("entity_kind") != "faction":
+        raise ValueError(
+            f"Operation {operation.get('operation_id')!r} targets "
+            f"entity_kind={target.get('entity_kind')!r}, expected 'faction'"
+        )
+
+    entity_id = target.get("entity_id")
+    category = target.get("category")
+    tag = target.get("tag")
+    if entity_id is None:
+        raise ValueError(
+            f"Operation {operation.get('operation_id')!r} has no target entity_id"
+        )
+    if not category or not tag:
+        raise ValueError(
+            f"Operation {operation.get('operation_id')!r} must name category and tag"
+        )
+    return {
+        "entity_id": int(entity_id),
+        "category": str(category),
+        "tag": str(tag),
+    }
+
+
+def _validate_entity_tag_source_kind(cur: Any, source_kind: str) -> None:
+    cur.execute(
+        """
+        SELECT 1
+        FROM pg_enum
+        JOIN pg_type ON pg_type.oid = pg_enum.enumtypid
+        WHERE pg_type.typname = 'entity_tag_source_kind'
+          AND pg_enum.enumlabel = %s
+        """,
+        (source_kind,),
+    )
+    if cur.fetchone() is None:
+        raise ValueError(f"Unknown entity_tag_source_kind {source_kind!r}")
+
+
+def _load_faction_allowed_categories(cur: Any) -> set[str]:
+    cur.execute(
+        """
+        SELECT category
+        FROM tag_category_registry
+        WHERE entity_kind = 'faction'::entity_kind
+        """
+    )
+    return {str(_row_value(row, "category")) for row in cur.fetchall()}
+
+
+def _load_current_world_time(cur: Any) -> Any:
+    cur.execute("SELECT max(world_time) AS world_time FROM chunk_metadata")
+    row = cur.fetchone()
+    if row is None:
+        return None
+    return _row_value(row, "world_time")
+
+
+def _lookup_apply_tag(cur: Any, *, tag: str, category: str) -> Mapping[str, Any]:
+    cur.execute(
+        """
+        SELECT id, tag, category
+        FROM tags
+        WHERE tag = %s
+          AND category = %s
+          AND NOT deprecated
+          AND synonym_for IS NULL
+        """,
+        (tag, category),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(
+            f"Unknown or deprecated faction tag {category}:{tag} in manifest"
+        )
+    return row
+
+
+def _validate_faction_entity(cur: Any, entity_id: int) -> None:
+    cur.execute(
+        """
+        SELECT id, kind::text AS kind
+        FROM entities
+        WHERE id = %s
+        """,
+        (entity_id,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"Manifest targets missing entity_id={entity_id}")
+    entity_kind = str(_row_value(row, "kind"))
+    if entity_kind != "faction":
+        raise ValueError(
+            f"Manifest targets entity_id={entity_id} with kind={entity_kind!r}; "
+            "expected 'faction'"
+        )
+
+
+def _active_entity_tag_id(cur: Any, *, entity_id: int, tag_id: int) -> Optional[int]:
+    cur.execute(
+        """
+        SELECT id
+        FROM entity_tags
+        WHERE entity_id = %s
+          AND tag_id = %s
+          AND cleared_at IS NULL
+        """,
+        (entity_id, tag_id),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    return int(_row_value(row, "id"))
+
+
+def _active_exclusive_sibling_tags(
+    cur: Any,
+    *,
+    entity_id: int,
+    category: str,
+    tag_id: int,
+) -> list[str]:
+    if category not in EXCLUSIVE_FACTION_CATEGORIES:
+        return []
+    cur.execute(
+        """
+        SELECT t.tag
+        FROM entity_tags et
+        JOIN tags t ON t.id = et.tag_id
+        WHERE et.entity_id = %s
+          AND et.cleared_at IS NULL
+          AND t.category = %s
+          AND t.id <> %s
+          AND NOT t.deprecated
+        ORDER BY t.tag
+        """,
+        (entity_id, category, tag_id),
+    )
+    return [str(_row_value(row, "tag")) for row in cur.fetchall()]
+
+
+def _insert_entity_tag_operation(
+    cur: Any,
+    *,
+    entity_id: int,
+    tag_id: int,
+    world_time: Any,
+    source_kind: str,
+) -> Optional[int]:
+    cur.execute(
+        """
+        INSERT INTO entity_tags (
+            entity_id,
+            tag_id,
+            applied_at_world_time,
+            source_kind
+        )
+        VALUES (
+            %s,
+            %s,
+            %s,
+            %s::entity_tag_source_kind
+        )
+        ON CONFLICT (entity_id, tag_id)
+          WHERE cleared_at IS NULL
+          DO NOTHING
+        RETURNING id
+        """,
+        (entity_id, tag_id, world_time, source_kind),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    return int(_row_value(row, "id"))
 
 
 def _obsolete_values(row: Mapping[str, Any]) -> dict[str, Any]:

--- a/nexus/api/faction_table_audit.py
+++ b/nexus/api/faction_table_audit.py
@@ -15,12 +15,18 @@ from typing import Any, Mapping, Optional, Sequence
 FACTION_MANIFEST_SCHEMA_VERSION = "faction-migration-manifest.v1"
 FACTION_APPLY_SCHEMA_VERSION = "faction-migration-apply.v1"
 FACTION_MIGRATION_SOURCE_KIND = "system"
+FACTION_CATEGORY_CARDINALITY = {
+    "ideology": "multi",
+    "resource_base": "multi",
+    "legitimacy": "exclusive",
+    "operational_mode": "exclusive",
+    "power_status": "exclusive",
+    "agenda": "multi",
+}
 EXCLUSIVE_FACTION_CATEGORIES = frozenset(
-    {
-        "legitimacy",
-        "operational_mode",
-        "power_status",
-    }
+    category
+    for category, cardinality in FACTION_CATEGORY_CARDINALITY.items()
+    if cardinality == "exclusive"
 )
 _CATEGORY_REFACTOR = importlib.import_module(
     "migrations.043_orrery_category_refactor_phase1"
@@ -1314,8 +1320,8 @@ def _manifest_operation(
 ) -> dict[str, Any]:
     target_kind = str(candidate.get("target_kind") or "manual_review")
     if target_kind == "entity_tag":
-        apply_ready = _candidate_is_apply_ready(candidate) and bool(
-            faction.get("entity_id")
+        apply_ready = _candidate_is_apply_ready(candidate) and (
+            faction.get("entity_id") is not None
         )
         operation_type = "insert_entity_tag" if apply_ready else "review_entity_tag"
         status = "ready" if apply_ready else "review_required"
@@ -1428,7 +1434,7 @@ def _manifest_operation_reason(
     if (
         status != "ready"
         and candidate.get("target_kind") == "entity_tag"
-        and not faction.get("entity_id")
+        and faction.get("entity_id") is None
     ):
         suffix = "Faction row has no entity_id, so an entity_tag cannot be written."
         return f"{reason} {suffix}".strip()
@@ -1525,7 +1531,10 @@ def _load_current_world_time(cur: Any) -> Any:
     row = cur.fetchone()
     if row is None:
         return None
-    return _row_value(row, "world_time")
+    world_time = _row_value(row, "world_time")
+    if world_time is None:
+        return None
+    return world_time
 
 
 def _lookup_apply_tag(cur: Any, *, tag: str, category: str) -> Mapping[str, Any]:

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -10,7 +10,7 @@ Commands:
     nexus trait-audit --slot N  Dry-run new-story trait compiler audit
     nexus faction-audit --slot N  Dry-run legacy faction column migration audit
     nexus faction-manifest --slot N  Build reviewed faction migration manifest
-    nexus faction-apply --slot N  Dry-run/apply ready faction manifest operations
+    nexus faction-apply --slot N  Dry-run ready faction manifest operations
 
 The CLI is slot-centric: only --slot N is required. The backend resolves
 all other state (wizard phase, current chunk, thread ID) automatically.
@@ -21,9 +21,10 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+from pathlib import Path
 import sys
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional
 
 import requests
 
@@ -39,6 +40,13 @@ TERMINAL_GENERATION_STATUSES = {
     "committed",
 }
 GENERATION_POLL_SECONDS = 240
+FACTION_APPLY_SOURCE_KIND_CHOICES = (
+    "authored",
+    "llm_generated",
+    "system",
+    "template",
+    "skald_inline",
+)
 
 
 def get_api_url() -> str:
@@ -1163,12 +1171,20 @@ def run_faction_manifest(args: argparse.Namespace) -> Dict[str, Any]:
         slot=args.slot,
         dbname=dbname,
     )
+    output_path = getattr(args, "output", None)
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
     return {
         "success": True,
         "message": f"Faction migration manifest for slot {args.slot} (dry run).",
         "slot": args.slot,
         "dbname": dbname,
         "faction_manifest": manifest,
+        "manifest_output": str(output_path) if output_path is not None else None,
     }
 
 
@@ -1185,16 +1201,58 @@ def run_faction_apply(args: argparse.Namespace) -> Dict[str, Any]:
 
     dbname = slot_dbname(args.slot)
     dry_run = not args.execute
+    if args.source_kind not in FACTION_APPLY_SOURCE_KIND_CHOICES:
+        return {
+            "success": False,
+            "error": (
+                f"--source-kind must be one of "
+                f"{', '.join(FACTION_APPLY_SOURCE_KIND_CHOICES)}"
+            ),
+        }
+
+    manifest_path = getattr(args, "manifest", None)
+    if args.execute and manifest_path is None:
+        return {
+            "success": False,
+            "error": (
+                "--manifest is required with --execute; first persist a reviewed "
+                "manifest with `nexus faction-manifest --slot N --output PATH`."
+            ),
+        }
+
+    manifest: Mapping[str, Any] | None = None
+    if manifest_path is not None:
+        manifest = _load_faction_manifest_file(manifest_path)
+        manifest_slot = (manifest.get("source") or {}).get("slot")
+        manifest_dbname = (manifest.get("source") or {}).get("dbname")
+        if manifest_slot is not None and int(manifest_slot) != args.slot:
+            return {
+                "success": False,
+                "error": (
+                    f"Manifest slot {manifest_slot} does not match "
+                    f"--slot {args.slot}"
+                ),
+            }
+        if manifest_dbname is not None and manifest_dbname != dbname:
+            return {
+                "success": False,
+                "error": (
+                    f"Manifest dbname {manifest_dbname!r} does not match "
+                    f"slot {args.slot} dbname {dbname!r}"
+                ),
+            }
+
     with get_connection(dbname, dict_cursor=True) as conn:
         with conn.cursor() as cur:
             if dry_run:
                 cur.execute("BEGIN READ ONLY")
-            audit = build_faction_table_audit(cur)
-            manifest = build_faction_migration_manifest(
-                audit,
-                slot=args.slot,
-                dbname=dbname,
-            )
+            if manifest is None:
+                audit = build_faction_table_audit(cur)
+                manifest = build_faction_migration_manifest(
+                    audit,
+                    slot=args.slot,
+                    dbname=dbname,
+                )
             apply_result = apply_faction_migration_manifest(
                 cur,
                 manifest,
@@ -1210,6 +1268,19 @@ def run_faction_apply(args: argparse.Namespace) -> Dict[str, Any]:
         "dbname": dbname,
         "faction_apply": apply_result,
     }
+
+
+def _load_faction_manifest_file(path: Path) -> Mapping[str, Any]:
+    """Load a raw faction manifest or full CLI JSON payload from disk."""
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Faction manifest file must contain a JSON object")
+
+    manifest = data.get("faction_manifest", data)
+    if not isinstance(manifest, dict):
+        raise ValueError("Faction manifest payload must be a JSON object")
+    return manifest
 
 
 def run_lock(args: argparse.Namespace) -> Dict[str, Any]:
@@ -1285,6 +1356,7 @@ Examples:
   nexus faction-audit --slot 2  Dry-run faction column migration audit
   nexus faction-manifest --slot 2  Build faction migration manifest
   nexus faction-apply --slot 2  Dry-run ready faction manifest operations
+  nexus faction-apply --slot 2 --manifest manifest.json --execute
 """,
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON output")
@@ -1428,6 +1500,11 @@ Examples:
     faction_manifest_parser.add_argument(
         "--slot", type=int, required=True, help="Slot number (1-5)"
     )
+    faction_manifest_parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path for the raw faction migration manifest JSON.",
+    )
 
     # faction-apply command
     faction_apply_parser = subparsers.add_parser(
@@ -1440,16 +1517,25 @@ Examples:
         "--slot", type=int, required=True, help="Slot number (1-5)"
     )
     faction_apply_parser.add_argument(
+        "--manifest",
+        type=Path,
+        help=(
+            "Reviewed manifest JSON to apply. Required with --execute; "
+            "without it, dry-run rebuilds the manifest from the live slot."
+        ),
+    )
+    faction_apply_parser.add_argument(
         "--execute",
         action="store_true",
         help=(
-            "Write ready entity_tags. Without this flag the command uses a "
-            "read-only dry run."
+            "Write ready entity_tags from --manifest. Without this flag the "
+            "command uses a read-only dry run."
         ),
     )
     faction_apply_parser.add_argument(
         "--source-kind",
         default="system",
+        choices=FACTION_APPLY_SOURCE_KIND_CHOICES,
         help="entity_tag_source_kind stamped on inserted rows when --execute is set.",
     )
 

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -10,6 +10,7 @@ Commands:
     nexus trait-audit --slot N  Dry-run new-story trait compiler audit
     nexus faction-audit --slot N  Dry-run legacy faction column migration audit
     nexus faction-manifest --slot N  Build reviewed faction migration manifest
+    nexus faction-apply --slot N  Dry-run/apply ready faction manifest operations
 
 The CLI is slot-centric: only --slot N is required. The backend resolves
 all other state (wizard phase, current chunk, thread ID) automatically.
@@ -313,6 +314,56 @@ def _print_faction_manifest(payload: Dict[str, Any]) -> None:
             print(f"  ...{len(review_factions) - 10} more")
 
 
+def _print_faction_apply(payload: Dict[str, Any]) -> None:
+    """Print a faction migration apply summary."""
+
+    apply_result = payload.get("faction_apply") or {}
+    counters = apply_result.get("counters") or {}
+    operations = apply_result.get("operations") or []
+
+    print("Apply:")
+    print(f"  schema_version: {apply_result.get('schema_version')}")
+    print(f"  dry_run: {apply_result.get('dry_run')}")
+    print(f"  source_kind: {apply_result.get('source_kind')}")
+
+    print()
+    print("Counters:")
+    printed_counters = set()
+    for key in (
+        "operation_items",
+        "ready_entity_tag_operations",
+        "entity_tags_would_insert",
+        "entity_tags_inserted",
+        "entity_tags_already_present",
+        "duplicate_ready_operations_skipped",
+        "blocked_existing_sibling_operations",
+        "review_required_operations_skipped",
+        "non_entity_tag_operations_skipped",
+    ):
+        print(f"  {key}: {counters.get(key, 0)}")
+        printed_counters.add(key)
+    for key in sorted(key for key in counters if key not in printed_counters):
+        print(f"  {key}: {counters[key]}")
+
+    blocked = [
+        item for item in operations if item.get("status") == "blocked_existing_sibling"
+    ]
+    if blocked:
+        print()
+        print("Blocked by existing exclusive-category tags:")
+        for item in blocked[:10]:
+            siblings = ", ".join(item.get("existing_sibling_tags") or [])
+            print(
+                "  - "
+                f"{item.get('faction_name')} "
+                f"(id {item.get('faction_id')}): "
+                f"{item.get('category')}:{item.get('tag')} conflicts with "
+                f"{siblings}"
+            )
+        if len(blocked) > 10:
+            print(f"  ...{len(blocked) - 10} more")
+
+
 def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) -> None:
     """Emit payload to stdout in JSON or human-readable format."""
     if as_json:
@@ -340,6 +391,10 @@ def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) 
 
     if payload.get("faction_manifest"):
         _print_faction_manifest(payload)
+        print()
+
+    if payload.get("faction_apply"):
+        _print_faction_apply(payload)
         print()
 
     # Get display elements
@@ -1117,6 +1172,46 @@ def run_faction_manifest(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
+def run_faction_apply(args: argparse.Namespace) -> Dict[str, Any]:
+    """Dry-run or execute ready faction manifest operations."""
+
+    from nexus.api.db_pool import get_connection
+    from nexus.api.faction_table_audit import (
+        apply_faction_migration_manifest,
+        build_faction_migration_manifest,
+        build_faction_table_audit,
+    )
+    from nexus.api.slot_utils import slot_dbname
+
+    dbname = slot_dbname(args.slot)
+    dry_run = not args.execute
+    with get_connection(dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            if dry_run:
+                cur.execute("BEGIN READ ONLY")
+            audit = build_faction_table_audit(cur)
+            manifest = build_faction_migration_manifest(
+                audit,
+                slot=args.slot,
+                dbname=dbname,
+            )
+            apply_result = apply_faction_migration_manifest(
+                cur,
+                manifest,
+                dry_run=dry_run,
+                source_kind=args.source_kind,
+            )
+
+    mode = "dry run" if dry_run else "executed"
+    return {
+        "success": True,
+        "message": f"Faction migration apply for slot {args.slot} ({mode}).",
+        "slot": args.slot,
+        "dbname": dbname,
+        "faction_apply": apply_result,
+    }
+
+
 def run_lock(args: argparse.Namespace) -> Dict[str, Any]:
     """
     Lock a slot to prevent modifications.
@@ -1189,6 +1284,7 @@ Examples:
   nexus trait-audit --slot 5    Dry-run trait compiler audit
   nexus faction-audit --slot 2  Dry-run faction column migration audit
   nexus faction-manifest --slot 2  Build faction migration manifest
+  nexus faction-apply --slot 2  Dry-run ready faction manifest operations
 """,
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON output")
@@ -1333,6 +1429,30 @@ Examples:
         "--slot", type=int, required=True, help="Slot number (1-5)"
     )
 
+    # faction-apply command
+    faction_apply_parser = subparsers.add_parser(
+        "faction-apply",
+        help=(
+            "Dry-run or execute ready faction manifest operations " "into entity_tags"
+        ),
+    )
+    faction_apply_parser.add_argument(
+        "--slot", type=int, required=True, help="Slot number (1-5)"
+    )
+    faction_apply_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help=(
+            "Write ready entity_tags. Without this flag the command uses a "
+            "read-only dry run."
+        ),
+    )
+    faction_apply_parser.add_argument(
+        "--source-kind",
+        default="system",
+        help="entity_tag_source_kind stamped on inserted rows when --execute is set.",
+    )
+
     # lock command
     lock_parser = subparsers.add_parser(
         "lock", help="Lock a slot to prevent modifications"
@@ -1367,6 +1487,7 @@ def main() -> int:
         "trait-audit",
         "faction-audit",
         "faction-manifest",
+        "faction-apply",
         "lock",
         "unlock",
     ):
@@ -1401,6 +1522,8 @@ def main() -> int:
         result = run_faction_audit(args)
     elif args.command == "faction-manifest":
         result = run_faction_manifest(args)
+    elif args.command == "faction-apply":
+        result = run_faction_apply(args)
     elif args.command == "lock":
         result = run_lock(args)
     elif args.command == "unlock":

--- a/tests/test_faction_table_audit.py
+++ b/tests/test_faction_table_audit.py
@@ -14,8 +14,10 @@ import pytest
 from nexus import cli
 from nexus.api.db_pool import close_pool, get_connection
 from nexus.api.faction_table_audit import (
+    FACTION_MANIFEST_SCHEMA_VERSION,
     LEGACY_TAG_CATEGORIES,
     LegacyTagRow,
+    apply_faction_migration_manifest,
     audit_faction_row,
     build_faction_migration_manifest,
     build_faction_table_audit,
@@ -23,6 +25,176 @@ from nexus.api.faction_table_audit import (
 
 
 TEST_DBNAME = "save_02"
+
+
+class FactionApplyCursor:
+    """Small fake cursor for deterministic faction manifest apply tests."""
+
+    def __init__(
+        self,
+        *,
+        active_entity_tags: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.source_kinds = {"system", "skald_inline", "llm_generated"}
+        self.allowed_categories = {
+            "agenda",
+            "ideology",
+            "legitimacy",
+            "operational_mode",
+            "power_status",
+            "resource_base",
+        }
+        self.tags: dict[tuple[str, str], dict[str, Any]] = {
+            ("ideology", "mercantilist"): {
+                "id": 101,
+                "tag": "mercantilist",
+                "category": "ideology",
+            },
+            ("legitimacy", "outlaw"): {
+                "id": 202,
+                "tag": "outlaw",
+                "category": "legitimacy",
+            },
+            ("legitimacy", "contested"): {
+                "id": 203,
+                "tag": "contested",
+                "category": "legitimacy",
+            },
+        }
+        self.tag_by_id: dict[int, dict[str, Any]] = {
+            int(row["id"]): row for row in self.tags.values()
+        }
+        self.entities: dict[int, str] = {1111: "faction"}
+        self.entity_tags: list[dict[str, Any]] = list(active_entity_tags or [])
+        self.next_entity_tag_id = 9001
+        self.rowcount = 0
+        self._rows: list[dict[str, Any]] = []
+
+    def execute(self, sql: str, params: tuple[Any, ...] = ()) -> None:
+        """Handle the SQL shapes emitted by faction apply."""
+
+        normalized = " ".join(sql.split())
+        self.rowcount = 0
+        if "FROM pg_enum" in normalized:
+            source_kind = str(params[0])
+            self._rows = [{"exists": 1}] if source_kind in self.source_kinds else []
+        elif "FROM tag_category_registry" in normalized:
+            self._rows = [
+                {"category": category} for category in sorted(self.allowed_categories)
+            ]
+        elif normalized == "SELECT max(world_time) AS world_time FROM chunk_metadata":
+            self._rows = [{"world_time": None}]
+        elif "FROM tags" in normalized and "WHERE tag = %s" in normalized:
+            tag, category = params
+            row = self.tags.get((str(category), str(tag)))
+            self._rows = [row] if row else []
+        elif "FROM entities" in normalized:
+            entity_id = int(params[0])
+            kind = self.entities.get(entity_id)
+            self._rows = [{"id": entity_id, "kind": kind}] if kind else []
+        elif (
+            normalized.startswith("SELECT id FROM entity_tags")
+            and "tag_id = %s" in normalized
+        ):
+            entity_id, tag_id = (int(params[0]), int(params[1]))
+            self._rows = [
+                {"id": row["id"]}
+                for row in self.entity_tags
+                if row["entity_id"] == entity_id
+                and row["tag_id"] == tag_id
+                and row.get("cleared_at") is None
+            ]
+        elif "JOIN tags t ON t.id = et.tag_id" in normalized:
+            entity_id, category, excluded_tag_id = (
+                int(params[0]),
+                str(params[1]),
+                int(params[2]),
+            )
+            self._rows = []
+            for row in self.entity_tags:
+                tag_row = self.tag_by_id[int(row["tag_id"])]
+                if (
+                    row["entity_id"] == entity_id
+                    and row.get("cleared_at") is None
+                    and tag_row["category"] == category
+                    and tag_row["id"] != excluded_tag_id
+                ):
+                    self._rows.append({"tag": tag_row["tag"]})
+            self._rows.sort(key=lambda item: item["tag"])
+        elif normalized.startswith("INSERT INTO entity_tags"):
+            entity_id, tag_id, world_time, source_kind = params
+            existing = [
+                row
+                for row in self.entity_tags
+                if row["entity_id"] == entity_id
+                and row["tag_id"] == tag_id
+                and row.get("cleared_at") is None
+            ]
+            if existing:
+                self._rows = []
+                return
+
+            entity_tag_id = self.next_entity_tag_id
+            self.next_entity_tag_id += 1
+            self.entity_tags.append(
+                {
+                    "id": entity_tag_id,
+                    "entity_id": entity_id,
+                    "tag_id": tag_id,
+                    "applied_at_world_time": world_time,
+                    "source_kind": source_kind,
+                    "cleared_at": None,
+                }
+            )
+            self.rowcount = 1
+            self._rows = [{"id": entity_tag_id}]
+        else:
+            raise AssertionError(f"Unhandled SQL in fake cursor: {normalized}")
+
+    def fetchone(self) -> dict[str, Any] | None:
+        """Return one pending row."""
+
+        if not self._rows:
+            return None
+        return self._rows.pop(0)
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        """Return all pending rows."""
+
+        rows = list(self._rows)
+        self._rows.clear()
+        return rows
+
+
+def _manifest_operation(
+    *,
+    operation_id: str,
+    status: str,
+    operation_type: str,
+    target: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "operation_id": operation_id,
+        "operation_type": operation_type,
+        "status": status,
+        "faction_id": 11,
+        "faction_name": "Canal League",
+        "entity_id": target.get("entity_id"),
+        "source": {"column": "ideology", "value": "mercantilist"},
+        "target": target,
+        "confidence": "deterministic",
+        "review_required": status != "ready",
+        "reason": "test",
+    }
+
+
+def _apply_manifest(operations: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": FACTION_MANIFEST_SCHEMA_VERSION,
+        "dry_run": True,
+        "operations": operations,
+        "source": {"slot": 2, "dbname": "save_02"},
+    }
 
 
 def _slot2_faction_audit() -> dict[str, Any]:
@@ -457,6 +629,163 @@ def test_faction_migration_manifest_classifies_operations() -> None:
     )
 
 
+def test_manifest_requires_entity_id_for_ready_entity_tag_operations() -> None:
+    """A deterministic mapping cannot be ready if the faction has no entity."""
+
+    entry = audit_faction_row(
+        {
+            "id": 12,
+            "name": "Unattached League",
+            "entity_id": None,
+            "ideology": "mercantilist",
+            "history": None,
+            "current_activity": None,
+            "hidden_agenda": None,
+            "territory": None,
+            "primary_location": None,
+            "power_level": None,
+            "resources": None,
+        },
+        existing_pair_tags={},
+        legacy_tags=[],
+    )
+    audit = {
+        "counters": {},
+        "source_columns": ["ideology"],
+        "keep_columns": ["id", "name"],
+        "factions": [asdict(entry)],
+    }
+
+    manifest = build_faction_migration_manifest(
+        audit,
+        slot=2,
+        dbname="save_02",
+    )
+
+    assert manifest["counters"]["ready_operations"] == 0
+    assert manifest["operations"][0]["operation_type"] == "review_entity_tag"
+    assert "no entity_id" in manifest["operations"][0]["reason"]
+
+
+def test_apply_faction_manifest_dry_run_only_counts_ready_writes() -> None:
+    """The apply pass should report ready inserts without mutating in dry run."""
+
+    cur = FactionApplyCursor()
+    manifest = _apply_manifest(
+        [
+            _manifest_operation(
+                operation_id="ready",
+                status="ready",
+                operation_type="insert_entity_tag",
+                target={
+                    "entity_kind": "faction",
+                    "entity_id": 1111,
+                    "category": "ideology",
+                    "tag": "mercantilist",
+                },
+            ),
+            _manifest_operation(
+                operation_id="review",
+                status="review_required",
+                operation_type="review_entity_tag",
+                target={
+                    "entity_kind": "faction",
+                    "entity_id": 1111,
+                    "category": "ideology",
+                    "tag": "mercantilist",
+                },
+            ),
+        ]
+    )
+
+    result = apply_faction_migration_manifest(cur, manifest, dry_run=True)
+
+    assert result["dry_run"] is True
+    assert result["counters"]["ready_entity_tag_operations"] == 1
+    assert result["counters"]["entity_tags_would_insert"] == 1
+    assert result["counters"]["review_required_operations_skipped"] == 1
+    assert result["counters"].get("entity_tags_inserted", 0) == 0
+    assert cur.entity_tags == []
+    assert [operation["status"] for operation in result["operations"]] == [
+        "would_insert",
+        "skipped_review_required",
+    ]
+
+
+def test_apply_faction_manifest_execute_inserts_ready_tag() -> None:
+    """The execute pass should insert ready faction entity tags."""
+
+    cur = FactionApplyCursor()
+    manifest = _apply_manifest(
+        [
+            _manifest_operation(
+                operation_id="ready",
+                status="ready",
+                operation_type="insert_entity_tag",
+                target={
+                    "entity_kind": "faction",
+                    "entity_id": 1111,
+                    "category": "ideology",
+                    "tag": "mercantilist",
+                },
+            )
+        ]
+    )
+
+    result = apply_faction_migration_manifest(cur, manifest, dry_run=False)
+
+    assert result["dry_run"] is False
+    assert result["counters"]["entity_tags_inserted"] == 1
+    assert result["operations"][0]["status"] == "inserted"
+    assert cur.entity_tags == [
+        {
+            "id": 9001,
+            "entity_id": 1111,
+            "tag_id": 101,
+            "applied_at_world_time": None,
+            "source_kind": "system",
+            "cleared_at": None,
+        }
+    ]
+
+
+def test_apply_faction_manifest_blocks_exclusive_category_conflicts() -> None:
+    """Exclusive faction axes should not be overwritten without review."""
+
+    cur = FactionApplyCursor(
+        active_entity_tags=[
+            {
+                "id": 8001,
+                "entity_id": 1111,
+                "tag_id": 203,
+                "cleared_at": None,
+            }
+        ],
+    )
+    manifest = _apply_manifest(
+        [
+            _manifest_operation(
+                operation_id="ready",
+                status="ready",
+                operation_type="insert_entity_tag",
+                target={
+                    "entity_kind": "faction",
+                    "entity_id": 1111,
+                    "category": "legitimacy",
+                    "tag": "outlaw",
+                },
+            )
+        ]
+    )
+
+    result = apply_faction_migration_manifest(cur, manifest, dry_run=False)
+
+    assert result["counters"]["blocked_existing_sibling_operations"] == 1
+    assert result["operations"][0]["status"] == "blocked_existing_sibling"
+    assert result["operations"][0]["existing_sibling_tags"] == ["contested"]
+    assert len(cur.entity_tags) == 1
+
+
 @pytest.mark.requires_postgres
 def test_cli_faction_manifest_returns_live_slot2_payload() -> None:
     """The faction manifest CLI should build from the real slot 2 audit."""
@@ -475,6 +804,37 @@ def test_cli_faction_manifest_returns_live_slot2_payload() -> None:
     assert manifest["dry_run"] is True
     assert manifest["counters"]["operation_items"] >= 1
     assert manifest["counters"]["operation_items"] == len(manifest["operations"])
+
+
+@pytest.mark.requires_postgres
+def test_cli_faction_apply_dry_run_returns_live_slot2_payload() -> None:
+    """The faction apply CLI should validate ready writes without mutating."""
+
+    try:
+        result = cli.run_faction_apply(
+            Namespace(slot=2, execute=False, source_kind="system")
+        )
+    except psycopg2.Error as exc:
+        pytest.skip(f"{TEST_DBNAME} PostgreSQL test database unavailable: {exc}")
+    except ValueError as exc:
+        message = str(exc)
+        if (
+            "Unknown or deprecated faction tag" in message
+            or "No Orrery tag categories registered" in message
+            or "not registered for factions" in message
+        ):
+            pytest.skip(f"{TEST_DBNAME} faction vocabulary not seeded: {exc}")
+        raise
+    finally:
+        close_pool(TEST_DBNAME)
+
+    apply_result = result["faction_apply"]
+
+    assert result["success"] is True
+    assert result["slot"] == 2
+    assert apply_result["dry_run"] is True
+    assert apply_result["counters"]["operation_items"] >= 1
+    assert apply_result["counters"]["ready_entity_tag_operations"] >= 0
 
 
 def test_cli_prints_faction_manifest_summary(capsys) -> None:
@@ -510,3 +870,33 @@ def test_cli_prints_faction_manifest_summary(capsys) -> None:
     assert "ready_operations: 1" in output
     assert "manual_review_operations: 1" in output
     assert "Canal League (id 11): 1 item(s)" in output
+
+
+def test_cli_prints_faction_apply_summary(capsys) -> None:
+    """Human faction apply output should show write/read-only counters."""
+
+    cli.emit_output(
+        {
+            "message": "Faction migration apply for slot 2 (dry run).",
+            "faction_apply": {
+                "schema_version": "faction-migration-apply.v1",
+                "dry_run": True,
+                "source_kind": "system",
+                "counters": {
+                    "operation_items": 2,
+                    "ready_entity_tag_operations": 1,
+                    "entity_tags_would_insert": 1,
+                    "review_required_operations_skipped": 1,
+                },
+                "operations": [],
+            },
+        },
+        as_json=False,
+    )
+
+    output = capsys.readouterr().out
+
+    assert "schema_version: faction-migration-apply.v1" in output
+    assert "dry_run: True" in output
+    assert "entity_tags_would_insert: 1" in output
+    assert "review_required_operations_skipped: 1" in output

--- a/tests/test_faction_table_audit.py
+++ b/tests/test_faction_table_audit.py
@@ -9,11 +9,14 @@ import json
 from typing import Any
 
 import psycopg2  # type: ignore[import-untyped]
+from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
 import pytest
 
 from nexus import cli
 from nexus.api.db_pool import close_pool, get_connection
 from nexus.api.faction_table_audit import (
+    EXCLUSIVE_FACTION_CATEGORIES,
+    FACTION_CATEGORY_CARDINALITY,
     FACTION_MANIFEST_SCHEMA_VERSION,
     LEGACY_TAG_CATEGORIES,
     LegacyTagRow,
@@ -22,6 +25,7 @@ from nexus.api.faction_table_audit import (
     build_faction_migration_manifest,
     build_faction_table_audit,
 )
+from nexus.api.slot_utils import get_slot_db_url
 
 
 TEST_DBNAME = "save_02"
@@ -195,6 +199,30 @@ def _apply_manifest(operations: list[dict[str, Any]]) -> dict[str, Any]:
         "operations": operations,
         "source": {"slot": 2, "dbname": "save_02"},
     }
+
+
+def _ready_entity_tag_manifest(
+    *,
+    operation_id: str = "ready",
+    entity_id: int = 1111,
+    category: str = "ideology",
+    tag: str = "mercantilist",
+) -> dict[str, Any]:
+    return _apply_manifest(
+        [
+            _manifest_operation(
+                operation_id=operation_id,
+                status="ready",
+                operation_type="insert_entity_tag",
+                target={
+                    "entity_kind": "faction",
+                    "entity_id": entity_id,
+                    "category": category,
+                    "tag": tag,
+                },
+            )
+        ]
+    )
 
 
 def _slot2_faction_audit() -> dict[str, Any]:
@@ -629,6 +657,24 @@ def test_faction_migration_manifest_classifies_operations() -> None:
     )
 
 
+def test_exclusive_faction_categories_derive_from_cardinality_map() -> None:
+    """Exclusive-axis enforcement should not use a standalone category list."""
+
+    assert EXCLUSIVE_FACTION_CATEGORIES == {
+        category
+        for category, cardinality in FACTION_CATEGORY_CARDINALITY.items()
+        if cardinality == "exclusive"
+    }
+    assert FACTION_CATEGORY_CARDINALITY == {
+        "agenda": "multi",
+        "ideology": "multi",
+        "legitimacy": "exclusive",
+        "operational_mode": "exclusive",
+        "power_status": "exclusive",
+        "resource_base": "multi",
+    }
+
+
 def test_manifest_requires_entity_id_for_ready_entity_tag_operations() -> None:
     """A deterministic mapping cannot be ready if the faction has no entity."""
 
@@ -716,21 +762,7 @@ def test_apply_faction_manifest_execute_inserts_ready_tag() -> None:
     """The execute pass should insert ready faction entity tags."""
 
     cur = FactionApplyCursor()
-    manifest = _apply_manifest(
-        [
-            _manifest_operation(
-                operation_id="ready",
-                status="ready",
-                operation_type="insert_entity_tag",
-                target={
-                    "entity_kind": "faction",
-                    "entity_id": 1111,
-                    "category": "ideology",
-                    "tag": "mercantilist",
-                },
-            )
-        ]
-    )
+    manifest = _ready_entity_tag_manifest()
 
     result = apply_faction_migration_manifest(cur, manifest, dry_run=False)
 
@@ -786,6 +818,38 @@ def test_apply_faction_manifest_blocks_exclusive_category_conflicts() -> None:
     assert len(cur.entity_tags) == 1
 
 
+def test_cli_faction_apply_execute_requires_manifest_file() -> None:
+    """Executing from a freshly rebuilt manifest would violate review contract."""
+
+    result = cli.run_faction_apply(
+        Namespace(slot=2, execute=True, source_kind="system", manifest=None)
+    )
+
+    assert result["success"] is False
+    assert "--manifest is required" in result["error"]
+
+
+def test_cli_faction_apply_rejects_manifest_slot_mismatch(tmp_path) -> None:
+    """Persisted manifests should be scoped to the requested slot."""
+
+    manifest_path = tmp_path / "manifest.json"
+    manifest = _ready_entity_tag_manifest()
+    manifest["source"] = {"slot": 5, "dbname": "save_05"}
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = cli.run_faction_apply(
+        Namespace(
+            slot=2,
+            execute=True,
+            source_kind="system",
+            manifest=manifest_path,
+        )
+    )
+
+    assert result["success"] is False
+    assert "does not match --slot" in result["error"]
+
+
 @pytest.mark.requires_postgres
 def test_cli_faction_manifest_returns_live_slot2_payload() -> None:
     """The faction manifest CLI should build from the real slot 2 audit."""
@@ -804,6 +868,111 @@ def test_cli_faction_manifest_returns_live_slot2_payload() -> None:
     assert manifest["dry_run"] is True
     assert manifest["counters"]["operation_items"] >= 1
     assert manifest["counters"]["operation_items"] == len(manifest["operations"])
+
+
+@pytest.mark.requires_postgres
+def test_live_faction_apply_execute_inserts_and_rolls_back() -> None:
+    """The execute path should hit real FK, enum, and ON CONFLICT behavior."""
+
+    conn = None
+    try:
+        conn = psycopg2.connect(get_slot_db_url(dbname=TEST_DBNAME))
+    except psycopg2.Error as exc:
+        pytest.skip(f"{TEST_DBNAME} PostgreSQL test database unavailable: {exc}")
+
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT f.id AS faction_id, f.name, f.entity_id
+                FROM factions f
+                JOIN entities e ON e.id = f.entity_id
+                WHERE e.kind = 'faction'::entity_kind
+                ORDER BY f.id
+                LIMIT 1
+                """
+            )
+            faction = cur.fetchone()
+            if faction is None:
+                pytest.skip(f"{TEST_DBNAME} has no faction entity to target")
+
+            entity_id = int(faction["entity_id"])
+            cur.execute(
+                """
+                INSERT INTO tag_category_registry (
+                    category, entity_kind, prompt_order, description
+                )
+                VALUES (
+                    'ideology', 'faction'::entity_kind, 999,
+                    'Test-scoped faction apply category registration.'
+                )
+                ON CONFLICT (category, entity_kind) DO NOTHING
+                """
+            )
+            cur.execute(
+                """
+                INSERT INTO tags (
+                    tag, category, is_ephemeral, deprecated, description
+                )
+                VALUES (
+                    'test_faction_apply_temp',
+                    'ideology',
+                    FALSE,
+                    FALSE,
+                    'Rollback-scoped test tag for faction apply.'
+                )
+                ON CONFLICT (tag) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    is_ephemeral = FALSE,
+                    clearance_kind = NULL,
+                    clear_on = NULL,
+                    synonym_for = NULL,
+                    deprecated = FALSE,
+                    description = EXCLUDED.description
+                RETURNING id, tag, category
+                """
+            )
+            tag_row = cur.fetchone()
+            if tag_row is None:
+                pytest.skip(f"{TEST_DBNAME} could not seed rollback-scoped test tag")
+            cur.execute(
+                """
+                DELETE FROM entity_tags
+                WHERE entity_id = %s
+                  AND tag_id = %s
+                """,
+                (entity_id, int(tag_row["id"])),
+            )
+
+            manifest = _ready_entity_tag_manifest(
+                entity_id=entity_id,
+                category=str(tag_row["category"]),
+                tag=str(tag_row["tag"]),
+            )
+            manifest["source"] = {"slot": 2, "dbname": TEST_DBNAME}
+
+            result = apply_faction_migration_manifest(cur, manifest, dry_run=False)
+
+            assert result["counters"]["entity_tags_inserted"] == 1
+            assert result["operations"][0]["status"] == "inserted"
+
+            cur.execute(
+                """
+                SELECT source_kind::text AS source_kind
+                FROM entity_tags
+                WHERE entity_id = %s
+                  AND tag_id = %s
+                  AND cleared_at IS NULL
+                """,
+                (entity_id, int(tag_row["id"])),
+            )
+            inserted = cur.fetchone()
+            assert inserted is not None
+            assert inserted["source_kind"] == "system"
+    finally:
+        if conn is not None:
+            conn.rollback()
+            conn.close()
 
 
 @pytest.mark.requires_postgres


### PR DESCRIPTION
## Summary

- Add `apply_faction_migration_manifest()` for the deterministic faction rewrite slice from issue #337.
- Add `nexus faction-apply --slot N [--execute]`, dry-run by default, to validate/apply only ready `insert_entity_tag` manifest operations.
- Block silent overwrites on exclusive faction axes and keep review-required operations, pair-tags, prose, legacy drops, and column cleanup out of scope.
- Update faction/tag/design docs with the new apply command boundary.

Refs #337.

## Validation

- `poetry run pytest tests/test_faction_table_audit.py tests/test_cli.py`
- `NEXUS_RUN_POSTGRES=1 poetry run pytest tests/test_faction_table_audit.py -q`
- `poetry run flake8 nexus/api/faction_table_audit.py nexus/cli.py tests/test_faction_table_audit.py`
- `poetry run mypy nexus/api/faction_table_audit.py tests/test_faction_table_audit.py`
- `poetry run python - <<'PY' ... cli.run_faction_apply(Namespace(slot=2, execute=False, source_kind='system')) ... PY`

Live slot 2 dry-run result: `operation_items=145`, `ready_entity_tag_operations=0`, `entity_tags_would_insert=0`, `review_required_operations_skipped=145`.

## Data Impact

- Default command path is read-only.
- `--execute` inserts only deterministic ready `entity_tags` rows with `source_kind=system`.
- This PR does not clear legacy tags, write pair-tags, edit faction prose columns, or drop obsolete faction columns.
