### PR TITLE
[codex] Retire legacy faction columns

### DIFF
--- a/docs/orrery_faction_vocabulary.md
+++ b/docs/orrery_faction_vocabulary.md
@@ -320,7 +320,8 @@ Preflight command:
 - `nexus faction-audit --slot N` performs a read-only dry run over the legacy
   faction columns, existing `claims` / `operates_from` pair-tags, and legacy
   faction tag categories. Review its JSON output before any destructive data
-  rewrite or column-drop migration.
+  rewrite or column-drop migration. After column retirement, the command remains
+  valid and reports the legacy source columns as retired.
 - `nexus faction-manifest --slot N --output PATH` folds the audit into a
   read-only migration manifest with stable operation IDs. It separates
   deterministic entity-tag inserts from review-required tag candidates,
@@ -344,6 +345,12 @@ Runtime write boundary:
   `orrery_tags` or reviewed pair-tag/world-event paths.
 - Migration 053 removes the `factions.power_level` default so omitted runtime
   inserts do not silently create fresh legacy `0.5` values.
+- Migration 058 snapshots non-null legacy faction column values under
+  `extra_data.legacy_faction_columns`, records the source columns under
+  `extra_data.legacy_faction_column_retirement`, and drops the obsolete columns.
+  Runtime and LORE context should read faction semantics from Orrery tags,
+  pair-tags, `summary`, and structured `extra_data`, not the retired table
+  columns.
 
 ---
 

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1917,6 +1917,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/054_orrery_completed_tag_vocab.py`
 - `migrations/055_orrery_character_tag_vocab.py`
 - `migrations/056_orrery_routine_anchors.py`
+- `migrations/057_orrery_need_bodyform_applicability.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 

--- a/docs/orrery_tag_vocabulary.md
+++ b/docs/orrery_tag_vocabulary.md
@@ -996,6 +996,7 @@ Compiler surfaces:
 - `migrations/052_orrery_faction_tag_vocab.py` — seeds the 65 faction tag anchors across `ideology`, `resource_base`, `legitimacy`, `operational_mode`, `power_status`, and `agenda`.
 - `migrations/053_retire_faction_legacy_write_defaults.py` — drops the legacy `factions.power_level` default so new runtime inserts do not create fresh obsolete faction strength values.
 - `migrations/054_orrery_completed_tag_vocab.py` — seeds completed state and place anchors, including globally unique place registry names and the `wilderness` legacy-category rewrite.
+- `migrations/058_retire_faction_legacy_columns.py` — snapshots obsolete faction-table semantic columns into `extra_data.legacy_faction_columns` and drops the columns after the Orrery tag cutover.
 - Issue #275 / PR #276 — Skald sovereignty (adjudication) model. *Merged.*
 - Issue #282 — Package self-awareness architectural pattern (three-stage gating: entry → branch → outcome; `hunting` tags confer targeted detection sensitivity). *Open.*
 - PR #283 — `entity_pair_tags` substrate (migration 042 + writer functions). *Merged.*

