### PR TITLE
Seed completed Orrery tag vocabulary

### DIFF
--- a/docs/orrery_tag_vocabulary.md
+++ b/docs/orrery_tag_vocabulary.md
@@ -948,8 +948,8 @@ Compiler surfaces:
 
 ## Open Items
 
-1. **Character category implementation.** `bodyform`, `disposition`, `capacity`, the role split (`role.function`, `role.resources`, `role.fame`, scope-bound `status`), and the companion `state` vocabulary are now drafted. Remaining work is implementation-specific: seed any still-missing tags and keep compiler support aligned with typed inputs.
-2. **Place category implementation.** Values are drafted here. Migration 043 registers the replacement categories, but follow-up work still needs to seed the new place anchors, migrate/deprecate legacy `place_affordance` rows, and remove the resolver shim after backfill.
+1. **Character category implementation.** `bodyform`, `disposition`, `capacity`, the role split (`role.function`, `role.resources`, `role.fame`, scope-bound `status`), and the companion `state` vocabulary are now drafted. Migration 054 seeds the completed `state` anchors; remaining work is implementation-specific compiler/template alignment.
+2. **Place category implementation.** Values are drafted here. Migration 043 registers the replacement categories and migration 054 seeds the place anchors; follow-up work still needs to migrate/deprecate legacy `place_affordance` rows and remove the resolver shim after backfill.
 3. **Faction category implementation.** Drafted in `docs/orrery_faction_vocabulary.md`; migration 052 seeds the closed 65-anchor tag vocabulary. Remaining work: Slot 2 mapping, faction-table cleanup, and clearance-event collapse.
 4. **Story/genre implementation.** Values are drafted here from the existing `Genre` enum. The runtime currently stores them on new-story setting columns; a story-slot entity/category mirror is optional future substrate, blocked on an entity-kind/category-registration migration and not a blocker for current packages.
 5. **Clearance vocabulary for ephemerals.** State clearance events are enumerated in `docs/orrery_state_vocabulary.md`. Faction `agenda` / `power_status`, `place_threat`, and any future ephemeral pair-tags still need event-collapse passes before event-cleared registry rows replace today's semantic-clearance defaults.
@@ -976,6 +976,7 @@ Compiler surfaces:
 - `migrations/048_orrery_hunting_pair_tag.py` — `pursuing` → `hunting` pair-tag rename plus deprecation of `under_active_pursuit`.
 - `migrations/052_orrery_faction_tag_vocab.py` — seeds the 65 faction tag anchors across `ideology`, `resource_base`, `legitimacy`, `operational_mode`, `power_status`, and `agenda`.
 - `migrations/053_retire_faction_legacy_write_defaults.py` — drops the legacy `factions.power_level` default so new runtime inserts do not create fresh obsolete faction strength values.
+- `migrations/054_orrery_completed_tag_vocab.py` — seeds completed state and place anchors, including globally unique place registry names and the `wilderness` legacy-category rewrite.
 - Issue #275 / PR #276 — Skald sovereignty (adjudication) model. *Merged.*
 - Issue #282 — Package self-awareness architectural pattern (three-stage gating: entry → branch → outcome; `hunting` tags confer targeted detection sensitivity). *Open.*
 - PR #283 — `entity_pair_tags` substrate (migration 042 + writer functions). *Merged.*

--- a/migrations/054_orrery_completed_tag_vocab.py
+++ b/migrations/054_orrery_completed_tag_vocab.py
@@ -153,16 +153,26 @@ STATE_EVENT_TAGS: Sequence[tuple[str, str, str, str]] = (
     ),
 )
 
