### PR TITLE
Resolve character tag registry collisions

### DIFF
--- a/docs/orrery_needs.md
+++ b/docs/orrery_needs.md
@@ -215,7 +215,7 @@ An `extroversion_low` character can go weeks before reaching `under_socialized_2
 | `libido_moderate` | Default | Default mapping |
 | `libido_high` | Strong need; shorter tolerance | Severity triggers at ~0.6× default debt values |
 
-`libido_absent` is the cleanest immunity pattern — maintenance pass skips severity computation entirely. Unlike `bodyform:android` (categorical embodiment), `libido_absent` is about orientation/identity and can apply to fully embodied characters.
+`libido_absent` is the cleanest immunity pattern — maintenance pass skips severity computation entirely. Unlike `bodyform.lineage:inorganic` (categorical embodiment), `libido_absent` is about orientation/identity and can apply to fully embodied characters.
 
 ---
 
@@ -244,11 +244,10 @@ Single namespace, applied at character-creation time and never removed by the si
 
 | Tag | Immunity scope |
 |---|---|
-| `bodyform:android` | All basic needs (no rows in `character_need_states`) |
-| `bodyform:undead` | Setting-specific — some variants null all needs, some redefine |
-| `bodyform:construct` | Typically all basic needs |
-| `bodyform:non_corporeal` | All embodied needs (basic + intimacy) |
-| `bodyform:biologically_immortal` | Tracks all needs but with attenuated curves |
+| `bodyform.lineage:inorganic` | Typically all basic needs; legacy `bodyform:android` / `bodyform:construct` proposals canonicalize here |
+| `bodyform.condition:undead` | Setting-specific — some variants null all needs, some redefine |
+| `bodyform.condition:virtual` | All embodied needs (basic + intimacy); legacy `bodyform:non_corporeal` / `digital_mind` proposals canonicalize here |
+| reviewed prose / future modifier | Biologically immortal characters track all needs but may have attenuated curves; no canonical `bodyform:biologically_immortal` alias is automatic |
 
 Setting-specific supernaturals (fae, golems, intelligent undead variants, AI uplifts) get their bodyform tags seeded in setting-specific migrations. The bodyform tags remain durable identity facts; they should not be consulted repeatedly by every basic-needs branch — the maintenance pass simply doesn't create rows for immune needs.
 

--- a/docs/orrery_slot2_backfill_plan.md
+++ b/docs/orrery_slot2_backfill_plan.md
@@ -23,11 +23,11 @@ Registry and substrate prerequisites:
 - Hard prerequisite gate: migration 054 must be applied to the target slot
   before any place or state apply step. Until that lands, the place/state
   rewrite is planning-only.
-- Character `role.function` remains a registry alignment decision: the design
-  spec names `role.function`, but live migrations currently keep function tags
-  under `role` and only split `role.fame` / `role.resources`. Do not run a
-  destructive character rewrite until this is resolved by either a registry
-  migration or an explicit doc correction.
+- Migration 055 resolves the durable-character registry target: it keeps
+  `tags.tag` globally keyed, registers `bodyform.lineage`,
+  `bodyform.condition`, and `role.function`, seeds accepted durable character
+  anchors, stores character lawfulness as `tradition_bound`, and moves the
+  `hunter` tag definition to `role.function`.
 
 ## Slot 2 Preflight
 
@@ -53,22 +53,20 @@ Observed active legacy/rewrite surface:
 | `place_affordance` entity tags | 0 | No existing place tags to rewrite deterministically; place backfill must come from place prose/manual review. |
 | faction manifest operations | 145 | All review-required; no ready writes should be applied without human review. |
 | faction legacy tag rows | 56 | Covered by `nexus faction-audit` / `faction-manifest`. |
-| `profession_lite` rows | 26 | Character function rewrite needed after `role` vs `role.function` decision. |
+| `profession_lite` rows | 26 | Character function rewrite needed into `role.function`; migration 055 resolves the target category but does not rewrite rows. |
 | `orrery_signal` rows | 1 | `under_active_pursuit` should become inbound `hunting` pair-tag or be dropped if already represented. |
 | `orrery_state` rows | 50 | Mixed old semantic states; classify into canonical state, need/travel/work/intimacy substrate, pair-tags, or prose. |
-| old `role` rows | 110 | Many remain useful, but target category is blocked by role registry alignment. |
+| old `role` rows | 110 | Many remain useful; accepted function anchors now target `role.function`, while noncanonical legacy role rows need review. |
 | `role.fame` / `role.resources` rows | 0 | No live rows to rewrite; future compiler/backfill may add reviewed values. |
 
 Registry spot-checks:
 
-- The current Slot 2 `tags` table has no `traditionalist` row. Re-check the
-  live category before applying either faction or character rows because
-  `traditionalist` cannot simultaneously be faction `ideology` and character
-  `disposition` while `tags.tag` is globally keyed.
-- The current Slot 2 `hunter` row is still category `capacity`. The accepted
-  capacity vocabulary no longer retains `hunter`, so the migration decision is
-  whether to retire/alias that legacy row into the role-function vocabulary
-  after the `role` vs `role.function` target is settled.
+- The current Slot 2 `tags` table had no `traditionalist` row before migration
+  055. The resolved character anchor is `tradition_bound`; faction ideology
+  keeps `traditionalist`.
+- The current Slot 2 `hunter` row was category `capacity` before migration 055.
+  The accepted capacity vocabulary no longer retains `hunter`; migration 055
+  moves the tag definition to `role.function` without clearing entity rows.
 
 ## Manifest Operation Classes
 
@@ -150,24 +148,15 @@ Next actions:
 
 ### Characters
 
-Current status: largest unresolved planning surface.
+Current status: largest remaining data-rewrite surface.
 
-Do not run a broad character apply until these are decided:
+Do not run a broad character apply until these remaining surfaces are reviewed:
 
-- `role` vs `role.function` registry target.
-- Whether old prefixed bodyform tags such as `bodyform:android` become
-  canonical aliases or are migrated to unprefixed anchors such as `inorganic`
-  and `virtual`.
-- Global tag-name collisions created by category-qualified design language.
-  The live `tags` table keys by global tag string, not by `(category, tag)`.
-  Known blockers include `disposition:traditionalist` colliding with faction
-  `ideology:traditionalist`. Verify the current live `traditionalist` category
-  before apply because one side may already be absent or overwritten in a
-  migrated slot. `role.function:hunter` also collides with legacy
-  `capacity:hunter`; because the accepted capacity vocabulary drops `hunter`,
-  resolve this as a retirement/alias decision rather than a simple rename.
-  Resolve these with globally unique tag names, aliases, or category rewrites
-  before inserting character rows.
+- Legacy `role` / `profession_lite` rows that do not match an accepted
+  `role.function` anchor.
+- Ambiguous bodyform history rows such as `uploaded_consciousness` and
+  `bodyform:biologically_immortal`; deterministic legacy proposals canonicalize
+  through `CANONICAL_TAGS`, but these history-bearing rows need review.
 - Which legacy `orrery_state` values move to canonical `state`, which move to
   dedicated need/travel/work/intimacy substrates, and which become prose.
 - Which old `profession_lite` rows are tag renames, role-function folds, or
@@ -177,8 +166,8 @@ Initial classification:
 
 | Legacy surface | Default classification |
 |---|---|
-| `profession_lite` | Rename/fold into function role after registry decision. |
-| old `role` | Keep or migrate category, depending on `role.function` decision. |
+| `profession_lite` | Rename/fold into `role.function`, or prose/pair-tag remainder when no accepted function anchor fits. |
+| old `role` | Accepted anchors migrate to `role.function`; noncanonical legacy role rows remain review items. |
 | `orrery_signal:under_active_pursuit` | Convert to inbound `hunting` pair-tag, or drop if already represented. |
 | `orrery_signal:debt_pulse_active` | Drop or structured remainder; Skald sovereignty model supersedes debt-pulse forcing. |
 | `orrery_state:contacts_available` | Decompose to `contact:<kind>` pair-tags or relationship rows; never keep as single entity state. |
@@ -188,33 +177,29 @@ Initial classification:
 
 Next actions:
 
-1. Resolve `role.function` registry alignment.
-2. Resolve global character vocabulary collisions against the live
-   single-string tag registry.
-3. Seed any missing accepted character anchors and aliases.
-4. Add a character manifest builder that reports keep/rename/drop/pair-tag/prose
+1. Apply migration 055 before building a character manifest.
+2. Add a character manifest builder that reports keep/rename/drop/pair-tag/prose
    decisions without applying them.
-5. Reconcile the existing Slot 2 reference taggings in
+3. Reconcile the existing Slot 2 reference taggings in
    `docs/orrery_tag_vocabulary.md` against the manifest output.
 
 ## Execution Order
 
-Do not begin any apply step until migration 054 has been applied to the target
-slot.
+Do not begin any apply step until migrations 054 and 055 have been applied to
+the target slot.
 
 1. Apply migration 054 so the state/place seed exists in target slots.
-2. Resolve the character registry alignment blocker.
-3. Resolve globally colliding character anchor names before seeding or applying
-   character rows.
-4. Generate three read-only manifests for Slot 2: faction, place, character.
-5. Review manifests in that order: faction first because tooling exists, place
+2. Apply migration 055 so the durable character seed and collision resolutions
+   exist in target slots.
+3. Generate three read-only manifests for Slot 2: faction, place, character.
+4. Review manifests in that order: faction first because tooling exists, place
    second because there are no existing place rows to preserve, character last
    because it has the most category drift.
-6. Apply ready non-destructive `insert_entity_tag` rows to Slot 2 only.
-7. Re-run Orrery resolver/template tests and a Slot 2 dry run.
-8. Only then clear legacy rows, drop obsolete faction columns, and remove
+5. Apply ready non-destructive `insert_entity_tag` rows to Slot 2 only.
+6. Re-run Orrery resolver/template tests and a Slot 2 dry run.
+7. Only then clear legacy rows, drop obsolete faction columns, and remove
    resolver shims in separate migrations.
-9. Refresh retrograde seed vocabulary/config after the registry-backed Slot 2
+8. Refresh retrograde seed vocabulary/config after the registry-backed Slot 2
    rewrite is stable.
 
 ## Stop Conditions

--- a/docs/orrery_slot2_backfill_plan.md
+++ b/docs/orrery_slot2_backfill_plan.md
@@ -177,9 +177,9 @@ Initial classification:
 
 Next actions:
 
-1. Apply migration 055 before building a character manifest.
-2. Add a character manifest builder that reports keep/rename/drop/pair-tag/prose
-   decisions without applying them.
+1. Apply migration 055 before building the final reviewed character manifest.
+2. Run `nexus character-manifest --slot 2 --output PATH` to report
+   keep/rename/drop/pair-tag/prose decisions without applying them.
 3. Reconcile the existing Slot 2 reference taggings in
    `docs/orrery_tag_vocabulary.md` against the manifest output.
 

--- a/docs/orrery_state_vocabulary.md
+++ b/docs/orrery_state_vocabulary.md
@@ -6,7 +6,7 @@
 
 ## Scope and Boundaries
 
-`state` is the **only ephemeral character category** — durable categories (bodyform, disposition, capacity, role) answer *what a character is*; `state` answers *what is currently true that wasn't always and won't always be*.
+`state` is the **only ephemeral character category** — durable categories (`bodyform.lineage`, `bodyform.condition`, disposition, capacity, and role subcategories) answer *what a character is*; `state` answers *what is currently true that wasn't always and won't always be*.
 
 **Membership test (temporal, not semantic):** a state is a character condition that came from a describable event and ends at a describable event — or, for the pharmacologic cluster, at a describable *time*. If you cannot name what clears it, it is not a state: it is a durable tag, a need, or prose.
 

--- a/docs/orrery_tag_vocabulary.md
+++ b/docs/orrery_tag_vocabulary.md
@@ -1,6 +1,6 @@
 # Orrery Tag Vocabulary
 
-The closed-vocabulary registry for Orrery's tag system: entity-property tag categories (`bodyform`, `disposition`, `capacity`, `role`, `state`), multi-entity (relational) tag families, place + faction categories, and the trait_menu alignment layer. Companion to `docs/orrery_design_plan.md`.
+The closed-vocabulary registry for Orrery's tag system: entity-property tag categories (`bodyform.lineage`, `bodyform.condition`, `disposition`, `capacity`, `role.function`, `role.fame`, `role.resources`, `state`), multi-entity (relational) tag families, place + faction categories, and the trait_menu alignment layer. Companion to `docs/orrery_design_plan.md`.
 
 Closed-vocabulary discipline: tags do not grow at runtime. Every candidate is filtered through three design tests (differential + gating, reskinning, granularity — see Architectural Foundations). The auditable invariant is **"tags must do work prose can't,"** not a fixed count.
 
@@ -12,7 +12,7 @@ Closed-vocabulary discipline: tags do not grow at runtime. Every candidate is fi
 
 | Structure | Application table | Carries | Example |
 |---|---|---|---|
-| **Single-entity tag** | `entity_tags` (existing) | Property of one entity | `bodyform:cybernetic` on Nyati |
+| **Single-entity tag** | `entity_tags` (existing) | Property of one entity | `bodyform.condition:cybernetic` on Nyati |
 | **Multi-entity tag** | `entity_pair_tags` (shipped — see PR #283) | Binary property of an ordered pair | `knows_location(Alex → Burrow)` |
 | **Rich relationship** | `character_relationships` (existing) | Affective/social state with valence, history, sub-states | Alex/Emilia trust=high, valence=positive |
 
@@ -69,7 +69,7 @@ A property earns a tag only if BOTH:
 - *Differential:* it differs meaningfully across characters. If the tag would fire on most characters, it's an entity attribute, not a tag. Universal-with-variation identity attributes (pronouns, gender identity, biographical detail) go in entity metadata (columns or `extra_data`); historical events go in `world_events`; relational properties (sexual orientation) are compositionally inferred from `character_relationships`.
 - *Gating:* at least one narrative or adjudication decision needs to read it to function. If prose already carries the information for Skald, the tag is decorative.
 
-Examples: `bodyform:undead` fires on a small subset and gates package/affordance decisions → tag. `gender:female` fires on most characters and Skald reads pronouns from prose anyway → entity metadata. `disposition:cautious` fires differentially and gates Skald's plausible-action set → tag.
+Examples: `bodyform.condition:undead` fires on a small subset and gates package/affordance decisions → tag. `gender:female` fires on most characters and Skald reads pronouns from prose anyway → entity metadata. `disposition:cautious` fires differentially and gates Skald's plausible-action set → tag.
 
 The pattern: **a tag must do work that prose and metadata can't already do.**
 
@@ -107,10 +107,13 @@ A candidate that passes all three earns its place in the registry.
 
 | Category      | Cardinality  | Ephemerality     | Notes                                 |
 | ------------- | ------------ | ---------------- | ------------------------------------- |
-| `bodyform`    | Multi-valued | Durable          | Hybrid lineages, layered augmentation |
+| `bodyform.lineage` | Multi-valued | Durable      | Essential lineage or personhood substrate |
+| `bodyform.condition` | Multi-valued | Durable    | Fundamental embodiment conditions layered onto lineage |
 | `capacity`    | Multi-valued | Durable (mostly) | Capabilities and affordances          |
 | `disposition` | Multi-valued | Durable          | Stable behavioral patterns            |
-| `role`        | Multi-valued | Durable          | Merged from role + profession_lite    |
+| `role.function` | Multi-valued | Durable       | Social or operational function recognized by others |
+| `role.fame` | Exclusive | Durable             | Ambient recognition radius            |
+| `role.resources` | Exclusive | Durable        | Economic capacity / wealth tier       |
 | `state`       | Multi-valued | Ephemeral        | Merged from state + orrery_signal     |
 
 ### `bodyform`
@@ -185,6 +188,10 @@ Alina (character ID 4) was a human; then became virtualized, and her body destro
 
 Subtype hierarchy is deferred by default. `undead` remains the only admitted undead condition; `vampire`, `lich`, `zombie`, and similar subtypes stay in prose plus composition (`undead` + `enchanted`, needs pressure, vulnerability prose, event history) until a package names a gate that must distinguish them. If that happens, add a deliberate registry migration using the same colon-subtype convention as `intoxicated:*`; do not improvise runtime sub-tags.
 
+#### Legacy Alias Decisions
+
+Migration 055 seeds `bodyform.lineage` and `bodyform.condition` as the registry categories. Deterministic legacy proposal names canonicalize through `CANONICAL_TAGS`: `bodyform:android` and `bodyform:construct` become `inorganic`; `bodyform:non_corporeal` and `digital_mind` become `virtual`; `bodyform:undead` becomes `undead`. Ambiguous history-bearing rows such as `uploaded_consciousness` and `bodyform:biologically_immortal` are not auto-aliased; the Slot 2 backfill manifest must review them as prose/event history or compose them with current bodyform evidence.
+
 ---
 
 ### `disposition`
@@ -200,7 +207,7 @@ Disposition tags are organized along twelve single-word axes, each capturing one
 | **Loyalty** | Commitment to persons/groups | `loyal`, `treacherous`, `trusting`, `suspicious` |
 | **Compassion** | Response to others' suffering | `compassionate`, `callous`, `merciful`, `cruel`, `generous`, `miserly` |
 | **Honesty** | Relationship with truth | `forthright`, `deceitful`, `honorable`, `manipulative` |
-| **Lawfulness** | Posture toward institutional structure | `dutiful`, `independent`, `traditionalist`, `iconoclast`, `principled`, `expedient` |
+| **Lawfulness** | Posture toward institutional structure | `dutiful`, `independent`, `tradition_bound`, `iconoclast`, `principled`, `expedient` |
 | **Mutuality** | Reciprocity orientation in relations | `reciprocal`, `transactional`, `cooperative`, `exploitative` |
 | **Drive** | Ambition and effort | `ambitious`, `complacent`, `industrious`, `indolent` |
 | **Will** | Self-mastery over impulse, appetite, emotion, and commitment | `disciplined`, `impulsive`, `temperate`, `hedonistic`, `stoic`, `volatile`, `resolute`, `wavering` |
@@ -246,6 +253,7 @@ Intentionally **not** imported:
 1. **`idealistic` Outlook anchor.** Kept. It did not fire in the initial six-character pass, but the wildcard round later exercised it across Sam, Black Kite, and the Bridge.
 2. **`pessimistic` Outlook anchor.** Not admitted. Emilia and Pete can be read through `cynical`, `realistic`, `insecure`, and prose without adding a neighboring Outlook anchor that gates differently.
 3. **Will anchor count.** Kept. Eight anchors held up across the twelve-character stress test: max-self-mastery (Alina), high-cluster (`disciplined` + `stoic` + `resolute`), moderate (`disciplined` alone), and opposite-pole (`impulsive` + `volatile` + `wavering`). No trim warranted.
+4. **`traditionalist` collision.** The faction ideology vocabulary already owns the global tag string `traditionalist`. Because `tags.tag` is globally keyed, the character disposition anchor is stored as `tradition_bound` instead of overloading the same physical tag name.
 
 ### `role`
 
@@ -939,7 +947,7 @@ Compiler surfaces:
 | `controls` | Too vague — Skald-confusion attractor |
 | `orrery_state` (category) | System-bookkeeping moves to dedicated tables |
 | `place_affordance` (category) | Decomposed into function / visibility / access / environment / threat. Migration 043 marks the category deprecated and registers replacement categories; legacy tag rows remain readable through the resolver shim until data rewrite. |
-| `profession_lite` (category) | Merged into `role`. Migration 043 marks the category deprecated; legacy tag rows remain live until rewritten. |
+| `profession_lite` (category) | Merged into `role.function`. Migration 055 updates the replacement category; legacy tag rows remain live until rewritten. |
 | `orrery_signal` (category) | Merged into `state`. Migration 043 marks the category deprecated; legacy tag rows remain live until rewritten. |
 | `defensive_position` (place_function value) | Renamed to `fortification`; `haven` added |
 | Vocabulary Growth Contract | Replaced by locked-vocabulary discipline |
@@ -948,7 +956,7 @@ Compiler surfaces:
 
 ## Open Items
 
-1. **Character category implementation.** `bodyform`, `disposition`, `capacity`, the role split (`role.function`, `role.resources`, `role.fame`, scope-bound `status`), and the companion `state` vocabulary are now drafted. Migration 054 seeds the completed `state` anchors; remaining work is implementation-specific compiler/template alignment.
+1. **Character category implementation.** `bodyform.lineage`, `bodyform.condition`, `disposition`, `capacity`, `role.function`, `role.resources`, `role.fame`, scope-bound `status`, and the companion `state` vocabulary are now drafted. Migration 054 seeds the completed `state` anchors; migration 055 seeds the durable character anchors and resolves the `traditionalist` / `hunter` registry collisions. Remaining work is Slot 2 backfill plus compiler/template alignment.
 2. **Place category implementation.** Values are drafted here. Migration 043 registers the replacement categories and migration 054 seeds the place anchors; follow-up work still needs to migrate/deprecate legacy `place_affordance` rows and remove the resolver shim after backfill.
 3. **Faction category implementation.** Drafted in `docs/orrery_faction_vocabulary.md`; migration 052 seeds the closed 65-anchor tag vocabulary. Remaining work: Slot 2 mapping, faction-table cleanup, and clearance-event collapse.
 4. **Story/genre implementation.** Values are drafted here from the existing `Genre` enum. The runtime currently stores them on new-story setting columns; a story-slot entity/category mirror is optional future substrate, blocked on an entity-kind/category-registration migration and not a blocker for current packages.

--- a/migrations/055_orrery_character_tag_vocab.py
+++ b/migrations/055_orrery_character_tag_vocab.py
@@ -1,0 +1,390 @@
+"""Seed accepted durable character vocabulary and resolve registry collisions."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence
+
+from psycopg2.extensions import connection
+
+
+# (category, entity_kind, prompt_order, description)
+NEW_CATEGORY_REGISTRY: Sequence[tuple[str, str, int, str]] = (
+    (
+        "bodyform.lineage",
+        "character",
+        10,
+        "Essential character lineage or personhood substrate.",
+    ),
+    (
+        "bodyform.condition",
+        "character",
+        11,
+        "Fundamental character embodiment conditions layered onto lineage.",
+    ),
+    (
+        "role.function",
+        "character",
+        40,
+        "Multi-valued social or operational function recognized by others.",
+    ),
+)
+
+# (legacy_category, entity_kind, replacement_categories)
+DEPRECATED_CATEGORY_REPLACEMENTS: Sequence[
+    tuple[str, str, Optional[tuple[str, ...]]]
+] = (
+    ("bodyform", "character", ("bodyform.lineage", "bodyform.condition")),
+    ("role", "character", ("role.function",)),
+    ("profession_lite", "character", ("role.function",)),
+)
+
+BODYFORM_LINEAGE_TAGS: Sequence[str] = (
+    "human",
+    "elf",
+    "dwarf",
+    "orc",
+    "goblinoid",
+    "beastfolk",
+    "animal",
+    "dragon",
+    "fey",
+    "giant",
+    "eldritch",
+    "spirit",
+    "inorganic",
+    "alien",
+)
+
+BODYFORM_CONDITION_TAGS: Sequence[str] = (
+    "undead",
+    "lycanthrope",
+    "enchanted",
+    "awakened",
+    "virtual",
+    "extraplanar",
+    "cybernetic",
+)
+
+DISPOSITION_TAGS: Sequence[str] = (
+    "brave",
+    "cowardly",
+    "reckless",
+    "cautious",
+    "aggressive",
+    "peaceable",
+    "belligerent",
+    "gentle",
+    "fierce",
+    "loyal",
+    "treacherous",
+    "trusting",
+    "suspicious",
+    "compassionate",
+    "callous",
+    "merciful",
+    "cruel",
+    "generous",
+    "miserly",
+    "forthright",
+    "deceitful",
+    "honorable",
+    "manipulative",
+    "dutiful",
+    "independent",
+    "tradition_bound",
+    "iconoclast",
+    "principled",
+    "expedient",
+    "reciprocal",
+    "transactional",
+    "cooperative",
+    "exploitative",
+    "ambitious",
+    "complacent",
+    "industrious",
+    "indolent",
+    "disciplined",
+    "impulsive",
+    "temperate",
+    "hedonistic",
+    "stoic",
+    "volatile",
+    "resolute",
+    "wavering",
+    "humble",
+    "proud",
+    "arrogant",
+    "self_effacing",
+    "secure",
+    "insecure",
+    "optimistic",
+    "cynical",
+    "idealistic",
+    "romantic",
+    "realistic",
+    "dispassionate",
+    "gregarious",
+    "solitary",
+    "reserved",
+)
+
+CAPACITY_TAGS: Sequence[str] = (
+    "strong",
+    "agile",
+    "hardy",
+    "frail",
+    "clumsy",
+    "sickly",
+    "educated",
+    "perceptive",
+    "resourceful",
+    "tactician",
+    "unlettered",
+    "oblivious",
+    "persuasive",
+    "intimidating",
+    "deceptive",
+    "empathic",
+    "inarticulate",
+    "martial",
+    "medical",
+    "mechanical",
+    "stealthy",
+    "arcane",
+    "wild",
+    "urban",
+)
+
+ROLE_FUNCTION_TAGS: Sequence[str] = (
+    "advocate",
+    "artisan",
+    "artist",
+    "caregiver",
+    "clergy",
+    "entertainer",
+    "farmer",
+    "functionary",
+    "healer",
+    "hunter",
+    "investigator",
+    "laborer",
+    "leader",
+    "merchant",
+    "scholar",
+    "sex_worker",
+    "spy",
+    "teacher",
+    "technician",
+    "thief",
+    "warrior",
+)
+
+ALLOWED_CATEGORY_REWRITES: dict[str, frozenset[str]] = {
+    **{tag: frozenset({"role"}) for tag in ROLE_FUNCTION_TAGS},
+    "hunter": frozenset({"capacity", "role"}),
+}
+
+
+def run(conn: connection) -> None:
+    """Seed durable character vocabulary rows idempotently."""
+
+    expected = _expected_rows()
+    with conn.cursor() as cur:
+        _ensure_category_cutover_columns(cur)
+        _assert_no_unexpected_category_conflicts(cur, expected)
+        for category, entity_kind, prompt_order, description in NEW_CATEGORY_REGISTRY:
+            _upsert_category(
+                cur,
+                category=category,
+                entity_kind=entity_kind,
+                prompt_order=prompt_order,
+                description=description,
+            )
+
+        for (
+            legacy_category,
+            entity_kind,
+            replacements,
+        ) in DEPRECATED_CATEGORY_REPLACEMENTS:
+            cur.execute(
+                """
+                UPDATE tag_category_registry
+                SET deprecated = TRUE,
+                    replacement_categories = %s
+                WHERE category = %s
+                  AND entity_kind = %s::entity_kind
+                """,
+                (
+                    list(replacements) if replacements else None,
+                    legacy_category,
+                    entity_kind,
+                ),
+            )
+
+        for tag, (category, description) in expected.items():
+            _upsert_tag(cur, tag=tag, category=category, description=description)
+
+        _assert_seeded_tags(cur, expected)
+    conn.commit()
+
+
+def _ensure_category_cutover_columns(cur: Any) -> None:
+    cur.execute(
+        """
+        ALTER TABLE tag_category_registry
+        ADD COLUMN IF NOT EXISTS deprecated boolean NOT NULL DEFAULT false
+        """
+    )
+    cur.execute(
+        """
+        ALTER TABLE tag_category_registry
+        ADD COLUMN IF NOT EXISTS replacement_categories text[]
+        """
+    )
+
+
+def _upsert_category(
+    cur: Any,
+    *,
+    category: str,
+    entity_kind: str,
+    prompt_order: int,
+    description: str,
+) -> None:
+    cur.execute(
+        """
+        INSERT INTO tag_category_registry (
+            category, entity_kind, prompt_order, description,
+            deprecated, replacement_categories
+        ) VALUES (
+            %s, %s::entity_kind, %s, %s,
+            FALSE, NULL
+        )
+        ON CONFLICT (category, entity_kind) DO UPDATE SET
+            prompt_order = EXCLUDED.prompt_order,
+            description = EXCLUDED.description,
+            deprecated = FALSE,
+            replacement_categories = NULL
+        """,
+        (category, entity_kind, prompt_order, description),
+    )
+
+
+def _upsert_tag(cur: Any, *, tag: str, category: str, description: str) -> None:
+    cur.execute(
+        """
+        INSERT INTO tags (
+            tag, category, is_ephemeral,
+            clearance_kind, reapplication_policy, clear_on,
+            synonym_for, deprecated, description
+        ) VALUES (
+            %s, %s, FALSE,
+            NULL, NULL, NULL,
+            NULL, FALSE, %s
+        )
+        ON CONFLICT (tag) DO UPDATE SET
+            category = EXCLUDED.category,
+            is_ephemeral = EXCLUDED.is_ephemeral,
+            clearance_kind = EXCLUDED.clearance_kind,
+            reapplication_policy = EXCLUDED.reapplication_policy,
+            clear_on = EXCLUDED.clear_on,
+            synonym_for = NULL,
+            deprecated = FALSE,
+            description = EXCLUDED.description
+        """,
+        (tag, category, description),
+    )
+
+
+def _assert_no_unexpected_category_conflicts(
+    cur: Any,
+    expected: dict[str, tuple[str, str]],
+) -> None:
+    cur.execute(
+        """
+        SELECT tag, category
+        FROM tags
+        WHERE tag = ANY(%s)
+          AND deprecated = FALSE
+          AND synonym_for IS NULL
+        ORDER BY tag
+        """,
+        (list(expected),),
+    )
+    conflicts = []
+    for tag, existing_category in cur.fetchall():
+        expected_category = expected[tag][0]
+        if existing_category == expected_category:
+            continue
+        if existing_category in ALLOWED_CATEGORY_REWRITES.get(tag, frozenset()):
+            continue
+        conflicts.append(f"{tag}: {existing_category} -> {expected_category}")
+    if conflicts:
+        detail = ", ".join(conflicts)
+        raise RuntimeError(f"Character vocabulary tag name collisions: {detail}")
+
+
+def _assert_seeded_tags(
+    cur: Any,
+    expected: dict[str, tuple[str, str]],
+) -> None:
+    cur.execute(
+        """
+        SELECT tag, category, is_ephemeral, deprecated, synonym_for, description
+        FROM tags
+        WHERE tag = ANY(%s)
+        ORDER BY tag
+        """,
+        (list(expected),),
+    )
+    actual = {
+        tag: (category, is_ephemeral, deprecated, synonym_for, description)
+        for tag, category, is_ephemeral, deprecated, synonym_for, description in (
+            cur.fetchall()
+        )
+    }
+    missing = sorted(set(expected) - set(actual))
+    mismatched = sorted(
+        f"{tag}={actual[tag]}"
+        for tag, (category, description) in expected.items()
+        if tag in actual and actual[tag] != (category, False, False, None, description)
+    )
+    if missing or mismatched:
+        message = "Orrery character vocabulary seed mismatch"
+        if missing:
+            message += f"; missing={missing}"
+        if mismatched:
+            message += f"; mismatched={mismatched}"
+        raise RuntimeError(message)
+
+
+def _expected_rows() -> dict[str, tuple[str, str]]:
+    expected: dict[str, tuple[str, str]] = {}
+    expected.update(
+        {
+            tag: ("bodyform.lineage", f"Bodyform lineage anchor: {tag}.")
+            for tag in BODYFORM_LINEAGE_TAGS
+        }
+    )
+    expected.update(
+        {
+            tag: ("bodyform.condition", f"Bodyform condition anchor: {tag}.")
+            for tag in BODYFORM_CONDITION_TAGS
+        }
+    )
+    expected.update(
+        {
+            tag: ("disposition", f"Disposition anchor: {tag}.")
+            for tag in DISPOSITION_TAGS
+        }
+    )
+    expected.update(
+        {tag: ("capacity", f"Capacity anchor: {tag}.") for tag in CAPACITY_TAGS}
+    )
+    expected.update(
+        {
+            tag: ("role.function", f"Role function anchor: {tag}.")
+            for tag in ROLE_FUNCTION_TAGS
+        }
+    )
+    return expected

--- a/migrations/055_orrery_character_tag_vocab.py
+++ b/migrations/055_orrery_character_tag_vocab.py
@@ -180,9 +180,10 @@ ROLE_FUNCTION_TAGS: Sequence[str] = (
 )
 
 ALLOWED_CATEGORY_REWRITES: dict[str, frozenset[str]] = {
-    **{tag: frozenset({"role"}) for tag in ROLE_FUNCTION_TAGS},
-    "hunter": frozenset({"capacity", "role"}),
+    tag: frozenset({"role"}) for tag in ROLE_FUNCTION_TAGS
 }
+# ``hunter`` used to be a capacity anchor before the role.function split.
+ALLOWED_CATEGORY_REWRITES["hunter"] = frozenset({"capacity", "role"})
 
 
 def run(conn: connection) -> None:
@@ -239,6 +240,20 @@ def _ensure_category_cutover_columns(cur: Any) -> None:
         """
         ALTER TABLE tag_category_registry
         ADD COLUMN IF NOT EXISTS replacement_categories text[]
+        """
+    )
+    cur.execute(
+        """
+        COMMENT ON COLUMN tag_category_registry.deprecated IS
+            'Category-level cutover marker; existing tag rows remain live '
+            'until a reviewed data migration rewrites or clears them.'
+        """
+    )
+    cur.execute(
+        """
+        COMMENT ON COLUMN tag_category_registry.replacement_categories IS
+            'Preferred successor categories for deprecated category rows, '
+            'when any exist.'
         """
     )
 
@@ -303,17 +318,23 @@ def _assert_no_unexpected_category_conflicts(
     cur.execute(
         """
         SELECT tag, category
+             , deprecated
+             , synonym_for
         FROM tags
         WHERE tag = ANY(%s)
-          AND deprecated = FALSE
-          AND synonym_for IS NULL
         ORDER BY tag
         """,
         (list(expected),),
     )
     conflicts = []
-    for tag, existing_category in cur.fetchall():
+    for tag, existing_category, deprecated, synonym_for in cur.fetchall():
         expected_category = expected[tag][0]
+        if deprecated:
+            conflicts.append(f"{tag}: deprecated row cannot be promoted implicitly")
+            continue
+        if synonym_for is not None:
+            conflicts.append(f"{tag}: synonym row cannot be promoted implicitly")
+            continue
         if existing_category == expected_category:
             continue
         if existing_category in ALLOWED_CATEGORY_REWRITES.get(tag, frozenset()):

--- a/nexus/agents/orrery/tag_constants.py
+++ b/nexus/agents/orrery/tag_constants.py
@@ -12,11 +12,16 @@ from typing import Mapping
 
 CANONICAL_TAGS: Mapping[str, str] = {
     "bereaved": "grieving",
+    "bodyform:android": "inorganic",
+    "bodyform:construct": "inorganic",
+    "bodyform:non_corporeal": "virtual",
+    "bodyform:undead": "undead",
     "bridge_linked": "bridge_aware",
     "captive_subject": "captive",
     "collapse_survivor": "trauma_survivor",
     "corporate_defector": "corporate_exile",
-    "digital_consciousness": "digital_mind",
+    "digital_consciousness": "virtual",
+    "digital_mind": "virtual",
     "disaster_survivor": "trauma_survivor",
     "echo_survivor": "trauma_survivor",
     "estranged_parent": "parent",

--- a/nexus/api/character_tag_manifest.py
+++ b/nexus/api/character_tag_manifest.py
@@ -1,0 +1,372 @@
+"""Read-only character tag rewrite manifest builder for Orrery backfills."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Any, Mapping, Sequence
+
+from nexus.agents.orrery.tag_constants import CANONICAL_TAGS
+
+
+CHARACTER_MANIFEST_SCHEMA_VERSION = "orrery_character_manifest.v1"
+
+LEGACY_CHARACTER_CATEGORIES: Sequence[str] = (
+    "bodyform",
+    "profession_lite",
+    "role",
+    "orrery_signal",
+    "orrery_state",
+)
+
+TARGET_CHARACTER_CATEGORIES = frozenset(
+    {
+        "bodyform.lineage",
+        "bodyform.condition",
+        "disposition",
+        "capacity",
+        "role.function",
+        "role.fame",
+        "role.resources",
+        "state",
+    }
+)
+
+WATCHED_COLLISION_TAGS = frozenset(
+    {
+        "hunter",
+        "traditionalist",
+    }
+)
+
+CONTEXTUAL_CHARACTER_ALIASES: Mapping[str, str] = {
+    **CANONICAL_TAGS,
+    "traditionalist": "tradition_bound",
+}
+
+RELATIONAL_REMAINDERS: Mapping[str, tuple[str, str]] = {
+    "under_active_pursuit": (
+        "hunting",
+        "Legacy single-entity pursuit signal is relational; resolve the hunter "
+        "endpoint before writing an inbound hunting pair-tag.",
+    ),
+    "contacts_available": (
+        "contact:<kind>",
+        "Legacy contacts_available overloaded lodging, social, and intimate "
+        "networks; decompose to kind-qualified contacts or relationship rows.",
+    ),
+}
+
+STRUCTURED_REMAINDERS: Mapping[str, str] = {
+    "debt_pulse_active": (
+        "Skald sovereignty supersedes the old debt-pulse forcing model; review "
+        "whether any structured state remains."
+    ),
+    "seeking_identity": (
+        "Identity seeking is package-relevant context but not a canonical state "
+        "anchor by default."
+    ),
+}
+
+PROSE_REMAINDERS: Mapping[str, str] = {
+    "bodyform:biologically_immortal": (
+        "Biological immortality modulates needs/longevity but is not a canonical "
+        "bodyform anchor."
+    ),
+    "uploaded_consciousness": (
+        "Upload history is event/prose unless current embodiment evidence also "
+        "supports virtual or inorganic."
+    ),
+    "off_grid": (
+        "Off-grid status may be concealment, travel, or prose depending on the "
+        "current actor/location context."
+    ),
+    "ghostprint_active": (
+        "Ghostprint exposure is setting-specific concealment/prose unless a "
+        "package names a sharper substrate."
+    ),
+}
+
+
+def build_character_migration_manifest(
+    cur: Any,
+    *,
+    slot: int,
+    dbname: str,
+) -> dict[str, Any]:
+    """Build a read-only manifest for legacy character tag rewrite review."""
+
+    registered_tags = _load_registered_tags(cur)
+    rows = _load_legacy_character_rows(cur)
+    return build_character_migration_manifest_from_rows(
+        rows,
+        registered_tags=registered_tags,
+        slot=slot,
+        dbname=dbname,
+    )
+
+
+def build_character_migration_manifest_from_rows(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    registered_tags: Mapping[str, Mapping[str, Any]],
+    slot: int,
+    dbname: str,
+) -> dict[str, Any]:
+    """Build a manifest from preloaded legacy rows for tests and callers."""
+
+    counters: Counter[str] = Counter()
+    operations: list[dict[str, Any]] = []
+    characters: dict[int, dict[str, Any]] = {}
+
+    for row in rows:
+        character_id = int(row["character_id"])
+        character_name = str(row["character_name"])
+        source_tag = str(row["tag"])
+        source_category = str(row["category"])
+        counters["legacy_character_tag_rows"] += 1
+        counters[f"legacy_category:{source_category}"] += 1
+
+        operation = _operation_for_row(
+            row,
+            registered_tags=registered_tags,
+            operation_index=len(operations) + 1,
+        )
+        operations.append(operation)
+        counters["operation_items"] += 1
+        counters[f"{operation['operation_type']}_operations"] += 1
+        counters[f"{operation['status']}_operations"] += 1
+        if (
+            operation.get("review_required")
+            and operation["status"] != "review_required"
+        ):
+            counters["review_required_operations"] += 1
+        if operation.get("target", {}).get("target_registered") is False:
+            counters["missing_target_tag_operations"] += 1
+
+        character = characters.setdefault(
+            character_id,
+            {
+                "character_id": character_id,
+                "character_name": character_name,
+                "operations": [],
+                "review_required_operations": 0,
+            },
+        )
+        character["operations"].append(operation["operation_id"])
+        if operation.get("review_required"):
+            character["review_required_operations"] += 1
+
+        if source_tag != operation.get("target", {}).get("tag", source_tag):
+            counters["candidate_renames"] += 1
+
+    return {
+        "schema_version": CHARACTER_MANIFEST_SCHEMA_VERSION,
+        "dry_run": True,
+        "source": {
+            "slot": slot,
+            "dbname": dbname,
+            "legacy_categories": list(LEGACY_CHARACTER_CATEGORIES),
+            "watched_collision_tags": sorted(WATCHED_COLLISION_TAGS),
+        },
+        "counters": dict(sorted(counters.items())),
+        "characters": sorted(
+            characters.values(),
+            key=lambda item: (
+                str(item["character_name"]).lower(),
+                item["character_id"],
+            ),
+        ),
+        "operations": operations,
+    }
+
+
+def _operation_for_row(
+    row: Mapping[str, Any],
+    *,
+    registered_tags: Mapping[str, Mapping[str, Any]],
+    operation_index: int,
+) -> dict[str, Any]:
+    source_tag = str(row["tag"])
+    source_category = str(row["category"])
+    character_id = int(row["character_id"])
+
+    if source_tag in RELATIONAL_REMAINDERS:
+        pair_tag, reason = RELATIONAL_REMAINDERS[source_tag]
+        return _operation(
+            row,
+            operation_index=operation_index,
+            operation_type="resolve_pair_tag_target",
+            target={
+                "entity_kind": "character",
+                "entity_id": character_id,
+                "pair_tag": pair_tag,
+                "subject_entity_id": None,
+                "object_entity_id": character_id,
+            },
+            reason=reason,
+        )
+
+    if source_tag in STRUCTURED_REMAINDERS:
+        return _operation(
+            row,
+            operation_index=operation_index,
+            operation_type="structured_remainder",
+            target={"entity_kind": "character", "entity_id": character_id},
+            reason=STRUCTURED_REMAINDERS[source_tag],
+        )
+
+    if source_tag in PROSE_REMAINDERS:
+        return _operation(
+            row,
+            operation_index=operation_index,
+            operation_type="preserve_prose",
+            target={"entity_kind": "character", "entity_id": character_id},
+            reason=PROSE_REMAINDERS[source_tag],
+        )
+
+    target_tag = CONTEXTUAL_CHARACTER_ALIASES.get(source_tag, source_tag)
+    target_row = registered_tags.get(target_tag)
+    if target_row:
+        target_category = str(target_row["category"])
+        reason = _rewrite_reason(
+            source_tag=source_tag,
+            source_category=source_category,
+            target_tag=target_tag,
+            target_category=target_category,
+        )
+    else:
+        target_category = None
+        reason = (
+            "No registered character target tag exists yet; review as prose, "
+            "pair-tag, or future vocabulary."
+        )
+
+    return _operation(
+        row,
+        operation_index=operation_index,
+        operation_type="review_entity_tag",
+        target={
+            "entity_kind": "character",
+            "entity_id": character_id,
+            "category": target_category,
+            "tag": target_tag,
+            "target_registered": target_row is not None,
+        },
+        reason=reason,
+    )
+
+
+def _operation(
+    row: Mapping[str, Any],
+    *,
+    operation_index: int,
+    operation_type: str,
+    target: Mapping[str, Any],
+    reason: str,
+) -> dict[str, Any]:
+    character_id = int(row["character_id"])
+    source_tag = str(row["tag"])
+    return {
+        "operation_id": f"character-{operation_index:04d}-{character_id}-{source_tag}",
+        "operation_type": operation_type,
+        "status": "review_required",
+        "review_required": True,
+        "character_id": character_id,
+        "character_name": str(row["character_name"]),
+        "entity_id": int(row["entity_id"]),
+        "source": {
+            "tag_id": int(row["tag_id"]),
+            "tag": source_tag,
+            "category": str(row["category"]),
+        },
+        "target": dict(target),
+        "confidence": "review",
+        "reason": reason,
+    }
+
+
+def _rewrite_reason(
+    *,
+    source_tag: str,
+    source_category: str,
+    target_tag: str,
+    target_category: str,
+) -> str:
+    if source_tag != target_tag:
+        return (
+            f"Legacy tag {source_category}:{source_tag} canonicalizes to "
+            f"{target_category}:{target_tag}; review before inserting."
+        )
+    if source_category != target_category:
+        return (
+            f"Legacy category {source_category} rewrites to {target_category} "
+            "for the same physical tag name; review before inserting."
+        )
+    return "Registered target already matches; review whether the row should remain."
+
+
+def _load_registered_tags(cur: Any) -> dict[str, dict[str, Any]]:
+    cur.execute(
+        """
+        SELECT t.tag,
+               t.category,
+               t.deprecated,
+               t.synonym_for
+        FROM tags t
+        WHERE t.deprecated = FALSE
+          AND t.synonym_for IS NULL
+          AND t.category = ANY(%s)
+        """,
+        (list(TARGET_CHARACTER_CATEGORIES),),
+    )
+    rows = cur.fetchall()
+    return {
+        str(row["tag"]): {
+            "category": str(row["category"]),
+            "deprecated": bool(row["deprecated"]),
+            "synonym_for": row["synonym_for"],
+        }
+        for row in rows
+    }
+
+
+def _load_legacy_character_rows(cur: Any) -> list[dict[str, Any]]:
+    cur.execute(
+        """
+        SELECT c.id AS character_id,
+               c.name AS character_name,
+               e.id AS entity_id,
+               t.id AS tag_id,
+               t.tag,
+               t.category
+        FROM entity_tags et
+        JOIN tags t ON t.id = et.tag_id
+        JOIN entities e ON e.id = et.entity_id
+        JOIN characters c ON c.entity_id = e.id
+        WHERE et.cleared_at IS NULL
+          AND e.kind = 'character'::entity_kind
+          AND (
+              t.category = ANY(%s)
+              OR t.tag = ANY(%s)
+          )
+        ORDER BY lower(c.name), c.id, t.category, t.tag
+        """,
+        (list(LEGACY_CHARACTER_CATEGORIES), list(WATCHED_COLLISION_TAGS)),
+    )
+    grouped: dict[tuple[int, str], dict[str, Any]] = defaultdict(dict)
+    result: list[dict[str, Any]] = []
+    for row in cur.fetchall():
+        key = (int(row["character_id"]), str(row["tag"]))
+        if key in grouped:
+            continue
+        item = {
+            "character_id": int(row["character_id"]),
+            "character_name": str(row["character_name"]),
+            "entity_id": int(row["entity_id"]),
+            "tag_id": int(row["tag_id"]),
+            "tag": str(row["tag"]),
+            "category": str(row["category"]),
+        }
+        grouped[key] = item
+        result.append(item)
+    return result

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -11,6 +11,7 @@ Commands:
     nexus faction-audit --slot N  Dry-run legacy faction column migration audit
     nexus faction-manifest --slot N  Build reviewed faction migration manifest
     nexus faction-apply --slot N  Dry-run ready faction manifest operations
+    nexus character-manifest --slot N  Build reviewed character tag manifest
 
 The CLI is slot-centric: only --slot N is required. The backend resolves
 all other state (wizard phase, current chunk, thread ID) automatically.
@@ -372,6 +373,53 @@ def _print_faction_apply(payload: Dict[str, Any]) -> None:
             print(f"  ...{len(blocked) - 10} more")
 
 
+def _print_character_manifest(payload: Dict[str, Any]) -> None:
+    """Print a character tag migration manifest summary."""
+
+    manifest = payload.get("character_manifest") or {}
+    counters = manifest.get("counters") or {}
+    characters = manifest.get("characters") or []
+
+    print("Manifest:")
+    print(f"  schema_version: {manifest.get('schema_version')}")
+    print(f"  dry_run: {manifest.get('dry_run')}")
+
+    print()
+    print("Counters:")
+    printed_counters = set()
+    for key in (
+        "legacy_character_tag_rows",
+        "operation_items",
+        "review_required_operations",
+        "review_entity_tag_operations",
+        "resolve_pair_tag_target_operations",
+        "structured_remainder_operations",
+        "preserve_prose_operations",
+        "candidate_renames",
+        "missing_target_tag_operations",
+    ):
+        print(f"  {key}: {counters.get(key, 0)}")
+        printed_counters.add(key)
+    for key in sorted(key for key in counters if key not in printed_counters):
+        print(f"  {key}: {counters[key]}")
+
+    review_characters = [
+        item for item in characters if item.get("review_required_operations", 0)
+    ]
+    if review_characters:
+        print()
+        print("Manual review:")
+        for item in review_characters[:10]:
+            print(
+                "  - "
+                f"{item['character_name']} "
+                f"(id {item['character_id']}): "
+                f"{item.get('review_required_operations', 0)} item(s)"
+            )
+        if len(review_characters) > 10:
+            print(f"  ...{len(review_characters) - 10} more")
+
+
 def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) -> None:
     """Emit payload to stdout in JSON or human-readable format."""
     if as_json:
@@ -403,6 +451,10 @@ def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) 
 
     if payload.get("faction_apply"):
         _print_faction_apply(payload)
+        print()
+
+    if payload.get("character_manifest"):
+        _print_character_manifest(payload)
         print()
 
     # Get display elements
@@ -1188,6 +1240,40 @@ def run_faction_manifest(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
+def run_character_manifest(args: argparse.Namespace) -> Dict[str, Any]:
+    """Build a read-only character tag migration manifest."""
+
+    from nexus.api.character_tag_manifest import build_character_migration_manifest
+    from nexus.api.db_pool import get_connection
+    from nexus.api.slot_utils import slot_dbname
+
+    dbname = slot_dbname(args.slot)
+    with get_connection(dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute("BEGIN READ ONLY")
+            manifest = build_character_migration_manifest(
+                cur,
+                slot=args.slot,
+                dbname=dbname,
+            )
+
+    output_path = getattr(args, "output", None)
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+    return {
+        "success": True,
+        "message": f"Character tag migration manifest for slot {args.slot} (dry run).",
+        "slot": args.slot,
+        "dbname": dbname,
+        "character_manifest": manifest,
+        "manifest_output": str(output_path) if output_path is not None else None,
+    }
+
+
 def run_faction_apply(args: argparse.Namespace) -> Dict[str, Any]:
     """Dry-run or execute ready faction manifest operations."""
 
@@ -1357,6 +1443,7 @@ Examples:
   nexus faction-manifest --slot 2  Build faction migration manifest
   nexus faction-apply --slot 2  Dry-run ready faction manifest operations
   nexus faction-apply --slot 2 --manifest manifest.json --execute
+  nexus character-manifest --slot 2  Build character tag manifest
 """,
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON output")
@@ -1539,6 +1626,20 @@ Examples:
         help="entity_tag_source_kind stamped on inserted rows when --execute is set.",
     )
 
+    # character-manifest command
+    character_manifest_parser = subparsers.add_parser(
+        "character-manifest",
+        help="Build read-only character tag migration manifest",
+    )
+    character_manifest_parser.add_argument(
+        "--slot", type=int, required=True, help="Slot number (1-5)"
+    )
+    character_manifest_parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path for the raw character migration manifest JSON.",
+    )
+
     # lock command
     lock_parser = subparsers.add_parser(
         "lock", help="Lock a slot to prevent modifications"
@@ -1574,6 +1675,7 @@ def main() -> int:
         "faction-audit",
         "faction-manifest",
         "faction-apply",
+        "character-manifest",
         "lock",
         "unlock",
     ):
@@ -1610,6 +1712,8 @@ def main() -> int:
         result = run_faction_manifest(args)
     elif args.command == "faction-apply":
         result = run_faction_apply(args)
+    elif args.command == "character-manifest":
+        result = run_character_manifest(args)
     elif args.command == "lock":
         result = run_lock(args)
     elif args.command == "unlock":

--- a/tests/test_character_tag_manifest.py
+++ b/tests/test_character_tag_manifest.py
@@ -1,0 +1,106 @@
+"""Tests for character tag migration manifest helpers."""
+
+from argparse import Namespace
+from typing import Any
+
+import psycopg2  # type: ignore[import-untyped]
+import pytest
+
+from nexus import cli
+from nexus.api.character_tag_manifest import (
+    CHARACTER_MANIFEST_SCHEMA_VERSION,
+    build_character_migration_manifest_from_rows,
+)
+from nexus.api.db_pool import close_pool
+
+
+TEST_DBNAME = "save_02"
+
+
+def test_character_manifest_canonicalizes_resolved_collision_names() -> None:
+    """Legacy rows should target the resolved physical tag names."""
+
+    manifest = build_character_migration_manifest_from_rows(
+        [
+            _row(tag="bodyform:android", category="bodyform"),
+            _row(tag="traditionalist", category="disposition"),
+            _row(tag="hunter", category="capacity"),
+            _row(tag="contacts_available", category="orrery_state"),
+            _row(tag="uploaded_consciousness", category="bodyform"),
+        ],
+        registered_tags={
+            "inorganic": {"category": "bodyform.lineage"},
+            "tradition_bound": {"category": "disposition"},
+            "hunter": {"category": "role.function"},
+        },
+        slot=2,
+        dbname="save_02",
+    )
+
+    operations = {
+        operation["source"]["tag"]: operation for operation in (manifest["operations"])
+    }
+
+    assert manifest["schema_version"] == CHARACTER_MANIFEST_SCHEMA_VERSION
+    assert manifest["counters"]["legacy_character_tag_rows"] == 5
+    assert manifest["counters"]["review_required_operations"] == 5
+    assert operations["bodyform:android"]["target"]["tag"] == "inorganic"
+    assert operations["bodyform:android"]["target"]["category"] == ("bodyform.lineage")
+    assert operations["traditionalist"]["target"]["tag"] == "tradition_bound"
+    assert operations["hunter"]["target"]["category"] == "role.function"
+    assert operations["contacts_available"]["operation_type"] == (
+        "resolve_pair_tag_target"
+    )
+    assert operations["uploaded_consciousness"]["operation_type"] == "preserve_prose"
+
+
+def test_character_manifest_reports_missing_target_tags() -> None:
+    """Unknown legacy rows remain review items instead of inventing vocabulary."""
+
+    manifest = build_character_migration_manifest_from_rows(
+        [_row(tag="black_market_operator", category="profession_lite")],
+        registered_tags={},
+        slot=2,
+        dbname="save_02",
+    )
+
+    operation = manifest["operations"][0]
+    assert operation["operation_type"] == "review_entity_tag"
+    assert operation["target"]["target_registered"] is False
+    assert manifest["counters"]["missing_target_tag_operations"] == 1
+
+
+@pytest.mark.requires_postgres
+def test_cli_character_manifest_returns_live_slot2_payload() -> None:
+    """CLI character-manifest should read the slot and return a manifest."""
+
+    try:
+        result = cli.run_character_manifest(Namespace(slot=2, output=None))
+    except psycopg2.Error as exc:
+        pytest.skip(f"{TEST_DBNAME} PostgreSQL test database unavailable: {exc}")
+    finally:
+        close_pool(TEST_DBNAME)
+
+    assert result["success"] is True
+    assert result["character_manifest"]["schema_version"] == (
+        CHARACTER_MANIFEST_SCHEMA_VERSION
+    )
+    assert result["character_manifest"]["dry_run"] is True
+    assert result["character_manifest"]["source"]["slot"] == 2
+
+
+def _row(
+    *,
+    tag: str,
+    category: str,
+    character_id: int = 42,
+    character_name: str = "Alex",
+) -> dict[str, Any]:
+    return {
+        "character_id": character_id,
+        "character_name": character_name,
+        "entity_id": 1000 + character_id,
+        "tag_id": hash((tag, category)) & 0xFFFFFF,
+        "tag": tag,
+        "category": category,
+    }

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -754,6 +754,142 @@ def test_completed_tag_vocab_migration_seeds_state_and_place_anchors() -> None:
     }
 
 
+def test_character_tag_vocab_migration_resolves_registry_collisions() -> None:
+    """Migration 055 seeds durable character anchors with global tag names."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "055_orrery_character_tag_vocab.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    expected = migration._expected_rows()
+    registered = {
+        (category, entity_kind)
+        for category, entity_kind, _order, _description in (
+            migration.NEW_CATEGORY_REGISTRY
+        )
+    }
+    deprecated = {
+        (category, entity_kind): replacements
+        for category, entity_kind, replacements in (
+            migration.DEPRECATED_CATEGORY_REPLACEMENTS
+        )
+    }
+
+    assert {
+        ("bodyform.lineage", "character"),
+        ("bodyform.condition", "character"),
+        ("role.function", "character"),
+    } <= registered
+    assert deprecated[("bodyform", "character")] == (
+        "bodyform.lineage",
+        "bodyform.condition",
+    )
+    assert deprecated[("role", "character")] == ("role.function",)
+    assert deprecated[("profession_lite", "character")] == ("role.function",)
+    assert expected["tradition_bound"][0] == "disposition"
+    assert "traditionalist" not in expected
+    assert expected["hunter"][0] == "role.function"
+    assert "hunter" not in migration.CAPACITY_TAGS
+    assert migration.ALLOWED_CATEGORY_REWRITES["hunter"] == frozenset(
+        {"capacity", "role"}
+    )
+    assert len(expected) == (
+        len(migration.BODYFORM_LINEAGE_TAGS)
+        + len(migration.BODYFORM_CONDITION_TAGS)
+        + len(migration.DISPOSITION_TAGS)
+        + len(migration.CAPACITY_TAGS)
+        + len(migration.ROLE_FUNCTION_TAGS)
+    )
+
+
+@pytest.mark.requires_postgres
+def test_character_tag_vocab_migration_executes_against_slot_db() -> None:
+    """Migration 055 executes guard, registry updates, and tag seed live."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "055_orrery_character_tag_vocab.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    expected = migration._expected_rows()
+    tag_names = list(expected)
+    category_names = [
+        *(
+            category
+            for category, _kind, _order, _description in (
+                migration.NEW_CATEGORY_REGISTRY
+            )
+        ),
+        *(
+            category
+            for category, _kind, _replacements in (
+                migration.DEPRECATED_CATEGORY_REPLACEMENTS
+            )
+        ),
+    ]
+
+    try:
+        conn = psycopg2.connect(get_slot_db_url(dbname="save_05"))
+    except psycopg2.Error as exc:
+        pytest.skip(f"save_05 PostgreSQL test database unavailable: {exc}")
+
+    tag_snapshot = _snapshot_tags(conn, tag_names)
+    category_snapshot = _snapshot_tag_categories(conn, category_names)
+    try:
+        migration.run(conn)
+        migration.run(conn)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT tag, category, is_ephemeral, deprecated, synonym_for,
+                       description
+                FROM tags
+                WHERE tag = ANY(%s)
+                """,
+                (tag_names,),
+            )
+            rows = {row[0]: row[1:] for row in cur.fetchall()}
+
+            cur.execute(
+                """
+                SELECT category, entity_kind::text, deprecated,
+                       replacement_categories
+                FROM tag_category_registry
+                WHERE category = ANY(%s)
+                """,
+                (category_names,),
+            )
+            categories = {row[0]: row[1:] for row in cur.fetchall()}
+
+        assert set(rows) == set(expected)
+        for tag, (category, description) in expected.items():
+            assert rows[tag] == (category, False, False, None, description)
+        assert categories["bodyform.lineage"] == ("character", False, None)
+        assert categories["bodyform.condition"] == ("character", False, None)
+        assert categories["role.function"] == ("character", False, None)
+        assert categories["bodyform"] == (
+            "character",
+            True,
+            ["bodyform.lineage", "bodyform.condition"],
+        )
+        assert categories["role"] == ("character", True, ["role.function"])
+        assert categories["profession_lite"] == (
+            "character",
+            True,
+            ["role.function"],
+        )
+        assert rows["hunter"][0] == "role.function"
+    finally:
+        conn.rollback()
+        _restore_tags(conn, tag_snapshot, tag_names)
+        _restore_tag_categories(conn, category_snapshot, category_names)
+        conn.close()
+
+
 @pytest.mark.requires_postgres
 def test_completed_tag_vocab_migration_executes_against_slot_db() -> None:
     """Migration 054 executes its guard, upserts, and post-check on a real slot."""
@@ -1423,4 +1559,50 @@ def _restore_tags(
                     WHERE tag = %s
                     """,
                     (*row, tag),
+                )
+
+
+def _snapshot_tag_categories(
+    conn: Any,
+    category_names: Iterable[str],
+) -> dict[str, tuple[Any, ...]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT category, entity_kind::text, prompt_order, description,
+                   deprecated, replacement_categories
+            FROM tag_category_registry
+            WHERE category = ANY(%s)
+            """,
+            (list(category_names),),
+        )
+        return {row[0]: row[1:] for row in cur.fetchall()}
+
+
+def _restore_tag_categories(
+    conn: Any,
+    snapshot: dict[str, tuple[Any, ...]],
+    category_names: Iterable[str],
+) -> None:
+    with conn:
+        with conn.cursor() as cur:
+            for category in category_names:
+                row = snapshot.get(category)
+                if row is None:
+                    cur.execute(
+                        "DELETE FROM tag_category_registry WHERE category = %s",
+                        (category,),
+                    )
+                    continue
+                cur.execute(
+                    """
+                    UPDATE tag_category_registry
+                    SET entity_kind = %s::entity_kind,
+                        prompt_order = %s,
+                        description = %s,
+                        deprecated = %s,
+                        replacement_categories = %s
+                    WHERE category = %s
+                    """,
+                    (*row, category),
                 )

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -802,6 +802,36 @@ def test_character_tag_vocab_migration_resolves_registry_collisions() -> None:
         + len(migration.CAPACITY_TAGS)
         + len(migration.ROLE_FUNCTION_TAGS)
     )
+    source = migration_path.read_text()
+    assert "COMMENT ON COLUMN tag_category_registry.deprecated" in source
+    assert "COMMENT ON COLUMN tag_category_registry.replacement_categories" in source
+
+
+def test_character_tag_vocab_guard_rejects_silent_alias_promotion() -> None:
+    """Migration 055 guard should catch deprecated or synonym collisions."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "055_orrery_character_tag_vocab.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+
+    class FakeCursor:
+        def execute(self, _sql: str, _params: object = None) -> None:
+            return None
+
+        def fetchall(self) -> list[tuple[str, str, bool, int | None]]:
+            return [
+                ("human", "bodyform", True, None),
+                ("elf", "bodyform", False, 101),
+            ]
+
+    with pytest.raises(RuntimeError, match="cannot be promoted implicitly"):
+        migration._assert_no_unexpected_category_conflicts(
+            FakeCursor(),
+            migration._expected_rows(),
+        )
 
 
 @pytest.mark.requires_postgres

--- a/tests/test_orrery/test_slot2_tag_backfill.py
+++ b/tests/test_orrery/test_slot2_tag_backfill.py
@@ -29,6 +29,7 @@ def test_slot2_tag_backfill_filters_and_canonicalizes_proposals() -> None:
                 ],
                 "unregistered_tag_candidates": [
                     {"tag": "found_family_anchor", "confidence": "high"},
+                    {"tag": "bodyform:android", "confidence": "high"},
                     {"tag": "unknown_one_off", "confidence": "high"},
                 ],
             },
@@ -50,6 +51,9 @@ def test_slot2_tag_backfill_filters_and_canonicalizes_proposals() -> None:
         ),
         "corporate_exile": TagDefinition(id=2, category="state", is_ephemeral=False),
         "extended_household": TagDefinition(id=3, category="role", is_ephemeral=False),
+        "inorganic": TagDefinition(
+            id=7, category="bodyform.lineage", is_ephemeral=False
+        ),
         "militarized": TagDefinition(
             id=4, category="power_posture", is_ephemeral=False
         ),
@@ -69,7 +73,13 @@ def test_slot2_tag_backfill_filters_and_canonicalizes_proposals() -> None:
         manifest,
         tags=tags,
         allowed_categories={
-            "character": {"orrery_need", "orrery_state", "role", "state"},
+            "character": {
+                "bodyform.lineage",
+                "orrery_need",
+                "orrery_state",
+                "role",
+                "state",
+            },
             "faction": {"power_posture"},
             "place": {"place_affordance"},
         },
@@ -80,6 +90,7 @@ def test_slot2_tag_backfill_filters_and_canonicalizes_proposals() -> None:
 
     assert [(candidate.entity_id, candidate.tag) for candidate in candidates] == [
         (1, "extended_household"),
+        (1, "inorganic"),
         (1, "sleep_deprived_1_mild"),
         (2, "militarized"),
     ]

--- a/tests/test_orrery/test_tag_writer.py
+++ b/tests/test_orrery/test_tag_writer.py
@@ -301,6 +301,8 @@ def _registered(*entries):
 def _default_category_registry() -> dict[str, set[str]]:
     return {
         "bodyform": {"character"},
+        "bodyform.condition": {"character"},
+        "bodyform.lineage": {"character"},
         "capacity": {"character"},
         "disposition": {"character"},
         "orrery_need": {"character"},
@@ -308,6 +310,7 @@ def _default_category_registry() -> dict[str, set[str]]:
         "place_affordance": {"place"},
         "power_posture": {"faction"},
         "profession_lite": {"character"},
+        "role.function": {"character"},
         "role.fame": {"character"},
         "role.resources": {"character"},
         "state": {"character"},
@@ -655,6 +658,21 @@ def test_canonical_alias_applied_as_canonical():
     )
     assert counters["applied"] == 1
     canonical_id = hash("corporate_exile") & 0xFFFFFF
+    assert cur.inserted_entity_tag_rows[0]["tag_id"] == canonical_id
+
+
+def test_bodyform_alias_applied_as_canonical_character_anchor():
+    cur = FakeCursor(tags=_registered(("inorganic", "bodyform.lineage", False)))
+
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=42,
+        entity_kind="character",
+        bestowal=OrreryTagBestowal(applied_tags=["bodyform:android"]),
+    )
+
+    assert counters["applied"] == 1
+    canonical_id = hash("inorganic") & 0xFFFFFF
     assert cur.inserted_entity_tag_rows[0]["tag_id"] == canonical_id
 
 


### PR DESCRIPTION
## Summary
- add migration 055 to register `bodyform.lineage`, `bodyform.condition`, and `role.function`, seed accepted durable character anchors, and keep `tags.tag` globally keyed
- resolve the `traditionalist` collision by storing the character disposition anchor as `tradition_bound`, and move the legacy `hunter` tag definition from `capacity` to `role.function`
- add deterministic bodyform canonical aliases for future proposals and update Slot 2 backfill/vocabulary docs around the remaining review-only rows
- add `nexus character-manifest --slot N --output PATH` as a read-only review manifest for legacy character tag rows before any Slot 2 data rewrite

## Validation
- `poetry run flake8 nexus/api/character_tag_manifest.py nexus/cli.py tests/test_character_tag_manifest.py migrations/055_orrery_character_tag_vocab.py tests/test_orrery/test_migrate.py tests/test_orrery/test_tag_writer.py tests/test_orrery/test_slot2_tag_backfill.py nexus/agents/orrery/tag_constants.py`
- `NEXUS_RUN_POSTGRES=1 poetry run pytest tests/test_character_tag_manifest.py tests/test_orrery/test_migrate.py::test_character_tag_vocab_migration_resolves_registry_collisions tests/test_orrery/test_migrate.py::test_character_tag_vocab_migration_executes_against_slot_db tests/test_orrery/test_tag_writer.py::test_bodyform_alias_applied_as_canonical_character_anchor tests/test_orrery/test_slot2_tag_backfill.py::test_slot2_tag_backfill_filters_and_canonicalizes_proposals`
- `poetry run pytest tests/test_character_tag_manifest.py tests/test_orrery/test_migrate.py tests/test_orrery/test_tag_writer.py tests/test_orrery/test_slot2_tag_backfill.py tests/test_trait_compiler.py`
- `poetry run nexus --json character-manifest --slot 2 --output temp/slot2_backfill/character_manifest_phase4.json`
- `git diff --check`

## Data / Schema Impact
- Adds migration 055.
- Non-destructively updates tag registry metadata and tag definitions; the `hunter` tag row becomes `role.function` and legacy `role` / `profession_lite` / `bodyform` categories are marked deprecated with replacement categories.
- Does not run the Slot 2 character data rewrite; ambiguous bodyform/history rows remain manifest-review work.

Closes #348.