--- a/migrations/058_retire_faction_legacy_columns.py
+++ b/migrations/058_retire_faction_legacy_columns.py
@@ -1,0 +1,85 @@
+"""Retire legacy faction semantic columns after the Orrery cutover."""
+
+from __future__ import annotations
+
+import json
+
+
+LEGACY_FACTION_COLUMNS = (
+    "ideology",
+    "history",
+    "current_activity",
+    "hidden_agenda",
+    "territory",
+    "power_level",
+    "resources",
+)
+SNAPSHOT_KEY = "legacy_faction_columns"
+RETIREMENT_KEY = "legacy_faction_column_retirement"
+MIGRATION_ID = "058_retire_faction_legacy_columns"
+
+
+def run(conn) -> None:
+    """Snapshot old faction columns into extra_data, then drop the columns."""
+
+    with conn.cursor() as cur:
+        legacy_columns = _existing_legacy_columns(cur)
+        if legacy_columns:
+            _snapshot_legacy_columns(cur, legacy_columns)
+            _drop_legacy_columns(cur, legacy_columns)
+
+    conn.commit()
+
+
+def _existing_legacy_columns(cur) -> tuple[str, ...]:
+    cur.execute(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'factions'
+          AND column_name = ANY(%s)
+        """,
+        (list(LEGACY_FACTION_COLUMNS),),
+    )
+    existing = {row[0] for row in cur.fetchall()}
+    return tuple(column for column in LEGACY_FACTION_COLUMNS if column in existing)
+
+
+def _snapshot_legacy_columns(cur, legacy_columns: tuple[str, ...]) -> None:
+    snapshot_pairs = ", ".join(f"'{column}', {column}" for column in legacy_columns)
+    snapshot_expr = f"jsonb_strip_nulls(jsonb_build_object({snapshot_pairs}))"
+    cur.execute(
+        f"""
+        UPDATE factions
+        SET extra_data = jsonb_set(
+            jsonb_set(
+                COALESCE(extra_data, '{{}}'::jsonb),
+                %s,
+                COALESCE(extra_data -> %s, '{{}}'::jsonb) || {snapshot_expr},
+                true
+            ),
+            %s,
+            jsonb_build_object(
+                'migration',
+                %s,
+                'source_columns',
+                %s::jsonb
+            ),
+            true
+        )
+        WHERE {snapshot_expr} <> '{{}}'::jsonb
+        """,
+        (
+            [SNAPSHOT_KEY],
+            SNAPSHOT_KEY,
+            [RETIREMENT_KEY],
+            MIGRATION_ID,
+            json.dumps(list(legacy_columns)),
+        ),
+    )
+
+
+def _drop_legacy_columns(cur, legacy_columns: tuple[str, ...]) -> None:
+    for column in legacy_columns:
+        cur.execute(f"ALTER TABLE factions DROP COLUMN IF EXISTS {column}")

--- a/migrations/058_retire_faction_legacy_columns.py
+++ b/migrations/058_retire_faction_legacy_columns.py
@@ -47,16 +47,26 @@ def _existing_legacy_columns(cur) -> tuple[str, ...]:
 
 
 def _snapshot_legacy_columns(cur, legacy_columns: tuple[str, ...]) -> None:
-    snapshot_pairs = ", ".join(f"'{column}', {column}" for column in legacy_columns)
-    snapshot_expr = f"jsonb_strip_nulls(jsonb_build_object({snapshot_pairs}))"
+    snapshot_pairs = ", ".join(f"'{column}', f.{column}" for column in legacy_columns)
     cur.execute(
         f"""
-        UPDATE factions
+        WITH legacy_snapshots AS (
+            SELECT
+                f.id,
+                snapshot.value AS snapshot
+            FROM factions AS f
+            CROSS JOIN LATERAL (
+                VALUES (jsonb_strip_nulls(jsonb_build_object({snapshot_pairs})))
+            ) AS snapshot(value)
+            WHERE snapshot.value <> '{{}}'::jsonb
+        )
+        UPDATE factions AS f
         SET extra_data = jsonb_set(
             jsonb_set(
-                COALESCE(extra_data, '{{}}'::jsonb),
+                COALESCE(f.extra_data, '{{}}'::jsonb),
                 %s,
-                COALESCE(extra_data -> %s, '{{}}'::jsonb) || {snapshot_expr},
+                COALESCE(f.extra_data -> %s, '{{}}'::jsonb)
+                    || legacy_snapshots.snapshot,
                 true
             ),
             %s,
@@ -68,7 +78,8 @@ def _snapshot_legacy_columns(cur, legacy_columns: tuple[str, ...]) -> None:
             ),
             true
         )
