### PR TITLE
[codex] Stop legacy faction column writes

### DIFF
--- a/docs/orrery_faction_vocabulary.md
+++ b/docs/orrery_faction_vocabulary.md
@@ -335,6 +335,16 @@ Preflight command:
   exclusive-category conflicts are skipped rather than inferred. This still
   does not clear legacy columns or old tag rows.
 
+Runtime write boundary:
+
+- New faction creation and faction state updates should not write
+  `ideology`, `history`, `current_activity`, `hidden_agenda`, `territory`,
+  `power_level`, or `resources`. New prose goes in `summary` / `extra_data`
+  when it is descriptive context; package-relevant facts go through
+  `orrery_tags` or reviewed pair-tag/world-event paths.
+- Migration 053 removes the `factions.power_level` default so omitted runtime
+  inserts do not silently create fresh legacy `0.5` values.
+
 ---
 
 ## Mechanical Implications

--- a/docs/orrery_tag_vocabulary.md
+++ b/docs/orrery_tag_vocabulary.md
@@ -786,6 +786,7 @@ Compiler surfaces:
 - `migrations/047_kind_qualified_contact_pair_tags.py` — `contact:<kind>` registry additions plus deprecation of `contacts_available`, `intimate_services_contact`, and bare `contact`.
 - `migrations/048_orrery_hunting_pair_tag.py` — `pursuing` → `hunting` pair-tag rename plus deprecation of `under_active_pursuit`.
 - `migrations/052_orrery_faction_tag_vocab.py` — seeds the 65 faction tag anchors across `ideology`, `resource_base`, `legitimacy`, `operational_mode`, `power_status`, and `agenda`.
+- `migrations/053_retire_faction_legacy_write_defaults.py` — drops the legacy `factions.power_level` default so new runtime inserts do not create fresh obsolete faction strength values.
 - Issue #275 / PR #276 — Skald sovereignty (adjudication) model. *Merged.*
 - Issue #282 — Package self-awareness architectural pattern (three-stage gating: entry → branch → outcome; `hunting` tags confer targeted detection sensitivity). *Open.*
 - PR #283 — `entity_pair_tags` substrate (migration 042 + writer functions). *Merged.*

--- a/migrations/053_retire_faction_legacy_write_defaults.py
+++ b/migrations/053_retire_faction_legacy_write_defaults.py
@@ -1,0 +1,21 @@
+"""Retire defaults that create new legacy faction semantic data."""
+
+from __future__ import annotations
+
+
+def run(conn) -> None:
+    """Stop omitted faction inserts from backfilling legacy power_level."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            ALTER TABLE factions
+                ALTER COLUMN power_level DROP DEFAULT;
+
+            COMMENT ON COLUMN factions.power_level IS
+                'Legacy faction-strength column retained for staged migration. '
+                'New runtime writers should use Orrery power_status tags instead.';
+            """
+        )
+
+    conn.commit()

