### PR TITLE
[codex] Drive-band packages, social travel, and Retrograde packet

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,10 +14,10 @@ repos:
         entry: poetry run python -m nexus.agents.orrery.catalog --write
         language: system
         pass_filenames: false
-        files: ^nexus/agents/orrery/(templates|substrate|catalog)\.py$
+        always_run: true
         description: >
-          When templates.py, substrate.py, or catalog.py changes, regenerate
-          docs/orrery_packages.md so the human-readable catalog stays in
-          lockstep with the canonical Python source. If the doc changes,
-          pre-commit aborts the commit; re-stage the regenerated file and
-          commit again.
+          Always regenerate docs/orrery_packages.md because the catalog's
+          dependency surface includes migrations and adjacent Orrery vocabulary
+          files, not only templates.py/substrate.py/catalog.py. If the doc
+          changes, pre-commit aborts the commit; re-stage the regenerated file
+          and commit again.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Pre-commit hooks
 
-Config in `.pre-commit-config.yaml`. Hooks fire on `git commit` when matching
-files are staged. Currently:
+Config in `.pre-commit-config.yaml`. Hooks fire on `git commit`. Currently:
 
-- **regenerate-orrery-catalog** — when `nexus/agents/orrery/{templates,substrate,catalog}.py` changes, regenerates `docs/orrery_packages.md` so the human-readable catalog stays in lockstep with the canonical Python source. The hook modifies the file; if it does, pre-commit aborts the commit and prompts you to re-stage the regenerated doc + commit again.
+- **regenerate-orrery-catalog** — always runs and regenerates `docs/orrery_packages.md` so the human-readable catalog stays in lockstep with the canonical Python source. The hook modifies the file; if it does, pre-commit aborts the commit and prompts you to re-stage the regenerated doc + commit again.
 
 Bypass (use sparingly): `git commit --no-verify`. CI staleness tests still gate merges.
 

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1491,16 +1491,29 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - actor has `socialize` debt ≥ 24
   - ≥ 4 ticks since last `socialized` event for actor
   - ≥ 4 ticks since last `socialized_alone` event for actor
+  - ≥ 4 ticks since last `travel_departed` event for actor
   - **NOT:** actor has inbound `hunting` pair tag
   - **NOT:** actor has `grieving` ephemeral
   - **NOT:** actor has `wounded` ephemeral
 
 ### Branch 1 — Seek company after extended isolation  *(mag 0.54)*
 
-**When:** actor has `socialize` debt ≥ 168
+**When:**
 
-**Does:** activity → "seeking company after isolation"; fulfills `socialize` need, quality `sought_company_after_isolation`, discharge 9999
-**Event:** `socialized`
+- **AND:**
+  - actor has `socialize` debt ≥ 168
+  - **NOT:** 1+ other entities co-located with actor
+  - **NOT:**
+    - **OR:**
+      - actor is in `commerce` place class
+      - actor is in `entertainment` place class
+      - actor is in `meeting` place class
+      - actor is in `place_open` place class
+  - actor can plausibly move through public flow
+  - actor can resolve a destination with place class `commerce,entertainment,meeting,place_open`
+
+**Does:** activity → "seeking company after isolation"; starts travel toward a `commerce`, `entertainment`, `meeting`, `place_open` destination
+**Event:** `travel_departed`
 
 > {actor} feels the particular pressure that comes from going too long without other people in their life, and moves toward somewhere there will be voices, even if those voices are not for them.
 
@@ -1513,7 +1526,27 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} spends real attention on the people around them — not transactional attention, the other kind — for long enough that the social need is briefly met without anyone naming it as such.
 
-### Branch 3 — Go where people are  *(mag 0.2)*
+### Branch 3 — Set out toward public company  *(mag 0.26)*
+
+**When:**
+
+- **AND:**
+  - **NOT:** 1+ other entities co-located with actor
+  - **NOT:**
+    - **OR:**
+      - actor is in `commerce` place class
+      - actor is in `entertainment` place class
+      - actor is in `meeting` place class
+      - actor is in `place_open` place class
+  - actor can plausibly move through public flow
+  - actor can resolve a destination with place class `commerce,entertainment,meeting,place_open`
+
+**Does:** activity → "seeking public company"; starts travel toward a `commerce`, `entertainment`, `meeting`, `place_open` destination
+**Event:** `travel_departed`
+
+> {actor} chooses movement over more empty time and sets out toward a place where other people can be encountered without requiring the story to pre-name them.
+
+### Branch 4 — Go where people are  *(mag 0.2)*
 
 **When:**
 
@@ -1528,7 +1561,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} goes to one of the places built around the fact that people gather there, and stays long enough to become part of the room's ordinary texture.
 
-### Branch 4 — Reach out to a contact for no urgent reason  *(mag 0.24)*
+### Branch 5 — Reach out to a contact for no urgent reason  *(mag 0.24)*
 
 **When:** actor has outbound `contact:social` pair tag
 
@@ -1537,7 +1570,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} thinks of someone they have not spoken with in too long and reaches out for no urgent reason, which is its own kind of reason.
 
-### Branch 5 — Practice parasocial company  *(mag 0.16)*
+### Branch 6 — Practice parasocial company  *(mag 0.16)*
 
 **When:** *(always)*
 

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -5,6 +5,8 @@
 
 Behavior templates evaluated by the Orrery off-screen resolver, ordered by priority (highest first).
 
+Drive bands are authoring metadata: they explain whether a package is crisis/constraint, embodied maintenance, anchored routine, affiliation, or project/identity pressure. Static priority still decides resolver order; any lower-band package that outranks a higher-band package should carry an explicit rationale.
+
 **Source-of-truth:** `nexus/agents/orrery/templates.py` (`BUILTIN_TEMPLATES`).  
 **Substrate:** `nexus/agents/orrery/substrate.py` (`Template`, `Branch`, `CompoundCondition`).  
 **Design plan:** [docs/orrery_design_plan.md](orrery_design_plan.md)
@@ -15,6 +17,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > When the city is closing in.
 
+**Drive band:** crisis constraint
 **Slots:** ACTOR
 
 **Gate:**
@@ -79,6 +82,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > A bond pulls the actor toward someone in active danger.
 
+**Drive band:** crisis constraint
 **Slots:** ACTOR, TARGET
 **Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
 
@@ -162,6 +166,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > A grudge ripens until the moment is right to settle it.
 
+**Drive band:** project identity — Active vengeance is a high-pressure identity project; left alone, it should interrupt ordinary life.
 **Slots:** ACTOR, TARGET
 **Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
 
@@ -234,6 +239,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > A wounded body pulls the actor toward the small work of mending.
 
+**Drive band:** crisis constraint
 **Slots:** ACTOR, TARGET
 **Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
 
@@ -305,6 +311,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > Steady-state concealment for people who are already living out of sight.
 
+**Drive band:** crisis constraint
 **Slots:** ACTOR
 
 **Gate:**
@@ -389,6 +396,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > A binding obligation surfaces from the blank years.
 
+**Drive band:** project identity — Honor/debt pressure is a story obligation that may preempt ordinary maintenance when the relevant ledger is hot.
 **Slots:** ACTOR
 
 **Gate:**
@@ -436,6 +444,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > A threat surfaces; word reaches the people who need to know.
 
+**Drive band:** crisis constraint
 **Slots:** ACTOR, TARGET
 **Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
 
@@ -505,6 +514,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > The fragments of a buried identity tug at the actor.
 
+**Drive band:** project identity — Ghost-lead pursuit is a long-arc motive with explicit clue pressure, so it can outrank routine maintenance.
 **Slots:** ACTOR
 
 **Gate:**
@@ -551,6 +561,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > A duty of care surfaces between the actor and someone in their charge.
 
+**Drive band:** affiliation — Dependent care is affiliation with responsibility attached, so it can preempt ordinary maintenance.
 **Slots:** ACTOR, TARGET
 **Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
 
@@ -604,6 +615,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > Patient intelligence work with a specific asset.
 
+**Drive band:** project identity — Informant cultivation is relationship-shaped, but it serves an active project rather than ordinary affiliation.
 **Slots:** ACTOR, TARGET
 **Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
 
@@ -674,6 +686,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > The actor remains present through a slow, uncertain hour.
 
+**Drive band:** affiliation — Vigil is affiliation under acute pressure, so it can outrank ordinary maintenance while a target is wounded or dying.
 **Slots:** ACTOR, TARGET
 **Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
 
@@ -742,6 +755,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > Watching from afar without turning observation into contact.
 
+**Drive band:** project identity — Surveillance usually serves live threat or investigation arcs, so it can sit above routine and social maintenance.
 **Slots:** ACTOR, TARGET
 **Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
 
@@ -856,6 +870,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > A small thread of contact between people who hold each other.
 
+**Drive band:** affiliation — Kin maintenance is allowed to beat everyday self-maintenance when the relationship has gone quiet long enough.
 **Slots:** ACTOR, TARGET
 **Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
 
@@ -949,6 +964,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > Two people who do not trust each other are forced into contact anyway.
 
+**Drive band:** project identity — Rival consultation is a deliberate project move, not casual social contact, and can outrank routine obligations.
 **Slots:** ACTOR, TARGET
 **Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
 
@@ -1019,6 +1035,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > Ordinary home/work movement from explicit routine anchors.
 
+**Drive band:** anchored routine — Commute resolves where a routine-bound actor should be before nearby maintenance packages pick a place-shaped branch.
 **Slots:** ACTOR
 
 **Gate:**
@@ -1085,6 +1102,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > A loss settles into the body across many quiet days.
 
+**Drive band:** affiliation — Fresh grief suppresses ordinary social, intimacy, and routine loops; it should beat low-grade bodily maintenance.
 **Slots:** ACTOR
 
 **Gate:**
@@ -1140,6 +1158,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > The body asks for the thing without which it cannot continue.
 
+**Drive band:** embodied maintenance
 **Slots:** ACTOR
 
 **Gate:**
@@ -1205,6 +1224,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > The body asks for water; what it accepts shapes the small hour.
 
+**Drive band:** embodied maintenance
 **Slots:** ACTOR
 
 **Gate:**
@@ -1279,6 +1299,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > The body asks for fuel; what it gets matters more than the cookbook suggests.
 
+**Drive band:** embodied maintenance
 **Slots:** ACTOR
 
 **Gate:**
@@ -1379,6 +1400,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > A character moves between meaningful places without pretending the road is a room.
 
+**Drive band:** anchored routine
 **Slots:** ACTOR
 
 **Gate:**
@@ -1460,6 +1482,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > The need for the company of others, on whatever terms a character can have it.
 
+**Drive band:** affiliation — Accumulated social debt is allowed to interrupt generic work/routine before it becomes a crisis.
 **Slots:** ACTOR
 
 **Gate:**
@@ -1529,6 +1552,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > The body asks for the kind of connection that is not conversation.
 
+**Drive band:** affiliation — Intimacy pressure should beat generic work when gates and suppressors allow it, but remain below basic embodied maintenance.
 **Slots:** ACTOR
 
 **Gate:**
@@ -1622,6 +1646,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > A small act of care for the work that defines them.
 
+**Drive band:** project identity — Craft is the low-pressure identity/project floor and intentionally sits just above generic work.
 **Slots:** ACTOR
 
 **Gate:**
@@ -1720,6 +1745,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > The recurring work that keeps a life, household, or organization functioning.
 
+**Drive band:** anchored routine
 **Slots:** ACTOR
 
 **Gate:**
@@ -1811,6 +1837,7 @@ Behavior templates evaluated by the Orrery off-screen resolver, ordered by prior
 
 > Specific public-cover maintenance, not a universal fallback.
 
+**Drive band:** crisis constraint — priority-order exempt: Public-cover upkeep is crisis/constraint-flavored, but it is intentionally a floor package that should not force routine needs or story obligations to justify outranking it.
 **Slots:** ACTOR
 
 **Gate:**

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1491,7 +1491,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - actor has `socialize` debt ≥ 24
   - ≥ 4 ticks since last `socialized` event for actor
   - ≥ 4 ticks since last `socialized_alone` event for actor