-        WHERE {snapshot_expr} <> '{{}}'::jsonb
+        FROM legacy_snapshots
+        WHERE f.id = legacy_snapshots.id
         """,
         (
             [SNAPSHOT_KEY],
@@ -81,5 +92,7 @@ def _snapshot_legacy_columns(cur, legacy_columns: tuple[str, ...]) -> None:
 
 
 def _drop_legacy_columns(cur, legacy_columns: tuple[str, ...]) -> None:
-    for column in legacy_columns:
-        cur.execute(f"ALTER TABLE factions DROP COLUMN IF EXISTS {column}")
+    drop_clauses = ",\n    ".join(
+        f"DROP COLUMN IF EXISTS {column}" for column in legacy_columns
+    )
+    cur.execute(f"ALTER TABLE factions\n    {drop_clauses}")

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -493,31 +493,35 @@ class LogonUtility:
                     sections.append("\nAll Factions (brief):")
                     for faction in baseline_factions:
                         name = faction.get("name", "Unknown")
-                        activity = faction.get("current_activity", "")
-                        sections.append(f"- {name}: {activity}")
+                        tags = faction.get("orrery_tag_summary") or ""
+                        summary = faction.get("summary") or ""
+                        detail = tags or summary
+                        sections.append(f"- {name}: {detail}")
 
                 if featured_factions:
                     sections.append("\nFeatured Factions (full details):")
                     for faction in featured_factions:
                         name = faction.get("name", "Unknown")
                         summary = faction.get("summary", "")
-                        sections.append(f"- {name}: {summary}")
+                        tags = faction.get("orrery_tag_summary") or ""
+                        detail = f"{summary} Tags: {tags}" if tags else summary
+                        sections.append(f"- {name}: {detail}")
             else:
                 # Flat format (backward compatibility)
                 if characters:
                     sections.append("\nCharacters:")
                     for char in characters:
-                        sections.append(
-                            f"- {char.get('name', 'Unknown')}: {char.get('summary', '')}"
-                        )
+                        name = char.get("name", "Unknown")
+                        summary = char.get("summary", "")
+                        sections.append(f"- {name}: {summary}")
 
                 locations = entity_data.get("locations", [])
                 if locations:
                     sections.append("\nLocations:")
                     for loc in locations:
-                        sections.append(
-                            f"- {loc.get('name', 'Unknown')}: {loc.get('description', '') or loc.get('summary', '')}"
-                        )
+                        name = loc.get("name", "Unknown")
+                        summary = loc.get("description", "") or loc.get("summary", "")
+                        sections.append(f"- {name}: {summary}")
 
             # Relationships, events, threats (same for both formats)
             relationships = entity_data.get("relationships", [])

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -504,7 +504,10 @@ class LogonUtility:
                         name = faction.get("name", "Unknown")
                         summary = faction.get("summary", "")
                         tags = faction.get("orrery_tag_summary") or ""
-                        detail = f"{summary} Tags: {tags}" if tags else summary
+                        tag_detail = f"Tags: {tags}" if tags else ""
+                        detail = " ".join(
+                            part for part in (summary, tag_detail) if part
+                        )
                         sections.append(f"- {name}: {detail}")
             else:
                 # Flat format (backward compatibility)

--- a/nexus/agents/lore/lore_system_prompt.md
+++ b/nexus/agents/lore/lore_system_prompt.md
@@ -288,7 +288,7 @@ ITERATION 2 - Targeted Search:
 - Analysis: Eclipse Biotech is key lead
 
 ITERATION 3 - Targeted Follow-up:
-- SQL: SELECT id,name,summary,ideology FROM factions WHERE name ILIKE '%Eclipse%'
+- SQL: SELECT id,name,summary FROM factions WHERE name ILIKE '%Eclipse%'
 - Result: Eclipse Biotech - rival corp, neural tech specialist
 - Text search: "Eclipse Biotech implant Alex discovery"
 - Result: Chunks 1247-1251 contain full discovery sequence

--- a/nexus/agents/lore/utils/entity_queries.py
+++ b/nexus/agents/lore/utils/entity_queries.py
@@ -17,7 +17,7 @@ def fetch_all_characters_with_references(
     featured_chunk_ids: List[int],
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
-    Fetch ALL characters with baseline tracking fields, plus full details for referenced characters.
+    Fetch ALL characters with baseline tracking fields, plus referenced details.
 
     Args:
         session: SQLAlchemy session
@@ -25,28 +25,32 @@ def fetch_all_characters_with_references(
 
     Returns:
         Dict with:
-        - baseline: All characters (id, name, summary, current_activity, current_location)
+        - baseline: All characters with activity and location fields
         - featured: Referenced characters with full details + reference_type
     """
     # Get ALL characters with baseline fields
-    baseline_query = text("""
+    baseline_query = text(
+        """
         SELECT
             id, name, summary,
             current_activity, current_location
         FROM characters
         ORDER BY name
-    """)
+    """
+    )
     baseline_rows = session.execute(baseline_query).fetchall()
 
     # Get user character ID from global_variables
     user_char_id = None
     try:
-        user_char_query = text("""
+        user_char_query = text(
+            """
             SELECT user_character
             FROM global_variables
             WHERE id = true
             LIMIT 1
-        """)
+        """
+        )
         user_char_row = session.execute(user_char_query).fetchone()
         if user_char_row and user_char_row.user_character:
             user_char_id = user_char_row.user_character