-# (tag, description)
-STATE_TIME_TAGS: Sequence[tuple[str, str]] = (
-    ("intoxicated:stimulant", "Character is wired or activated by a stimulant."),
-    ("intoxicated:depressant", "Character is sedated or impaired by a depressant."),
+# (tag, reapplication_policy, description)
+STATE_TIME_TAGS: Sequence[tuple[str, str, str]] = (
+    (
+        "intoxicated:stimulant",
+        "extend_expiry",
+        "Character is wired or activated by a stimulant.",
+    ),
+    (
+        "intoxicated:depressant",
+        "extend_expiry",
+        "Character is sedated or impaired by a depressant.",
+    ),
     (
         "intoxicated:hallucinogen",
+        "extend_expiry",
         "Character has perceptual distortion from a hallucinogen.",
     ),
     (
         "intoxicated:dissociative",
+        "extend_expiry",
         "Character is detached or depersonalized by a dissociative.",
     ),
 )
@@ -176,8 +186,9 @@ ALLOWED_CATEGORY_REWRITES: dict[str, frozenset[str]] = {
 def run(conn: connection) -> None:
     """Seed completed vocabulary rows idempotently."""
 
+    expected = _expected_rows()
     with conn.cursor() as cur:
-        _assert_no_unexpected_category_conflicts(cur)
+        _assert_no_unexpected_category_conflicts(cur, expected)
         for tag, category, description in PLACE_DURABLE_TAGS:
             _upsert_tag(
                 cur,
@@ -214,19 +225,19 @@ def run(conn: connection) -> None:
                 description=description,
             )
 
-        for tag, description in STATE_TIME_TAGS:
+        for tag, reapplication_policy, description in STATE_TIME_TAGS:
             _upsert_tag(
                 cur,
                 tag=tag,
                 category="state",
                 is_ephemeral=True,
                 clearance_kind="time",
-                reapplication_policy="extend_expiry",
+                reapplication_policy=reapplication_policy,
                 clear_on_json=None,
                 description=description,
             )
 
-        _assert_seeded_tags(cur)
+        _assert_seeded_tags(cur, expected)
     conn.commit()
 
 
@@ -276,8 +287,11 @@ def _upsert_tag(
     )
 
 
-def _assert_no_unexpected_category_conflicts(cur: Any) -> None:
-    expected_categories = _expected_categories()
+def _assert_no_unexpected_category_conflicts(
+    cur: Any,
+    expected: dict[str, tuple[Any, ...]],
+) -> None:
+    expected_categories = {tag: row[0] for tag, row in expected.items()}
     cur.execute(
         """
         SELECT tag, category
@@ -304,8 +318,7 @@ def _assert_no_unexpected_category_conflicts(cur: Any) -> None:
         raise RuntimeError(f"Completed vocabulary tag name collisions: {detail}")
 
 
-def _assert_seeded_tags(cur: Any) -> None:
-    expected = _expected_rows()
+def _assert_seeded_tags(cur: Any, expected: dict[str, tuple[Any, ...]]) -> None:
     cur.execute(
         """
         SELECT tag,
@@ -358,10 +371,6 @@ def _assert_seeded_tags(cur: Any) -> None:
         raise RuntimeError(message)
 
 
-def _expected_categories() -> dict[str, str]:
-    return {tag: row[0] for tag, row in _expected_rows().items()}
-
-
 def _expected_rows() -> dict[str, tuple[Any, ...]]:
     expected: dict[str, tuple[Any, ...]] = {
         tag: (category, False, None, None, None, False, description)
@@ -402,8 +411,8 @@ def _expected_rows() -> dict[str, tuple[Any, ...]]:
     )
     expected.update(
         {
-            tag: ("state", True, "time", "extend_expiry", None, False, description)
-            for tag, description in STATE_TIME_TAGS
+            tag: ("state", True, "time", reapplication_policy, None, False, description)
+            for tag, reapplication_policy, description in STATE_TIME_TAGS
         }
     )
     return expected

--- a/migrations/054_orrery_completed_tag_vocab.py
+++ b/migrations/054_orrery_completed_tag_vocab.py
@@ -1,0 +1,415 @@
+"""Seed completed Orrery state and place tag vocabulary anchors."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Sequence
+
+from psycopg2.extensions import connection
+
+
+# (tag, category, description)
+PLACE_DURABLE_TAGS: Sequence[tuple[str, str, str]] = (
+    ("commerce", "place_function", "Place supports ordinary buying and selling."),
+    ("dwelling", "place_function", "Place supports shelter or domestic routines."),
+    ("place_medical", "place_function", "Place supports care, triage, or healing."),
+    ("transit", "place_function", "Place supports route movement or transfers."),
+    ("archive", "place_function", "Place stores records, memory, or evidence."),
+    ("fortification", "place_function", "Place is defensible or fortified."),
+    ("haven", "place_function", "Place can shelter or hide someone safely."),
+    ("sacred", "place_function", "Place supports ritual, taboo, or worship."),
+    ("meeting", "place_function", "Place can host gatherings or negotiations."),
+    ("tomb", "place_function", "Place supports burial or remembrance."),
+    ("confinement", "place_function", "Place can hold or restrain occupants."),
+    ("learning", "place_function", "Place supports instruction or study."),
+    ("craft", "place_function", "Place supports making, repair, or workshop labor."),
+    ("military", "place_function", "Place supports armed, policing, or command work."),
+    ("production", "place_function", "Place supports extraction or throughput."),
+    (
+        "administration",
+        "place_function",
+        "Place supports bureaucratic, judicial, or institutional paperwork.",
+    ),
+    ("water_source", "place_function", "Place has routine or urgent water access."),
+    ("entertainment", "place_function", "Place supports leisure or performance."),
+    (
+        "place_known",
+        "place_visibility",
+        "Place is broadly discoverable without special knowledge.",
+    ),
+    (
+        "place_hidden",
+        "place_visibility",
+        "Place is secret, concealed, unmapped, or otherwise hard to find.",
+    ),
+    (
+        "place_open",
+        "place_access",
+        "Place can be entered or used without special permission.",
+    ),
+    (
+        "place_restricted",
+        "place_access",
+        "Place requires permission, status, cover, force, or a key to enter.",
+    ),
+    ("urban_dense", "place_environment", "Dense built environment."),
+    ("urban_sparse", "place_environment", "Low-density built environment."),
+    ("rural", "place_environment", "Cultivated or settled countryside."),
+    ("wilderness", "place_environment", "Uncultivated or minimally settled terrain."),
+    ("subterranean", "place_environment", "Underground or buried environment."),
+    ("underwater", "place_environment", "Submerged or aquatic environment."),
+    ("aerial", "place_environment", "Airborne, elevated, or height-dominant place."),
+    ("mountainous", "place_environment", "Steep, high-altitude, or cliff terrain."),
+    ("forest", "place_environment", "Dense tree or vegetation cover."),
+    ("desert", "place_environment", "Arid terrain with water/exposure pressure."),
+    ("polar", "place_environment", "Extreme cold, ice, or snow environment."),
+    ("marshland", "place_environment", "Wetland, swamp, bog, or unstable wet ground."),
+    ("coastal", "place_environment", "Shore, tide, port, beach, or sea access."),
+)
+
+# (tag, category, clear_on_json, description)
+PLACE_EPHEMERAL_TAGS: Sequence[tuple[str, str, str, str]] = (
+    (
+        "place_safe",
+        "place_threat",
+        '{"description": "replace when danger posture changes"}',
+        "Place is currently low-risk enough for rest or routine activity.",
+    ),
+    (
+        "place_contested",
+        "place_threat",
+        '{"description": "replace when contestation resolves or worsens"}',
+        "Place is under active dispute, occupation, siege, or pressure.",
+    ),
+    (
+        "place_dangerous",
+        "place_threat",
+        '{"description": "replace when danger is removed or transformed"}',
+        "Place currently presents immediate or predictable harm.",
+    ),
+)
+
+# (tag, clear_on_json, reapplication_policy, description)
+STATE_EVENT_TAGS: Sequence[tuple[str, str, str, str]] = (
+    (
+        "wounded",
+        '{"event_types": ["tended_wound", "wound_healed"]}',
+        "replace",
+        "Character is injured; physical scenes and travel are impeded.",
+    ),
+    (
+        "sick",
+        '{"event_types": ["recovered_from_illness", "cured"]}',
+        "replace",
+        "Character is ill or diseased.",
+    ),
+    (
+        "restrained",
+        '{"event_types": ["captivity_ended", "escaped"]}',
+        "replace",
+        "Character is physically bound, pinned, or immobilized this scene.",
+    ),
+    (
+        "enraged",
+        '{"event_types": ["retaliation_executed", "confrontation_resolved"]}',
+        "replace",
+        "Character is in acute anger overriding normal judgment.",
+    ),
+    (
+        "afraid",
+        '{"event_types": ["threat_removed"]}',
+        "replace",
+        "Character is in acute fear and biased toward flight or avoidance.",
+    ),
+    (
+        "grieving",
+        '{"event_types": ["mourning_completed"]}',
+        "extend_expiry",
+        "Character is grieving a consequential loss.",
+    ),
+    (
+        "despairing",
+        '{"event_types": ["circumstance_reversed"]}',
+        "replace",
+        "Character is in acute hopelessness or withdrawal pressure.",
+    ),
+    (
+        "imprisoned",
+        '{"event_types": ["captivity_ended", "escaped"]}',
+        "replace",
+        "Character is held captive across chunks.",
+    ),
+    (
+        "concealed",
+        '{"event_types": ["revealed", "discovered"]}',
+        "replace",
+        "Character is currently unseen or hidden.",
+    ),
+    (
+        "disguised",
+        '{"event_types": ["unmasked", "exposed"]}',
+        "replace",
+        "Character is seen but misidentified.",
+    ),
+)
+
+# (tag, description)
+STATE_TIME_TAGS: Sequence[tuple[str, str]] = (
+    ("intoxicated:stimulant", "Character is wired or activated by a stimulant."),
+    ("intoxicated:depressant", "Character is sedated or impaired by a depressant."),
+    (
+        "intoxicated:hallucinogen",
+        "Character has perceptual distortion from a hallucinogen.",
+    ),
+    (
+        "intoxicated:dissociative",
+        "Character is detached or depersonalized by a dissociative.",
+    ),
+)
+
+ALLOWED_CATEGORY_REWRITES: dict[str, frozenset[str]] = {
+    # Legacy place-affordance row with the same mechanical meaning.
+    "wilderness": frozenset({"place_affordance"}),
+}
+
+
+def run(conn: connection) -> None:
+    """Seed completed vocabulary rows idempotently."""
+
+    with conn.cursor() as cur:
+        _assert_no_unexpected_category_conflicts(cur)
+        for tag, category, description in PLACE_DURABLE_TAGS:
+            _upsert_tag(
+                cur,
+                tag=tag,
+                category=category,
+                is_ephemeral=False,
+                clearance_kind=None,
+                reapplication_policy=None,
+                clear_on_json=None,
+                description=description,
+            )
+
+        for tag, category, clear_on_json, description in PLACE_EPHEMERAL_TAGS:
+            _upsert_tag(
+                cur,
+                tag=tag,
+                category=category,
+                is_ephemeral=True,
+                clearance_kind="semantic",
+                reapplication_policy="replace",
+                clear_on_json=clear_on_json,
+                description=description,
+            )
+
+        for tag, clear_on_json, reapplication_policy, description in STATE_EVENT_TAGS:
+            _upsert_tag(
+                cur,
+                tag=tag,
+                category="state",
+                is_ephemeral=True,
+                clearance_kind="event",
+                reapplication_policy=reapplication_policy,
+                clear_on_json=clear_on_json,
+                description=description,
+            )
+
+        for tag, description in STATE_TIME_TAGS:
+            _upsert_tag(
+                cur,
+                tag=tag,
+                category="state",
+                is_ephemeral=True,
+                clearance_kind="time",
+                reapplication_policy="extend_expiry",
+                clear_on_json=None,
+                description=description,
+            )
+
+        _assert_seeded_tags(cur)
+    conn.commit()
+
+
+def _upsert_tag(
+    cur: Any,
+    *,
+    tag: str,
+    category: str,
+    is_ephemeral: bool,
+    clearance_kind: str | None,
+    reapplication_policy: str | None,
+    clear_on_json: str | None,
+    description: str,
+) -> None:
+    cur.execute(
+        """
+        INSERT INTO tags (
+            tag, category, is_ephemeral,
+            clearance_kind, reapplication_policy, clear_on,
+            synonym_for, deprecated, description
+        ) VALUES (
+            %s, %s, %s,
+            %s::entity_tag_clearance_kind,
+            %s::entity_tag_reapplication_policy,
+            %s::jsonb,
+            NULL, FALSE, %s
+        )
+        ON CONFLICT (tag) DO UPDATE SET
+            category = EXCLUDED.category,
+            is_ephemeral = EXCLUDED.is_ephemeral,
+            clearance_kind = EXCLUDED.clearance_kind,
+            reapplication_policy = EXCLUDED.reapplication_policy,
+            clear_on = EXCLUDED.clear_on,
+            synonym_for = NULL,
+            deprecated = FALSE,
+            description = EXCLUDED.description
+        """,
+        (
+            tag,
+            category,
+            is_ephemeral,
+            clearance_kind,
+            reapplication_policy,
+            clear_on_json,
+            description,
+        ),
+    )
+
+
+def _assert_no_unexpected_category_conflicts(cur: Any) -> None:
+    expected_categories = _expected_categories()
+    cur.execute(
+        """
+        SELECT tag, category
+        FROM tags
+        WHERE tag = ANY(%s)
+        ORDER BY tag
+        """,
+        (list(expected_categories),),
+    )
+    conflicts: dict[str, tuple[str, str]] = {}
+    for tag, actual_category in cur.fetchall():
+        expected_category = expected_categories[tag]
+        if actual_category == expected_category:
+            continue
+        if actual_category in ALLOWED_CATEGORY_REWRITES.get(tag, frozenset()):
+            continue
+        conflicts[tag] = (actual_category, expected_category)
+
+    if conflicts:
+        detail = ", ".join(
+            f"{tag}={actual} (expected {expected})"
+            for tag, (actual, expected) in conflicts.items()
+        )
+        raise RuntimeError(f"Completed vocabulary tag name collisions: {detail}")
+
+
+def _assert_seeded_tags(cur: Any) -> None:
+    expected = _expected_rows()
+    cur.execute(
+        """
+        SELECT tag,
+               category,
+               is_ephemeral,
+               clearance_kind::text,
+               reapplication_policy::text,
+               clear_on,
+               deprecated,
+               description
+        FROM tags
+        WHERE tag = ANY(%s)
+        ORDER BY tag
+        """,
+        (list(expected),),
+    )
+    actual = {}
+    for (
+        tag,
+        category,
+        is_ephemeral,
+        clearance_kind,
+        reapplication_policy,
+        clear_on,
+        deprecated,
+        description,
+    ) in cur.fetchall():
+        actual[tag] = (
+            category,
+            is_ephemeral,
+            clearance_kind,
+            reapplication_policy,
+            _normalize_clear_on(clear_on),
+            deprecated,
+            description,
+        )
+
+    missing = sorted(set(expected) - set(actual))
+    mismatched = sorted(
+        f"{tag}: expected={expected[tag]!r}, got={actual[tag]!r}"
+        for tag in set(expected) & set(actual)
+        if actual[tag] != expected[tag]
+    )
+    if missing or mismatched:
+        message = "Completed Orrery vocabulary seed mismatch"
+        if missing:
+            message += f"; missing={missing}"
+        if mismatched:
+            message += f"; mismatched={mismatched}"
+        raise RuntimeError(message)
+
+
+def _expected_categories() -> dict[str, str]:
+    return {tag: row[0] for tag, row in _expected_rows().items()}
+
+
+def _expected_rows() -> dict[str, tuple[Any, ...]]:
+    expected: dict[str, tuple[Any, ...]] = {
+        tag: (category, False, None, None, None, False, description)
+        for tag, category, description in PLACE_DURABLE_TAGS
+    }
+    expected.update(
+        {
+            tag: (
+                category,
+                True,
+                "semantic",
+                "replace",
+                _normalize_clear_on(clear_on_json),
+                False,
+                description,
+            )
+            for tag, category, clear_on_json, description in PLACE_EPHEMERAL_TAGS
+        }
+    )
+    expected.update(
+        {
+            tag: (
+                "state",
+                True,
+                "event",
+                reapplication_policy,
+                _normalize_clear_on(clear_on_json),
+                False,
+                description,
+            )
+            for (
+                tag,
+                clear_on_json,
+                reapplication_policy,
+                description,
+            ) in STATE_EVENT_TAGS
+        }
+    )
+    expected.update(
+        {
+            tag: ("state", True, "time", "extend_expiry", None, False, description)
+            for tag, description in STATE_TIME_TAGS
+        }
+    )
+    return expected
+
+
+def _normalize_clear_on(value: Any) -> Any:
+    if isinstance(value, str):
+        return json.loads(value)
+    return value

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -697,7 +697,9 @@ def test_completed_tag_vocab_migration_seeds_state_and_place_anchors() -> None:
             migration.STATE_EVENT_TAGS
         )
     }
-    state_time = {tag for tag, _description in migration.STATE_TIME_TAGS}
+    state_time = {
+        tag for tag, _reapplication_policy, _description in migration.STATE_TIME_TAGS
+    }
     tag_names = (
         {tag for tag, _category in place_durable | place_ephemeral}
         | state_event
@@ -735,16 +737,118 @@ def test_completed_tag_vocab_migration_seeds_state_and_place_anchors() -> None:
         "place_environment",
     } == {category for _tag, category in place_durable}
     assert {"place_threat"} == {category for _tag, category in place_ephemeral}
-    assert {tag for tag, _description in migration.STATE_TIME_TAGS} == {
+    assert {
+        tag for tag, _reapplication_policy, _description in migration.STATE_TIME_TAGS
+    } == {
         "intoxicated:stimulant",
         "intoxicated:depressant",
         "intoxicated:hallucinogen",
         "intoxicated:dissociative",
     }
+    assert {
+        reapplication_policy
+        for _tag, reapplication_policy, _description in migration.STATE_TIME_TAGS
+    } == {"extend_expiry"}
     assert migration.ALLOWED_CATEGORY_REWRITES == {
         "wilderness": frozenset({"place_affordance"})
     }
-    assert "Completed vocabulary tag name collisions" in migration_path.read_text()
+
+
+@pytest.mark.requires_postgres
+def test_completed_tag_vocab_migration_executes_against_slot_db() -> None:
+    """Migration 054 executes its guard, upserts, and post-check on a real slot."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "054_orrery_completed_tag_vocab.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    clearance_kind_migration = migrate._load_python_migration(
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "051_orrery_time_tag_clearance_kind.py"
+    )
+    expected = migration._expected_rows()
+    tag_names = list(expected)
+
+    try:
+        conn = psycopg2.connect(get_slot_db_url(dbname="save_05"))
+    except psycopg2.Error as exc:
+        pytest.skip(f"save_05 PostgreSQL test database unavailable: {exc}")
+
+    snapshot = _snapshot_tags(conn, tag_names)
+    try:
+        clearance_kind_migration.run(conn)
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO tags (
+                        tag, category, is_ephemeral, clearance_kind,
+                        reapplication_policy, clear_on, synonym_for,
+                        deprecated, description
+                    ) VALUES (
+                        'wilderness', 'place_affordance', FALSE, NULL,
+                        NULL, NULL, NULL, FALSE,
+                        'legacy wilderness test seed.'
+                    )
+                    ON CONFLICT (tag) DO UPDATE SET
+                        category = EXCLUDED.category,
+                        is_ephemeral = EXCLUDED.is_ephemeral,
+                        clearance_kind = EXCLUDED.clearance_kind,
+                        reapplication_policy = EXCLUDED.reapplication_policy,
+                        clear_on = EXCLUDED.clear_on,
+                        synonym_for = NULL,
+                        deprecated = FALSE,
+                        description = EXCLUDED.description
+                    """
+                )
+
+        migration.run(conn)
+        migration.run(conn)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT tag,
+                       category,
+                       is_ephemeral,
+                       clearance_kind::text,
+                       reapplication_policy::text,
+                       clear_on,
+                       deprecated,
+                       synonym_for,
+                       description
+                FROM tags
+                WHERE tag = ANY(%s)
+                ORDER BY tag
+                """,
+                (tag_names,),
+            )
+            rows = {
+                row[0]: (
+                    row[1],
+                    row[2],
+                    row[3],
+                    row[4],
+                    _normalize_jsonb(row[5]),
+                    row[6],
+                    row[7],
+                    row[8],
+                )
+                for row in cur.fetchall()
+            }
+
+        assert set(rows) == set(expected)
+        for tag, expected_row in expected.items():
+            assert rows[tag] == (*expected_row[:-1], None, expected_row[-1])
+        assert rows["wilderness"][0] == "place_environment"
+        assert rows["intoxicated:stimulant"][3] == "extend_expiry"
+    finally:
+        conn.rollback()
+        _restore_tags(conn, snapshot, tag_names)
+        conn.close()
 
 
 @pytest.mark.requires_postgres

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -672,6 +672,81 @@ def test_faction_legacy_write_default_migration_drops_power_default() -> None:
     assert "Orrery power_status tags" in source
 
 
+def test_completed_tag_vocab_migration_seeds_state_and_place_anchors() -> None:
+    """Migration 054 seeds completed state/place vocabulary without collisions."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "054_orrery_completed_tag_vocab.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+
+    place_durable = {
+        (tag, category) for tag, category, _description in migration.PLACE_DURABLE_TAGS
+    }
+    place_ephemeral = {
+        (tag, category)
+        for tag, category, _clear_on_json, _description in (
+            migration.PLACE_EPHEMERAL_TAGS
+        )
+    }
+    state_event = {
+        tag
+        for tag, _clear_on_json, _reapplication_policy, _description in (
+            migration.STATE_EVENT_TAGS
+        )
+    }
+    state_time = {tag for tag, _description in migration.STATE_TIME_TAGS}
+    tag_names = (
+        {tag for tag, _category in place_durable | place_ephemeral}
+        | state_event
+        | state_time
+    )
+
+    assert len(tag_names) == 52
+    assert len(tag_names) == (
+        len(migration.PLACE_DURABLE_TAGS)
+        + len(migration.PLACE_EPHEMERAL_TAGS)
+        + len(migration.STATE_EVENT_TAGS)
+        + len(migration.STATE_TIME_TAGS)
+    )
+    assert len(migration.PLACE_DURABLE_TAGS) == 35
+    assert len(migration.PLACE_EPHEMERAL_TAGS) == 3
+    assert len(migration.STATE_EVENT_TAGS) == 10
+    assert len(migration.STATE_TIME_TAGS) == 4
+    assert {
+        "place_known",
+        "place_hidden",
+        "place_open",
+        "place_restricted",
+        "place_contested",
+        "place_medical",
+        "water_source",
+        "administration",
+        "intoxicated:stimulant",
+        "disguised",
+    } <= tag_names
+    assert not ({"known", "medical", "contested"} & tag_names)
+    assert {
+        "place_function",
+        "place_visibility",
+        "place_access",
+        "place_environment",
+    } == {category for _tag, category in place_durable}
+    assert {"place_threat"} == {category for _tag, category in place_ephemeral}
+    assert {tag for tag, _description in migration.STATE_TIME_TAGS} == {
+        "intoxicated:stimulant",
+        "intoxicated:depressant",
+        "intoxicated:hallucinogen",
+        "intoxicated:dissociative",
+    }
+    assert migration.ALLOWED_CATEGORY_REWRITES == {
+        "wilderness": frozenset({"place_affordance"})
+    }
+    assert "Completed vocabulary tag name collisions" in migration_path.read_text()
+
+
 @pytest.mark.requires_postgres
 def test_entity_tag_expiry_substrate_migration_executes_against_slot_db() -> None:
     """Migration 049 DDL is idempotent against a real slot schema."""


### PR DESCRIPTION
## Summary
- seed the completed Orrery state and place tag anchors in migration 054
- preserve globally unique place registry names and guard against unexpected tag/category collisions
- document the seeded state/place anchors and add migration catalog coverage

## Verification
- poetry run pytest tests/test_orrery/test_migrate.py::test_completed_tag_vocab_migration_seeds_state_and_place_anchors tests/test_orrery/test_migrate.py::test_category_refactor_phase1_migration_marks_cutover_categories tests/test_orrery/test_migrate.py::test_faction_tag_vocab_migration_seeds_closed_anchor_set
- poetry run flake8 migrations/054_orrery_completed_tag_vocab.py tests/test_orrery/test_migrate.py
- poetry run pytest tests/test_orrery/test_migrate.py tests/test_orrery/test_tag_writer.py tests/test_orrery/test_resolver.py::test_hydrate_world_state_loads_new_place_category_classes