### PR TITLE
Add Orrery routine anchors for ordinary NPC cycles

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -477,7 +477,7 @@ Travel route selection cascades: local OSM-derived `osm_graph` routing first, th
 
 ### Routine Anchors
 
-Ordinary home/work routines are explicit actor facts, not inferred from the class of the place an actor happens to occupy. `character_routine_anchors` records a character entity, an `anchor_type` (`home` or `work` in the MVP), an optional concrete `place_id`, an optional coarse `zone_id`, a `mobility_policy`, and a JSON schedule window (`weekdays`, `start`, `end`). This gives Orrery a Radiant-AI-style surface for boring citizens without inventing a generic job for every entity standing in a mall, tavern, lab, or public street.
+Ordinary home/work routines are explicit actor facts, not inferred from the class of the place an actor happens to occupy. `character_routine_anchors` records a character entity, an `anchor_type` (`home` or `work` in the MVP), an optional concrete `place_id`, an optional coarse `zone_id`, a `mobility_policy`, and a JSON schedule window (`weekdays`, `start`, `end`). `weekdays` uses Python `datetime.weekday()` numbering (`0=Monday` through `6=Sunday`), and an empty schedule means "always due" rather than "not scheduled." This gives Orrery a Radiant-AI-style surface for boring citizens without inventing a generic job for every entity standing in a mall, tavern, lab, or public street.
 
 Mobility policy is the exception surface:
 

--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -475,6 +475,19 @@ Travel-state lifecycle is additive to existing location tracking. `characters.cu
 
 Travel route selection cascades: local OSM-derived `osm_graph` routing first, then authored `orrery_travel_edges`, then a coordinate-distance estimate. The graph path is intentionally offline — normal Orrery ticks read only local tables and never call map APIs or inference. Authored edges (`mixed` generic, plus authored overrides) are an exception surface. See `docs/orrery_route_graph.md` for the graph importer contract.
 
+### Routine Anchors
+
+Ordinary home/work routines are explicit actor facts, not inferred from the class of the place an actor happens to occupy. `character_routine_anchors` records a character entity, an `anchor_type` (`home` or `work` in the MVP), an optional concrete `place_id`, an optional coarse `zone_id`, a `mobility_policy`, and a JSON schedule window (`weekdays`, `start`, `end`). This gives Orrery a Radiant-AI-style surface for boring citizens without inventing a generic job for every entity standing in a mall, tavern, lab, or public street.
+
+Mobility policy is the exception surface:
+
+- `fixed_place` — the routine resolves to a known place row.
+- `zone_resolved` — the routine resolves to a preferred place in the zone at runtime. This is for "lives somewhere in District 07" or "works somewhere in the industrial district" before a precise place row is worth authoring.
+- `works_from_home` — a work anchor that resolves through the character's home anchor.
+- `nomadic` / `none` — explicit non-routine cases. These keep Orrery from backfilling normality onto travelers, drifters, abyssal aliens, fugitives, and other exceptions.
+
+The `WORK` package now requires an actor-side work surface (`has_routine_anchor("work")` due now and at that anchor, or legacy semantic tags such as `work_obligation`, `domestic_role`, `cares_for_household`, `field_worker`). Workplace-like place classes are branch discriminators only. The `ROUTINE_COMMUTE` package owns schedule-driven movement between anchors and emits `travel.start` with `destination_anchor`; commit-time travel materialization resolves that anchor into a concrete place before writing `character_travel_states`.
+
 ### EntityRef Helper
 
 ```python
@@ -512,7 +525,7 @@ If a template package gate includes `since_last_event_at_least(...)` cooldowns, 
 
 ### Sliding-Window Binding Scope
 
-The binding composer filters to recently-relevant entities: `(referenced in chunk_character_references in last N chunks) ∪ (has an active ephemeral tag) ∪ (has un-superseded world_events in last N chunks)`. N is config-tunable via `[orrery.binding] window_chunks`; default is 30.
+The binding composer filters to recently-relevant entities: `(referenced in chunk_character_references in last N chunks) ∪ (has an active ephemeral tag) ∪ (has un-superseded world_events in last N chunks) ∪ (has an active routine anchor)`. Routine anchors are deliberately outside the recency window so boring off-screen citizens can still tick through work/home/needs cycles when the story camera has not looked at them recently. N is config-tunable via `[orrery.binding] window_chunks`; default is 30.
 
 ---
 
@@ -601,7 +614,7 @@ Verification uses live NEXUS flows where the feature touches LORE, LOGON, MEMNON
 - **Resolver tests**: hydration shape, binding composition (actor-only and actor-target), `evaluate_stack` semantics, dry-run against fixture `WorldState`.
 - **Integration tests**: idempotency (UNIQUE key fires on regeneration), incubator-rejection rollback (Step 8.5 writes get reverted), warm-slice contamination (none), deterministic promotion behavior, async-worker state transitions (`queued → leased → succeeded|failed`).
 - **Bleed tests**: apt-bleed (ambient peripheral surfaces in payload), null-bleed (no candidates produces empty menu and no inference call), chronology/surfacing boundary (only accepted prior narrated resolutions are eligible).
-- **Live dry-runs** against mature-state slots (typically slot 2) to validate package behavior against canonical narrative content; see `scripts/orrery_sample.py` for the harness.
+- **Live dry-runs** against mature-state slots (typically slot 2) to validate package behavior against canonical narrative content; see `scripts/orrery_sample.py` for the harness. The harness supports `--world-time` and `--override-location CHARACTER=PLACE` so routine cycles can be probed without making Skald API calls or permanently moving test-slot characters.
 - **Trait compiler audits**: `poetry run nexus trait-audit --slot N` for opt-in wizard-cache inspection, plus `--fail-on-remainders` when a test loop should fail on any prose-only fallback.
 
 ---

