### PR TITLE
[codex] Honor bodyform need applicability

### DIFF
--- a/docs/orrery_needs.md
+++ b/docs/orrery_needs.md
@@ -253,6 +253,8 @@ Single namespace, applied at character-creation time and never removed by the si
 
 Setting-specific supernaturals (fae, golems, intelligent undead variants, AI uplifts) get their bodyform tags seeded in setting-specific migrations. The bodyform tags remain durable identity facts; they should not be consulted repeatedly by every basic-needs branch — the maintenance pass simply doesn't create rows for immune needs.
 
+**Implementation status.** Migration 057 installs `orrery_sync_character_need_states()`, rewires the character initializer through that helper, and adds an `entity_tags` trigger so bodyform/modulator changes prune or restore need rows. The resolver also filters stale inapplicable rows at hydration time, so pre-migration or queued data cannot make `inorganic` / `virtual` characters fire ordinary SLEEP / EAT / DRINK packages. `virtual` also suppresses INTIMACY row hydration; SOCIALIZE remains available because disembodied minds can still need company.
+
 ---
 
 ## DF Heritage and Where NEXUS Diverges

--- a/migrations/057_orrery_need_bodyform_applicability.py
+++ b/migrations/057_orrery_need_bodyform_applicability.py
@@ -6,6 +6,26 @@ from psycopg2.extensions import connection
 
 
 NEED_TYPES: tuple[str, ...] = ("sleep", "hunger", "thirst", "socialize", "intimacy")
+EMBODIED_NEED_IMMUNITY_TAGS: tuple[str, ...] = (
+    "bodyform:android",
+    "bodyform:construct",
+    "bodyform:non_corporeal",
+    "digital_mind",
+    "inorganic",
+    "virtual",
+)
+NEED_IMMUNITY_TAGS: dict[str, tuple[str, ...]] = {
+    "sleep": EMBODIED_NEED_IMMUNITY_TAGS,
+    "hunger": EMBODIED_NEED_IMMUNITY_TAGS,
+    "thirst": EMBODIED_NEED_IMMUNITY_TAGS,
+    "socialize": (),
+    "intimacy": (
+        "bodyform:non_corporeal",
+        "digital_mind",
+        "libido_absent",
+        "virtual",
+    ),
+}
 
 
 def run(conn: connection) -> None:
@@ -20,8 +40,10 @@ def run(conn: connection) -> None:
 
 
 def _install_applicability_functions(cur) -> None:
+    embodied_immunity = _sql_text_array(EMBODIED_NEED_IMMUNITY_TAGS)
+    intimacy_immunity = _sql_text_array(NEED_IMMUNITY_TAGS["intimacy"])
     cur.execute(
-        """
+        f"""
         CREATE OR REPLACE FUNCTION orrery_need_applies_to_tags(
             p_need_type character_need_type,
             p_active_tags text[]
@@ -31,24 +53,12 @@ def _install_applicability_functions(cur) -> None:
             active_tags text[] := COALESCE(p_active_tags, ARRAY[]::text[]);
         BEGIN
             IF p_need_type::text IN ('sleep', 'hunger', 'thirst')
-               AND active_tags && ARRAY[
-                   'bodyform:android',
-                   'bodyform:construct',
-                   'bodyform:non_corporeal',
-                   'digital_mind',
-                   'inorganic',
-                   'virtual'
-               ]::text[] THEN
+               AND active_tags && {embodied_immunity} THEN
                 RETURN FALSE;
             END IF;
 
             IF p_need_type::text = 'intimacy'
-               AND active_tags && ARRAY[
-                   'bodyform:non_corporeal',
-                   'digital_mind',
-                   'libido_absent',
-                   'virtual'
-               ]::text[] THEN
+               AND active_tags && {intimacy_immunity} THEN
                 RETURN FALSE;
             END IF;
 
@@ -109,7 +119,7 @@ def _install_applicability_functions(cur) -> None:
                    needs.need_type::character_need_type,
                    0,
                    anchor_world_time,
-                   '{"synced_by": "need_applicability"}'::jsonb
+                   '{{"synced_by": "need_applicability"}}'::jsonb
             FROM (
                 VALUES
                     ('sleep'),
@@ -194,6 +204,10 @@ def _install_entity_tag_sync_trigger(cur) -> None:
         DECLARE
             affected_entity_id bigint;
         BEGIN
+            IF pg_trigger_depth() > 1 THEN
+                RETURN COALESCE(NEW, OLD);
+            END IF;
+
             affected_entity_id := COALESCE(NEW.entity_id, OLD.entity_id);
             PERFORM orrery_sync_character_need_states(affected_entity_id);
             RETURN COALESCE(NEW, OLD);
@@ -214,9 +228,14 @@ def _install_entity_tag_sync_trigger(cur) -> None:
 def _sync_existing_characters(cur) -> None:
     cur.execute(
         """
-        SELECT orrery_sync_character_need_states(e.id)
+        SELECT count(orrery_sync_character_need_states(e.id))
         FROM entities e
         WHERE e.kind = 'character'
           AND e.is_active = true
         """
     )
+
+
+def _sql_text_array(tags: tuple[str, ...]) -> str:
+    values = ", ".join(f"'{tag}'" for tag in tags)
+    return f"ARRAY[{values}]::text[]"

--- a/migrations/057_orrery_need_bodyform_applicability.py
+++ b/migrations/057_orrery_need_bodyform_applicability.py
@@ -1,0 +1,222 @@
+"""Sync Orrery need rows with bodyform-driven applicability."""
+
+from __future__ import annotations
+
+from psycopg2.extensions import connection
+
+
+NEED_TYPES: tuple[str, ...] = ("sleep", "hunger", "thirst", "socialize", "intimacy")
+
+
+def run(conn: connection) -> None:
+    """Install need-applicability sync helpers and prune stale rows."""
+
+    with conn.cursor() as cur:
+        _install_applicability_functions(cur)
+        _replace_character_initializer(cur)
+        _install_entity_tag_sync_trigger(cur)
+        _sync_existing_characters(cur)
+    conn.commit()
+
+
+def _install_applicability_functions(cur) -> None:
+    cur.execute(
+        """
+        CREATE OR REPLACE FUNCTION orrery_need_applies_to_tags(
+            p_need_type character_need_type,
+            p_active_tags text[]
+        )
+        RETURNS boolean AS $$
+        DECLARE
+            active_tags text[] := COALESCE(p_active_tags, ARRAY[]::text[]);
+        BEGIN
+            IF p_need_type::text IN ('sleep', 'hunger', 'thirst')
+               AND active_tags && ARRAY[
+                   'bodyform:android',
+                   'bodyform:construct',
+                   'bodyform:non_corporeal',
+                   'digital_mind',
+                   'inorganic',
+                   'virtual'
+               ]::text[] THEN
+                RETURN FALSE;
+            END IF;
+
+            IF p_need_type::text = 'intimacy'
+               AND active_tags && ARRAY[
+                   'bodyform:non_corporeal',
+                   'digital_mind',
+                   'libido_absent',
+                   'virtual'
+               ]::text[] THEN
+                RETURN FALSE;
+            END IF;
+
+            RETURN TRUE;
+        END;
+        $$ LANGUAGE plpgsql IMMUTABLE;
+
+        CREATE OR REPLACE FUNCTION orrery_active_character_tag_names(
+            p_character_entity_id bigint
+        )
+        RETURNS text[] AS $$
+            SELECT COALESCE(array_agg(DISTINCT t.tag), ARRAY[]::text[])
+            FROM entity_tags et
+            JOIN tags t ON t.id = et.tag_id
+            WHERE et.entity_id = p_character_entity_id
+              AND et.cleared_at IS NULL;
+        $$ LANGUAGE sql STABLE;
+
+        CREATE OR REPLACE FUNCTION orrery_sync_character_need_states(
+            p_character_entity_id bigint
+        )
+        RETURNS integer AS $$
+        DECLARE
+            active_tags text[];
+            anchor_world_time timestamptz;
+            affected integer := 0;
+            row_count integer := 0;
+        BEGIN
+            IF p_character_entity_id IS NULL THEN
+                RETURN 0;
+            END IF;
+
+            IF NOT EXISTS (
+                SELECT 1
+                FROM entities e
+                WHERE e.id = p_character_entity_id
+                  AND e.kind = 'character'
+                  AND e.is_active = true
+            ) THEN
+                RETURN 0;
+            END IF;
+
+            SELECT orrery_active_character_tag_names(p_character_entity_id)
+            INTO active_tags;
+
+            SELECT COALESCE(MAX(world_time), now())
+            INTO anchor_world_time
+            FROM chunk_metadata;
+
+            INSERT INTO character_need_states (
+                character_entity_id,
+                need_type,
+                debt_score,
+                last_evaluated_at,
+                metadata
+            )
+            SELECT p_character_entity_id,
+                   needs.need_type::character_need_type,
+                   0,
+                   anchor_world_time,
+                   '{"synced_by": "need_applicability"}'::jsonb
+            FROM (
+                VALUES
+                    ('sleep'),
+                    ('hunger'),
+                    ('thirst'),
+                    ('socialize'),
+                    ('intimacy')
+            ) AS needs(need_type)
+            WHERE orrery_need_applies_to_tags(
+                needs.need_type::character_need_type,
+                active_tags
+            )
+            ON CONFLICT (character_entity_id, need_type) DO NOTHING;
+            GET DIAGNOSTICS row_count = ROW_COUNT;
+            affected := affected + row_count;
+
+            DELETE FROM character_need_states cns
+            WHERE cns.character_entity_id = p_character_entity_id
+              AND NOT orrery_need_applies_to_tags(cns.need_type, active_tags);
+            GET DIAGNOSTICS row_count = ROW_COUNT;
+            affected := affected + row_count;
+
+            UPDATE entity_tags et
+            SET cleared_at = now()
+            FROM tags t,
+                 (
+                    VALUES
+                        ('sleep', 'sleep_deprived'),
+                        ('hunger', 'hungry'),
+                        ('thirst', 'thirsty'),
+                        ('socialize', 'under_socialized'),
+                        ('intimacy', 'intimacy_starved')
+                 ) AS severity(need_type, prefix)
+            WHERE et.entity_id = p_character_entity_id
+              AND et.tag_id = t.id
+              AND et.cleared_at IS NULL
+              AND t.tag LIKE severity.prefix || '\\_%'
+              AND NOT orrery_need_applies_to_tags(
+                  severity.need_type::character_need_type,
+                  active_tags
+              );
+            GET DIAGNOSTICS row_count = ROW_COUNT;
+            affected := affected + row_count;
+
+            RETURN affected;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+
+def _replace_character_initializer(cur) -> None:
+    cur.execute(
+        """
+        CREATE OR REPLACE FUNCTION orrery_initialize_character_need_states()
+        RETURNS trigger AS $$
+        BEGIN
+            IF NEW.entity_id IS NOT NULL THEN
+                PERFORM orrery_sync_character_need_states(NEW.entity_id);
+            END IF;
+
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+
+        DROP TRIGGER IF EXISTS trg_characters_need_state_init ON characters;
+
+        CREATE TRIGGER trg_characters_need_state_init
+        AFTER INSERT OR UPDATE OF entity_id ON characters
+        FOR EACH ROW
+        WHEN (NEW.entity_id IS NOT NULL)
+        EXECUTE FUNCTION orrery_initialize_character_need_states();
+        """
+    )
+
+
+def _install_entity_tag_sync_trigger(cur) -> None:
+    cur.execute(
+        """
+        CREATE OR REPLACE FUNCTION orrery_sync_need_states_after_entity_tag_change()
+        RETURNS trigger AS $$
+        DECLARE
+            affected_entity_id bigint;
+        BEGIN
+            affected_entity_id := COALESCE(NEW.entity_id, OLD.entity_id);
+            PERFORM orrery_sync_character_need_states(affected_entity_id);
+            RETURN COALESCE(NEW, OLD);
+        END;
+        $$ LANGUAGE plpgsql;
+
+        DROP TRIGGER IF EXISTS trg_entity_tags_need_state_applicability
+            ON entity_tags;
+
+        CREATE TRIGGER trg_entity_tags_need_state_applicability
+        AFTER INSERT OR UPDATE OR DELETE ON entity_tags
+        FOR EACH ROW
+        EXECUTE FUNCTION orrery_sync_need_states_after_entity_tag_change();
+        """
+    )
+
+
+def _sync_existing_characters(cur) -> None:
+    cur.execute(
+        """
+        SELECT orrery_sync_character_need_states(e.id)
+        FROM entities e
+        WHERE e.kind = 'character'
+          AND e.is_active = true
+        """
+    )

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -15,9 +15,10 @@ from typing import Any, Mapping, Optional
 from nexus.agents.orrery.needs import (
     NeedTuning,
     coerce_need_tuning,
+    need_applies_to_tags,
+    normalize_need_type,
     severity_tag_for_debt,
     severity_tags_for_need,
-    normalize_need_type,
 )
 from nexus.agents.orrery.resolver import (
     OrreryResolutionDraft,
@@ -1833,6 +1834,15 @@ def _load_or_create_need_debt_sync(
     world_time: Any,
     need_tuning: NeedTuning,
 ) -> float:
+    if not _need_applies_to_entity_sync(
+        cur,
+        actor_entity_id=actor_entity_id,
+        need_type=need_type,
+    ):
+        raise ValueError(
+            f"Orrery need {need_type!r} does not apply to actor {actor_entity_id}"
+        )
+
     cur.execute(
         """
         INSERT INTO character_need_states (
@@ -1874,6 +1884,15 @@ async def _load_or_create_need_debt_async(
     world_time: Any,
     need_tuning: NeedTuning,
 ) -> float:
+    if not await _need_applies_to_entity_async(
+        conn,
+        actor_entity_id=actor_entity_id,
+        need_type=need_type,
+    ):
+        raise ValueError(
+            f"Orrery need {need_type!r} does not apply to actor {actor_entity_id}"
+        )
+
     await conn.execute(
         """
         INSERT INTO character_need_states (
@@ -1907,6 +1926,50 @@ async def _load_or_create_need_debt_async(
     if elapsed <= 0:
         return max(0.0, debt_score)
     return max(0.0, debt_score + elapsed * need_tuning.accrual_rates[need_type])
+
+
+def _need_applies_to_entity_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    need_type: str,
+) -> bool:
+    cur.execute(
+        """
+        SELECT t.tag
+        FROM entity_tags et
+        JOIN tags t ON t.id = et.tag_id
+        WHERE et.entity_id = %s
+          AND et.cleared_at IS NULL
+        """,
+        (actor_entity_id,),
+    )
+    return need_applies_to_tags(
+        need_type,
+        (str(_row_get(row, "tag", 0)) for row in cur.fetchall()),
+    )
+
+
+async def _need_applies_to_entity_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    need_type: str,
+) -> bool:
+    rows = await conn.fetch(
+        """
+        SELECT t.tag
+        FROM entity_tags et
+        JOIN tags t ON t.id = et.tag_id
+        WHERE et.entity_id = $1
+          AND et.cleared_at IS NULL
+        """,
+        actor_entity_id,
+    )
+    return need_applies_to_tags(
+        need_type,
+        (str(_row_get(row, "tag", 0)) for row in rows),
+    )
 
 
 def _sync_need_severity_tags_sync(

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -1936,11 +1936,9 @@ def _need_applies_to_entity_sync(
 ) -> bool:
     cur.execute(
         """
-        SELECT t.tag
-        FROM entity_tags et
-        JOIN tags t ON t.id = et.tag_id
-        WHERE et.entity_id = %s
-          AND et.cleared_at IS NULL
+        SELECT etc.tag
+        FROM entity_tags_current etc
+        WHERE etc.entity_id = %s
         """,
         (actor_entity_id,),
     )
@@ -1958,11 +1956,9 @@ async def _need_applies_to_entity_async(
 ) -> bool:
     rows = await conn.fetch(
         """
-        SELECT t.tag
-        FROM entity_tags et
-        JOIN tags t ON t.id = et.tag_id
-        WHERE et.entity_id = $1
-          AND et.cleared_at IS NULL
+        SELECT etc.tag
+        FROM entity_tags_current etc
+        WHERE etc.entity_id = $1
         """,
         actor_entity_id,
     )

--- a/nexus/agents/orrery/needs.py
+++ b/nexus/agents/orrery/needs.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from functools import lru_cache
-from typing import Any, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 
 class NeedType(str, Enum):
@@ -26,6 +26,47 @@ NEED_SEVERITY_PREFIX: Mapping[str, str] = {
     NeedType.THIRST.value: "thirsty",
     NeedType.SOCIALIZE.value: "under_socialized",
     NeedType.INTIMACY.value: "intimacy_starved",
+}
+NEED_IMMUNITY_TAGS: Mapping[str, frozenset[str]] = {
+    NeedType.SLEEP.value: frozenset(
+        {
+            "bodyform:android",
+            "bodyform:construct",
+            "bodyform:non_corporeal",
+            "digital_mind",
+            "inorganic",
+            "virtual",
+        }
+    ),
+    NeedType.HUNGER.value: frozenset(
+        {
+            "bodyform:android",
+            "bodyform:construct",
+            "bodyform:non_corporeal",
+            "digital_mind",
+            "inorganic",
+            "virtual",
+        }
+    ),
+    NeedType.THIRST.value: frozenset(
+        {
+            "bodyform:android",
+            "bodyform:construct",
+            "bodyform:non_corporeal",
+            "digital_mind",
+            "inorganic",
+            "virtual",
+        }
+    ),
+    NeedType.SOCIALIZE.value: frozenset(),
+    NeedType.INTIMACY.value: frozenset(
+        {
+            "bodyform:non_corporeal",
+            "digital_mind",
+            "libido_absent",
+            "virtual",
+        }
+    ),
 }
 NEED_SEVERITY_LEVELS: tuple[tuple[int, str], ...] = (
     (4, "critical"),
@@ -220,6 +261,14 @@ def normalize_need_type(need_type: str) -> str:
     if normalized not in NEED_TYPES:
         raise ValueError(f"Unsupported Orrery need type: {need_type!r}")
     return normalized
+
+
+def need_applies_to_tags(need_type: str, tags: Iterable[str]) -> bool:
+    """Return whether a need clock should exist for an entity's active tags."""
+
+    normalized = normalize_need_type(need_type)
+    active_tags = frozenset(str(tag) for tag in tags)
+    return not bool(NEED_IMMUNITY_TAGS[normalized] & active_tags)
 
 
 def effective_debt_score(

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -28,6 +28,7 @@ from nexus.agents.orrery.needs import (
     NeedTuning,
     coerce_need_tuning,
     effective_debt_score,
+    need_applies_to_tags,
     severity_for_debt,
 )
 
@@ -407,6 +408,9 @@ def hydrate_world_state(
         session,
         current_world_time=world_time,
         need_tuning=need_tuning,
+        tags_by_entity={
+            entity_id: frozenset(values) for entity_id, values in tags.items()
+        },
     )
     travel_states = _load_travel_states(session)
     routine_anchors = _load_routine_anchors(session)
@@ -990,6 +994,7 @@ def _load_need_debt_scores(
     *,
     current_world_time: Optional[datetime],
     need_tuning: NeedTuning,
+    tags_by_entity: Mapping[int, frozenset[str]],
 ) -> dict[tuple[int, str], float]:
     """Load effective need debt scores without mutating canonical state."""
 
@@ -1011,6 +1016,11 @@ def _load_need_debt_scores(
         )
     ).mappings():
         need_type = str(row["need_type"])
+        if not need_applies_to_tags(
+            need_type,
+            tags_by_entity.get(row["character_entity_id"], frozenset()),
+        ):
+            continue
         scores[(row["character_entity_id"], need_type)] = effective_debt_score(
             need_type,
             float(row["debt_score"] or 0.0),

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -143,6 +143,16 @@ class RecordingCursor:
                 "debt_score": debt_score,
                 "last_evaluated_at": world_time,
             }
+        elif (
+            "SELECT t.tag FROM entity_tags et JOIN tags t" in normalized
+            and "t.tag = ANY" not in normalized
+        ):
+            entity_id = params[0]
+            self._fetchall = [
+                {"tag": tag}
+                for current_entity_id, tag in self.current_tags
+                if current_entity_id == entity_id
+            ]
         elif "SELECT t.tag FROM entity_tags et JOIN tags t" in normalized:
             entity_id, tags = params
             self._fetchall = [
@@ -2167,6 +2177,39 @@ def test_commit_orrery_tick_reports_missing_need_type() -> None:
     with pytest.raises(ValueError, match="must include a 'type' or 'need' field"):
         commit_orrery_tick_sync(
             RecordingConn(RecordingCursor()),
+            proposal,
+            tick_chunk_id=100,
+            slot=5,
+            world_layer="primary",
+        )
+
+
+def test_commit_orrery_tick_rejects_inapplicable_need_fulfillment() -> None:
+    """Commit-time need fulfillment refuses bodyform-impossible clocks."""
+
+    draft = OrreryResolutionDraft(
+        template_id="sleep",
+        priority=25,
+        binding_hash="sleep-1",
+        bindings={"actor": 1},
+        branch_label="Sleep rough in cover or transit",
+        narrative_stub="{actor} sleeps in fragments.",
+        state_delta={"need.fulfill": {"type": "sleep", "quality": "rough"}},
+        event_type="slept",
+        changed_fields=("character_need_states.debt_score",),
+        magnitude=0.36,
+    )
+    proposal = OrreryTickProposal(
+        anchor_chunk_id=99,
+        actor_count=1,
+        resolutions=(draft,),
+        generated_at="2073-10-31T18:00:00+00:00",
+    )
+    cursor = RecordingCursor(current_tags={(1, "virtual")})
+
+    with pytest.raises(ValueError, match="does not apply to actor 1"):
+        commit_orrery_tick_sync(
+            RecordingConn(cursor),
             proposal,
             tick_chunk_id=100,
             slot=5,

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -143,10 +143,7 @@ class RecordingCursor:
                 "debt_score": debt_score,
                 "last_evaluated_at": world_time,
             }
-        elif (
-            "SELECT t.tag FROM entity_tags et JOIN tags t" in normalized
-            and "t.tag = ANY" not in normalized
-        ):
+        elif "SELECT etc.tag FROM entity_tags_current etc" in normalized:
             entity_id = params[0]
             self._fetchall = [
                 {"tag": tag}

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -8,6 +8,8 @@ import psycopg2
 import pytest
 
 import scripts.migrate as migrate
+from nexus.agents.orrery.needs import NEED_IMMUNITY_TAGS as RUNTIME_NEED_IMMUNITY_TAGS
+from nexus.agents.orrery.needs import NEED_TYPES, need_applies_to_tags
 from nexus.api.slot_utils import get_slot_db_url
 
 
@@ -246,6 +248,30 @@ def test_need_applicability_migration_syncs_bodyform_immunity() -> None:
     assert "inorganic" in migration_source
     assert "virtual" in migration_source
     assert "libido_absent" in migration_source
+
+
+def test_need_applicability_migration_matches_runtime_immunity_map() -> None:
+    """Migration 057's SQL source map should stay equivalent to runtime gates."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "057_orrery_need_bodyform_applicability.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    migration_map = {
+        need_type: frozenset(tags)
+        for need_type, tags in migration.NEED_IMMUNITY_TAGS.items()
+    }
+
+    assert migration_map == dict(RUNTIME_NEED_IMMUNITY_TAGS)
+
+    tags = sorted(set().union(*migration_map.values()))
+    for need_type in NEED_TYPES:
+        for tag in tags:
+            assert need_applies_to_tags(need_type, {tag}) is (
+                tag not in migration_map[need_type]
+            )
 
 
 def test_travel_work_migration_keeps_routing_schema_extensible() -> None:

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -221,6 +221,33 @@ def test_interpersonal_need_migration_uses_safe_enum_extension_pattern() -> None
     assert "ADD VALUE IF NOT EXISTS" not in migration_source
 
 
+def test_need_applicability_migration_syncs_bodyform_immunity() -> None:
+    """Migration 057 updates triggers and prunes impossible bodyform need rows."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "057_orrery_need_bodyform_applicability.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    migration_source = migration_path.read_text()
+
+    assert migration.NEED_TYPES == (
+        "sleep",
+        "hunger",
+        "thirst",
+        "socialize",
+        "intimacy",
+    )
+    assert "orrery_need_applies_to_tags" in migration_source
+    assert "orrery_sync_character_need_states" in migration_source
+    assert "trg_entity_tags_need_state_applicability" in migration_source
+    assert "DELETE FROM character_need_states" in migration_source
+    assert "inorganic" in migration_source
+    assert "virtual" in migration_source
+    assert "libido_absent" in migration_source
+
+
 def test_travel_work_migration_keeps_routing_schema_extensible() -> None:
     """Migration 033 stores estimates now while leaving space for real routes."""
 

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -621,6 +621,74 @@ def test_resolve_dry_run_fires_sunhelm_need_template() -> None:
     assert proposal.resolutions[0].state_delta["need.fulfill"]["type"] == "sleep"
 
 
+@pytest.mark.parametrize(
+    ("tag", "need_type"),
+    [
+        ("inorganic", "sleep"),
+        ("inorganic", "hunger"),
+        ("inorganic", "thirst"),
+        ("virtual", "sleep"),
+        ("virtual", "hunger"),
+        ("virtual", "thirst"),
+        ("virtual", "intimacy"),
+        ("libido_absent", "intimacy"),
+    ],
+)
+def test_resolve_dry_run_filters_inapplicable_need_rows(
+    tag: str,
+    need_type: str,
+) -> None:
+    """Stale need rows for immune bodyforms do not hydrate into packages."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            tag_rows=[{"entity_id": 1, "tag": tag, "is_ephemeral": False}],
+            need_debt_rows=[
+                {
+                    "character_entity_id": 1,
+                    "need_type": need_type,
+                    "debt_score": 999,
+                    "last_evaluated_at": datetime(
+                        2073, 10, 31, 12, tzinfo=timezone.utc
+                    ),
+                }
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 0
+    assert proposal.pressure_count == 0
+
+
+def test_resolve_dry_run_keeps_socialize_for_virtual_characters() -> None:
+    """Virtual minds do not snack, but they can still need company."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            tag_rows=[{"entity_id": 1, "tag": "virtual", "is_ephemeral": False}],
+            need_debt_rows=[
+                {
+                    "character_entity_id": 1,
+                    "need_type": "socialize",
+                    "debt_score": 200,
+                    "last_evaluated_at": datetime(
+                        2073, 10, 31, 12, tzinfo=timezone.utc
+                    ),
+                }
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "socialize"
+
+
 def test_resolve_dry_run_fires_socialize_need_template() -> None:
     """Interpersonal need debt can resolve through SOCIALIZE."""
 


### PR DESCRIPTION
## Summary

- add shared Orrery need-applicability rules so `inorganic` and `virtual` bodyforms do not hydrate impossible embodied need clocks
- filter stale inapplicable `character_need_states` rows during resolver hydration and reject impossible `need.fulfill` commits
- add migration 057 to sync/prune need rows from character/tag triggers and clear obsolete need severity tags
- document the implemented bodyform immunity behavior in `docs/orrery_needs.md`

## Behavioral Notes

`inorganic` suppresses SLEEP / EAT / DRINK need rows. `virtual` suppresses SLEEP / EAT / DRINK plus INTIMACY. SOCIALIZE remains available for virtual minds because disembodied characters can still need company.

This keeps the package templates clean: the row/applicability layer decides whether a need clock exists, not every individual package gate.

## Validation

- `poetry run pytest -q tests/test_orrery/test_resolver.py::test_resolve_dry_run_filters_inapplicable_need_rows tests/test_orrery/test_resolver.py::test_resolve_dry_run_keeps_socialize_for_virtual_characters tests/test_orrery/test_events.py::test_commit_orrery_tick_rejects_inapplicable_need_fulfillment tests/test_orrery/test_migrate.py::test_need_applicability_migration_syncs_bodyform_immunity`
- `poetry run pytest -q tests/test_orrery/test_resolver.py tests/test_orrery/test_events.py tests/test_orrery/test_migrate.py::test_need_applicability_migration_syncs_bodyform_immunity`
- `poetry run pytest -q tests/test_orrery/test_migrate.py`
- rolled-back SQL compile check for migration 057 helper functions against `save_05`: `(virtual_sleep=False, virtual_socialize=True, inorganic_hunger=False, inorganic_intimacy=True)`
- `poetry run flake8 nexus/agents/orrery/needs.py nexus/agents/orrery/resolver.py nexus/agents/orrery/events.py migrations/057_orrery_need_bodyform_applicability.py tests/test_orrery/test_resolver.py tests/test_orrery/test_events.py tests/test_orrery/test_migrate.py`
- Slot 2 dry-run probes on chunk 1428 at 17:00, 18:30, and 00:00 under `/tmp/nexus_orrery_bodyform_need_dry_runs`: Sam/Page/Cradle remain candidates but no longer fire SLEEP/EAT/DRINK; ordinary characters still resolve commute, meals, drinks, and sleep.

## Data / Migration Impact

Migration 057 installs `orrery_need_applies_to_tags()`, `orrery_sync_character_need_states()`, rewires the character need initializer, adds an `entity_tags` sync trigger, and prunes inapplicable need rows for existing active characters. It also clears active need severity tags whose underlying need no longer applies.