@@ -57,12 +61,16 @@ def fetch_all_characters_with_references(
     # Get character IDs referenced in chunks
     featured_ids = {}
     if featured_chunk_ids:
-        ref_query = text("""
+        ref_query = text(
+            """
             SELECT DISTINCT character_id, reference
             FROM chunk_character_references
             WHERE chunk_id = ANY(:chunk_ids)
-        """)
-        ref_rows = session.execute(ref_query, {"chunk_ids": featured_chunk_ids}).fetchall()
+        """
+        )
+        ref_rows = session.execute(
+            ref_query, {"chunk_ids": featured_chunk_ids}
+        ).fetchall()
         featured_ids = {row.character_id: str(row.reference) for row in ref_rows}
 
     # ALWAYS feature the user character, regardless of chunk references
@@ -73,22 +81,26 @@ def fetch_all_characters_with_references(
     # Get full details for featured characters
     featured_rows = []
     if featured_ids:
-        featured_query = text("""
+        featured_query = text(
+            """
             SELECT
                 id, name, summary, appearance, background,
                 personality, emotional_state, current_activity,
                 current_location, extra_data
             FROM characters
             WHERE id = ANY(:ids)
-        """)
-        featured_rows = session.execute(featured_query, {"ids": list(featured_ids.keys())}).fetchall()
+        """
+        )
+        featured_rows = session.execute(
+            featured_query, {"ids": list(featured_ids.keys())}
+        ).fetchall()
 
     return {
         "baseline": [dict(row._mapping) for row in baseline_rows],
         "featured": [
             {**dict(row._mapping), "reference_type": featured_ids.get(row.id)}
             for row in featured_rows
-        ]
+        ],
     }
 
 
@@ -98,7 +110,7 @@ def fetch_all_places_with_references(
     featured_place_ids: Optional[Set[int]] = None,
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
-    Fetch ALL places with baseline tracking fields, plus full details for referenced places.
+    Fetch ALL places with baseline tracking fields, plus referenced details.
 
     Args:
         session: SQLAlchemy session
@@ -111,25 +123,31 @@ def fetch_all_places_with_references(
         - featured: Referenced places with full details + reference_type
     """
     # Get ALL places with baseline fields
-    baseline_query = text("""
+    baseline_query = text(
+        """
         SELECT
             id, name, type, summary, current_status,
             ST_X(coordinates::geometry) as longitude,
             ST_Y(coordinates::geometry) as latitude
         FROM places
         ORDER BY name
-    """)
+    """
+    )
     baseline_rows = session.execute(baseline_query).fetchall()
 
     # Get place IDs referenced in chunks
     featured_ids = {}
     if featured_chunk_ids:
-        ref_query = text("""
+        ref_query = text(
+            """
             SELECT DISTINCT place_id, reference_type
             FROM place_chunk_references
             WHERE chunk_id = ANY(:chunk_ids)
-        """)
-        ref_rows = session.execute(ref_query, {"chunk_ids": featured_chunk_ids}).fetchall()
+        """
+        )
+        ref_rows = session.execute(
+            ref_query, {"chunk_ids": featured_chunk_ids}
+        ).fetchall()
         featured_ids = {row.place_id: str(row.reference_type) for row in ref_rows}
 
     # Add additional featured place IDs (e.g., from character current_location)
@@ -140,7 +158,8 @@ def fetch_all_places_with_references(
     # Get full details for featured places
     featured_rows = []
     if featured_ids:
-        featured_query = text("""
+        featured_query = text(
+            """
             SELECT
                 id, name, type, zone, summary, inhabitants,
                 history, current_status, secrets, extra_data,
@@ -148,15 +167,18 @@ def fetch_all_places_with_references(
                 ST_Y(coordinates::geometry) as latitude
             FROM places
             WHERE id = ANY(:ids)
-        """)
-        featured_rows = session.execute(featured_query, {"ids": list(featured_ids.keys())}).fetchall()
+        """
+        )
+        featured_rows = session.execute(
+            featured_query, {"ids": list(featured_ids.keys())}
+        ).fetchall()
 
     return {
         "baseline": [dict(row._mapping) for row in baseline_rows],
         "featured": [
             {**dict(row._mapping), "reference_type": featured_ids.get(row.id)}
             for row in featured_rows
-        ]
+        ],
     }
 
 
@@ -165,7 +187,7 @@ def fetch_all_factions_with_references(
     featured_chunk_ids: List[int],
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
-    Fetch ALL factions with baseline tracking fields, plus full details for referenced factions.
+    Fetch ALL factions with baseline tracking fields, plus referenced details.
 
     Args:
         session: SQLAlchemy session
@@ -173,43 +195,98 @@ def fetch_all_factions_with_references(
 
     Returns:
         Dict with:
-        - baseline: All factions (id, name, summary, current_activity)
-        - featured: Referenced factions with full details
+        - baseline: All factions (id, name, summary, orrery_tag_summary)
+        - featured: Referenced factions with details and current Orrery tags
     """
     # Get ALL factions with baseline fields
-    baseline_query = text("""
+    baseline_query = text(
+        """
         SELECT
-            id, name, summary, current_activity
-        FROM factions
-        ORDER BY name
-    """)
+            f.id,
+            f.name,
+            f.summary,
+            COALESCE(
+                string_agg(
+                    etc.category || ':' || etc.tag,
+                    ', '
+                    ORDER BY etc.category, etc.tag
+                ) FILTER (WHERE etc.tag IS NOT NULL),
+                ''
+            ) AS orrery_tag_summary
+        FROM factions f
+        LEFT JOIN entity_tags_current etc
+               ON etc.entity_id = f.entity_id
+              AND etc.entity_kind = 'faction'
+              AND etc.category IN (
+                  'ideology',
+                  'resource_base',
+                  'legitimacy',
+                  'operational_mode',
+                  'power_status',
+                  'agenda'
+              )
+        GROUP BY f.id, f.name, f.summary
+        ORDER BY f.name
+    """
+    )
     baseline_rows = session.execute(baseline_query).fetchall()
 
     # Get faction IDs referenced in chunks
     featured_ids = set()
     if featured_chunk_ids:
-        ref_query = text("""
+        ref_query = text(
+            """
             SELECT DISTINCT faction_id
             FROM chunk_faction_references
             WHERE chunk_id = ANY(:chunk_ids)
-        """)
-        ref_rows = session.execute(ref_query, {"chunk_ids": featured_chunk_ids}).fetchall()
+        """
+        )
+        ref_rows = session.execute(
+            ref_query, {"chunk_ids": featured_chunk_ids}
+        ).fetchall()
         featured_ids = {row.faction_id for row in ref_rows}
 
     # Get full details for featured factions
     featured_rows = []
     if featured_ids:
-        featured_query = text("""
+        featured_query = text(
+            """
             SELECT
-                id, name, summary, ideology, history,
-                current_activity, hidden_agenda, territory,
-                primary_location, power_level, resources, extra_data
-            FROM factions
-            WHERE id = ANY(:ids)
-        """)
-        featured_rows = session.execute(featured_query, {"ids": list(featured_ids)}).fetchall()
+                f.id,
+                f.name,
+                f.summary,
+                f.primary_location,
+                f.extra_data,
+                COALESCE(
+                    string_agg(
+                        etc.category || ':' || etc.tag,
+                        ', '
+                        ORDER BY etc.category, etc.tag
+                    ) FILTER (WHERE etc.tag IS NOT NULL),
+                    ''
+                ) AS orrery_tag_summary
+            FROM factions f
+            LEFT JOIN entity_tags_current etc
+                   ON etc.entity_id = f.entity_id
+                  AND etc.entity_kind = 'faction'
+                  AND etc.category IN (
+                      'ideology',
+                      'resource_base',
+                      'legitimacy',
+                      'operational_mode',
+                      'power_status',
+                      'agenda'
+                  )
+            WHERE f.id = ANY(:ids)
+            GROUP BY f.id, f.name, f.summary, f.primary_location, f.extra_data
+            ORDER BY f.name
+        """
+        )
+        featured_rows = session.execute(
+            featured_query, {"ids": list(featured_ids)}
+        ).fetchall()
 
     return {
         "baseline": [dict(row._mapping) for row in baseline_rows],
-        "featured": [dict(row._mapping) for row in featured_rows]
+        "featured": [dict(row._mapping) for row in featured_rows],
     }

--- a/nexus/agents/lore/utils/entity_queries.py
+++ b/nexus/agents/lore/utils/entity_queries.py
@@ -11,6 +11,18 @@ from sqlalchemy.orm import Session
 
 logger = logging.getLogger("nexus.lore.entity_queries")
 
+FACTION_TAG_CONTEXT_CATEGORIES = (
+    "ideology",
+    "resource_base",
+    "legitimacy",
+    "operational_mode",
+    "power_status",
+    "agenda",
+)
+FACTION_TAG_CONTEXT_CATEGORY_SQL = ", ".join(
+    f"'{category}'" for category in FACTION_TAG_CONTEXT_CATEGORIES
+)
+
 
 def fetch_all_characters_with_references(
     session: Session,
@@ -200,7 +212,7 @@ def fetch_all_factions_with_references(
     """
     # Get ALL factions with baseline fields
     baseline_query = text(
-        """
+        f"""
         SELECT
             f.id,
             f.name,
@@ -217,15 +229,8 @@ def fetch_all_factions_with_references(
         LEFT JOIN entity_tags_current etc
                ON etc.entity_id = f.entity_id
               AND etc.entity_kind = 'faction'
-              AND etc.category IN (
-                  'ideology',
-                  'resource_base',
-                  'legitimacy',
-                  'operational_mode',
-                  'power_status',
-                  'agenda'
-              )
-        GROUP BY f.id, f.name, f.summary
+              AND etc.category IN ({FACTION_TAG_CONTEXT_CATEGORY_SQL})
+        GROUP BY f.id
         ORDER BY f.name
     """
     )
@@ -250,7 +255,7 @@ def fetch_all_factions_with_references(
     featured_rows = []
     if featured_ids:
         featured_query = text(
-            """
+            f"""
             SELECT
                 f.id,
                 f.name,
@@ -269,16 +274,9 @@ def fetch_all_factions_with_references(
             LEFT JOIN entity_tags_current etc
                    ON etc.entity_id = f.entity_id
                   AND etc.entity_kind = 'faction'
-                  AND etc.category IN (
-                      'ideology',
-                      'resource_base',
-                      'legitimacy',
-                      'operational_mode',
-                      'power_status',
-                      'agenda'
-                  )
+                  AND etc.category IN ({FACTION_TAG_CONTEXT_CATEGORY_SQL})
             WHERE f.id = ANY(:ids)
-            GROUP BY f.id, f.name, f.summary, f.primary_location, f.extra_data
+            GROUP BY f.id
             ORDER BY f.name
         """
         )

--- a/nexus/api/faction_table_audit.py
+++ b/nexus/api/faction_table_audit.py
@@ -51,6 +51,15 @@ LEGACY_FACTION_COLUMNS = (
     "power_level",
     "resources",
 )
+MISSING_FACTION_COLUMN_SELECTS = {
+    "ideology": "NULL::text AS ideology",
+    "history": "NULL::text AS history",
+    "current_activity": "NULL::text AS current_activity",
+    "hidden_agenda": "NULL::text AS hidden_agenda",
+    "territory": "NULL::text AS territory",
+    "power_level": "NULL::numeric AS power_level",
+    "resources": "NULL::text AS resources",
+}
 KEEP_FACTION_COLUMNS = (
     "id",
     "name",
@@ -752,9 +761,9 @@ def _fetch_faction_rows(
 def _faction_column_select_expr(column: str, *, existing_columns: set[str]) -> str:
     if column in existing_columns:
         return column
-    if column == "power_level":
-        return "NULL::numeric AS power_level"
-    return f"NULL::text AS {column}"
+    if column in MISSING_FACTION_COLUMN_SELECTS:
+        return MISSING_FACTION_COLUMN_SELECTS[column]
+    raise ValueError(f"Required factions column {column!r} is missing")
 
 
 def _fetch_pair_tag_counts(cur: Any) -> dict[int, dict[str, int]]:

--- a/nexus/api/faction_table_audit.py
+++ b/nexus/api/faction_table_audit.py
@@ -343,7 +343,8 @@ class FactionAuditEntry:
 def build_faction_table_audit(cur: Any) -> dict[str, Any]:
     """Build a read-only dry-run audit for legacy faction table cleanup."""
 
-    faction_rows = _fetch_faction_rows(cur)
+    existing_columns = _fetch_existing_faction_columns(cur)
+    faction_rows = _fetch_faction_rows(cur, existing_columns=existing_columns)
     pair_counts = _fetch_pair_tag_counts(cur)
     legacy_tags = _fetch_legacy_tag_rows(cur)
     legacy_tags_by_entity = _group_legacy_tags_by_entity(legacy_tags)
@@ -367,6 +368,14 @@ def build_faction_table_audit(cur: Any) -> dict[str, Any]:
     return {
         "dry_run": True,
         "source_columns": list(LEGACY_FACTION_COLUMNS),
+        "available_source_columns": [
+            column for column in LEGACY_FACTION_COLUMNS if column in existing_columns
+        ],
+        "retired_source_columns": [
+            column
+            for column in LEGACY_FACTION_COLUMNS
+            if column not in existing_columns
+        ],
         "keep_columns": list(KEEP_FACTION_COLUMNS),
         "counters": counters,
         "non_null_counts": non_null_counts,
@@ -696,26 +705,56 @@ def audit_faction_row(
     return entry
 
 
-def _fetch_faction_rows(cur: Any) -> list[Mapping[str, Any]]:
+def _fetch_existing_faction_columns(cur: Any) -> set[str]:
     cur.execute(
         """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'factions'
+          AND column_name = ANY(%s)
+        """,
+        (list(KEEP_FACTION_COLUMNS + LEGACY_FACTION_COLUMNS),),
+    )
+    return {str(_row_value(row, "column_name")) for row in cur.fetchall()}
+
+
+def _fetch_faction_rows(
+    cur: Any, *, existing_columns: set[str]
+) -> list[Mapping[str, Any]]:
+    select_columns = [
+        _faction_column_select_expr(column, existing_columns=existing_columns)
+        for column in (
+            "id",
+            "name",
+            "entity_id",
+            "ideology",
+            "history",
+            "current_activity",
+            "hidden_agenda",
+            "territory",
+            "primary_location",
+            "power_level",
+            "resources",
+        )
+    ]
+    cur.execute(
+        f"""
         SELECT
-            id,
-            name,
-            entity_id,
-            ideology,
-            history,
-            current_activity,
-            hidden_agenda,
-            territory,
-            primary_location,
-            power_level,
-            resources
+            {', '.join(select_columns)}
         FROM factions
         ORDER BY id
         """
     )
     return list(cur.fetchall())
+
+
+def _faction_column_select_expr(column: str, *, existing_columns: set[str]) -> str:
+    if column in existing_columns:
+        return column
+    if column == "power_level":
+        return "NULL::numeric AS power_level"
+    return f"NULL::text AS {column}"
 
 
 def _fetch_pair_tag_counts(cur: Any) -> dict[int, dict[str, int]]:

--- a/nexus/memory/entity_detector.py
+++ b/nexus/memory/entity_detector.py
@@ -5,10 +5,10 @@ only against known entities from the database. No regex patterns, no guessing,
 just exact matches against characters (including aliases), places, and factions.
 """
 
+from dataclasses import dataclass
 import logging
 import re
-from typing import Dict, List, Set, Optional, Any
-from dataclasses import dataclass
+from typing import Any, Dict, List
 
 from sqlalchemy import text as sql_text
 
@@ -144,13 +144,13 @@ class HighSpecificityEntityDetector:
     def _load_factions(self) -> None:
         """Load factions from database."""
         result = self._execute(
-            "SELECT id, name, ideology FROM factions WHERE name IS NOT NULL"
+            "SELECT id, name, summary FROM factions WHERE name IS NOT NULL"
         )
         for row in result:
             faction_record = {
                 "id": row.id,
                 "name": row.name,
-                "ideology": row.ideology,
+                "summary": row.summary,
             }
             # Add to lookup (case-insensitive)
             self.faction_lookup[row.name.lower()] = faction_record
@@ -232,7 +232,8 @@ class HighSpecificityEntityDetector:
 
         if result.detected:
             logger.info(
-                "High-specificity detection found: %d characters, %d places, %d factions",
+                "High-specificity detection found: %d characters, %d places, "
+                "%d factions",
                 len(result.characters),
                 len(result.places),
                 len(result.factions),

--- a/tests/test_commit_handler.py
+++ b/tests/test_commit_handler.py
@@ -62,7 +62,19 @@ async def test_live_async_faction_writes_tags_without_legacy_columns():
                 ADD COLUMN IF NOT EXISTS expires_at_world_time timestamptz
             """
         )
-        await conn.execute("ALTER TABLE factions ALTER COLUMN power_level DROP DEFAULT")
+        has_power_level = await conn.fetchval(
+            """
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'factions'
+              AND column_name = 'power_level'
+            """
+        )
+        if has_power_level:
+            await conn.execute(
+                "ALTER TABLE factions ALTER COLUMN power_level DROP DEFAULT"
+            )
         tag_suffix = uuid.uuid4().hex[:12]
         created_tag = f"test_async_faction_created_{tag_suffix}"
         updated_tag = f"test_async_faction_updated_{tag_suffix}"
@@ -80,21 +92,45 @@ async def test_live_async_faction_writes_tags_without_legacy_columns():
         )
         faction = await conn.fetchrow(
             """
-            SELECT entity_id, ideology, history, current_activity, hidden_agenda,
-                   territory, power_level, resources
+            SELECT entity_id
             FROM factions
             WHERE id = $1
             """,
             faction_id,
         )
         assert faction is not None
-        assert faction["ideology"] is None
-        assert faction["history"] is None
-        assert faction["current_activity"] is None
-        assert faction["hidden_agenda"] is None
-        assert faction["territory"] is None
-        assert faction["power_level"] is None
-        assert faction["resources"] is None
+        legacy_columns = await conn.fetch(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'factions'
+              AND column_name = ANY($1::text[])
+            ORDER BY column_name
+            """,
+            [
+                "ideology",
+                "history",
+                "current_activity",
+                "hidden_agenda",
+                "territory",
+                "power_level",
+                "resources",
+            ],
+        )
+        if legacy_columns:
+            column_names = [row["column_name"] for row in legacy_columns]
+            legacy_row = await conn.fetchrow(
+                f"""
+                SELECT {', '.join(column_names)}
+                FROM factions
+                WHERE id = $1
+                """,
+                faction_id,
+            )
+            assert legacy_row is not None
+            for column_name in column_names:
+                assert legacy_row[column_name] is None
         assert await _has_active_tag(conn, faction["entity_id"], created_tag)
 
         await apply_state_updates(

--- a/tests/test_faction_table_audit.py
+++ b/tests/test_faction_table_audit.py
@@ -20,6 +20,7 @@ from nexus.api.faction_table_audit import (
     FACTION_MANIFEST_SCHEMA_VERSION,
     LEGACY_TAG_CATEGORIES,
     LegacyTagRow,
+    _faction_column_select_expr,
     apply_faction_migration_manifest,
     audit_faction_row,
     build_faction_migration_manifest,
@@ -423,6 +424,13 @@ def test_build_faction_table_audit_handles_retired_legacy_columns() -> None:
     }
     assert audit["counters"]["factions_scanned"] == 1
     assert audit["counters"]["non_null_legacy_values"] == 0
+
+
+def test_missing_unknown_faction_column_type_fails_loudly() -> None:
+    """Only known retired columns should get synthetic NULL expressions."""
+
+    with pytest.raises(ValueError, match="Required factions column"):
+        _faction_column_select_expr("created_at", existing_columns=set())
 
 
 @pytest.mark.requires_postgres

--- a/tests/test_faction_table_audit.py
+++ b/tests/test_faction_table_audit.py
@@ -170,6 +170,72 @@ class FactionApplyCursor:
         return rows
 
 
+class RetiredFactionColumnsAuditCursor:
+    """Fake cursor for auditing after legacy faction columns are dropped."""
+
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+        self._rows: list[dict[str, Any]] = []
+
+    def execute(self, sql: str, params: tuple[Any, ...] = ()) -> None:
+        """Handle the SQL shapes emitted by the audit path."""
+
+        normalized = " ".join(sql.split())
+        self.statements.append(normalized)
+        if "FROM information_schema.columns" in normalized:
+            self._rows = [
+                {"column_name": column}
+                for column in (
+                    "id",
+                    "name",
+                    "entity_id",
+                    "summary",
+                    "primary_location",
+                    "created_at",
+                    "updated_at",
+                    "extra_data",
+                )
+            ]
+        elif "FROM factions ORDER BY id" in normalized:
+            assert "NULL::text AS ideology" in normalized
+            assert "NULL::numeric AS power_level" in normalized
+            self._rows = [
+                {
+                    "id": 1,
+                    "name": "Columnless League",
+                    "entity_id": 1001,
+                    "ideology": None,
+                    "history": None,
+                    "current_activity": None,
+                    "hidden_agenda": None,
+                    "territory": None,
+                    "primary_location": None,
+                    "power_level": None,
+                    "resources": None,
+                }
+            ]
+        elif "FROM entity_pair_tags" in normalized:
+            self._rows = []
+        elif "FROM entity_tags_current" in normalized:
+            self._rows = []
+        else:
+            raise AssertionError(f"Unhandled SQL in fake cursor: {normalized}")
+
+    def fetchone(self) -> dict[str, Any] | None:
+        """Return one pending row."""
+
+        if not self._rows:
+            return None
+        return self._rows.pop(0)
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        """Return all pending rows."""
+
+        rows = list(self._rows)
+        self._rows.clear()
+        return rows
+
+
 def _manifest_operation(
     *,
     operation_id: str,
@@ -327,6 +393,36 @@ def test_power_level_point_one_maps_to_declining() -> None:
     ]
 
     assert candidates[0].target_tag == "declining"
+
+
+def test_build_faction_table_audit_handles_retired_legacy_columns() -> None:
+    """The dry-run audit should still work after migration 058 drops columns."""
+
+    cur = RetiredFactionColumnsAuditCursor()
+
+    audit = build_faction_table_audit(cur)
+
+    assert audit["available_source_columns"] == []
+    assert audit["retired_source_columns"] == [
+        "ideology",
+        "history",
+        "current_activity",
+        "hidden_agenda",
+        "territory",
+        "power_level",
+        "resources",
+    ]
+    assert audit["non_null_counts"] == {
+        "ideology": 0,
+        "history": 0,
+        "current_activity": 0,
+        "hidden_agenda": 0,
+        "territory": 0,
+        "power_level": 0,
+        "resources": 0,
+    }
+    assert audit["counters"]["factions_scanned"] == 1
+    assert audit["counters"]["non_null_legacy_values"] == 0
 
 
 @pytest.mark.requires_postgres

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -741,6 +741,32 @@ def test_faction_legacy_write_default_migration_drops_power_default() -> None:
     assert "Orrery power_status tags" in source
 
 
+def test_faction_legacy_column_retirement_snapshots_before_drop() -> None:
+    """Migration 058 should preserve faction prose before removing old columns."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "058_retire_faction_legacy_columns.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    source = migration_path.read_text()
+
+    assert migration.LEGACY_FACTION_COLUMNS == (
+        "ideology",
+        "history",
+        "current_activity",
+        "hidden_agenda",
+        "territory",
+        "power_level",
+        "resources",
+    )
+    assert "legacy_faction_columns" in source
+    assert "legacy_faction_column_retirement" in source
+    assert "jsonb_strip_nulls(jsonb_build_object" in source
+    assert "DROP COLUMN IF EXISTS" in source
+
+
 def test_completed_tag_vocab_migration_seeds_state_and_place_anchors() -> None:
     """Migration 054 seeds completed state/place vocabulary without collisions."""
 

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -763,7 +763,9 @@ def test_faction_legacy_column_retirement_snapshots_before_drop() -> None:
     )
     assert "legacy_faction_columns" in source
     assert "legacy_faction_column_retirement" in source
+    assert "CROSS JOIN LATERAL" in source
     assert "jsonb_strip_nulls(jsonb_build_object" in source
+    assert source.count("ALTER TABLE factions") == 1
     assert "DROP COLUMN IF EXISTS" in source
 
 


### PR DESCRIPTION
## Summary
- Add migration 058 to snapshot obsolete `factions` semantic columns into `extra_data.legacy_faction_columns` and drop the old columns after the Orrery faction-tag cutover.
- Make faction audit/manifest tooling tolerate already-retired columns by reporting `available_source_columns` / `retired_source_columns` instead of failing on missing legacy fields.
- Move LORE/entity faction reads off `ideology` / `current_activity` columns and onto `summary`, `extra_data`, and current Orrery faction tag summaries.
- Update docs/tests, including the generated Orrery package catalog sync needed by the full test suite.

## Data / Schema Impact
- Migration 058 is destructive to table shape, but preserves non-null values under `extra_data.legacy_faction_columns` before dropping `ideology`, `history`, `current_activity`, `hidden_agenda`, `territory`, `power_level`, and `resources`.
- Slot 2 was exercised in a rollback-scoped transaction: all seven legacy columns dropped inside the transaction, Dynacorp snapshot contained all seven legacy keys, then the transaction was rolled back.

## Validation
- `poetry run pytest -q tests/test_faction_table_audit.py tests/test_commit_handler.py tests/test_commit_handler_sync.py tests/test_db_converters.py tests/test_lore/test_apex_schema.py tests/test_orrery/test_migrate.py`
- `poetry run flake8 nexus/api/faction_table_audit.py nexus/memory/entity_detector.py nexus/agents/lore/utils/entity_queries.py migrations/058_retire_faction_legacy_columns.py tests/test_faction_table_audit.py tests/test_commit_handler.py tests/test_orrery/test_migrate.py`
- `poetry run pytest -q`
- `git diff --check`

Closes #337