--- a/docs/orrery_needs.md
+++ b/docs/orrery_needs.md
@@ -146,6 +146,8 @@ The same pattern applies to INTIMACY suppressors (`closeted`, `vow_of_celibacy`,
 
 Mechanical details (gates, branch conditions, magnitudes, scene-pressure stubs) live in `docs/orrery_packages.md`. This section is the orientation layer.
 
+Home/work routines are now driven by `character_routine_anchors` rather than by place-class inference. The needs packages read the actor's current place and pair-tags (`resides_at`, place functions, travel state), while `ROUTINE_COMMUTE` handles movement between scheduled anchors. In practice this means a normal citizen can commute home before EAT/SLEEP fire, while a character with `nomadic`, `none`, or `works_from_home` policy does not get forced into a generic 9-5 loop.
+
 ### SLEEP (priority 25)
 
 The architecturally most significant of the basic-needs templates. Sleep is the substrate's most reliable source of small narrative texture — most ticks where it fires produce no prose, but the cumulative record of *where* a character has been sleeping is one of the densest queryable signals about their life situation.
@@ -168,7 +170,7 @@ Architectural sibling to SLEEP. Same severity-tag gate pattern, location-discrim
 
 Slightly higher priority than EAT because thirst ramps faster. Structurally simpler — fewer branches, faster cooldown, more uniformly low magnitudes because routine hydration is rarely narratively interesting on its own.
 
-- **Gate**: `has_severity_tag("thirsty")` OR routine (no time window — humans drink throughout the day). Plus `NOT(has_ephemeral("recently_drunk"))`.
+- **Gate**: `has_severity_tag("thirsty")` OR routine (no time window — humans drink throughout the day). Plus `NOT(has_ephemeral("recently_drunk"))`. Routine thirst yields to an otherwise-due home/public meal unless thirst is severe; the dinner package gets to carry the ordinary "food and drink together" beat, while dehydration still interrupts.
 - **Why not merged with EAT?** Different ramping curves, different cultural rhythms (water all day vs. meals at mealtimes), different fulfillment-affordances. Reuse belongs in primitives and maintenance helpers; merging would create one template with awkwardly disjoint branches.
 - **Branches**: desperate-drink (severe-thirst), drink socially in public room, public/wild water source, routine drinking.
 

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1015,6 +1015,70 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 ---
 
+## ROUTINE_COMMUTE — priority 26
+
+> Ordinary home/work movement from explicit routine anchors.
+
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor has enough hydrated context
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:** actor is in transit
+  - **NOT:** actor has inbound `hunting` pair tag
+  - **NOT:** actor has `wounded` ephemeral
+  - **NOT:** actor has `grieving` ephemeral
+  - **OR:**
+    - **AND:**
+      - actor has `work` routine anchor
+      - actor's `work` routine is due now
+      - actor is away from `work` anchor
+    - **AND:**
+      - actor has `home` routine anchor
+      - actor's `home` routine is due now
+      - actor is away from `home` anchor
+
+### Branch 1 — Commute to the scheduled workplace  *(mag 0.16)*
+
+**When:**
+
+- **AND:**
+  - actor has `work` routine anchor
+  - actor's `work` routine is due now
+  - actor is away from `work` anchor
+
+**Does:** activity → "commuting to work"; starts planned travel
+**Event:** `travel_departed`
+
+> {actor} follows the ordinary route toward work: not a quest, not a crisis, just the daily movement that keeps a normal life legible.
+
+### Branch 2 — Commute home after the day's obligations  *(mag 0.14)*
+
+**When:**
+
+- **AND:**
+  - actor has `home` routine anchor
+  - actor's `home` routine is due now
+  - actor is away from `home` anchor
+
+**Does:** activity → "commuting home"; starts planned travel
+**Event:** `travel_departed`
+
+> {actor} turns toward home with the unremarkable certainty of someone whose day has a next place.
+
+### Branch 3 — Recheck routine before moving  *(mag 0.04)*
+
+**When:** *(always)*
+
+**Does:** activity → "checking routine timing"
+**Event:** `travel_prepared`
+
+> {actor} pauses at the edge of routine and checks the ordinary facts before moving: where they are, where the day says they should be, and whether the next leg is real.
+
+---
+
 ## MOURN_LOSS — priority 25
 
 > A loss settles into the body across many quiet days.
@@ -1145,6 +1209,21 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 - **AND:**
   - actor has `thirst` debt ≥ 2
+  - **OR:**
+    - actor has `thirst` debt ≥ 16
+    - **NOT:**
+      - **AND:**
+        - actor has `hunger` debt ≥ 4
+        - time of day is one of [morning, afternoon, evening]
+        - **OR:**
+          - **AND:**
+            - actor is in `dwelling` place class
+            - actor has `resides_at` pair tag to current location
+          - **OR:**
+            - actor is in `commerce` place class
+            - actor is in `entertainment` place class
+            - actor is in `meeting` place class
+            - actor is in `production` place class
   - **NOT:** actor has inbound `hunting` pair tag
 
 ### Branch 1 — Drink desperately, whatever is available  *(mag 0.56)*
@@ -1233,7 +1312,20 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > {actor} sits down to the meal that home means and lets being-with stand in for being-alone for a while.
 
-### Branch 3 — Eat in a public dining place  *(mag 0.26)*
+### Branch 3 — Eat at home alone  *(mag 0.2)*
+
+**When:**
+
+- **AND:**
+  - actor is in `dwelling` place class
+  - actor has `resides_at` pair tag to current location
+
+**Does:** activity → "eating at home"; fulfills `hunger` need, quality `home_meal`, discharge 9999
+**Event:** `ate`
+
+> {actor} makes the kind of meal home makes possible: unremarkable, private, and enough to let the evening continue on ordinary terms.
+
+### Branch 4 — Eat in a public dining place  *(mag 0.26)*
 
 **When:**
 
@@ -1248,7 +1340,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > {actor} eats something the place can provide and watches the room continue its public life around them.
 
-### Branch 4 — Forage or hunt from the country  *(mag 0.38)*
+### Branch 5 — Forage or hunt from the country  *(mag 0.38)*
 
 **When:**
 
@@ -1261,7 +1353,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > {actor} works the country for what the season has put within reach and makes a meal out of survival knowledge.
 
-### Branch 5 — Eat from rations or what was packed  *(mag 0.18)*
+### Branch 6 — Eat from rations or what was packed  *(mag 0.18)*
 
 **When:** actor has `travel_provisioned` tag
 
@@ -1270,7 +1362,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > {actor} eats what was packed for exactly this kind of hour: practical, portable, and enough.
 
-### Branch 6 — Find something and eat it  *(mag 0.14)*
+### Branch 7 — Find something and eat it  *(mag 0.14)*
 
 **When:** *(always)*
 
@@ -1632,14 +1724,12 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 - **AND:**
   - **OR:**
+    - **AND:**
+      - actor has `work` routine anchor
+      - actor's `work` routine is due now
+      - actor is at `work` anchor
     - actor has `work_obligation` tag
-    - actor has any of [`keeps_shop`, `merchant`, `innkeeper`, `trader`, `domestic_role`, `cares_for_household`, `field_worker`, `soldier`, `researcher`, `academic`]
-    - **OR:**
-      - actor is in `administration` place class
-      - actor is in `craft` place class
-      - actor is in `military` place class
-      - actor is in `place_medical` place class
-      - actor is in `production` place class
+    - actor has any of [`domestic_role`, `cares_for_household`, `field_worker`]
   - **NOT:** actor is in transit
   - ≥ 4 ticks since last `work_performed` event for actor
   - ≥ 4 ticks since last `household_work_performed` event for actor
@@ -1730,12 +1820,6 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
   - **NOT:** actor is in transit
   - **OR:**
     - actor has any current tag of [`broker`, `cover_identity`, `fixer`, `operative`, `public_role`, `undercover`]
-    - **OR:**
-      - actor is in `urban_dense` place class
-      - actor is in `place_open` place class
-      - actor is in `transit` place class
-      - actor is in `commerce` place class
-      - actor is in `meeting` place class
   - ≥ 6 ticks since last `maintain_cover` event for actor
 
 ### Branch 1 — Run a low-level courier job  *(mag 0.16)*
@@ -1824,6 +1908,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/052_orrery_faction_tag_vocab.py`
 - `migrations/054_orrery_completed_tag_vocab.py`
 - `migrations/055_orrery_character_tag_vocab.py`
+- `migrations/056_orrery_routine_anchors.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1033,11 +1033,11 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
   - **OR:**
     - **AND:**
       - actor has `work` routine anchor
-      - actor's `work` routine is due now
+      - actor's `work` routine is due now (weekdays 0=Monday; empty schedule always due)
       - actor is away from `work` anchor
     - **AND:**
       - actor has `home` routine anchor
-      - actor's `home` routine is due now
+      - actor's `home` routine is due now (weekdays 0=Monday; empty schedule always due)
       - actor is away from `home` anchor
 
 ### Branch 1 — Commute to the scheduled workplace  *(mag 0.16)*
@@ -1046,8 +1046,9 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 - **AND:**
   - actor has `work` routine anchor
-  - actor's `work` routine is due now
+  - actor's `work` routine is due now (weekdays 0=Monday; empty schedule always due)
   - actor is away from `work` anchor
+  - actor's `work` routine can resolve a destination
 
 **Does:** activity → "commuting to work"; starts planned travel
 **Event:** `travel_departed`
@@ -1060,8 +1061,9 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 - **AND:**
   - actor has `home` routine anchor
-  - actor's `home` routine is due now
+  - actor's `home` routine is due now (weekdays 0=Monday; empty schedule always due)
   - actor is away from `home` anchor
+  - actor's `home` routine can resolve a destination
 
 **Does:** activity → "commuting home"; starts planned travel
 **Event:** `travel_departed`
@@ -1726,7 +1728,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
   - **OR:**
     - **AND:**
       - actor has `work` routine anchor
-      - actor's `work` routine is due now
+      - actor's `work` routine is due now (weekdays 0=Monday; empty schedule always due)
       - actor is at `work` anchor
     - actor has `work_obligation` tag
     - actor has any of [`domestic_role`, `cares_for_household`, `field_worker`]
@@ -1820,6 +1822,12 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
   - **NOT:** actor is in transit
   - **OR:**
     - actor has any current tag of [`broker`, `cover_identity`, `fixer`, `operative`, `public_role`, `undercover`]
+  - **OR:**
+    - actor is in `urban_dense` place class
+    - actor is in `place_open` place class
+    - actor is in `transit` place class
+    - actor is in `commerce` place class
+    - actor is in `meeting` place class
   - ≥ 6 ticks since last `maintain_cover` event for actor
 
 ### Branch 1 — Run a low-level courier job  *(mag 0.16)*

--- a/docs/orrery_tag_vocabulary.md
+++ b/docs/orrery_tag_vocabulary.md
@@ -16,6 +16,16 @@ Closed-vocabulary discipline: tags do not grow at runtime. Every candidate is fi
 | **Multi-entity tag** | `entity_pair_tags` (shipped — see PR #283) | Binary property of an ordered pair | `knows_location(Alex → Burrow)` |
 | **Rich relationship** | `character_relationships` (existing) | Affective/social state with valence, history, sub-states | Alex/Emilia trust=high, valence=positive |
 
+### What Is Not a Tag
+
+Use the tag registry for properties that need differential gating. Use dedicated structured surfaces for facts that have their own shape:
+
+- Home/work schedules live in `character_routine_anchors`, not `role.function` or place tags. A character can be unemployed, nomadic, work from home, or have only a zone-level anchor without needing fake profession vocabulary.
+- Current movement lives in `character_travel_states`, not transient location tags.
+- Canonical residence and access are pair-tags (`resides_at`, `can_access`) when the relation itself matters; routine anchors can reference those places but do not replace the relation.
+
+This distinction keeps the closed vocabulary from absorbing every row-shaped fact just because Orrery can read it.
+
 ### Locked Vocabulary — No Runtime Growth
 
 Skald applies from a closed registry. `skald_inline` remains the provenance marker for runtime bestowals of registered tags; the `auto_registered` source kind and runtime vocabulary-growth path are removed. Bestowal of an unknown tag name is a hard error, not an opportunity to auto-register.

--- a/migrations/056_orrery_routine_anchors.py
+++ b/migrations/056_orrery_routine_anchors.py
@@ -1,0 +1,126 @@
+"""Add routine anchors for home/work schedule behavior.
+
+Orrery's first work package treated workplace-like places as sufficient
+evidence that any actor standing there had work to do. Routine anchors make the
+missing fact explicit: some characters have a home anchor, some have a work
+anchor, some have neither, and special cases can collapse or avoid those
+anchors without inventing generic jobs for everyone.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from psycopg2 import sql
+from psycopg2.extensions import connection
+
+
+ROUTINE_ANCHOR_TYPES: Sequence[str] = ("home", "work")
+ROUTINE_MOBILITY_POLICIES: Sequence[str] = (
+    "fixed_place",
+    "zone_resolved",
+    "works_from_home",
+    "nomadic",
+    "none",
+)
+
+
+def run(conn: connection) -> None:
+    """Create routine anchor enums and table."""
+
+    _create_enum(conn, "orrery_routine_anchor_type", ROUTINE_ANCHOR_TYPES)
+    _create_enum(
+        conn,
+        "orrery_routine_mobility_policy",
+        ROUTINE_MOBILITY_POLICIES,
+    )
+    _create_routine_anchor_table(conn)
+
+
+def _create_enum(conn: connection, type_name: str, values: Sequence[str]) -> None:
+    with conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM pg_type WHERE typname = %s", (type_name,))
+        if cur.fetchone() is not None:
+            return
+        cur.execute(
+            sql.SQL("CREATE TYPE {} AS ENUM ({})").format(
+                sql.Identifier(type_name),
+                sql.SQL(", ").join(sql.Literal(value) for value in values),
+            )
+        )
+    conn.commit()
+
+
+def _create_routine_anchor_table(conn: connection) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS character_routine_anchors (
+                id bigserial PRIMARY KEY,
+                character_entity_id bigint NOT NULL
+                    REFERENCES entities(id) ON DELETE CASCADE,
+                anchor_type orrery_routine_anchor_type NOT NULL,
+                place_id bigint REFERENCES places(id) ON DELETE SET NULL,
+                zone_id bigint REFERENCES zones(id) ON DELETE SET NULL,
+                mobility_policy orrery_routine_mobility_policy
+                    NOT NULL DEFAULT 'fixed_place',
+                schedule jsonb NOT NULL DEFAULT '{}'::jsonb,
+                source text NOT NULL DEFAULT 'manual',
+                created_at timestamptz NOT NULL DEFAULT now(),
+                updated_at timestamptz NOT NULL DEFAULT now(),
+                UNIQUE (character_entity_id, anchor_type),
+                CHECK (
+                    (
+                        mobility_policy = 'fixed_place'
+                        AND place_id IS NOT NULL
+                    )
+                    OR (
+                        mobility_policy = 'zone_resolved'
+                        AND zone_id IS NOT NULL
+                    )
+                    OR (
+                        mobility_policy IN (
+                            'works_from_home',
+                            'nomadic',
+                            'none'
+                        )
+                        AND place_id IS NULL
+                    )
+                ),
+                CHECK (
+                    anchor_type = 'work'
+                    OR mobility_policy <> 'works_from_home'
+                )
+            );
+            CREATE INDEX IF NOT EXISTS ix_character_routine_anchors_type
+                ON character_routine_anchors (anchor_type);
+            CREATE INDEX IF NOT EXISTS ix_character_routine_anchors_place
+                ON character_routine_anchors (place_id);
+            CREATE INDEX IF NOT EXISTS ix_character_routine_anchors_zone
+                ON character_routine_anchors (zone_id);
+            """
+        )
+        cur.execute(
+            """
+            COMMENT ON TABLE character_routine_anchors IS
+                'Home/work schedule anchors for ordinary off-screen routines.
+                Anchors are explicit actor facts, not inferred from the class of
+                the place the actor currently occupies.';
+            COMMENT ON COLUMN character_routine_anchors.anchor_type IS
+                'Routine kind. MVP values are home and work.';
+            COMMENT ON COLUMN character_routine_anchors.place_id IS
+                'Concrete place target when the routine has a known place.';
+            COMMENT ON COLUMN character_routine_anchors.zone_id IS
+                'Coarse zone target for routines that can hydrate a concrete
+                place later.';
+            COMMENT ON COLUMN character_routine_anchors.mobility_policy IS
+                'How Orrery interprets the anchor: concrete place, zone-only,
+                work-from-home, nomadic, or intentionally absent.';
+            COMMENT ON COLUMN character_routine_anchors.schedule IS
+                'JSON schedule. Supported MVP shape: weekdays array, start
+                HH:MM, end HH:MM. Windows may cross midnight.';
+            COMMENT ON COLUMN character_routine_anchors.source IS
+                'Human/source provenance for the anchor.';
+            """
+        )
+    conn.commit()

--- a/migrations/056_orrery_routine_anchors.py
+++ b/migrations/056_orrery_routine_anchors.py
@@ -118,7 +118,9 @@ def _create_routine_anchor_table(conn: connection) -> None:
                 work-from-home, nomadic, or intentionally absent.';
             COMMENT ON COLUMN character_routine_anchors.schedule IS
                 'JSON schedule. Supported MVP shape: weekdays array, start
-                HH:MM, end HH:MM. Windows may cross midnight.';
+                HH:MM, end HH:MM. Weekdays use Python datetime.weekday()
+                numbering: 0=Monday through 6=Sunday. Empty JSON means always
+                due. Windows may cross midnight.';
             COMMENT ON COLUMN character_routine_anchors.source IS
                 'Human/source provenance for the anchor.';
             """

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -207,6 +207,22 @@ _register(
     lambda m: f"{_slot(m.group('slot'))} has a planned travel destination",
 )
 _register(
+    r"has_routine_anchor\((?P<anchor>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: (f"{_slot(m.group('slot'))} has `{m.group('anchor')}` routine anchor"),
+)
+_register(
+    r"routine_anchor_due\((?P<anchor>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: (f"{_slot(m.group('slot'))}'s `{m.group('anchor')}` routine is due now"),
+)
+_register(
+    r"at_routine_anchor\((?P<anchor>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: f"{_slot(m.group('slot'))} is at `{m.group('anchor')}` anchor",
+)
+_register(
+    r"away_from_routine_anchor\((?P<anchor>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: f"{_slot(m.group('slot'))} is away from `{m.group('anchor')}` anchor",
+)
+_register(
     r"travel_progress_at_or_above\((?P<threshold>[\d.]+)@(?P<slot>\w+)\)",
     lambda m: (f"{_slot(m.group('slot'))} travel progress ≥ {m.group('threshold')}"),
 )

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -212,7 +212,10 @@ _register(
 )
 _register(
     r"routine_anchor_due\((?P<anchor>[^@()]+)@(?P<slot>\w+)\)",
-    lambda m: (f"{_slot(m.group('slot'))}'s `{m.group('anchor')}` routine is due now"),
+    lambda m: (
+        f"{_slot(m.group('slot'))}'s `{m.group('anchor')}` routine is due now "
+        "(weekdays 0=Monday; empty schedule always due)"
+    ),
 )
 _register(
     r"at_routine_anchor\((?P<anchor>[^@()]+)@(?P<slot>\w+)\)",
@@ -221,6 +224,13 @@ _register(
 _register(
     r"away_from_routine_anchor\((?P<anchor>[^@()]+)@(?P<slot>\w+)\)",
     lambda m: f"{_slot(m.group('slot'))} is away from `{m.group('anchor')}` anchor",
+)
+_register(
+    r"routine_anchor_has_destination\((?P<anchor>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('slot'))}'s `{m.group('anchor')}` routine "
+        "can resolve a destination"
+    ),
 )
 _register(
     r"travel_progress_at_or_above\((?P<threshold>[\d.]+)@(?P<slot>\w+)\)",

--- a/nexus/agents/orrery/demo.py
+++ b/nexus/agents/orrery/demo.py
@@ -97,7 +97,7 @@ def build_presets() -> Dict[str, WorldState]:
             current_tick=100,
         ),
         "quiet": WorldState(
-            tags={ACTOR_ID: frozenset({"seeking_identity"})},
+            tags={ACTOR_ID: frozenset({"public_role", "seeking_identity"})},
             locations={ACTOR_ID: GLOW_PLACE_ID},
             location_class=legacy_location_class,
             location_classes=semantic_location_classes,

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -2444,6 +2444,8 @@ def _routine_anchor_destination_sync(
     if policy == "fixed_place":
         return place_id
     if policy == "works_from_home":
+        if anchor_type == "home":
+            return None
         return _routine_anchor_destination_sync(
             cur,
             actor_entity_id=actor_entity_id,
@@ -2529,6 +2531,8 @@ async def _routine_anchor_destination_async(
     if policy == "fixed_place":
         return place_id
     if policy == "works_from_home":
+        if anchor_type == "home":
+            return None
         return await _routine_anchor_destination_async(
             conn,
             actor_entity_id=actor_entity_id,

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -1401,7 +1401,15 @@ def _apply_travel_start_sync(
     )
     destination_place_id = data.get("destination_place_id")
     if destination_place_id is None:
-        destination_place_id = _planned_destination_sync(cur, actor_entity_id)
+        destination_anchor = data.get("destination_anchor")
+        if destination_anchor is not None:
+            destination_place_id = _routine_anchor_destination_sync(
+                cur,
+                actor_entity_id=actor_entity_id,
+                anchor_type=str(destination_anchor),
+            )
+        else:
+            destination_place_id = _planned_destination_sync(cur, actor_entity_id)
     if origin_place_id is None or destination_place_id is None:
         raise ValueError("travel.start requires origin and destination places")
 
@@ -1488,7 +1496,17 @@ async def _apply_travel_start_async(
     )
     destination_place_id = data.get("destination_place_id")
     if destination_place_id is None:
-        destination_place_id = await _planned_destination_async(conn, actor_entity_id)
+        destination_anchor = data.get("destination_anchor")
+        if destination_anchor is not None:
+            destination_place_id = await _routine_anchor_destination_async(
+                conn,
+                actor_entity_id=actor_entity_id,
+                anchor_type=str(destination_anchor),
+            )
+        else:
+            destination_place_id = await _planned_destination_async(
+                conn, actor_entity_id
+            )
     if origin_place_id is None or destination_place_id is None:
         raise ValueError("travel.start requires origin and destination places")
 
@@ -2402,6 +2420,79 @@ def _planned_destination_sync(cur: Any, actor_entity_id: int) -> Optional[int]:
     return _row_get(row, "destination_place_id", 0) if row else None
 
 
+def _routine_anchor_destination_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    anchor_type: str,
+) -> Optional[int]:
+    cur.execute(
+        """
+        SELECT place_id, zone_id, mobility_policy::text AS mobility_policy
+        FROM character_routine_anchors
+        WHERE character_entity_id = %s
+          AND anchor_type = %s::orrery_routine_anchor_type
+        """,
+        (actor_entity_id, anchor_type),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    policy = _row_get(row, "mobility_policy", 2)
+    place_id = _row_get(row, "place_id", 0)
+    zone_id = _row_get(row, "zone_id", 1)
+    if policy == "fixed_place":
+        return place_id
+    if policy == "works_from_home":
+        return _routine_anchor_destination_sync(
+            cur,
+            actor_entity_id=actor_entity_id,
+            anchor_type="home",
+        )
+    if policy == "zone_resolved" and zone_id is not None:
+        return _routine_zone_destination_sync(
+            cur, zone_id=int(zone_id), anchor_type=anchor_type
+        )
+    return None
+
+
+def _routine_zone_destination_sync(
+    cur: Any,
+    *,
+    zone_id: int,
+    anchor_type: str,
+) -> Optional[int]:
+    preferred_tags = (
+        ("dwelling", "haven")
+        if anchor_type == "home"
+        else (
+            "commerce",
+            "administration",
+            "craft",
+            "production",
+            "place_medical",
+            "military",
+        )
+    )
+    cur.execute(
+        """
+        SELECT p.id
+        FROM places p
+        LEFT JOIN entity_tags_current etc
+          ON etc.entity_id = p.entity_id
+         AND etc.category = 'place_function'
+         AND etc.tag = ANY(%s)
+        WHERE p.zone = %s
+        GROUP BY p.id
+        ORDER BY CASE WHEN count(etc.tag) > 0 THEN 0 ELSE 1 END, p.id
+        LIMIT 1
+        """,
+        (list(preferred_tags), zone_id),
+    )
+    row = cur.fetchone()
+    return _row_get(row, "id", 0) if row else None
+
+
 async def _planned_destination_async(conn: Any, actor_entity_id: int) -> Optional[int]:
     return await conn.fetchval(
         """
@@ -2411,6 +2502,80 @@ async def _planned_destination_async(conn: Any, actor_entity_id: int) -> Optiona
           AND status = 'planned'
         """,
         actor_entity_id,
+    )
+
+
+async def _routine_anchor_destination_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    anchor_type: str,
+) -> Optional[int]:
+    row = await conn.fetchrow(
+        """
+        SELECT place_id, zone_id, mobility_policy::text AS mobility_policy
+        FROM character_routine_anchors
+        WHERE character_entity_id = $1
+          AND anchor_type = $2::orrery_routine_anchor_type
+        """,
+        actor_entity_id,
+        anchor_type,
+    )
+    if row is None:
+        return None
+    policy = _row_get(row, "mobility_policy", 2)
+    place_id = _row_get(row, "place_id", 0)
+    zone_id = _row_get(row, "zone_id", 1)
+    if policy == "fixed_place":
+        return place_id
+    if policy == "works_from_home":
+        return await _routine_anchor_destination_async(
+            conn,
+            actor_entity_id=actor_entity_id,
+            anchor_type="home",
+        )
+    if policy == "zone_resolved" and zone_id is not None:
+        return await _routine_zone_destination_async(
+            conn,
+            zone_id=int(zone_id),
+            anchor_type=anchor_type,
+        )
+    return None
+
+
+async def _routine_zone_destination_async(
+    conn: Any,
+    *,
+    zone_id: int,
+    anchor_type: str,
+) -> Optional[int]:
+    preferred_tags = (
+        ("dwelling", "haven")
+        if anchor_type == "home"
+        else (
+            "commerce",
+            "administration",
+            "craft",
+            "production",
+            "place_medical",
+            "military",
+        )
+    )
+    return await conn.fetchval(
+        """
+        SELECT p.id
+        FROM places p
+        LEFT JOIN entity_tags_current etc
+          ON etc.entity_id = p.entity_id
+         AND etc.category = 'place_function'
+         AND etc.tag = ANY($1::text[])
+        WHERE p.zone = $2
+        GROUP BY p.id
+        ORDER BY CASE WHEN count(etc.tag) > 0 THEN 0 ELSE 1 END, p.id
+        LIMIT 1
+        """,
+        list(preferred_tags),
+        zone_id,
     )
 
 

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -15,6 +15,7 @@ from nexus.agents.orrery.substrate import (
     INTIMACY_SUPPRESSOR_TAGS,
     PresentTargetPolicy,
     Resolution,
+    RoutineAnchor,
     Slot,
     Template,
     TravelState,
@@ -234,6 +235,7 @@ def hydrate_world_state(
     anchor_chunk_id: Optional[int],
     window_chunks: int,
     need_tuning: Optional[NeedTuning] = None,
+    world_time_override: Optional[datetime] = None,
 ) -> WorldState:
     """Hydrate the read-side Orrery state snapshot from database tables."""
 
@@ -271,12 +273,14 @@ def hydrate_world_state(
     location_class: dict[int, str] = {}
     location_classes: dict[int, set[str]] = {}
     location_entity_ids: dict[int, int] = {}
+    location_zones: dict[int, int] = {}
     for row in session.execute(
         text(
             f"""
             /* orrery:location_classes */
             SELECT p.id,
                    p.entity_id AS place_entity_id,
+                   p.zone AS zone_id,
                    p.type::text AS location_class,
                    true AS is_primary
             FROM places p
@@ -284,6 +288,7 @@ def hydrate_world_state(
             UNION ALL
             SELECT p.id,
                    p.entity_id AS place_entity_id,
+                   p.zone AS zone_id,
                    etc.tag AS location_class,
                    false AS is_primary
             FROM places p
@@ -300,6 +305,9 @@ def hydrate_world_state(
         place_entity_id = row.get("place_entity_id")
         if place_entity_id is not None:
             location_entity_ids[place_id] = place_entity_id
+        zone_id = row.get("zone_id")
+        if zone_id is not None:
+            location_zones[place_id] = zone_id
         location_classes.setdefault(place_id, set()).add(class_name)
         if row["is_primary"]:
             location_class[place_id] = class_name
@@ -390,7 +398,9 @@ def hydrate_world_state(
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
     )
-    world_time = _load_world_time(session, anchor_chunk_id=anchor_chunk_id)
+    world_time = world_time_override or _load_world_time(
+        session, anchor_chunk_id=anchor_chunk_id
+    )
     time_of_day = _load_time_of_day(world_time)
     weather = _load_weather(session)
     need_debt_scores = _load_need_debt_scores(
@@ -399,6 +409,7 @@ def hydrate_world_state(
         need_tuning=need_tuning,
     )
     travel_states = _load_travel_states(session)
+    routine_anchors = _load_routine_anchors(session)
 
     return WorldState(
         tags={entity_id: frozenset(values) for entity_id, values in tags.items()},
@@ -424,13 +435,49 @@ def hydrate_world_state(
             for location_id, values in location_classes.items()
         },
         location_entity_ids=location_entity_ids,
+        location_zones=location_zones,
         need_debt_scores=need_debt_scores,
         travel_states=travel_states,
+        routine_anchors=routine_anchors,
         recent_events=recent_events,
         time_of_day=time_of_day,
+        world_time=world_time,
         weather=weather,
         current_tick=anchor_chunk_id or 0,
     )
+
+
+def _load_routine_anchors(session: Any) -> dict[tuple[int, str], RoutineAnchor]:
+    """Load explicit home/work anchors for routine package gates."""
+
+    anchors: dict[tuple[int, str], RoutineAnchor] = {}
+    for row in session.execute(
+        text(
+            """
+            /* orrery:routine_anchors */
+            SELECT cra.character_entity_id,
+                   cra.anchor_type::text AS anchor_type,
+                   cra.place_id,
+                   cra.zone_id,
+                   cra.mobility_policy::text AS mobility_policy,
+                   cra.schedule
+            FROM character_routine_anchors cra
+            JOIN entities e
+              ON e.id = cra.character_entity_id
+             AND e.kind = 'character'
+             AND e.is_active = true
+            """
+        )
+    ).mappings():
+        anchor_type = str(row["anchor_type"])
+        anchors[(row["character_entity_id"], anchor_type)] = RoutineAnchor(
+            anchor_type=anchor_type,
+            place_id=row.get("place_id"),
+            zone_id=row.get("zone_id"),
+            mobility_policy=str(row["mobility_policy"]),
+            schedule=row.get("schedule") or {},
+        )
+    return anchors
 
 
 def _load_travel_states(session: Any) -> dict[int, TravelState]:
@@ -579,6 +626,21 @@ def compose_actor_bindings(
     ).mappings():
         actor_ids.add(row["entity_id"])
 
+    for row in session.execute(
+        text(
+            """
+            /* orrery:actor_bindings_routine_anchors */
+            SELECT DISTINCT cra.character_entity_id AS entity_id
+            FROM character_routine_anchors cra
+            JOIN entities e ON e.id = cra.character_entity_id
+            WHERE e.kind = 'character'
+              AND e.is_active = true
+              AND cra.mobility_policy NOT IN ('none', 'nomadic')
+            """
+        )
+    ).mappings():
+        actor_ids.add(row["entity_id"])
+
     offscreen_actor_ids = actor_ids - present_actor_ids
     return tuple({Slot.ACTOR: actor_id} for actor_id in sorted(offscreen_actor_ids))
 
@@ -721,6 +783,7 @@ def resolve_dry_run(
     anchor_chunk_id: Optional[int],
     window_chunks: int,
     sunhelm_settings: Optional[Any] = None,
+    world_time_override: Optional[datetime] = None,
 ) -> OrreryTickProposal:
     """Hydrate, bind, and evaluate Orrery packages without database writes."""
 
@@ -730,6 +793,7 @@ def resolve_dry_run(
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
         need_tuning=need_tuning,
+        world_time_override=world_time_override,
     )
 
     templates_list = list(templates)

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from hashlib import sha256
 import json
@@ -146,6 +147,27 @@ class TravelState:
 
 
 @dataclass(frozen=True, slots=True)
+class RoutineAnchor:
+    """Read-side home/work routine anchor for one character."""
+
+    anchor_type: str
+    place_id: Optional[int] = None
+    zone_id: Optional[int] = None
+    mobility_policy: str = "fixed_place"
+    schedule: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def has_destination(self) -> bool:
+        """Return whether this anchor can resolve to a concrete destination."""
+
+        return self.mobility_policy in {
+            "fixed_place",
+            "zone_resolved",
+            "works_from_home",
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class EventRecord:
     """Compact read-side event shape consumed by condition predicates."""
 
@@ -176,11 +198,16 @@ class WorldState:
     location_class: Mapping[int, str] = field(default_factory=dict)
     location_classes: Mapping[int, frozenset[str]] = field(default_factory=dict)
     location_entity_ids: Mapping[int, int] = field(default_factory=dict)
+    location_zones: Mapping[int, int] = field(default_factory=dict)
     orbit_distance: Mapping[Tuple[int, int], int] = field(default_factory=dict)
     need_debt_scores: Mapping[Tuple[int, str], float] = field(default_factory=dict)
     travel_states: Mapping[int, TravelState] = field(default_factory=dict)
+    routine_anchors: Mapping[Tuple[int, str], RoutineAnchor] = field(
+        default_factory=dict
+    )
     recent_events: Tuple[EventRecord, ...] = ()
     time_of_day: str = "midday"
+    world_time: Optional[datetime] = None
     weather: str = "clear"
     current_tick: int = 0
 
@@ -724,6 +751,128 @@ def has_travel_destination(slot: Slot = Slot.ACTOR) -> Condition:
         return bool(travel_state and travel_state.destination_place_id is not None)
 
     return _named(_condition, f"has_travel_destination(@{slot.value})")
+
+
+def has_routine_anchor(anchor_type: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether the slot-bound actor has an active routine anchor."""
+
+    normalized = str(anchor_type)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        anchor = _routine_anchor(state, entity_id, normalized)
+        return bool(anchor and anchor.mobility_policy not in {"none", "nomadic"})
+
+    return _named(_condition, f"has_routine_anchor({normalized}@{slot.value})")
+
+
+def routine_anchor_due(anchor_type: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether the actor's anchor is scheduled for the current time."""
+
+    normalized = str(anchor_type)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        anchor = _routine_anchor(state, entity_id, normalized)
+        if anchor is None or anchor.mobility_policy in {"none", "nomadic"}:
+            return False
+        return _routine_schedule_due(anchor.schedule, state.world_time)
+
+    return _named(_condition, f"routine_anchor_due({normalized}@{slot.value})")
+
+
+def at_routine_anchor(anchor_type: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether the actor is currently at the named routine anchor."""
+
+    normalized = str(anchor_type)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        return _at_routine_anchor(state, entity_id, normalized)
+
+    return _named(_condition, f"at_routine_anchor({normalized}@{slot.value})")
+
+
+def away_from_routine_anchor(anchor_type: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether the actor is not currently at the named routine anchor."""
+
+    normalized = str(anchor_type)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        anchor = _routine_anchor(state, entity_id, normalized)
+        if anchor is None or anchor.mobility_policy in {"none", "nomadic"}:
+            return False
+        return not _at_routine_anchor(state, entity_id, normalized)
+
+    return _named(_condition, f"away_from_routine_anchor({normalized}@{slot.value})")
+
+
+def _routine_anchor(
+    state: WorldState,
+    entity_id: int,
+    anchor_type: str,
+) -> Optional[RoutineAnchor]:
+    return state.routine_anchors.get((entity_id, anchor_type))
+
+
+def _at_routine_anchor(state: WorldState, entity_id: int, anchor_type: str) -> bool:
+    anchor = _routine_anchor(state, entity_id, anchor_type)
+    if anchor is None or anchor.mobility_policy in {"none", "nomadic"}:
+        return False
+    if anchor.mobility_policy == "works_from_home":
+        return _at_routine_anchor(state, entity_id, "home")
+    current_place_id = state.locations.get(entity_id)
+    if current_place_id is None:
+        return False
+    if anchor.place_id is not None:
+        return current_place_id == anchor.place_id
+    if anchor.zone_id is not None:
+        return state.location_zones.get(current_place_id) == anchor.zone_id
+    return False
+
+
+def _routine_schedule_due(
+    schedule: Mapping[str, Any],
+    world_time: Optional[datetime],
+) -> bool:
+    if world_time is None or not schedule:
+        return True
+    weekdays = schedule.get("weekdays")
+    if weekdays is not None and world_time.weekday() not in {
+        int(day) for day in weekdays
+    }:
+        return False
+    start = _minute_of_day(schedule.get("start"))
+    end = _minute_of_day(schedule.get("end"))
+    if start is None or end is None:
+        return True
+    minute = world_time.hour * 60 + world_time.minute
+    if start <= end:
+        return start <= minute < end
+    return minute >= start or minute < end
+
+
+def _minute_of_day(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    raw = str(value)
+    parts = raw.split(":", 1)
+    if len(parts) != 2:
+        raise ValueError(f"Routine schedule time must be HH:MM, got {raw!r}")
+    hour = int(parts[0])
+    minute = int(parts[1])
+    if not 0 <= hour <= 23 or not 0 <= minute <= 59:
+        raise ValueError(f"Routine schedule time out of range: {raw!r}")
+    return hour * 60 + minute
 
 
 def travel_progress_at_or_above(

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -816,6 +816,26 @@ def away_from_routine_anchor(anchor_type: str, slot: Slot = Slot.ACTOR) -> Condi
     return _named(_condition, f"away_from_routine_anchor({normalized}@{slot.value})")
 
 
+def routine_anchor_has_destination(
+    anchor_type: str,
+    slot: Slot = Slot.ACTOR,
+) -> Condition:
+    """Return whether the actor's anchor can resolve to a place destination."""
+
+    normalized = str(anchor_type)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        return _routine_anchor_destination_available(state, entity_id, normalized)
+
+    return _named(
+        _condition,
+        f"routine_anchor_has_destination({normalized}@{slot.value})",
+    )
+
+
 def _routine_anchor(
     state: WorldState,
     entity_id: int,
@@ -829,6 +849,8 @@ def _at_routine_anchor(state: WorldState, entity_id: int, anchor_type: str) -> b
     if anchor is None or anchor.mobility_policy in {"none", "nomadic"}:
         return False
     if anchor.mobility_policy == "works_from_home":
+        if anchor_type == "home":
+            return False
         return _at_routine_anchor(state, entity_id, "home")
     current_place_id = state.locations.get(entity_id)
     if current_place_id is None:
@@ -837,6 +859,35 @@ def _at_routine_anchor(state: WorldState, entity_id: int, anchor_type: str) -> b
         return current_place_id == anchor.place_id
     if anchor.zone_id is not None:
         return state.location_zones.get(current_place_id) == anchor.zone_id
+    return False
+
+
+def _routine_anchor_destination_available(
+    state: WorldState,
+    entity_id: int,
+    anchor_type: str,
+    seen: frozenset[str] = frozenset(),
+) -> bool:
+    if anchor_type in seen:
+        return False
+    anchor = _routine_anchor(state, entity_id, anchor_type)
+    if anchor is None or anchor.mobility_policy in {"none", "nomadic"}:
+        return False
+    if anchor.mobility_policy == "fixed_place":
+        return anchor.place_id is not None
+    if anchor.mobility_policy == "zone_resolved":
+        return anchor.zone_id is not None and anchor.zone_id in set(
+            state.location_zones.values()
+        )
+    if anchor.mobility_policy == "works_from_home":
+        if anchor_type == "home":
+            return False
+        return _routine_anchor_destination_available(
+            state,
+            entity_id,
+            "home",
+            seen | {anchor_type},
+        )
     return False
 
 
@@ -868,8 +919,11 @@ def _minute_of_day(value: Any) -> Optional[int]:
     parts = raw.split(":", 1)
     if len(parts) != 2:
         raise ValueError(f"Routine schedule time must be HH:MM, got {raw!r}")
-    hour = int(parts[0])
-    minute = int(parts[1])
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1])
+    except ValueError as exc:
+        raise ValueError(f"Routine schedule time must be HH:MM, got {raw!r}") from exc
     if not 0 <= hour <= 23 or not 0 <= minute <= 59:
         raise ValueError(f"Routine schedule time out of range: {raw!r}")
     return hour * 60 + minute

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -30,6 +30,7 @@ from nexus.agents.orrery.substrate import (
     has_symmetric_relationship_of_type,
     has_tag,
     has_travel_destination,
+    has_routine_anchor,
     in_location_class,
     is_constrained,
     is_hidden,
@@ -37,6 +38,9 @@ from nexus.agents.orrery.substrate import (
     recent_event,
     relationship_is_asymmetric,
     relationship_is_mutual_warm,
+    at_routine_anchor,
+    away_from_routine_anchor,
+    routine_anchor_due,
     since_last_event_at_least,
     time_of_day_in,
     travel_progress_at_or_above,
@@ -420,7 +424,6 @@ MAINTAIN_COVER = Template(
                 "public_role",
                 "undercover",
             ),
-            URBAN_PUBLIC_FLOW_PLACE,
         ),
         since_last_event_at_least("maintain_cover", minimum_ticks=6),
     ),
@@ -1391,6 +1394,106 @@ KEEP_VIGIL = Template(
 # Section B — Maintenance of self
 
 
+ROUTINE_COMMUTE = Template(
+    id="routine_commute",
+    priority=26,
+    blurb="Ordinary home/work movement from explicit routine anchors.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        has_minimal_context(),
+        NOT(is_constrained()),
+        NOT(is_in_transit()),
+        NOT(has_inbound_pair_tag("hunting")),
+        NOT(has_ephemeral("wounded")),
+        NOT(has_ephemeral("grieving")),
+        OR(
+            AND(
+                has_routine_anchor("work"),
+                routine_anchor_due("work"),
+                away_from_routine_anchor("work"),
+            ),
+            AND(
+                has_routine_anchor("home"),
+                routine_anchor_due("home"),
+                away_from_routine_anchor("home"),
+            ),
+        ),
+    ),
+    branches=(
+        Branch(
+            label="Commute to the scheduled workplace",
+            conditions=AND(
+                has_routine_anchor("work"),
+                routine_anchor_due("work"),
+                away_from_routine_anchor("work"),
+            ),
+            narrative_stub=(
+                "{actor} follows the ordinary route toward work: not a quest, "
+                "not a crisis, just the daily movement that keeps a normal "
+                "life legible."
+            ),
+            state_delta={
+                "character.current_activity": "commuting to work",
+                "travel.start": {
+                    "destination_anchor": "work",
+                    "mode": "mixed",
+                    "initial_progress": 0.05,
+                },
+            },
+            event_type="travel_departed",
+            changed_fields=(
+                "character.current_activity",
+                "character_travel_states.status",
+                "character_travel_states.progress_ratio",
+            ),
+            magnitude=0.16,
+        ),
+        Branch(
+            label="Commute home after the day's obligations",
+            conditions=AND(
+                has_routine_anchor("home"),
+                routine_anchor_due("home"),
+                away_from_routine_anchor("home"),
+            ),
+            narrative_stub=(
+                "{actor} turns toward home with the unremarkable certainty of "
+                "someone whose day has a next place."
+            ),
+            state_delta={
+                "character.current_activity": "commuting home",
+                "travel.start": {
+                    "destination_anchor": "home",
+                    "mode": "mixed",
+                    "initial_progress": 0.05,
+                },
+            },
+            event_type="travel_departed",
+            changed_fields=(
+                "character.current_activity",
+                "character_travel_states.status",
+                "character_travel_states.progress_ratio",
+            ),
+            magnitude=0.14,
+        ),
+        Branch(
+            label="Recheck routine before moving",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} pauses at the edge of routine and checks the "
+                "ordinary facts before moving: where they are, where the "
+                "day says they should be, and whether the next leg is real."
+            ),
+            state_delta={
+                "character.current_activity": "checking routine timing",
+            },
+            event_type="travel_prepared",
+            changed_fields=("character.current_activity",),
+            magnitude=0.04,
+        ),
+    ),
+)
+
+
 TRAVEL = Template(
     id="travel",
     priority=21,
@@ -1528,20 +1631,13 @@ WORK = Template(
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
         OR(
-            has_tag("work_obligation"),
-            has_any_tag(
-                "keeps_shop",
-                "merchant",
-                "innkeeper",
-                "trader",
-                "domestic_role",
-                "cares_for_household",
-                "field_worker",
-                "soldier",
-                "researcher",
-                "academic",
+            AND(
+                has_routine_anchor("work"),
+                routine_anchor_due("work"),
+                at_routine_anchor("work"),
             ),
-            WORKPLACE_PLACE,
+            has_tag("work_obligation"),
+            has_any_tag("domestic_role", "cares_for_household", "field_worker"),
         ),
         NOT(is_in_transit()),
         since_last_event_at_least("work_performed", minimum_ticks=4),
@@ -2440,6 +2536,16 @@ DRINK = Template(
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
         has_need_debt_at_or_above("thirst", 2),
+        OR(
+            has_need_debt_at_or_above("thirst", 16),
+            NOT(
+                AND(
+                    has_need_debt_at_or_above("hunger", 4),
+                    time_of_day_in("morning", "afternoon", "evening"),
+                    OR(HOME_PLACE, PUBLIC_DINING_PLACE),
+                )
+            ),
+        ),
         NOT(has_inbound_pair_tag("hunting")),
     ),
     branches=(
@@ -2598,6 +2704,29 @@ EAT = Template(
                 "character_need_states.debt_score",
             ),
             magnitude=0.22,
+        ),
+        Branch(
+            label="Eat at home alone",
+            conditions=HOME_PLACE,
+            narrative_stub=(
+                "{actor} makes the kind of meal home makes possible: "
+                "unremarkable, private, and enough to let the evening "
+                "continue on ordinary terms."
+            ),
+            state_delta={
+                "character.current_activity": "eating at home",
+                "need.fulfill": {
+                    "type": "hunger",
+                    "quality": "home_meal",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="ate",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.20,
         ),
         Branch(
             label="Eat in a public dining place",
@@ -2998,6 +3127,7 @@ BUILTIN_TEMPLATES = (
     REACH_OUT_TO_KIN,
     CONSULT_RIVAL,
     MOURN_LOSS,
+    ROUTINE_COMMUTE,
     TRAVEL,
     WORK,
     TEND_CRAFT,

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -41,6 +41,7 @@ from nexus.agents.orrery.substrate import (
     at_routine_anchor,
     away_from_routine_anchor,
     routine_anchor_due,
+    routine_anchor_has_destination,
     since_last_event_at_least,
     time_of_day_in,
     travel_progress_at_or_above,
@@ -425,6 +426,7 @@ MAINTAIN_COVER = Template(
                 "undercover",
             ),
         ),
+        URBAN_PUBLIC_FLOW_PLACE,
         since_last_event_at_least("maintain_cover", minimum_ticks=6),
     ),
     branches=(
@@ -1426,6 +1428,7 @@ ROUTINE_COMMUTE = Template(
                 has_routine_anchor("work"),
                 routine_anchor_due("work"),
                 away_from_routine_anchor("work"),
+                routine_anchor_has_destination("work"),
             ),
             narrative_stub=(
                 "{actor} follows the ordinary route toward work: not a quest, "
@@ -1454,6 +1457,7 @@ ROUTINE_COMMUTE = Template(
                 has_routine_anchor("home"),
                 routine_anchor_due("home"),
                 away_from_routine_anchor("home"),
+                routine_anchor_has_destination("home"),
             ),
             narrative_stub=(
                 "{actor} turns toward home with the unremarkable certainty of "

--- a/scripts/orrery_sample.py
+++ b/scripts/orrery_sample.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 import argparse
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
@@ -23,7 +24,6 @@ from nexus.agents.orrery.resolver import (
     compose_actor_bindings,
     compose_actor_target_bindings,
     hydrate_world_state,
-    _present_actor_ids_at_anchor,
 )
 from nexus.agents.orrery.substrate import PresentTargetPolicy, Slot, evaluate
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
@@ -201,6 +201,20 @@ def fetch_actor_sources(
     ).mappings():
         sources[row["entity_id"]].append(f"ephemeral:{row['tag']}")
 
+    for row in session.execute(
+        text(
+            """
+            SELECT DISTINCT cra.character_entity_id AS entity_id,
+                   cra.anchor_type::text AS anchor_type
+            FROM character_routine_anchors cra
+            WHERE cra.character_entity_id = ANY(:ids)
+              AND cra.mobility_policy NOT IN ('none', 'nomadic')
+            """
+        ),
+        {"ids": list(actor_ids)},
+    ).mappings():
+        sources[row["entity_id"]].append(f"routine:{row['anchor_type']}")
+
     return sources
 
 
@@ -239,17 +253,87 @@ def fetch_first_reference_chunk(
 
 
 def fetch_chunk_context(session: Session, anchor_chunk_id: int) -> Optional[dict]:
-    row = session.execute(
-        text(
-            """
+    row = (
+        session.execute(
+            text(
+                """
             SELECT id AS chunk_id, world_time, LEFT(raw_text, 320) AS preview
             FROM narrative_view
             WHERE id = :chunk_id
             """
-        ),
-        {"chunk_id": anchor_chunk_id},
-    ).mappings().first()
+            ),
+            {"chunk_id": anchor_chunk_id},
+        )
+        .mappings()
+        .first()
+    )
     return dict(row) if row else None
+
+
+def parse_location_overrides(raw_values: list[str]) -> list[tuple[str, str]]:
+    """Parse CHARACTER=PLACE override specs for test harness dry-runs."""
+
+    overrides = []
+    for raw in raw_values:
+        if "=" not in raw:
+            raise ValueError(
+                "--override-location must use CHARACTER=PLACE, got " f"{raw!r}"
+            )
+        character, place = raw.split("=", 1)
+        character = character.strip()
+        place = place.strip()
+        if not character or not place:
+            raise ValueError(
+                "--override-location must include both CHARACTER and PLACE, "
+                f"got {raw!r}"
+            )
+        overrides.append((character, place))
+    return overrides
+
+
+def resolve_location_overrides(
+    session: Session,
+    overrides: list[tuple[str, str]],
+) -> tuple[dict[int, int], list[str]]:
+    """Resolve parsed location override names to read-side state ids."""
+
+    resolved: dict[int, int] = {}
+    labels: list[str] = []
+    for character_name, place_name in overrides:
+        rows = list(
+            session.execute(
+                text(
+                    """
+                    SELECT c.entity_id AS character_entity_id,
+                           c.name AS character_name,
+                           p.id AS place_id,
+                           p.name AS place_name
+                    FROM characters c
+                    CROSS JOIN places p
+                    WHERE lower(c.name) = lower(:character_name)
+                      AND lower(p.name) = lower(:place_name)
+                    LIMIT 2
+                    """
+                ),
+                {
+                    "character_name": character_name,
+                    "place_name": place_name,
+                },
+            ).mappings()
+        )
+        if not rows:
+            raise ValueError(
+                "Could not resolve --override-location "
+                f"{character_name!r}={place_name!r}"
+            )
+        if len(rows) > 1:
+            raise ValueError(
+                "Ambiguous --override-location " f"{character_name!r}={place_name!r}"
+            )
+        row = rows[0]
+        resolved[row["character_entity_id"]] = row["place_id"]
+        labels.append(f"{row['character_name']} → {row['place_name']}")
+    return resolved, labels
 
 
 def render_stub(stub: Optional[str], bindings: dict, names: dict[int, str]) -> str:
@@ -259,9 +343,13 @@ def render_stub(stub: Optional[str], bindings: dict, names: dict[int, str]) -> s
     actor_id = bindings.get(Slot.ACTOR)
     target_id = bindings.get(Slot.TARGET)
     if actor_id is not None:
-        s = s.replace("{actor}", names.get(actor_id, f"entity_{actor_id}").split(" (")[0])
+        s = s.replace(
+            "{actor}", names.get(actor_id, f"entity_{actor_id}").split(" (")[0]
+        )
     if target_id is not None:
-        s = s.replace("{target}", names.get(target_id, f"entity_{target_id}").split(" (")[0])
+        s = s.replace(
+            "{target}", names.get(target_id, f"entity_{target_id}").split(" (")[0]
+        )
     return s
 
 
@@ -277,6 +365,7 @@ def render_markdown(
     anchor_chunk_id: int,
     window_chunks: int,
     chunk_ctx: Optional[dict],
+    world_time_override: Optional[datetime],
     binding_reports: list[BindingReport],
     sources: dict[int, list[str]],
     names: dict[int, str],
@@ -284,15 +373,19 @@ def render_markdown(
     raw_candidate_count: int,
     filtered_out_actor_ids: list[int],
     first_chunks: dict[int, int],
+    location_override_labels: list[str],
 ) -> str:
     lines = []
     lines.append(f"# Orrery Dry Run — chunk_{anchor_chunk_id:04d}")
     lines.append("")
     lines.append(f"- **Slot**: {slot}")
     lines.append(f"- **Anchor chunk**: {anchor_chunk_id}")
-    lines.append(
-        f"- **World time**: {chunk_ctx['world_time'] if chunk_ctx else 'unknown'}"
-    )
+    world_time = world_time_override or (chunk_ctx["world_time"] if chunk_ctx else None)
+    lines.append(f"- **World time**: {world_time if world_time else 'unknown'}")
+    if world_time_override is not None:
+        lines.append("- **World time source**: command-line override")
+    if location_override_labels:
+        lines.append("- **Location overrides**: " + "; ".join(location_override_labels))
     lines.append(
         f"- **Window**: {window_chunks} chunks "
         f"({max(0, anchor_chunk_id - window_chunks + 1)} → {anchor_chunk_id})"
@@ -322,9 +415,7 @@ def render_markdown(
 
     # Filtered-out actors
     if filtered_out_actor_ids:
-        lines.append(
-            f"## Filtered as not-yet-existing ({len(filtered_out_actor_ids)})"
-        )
+        lines.append(f"## Filtered as not-yet-existing ({len(filtered_out_actor_ids)})")
         lines.append("")
         lines.append(
             "Actors whose first appearance in `chunk_entity_references_v` "
@@ -378,15 +469,23 @@ def render_markdown(
     lines.append(f"## Fired — off-screen activity ({len(offscreen_fired)})")
     lines.append("")
     if offscreen_fired:
-        lines.append("| Actor | Target | Template | Pri | Branch | Rendered stub | event_type | mag |")
+        lines.append(
+            "| Actor | Target | Template | Pri | Branch | Rendered stub | "
+            "event_type | mag |"
+        )
         lines.append("|---|---|---|---|---|---|---|---|")
         for br, e in sorted(offscreen_fired, key=lambda x: -x[1].priority):
             actor = name_for(br.bindings.get(Slot.ACTOR), names)
-            target = name_for(br.bindings.get(Slot.TARGET), names) if Slot.TARGET in br.bindings else "—"
+            target = (
+                name_for(br.bindings.get(Slot.TARGET), names)
+                if Slot.TARGET in br.bindings
+                else "—"
+            )
             stub = render_stub(e.narrative_stub, br.bindings, names)
             lines.append(
                 f"| {actor} | {target} | `{e.template_id}` | {e.priority} | "
-                f"{e.branch_label or '—'} | {stub} | {e.event_type or '—'} | {e.magnitude:.2f} |"
+                f"{e.branch_label or '—'} | {stub} | "
+                f"{e.event_type or '—'} | {e.magnitude:.2f} |"
             )
         lines.append("")
         lines.append("### State deltas for fired resolutions")
@@ -399,7 +498,9 @@ def render_markdown(
         lines.append("(none)")
         lines.append("")
 
-    lines.append(f"## Fired — scene pressures (present-target) ({len(scene_pressure_fired)})")
+    lines.append(
+        f"## Fired — scene pressures (present-target) ({len(scene_pressure_fired)})"
+    )
     lines.append("")
     if scene_pressure_fired:
         lines.append(
@@ -408,19 +509,30 @@ def render_markdown(
             "them as Storyteller-facing scene pressures."
         )
         lines.append("")
-        lines.append("| Actor | Present target | Template | Pri | Branch | Rendered stub | event_type | mag |")
+        lines.append(
+            "| Actor | Present target | Template | Pri | Branch | Rendered stub | "
+            "event_type | mag |"
+        )
         lines.append("|---|---|---|---|---|---|---|---|")
         for br, e in sorted(scene_pressure_fired, key=lambda x: -x[1].priority):
             actor = name_for(br.bindings.get(Slot.ACTOR), names)
-            target = name_for(br.bindings.get(Slot.TARGET), names) if Slot.TARGET in br.bindings else "—"
+            target = (
+                name_for(br.bindings.get(Slot.TARGET), names)
+                if Slot.TARGET in br.bindings
+                else "—"
+            )
             stub = render_stub(e.narrative_stub, br.bindings, names)
             lines.append(
                 f"| {actor} | {target} | `{e.template_id}` | {e.priority} | "
-                f"{e.branch_label or '—'} | {stub} | {e.event_type or '—'} | {e.magnitude:.2f} |"
+                f"{e.branch_label or '—'} | {stub} | "
+                f"{e.event_type or '—'} | {e.magnitude:.2f} |"
             )
         lines.append("")
     else:
-        lines.append("(none — either no pressure-policy templates eligible, or no on-screen targets at this anchor)")
+        lines.append(
+            "(none — either no pressure-policy templates eligible, or no "
+            "on-screen targets at this anchor)"
+        )
         lines.append("")
 
     # Priority-loss
@@ -437,7 +549,11 @@ def render_markdown(
         lines.append("|---|---|---|---|---|---|")
         for br, e in sorted(pl, key=lambda x: -x[1].priority):
             actor = name_for(br.bindings.get(Slot.ACTOR), names)
-            target = name_for(br.bindings.get(Slot.TARGET), names) if Slot.TARGET in br.bindings else "—"
+            target = (
+                name_for(br.bindings.get(Slot.TARGET), names)
+                if Slot.TARGET in br.bindings
+                else "—"
+            )
             stub = render_stub(e.narrative_stub, br.bindings, names)
             lines.append(
                 f"| {actor} | {target} | `{e.template_id}` | {e.priority} | "
@@ -464,7 +580,11 @@ def render_markdown(
         lines.append("|---|---|---|---|")
         for br, e in sorted(nbm, key=lambda x: -x[1].priority):
             actor = name_for(br.bindings.get(Slot.ACTOR), names)
-            target = name_for(br.bindings.get(Slot.TARGET), names) if Slot.TARGET in br.bindings else "—"
+            target = (
+                name_for(br.bindings.get(Slot.TARGET), names)
+                if Slot.TARGET in br.bindings
+                else "—"
+            )
             lines.append(f"| {actor} | {target} | `{e.template_id}` | {e.priority} |")
         lines.append("")
     else:
@@ -478,14 +598,14 @@ def render_markdown(
             if e.outcome == "gate_fail":
                 gf_by_template[e.template_id] += 1
     total_gf = sum(gf_by_template.values())
-    lines.append(f"## Gate-fail summary ({total_gf} total, top 10 templates by frequency)")
+    lines.append(
+        f"## Gate-fail summary ({total_gf} total, top 10 templates by frequency)"
+    )
     lines.append("")
     if gf_by_template:
         lines.append("| Template | Bindings rejected |")
         lines.append("|---|---|")
-        for tid, count in sorted(
-            gf_by_template.items(), key=lambda x: -x[1]
-        )[:10]:
+        for tid, count in sorted(gf_by_template.items(), key=lambda x: -x[1])[:10]:
             lines.append(f"| `{tid}` | {count} |")
         lines.append("")
     else:
@@ -528,7 +648,15 @@ def render_markdown(
     return "\n".join(lines)
 
 
-def sample_anchor(slot: int, anchor_chunk_id: int, window_chunks: int, output_dir: Path) -> Path:
+def sample_anchor(
+    slot: int,
+    anchor_chunk_id: int,
+    window_chunks: int,
+    output_dir: Path,
+    *,
+    world_time_override: Optional[datetime] = None,
+    location_overrides: Optional[list[tuple[str, str]]] = None,
+) -> Path:
     engine = create_engine(get_slot_db_url(slot=slot))
     with Session(engine) as session:
         actor_only_templates = [
@@ -543,7 +671,22 @@ def sample_anchor(slot: int, anchor_chunk_id: int, window_chunks: int, output_di
             anchor_chunk_id=anchor_chunk_id,
             window_chunks=window_chunks,
             need_tuning=None,
+            world_time_override=world_time_override,
         )
+        override_locations, override_labels = resolve_location_overrides(
+            session,
+            location_overrides or [],
+        )
+        if override_locations:
+            state = replace(
+                state,
+                locations={**state.locations, **override_locations},
+                travel_states={
+                    entity_id: travel_state
+                    for entity_id, travel_state in state.travel_states.items()
+                    if entity_id not in override_locations
+                },
+            )
 
         raw_actor_bindings = compose_actor_bindings(
             session,
@@ -685,6 +828,7 @@ def sample_anchor(slot: int, anchor_chunk_id: int, window_chunks: int, output_di
             anchor_chunk_id=anchor_chunk_id,
             window_chunks=window_chunks,
             chunk_ctx=chunk_ctx,
+            world_time_override=world_time_override,
             binding_reports=binding_reports,
             sources=sources,
             names=names,
@@ -692,6 +836,7 @@ def sample_anchor(slot: int, anchor_chunk_id: int, window_chunks: int, output_di
             raw_candidate_count=len(raw_actor_bindings),
             filtered_out_actor_ids=filtered_out_actor_ids,
             first_chunks=first_chunks,
+            location_override_labels=override_labels,
         )
 
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -711,9 +856,32 @@ def main() -> None:
         type=Path,
         default=Path("docs/orrery_dry_runs"),
     )
+    parser.add_argument(
+        "--world-time",
+        type=datetime.fromisoformat,
+        default=None,
+        help="Override anchor world_time for schedule/need dry-runs.",
+    )
+    parser.add_argument(
+        "--override-location",
+        action="append",
+        default=[],
+        metavar="CHARACTER=PLACE",
+        help=(
+            "Override a character's current place in the dry-run state only. "
+            "May be repeated."
+        ),
+    )
     args = parser.parse_args()
 
-    out = sample_anchor(args.slot, args.anchor, args.window_chunks, args.output_dir)
+    out = sample_anchor(
+        args.slot,
+        args.anchor,
+        args.window_chunks,
+        args.output_dir,
+        world_time_override=args.world_time,
+        location_overrides=parse_location_overrides(args.override_location),
+    )
     print(f"Wrote {out}")
 
 

--- a/scripts/seed_slot2_routine_anchors.py
+++ b/scripts/seed_slot2_routine_anchors.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Seed Slot 2 reference routine anchors for Cam and Celia.
+
+This is intentionally narrow test-slot data: Cam and Celia are boring-citizen
+fixtures for Orrery's home/work cycle. The script is idempotent and does not
+move characters; it only records routine anchors and home residence pair-tags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any
+
+import psycopg2
+from psycopg2.extensions import connection
+from psycopg2.extras import Json
+
+from nexus.agents.orrery.tag_writer import apply_pair_tag_bestowal
+
+
+WORK_SCHEDULE = {"weekdays": [0, 1, 2, 3, 4], "start": "09:00", "end": "17:00"}
+HOME_SCHEDULE = {"start": "17:00", "end": "08:30"}
+
+ROUTINES = (
+    {
+        "character": "Cam",
+        "work_place": "Bougie Mall High-End Fashion Outlet",
+        "home_place": "Coastal Safehouse",
+    },
+    {
+        "character": "Celia",
+        "work_place": "Low Tide",
+        "home_place": "Back-Alley Hacker Den",
+    },
+)
+
+
+def _connect(slot: int) -> connection:
+    return psycopg2.connect(
+        dbname=f"save_{slot:02d}",
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+def _character(cur: Any, name: str) -> dict[str, Any]:
+    cur.execute(
+        """
+        SELECT id, entity_id, name
+        FROM characters
+        WHERE name = %s
+        """,
+        (name,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"Character not found: {name!r}")
+    return {"id": row[0], "entity_id": row[1], "name": row[2]}
+
+
+def _place(cur: Any, name: str) -> dict[str, Any]:
+    cur.execute(
+        """
+        SELECT id, entity_id, name, zone
+        FROM places
+        WHERE name = %s
+        """,
+        (name,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"Place not found: {name!r}")
+    return {"id": row[0], "entity_id": row[1], "name": row[2], "zone_id": row[3]}
+
+
+def _upsert_anchor(
+    cur: Any,
+    *,
+    character_entity_id: int,
+    anchor_type: str,
+    place_id: int,
+    zone_id: int | None,
+    schedule: dict[str, Any],
+) -> None:
+    cur.execute(
+        """
+        INSERT INTO character_routine_anchors (
+            character_entity_id, anchor_type, place_id, zone_id,
+            mobility_policy, schedule, source
+        ) VALUES (
+            %s, %s::orrery_routine_anchor_type, %s, %s,
+            'fixed_place', %s::jsonb, 'slot2_reference_seed'
+        )
+        ON CONFLICT (character_entity_id, anchor_type) DO UPDATE SET
+            place_id = EXCLUDED.place_id,
+            zone_id = EXCLUDED.zone_id,
+            mobility_policy = EXCLUDED.mobility_policy,
+            schedule = EXCLUDED.schedule,
+            source = EXCLUDED.source,
+            updated_at = now()
+        """,
+        (
+            character_entity_id,
+            anchor_type,
+            place_id,
+            zone_id,
+            Json(schedule),
+        ),
+    )
+
+
+def seed(slot: int) -> dict[str, Any]:
+    """Seed routine fixtures and return a summary."""
+
+    summary: list[dict[str, Any]] = []
+    with _connect(slot) as conn:
+        with conn.cursor() as cur:
+            for item in ROUTINES:
+                character = _character(cur, item["character"])
+                work_place = _place(cur, item["work_place"])
+                home_place = _place(cur, item["home_place"])
+                _upsert_anchor(
+                    cur,
+                    character_entity_id=character["entity_id"],
+                    anchor_type="work",
+                    place_id=work_place["id"],
+                    zone_id=work_place["zone_id"],
+                    schedule=WORK_SCHEDULE,
+                )
+                _upsert_anchor(
+                    cur,
+                    character_entity_id=character["entity_id"],
+                    anchor_type="home",
+                    place_id=home_place["id"],
+                    zone_id=home_place["zone_id"],
+                    schedule=HOME_SCHEDULE,
+                )
+                inserted_residence = apply_pair_tag_bestowal(
+                    cur,
+                    subject_entity_id=character["entity_id"],
+                    object_entity_id=home_place["entity_id"],
+                    tag="resides_at",
+                    subject_kind="character",
+                    object_kind="place",
+                    source_kind="authored",
+                )
+                summary.append(
+                    {
+                        "character": character["name"],
+                        "entity_id": character["entity_id"],
+                        "work_place": work_place["name"],
+                        "home_place": home_place["name"],
+                        "inserted_residence": inserted_residence,
+                    }
+                )
+    return {"slot": slot, "routines": summary}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--slot", type=int, default=2)
+    args = parser.parse_args()
+    print(json.dumps(seed(args.slot), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed_slot2_routine_anchors.py
+++ b/scripts/seed_slot2_routine_anchors.py
@@ -127,7 +127,7 @@ def seed(slot: int) -> dict[str, Any]:
                     character_entity_id=character["entity_id"],
                     anchor_type="work",
                     place_id=work_place["id"],
-                    zone_id=work_place["zone_id"],
+                    zone_id=None,
                     schedule=WORK_SCHEDULE,
                 )
                 _upsert_anchor(
@@ -135,7 +135,7 @@ def seed(slot: int) -> dict[str, Any]:
                     character_entity_id=character["entity_id"],
                     anchor_type="home",
                     place_id=home_place["id"],
-                    zone_id=home_place["zone_id"],
+                    zone_id=None,
                     schedule=HOME_SCHEDULE,
                 )
                 inserted_residence = apply_pair_tag_bestowal(

--- a/tests/test_orrery/test_catalog.py
+++ b/tests/test_orrery/test_catalog.py
@@ -142,11 +142,16 @@ def test_render_predicate_name_handles_known_predicates() -> None:
         ),
         (
             "routine_anchor_due(home@actor)",
-            "actor's `home` routine is due now",
+            "actor's `home` routine is due now "
+            "(weekdays 0=Monday; empty schedule always due)",
         ),
         (
             "away_from_routine_anchor(home@actor)",
             "actor is away from `home` anchor",
+        ),
+        (
+            "routine_anchor_has_destination(home@actor)",
+            "actor's `home` routine can resolve a destination",
         ),
         (
             "has_any_pair_tag(claims,protects@actor->target)",

--- a/tests/test_orrery/test_catalog.py
+++ b/tests/test_orrery/test_catalog.py
@@ -137,6 +137,18 @@ def test_render_predicate_name_handles_known_predicates() -> None:
             "actor has inbound `hunting` pair tag",
         ),
         (
+            "has_routine_anchor(work@actor)",
+            "actor has `work` routine anchor",
+        ),
+        (
+            "routine_anchor_due(home@actor)",
+            "actor's `home` routine is due now",
+        ),
+        (
+            "away_from_routine_anchor(home@actor)",
+            "actor is away from `home` anchor",
+        ),
+        (
             "has_any_pair_tag(claims,protects@actor->target)",
             "actor has any of [`claims`, `protects`] pair tags to target",
         ),

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -44,6 +44,7 @@ class RecordingCursor:
         character_entity_ids=None,
         inbound_pair_tag_clear_count=0,
         expired_entity_tags=None,
+        routine_anchors=None,
     ):
         self.duplicate_resolution = duplicate_resolution
         self.known_tags = {"off_grid": 77} if known_tags is None else known_tags
@@ -65,6 +66,7 @@ class RecordingCursor:
         )
         self.inbound_pair_tag_clear_count = inbound_pair_tag_clear_count
         self.expired_entity_tags = list(expired_entity_tags or [])
+        self.routine_anchors = dict(routine_anchors or {})
         self.executed = []
         self.rowcount = 1
         self._fetchone = None
@@ -278,6 +280,9 @@ class RecordingCursor:
             self._fetchone = {"geodesic_distance_m": self.geodesic_distance_m}
         elif "SELECT current_location FROM characters" in normalized:
             self._fetchone = {"current_location": self.current_location}
+        elif "FROM character_routine_anchors" in normalized:
+            actor_entity_id, anchor_type = params
+            self._fetchone = self.routine_anchors.get((actor_entity_id, anchor_type))
         elif "INSERT INTO character_travel_states" in normalized:
             self.rowcount = 1
         elif "UPDATE character_travel_states" in normalized:
@@ -1124,6 +1129,114 @@ def test_commit_orrery_tick_starts_estimated_travel_without_moving_actor() -> No
     assert route_metadata["destination_place_id"] == 42
     assert route_metadata["travel_mode"] == "vehicle"
     assert route_metadata["detour_factor"] > 1
+
+
+def test_commit_orrery_tick_resolves_travel_destination_anchor() -> None:
+    """Routine commute branches can name a home/work anchor, not a place id."""
+
+    draft = OrreryResolutionDraft(
+        template_id="routine_commute",
+        priority=26,
+        binding_hash="routine-home-1",
+        bindings={"actor": 1},
+        branch_label="Commute home after the day's obligations",
+        narrative_stub="{actor} starts home.",
+        state_delta={
+            "character.current_activity": "commuting home",
+            "travel.start": {
+                "destination_anchor": "home",
+                "mode": "mixed",
+                "initial_progress": 0.05,
+            },
+        },
+        event_type="travel_departed",
+        changed_fields=("character_travel_states.status",),
+        magnitude=0.14,
+    )
+    proposal = OrreryTickProposal(
+        anchor_chunk_id=99,
+        actor_count=1,
+        resolutions=(draft,),
+        generated_at="2073-10-31T18:00:00+00:00",
+    )
+    cursor = RecordingCursor(
+        current_location=99,
+        routine_anchors={
+            (1, "home"): {
+                "place_id": 7,
+                "zone_id": None,
+                "mobility_policy": "fixed_place",
+            }
+        },
+    )
+
+    commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        proposal,
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    travel_row = _travel_insert_row(cursor)
+
+    assert travel_row["origin_place_id"] == 99
+    assert travel_row["destination_place_id"] == 7
+    assert travel_row["progress_ratio"] == pytest.approx(0.05)
+
+
+def test_commit_orrery_tick_resolves_work_from_home_anchor() -> None:
+    """Work-from-home anchors collapse work travel to the home anchor."""
+
+    draft = OrreryResolutionDraft(
+        template_id="routine_commute",
+        priority=26,
+        binding_hash="routine-work-from-home-1",
+        bindings={"actor": 1},
+        branch_label="Commute to the scheduled workplace",
+        narrative_stub="{actor} starts work.",
+        state_delta={
+            "travel.start": {
+                "destination_anchor": "work",
+                "mode": "mixed",
+                "initial_progress": 0.05,
+            },
+        },
+        event_type="travel_departed",
+        changed_fields=("character_travel_states.status",),
+        magnitude=0.16,
+    )
+    proposal = OrreryTickProposal(
+        anchor_chunk_id=99,
+        actor_count=1,
+        resolutions=(draft,),
+        generated_at="2073-10-31T18:00:00+00:00",
+    )
+    cursor = RecordingCursor(
+        current_location=99,
+        routine_anchors={
+            (1, "work"): {
+                "place_id": None,
+                "zone_id": None,
+                "mobility_policy": "works_from_home",
+            },
+            (1, "home"): {
+                "place_id": 7,
+                "zone_id": None,
+                "mobility_policy": "fixed_place",
+            },
+        },
+    )
+
+    commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        proposal,
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    assert _travel_insert_row(cursor)["destination_place_id"] == 7
 
 
 def test_commit_orrery_tick_prefers_osm_graph_route() -> None:

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -328,6 +328,20 @@ class RecordingConn:
         return self.cursor_obj
 
 
+class AsyncRoutineConn:
+    """Small asyncpg stand-in for routine destination helper tests."""
+
+    def __init__(self, *, routine_anchors=None, zone_destination=None):
+        self.routine_anchors = dict(routine_anchors or {})
+        self.zone_destination = zone_destination
+
+    async def fetchrow(self, _sql, actor_entity_id, anchor_type):
+        return self.routine_anchors.get((actor_entity_id, anchor_type))
+
+    async def fetchval(self, _sql, _preferred_tags, _zone_id):
+        return self.zone_destination
+
+
 class MinimalStoryResponse:
     """Tiny response object for lore_adapter serialization tests."""
 
@@ -1237,6 +1251,104 @@ def test_commit_orrery_tick_resolves_work_from_home_anchor() -> None:
     )
 
     assert _travel_insert_row(cursor)["destination_place_id"] == 7
+
+
+def test_sync_malformed_home_work_from_home_anchor_fails_closed() -> None:
+    """Sync helper avoids recursive home->home work-from-home loops."""
+
+    cursor = RecordingCursor(
+        routine_anchors={
+            (1, "home"): {
+                "place_id": None,
+                "zone_id": None,
+                "mobility_policy": "works_from_home",
+            },
+        }
+    )
+
+    assert (
+        orrery_events._routine_anchor_destination_sync(
+            cursor,
+            actor_entity_id=1,
+            anchor_type="home",
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_routine_anchor_destination_resolves_work_from_home() -> None:
+    """Async travel start helper matches sync work-from-home resolution."""
+
+    conn = AsyncRoutineConn(
+        routine_anchors={
+            (1, "work"): {
+                "place_id": None,
+                "zone_id": None,
+                "mobility_policy": "works_from_home",
+            },
+            (1, "home"): {
+                "place_id": 7,
+                "zone_id": None,
+                "mobility_policy": "fixed_place",
+            },
+        }
+    )
+
+    destination = await orrery_events._routine_anchor_destination_async(
+        conn,
+        actor_entity_id=1,
+        anchor_type="work",
+    )
+
+    assert destination == 7
+
+
+@pytest.mark.asyncio
+async def test_async_routine_anchor_destination_resolves_zone() -> None:
+    """Async zone-resolved anchors use the preferred-place query result."""
+
+    conn = AsyncRoutineConn(
+        routine_anchors={
+            (1, "home"): {
+                "place_id": None,
+                "zone_id": 5,
+                "mobility_policy": "zone_resolved",
+            },
+        },
+        zone_destination=42,
+    )
+
+    destination = await orrery_events._routine_anchor_destination_async(
+        conn,
+        actor_entity_id=1,
+        anchor_type="home",
+    )
+
+    assert destination == 42
+
+
+@pytest.mark.asyncio
+async def test_async_malformed_home_work_from_home_anchor_fails_closed() -> None:
+    """Async helper avoids recursive home->home work-from-home loops."""
+
+    conn = AsyncRoutineConn(
+        routine_anchors={
+            (1, "home"): {
+                "place_id": None,
+                "zone_id": None,
+                "mobility_policy": "works_from_home",
+            },
+        }
+    )
+
+    destination = await orrery_events._routine_anchor_destination_async(
+        conn,
+        actor_entity_id=1,
+        anchor_type="home",
+    )
+
+    assert destination is None
 
 
 def test_commit_orrery_tick_prefers_osm_graph_route() -> None:

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -157,6 +157,22 @@ def test_slot2_semantic_vocab_documents_new_faction_categories() -> None:
     } <= documented
 
 
+def test_routine_anchor_migration_creates_explicit_schedule_surface() -> None:
+    """Routine anchors model home/work facts instead of inferring from places."""
+
+    migration_source = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "056_orrery_routine_anchors.py"
+    ).read_text()
+
+    assert "character_routine_anchors" in migration_source
+    assert "orrery_routine_anchor_type" in migration_source
+    assert "orrery_routine_mobility_policy" in migration_source
+    assert '"works_from_home"' in migration_source
+    assert "UNIQUE (character_entity_id, anchor_type)" in migration_source
+
+
 def test_interpersonal_need_migration_extends_need_vocab() -> None:
     """Migration 032 seeds the interpersonal need vocabulary."""
 

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -65,6 +65,7 @@ class FakeSession:
         entity_name_rows=None,
         need_debt_rows=None,
         travel_state_rows=None,
+        routine_anchor_rows=None,
         world_time=None,
         weather="",
         max_chunk_id=100,
@@ -94,6 +95,7 @@ class FakeSession:
         ]
         self.need_debt_rows = need_debt_rows or []
         self.travel_state_rows = travel_state_rows or []
+        self.routine_anchor_rows = routine_anchor_rows or []
         self.world_time = world_time or datetime(2073, 10, 31, 12, tzinfo=timezone.utc)
         self.weather = weather
         self.max_chunk_id = max_chunk_id
@@ -146,6 +148,15 @@ class FakeSession:
             assert "NOT pt.deprecated" in sql
             assert "subject_entity.is_active = true" in sql
             return FakeResult(self.inbound_ephemeral_pair_actor_rows)
+        if "/* orrery:actor_bindings_routine_anchors */" in sql:
+            return FakeResult(
+                [
+                    {"entity_id": row["character_entity_id"]}
+                    for row in self.routine_anchor_rows
+                    if row.get("mobility_policy", "fixed_place")
+                    not in {"none", "nomadic"}
+                ]
+            )
         if "/* orrery:present_actor_ids_at_anchor */" in sql:
             return FakeResult(self.present_actor_rows)
         if "/* orrery:actor_target_bindings_character_relationships */" in sql:
@@ -161,6 +172,10 @@ class FakeSession:
             assert "JOIN entities e" in sql
             assert "e.is_active = true" in sql
             return FakeResult(self.travel_state_rows)
+        if "/* orrery:routine_anchors */" in sql:
+            assert "JOIN entities e" in sql
+            assert "e.is_active = true" in sql
+            return FakeResult(self.routine_anchor_rows)
         if "/* orrery:anchor_world_time */" in sql:
             self.world_time_queries += 1
             return FakeResult([{"world_time": self.world_time}])
@@ -1160,6 +1175,146 @@ def test_resolve_dry_run_fires_work_for_obligation_without_craft_tags() -> None:
     assert proposal.resolution_count == 1
     assert proposal.resolutions[0].template_id == "work"
     assert proposal.resolutions[0].branch_label == "Keep the obligation from slipping"
+
+
+def test_work_does_not_fire_from_workplace_place_class_alone() -> None:
+    """A workplace-like place is not proof that every actor has a job."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            location_class_rows=[
+                {
+                    "id": 10,
+                    "place_entity_id": 1000,
+                    "zone_id": 5,
+                    "location_class": "commerce",
+                    "is_primary": False,
+                },
+                {
+                    "id": 10,
+                    "place_entity_id": 1000,
+                    "zone_id": 5,
+                    "location_class": "fixed_location",
+                    "is_primary": True,
+                },
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 0
+
+
+def test_routine_work_anchor_allows_scheduled_work_at_workplace() -> None:
+    """Explicit work anchors make boring citizen work routine eligible."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[],
+            location_class_rows=[
+                {
+                    "id": 10,
+                    "place_entity_id": 1000,
+                    "zone_id": 5,
+                    "location_class": "commerce",
+                    "is_primary": False,
+                },
+                {
+                    "id": 10,
+                    "place_entity_id": 1000,
+                    "zone_id": 5,
+                    "location_class": "fixed_location",
+                    "is_primary": True,
+                },
+            ],
+            routine_anchor_rows=[
+                {
+                    "character_entity_id": 1,
+                    "anchor_type": "work",
+                    "place_id": 10,
+                    "zone_id": None,
+                    "mobility_policy": "fixed_place",
+                    "schedule": {
+                        "weekdays": [0, 1, 2, 3, 4],
+                        "start": "09:00",
+                        "end": "17:00",
+                    },
+                }
+            ],
+            world_time=datetime(2073, 10, 30, 10, 30, tzinfo=timezone.utc),
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.actor_count == 1
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "work"
+    assert proposal.resolutions[0].branch_label == "Work a public-facing shift"
+
+
+def test_routine_commute_sends_actor_home_after_work_window() -> None:
+    """Due home anchors start travel instead of leaving actors at work forever."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[],
+            location_rows=[{"entity_id": 1, "current_location": 10}],
+            location_class_rows=[
+                {
+                    "id": 10,
+                    "place_entity_id": 1000,
+                    "zone_id": 5,
+                    "location_class": "commerce",
+                    "is_primary": False,
+                },
+                {
+                    "id": 20,
+                    "place_entity_id": 2000,
+                    "zone_id": 5,
+                    "location_class": "dwelling",
+                    "is_primary": False,
+                },
+            ],
+            routine_anchor_rows=[
+                {
+                    "character_entity_id": 1,
+                    "anchor_type": "work",
+                    "place_id": 10,
+                    "zone_id": None,
+                    "mobility_policy": "fixed_place",
+                    "schedule": {"start": "09:00", "end": "17:00"},
+                },
+                {
+                    "character_entity_id": 1,
+                    "anchor_type": "home",
+                    "place_id": 20,
+                    "zone_id": None,
+                    "mobility_policy": "fixed_place",
+                    "schedule": {"start": "17:00", "end": "08:30"},
+                },
+            ],
+            world_time=datetime(2073, 10, 30, 17, 30, tzinfo=timezone.utc),
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.actor_count == 1
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "routine_commute"
+    assert (
+        proposal.resolutions[0].branch_label
+        == "Commute home after the day's obligations"
+    )
+    assert (
+        proposal.resolutions[0].state_delta["travel.start"]["destination_anchor"]
+        == "home"
+    )
 
 
 def test_work_template_uses_one_global_work_cooldown() -> None:

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -240,6 +240,10 @@ def test_resolve_dry_run_excludes_anchor_present_characters() -> None:
                 {"entity_id": 3, "current_location": 10},
                 {"entity_id": 4, "current_location": 10},
             ],
+            location_class_rows=[
+                {"id": 10, "location_class": "fixed_location", "is_primary": True},
+                {"id": 10, "location_class": "place_open", "is_primary": False},
+            ],
             activity_rows=[
                 {"entity_id": 1, "current_activity": "in scene"},
                 {"entity_id": 2, "current_activity": "mentioned elsewhere"},
@@ -356,7 +360,8 @@ def test_maintain_cover_requires_positive_cover_context() -> None:
         FakeSession(
             tag_rows=[{"entity_id": 1, "tag": "cover_identity", "is_ephemeral": False}],
             location_class_rows=[
-                {"id": 10, "location_class": "fixed_location", "is_primary": True}
+                {"id": 10, "location_class": "fixed_location", "is_primary": True},
+                {"id": 10, "location_class": "place_open", "is_primary": False},
             ],
         ),
         BUILTIN_TEMPLATES,
@@ -366,7 +371,7 @@ def test_maintain_cover_requires_positive_cover_context() -> None:
 
     assert proposal.resolution_count == 1
     assert proposal.resolutions[0].template_id == "maintain_cover"
-    assert proposal.resolutions[0].branch_label == "Maintain a specific cover identity"
+    assert proposal.resolutions[0].branch_label == "Run a low-level courier job"
 
 
 def test_maintain_cover_skips_constrained_actor() -> None:
@@ -1315,6 +1320,36 @@ def test_routine_commute_sends_actor_home_after_work_window() -> None:
         proposal.resolutions[0].state_delta["travel.start"]["destination_anchor"]
         == "home"
     )
+
+
+def test_routine_commute_fallback_handles_incomplete_anchor() -> None:
+    """The terminal fallback is reachable for malformed in-memory anchors."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            chunk_ref_actor_rows=[],
+            location_rows=[{"entity_id": 1, "current_location": 10}],
+            routine_anchor_rows=[
+                {
+                    "character_entity_id": 1,
+                    "anchor_type": "home",
+                    "place_id": None,
+                    "zone_id": None,
+                    "mobility_policy": "fixed_place",
+                    "schedule": {"start": "17:00", "end": "08:30"},
+                },
+            ],
+            world_time=datetime(2073, 10, 30, 17, 30, tzinfo=timezone.utc),
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.actor_count == 1
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "routine_commute"
+    assert proposal.resolutions[0].branch_label == "Recheck routine before moving"
 
 
 def test_work_template_uses_one_global_work_cooldown() -> None:

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -47,6 +47,7 @@ from nexus.agents.orrery.substrate import (
     relationship_is_asymmetric,
     relationship_is_mutual_warm,
     routine_anchor_due,
+    routine_anchor_has_destination,
     since_last_event_at_least,
     validate_always_fallbacks,
 )
@@ -387,6 +388,42 @@ def test_work_from_home_anchor_resolves_against_home_anchor() -> None:
     )
 
     assert at_routine_anchor("work")(state, {Slot.ACTOR: 1})
+    assert routine_anchor_has_destination("work")(state, {Slot.ACTOR: 1})
+
+
+def test_malformed_home_work_from_home_anchor_does_not_recurse() -> None:
+    """In-memory fixtures fail closed if home is accidentally work-from-home."""
+
+    state = WorldState(
+        locations={1: 10},
+        routine_anchors={
+            (1, "home"): RoutineAnchor(
+                anchor_type="home",
+                mobility_policy="works_from_home",
+            ),
+        },
+    )
+
+    assert not at_routine_anchor("home")(state, {Slot.ACTOR: 1})
+    assert not routine_anchor_has_destination("home")(state, {Slot.ACTOR: 1})
+
+
+def test_routine_schedule_reports_non_numeric_times_cleanly() -> None:
+    """Malformed schedule times raise the same actionable HH:MM error."""
+
+    state = WorldState(
+        routine_anchors={
+            (1, "home"): RoutineAnchor(
+                anchor_type="home",
+                place_id=10,
+                schedule={"start": "HH:MM", "end": "08:30"},
+            ),
+        },
+        world_time=datetime(2073, 10, 31, 0, 15, tzinfo=timezone.utc),
+    )
+
+    with pytest.raises(ValueError, match="must be HH:MM"):
+        routine_anchor_due("home")(state, {Slot.ACTOR: 1})
 
 
 def test_context_and_constraint_predicates_read_current_tags() -> None:

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -1,5 +1,6 @@
 """Tests for the Orrery pure-Python behavior substrate."""
 
+from datetime import datetime, timezone
 import re
 from typing import Any
 
@@ -11,11 +12,14 @@ from nexus.agents.orrery.substrate import (
     Branch,
     CompoundCondition,
     PresentTargetPolicy,
+    RoutineAnchor,
     Slot,
     Template,
     TravelState,
     WorldState,
+    at_routine_anchor,
     binding_hash,
+    away_from_routine_anchor,
     can_move_publicly,
     co_located,
     count_co_located,
@@ -31,6 +35,7 @@ from nexus.agents.orrery.substrate import (
     has_need_debt_at_or_above,
     has_pair_tag,
     has_pair_tag_to_current_location,
+    has_routine_anchor,
     has_severity_tag_at_or_above,
     has_symmetric_relationship_of_type,
     in_location,
@@ -41,6 +46,7 @@ from nexus.agents.orrery.substrate import (
     recent_event,
     relationship_is_asymmetric,
     relationship_is_mutual_warm,
+    routine_anchor_due,
     since_last_event_at_least,
     validate_always_fallbacks,
 )
@@ -322,6 +328,67 @@ def test_pair_tag_to_current_location_uses_place_entity_id() -> None:
     )
 
 
+def test_routine_anchor_predicates_use_schedule_and_place() -> None:
+    """Routine anchors are explicit actor facts with clock windows."""
+
+    state = WorldState(
+        locations={1: 10},
+        routine_anchors={
+            (1, "work"): RoutineAnchor(
+                anchor_type="work",
+                place_id=10,
+                schedule={
+                    "weekdays": [0, 1, 2, 3, 4],
+                    "start": "09:00",
+                    "end": "17:00",
+                },
+            )
+        },
+        world_time=datetime(2073, 10, 30, 10, 30, tzinfo=timezone.utc),
+    )
+
+    assert has_routine_anchor("work")(state, {Slot.ACTOR: 1})
+    assert routine_anchor_due("work")(state, {Slot.ACTOR: 1})
+    assert at_routine_anchor("work")(state, {Slot.ACTOR: 1})
+    assert not away_from_routine_anchor("work")(state, {Slot.ACTOR: 1})
+
+
+def test_routine_anchor_predicates_support_overnight_home_windows() -> None:
+    """Home schedules can cross midnight without special-case templates."""
+
+    state = WorldState(
+        locations={1: 10},
+        routine_anchors={
+            (1, "home"): RoutineAnchor(
+                anchor_type="home",
+                place_id=10,
+                schedule={"start": "17:00", "end": "08:30"},
+            )
+        },
+        world_time=datetime(2073, 10, 31, 0, 15, tzinfo=timezone.utc),
+    )
+
+    assert routine_anchor_due("home")(state, {Slot.ACTOR: 1})
+    assert at_routine_anchor("home")(state, {Slot.ACTOR: 1})
+
+
+def test_work_from_home_anchor_resolves_against_home_anchor() -> None:
+    """A work anchor can intentionally collapse onto the home place."""
+
+    state = WorldState(
+        locations={1: 10},
+        routine_anchors={
+            (1, "home"): RoutineAnchor(anchor_type="home", place_id=10),
+            (1, "work"): RoutineAnchor(
+                anchor_type="work",
+                mobility_policy="works_from_home",
+            ),
+        },
+    )
+
+    assert at_routine_anchor("work")(state, {Slot.ACTOR: 1})
+
+
 def test_context_and_constraint_predicates_read_current_tags() -> None:
     """Package guards can distinguish hydrated actors from constrained ones."""
 
@@ -481,6 +548,29 @@ def test_targeted_events_fire_builtin_package_gates() -> None:
 
     assert result is not None
     assert result.template_id == "evade_pursuers"
+
+
+def test_mealtime_at_home_beats_routine_thirst() -> None:
+    """Moderate thirst yields to dinner when a home meal is otherwise due."""
+
+    state = WorldState(
+        locations={1: 10},
+        location_classes={10: frozenset({"dwelling"})},
+        location_entity_ids={10: 100},
+        pair_tags={(1, 100): frozenset({"resides_at"})},
+        need_debt_scores={
+            (1, "hunger"): 8.0,
+            (1, "thirst"): 8.0,
+        },
+        time_of_day="evening",
+        current_tick=100,
+    )
+
+    result = evaluate_stack(BUILTIN_TEMPLATES, state, {Slot.ACTOR: 1})
+
+    assert result is not None
+    assert result.template_id == "eat"
+    assert result.branch_label == "Eat at home alone"
 
 
 def test_count_co_located_condition_filters_by_tag() -> None:


### PR DESCRIPTION
## Summary

- add explicit `character_routine_anchors` home/work schedule substrate with fixed-place, zone-resolved, work-from-home, nomadic, and none policies
- hydrate routine anchors into Orrery state, add schedule/anchor predicates, and add `routine_commute` so ordinary actors move between home/work anchors by world time
- stop `WORK` from firing just because a character is standing in a workplace-like place; place classes now choose branches after an actor-side work surface exists
- teach `travel.start` to resolve `destination_anchor` at commit time, extend the dry-run sampler with `--world-time` and `--override-location`, and seed Slot 2 Cam/Celia routine fixtures
- update generated package docs plus design/vocabulary/needs notes for the new structured routine surface

## Validation

- `poetry run flake8 nexus/agents/orrery/substrate.py nexus/agents/orrery/resolver.py nexus/agents/orrery/templates.py nexus/agents/orrery/events.py nexus/agents/orrery/catalog.py nexus/agents/orrery/demo.py scripts/orrery_sample.py scripts/seed_slot2_routine_anchors.py tests/test_orrery/test_resolver.py tests/test_orrery/test_substrate.py tests/test_orrery/test_migrate.py tests/test_orrery/test_events.py tests/test_orrery/test_catalog.py migrations/056_orrery_routine_anchors.py`
- `poetry run pytest tests/test_orrery/test_substrate.py tests/test_orrery/test_resolver.py tests/test_orrery/test_events.py tests/test_orrery/test_catalog.py tests/test_orrery/test_migrate.py -q` (193 passed, 7 skipped)
- `poetry run pytest -q` (559 passed, 77 skipped)
- `poetry run python scripts/migrate.py --slot 2 --dry-run`
- `poetry run python scripts/migrate.py --slot 2`
- `poetry run python scripts/seed_slot2_routine_anchors.py --slot 2`

## Slot 2 live dry-run evidence

Dry-run reports were generated under `/tmp/nexus_orrery_routine_dry_runs` without Skald API calls.

- `2073-10-31T10:30:00-04:00`: Cam and Celia fire `work` / `Work a public-facing shift` at their seeded workplaces.
- `2073-10-31T17:00:00-04:00`: Cam and Celia fire `routine_commute` / `Commute home after the day's obligations` with `travel.start.destination_anchor = home`.
- `2073-10-31T18:30:00-04:00` with dry-run home location overrides: Cam and Celia fire `eat` / `Eat at home alone`.
- `2073-11-01T00:00:00-04:00` with dry-run home location overrides: Cam and Celia fire `sleep` / `Sleep at home`.

## Schema / data notes

Migration 056 is additive: it creates `orrery_routine_anchor_type`, `orrery_routine_mobility_policy`, and `character_routine_anchors`. No existing columns or rows are removed.

The included Slot 2 seed script is idempotent reference/test data only. I applied it locally to `save_02` for Cam and Celia; it records routine anchors plus `resides_at` pair-tags, and does not move either character.
