### PR TITLE
Add Slot 2 backfill review packet

### DIFF
--- a/docs/orrery_slot2_backfill_plan.md
+++ b/docs/orrery_slot2_backfill_plan.md
@@ -52,6 +52,11 @@ poetry run nexus --json character-manifest --slot 2 --output temp/slot2_backfill
 poetry run nexus --json faction-apply --slot 2 --manifest temp/slot2_backfill/faction_manifest_phase4_post055.json
 poetry run nexus --json character-apply --slot 2
 poetry run nexus --json place-apply --slot 2
+poetry run nexus backfill-review-packet --slot 2 \
+  --faction-manifest temp/slot2_backfill/faction_manifest_phase4_post055.json \
+  --character-manifest temp/slot2_backfill/character_manifest_phase4_post055.json \
+  --place-manifest temp/slot2_backfill/place_manifest_phase5.json \
+  --output temp/slot2_backfill/review_packet_phase6.md
 ```
 
 Observed entity counts:
@@ -84,6 +89,17 @@ Post-migration manifest results:
 | faction | 145 | 0 | 145 | `faction-apply` dry-run skipped all rows as review-required and would insert 0 tags. |
 | character | 188 | 0 | 188 | 15 candidate renames resolve to registered target tags; 118 operations still lack registered target tags and need review/prose/pair-tag handling. `character-apply` dry-run skipped all rows and would insert 0 tags. |
 | place | 889 | 0 | 889 | All target tags are registered; `place-apply` dry-run skipped all rows and would insert 0 tags. |
+
+Review packet result:
+
+| Queue | Operations | Reading |
+|---|---:|---|
+| registered single-entity candidates | 980 | Narrowest non-destructive review surface; still not apply-ready until the reviewer promotes individual rows. |
+| missing target tags | 118 | Requires vocabulary, prose, or pair-tag decisions. |
+| pair target resolution | 36 | Requires endpoint decisions before any pair-tag apply path. |
+| prose/event rows | 36 | Outside `entity_tags`; preserve or convert through a later prose/world-event slice. |
+| structured remainders | 50 | Requires a substrate decision before mutation. |
+| drop-after-review rows | 2 | Destructive; later reviewed cleanup only. |
 
 Registry spot-checks:
 
@@ -138,6 +154,7 @@ Existing surfaces:
 - `nexus faction-audit --slot N`
 - `nexus faction-manifest --slot N --output PATH`
 - `nexus faction-apply --slot N --manifest PATH [--execute]`
+- `nexus backfill-review-packet --slot N ...`
 
 Slot 2 dry-run result: 145 operations, all review-required. This is expected
 because faction columns are prose-heavy and many legacy values are aliases or
@@ -164,6 +181,7 @@ Existing surface:
 
 - `nexus place-manifest --slot N --output PATH`
 - `nexus place-apply --slot N --manifest PATH [--execute]`
+- `nexus backfill-review-packet --slot N ...`
 
 Slot 2 dry-run result: 889 operations across 78 places, all review-required.
 Every target tag is registered; there are no ready writes. The manifest scans
@@ -208,6 +226,7 @@ Existing surfaces:
 
 - `nexus character-manifest --slot N --output PATH`
 - `nexus character-apply --slot N --manifest PATH [--execute]`
+- `nexus backfill-review-packet --slot N ...`
 
 Do not run a broad character apply until these remaining surfaces are reviewed:
 
@@ -258,16 +277,18 @@ checkpoint.
    exist in target slots. **Done locally for Slot 2.**
 3. Generate three read-only manifests for Slot 2: faction, place, character.
    **Done.**
-4. Review manifests in that order: faction first because tooling exists, place
+4. Generate a read-only review packet from the three manifests. **Done.**
+5. Review manifests in that order: faction first because tooling exists, place
    second because there are no existing place rows to preserve, character last
-   because it has the most category drift.
-5. Apply ready non-destructive entity-tag rows to Slot 2 only. **Apply
+   because it has the most category drift. Use the review packet queues to find
+   narrow registered single-entity candidates before pair/prose/remainder work.
+6. Apply ready non-destructive entity-tag rows to Slot 2 only. **Apply
    commands are in place; current manifests have 0 ready rows, so dry-runs
    insert 0 tags.**
-6. Re-run Orrery resolver/template tests and a Slot 2 dry run.
-7. Only then clear legacy rows, drop obsolete faction columns, and remove
+7. Re-run Orrery resolver/template tests and a Slot 2 dry run.
+8. Only then clear legacy rows, drop obsolete faction columns, and remove
    resolver shims in separate migrations.
-8. Refresh retrograde seed vocabulary/config after the registry-backed Slot 2
+9. Refresh retrograde seed vocabulary/config after the registry-backed Slot 2
    rewrite is stable.
 
 ## Stop Conditions

--- a/nexus/api/backfill_review_packet.py
+++ b/nexus/api/backfill_review_packet.py
@@ -1,0 +1,389 @@
+"""Build human review packets for Orrery backfill manifests."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Mapping
+from typing import Any
+
+
+BACKFILL_REVIEW_PACKET_SCHEMA_VERSION = "orrery_backfill_review_packet.v1"
+BACKFILL_MANIFEST_FAMILIES = ("faction", "character", "place")
+
+
+def build_backfill_review_packet(
+    manifests: Mapping[str, Mapping[str, Any]],
+    *,
+    slot: int,
+    examples_per_queue: int = 5,
+) -> dict[str, Any]:
+    """Summarize review-required backfill manifests without changing readiness."""
+
+    if examples_per_queue < 1:
+        raise ValueError("examples_per_queue must be at least 1")
+
+    family_packets: dict[str, Any] = {}
+    overall_counters: Counter[str] = Counter()
+    for family in BACKFILL_MANIFEST_FAMILIES:
+        manifest = manifests.get(family)
+        if manifest is None:
+            raise ValueError(f"Missing {family} manifest")
+        _validate_manifest_slot(manifest, slot=slot, family=family)
+        family_packet = _build_family_packet(
+            family,
+            manifest,
+            examples_per_queue=examples_per_queue,
+        )
+        family_packets[family] = family_packet
+        for key, value in family_packet["counters"].items():
+            if isinstance(value, int):
+                overall_counters[key] += value
+
+    return {
+        "schema_version": BACKFILL_REVIEW_PACKET_SCHEMA_VERSION,
+        "slot": slot,
+        "policy": {
+            "mutates_data": False,
+            "promotes_ready_rows": False,
+            "ready_contract": (
+                "Rows become apply-eligible only after a reviewer edits the source "
+                "manifest to status=ready and review_required=false."
+            ),
+        },
+        "counters": dict(overall_counters),
+        "families": family_packets,
+        "review_order": [
+            {
+                "queue": "registered_single_entity",
+                "reason": (
+                    "Registered single-entity candidates are the narrowest "
+                    "non-destructive review surface."
+                ),
+            },
+            {
+                "queue": "pair_target_resolution",
+                "reason": (
+                    "Pair-tag rows need endpoint decisions before any apply path."
+                ),
+            },
+            {
+                "queue": "missing_target_tag",
+                "reason": (
+                    "Missing target tags require vocabulary, prose, or pair-tag "
+                    "decisions before promotion."
+                ),
+            },
+            {
+                "queue": "prose_or_event",
+                "reason": "Prose/world-event rows are outside entity_tags apply.",
+            },
+            {
+                "queue": "structured_remainder",
+                "reason": "Remainders need a substrate decision before mutation.",
+            },
+            {
+                "queue": "drop_after_review",
+                "reason": "Drops are destructive and belong to a later reviewed slice.",
+            },
+        ],
+    }
+
+
+def render_backfill_review_packet_markdown(packet: Mapping[str, Any]) -> str:
+    """Render a packet as a compact Markdown review aid."""
+
+    lines = [
+        f"# Slot {packet.get('slot')} Orrery Backfill Review Packet",
+        "",
+        "This packet is read-only. It does not mark any manifest row ready and "
+        "does not authorize data mutation.",
+        "",
+        "## Summary",
+        "",
+        "| Family | Operations | Ready | Review-required | Registered entity "
+        "candidates | Missing target tags | Pair target rows | Prose/event rows | "
+        "Remainders | Drops |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+
+    families = packet.get("families") or {}
+    for family in BACKFILL_MANIFEST_FAMILIES:
+        family_packet = families.get(family) or {}
+        counters = family_packet.get("counters") or {}
+        lines.append(
+            "| {family} | {operation_items} | {ready_operations} | "
+            "{review_required_operations} | {registered_single_entity} | "
+            "{missing_target_tag} | {pair_target_resolution} | "
+            "{prose_or_event} | {structured_remainder} | {drop_after_review} |".format(
+                family=family,
+                operation_items=counters.get("operation_items", 0),
+                ready_operations=counters.get("ready_operations", 0),
+                review_required_operations=counters.get(
+                    "review_required_operations", 0
+                ),
+                registered_single_entity=counters.get(
+                    "queue:registered_single_entity", 0
+                ),
+                missing_target_tag=counters.get("queue:missing_target_tag", 0),
+                pair_target_resolution=counters.get("queue:pair_target_resolution", 0),
+                prose_or_event=counters.get("queue:prose_or_event", 0),
+                structured_remainder=counters.get("queue:structured_remainder", 0),
+                drop_after_review=counters.get("queue:drop_after_review", 0),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Suggested Review Order",
+            "",
+        ]
+    )
+    for item in packet.get("review_order") or []:
+        lines.append(f"- `{item['queue']}`: {item['reason']}")
+
+    for family in BACKFILL_MANIFEST_FAMILIES:
+        family_packet = families.get(family) or {}
+        lines.extend(_render_family_markdown(family, family_packet))
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _build_family_packet(
+    family: str,
+    manifest: Mapping[str, Any],
+    *,
+    examples_per_queue: int,
+) -> dict[str, Any]:
+    operations = list(manifest.get("operations") or [])
+    counters: Counter[str] = Counter()
+    counters["operation_items"] = len(operations)
+    queue_examples: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    target_counts: Counter[str] = Counter()
+    source_counts: Counter[str] = Counter()
+    operation_type_counts: Counter[str] = Counter()
+
+    for operation in operations:
+        status = str(operation.get("status") or "")
+        operation_type = str(operation.get("operation_type") or "")
+        queue = _review_queue(operation)
+        counters[f"queue:{queue}"] += 1
+        counters[f"status:{status}"] += 1
+        counters[f"operation_type:{operation_type}"] += 1
+        operation_type_counts[operation_type] += 1
+        if status == "ready":
+            counters["ready_operations"] += 1
+        if bool(operation.get("review_required", False)):
+            counters["review_required_operations"] += 1
+
+        target_label = _target_label(operation)
+        source_label = _source_label(operation)
+        if target_label:
+            target_counts[target_label] += 1
+        if source_label:
+            source_counts[source_label] += 1
+        if len(queue_examples[queue]) < examples_per_queue:
+            queue_examples[queue].append(_operation_example(operation, queue=queue))
+
+    for queue in (
+        "registered_single_entity",
+        "missing_target_tag",
+        "pair_target_resolution",
+        "prose_or_event",
+        "structured_remainder",
+        "drop_after_review",
+        "other_review",
+    ):
+        counters.setdefault(f"queue:{queue}", 0)
+    counters.setdefault("ready_operations", 0)
+    counters.setdefault("review_required_operations", 0)
+
+    return {
+        "schema_version": manifest.get("schema_version"),
+        "source": manifest.get("source") or {},
+        "counters": dict(counters),
+        "operation_types": dict(operation_type_counts.most_common()),
+        "top_targets": dict(target_counts.most_common(20)),
+        "top_sources": dict(source_counts.most_common(20)),
+        "queue_examples": dict(queue_examples),
+    }
+
+
+def _validate_manifest_slot(
+    manifest: Mapping[str, Any],
+    *,
+    slot: int,
+    family: str,
+) -> None:
+    source = manifest.get("source") or {}
+    manifest_slot = source.get("slot")
+    if manifest_slot is not None and int(manifest_slot) != slot:
+        raise ValueError(
+            f"{family} manifest slot {manifest_slot} does not match --slot {slot}"
+        )
+
+
+def _review_queue(operation: Mapping[str, Any]) -> str:
+    operation_type = str(operation.get("operation_type") or "")
+    target = operation.get("target") or {}
+    if operation_type == "review_entity_tag":
+        if target.get("target_registered") is False:
+            return "missing_target_tag"
+        if target.get("category") and target.get("tag"):
+            return "registered_single_entity"
+        return "other_review"
+    if operation_type == "resolve_pair_tag_target":
+        return "pair_target_resolution"
+    if operation_type in {"preserve_prose", "world_event_or_prose"}:
+        return "prose_or_event"
+    if operation_type in {
+        "structured_remainder",
+        "classify_structured_remainder",
+    }:
+        return "structured_remainder"
+    if operation_type == "drop_legacy_tag_after_review":
+        return "drop_after_review"
+    return "other_review"
+
+
+def _operation_example(operation: Mapping[str, Any], *, queue: str) -> dict[str, Any]:
+    return {
+        "queue": queue,
+        "operation_id": operation.get("operation_id"),
+        "operation_type": operation.get("operation_type"),
+        "status": operation.get("status"),
+        "review_required": operation.get("review_required"),
+        "entity": _entity_label(operation),
+        "source": _source_label(operation),
+        "target": _target_label(operation),
+        "reason": operation.get("reason"),
+    }
+
+
+def _entity_label(operation: Mapping[str, Any]) -> str:
+    for name_key, id_key, label in (
+        ("faction_name", "faction_id", "faction"),
+        ("character_name", "character_id", "character"),
+        ("place_name", "place_id", "place"),
+    ):
+        name = operation.get(name_key)
+        entity_id = operation.get(id_key)
+        if name is not None or entity_id is not None:
+            return f"{name or label} ({label} {entity_id})"
+    entity_id = operation.get("entity_id")
+    return f"entity {entity_id}" if entity_id is not None else "unknown entity"
+
+
+def _source_label(operation: Mapping[str, Any]) -> str:
+    source = operation.get("source") or {}
+    category = source.get("category")
+    tag = source.get("tag")
+    if category or tag:
+        return f"{category or '?'}:{tag or '?'}"
+    column = source.get("column")
+    if column:
+        value = str(source.get("value", ""))
+        return f"{column}={_compact(value)}"
+    kind = source.get("kind")
+    matches = source.get("matches") or []
+    if kind and matches:
+        keywords = []
+        for match in matches[:3]:
+            keywords.extend(str(item) for item in match.get("keywords") or [])
+        keyword_text = ", ".join(keywords[:5])
+        return f"{kind}: {keyword_text}" if keyword_text else str(kind)
+    return str(kind or "")
+
+
+def _target_label(operation: Mapping[str, Any]) -> str:
+    target = operation.get("target") or {}
+    category = target.get("category") or target.get("target_category")
+    tag = target.get("tag")
+    if category and tag:
+        return f"{category}:{tag}"
+    pair_tag = target.get("pair_tag")
+    if pair_tag:
+        subject = target.get("subject_entity_id")
+        obj = target.get("object_entity_id")
+        return f"{pair_tag}({subject or '?'} -> {obj or '?'})"
+    destination = target.get("destination")
+    if destination:
+        return str(destination)
+    if category:
+        return str(category)
+    return ""
+
+
+def _compact(value: str, limit: int = 80) -> str:
+    text = " ".join(value.split())
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 3]}..."
+
+
+def _render_family_markdown(
+    family: str,
+    family_packet: Mapping[str, Any],
+) -> list[str]:
+    counters = family_packet.get("counters") or {}
+    lines = [
+        "",
+        f"## {family.title()}",
+        "",
+        f"- Manifest schema: `{family_packet.get('schema_version')}`",
+        f"- Operations: {counters.get('operation_items', 0)}",
+        f"- Ready rows: {counters.get('ready_operations', 0)}",
+        f"- Review-required rows: {counters.get('review_required_operations', 0)}",
+        "",
+        "### Queue Counts",
+        "",
+    ]
+    for queue in (
+        "registered_single_entity",
+        "missing_target_tag",
+        "pair_target_resolution",
+        "prose_or_event",
+        "structured_remainder",
+        "drop_after_review",
+        "other_review",
+    ):
+        lines.append(f"- `{queue}`: {counters.get(f'queue:{queue}', 0)}")
+
+    top_targets = family_packet.get("top_targets") or {}
+    if top_targets:
+        lines.extend(["", "### Top Targets", ""])
+        for target, count in list(top_targets.items())[:10]:
+            lines.append(f"- `{target}`: {count}")
+
+    top_sources = family_packet.get("top_sources") or {}
+    if top_sources:
+        lines.extend(["", "### Top Sources", ""])
+        for source, count in list(top_sources.items())[:10]:
+            lines.append(f"- `{source}`: {count}")
+
+    queue_examples = family_packet.get("queue_examples") or {}
+    if queue_examples:
+        lines.extend(["", "### Review Examples", ""])
+        for queue, examples in queue_examples.items():
+            lines.extend(["", f"#### `{queue}`", ""])
+            lines.append("| Operation | Entity | Source | Target | Reason |")
+            lines.append("|---|---|---|---|---|")
+            for item in examples:
+                lines.append(
+                    (
+                        "| `{operation}` | {entity} | `{source}` | `{target}` | "
+                        "{reason} |"
+                    ).format(
+                        operation=item.get("operation_id"),
+                        entity=_escape_table(str(item.get("entity") or "")),
+                        source=_escape_table(str(item.get("source") or "")),
+                        target=_escape_table(str(item.get("target") or "")),
+                        reason=_escape_table(str(item.get("reason") or "")),
+                    )
+                )
+    return lines
+
+
+def _escape_table(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")

--- a/nexus/api/backfill_review_packet.py
+++ b/nexus/api/backfill_review_packet.py
@@ -102,8 +102,8 @@ def render_backfill_review_packet_markdown(packet: Mapping[str, Any]) -> str:
         "",
         "| Family | Operations | Ready | Review-required | Registered entity "
         "candidates | Missing target tags | Pair target rows | Prose/event rows | "
-        "Remainders | Drops |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        "Remainders | Drops | Other review |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
     ]
 
     families = packet.get("families") or {}
@@ -114,7 +114,8 @@ def render_backfill_review_packet_markdown(packet: Mapping[str, Any]) -> str:
             "| {family} | {operation_items} | {ready_operations} | "
             "{review_required_operations} | {registered_single_entity} | "
             "{missing_target_tag} | {pair_target_resolution} | "
-            "{prose_or_event} | {structured_remainder} | {drop_after_review} |".format(
+            "{prose_or_event} | {structured_remainder} | {drop_after_review} | "
+            "{other_review} |".format(
                 family=family,
                 operation_items=counters.get("operation_items", 0),
                 ready_operations=counters.get("ready_operations", 0),
@@ -129,6 +130,7 @@ def render_backfill_review_packet_markdown(packet: Mapping[str, Any]) -> str:
                 prose_or_event=counters.get("queue:prose_or_event", 0),
                 structured_remainder=counters.get("queue:structured_remainder", 0),
                 drop_after_review=counters.get("queue:drop_after_review", 0),
+                other_review=counters.get("queue:other_review", 0),
             )
         )
 
@@ -218,7 +220,15 @@ def _validate_manifest_slot(
 ) -> None:
     source = manifest.get("source") or {}
     manifest_slot = source.get("slot")
-    if manifest_slot is not None and int(manifest_slot) != slot:
+    if manifest_slot is None:
+        return
+    try:
+        normalized_slot = int(manifest_slot)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{family} manifest has non-integer slot {manifest_slot!r}"
+        ) from exc
+    if normalized_slot != slot:
         raise ValueError(
             f"{family} manifest slot {manifest_slot} does not match --slot {slot}"
         )

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -1664,16 +1664,24 @@ def run_backfill_review_packet(args: argparse.Namespace) -> Dict[str, Any]:
         build_backfill_review_packet,
         render_backfill_review_packet_markdown,
     )
+    from nexus.api.character_tag_manifest import CHARACTER_MANIFEST_SCHEMA_VERSION
+    from nexus.api.faction_table_audit import FACTION_MANIFEST_SCHEMA_VERSION
+    from nexus.api.place_tag_manifest import PLACE_MANIFEST_SCHEMA_VERSION
 
     manifests = {
-        "faction": _load_faction_manifest_file(args.faction_manifest),
+        "faction": _load_faction_manifest_file(
+            args.faction_manifest,
+            expected_schema_version=FACTION_MANIFEST_SCHEMA_VERSION,
+        ),
         "character": _load_entity_manifest_file(
             args.character_manifest,
             payload_key="character_manifest",
+            expected_schema_version=CHARACTER_MANIFEST_SCHEMA_VERSION,
         ),
         "place": _load_entity_manifest_file(
             args.place_manifest,
             payload_key="place_manifest",
+            expected_schema_version=PLACE_MANIFEST_SCHEMA_VERSION,
         ),
     }
     packet = build_backfill_review_packet(
@@ -1698,30 +1706,81 @@ def run_backfill_review_packet(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
-def _load_faction_manifest_file(path: Path) -> Mapping[str, Any]:
+def _load_faction_manifest_file(
+    path: Path,
+    *,
+    expected_schema_version: Optional[str] = None,
+) -> Mapping[str, Any]:
     """Load a raw faction manifest or full CLI JSON payload from disk."""
 
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError("Faction manifest file must contain a JSON object")
 
+    _reject_mismatched_manifest_payload(data, expected_key="faction_manifest")
     manifest = data.get("faction_manifest", data)
     if not isinstance(manifest, dict):
         raise ValueError("Faction manifest payload must be a JSON object")
+    _validate_manifest_schema(
+        manifest,
+        expected_schema_version=expected_schema_version,
+        manifest_label="Faction",
+    )
     return manifest
 
 
-def _load_entity_manifest_file(path: Path, *, payload_key: str) -> Mapping[str, Any]:
+def _load_entity_manifest_file(
+    path: Path,
+    *,
+    payload_key: str,
+    expected_schema_version: Optional[str] = None,
+) -> Mapping[str, Any]:
     """Load a raw entity-tag manifest or full CLI JSON payload from disk."""
 
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError("Entity-tag manifest file must contain a JSON object")
 
+    _reject_mismatched_manifest_payload(data, expected_key=payload_key)
     manifest = data.get(payload_key, data)
     if not isinstance(manifest, dict):
         raise ValueError("Entity-tag manifest payload must be a JSON object")
+    _validate_manifest_schema(
+        manifest,
+        expected_schema_version=expected_schema_version,
+        manifest_label=payload_key.removesuffix("_manifest").title(),
+    )
     return manifest
+
+
+def _reject_mismatched_manifest_payload(
+    data: Mapping[str, Any],
+    *,
+    expected_key: str,
+) -> None:
+    manifest_keys = sorted(
+        key for key in data if key.endswith("_manifest") and key != expected_key
+    )
+    if manifest_keys and expected_key not in data:
+        raise ValueError(
+            f"Expected {expected_key} payload; found {', '.join(manifest_keys)}"
+        )
+
+
+def _validate_manifest_schema(
+    manifest: Mapping[str, Any],
+    *,
+    expected_schema_version: Optional[str],
+    manifest_label: str,
+) -> None:
+    if expected_schema_version is None:
+        return
+    schema_version = manifest.get("schema_version")
+    if schema_version != expected_schema_version:
+        raise ValueError(
+            f"{manifest_label} manifest requires {expected_schema_version}; "
+            f"got {schema_version!r}"
+        )
 
 
 def _load_optional_entity_manifest(

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -15,6 +15,7 @@ Commands:
     nexus character-apply --slot N  Dry-run ready character manifest operations
     nexus place-manifest --slot N  Build reviewed place tag manifest
     nexus place-apply --slot N  Dry-run ready place manifest operations
+    nexus backfill-review-packet --slot N  Summarize manifest review queues
 
 The CLI is slot-centric: only --slot N is required. The backend resolves
 all other state (wizard phase, current chunk, thread ID) automatically.
@@ -520,6 +521,46 @@ def _print_entity_tag_apply(payload: Dict[str, Any], payload_key: str) -> None:
             print(f"  ...{len(blocked) - 10} more")
 
 
+def _print_backfill_review_packet(payload: Dict[str, Any]) -> None:
+    """Print a Slot backfill review packet summary."""
+
+    packet = payload.get("backfill_review_packet") or {}
+    counters = packet.get("counters") or {}
+    families = packet.get("families") or {}
+    print("Review packet:")
+    print(f"  schema_version: {packet.get('schema_version')}")
+    print(f"  slot: {packet.get('slot')}")
+    if payload.get("packet_output"):
+        print(f"  output: {payload.get('packet_output')}")
+
+    print()
+    print("Counters:")
+    for key in (
+        "operation_items",
+        "ready_operations",
+        "review_required_operations",
+        "queue:registered_single_entity",
+        "queue:missing_target_tag",
+        "queue:pair_target_resolution",
+        "queue:prose_or_event",
+        "queue:structured_remainder",
+        "queue:drop_after_review",
+    ):
+        print(f"  {key}: {counters.get(key, 0)}")
+
+    print()
+    print("Families:")
+    for family in ("faction", "character", "place"):
+        family_packet = families.get(family) or {}
+        family_counters = family_packet.get("counters") or {}
+        print(
+            "  - "
+            f"{family}: {family_counters.get('operation_items', 0)} ops, "
+            f"{family_counters.get('ready_operations', 0)} ready, "
+            f"{family_counters.get('review_required_operations', 0)} review-required"
+        )
+
+
 def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) -> None:
     """Emit payload to stdout in JSON or human-readable format."""
     if as_json:
@@ -567,6 +608,10 @@ def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) 
 
     if payload.get("place_apply"):
         _print_entity_tag_apply(payload, "place_apply")
+        print()
+
+    if payload.get("backfill_review_packet"):
+        _print_backfill_review_packet(payload)
         print()
 
     # Get display elements
@@ -1612,6 +1657,47 @@ def run_faction_apply(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
+def run_backfill_review_packet(args: argparse.Namespace) -> Dict[str, Any]:
+    """Build a read-only review packet from Slot backfill manifests."""
+
+    from nexus.api.backfill_review_packet import (
+        build_backfill_review_packet,
+        render_backfill_review_packet_markdown,
+    )
+
+    manifests = {
+        "faction": _load_faction_manifest_file(args.faction_manifest),
+        "character": _load_entity_manifest_file(
+            args.character_manifest,
+            payload_key="character_manifest",
+        ),
+        "place": _load_entity_manifest_file(
+            args.place_manifest,
+            payload_key="place_manifest",
+        ),
+    }
+    packet = build_backfill_review_packet(
+        manifests,
+        slot=args.slot,
+        examples_per_queue=args.examples_per_queue,
+    )
+    packet_markdown = render_backfill_review_packet_markdown(packet)
+
+    output_path = getattr(args, "output", None)
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(packet_markdown, encoding="utf-8")
+
+    return {
+        "success": True,
+        "message": f"Backfill review packet for slot {args.slot}.",
+        "slot": args.slot,
+        "backfill_review_packet": packet,
+        "packet_output": str(output_path) if output_path is not None else None,
+        "packet_markdown": None if output_path is not None else packet_markdown,
+    }
+
+
 def _load_faction_manifest_file(path: Path) -> Mapping[str, Any]:
     """Load a raw faction manifest or full CLI JSON payload from disk."""
 
@@ -1771,7 +1857,8 @@ Examples:
   nexus character-apply --slot 2  Dry-run ready character manifest operations
   nexus place-manifest --slot 2  Build place tag manifest
   nexus place-apply --slot 2  Dry-run ready place manifest operations
-""",
+  nexus backfill-review-packet --slot 2 --faction-manifest faction.json ...
+        """,
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON output")
     parser.add_argument(
@@ -2043,6 +2130,44 @@ Examples:
         help="entity_tag_source_kind stamped on inserted rows when --execute is set.",
     )
 
+    # backfill-review-packet command
+    review_packet_parser = subparsers.add_parser(
+        "backfill-review-packet",
+        help="Build a read-only review packet from backfill manifests",
+    )
+    review_packet_parser.add_argument(
+        "--slot", type=int, required=True, help="Slot number (1-5)"
+    )
+    review_packet_parser.add_argument(
+        "--faction-manifest",
+        type=Path,
+        required=True,
+        help="Faction manifest JSON to summarize.",
+    )
+    review_packet_parser.add_argument(
+        "--character-manifest",
+        type=Path,
+        required=True,
+        help="Character manifest JSON to summarize.",
+    )
+    review_packet_parser.add_argument(
+        "--place-manifest",
+        type=Path,
+        required=True,
+        help="Place manifest JSON to summarize.",
+    )
+    review_packet_parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional Markdown output path for the review packet.",
+    )
+    review_packet_parser.add_argument(
+        "--examples-per-queue",
+        type=int,
+        default=5,
+        help="Maximum example rows to show per family review queue.",
+    )
+
     # lock command
     lock_parser = subparsers.add_parser(
         "lock", help="Lock a slot to prevent modifications"
@@ -2082,6 +2207,7 @@ def main() -> int:
         "character-apply",
         "place-manifest",
         "place-apply",
+        "backfill-review-packet",
         "lock",
         "unlock",
     ):
@@ -2126,6 +2252,8 @@ def main() -> int:
         result = run_place_manifest(args)
     elif args.command == "place-apply":
         result = run_place_apply(args)
+    elif args.command == "backfill-review-packet":
+        result = run_backfill_review_packet(args)
     elif args.command == "lock":
         result = run_lock(args)
     elif args.command == "unlock":

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -545,8 +545,11 @@ def _print_backfill_review_packet(payload: Dict[str, Any]) -> None:
         "queue:prose_or_event",
         "queue:structured_remainder",
         "queue:drop_after_review",
+        "queue:other_review",
     ):
         print(f"  {key}: {counters.get(key, 0)}")
+    if counters.get("queue:other_review", 0):
+        print("  warning: other_review rows need manifest/tooling classification")
 
     print()
     print("Families:")
@@ -1380,7 +1383,7 @@ def run_faction_manifest(args: argparse.Namespace) -> Dict[str, Any]:
         slot=args.slot,
         dbname=dbname,
     )
-    output_path = getattr(args, "output", None)
+    output_path = args.output
     if output_path is not None:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(

--- a/tests/test_backfill_review_packet.py
+++ b/tests/test_backfill_review_packet.py
@@ -35,6 +35,12 @@ def test_build_backfill_review_packet_groups_review_queues() -> None:
                         source={"column": "legacy", "value": "old"},
                         target={"destination": "drop_after_review"},
                     ),
+                    _operation(
+                        operation_id="faction-unknown",
+                        operation_type="future_operation",
+                        source={"column": "future", "value": "unknown"},
+                        target={},
+                    ),
                 ],
             ),
             "character": _manifest(
@@ -82,13 +88,14 @@ def test_build_backfill_review_packet_groups_review_queues() -> None:
     assert packet["policy"]["mutates_data"] is False
     assert packet["policy"]["promotes_ready_rows"] is False
     counters = packet["counters"]
-    assert counters["operation_items"] == 5
+    assert counters["operation_items"] == 6
     assert counters["ready_operations"] == 0
-    assert counters["review_required_operations"] == 5
+    assert counters["review_required_operations"] == 6
     assert counters["queue:registered_single_entity"] == 2
     assert counters["queue:missing_target_tag"] == 1
     assert counters["queue:pair_target_resolution"] == 1
     assert counters["queue:drop_after_review"] == 1
+    assert counters["queue:other_review"] == 1
 
 
 def test_render_backfill_review_packet_markdown_names_gate() -> None:
@@ -106,6 +113,7 @@ def test_render_backfill_review_packet_markdown_names_gate() -> None:
 
     assert "# Slot 2 Orrery Backfill Review Packet" in markdown
     assert "does not mark any manifest row ready" in markdown
+    assert "Other review" in markdown
     assert "| faction | 0 | 0 | 0 |" in markdown
 
 
@@ -117,6 +125,23 @@ def test_backfill_review_packet_rejects_slot_mismatch() -> None:
             {
                 "faction": _manifest("test.v1", []),
                 "character": _manifest("test.v1", [], slot=3),
+                "place": _manifest("test.v1", []),
+            },
+            slot=2,
+        )
+
+
+def test_backfill_review_packet_rejects_non_integer_slot() -> None:
+    """Malformed slot metadata should produce a contextual error."""
+
+    manifest = _manifest("test.v1", [])
+    manifest["source"] = {"slot": "save_02", "dbname": "save_02"}
+
+    with pytest.raises(ValueError, match="character manifest has non-integer slot"):
+        build_backfill_review_packet(
+            {
+                "faction": _manifest("test.v1", []),
+                "character": manifest,
                 "place": _manifest("test.v1", []),
             },
             slot=2,
@@ -162,6 +187,43 @@ def test_cli_backfill_review_packet_writes_markdown(tmp_path) -> None:
     assert "Slot 2 Orrery Backfill Review Packet" in output_path.read_text(
         encoding="utf-8"
     )
+
+
+def test_cli_backfill_review_packet_returns_markdown_without_output(tmp_path) -> None:
+    """Without --output, the Markdown packet should remain in the return payload."""
+
+    faction_path = tmp_path / "faction.json"
+    character_path = tmp_path / "character.json"
+    place_path = tmp_path / "place.json"
+    faction_path.write_text(
+        json.dumps(_manifest("faction-migration-manifest.v1", [])),
+        encoding="utf-8",
+    )
+    character_path.write_text(
+        json.dumps(
+            {"character_manifest": _manifest("orrery_character_manifest.v1", [])}
+        ),
+        encoding="utf-8",
+    )
+    place_path.write_text(
+        json.dumps({"place_manifest": _manifest("orrery_place_manifest.v1", [])}),
+        encoding="utf-8",
+    )
+
+    result = cli.run_backfill_review_packet(
+        Namespace(
+            slot=2,
+            faction_manifest=faction_path,
+            character_manifest=character_path,
+            place_manifest=place_path,
+            output=None,
+            examples_per_queue=2,
+        )
+    )
+
+    assert result["success"] is True
+    assert result["packet_output"] is None
+    assert "Slot 2 Orrery Backfill Review Packet" in result["packet_markdown"]
 
 
 def test_cli_backfill_review_packet_rejects_swapped_manifest_payload(tmp_path) -> None:

--- a/tests/test_backfill_review_packet.py
+++ b/tests/test_backfill_review_packet.py
@@ -1,0 +1,196 @@
+"""Tests for Slot backfill review packet helpers."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+import json
+
+import pytest
+
+from nexus import cli
+from nexus.api.backfill_review_packet import (
+    BACKFILL_REVIEW_PACKET_SCHEMA_VERSION,
+    build_backfill_review_packet,
+    render_backfill_review_packet_markdown,
+)
+
+
+def test_build_backfill_review_packet_groups_review_queues() -> None:
+    """Review packets summarize current manifests without promoting rows."""
+
+    packet = build_backfill_review_packet(
+        {
+            "faction": _manifest(
+                "faction-migration-manifest.v1",
+                [
+                    _operation(
+                        operation_id="faction-tag",
+                        operation_type="review_entity_tag",
+                        source={"column": "power_level", "value": "0.5"},
+                        target={"category": "power_status", "tag": "stable"},
+                    ),
+                    _operation(
+                        operation_id="faction-drop",
+                        operation_type="drop_legacy_tag_after_review",
+                        source={"column": "legacy", "value": "old"},
+                        target={"destination": "drop_after_review"},
+                    ),
+                ],
+            ),
+            "character": _manifest(
+                "orrery_character_manifest.v1",
+                [
+                    _operation(
+                        operation_id="character-missing",
+                        operation_type="review_entity_tag",
+                        source={"category": "profession_lite", "tag": "fixer"},
+                        target={
+                            "category": None,
+                            "tag": "fixer",
+                            "target_registered": False,
+                        },
+                    ),
+                    _operation(
+                        operation_id="character-pair",
+                        operation_type="resolve_pair_tag_target",
+                        source={"category": "orrery_state", "tag": "contacts"},
+                        target={"pair_tag": "contact:<kind>"},
+                    ),
+                ],
+            ),
+            "place": _manifest(
+                "orrery_place_manifest.v1",
+                [
+                    _operation(
+                        operation_id="place-tag",
+                        operation_type="review_entity_tag",
+                        source={"kind": "prose_keyword"},
+                        target={
+                            "category": "place_function",
+                            "tag": "dwelling",
+                            "target_registered": True,
+                        },
+                    )
+                ],
+            ),
+        },
+        slot=2,
+        examples_per_queue=1,
+    )
+
+    assert packet["schema_version"] == BACKFILL_REVIEW_PACKET_SCHEMA_VERSION
+    assert packet["policy"]["mutates_data"] is False
+    assert packet["policy"]["promotes_ready_rows"] is False
+    counters = packet["counters"]
+    assert counters["operation_items"] == 5
+    assert counters["ready_operations"] == 0
+    assert counters["review_required_operations"] == 5
+    assert counters["queue:registered_single_entity"] == 2
+    assert counters["queue:missing_target_tag"] == 1
+    assert counters["queue:pair_target_resolution"] == 1
+    assert counters["queue:drop_after_review"] == 1
+
+
+def test_render_backfill_review_packet_markdown_names_gate() -> None:
+    """Markdown output should make the no-promotion policy visible."""
+
+    packet = build_backfill_review_packet(
+        {
+            family: _manifest("test.v1", [])
+            for family in ("faction", "character", "place")
+        },
+        slot=2,
+    )
+
+    markdown = render_backfill_review_packet_markdown(packet)
+
+    assert "# Slot 2 Orrery Backfill Review Packet" in markdown
+    assert "does not mark any manifest row ready" in markdown
+    assert "| faction | 0 | 0 | 0 |" in markdown
+
+
+def test_backfill_review_packet_rejects_slot_mismatch() -> None:
+    """Manifests cannot be mixed across slots."""
+
+    with pytest.raises(ValueError, match="character manifest slot 3"):
+        build_backfill_review_packet(
+            {
+                "faction": _manifest("test.v1", []),
+                "character": _manifest("test.v1", [], slot=3),
+                "place": _manifest("test.v1", []),
+            },
+            slot=2,
+        )
+
+
+def test_cli_backfill_review_packet_writes_markdown(tmp_path) -> None:
+    """CLI command loads manifest files and writes a Markdown packet."""
+
+    faction_path = tmp_path / "faction.json"
+    character_path = tmp_path / "character.json"
+    place_path = tmp_path / "place.json"
+    output_path = tmp_path / "packet.md"
+    faction_path.write_text(
+        json.dumps(_manifest("faction-migration-manifest.v1", [])),
+        encoding="utf-8",
+    )
+    character_path.write_text(
+        json.dumps(
+            {"character_manifest": _manifest("orrery_character_manifest.v1", [])}
+        ),
+        encoding="utf-8",
+    )
+    place_path.write_text(
+        json.dumps({"place_manifest": _manifest("orrery_place_manifest.v1", [])}),
+        encoding="utf-8",
+    )
+
+    result = cli.run_backfill_review_packet(
+        Namespace(
+            slot=2,
+            faction_manifest=faction_path,
+            character_manifest=character_path,
+            place_manifest=place_path,
+            output=output_path,
+            examples_per_queue=2,
+        )
+    )
+
+    assert result["success"] is True
+    assert result["packet_output"] == str(output_path)
+    assert result["packet_markdown"] is None
+    assert "Slot 2 Orrery Backfill Review Packet" in output_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def _manifest(
+    schema_version: str,
+    operations: list[dict[str, object]],
+    *,
+    slot: int = 2,
+) -> dict[str, object]:
+    return {
+        "schema_version": schema_version,
+        "source": {"slot": slot, "dbname": f"save_{slot:02d}"},
+        "operations": operations,
+    }
+
+
+def _operation(
+    *,
+    operation_id: str,
+    operation_type: str,
+    source: dict[str, object],
+    target: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "operation_id": operation_id,
+        "operation_type": operation_type,
+        "status": "review_required",
+        "review_required": True,
+        "entity_id": 1,
+        "source": source,
+        "target": target,
+        "reason": "Needs review.",
+    }

--- a/tests/test_backfill_review_packet.py
+++ b/tests/test_backfill_review_packet.py
@@ -164,6 +164,70 @@ def test_cli_backfill_review_packet_writes_markdown(tmp_path) -> None:
     )
 
 
+def test_cli_backfill_review_packet_rejects_swapped_manifest_payload(tmp_path) -> None:
+    """A wrong-family CLI payload should fail instead of counting zero rows."""
+
+    faction_path = tmp_path / "faction.json"
+    character_path = tmp_path / "character.json"
+    place_path = tmp_path / "place.json"
+    faction_path.write_text(
+        json.dumps(_manifest("faction-migration-manifest.v1", [])),
+        encoding="utf-8",
+    )
+    character_path.write_text(
+        json.dumps({"place_manifest": _manifest("orrery_place_manifest.v1", [])}),
+        encoding="utf-8",
+    )
+    place_path.write_text(
+        json.dumps({"place_manifest": _manifest("orrery_place_manifest.v1", [])}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Expected character_manifest payload"):
+        cli.run_backfill_review_packet(
+            Namespace(
+                slot=2,
+                faction_manifest=faction_path,
+                character_manifest=character_path,
+                place_manifest=place_path,
+                output=None,
+                examples_per_queue=2,
+            )
+        )
+
+
+def test_cli_backfill_review_packet_rejects_raw_wrong_schema(tmp_path) -> None:
+    """A raw manifest with the wrong schema should fail before summarizing."""
+
+    faction_path = tmp_path / "faction.json"
+    character_path = tmp_path / "character.json"
+    place_path = tmp_path / "place.json"
+    faction_path.write_text(
+        json.dumps(_manifest("faction-migration-manifest.v1", [])),
+        encoding="utf-8",
+    )
+    character_path.write_text(
+        json.dumps(_manifest("orrery_place_manifest.v1", [])),
+        encoding="utf-8",
+    )
+    place_path.write_text(
+        json.dumps(_manifest("orrery_place_manifest.v1", [])),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Character manifest requires"):
+        cli.run_backfill_review_packet(
+            Namespace(
+                slot=2,
+                faction_manifest=faction_path,
+                character_manifest=character_path,
+                place_manifest=place_path,
+                output=None,
+                examples_per_queue=2,
+            )
+        )
+
+
 def _manifest(
     schema_version: str,
     operations: list[dict[str, object]],


### PR DESCRIPTION
## Summary

- add a read-only `backfill-review-packet` builder that groups faction, character, and place manifests into review queues without promoting rows
- expose the packet through `nexus backfill-review-packet --slot N --... --output packet.md`
- document the Slot 2 phase-6 review packet counts in `docs/orrery_slot2_backfill_plan.md`

## Review Packet Output

Generated `temp/slot2_backfill/review_packet_phase6.md` locally from the current Slot 2 manifests. It reports 1,222 review-required operations and 0 ready rows:

- 980 registered single-entity candidates
- 118 missing target tags
- 36 pair-target rows
- 36 prose/event rows
- 50 structured remainders
- 2 drop-after-review rows

This is still non-mutating and does not authorize data apply or shim removal.

## Validation

- `poetry run flake8 nexus/api/backfill_review_packet.py nexus/cli.py tests/test_backfill_review_packet.py`
- `poetry run pytest tests/test_backfill_review_packet.py tests/test_entity_tag_manifest_apply.py tests/test_character_tag_manifest.py tests/test_place_tag_manifest.py`
- `poetry run pytest tests/test_orrery/test_slot2_tag_backfill.py tests/test_backfill_review_packet.py`
- `poetry run nexus --json backfill-review-packet --slot 2 --faction-manifest temp/slot2_backfill/faction_manifest_phase4_post055.json --character-manifest temp/slot2_backfill/character_manifest_phase4_post055.json --place-manifest temp/slot2_backfill/place_manifest_phase5.json`

Refs #326.
