### PR TITLE
[codex] Carry social travel intent through arrival

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1412,7 +1412,21 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **NOT:** actor has `wounded` ephemeral
   - **NOT:** actor has `grieving` ephemeral
 
-### Branch 1 — Arrive at the planned destination  *(mag 0.34)*
+### Branch 1 — Arrive where people can be encountered  *(mag 0.36)*
+
+**When:**
+
+- **AND:**
+  - actor is in transit
+  - actor travel progress ≥ 0.95
+  - actor is traveling for `socialize` purpose
+
+**Does:** activity → "arriving where people gather"; arrives at travel destination
+**Event:** `travel_arrived`
+
+> {actor} reaches the place they picked because other people would be there. The route ends, and the social possibility becomes immediate rather than theoretical.
+
+### Branch 2 — Arrive at the planned destination  *(mag 0.34)*
 
 **When:**
 
@@ -1425,7 +1439,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} reaches the destination at last. The route drops away behind them into the ordinary unreliability of maps, and the place ahead becomes immediate.
 
-### Branch 2 — Lose time to bad conditions or route friction  *(mag 0.24)*
+### Branch 3 — Lose time to bad conditions or route friction  *(mag 0.24)*
 
 **When:**
 
@@ -1440,7 +1454,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} loses time to the route itself — weather, traffic, closed access, or the thousand small refusals a city can make when someone is trying to cross it.
 
-### Branch 3 — Make steady progress along the route  *(mag 0.18)*
+### Branch 4 — Make steady progress along the route  *(mag 0.18)*
 
 **When:** actor is in transit
 
@@ -1449,7 +1463,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} keeps moving: transfers, crossings, service corridors, streets whose names matter less than the fact that each one puts the destination a little closer.
 
-### Branch 4 — Depart toward the planned destination  *(mag 0.28)*
+### Branch 5 — Depart toward the planned destination  *(mag 0.28)*
 
 **When:**
 
@@ -1467,7 +1481,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} starts the journey with enough of a route in mind to make the first leg real. The exact path can change; the destination no longer can.
 
-### Branch 5 — Prepare the journey rather than starting badly  *(mag 0.12)*
+### Branch 6 — Prepare the journey rather than starting badly  *(mag 0.12)*
 
 **When:** *(always)*
 

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -61,6 +61,15 @@ def _slot(value: str) -> str:
     return value.lower()
 
 