-  - ≥ 4 ticks since last `travel_departed` event for actor
+  - ≥ 4 ticks since last `social_travel_departed` event for actor
   - **NOT:** actor has inbound `hunting` pair tag
   - **NOT:** actor has `grieving` ephemeral
   - **NOT:** actor has `wounded` ephemeral
@@ -1513,7 +1513,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - actor can resolve a destination with place class `commerce,entertainment,meeting,place_open`
 
 **Does:** activity → "seeking company after isolation"; starts travel toward a `commerce`, `entertainment`, `meeting`, `place_open` destination
-**Event:** `travel_departed`
+**Event:** `social_travel_departed`
 
 > {actor} feels the particular pressure that comes from going too long without other people in their life, and moves toward somewhere there will be voices, even if those voices are not for them.
 
@@ -1542,7 +1542,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - actor can resolve a destination with place class `commerce,entertainment,meeting,place_open`
 
 **Does:** activity → "seeking public company"; starts travel toward a `commerce`, `entertainment`, `meeting`, `place_open` destination
-**Event:** `travel_departed`
+**Event:** `social_travel_departed`
 
 > {actor} chooses movement over more empty time and sets out toward a place where other people can be encountered without requiring the story to pre-name them.
 
@@ -1978,6 +1978,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/055_orrery_character_tag_vocab.py`
 - `migrations/056_orrery_routine_anchors.py`
 - `migrations/057_orrery_need_bodyform_applicability.py`
+- `migrations/059_orrery_social_travel_event.py`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 
@@ -2133,6 +2134,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `rival_consulted`
 - `signal_exposure_reduced`
 - `slept`
+- `social_travel_departed`
 - `socialized`
 - `socialized_alone`
 - `surveillance_performed`

--- a/docs/orrery_retrograde_spec.md
+++ b/docs/orrery_retrograde_spec.md
@@ -1,6 +1,6 @@
 # Orrery Retrograde — Deep-History Generation Spec
 
-**Status:** Design spec, deliberately compressed. Implementation decisions deferred to downstream agents; flagged inline as **[OPEN]**.
+**Status:** Design spec, deliberately compressed. Phase A0 now has a non-mutating dry-run packet surface; larger implementation decisions remain deferred and flagged inline as **[OPEN]**.
 **One-line frame:** Deep history is Orrery run backward. Same substrate, same vocabulary, opposite temporal direction. Output is `world_events` rows retrieved by MEMNON identically to play-generated history. Fires at wizard-time (whole-world cold start, pre-game tick stamps) and at runtime (per-entity stub maturation, current tick stamps) — see Stub Maturation below.
 
 ---
@@ -74,7 +74,7 @@ This is what keeps Retrograde non-recursive: implied entities accrete just enoug
 
 Six stages, labeled **R1–R6** to disambiguate from the forward Orrery pipeline's Stage 1–6 (Resolve/Commit/Clear/Promote/Narrate/Bleed in `orrery_design_plan.md`). Each consumes the prior; **[OPEN]** boundaries may merge during implementation.
 
-- **R1. Vocabulary table.** Enumerate the seed-eligible primitives: event types, tags, relationship types, and semantic place classes already in the Orrery registries. Retrograde generates *only* in existing vocabulary so output is substrate-legal by construction. New vocabulary is out of scope for a generation run. The first-pass enumerator exists at `nexus/agents/orrery/retrograde_vocabulary.py`; pass a target slot `dbname` once migrations are applied so it folds live `tag_category_registry` / `tags` rows into the template-derived primitive set. The remaining pre-Phase-A work is prompt shaping and deciding which registered categories are seed-eligible versus merely prompt-visible.
+- **R1. Vocabulary table.** Enumerate the seed-eligible primitives: event types, tags, relationship types, and semantic place classes already in the Orrery registries. Retrograde generates *only* in existing vocabulary so output is substrate-legal by construction. New vocabulary is out of scope for a generation run. The first-pass enumerator exists at `nexus/agents/orrery/retrograde_vocabulary.py`; pass a target slot `dbname` once migrations are applied so it folds live `tag_category_registry` / `tags` rows into the template-derived primitive set. Phase A0 packet assembly now exists at `nexus/agents/orrery/retrograde_packet.py` and is exposed as `nexus retrograde-packet --slot N [--weird low|medium|high] [--weird-raw FLOAT] [--output packet.json]`. It reads wizard cache + vocabulary + configured weird bands, writes no canonical rows, and produces candidate prompt material for a later Skald-as-weaver selection/expansion pass.
 
 - **R2. Stub generator.** From wizard choices (setting, genre, starting characters, selected traits), emit entity stubs and a sparse relationship graph — the *intentional core*. This is deterministic-ish scaffolding, low entropy, fully implied by wizard input.
 

--- a/migrations/059_orrery_social_travel_event.py
+++ b/migrations/059_orrery_social_travel_event.py
@@ -1,0 +1,42 @@
+"""Register scoped event vocabulary for social travel departures."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+EVENT_TYPES: Sequence[tuple[str, str, str, str]] = (
+    (
+        "social_travel_departed",
+        "social",
+        "minor",
+        "A character begins travel specifically to seek social company.",
+    ),
+)
+
+
+def run(conn) -> None:
+    """Seed social travel event types idempotently."""
+
+    with conn.cursor() as cur:
+        for event_type, category, severity, description in EVENT_TYPES:
+            cur.execute(
+                """
+                INSERT INTO event_types (
+                    type, category, severity, description,
+                    deprecated, synonym_for
+                ) VALUES (
+                    %s, %s, %s::event_severity_kind, %s,
+                    FALSE, NULL
+                )
+                ON CONFLICT (type) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    severity = EXCLUDED.severity,
+                    description = EXCLUDED.description,
+                    deprecated = FALSE,
+                    synonym_for = NULL
+                """,
+                (event_type, category, severity, description),
+            )
+
+    conn.commit()

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -177,6 +177,13 @@ _register(
     lambda m: f"{_slot(m.group('slot'))} is in `{m.group('lc')}` place class",
 )
 _register(
+    r"has_location_class_destination\((?P<lc>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('slot'))} can resolve a destination with place class "
+        f"`{m.group('lc')}`"
+    ),
+)
+_register(
     r"in_location\((?P<lid>\d+)@(?P<slot>\w+)\)",
     lambda m: f"{_slot(m.group('slot'))} is at location id `{m.group('lid')}`",
 )
@@ -450,7 +457,22 @@ def _render_state_delta(delta: Mapping[str, Any]) -> str:
                 parts.append(f"fulfills `{value}` need")
             continue
         if key == "travel.start":
-            parts.append("starts planned travel")
+            if isinstance(value, Mapping):
+                destination_classes = value.get(
+                    "destination_place_classes"
+                ) or value.get("destination_place_class")
+                if destination_classes:
+                    if isinstance(destination_classes, str):
+                        destination = f"`{destination_classes}`"
+                    else:
+                        destination = ", ".join(
+                            f"`{item}`" for item in destination_classes
+                        )
+                    parts.append(f"starts travel toward a {destination} destination")
+                else:
+                    parts.append("starts planned travel")
+            else:
+                parts.append("starts planned travel")
             continue
         if key == "travel.advance":
             progress = (
@@ -585,6 +607,7 @@ _VOCAB_PATTERNS: List[Tuple[str, re.Pattern]] = [
     ("event_type", re.compile(r"recent_event\(([^,*()]+),")),
     ("event_type", re.compile(r"since_last_event_at_least\(([^,()]+),")),
     ("place_class", re.compile(r"in_location_class\(([^@()]+)@")),
+    ("place_class_list", re.compile(r"has_location_class_destination\(([^@()]+)@")),
     ("relationship", re.compile(r"has_relationship_of_type\(([^,()]+),")),
     (
         "relationship",
@@ -647,6 +670,9 @@ def _collect_vocabulary(
                 events.add(captured)
             elif kind == "place_class":
                 place_classes.add(captured)
+            elif kind == "place_class_list":
+                for tag in captured.split(","):
+                    place_classes.add(tag.strip())
             elif kind == "relationship":
                 relationships.add(captured)
             # First-match-wins: prevents future overlapping patterns from

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -460,7 +460,9 @@ def _render_state_delta(delta: Mapping[str, Any]) -> str:
             if isinstance(value, Mapping):
                 destination_classes = value.get(
                     "destination_place_classes"
-                ) or value.get("destination_place_class")
+                ) or value.get("destination_place_class") or value.get(
+                    "destination_class"
+                )
                 if destination_classes:
                     if isinstance(destination_classes, str):
                         destination = f"`{destination_classes}`"

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -32,6 +32,7 @@ from nexus.agents.orrery.substrate import (
     Branch,
     CompoundCondition,
     Template,
+    drive_band_priority_warnings,
 )
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 
@@ -523,6 +524,21 @@ def _render_present_target_policy(template: Template) -> str | None:
     return f"`{value}`"
 
 
+def _render_drive_band(template: Template) -> str:
+    """Render one template's drive band and any priority rationale."""
+
+    value = template.drive_band.value.replace("_", " ")
+    if template.drive_band_priority_exempt:
+        if not template.priority_override_rationale:
+            return f"{value} — priority-order exempt"
+        return (
+            f"{value} — priority-order exempt: {template.priority_override_rationale}"
+        )
+    if not template.priority_override_rationale:
+        return value
+    return f"{value} — {template.priority_override_rationale}"
+
+
 def _render_template(template: Template) -> List[str]:
     slots = ", ".join(s.value.upper() for s in template.required_slots)
     lines = [
@@ -530,6 +546,7 @@ def _render_template(template: Template) -> List[str]:
         "",
         f"> {template.blurb}",
         "",
+        f"**Drive band:** {_render_drive_band(template)}",
         f"**Slots:** {slots}",
     ]
     policy_prose = _render_present_target_policy(template)
@@ -760,6 +777,12 @@ def render_catalog(templates: Iterable[Template]) -> str:
         "Behavior templates evaluated by the Orrery off-screen resolver, "
         "ordered by priority (highest first).",
         "",
+        "Drive bands are authoring metadata: they explain whether a package is "
+        "crisis/constraint, embodied maintenance, anchored routine, affiliation, "
+        "or project/identity pressure. Static priority still decides resolver "
+        "order; any lower-band package that outranks a higher-band package should "
+        "carry an explicit rationale.",
+        "",
         "**Source-of-truth:** `nexus/agents/orrery/templates.py` "
         "(`BUILTIN_TEMPLATES`).  ",
         "**Substrate:** `nexus/agents/orrery/substrate.py` "
@@ -770,6 +793,20 @@ def render_catalog(templates: Iterable[Template]) -> str:
         "",
     ]
     sorted_templates = sorted(templates, key=lambda t: -t.priority)
+    warnings = drive_band_priority_warnings(sorted_templates)
+    if warnings:
+        lines.extend(
+            [
+                "## Drive-Band Priority Warnings",
+                "",
+                "These package priorities contradict the default drive-band order "
+                "without an explicit rationale:",
+                "",
+            ]
+        )
+        for warning in warnings:
+            lines.append(f"- {warning}")
+        lines.extend(["", "---", ""])
     for template in sorted_templates:
         lines.extend(_render_template(template))
         lines.append("---")

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -1361,10 +1361,12 @@ def _destination_place_classes(payload: Mapping[str, Any]) -> tuple[str, ...]:
         return ()
     if isinstance(raw, str):
         values = (raw,)
-    elif isinstance(raw, Iterable):
+    elif isinstance(raw, (list, tuple)):
         values = tuple(raw)
     else:
-        raise ValueError("destination place classes must be a string or iterable")
+        raise ValueError(
+            "destination place classes must be a string, list, or tuple"
+        )
     classes = tuple(dict.fromkeys(str(item) for item in values if str(item)))
     if not classes:
         raise ValueError("destination place classes cannot be empty")
@@ -2610,6 +2612,8 @@ def _location_class_destination_sync(
          AND etc.tag = ANY(%s)
         WHERE p.id <> %s
           AND (p.type::text = ANY(%s) OR etc.tag IS NOT NULL)
+        -- Collapse multiple matching tags per place before preferring same-zone
+        -- destinations.
         GROUP BY p.id, p.zone, origin.zone
         ORDER BY CASE
                    WHEN origin.zone IS NOT NULL AND p.zone = origin.zone THEN 0
@@ -2735,6 +2739,8 @@ async def _location_class_destination_async(
          AND etc.tag = ANY($3::text[])
         WHERE p.id <> $1
           AND (p.type::text = ANY($3::text[]) OR etc.tag IS NOT NULL)
+        -- Collapse multiple matching tags per place before preferring same-zone
+        -- destinations.
         GROUP BY p.id, p.zone, origin.zone
         ORDER BY CASE
                    WHEN origin.zone IS NOT NULL AND p.zone = origin.zone THEN 0

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -21,6 +21,7 @@ from nexus.agents.orrery.needs import (
     severity_tags_for_need,
 )
 from nexus.agents.orrery.resolver import (
+    LOCATION_CLASS_TAG_CATEGORIES,
     OrreryResolutionDraft,
     OrreryTickProposal,
 )
@@ -1348,6 +1349,28 @@ def _coerce_travel_payload(raw: Any) -> dict[str, Any]:
     raise ValueError("travel state_delta values must be mappings or true")
 
 
+def _destination_place_classes(payload: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return class-based destination selectors from a travel payload."""
+
+    raw = (
+        payload.get("destination_place_classes")
+        or payload.get("destination_place_class")
+        or payload.get("destination_class")
+    )
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        values = (raw,)
+    elif isinstance(raw, Iterable):
+        values = tuple(raw)
+    else:
+        raise ValueError("destination place classes must be a string or iterable")
+    classes = tuple(dict.fromkeys(str(item) for item in values if str(item)))
+    if not classes:
+        raise ValueError("destination place classes cannot be empty")
+    return classes
+
+
 def _travel_mode(payload: Mapping[str, Any], fallback: str = "mixed") -> str:
     mode = str(payload.get("mode") or payload.get("travel_mode") or fallback)
     if mode not in TRAVEL_MODE_DETOUR_FACTOR:
@@ -1410,7 +1433,15 @@ def _apply_travel_start_sync(
                 anchor_type=str(destination_anchor),
             )
         else:
-            destination_place_id = _planned_destination_sync(cur, actor_entity_id)
+            destination_classes = _destination_place_classes(data)
+            if destination_classes and origin_place_id is not None:
+                destination_place_id = _location_class_destination_sync(
+                    cur,
+                    origin_place_id=int(origin_place_id),
+                    location_classes=destination_classes,
+                )
+            else:
+                destination_place_id = _planned_destination_sync(cur, actor_entity_id)
     if origin_place_id is None or destination_place_id is None:
         raise ValueError("travel.start requires origin and destination places")
 
@@ -1505,9 +1536,17 @@ async def _apply_travel_start_async(
                 anchor_type=str(destination_anchor),
             )
         else:
-            destination_place_id = await _planned_destination_async(
-                conn, actor_entity_id
-            )
+            destination_classes = _destination_place_classes(data)
+            if destination_classes and origin_place_id is not None:
+                destination_place_id = await _location_class_destination_async(
+                    conn,
+                    origin_place_id=int(origin_place_id),
+                    location_classes=destination_classes,
+                )
+            else:
+                destination_place_id = await _planned_destination_async(
+                    conn, actor_entity_id
+                )
     if origin_place_id is None or destination_place_id is None:
         raise ValueError("travel.start requires origin and destination places")
 
@@ -2554,6 +2593,43 @@ def _routine_zone_destination_sync(
     return _row_get(row, "id", 0) if row else None
 
 
+def _location_class_destination_sync(
+    cur: Any,
+    *,
+    origin_place_id: int,
+    location_classes: tuple[str, ...],
+) -> Optional[int]:
+    cur.execute(
+        """
+        SELECT p.id
+        FROM places p
+        LEFT JOIN places origin ON origin.id = %s
+        LEFT JOIN entity_tags_current etc
+          ON etc.entity_id = p.entity_id
+         AND etc.category = ANY(%s)
+         AND etc.tag = ANY(%s)
+        WHERE p.id <> %s
+          AND (p.type::text = ANY(%s) OR etc.tag IS NOT NULL)
+        GROUP BY p.id, p.zone, origin.zone
+        ORDER BY CASE
+                   WHEN origin.zone IS NOT NULL AND p.zone = origin.zone THEN 0
+                   ELSE 1
+                 END,
+                 p.id
+        LIMIT 1
+        """,
+        (
+            origin_place_id,
+            list(LOCATION_CLASS_TAG_CATEGORIES),
+            list(location_classes),
+            origin_place_id,
+            list(location_classes),
+        ),
+    )
+    row = cur.fetchone()
+    return _row_get(row, "id", 0) if row else None
+
+
 async def _planned_destination_async(conn: Any, actor_entity_id: int) -> Optional[int]:
     return await conn.fetchval(
         """
@@ -2639,6 +2715,37 @@ async def _routine_zone_destination_async(
         """,
         list(preferred_tags),
         zone_id,
+    )
+
+
+async def _location_class_destination_async(
+    conn: Any,
+    *,
+    origin_place_id: int,
+    location_classes: tuple[str, ...],
+) -> Optional[int]:
+    return await conn.fetchval(
+        """
+        SELECT p.id
+        FROM places p
+        LEFT JOIN places origin ON origin.id = $1
+        LEFT JOIN entity_tags_current etc
+          ON etc.entity_id = p.entity_id
+         AND etc.category = ANY($2::text[])
+         AND etc.tag = ANY($3::text[])
+        WHERE p.id <> $1
+          AND (p.type::text = ANY($3::text[]) OR etc.tag IS NOT NULL)
+        GROUP BY p.id, p.zone, origin.zone
+        ORDER BY CASE
+                   WHEN origin.zone IS NOT NULL AND p.zone = origin.zone THEN 0
+                   ELSE 1
+                 END,
+                 p.id
+        LIMIT 1
+        """,
+        origin_place_id,
+        list(LOCATION_CLASS_TAG_CATEGORIES),
+        list(location_classes),
     )
 
 

--- a/nexus/agents/orrery/retrograde_packet.py
+++ b/nexus/agents/orrery/retrograde_packet.py
@@ -1,0 +1,313 @@
+"""Dry-run Retrograde review packet assembly."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional
+
+from nexus.agents.orrery.retrograde_vocabulary import SeedEligibleVocabulary
+from nexus.config.settings_models import Settings
+
+PACKET_SCHEMA_VERSION = "orrery_retrograde_dry_run_packet.v0"
+WEIRD_LEVELS = frozenset({"low", "medium", "high"})
+
+
+def build_retrograde_dry_run_packet(
+    *,
+    slot: int,
+    dbname: str,
+    cache: Any,
+    vocabulary: SeedEligibleVocabulary,
+    settings: Settings,
+    weird_level: Optional[str] = None,
+    weird_raw: Optional[float] = None,
+) -> dict[str, Any]:
+    """Build a non-mutating Retrograde packet from wizard cache and vocabulary."""
+
+    setting = _require_cache_section(cache, "get_setting_dict", "setting")
+    character = _require_cache_section(cache, "get_character_dict", "character")
+    seed = _require_cache_section(cache, "get_seed_dict", "seed")
+    layer = _optional_cache_section(cache, "get_layer_dict")
+    zone = _optional_cache_section(cache, "get_zone_dict")
+    initial_location = _optional_cache_section(cache, "get_initial_location")
+    weird = resolve_weird_profile(
+        settings=settings,
+        setting=setting,
+        weird_level=weird_level,
+        weird_raw=weird_raw,
+    )
+
+    candidate_scaffolds = _candidate_scaffolds(
+        character=character,
+        seed=seed,
+        layer=layer,
+        zone=zone,
+        initial_location=initial_location,
+    )
+
+    return {
+        "schema_version": PACKET_SCHEMA_VERSION,
+        "dry_run": True,
+        "mutation_policy": {
+            "writes": "none",
+            "review_contract": (
+                "Retrograde A0 only assembles candidate prompt material. No "
+                "world_events, entity_tags, relationships, or wizard cache rows "
+                "are written. A later Skald-as-weaver pass must select, reject, "
+                "or connect candidate seeds before any bootstrap persistence."
+            ),
+        },
+        "slot": slot,
+        "dbname": dbname,
+        "wizard_phase": (
+            cache.current_phase() if hasattr(cache, "current_phase") else "unknown"
+        ),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "inputs": {
+            "setting": setting,
+            "character": character,
+            "seed": seed,
+            "layer": layer,
+            "zone": zone,
+            "initial_location": initial_location,
+        },
+        "weird": weird,
+        "vocabulary_summary": _vocabulary_summary(vocabulary),
+        "seed_eligible_vocabulary": vocabulary,
+        "candidate_scaffolds": candidate_scaffolds,
+        "skald_weaver_instructions": _skald_weaver_instructions(),
+    }
+
+
+def resolve_weird_profile(
+    *,
+    settings: Settings,
+    setting: Mapping[str, Any],
+    weird_level: Optional[str] = None,
+    weird_raw: Optional[float] = None,
+) -> dict[str, Any]:
+    """Resolve player-facing weirdness into the configured raw calibration band."""
+
+    if settings.orrery is None:
+        raise ValueError("settings.orrery is required for Retrograde weirdness")
+    weird_settings = settings.orrery.retrograde.weird
+    level = weird_level or weird_settings.default_level
+    if level not in WEIRD_LEVELS:
+        raise ValueError("Retrograde weird level must be low, medium, or high")
+
+    selected_genre = _select_genre(setting, weird_settings.bands_by_genre)
+    if weird_raw is not None:
+        if not weird_settings.dev.min <= weird_raw <= weird_settings.dev.max:
+            raise ValueError(
+                "Retrograde raw weirdness must be within "
+                f"{weird_settings.dev.min:g}..{weird_settings.dev.max:g}"
+            )
+        return {
+            "source": "raw_override",
+            "level": level,
+            "genre": selected_genre["genre"],
+            "genre_input": selected_genre["input"],
+            "raw": float(weird_raw),
+            "raw_min": float(weird_raw),
+            "raw_max": float(weird_raw),
+        }
+
+    bands = weird_settings.bands_by_genre.get(selected_genre["genre"])
+    if bands is None:
+        raise ValueError(
+            "No Retrograde weirdness bands configured for genre "
+            f"{selected_genre['input']!r}"
+        )
+    band = getattr(bands, level)
+    return {
+        "source": "configured_band",
+        "level": level,
+        "genre": selected_genre["genre"],
+        "genre_input": selected_genre["input"],
+        "raw_min": band.min,
+        "raw_max": band.max,
+        "raw_midpoint": (band.min + band.max) / 2.0,
+    }
+
+
+def _candidate_scaffolds(
+    *,
+    character: Mapping[str, Any],
+    seed: Mapping[str, Any],
+    layer: Optional[Mapping[str, Any]],
+    zone: Optional[Mapping[str, Any]],
+    initial_location: Optional[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Return deterministic R2/R3 scaffold cards for later seed generation."""
+
+    concept = _mapping(character.get("concept"))
+    trait_selection = _mapping(character.get("trait_selection"))
+    wildcard = _mapping(character.get("wildcard"))
+    selected_traits = list(trait_selection.get("selected_traits") or ())
+
+    return {
+        "core_entities": [
+            _compact_card(
+                kind="character",
+                role="protagonist",
+                name=concept.get("name"),
+                summary=concept.get("background") or concept.get("archetype"),
+                details={
+                    "archetype": concept.get("archetype"),
+                    "appearance": concept.get("appearance"),
+                },
+            ),
+            _compact_card(
+                kind="place",
+                role="starting_location",
+                name=_mapping(initial_location).get("name"),
+                summary=_mapping(initial_location).get("description")
+                or _mapping(initial_location).get("summary"),
+                details=_mapping(initial_location),
+            ),
+            _compact_card(
+                kind="zone",
+                role="starting_zone",
+                name=_mapping(zone).get("name"),
+                summary=_mapping(zone).get("summary"),
+                details=_mapping(zone),
+            ),
+            _compact_card(
+                kind="layer",
+                role="starting_layer",
+                name=_mapping(layer).get("name"),
+                summary=_mapping(layer).get("description"),
+                details=_mapping(layer),
+            ),
+        ],
+        "named_seed_npcs": [
+            {"kind": "character", "role": "seed_npc", "name": name}
+            for name in seed.get("key_npcs", [])
+            if name
+        ],
+        "pressure_axes": [
+            _axis("stakes", seed.get("stakes")),
+            _axis("tension_source", seed.get("tension_source")),
+            _axis("hook", seed.get("hook")),
+            _axis("immediate_goal", seed.get("immediate_goal")),
+            _axis("seed_secrets", seed.get("secrets")),
+        ],
+        "trait_hooks": {
+            "selected_traits": selected_traits,
+            "rationales": trait_selection.get("trait_rationales") or {},
+            "wildcard": {
+                "name": wildcard.get("wildcard_name"),
+                "description": wildcard.get("wildcard_description"),
+                "orrery_tags": wildcard.get("orrery_tags"),
+            },
+        },
+        "candidate_seed_contract": {
+            "stage": "R4 seed generation input",
+            "target_output": "candidate seeds only",
+            "selection_required": True,
+            "discard_cost": "inference only",
+            "anchor_rule": "Every surviving thread must connect back to a core entity.",
+        },
+    }
+
+
+def _vocabulary_summary(vocabulary: SeedEligibleVocabulary) -> dict[str, int]:
+    """Return compact counts for CLI and review-packet scanning."""
+
+    return {
+        "entity_kinds": len(vocabulary["entity_kinds"]),
+        "single_entity_tag_anchors": len(vocabulary["single_entity_tag_anchors"]),
+        "registered_tag_categories": len(vocabulary["registered_tag_categories"]),
+        "multi_entity_tag_families": len(vocabulary["multi_entity_tag_families"]),
+        "event_types": len(vocabulary["event_types"]),
+        "place_classes": len(vocabulary["place_classes"]),
+        "relationship_types": len(vocabulary["relationship_types"]),
+    }
+
+
+def _skald_weaver_instructions() -> list[str]:
+    """Return the non-mutating prompt contract for the next Retrograde stage."""
+
+    return [
+        "Generate candidate deep-history seeds, not canonical history.",
+        "Use only seed_eligible_vocabulary primitives for mechanical tags/events.",
+        "Over-generate; later selection must be allowed to discard weak seeds.",
+        (
+            "Prefer surprise at the seed origin, but require leaf anchoring "
+            "to present canon."
+        ),
+        "Do not write rows. Persistence belongs to a later reviewed expansion pass.",
+    ]
+
+
+def _select_genre(
+    setting: Mapping[str, Any],
+    configured_bands: Mapping[str, Any],
+) -> dict[str, str]:
+    candidates = [setting.get("genre"), *(setting.get("secondary_genres") or ())]
+    for candidate in candidates:
+        normalized = _normalize_genre(candidate)
+        if normalized in configured_bands:
+            return {"input": str(candidate), "genre": normalized}
+    primary = candidates[0] if candidates else None
+    normalized_primary = _normalize_genre(primary)
+    return {"input": str(primary or ""), "genre": normalized_primary}
+
+
+def _normalize_genre(value: Any) -> str:
+    normalized = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "science_fiction": "scifi",
+        "sci_fi": "scifi",
+        "post_apocalyptic": "postapocalyptic",
+        "post_apocalypse": "postapocalyptic",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def _require_cache_section(
+    cache: Any, method_name: str, label: str
+) -> Mapping[str, Any]:
+    section = _optional_cache_section(cache, method_name)
+    if section is None:
+        raise ValueError(f"Retrograde packet requires complete wizard {label} data")
+    return section
+
+
+def _optional_cache_section(
+    cache: Any, method_name: str
+) -> Optional[Mapping[str, Any]]:
+    method = getattr(cache, method_name, None)
+    if method is None:
+        return None
+    section = method()
+    if section is None:
+        return None
+    if not isinstance(section, Mapping):
+        raise ValueError(f"{method_name} must return a mapping or None")
+    return section
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _axis(kind: str, text: Any) -> dict[str, Any]:
+    return {"kind": kind, "text": text}
+
+
+def _compact_card(
+    *,
+    kind: str,
+    role: str,
+    name: Any,
+    summary: Any,
+    details: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "role": role,
+        "name": name,
+        "summary": summary,
+        "details": {key: value for key, value in details.items() if value is not None},
+    }

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -642,6 +642,40 @@ def in_location_class(location_class: str, slot: Slot = Slot.ACTOR) -> Condition
     return _named(_condition, f"in_location_class({location_class}@{slot.value})")
 
 
+def has_location_class_destination(
+    *location_classes: str,
+    slot: Slot = Slot.ACTOR,
+) -> Condition:
+    """Return whether the actor can target another place by semantic class."""
+
+    classes = tuple(dict.fromkeys(str(item) for item in location_classes if str(item)))
+    if not classes:
+        raise ValueError("has_location_class_destination requires at least one class")
+    class_set = frozenset(classes)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None or _is_in_transit(state, entity_id):
+            return False
+        current_place_id = state.locations.get(entity_id)
+        if current_place_id is None:
+            return False
+        for place_id, semantic_classes in state.location_classes.items():
+            if place_id == current_place_id:
+                continue
+            if class_set & semantic_classes:
+                return True
+            if state.location_class.get(place_id) in class_set:
+                return True
+        return False
+
+    class_names = ",".join(classes)
+    return _named(
+        _condition,
+        f"has_location_class_destination({class_names}@{slot.value})",
+    )
+
+
 def in_location(location_id: int, slot: Slot = Slot.ACTOR) -> Condition:
     """Return whether an entity is currently at a specific place id."""
 

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -665,7 +665,10 @@ def has_location_class_destination(
                 continue
             if class_set & semantic_classes:
                 return True
-            if state.location_class.get(place_id) in class_set:
+        for place_id, location_class in state.location_class.items():
+            if place_id == current_place_id:
+                continue
+            if location_class in class_set:
                 return True
         return False
 

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -40,9 +40,31 @@ class PresentTargetPolicy(str, Enum):
     STORYTELLER_PRESSURE = "storyteller_pressure"
 
 
+class DriveBand(str, Enum):
+    """Authoring-level package priority band.
+
+    Drive bands explain why a package sits where it does in the priority
+    ladder. They are not a replacement for static priority; they make unusual
+    ordering choices visible so package composition stays intentional.
+    """
+
+    CRISIS_CONSTRAINT = "crisis_constraint"
+    EMBODIED_MAINTENANCE = "embodied_maintenance"
+    ANCHORED_ROUTINE = "anchored_routine"
+    AFFILIATION = "affiliation"
+    PROJECT_IDENTITY = "project_identity"
+
+
 Bindings = Dict[Slot, Any]
 Condition = Callable[["WorldState", Bindings], bool]
 ContactKind = Literal["lodging", "social", "intimate"]
+DRIVE_BAND_ORDER: Mapping[DriveBand, int] = {
+    DriveBand.CRISIS_CONSTRAINT: 0,
+    DriveBand.EMBODIED_MAINTENANCE: 1,
+    DriveBand.ANCHORED_ROUTINE: 2,
+    DriveBand.AFFILIATION: 3,
+    DriveBand.PROJECT_IDENTITY: 4,
+}
 
 INTIMACY_SUPPRESSOR_TAGS: frozenset[str] = frozenset(
     {
@@ -1379,26 +1401,32 @@ class Template:
 
     id: str
     priority: int
+    drive_band: DriveBand
     blurb: str
     required_slots: Tuple[Slot, ...]
     package_gate: Condition
     branches: Tuple[Branch, ...]
     present_target_policy: PresentTargetPolicy = PresentTargetPolicy.OFFSCREEN_ONLY
+    priority_override_rationale: Optional[str] = None
+    drive_band_priority_exempt: bool = False
 
     def __post_init__(self) -> None:
         """Validate authoring invariants that affect resolver routing."""
 
-        if self.present_target_policy is not PresentTargetPolicy.STORYTELLER_PRESSURE:
-            return
+        if isinstance(self.drive_band, str):
+            object.__setattr__(self, "drive_band", DriveBand(self.drive_band))
 
-        missing = [
-            branch.label for branch in self.branches if not branch.scene_pressure_stub
-        ]
-        if missing:
-            raise ValueError(
-                f"Template {self.id!r}: STORYTELLER_PRESSURE branches must set "
-                f"scene_pressure_stub; missing on: {missing}"
-            )
+        if self.present_target_policy is PresentTargetPolicy.STORYTELLER_PRESSURE:
+            missing = [
+                branch.label
+                for branch in self.branches
+                if not branch.scene_pressure_stub
+            ]
+            if missing:
+                raise ValueError(
+                    f"Template {self.id!r}: STORYTELLER_PRESSURE branches must set "
+                    f"scene_pressure_stub; missing on: {missing}"
+                )
 
 
 @dataclass(frozen=True, slots=True)
@@ -1498,3 +1526,40 @@ def validate_always_fallbacks(templates: Iterable[Template]) -> None:
             "Orrery templates missing terminal ALWAYS branch: "
             + ", ".join(sorted(missing))
         )
+
+
+def drive_band_priority_warnings(templates: Iterable[Template]) -> Tuple[str, ...]:
+    """Return package priority inversions without explicit rationale.
+
+    A warning means a lower-urgency drive band outranks a higher-urgency band
+    and the outranking template does not explain why. This is deliberately an
+    authoring check, not a runtime resolver rule: Skald-facing story obligations
+    can outrank routine needs, but the catalog should say so.
+    """
+
+    ordered = tuple(templates)
+    warnings: list[str] = []
+    for template in ordered:
+        if template.drive_band_priority_exempt:
+            continue
+        template_rank = DRIVE_BAND_ORDER[template.drive_band]
+        if template.priority_override_rationale:
+            continue
+        contradicted = [
+            other
+            for other in ordered
+            if not other.drive_band_priority_exempt
+            and other.priority < template.priority
+            and DRIVE_BAND_ORDER[other.drive_band] < template_rank
+        ]
+        if contradicted:
+            strongest = min(
+                contradicted, key=lambda item: DRIVE_BAND_ORDER[item.drive_band]
+            )
+            warnings.append(
+                f"{template.id} ({template.drive_band.value}, priority "
+                f"{template.priority}) outranks {strongest.id} "
+                f"({strongest.drive_band.value}, priority {strongest.priority}) "
+                "without priority_override_rationale"
+            )
+    return tuple(sorted(warnings))

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -2923,7 +2923,7 @@ SOCIALIZE = Template(
         has_need_debt_at_or_above("socialize", 24),
         since_last_event_at_least("socialized", minimum_ticks=4),
         since_last_event_at_least("socialized_alone", minimum_ticks=4),
-        since_last_event_at_least("travel_departed", minimum_ticks=4),
+        since_last_event_at_least("social_travel_departed", minimum_ticks=4),
         NOT(has_inbound_pair_tag("hunting")),
         NOT(has_ephemeral("grieving")),
         NOT(has_ephemeral("wounded")),
@@ -2959,7 +2959,7 @@ SOCIALIZE = Template(
                     "initial_progress": 0.05,
                 },
             },
-            event_type="travel_departed",
+            event_type="social_travel_departed",
             changed_fields=(
                 "character.current_activity",
                 "character_travel_states.status",
@@ -3019,7 +3019,7 @@ SOCIALIZE = Template(
                     "initial_progress": 0.05,
                 },
             },
-            event_type="travel_departed",
+            event_type="social_travel_departed",
             changed_fields=(
                 "character.current_activity",
                 "character_travel_states.status",

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -24,6 +24,7 @@ from nexus.agents.orrery.substrate import (
     has_ephemeral,
     has_established_partner_co_located,
     has_inbound_pair_tag,
+    has_location_class_destination,
     has_minimal_context,
     has_need_debt_at_or_above,
     has_pair_tag_to_current_location,
@@ -2922,6 +2923,7 @@ SOCIALIZE = Template(
         has_need_debt_at_or_above("socialize", 24),
         since_last_event_at_least("socialized", minimum_ticks=4),
         since_last_event_at_least("socialized_alone", minimum_ticks=4),
+        since_last_event_at_least("travel_departed", minimum_ticks=4),
         NOT(has_inbound_pair_tag("hunting")),
         NOT(has_ephemeral("grieving")),
         NOT(has_ephemeral("wounded")),
@@ -2929,7 +2931,15 @@ SOCIALIZE = Template(
     branches=(
         Branch(
             label="Seek company after extended isolation",
-            conditions=has_need_debt_at_or_above("socialize", 168),
+            conditions=AND(
+                has_need_debt_at_or_above("socialize", 168),
+                NOT(count_co_located(1)),
+                NOT(SOCIAL_VENUE_PLACE),
+                can_move_publicly(),
+                has_location_class_destination(
+                    "commerce", "entertainment", "meeting", "place_open"
+                ),
+            ),
             narrative_stub=(
                 "{actor} feels the particular pressure that comes from going "
                 "too long without other people in their life, and moves "
@@ -2938,16 +2948,22 @@ SOCIALIZE = Template(
             ),
             state_delta={
                 "character.current_activity": "seeking company after isolation",
-                "need.fulfill": {
-                    "type": "socialize",
-                    "quality": "sought_company_after_isolation",
-                    "discharge_debt": 9999,
+                "travel.start": {
+                    "destination_place_classes": [
+                        "commerce",
+                        "entertainment",
+                        "meeting",
+                        "place_open",
+                    ],
+                    "mode": "mixed",
+                    "initial_progress": 0.05,
                 },
             },
-            event_type="socialized",
+            event_type="travel_departed",
             changed_fields=(
                 "character.current_activity",
-                "character_need_states.debt_score",
+                "character_travel_states.status",
+                "character_travel_states.progress_ratio",
             ),
             magnitude=0.54,
         ),
@@ -2974,6 +2990,42 @@ SOCIALIZE = Template(
                 "character_need_states.debt_score",
             ),
             magnitude=0.22,
+        ),
+        Branch(
+            label="Set out toward public company",
+            conditions=AND(
+                NOT(count_co_located(1)),
+                NOT(SOCIAL_VENUE_PLACE),
+                can_move_publicly(),
+                has_location_class_destination(
+                    "commerce", "entertainment", "meeting", "place_open"
+                ),
+            ),
+            narrative_stub=(
+                "{actor} chooses movement over more empty time and sets out "
+                "toward a place where other people can be encountered without "
+                "requiring the story to pre-name them."
+            ),
+            state_delta={
+                "character.current_activity": "seeking public company",
+                "travel.start": {
+                    "destination_place_classes": [
+                        "commerce",
+                        "entertainment",
+                        "meeting",
+                        "place_open",
+                    ],
+                    "mode": "mixed",
+                    "initial_progress": 0.05,
+                },
+            },
+            event_type="travel_departed",
+            changed_fields=(
+                "character.current_activity",
+                "character_travel_states.status",
+                "character_travel_states.progress_ratio",
+            ),
+            magnitude=0.26,
         ),
         Branch(
             label="Go where people are",

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -9,6 +9,7 @@ from nexus.agents.orrery.substrate import (
     OR,
     Branch,
     Condition,
+    DriveBand,
     PresentTargetPolicy,
     Slot,
     Template,
@@ -95,6 +96,7 @@ PRIVATE_PLACE = _place_any("dwelling", "place_restricted")
 EVADE_PURSUERS = Template(
     id="evade_pursuers",
     priority=100,
+    drive_band=DriveBand.CRISIS_CONSTRAINT,
     blurb="When the city is closing in.",
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
@@ -171,6 +173,7 @@ EVADE_PURSUERS = Template(
 HIDE = Template(
     id="hide",
     priority=84,
+    drive_band=DriveBand.CRISIS_CONSTRAINT,
     blurb="Steady-state concealment for people who are already living out of sight.",
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
@@ -306,6 +309,11 @@ HIDE = Template(
 HONOR_DEBT = Template(
     id="honor_debt",
     priority=80,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "Honor/debt pressure is a story obligation that may preempt ordinary "
+        "maintenance when the relevant ledger is hot."
+    ),
     blurb="A binding obligation surfaces from the blank years.",
     required_slots=(Slot.ACTOR,),
     package_gate=OR(
@@ -358,6 +366,11 @@ HONOR_DEBT = Template(
 PURSUE_GHOST_LEAD = Template(
     id="pursue_ghost_lead",
     priority=60,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "Ghost-lead pursuit is a long-arc motive with explicit clue pressure, "
+        "so it can outrank routine maintenance."
+    ),
     blurb="The fragments of a buried identity tug at the actor.",
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
@@ -409,6 +422,13 @@ PURSUE_GHOST_LEAD = Template(
 MAINTAIN_COVER = Template(
     id="maintain_cover",
     priority=0,
+    drive_band=DriveBand.CRISIS_CONSTRAINT,
+    drive_band_priority_exempt=True,
+    priority_override_rationale=(
+        "Public-cover upkeep is crisis/constraint-flavored, but it is "
+        "intentionally a floor package that should not force routine needs or "
+        "story obligations to justify outranking it."
+    ),
     blurb="Specific public-cover maintenance, not a universal fallback.",
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
@@ -535,6 +555,11 @@ MAINTAIN_COVER = Template(
 EXTRACT_VENGEANCE = Template(
     id="extract_vengeance",
     priority=90,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "Active vengeance is a high-pressure identity project; left alone, it "
+        "should interrupt ordinary life."
+    ),
     blurb="A grudge ripens until the moment is right to settle it.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
     # Cooldown is intentionally actor-global (no target_slot=): an active
@@ -640,6 +665,7 @@ EXTRACT_VENGEANCE = Template(
 PROTECT_KIN = Template(
     id="protect_kin",
     priority=95,
+    drive_band=DriveBand.CRISIS_CONSTRAINT,
     blurb="A bond pulls the actor toward someone in active danger.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
     package_gate=AND(
@@ -762,6 +788,11 @@ PROTECT_KIN = Template(
 SURVEIL = Template(
     id="surveil",
     priority=48,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "Surveillance usually serves live threat or investigation arcs, so it "
+        "can sit above routine and social maintenance."
+    ),
     blurb="Watching from afar without turning observation into contact.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
     package_gate=AND(
@@ -943,6 +974,11 @@ SURVEIL = Template(
 CULTIVATE_INFORMANT = Template(
     id="cultivate_informant",
     priority=50,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "Informant cultivation is relationship-shaped, but it serves an active "
+        "project rather than ordinary affiliation."
+    ),
     blurb="Patient intelligence work with a specific asset.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
     # Cooldowns here are per-(actor, target) via target_slot=: handler A
@@ -1096,6 +1132,7 @@ CULTIVATE_INFORMANT = Template(
 TEND_WOUNDED = Template(
     id="tend_wounded",
     priority=88,
+    drive_band=DriveBand.CRISIS_CONSTRAINT,
     blurb="A wounded body pulls the actor toward the small work of mending.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
     # Gate must cover both emitted care events: healing the wound is higher
@@ -1209,6 +1246,11 @@ TEND_WOUNDED = Template(
 MOURN_LOSS = Template(
     id="mourn_loss",
     priority=25,
+    drive_band=DriveBand.AFFILIATION,
+    priority_override_rationale=(
+        "Fresh grief suppresses ordinary social, intimacy, and routine loops; "
+        "it should beat low-grade bodily maintenance."
+    ),
     blurb="A loss settles into the body across many quiet days.",
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
@@ -1297,6 +1339,11 @@ MOURN_LOSS = Template(
 KEEP_VIGIL = Template(
     id="keep_vigil",
     priority=50,
+    drive_band=DriveBand.AFFILIATION,
+    priority_override_rationale=(
+        "Vigil is affiliation under acute pressure, so it can outrank ordinary "
+        "maintenance while a target is wounded or dying."
+    ),
     blurb="The actor remains present through a slow, uncertain hour.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
     # Divergence: `captive` is ephemeral (per migration 027), so the captive
@@ -1399,6 +1446,11 @@ KEEP_VIGIL = Template(
 ROUTINE_COMMUTE = Template(
     id="routine_commute",
     priority=26,
+    drive_band=DriveBand.ANCHORED_ROUTINE,
+    priority_override_rationale=(
+        "Commute resolves where a routine-bound actor should be before nearby "
+        "maintenance packages pick a place-shaped branch."
+    ),
     blurb="Ordinary home/work movement from explicit routine anchors.",
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
@@ -1501,6 +1553,7 @@ ROUTINE_COMMUTE = Template(
 TRAVEL = Template(
     id="travel",
     priority=21,
+    drive_band=DriveBand.ANCHORED_ROUTINE,
     blurb=(
         "A character moves between meaningful places without pretending the "
         "road is a room."
@@ -1628,6 +1681,7 @@ TRAVEL = Template(
 WORK = Template(
     id="work",
     priority=14,
+    drive_band=DriveBand.ANCHORED_ROUTINE,
     blurb=(
         "The recurring work that keeps a life, household, or organization "
         "functioning."
@@ -1741,6 +1795,11 @@ WORK = Template(
 TEND_CRAFT = Template(
     id="tend_craft",
     priority=15,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "Craft is the low-pressure identity/project floor and intentionally "
+        "sits just above generic work."
+    ),
     blurb="A small act of care for the work that defines them.",
     required_slots=(Slot.ACTOR,),
     # Discipline: TEND_CRAFT is for characters with identity-defining
@@ -1978,6 +2037,7 @@ TEND_CRAFT = Template(
 WARN_ALLY = Template(
     id="warn_ally",
     priority=75,
+    drive_band=DriveBand.CRISIS_CONSTRAINT,
     blurb="A threat surfaces; word reaches the people who need to know.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
     # No contact cooldown — urgency overrides ordinary contact pacing.
@@ -2085,6 +2145,11 @@ WARN_ALLY = Template(
 CHECK_ON_DEPENDENT = Template(
     id="check_on_dependent",
     priority=55,
+    drive_band=DriveBand.AFFILIATION,
+    priority_override_rationale=(
+        "Dependent care is affiliation with responsibility attached, so it can "
+        "preempt ordinary maintenance."
+    ),
     blurb="A duty of care surfaces between the actor and someone in their charge.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
     # Discipline: CULTIVATE_INFORMANT (priority 50) owns the
@@ -2171,6 +2236,11 @@ CHECK_ON_DEPENDENT = Template(
 REACH_OUT_TO_KIN = Template(
     id="reach_out_to_kin",
     priority=40,
+    drive_band=DriveBand.AFFILIATION,
+    priority_override_rationale=(
+        "Kin maintenance is allowed to beat everyday self-maintenance when "
+        "the relationship has gone quiet long enough."
+    ),
     blurb="A small thread of contact between people who hold each other.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
     # Cooldown: gate must check BOTH events any branch can emit
@@ -2301,6 +2371,11 @@ REACH_OUT_TO_KIN = Template(
 CONSULT_RIVAL = Template(
     id="consult_rival",
     priority=35,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "Rival consultation is a deliberate project move, not casual social "
+        "contact, and can outrank routine obligations."
+    ),
     blurb="Two people who do not trust each other are forced into contact anyway.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
     # Divergence: the draft included `has_ephemeral("grudge_active")` in the
@@ -2419,6 +2494,7 @@ CONSULT_RIVAL = Template(
 SLEEP = Template(
     id="sleep",
     priority=25,
+    drive_band=DriveBand.EMBODIED_MAINTENANCE,
     blurb="The body asks for the thing without which it cannot continue.",
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
@@ -2536,6 +2612,7 @@ SLEEP = Template(
 DRINK = Template(
     id="drink",
     priority=24,
+    drive_band=DriveBand.EMBODIED_MAINTENANCE,
     blurb="The body asks for water; what it accepts shapes the small hour.",
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
@@ -2648,6 +2725,7 @@ DRINK = Template(
 EAT = Template(
     id="eat",
     priority=22,
+    drive_band=DriveBand.EMBODIED_MAINTENANCE,
     blurb=(
         "The body asks for fuel; what it gets matters more than the cookbook "
         "suggests."
@@ -2830,6 +2908,11 @@ EAT = Template(
 SOCIALIZE = Template(
     id="socialize",
     priority=18,
+    drive_band=DriveBand.AFFILIATION,
+    priority_override_rationale=(
+        "Accumulated social debt is allowed to interrupt generic work/routine "
+        "before it becomes a crisis."
+    ),
     blurb=(
         "The need for the company of others, on whatever terms a character "
         "can have it."
@@ -2969,6 +3052,11 @@ SOCIALIZE = Template(
 INTIMACY = Template(
     id="intimacy",
     priority=16,
+    drive_band=DriveBand.AFFILIATION,
+    priority_override_rationale=(
+        "Intimacy pressure should beat generic work when gates and suppressors "
+        "allow it, but remain below basic embodied maintenance."
+    ),
     blurb="The body asks for the kind of connection that is not conversation.",
     required_slots=(Slot.ACTOR,),
     package_gate=AND(

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -8,6 +8,7 @@ Commands:
     nexus regenerate --slot N   Regenerate the last storyteller turn
     nexus model --slot N        Get or set the model for a slot
     nexus trait-audit --slot N  Dry-run new-story trait compiler audit
+    nexus retrograde-packet --slot N  Build dry-run Retrograde seed packet
     nexus faction-audit --slot N  Dry-run legacy faction column migration audit
     nexus faction-manifest --slot N  Build reviewed faction migration manifest
     nexus faction-apply --slot N  Dry-run ready faction manifest operations
@@ -225,6 +226,41 @@ def _print_trait_audit(payload: Dict[str, Any]) -> None:
     if payload.get("failed_policy"):
         print()
         print("Policy: failed because --fail-on-remainders was set.")
+
+
+def _print_retrograde_packet(payload: Dict[str, Any]) -> None:
+    """Print a Retrograde dry-run packet summary."""
+
+    packet = payload.get("retrograde_packet") or {}
+    weird = packet.get("weird") or {}
+    summary = packet.get("vocabulary_summary") or {}
+    scaffolds = packet.get("candidate_scaffolds") or {}
+
+    print("Packet:")
+    print(f"  schema_version: {packet.get('schema_version')}")
+    print(f"  dry_run: {packet.get('dry_run')}")
+    print(f"  mutation_policy: {packet.get('mutation_policy', {}).get('writes')}")
+    print()
+    print("Weird:")
+    print(f"  level: {weird.get('level')}")
+    print(f"  genre: {weird.get('genre')}")
+    print(f"  source: {weird.get('source')}")
+    if weird.get("raw") is not None:
+        print(f"  raw: {weird.get('raw')}")
+    else:
+        print(f"  raw_band: {weird.get('raw_min')}..{weird.get('raw_max')}")
+    print()
+    print("Vocabulary counts:")
+    for key in sorted(summary):
+        print(f"  {key}: {summary[key]}")
+    print()
+    print("Scaffold counts:")
+    print(f"  core_entities: {len(scaffolds.get('core_entities') or [])}")
+    print(f"  named_seed_npcs: {len(scaffolds.get('named_seed_npcs') or [])}")
+    print(f"  pressure_axes: {len(scaffolds.get('pressure_axes') or [])}")
+    if payload.get("packet_output"):
+        print()
+        print(f"Output: {payload['packet_output']}")
 
 
 def _print_faction_audit(payload: Dict[str, Any]) -> None:
@@ -583,6 +619,10 @@ def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) 
 
     if payload.get("trait_audit"):
         _print_trait_audit(payload)
+        print()
+
+    if payload.get("retrograde_packet"):
+        _print_retrograde_packet(payload)
         print()
 
     if payload.get("faction_audit"):
@@ -1340,6 +1380,56 @@ def run_trait_audit(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
+def run_retrograde_packet(args: argparse.Namespace) -> Dict[str, Any]:
+    """Build a non-mutating Retrograde dry-run packet from wizard cache."""
+
+    from nexus.agents.orrery.retrograde_packet import build_retrograde_dry_run_packet
+    from nexus.agents.orrery.retrograde_vocabulary import (
+        enumerate_seed_eligible_vocabulary,
+    )
+    from nexus.api.new_story_cache import read_cache
+    from nexus.api.slot_utils import slot_dbname
+    from nexus.config import load_settings
+
+    dbname = slot_dbname(args.slot)
+    cache = read_cache(dbname)
+    if cache is None:
+        return {
+            "success": False,
+            "error": f"Slot {args.slot} has no new-story wizard cache.",
+        }
+
+    try:
+        packet = build_retrograde_dry_run_packet(
+            slot=args.slot,
+            dbname=dbname,
+            cache=cache,
+            vocabulary=enumerate_seed_eligible_vocabulary(dbname=dbname),
+            settings=load_settings(),
+            weird_level=args.weird,
+            weird_raw=args.weird_raw,
+        )
+    except ValueError as exc:
+        return {"success": False, "error": str(exc)}
+
+    output_path = args.output
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(packet, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+
+    return {
+        "success": True,
+        "message": f"Retrograde dry-run packet for slot {args.slot}.",
+        "slot": args.slot,
+        "dbname": dbname,
+        "retrograde_packet": packet,
+        "packet_output": str(output_path) if output_path is not None else None,
+    }
+
+
 def run_faction_audit(args: argparse.Namespace) -> Dict[str, Any]:
     """Dry-run the legacy faction table to Orrery substrate migration."""
 
@@ -1911,6 +2001,7 @@ Examples:
   nexus lock --slot 1           Lock slot to prevent modifications
   nexus unlock --slot 2         Unlock slot to allow modifications
   nexus trait-audit --slot 5    Dry-run trait compiler audit
+  nexus retrograde-packet --slot 5 --output packet.json
   nexus faction-audit --slot 2  Dry-run faction column migration audit
   nexus faction-manifest --slot 2  Build faction migration manifest
   nexus faction-apply --slot 2  Dry-run ready faction manifest operations
@@ -2044,6 +2135,33 @@ Examples:
             "Exit with status 1 if any trait falls back to prose-only storage; "
             "JSON callers should check the exit code or failed_policy"
         ),
+    )
+
+    # retrograde-packet command
+    retrograde_packet_parser = subparsers.add_parser(
+        "retrograde-packet",
+        help="Build a non-mutating Retrograde seed review packet",
+    )
+    retrograde_packet_parser.add_argument(
+        "--slot", type=int, required=True, help="Slot number (1-5)"
+    )
+    retrograde_packet_parser.add_argument(
+        "--weird",
+        choices=("low", "medium", "high"),
+        help="Player-facing Retrograde weirdness level for this packet.",
+    )
+    retrograde_packet_parser.add_argument(
+        "--weird-raw",
+        type=float,
+        help=(
+            "Developer calibration override for raw weirdness. This does not "
+            "write to wizard state."
+        ),
+    )
+    retrograde_packet_parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path for the raw Retrograde dry-run packet JSON.",
     )
 
     # faction-audit command
@@ -2262,6 +2380,7 @@ def main() -> int:
         "regenerate",
         "clear",
         "trait-audit",
+        "retrograde-packet",
         "faction-audit",
         "faction-manifest",
         "faction-apply",
@@ -2300,6 +2419,8 @@ def main() -> int:
         result = run_clear(args)
     elif args.command == "trait-audit":
         result = run_trait_audit(args)
+    elif args.command == "retrograde-packet":
+        result = run_retrograde_packet(args)
     elif args.command == "faction-audit":
         result = run_faction_audit(args)
     elif args.command == "faction-manifest":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for the NEXUS CLI helpers."""
 
+import json
 import sys
 from argparse import Namespace
 from typing import Any
@@ -146,6 +147,59 @@ class FakeWizardCache:
         }
 
 
+class FakeRetrogradeWizardCache:
+    """Wizard cache double with complete Retrograde packet inputs."""
+
+    def current_phase(self) -> str:
+        return "ready"
+
+    def get_setting_dict(self) -> dict[str, Any]:
+        return {
+            "genre": "cyberpunk",
+            "secondary_genres": [],
+            "world_name": "Glass District",
+        }
+
+    def get_character_dict(self) -> dict[str, Any]:
+        return {
+            "concept": {
+                "name": "Mara",
+                "archetype": "wary operator",
+                "background": "Mara survives by tracking debts.",
+            },
+            "trait_selection": {
+                "selected_traits": ["resources"],
+                "trait_rationales": {"resources": "Money opens doors."},
+            },
+            "wildcard": {
+                "wildcard_name": "Storm Marked",
+                "wildcard_description": "Weather notices her.",
+            },
+        }
+
+    def get_seed_dict(self) -> dict[str, Any]:
+        return {
+            "seed_type": "inciting pressure",
+            "title": "The Ledger Wakes",
+            "situation": "An old debt becomes active.",
+            "hook": "A message arrives in a dead person's voice.",
+            "immediate_goal": "Find who sent it.",
+            "stakes": "Mara's safe names may burn.",
+            "tension_source": "A sponsor wants the secret first.",
+            "key_npcs": ["Vale"],
+            "secrets": "The debt was never hers.",
+        }
+
+    def get_layer_dict(self) -> dict[str, Any]:
+        return {"name": "Night City", "type": "urban"}
+
+    def get_zone_dict(self) -> dict[str, Any]:
+        return {"name": "The Mall", "summary": "Commerce and surveillance."}
+
+    def get_initial_location(self) -> dict[str, Any]:
+        return {"name": "Shutter Hall", "description": "A quiet mall corridor."}
+
+
 class FakeConnection:
     """Context-manager connection double for dry-run compiler tests."""
 
@@ -286,3 +340,40 @@ def test_main_trait_audit_policy_failure_keeps_output(monkeypatch, capsys) -> No
     captured = capsys.readouterr()
     assert "Trait compiler audit for slot 5" in captured.out
     assert "resources: missing_structured_trait_input" in captured.out
+
+
+def test_retrograde_packet_writes_dry_run_packet(monkeypatch, tmp_path) -> None:
+    """The CLI Retrograde packet command is read-only except optional output JSON."""
+
+    from nexus.agents.orrery import retrograde_vocabulary
+    from nexus.api import new_story_cache
+
+    real_enumerator = retrograde_vocabulary.enumerate_seed_eligible_vocabulary
+    output_path = tmp_path / "retrograde_packet.json"
+    monkeypatch.setattr(
+        new_story_cache,
+        "read_cache",
+        lambda dbname: FakeRetrogradeWizardCache(),
+    )
+    monkeypatch.setattr(
+        retrograde_vocabulary,
+        "enumerate_seed_eligible_vocabulary",
+        lambda dbname: real_enumerator(),
+    )
+
+    result = cli.run_retrograde_packet(
+        Namespace(
+            slot=5,
+            weird="medium",
+            weird_raw=None,
+            output=output_path,
+        )
+    )
+
+    packet = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert result["success"] is True
+    assert result["packet_output"] == str(output_path)
+    assert packet["dry_run"] is True
+    assert packet["mutation_policy"]["writes"] == "none"
+    assert packet["weird"]["level"] == "medium"

--- a/tests/test_orrery/test_catalog.py
+++ b/tests/test_orrery/test_catalog.py
@@ -12,6 +12,7 @@ from nexus.agents.orrery.catalog import (
     _render_predicate_name,
     render_catalog,
 )
+from nexus.agents.orrery.substrate import DriveBand, drive_band_priority_warnings
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 
 
@@ -26,6 +27,15 @@ def test_catalog_includes_all_templates() -> None:
         assert (
             f"priority {template.priority}" in content
         ), f"Template {template.id} priority missing from header"
+        assert (
+            f"**Drive band:** {template.drive_band.value.replace('_', ' ')}" in content
+        ), f"Template {template.id} drive band missing from catalog"
+
+
+def test_builtin_drive_band_priorities_have_rationales() -> None:
+    """Priority inversions across drive bands must be deliberate."""
+
+    assert drive_band_priority_warnings(BUILTIN_TEMPLATES) == ()
 
 
 def test_catalog_includes_every_branch() -> None:
@@ -206,6 +216,7 @@ def test_pair_tag_predicates_populate_vocabulary_appendix() -> None:
     template = Template(
         id="pair_tag_catalog_fixture",
         priority=1,
+        drive_band=DriveBand.PROJECT_IDENTITY,
         blurb="Catalog fixture.",
         required_slots=(Slot.ACTOR, Slot.TARGET),
         package_gate=has_pair_tag("mentors"),

--- a/tests/test_orrery/test_catalog.py
+++ b/tests/test_orrery/test_catalog.py
@@ -10,6 +10,7 @@ from nexus.agents.orrery import templates as template_module
 from nexus.agents.orrery.catalog import (
     _collect_vocabulary,
     _render_predicate_name,
+    _render_state_delta,
     render_catalog,
 )
 from nexus.agents.orrery.substrate import DriveBand, drive_band_priority_warnings
@@ -97,6 +98,29 @@ def test_catalog_vocabulary_appendix_collects_referenced_terms() -> None:
     assert "place_affordances" not in vocab
     assert "family" in vocab["relationship_types"]
     assert "handler" in vocab["relationship_types"]
+
+
+def test_catalog_renders_destination_class_alias() -> None:
+    """Catalog prose stays in sync with travel payload aliases accepted at commit."""
+
+    rendered = _render_state_delta(
+        {"travel.start": {"destination_class": "commerce", "mode": "mixed"}}
+    )
+
+    assert "starts travel toward a `commerce` destination" in rendered
+
+
+def test_catalog_renders_drive_band_exemption_rationale() -> None:
+    """Priority-exempt templates still show the rationale in the catalog."""
+
+    content = render_catalog(BUILTIN_TEMPLATES)
+
+    assert (
+        "**Drive band:** crisis constraint — priority-order exempt: "
+        "Public-cover upkeep is crisis/constraint-flavored, but it is "
+        "intentionally a floor package that should not force routine needs "
+        "or story obligations to justify outranking it."
+    ) in content
 
 
 def test_place_class_wrappers_reject_empty_inputs() -> None:

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -508,6 +508,15 @@ def _travel_insert_row(cursor: RecordingCursor) -> dict[str, Any]:
     }
 
 
+def test_destination_place_classes_rejects_mapping_payloads() -> None:
+    """Class selectors fail fast instead of accepting dict keys accidentally."""
+
+    with pytest.raises(ValueError, match="string, list, or tuple"):
+        orrery_events._destination_place_classes(
+            {"destination_place_classes": {"commerce": True}}
+        )
+
+
 def test_proposal_round_trips_through_json_shape() -> None:
     """Commit can hydrate the exact proposal shape stored in incubator JSONB."""
 

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -45,6 +45,8 @@ class RecordingCursor:
         inbound_pair_tag_clear_count=0,
         expired_entity_tags=None,
         routine_anchors=None,
+        location_class_destinations=None,
+        place_zones=None,
     ):
         self.duplicate_resolution = duplicate_resolution
         self.known_tags = {"off_grid": 77} if known_tags is None else known_tags
@@ -67,6 +69,8 @@ class RecordingCursor:
         self.inbound_pair_tag_clear_count = inbound_pair_tag_clear_count
         self.expired_entity_tags = list(expired_entity_tags or [])
         self.routine_anchors = dict(routine_anchors or {})
+        self.location_class_destinations = list(location_class_destinations or [])
+        self.place_zones = dict(place_zones or {})
         self.executed = []
         self.rowcount = 1
         self._fetchone = None
@@ -287,6 +291,34 @@ class RecordingCursor:
             self._fetchone = {"geodesic_distance_m": self.geodesic_distance_m}
         elif "SELECT current_location FROM characters" in normalized:
             self._fetchone = {"current_location": self.current_location}
+        elif "LEFT JOIN places origin ON origin.id" in normalized:
+            (
+                origin_place_id,
+                _categories,
+                location_classes,
+                excluded_place_id,
+                _type_classes,
+            ) = params
+            requested = set(location_classes)
+            origin_zone = self.place_zones.get(origin_place_id)
+            candidates = []
+            for destination in self.location_class_destinations:
+                place_id = destination["id"]
+                if place_id == excluded_place_id:
+                    continue
+                classes = set(destination.get("classes", ()))
+                if not (classes & requested):
+                    continue
+                zone = destination.get("zone")
+                candidates.append(
+                    (
+                        0 if origin_zone is not None and zone == origin_zone else 1,
+                        place_id,
+                    )
+                )
+            if candidates:
+                _zone_rank, place_id = sorted(candidates)[0]
+                self._fetchone = {"id": place_id}
         elif "FROM character_routine_anchors" in normalized:
             actor_entity_id, anchor_type = params
             self._fetchone = self.routine_anchors.get((actor_entity_id, anchor_type))
@@ -336,16 +368,25 @@ class RecordingConn:
 
 
 class AsyncRoutineConn:
-    """Small asyncpg stand-in for routine destination helper tests."""
+    """Small asyncpg stand-in for destination helper tests."""
 
-    def __init__(self, *, routine_anchors=None, zone_destination=None):
+    def __init__(
+        self,
+        *,
+        routine_anchors=None,
+        zone_destination=None,
+        class_destination=None,
+    ):
         self.routine_anchors = dict(routine_anchors or {})
         self.zone_destination = zone_destination
+        self.class_destination = class_destination
 
     async def fetchrow(self, _sql, actor_entity_id, anchor_type):
         return self.routine_anchors.get((actor_entity_id, anchor_type))
 
-    async def fetchval(self, _sql, _preferred_tags, _zone_id):
+    async def fetchval(self, sql, *params):
+        if "LEFT JOIN places origin ON origin.id" in str(sql):
+            return self.class_destination
         return self.zone_destination
 
 
@@ -1152,6 +1193,61 @@ def test_commit_orrery_tick_starts_estimated_travel_without_moving_actor() -> No
     assert route_metadata["detour_factor"] > 1
 
 
+def test_commit_orrery_tick_resolves_travel_destination_by_place_class() -> None:
+    """Class-based travel starts with a concrete destination place."""
+
+    draft = OrreryResolutionDraft(
+        template_id="socialize",
+        priority=18,
+        binding_hash="socialize-travel-start-1",
+        bindings={"actor": 1},
+        branch_label="Seek company after extended isolation",
+        narrative_stub="{actor} sets out toward company.",
+        state_delta={
+            "character.current_activity": "seeking public company",
+            "travel.start": {
+                "destination_place_classes": ["meeting", "commerce"],
+                "mode": "mixed",
+                "initial_progress": 0.05,
+            },
+        },
+        event_type="travel_departed",
+        changed_fields=(
+            "character.current_activity",
+            "character_travel_states.status",
+        ),
+        magnitude=0.54,
+    )
+    proposal = OrreryTickProposal(
+        anchor_chunk_id=99,
+        actor_count=1,
+        resolutions=(draft,),
+        generated_at="2073-10-31T18:00:00+00:00",
+    )
+    cursor = RecordingCursor(
+        current_location=99,
+        place_zones={99: 1},
+        location_class_destinations=[
+            {"id": 77, "classes": {"meeting"}, "zone": 2},
+            {"id": 42, "classes": {"commerce"}, "zone": 1},
+        ],
+    )
+
+    result = commit_orrery_tick_sync(
+        RecordingConn(cursor),
+        proposal,
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+    )
+
+    travel_row = _travel_insert_row(cursor)
+
+    assert result.resolution_count == 1
+    assert travel_row["origin_place_id"] == 99
+    assert travel_row["destination_place_id"] == 42
+
+
 def test_commit_orrery_tick_resolves_travel_destination_anchor() -> None:
     """Routine commute branches can name a home/work anchor, not a place id."""
 
@@ -1330,6 +1426,21 @@ async def test_async_routine_anchor_destination_resolves_zone() -> None:
         conn,
         actor_entity_id=1,
         anchor_type="home",
+    )
+
+    assert destination == 42
+
+
+@pytest.mark.asyncio
+async def test_async_location_class_destination_resolves_place() -> None:
+    """Async class-based destinations use the matching-place query result."""
+
+    conn = AsyncRoutineConn(class_destination=42)
+
+    destination = await orrery_events._location_class_destination_async(
+        conn,
+        origin_place_id=99,
+        location_classes=("meeting", "commerce"),
     )
 
     assert destination == 42

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -769,6 +769,27 @@ def test_faction_legacy_column_retirement_snapshots_before_drop() -> None:
     assert "DROP COLUMN IF EXISTS" in source
 
 
+def test_social_travel_event_migration_registers_scoped_cooldown_event() -> None:
+    """Migration 059 registers the SOCIALIZE travel cooldown event."""
+
+    migration_path = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "059_orrery_social_travel_event.py"
+    )
+    migration = migrate._load_python_migration(migration_path)
+    migration_source = migration_path.read_text()
+
+    assert {
+        "social_travel_departed",
+    } == {
+        event_type
+        for event_type, _category, _severity, _description in migration.EVENT_TYPES
+    }
+    assert "ON CONFLICT (type) DO UPDATE SET" in migration_source
+    assert "synonym_for = NULL" in migration_source
+
+
 def test_completed_tag_vocab_migration_seeds_state_and_place_anchors() -> None:
     """Migration 054 seeds completed state/place vocabulary without collisions."""
 

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -691,10 +691,15 @@ def test_resolve_dry_run_keeps_socialize_for_virtual_characters() -> None:
 
 
 def test_resolve_dry_run_fires_socialize_need_template() -> None:
-    """Interpersonal need debt can resolve through SOCIALIZE."""
+    """Extreme social debt can start movement toward real company."""
 
     proposal = resolve_dry_run(
         FakeSession(
+            tag_rows=[{"entity_id": 1, "tag": "route_familiar", "is_ephemeral": False}],
+            location_class_rows=[
+                {"id": 10, "location_class": "dwelling", "is_primary": True},
+                {"id": 20, "location_class": "meeting", "is_primary": True},
+            ],
             need_debt_rows=[
                 {
                     "character_entity_id": 1,
@@ -716,6 +721,40 @@ def test_resolve_dry_run_fires_socialize_need_template() -> None:
     assert proposal.resolutions[0].branch_label == (
         "Seek company after extended isolation"
     )
+    assert "need.fulfill" not in proposal.resolutions[0].state_delta
+    assert proposal.resolutions[0].state_delta["travel.start"][
+        "destination_place_classes"
+    ] == ["commerce", "entertainment", "meeting", "place_open"]
+
+
+def test_resolve_dry_run_socialize_uses_present_company_before_movement() -> None:
+    """Co-located NPCs can satisfy social pressure without going elsewhere."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            location_rows=[
+                {"entity_id": 1, "current_location": 10},
+                {"entity_id": 2, "current_location": 10},
+            ],
+            need_debt_rows=[
+                {
+                    "character_entity_id": 1,
+                    "need_type": "socialize",
+                    "debt_score": 200,
+                    "last_evaluated_at": datetime(
+                        2073, 10, 31, 12, tzinfo=timezone.utc
+                    ),
+                }
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "socialize"
+    assert proposal.resolutions[0].branch_label == "Engage with company already present"
     assert proposal.resolutions[0].state_delta["need.fulfill"]["type"] == "socialize"
 
 

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -17,6 +17,7 @@ from nexus.agents.orrery.substrate import (
     ALWAYS,
     AND,
     Branch,
+    DriveBand,
     PresentTargetPolicy,
     Slot,
     Template,
@@ -1466,6 +1467,7 @@ def test_resolve_dry_run_trust_predicates_use_hydrated_valence(
     template = Template(
         id="trust_gate_test",
         priority=10,
+        drive_band=DriveBand.PROJECT_IDENTITY,
         blurb="test trust hydration",
         required_slots=(Slot.ACTOR, Slot.TARGET),
         package_gate=ALWAYS,
@@ -1677,6 +1679,7 @@ def test_resolve_dry_run_routes_present_targets_to_scene_pressures() -> None:
     pressure_template = Template(
         id="pressure_test",
         priority=10,
+        drive_band=DriveBand.PROJECT_IDENTITY,
         blurb="test pressure",
         required_slots=(Slot.ACTOR, Slot.TARGET),
         package_gate=ALWAYS,
@@ -1883,6 +1886,7 @@ def test_default_templates_keep_present_targets_offscreen_only() -> None:
     default_template = Template(
         id="default_present_target",
         priority=10,
+        drive_band=DriveBand.PROJECT_IDENTITY,
         blurb="default policy",
         required_slots=(Slot.ACTOR, Slot.TARGET),
         package_gate=ALWAYS,
@@ -1918,6 +1922,7 @@ def test_pressure_templates_still_commit_for_offscreen_targets() -> None:
     pressure_template = Template(
         id="dual_mode_pressure",
         priority=10,
+        drive_band=DriveBand.PROJECT_IDENTITY,
         blurb="dual-mode policy",
         required_slots=(Slot.ACTOR, Slot.TARGET),
         package_gate=ALWAYS,
@@ -1959,6 +1964,7 @@ def test_resolve_dry_run_rejects_unsupported_slot_signatures() -> None:
     weird_template = Template(
         id="weird",
         priority=1,
+        drive_band=DriveBand.PROJECT_IDENTITY,
         blurb="declares an unsupported slot signature",
         required_slots=(Slot.ACTOR, Slot.FACTION),
         package_gate=ALWAYS,

--- a/tests/test_orrery/test_retrograde_packet.py
+++ b/tests/test_orrery/test_retrograde_packet.py
@@ -1,0 +1,141 @@
+"""Tests for Retrograde dry-run packet assembly."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.agents.orrery.retrograde_packet import (
+    build_retrograde_dry_run_packet,
+    resolve_weird_profile,
+)
+from nexus.agents.orrery.retrograde_vocabulary import (
+    enumerate_seed_eligible_vocabulary,
+)
+from nexus.config import load_settings
+
+
+class FakeRetrogradeCache:
+    """Complete wizard cache stand-in for Retrograde packet tests."""
+
+    def current_phase(self) -> str:
+        return "ready"
+
+    def get_setting_dict(self) -> dict[str, object]:
+        return {
+            "genre": "cyberpunk",
+            "secondary_genres": ["noir"],
+            "world_name": "Glass District",
+            "tone": "dangerous but intimate",
+        }
+
+    def get_character_dict(self) -> dict[str, object]:
+        return {
+            "concept": {
+                "name": "Mara",
+                "archetype": "wary operator",
+                "background": "Mara survives by tracking debts.",
+                "appearance": "Prepared for quick exits.",
+            },
+            "trait_selection": {
+                "selected_traits": ["resources", "status"],
+                "trait_rationales": {
+                    "resources": "Money opens doors.",
+                    "status": "The badge matters narrowly.",
+                },
+            },
+            "wildcard": {
+                "wildcard_name": "Storm Marked",
+                "wildcard_description": "Weather notices her.",
+            },
+        }
+
+    def get_seed_dict(self) -> dict[str, object]:
+        return {
+            "seed_type": "inciting pressure",
+            "title": "The Ledger Wakes",
+            "situation": "An old debt becomes active.",
+            "hook": "A message arrives in a dead person's voice.",
+            "immediate_goal": "Find who sent it.",
+            "stakes": "Mara's safe names may burn.",
+            "tension_source": "A sponsor wants the secret first.",
+            "key_npcs": ["Vale"],
+            "secrets": "The debt was never hers.",
+        }
+
+    def get_layer_dict(self) -> dict[str, object]:
+        return {"name": "Night City", "type": "urban", "description": "Dense sprawl."}
+
+    def get_zone_dict(self) -> dict[str, object]:
+        return {"name": "The Mall", "summary": "Commerce and surveillance."}
+
+    def get_initial_location(self) -> dict[str, object]:
+        return {"name": "Shutter Hall", "description": "A quiet mall corridor."}
+
+
+def test_retrograde_packet_is_dry_run_and_selection_oriented() -> None:
+    """A0 packets expose candidate material without implying persistence."""
+
+    packet = build_retrograde_dry_run_packet(
+        slot=5,
+        dbname="save_05",
+        cache=FakeRetrogradeCache(),
+        vocabulary=enumerate_seed_eligible_vocabulary(),
+        settings=load_settings(),
+        weird_level="high",
+    )
+
+    assert packet["dry_run"] is True
+    assert packet["mutation_policy"]["writes"] == "none"
+    assert (
+        "Skald-as-weaver pass must select"
+        in packet["mutation_policy"]["review_contract"]
+    )
+    assert packet["weird"]["level"] == "high"
+    assert packet["weird"]["genre"] == "cyberpunk"
+    assert (
+        packet["candidate_scaffolds"]["candidate_seed_contract"]["selection_required"]
+        is True
+    )
+    assert packet["candidate_scaffolds"]["named_seed_npcs"] == [
+        {"kind": "character", "role": "seed_npc", "name": "Vale"}
+    ]
+    assert packet["vocabulary_summary"]["event_types"] > 0
+
+
+def test_retrograde_packet_requires_complete_wizard_sections() -> None:
+    """Incomplete wizard cache state fails before packet assembly."""
+
+    class IncompleteCache(FakeRetrogradeCache):
+        def get_seed_dict(self) -> None:
+            return None
+
+    with pytest.raises(ValueError, match="complete wizard seed data"):
+        build_retrograde_dry_run_packet(
+            slot=5,
+            dbname="save_05",
+            cache=IncompleteCache(),
+            vocabulary=enumerate_seed_eligible_vocabulary(),
+            settings=load_settings(),
+        )
+
+
+def test_retrograde_weird_raw_override_stays_in_dev_range() -> None:
+    """Developer raw weirdness overrides are explicit and range checked."""
+
+    settings = load_settings()
+    profile = resolve_weird_profile(
+        settings=settings,
+        setting={"genre": "cyberpunk"},
+        weird_level="low",
+        weird_raw=0.42,
+    )
+
+    assert profile["source"] == "raw_override"
+    assert profile["raw"] == 0.42
+
+    with pytest.raises(ValueError, match="raw weirdness"):
+        resolve_weird_profile(
+            settings=settings,
+            setting={"genre": "cyberpunk"},
+            weird_raw=999,
+        )

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -11,6 +11,7 @@ from nexus.agents.orrery.substrate import (
     ALWAYS,
     Branch,
     CompoundCondition,
+    DriveBand,
     PresentTargetPolicy,
     RoutineAnchor,
     Slot,
@@ -107,6 +108,7 @@ def test_missing_always_fallback_is_rejected() -> None:
     template = Template(
         id="bad_template",
         priority=1,
+        drive_band=DriveBand.PROJECT_IDENTITY,
         blurb="No terminal fallback.",
         required_slots=(Slot.ACTOR,),
         package_gate=ALWAYS,
@@ -130,6 +132,7 @@ def test_storyteller_pressure_templates_require_pressure_stubs() -> None:
         Template(
             id="bad_pressure_template",
             priority=1,
+            drive_band=DriveBand.PROJECT_IDENTITY,
             blurb="Missing prompt-only pressure text.",
             required_slots=(Slot.ACTOR, Slot.TARGET),
             package_gate=ALWAYS,
@@ -816,6 +819,7 @@ def test_evaluate_stack_returns_none_when_no_template_passes() -> None:
     template = Template(
         id="never",
         priority=1,
+        drive_band=DriveBand.PROJECT_IDENTITY,
         blurb="Never fires.",
         required_slots=(Slot.ACTOR,),
         package_gate=lambda _state, _bindings: False,

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -32,6 +32,7 @@ from nexus.agents.orrery.substrate import (
     has_contact_of_kind,
     has_established_partner_co_located,
     has_inbound_pair_tag,
+    has_location_class_destination,
     has_minimal_context,
     has_need_debt_at_or_above,
     has_pair_tag,
@@ -679,6 +680,26 @@ def test_location_class_condition_preserves_single_value_fallback() -> None:
     state = WorldState(locations={1: 10}, location_class={10: "the_roots"})
 
     assert in_location_class("the_roots")(state, {Slot.ACTOR: 1})
+
+
+def test_location_class_destination_condition_finds_other_places() -> None:
+    """Movement packages can ask whether a class-resolved destination exists."""
+
+    state = WorldState(
+        locations={1: 10},
+        location_classes={
+            10: frozenset({"dwelling"}),
+            20: frozenset({"meeting", "commerce"}),
+        },
+    )
+    current_only = WorldState(
+        locations={1: 10},
+        location_classes={10: frozenset({"meeting"})},
+    )
+
+    assert has_location_class_destination("meeting")(state, {Slot.ACTOR: 1})
+    assert has_location_class_destination("commerce")(state, {Slot.ACTOR: 1})
+    assert not has_location_class_destination("meeting")(current_only, {Slot.ACTOR: 1})
 
 
 def test_need_debt_condition_rejects_unknown_need_type() -> None:

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -702,6 +702,20 @@ def test_location_class_destination_condition_finds_other_places() -> None:
     assert not has_location_class_destination("meeting")(current_only, {Slot.ACTOR: 1})
 
 
+def test_location_class_destination_condition_supports_legacy_single_class() -> None:
+    """The destination check also covers the pre-multi-class location mapping."""
+
+    state = WorldState(
+        locations={1: 10},
+        location_class={
+            10: "dwelling",
+            20: "meeting",
+        },
+    )
+
+    assert has_location_class_destination("meeting")(state, {Slot.ACTOR: 1})
+
+
 def test_need_debt_condition_rejects_unknown_need_type() -> None:
     """Typos in authored need predicates fail at construction time."""
 


### PR DESCRIPTION
## What changed

- Added Orrery drive-band metadata, catalog rendering, and priority-inversion checks with an explicit floor-package exemption for `maintain_cover`.
- Made the Orrery catalog hook always run in pre-commit so generated docs stay current across adjacent Orrery changes.
- Let SOCIALIZE start concrete class-resolved travel toward public company instead of implying movement without state effects.
- Added commit-time destination resolution by place class for `travel.start` payloads, with sync/async coverage.
- Added a non-mutating Retrograde A0 dry-run packet builder and `nexus retrograde-packet` CLI.

## Validation

- `poetry run pytest -q tests/test_orrery/test_substrate.py tests/test_orrery/test_resolver.py tests/test_orrery/test_events.py tests/test_orrery/test_catalog.py tests/test_orrery/test_retrograde_packet.py tests/test_orrery/test_retrograde_vocabulary.py tests/test_cli.py`
- `poetry run pre-commit run regenerate-orrery-catalog --all-files`
- `poetry run flake8 nexus/agents/orrery/retrograde_packet.py nexus/agents/orrery/substrate.py nexus/agents/orrery/templates.py nexus/agents/orrery/events.py nexus/agents/orrery/catalog.py nexus/cli.py tests/test_orrery/test_retrograde_packet.py tests/test_cli.py tests/test_orrery/test_resolver.py tests/test_orrery/test_events.py tests/test_orrery/test_substrate.py`
- `poetry run python -m nexus.cli retrograde-packet --help`

## Slot 2 dry-run evidence

- Anchor 1428, `2073-10-30T10:30:00+00:00`: Cam and Celia both resolved `work` / public-facing shift.
- Anchor 1428, `2073-10-30T17:30:00+00:00`: Cam and Celia both resolved `routine_commute` with `travel.start` toward `home`.
- Anchor 1428, live need rows show Cam/Celia social and sleep debt currently at `0.00`, so SOCIALIZE/SLEEP correctly did not fire in Slot 2 without synthetic debt mutation; unit tests cover the high-social-debt travel branch.
