### PR TITLE
M6: Turn On the Orrery, End to End

### DIFF
--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -424,6 +424,8 @@ CREATE TABLE offscreen_narrations (
 
 `narrative_chunks` is always player-visible; `offscreen_narrations` never is. MEMNON's retrieval logic queries both tables with explicit semantic intent: warm-slice → `narrative_chunks` only; off-screen retrieval → both, with `offscreen_narrations` clearly labeled. `narrative_view.world_time` does NOT count off-screen narrations toward chronological advancement.
 
+**Embedding path is deliberately deferred (decided 2026-06, M6).** `embedding_status` stays at its `'pending'` default and no processor drains it. Rationale: no off-screen retrieval surface exists yet — `tests/test_orrery/test_retrieval_boundaries.py` deliberately excludes `offscreen_narrations` from every MEMNON surface (warm slice, text search, vector collections), and Bleed reads narrations relationally, not semantically. Embedding rows today would burn tokens for vectors nothing may query, and wiring them into the existing `narrative_chunks` collection would violate the boundary tests. The durable `'pending'` backlog (visible via `python -m nexus.agents.orrery.worker --status`) is the designed re-entry point: when a labeled off-screen retrieval surface lands (post-1.0), a processor can drain the backlog without schema changes.
+
 ### Bleed Selector — Cross-Turn Ambient Surfacing
 
 **Bleed handles cross-turn grace, not current-tick proposals.** Current-tick proposals flow through the authority model above — Skald sees them directly in `orrery_imminent_activity` and adjudicates. Bleed's role is narrower: surfacing *prior-turn* narrated events that weren't included in any chunk yet but remain eligible to bleed through within a temporal grace window.
@@ -547,10 +549,21 @@ model_ref = "@anthropic.default"                # resolved via [global.model.api
 max_candidates = 3
 
 [orrery.promote]
-priority_threshold = 50.0
-magnitude_threshold = 0.5
+priority_threshold = 30.0    # template seam: mundane needs <= 26, relational/dramatic >= 35
+magnitude_threshold = 0.35   # routine outcomes observed <= 0.22; noteworthy branches >= ~0.34
 perceptual_summary_max_chars = 240
 ```
+
+Promotion thresholds were calibrated 2026-06 against the 106-resolution corpus
+on `save_05` (39 ticks). The discriminator promotes on `priority >= threshold
+OR magnitude >= threshold` provided the resolution carries content. The
+priority axis separates the template catalog's mundane-needs band (`work` 14
+through `routine_commute` 26) from relational and dramatic templates
+(`consult_rival` 35 through `evade_pursuers` 100). The magnitude axis exists
+for dramatic outcomes of mundane templates (e.g. `sleep` branches up to 0.74);
+observed routine outcomes never exceeded 0.22, so 0.35 cannot fire on the
+noise floor. The previous defaults (50.0 / 0.5) made magnitude unreachable in
+practice.
 
 Every model reference uses the `@provider.role` syntax that the config loader resolves against `[global.model.api_models]` — never a hardcoded model ID in runtime code (per `CLAUDE.md` "Testing Defaults").
 

--- a/nexus.toml
+++ b/nexus.toml
@@ -127,7 +127,7 @@ max_total_threats = 10
 # =============================================================================
 
 [orrery]
-enabled = false
+enabled = true
 
 [orrery.binding]
 window_chunks = 30
@@ -144,8 +144,19 @@ model_ref = "@anthropic.default"
 max_candidates = 3
 
 [orrery.promote]
-priority_threshold = 50.0
-magnitude_threshold = 0.5
+# Calibrated against the 106-resolution corpus on save_05 (39 ticks, 2026-06).
+# Template priorities seam cleanly: mundane needs band tops out at 26
+# (routine_commute); relational/dramatic templates start at 35 (consult_rival).
+# priority_threshold = 30 promotes every above-mundane template while skipping
+# the drink/eat/work/tend_craft/maintain_cover noise floor (4/106 = 3.8% of the
+# historical corpus, ~1 promotion per 10 ticks of a quiet stretch).
+# Observed routine-outcome magnitudes max at 0.22; catalog branch magnitudes
+# for noteworthy outcomes start at ~0.34-0.40. magnitude_threshold = 0.35 lets
+# a dramatic outcome of a mundane template (e.g. sleep 0.74, eat 0.62) promote
+# via the OR-side without ever firing on routine outcomes. The old default of
+# 0.5 was unreachable: no observed resolution exceeded 0.22.
+priority_threshold = 30.0
+magnitude_threshold = 0.35
 perceptual_summary_max_chars = 240
 
 [orrery.sunhelm]

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -290,12 +290,12 @@ class OrreryPromoteSettings(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     priority_threshold: float = Field(
-        default=50.0,
+        default=30.0,
         ge=0.0,
         description="Promote resolutions whose priority is at or above this value.",
     )
     magnitude_threshold: float = Field(
-        default=0.5,
+        default=0.35,
         ge=0.0,
         description="Promote resolutions whose magnitude is at or above this value.",
     )
@@ -571,7 +571,7 @@ class OrrerySettings(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    enabled: bool = False
+    enabled: bool = True
     binding: OrreryBindingSettings = Field(default_factory=OrreryBindingSettings)
     route_graph: OrreryRouteGraphSettings = Field(
         default_factory=OrreryRouteGraphSettings

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -78,8 +78,8 @@ def test_orrery_promote_accepts_deprecated_provider_key() -> None:
 
     assert settings.provider == "local"
     dumped = settings.model_dump()
-    assert dumped["priority_threshold"] == 50.0
-    assert dumped["magnitude_threshold"] == 0.5
+    assert dumped["priority_threshold"] == 30.0
+    assert dumped["magnitude_threshold"] == 0.35
     assert dumped["perceptual_summary_max_chars"] == 240
     assert "provider" not in dumped
 

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -21,13 +21,13 @@ def test_orrery_settings_resolve_model_reference() -> None:
     settings = load_settings("nexus.toml")
 
     assert settings.orrery is not None
-    assert settings.orrery.enabled is False
+    assert settings.orrery.enabled is True
     assert settings.orrery.binding.window_chunks == 30
     expected_model = settings.global_.model.api_models["anthropic"].roles["default"]
     assert settings.orrery.narration.model_ref == expected_model
     assert settings.orrery.promote.provider is None
-    assert settings.orrery.promote.priority_threshold == 50.0
-    assert settings.orrery.promote.magnitude_threshold == 0.5
+    assert settings.orrery.promote.priority_threshold == 30.0
+    assert settings.orrery.promote.magnitude_threshold == 0.35
     assert settings.orrery.promote.perceptual_summary_max_chars == 240
     assert settings.orrery.sunhelm.accrual_rates == {
         "sleep": 1.0,

--- a/tests/test_orrery/test_live_cycle.py
+++ b/tests/test_orrery/test_live_cycle.py
@@ -1,0 +1,227 @@
+"""Live Orrery cycle integration test on slot 2.
+
+Exercises Resolve -> Commit -> Promote -> Narrate -> Bleed against the real
+``save_02`` database with a real frontier narration call. Skipped unless both
+``NEXUS_RUN_LIVE_LLM=1`` and ``NEXUS_RUN_POSTGRES=1`` are set.
+
+The test commits one synthetic high-salience resolution (real entity, valid
+template) so Promote is guaranteed a row above the configured thresholds
+regardless of current story state, then cleans up every row it created.
+Resolve runs read-only against live world state. Narration drain may also
+process unrelated queued jobs - that is the worker's actual contract.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+import psycopg2
+import pytest
+from psycopg2.extras import RealDictCursor
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from nexus.agents.orrery.bleed import select_bleed_menu
+from nexus.agents.orrery.events import commit_orrery_tick_sync
+from nexus.agents.orrery.resolver import (
+    OrreryResolutionDraft,
+    OrreryTickProposal,
+    resolve_dry_run,
+)
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+from nexus.agents.orrery.worker import (
+    drain_narration_outbox_sync,
+    promote_pending_resolutions_sync,
+)
+from nexus.api.slot_utils import get_slot_db_url
+from nexus.config import load_settings_as_dict
+
+LIVE_SLOT = 2
+
+pytestmark = [pytest.mark.live_llm, pytest.mark.requires_postgres]
+
+
+def _connect() -> Any:
+    return psycopg2.connect(
+        host=os.environ.get("PGHOST", "localhost"),
+        database=f"save_{LIVE_SLOT:02d}",
+        user=os.environ.get("PGUSER", "pythagor"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+def _cleanup_resolutions(conn: Any, resolution_ids: list[int]) -> None:
+    if not resolution_ids:
+        return
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE orrery_resolutions
+                SET narration_chunk_id = NULL
+                WHERE id = ANY(%s)
+                """,
+                (resolution_ids,),
+            )
+            cur.execute(
+                "DELETE FROM offscreen_narrations WHERE resolution_id = ANY(%s)",
+                (resolution_ids,),
+            )
+            cur.execute(
+                "DELETE FROM orrery_narration_jobs WHERE resolution_id = ANY(%s)",
+                (resolution_ids,),
+            )
+            cur.execute(
+                "DELETE FROM world_events WHERE resolution_id = ANY(%s)",
+                (resolution_ids,),
+            )
+            cur.execute(
+                "DELETE FROM orrery_resolutions WHERE id = ANY(%s)",
+                (resolution_ids,),
+            )
+
+
+def test_live_orrery_cycle_resolve_commit_promote_narrate_bleed() -> None:
+    """The full Orrery pipeline runs live on slot 2 with config thresholds."""
+
+    settings = load_settings_as_dict()
+    orrery_settings = settings["orrery"]
+    assert orrery_settings["enabled"] is True, "Orrery must ship default-on"
+    promote_settings = orrery_settings["promote"]
+    priority_threshold = float(promote_settings["priority_threshold"])
+
+    engine = create_engine(get_slot_db_url(slot=LIVE_SLOT))
+    session_factory = sessionmaker(bind=engine)
+
+    # Stage 1 - Resolve: read-only dry run against live world state.
+    with session_factory() as session:
+        anchor_row = (
+            session.execute(text("SELECT max(id) AS max_id FROM narrative_chunks"))
+            .mappings()
+            .first()
+        )
+        assert anchor_row is not None and anchor_row["max_id"] is not None
+        anchor_chunk_id = int(anchor_row["max_id"])
+        proposal = resolve_dry_run(
+            session,
+            BUILTIN_TEMPLATES,
+            anchor_chunk_id=anchor_chunk_id,
+            window_chunks=int(orrery_settings["binding"]["window_chunks"]),
+            sunhelm_settings=orrery_settings.get("sunhelm"),
+        )
+    assert proposal.anchor_chunk_id == anchor_chunk_id
+    assert proposal.actor_count >= 0
+
+    conn = _connect()
+    created_resolution_ids: list[int] = []
+    try:
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute("SELECT id FROM entities ORDER BY id LIMIT 1")
+                actor_entity_id = int(cur.fetchone()["id"])
+
+        # Stage 2 - Commit: materialize a synthetic salient draft stamped to
+        # the anchor chunk. The unique binding hash keeps reruns idempotent.
+        binding_hash = f"live-cycle-{uuid.uuid4().hex}"
+        salient_draft = OrreryResolutionDraft(
+            template_id="hide",
+            priority=int(priority_threshold) + 1,
+            binding_hash=binding_hash,
+            bindings={"actor": actor_entity_id},
+            branch_label="Live-cycle integration probe",
+            narrative_stub=(
+                "{actor} drops out of sight for a few hours, testing how far "
+                "the city's attention can be made to slide off."
+            ),
+            magnitude=0.2,
+        )
+        synthetic_proposal = OrreryTickProposal(
+            anchor_chunk_id=anchor_chunk_id,
+            actor_count=1,
+            resolutions=(salient_draft,),
+        )
+        with conn:
+            result = commit_orrery_tick_sync(
+                conn,
+                synthetic_proposal,
+                tick_chunk_id=anchor_chunk_id,
+                slot=LIVE_SLOT,
+                sunhelm_settings=orrery_settings.get("sunhelm"),
+            )
+        assert result.resolution_count == 1
+
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT id, promotion_status FROM orrery_resolutions
+                    WHERE binding_hash = %s
+                    """,
+                    (binding_hash,),
+                )
+                row = cur.fetchone()
+        resolution_id = int(row["id"])
+        created_resolution_ids.append(resolution_id)
+        assert row["promotion_status"] == "pending"
+
+        # Stage 4 - Promote: deterministic discriminator with config values.
+        promoted, _skipped = promote_pending_resolutions_sync(
+            LIVE_SLOT,
+            limit=50,
+            settings=settings,
+            conn=conn,
+        )
+        assert promoted >= 1
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT promotion_status, narration_status,
+                           promotion_verdict->>'reason' AS reason
+                    FROM orrery_resolutions WHERE id = %s
+                    """,
+                    (resolution_id,),
+                )
+                promoted_row = cur.fetchone()
+        assert promoted_row["promotion_status"] == "promoted"
+        assert promoted_row["narration_status"] == "queued"
+        assert "Deterministic promotion" in promoted_row["reason"]
+
+        # Stage 5 - Narrate: real frontier call via the durable outbox.
+        narrated, failed = drain_narration_outbox_sync(
+            LIVE_SLOT,
+            limit=20,
+            settings=settings,
+            conn=conn,
+        )
+        assert failed == 0
+        assert narrated >= 1
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT text, embedding_status FROM offscreen_narrations
+                    WHERE resolution_id = %s
+                    """,
+                    (resolution_id,),
+                )
+                narration = cur.fetchone()
+        assert narration is not None
+        assert len(narration["text"].strip()) > 40
+        assert narration["embedding_status"] == "pending"
+
+        # Stage 6 - Bleed: the narrated resolution is a deterministic
+        # candidate for the next turn's ambient menu.
+        with session_factory() as session:
+            menu = select_bleed_menu(
+                session,
+                anchor_chunk_id=anchor_chunk_id,
+                max_candidates=int(orrery_settings["bleed"]["max_candidates"]),
+            )
+        assert menu.candidates_considered >= 1
+    finally:
+        _cleanup_resolutions(conn, created_resolution_ids)
+        conn.close()
+        engine.dispose()

--- a/tests/test_orrery/test_live_cycle.py
+++ b/tests/test_orrery/test_live_cycle.py
@@ -167,48 +167,67 @@ def test_live_orrery_cycle_resolve_commit_promote_narrate_bleed() -> None:
         assert row["promotion_status"] == "pending"
 
         # Stage 4 - Promote: deterministic discriminator with config values.
-        promoted, _skipped = promote_pending_resolutions_sync(
-            LIVE_SLOT,
-            limit=50,
-            settings=settings,
-            conn=conn,
-        )
-        assert promoted >= 1
-        with conn:
-            with conn.cursor(cursor_factory=RealDictCursor) as cur:
-                cur.execute(
-                    """
-                    SELECT promotion_status, narration_status,
-                           promotion_verdict->>'reason' AS reason
-                    FROM orrery_resolutions WHERE id = %s
-                    """,
-                    (resolution_id,),
-                )
-                promoted_row = cur.fetchone()
+        # The worker drains pending rows oldest-tick first, so loop (bounded)
+        # until any pre-existing backlog ahead of the synthetic row is
+        # processed rather than relying on a single global limit.
+        promoted_row = None
+        for _attempt in range(20):
+            promoted, skipped = promote_pending_resolutions_sync(
+                LIVE_SLOT,
+                limit=50,
+                settings=settings,
+                conn=conn,
+            )
+            with conn:
+                with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                    cur.execute(
+                        """
+                        SELECT promotion_status, narration_status,
+                               promotion_verdict->>'reason' AS reason
+                        FROM orrery_resolutions WHERE id = %s
+                        """,
+                        (resolution_id,),
+                    )
+                    promoted_row = cur.fetchone()
+            if promoted_row["promotion_status"] != "pending":
+                break
+            if promoted == 0 and skipped == 0:
+                break  # nothing left to drain; assertions below fail loudly
+        assert promoted_row is not None
         assert promoted_row["promotion_status"] == "promoted"
         assert promoted_row["narration_status"] == "queued"
         assert "Deterministic promotion" in promoted_row["reason"]
 
         # Stage 5 - Narrate: real frontier call via the durable outbox.
-        narrated, failed = drain_narration_outbox_sync(
-            LIVE_SLOT,
-            limit=20,
-            settings=settings,
-            conn=conn,
+        # Same isolation concern: the outbox may hold unrelated queued jobs,
+        # so loop (bounded) until this resolution's job is processed and
+        # assert on the synthetic row, not on global drain counters.
+        narration = None
+        for _attempt in range(10):
+            narrated, failed = drain_narration_outbox_sync(
+                LIVE_SLOT,
+                limit=20,
+                settings=settings,
+                conn=conn,
+            )
+            with conn:
+                with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                    cur.execute(
+                        """
+                        SELECT text, embedding_status FROM offscreen_narrations
+                        WHERE resolution_id = %s
+                        """,
+                        (resolution_id,),
+                    )
+                    narration = cur.fetchone()
+            if narration is not None:
+                break
+            if narrated == 0 and failed == 0:
+                break  # outbox idle without our row; assertions fail loudly
+        assert narration is not None, (
+            "Narration outbox drained without producing a narration for the "
+            f"synthetic resolution {resolution_id}"
         )
-        assert failed == 0
-        assert narrated >= 1
-        with conn:
-            with conn.cursor(cursor_factory=RealDictCursor) as cur:
-                cur.execute(
-                    """
-                    SELECT text, embedding_status FROM offscreen_narrations
-                    WHERE resolution_id = %s
-                    """,
-                    (resolution_id,),
-                )
-                narration = cur.fetchone()
-        assert narration is not None
         assert len(narration["text"].strip()) > 40
         assert narration["embedding_status"] == "pending"
 

--- a/tests/test_orrery/test_live_cycle.py
+++ b/tests/test_orrery/test_live_cycle.py
@@ -1,14 +1,16 @@
 """Live Orrery cycle integration test on slot 2.
 
-Exercises Resolve -> Commit -> Promote -> Narrate -> Bleed against the real
-``save_02`` database with a real frontier narration call. Skipped unless both
-``NEXUS_RUN_LIVE_LLM=1`` and ``NEXUS_RUN_POSTGRES=1`` are set.
+Exercises Resolve -> Commit (with Clear's expiry sweep) -> Promote ->
+Narrate -> Bleed against the real ``save_02`` database with a real frontier
+narration call. Skipped unless both ``NEXUS_RUN_LIVE_LLM=1`` and
+``NEXUS_RUN_POSTGRES=1`` are set.
 
 The test commits one synthetic high-salience resolution (real entity, valid
 template) so Promote is guaranteed a row above the configured thresholds
 regardless of current story state, then cleans up every row it created.
-Resolve runs read-only against live world state. Narration drain may also
-process unrelated queued jobs - that is the worker's actual contract.
+Resolve runs read-only against live world state. Narration drains are
+bounded to at most ten single-job iterations so ambient outbox backlog
+cannot turn the test into an unbounded API spend.
 """
 
 from __future__ import annotations
@@ -39,6 +41,8 @@ from nexus.api.slot_utils import get_slot_db_url
 from nexus.config import load_settings_as_dict
 
 LIVE_SLOT = 2
+PROMOTION_DRAIN_ATTEMPTS = 20
+NARRATION_DRAIN_ATTEMPTS = 10
 
 pytestmark = [pytest.mark.live_llm, pytest.mark.requires_postgres]
 
@@ -93,37 +97,41 @@ def test_live_orrery_cycle_resolve_commit_promote_narrate_bleed() -> None:
     priority_threshold = float(promote_settings["priority_threshold"])
 
     engine = create_engine(get_slot_db_url(slot=LIVE_SLOT))
-    session_factory = sessionmaker(bind=engine)
-
-    # Stage 1 - Resolve: read-only dry run against live world state.
-    with session_factory() as session:
-        anchor_row = (
-            session.execute(text("SELECT max(id) AS max_id FROM narrative_chunks"))
-            .mappings()
-            .first()
-        )
-        assert anchor_row is not None and anchor_row["max_id"] is not None
-        anchor_chunk_id = int(anchor_row["max_id"])
-        proposal = resolve_dry_run(
-            session,
-            BUILTIN_TEMPLATES,
-            anchor_chunk_id=anchor_chunk_id,
-            window_chunks=int(orrery_settings["binding"]["window_chunks"]),
-            sunhelm_settings=orrery_settings.get("sunhelm"),
-        )
-    assert proposal.anchor_chunk_id == anchor_chunk_id
-    assert proposal.actor_count >= 0
-
-    conn = _connect()
+    conn: Any = None
     created_resolution_ids: list[int] = []
     try:
+        session_factory = sessionmaker(engine)
+
+        # Stage 1 - Resolve: read-only dry run against live world state.
+        with session_factory() as session:
+            anchor_row = (
+                session.execute(text("SELECT max(id) AS max_id FROM narrative_chunks"))
+                .mappings()
+                .first()
+            )
+            assert anchor_row is not None and anchor_row["max_id"] is not None
+            anchor_chunk_id = int(anchor_row["max_id"])
+            proposal = resolve_dry_run(
+                session,
+                BUILTIN_TEMPLATES,
+                anchor_chunk_id=anchor_chunk_id,
+                window_chunks=int(orrery_settings["binding"]["window_chunks"]),
+                sunhelm_settings=orrery_settings.get("sunhelm"),
+            )
+        assert proposal.anchor_chunk_id == anchor_chunk_id
+        assert proposal.actor_count >= 1, "Mature slot 2 must bind live actors"
+
+        conn = _connect()
         with conn:
             with conn.cursor(cursor_factory=RealDictCursor) as cur:
                 cur.execute("SELECT id FROM entities ORDER BY id LIMIT 1")
                 actor_entity_id = int(cur.fetchone()["id"])
 
-        # Stage 2 - Commit: materialize a synthetic salient draft stamped to
-        # the anchor chunk. The unique binding hash keeps reruns idempotent.
+        # Stages 2+3 - Commit: materialize a synthetic salient draft stamped
+        # to the anchor chunk; Clear's scheduled-expiry sweep runs inside the
+        # same commit transaction. The unique binding hash keeps reruns
+        # idempotent. Magnitude is set high so the Bleed selector's
+        # tick-then-magnitude ordering deterministically ranks this row.
         binding_hash = f"live-cycle-{uuid.uuid4().hex}"
         salient_draft = OrreryResolutionDraft(
             template_id="hide",
@@ -135,7 +143,7 @@ def test_live_orrery_cycle_resolve_commit_promote_narrate_bleed() -> None:
                 "{actor} drops out of sight for a few hours, testing how far "
                 "the city's attention can be made to slide off."
             ),
-            magnitude=0.2,
+            magnitude=0.9,
         )
         synthetic_proposal = OrreryTickProposal(
             anchor_chunk_id=anchor_chunk_id,
@@ -150,9 +158,9 @@ def test_live_orrery_cycle_resolve_commit_promote_narrate_bleed() -> None:
                 slot=LIVE_SLOT,
                 sunhelm_settings=orrery_settings.get("sunhelm"),
             )
-        assert result.resolution_count == 1
-
-        with conn:
+            assert result.resolution_count == 1
+            # Capture the id inside the commit transaction so cleanup can
+            # never miss a row that made it to disk.
             with conn.cursor(cursor_factory=RealDictCursor) as cur:
                 cur.execute(
                     """
@@ -162,8 +170,8 @@ def test_live_orrery_cycle_resolve_commit_promote_narrate_bleed() -> None:
                     (binding_hash,),
                 )
                 row = cur.fetchone()
-        resolution_id = int(row["id"])
-        created_resolution_ids.append(resolution_id)
+            resolution_id = int(row["id"])
+            created_resolution_ids.append(resolution_id)
         assert row["promotion_status"] == "pending"
 
         # Stage 4 - Promote: deterministic discriminator with config values.
@@ -171,7 +179,7 @@ def test_live_orrery_cycle_resolve_commit_promote_narrate_bleed() -> None:
         # until any pre-existing backlog ahead of the synthetic row is
         # processed rather than relying on a single global limit.
         promoted_row = None
-        for _attempt in range(20):
+        for _attempt in range(PROMOTION_DRAIN_ATTEMPTS):
             promoted, skipped = promote_pending_resolutions_sync(
                 LIVE_SLOT,
                 limit=50,
@@ -199,14 +207,14 @@ def test_live_orrery_cycle_resolve_commit_promote_narrate_bleed() -> None:
         assert "Deterministic promotion" in promoted_row["reason"]
 
         # Stage 5 - Narrate: real frontier call via the durable outbox.
-        # Same isolation concern: the outbox may hold unrelated queued jobs,
-        # so loop (bounded) until this resolution's job is processed and
-        # assert on the synthetic row, not on global drain counters.
+        # Single-job drains keep total API spend bounded by the attempt cap
+        # even when the outbox holds unrelated queued jobs; assertions are
+        # scoped to the synthetic row, not global drain counters.
         narration = None
-        for _attempt in range(10):
+        for _attempt in range(NARRATION_DRAIN_ATTEMPTS):
             narrated, failed = drain_narration_outbox_sync(
                 LIVE_SLOT,
-                limit=20,
+                limit=1,
                 settings=settings,
                 conn=conn,
             )
@@ -231,16 +239,20 @@ def test_live_orrery_cycle_resolve_commit_promote_narrate_bleed() -> None:
         assert len(narration["text"].strip()) > 40
         assert narration["embedding_status"] == "pending"
 
-        # Stage 6 - Bleed: the narrated resolution is a deterministic
-        # candidate for the next turn's ambient menu.
+        # Stage 6 - Bleed: the synthetic narrated resolution must propagate
+        # into the deterministic ambient menu for the next turn.
         with session_factory() as session:
             menu = select_bleed_menu(
                 session,
                 anchor_chunk_id=anchor_chunk_id,
                 max_candidates=int(orrery_settings["bleed"]["max_candidates"]),
             )
-        assert menu.candidates_considered >= 1
+        selected_resolution_ids = {
+            candidate.resolution_id for candidate in menu.selected
+        }
+        assert resolution_id in selected_resolution_ids
     finally:
-        _cleanup_resolutions(conn, created_resolution_ids)
-        conn.close()
+        if conn is not None:
+            _cleanup_resolutions(conn, created_resolution_ids)
+            conn.close()
         engine.dispose()

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -233,6 +233,46 @@ def test_promote_pending_resolutions_uses_state_signal_without_brief() -> None:
     assert verdict["perceptual_summary"] is None
 
 
+def test_promote_default_thresholds_match_calibrated_seams() -> None:
+    """Default thresholds promote eventful templates and dramatic outcomes only.
+
+    Calibrated against the save_05 corpus (2026-06): the template catalog's
+    mundane-needs band tops out at priority 26 / routine magnitude 0.22, while
+    relational and dramatic templates start at priority 35 and noteworthy
+    branch magnitudes start near 0.34.
+    """
+
+    rows = [
+        # (template-like row, expected_promote)
+        (dict(_promotion_row(), id=1, priority=14, magnitude=0.18), False),  # work
+        (dict(_promotion_row(), id=2, priority=25, magnitude=0.28), False),  # mourn
+        (dict(_promotion_row(), id=3, priority=35, magnitude=0.34), True),  # rival
+        (dict(_promotion_row(), id=4, priority=84, magnitude=0.36), True),  # hide
+        (dict(_promotion_row(), id=5, priority=25, magnitude=0.74), True),  # sleep!
+    ]
+    settings = _settings()
+    del settings["orrery"]["promote"]  # exercise OrreryPromoteSettings defaults
+    cursor = WorkerCursor(promotion_rows=[row for row, _expected in rows])
+
+    promoted, skipped = promote_pending_resolutions_sync(
+        slot=5,
+        settings=settings,
+        conn=WorkerConn(cursor),
+    )
+
+    verdicts = [
+        json.loads(params[0])
+        for sql, params in cursor.executed
+        if "promotion_verdict" in str(sql)
+    ]
+
+    assert promoted == 3
+    assert skipped == 2
+    assert [verdict["promote"] for verdict in verdicts] == [
+        expected for _row, expected in rows
+    ]
+
+
 def test_promote_pending_resolutions_uses_configured_thresholds() -> None:
     """Promotion salience should be tuned through Orrery promote config."""
 


### PR DESCRIPTION
## Summary

Ships the Orrery default-on (`[orrery] enabled = true`) with empirically calibrated promotion thresholds, validated live end to end on slot 2 with real frontier calls: Resolve -> Skald adjudication -> CommitOrreryTick -> Promote -> Narrate -> Bleed.

- `nexus.toml`: `enabled = true`; `[orrery.promote]` `priority_threshold` 50.0 -> 30.0, `magnitude_threshold` 0.5 -> 0.35 (calibration evidence below, inline comment in config)
- `nexus/config/settings_models.py`: Pydantic defaults aligned (`OrrerySettings.enabled`, `OrreryPromoteSettings` thresholds)
- `tests/test_orrery/test_live_cycle.py`: new live-gated integration test (`NEXUS_RUN_LIVE_LLM=1` + `NEXUS_RUN_POSTGRES=1`) exercising resolve -> commit -> promote -> narrate -> bleed on save_02 with thresholds from config and a real Anthropic narration call; cleans up all rows it creates
- `tests/test_orrery/test_worker.py`: offline calibration-seam unit test pinning default-threshold behavior
- `docs/orrery_design_plan.md`: calibration evidence + explicit deferral of the `offscreen_narrations` embedding path

## Live Validation (save_02, 3 real player turns via NEXUS CLI)

Drove `nexus continue --slot 2 --choice N` against a server running this branch. Observed counts:

| Stage | Evidence |
|---|---|
| Resolve | dry-runs of 2 and 14 draft resolutions + 3 scene pressures per turn (17 actors), persisted into `incubator.orrery_proposal` |
| Skald adjudication | 5 explicit adjudications on one turn: 3 `void` (eat) + 2 `defer` (drink), with reasoned notes ("public dining is incompatible with the immediate narrative moment"), all logged in `orrery_adjudication_log` |
| Commit | tick 1429: 2 resolutions + 2 events; tick 1430: 14 proposals -> 5 adjudicated away -> 9 materialized + 9 events |
| Promote | 33 total resolutions on slot 2: **9 promoted** (5x evade_pursuers 100/0.58, 4x hide 84/0.36), **24 skipped** (eat/drink/work/tend_craft/maintain_cover/mourn_loss noise floor) |
| Narrate | **9/9 offscreen_narrations** written by real Anthropic calls (`@anthropic.default` -> claude-sonnet-4-6), 0 failures; both the post-commit BackgroundTasks dispatch and the manual `python -m nexus.agents.orrery.worker --slot 2` catch-up path exercised |
| Bleed | 3 narrated evade_pursuers candidates offered at anchor chunk 1429 (`offer_count=1`, bookkeeping recorded) and visibly woven into the next turn's generated prose as ambient pressure |

## Calibration Evidence (save_05, read-only, 106 resolutions / 39 ticks)

The historical "0 promotions ever" predates the deterministic discriminator (old skip verdicts carry LLM-prose reasons). Distribution is discrete per template:

| template | priority | magnitude | n |
|---|---|---|---|
| hide | 84 | 0.22 | 4 |
| drink | 24 | 0.10 | 18 |
| eat | 22 | 0.14 | 8 |
| tend_craft | 15 | 0.18 | 28 |
| work | 14 | 0.10 | 9 |
| maintain_cover | 0 | 0.12-0.14 | 39 |

- **Magnitude 0.5 was unreachable**: observed max 0.22. The magnitude OR-side never fired once in 39 ticks.
- **Priority seam in the template catalog**: mundane-needs band tops out at 26 (`routine_commute`); relational/dramatic templates start at 35 (`consult_rival`) and run to 100 (`evade_pursuers`). Threshold 30.0 splits it cleanly.
- **Magnitude 0.35**: routine outcomes observed <= 0.22; catalog noteworthy branches start ~0.34 (mundane templates carry dramatic branches: sleep 0.74, eat 0.62, drink 0.56 - exactly what the OR-side is for).
- On the save_05 corpus the new thresholds promote 4/106 = 3.8% (~1 per 10 quiet ticks). The distribution is discrete: the next achievable point is 20.8% (every `drink` narrated - a firehose). On slot 2's more dramatic corpus they promoted 9/33 = 27% of an evasion-arc backlog while skipping 100% of needs noise across two live ticks.

## Offscreen Embedding Decision: Defer (documented)

`offscreen_narrations.embedding_status` stays at `'pending'` with no processor. Rationale recorded in `docs/orrery_design_plan.md`: no off-screen retrieval surface exists; `tests/test_orrery/test_retrieval_boundaries.py` deliberately excludes `offscreen_narrations` from every MEMNON surface, and Bleed reads narrations relationally. Embedding now would either spend tokens on unqueryable vectors or violate the boundary tests. The durable `'pending'` backlog (visible via `worker --status`) is the re-entry point when a labeled surface lands post-1.0 (M3+ territory).

## Config Impact

- `[orrery] enabled = true` ships default-on (M6 scope call). Slot 5's existing settings are unaffected beyond the shared nexus.toml.
- `[orrery.promote]` thresholds are the only tuned values; all other Orrery knobs untouched.
- Pydantic defaults now match nexus.toml (no behavior change for configs that set values explicitly).

## Validation Commands

```bash
poetry run python -m pytest tests/test_orrery/ -q          # 332 passed, 37 skipped
poetry run python -m pytest -q --ignore=tests/test_ir_eval_v2  # 619 passed, 80 skipped
NEXUS_RUN_LIVE_LLM=1 NEXUS_RUN_POSTGRES=1 poetry run python -m pytest tests/test_orrery/test_live_cycle.py -q  # 1 passed (~11s, 1 real Anthropic call)
poetry run python -m nexus.agents.orrery.worker --slot 2 --status
```

## Findings (out of scope, reported not fixed)

- Importing the worker creates a connection pool to the *default* slot's DB (`save_01` log line) even when `--slot 2` is passed - import side effect, known issue #369 / M10 scope. All writes verified to go to save_02 only.
- Bare `poetry run pytest` in a worktree imports `nexus` from the main checkout via the venv's `nexus.pth`; `poetry run python -m pytest` (cwd-first) imports the worktree. Worth a note in the agent workflow docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)