+def _render_travel_purpose_predicate(match: re.Match) -> str:
+    """Render travel_purpose_is(...) with singular/plural purpose wording."""
+
+    purposes = [item for item in match.group("purpose").split(",") if item]
+    rendered = ", ".join(f"`{purpose}`" for purpose in purposes)
+    noun = "purpose" if len(purposes) == 1 else "purposes"
+    return f"{_slot(match.group('slot'))} is traveling for {rendered} {noun}"
+
+
 # Tag predicates
 _register(
     r"has_tag\((?P<tag>[^@()]+)@(?P<slot>\w+)\)",
@@ -216,9 +225,7 @@ _register(
 )
 _register(
     r"travel_purpose_is\((?P<purpose>[^@()]+)@(?P<slot>\w+)\)",
-    lambda m: (
-        f"{_slot(m.group('slot'))} is traveling for " f"`{m.group('purpose')}` purpose"
-    ),
+    _render_travel_purpose_predicate,
 )
 _register(
     r"has_routine_anchor\((?P<anchor>[^@()]+)@(?P<slot>\w+)\)",

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -215,6 +215,12 @@ _register(
     lambda m: f"{_slot(m.group('slot'))} has a planned travel destination",
 )
 _register(
+    r"travel_purpose_is\((?P<purpose>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('slot'))} is traveling for " f"`{m.group('purpose')}` purpose"
+    ),
+)
+_register(
     r"has_routine_anchor\((?P<anchor>[^@()]+)@(?P<slot>\w+)\)",
     lambda m: (f"{_slot(m.group('slot'))} has `{m.group('anchor')}` routine anchor"),
 )
@@ -458,10 +464,10 @@ def _render_state_delta(delta: Mapping[str, Any]) -> str:
             continue
         if key == "travel.start":
             if isinstance(value, Mapping):
-                destination_classes = value.get(
-                    "destination_place_classes"
-                ) or value.get("destination_place_class") or value.get(
-                    "destination_class"
+                destination_classes = (
+                    value.get("destination_place_classes")
+                    or value.get("destination_place_class")
+                    or value.get("destination_class")
                 )
                 if destination_classes:
                     if isinstance(destination_classes, str):

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -1364,9 +1364,7 @@ def _destination_place_classes(payload: Mapping[str, Any]) -> tuple[str, ...]:
     elif isinstance(raw, (list, tuple)):
         values = tuple(raw)
     else:
-        raise ValueError(
-            "destination place classes must be a string, list, or tuple"
-        )
+        raise ValueError("destination place classes must be a string, list, or tuple")
     classes = tuple(dict.fromkeys(str(item) for item in values if str(item)))
     if not classes:
         raise ValueError("destination place classes cannot be empty")
@@ -1385,6 +1383,19 @@ def _travel_risk(payload: Mapping[str, Any], fallback: str = "low") -> str:
     if risk not in {"low", "moderate", "high", "extreme"}:
         raise ValueError(f"Unsupported Orrery travel risk: {risk!r}")
     return risk
+
+
+def _travel_intent_metadata(payload: Mapping[str, Any]) -> dict[str, str]:
+    """Return whitelisted route-intent metadata from authored travel payloads."""
+
+    metadata: dict[str, str] = {}
+    purpose = payload.get("purpose") or payload.get("travel_purpose")
+    if purpose:
+        metadata["purpose"] = str(purpose)
+    purpose_need = payload.get("purpose_need")
+    if purpose_need:
+        metadata["purpose_need"] = str(purpose_need)
+    return metadata
 
 
 def _route_graph_key(payload: Mapping[str, Any]) -> str:
@@ -1457,6 +1468,8 @@ def _apply_travel_start_sync(
     )
     eta = _eta(world_time, route["duration_minutes"])
     progress = float(data.get("initial_progress", 0.0))
+    route_metadata = dict(route["metadata"])
+    route_metadata.update(_travel_intent_metadata(data))
     cur.execute(
         """
         INSERT INTO character_travel_states (
@@ -1506,7 +1519,7 @@ def _apply_travel_start_sync(
             world_time,
             world_time,
             eta,
-            json.dumps(route["metadata"]),
+            json.dumps(route_metadata),
         ),
     )
 
@@ -1562,6 +1575,8 @@ async def _apply_travel_start_async(
     )
     eta = _eta(world_time, route["duration_minutes"])
     progress = float(data.get("initial_progress", 0.0))
+    route_metadata = dict(route["metadata"])
+    route_metadata.update(_travel_intent_metadata(data))
     await conn.execute(
         """
         INSERT INTO character_travel_states (
@@ -1610,7 +1625,7 @@ async def _apply_travel_start_async(
         world_time,
         world_time,
         eta,
-        json.dumps(route["metadata"]),
+        json.dumps(route_metadata),
     )
 
 

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -31,6 +31,7 @@ from nexus.agents.orrery.routing import (
     RouteGraphEdge,
     shortest_route,
 )
+from nexus.agents.orrery.substrate import SUPPORTED_TRAVEL_PURPOSES
 
 
 ENTITY_BINDING_SLOTS = frozenset({"actor", "target", "targets", "faction"})
@@ -1386,15 +1387,24 @@ def _travel_risk(payload: Mapping[str, Any], fallback: str = "low") -> str:
 
 
 def _travel_intent_metadata(payload: Mapping[str, Any]) -> dict[str, str]:
-    """Return whitelisted route-intent metadata from authored travel payloads."""
+    """Return normalized route-intent metadata from authored travel payloads.
+
+    ``purpose`` identifies the behavioral route purpose that travel packages can
+    branch on. ``purpose_need`` optionally names the underlying need pressure
+    that caused the travel; it can diverge from purpose when one behavior is a
+    means to satisfy another need.
+    """
 
     metadata: dict[str, str] = {}
     purpose = payload.get("purpose") or payload.get("travel_purpose")
     if purpose:
-        metadata["purpose"] = str(purpose)
+        normalized_purpose = str(purpose).strip().lower()
+        if normalized_purpose not in SUPPORTED_TRAVEL_PURPOSES:
+            raise ValueError(f"Unsupported Orrery travel purpose: {purpose!r}")
+        metadata["purpose"] = normalized_purpose
     purpose_need = payload.get("purpose_need")
     if purpose_need:
-        metadata["purpose_need"] = str(purpose_need)
+        metadata["purpose_need"] = normalize_need_type(str(purpose_need).strip())
     return metadata
 
 

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -502,7 +502,8 @@ def _load_travel_states(session: Any) -> dict[int, TravelState]:
                    cts.risk::text AS risk,
                    cts.progress_ratio,
                    cts.estimated_distance_m,
-                   cts.estimated_duration_minutes
+                   cts.estimated_duration_minutes,
+                   cts.route_metadata ->> 'purpose' AS route_purpose
             FROM character_travel_states cts
             JOIN entities e
               ON e.id = cts.character_entity_id
@@ -530,6 +531,7 @@ def _load_travel_states(session: Any) -> dict[int, TravelState]:
                 if row["estimated_duration_minutes"] is not None
                 else None
             ),
+            route_purpose=row.get("route_purpose"),
         )
     return states
 

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -58,6 +58,7 @@ class DriveBand(str, Enum):
 Bindings = Dict[Slot, Any]
 Condition = Callable[["WorldState", Bindings], bool]
 ContactKind = Literal["lodging", "social", "intimate"]
+SUPPORTED_TRAVEL_PURPOSES: frozenset[str] = frozenset({"socialize"})
 DRIVE_BAND_ORDER: Mapping[DriveBand, int] = {
     DriveBand.CRISIS_CONSTRAINT: 0,
     DriveBand.EMBODIED_MAINTENANCE: 1,
@@ -1013,9 +1014,18 @@ def travel_progress_at_or_above(
 def travel_purpose_is(*purposes: str, slot: Slot = Slot.ACTOR) -> Condition:
     """Return whether current travel state carries one of the given purposes."""
 
-    purpose_values = tuple(dict.fromkeys(str(item) for item in purposes if str(item)))
+    purpose_values = tuple(
+        dict.fromkeys(
+            normalized for item in purposes if (normalized := str(item).strip().lower())
+        )
+    )
     if not purpose_values:
         raise ValueError("travel_purpose_is requires at least one purpose")
+    unsupported = set(purpose_values) - SUPPORTED_TRAVEL_PURPOSES
+    if unsupported:
+        raise ValueError(
+            f"Unsupported Orrery travel purpose(s): {sorted(unsupported)!r}"
+        )
     candidates = frozenset(purpose_values)
 
     def _condition(state: WorldState, bindings: Bindings) -> bool:
@@ -1023,7 +1033,9 @@ def travel_purpose_is(*purposes: str, slot: Slot = Slot.ACTOR) -> Condition:
         if entity_id is None:
             return False
         travel_state = state.travel_states.get(entity_id)
-        return bool(travel_state and travel_state.route_purpose in candidates)
+        if travel_state is None or travel_state.route_purpose is None:
+            return False
+        return str(travel_state.route_purpose).strip().lower() in candidates
 
     purpose_names = ",".join(purpose_values)
     return _named(_condition, f"travel_purpose_is({purpose_names}@{slot.value})")

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -160,6 +160,7 @@ class TravelState:
     progress_ratio: float = 0.0
     estimated_distance_m: Optional[float] = None
     estimated_duration_minutes: Optional[float] = None
+    route_purpose: Optional[str] = None
 
     @property
     def is_in_transit(self) -> bool:
@@ -1007,6 +1008,25 @@ def travel_progress_at_or_above(
         _condition,
         f"travel_progress_at_or_above({threshold:g}@{slot.value})",
     )
+
+
+def travel_purpose_is(*purposes: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether current travel state carries one of the given purposes."""
+
+    purpose_values = tuple(dict.fromkeys(str(item) for item in purposes if str(item)))
+    if not purpose_values:
+        raise ValueError("travel_purpose_is requires at least one purpose")
+    candidates = frozenset(purpose_values)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        travel_state = state.travel_states.get(entity_id)
+        return bool(travel_state and travel_state.route_purpose in candidates)
+
+    purpose_names = ",".join(purpose_values)
+    return _named(_condition, f"travel_purpose_is({purpose_names}@{slot.value})")
 
 
 def travel_risk_is(*risks: str, slot: Slot = Slot.ACTOR) -> Condition:

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -47,6 +47,7 @@ from nexus.agents.orrery.substrate import (
     since_last_event_at_least,
     time_of_day_in,
     travel_progress_at_or_above,
+    travel_purpose_is,
     travel_risk_is,
     trust_at_least,
     trust_below,
@@ -1567,6 +1568,30 @@ TRAVEL = Template(
     ),
     branches=(
         Branch(
+            label="Arrive where people can be encountered",
+            conditions=AND(
+                is_in_transit(),
+                travel_progress_at_or_above(0.95),
+                travel_purpose_is("socialize"),
+            ),
+            narrative_stub=(
+                "{actor} reaches the place they picked because other people "
+                "would be there. The route ends, and the social possibility "
+                "becomes immediate rather than theoretical."
+            ),
+            state_delta={
+                "character.current_activity": "arriving where people gather",
+                "travel.arrive": True,
+            },
+            event_type="travel_arrived",
+            changed_fields=(
+                "character.current_location",
+                "character.current_activity",
+                "character_travel_states.status",
+            ),
+            magnitude=0.36,
+        ),
+        Branch(
             label="Arrive at the planned destination",
             conditions=AND(is_in_transit(), travel_progress_at_or_above(0.95)),
             narrative_stub=(
@@ -2956,6 +2981,8 @@ SOCIALIZE = Template(
                         "place_open",
                     ],
                     "mode": "mixed",
+                    "purpose": "socialize",
+                    "purpose_need": "socialize",
                     "initial_progress": 0.05,
                 },
             },
@@ -3016,6 +3043,8 @@ SOCIALIZE = Template(
                         "place_open",
                     ],
                     "mode": "mixed",
+                    "purpose": "socialize",
+                    "purpose_need": "socialize",
                     "initial_progress": 0.05,
                 },
             },

--- a/tests/test_orrery/test_catalog.py
+++ b/tests/test_orrery/test_catalog.py
@@ -192,6 +192,10 @@ def test_render_predicate_name_handles_known_predicates() -> None:
             "actor is traveling for `socialize` purpose",
         ),
         (
+            "travel_purpose_is(socialize,errand@actor)",
+            "actor is traveling for `socialize`, `errand` purposes",
+        ),
+        (
             "has_any_pair_tag(claims,protects@actor->target)",
             "actor has any of [`claims`, `protects`] pair tags to target",
         ),

--- a/tests/test_orrery/test_catalog.py
+++ b/tests/test_orrery/test_catalog.py
@@ -188,6 +188,10 @@ def test_render_predicate_name_handles_known_predicates() -> None:
             "actor's `home` routine can resolve a destination",
         ),
         (
+            "travel_purpose_is(socialize@actor)",
+            "actor is traveling for `socialize` purpose",
+        ),
+        (
             "has_any_pair_tag(claims,protects@actor->target)",
             "actor has any of [`claims`, `protects`] pair tags to target",
         ),

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -508,6 +508,32 @@ def _travel_insert_row(cursor: RecordingCursor) -> dict[str, Any]:
     }
 
 
+def test_travel_intent_metadata_normalizes_purpose_and_need() -> None:
+    """Route intent stores canonical purpose and need values."""
+
+    metadata = orrery_events._travel_intent_metadata(
+        {"purpose": " Socialize ", "purpose_need": " INTIMACY "}
+    )
+
+    assert metadata == {"purpose": "socialize", "purpose_need": "intimacy"}
+
+
+def test_travel_intent_metadata_rejects_unknown_purpose() -> None:
+    """Unsupported travel-purpose values fail before they can miss a branch."""
+
+    with pytest.raises(ValueError, match="Unsupported Orrery travel purpose"):
+        orrery_events._travel_intent_metadata({"purpose": "work"})
+
+
+def test_travel_intent_metadata_rejects_unknown_purpose_need() -> None:
+    """Purpose-need metadata must remain inside the Sunhelm need vocabulary."""
+
+    with pytest.raises(ValueError, match="Unsupported Orrery need type"):
+        orrery_events._travel_intent_metadata(
+            {"purpose": "socialize", "purpose_need": "status"}
+        )
+
+
 def test_destination_place_classes_rejects_mapping_payloads() -> None:
     """Class selectors fail fast instead of accepting dict keys accidentally."""
 
@@ -1217,8 +1243,8 @@ def test_commit_orrery_tick_resolves_travel_destination_by_place_class() -> None
             "travel.start": {
                 "destination_place_classes": ["meeting", "commerce"],
                 "mode": "mixed",
-                "purpose": "socialize",
-                "purpose_need": "socialize",
+                "purpose": "Socialize",
+                "purpose_need": "INTIMACY",
                 "initial_progress": 0.05,
             },
         },
@@ -1258,7 +1284,7 @@ def test_commit_orrery_tick_resolves_travel_destination_by_place_class() -> None
     assert travel_row["origin_place_id"] == 99
     assert travel_row["destination_place_id"] == 42
     assert travel_row["route_metadata"]["purpose"] == "socialize"
-    assert travel_row["route_metadata"]["purpose_need"] == "socialize"
+    assert travel_row["route_metadata"]["purpose_need"] == "intimacy"
 
 
 def test_commit_orrery_tick_resolves_travel_destination_anchor() -> None:

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -1217,6 +1217,8 @@ def test_commit_orrery_tick_resolves_travel_destination_by_place_class() -> None
             "travel.start": {
                 "destination_place_classes": ["meeting", "commerce"],
                 "mode": "mixed",
+                "purpose": "socialize",
+                "purpose_need": "socialize",
                 "initial_progress": 0.05,
             },
         },
@@ -1255,6 +1257,8 @@ def test_commit_orrery_tick_resolves_travel_destination_by_place_class() -> None
     assert result.resolution_count == 1
     assert travel_row["origin_place_id"] == 99
     assert travel_row["destination_place_id"] == 42
+    assert travel_row["route_metadata"]["purpose"] == "socialize"
+    assert travel_row["route_metadata"]["purpose_need"] == "socialize"
 
 
 def test_commit_orrery_tick_resolves_travel_destination_anchor() -> None:

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -1294,7 +1294,7 @@ def test_resolve_dry_run_fires_social_travel_arrival_by_purpose() -> None:
                     "progress_ratio": 0.96,
                     "estimated_distance_m": 5000,
                     "estimated_duration_minutes": 20,
-                    "route_purpose": "socialize",
+                    "route_purpose": "Socialize",
                 }
             ],
         ),
@@ -1308,6 +1308,7 @@ def test_resolve_dry_run_fires_social_travel_arrival_by_purpose() -> None:
     assert (
         proposal.resolutions[0].branch_label == "Arrive where people can be encountered"
     )
+    assert proposal.resolutions[0].event_type == "travel_arrived"
     assert (
         proposal.resolutions[0].state_delta["character.current_activity"]
         == "arriving where people gather"

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -725,6 +725,11 @@ def test_resolve_dry_run_fires_socialize_need_template() -> None:
     assert proposal.resolutions[0].state_delta["travel.start"][
         "destination_place_classes"
     ] == ["commerce", "entertainment", "meeting", "place_open"]
+    assert proposal.resolutions[0].state_delta["travel.start"]["purpose"] == "socialize"
+    assert (
+        proposal.resolutions[0].state_delta["travel.start"]["purpose_need"]
+        == "socialize"
+    )
 
 
 def test_resolve_dry_run_socialize_uses_present_company_before_movement() -> None:
@@ -1269,6 +1274,44 @@ def test_resolve_dry_run_fires_travel_arrival_at_high_progress() -> None:
     assert proposal.resolutions[0].template_id == "travel"
     assert proposal.resolutions[0].branch_label == "Arrive at the planned destination"
     assert proposal.resolutions[0].state_delta["travel.arrive"] is True
+
+
+def test_resolve_dry_run_fires_social_travel_arrival_by_purpose() -> None:
+    """Social-purpose travel gets a specific arrival beat before generic arrival."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            travel_state_rows=[
+                {
+                    "character_entity_id": 1,
+                    "status": "in_transit",
+                    "anchor_place_id": 10,
+                    "origin_place_id": 10,
+                    "destination_place_id": 20,
+                    "route_method": "estimated",
+                    "travel_mode": "mixed",
+                    "risk": "low",
+                    "progress_ratio": 0.96,
+                    "estimated_distance_m": 5000,
+                    "estimated_duration_minutes": 20,
+                    "route_purpose": "socialize",
+                }
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id == "travel"
+    assert (
+        proposal.resolutions[0].branch_label == "Arrive where people can be encountered"
+    )
+    assert (
+        proposal.resolutions[0].state_delta["character.current_activity"]
+        == "arriving where people gather"
+    )
 
 
 def test_resolve_dry_run_fires_work_for_obligation_without_craft_tags() -> None:

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -52,6 +52,7 @@ from nexus.agents.orrery.substrate import (
     routine_anchor_has_destination,
     since_last_event_at_least,
     validate_always_fallbacks,
+    travel_purpose_is,
 )
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 
@@ -714,6 +715,19 @@ def test_location_class_destination_condition_supports_legacy_single_class() -> 
     )
 
     assert has_location_class_destination("meeting")(state, {Slot.ACTOR: 1})
+
+
+def test_travel_purpose_condition_reads_route_metadata() -> None:
+    """Travel branches can distinguish why an actor is currently moving."""
+
+    state = WorldState(
+        travel_states={
+            1: TravelState(status="in_transit", route_purpose="socialize"),
+        }
+    )
+
+    assert travel_purpose_is("socialize")(state, {Slot.ACTOR: 1})
+    assert not travel_purpose_is("work")(state, {Slot.ACTOR: 1})
 
 
 def test_need_debt_condition_rejects_unknown_need_type() -> None:

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -51,8 +51,8 @@ from nexus.agents.orrery.substrate import (
     routine_anchor_due,
     routine_anchor_has_destination,
     since_last_event_at_least,
-    validate_always_fallbacks,
     travel_purpose_is,
+    validate_always_fallbacks,
 )
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 
@@ -722,12 +722,22 @@ def test_travel_purpose_condition_reads_route_metadata() -> None:
 
     state = WorldState(
         travel_states={
-            1: TravelState(status="in_transit", route_purpose="socialize"),
+            1: TravelState(status="in_transit", route_purpose="Socialize"),
         }
     )
 
-    assert travel_purpose_is("socialize")(state, {Slot.ACTOR: 1})
-    assert not travel_purpose_is("work")(state, {Slot.ACTOR: 1})
+    assert travel_purpose_is("SOCIALIZE")(state, {Slot.ACTOR: 1})
+    assert not travel_purpose_is("socialize")(
+        WorldState(travel_states={1: TravelState(status="in_transit")}),
+        {Slot.ACTOR: 1},
+    )
+
+
+def test_travel_purpose_condition_rejects_unknown_purposes() -> None:
+    """Typos in travel-purpose predicates fail at construction time."""
+
+    with pytest.raises(ValueError, match="Unsupported Orrery travel purpose"):
+        travel_purpose_is("work")
 
 
 def test_need_debt_condition_rejects_unknown_need_type() -> None:


### PR DESCRIPTION
## Summary
- persist whitelisted travel intent metadata from authored travel.start payloads into character_travel_states.route_metadata
- hydrate route purpose into the Orrery read-side TravelState and add a travel_purpose_is predicate/catalog renderer
- let social-purpose travel use a specific arrival branch before generic travel arrival, so SOCIALIZE can fulfill at the destination on the next tick

## Validation
- poetry run pytest -q tests/test_orrery/test_substrate.py tests/test_orrery/test_events.py tests/test_orrery/test_resolver.py tests/test_orrery/test_catalog.py
- poetry run pytest -q tests/test_orrery
- poetry run pre-commit run regenerate-orrery-catalog --all-files
- poetry run flake8 nexus/agents/orrery/substrate.py nexus/agents/orrery/resolver.py nexus/agents/orrery/events.py nexus/agents/orrery/catalog.py nexus/agents/orrery/templates.py tests/test_orrery/test_substrate.py tests/test_orrery/test_events.py tests/test_orrery/test_resolver.py tests/test_orrery/test_catalog.py
- poetry run python scripts/orrery_sample.py --slot 2 --anchor 1428 --world-time 2073-10-30T10:30:00+00:00

## Data / schema notes
- no schema migration; this uses existing character_travel_states.route_metadata
- SOCIALIZE travel now writes purpose/purpose_need metadata into that JSONB route metadata