### PR TITLE
Fix extract-vector-grid dropping axis-aligned line segments

### DIFF
--- a/.claude/skills/extract-vector-grid/SKILL.md
+++ b/.claude/skills/extract-vector-grid/SKILL.md
@@ -14,6 +14,7 @@ It bakes in several hard-won failure modes that naïve grid-cutters hit:
 3. **There is usually a page-spanning background shape.** Detect it generically by bbox-area ≈ page area (no fill-color assumption, no assumption a background exists).
 4. **Never cut on nominal grid divisions** (`page_width / cols`). Ornaments routinely overhang their cell by a few points — cutting on grid lines amputates corner details. Use projection-profile gutter detection and cut through the **middle of the empty bands**.
 5. **`svgelements` normalizes `width="...pt"` to 96-DPI pixels**, but the original path `d=` strings stay in viewBox user-units. The two coordinate systems must be reconciled before emitting per-cell SVGs (a 0.75 factor for any `pt`-declared source).
+6. **Axis-aligned line segments have a zero-area bbox — never reject them.** A horizontal line has `ymax == ymin`; a vertical line has `xmax == xmin`. A `bbox` filter written as `xmax <= xmin or ymax <= ymin` silently discards *every* straight stroke — catastrophic for line-art (frame borders, radial ticks), which is mostly straight lines. Reject only inverted boxes and true zero-extent points (degenerate on **both** axes). This is enforced two ways: the filters in `collect_shapes`/`_shape_signature`, and a **path-conservation guard** in `extract()` that fails loudly if `emitted + background_dropped != total_shape_nodes`. Curve-heavy sets (e.g. Art Nouveau) hid this bug for a while; line-art (Art Deco) is the adversarial case. Regression test: `.venv/bin/python scripts/selftest.py`.
 
 ## When to invoke
 
@@ -61,7 +62,21 @@ Per-design renaming (e.g. `…-CrescentMoon.svg`) is left to the human because t
 
 ## Validation
 
