### PR TITLE
[codex] Add Retrograde seed request contract

### DIFF
--- a/docs/orrery_needs.md
+++ b/docs/orrery_needs.md
@@ -183,6 +183,17 @@ Routine-trigger gate plus pressure gate. The routine clause (`count_co_located(1
 - **Parasocial branch** (reading, listening to a recording, watching a serial) uses partial decrement (`socialize_debt_delta: -0.4`) rather than full reset — captures "takes the edge off" without fully discharging.
 - **Branches**: seek-after-critical-isolation, engage with present company, go where people are (tavern/square/market), reach out to a contact, parasocial.
 
+**Social hydration policy.** SOCIALIZE should satisfy ordinary loneliness without
+forcing every implied acquaintance into the database. Branch selection uses four
+layers, in order: real co-located NPCs when present; explicit `contact:social`
+edges when the actor has one; public or semi-public place affordances where
+off-book people can satisfy the need without a concrete character row; and
+parasocial media/ritual contact as a partial fallback. Off-book people are lazily
+hydrated into entities only when Skald attends to them, the interaction repeats,
+or another package needs a concrete target. This keeps the routine social loop
+useful while preserving the broader dehydrated-entity principle used for implied
+spouses, families, coworkers, neighbors, and casual friends.
+
 ### INTIMACY (priority 16)
 
 The most sensitive in the catalog. Single-slot template (ACTOR only); branches that involve a partner read partner identity from the actor's relationship data. **No binding-composer pairing** — see Core Principle above.

--- a/docs/orrery_retrograde_spec.md
+++ b/docs/orrery_retrograde_spec.md
@@ -1,6 +1,6 @@
 # Orrery Retrograde — Deep-History Generation Spec
 
-**Status:** Design spec, deliberately compressed. Phase A0 now has a non-mutating dry-run packet surface; larger implementation decisions remain deferred and flagged inline as **[OPEN]**.
+**Status:** Design spec, deliberately compressed. Phase A0 now has a non-mutating dry-run packet surface, and Phase A1 adds a non-mutating R4/R5 seed-generation request contract inside that packet. Larger implementation decisions remain deferred and flagged inline as **[OPEN]**.
 **One-line frame:** Deep history is Orrery run backward. Same substrate, same vocabulary, opposite temporal direction. Output is `world_events` rows retrieved by MEMNON identically to play-generated history. Fires at wizard-time (whole-world cold start, pre-game tick stamps) and at runtime (per-entity stub maturation, current tick stamps) — see Stub Maturation below.
 
 ---
@@ -74,7 +74,9 @@ This is what keeps Retrograde non-recursive: implied entities accrete just enoug
 
 Six stages, labeled **R1–R6** to disambiguate from the forward Orrery pipeline's Stage 1–6 (Resolve/Commit/Clear/Promote/Narrate/Bleed in `orrery_design_plan.md`). Each consumes the prior; **[OPEN]** boundaries may merge during implementation.
 
-- **R1. Vocabulary table.** Enumerate the seed-eligible primitives: event types, tags, relationship types, and semantic place classes already in the Orrery registries. Retrograde generates *only* in existing vocabulary so output is substrate-legal by construction. New vocabulary is out of scope for a generation run. The first-pass enumerator exists at `nexus/agents/orrery/retrograde_vocabulary.py`; pass a target slot `dbname` once migrations are applied so it folds live `tag_category_registry` / `tags` rows into the template-derived primitive set. Phase A0 packet assembly now exists at `nexus/agents/orrery/retrograde_packet.py` and is exposed as `nexus retrograde-packet --slot N [--weird low|medium|high] [--weird-raw FLOAT] [--output packet.json]`. It reads wizard cache + vocabulary + configured weird bands, writes no canonical rows, and produces candidate prompt material for a later Skald-as-weaver selection/expansion pass.
+- **R1. Vocabulary table.** Enumerate the seed-eligible primitives: event types, tags, relationship types, and semantic place classes already in the Orrery registries. Retrograde generates *only* in existing vocabulary so output is substrate-legal by construction. New vocabulary is out of scope for a generation run. The first-pass enumerator exists at `nexus/agents/orrery/retrograde_vocabulary.py`; pass a target slot `dbname` once migrations are applied so it folds live `tag_category_registry` / `tags` rows into the template-derived primitive set. The enumerator now also classifies registered tag categories as `stable_seed`, `event_anchored`, or `prompt_visible_only`: stable categories may appear as present-state seed outcomes, event-anchored categories require an explicit causing/recent-refresh event, and prompt-visible-only categories may guide prose but not mechanical seed writes.
+
+  Phase A0/A1 packet assembly exists at `nexus/agents/orrery/retrograde_packet.py` and is exposed as `nexus retrograde-packet --slot N [--weird low|medium|high] [--weird-raw FLOAT] [--output packet.json]`. It reads wizard cache + vocabulary + configured weird bands, writes no canonical rows, and produces candidate prompt material plus a seed-generation request for a later Skald-as-weaver selection/expansion pass.
 
 - **R2. Stub generator.** From wizard choices (setting, genre, starting characters, selected traits), emit entity stubs and a sparse relationship graph — the *intentional core*. This is deterministic-ish scaffolding, low entropy, fully implied by wizard input.
 

--- a/nexus/agents/orrery/retrograde_packet.py
+++ b/nexus/agents/orrery/retrograde_packet.py
@@ -9,7 +9,43 @@ from nexus.agents.orrery.retrograde_vocabulary import SeedEligibleVocabulary
 from nexus.config.settings_models import Settings
 
 PACKET_SCHEMA_VERSION = "orrery_retrograde_dry_run_packet.v0"
+SEED_REQUEST_SCHEMA_VERSION = "orrery_retrograde_seed_request.v0"
 WEIRD_LEVELS = frozenset({"low", "medium", "high"})
+SEED_BUDGETS: Mapping[str, Mapping[str, int]] = {
+    "low": {"generate_candidates": 6, "select_target": 3, "deferred_secret_cap": 1},
+    "medium": {"generate_candidates": 9, "select_target": 4, "deferred_secret_cap": 2},
+    "high": {"generate_candidates": 12, "select_target": 5, "deferred_secret_cap": 3},
+}
+RETROGRADE_COVERAGE_FUNCTIONS: tuple[dict[str, str], ...] = (
+    {
+        "id": "foundational_wound",
+        "question": "What past harm, loss, bargain, or mistake still pressures now?",
+    },
+    {
+        "id": "current_power_arrangement",
+        "question": "Who benefits from the current order, and who is excluded?",
+    },
+    {
+        "id": "hidden_truth",
+        "question": "What consequential fact is concealed, misunderstood, or misfiled?",
+    },
+    {
+        "id": "trait_bound_hook",
+        "question": "Which selected trait becomes historically load-bearing?",
+    },
+    {
+        "id": "opening_pressure",
+        "question": "What old event makes the starting scenario urgent now?",
+    },
+    {
+        "id": "optional_mythic_layer",
+        "question": "What symbol, omen, legend, or myth can echo without dominating?",
+    },
+    {
+        "id": "unresolved_ledger",
+        "question": "What debt, oath, grudge, promise, or claim remains unpaid?",
+    },
+)
 
 
 def build_retrograde_dry_run_packet(
@@ -75,7 +111,70 @@ def build_retrograde_dry_run_packet(
         "vocabulary_summary": _vocabulary_summary(vocabulary),
         "seed_eligible_vocabulary": vocabulary,
         "candidate_scaffolds": candidate_scaffolds,
+        "seed_generation_request": build_seed_generation_request(
+            candidate_scaffolds=candidate_scaffolds,
+            vocabulary=vocabulary,
+            weird=weird,
+        ),
         "skald_weaver_instructions": _skald_weaver_instructions(),
+    }
+
+
+def build_seed_generation_request(
+    *,
+    candidate_scaffolds: Mapping[str, Any],
+    vocabulary: SeedEligibleVocabulary,
+    weird: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build the non-mutating R4/R5 request contract for Skald-as-weaver."""
+
+    level = str(weird.get("level") or "medium")
+    budget = dict(SEED_BUDGETS.get(level, SEED_BUDGETS["medium"]))
+    budget["overgenerate_multiplier"] = max(
+        1,
+        round(budget["generate_candidates"] / budget["select_target"]),
+    )
+
+    return {
+        "schema_version": SEED_REQUEST_SCHEMA_VERSION,
+        "stage": "R4/R5 seed generation and selection input",
+        "mutation_policy": {
+            "writes": "none",
+            "selection_required_before_persistence": True,
+            "discarded_seed_cost": "inference only",
+        },
+        "budget": budget,
+        "weird_policy": _weird_generation_policy(weird),
+        "mechanical_tag_policy": _mechanical_tag_policy(vocabulary),
+        "coverage_functions": list(RETROGRADE_COVERAGE_FUNCTIONS),
+        "selection_rubric": _selection_rubric(level),
+        "prompt_sections": _seed_prompt_sections(candidate_scaffolds),
+        "candidate_output_schema": {
+            "type": "object",
+            "required_fields": [
+                "seed_id",
+                "summary",
+                "origin_friction",
+                "present_leaf_anchor",
+                "coverage_functions",
+                "mechanical_hints",
+                "defer_or_reject_if",
+            ],
+            "mechanical_hints": {
+                "event_types": "Use only seed_eligible_vocabulary.event_types.",
+                "single_entity_tags": (
+                    "Use only seed_eligible_vocabulary.registered_* tags and "
+                    "respect mechanical_tag_policy."
+                ),
+                "pair_tags": (
+                    "Use only seed_eligible_vocabulary.multi_entity_tag_definitions "
+                    "with matching subject/object kinds."
+                ),
+                "relationships": (
+                    "Use only seed_eligible_vocabulary.relationship_types."
+                ),
+            },
+        },
     }
 
 
@@ -128,6 +227,116 @@ def resolve_weird_profile(
         "raw_max": band.max,
         "raw_midpoint": (band.min + band.max) / 2.0,
     }
+
+
+def _weird_generation_policy(weird: Mapping[str, Any]) -> dict[str, Any]:
+    """Describe how the resolved weird profile should affect seed generation."""
+
+    level = str(weird.get("level") or "medium")
+    raw = weird.get("raw")
+    if raw is None:
+        raw = weird.get("raw_midpoint")
+    return {
+        "level": level,
+        "raw": raw,
+        "genre": weird.get("genre"),
+        "rubric_bias": {
+            "low": "favor seeds that serve one or more coverage functions directly",
+            "medium": "mix coverage-serving seeds with stranger connective tissue",
+            "high": "admit orthogonal seeds if the leaf anchor is strong",
+        }.get(level, "mix coverage-serving seeds with stranger connective tissue"),
+        "friction_guidance": {
+            "low": "low origin friction; surprise should feel latent in the premise",
+            "medium": "moderate origin friction; preserve genre coherence",
+            "high": "high origin friction; coherence is enforced at the leaf anchor",
+        }.get(level, "moderate origin friction; preserve genre coherence"),
+    }
+
+
+def _mechanical_tag_policy(vocabulary: SeedEligibleVocabulary) -> dict[str, Any]:
+    """Summarize how registered vocabulary may be used in seed candidates."""
+
+    policies = vocabulary.get("registered_category_seed_policies", [])
+    categories_by_policy: dict[str, list[str]] = {}
+    for policy in policies:
+        categories_by_policy.setdefault(policy["policy"], []).append(policy["category"])
+
+    return {
+        "stable_seed_categories": sorted(
+            set(categories_by_policy.get("stable_seed", []))
+        ),
+        "event_anchored_categories": sorted(
+            set(categories_by_policy.get("event_anchored", []))
+        ),
+        "prompt_visible_only_categories": sorted(
+            set(categories_by_policy.get("prompt_visible_only", []))
+        ),
+        "registered_tags_by_seed_policy": vocabulary.get(
+            "registered_tags_by_seed_policy", {}
+        ),
+        "rules": [
+            (
+                "Stable seed categories may be proposed as present-state tags "
+                "when supported by the seed."
+            ),
+            (
+                "Event-anchored categories may be proposed only with an explicit "
+                "event that caused or recently refreshed the current state."
+            ),
+            (
+                "Prompt-visible-only categories may guide prose but must not be "
+                "proposed as mechanical writes in this stage."
+            ),
+            "Unknown tag names are invalid; omit marginal mechanics instead.",
+        ],
+    }
+
+
+def _selection_rubric(level: str) -> dict[str, Any]:
+    """Return R5 selection instructions for the generated seed pool."""
+
+    return {
+        "coverage_is_checklist_not_scaffold": True,
+        "priorities": [
+            "Keep seeds with strong leaf anchors to core entities.",
+            "Keep seeds that can be made substrate-legal with registered vocabulary.",
+            (
+                "Reject seeds that require unregistered tags, recursive entity "
+                "expansion, or timeline contortions."
+            ),
+            "Prefer fewer, sharper surviving seeds over a busy history web.",
+        ],
+        "weird_level_adjustment": {
+            "low": "coverage function service is a strong positive prior",
+            "medium": "coverage service and origin surprise should be balanced",
+            "high": "coverage service is optional when the present anchor is strong",
+        }.get(level, "coverage service and origin surprise should be balanced"),
+    }
+
+
+def _seed_prompt_sections(
+    candidate_scaffolds: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Return deterministic prompt sections for R4 seed generation."""
+
+    return [
+        {
+            "heading": "Core entities",
+            "items": _present_items(candidate_scaffolds.get("core_entities")),
+        },
+        {
+            "heading": "Named seed NPCs",
+            "items": _present_items(candidate_scaffolds.get("named_seed_npcs")),
+        },
+        {
+            "heading": "Pressure axes",
+            "items": _present_items(candidate_scaffolds.get("pressure_axes")),
+        },
+        {
+            "heading": "Trait hooks",
+            "items": candidate_scaffolds.get("trait_hooks") or {},
+        },
+    ]
 
 
 def _candidate_scaffolds(
@@ -290,6 +499,12 @@ def _optional_cache_section(
 
 def _mapping(value: Any) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
+
+
+def _present_items(value: Any) -> list[Any]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if item]
 
 
 def _axis(kind: str, text: Any) -> dict[str, Any]:

--- a/nexus/agents/orrery/retrograde_packet.py
+++ b/nexus/agents/orrery/retrograde_packet.py
@@ -130,6 +130,8 @@ def build_seed_generation_request(
 
     level = str(weird.get("level") or "medium")
     budget = dict(SEED_BUDGETS.get(level, SEED_BUDGETS["medium"]))
+    # This is a coarse review hint, not an extra tuning knob; the explicit
+    # generate/select counts carry the meaningful level-specific budget.
     budget["overgenerate_multiplier"] = max(
         1,
         round(budget["generate_candidates"] / budget["select_target"]),
@@ -334,7 +336,7 @@ def _seed_prompt_sections(
         },
         {
             "heading": "Trait hooks",
-            "items": candidate_scaffolds.get("trait_hooks") or {},
+            "items": _trait_prompt_items(candidate_scaffolds.get("trait_hooks")),
         },
     ]
 
@@ -505,6 +507,22 @@ def _present_items(value: Any) -> list[Any]:
     if not isinstance(value, list):
         return []
     return [item for item in value if item]
+
+
+def _trait_prompt_items(value: Any) -> list[dict[str, Any]]:
+    hooks = _mapping(value)
+    selected_traits = hooks.get("selected_traits") or []
+    rationales = _mapping(hooks.get("rationales"))
+    wildcard = _mapping(hooks.get("wildcard"))
+
+    items: list[dict[str, Any]] = [
+        {"kind": "trait", "name": trait, "rationale": rationales.get(str(trait))}
+        for trait in selected_traits
+        if trait
+    ]
+    if wildcard:
+        items.append({"kind": "wildcard", **dict(wildcard)})
+    return items
 
 
 def _axis(kind: str, text: Any) -> dict[str, Any]:

--- a/nexus/agents/orrery/retrograde_vocabulary.py
+++ b/nexus/agents/orrery/retrograde_vocabulary.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 from nexus.agents.orrery.catalog import collect_template_vocabulary
 from nexus.agents.orrery.pair_tag_registry import PAIR_TAG_SEED
@@ -20,6 +20,18 @@ class PairTagPrimitive(TypedDict):
     is_ephemeral: bool
 
 
+SeedTagPolicy = Literal["stable_seed", "event_anchored", "prompt_visible_only"]
+
+
+class CategorySeedPolicy(TypedDict):
+    """Retrograde policy for one prompt-visible registered tag category."""
+
+    category: str
+    entity_kind: str
+    policy: SeedTagPolicy
+    reason: str
+
+
 class SeedEligibleVocabulary(TypedDict):
     """Primitive vocabulary Retrograde may use for substrate-legal seeds."""
 
@@ -34,11 +46,42 @@ class SeedEligibleVocabulary(TypedDict):
     registered_tag_categories: list[str]
     registered_tags_by_category: dict[str, list[str]]
     registered_tags_by_entity_kind: dict[str, list[str]]
+    registered_category_seed_policies: list[CategorySeedPolicy]
+    registered_tags_by_seed_policy: dict[str, list[str]]
     multi_entity_tag_families: list[str]
     multi_entity_tag_definitions: list[PairTagPrimitive]
     event_types: list[str]
     place_classes: list[str]
     relationship_types: list[str]
+
+
+STABLE_SEED_TAG_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "bodyform.lineage",
+        "bodyform.condition",
+        "disposition",
+        "capacity",
+        "role.function",
+        "role.resources",
+        "role.fame",
+        "place_function",
+        "place_visibility",
+        "place_access",
+        "place_environment",
+        "ideology",
+        "resource_base",
+        "legitimacy",
+        "operational_mode",
+    }
+)
+EVENT_ANCHORED_TAG_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "state",
+        "place_threat",
+        "power_status",
+        "agenda",
+    }
+)
 
 
 def enumerate_seed_eligible_vocabulary(
@@ -81,6 +124,12 @@ def enumerate_seed_eligible_vocabulary(
         "registered_tags_by_entity_kind": registry_vocab[
             "registered_tags_by_entity_kind"
         ],
+        "registered_category_seed_policies": registry_vocab[
+            "registered_category_seed_policies"
+        ],
+        "registered_tags_by_seed_policy": registry_vocab[
+            "registered_tags_by_seed_policy"
+        ],
         "multi_entity_tag_families": [item["tag"] for item in pair_tag_definitions],
         "multi_entity_tag_definitions": pair_tag_definitions,
         "event_types": _sorted_strings(template_vocab["event_types"]),
@@ -96,6 +145,8 @@ class _RegistryVocabulary(TypedDict):
     registered_tag_categories: list[str]
     registered_tags_by_category: dict[str, list[str]]
     registered_tags_by_entity_kind: dict[str, list[str]]
+    registered_category_seed_policies: list[CategorySeedPolicy]
+    registered_tags_by_seed_policy: dict[str, list[str]]
 
 
 def _collect_registry_vocabulary(dbname: str | None) -> _RegistryVocabulary:
@@ -107,14 +158,21 @@ def _collect_registry_vocabulary(dbname: str | None) -> _RegistryVocabulary:
             "registered_tag_categories": [],
             "registered_tags_by_category": {},
             "registered_tags_by_entity_kind": {},
+            "registered_category_seed_policies": [],
+            "registered_tags_by_seed_policy": {},
         }
 
     entries = read_tag_library(dbname)
     tags_by_category: dict[str, set[str]] = {}
     tags_by_entity_kind: dict[str, set[str]] = {}
+    tags_by_seed_policy: dict[str, set[str]] = {}
+    category_entity_kinds: dict[tuple[str, str], None] = {}
     for entry in entries:
         _add_registry_entry(tags_by_category, entry.category, entry.tag)
         _add_registry_entry(tags_by_entity_kind, entry.entity_kind, entry.tag)
+        seed_policy = category_seed_policy(entry.category)
+        _add_registry_entry(tags_by_seed_policy, seed_policy["policy"], entry.tag)
+        category_entity_kinds[(entry.category, entry.entity_kind)] = None
     registered_tags = {entry.tag for entry in entries}
     registered_categories = {entry.category for entry in entries}
 
@@ -123,6 +181,14 @@ def _collect_registry_vocabulary(dbname: str | None) -> _RegistryVocabulary:
         "registered_tag_categories": _sorted_strings(registered_categories),
         "registered_tags_by_category": _sort_registry_mapping(tags_by_category),
         "registered_tags_by_entity_kind": _sort_registry_mapping(tags_by_entity_kind),
+        "registered_category_seed_policies": [
+            {
+                **category_seed_policy(category),
+                "entity_kind": entity_kind,
+            }
+            for category, entity_kind in sorted(category_entity_kinds)
+        ],
+        "registered_tags_by_seed_policy": _sort_registry_mapping(tags_by_seed_policy),
     }
 
 
@@ -142,6 +208,41 @@ def _sort_registry_mapping(values: dict[str, set[str]]) -> dict[str, list[str]]:
     return {
         key: _sorted_strings(tags)
         for key, tags in sorted(values.items(), key=lambda item: item[0])
+    }
+
+
+def category_seed_policy(category: str) -> CategorySeedPolicy:
+    """Return the Retrograde generation policy for one registered category."""
+
+    normalized = str(category)
+    if normalized in STABLE_SEED_TAG_CATEGORIES:
+        return {
+            "category": normalized,
+            "entity_kind": "",
+            "policy": "stable_seed",
+            "reason": (
+                "Stable identity, role, faction, or place affordance tags may "
+                "be proposed as present-state seed outcomes."
+            ),
+        }
+    if normalized in EVENT_ANCHORED_TAG_CATEGORIES:
+        return {
+            "category": normalized,
+            "entity_kind": "",
+            "policy": "event_anchored",
+            "reason": (
+                "Current pressure tags in this category require an explicit "
+                "retrograde event that caused or recently refreshed them."
+            ),
+        }
+    return {
+        "category": normalized,
+        "entity_kind": "",
+        "policy": "prompt_visible_only",
+        "reason": (
+            "Category is prompt-visible but not yet approved for mechanical "
+            "Retrograde seed writes; use as prose context only."
+        ),
     }
 
 

--- a/nexus/agents/orrery/retrograde_vocabulary.py
+++ b/nexus/agents/orrery/retrograde_vocabulary.py
@@ -166,13 +166,13 @@ def _collect_registry_vocabulary(dbname: str | None) -> _RegistryVocabulary:
     tags_by_category: dict[str, set[str]] = {}
     tags_by_entity_kind: dict[str, set[str]] = {}
     tags_by_seed_policy: dict[str, set[str]] = {}
-    category_entity_kinds: dict[tuple[str, str], None] = {}
+    category_entity_kinds: set[tuple[str, str]] = set()
     for entry in entries:
         _add_registry_entry(tags_by_category, entry.category, entry.tag)
         _add_registry_entry(tags_by_entity_kind, entry.entity_kind, entry.tag)
-        seed_policy = category_seed_policy(entry.category)
+        seed_policy = category_seed_policy(entry.category, entry.entity_kind)
         _add_registry_entry(tags_by_seed_policy, seed_policy["policy"], entry.tag)
-        category_entity_kinds[(entry.category, entry.entity_kind)] = None
+        category_entity_kinds.add((entry.category, entry.entity_kind))
     registered_tags = {entry.tag for entry in entries}
     registered_categories = {entry.category for entry in entries}
 
@@ -182,10 +182,7 @@ def _collect_registry_vocabulary(dbname: str | None) -> _RegistryVocabulary:
         "registered_tags_by_category": _sort_registry_mapping(tags_by_category),
         "registered_tags_by_entity_kind": _sort_registry_mapping(tags_by_entity_kind),
         "registered_category_seed_policies": [
-            {
-                **category_seed_policy(category),
-                "entity_kind": entity_kind,
-            }
+            category_seed_policy(category, entity_kind)
             for category, entity_kind in sorted(category_entity_kinds)
         ],
         "registered_tags_by_seed_policy": _sort_registry_mapping(tags_by_seed_policy),
@@ -211,14 +208,15 @@ def _sort_registry_mapping(values: dict[str, set[str]]) -> dict[str, list[str]]:
     }
 
 
-def category_seed_policy(category: str) -> CategorySeedPolicy:
+def category_seed_policy(category: str, entity_kind: str) -> CategorySeedPolicy:
     """Return the Retrograde generation policy for one registered category."""
 
     normalized = str(category)
+    normalized_kind = str(entity_kind)
     if normalized in STABLE_SEED_TAG_CATEGORIES:
         return {
             "category": normalized,
-            "entity_kind": "",
+            "entity_kind": normalized_kind,
             "policy": "stable_seed",
             "reason": (
                 "Stable identity, role, faction, or place affordance tags may "
@@ -228,7 +226,7 @@ def category_seed_policy(category: str) -> CategorySeedPolicy:
     if normalized in EVENT_ANCHORED_TAG_CATEGORIES:
         return {
             "category": normalized,
-            "entity_kind": "",
+            "entity_kind": normalized_kind,
             "policy": "event_anchored",
             "reason": (
                 "Current pressure tags in this category require an explicit "
@@ -237,7 +235,7 @@ def category_seed_policy(category: str) -> CategorySeedPolicy:
         }
     return {
         "category": normalized,
-        "entity_kind": "",
+        "entity_kind": normalized_kind,
         "policy": "prompt_visible_only",
         "reason": (
             "Category is prompt-visible but not yet approved for mechanical "

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -235,6 +235,8 @@ def _print_retrograde_packet(payload: Dict[str, Any]) -> None:
     weird = packet.get("weird") or {}
     summary = packet.get("vocabulary_summary") or {}
     scaffolds = packet.get("candidate_scaffolds") or {}
+    seed_request = packet.get("seed_generation_request") or {}
+    seed_budget = seed_request.get("budget") or {}
 
     print("Packet:")
     print(f"  schema_version: {packet.get('schema_version')}")
@@ -258,6 +260,12 @@ def _print_retrograde_packet(payload: Dict[str, Any]) -> None:
     print(f"  core_entities: {len(scaffolds.get('core_entities') or [])}")
     print(f"  named_seed_npcs: {len(scaffolds.get('named_seed_npcs') or [])}")
     print(f"  pressure_axes: {len(scaffolds.get('pressure_axes') or [])}")
+    if seed_budget:
+        print()
+        print("Seed request:")
+        print(f"  generate_candidates: {seed_budget.get('generate_candidates')}")
+        print(f"  select_target: {seed_budget.get('select_target')}")
+        print(f"  deferred_secret_cap: {seed_budget.get('deferred_secret_cap')}")
     if payload.get("packet_output"):
         print()
         print(f"Output: {payload['packet_output']}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -377,3 +377,4 @@ def test_retrograde_packet_writes_dry_run_packet(monkeypatch, tmp_path) -> None:
     assert packet["dry_run"] is True
     assert packet["mutation_policy"]["writes"] == "none"
     assert packet["weird"]["level"] == "medium"
+    assert packet["seed_generation_request"]["mutation_policy"]["writes"] == "none"

--- a/tests/test_orrery/test_retrograde_packet.py
+++ b/tests/test_orrery/test_retrograde_packet.py
@@ -107,6 +107,25 @@ def test_retrograde_packet_is_dry_run_and_selection_oriented() -> None:
     assert (
         "mechanical_hints" in seed_request["candidate_output_schema"]["required_fields"]
     )
+    sections = seed_request["prompt_sections"]
+    assert all(isinstance(section["items"], list) for section in sections)
+    trait_section = next(
+        section for section in sections if section["heading"] == "Trait hooks"
+    )
+    assert trait_section["items"] == [
+        {"kind": "trait", "name": "resources", "rationale": "Money opens doors."},
+        {
+            "kind": "trait",
+            "name": "status",
+            "rationale": "The badge matters narrowly.",
+        },
+        {
+            "kind": "wildcard",
+            "name": "Storm Marked",
+            "description": "Weather notices her.",
+            "orrery_tags": None,
+        },
+    ]
     assert {function["id"] for function in seed_request["coverage_functions"]} == {
         "foundational_wound",
         "current_power_arrangement",

--- a/tests/test_orrery/test_retrograde_packet.py
+++ b/tests/test_orrery/test_retrograde_packet.py
@@ -96,10 +96,76 @@ def test_retrograde_packet_is_dry_run_and_selection_oriented() -> None:
         packet["candidate_scaffolds"]["candidate_seed_contract"]["selection_required"]
         is True
     )
+    seed_request = packet["seed_generation_request"]
+    assert seed_request["mutation_policy"]["writes"] == "none"
+    assert seed_request["budget"]["generate_candidates"] == 12
+    assert seed_request["budget"]["select_target"] == 5
+    assert seed_request["weird_policy"]["level"] == "high"
+    assert (
+        seed_request["selection_rubric"]["coverage_is_checklist_not_scaffold"] is True
+    )
+    assert (
+        "mechanical_hints" in seed_request["candidate_output_schema"]["required_fields"]
+    )
+    assert {function["id"] for function in seed_request["coverage_functions"]} == {
+        "foundational_wound",
+        "current_power_arrangement",
+        "hidden_truth",
+        "trait_bound_hook",
+        "opening_pressure",
+        "optional_mythic_layer",
+        "unresolved_ledger",
+    }
     assert packet["candidate_scaffolds"]["named_seed_npcs"] == [
         {"kind": "character", "role": "seed_npc", "name": "Vale"}
     ]
     assert packet["vocabulary_summary"]["event_types"] > 0
+
+
+def test_retrograde_seed_request_respects_vocabulary_policy() -> None:
+    """Registered categories are prompt-visible but not equally seed-writeable."""
+
+    vocabulary = enumerate_seed_eligible_vocabulary()
+    vocabulary["registered_category_seed_policies"] = [
+        {
+            "category": "role.function",
+            "entity_kind": "character",
+            "policy": "stable_seed",
+            "reason": "Stable role.",
+        },
+        {
+            "category": "state",
+            "entity_kind": "character",
+            "policy": "event_anchored",
+            "reason": "Needs an event.",
+        },
+        {
+            "category": "experimental_signal",
+            "entity_kind": "character",
+            "policy": "prompt_visible_only",
+            "reason": "Not approved.",
+        },
+    ]
+    vocabulary["registered_tags_by_seed_policy"] = {
+        "stable_seed": ["scholar"],
+        "event_anchored": ["grieving"],
+        "prompt_visible_only": ["untested_signal"],
+    }
+
+    packet = build_retrograde_dry_run_packet(
+        slot=5,
+        dbname="save_05",
+        cache=FakeRetrogradeCache(),
+        vocabulary=vocabulary,
+        settings=load_settings(),
+        weird_level="medium",
+    )
+    policy = packet["seed_generation_request"]["mechanical_tag_policy"]
+
+    assert policy["stable_seed_categories"] == ["role.function"]
+    assert policy["event_anchored_categories"] == ["state"]
+    assert policy["prompt_visible_only_categories"] == ["experimental_signal"]
+    assert policy["registered_tags_by_seed_policy"]["event_anchored"] == ["grieving"]
 
 
 def test_retrograde_packet_requires_complete_wizard_sections() -> None:

--- a/tests/test_orrery/test_retrograde_vocabulary.py
+++ b/tests/test_orrery/test_retrograde_vocabulary.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import pytest
 
+from nexus.agents.orrery import retrograde_vocabulary
+from nexus.agents.orrery.tag_library import TagLibraryEntry
 from nexus.agents.orrery.retrograde_vocabulary import (
     enumerate_seed_eligible_vocabulary,
 )
@@ -46,6 +48,12 @@ def test_seed_eligible_vocabulary_can_include_live_tag_registry() -> None:
     )
     assert "grieving" in vocabulary["registered_tags_by_entity_kind"]["character"]
     assert "commerce" in vocabulary["registered_tags_by_entity_kind"]["place"]
+    policies = {
+        item["category"]: item["policy"]
+        for item in vocabulary["registered_category_seed_policies"]
+    }
+    assert policies["place_function"] == "stable_seed"
+    assert policies["state"] == "event_anchored"
 
     for key in (
         "single_entity_tag_anchors",
@@ -73,6 +81,65 @@ def test_seed_eligible_vocabulary_includes_pair_tag_kind_constraints() -> None:
     assert definitions["hunting"]["subject_kinds"] == ["character", "faction"]
     assert definitions["hunting"]["object_kinds"] == ["character"]
     assert definitions["hunting"]["is_ephemeral"] is True
+
+
+def test_seed_eligible_vocabulary_classifies_registered_categories(
+    monkeypatch,
+) -> None:
+    """Retrograde distinguishes stable, event-anchored, and prompt-only tags."""
+
+    monkeypatch.setattr(
+        retrograde_vocabulary,
+        "read_tag_library",
+        lambda _dbname: [
+            TagLibraryEntry(
+                entity_kind="character",
+                category="role.function",
+                tag="scholar",
+                is_ephemeral=False,
+                description="",
+                category_description="",
+                prompt_order=10,
+            ),
+            TagLibraryEntry(
+                entity_kind="character",
+                category="state",
+                tag="grieving",
+                is_ephemeral=True,
+                description="",
+                category_description="",
+                prompt_order=20,
+            ),
+            TagLibraryEntry(
+                entity_kind="character",
+                category="experimental_signal",
+                tag="untested_signal",
+                is_ephemeral=False,
+                description="",
+                category_description="",
+                prompt_order=30,
+            ),
+        ],
+    )
+
+    vocabulary = enumerate_seed_eligible_vocabulary(dbname="save_05")
+    policies = {
+        item["category"]: item["policy"]
+        for item in vocabulary["registered_category_seed_policies"]
+    }
+
+    assert policies == {
+        "experimental_signal": "prompt_visible_only",
+        "role.function": "stable_seed",
+        "state": "event_anchored",
+    }
+    assert vocabulary["registered_tags_by_seed_policy"]["stable_seed"] == ["scholar"]
+    assert vocabulary["registered_tags_by_seed_policy"]["event_anchored"] == [
+        "grieving"
+    ]
+    assert vocabulary["registered_tags_by_seed_policy"]["prompt_visible_only"] == [
+        "untested_signal"
+    ]
 
 
 def test_seed_eligible_pair_tags_are_sorted() -> None:

--- a/tests/test_orrery/test_retrograde_vocabulary.py
+++ b/tests/test_orrery/test_retrograde_vocabulary.py
@@ -7,6 +7,7 @@ import pytest
 from nexus.agents.orrery import retrograde_vocabulary
 from nexus.agents.orrery.tag_library import TagLibraryEntry
 from nexus.agents.orrery.retrograde_vocabulary import (
+    category_seed_policy,
     enumerate_seed_eligible_vocabulary,
 )
 
@@ -140,6 +141,20 @@ def test_seed_eligible_vocabulary_classifies_registered_categories(
     assert vocabulary["registered_tags_by_seed_policy"]["prompt_visible_only"] == [
         "untested_signal"
     ]
+
+
+def test_category_seed_policy_returns_complete_struct() -> None:
+    """Direct callers get a complete category/entity policy, not a stub."""
+
+    assert category_seed_policy("role.function", "character") == {
+        "category": "role.function",
+        "entity_kind": "character",
+        "policy": "stable_seed",
+        "reason": (
+            "Stable identity, role, faction, or place affordance tags may "
+            "be proposed as present-state seed outcomes."
+        ),
+    }
 
 
 def test_seed_eligible_pair_tags_are_sorted() -> None:


### PR DESCRIPTION
## Summary

- add Retrograde category seed policies so registered tags are classified as stable seed, event anchored, or prompt visible only
- add a non-mutating R4/R5 seed generation request to the existing Retrograde dry-run packet
- show seed request budget in the CLI packet summary
- document SOCIALIZE off-book hydration policy and update the Retrograde spec for Phase A1

Closes #360.
Progresses #300.

## Validation

- poetry run pre-commit run regenerate-orrery-catalog --all-files
- poetry run pytest -q tests/test_orrery/test_catalog.py::test_orrery_packages_md_is_up_to_date tests/test_orrery/test_catalog.py::test_builtin_drive_band_priorities_have_rationales tests/test_orrery/test_catalog.py::test_catalog_includes_all_templates
- poetry run pytest -q tests/test_orrery/test_retrograde_packet.py tests/test_orrery/test_retrograde_vocabulary.py tests/test_cli.py::test_retrograde_packet_writes_dry_run_packet tests/test_orrery/test_catalog.py::test_orrery_packages_md_is_up_to_date tests/test_orrery/test_catalog.py::test_builtin_drive_band_priorities_have_rationales
- poetry run pytest -q tests/test_cli.py
- poetry run pytest -q tests/test_orrery
- poetry run flake8 nexus/agents/orrery/retrograde_packet.py nexus/agents/orrery/retrograde_vocabulary.py nexus/cli.py tests/test_orrery/test_retrograde_packet.py tests/test_orrery/test_retrograde_vocabulary.py tests/test_cli.py