--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -360,41 +360,20 @@ class NewPlace(BaseModel):
 
 class NewFaction(BaseModel):
     """
-    Schema for introducing a new faction - aligned with DB schema.
-    Leader info goes in extra_data or character relationships.
+    Schema for introducing a new faction.
+
+    Faction semantics live in Orrery tags and pair-tags, not legacy prose
+    columns. Leader/member/color detail goes in extra_data or relationships.
     """
 
     name: str = Field(description="Faction name")
     summary: Optional[str] = Field(
         default=None,
         max_length=500,
-        description="Brief faction description (max 500 chars)",
-    )
-    ideology: Optional[str] = Field(
-        default=None, description="Faction's core ideology or purpose"
-    )
-    history: Optional[str] = Field(
-        default=None, description="Faction origins, past events, and evolution"
-    )
-    current_activity: Optional[str] = Field(
-        default=None, description="What the faction is currently doing"
-    )
-    hidden_agenda: Optional[str] = Field(
-        default=None,
-        description="Secret goals, plots, and agendas (like place secrets - narrative gold!)",
-    )
-    territory: Optional[str] = Field(
-        default=None,
-        description="Controlled areas, zones of influence, or operational reach",
-    )
-    power_level: float = Field(
-        default=0.5,
-        ge=0.0,
-        le=1.0,
-        description="Faction influence/power rating (0.0-1.0, default 0.5 for new factions)",
-    )
-    resources: Optional[str] = Field(
-        default=None, description="Assets, capabilities, personnel, and resources"
+        description=(
+            "Brief faction description (max 500 chars). Put narrative prose "
+            "here when no accepted Orrery tag applies."
+        ),
     )
     primary_location: Optional[int] = Field(
         default=None,
@@ -407,12 +386,13 @@ class NewFaction(BaseModel):
     orrery_tags: Optional[OrreryTagBestowal] = Field(
         default=None,
         description=(
-            "Semantic Orrery tags for this faction (ideology_axis, "
-            "power_posture, legitimacy_status, operational_secrecy, "
-            "resource_class, hidden_agenda_class, history_class). Propose new "
-            "ones when the setting needs vocabulary that doesn't yet exist."
+            "Closed-vocabulary Orrery tags for this faction. Use registered "
+            "tags from ideology, resource_base, legitimacy, operational_mode, "
+            "power_status, and agenda; omit tags when prose is more accurate."
         ),
     )
+
+    model_config = ConfigDict(extra="forbid")
 
 
 # ============================================================================
@@ -703,7 +683,7 @@ class LocationStateUpdate(BaseModel):
 
 class FactionStateUpdate(BaseModel):
     """
-    Update to a faction's state.
+    Update to a faction's Orrery state.
     """
 
     faction_id: Optional[int] = Field(
@@ -712,11 +692,12 @@ class FactionStateUpdate(BaseModel):
     faction_name: Optional[str] = Field(
         default=None, description="Faction name (if ID unknown)"
     )
-    current_activity: Optional[str] = Field(
-        default=None, description="Current faction activity or operational focus"
-    )
     recent_actions: Optional[List[str]] = Field(
-        default_factory=list, description="Recent faction actions"
+        default_factory=list,
+        description=(
+            "Recent faction actions for narrative context. Persist durable "
+            "facts through world_events or accepted Orrery tags."
+        ),
     )
     stance_changes: Optional[Dict[str, str]] = Field(
         default=None, description="Changes in stance toward other entities"
@@ -724,11 +705,14 @@ class FactionStateUpdate(BaseModel):
     orrery_tags: Optional[OrreryTagBestowal] = Field(
         default=None,
         description=(
-            "Tag deltas for this faction. Use applied_tags to add tags (e.g., "
-            "they just lost state sanction → ousted_remnant), tags_to_clear to "
-            "retire ones that no longer apply."
+            "Tag deltas for this faction. Use applied_tags to add registered "
+            "faction tags such as ideology, resource_base, legitimacy, "
+            "operational_mode, power_status, or agenda values; use "
+            "tags_to_clear to retire active tags that no longer apply."
         ),
     )
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class StateUpdates(BaseModel):

--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -144,6 +144,91 @@ def apply_tag_bestowal(
     return counters
 
 
+async def apply_tag_bestowal_async(
+    conn: Any,
+    *,
+    entity_id: int,
+    entity_kind: str,
+    bestowal: Optional[OrreryTagBestowal],
+    source_kind: str = "skald_inline",
+    world_time: Optional[datetime] = None,
+    duration_override: Optional[timedelta] = None,
+) -> dict[str, int]:
+    """Asyncpg equivalent of apply_tag_bestowal for async commit paths."""
+
+    counters = {
+        "applied": 0,
+        "cleared": 0,
+    }
+
+    if bestowal is None:
+        return counters
+
+    _validate_source_kind(source_kind)
+    if entity_kind not in VALID_ENTITY_KINDS:
+        raise ValueError(
+            f"Unknown entity_kind={entity_kind!r}; expected one of "
+            f"{sorted(VALID_ENTITY_KINDS)}"
+        )
+
+    allowed = await _lookup_allowed_categories_async(conn, entity_kind)
+    if not allowed:
+        raise ValueError(
+            f"No Orrery tag categories registered for entity_kind={entity_kind!r}"
+        )
+
+    if world_time is None:
+        world_time = await _load_world_time_async(conn)
+
+    tags_to_apply: list[_TagApplication] = []
+    for tag_name in bestowal.applied_tags:
+        canonical_name, tag_row = await _lookup_canonical_tag_async(conn, tag_name)
+        category = _row_value(tag_row, "category", 1)
+        _validate_allowed_category(
+            category=category,
+            allowed=allowed,
+            tag_name=canonical_name,
+            entity_kind=entity_kind,
+        )
+        tags_to_apply.append(
+            _TagApplication(
+                tag_id=_row_value(tag_row, "id", 0),
+                reapplication_policy=_row_value(tag_row, "reapplication_policy", 3),
+            )
+        )
+
+    tags_to_clear: list[int] = []
+    for clear_name in bestowal.tags_to_clear:
+        canonical_clear, tag_row = await _lookup_canonical_tag_async(conn, clear_name)
+        category = _row_value(tag_row, "category", 1)
+        _validate_allowed_category(
+            category=category,
+            allowed=allowed,
+            tag_name=canonical_clear,
+            entity_kind=entity_kind,
+        )
+        tags_to_clear.append(_row_value(tag_row, "id", 0))
+
+    for tag_application in tags_to_apply:
+        applied = await _insert_entity_tag_async(
+            conn,
+            entity_id=entity_id,
+            tag_id=tag_application.tag_id,
+            source_kind=source_kind,
+            world_time=world_time,
+            duration_override=duration_override,
+            reapplication_policy=tag_application.reapplication_policy,
+        )
+        if applied:
+            counters["applied"] += 1
+
+    for tag_id in tags_to_clear:
+        if await _clear_entity_tag_async(conn, entity_id=entity_id, tag_id=tag_id):
+            counters["cleared"] += 1
+
+    return counters
+
+
 def apply_exclusive_tag_bestowal(
     cur: Any,
     *,
@@ -223,6 +308,18 @@ def _lookup_allowed_categories(cur: Any, entity_kind: str) -> set[str]:
     return {_row_value(row, "category", 0) for row in cur.fetchall()}
 
 
+async def _lookup_allowed_categories_async(conn: Any, entity_kind: str) -> set[str]:
+    rows = await conn.fetch(
+        """
+        SELECT category
+        FROM tag_category_registry
+        WHERE entity_kind = $1::entity_kind
+        """,
+        entity_kind,
+    )
+    return {_row_value(row, "category", 0) for row in rows}
+
+
 def _lookup_tag(cur: Any, tag_name: str) -> Optional[Any]:
     cur.execute(
         """
@@ -235,9 +332,33 @@ def _lookup_tag(cur: Any, tag_name: str) -> Optional[Any]:
     return cur.fetchone()
 
 
+async def _lookup_tag_async(conn: Any, tag_name: str) -> Optional[Any]:
+    return await conn.fetchrow(
+        """
+        SELECT id, category, is_ephemeral, reapplication_policy
+        FROM tags
+        WHERE tag = $1 AND NOT deprecated AND synonym_for IS NULL
+        """,
+        tag_name,
+    )
+
+
 def _lookup_canonical_tag(cur: Any, tag_name: str) -> tuple[str, Any]:
     canonical_name = CANONICAL_TAGS.get(tag_name, tag_name)
     tag_row = _lookup_tag(cur, canonical_name)
+    if tag_row is None:
+        if canonical_name == tag_name:
+            raise ValueError(f"Unknown or deprecated Orrery tag {tag_name!r}")
+        raise ValueError(
+            f"Unknown or deprecated Orrery tag {tag_name!r} "
+            f"(canonicalized to {canonical_name!r})"
+        )
+    return canonical_name, tag_row
+
+
+async def _lookup_canonical_tag_async(conn: Any, tag_name: str) -> tuple[str, Any]:
+    canonical_name = CANONICAL_TAGS.get(tag_name, tag_name)
+    tag_row = await _lookup_tag_async(conn, canonical_name)
     if tag_row is None:
         if canonical_name == tag_name:
             raise ValueError(f"Unknown or deprecated Orrery tag {tag_name!r}")
@@ -273,6 +394,15 @@ def _validate_source_kind(source_kind: str) -> None:
 def _load_world_time(cur: Any) -> Optional[datetime]:
     cur.execute("SELECT max(world_time) AS world_time FROM chunk_metadata")
     row = cur.fetchone()
+    if row is None:
+        return None
+    return _row_value(row, "world_time", 0)
+
+
+async def _load_world_time_async(conn: Any) -> Optional[datetime]:
+    row = await conn.fetchrow(
+        "SELECT max(world_time) AS world_time FROM chunk_metadata"
+    )
     if row is None:
         return None
     return _row_value(row, "world_time", 0)
@@ -374,6 +504,106 @@ def _insert_entity_tag(
     return bool(cur.rowcount)
 
 
+async def _insert_entity_tag_async(
+    conn: Any,
+    *,
+    entity_id: int,
+    tag_id: int,
+    source_kind: str,
+    world_time: Optional[datetime],
+    duration_override: Optional[timedelta],
+    reapplication_policy: Optional[ReapplicationPolicy],
+) -> bool:
+    reapplication_policy = reapplication_policy or "new_row"
+    if reapplication_policy not in _REAPPLICATION_POLICIES:
+        raise ValueError(
+            f"Unsupported entity tag reapplication_policy={reapplication_policy!r}"
+        )
+    if reapplication_policy == "extend_expiry" and duration_override is None:
+        raise ValueError(
+            "reapplication_policy='extend_expiry' requires duration_override"
+        )
+
+    expires_at_world_time = _compute_expires_at_world_time(
+        world_time=world_time,
+        duration_override=duration_override,
+    )
+
+    if reapplication_policy == "replace":
+        result = await conn.execute(
+            """
+            INSERT INTO entity_tags (
+                entity_id, tag_id, applied_at_world_time,
+                expires_at_world_time, source_kind
+            )
+            VALUES ($1, $2, $3, $4, $5::entity_tag_source_kind)
+            ON CONFLICT (entity_id, tag_id)
+              WHERE cleared_at IS NULL
+              DO UPDATE SET
+                applied_at = now(),
+                applied_at_world_time = EXCLUDED.applied_at_world_time,
+                expires_at_world_time = EXCLUDED.expires_at_world_time,
+                source_kind = EXCLUDED.source_kind
+            """,
+            entity_id,
+            tag_id,
+            world_time,
+            expires_at_world_time,
+            source_kind,
+        )
+        return _asyncpg_status_changed(result)
+
+    if reapplication_policy == "extend_expiry":
+        result = await conn.execute(
+            """
+            INSERT INTO entity_tags (
+                entity_id, tag_id, applied_at_world_time,
+                expires_at_world_time, source_kind
+            )
+            VALUES ($1, $2, $3, $4, $5::entity_tag_source_kind)
+            ON CONFLICT (entity_id, tag_id)
+              WHERE cleared_at IS NULL
+              DO UPDATE SET
+                applied_at = now(),
+                applied_at_world_time = EXCLUDED.applied_at_world_time,
+                expires_at_world_time = GREATEST(
+                    COALESCE(
+                        entity_tags.expires_at_world_time,
+                        EXCLUDED.applied_at_world_time
+                    ),
+                    EXCLUDED.applied_at_world_time
+                ) + $6,
+                source_kind = EXCLUDED.source_kind
+            """,
+            entity_id,
+            tag_id,
+            world_time,
+            expires_at_world_time,
+            source_kind,
+            duration_override,
+        )
+        return _asyncpg_status_changed(result)
+
+    result = await conn.execute(
+        """
+        INSERT INTO entity_tags (
+            entity_id, tag_id, applied_at_world_time,
+            expires_at_world_time, source_kind
+        )
+        VALUES ($1, $2, $3, $4, $5::entity_tag_source_kind)
+        ON CONFLICT (entity_id, tag_id)
+          WHERE cleared_at IS NULL
+          DO NOTHING
+        """,
+        entity_id,
+        tag_id,
+        world_time,
+        expires_at_world_time,
+        source_kind,
+    )
+    return _asyncpg_status_changed(result)
+
+
 def _compute_expires_at_world_time(
     *,
     world_time: Optional[datetime],
@@ -453,6 +683,26 @@ def _clear_entity_tag(cur: Any, *, entity_id: int, tag_id: int) -> bool:
         (entity_id, tag_id),
     )
     return bool(cur.rowcount)
+
+
+async def _clear_entity_tag_async(conn: Any, *, entity_id: int, tag_id: int) -> bool:
+    result = await conn.execute(
+        """
+        UPDATE entity_tags
+        SET cleared_at = now()
+        WHERE entity_id = $1 AND tag_id = $2 AND cleared_at IS NULL
+        """,
+        entity_id,
+        tag_id,
+    )
+    return _asyncpg_status_changed(result)
+
+
+def _asyncpg_status_changed(status: str) -> bool:
+    try:
+        return int(status.rsplit(" ", 1)[-1]) > 0
+    except (TypeError, ValueError):
+        return False
 
 
 def _row_value(row: Any, key: str, index: int) -> Any:

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -19,6 +19,7 @@ from nexus.agents.logon.apex_schema import (
     StateUpdates,
 )
 from nexus.agents.orrery.events import commit_orrery_tick_async
+from nexus.agents.orrery.tag_writer import apply_tag_bestowal_async
 from nexus.api.db_converters import (
     chronology_to_db_values,
     resolve_character_references,
@@ -279,6 +280,16 @@ async def apply_state_updates(
                 )
                 logger.info(f"Updated character {char_update.character_id}")
 
+            bestowal = getattr(char_update, "orrery_tags", None)
+            if bestowal is not None:
+                await apply_state_tags_async(
+                    conn,
+                    kind="character",
+                    subtype_table="characters",
+                    subtype_id=char_update.character_id,
+                    bestowal=bestowal,
+                )
+
     # Update place states
     for place_update in state_updates.locations:
         if place_update.place_id and place_update.current_status:
@@ -293,12 +304,55 @@ async def apply_state_updates(
             )
             logger.info(f"Updated place {place_update.place_id}")
 
-    for faction_update in state_updates.factions:
-        if faction_update.faction_id:
-            logger.debug(
-                "Skipping legacy faction column update for faction %s",
-                faction_update.faction_id,
+        bestowal = getattr(place_update, "orrery_tags", None)
+        if place_update.place_id and bestowal is not None:
+            await apply_state_tags_async(
+                conn,
+                kind="place",
+                subtype_table="places",
+                subtype_id=place_update.place_id,
+                bestowal=bestowal,
             )
+
+    for faction_update in state_updates.factions:
+        bestowal = getattr(faction_update, "orrery_tags", None)
+        if faction_update.faction_id and bestowal is not None:
+            await apply_state_tags_async(
+                conn,
+                kind="faction",
+                subtype_table="factions",
+                subtype_id=faction_update.faction_id,
+                bestowal=bestowal,
+            )
+
+
+async def apply_state_tags_async(
+    conn: asyncpg.Connection,
+    *,
+    kind: str,
+    subtype_table: str,
+    subtype_id: int,
+    bestowal,
+) -> None:
+    """Look up the entity_id for a subtype row and apply Skald-bestowed tags."""
+
+    row = await conn.fetchrow(
+        f"SELECT entity_id FROM {subtype_table} WHERE id = $1",
+        subtype_id,
+    )
+    if row is None:
+        logger.warning(f"Skipping tag bestowal: no {kind} row for id={subtype_id}")
+        return
+
+    counters = await apply_tag_bestowal_async(
+        conn,
+        entity_id=row["entity_id"],
+        entity_kind=kind,
+        bestowal=bestowal,
+        source_kind="skald_inline",
+    )
+    if any(counters.values()):
+        logger.info(f"Tag bestowal {kind}/{subtype_id}: {counters}")
 
 
 async def clear_incubator(conn: asyncpg.Connection, session_id: str = None) -> None:

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -241,8 +241,9 @@ async def apply_state_updates(
     """
     Apply entity state updates from the LLM response.
 
-    This updates current_activity, emotional_state, etc. for characters,
-    and similar fields for places and factions.
+    This updates scalar state for characters and places. Faction semantics are
+    intentionally not written to legacy faction prose columns; use Orrery tag
+    deltas / pair-tags and world events instead.
     """
     # Update character states
     for char_update in state_updates.characters:
@@ -292,19 +293,12 @@ async def apply_state_updates(
             )
             logger.info(f"Updated place {place_update.place_id}")
 
-    # Update faction states
     for faction_update in state_updates.factions:
-        if faction_update.faction_id and faction_update.current_activity:
-            await conn.execute(
-                """
-                UPDATE factions
-                SET current_activity = $1
-                WHERE id = $2
-                """,
-                faction_update.current_activity,
+        if faction_update.faction_id:
+            logger.debug(
+                "Skipping legacy faction column update for faction %s",
                 faction_update.faction_id,
             )
-            logger.info(f"Updated faction {faction_update.faction_id}")
 
 
 async def clear_incubator(conn: asyncpg.Connection, session_id: str = None) -> None:

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -270,23 +270,14 @@ def create_new_faction_sync(cur, new_faction):
     cur.execute(
         """
         INSERT INTO factions (
-            id, name, summary, ideology, history, current_activity,
-            hidden_agenda, territory, power_level, resources,
-            primary_location, extra_data
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            id, name, summary, primary_location, extra_data
+        ) VALUES (%s, %s, %s, %s, %s)
         RETURNING id, entity_id
     """,
         (
             faction_id,
             new_faction.name,
             new_faction.summary,
-            new_faction.ideology,
-            new_faction.history,
-            new_faction.current_activity,
-            new_faction.hidden_agenda,
-            new_faction.territory,
-            new_faction.power_level,
-            new_faction.resources,
             new_faction.primary_location,
             _json_dumps_model(new_faction.extra_data),
         ),
@@ -651,13 +642,6 @@ def apply_state_updates_sync(conn, state_updates: StateUpdates):
 
         # Update faction states
         for faction_update in state_updates.factions:
-            if faction_update.faction_id and faction_update.current_activity:
-                cur.execute(
-                    "UPDATE factions SET current_activity = %s WHERE id = %s",
-                    (faction_update.current_activity, faction_update.faction_id),
-                )
-                logger.info(f"Updated faction {faction_update.faction_id}")
-
             bestowal = getattr(faction_update, "orrery_tags", None)
             if faction_update.faction_id and bestowal is not None:
                 _apply_state_tags(

--- a/nexus/api/db_converters.py
+++ b/nexus/api/db_converters.py
@@ -23,6 +23,7 @@ from nexus.agents.logon.apex_schema import (
     ReferenceType,
     ReferencedEntities
 )
+from nexus.agents.orrery.tag_writer import apply_tag_bestowal_async
 
 logger = logging.getLogger("nexus.api.db_converters")
 
@@ -400,4 +401,32 @@ async def create_new_faction(conn: asyncpg.Connection, new_faction: NewFaction) 
         _json_dumps_model(new_faction.extra_data),
     )
 
+    await apply_new_faction_tags(conn, faction_id, new_faction)
     return faction_id
+
+
+async def apply_new_faction_tags(
+    conn: asyncpg.Connection, faction_id: int, new_faction: NewFaction
+) -> None:
+    """Apply inline Orrery tags for async-created factions."""
+
+    bestowal = getattr(new_faction, "orrery_tags", None)
+    if bestowal is None:
+        return
+
+    entity_id = await conn.fetchval(
+        "SELECT entity_id FROM factions WHERE id = $1",
+        faction_id,
+    )
+    if entity_id is None:
+        raise ValueError(f"Faction ID {faction_id} not found for tag bestowal")
+
+    counters = await apply_tag_bestowal_async(
+        conn,
+        entity_id=entity_id,
+        entity_kind="faction",
+        bestowal=bestowal,
+        source_kind="skald_inline",
+    )
+    if any(counters.values()):
+        logger.info(f"Tag bestowal faction/{faction_id}: {counters}")

--- a/nexus/api/db_converters.py
+++ b/nexus/api/db_converters.py
@@ -389,22 +389,13 @@ async def create_new_faction(conn: asyncpg.Connection, new_faction: NewFaction) 
     # Insert faction
     faction_id = await conn.fetchval("""
         INSERT INTO factions (
-            id, name, summary, ideology, history, current_activity,
-            hidden_agenda, territory, power_level, resources,
-            primary_location, extra_data
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+            id, name, summary, primary_location, extra_data
+        ) VALUES ($1, $2, $3, $4, $5)
         RETURNING id
     """,
         faction_id,
         new_faction.name,
         new_faction.summary,
-        new_faction.ideology,
-        new_faction.history,
-        new_faction.current_activity,
-        new_faction.hidden_agenda,
-        new_faction.territory,
-        new_faction.power_level,
-        new_faction.resources,
         new_faction.primary_location,
         _json_dumps_model(new_faction.extra_data),
     )

--- a/nexus/api/lore_adapter.py
+++ b/nexus/api/lore_adapter.py
@@ -282,8 +282,6 @@ def extract_entity_updates(response: StoryTurnResponse) -> Dict[str, Any]:
 
                 if hasattr(faction, "faction_name") and faction.faction_name:
                     update["faction_name"] = faction.faction_name
-                if hasattr(faction, "current_activity") and faction.current_activity:
-                    update["current_activity"] = faction.current_activity
 
                 entity_updates["factions"].append(update)
 

--- a/tests/test_commit_handler.py
+++ b/tests/test_commit_handler.py
@@ -1,9 +1,15 @@
 """Unit tests for asynchronous narrative commit helpers."""
 
+import uuid
+
+import asyncpg
 import pytest
 
-from nexus.agents.logon.apex_schema import FactionStateUpdate, StateUpdates
+from nexus.agents.logon.apex_schema import FactionStateUpdate, NewFaction, StateUpdates
+from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
 from nexus.api.commit_handler import apply_state_updates
+from nexus.api.db_converters import create_new_faction
+from nexus.api.slot_utils import get_slot_db_url
 
 
 class RecordingAsyncConnection:
@@ -35,3 +41,113 @@ async def test_async_faction_state_updates_do_not_write_legacy_activity():
     )
 
     assert all("UPDATE factions" not in sql for sql in conn.statements)
+
+
+@pytest.mark.requires_postgres
+@pytest.mark.asyncio
+async def test_live_async_faction_writes_tags_without_legacy_columns():
+    """Async faction creation/update should use tags and leave retired columns empty."""
+
+    try:
+        conn = await asyncpg.connect(get_slot_db_url(dbname="save_05"))
+    except asyncpg.PostgresError as exc:
+        pytest.skip(f"save_05 PostgreSQL test database unavailable: {exc}")
+
+    transaction = conn.transaction()
+    await transaction.start()
+    try:
+        await conn.execute(
+            """
+            ALTER TABLE entity_tags
+                ADD COLUMN IF NOT EXISTS expires_at_world_time timestamptz
+            """
+        )
+        await conn.execute("ALTER TABLE factions ALTER COLUMN power_level DROP DEFAULT")
+        tag_suffix = uuid.uuid4().hex[:12]
+        created_tag = f"test_async_faction_created_{tag_suffix}"
+        updated_tag = f"test_async_faction_updated_{tag_suffix}"
+
+        await _seed_faction_tag(conn, created_tag)
+        await _seed_faction_tag(conn, updated_tag)
+
+        faction_id = await create_new_faction(
+            conn,
+            NewFaction(
+                name=f"Async Faction Write Test {tag_suffix}",
+                summary="Rollback-scoped faction write-boundary test.",
+                orrery_tags=OrreryTagBestowal(applied_tags=[created_tag]),
+            ),
+        )
+        faction = await conn.fetchrow(
+            """
+            SELECT entity_id, ideology, history, current_activity, hidden_agenda,
+                   territory, power_level, resources
+            FROM factions
+            WHERE id = $1
+            """,
+            faction_id,
+        )
+        assert faction is not None
+        assert faction["ideology"] is None
+        assert faction["history"] is None
+        assert faction["current_activity"] is None
+        assert faction["hidden_agenda"] is None
+        assert faction["territory"] is None
+        assert faction["power_level"] is None
+        assert faction["resources"] is None
+        assert await _has_active_tag(conn, faction["entity_id"], created_tag)
+
+        await apply_state_updates(
+            conn,
+            StateUpdates(
+                factions=[
+                    FactionStateUpdate(
+                        faction_id=faction_id,
+                        orrery_tags=OrreryTagBestowal(
+                            applied_tags=[updated_tag],
+                            tags_to_clear=[created_tag],
+                        ),
+                    )
+                ]
+            ),
+        )
+
+        assert await _has_active_tag(conn, faction["entity_id"], updated_tag)
+        assert not await _has_active_tag(conn, faction["entity_id"], created_tag)
+    finally:
+        await transaction.rollback()
+        await conn.close()
+
+
+async def _seed_faction_tag(conn, tag: str) -> None:
+    await conn.execute(
+        """
+        INSERT INTO tag_category_registry (category, entity_kind, prompt_order)
+        VALUES ('ideology', 'faction'::entity_kind, 999)
+        ON CONFLICT (category, entity_kind) DO NOTHING
+        """
+    )
+    await conn.execute(
+        """
+        INSERT INTO tags (tag, category, is_ephemeral, deprecated, description)
+        VALUES ($1, 'ideology', FALSE, FALSE, 'Rollback-scoped async test tag.')
+        """,
+        tag,
+    )
+
+
+async def _has_active_tag(conn, entity_id: int, tag: str) -> bool:
+    return bool(
+        await conn.fetchval(
+            """
+            SELECT 1
+            FROM entity_tags et
+            JOIN tags t ON t.id = et.tag_id
+            WHERE et.entity_id = $1
+              AND t.tag = $2
+              AND et.cleared_at IS NULL
+            """,
+            entity_id,
+            tag,
+        )
+    )

--- a/tests/test_commit_handler.py
+++ b/tests/test_commit_handler.py
@@ -1,0 +1,37 @@
+"""Unit tests for asynchronous narrative commit helpers."""
+
+import pytest
+
+from nexus.agents.logon.apex_schema import FactionStateUpdate, StateUpdates
+from nexus.api.commit_handler import apply_state_updates
+
+
+class RecordingAsyncConnection:
+    """Async connection stand-in that records executed SQL."""
+
+    def __init__(self):
+        self.statements = []
+
+    async def execute(self, sql, *args):
+        self.statements.append(" ".join(sql.split()))
+
+
+@pytest.mark.asyncio
+async def test_async_faction_state_updates_do_not_write_legacy_activity():
+    """Faction state updates should not touch obsolete faction columns."""
+
+    conn = RecordingAsyncConnection()
+
+    await apply_state_updates(
+        conn,
+        StateUpdates(
+            factions=[
+                FactionStateUpdate(
+                    faction_id=42,
+                    recent_actions=["Shifted lookouts to the tram stop."],
+                )
+            ]
+        ),
+    )
+
+    assert all("UPDATE factions" not in sql for sql in conn.statements)

--- a/tests/test_commit_handler_sync.py
+++ b/tests/test_commit_handler_sync.py
@@ -1,7 +1,17 @@
 """Unit tests for synchronous narrative commit helpers."""
 
-from nexus.agents.logon.apex_schema import CharacterReference, ReferenceType
-from nexus.api.commit_handler_sync import resolve_character_references_sync
+from nexus.agents.logon.apex_schema import (
+    CharacterReference,
+    FactionStateUpdate,
+    NewFaction,
+    ReferenceType,
+    StateUpdates,
+)
+from nexus.api.commit_handler_sync import (
+    apply_state_updates_sync,
+    create_new_faction_sync,
+    resolve_character_references_sync,
+)
 
 
 class MissingLookupCursor:
@@ -27,6 +37,48 @@ class MissingLookupConnection:
         return MissingLookupCursor()
 
 
+class RecordingFactionInsertCursor:
+    """Cursor stand-in for the synchronous new-faction insert path."""
+
+    def __init__(self):
+        self.statements = []
+        self.params = []
+        self._fetches = [(77,), (77, 7700)]
+
+    def execute(self, sql, params=None):
+        self.statements.append(" ".join(sql.split()))
+        self.params.append(params)
+
+    def fetchone(self):
+        return self._fetches.pop(0)
+
+
+class RecordingStateUpdateCursor:
+    """Cursor stand-in that records state-update SQL."""
+
+    def __init__(self):
+        self.statements = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def execute(self, sql, params=None):
+        self.statements.append(" ".join(sql.split()))
+
+
+class RecordingStateUpdateConnection:
+    """Connection stand-in for state update tests."""
+
+    def __init__(self):
+        self.cursor_instance = RecordingStateUpdateCursor()
+
+    def cursor(self):
+        return self.cursor_instance
+
+
 def test_sync_unresolved_character_reference_is_skipped(caplog):
     """Unresolved group labels should not block chunk commit."""
     refs = resolve_character_references_sync(
@@ -41,3 +93,50 @@ def test_sync_unresolved_character_reference_is_skipped(caplog):
 
     assert refs == []
     assert "Skipping unresolved character reference" in caplog.text
+
+
+def test_sync_create_new_faction_does_not_insert_obsolete_columns():
+    """New faction inserts should write only retained faction columns."""
+
+    cur = RecordingFactionInsertCursor()
+
+    faction_id = create_new_faction_sync(
+        cur,
+        NewFaction(
+            name="Project Palimpsest",
+            summary="A covert continuity office.",
+            extra_data={"leader": "unknown"},
+        ),
+    )
+
+    insert_sql = next(sql for sql in cur.statements if sql.startswith("INSERT"))
+
+    assert faction_id == 77
+    assert "ideology" not in insert_sql
+    assert "history" not in insert_sql
+    assert "current_activity" not in insert_sql
+    assert "hidden_agenda" not in insert_sql
+    assert "territory" not in insert_sql
+    assert "power_level" not in insert_sql
+    assert "resources" not in insert_sql
+    assert "id, name, summary, primary_location, extra_data" in insert_sql
+
+
+def test_sync_faction_state_updates_do_not_write_legacy_activity():
+    """Faction state updates should not write obsolete current_activity."""
+
+    conn = RecordingStateUpdateConnection()
+
+    apply_state_updates_sync(
+        conn,
+        StateUpdates(
+            factions=[
+                FactionStateUpdate(
+                    faction_id=77,
+                    recent_actions=["Moved lookouts to the rail station."],
+                )
+            ]
+        ),
+    )
+
+    assert all("UPDATE factions" not in sql for sql in conn.cursor_instance.statements)

--- a/tests/test_db_converters.py
+++ b/tests/test_db_converters.py
@@ -3,6 +3,7 @@
 import pytest
 from datetime import timedelta
 from nexus.api.db_converters import (
+    create_new_faction,
     time_fields_to_interval,
     interval_to_time_fields,
     chronology_to_db_values,
@@ -14,6 +15,7 @@ from nexus.agents.logon.apex_schema import (
     CharacterReference,
     ChronologyUpdate,
     FactionReference,
+    NewFaction,
     PlaceReference,
     PlaceReferenceType,
     ReferenceType,
@@ -24,6 +26,27 @@ class MissingLookupConnection:
     """Async connection stand-in whose name lookups find no rows."""
 
     async def fetchval(self, *_args, **_kwargs):
+        return None
+
+
+class RecordingAsyncFactionConnection:
+    """Async connection stand-in for new-faction insert tests."""
+
+    def __init__(self):
+        self.statements = []
+        self.params = []
+
+    async def execute(self, sql, *args):
+        self.statements.append(" ".join(sql.split()))
+        self.params.append(args)
+
+    async def fetchval(self, sql, *args):
+        self.statements.append(" ".join(sql.split()))
+        self.params.append(args)
+        if "SELECT COALESCE(MAX(id), 0) + 1 FROM factions" in sql:
+            return 88
+        if "INSERT INTO factions" in sql:
+            return 88
         return None
 
 
@@ -212,6 +235,33 @@ class TestReferenceResolution:
 
         assert refs == []
         assert "Skipping unresolved faction reference" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_create_new_faction_omits_obsolete_columns(self):
+        """Async faction creation should not write retired semantic columns."""
+
+        conn = RecordingAsyncFactionConnection()
+
+        faction_id = await create_new_faction(
+            conn,
+            NewFaction(
+                name="Project Palimpsest",
+                summary="A covert continuity office.",
+                extra_data={"leader": "unknown"},
+            ),
+        )
+
+        insert_sql = next(sql for sql in conn.statements if sql.startswith("INSERT"))
+
+        assert faction_id == 88
+        assert "ideology" not in insert_sql
+        assert "history" not in insert_sql
+        assert "current_activity" not in insert_sql
+        assert "hidden_agenda" not in insert_sql
+        assert "territory" not in insert_sql
+        assert "power_level" not in insert_sql
+        assert "resources" not in insert_sql
+        assert "id, name, summary, primary_location, extra_data" in insert_sql
 
 
 class TestTimeFieldValidation:

--- a/tests/test_lore/test_apex_schema.py
+++ b/tests/test_lore/test_apex_schema.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from nexus.agents.logon.apex_schema import (
     FactionStateUpdate,
+    NewFaction,
     NewPlace,
     OrreryAdjudication,
     PlaceType,
@@ -65,15 +66,36 @@ def test_new_place_normalization_does_not_mutate_input_payload() -> None:
     assert place.type == PlaceType.FIXED_LOCATION
 
 
-def test_faction_state_update_accepts_current_activity() -> None:
-    """Faction updates can carry the activity field commit handlers persist."""
+def test_faction_state_update_rejects_legacy_current_activity() -> None:
+    """Faction updates should use Orrery tags, not legacy activity columns."""
 
-    update = FactionStateUpdate(
-        faction_id=42,
-        current_activity="Watching the station exits.",
+    with pytest.raises(ValidationError):
+        FactionStateUpdate(
+            faction_id=42,
+            current_activity="Watching the station exits.",
+        )
+
+
+def test_new_faction_schema_excludes_obsolete_legacy_columns() -> None:
+    """New faction creation should no longer advertise obsolete table columns."""
+
+    obsolete_fields = {
+        "ideology",
+        "history",
+        "current_activity",
+        "hidden_agenda",
+        "territory",
+        "power_level",
+        "resources",
+    }
+
+    assert obsolete_fields.isdisjoint(NewFaction.model_fields)
+    assert {"name", "summary", "primary_location", "extra_data", "orrery_tags"} <= set(
+        NewFaction.model_fields
     )
 
-    assert update.current_activity == "Watching the station exits."
+    with pytest.raises(ValidationError):
+        NewFaction(name="The Glass Choir", ideology="memory control")
 
 
 def test_orrery_adjudication_schema_accepts_replace_delta() -> None:
@@ -149,13 +171,13 @@ def test_extended_response_accepts_partial_new_character_context() -> None:
                 {
                     "new_faction": {
                         "name": "The Glass Choir",
-                        "ideology": "Control the city by controlling what it remembers.",
-                        "history": "Formed after the station fire.",
-                        "hidden_agenda": "Recover a witness list before dawn.",
-                        "territory": "Transit stops, pharmacies, and late-night diners.",
-                        "resources": "Lookouts, dead drops, and radio scanners.",
+                        "summary": "A memory-control conspiracy around transit stops.",
                         "primary_location": None,
                         "extra_data": {"leader": "unknown"},
+                        "orrery_tags": {
+                            "applied_tags": ["covert", "information"],
+                            "tags_to_clear": [],
+                        },
                     },
                     "reference_type": "mentioned",
                 }

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -657,6 +657,21 @@ def test_faction_tag_vocab_migration_seeds_closed_anchor_set() -> None:
     assert "'replace'::entity_tag_reapplication_policy" in migration_path.read_text()
 
 
+def test_faction_legacy_write_default_migration_drops_power_default() -> None:
+    """Migration 053 should stop new inserts from creating power_level data."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "053_retire_faction_legacy_write_defaults.py"
+    )
+    source = migration_path.read_text()
+
+    assert "ALTER TABLE factions" in source
+    assert "ALTER COLUMN power_level DROP DEFAULT" in source
+    assert "Orrery power_status tags" in source
+
+
 @pytest.mark.requires_postgres
 def test_entity_tag_expiry_substrate_migration_executes_against_slot_db() -> None:
     """Migration 049 DDL is idempotent against a real slot schema."""


### PR DESCRIPTION
## Summary

Refs #337.

- Removes obsolete faction prose/semantic fields from `NewFaction` and `FactionStateUpdate`, forbidding legacy extras so Skald no longer sees or returns those write surfaces.
- Stops async/sync faction creation and state-update paths from writing `factions.ideology`, `history`, `current_activity`, `hidden_agenda`, `territory`, `power_level`, or `resources`.
- Adds migration 053 to drop the `factions.power_level` default, so omitted runtime inserts do not create fresh legacy `0.5` values while the staged data rewrite/column retirement remains pending.
- Updates Orrery faction docs and tests for the new runtime write boundary.

## Data / schema note

This is the non-destructive API/schema-cleanup slice of #337. It does not rewrite existing faction data or drop obsolete columns; those remain for the audited migration/manual-review phase.

## Validation

- `poetry run pytest` -> 517 passed, 69 skipped
- `poetry run pytest tests/test_lore/test_apex_schema.py tests/test_commit_handler.py tests/test_commit_handler_sync.py tests/test_db_converters.py tests/test_api/test_lore_adapter.py tests/test_orrery/test_migrate.py` -> 56 passed, 5 skipped
- `poetry run flake8 tests/test_commit_handler.py migrations/053_retire_faction_legacy_write_defaults.py` -> passed

Known existing validation debt:

- Broader flake8 over touched legacy modules still reports pre-existing unused imports/long lines/SQL continuation style in `apex_schema.py`, `db_converters.py`, and `commit_handler_sync.py`.
- Targeted mypy over touched source modules still reports existing missing stubs and type issues in the same legacy surfaces.