### PR TITLE
Finish the Trait Compiler: Domain, Patron, Dependents, Obligations (M5)

### DIFF
--- a/docs/orrery_tag_vocabulary.md
+++ b/docs/orrery_tag_vocabulary.md
@@ -855,16 +855,17 @@ entity tags describe facts.
 | `operates_from` | faction | place | Operational base (distinct from `claims`) |
 | `originates_from` | character | place | Origin / hometown |
 
-### Character / Faction Relations (6)
+### Character / Faction Relations (7)
 
 | Tag | Subject | Object | Purpose |
 |---|---|---|---|
 | `hunting` | character \| faction | character | Active intentional targeting; ephemeral. Confers narrow elevated detection sensitivity for the target (see issue #282). Migration 048 renames live `pursuing` rows to `hunting`, deprecates the old pair-tag, and retires the single-entity `under_active_pursuit` signal. *Reskinning rationale: "hunt" generalizes better than "pursue" across genres; the concept is not physical-chase-specific.* |
 | `handles` | character | character | Operative-handler relationship; covert/operational |
-| `obligation` | character \| faction | character \| faction | Debt / oath / loyalty; kind inferable from establishing event |
+| `obligation` | character \| faction | character \| faction | Debt / oath / loyalty; kind inferable from establishing event. The Obligations trait compiler writes `obligation(protagonist → counterparty)` at wizard time; for those rows the establishing context lives in the companion relationship row / trait prose |
 | `authority_over` | character \| faction | character \| faction | Interpersonal/positional power over a specific other entity. Distinct from scope-bound status (a king has `authority_over` a vassal directly; a senior officer in an institution holds `status:senior(→ faction)` against that institution's membership) |
 | `protects` | character \| faction | character | Active protective relationship; durable |
 | `mentors` | character | character | Teaching/training |
+| `sponsors` | character \| faction | character | Economic or positional backing without implied command or instruction. Registered by migration 061 to fill the Patron trait "sponsors gap" (#305): a benefactor who bankrolls but neither commands nor mentors. Written by the Patron compiler only for user-affirmed patron functions, never as a default bundle |
 
 ### Scope-Bound Status (1 Family — `status:<level>`)
 
@@ -939,13 +940,15 @@ Compiler surfaces:
 | `Allies` | Writes `character_relationships` rows from structured targets. No pair-tag by default; optional `apply_pair_tag=True` writes `ally(char → char)` in the same transaction. | Per #303, affective relationship row first; pair-tag only when a package gate needs the binary edge. |
 | `Contacts` | Writes `character_relationships` rows from structured targets. No pair-tag by default; optional `apply_pair_tag=True` requires `contact_kind` (`lodging`, `social`, or `intimate`) or an explicit `contact:<kind>` pair-tag. | The bare `contact` pair-tag is deprecated as a package gate. Needs templates consume `has_contact_of_kind(...)` predicates. |
 | `Enemies` | Writes `character_relationships` rows from structured targets. Optional `apply_pair_tag=True` can write `hostile_to`; target-to-protagonist direction is supported. | Acute targeting remains the `hunting` pair-tag track, not default `hostile_to`. |
-| `Domain` | Current MVP returns a prose-only remainder. | Target design: create/identify a place entity and write `claims(char → place)`; registry polymorphism is ready, compiler input/schema is not. |
-| `Patron` | Current MVP returns a prose-only remainder. | Target design: one `character_relationships` row for the patron-client bond; package-specific pair-tags later as needed. This preserves the #305 resolution: patron is not decomposed into a default OR/AND bundle of mentor, sponsor, protector, and authority edges. |
-| `Dependents` | Current MVP returns a prose-only remainder. | Target design: `protects(char → dependent)` plus affective relationship row; no default `authority_over`/`obligation` edge. |
-| `Obligations` | Current MVP returns a prose-only remainder. | Target design: `obligation(char → target)` when a structured target exists. |
+| `Domain` | Writes `claims(char → place)` from `TraitCompileInputs.domain`. The place is resolved by id/entity-id/exact name; an unmatched name creates a minimum-viable place stub (`type='other'`, trait-compiler provenance in `extra_data`). Unknown ids and ambiguous names become structured remainders. | Landed in M5 (migration 061 era). The `claims` subject-kind polymorphism shipped in migration 045. |
+| `Patron` | Writes one `character_relationships` row (`relationship_type='patron'`, default valence `+2\|deferential`); the patron is resolved or stub-created. User-affirmed `functions` (`mentors`, `sponsors`, `protects`, `authority_over`) each add one pair-tag from patron to protagonist; no functions means relationship row only. | Preserves the #305 resolution: patron is never decomposed into a default OR/AND bundle of mentor, sponsor, protector, and authority edges. Migration 061 registered `sponsors` to close the #305 sponsors gap. |
+| `Dependents` | Per target: `protects(char → dependent)` pair-tag plus a `character_relationships` row (`relationship_type='dependent'`, default valence `+3\|devoted`); targets are resolved or stub-created. No default `authority_over`/`obligation` edge (per the #306 resolution). | A target name resolving to the protagonist, or matching multiple rows, becomes a structured remainder. |
+| `Obligations` | Per target: `obligation(protagonist → counterparty)` where the counterparty is a character or faction (resolved or stub-created by name). Character counterparties also get a `character_relationships` row (`relationship_type='obligation'`, default valence `-1\|beholden`) carrying the affective aspect; faction counterparties carry the pair-tag alone. | Obligations to pure concepts (an unwitnessed oath, filial piety in the abstract) have no mechanical referent: bind them to the enforcing/benefiting entity — stub allowed — to compile, or leave them as prose in the trait description. |
 | `Wildcard` | Outside the current selected-trait compiler loop. The wizard persists prose in `characters.extra_data.wildcard`, and any Skald-bestowed `orrery_tags` apply through the ordinary tag bestowal surface. | Future wildcard decomposition may only use registered vocabulary. It cannot mint tags; novel mechanics remain prose/`extra_data` until a compiler surface exists. There is no planned `items` table; inanimate artifacts stay prose/`extra_data` unless/until project scope changes. |
 
-**Migration 045 landed the trait-compiler substrate portion**: `role.resources`, `role.fame`, the status pair-tag family, `ally`, `contact`, `hostile_to`, the `claims` subject-kind extension, the `assets.traits` `reputation` → `fame` rename, and the `trait_compile_result` cache column. **Migration 047 refines contacts** by deprecating bare `contact`, adding `contact:lodging` / `contact:social` / `contact:intimate`, and deprecating the old single-entity contact flags. The compiler code owns only the current MVP rows above; the table is deliberately split so future docs do not confuse registry readiness with compiler readiness.
+**Migration 045 landed the trait-compiler substrate portion**: `role.resources`, `role.fame`, the status pair-tag family, `ally`, `contact`, `hostile_to`, the `claims` subject-kind extension, the `assets.traits` `reputation` → `fame` rename, and the `trait_compile_result` cache column. **Migration 047 refines contacts** by deprecating bare `contact`, adding `contact:lodging` / `contact:social` / `contact:intimate`, and deprecating the old single-entity contact flags. **Migration 061 closes the vocabulary for the M5 compiler completion** by registering `sponsors`; `claims`, `protects`, and `obligation` needed no new rows (042/045 already carried the required polymorphism). With M5, every menu trait except the wildcard compiles; the wildcard-cannot-mint rule stands.
+
+**Stub creation (M5).** Patron, Dependents, and Obligations targets — and Domain places — may be named without existing rows. The compiler then creates minimum-viable stub entities following the Retrograde persistence conventions (sparse columns; `extra_data.source='trait_compiler'`, `stub_kind='trait_compiler_target_ref'`, plus a `sources` provenance list), exactly the input wizard-time Retrograde Phase A matures into history. Nothing is generated recursively for stubs. On dry-run (`nexus trait-audit`), pending stubs are reported in `created_entities` with `entity_id: null` and named pair-tag/relationship endpoints instead of being created.
 
 ---
 
@@ -997,6 +1000,7 @@ Compiler surfaces:
 - `migrations/053_retire_faction_legacy_write_defaults.py` — drops the legacy `factions.power_level` default so new runtime inserts do not create fresh obsolete faction strength values.
 - `migrations/054_orrery_completed_tag_vocab.py` — seeds completed state and place anchors, including globally unique place registry names and the `wilderness` legacy-category rewrite.
 - `migrations/058_retire_faction_legacy_columns.py` — snapshots obsolete faction-table semantic columns into `extra_data.legacy_faction_columns` and drops the columns after the Orrery tag cutover.
+- `migrations/061_trait_compiler_sponsors_pair_tag.py` — registers `sponsors` for user-affirmed Patron functions (the #305 sponsors gap); the complete vocabulary delta for the M5 compiler completion.
 - Issue #275 / PR #276 — Skald sovereignty (adjudication) model. *Merged.*
 - Issue #282 — Package self-awareness architectural pattern (three-stage gating: entry → branch → outcome; `hunting` tags confer targeted detection sensitivity). *Open.*
 - PR #283 — `entity_pair_tags` substrate (migration 042 + writer functions). *Merged.*

--- a/migrations/061_trait_compiler_sponsors_pair_tag.py
+++ b/migrations/061_trait_compiler_sponsors_pair_tag.py
@@ -1,0 +1,87 @@
+"""Register the ``sponsors`` pair-tag for the Patron trait compiler (M5).
+
+M5 finishes the trait compiler: Domain, Patron, Dependents, and Obligations
+join Resources, Fame, Status, and Contacts as deterministic compilers. This
+migration is the complete design-time vocabulary delta for those four
+compilers; it is compatible with the #293 runtime vocabulary lockdown, which
+froze runtime growth paths, not authored migrations.
+
+Vocabulary audit per compiler:
+
+- ``Domain`` -> ``claims(character -> place)``. Already registered: migration
+  042 seeded ``claims`` and migration 045 extended its subject kinds to
+  ``{character, faction}`` explicitly so the registry could accept future
+  Domain trait bestowals. No new rows needed.
+- ``Dependents`` -> ``protects(character -> dependent)`` plus an affective
+  ``character_relationships`` row. ``protects`` was seeded by migration 042
+  with subject kinds ``{character, faction}`` / object ``{character}``. No
+  new rows needed.
+- ``Obligations`` -> ``obligation(character -> creditor)`` where the creditor
+  is a character or faction. ``obligation`` was seeded by migration 042 with
+  full ``{character, faction}`` polymorphism on both endpoints. No new rows
+  needed.
+- ``Patron`` -> one ``character_relationships`` row by default (per the #305
+  resolution patron is NOT decomposed into a default AND-bundle of edges).
+  User-affirmed patron functions selectively add functional pair-tags:
+  ``mentors``, ``protects``, and ``authority_over`` are already registered,
+  but economic/positional backing -- the "sponsors gap" documented in issue
+  #305 -- has no registered edge. This migration adds it.
+
+``sponsors`` subject kinds include ``faction`` to mirror the polymorphism of
+its siblings ``protects`` and ``authority_over`` (institutional sponsorship is
+a normal world fact); the trait compiler itself only writes the
+``character -> character`` form. The tag is durable: sponsorship ends via an
+explicit clearance write, not an ephemeral decay rule.
+
+``character_relationships.relationship_type`` is free text (varchar) with no
+registry table, so the new ``patron`` / ``dependent`` / ``obligation``
+relationship-type strings used by the compilers require no registry rows.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+PAIR_TAGS: Sequence[tuple[str, list[str], list[str], bool, str]] = (
+    (
+        "sponsors",
+        ["character", "faction"],
+        ["character"],
+        False,
+        (
+            "Provides economic or positional backing for the object character "
+            "without implied command or instruction. Fills the Patron trait "
+            "sponsors gap (#305); written only for user-affirmed patron "
+            "functions, never as a default bundle."
+        ),
+    ),
+)
+
+
+def run(conn) -> None:
+    """Register trait-compiler pair-tag vocabulary for the Patron trait."""
+
+    with conn.cursor() as cur:
+        for tag, subject_kinds, object_kinds, is_ephemeral, description in PAIR_TAGS:
+            cur.execute(
+                """
+                INSERT INTO pair_tags (
+                    tag, subject_kinds, object_kinds,
+                    is_ephemeral, clearance_kind, description, deprecated
+                ) VALUES (
+                    %s, %s, %s,
+                    %s, NULL, %s, FALSE
+                )
+                ON CONFLICT (tag) DO UPDATE SET
+                    subject_kinds = EXCLUDED.subject_kinds,
+                    object_kinds = EXCLUDED.object_kinds,
+                    is_ephemeral = EXCLUDED.is_ephemeral,
+                    clearance_kind = EXCLUDED.clearance_kind,
+                    description = EXCLUDED.description,
+                    deprecated = FALSE
+                """,
+                (tag, subject_kinds, object_kinds, is_ephemeral, description),
+            )
+
+    conn.commit()

--- a/nexus/api/trait_compiler.py
+++ b/nexus/api/trait_compiler.py
@@ -1405,16 +1405,25 @@ def _create_target_stub(
     """
 
     if dry_run:
-        result.created_entities.append(
-            CreatedEntity(
-                trait=trait,
-                entity_kind=entity_kind,
-                entity_id=None,
-                row_id=None,
-                name=name,
-                dry_run=True,
-            )
+        # Coalesce repeated references to one absent target: apply mode
+        # creates the stub once and resolves later same-name lookups to that
+        # row, so the dry-run audit must plan exactly one stub per
+        # (entity_kind, name) too.
+        already_planned = any(
+            item.dry_run and item.entity_kind == entity_kind and item.name == name
+            for item in result.created_entities
         )
+        if not already_planned:
+            result.created_entities.append(
+                CreatedEntity(
+                    trait=trait,
+                    entity_kind=entity_kind,
+                    entity_id=None,
+                    row_id=None,
+                    name=name,
+                    dry_run=True,
+                )
+            )
         return _ResolvedTarget(
             row_id=None,
             entity_id=None,

--- a/nexus/api/trait_compiler.py
+++ b/nexus/api/trait_compiler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import Any, Iterable, Optional
 
 from nexus.agents.orrery.status_family import (
@@ -19,7 +20,14 @@ from nexus.api.new_story_schemas import CharacterSheet
 from nexus.api.trait_compiler_schemas import (
     AppliedPairTag,
     AppliedTag,
+    CreatedEntity,
     CreatedRelationship,
+    DependentsTraitInput,
+    DependentTargetInput,
+    DomainTraitInput,
+    ObligationsTraitInput,
+    ObligationTargetInput,
+    PatronTraitInput,
     RelationshipTargetInput,
     SingleEntityTraitInput,
     StatusTraitInput,
@@ -53,6 +61,31 @@ RELATIONSHIP_DEFAULTS = {
         "pair_tag": "hostile_to",
     },
 }
+
+DOMAIN_PAIR_TAG = "claims"
+DEPENDENT_PAIR_TAG = "protects"
+OBLIGATION_PAIR_TAG = "obligation"
+
+PATRON_RELATIONSHIP_TYPE = "patron"
+PATRON_DEFAULT_VALENCE = "+2|deferential"
+DEPENDENT_RELATIONSHIP_TYPE = "dependent"
+DEPENDENT_DEFAULT_VALENCE = "+3|devoted"
+OBLIGATION_RELATIONSHIP_TYPE = "obligation"
+OBLIGATION_DEFAULT_VALENCE = "-1|beholden"
+
+TRAIT_COMPILER_SOURCE = "trait_compiler"
+TRAIT_STUB_KIND = "trait_compiler_target_ref"
+
+
+@dataclass(frozen=True)
+class _ResolvedTarget:
+    """A trait target resolved to canonical ids or a pending dry-run stub."""
+
+    row_id: Optional[int]
+    entity_id: Optional[int]
+    name: Optional[str]
+    pending_stub: bool = False
+
 
 PAIR_TAG_RELATIONSHIP_TYPES = frozenset({"ally", "hostile_to"}) | frozenset(
     CONTACT_PAIR_TAGS.values()
@@ -128,6 +161,45 @@ def compile_character_traits(
                 character_id=character_id,
                 character_entity_id=character_entity_id,
                 typed_input=getattr(inputs, canonical_trait),
+                dry_run=dry_run,
+            )
+        elif canonical_trait == "domain":
+            _compile_domain(
+                cur,
+                result=result,
+                trait=trait_name,
+                character_entity_id=character_entity_id,
+                typed_input=inputs.domain,
+                dry_run=dry_run,
+            )
+        elif canonical_trait == "patron":
+            _compile_patron(
+                cur,
+                result=result,
+                trait=trait_name,
+                character_id=character_id,
+                character_entity_id=character_entity_id,
+                typed_input=inputs.patron,
+                dry_run=dry_run,
+            )
+        elif canonical_trait == "dependents":
+            _compile_dependents(
+                cur,
+                result=result,
+                trait=trait_name,
+                character_id=character_id,
+                character_entity_id=character_entity_id,
+                typed_input=inputs.dependents,
+                dry_run=dry_run,
+            )
+        elif canonical_trait == "obligations":
+            _compile_obligations(
+                cur,
+                result=result,
+                trait=trait_name,
+                character_id=character_id,
+                character_entity_id=character_entity_id,
+                typed_input=inputs.obligations,
                 dry_run=dry_run,
             )
         else:
@@ -645,6 +717,828 @@ def _resolve_contact_pair_tag(
     return None
 
 
+def _compile_domain(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    character_entity_id: int,
+    typed_input: Optional[DomainTraitInput],
+    dry_run: bool,
+) -> None:
+    """Compile Domain to ``claims(protagonist -> place)`` per the design target."""
+
+    if typed_input is None:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT,
+            message="Domain has no structured place input.",
+        )
+        return
+    if not _registered_pair_tag_exists(cur, DOMAIN_PAIR_TAG):
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.REGISTRY_MISSING_PAIR_TAG,
+            message=f"No active registered pair_tag for {DOMAIN_PAIR_TAG}.",
+            details={"pair_tag": DOMAIN_PAIR_TAG},
+        )
+        return
+
+    resolved = _resolve_place_target(
+        cur,
+        result=result,
+        trait=trait,
+        place_id=typed_input.place_id,
+        place_entity_id=typed_input.place_entity_id,
+        name=typed_input.name,
+        dry_run=dry_run,
+    )
+    if resolved is None:
+        return
+
+    inserted: Optional[bool] = None
+    if not dry_run:
+        if resolved.entity_id is None:
+            raise AssertionError("apply-mode place target must have an entity id")
+        inserted = apply_pair_tag_bestowal(
+            cur,
+            subject_entity_id=character_entity_id,
+            object_entity_id=resolved.entity_id,
+            subject_kind="character",
+            object_kind="place",
+            tag=DOMAIN_PAIR_TAG,
+            source_kind="skald_inline",
+        )
+    result.applied_pair_tags.append(
+        AppliedPairTag(
+            trait=trait,
+            subject_entity_id=character_entity_id,
+            object_entity_id=resolved.entity_id,
+            object_name=resolved.name if resolved.pending_stub else None,
+            tag=DOMAIN_PAIR_TAG,
+            inserted=inserted,
+            dry_run=dry_run,
+        )
+    )
+
+
+def _compile_patron(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    character_id: int,
+    character_entity_id: int,
+    typed_input: Optional[PatronTraitInput],
+    dry_run: bool,
+) -> None:
+    """Compile Patron per #305: relationship row plus user-affirmed functions."""
+
+    if typed_input is None:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT,
+            message="Patron has no structured target input.",
+        )
+        return
+
+    functions = list(dict.fromkeys(typed_input.functions))
+    for function in functions:
+        if not _registered_pair_tag_exists(cur, function):
+            _add_remainder(
+                result,
+                trait=trait,
+                reason_code=TraitCompileReasonCode.REGISTRY_MISSING_PAIR_TAG,
+                message=f"No active registered pair_tag for {function}.",
+                details={"pair_tag": function},
+            )
+            return
+
+    resolved = _resolve_character_target(
+        cur,
+        result=result,
+        trait=trait,
+        role="patron",
+        target_character_id=typed_input.character_id,
+        target_character_entity_id=typed_input.character_entity_id,
+        name=typed_input.name,
+        protagonist_character_id=character_id,
+        dry_run=dry_run,
+    )
+    if resolved is None:
+        return
+
+    for function in functions:
+        inserted: Optional[bool] = None
+        if not dry_run:
+            if resolved.entity_id is None:
+                raise AssertionError("apply-mode patron must have an entity id")
+            inserted = apply_pair_tag_bestowal(
+                cur,
+                subject_entity_id=resolved.entity_id,
+                object_entity_id=character_entity_id,
+                subject_kind="character",
+                object_kind="character",
+                tag=function,
+                source_kind="skald_inline",
+            )
+        result.applied_pair_tags.append(
+            AppliedPairTag(
+                trait=trait,
+                subject_entity_id=resolved.entity_id,
+                subject_name=resolved.name if resolved.pending_stub else None,
+                object_entity_id=character_entity_id,
+                tag=function,
+                inserted=inserted,
+                dry_run=dry_run,
+            )
+        )
+
+    emotional_valence = typed_input.emotional_valence or PATRON_DEFAULT_VALENCE
+    additional_extra_data: dict[str, Any] = {}
+    if functions:
+        additional_extra_data["trait_compiler_patron_functions"] = functions
+    _write_trait_relationship(
+        cur,
+        result=result,
+        trait=trait,
+        character1_id=character_id,
+        target=resolved,
+        relationship_type=PATRON_RELATIONSHIP_TYPE,
+        emotional_valence=emotional_valence,
+        dynamic=typed_input.dynamic,
+        recent_events=typed_input.recent_events,
+        history=typed_input.history,
+        additional_extra_data=additional_extra_data,
+        dry_run=dry_run,
+    )
+
+
+def _compile_dependents(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    character_id: int,
+    character_entity_id: int,
+    typed_input: Optional[DependentsTraitInput],
+    dry_run: bool,
+) -> None:
+    """Compile Dependents per the settled target: protects edge + bond row."""
+
+    if typed_input is None or not typed_input.targets:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT,
+            message="Dependents has no structured targets.",
+        )
+        return
+    if not _registered_pair_tag_exists(cur, DEPENDENT_PAIR_TAG):
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.REGISTRY_MISSING_PAIR_TAG,
+            message=f"No active registered pair_tag for {DEPENDENT_PAIR_TAG}.",
+            details={"pair_tag": DEPENDENT_PAIR_TAG},
+        )
+        return
+
+    for target in typed_input.targets:
+        _compile_dependent_target(
+            cur,
+            result=result,
+            trait=trait,
+            character_id=character_id,
+            character_entity_id=character_entity_id,
+            target=target,
+            dry_run=dry_run,
+        )
+
+
+def _compile_dependent_target(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    character_id: int,
+    character_entity_id: int,
+    target: DependentTargetInput,
+    dry_run: bool,
+) -> None:
+    resolved = _resolve_character_target(
+        cur,
+        result=result,
+        trait=trait,
+        role="dependent",
+        target_character_id=target.character_id,
+        target_character_entity_id=target.character_entity_id,
+        name=target.name,
+        protagonist_character_id=character_id,
+        dry_run=dry_run,
+    )
+    if resolved is None:
+        return
+
+    inserted: Optional[bool] = None
+    if not dry_run:
+        if resolved.entity_id is None:
+            raise AssertionError("apply-mode dependent must have an entity id")
+        inserted = apply_pair_tag_bestowal(
+            cur,
+            subject_entity_id=character_entity_id,
+            object_entity_id=resolved.entity_id,
+            subject_kind="character",
+            object_kind="character",
+            tag=DEPENDENT_PAIR_TAG,
+            source_kind="skald_inline",
+        )
+    result.applied_pair_tags.append(
+        AppliedPairTag(
+            trait=trait,
+            subject_entity_id=character_entity_id,
+            object_entity_id=resolved.entity_id,
+            object_name=resolved.name if resolved.pending_stub else None,
+            tag=DEPENDENT_PAIR_TAG,
+            inserted=inserted,
+            dry_run=dry_run,
+        )
+    )
+
+    _write_trait_relationship(
+        cur,
+        result=result,
+        trait=trait,
+        character1_id=character_id,
+        target=resolved,
+        relationship_type=DEPENDENT_RELATIONSHIP_TYPE,
+        emotional_valence=target.emotional_valence or DEPENDENT_DEFAULT_VALENCE,
+        dynamic=target.dynamic,
+        recent_events=target.recent_events,
+        history=target.history,
+        additional_extra_data={
+            "trait_compiler_functional_pair_tag": DEPENDENT_PAIR_TAG
+        },
+        dry_run=dry_run,
+    )
+
+
+def _compile_obligations(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    character_id: int,
+    character_entity_id: int,
+    typed_input: Optional[ObligationsTraitInput],
+    dry_run: bool,
+) -> None:
+    """Compile Obligations to ``obligation(protagonist -> counterparty)``."""
+
+    if typed_input is None or not typed_input.targets:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT,
+            message="Obligations has no structured targets.",
+        )
+        return
+    if not _registered_pair_tag_exists(cur, OBLIGATION_PAIR_TAG):
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.REGISTRY_MISSING_PAIR_TAG,
+            message=f"No active registered pair_tag for {OBLIGATION_PAIR_TAG}.",
+            details={"pair_tag": OBLIGATION_PAIR_TAG},
+        )
+        return
+
+    for target in typed_input.targets:
+        _compile_obligation_target(
+            cur,
+            result=result,
+            trait=trait,
+            character_id=character_id,
+            character_entity_id=character_entity_id,
+            target=target,
+            dry_run=dry_run,
+        )
+
+
+def _compile_obligation_target(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    character_id: int,
+    character_entity_id: int,
+    target: ObligationTargetInput,
+    dry_run: bool,
+) -> None:
+    if target.counterparty_kind == "character":
+        resolved = _resolve_character_target(
+            cur,
+            result=result,
+            trait=trait,
+            role="obligation_counterparty",
+            target_character_id=target.counterparty_id,
+            target_character_entity_id=target.counterparty_entity_id,
+            name=target.name,
+            protagonist_character_id=character_id,
+            dry_run=dry_run,
+        )
+    else:
+        resolved = _resolve_faction_target(
+            cur,
+            result=result,
+            trait=trait,
+            faction_id=target.counterparty_id,
+            faction_entity_id=target.counterparty_entity_id,
+            name=target.name,
+            dry_run=dry_run,
+        )
+    if resolved is None:
+        return
+
+    inserted: Optional[bool] = None
+    if not dry_run:
+        if resolved.entity_id is None:
+            raise AssertionError("apply-mode counterparty must have an entity id")
+        inserted = apply_pair_tag_bestowal(
+            cur,
+            subject_entity_id=character_entity_id,
+            object_entity_id=resolved.entity_id,
+            subject_kind="character",
+            object_kind=target.counterparty_kind,
+            tag=OBLIGATION_PAIR_TAG,
+            source_kind="skald_inline",
+        )
+    result.applied_pair_tags.append(
+        AppliedPairTag(
+            trait=trait,
+            subject_entity_id=character_entity_id,
+            object_entity_id=resolved.entity_id,
+            object_name=resolved.name if resolved.pending_stub else None,
+            tag=OBLIGATION_PAIR_TAG,
+            inserted=inserted,
+            dry_run=dry_run,
+        )
+    )
+
+    if target.counterparty_kind == "character":
+        _write_trait_relationship(
+            cur,
+            result=result,
+            trait=trait,
+            character1_id=character_id,
+            target=resolved,
+            relationship_type=OBLIGATION_RELATIONSHIP_TYPE,
+            emotional_valence=target.emotional_valence or OBLIGATION_DEFAULT_VALENCE,
+            dynamic=target.dynamic,
+            recent_events=target.recent_events,
+            history=target.history,
+            additional_extra_data={
+                "trait_compiler_functional_pair_tag": OBLIGATION_PAIR_TAG
+            },
+            dry_run=dry_run,
+        )
+
+
+def _write_trait_relationship(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    character1_id: int,
+    target: _ResolvedTarget,
+    relationship_type: str,
+    emotional_valence: str,
+    dynamic: str,
+    recent_events: str,
+    history: str,
+    additional_extra_data: Optional[dict[str, Any]],
+    dry_run: bool,
+) -> None:
+    """Record (and on apply, upsert) a compiler-authored relationship row."""
+
+    if not dry_run:
+        if target.row_id is None:
+            raise AssertionError("apply-mode relationship target must have a row id")
+        _upsert_character_relationship(
+            cur,
+            character1_id=character1_id,
+            character2_id=target.row_id,
+            relationship_type=relationship_type,
+            emotional_valence=emotional_valence,
+            dynamic=dynamic,
+            recent_events=recent_events,
+            history=history,
+            trait=trait,
+            pair_tag=None,
+            pair_tag_direction=None,
+            contact_kind=None,
+            additional_extra_data=additional_extra_data,
+        )
+    result.created_relationships.append(
+        CreatedRelationship(
+            trait=trait,
+            character1_id=character1_id,
+            character2_id=target.row_id,
+            character2_name=target.name if target.pending_stub else None,
+            relationship_type=relationship_type,
+            emotional_valence=emotional_valence,
+            dry_run=dry_run,
+        )
+    )
+
+
+def _resolve_character_target(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    role: str,
+    target_character_id: Optional[int],
+    target_character_entity_id: Optional[int],
+    name: Optional[str],
+    protagonist_character_id: int,
+    dry_run: bool,
+) -> Optional[_ResolvedTarget]:
+    """Resolve a character target by id, entity id, or exact name (stub-creatable)."""
+
+    if target_character_id is not None:
+        cur.execute(
+            "SELECT id, entity_id, name FROM characters WHERE id = %s",
+            (target_character_id,),
+        )
+        rows = cur.fetchall()
+    elif target_character_entity_id is not None:
+        cur.execute(
+            "SELECT id, entity_id, name FROM characters WHERE entity_id = %s",
+            (target_character_entity_id,),
+        )
+        rows = cur.fetchall()
+    elif name:
+        cur.execute(
+            "SELECT id, entity_id, name FROM characters WHERE name = %s ORDER BY id",
+            (name,),
+        )
+        rows = cur.fetchall()
+        if not rows:
+            return _create_target_stub(
+                cur,
+                result=result,
+                trait=trait,
+                entity_kind="character",
+                name=name,
+                role=role,
+                dry_run=dry_run,
+            )
+    else:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT,
+            message=f"{trait} target requires a character id, entity id, or name.",
+        )
+        return None
+
+    resolved = _single_row_target(
+        result,
+        trait=trait,
+        rows=rows,
+        lookup={
+            "character_id": target_character_id,
+            "character_entity_id": target_character_entity_id,
+            "name": name,
+        },
+    )
+    if resolved is None:
+        return None
+    if resolved.row_id == protagonist_character_id:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.AMBIGUOUS_TARGET,
+            message=f"{trait} target resolves to the protagonist.",
+            details={"character_id": resolved.row_id},
+        )
+        return None
+    return resolved
+
+
+def _resolve_place_target(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    place_id: Optional[int],
+    place_entity_id: Optional[int],
+    name: Optional[str],
+    dry_run: bool,
+) -> Optional[_ResolvedTarget]:
+    """Resolve a place target by id, entity id, or exact name (stub-creatable)."""
+
+    if place_id is not None:
+        cur.execute(
+            "SELECT id, entity_id, name FROM places WHERE id = %s",
+            (place_id,),
+        )
+        rows = cur.fetchall()
+    elif place_entity_id is not None:
+        cur.execute(
+            "SELECT id, entity_id, name FROM places WHERE entity_id = %s",
+            (place_entity_id,),
+        )
+        rows = cur.fetchall()
+    elif name:
+        cur.execute(
+            "SELECT id, entity_id, name FROM places WHERE name = %s ORDER BY id",
+            (name,),
+        )
+        rows = cur.fetchall()
+        if not rows:
+            return _create_target_stub(
+                cur,
+                result=result,
+                trait=trait,
+                entity_kind="place",
+                name=name,
+                role="domain",
+                dry_run=dry_run,
+            )
+    else:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT,
+            message=f"{trait} requires a place id, entity id, or name.",
+        )
+        return None
+
+    return _single_row_target(
+        result,
+        trait=trait,
+        rows=rows,
+        lookup={
+            "place_id": place_id,
+            "place_entity_id": place_entity_id,
+            "name": name,
+        },
+    )
+
+
+def _resolve_faction_target(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    faction_id: Optional[int],
+    faction_entity_id: Optional[int],
+    name: Optional[str],
+    dry_run: bool,
+) -> Optional[_ResolvedTarget]:
+    """Resolve a faction target by id, entity id, or exact name (stub-creatable)."""
+
+    if faction_id is not None:
+        cur.execute(
+            "SELECT id, entity_id, name FROM factions WHERE id = %s",
+            (faction_id,),
+        )
+        rows = cur.fetchall()
+    elif faction_entity_id is not None:
+        cur.execute(
+            "SELECT id, entity_id, name FROM factions WHERE entity_id = %s",
+            (faction_entity_id,),
+        )
+        rows = cur.fetchall()
+    elif name:
+        cur.execute(
+            "SELECT id, entity_id, name FROM factions WHERE name = %s ORDER BY id",
+            (name,),
+        )
+        rows = cur.fetchall()
+        if not rows:
+            return _create_target_stub(
+                cur,
+                result=result,
+                trait=trait,
+                entity_kind="faction",
+                name=name,
+                role="obligation_counterparty",
+                dry_run=dry_run,
+            )
+    else:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT,
+            message=f"{trait} requires a faction id, entity id, or name.",
+        )
+        return None
+
+    return _single_row_target(
+        result,
+        trait=trait,
+        rows=rows,
+        lookup={
+            "faction_id": faction_id,
+            "faction_entity_id": faction_entity_id,
+            "name": name,
+        },
+    )
+
+
+def _single_row_target(
+    result: TraitCompileResult,
+    *,
+    trait: str,
+    rows: list[Any],
+    lookup: dict[str, Any],
+) -> Optional[_ResolvedTarget]:
+    details = {key: value for key, value in lookup.items() if value is not None}
+    if not rows:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.AMBIGUOUS_TARGET,
+            message=f"{trait} target was not found.",
+            details=details,
+        )
+        return None
+    if len(rows) > 1:
+        _add_remainder(
+            result,
+            trait=trait,
+            reason_code=TraitCompileReasonCode.AMBIGUOUS_TARGET,
+            message=f"{trait} target name matches multiple rows.",
+            details={**details, "match_count": len(rows)},
+        )
+        return None
+    row = rows[0]
+    return _ResolvedTarget(
+        row_id=_row_value(row, "id", 0),
+        entity_id=_row_value(row, "entity_id", 1),
+        name=_row_value(row, "name", 2),
+    )
+
+
+def _create_target_stub(
+    cur: Any,
+    *,
+    result: TraitCompileResult,
+    trait: str,
+    entity_kind: str,
+    name: str,
+    role: str,
+    dry_run: bool,
+) -> _ResolvedTarget:
+    """Create (or, on dry-run, plan) a minimum-viable stub for a trait target.
+
+    Stub rows follow the Retrograde persistence conventions: intentionally
+    sparse columns plus ``extra_data`` provenance, so wizard-time Retrograde
+    Phase A can mature them into history. Nothing is generated recursively
+    for stubs.
+    """
+
+    if dry_run:
+        result.created_entities.append(
+            CreatedEntity(
+                trait=trait,
+                entity_kind=entity_kind,
+                entity_id=None,
+                row_id=None,
+                name=name,
+                dry_run=True,
+            )
+        )
+        return _ResolvedTarget(
+            row_id=None,
+            entity_id=None,
+            name=name,
+            pending_stub=True,
+        )
+
+    if entity_kind == "character":
+        row_id, entity_id = _insert_character_stub(
+            cur, name=name, trait=trait, role=role
+        )
+    elif entity_kind == "place":
+        row_id, entity_id = _insert_place_stub(cur, name=name, trait=trait, role=role)
+    elif entity_kind == "faction":
+        row_id, entity_id = _insert_faction_stub(cur, name=name, trait=trait, role=role)
+    else:
+        raise ValueError(f"Unsupported trait stub entity kind {entity_kind!r}")
+    result.created_entities.append(
+        CreatedEntity(
+            trait=trait,
+            entity_kind=entity_kind,
+            entity_id=entity_id,
+            row_id=row_id,
+            name=name,
+            dry_run=False,
+        )
+    )
+    return _ResolvedTarget(row_id=row_id, entity_id=entity_id, name=name)
+
+
+def _insert_character_stub(
+    cur: Any, *, name: str, trait: str, role: str
+) -> tuple[int, int]:
+    cur.execute(
+        """
+        /* trait_compiler:insert_character_stub */
+        INSERT INTO characters (
+            name, summary, background, current_activity, extra_data
+        )
+        VALUES (%s, %s, %s, %s, %s::jsonb)
+        RETURNING id, entity_id
+        """,
+        (
+            name,
+            _stub_summary(name, "character"),
+            "Trait-compiler stub; details intentionally sparse until play.",
+            "latent in compiled trait backstory",
+            json.dumps(_stub_extra_data(trait=trait, role=role)),
+        ),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise RuntimeError(f"Character stub insert for {name!r} returned no row.")
+    return _row_value(row, "id", 0), _row_value(row, "entity_id", 1)
+
+
+def _insert_place_stub(
+    cur: Any, *, name: str, trait: str, role: str
+) -> tuple[int, int]:
+    cur.execute(
+        """
+        /* trait_compiler:insert_place_stub */
+        INSERT INTO places (
+            name, type, summary, current_status, extra_data
+        )
+        VALUES (%s, 'other'::place_type, %s, %s, %s::jsonb)
+        RETURNING id, entity_id
+        """,
+        (
+            name,
+            _stub_summary(name, "place"),
+            "latent in compiled trait backstory",
+            json.dumps(_stub_extra_data(trait=trait, role=role)),
+        ),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise RuntimeError(f"Place stub insert for {name!r} returned no row.")
+    return _row_value(row, "id", 0), _row_value(row, "entity_id", 1)
+
+
+def _insert_faction_stub(
+    cur: Any, *, name: str, trait: str, role: str
+) -> tuple[int, int]:
+    cur.execute("LOCK TABLE factions IN SHARE ROW EXCLUSIVE MODE")
+    cur.execute("SELECT COALESCE(MAX(id), 0) + 1 AS id FROM factions")
+    faction_id = int(_row_value(cur.fetchone(), "id", 0))
+    cur.execute(
+        """
+        /* trait_compiler:insert_faction_stub */
+        INSERT INTO factions (
+            id, name, summary, extra_data
+        )
+        VALUES (%s, %s, %s, %s::jsonb)
+        RETURNING entity_id
+        """,
+        (
+            faction_id,
+            name,
+            _stub_summary(name, "faction"),
+            json.dumps(_stub_extra_data(trait=trait, role=role)),
+        ),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise RuntimeError(f"Faction stub insert for {name!r} returned no row.")
+    return faction_id, _row_value(row, "entity_id", 0)
+
+
+def _stub_summary(name: str, entity_kind: str) -> str:
+    return (
+        f"Trait-compiler {entity_kind} stub for {name}. "
+        "Created so wizard trait selections resolve to canonical rows."
+    )
+
+
+def _stub_extra_data(*, trait: str, role: str) -> dict[str, Any]:
+    return {
+        "source": TRAIT_COMPILER_SOURCE,
+        "stub_kind": TRAIT_STUB_KIND,
+        "sources": [{"plan": "trait_compile", "trait": trait, "role": role}],
+    }
+
+
 def _upsert_character_relationship(
     cur: Any,
     *,
@@ -659,6 +1553,7 @@ def _upsert_character_relationship(
     pair_tag: Optional[str],
     pair_tag_direction: Optional[str],
     contact_kind: Optional[str],
+    additional_extra_data: Optional[dict[str, Any]] = None,
 ) -> None:
     extra_data: dict[str, Any] = {
         "source": "trait_compiler",
@@ -670,6 +1565,8 @@ def _upsert_character_relationship(
         extra_data["trait_compiler_pair_tag_direction"] = pair_tag_direction
     if contact_kind is not None:
         extra_data["trait_compiler_contact_kind"] = contact_kind
+    if additional_extra_data:
+        extra_data.update(additional_extra_data)
     cur.execute(
         """
         INSERT INTO character_relationships (

--- a/nexus/api/trait_compiler_schemas.py
+++ b/nexus/api/trait_compiler_schemas.py
@@ -13,6 +13,8 @@ from nexus.agents.orrery.substrate import ContactKind
 ResourceLevel = Literal["destitute", "poor", "comfortable", "wealthy", "magnate"]
 FameLevel = Literal["obscure", "known", "renowned", "legendary"]
 PairTagDirection = Literal["protagonist_to_target", "target_to_protagonist"]
+PatronFunction = Literal["mentors", "sponsors", "protects", "authority_over"]
+ObligationCounterpartyKind = Literal["character", "faction"]
 
 
 def canonical_trait_name(trait_name: str) -> str:
@@ -114,6 +116,171 @@ class RelationshipTraitInput(BaseModel):
     targets: List[RelationshipTargetInput] = Field(default_factory=list)
 
 
+class DomainTraitInput(BaseModel):
+    """Typed input for the Domain trait: a place the character claims.
+
+    The compiler resolves the place by ``place_id``, ``place_entity_id``, or
+    exact ``name`` lookup; an unmatched name creates a minimum-viable place
+    stub so Retrograde Phase A can mature it into history later.
+    """
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    place_id: Optional[int] = Field(None, description="Existing places row id.")
+    place_entity_id: Optional[int] = Field(
+        None, description="Existing place entity_id."
+    )
+    name: Optional[str] = Field(
+        None,
+        description="Place name for exact lookup or stub creation.",
+        min_length=1,
+    )
+
+
+class PatronTraitInput(BaseModel):
+    """Typed input for the Patron trait.
+
+    Per the #305 resolution the default compile is a single
+    ``character_relationships`` row for the patron-client bond. The optional
+    ``functions`` list holds user-affirmed functional edges only; each one
+    writes a registered pair-tag from patron to protagonist. The compiler
+    never pre-provisions a default bundle of patron edges.
+    """
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    character_id: Optional[int] = Field(
+        None, description="Existing patron characters row id."
+    )
+    character_entity_id: Optional[int] = Field(
+        None, description="Existing patron character entity_id."
+    )
+    name: Optional[str] = Field(
+        None,
+        description="Patron name for exact lookup or stub creation.",
+        min_length=1,
+    )
+    functions: List[PatronFunction] = Field(
+        default_factory=list,
+        description=(
+            "User-affirmed patron functions; each writes one functional "
+            "pair-tag from patron to protagonist."
+        ),
+    )
+    emotional_valence: Optional[str] = Field(
+        None, description="character_relationships.emotional_valence override."
+    )
+    dynamic: str = Field(
+        "",
+        description="Current relationship state written to character_relationships.",
+    )
+    recent_events: str = Field(
+        "",
+        description="Recent events summary written to character_relationships.",
+    )
+    history: str = Field(
+        "",
+        description="History summary written to character_relationships.",
+    )
+
+
+class DependentTargetInput(BaseModel):
+    """Typed input for one dependent under the Dependents trait."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    character_id: Optional[int] = Field(
+        None, description="Existing dependent characters row id."
+    )
+    character_entity_id: Optional[int] = Field(
+        None, description="Existing dependent character entity_id."
+    )
+    name: Optional[str] = Field(
+        None,
+        description="Dependent name for exact lookup or stub creation.",
+        min_length=1,
+    )
+    emotional_valence: Optional[str] = Field(
+        None, description="character_relationships.emotional_valence override."
+    )
+    dynamic: str = Field(
+        "",
+        description="Current relationship state written to character_relationships.",
+    )
+    recent_events: str = Field(
+        "",
+        description="Recent events summary written to character_relationships.",
+    )
+    history: str = Field(
+        "",
+        description="History summary written to character_relationships.",
+    )
+
+
+class DependentsTraitInput(BaseModel):
+    """Typed input for the Dependents trait."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    targets: List[DependentTargetInput] = Field(default_factory=list)
+
+
+class ObligationTargetInput(BaseModel):
+    """Typed input for one obligation counterparty.
+
+    Obligations compile to ``obligation(protagonist -> counterparty)``; the
+    counterparty is a character or faction (stub-creatable by name). An
+    obligation to a pure concept (an oath, filial piety) has no mechanical
+    referent: bind it to the enforcing or benefiting entity to compile, or
+    leave it as prose in the trait description.
+    """
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    counterparty_kind: ObligationCounterpartyKind = Field(
+        "character",
+        description="Entity kind of the obligation counterparty.",
+    )
+    counterparty_id: Optional[int] = Field(
+        None, description="Existing characters/factions row id for the counterparty."
+    )
+    counterparty_entity_id: Optional[int] = Field(
+        None, description="Existing counterparty entity_id."
+    )
+    name: Optional[str] = Field(
+        None,
+        description="Counterparty name for exact lookup or stub creation.",
+        min_length=1,
+    )
+    emotional_valence: Optional[str] = Field(
+        None,
+        description=(
+            "character_relationships.emotional_valence override; character "
+            "counterparties only."
+        ),
+    )
+    dynamic: str = Field(
+        "",
+        description="Current relationship state written to character_relationships.",
+    )
+    recent_events: str = Field(
+        "",
+        description="Recent events summary written to character_relationships.",
+    )
+    history: str = Field(
+        "",
+        description="History summary written to character_relationships.",
+    )
+
+
+class ObligationsTraitInput(BaseModel):
+    """Typed input for the Obligations trait."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    targets: List[ObligationTargetInput] = Field(default_factory=list)
+
+
 class TraitCompileInputs(BaseModel):
     """Optional typed mechanical inputs collected during the wizard."""
 
@@ -129,6 +296,10 @@ class TraitCompileInputs(BaseModel):
     allies: Optional[RelationshipTraitInput] = None
     contacts: Optional[RelationshipTraitInput] = None
     enemies: Optional[RelationshipTraitInput] = None
+    domain: Optional[DomainTraitInput] = None
+    patron: Optional[PatronTraitInput] = None
+    dependents: Optional[DependentsTraitInput] = None
+    obligations: Optional[ObligationsTraitInput] = None
 
 
 class AppliedTag(BaseModel):
@@ -143,33 +314,44 @@ class AppliedTag(BaseModel):
 
 
 class AppliedPairTag(BaseModel):
-    """Pair-tag that was or would be applied."""
+    """Pair-tag that was or would be applied.
+
+    Entity ids are ``None`` only on dry-run rows whose endpoint is a pending
+    stub; the matching ``*_name`` field then carries the stub reference.
+    """
 
     trait: str
-    subject_entity_id: int
-    object_entity_id: int
+    subject_entity_id: Optional[int] = None
+    object_entity_id: Optional[int] = None
+    subject_name: Optional[str] = None
+    object_name: Optional[str] = None
     tag: str
     inserted: Optional[bool] = None
     dry_run: bool = False
 
 
 class CreatedEntity(BaseModel):
-    """Entity created by trait compilation."""
+    """Entity created (or pending creation on dry-run) by trait compilation."""
 
     trait: str
     entity_kind: str
-    entity_id: int
+    entity_id: Optional[int] = None
     row_id: Optional[int] = None
     name: Optional[str] = None
     dry_run: bool = False
 
 
 class CreatedRelationship(BaseModel):
-    """character_relationships row that was or would be written."""
+    """character_relationships row that was or would be written.
+
+    ``character2_id`` is ``None`` only on dry-run rows whose target is a
+    pending stub; ``character2_name`` then carries the stub reference.
+    """
 
     trait: str
     character1_id: int
-    character2_id: int
+    character2_id: Optional[int] = None
+    character2_name: Optional[str] = None
     relationship_type: str
     emotional_valence: str
     pair_tag: Optional[str] = None

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -183,16 +183,21 @@ def _print_trait_audit(payload: Dict[str, Any]) -> None:
                 f"on entity {item['entity_id']}"
             )
 
+    def _endpoint_label(entity_id: Any, name: Any) -> str:
+        if entity_id is not None:
+            return str(entity_id)
+        return f"(pending stub) {name or '?'}"
+
     pair_tags = audit.get("applied_pair_tags") or []
     if pair_tags:
         print()
         print("Applied pair tags:")
         for item in pair_tags:
-            print(
-                "  - "
-                f"{item['trait']}: {item['tag']} "
-                f"{item['subject_entity_id']} -> {item['object_entity_id']}"
+            subject = _endpoint_label(
+                item.get("subject_entity_id"), item.get("subject_name")
             )
+            obj = _endpoint_label(item.get("object_entity_id"), item.get("object_name"))
+            print(f"  - {item['trait']}: {item['tag']} {subject} -> {obj}")
 
     created_entities = audit.get("created_entities") or []
     if created_entities:
@@ -200,10 +205,12 @@ def _print_trait_audit(payload: Dict[str, Any]) -> None:
         print("Created entities:")
         for item in created_entities:
             name = f" ({item['name']})" if item.get("name") else ""
+            entity_id = item.get("entity_id")
+            entity_label = entity_id if entity_id is not None else "pending"
             print(
                 "  - "
                 f"{item['trait']}: {item['entity_kind']} "
-                f"entity {item['entity_id']}{name}"
+                f"entity {entity_label}{name}"
             )
 
     created_relationships = audit.get("created_relationships") or []
@@ -211,10 +218,13 @@ def _print_trait_audit(payload: Dict[str, Any]) -> None:
         print()
         print("Created relationships:")
         for item in created_relationships:
+            target = _endpoint_label(
+                item.get("character2_id"), item.get("character2_name")
+            )
             print(
                 "  - "
                 f"{item['trait']}: character {item['character1_id']} -> "
-                f"{item['character2_id']} "
+                f"{target} "
                 f"({item['relationship_type']}, {item['emotional_valence']})"
             )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -342,6 +342,76 @@ def test_main_trait_audit_policy_failure_keeps_output(monkeypatch, capsys) -> No
     assert "resources: missing_structured_trait_input" in captured.out
 
 
+def test_print_trait_audit_renders_pending_stub_endpoints(capsys) -> None:
+    """Dry-run rows with pending stubs print names instead of null ids."""
+
+    cli._print_trait_audit(
+        {
+            "character_name": "Mara",
+            "traits": ["domain", "patron", "dependents"],
+            "trait_audit": {
+                "counters": {
+                    "applied_single_entity_tags": 0,
+                    "applied_pair_tags": 2,
+                    "created_entities": 2,
+                    "created_relationships": 1,
+                    "prose_only_remainders": 0,
+                },
+                "applied_pair_tags": [
+                    {
+                        "trait": "domain",
+                        "tag": "claims",
+                        "subject_entity_id": 501,
+                        "object_entity_id": None,
+                        "object_name": "Hollow Spire",
+                    },
+                    {
+                        "trait": "patron",
+                        "tag": "sponsors",
+                        "subject_entity_id": None,
+                        "subject_name": "Magistrate Hale",
+                        "object_entity_id": 501,
+                    },
+                ],
+                "created_entities": [
+                    {
+                        "trait": "domain",
+                        "entity_kind": "place",
+                        "entity_id": None,
+                        "name": "Hollow Spire",
+                    },
+                    {
+                        "trait": "patron",
+                        "entity_kind": "character",
+                        "entity_id": 1042,
+                        "name": "Magistrate Hale",
+                    },
+                ],
+                "created_relationships": [
+                    {
+                        "trait": "patron",
+                        "character1_id": 1,
+                        "character2_id": None,
+                        "character2_name": "Magistrate Hale",
+                        "relationship_type": "patron",
+                        "emotional_valence": "+2|deferential",
+                    }
+                ],
+            },
+        }
+    )
+
+    captured = capsys.readouterr()
+    assert "domain: claims 501 -> (pending stub) Hollow Spire" in captured.out
+    assert "patron: sponsors (pending stub) Magistrate Hale -> 501" in captured.out
+    assert "domain: place entity pending (Hollow Spire)" in captured.out
+    assert "patron: character entity 1042 (Magistrate Hale)" in captured.out
+    assert (
+        "patron: character 1 -> (pending stub) Magistrate Hale "
+        "(patron, +2|deferential)" in captured.out
+    )
+
+
 def test_retrograde_packet_writes_dry_run_packet(monkeypatch, tmp_path) -> None:
     """The CLI Retrograde packet command is read-only except optional output JSON."""
 

--- a/tests/test_trait_compiler.py
+++ b/tests/test_trait_compiler.py
@@ -1278,6 +1278,69 @@ def test_obligation_unknown_faction_creates_stub() -> None:
     assert cur.entity_pair_tags[0]["object_entity_id"] == created.entity_id
 
 
+def test_dry_run_coalesces_duplicate_pending_stubs() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        patron=PatronTraitInput(name="Magistrate Hale"),
+        obligations=ObligationsTraitInput(
+            targets=[
+                ObligationTargetInput(
+                    counterparty_kind="character", name="Magistrate Hale"
+                )
+            ]
+        ),
+    )
+
+    result = compile_character_traits(
+        cur,
+        character=_character("patron", "obligations", "resources", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+        dry_run=True,
+    )
+
+    assert len(result.created_entities) == 1
+    assert result.created_entities[0].name == "Magistrate Hale"
+    assert result.created_entities[0].entity_id is None
+    obligation_tags = [
+        item for item in result.applied_pair_tags if item.tag == "obligation"
+    ]
+    assert obligation_tags[0].object_name == "Magistrate Hale"
+
+
+def test_apply_resolves_second_reference_to_created_stub() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        patron=PatronTraitInput(name="Magistrate Hale"),
+        obligations=ObligationsTraitInput(
+            targets=[
+                ObligationTargetInput(
+                    counterparty_kind="character", name="Magistrate Hale"
+                )
+            ]
+        ),
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("patron", "obligations", "resources", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert len(result.created_entities) == 1
+    stub_entity_id = result.created_entities[0].entity_id
+    assert stub_entity_id is not None
+    obligation_tags = [
+        item for item in result.applied_pair_tags if item.tag == "obligation"
+    ]
+    assert obligation_tags[0].object_entity_id == stub_entity_id
+    assert {item.relationship_type for item in result.created_relationships} == {
+        "patron",
+        "obligation",
+    }
+
+
 def test_standard_selection_with_full_inputs_has_zero_remainders() -> None:
     cur = TraitCompilerCursor()
     inputs = TraitCompileInputs(

--- a/tests/test_trait_compiler.py
+++ b/tests/test_trait_compiler.py
@@ -16,6 +16,12 @@ from nexus.api.trait_compiler import (
     reconcile_trait_relationship_pair_tags,
 )
 from nexus.api.trait_compiler_schemas import (
+    DependentsTraitInput,
+    DependentTargetInput,
+    DomainTraitInput,
+    ObligationsTraitInput,
+    ObligationTargetInput,
+    PatronTraitInput,
     RelationshipTargetInput,
     RelationshipTraitInput,
     SingleEntityTraitInput,
@@ -74,12 +80,47 @@ class TraitCompilerCursor:
                 "subject_kinds": ["character", "faction"],
                 "object_kinds": ["character", "faction"],
             },
+            "claims": {
+                "id": 110,
+                "subject_kinds": ["character", "faction"],
+                "object_kinds": ["place"],
+            },
+            "protects": {
+                "id": 111,
+                "subject_kinds": ["character", "faction"],
+                "object_kinds": ["character"],
+            },
+            "obligation": {
+                "id": 112,
+                "subject_kinds": ["character", "faction"],
+                "object_kinds": ["character", "faction"],
+            },
+            "mentors": {
+                "id": 113,
+                "subject_kinds": ["character"],
+                "object_kinds": ["character"],
+            },
+            "sponsors": {
+                "id": 114,
+                "subject_kinds": ["character", "faction"],
+                "object_kinds": ["character"],
+            },
+            "authority_over": {
+                "id": 115,
+                "subject_kinds": ["character", "faction"],
+                "object_kinds": ["character", "faction"],
+            },
         }
-        self.characters = {
-            1: {"entity_id": 501},
-            2: {"entity_id": 502},
+        self.characters: dict[int, dict[str, Any]] = {
+            1: {"entity_id": 501, "name": "Mara"},
+            2: {"entity_id": 502, "name": "Bren"},
         }
-        self.factions = {"The Guild": 900}
+        self.places: dict[int, dict[str, Any]] = {
+            7: {"entity_id": 701, "name": "The Roost"},
+        }
+        self.factions: dict[int, dict[str, Any]] = {
+            3: {"entity_id": 900, "name": "The Guild"},
+        }
         self.entity_tags: list[dict[str, Any]] = []
         self.entity_pair_tags: list[dict[str, Any]] = []
         self.character_relationships: list[dict[str, Any]] = []
@@ -87,7 +128,28 @@ class TraitCompilerCursor:
         self.rowcount = 0
         self._next_row: Optional[Any] = None
         self._next_rows: list[Any] = []
-        self._savepoints: list[tuple[list[dict[str, Any]], list[dict[str, Any]]]] = []
+        self._savepoints: list[dict[str, Any]] = []
+
+    def _lookup_rows(
+        self, table: dict[int, dict[str, Any]], normalized: str, params: tuple
+    ) -> list[tuple[int, int, str]]:
+        (value,) = params
+        if "WHERE ID =" in normalized:
+            rows = [(row_id, row) for row_id, row in table.items() if row_id == value]
+        elif "WHERE ENTITY_ID =" in normalized:
+            rows = [
+                (row_id, row)
+                for row_id, row in table.items()
+                if row["entity_id"] == value
+            ]
+        else:
+            rows = [
+                (row_id, row) for row_id, row in table.items() if row["name"] == value
+            ]
+        return [
+            (row_id, row["entity_id"], row["name"])
+            for row_id, row in sorted(rows, key=lambda item: item[0])
+        ]
 
     def execute(self, sql: str, params: Optional[tuple] = None) -> None:
         params = params or ()
@@ -95,22 +157,94 @@ class TraitCompilerCursor:
 
         if normalized.startswith("SAVEPOINT"):
             self._savepoints.append(
-                (
-                    deepcopy(self.entity_pair_tags),
-                    deepcopy(self.character_relationships),
+                deepcopy(
+                    {
+                        "entity_pair_tags": self.entity_pair_tags,
+                        "character_relationships": self.character_relationships,
+                        "entity_tags": self.entity_tags,
+                        "characters": self.characters,
+                        "places": self.places,
+                        "factions": self.factions,
+                    }
                 )
             )
             self.rowcount = 0
             return
         if normalized.startswith("ROLLBACK TO SAVEPOINT"):
-            self.entity_pair_tags, self.character_relationships = deepcopy(
-                self._savepoints[-1]
-            )
+            snapshot = deepcopy(self._savepoints[-1])
+            self.entity_pair_tags = snapshot["entity_pair_tags"]
+            self.character_relationships = snapshot["character_relationships"]
+            self.entity_tags = snapshot["entity_tags"]
+            self.characters = snapshot["characters"]
+            self.places = snapshot["places"]
+            self.factions = snapshot["factions"]
             self.rowcount = 0
             return
         if normalized.startswith("RELEASE SAVEPOINT"):
             self._savepoints.pop()
             self.rowcount = 0
+            return
+
+        if normalized.startswith("SELECT ID, ENTITY_ID, NAME FROM CHARACTERS"):
+            self._next_rows = self._lookup_rows(self.characters, normalized, params)
+            self.rowcount = len(self._next_rows)
+            return
+
+        if normalized.startswith("SELECT ID, ENTITY_ID, NAME FROM PLACES"):
+            self._next_rows = self._lookup_rows(self.places, normalized, params)
+            self.rowcount = len(self._next_rows)
+            return
+
+        if normalized.startswith("SELECT ID, ENTITY_ID, NAME FROM FACTIONS"):
+            self._next_rows = self._lookup_rows(self.factions, normalized, params)
+            self.rowcount = len(self._next_rows)
+            return
+
+        if "TRAIT_COMPILER:INSERT_CHARACTER_STUB" in normalized:
+            name, _summary, _background, _activity, extra_data = params
+            row_id = max(self.characters, default=0) + 1
+            entity_id = 1000 + row_id
+            self.characters[row_id] = {
+                "entity_id": entity_id,
+                "name": name,
+                "extra_data": json.loads(extra_data),
+            }
+            self._next_row = (row_id, entity_id)
+            self.rowcount = 1
+            return
+
+        if "TRAIT_COMPILER:INSERT_PLACE_STUB" in normalized:
+            name, _summary, _status, extra_data = params
+            row_id = max(self.places, default=0) + 1
+            entity_id = 2000 + row_id
+            self.places[row_id] = {
+                "entity_id": entity_id,
+                "name": name,
+                "extra_data": json.loads(extra_data),
+            }
+            self._next_row = (row_id, entity_id)
+            self.rowcount = 1
+            return
+
+        if normalized.startswith("LOCK TABLE FACTIONS"):
+            self.rowcount = 0
+            return
+
+        if normalized.startswith("SELECT COALESCE(MAX(ID), 0) + 1 AS ID FROM FACTIONS"):
+            self._next_row = (max(self.factions, default=0) + 1,)
+            self.rowcount = 1
+            return
+
+        if "TRAIT_COMPILER:INSERT_FACTION_STUB" in normalized:
+            row_id, name, _summary, extra_data = params
+            entity_id = 3000 + row_id
+            self.factions[row_id] = {
+                "entity_id": entity_id,
+                "name": name,
+                "extra_data": json.loads(extra_data),
+            }
+            self._next_row = (entity_id,)
+            self.rowcount = 1
             return
 
         if normalized.startswith("SELECT MAX(WORLD_TIME)"):
@@ -162,9 +296,13 @@ class TraitCompilerCursor:
 
         if normalized.startswith("SELECT ENTITY_ID FROM FACTIONS"):
             (name,) = params
-            entity_id = self.factions.get(name)
-            self._next_row = (entity_id,) if entity_id is not None else None
-            self.rowcount = 1 if entity_id is not None else 0
+            entity_ids = [
+                row["entity_id"]
+                for row in self.factions.values()
+                if row["name"] == name
+            ]
+            self._next_row = (entity_ids[0],) if entity_ids else None
+            self.rowcount = 1 if entity_ids else 0
             return
 
         if normalized.startswith("UPDATE ENTITY_TAGS ET"):
@@ -795,6 +933,374 @@ def test_reconciliation_ignores_deprecated_bare_contact_pair_tag() -> None:
     )
 
     assert reconcile_trait_relationship_pair_tags(cur) == []
+
+
+def test_new_trait_compilers_without_inputs_return_structured_remainders() -> None:
+    cur = TraitCompilerCursor()
+    result = compile_character_traits(
+        cur,
+        character=_character("domain", "patron", "dependents"),
+        character_id=1,
+        character_entity_id=501,
+        dry_run=True,
+    )
+
+    assert result.counters.prose_only_remainders == 3
+    assert {item.trait for item in result.prose_only_remainders} == {
+        "domain",
+        "patron",
+        "dependents",
+    }
+    assert {item.reason_code for item in result.prose_only_remainders} == {
+        TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT
+    }
+
+
+def test_domain_claims_existing_place_by_name() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(domain=DomainTraitInput(name="The Roost"))
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("domain", "resources", "allies", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    domain_tags = [item for item in result.applied_pair_tags if item.trait == "domain"]
+    assert domain_tags[0].tag == "claims"
+    assert domain_tags[0].subject_entity_id == 501
+    assert domain_tags[0].object_entity_id == 701
+    assert result.created_entities == []
+    assert cur.entity_pair_tags[0]["pair_tag_id"] == 110
+
+
+def test_domain_creates_place_stub_for_unknown_name() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(domain=DomainTraitInput(name="Hollow Spire"))
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("domain", "resources", "allies", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    created = result.created_entities[0]
+    assert created.entity_kind == "place"
+    assert created.name == "Hollow Spire"
+    assert created.entity_id is not None
+    assert created.row_id is not None
+    stub_row = cur.places[created.row_id]
+    assert stub_row["extra_data"]["source"] == "trait_compiler"
+    assert stub_row["extra_data"]["stub_kind"] == "trait_compiler_target_ref"
+    assert stub_row["extra_data"]["sources"][0]["trait"] == "domain"
+    assert cur.entity_pair_tags[0]["object_entity_id"] == created.entity_id
+
+
+def test_domain_dry_run_reports_pending_stub_without_writes() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(domain=DomainTraitInput(name="Hollow Spire"))
+
+    result = compile_character_traits(
+        cur,
+        character=_character("domain", "resources", "allies", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+        dry_run=True,
+    )
+
+    domain_tags = [item for item in result.applied_pair_tags if item.trait == "domain"]
+    assert domain_tags[0].object_entity_id is None
+    assert domain_tags[0].object_name == "Hollow Spire"
+    assert result.created_entities[0].entity_id is None
+    assert result.created_entities[0].dry_run is True
+    assert cur.entity_pair_tags == []
+    assert all(item.trait != "domain" for item in result.prose_only_remainders)
+
+
+def test_domain_unknown_place_id_is_structured_remainder() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(domain=DomainTraitInput(place_id=999))
+
+    result = compile_character_traits(
+        cur,
+        character=_character("domain", "resources", "allies", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+        dry_run=True,
+    )
+
+    remainder = result.prose_only_remainders[0]
+    assert remainder.trait == "domain"
+    assert remainder.reason_code == TraitCompileReasonCode.AMBIGUOUS_TARGET
+    assert remainder.details["place_id"] == 999
+
+
+def test_patron_default_compiles_relationship_row_only() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        patron=PatronTraitInput(
+            name="Magistrate Hale",
+            dynamic="Hale opens doors and expects discretion.",
+        )
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("patron", "resources", "allies", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert result.applied_pair_tags == []
+    assert cur.entity_pair_tags == []
+    created = result.created_entities[0]
+    assert created.entity_kind == "character"
+    assert created.name == "Magistrate Hale"
+    relationship = result.created_relationships[0]
+    assert relationship.relationship_type == "patron"
+    assert relationship.emotional_valence == "+2|deferential"
+    assert relationship.character2_id == created.row_id
+    assert cur.character_relationships[0]["character2_id"] == created.row_id
+    extra_data = json.loads(cur.character_relationships[0]["extra_data"])
+    assert extra_data["source"] == "trait_compiler"
+    assert "trait_compiler_patron_functions" not in extra_data
+
+
+def test_patron_user_affirmed_functions_write_pair_tags() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        patron=PatronTraitInput(
+            character_id=2,
+            functions=["sponsors", "mentors", "sponsors"],
+        )
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("patron", "resources", "allies", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert [
+        (item.tag, item.subject_entity_id, item.object_entity_id)
+        for item in result.applied_pair_tags
+    ] == [
+        ("sponsors", 502, 501),
+        ("mentors", 502, 501),
+    ]
+    assert {row["pair_tag_id"] for row in cur.entity_pair_tags} == {113, 114}
+    extra_data = json.loads(cur.character_relationships[0]["extra_data"])
+    assert extra_data["trait_compiler_patron_functions"] == ["sponsors", "mentors"]
+
+
+def test_patron_unregistered_function_is_structured_remainder() -> None:
+    cur = TraitCompilerCursor()
+    del cur.pair_tags["sponsors"]
+    inputs = TraitCompileInputs(
+        patron=PatronTraitInput(character_id=2, functions=["sponsors"])
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("patron", "resources", "allies", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    remainder = result.prose_only_remainders[0]
+    assert remainder.trait == "patron"
+    assert remainder.reason_code == TraitCompileReasonCode.REGISTRY_MISSING_PAIR_TAG
+    assert remainder.details["pair_tag"] == "sponsors"
+    assert cur.entity_pair_tags == []
+    assert cur.character_relationships == []
+
+
+def test_dependents_compile_protects_edge_and_relationship_per_target() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        dependents=DependentsTraitInput(
+            targets=[
+                DependentTargetInput(character_id=2),
+                DependentTargetInput(name="Pip"),
+            ]
+        )
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("dependents", "resources", "allies", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert result.counters.prose_only_remainders == 2  # resources/allies no input
+    assert all(item.tag == "protects" for item in result.applied_pair_tags)
+    assert all(item.subject_entity_id == 501 for item in result.applied_pair_tags)
+    assert len(result.applied_pair_tags) == 2
+    assert len(result.created_relationships) == 2
+    assert {item.relationship_type for item in result.created_relationships} == {
+        "dependent"
+    }
+    created = result.created_entities[0]
+    assert created.entity_kind == "character"
+    assert created.name == "Pip"
+    extra_data = json.loads(cur.character_relationships[0]["extra_data"])
+    assert extra_data["trait_compiler_functional_pair_tag"] == "protects"
+    assert reconcile_trait_relationship_pair_tags(cur) == []
+
+
+def test_dependent_target_resolving_to_protagonist_is_remainder() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        dependents=DependentsTraitInput(targets=[DependentTargetInput(name="Mara")])
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("dependents", "resources", "allies", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    remainder = result.prose_only_remainders[0]
+    assert remainder.trait == "dependents"
+    assert remainder.reason_code == TraitCompileReasonCode.AMBIGUOUS_TARGET
+    assert "protagonist" in remainder.message
+    assert cur.entity_pair_tags == []
+    assert cur.character_relationships == []
+
+
+def test_ambiguous_target_name_is_structured_remainder() -> None:
+    cur = TraitCompilerCursor()
+    cur.characters[4] = {"entity_id": 504, "name": "Bren"}
+    inputs = TraitCompileInputs(
+        dependents=DependentsTraitInput(targets=[DependentTargetInput(name="Bren")])
+    )
+
+    result = compile_character_traits(
+        cur,
+        character=_character("dependents", "resources", "allies", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+        dry_run=True,
+    )
+
+    remainder = result.prose_only_remainders[0]
+    assert remainder.trait == "dependents"
+    assert remainder.reason_code == TraitCompileReasonCode.AMBIGUOUS_TARGET
+    assert remainder.details["match_count"] == 2
+
+
+def test_obligation_character_counterparty_writes_edge_and_relationship() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        obligations=ObligationsTraitInput(
+            targets=[
+                ObligationTargetInput(
+                    counterparty_kind="character",
+                    counterparty_id=2,
+                    dynamic="A debt collector with a patient ledger.",
+                )
+            ]
+        )
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("obligations", "resources", "allies", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    tag = result.applied_pair_tags[0]
+    assert tag.tag == "obligation"
+    assert tag.subject_entity_id == 501
+    assert tag.object_entity_id == 502
+    relationship = result.created_relationships[0]
+    assert relationship.relationship_type == "obligation"
+    assert relationship.emotional_valence == "-1|beholden"
+    assert cur.entity_pair_tags[0]["pair_tag_id"] == 112
+    extra_data = json.loads(cur.character_relationships[0]["extra_data"])
+    assert extra_data["trait_compiler_functional_pair_tag"] == "obligation"
+
+
+def test_obligation_faction_counterparty_writes_pair_tag_only() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        obligations=ObligationsTraitInput(
+            targets=[
+                ObligationTargetInput(counterparty_kind="faction", name="The Guild")
+            ]
+        )
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("obligations", "resources", "allies", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    tag = result.applied_pair_tags[0]
+    assert tag.tag == "obligation"
+    assert tag.object_entity_id == 900
+    assert result.created_relationships == []
+    assert cur.character_relationships == []
+    assert result.created_entities == []
+
+
+def test_obligation_unknown_faction_creates_stub() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        obligations=ObligationsTraitInput(
+            targets=[
+                ObligationTargetInput(counterparty_kind="faction", name="Iron Tithe")
+            ]
+        )
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("obligations", "resources", "allies", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    created = result.created_entities[0]
+    assert created.entity_kind == "faction"
+    assert created.name == "Iron Tithe"
+    assert created.row_id == 4
+    stub_row = cur.factions[4]
+    assert stub_row["extra_data"]["stub_kind"] == "trait_compiler_target_ref"
+    assert cur.entity_pair_tags[0]["object_entity_id"] == created.entity_id
+
+
+def test_standard_selection_with_full_inputs_has_zero_remainders() -> None:
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs(
+        domain=DomainTraitInput(name="The Roost"),
+        patron=PatronTraitInput(name="Magistrate Hale", functions=["sponsors"]),
+        obligations=ObligationsTraitInput(
+            targets=[
+                ObligationTargetInput(counterparty_kind="faction", name="The Guild")
+            ]
+        ),
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character("domain", "patron", "obligations", inputs=inputs),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert result.counters.prose_only_remainders == 0
+    assert result.counters.applied_pair_tags == 3  # claims, sponsors, obligation
+    assert result.counters.created_relationships == 1
+    assert result.counters.created_entities == 1
 
 
 def test_persist_trait_compile_result_requires_wizard_cache_row() -> None:

--- a/tests/test_trait_compiler_integration.py
+++ b/tests/test_trait_compiler_integration.py
@@ -1,0 +1,298 @@
+"""Postgres-gated integration tests for the finished trait compiler (M5).
+
+These tests run the real compiler against ``save_05`` inside a transaction
+that is always rolled back, so the dev slot is left untouched. They require
+migration 061 (the ``sponsors`` pair-tag) to be applied.
+
+Run with: ``NEXUS_RUN_POSTGRES=1 poetry run pytest
+tests/test_trait_compiler_integration.py``
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import psycopg2
+import pytest
+
+from nexus.api.new_story_schemas import CharacterSheet, CharacterTrait
+from nexus.api.trait_compiler import (
+    apply_character_trait_compilation,
+    compile_character_traits,
+    reconcile_trait_relationship_pair_tags,
+)
+from nexus.api.trait_compiler_schemas import (
+    DependentsTraitInput,
+    DependentTargetInput,
+    DomainTraitInput,
+    ObligationsTraitInput,
+    ObligationTargetInput,
+    PatronTraitInput,
+    SingleEntityTraitInput,
+    TraitCompileInputs,
+)
+
+TEST_DBNAME = "save_05"
+
+DOMAIN_PLACE_NAME = "M5 Trait Test Spire"
+PATRON_NAME = "M5 Trait Test Hale"
+OBLIGATION_CHARACTER_NAME = "M5 Trait Test Collector"
+OBLIGATION_FACTION_NAME = "M5 Trait Test Tithe"
+DEPENDENT_NAME = "M5 Trait Test Pip"
+
+
+def _character_sheet(
+    *trait_names: str, inputs: Optional[TraitCompileInputs]
+) -> CharacterSheet:
+    traits = [
+        CharacterTrait(name=trait_name, description=f"{trait_name} trait prose")
+        for trait_name in trait_names
+    ]
+    return CharacterSheet(
+        name="M5 Trait Test Protagonist",
+        summary="Integration-test protagonist for the M5 trait compiler.",
+        appearance="Deliberately nondescript; exists only inside a transaction.",
+        background=(
+            "Created by tests/test_trait_compiler_integration.py and rolled "
+            "back before commit."
+        ),
+        personality="Methodical, transactional, and gone before anyone commits.",
+        wildcard_name="Rollback Ghost",
+        wildcard_description="Vanishes whenever the transaction ends.",
+        trait_1=traits[0],
+        trait_2=traits[1],
+        trait_3=traits[2],
+        trait_compile_inputs=inputs,
+    )
+
+
+def _insert_protagonist(cur: Any) -> tuple[int, int]:
+    cur.execute(
+        """
+        INSERT INTO characters (name, summary, background, extra_data)
+        VALUES (%s, %s, %s, '{}'::jsonb)
+        RETURNING id, entity_id
+        """,
+        (
+            "M5 Trait Test Protagonist",
+            "Integration-test protagonist for the M5 trait compiler.",
+            "Rolled back before commit.",
+        ),
+    )
+    row = cur.fetchone()
+    assert row is not None
+    return row[0], row[1]
+
+
+def _active_pair_tags(cur: Any, subject_entity_id: int) -> set[tuple[str, int]]:
+    cur.execute(
+        """
+        SELECT pt.tag, ept.object_entity_id
+        FROM entity_pair_tags ept
+        JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+        WHERE ept.subject_entity_id = %s
+          AND ept.cleared_at IS NULL
+        """,
+        (subject_entity_id,),
+    )
+    return {(row[0], row[1]) for row in cur.fetchall()}
+
+
+@pytest.mark.requires_postgres
+def test_full_trait_selection_compiles_on_save_05() -> None:
+    """A standard selection compiles with zero prose-only remainders."""
+
+    try:
+        conn = psycopg2.connect(dbname=TEST_DBNAME)
+    except psycopg2.Error as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"{TEST_DBNAME} PostgreSQL test database unavailable: {exc}")
+
+    try:
+        with conn.cursor() as cur:
+            drift_before = reconcile_trait_relationship_pair_tags(cur)
+            character_id, character_entity_id = _insert_protagonist(cur)
+
+            inputs = TraitCompileInputs(
+                domain=DomainTraitInput(name=DOMAIN_PLACE_NAME),
+                patron=PatronTraitInput(
+                    name=PATRON_NAME,
+                    functions=["sponsors", "mentors"],
+                    dynamic="Backs the protagonist's ventures discreetly.",
+                ),
+                obligations=ObligationsTraitInput(
+                    targets=[
+                        ObligationTargetInput(
+                            counterparty_kind="character",
+                            name=OBLIGATION_CHARACTER_NAME,
+                            dynamic="A patient ledger, collected in favors.",
+                        ),
+                        ObligationTargetInput(
+                            counterparty_kind="faction",
+                            name=OBLIGATION_FACTION_NAME,
+                        ),
+                    ]
+                ),
+            )
+            sheet = _character_sheet("domain", "patron", "obligations", inputs=inputs)
+
+            result = apply_character_trait_compilation(
+                cur,
+                character=sheet,
+                character_id=character_id,
+                character_entity_id=character_entity_id,
+            )
+
+            assert (
+                result.counters.prose_only_remainders == 0
+            ), result.prose_only_remainders
+            # claims + sponsors + mentors + obligation x2.
+            assert result.counters.applied_pair_tags == 5
+            # place + patron char + obligation char + obligation faction.
+            assert result.counters.created_entities == 4
+            # patron + obligation character counterparty.
+            assert result.counters.created_relationships == 2
+
+            created_by_kind = {
+                item.entity_kind: item for item in result.created_entities
+            }
+            assert set(created_by_kind) == {"character", "place", "faction"}
+
+            place_entity_id = next(
+                item.entity_id
+                for item in result.created_entities
+                if item.entity_kind == "place"
+            )
+            assert place_entity_id is not None
+
+            protagonist_tags = _active_pair_tags(cur, character_entity_id)
+            assert ("claims", place_entity_id) in protagonist_tags
+            obligation_objects = {
+                object_id for tag, object_id in protagonist_tags if tag == "obligation"
+            }
+            assert len(obligation_objects) == 2
+
+            patron_entity_id = next(
+                item.entity_id
+                for item in result.created_entities
+                if item.name == PATRON_NAME
+            )
+            assert patron_entity_id is not None
+            patron_tags = _active_pair_tags(cur, patron_entity_id)
+            assert ("sponsors", character_entity_id) in patron_tags
+            assert ("mentors", character_entity_id) in patron_tags
+
+            cur.execute(
+                """
+                SELECT relationship_type, emotional_valence,
+                       extra_data->>'source'
+                FROM character_relationships
+                WHERE character1_id = %s
+                ORDER BY relationship_type
+                """,
+                (character_id,),
+            )
+            relationships = cur.fetchall()
+            assert [(row[0], row[2]) for row in relationships] == [
+                ("obligation", "trait_compiler"),
+                ("patron", "trait_compiler"),
+            ]
+
+            cur.execute(
+                """
+                SELECT extra_data->>'source', extra_data->>'stub_kind'
+                FROM characters
+                WHERE name = %s
+                """,
+                (PATRON_NAME,),
+            )
+            assert cur.fetchone() == ("trait_compiler", "trait_compiler_target_ref")
+            cur.execute(
+                "SELECT type::text, extra_data->>'stub_kind' FROM places "
+                "WHERE name = %s",
+                (DOMAIN_PLACE_NAME,),
+            )
+            assert cur.fetchone() == ("other", "trait_compiler_target_ref")
+            cur.execute(
+                "SELECT extra_data->>'stub_kind' FROM factions WHERE name = %s",
+                (OBLIGATION_FACTION_NAME,),
+            )
+            assert cur.fetchone() == ("trait_compiler_target_ref",)
+
+            # Functional trait edges must not add affective-layer drift.
+            assert reconcile_trait_relationship_pair_tags(cur) == drift_before
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+@pytest.mark.requires_postgres
+def test_dependents_apply_and_dry_run_audit_on_save_05() -> None:
+    """Dependents writes protects + bond; the audit surface reports cleanly."""
+
+    try:
+        conn = psycopg2.connect(dbname=TEST_DBNAME)
+    except psycopg2.Error as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"{TEST_DBNAME} PostgreSQL test database unavailable: {exc}")
+
+    try:
+        with conn.cursor() as cur:
+            character_id, character_entity_id = _insert_protagonist(cur)
+
+            inputs = TraitCompileInputs(
+                dependents=DependentsTraitInput(
+                    targets=[DependentTargetInput(name=DEPENDENT_NAME)]
+                ),
+                resources=SingleEntityTraitInput(level="wealthy"),
+                fame=SingleEntityTraitInput(level="known"),
+            )
+            sheet = _character_sheet("dependents", "resources", "fame", inputs=inputs)
+
+            # Dry-run first: the trait-audit surface must report zero
+            # remainders and a pending stub without touching the database.
+            audit = compile_character_traits(
+                cur,
+                character=sheet,
+                character_id=character_id,
+                character_entity_id=character_entity_id,
+                dry_run=True,
+            )
+            assert (
+                audit.counters.prose_only_remainders == 0
+            ), audit.prose_only_remainders
+            assert audit.created_entities[0].entity_id is None
+            assert audit.created_entities[0].name == DEPENDENT_NAME
+            assert audit.applied_pair_tags[0].object_entity_id is None
+            assert audit.applied_pair_tags[0].object_name == DEPENDENT_NAME
+            cur.execute(
+                "SELECT COUNT(*) FROM characters WHERE name = %s",
+                (DEPENDENT_NAME,),
+            )
+            assert cur.fetchone() == (0,)
+
+            result = apply_character_trait_compilation(
+                cur,
+                character=sheet,
+                character_id=character_id,
+                character_entity_id=character_entity_id,
+            )
+            assert result.counters.prose_only_remainders == 0
+            assert result.counters.applied_single_entity_tags == 2
+            dependent_entity_id = result.created_entities[0].entity_id
+            assert dependent_entity_id is not None
+
+            protagonist_tags = _active_pair_tags(cur, character_entity_id)
+            assert ("protects", dependent_entity_id) in protagonist_tags
+
+            cur.execute(
+                """
+                SELECT relationship_type, emotional_valence,
+                       extra_data->>'trait_compiler_functional_pair_tag'
+                FROM character_relationships
+                WHERE character1_id = %s
+                """,
+                (character_id,),
+            )
+            assert cur.fetchall() == [("dependent", "+3|devoted", "protects")]
+    finally:
+        conn.rollback()
+        conn.close()


### PR DESCRIPTION
## Summary

M5 of the backend v1.0 campaign: every wizard trait except the wildcard now compiles to deterministic mechanical state. The four remaining compilers follow the #295 typed-compiler pattern and the settled functional-vs-affective principle (#303/#305/#306/#308). The wildcard-cannot-mint rule stands; the wildcard remains outside the compile loop.

### Per-Trait Design

- **Domain** -> `claims(char -> place)`. The place is resolved by `place_id` / `place_entity_id` / exact name; an unmatched name creates a minimum-viable place stub (`type='other'`). Unknown ids and ambiguous names become structured remainders. Registry polymorphism was already in place (migration 045).
- **Patron** (per the #305 resolution) -> one `character_relationships` row (`relationship_type='patron'`, default valence `+2|deferential`); the patron is resolved or stub-created. User-affirmed `functions` (`mentors`, `sponsors`, `protects`, `authority_over`) each add one pair-tag **patron -> protagonist**; no functions means relationship row only — never a default bundle.
- **Dependents** (per the #306 resolution) -> per target: `protects(char -> dependent)` pair-tag plus a relationship row (`'dependent'`, `+3|devoted`); no `authority_over`/`obligation` subordination edge. Targets resolving to the protagonist or matching multiple rows are structured remainders.
- **Obligations** -> per target: `obligation(protagonist -> counterparty)` where the counterparty is a character or faction (stub-creatable by name). Character counterparties also get a relationship row (`'obligation'`, `-1|beholden`) carrying the affective aspect; faction counterparties carry the pair-tag alone (`character_relationships` is char-char). Obligations to pure concepts have no mechanical referent: the typed input requires binding to the enforcing/benefiting entity (stub allowed); otherwise the obligation stays prose in the trait description.

### Stub Entities

Patron/Dependents/Obligations character+faction targets and Domain places create stubs following the Retrograde persistence conventions: sparse columns, `extra_data.source='trait_compiler'`, `stub_kind='trait_compiler_target_ref'`, and a `sources` provenance list — exactly the input wizard-time Retrograde Phase A matures into history. Nothing is generated recursively for stubs. Dry-run (`nexus trait-audit`) reports pending stubs (`entity_id: null` + named endpoints) without touching the database.

### Vocabulary Additions (called out explicitly)

**Migration `061_trait_compiler_sponsors_pair_tag.py` — the complete vocabulary delta — registers exactly one row:**

- `sponsors` (pair_tag): subject `{character, faction}`, object `{character}`, durable. Fills the #305 "sponsors gap" — economic/positional backing that neither commands nor mentors. Written only for user-affirmed Patron functions.

No other registry rows were needed: `claims` (char-subject polymorphism via 045), `protects`, and `obligation` were already registered by 042/045 with the required kinds. `character_relationships.relationship_type` is free text, so the new `patron`/`dependent`/`obligation` strings need no registry. The addition is design-time/authored and fully compatible with the #293 runtime lockdown.

### Schema/Data Notes

- Migration 061 applied to **save_05 only** (now at 061); template and slots 1-4 remain at 060 for post-merge fleet catch-up.
- Result-schema fields loosened for honest dry-run reporting: `AppliedPairTag.subject/object_entity_id`, `CreatedEntity.entity_id`, `CreatedRelationship.character2_id` are now `Optional`, with companion `*_name` fields populated only for pending stubs. `nexus trait-audit` printing renders `(pending stub) <name>` for those endpoints.
- Latent bug found (not fixed here, flagged for the Retrograde lane): `retrograde_persistence._insert_faction_stub` still inserts `factions.current_activity`, which migration 058 dropped — it will fail on any 058+ database. My faction stub uses the live schema.

## Validation

```bash
# Offline unit tests (30 in test_trait_compiler.py incl. 14 new; CLI printer test)
poetry run pytest tests/test_trait_compiler.py tests/test_cli.py -q

# Postgres-gated integration on save_05 (rollback-wrapped; requires migration 061)
NEXUS_RUN_POSTGRES=1 poetry run pytest tests/test_trait_compiler_integration.py -q

# Full offline suite: 645 passed, 81 skipped (gated)
poetry run pytest -q
```

black/flake8 clean; mypy with the pydantic plugin introduces no new errors (the one flagged runtime line predates this PR). The live `nexus trait-audit --slot 5` CLI path was deliberately not exercised end-to-end: slot 5 has no wizard cache and inserting one would flip the slot into wizard mode (mode is data-presence-derived). The integration tests exercise the same audit surface (`compile_character_traits(dry_run=True)`) against the live database instead.

## Deferred

- Fleet catch-up of migration 061 (template + slots 1-4) post-merge.
- The `retrograde_persistence` faction-stub column bug above.
- Reconciliation invariants remain scoped to affective pair-tags (`ally`/`contact:*`/`hostile_to`); the new functional edges record `trait_compiler_functional_pair_tag` metadata so the surface can be extended later if a drift mode shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)