-After extraction, render PNGs against a tinted background to visually verify:
+**Visual checking is necessary but NOT sufficient.** Thin dropped strokes read
+as ordinary frame borders at a glance — a per-frame visual pass once missed 6 of
+7 broken frames in a real set. Always pair the eyeball check with a path-level
+check.
+
+1. **Path conservation (authoritative).** `extract()` raises if
+   `emitted + background_dropped != total_shape_nodes`, so a lossy extraction
+   fails loudly at generation time. To audit an *existing* set, diff the `d=`
+   strings of the per-cell SVGs against the flat converter SVG — every
+   non-background converter path must appear in exactly one cell.
+2. **Regression test.** `.venv/bin/python scripts/selftest.py` — confirms
+   axis-aligned line segments survive (guards failure mode #6). Re-run after any
+   `svgelements`/`CairoSVG` version bump.
+3. **Visual.** Render PNGs against a background that contrasts the ink color
+   (cream for black linework, dark for gold/white linework — `--bg` matters):
 
 ```bash
 .claude/skills/extract-vector-grid/.venv/bin/python \

--- a/.claude/skills/extract-vector-grid/scripts/extract.py
+++ b/.claude/skills/extract-vector-grid/scripts/extract.py
@@ -136,7 +136,12 @@ def collect_shapes(svg_path: Path) -> tuple[list[tuple[Shape, BBox]], BBox]:
         if bb is None:
             continue
         xmin, ymin, xmax, ymax = bb
-        if xmax <= xmin or ymax <= ymin:
+        # Keep axis-aligned line segments. A horizontal line has ymax == ymin
+        # and a vertical line has xmax == xmin, so a `<=` test on either axis
+        # silently discards every straight stroke (frame borders, radial ticks)
+        # — catastrophic for line-art sheets. Reject only inverted boxes and
+        # true zero-extent points (degenerate on BOTH axes).
+        if xmax < xmin or ymax < ymin or (xmax == xmin and ymax == ymin):
             continue
         shapes.append((element, BBox(xmin, ymin, xmax, ymax)))
     return shapes, page
@@ -256,7 +261,10 @@ def _shape_signature(shape: Shape) -> tuple | None:
     if bb is None:
         return None
     xmin, ymin, xmax, ymax = bb
-    if xmax <= xmin or ymax <= ymin:
+    # Mirror collect_shapes: keep zero-area line segments (frame borders, ticks);
+    # reject only inverted boxes and true zero-extent points. A `<=` test here
+    # would re-introduce the line-dropping bug at the emit/match stage.
+    if xmax < xmin or ymax < ymin or (xmax == xmin and ymax == ymin):
         return None
     rounded = (round(xmin, 3), round(ymin, 3), round(xmax, 3), round(ymax, 3))
     try:
@@ -499,6 +507,24 @@ def extract(
                     f"bbox={ubox.w:.1f}x{ubox.h:.1f}",
                     file=sys.stderr,
                 )
+
+        # Path-conservation guard. Every renderable shape node pdftocairo/Inkscape
+        # emitted must be accounted for — emitted into a cell or dropped as the
+        # page background. If the totals don't reconcile, a path was silently
+        # lost (the class of bug where a degenerate-bbox filter eats axis-aligned
+        # lines). Fail loudly rather than ship a lossy extraction.
+        total_nodes = len(xml_nodes_in_order)
+        emitted_total = sum(m["shape_count"] for m in manifest)
+        if emitted_total + dropped != total_nodes:
+            raise RuntimeError(
+                f"Path-conservation check failed: flat SVG has {total_nodes} "
+                f"renderable shape nodes, but {emitted_total} were emitted into "
+                f"cells + {dropped} dropped as background = "
+                f"{emitted_total + dropped}. "
+                f"{total_nodes - (emitted_total + dropped)} path(s) were lost — "
+                f"commonly axis-aligned lines rejected by a degenerate-bbox "
+                f"filter (xmax<=xmin / ymax<=ymin)."
+            )
 
         return {
             "input": str(input_path),

--- a/.claude/skills/extract-vector-grid/scripts/extract.py
+++ b/.claude/skills/extract-vector-grid/scripts/extract.py
@@ -136,11 +136,11 @@ def collect_shapes(svg_path: Path) -> tuple[list[tuple[Shape, BBox]], BBox]:
         if bb is None:
             continue
         xmin, ymin, xmax, ymax = bb
-        # Keep axis-aligned line segments. A horizontal line has ymax == ymin
-        # and a vertical line has xmax == xmin, so a `<=` test on either axis
-        # silently discards every straight stroke (frame borders, radial ticks)
-        # — catastrophic for line-art sheets. Reject only inverted boxes and
-        # true zero-extent points (degenerate on BOTH axes).
+        # Axis-aligned line segments have a zero-area bbox by definition
+        # (horizontal: ymax == ymin; vertical: xmax == xmin) yet are real
+        # strokes — keep them; reject only inverted boxes and true points.
+        # Exact `==` is deliberate: cull only mathematically zero-extent
+        # points, never thin-but-real geometry.
         if xmax < xmin or ymax < ymin or (xmax == xmin and ymax == ymin):
             continue
         shapes.append((element, BBox(xmin, ymin, xmax, ymax)))
@@ -261,9 +261,8 @@ def _shape_signature(shape: Shape) -> tuple | None:
     if bb is None:
         return None
     xmin, ymin, xmax, ymax = bb
-    # Mirror collect_shapes: keep zero-area line segments (frame borders, ticks);
-    # reject only inverted boxes and true zero-extent points. A `<=` test here
-    # would re-introduce the line-dropping bug at the emit/match stage.
+    # Mirror collect_shapes (see there for rationale): keep zero-area line
+    # segments; reject only inverted boxes and true zero-extent points.
     if xmax < xmin or ymax < ymin or (xmax == xmin and ymax == ymin):
         return None
     rounded = (round(xmin, 3), round(ymin, 3), round(xmax, 3), round(ymax, 3))
@@ -516,14 +515,14 @@ def extract(
         total_nodes = len(xml_nodes_in_order)
         emitted_total = sum(m["shape_count"] for m in manifest)
         if emitted_total + dropped != total_nodes:
+            unaccounted = total_nodes - (emitted_total + dropped)
             raise RuntimeError(
                 f"Path-conservation check failed: flat SVG has {total_nodes} "
-                f"renderable shape nodes, but {emitted_total} were emitted into "
-                f"cells + {dropped} dropped as background = "
-                f"{emitted_total + dropped}. "
-                f"{total_nodes - (emitted_total + dropped)} path(s) were lost — "
-                f"commonly axis-aligned lines rejected by a degenerate-bbox "
-                f"filter (xmax<=xmin / ymax<=ymin)."
+                f"renderable shape node(s); {emitted_total} emitted into cells "
+                f"+ {dropped} dropped as background = {emitted_total + dropped}. "
+                f"{unaccounted} shape node(s) unaccounted for — check the bbox "
+                f"filters (collect_shapes / _shape_signature), background "
+                f"detection, and cell coverage."
             )
 
         return {

--- a/.claude/skills/extract-vector-grid/scripts/selftest.py
+++ b/.claude/skills/extract-vector-grid/scripts/selftest.py
@@ -23,6 +23,7 @@ from extract import (  # noqa: E402
     drop_page_background,
     find_gutter_midpoints,
     assign_to_cells,
+    extract,
 )
 
 # Two frames built ENTIRELY from axis-aligned line segments (4 borders each),
@@ -69,6 +70,27 @@ def main() -> None:
     assert len(cells) == 2, f"expected 2 cells, got {len(cells)}"
     assert emitted == 8, f"expected all 8 lines bucketed into cells, got {emitted}"
     print("PASS: 8 axis-aligned line segments preserved across 2 cells")
+
+    # End-to-end through extract(): the low-level path above bypasses
+    # _shape_signature (the emit-stage filter) and the path-conservation guard.
+    # Running extract() exercises both — it raises if the guard trips.
+    with tempfile.TemporaryDirectory() as td:
+        svg = Path(td) / "synth.svg"
+        svg.write_text(SYNTH_SVG)
+        report = extract(
+            svg,
+            Path(td) / "out",
+            name_prefix="selftest",
+            padding=8.0,
+            bg_coverage=0.9,
+            verbose=False,
+        )
+    assert (
+        len(report["cells"]) == 2
+    ), f"extract() found {len(report['cells'])} cells, expected 2"
+    e2e = sum(c["shape_count"] for c in report["cells"])
+    assert e2e == 8, f"extract() emitted {e2e} line segments, expected 8"
+    print("PASS: extract() end-to-end emitted 8 segments; conservation guard satisfied")
 
 
 if __name__ == "__main__":

--- a/.claude/skills/extract-vector-grid/scripts/selftest.py
+++ b/.claude/skills/extract-vector-grid/scripts/selftest.py
@@ -1,0 +1,75 @@
+"""Self-contained regression test for extract-vector-grid.
+
+Guards the degenerate-bbox bug: axis-aligned line segments (a horizontal line
+has ymax == ymin; a vertical line has xmax == xmin) must NOT be discarded.
+This is the failure that silently dropped 64 strokes from the Art Deco set —
+most of a line-art frame is straight lines, so a `<=` bbox test annihilates it.
+
+Run with the skill's venv (no pytest dependency):
+
+    .venv/bin/python scripts/selftest.py
+
+Exits 0 on pass; raises AssertionError (non-zero) on regression.
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from extract import (  # noqa: E402
+    collect_shapes,
+    drop_page_background,
+    find_gutter_midpoints,
+    assign_to_cells,
+)
+
+# Two frames built ENTIRELY from axis-aligned line segments (4 borders each),
+# side by side with an empty vertical gutter at x≈200, on a page-spanning
+# background rect. A correct extractor keeps all 8 lines and finds 2 cells.
+SYNTH_SVG = """<svg xmlns="http://www.w3.org/2000/svg" width="400pt" height="200pt" viewBox="0 0 400 200">
+  <rect x="0" y="0" width="400" height="200" fill="black"/>
+  <path d="M 20 20 L 180 20"   fill="none" stroke="gold"/>
+  <path d="M 20 180 L 180 180" fill="none" stroke="gold"/>
+  <path d="M 20 20 L 20 180"   fill="none" stroke="gold"/>
+  <path d="M 180 20 L 180 180" fill="none" stroke="gold"/>
+  <path d="M 220 20 L 380 20"   fill="none" stroke="gold"/>
+  <path d="M 220 180 L 380 180" fill="none" stroke="gold"/>
+  <path d="M 220 20 L 220 180"   fill="none" stroke="gold"/>
+  <path d="M 380 20 L 380 180" fill="none" stroke="gold"/>
+</svg>
+"""
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        svg = Path(td) / "synth.svg"
+        svg.write_text(SYNTH_SVG)
+
+        shapes, page = collect_shapes(svg)
+        kept = drop_page_background(shapes, page, coverage=0.9)
+        bboxes = [bb for _, bb in kept]
+        x_cuts = find_gutter_midpoints(bboxes, "x")
+        y_cuts = find_gutter_midpoints(bboxes, "y")
+        cells = assign_to_cells(kept, x_cuts, y_cuts)
+        emitted = sum(len(v) for v in cells.values())
+
+    # The regression dropped every line: collect_shapes would return only the
+    # background rect, kept would be empty, and no cells would form.
+    assert len(kept) == 8, (
+        f"expected 8 axis-aligned line segments after background drop, "
+        f"got {len(kept)} — straight strokes are being discarded "
+        f"(degenerate-bbox regression)."
+    )
+    assert len(x_cuts) == 1, f"expected 1 vertical gutter, got {len(x_cuts)}: {x_cuts}"
+    assert (
+        len(y_cuts) == 0
+    ), f"expected no horizontal gutter, got {len(y_cuts)}: {y_cuts}"
+    assert len(cells) == 2, f"expected 2 cells, got {len(cells)}"
+    assert emitted == 8, f"expected all 8 lines bucketed into cells, got {emitted}"
+    print("PASS: 8 axis-aligned line segments preserved across 2 cells")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`extract-vector-grid` was silently dropping **axis-aligned line segments**. `collect_shapes` and `_shape_signature` rejected any shape whose bbox had zero width *or* zero height (`xmax <= xmin or ymax <= ymin`) — but a horizontal line has `ymax == ymin` and a vertical line has `xmax == xmin`. For line-art sheets, that's most of the artwork.

**Discovered while extracting the Art Deco set (Adobe Stock 549888080):** 64 of 552 paths dropped across 7 of 9 frames (frame borders, radial ticks). The curve-heavy Art Nouveau set (482408992, the original acceptance test) was unaffected — which is exactly why this shipped.

## Root cause

```python
# collect_shapes (line ~139) and _shape_signature (line ~261), before:
if xmax <= xmin or ymax <= ymin:   # kills every straight stroke
```

## Fix

- Reject only **inverted** boxes and **true zero-extent points** (degenerate on *both* axes); keep line segments:
  `if xmax < xmin or ymax < ymin or (xmax == xmin and ymax == ymin):`
- **Path-conservation guard** in `extract()`: raise if `emitted + background_dropped != total_shape_nodes`. A lossy extraction now fails loudly at generation time instead of shipping silently.
- **`scripts/selftest.py`** — self-contained regression test (no pytest dep; runs in the skill venv) that extracts a synthetic line-only 2-frame sheet and asserts all 8 segments survive. Verified it **fails on the pre-fix code** (`got 0`) and **passes after**.
- **SKILL.md** — failure mode #6 documented, plus a note that visual validation alone is insufficient (it missed 6 of 7 broken frames in practice).

## Verification

| Set | Before | After | Result |
|---|---|---|---|
| Art Deco 549888080 | 487 paths emitted | 551 | all 64 recovered; `flat_only=0`, no contamination |
| Art Nouveau 482408992 | 271 | 271 | **identical** — fix is non-disruptive to the merged set |

Path-level diff (every converter `d=` string must land in exactly one cell) + the new conservation guard both pass on both sets.

## Follow-ups (separate PRs)

- **#357** (Art Deco import) — re-extract with this fix before merge; current SVGs are defective.
- **Art Nouveau #355** — verified clean (fixed output ≡ committed); no action needed.

## Test plan

- [x] `selftest.py` passes on fixed code, fails on `origin/main` code
- [x] Conservation guard passes on both real sets (exit 0)
- [x] `flat_only=0` for Art Deco; fixed≡committed for Art Nouveau
- [x] Grid detection unchanged (3×3 / 2×5, same cuts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
