### PR TITLE
U3: NexusLayout Rebuild — the IRIS Reading Surface

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -60,6 +60,15 @@ test_mode = false
 test_database_suffix = "_test"
 
 # =============================================================================
+# UI Settings (read by the React client via GET /api/settings)
+# =============================================================================
+
+[ui]
+# Typewriter reveal speed for incoming narrative chunks (NEXUS IRIS design
+# system specifies 30-50 ms/char).
+typewriter_ms_per_char = 35
+
+# =============================================================================
 # Wizard Settings (New Story Setup)
 # =============================================================================
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -905,6 +905,26 @@ class IREvalSettings(BaseModel):
     judgment: IREvalJudgmentConfig
 
 
+class UISettings(BaseModel):
+    """Settings consumed by the React client.
+
+    Served verbatim to the browser through the Express ``GET /api/settings``
+    endpoint (which reads nexus.toml); keep keys JSON-friendly.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    typewriter_ms_per_char: int = Field(
+        default=35,
+        ge=1,
+        le=500,
+        description=(
+            "Typewriter reveal speed for incoming narrative chunks in "
+            "milliseconds per character (design system: 30-50 ms/char)"
+        ),
+    )
+
+
 class SecretsConfig(BaseModel):
     """Provider -> 1Password reference mappings.
 
@@ -952,6 +972,10 @@ class Settings(BaseModel):
     apex: APEXSettings
     wizard: WizardSettings
     api: Optional[APISettings] = Field(default=None, description="API settings")
+    ui: UISettings = Field(
+        default_factory=UISettings,
+        description="React client settings (served via GET /api/settings)",
+    )
     ir_eval: Optional[IREvalSettings] = Field(
         default=None,
         description="IR evaluation subsystem settings",

--- a/ui/client/src/App.tsx
+++ b/ui/client/src/App.tsx
@@ -10,12 +10,14 @@ import { ModelProvider } from "@/contexts/ModelContext";
 import NotFound from "@/pages/not-found";
 import SplashPage from "@/pages/SplashPage";
 import NewStoryPage from "@/pages/NewStoryPage";
+import { NexusLayout } from "@/components/nexus";
 
 function Router() {
   return (
     <Switch>
       <Route path="/" component={SplashPage} />
       <Route path="/new-story" component={NewStoryPage} />
+      <Route path="/nexus" component={NexusLayout} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/ui/client/src/components/deco/DecoDivider.tsx
+++ b/ui/client/src/components/deco/DecoDivider.tsx
@@ -1,17 +1,39 @@
 import { cn } from "@/lib/utils";
+import { useTheme, type Theme } from "@/contexts/ThemeContext";
 
 interface DecoDividerProps {
   className?: string;
-  variant?: 'diamond' | 'chevron' | 'line';
+  variant?: 'diamond' | 'chevron' | 'line' | 'glyph';
 }
+
+/** Theme-aware center glyphs for the `glyph` variant (NEXUS IRIS spec). */
+const THEME_GLYPHS: Record<Theme, string> = {
+  veil: '⟡',   // ⟡ white concave-sided diamond
+  gilded: '◆', // ◆ black diamond
+  vector: '▮', // ▮ black vertical rectangle
+};
 
 /**
  * Decorative horizontal separator with Art Deco motifs.
+ *
+ * The `glyph` variant centers the active theme's signature character
+ * (Veil ⟡, Gilded ◆, Vector ▮) between the gradient rules.
  */
-export function DecoDivider({ className, variant = 'diamond' }: DecoDividerProps) {
+export function DecoDivider({ className, variant = 'glyph' }: DecoDividerProps) {
+  const { theme } = useTheme();
+
   return (
     <div className={cn("w-full flex items-center justify-center gap-3 py-3", className)}>
       <div className="flex-1 h-px bg-gradient-to-r from-transparent via-muted-foreground/30 to-muted-foreground/50" />
+
+      {variant === 'glyph' && (
+        <span
+          aria-hidden="true"
+          className="text-primary/60 flex-shrink-0 text-[13px] leading-none"
+        >
+          {THEME_GLYPHS[theme]}
+        </span>
+      )}
 
       {variant === 'diamond' && (
         <svg width="24" height="12" viewBox="0 0 24 12" className="text-primary flex-shrink-0">

--- a/ui/client/src/components/deco/DecoDivider.tsx
+++ b/ui/client/src/components/deco/DecoDivider.tsx
@@ -17,9 +17,14 @@ const THEME_GLYPHS: Record<Theme, string> = {
  * Decorative horizontal separator with Art Deco motifs.
  *
  * The `glyph` variant centers the active theme's signature character
- * (Veil ⟡, Gilded ◆, Vector ▮) between the gradient rules.
+ * (Veil ⟡, Gilded ◆, Vector ▮) between the gradient rules. The default
+ * stays `diamond` so callers that omit `variant` are visually unchanged.
+ *
+ * Trade-off: `useTheme()` runs unconditionally (rules of hooks), so every
+ * DecoDivider subscribes to ThemeContext even when variant !== 'glyph'.
+ * Theme switches are rare user actions; the extra re-render is negligible.
  */
-export function DecoDivider({ className, variant = 'glyph' }: DecoDividerProps) {
+export function DecoDivider({ className, variant = 'diamond' }: DecoDividerProps) {
   const { theme } = useTheme();
 
   return (

--- a/ui/client/src/components/nexus/CharactersPane.tsx
+++ b/ui/client/src/components/nexus/CharactersPane.tsx
@@ -1,0 +1,147 @@
+/**
+ * CharactersPane - cast roster + dossier card.
+ *
+ * List on the left (single-letter glyph avatars, menu-font names), dossier
+ * detail on the right: portrait on a dark surface behind a thin violet
+ * border (lightly sepia + cool-rotated per the README imagery rules),
+ * name as a menu-font heading, and prose sections from the live
+ * characters table.
+ */
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { User } from "lucide-react";
+import { DecoDivider } from "@/components/deco";
+import { getCharacterImages, getCharacters } from "@/lib/narrative-api";
+import type { Character, CharacterImage } from "@shared/schema";
+
+interface CharactersPaneProps {
+  slot: number;
+}
+
+function DossierSection({ title, body }: { title: string; body: string | null }) {
+  if (!body) return null;
+  return (
+    <section className="char-section">
+      <span className="eyebrow">{title}</span>
+      <p>{body}</p>
+    </section>
+  );
+}
+
+export function CharactersPane({ slot }: CharactersPaneProps) {
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const { data: characters, isLoading, error } = useQuery<Character[]>({
+    queryKey: ["/api/characters", slot],
+    queryFn: () => getCharacters(slot),
+  });
+
+  const selected = useMemo(() => {
+    if (!characters || characters.length === 0) return null;
+    return characters.find((c) => c.id === selectedId) ?? characters[0];
+  }, [characters, selectedId]);
+
+  const { data: images } = useQuery<CharacterImage[]>({
+    queryKey: ["/api/characters/images", selected?.id, slot],
+    queryFn: () => getCharacterImages(selected!.id, slot),
+    enabled: !!selected,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="pane-notice">
+        <span className="notice-text">LOADING CAST…</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="pane-notice">
+        <span className="notice-text">[ CAST UNAVAILABLE ]</span>
+        <span className="notice-detail">{(error as Error).message}</span>
+      </div>
+    );
+  }
+
+  if (!characters || characters.length === 0) {
+    return (
+      <div className="pane-notice">
+        <span className="notice-text">[ NO CAST RECORDED ]</span>
+        <span className="notice-detail">
+          Characters appear here as the story introduces them.
+        </span>
+      </div>
+    );
+  }
+
+  const mainImage =
+    images?.find((img) => img.isMain === 1) ?? images?.[0] ?? null;
+
+  return (
+    <div className="charspane" data-testid="characters-pane">
+      <div className="charspane-list">
+        <span className="eyebrow brass-glow">CAST · {characters.length}</span>
+        <ul>
+          {characters.map((character) => (
+            <li
+              key={character.id}
+              className={selected?.id === character.id ? "on" : ""}
+              onClick={() => setSelectedId(character.id)}
+              data-testid={`cast-member-${character.id}`}
+            >
+              <span className="char-glyph">
+                {character.name.charAt(0).toUpperCase()}
+              </span>
+              <span className="char-name">{character.name}</span>
+              {character.currentLocation && (
+                <span className="char-role">· {character.currentLocation}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {selected && (
+        <div className="charspane-detail">
+          <div className="charspane-detail-inner">
+            <header className="char-head">
+              <div className="char-portrait">
+                {mainImage ? (
+                  <img src={`/${mainImage.filePath}`} alt={selected.name} />
+                ) : (
+                  <User className="char-portrait-empty" size={40} />
+                )}
+              </div>
+              <div>
+                <span className="eyebrow">CAST MEMBER</span>
+                <h2 className="char-title" data-testid="text-dossier-name">
+                  {selected.name}
+                </h2>
+                {selected.currentLocation && (
+                  <span className="caption">
+                    currently in {selected.currentLocation}
+                  </span>
+                )}
+              </div>
+            </header>
+            <DecoDivider variant="glyph" />
+            <div className="char-sections">
+              <DossierSection title="Summary" body={selected.summary} />
+              <DossierSection title="Appearance" body={selected.appearance} />
+              <DossierSection title="Personality" body={selected.personality} />
+              <DossierSection
+                title="Emotional State"
+                body={selected.emotionalState}
+              />
+              <DossierSection
+                title="Current Activity"
+                body={selected.currentActivity}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/client/src/components/nexus/LeftRail.tsx
+++ b/ui/client/src/components/nexus/LeftRail.tsx
@@ -1,0 +1,57 @@
+/**
+ * LeftRail - the 60px vertical icon rail (primary navigation).
+ *
+ * Home returns to the splash; the four tabs switch the main pane. The
+ * active tab carries the 3x22px magenta edge marker + glow (CSS ::before).
+ * Lucide icons inherit color from the surrounding text per the README.
+ */
+import { Book, Home, Map, Settings, Users } from "lucide-react";
+
+export type NexusTab = "narrative" | "map" | "characters" | "settings";
+
+const RAIL_TABS: Array<{ id: NexusTab; label: string; Icon: typeof Book }> = [
+  { id: "narrative", label: "Narrative", Icon: Book },
+  { id: "map", label: "Map", Icon: Map },
+  { id: "characters", label: "Characters", Icon: Users },
+  { id: "settings", label: "Settings", Icon: Settings },
+];
+
+interface LeftRailProps {
+  tab: NexusTab;
+  onTabChange: (tab: NexusTab) => void;
+  onHome: () => void;
+}
+
+export function LeftRail({ tab, onTabChange, onHome }: LeftRailProps) {
+  return (
+    <nav className="rail-left" aria-label="Primary navigation">
+      <button
+        className="rail-btn"
+        onClick={onHome}
+        title="Home"
+        data-testid="rail-home"
+      >
+        <Home size={18} />
+        <span className="rail-tip">HOME</span>
+      </button>
+      <div className="rail-divider" />
+      {RAIL_TABS.map(({ id, label, Icon }) => (
+        <button
+          key={id}
+          className={`rail-btn ${tab === id ? "on" : ""}`}
+          onClick={() => onTabChange(id)}
+          title={label}
+          aria-pressed={tab === id}
+          data-testid={`rail-${id}`}
+        >
+          <Icon size={18} />
+          <span className="rail-tip">{label.toUpperCase()}</span>
+        </button>
+      ))}
+      <div className="rail-spacer" />
+      <div className="rail-monogram" aria-hidden="true">
+        N·I
+      </div>
+    </nav>
+  );
+}

--- a/ui/client/src/components/nexus/MapPane.tsx
+++ b/ui/client/src/components/nexus/MapPane.tsx
@@ -1,0 +1,45 @@
+/**
+ * MapPane - styled shell only.
+ *
+ * The real PostGIS map is milestone U4 (see docs/maptab_rebuild_spec.md).
+ * This pane reserves the surface with the themed bordered canvas and a
+ * faint coordinate grid, deliberately pulling in no map libraries.
+ */
+export function MapPane() {
+  return (
+    <div className="mappane-shell" data-testid="map-pane">
+      <div className="mappane-canvas">
+        <svg
+          className="mappane-grid"
+          aria-hidden="true"
+          preserveAspectRatio="none"
+        >
+          <defs>
+            <pattern
+              id="nexus-map-grid"
+              width="40"
+              height="40"
+              patternUnits="userSpaceOnUse"
+            >
+              <path
+                d="M40 0H0V40"
+                fill="none"
+                stroke="var(--brass)"
+                strokeOpacity="0.06"
+              />
+            </pattern>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#nexus-map-grid)" />
+        </svg>
+        <div className="mappane-placeholder">
+          <span className="eyebrow brass-glow">[ CARTOGRAPHY ]</span>
+          <h2 className="map-title">SURVEY PENDING</h2>
+          <p className="map-sub">
+            The atlas is being re-engraved. Zones, places, and routes return
+            with the next survey.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/client/src/components/nexus/NarrativePane.tsx
+++ b/ui/client/src/components/nexus/NarrativePane.tsx
@@ -1,0 +1,323 @@
+/**
+ * NarrativePane - the typeset book-chapter reading surface.
+ *
+ * Renders the current episode's committed chunks plus the pending
+ * (incubator) chunk from slot state. Voice is differentiated by color only:
+ * storyteller prose in warm cream (--fg), player responses in muted cream
+ * (--fg-muted), with a thin centered rule between speaker changes. The
+ * current chunk carries a 3px magenta edge marker; earlier chunks read at
+ * 0.78 opacity. Choices 1-3 render with key boxes; the freeform directive
+ * is slot 0 - an unboxed italic input indented to the choice-text line.
+ */
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+import { useQuery } from "@tanstack/react-query";
+import { DecoDivider } from "@/components/deco";
+import { Textarea } from "@/components/ui/textarea";
+import { TypewriterText } from "./TypewriterText";
+import {
+  getChunkContext,
+  getEpisodeChunks,
+  getLatestChunk,
+} from "@/lib/narrative-api";
+import type { NarrativeEngine } from "@/hooks/useNarrativeEngine";
+import type { ChunkContext, ChunkWithMetadata } from "@/types/narrative";
+
+/** Render *emphasis* spans without dangerouslySetInnerHTML. */
+function renderProse(text: string): ReactNode[] {
+  return text.split(/\*([^*]+)\*/g).map((segment, i) =>
+    i % 2 === 1 ? <em key={i}>{segment}</em> : <Fragment key={i}>{segment}</Fragment>,
+  );
+}
+
+interface NarrativePaneProps {
+  slot: number;
+  engine: NarrativeEngine;
+  typewriterMsPerChar: number;
+}
+
+export function NarrativePane({
+  slot,
+  engine,
+  typewriterMsPerChar,
+}: NarrativePaneProps) {
+  const { slotState, isGenerating, completedGenerations, submitTurn, phase } =
+    engine;
+  const [freeform, setFreeform] = useState("");
+  const freeformRef = useRef<HTMLTextAreaElement>(null);
+  const tailRef = useRef<HTMLDivElement>(null);
+
+  const { data: latestChunk } = useQuery<ChunkWithMetadata | null>({
+    queryKey: ["/api/narrative/latest-chunk", slot],
+    queryFn: () => getLatestChunk(slot),
+  });
+
+  const season = latestChunk?.metadata?.season ?? null;
+  const episode = latestChunk?.metadata?.episode ?? null;
+
+  const { data: episodeChunks } = useQuery<{
+    chunks: ChunkWithMetadata[];
+    total: number;
+  }>({
+    queryKey: ["/api/narrative/chunks", season, episode, slot],
+    queryFn: () => getEpisodeChunks(season as number, episode as number, slot),
+    enabled: season !== null && episode !== null,
+  });
+
+  // Scene context (cast + setting place) keys off the latest committed
+  // chunk - pending chunks have no reference rows until approval.
+  const { data: chunkContext } = useQuery<ChunkContext>({
+    queryKey: ["/api/narrative/chunks/context", latestChunk?.id, slot],
+    queryFn: () => getChunkContext(latestChunk!.id, slot),
+    enabled: !!latestChunk?.id,
+  });
+
+  const chunks = episodeChunks?.chunks ?? [];
+  const hasPending = slotState?.has_pending ?? false;
+  const pendingText = hasPending ? slotState?.storyteller_text ?? null : null;
+  const choices = slotState?.choices ?? [];
+  const isBootstrapNeeded =
+    !!slotState &&
+    !slotState.is_empty &&
+    !slotState.is_wizard_mode &&
+    !hasPending &&
+    slotState.current_chunk_id === 0;
+
+  const settingPlace = chunkContext?.places.find(
+    (p) => p.referenceType === "setting",
+  );
+  const presentCast =
+    chunkContext?.characters.filter((c) => c.reference === "present") ?? [];
+
+  const sceneCoord = useMemo(() => {
+    const m = latestChunk?.metadata;
+    if (!m) return null;
+    return `S${m.season ?? 0}·E${m.episode ?? 0}·S${m.scene ?? 0}`;
+  }, [latestChunk?.metadata]);
+
+  const canSubmit = !isGenerating && !!slotState && !slotState.is_wizard_mode;
+
+  const handleChoice = useCallback(
+    (index: number) => {
+      if (!canSubmit) return;
+      setFreeform("");
+      void submitTurn({ choice: index });
+    },
+    [canSubmit, submitTurn],
+  );
+
+  const handleFreeformSubmit = useCallback(() => {
+    const text = freeform.trim();
+    if (!text || !canSubmit) return;
+    setFreeform("");
+    void submitTurn({ userText: text });
+  }, [freeform, canSubmit, submitTurn]);
+
+  const handleFreeformKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        handleFreeformSubmit();
+      }
+    },
+    [handleFreeformSubmit],
+  );
+
+  // Number keys 1-N select choices when focus is outside the freeform field.
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (document.activeElement === freeformRef.current) return;
+      const target = event.target as HTMLElement | null;
+      if (target && ["INPUT", "TEXTAREA"].includes(target.tagName)) return;
+      const n = parseInt(event.key, 10);
+      if (!isNaN(n) && n >= 1 && n <= choices.length) {
+        handleChoice(n);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [choices.length, handleChoice]);
+
+  // Keep the frontier in view when new content lands or generation starts.
+  useEffect(() => {
+    tailRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [pendingText, isGenerating, completedGenerations]);
+
+  if (!slotState) {
+    return (
+      <div className="pane-notice">
+        <span className="notice-text">LOADING SLOT STATE…</span>
+      </div>
+    );
+  }
+
+  if (slotState.is_wizard_mode) {
+    return (
+      <div className="pane-notice">
+        <span className="notice-text">[ SETUP INCOMPLETE ]</span>
+        <span className="notice-detail">
+          This slot is still in the New Story wizard. Finish setup to begin
+          reading.
+        </span>
+      </div>
+    );
+  }
+
+  if (slotState.is_empty) {
+    return (
+      <div className="pane-notice">
+        <span className="notice-text">[ EMPTY SLOT ]</span>
+        <span className="notice-detail">
+          No story lives here yet. Start a new story from the splash menu.
+        </span>
+      </div>
+    );
+  }
+
+  // Track speaker across chunk boundaries so the voice divider only appears
+  // on actual speaker changes.
+  let previousVoice: "st" | "you" | null = null;
+  const voiceDividerBefore = (voice: "st" | "you"): boolean => {
+    const changed = previousVoice !== null && previousVoice !== voice;
+    previousVoice = voice;
+    return changed;
+  };
+
+  const currentChunkId = hasPending
+    ? null // pending block below is current
+    : slotState.current_chunk_id;
+
+  return (
+    <article className="reader" data-testid="narrative-reader">
+      <div className="reader-frame">
+        <div className="reader-inner">
+          <header className="scene-head">
+            {sceneCoord && (
+              <span className="eyebrow brass-glow">[ SCENE {sceneCoord} ]</span>
+            )}
+            <h2 className="scene-title" data-testid="text-scene-location">
+              {settingPlace?.name ?? "UNCHARTED"}
+            </h2>
+            {presentCast.length > 0 && (
+              <div className="scene-meta">
+                <span className="caption">
+                  {presentCast.map((c) => c.name).join(" · ")}
+                </span>
+              </div>
+            )}
+            <DecoDivider variant="glyph" />
+          </header>
+
+          <section className="chunk-stream">
+            {chunks.map((chunk) => {
+              const isCurrent = chunk.id === currentChunkId;
+              const storyteller = chunk.storytellerText ?? chunk.rawText;
+              const response = chunk.choiceText;
+              return (
+                <div
+                  key={chunk.id}
+                  className={`chunk-block ${isCurrent ? "current" : ""}`}
+                  data-testid={`chunk-${chunk.id}`}
+                >
+                  <div className="prose-block">
+                    {storyteller && (
+                      <>
+                        {voiceDividerBefore("st") && <hr className="voice-divider" />}
+                        <p className="line st">{renderProse(storyteller)}</p>
+                      </>
+                    )}
+                    {response && (
+                      <>
+                        {voiceDividerBefore("you") && <hr className="voice-divider" />}
+                        <p className="line you">{renderProse(response)}</p>
+                      </>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+
+            {pendingText && (
+              <div className="chunk-block current" data-testid="chunk-pending">
+                <div className="prose-block">
+                  {voiceDividerBefore("st") && <hr className="voice-divider" />}
+                  <p className="line st">
+                    <TypewriterText
+                      key={completedGenerations}
+                      text={pendingText}
+                      msPerChar={typewriterMsPerChar}
+                      animate={completedGenerations > 0}
+                    />
+                  </p>
+                </div>
+              </div>
+            )}
+          </section>
+
+          {isGenerating && (
+            <div className="reader-status" data-testid="status-generating">
+              <span className="glyph">▸</span>
+              <span>SKALD · {phase?.replace(/_/g, " ") ?? "WORKING"}</span>
+            </div>
+          )}
+
+          {isBootstrapNeeded && !isGenerating && (
+            <section className="choices">
+              <button
+                className="choice"
+                onClick={() => void submitTurn({})}
+                data-testid="button-begin-story"
+              >
+                <span className="choice-glyph">◆</span>
+                <span className="choice-text">Begin the story.</span>
+              </button>
+            </section>
+          )}
+
+          {/* Freeform slot 0 stays available even when the storyteller
+              presented no numbered choices (matches the CLI continue flow). */}
+          {!isGenerating && !isBootstrapNeeded && (
+            <section className="choices" data-testid="story-choices">
+              {choices.map((text, i) => (
+                <button
+                  key={i}
+                  className="choice"
+                  onClick={() => handleChoice(i + 1)}
+                  disabled={!canSubmit}
+                  data-testid={`choice-${i + 1}`}
+                >
+                  <span className="choice-key">{i + 1}</span>
+                  <span className="choice-glyph">◆</span>
+                  <span className="choice-text">{text}</span>
+                </button>
+              ))}
+              <label className="choice freeform">
+                <Textarea
+                  ref={freeformRef}
+                  className="choice-input"
+                  rows={1}
+                  value={freeform}
+                  placeholder="…or something else"
+                  onChange={(e) => setFreeform(e.target.value)}
+                  onKeyDown={handleFreeformKeyDown}
+                  disabled={!canSubmit}
+                  data-testid="input-freeform"
+                />
+              </label>
+            </section>
+          )}
+
+          <div ref={tailRef} />
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/ui/client/src/components/nexus/NarrativePane.tsx
+++ b/ui/client/src/components/nexus/NarrativePane.tsx
@@ -103,6 +103,43 @@ export function NarrativePane({
     return `S${m.season ?? 0}·E${m.episode ?? 0}·S${m.scene ?? 0}`;
   }, [latestChunk?.metadata]);
 
+  const currentChunkId = hasPending
+    ? null // the pending block below is current
+    : slotState?.current_chunk_id ?? null;
+
+  // Pre-compute the prose segments per chunk. The voice divider appears only
+  // on actual speaker changes, tracked across chunk boundaries; doing this in
+  // a memo keeps render pure (no mutation during JSX evaluation).
+  const { chunkRenders, pendingDivider } = useMemo(() => {
+    let previousVoice: "st" | "you" | null = null;
+    const renders = chunks.map((chunk) => {
+      const parts: Array<{ voice: "st" | "you"; text: string; divider: boolean }> =
+        [];
+      const storyteller = chunk.storytellerText ?? chunk.rawText;
+      if (storyteller) {
+        parts.push({
+          voice: "st",
+          text: storyteller,
+          divider: previousVoice !== null && previousVoice !== "st",
+        });
+        previousVoice = "st";
+      }
+      if (chunk.choiceText) {
+        parts.push({
+          voice: "you",
+          text: chunk.choiceText,
+          divider: previousVoice !== null && previousVoice !== "you",
+        });
+        previousVoice = "you";
+      }
+      return { id: chunk.id, isCurrent: chunk.id === currentChunkId, parts };
+    });
+    return {
+      chunkRenders: renders,
+      pendingDivider: previousVoice !== null && previousVoice !== "st",
+    };
+  }, [chunks, currentChunkId]);
+
   const canSubmit = !isGenerating && !!slotState && !slotState.is_wizard_mode;
 
   const handleChoice = useCallback(
@@ -182,19 +219,6 @@ export function NarrativePane({
     );
   }
 
-  // Track speaker across chunk boundaries so the voice divider only appears
-  // on actual speaker changes.
-  let previousVoice: "st" | "you" | null = null;
-  const voiceDividerBefore = (voice: "st" | "you"): boolean => {
-    const changed = previousVoice !== null && previousVoice !== voice;
-    previousVoice = voice;
-    return changed;
-  };
-
-  const currentChunkId = hasPending
-    ? null // pending block below is current
-    : slotState.current_chunk_id;
-
   return (
     <article className="reader" data-testid="narrative-reader">
       <div className="reader-frame">
@@ -217,38 +241,29 @@ export function NarrativePane({
           </header>
 
           <section className="chunk-stream">
-            {chunks.map((chunk) => {
-              const isCurrent = chunk.id === currentChunkId;
-              const storyteller = chunk.storytellerText ?? chunk.rawText;
-              const response = chunk.choiceText;
-              return (
-                <div
-                  key={chunk.id}
-                  className={`chunk-block ${isCurrent ? "current" : ""}`}
-                  data-testid={`chunk-${chunk.id}`}
-                >
-                  <div className="prose-block">
-                    {storyteller && (
-                      <>
-                        {voiceDividerBefore("st") && <hr className="voice-divider" />}
-                        <p className="line st">{renderProse(storyteller)}</p>
-                      </>
-                    )}
-                    {response && (
-                      <>
-                        {voiceDividerBefore("you") && <hr className="voice-divider" />}
-                        <p className="line you">{renderProse(response)}</p>
-                      </>
-                    )}
-                  </div>
+            {chunkRenders.map((chunk) => (
+              <div
+                key={chunk.id}
+                className={`chunk-block ${chunk.isCurrent ? "current" : ""}`}
+                data-testid={`chunk-${chunk.id}`}
+              >
+                <div className="prose-block">
+                  {chunk.parts.map((part) => (
+                    <Fragment key={part.voice}>
+                      {part.divider && <hr className="voice-divider" />}
+                      <p className={`line ${part.voice}`}>
+                        {renderProse(part.text)}
+                      </p>
+                    </Fragment>
+                  ))}
                 </div>
-              );
-            })}
+              </div>
+            ))}
 
             {pendingText && (
               <div className="chunk-block current" data-testid="chunk-pending">
                 <div className="prose-block">
-                  {voiceDividerBefore("st") && <hr className="voice-divider" />}
+                  {pendingDivider && <hr className="voice-divider" />}
                   <p className="line st">
                     <TypewriterText
                       key={completedGenerations}
@@ -288,7 +303,7 @@ export function NarrativePane({
             <section className="choices" data-testid="story-choices">
               {choices.map((text, i) => (
                 <button
-                  key={i}
+                  key={`${i}-${text}`}
                   className="choice"
                   onClick={() => handleChoice(i + 1)}
                   disabled={!canSubmit}

--- a/ui/client/src/components/nexus/NexusLayout.tsx
+++ b/ui/client/src/components/nexus/NexusLayout.tsx
@@ -1,0 +1,133 @@
+/**
+ * NexusLayout - the long-lived "reading the story" surface.
+ *
+ * Composition (NEXUS IRIS design system):
+ * - 52px top operator strip (wordmark + slot label / SKALD status)
+ * - 60px left icon rail (Home, Narrative, Map, Characters, Settings)
+ * - main pane router
+ * - 320px right Session Ledger rail on the narrative tab only
+ *
+ * All data is live: Express read routes for committed narrative and cast,
+ * the FastAPI narrative service (proxied) for slot state, generation, and
+ * phase telemetry over /ws/narrative.
+ */
+import { useEffect, useState } from "react";
+import { useLocation } from "wouter";
+import { useQuery } from "@tanstack/react-query";
+import { useTheme } from "@/contexts/ThemeContext";
+import { useNarrativeEngine } from "@/hooks/useNarrativeEngine";
+import { getUserCharacter } from "@/lib/narrative-api";
+import { LeftRail, type NexusTab } from "./LeftRail";
+import { TopBar } from "./TopBar";
+import { NarrativePane } from "./NarrativePane";
+import { RightLedger } from "./RightLedger";
+import { CharactersPane } from "./CharactersPane";
+import { MapPane } from "./MapPane";
+import { SettingsPane } from "./SettingsPane";
+import "./nexus-layout.css";
+
+const TABS: NexusTab[] = ["narrative", "map", "characters", "settings"];
+const DEFAULT_TYPEWRITER_MS = 35;
+
+function initialTab(): NexusTab {
+  const requested = new URLSearchParams(window.location.search).get("tab");
+  return TABS.includes(requested as NexusTab)
+    ? (requested as NexusTab)
+    : "narrative";
+}
+
+function activeSlot(): number | null {
+  try {
+    const stored = localStorage.getItem("activeSlot");
+    if (!stored) return null;
+    const slot = parseInt(stored, 10);
+    return isNaN(slot) ? null : slot;
+  } catch {
+    return null;
+  }
+}
+
+interface SettingsPayload {
+  ui?: { typewriter_ms_per_char?: number };
+}
+
+export function NexusLayout() {
+  const [, setLocation] = useLocation();
+  const { isVector } = useTheme();
+  const [tab, setTab] = useState<NexusTab>(initialTab);
+  const [slot] = useState<number | null>(activeSlot);
+
+  const engine = useNarrativeEngine(slot);
+
+  const { data: userCharacter } = useQuery<{ name: string } | null>({
+    queryKey: ["/api/user-character", slot],
+    queryFn: () => getUserCharacter(slot as number),
+    enabled: slot !== null,
+  });
+
+  const { data: settings } = useQuery<SettingsPayload>({
+    queryKey: ["/api/settings"],
+  });
+  const typewriterMsPerChar =
+    settings?.ui?.typewriter_ms_per_char ?? DEFAULT_TYPEWRITER_MS;
+
+  // Keep ?tab= in the URL so deep links and refreshes restore the pane.
+  useEffect(() => {
+    const url = tab === "narrative" ? "/nexus" : `/nexus?tab=${tab}`;
+    window.history.replaceState(null, "", url);
+  }, [tab]);
+
+  const showLedger = tab === "narrative" && slot !== null;
+
+  return (
+    <div
+      className={`nexus-shell animate-fade-in ${isVector ? "terminal-scanlines" : ""}`}
+      data-testid="nexus-layout"
+    >
+      <TopBar
+        slot={slot}
+        characterName={userCharacter?.name ?? null}
+        skaldStatus={engine.skaldStatus}
+      />
+      <div className={`nexus-main ${showLedger ? "" : "no-ledger"}`}>
+        <LeftRail tab={tab} onTabChange={setTab} onHome={() => setLocation("/")} />
+        <main className="nexus-content">
+          {tab === "narrative" &&
+            (slot === null ? (
+              <div className="pane-notice">
+                <span className="notice-text">[ NO ACTIVE SLOT ]</span>
+                <span className="notice-detail">
+                  Choose Continue or start a New Story from the splash menu to
+                  bind a save slot.
+                </span>
+              </div>
+            ) : engine.slotStateError ? (
+              <div className="pane-notice">
+                <span className="notice-text">[ SLOT STATE UNAVAILABLE ]</span>
+                <span className="notice-detail">
+                  {engine.slotStateError.message}
+                </span>
+              </div>
+            ) : (
+              <NarrativePane
+                slot={slot}
+                engine={engine}
+                typewriterMsPerChar={typewriterMsPerChar}
+              />
+            ))}
+          {tab === "map" && <MapPane />}
+          {tab === "characters" &&
+            (slot === null ? (
+              <div className="pane-notice">
+                <span className="notice-text">[ NO ACTIVE SLOT ]</span>
+              </div>
+            ) : (
+              <CharactersPane slot={slot} />
+            ))}
+          {tab === "settings" && <SettingsPane />}
+        </main>
+        {showLedger && <RightLedger slot={slot as number} engine={engine} />}
+      </div>
+    </div>
+  );
+}

--- a/ui/client/src/components/nexus/NexusLayout.tsx
+++ b/ui/client/src/components/nexus/NexusLayout.tsx
@@ -17,6 +17,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useTheme } from "@/contexts/ThemeContext";
 import { useNarrativeEngine } from "@/hooks/useNarrativeEngine";
 import { getUserCharacter } from "@/lib/narrative-api";
+import type { SettingsPayload } from "@/types/settings";
 import { LeftRail, type NexusTab } from "./LeftRail";
 import { TopBar } from "./TopBar";
 import { NarrativePane } from "./NarrativePane";
@@ -27,6 +28,8 @@ import { SettingsPane } from "./SettingsPane";
 import "./nexus-layout.css";
 
 const TABS: NexusTab[] = ["narrative", "map", "characters", "settings"];
+// Fallback used only until GET /api/settings resolves. Must stay in sync
+// with `[ui] typewriter_ms_per_char` in nexus.toml (UISettings default).
 const DEFAULT_TYPEWRITER_MS = 35;
 
 function initialTab(): NexusTab {
@@ -45,10 +48,6 @@ function activeSlot(): number | null {
   } catch {
     return null;
   }
-}
-
-interface SettingsPayload {
-  ui?: { typewriter_ms_per_char?: number };
 }
 
 export function NexusLayout() {

--- a/ui/client/src/components/nexus/RightLedger.tsx
+++ b/ui/client/src/components/nexus/RightLedger.tsx
@@ -1,0 +1,223 @@
+/**
+ * RightLedger - the 320px Session Ledger rail (narrative tab only).
+ *
+ * Surfaces the generation phase stream + elapsed clock, the scene cast
+ * (live chunk_character_references), and the narrative hierarchy
+ * (seasons -> episodes -> chunks) in one place.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { DecoDivider } from "@/components/deco";
+import {
+  getChunkContext,
+  getEpisodeChunks,
+  getLatestChunk,
+  getSeasons,
+} from "@/lib/narrative-api";
+import type { NarrativeEngine } from "@/hooks/useNarrativeEngine";
+import type { ChunkContext, ChunkWithMetadata, NarrativePhase } from "@/types/narrative";
+import type { Season } from "@shared/schema";
+
+const PHASES: Array<{ key: NarrativePhase; label: string }> = [
+  { key: "initiated", label: "Request received…" },
+  { key: "loading_chunk", label: "Loading parent chunk…" },
+  { key: "building_context", label: "Assembling context package…" },
+  { key: "calling_llm", label: "Calling LORE / LOGON…" },
+  { key: "processing_response", label: "Processing response…" },
+  { key: "complete", label: "Awaiting approval" },
+];
+
+interface RightLedgerProps {
+  slot: number;
+  engine: NarrativeEngine;
+}
+
+export function RightLedger({ slot, engine }: RightLedgerProps) {
+  const { phase, elapsedMs, isGenerating, slotState } = engine;
+
+  const { data: latestChunk } = useQuery<ChunkWithMetadata | null>({
+    queryKey: ["/api/narrative/latest-chunk", slot],
+    queryFn: () => getLatestChunk(slot),
+  });
+
+  const { data: chunkContext } = useQuery<ChunkContext>({
+    queryKey: ["/api/narrative/chunks/context", latestChunk?.id, slot],
+    queryFn: () => getChunkContext(latestChunk!.id, slot),
+    enabled: !!latestChunk?.id,
+  });
+
+  const { data: seasons } = useQuery<Season[]>({
+    queryKey: ["/api/narrative/seasons", slot],
+    queryFn: () => getSeasons(slot),
+  });
+
+  const season = latestChunk?.metadata?.season ?? null;
+  const episode = latestChunk?.metadata?.episode ?? null;
+
+  const { data: episodeChunks } = useQuery<{
+    chunks: ChunkWithMetadata[];
+    total: number;
+  }>({
+    queryKey: ["/api/narrative/chunks", season, episode, slot],
+    queryFn: () => getEpisodeChunks(season as number, episode as number, slot),
+    enabled: season !== null && episode !== null,
+  });
+
+  // Phase index: -1 when idle (all rows dim); the "complete" row lights
+  // while the engine holds the RECEIVING beat.
+  const phaseIdx = phase ? PHASES.findIndex((p) => p.key === phase) : -1;
+  const stripPct =
+    phaseIdx >= 0 ? ((phaseIdx + 1) / PHASES.length) * 100 : 0;
+
+  const cast = chunkContext?.characters ?? [];
+  const currentChunkId = slotState?.has_pending
+    ? null
+    : slotState?.current_chunk_id ?? null;
+
+  // Early stories may have chunk metadata before the seasons table is
+  // populated (e.g. a season-0 prologue) - synthesize the current season
+  // node so the hierarchy still renders.
+  const seasonNodes: Array<{ id: number }> =
+    seasons && seasons.length > 0
+      ? seasons
+      : season !== null
+        ? [{ id: season }]
+        : [];
+
+  return (
+    <aside className="rail-right" data-testid="session-ledger">
+      {/* SESSION TELEMETRY */}
+      <section className="ledger-section">
+        <div className="ledger-head">
+          <span className="eyebrow brass-glow">SESSION TELEMETRY</span>
+          <span className="caption dim">
+            {isGenerating ? "SKALD · LIVE" : "SKALD · IDLE"}
+          </span>
+        </div>
+        <div className="phase-stream" data-testid="phase-stream">
+          {PHASES.map((p, i) => (
+            <div
+              key={p.key}
+              className={`phase-row ${phaseIdx >= 0 && i < phaseIdx ? "done" : ""} ${
+                i === phaseIdx ? "active" : ""
+              }`}
+            >
+              <span className="phase-glyph">
+                {phaseIdx >= 0 && i < phaseIdx ? "✓" : i === phaseIdx ? "▸" : "·"}
+              </span>
+              <span className="phase-label">{p.label}</span>
+            </div>
+          ))}
+        </div>
+        {isGenerating && (
+          <>
+            <div className="phase-strip">
+              <div className="phase-strip-bar" style={{ width: `${stripPct}%` }} />
+            </div>
+            <div className="phase-stat">
+              <span className="caption">ELAPSED</span>
+              <span className="phase-clock" data-testid="text-elapsed">
+                {(elapsedMs / 1000).toFixed(1)}s
+              </span>
+            </div>
+          </>
+        )}
+      </section>
+
+      <DecoDivider variant="glyph" />
+
+      {/* SCENE CAST */}
+      <section className="ledger-section">
+        <div className="ledger-head">
+          <span className="eyebrow brass-glow">SCENE CAST</span>
+          <span className="caption dim">
+            {cast.filter((c) => c.reference === "present").length}
+          </span>
+        </div>
+        <ul className="cast-list" data-testid="cast-list">
+          {cast.length === 0 && (
+            <li className="cast-row off">
+              <span className="cast-glyph dim">·</span>
+              <span className="cast-role">no references recorded</span>
+            </li>
+          )}
+          {cast.map((member) => (
+            <li
+              key={member.id}
+              className={`cast-row ${member.reference === "mentioned" ? "off" : ""}`}
+            >
+              <span className={`cast-glyph ${member.reference === "mentioned" ? "dim" : ""}`}>
+                {member.name.charAt(0).toUpperCase()}
+              </span>
+              <span className="cast-name">{member.name}</span>
+              <span className="cast-role">· {member.reference}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <DecoDivider variant="glyph" />
+
+      {/* NARRATIVE HIERARCHY */}
+      <section className="ledger-section">
+        <div className="ledger-head">
+          <span className="eyebrow brass-glow">HIERARCHY</span>
+          {season !== null && episode !== null && (
+            <span className="caption dim">
+              S{season}·E{episode}
+            </span>
+          )}
+        </div>
+        <ul className="hier-list" data-testid="hierarchy">
+          {seasonNodes.map((s) => {
+            const isOpen = s.id === season;
+            return (
+              <li key={s.id} className={`hier-season ${isOpen ? "open" : ""}`}>
+                <div className="hier-row">
+                  {isOpen ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
+                  <span className="hier-label">SEASON {s.id}</span>
+                </div>
+                {isOpen && episode !== null && (
+                  <ul>
+                    <li className="hier-ep open">
+                      <div className="hier-row">
+                        <ChevronDown size={10} />
+                        <span className="hier-label">Episode {episode}</span>
+                      </div>
+                      <ul>
+                        {(episodeChunks?.chunks ?? []).map((chunk) => {
+                          const m = chunk.metadata;
+                          return (
+                            <li
+                              key={chunk.id}
+                              className={`hier-chunk ${
+                                chunk.id === currentChunkId ? "current" : ""
+                              }`}
+                            >
+                              <span className="hier-coord">
+                                S{m?.season ?? 0}·E{m?.episode ?? 0}·S{m?.scene ?? 0}
+                              </span>
+                              <span className="hier-slug">
+                                {m?.slug ?? `chunk ${chunk.id}`}
+                              </span>
+                            </li>
+                          );
+                        })}
+                        {slotState?.has_pending && (
+                          <li className="hier-chunk current">
+                            <span className="hier-coord">PENDING</span>
+                            <span className="hier-slug">awaiting response</span>
+                          </li>
+                        )}
+                      </ul>
+                    </li>
+                  </ul>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+    </aside>
+  );
+}

--- a/ui/client/src/components/nexus/SettingsPane.tsx
+++ b/ui/client/src/components/nexus/SettingsPane.tsx
@@ -1,0 +1,120 @@
+/**
+ * SettingsPane - kit-fidelity placeholder (full settings wiring is U5).
+ *
+ * The theme picker is live (ThemeContext persists to localStorage today);
+ * the remaining rows are read-only values from GET /api/settings so the
+ * operator can verify configuration at a glance.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { useTheme, type Theme } from "@/contexts/ThemeContext";
+
+/** Palette swatches from the NEXUS IRIS theme matrix (display-only). */
+const THEME_CARDS: Array<{
+  id: Theme;
+  name: string;
+  motto: string;
+  swatches: string[];
+}> = [
+  {
+    id: "veil",
+    name: "Veil",
+    motto: "Magenta rain on blue-black",
+    swatches: ["#09101c", "#b83d7a", "#e86a4a", "#e1cd97"],
+  },
+  {
+    id: "gilded",
+    name: "Gilded",
+    motto: "Brass engraved on midnight",
+    swatches: ["#0a0a0a", "#c9a227", "#7b5524", "#ece2c1"],
+  },
+  {
+    id: "vector",
+    name: "Vector",
+    motto: "Scanline void · on the wire",
+    swatches: ["#031414", "#00e5ff", "#3aa1ff", "#a3f0ff"],
+  },
+];
+
+interface SettingsPayload {
+  ["Agent Settings"]?: {
+    global?: {
+      model?: { default_model?: string };
+      narrative?: { test_mode?: boolean };
+    };
+  };
+  ui?: { typewriter_ms_per_char?: number };
+}
+
+export function SettingsPane() {
+  const { theme, setTheme } = useTheme();
+
+  const { data: settings } = useQuery<SettingsPayload>({
+    queryKey: ["/api/settings"],
+  });
+
+  const defaultModel =
+    settings?.["Agent Settings"]?.global?.model?.default_model ?? "—";
+  const testMode = settings?.["Agent Settings"]?.global?.narrative?.test_mode;
+  const typeSpeed = settings?.ui?.typewriter_ms_per_char;
+
+  return (
+    <div className="settings-pane" data-testid="settings-pane">
+      <div className="settings-card">
+        <div className="settings-inner">
+          <span className="eyebrow brass-glow">[ APPEARANCE ]</span>
+          <h2 className="settings-title">Theme</h2>
+          <div className="theme-cards">
+            {THEME_CARDS.map((card) => (
+              <button
+                key={card.id}
+                className={`theme-card ${theme === card.id ? "on" : ""}`}
+                onClick={() => setTheme(card.id)}
+                data-testid={`theme-${card.id}`}
+              >
+                <span className="theme-name">
+                  {card.name}
+                  {theme === card.id ? " ✓" : ""}
+                </span>
+                <span className="theme-motto">{card.motto}</span>
+                <span className="theme-swatches">
+                  {card.swatches.map((color) => (
+                    <span key={color} style={{ background: color }} />
+                  ))}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="settings-card">
+        <div className="settings-inner">
+          <span className="eyebrow brass-glow">[ CONFIGURATION ]</span>
+          <h2 className="settings-title">Readout</h2>
+          <div className="set-row">
+            <span className="set-label">Default Model</span>
+            <span className="set-val" data-testid="text-setting-model">
+              {defaultModel}
+            </span>
+          </div>
+          <div className="set-row">
+            <span className="set-label">Test Mode</span>
+            <span className="set-val">
+              {testMode === undefined ? "—" : testMode ? "ENABLED" : "OFF"}
+            </span>
+          </div>
+          <div className="set-row">
+            <span className="set-label">Typewriter Speed</span>
+            <span className="set-val">
+              {typeSpeed !== undefined ? `${typeSpeed} ms/char` : "—"}
+            </span>
+          </div>
+          <div className="set-row">
+            <span className="set-label">Calibration Console</span>
+            <span className="set-val">ARRIVING · U5</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/client/src/components/nexus/SettingsPane.tsx
+++ b/ui/client/src/components/nexus/SettingsPane.tsx
@@ -7,6 +7,7 @@
  */
 import { useQuery } from "@tanstack/react-query";
 import { useTheme, type Theme } from "@/contexts/ThemeContext";
+import type { SettingsPayload } from "@/types/settings";
 
 /** Palette swatches from the NEXUS IRIS theme matrix (display-only). */
 const THEME_CARDS: Array<{
@@ -34,16 +35,6 @@ const THEME_CARDS: Array<{
     swatches: ["#031414", "#00e5ff", "#3aa1ff", "#a3f0ff"],
   },
 ];
-
-interface SettingsPayload {
-  ["Agent Settings"]?: {
-    global?: {
-      model?: { default_model?: string };
-      narrative?: { test_mode?: boolean };
-    };
-  };
-  ui?: { typewriter_ms_per_char?: number };
-}
 
 export function SettingsPane() {
   const { theme, setTheme } = useTheme();

--- a/ui/client/src/components/nexus/TopBar.tsx
+++ b/ui/client/src/components/nexus/TopBar.tsx
@@ -1,0 +1,46 @@
+/**
+ * TopBar - the 52px operator strip across the top of the NexusLayout.
+ *
+ * Left: NEXUS wordmark (the single marquee-font element on this surface)
+ * plus the slot label. Right: SKALD status field. Per the locked design
+ * decisions there is no scene cartouche and no MODEL field.
+ */
+import type { SkaldStatus } from "@/types/narrative";
+
+interface TopBarProps {
+  slot: number | null;
+  characterName: string | null;
+  skaldStatus: SkaldStatus;
+}
+
+export function TopBar({ slot, characterName, skaldStatus }: TopBarProps) {
+  return (
+    <header className="topbar" data-testid="nexus-topbar">
+      <div className="topbar-left">
+        <span className="wordmark">NEXUS</span>
+        <span className="brass-pip" aria-hidden="true" />
+        <span className="slot-label" data-testid="text-slot-label">
+          SLOT <b>{slot ?? "—"}</b>
+          {characterName && (
+            <>
+              {" · "}
+              <em>{characterName}</em>
+            </>
+          )}
+        </span>
+      </div>
+
+      <div className="topbar-right">
+        <span className="field">
+          <span className="k">SKALD</span>
+          <span
+            className={`v ${skaldStatus.toLowerCase()}`}
+            data-testid="text-skald-status"
+          >
+            {skaldStatus}
+          </span>
+        </span>
+      </div>
+    </header>
+  );
+}

--- a/ui/client/src/components/nexus/TypewriterText.tsx
+++ b/ui/client/src/components/nexus/TypewriterText.tsx
@@ -1,0 +1,60 @@
+/**
+ * TypewriterText - character-by-character reveal for incoming narrative.
+ *
+ * The signature interaction of the NEXUS IRIS design system: 30-50 ms/char
+ * (configurable via `[ui] typewriter_ms_per_char` in nexus.toml, surfaced
+ * through GET /api/settings). Chunks loaded from history render instantly;
+ * only freshly generated text animates (the parent decides via `animate`).
+ */
+import { useEffect, useRef, useState } from "react";
+
+interface TypewriterTextProps {
+  text: string;
+  /** Milliseconds per character. */
+  msPerChar: number;
+  /** When false, render the full text immediately. */
+  animate: boolean;
+  className?: string;
+  onDone?: () => void;
+}
+
+export function TypewriterText({
+  text,
+  msPerChar,
+  animate,
+  className,
+  onDone,
+}: TypewriterTextProps) {
+  const [visibleChars, setVisibleChars] = useState(animate ? 0 : text.length);
+  const onDoneRef = useRef(onDone);
+  onDoneRef.current = onDone;
+
+  useEffect(() => {
+    if (!animate) {
+      setVisibleChars(text.length);
+      return;
+    }
+
+    setVisibleChars(0);
+    let index = 0;
+    const interval = window.setInterval(() => {
+      index += 1;
+      setVisibleChars(index);
+      if (index >= text.length) {
+        window.clearInterval(interval);
+        onDoneRef.current?.();
+      }
+    }, msPerChar);
+
+    return () => window.clearInterval(interval);
+  }, [text, animate, msPerChar]);
+
+  const revealing = animate && visibleChars < text.length;
+
+  return (
+    <span className={className}>
+      {text.slice(0, visibleChars)}
+      {revealing && <span className="type-caret" aria-hidden="true" />}
+    </span>
+  );
+}

--- a/ui/client/src/components/nexus/index.ts
+++ b/ui/client/src/components/nexus/index.ts
@@ -1,0 +1,9 @@
+export { NexusLayout } from "./NexusLayout";
+export { TopBar } from "./TopBar";
+export { LeftRail, type NexusTab } from "./LeftRail";
+export { NarrativePane } from "./NarrativePane";
+export { RightLedger } from "./RightLedger";
+export { CharactersPane } from "./CharactersPane";
+export { MapPane } from "./MapPane";
+export { SettingsPane } from "./SettingsPane";
+export { TypewriterText } from "./TypewriterText";

--- a/ui/client/src/components/nexus/nexus-layout.css
+++ b/ui/client/src/components/nexus/nexus-layout.css
@@ -1,0 +1,1063 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   NEXUS LAYOUT — the long-lived "reading the story" surface.
+
+   Recreated from design_handoff/project/ui_kits/nexus_iris/ (styles.css +
+   nexus_layout.jsx) against the vendored brand tokens in index.css. Every
+   color is a token — no invented hues. Locked decisions applied:
+   - No CommandBar; freeform directive is slot 0 inside the choices block.
+   - Top bar: wordmark + slot label left, SKALD status right. No scene
+     cartouche, no MODEL field.
+   - Voice differentiation by color only (st = --fg, you = --fg-muted) with
+     a thin centered hr between speaker changes. No >/>> prefixes.
+   - Current chunk: 3px magenta left edge-marker + faint fill + glow.
+     Non-current chunks read at 0.78 opacity. No status pills.
+   - Plain 1px deep-violet borders on panes. No concave arcs, no corner pips.
+   The marquee font appears exactly once: the top-bar wordmark.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+@keyframes nexus-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: .55; }
+}
+@keyframes nexus-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+@keyframes nexus-fadein {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: none; }
+}
+
+.nexus-shell {
+  display: grid;
+  grid-template-rows: 52px 1fr;
+  height: 100vh;
+  width: 100%;
+  background:
+    radial-gradient(900px 380px at 50% 100%, hsl(320 55% 40% / .12), transparent 60%),
+    radial-gradient(1200px 600px at 10% 0%, hsl(15 75% 50% / .04), transparent 70%),
+    var(--bg);
+  overflow: hidden;
+}
+
+/* ─── Generic type (scoped to the shell) ─── */
+.nexus-shell .eyebrow {
+  font-family: var(--font-menu);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--brass);
+  font-weight: 600;
+}
+.nexus-shell .brass-glow { text-shadow: var(--glow-soft); }
+.nexus-shell .caption {
+  font-family: var(--font-menu);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.nexus-shell .caption.dim { opacity: .6; }
+.nexus-shell .btn-soft {
+  background: transparent;
+  border: none;
+  color: var(--fg-muted);
+  padding: 6px 10px;
+  font-family: var(--font-menu);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+.nexus-shell .btn-soft:hover:not(:disabled) {
+  color: var(--brass);
+  text-shadow: var(--glow-soft);
+}
+.nexus-shell .btn-soft:disabled { opacity: .35; cursor: not-allowed; }
+
+/* ─── Top status bar — operator strip ─── */
+.topbar {
+  position: relative;
+  background: var(--bg-elev-1);
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: center;
+  padding: 0 22px;
+  gap: 14px;
+  overflow: hidden;
+}
+.topbar-left,
+.topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  z-index: 1;
+}
+.topbar-right { justify-content: flex-end; }
+/* ONLY .topbar-left .wordmark uses the marquee font. */
+.topbar-left .wordmark {
+  font-family: var(--font-display);
+  font-size: 27px;
+  letter-spacing: 0.18em;
+  color: var(--brass);
+  text-shadow: var(--glow-soft);
+  line-height: 1;
+}
+.brass-pip {
+  width: 8px;
+  height: 8px;
+  background: var(--brass);
+  transform: rotate(45deg);
+  box-shadow: var(--glow-soft);
+  flex-shrink: 0;
+}
+.slot-label {
+  font-family: var(--font-menu);
+  font-size: 10px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  white-space: nowrap;
+}
+.slot-label b {
+  color: var(--brass);
+  text-shadow: var(--glow-soft);
+  font-weight: 600;
+  font-family: var(--font-menu);
+}
+.slot-label em {
+  color: var(--fg);
+  font-style: normal;
+  font-family: var(--font-menu);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  font-weight: 600;
+  margin-left: 2px;
+  text-transform: uppercase;
+}
+.topbar .field {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.topbar .field .k {
+  font-family: var(--font-menu);
+  font-size: 9px;
+  letter-spacing: 0.26em;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+}
+.topbar .field .v {
+  font-family: var(--font-menu);
+  font-size: 13px;
+  letter-spacing: 0.12em;
+  color: var(--brass-bright);
+  text-shadow: var(--glow-soft);
+  text-transform: uppercase;
+  font-weight: 600;
+}
+.topbar .field .v.generating {
+  animation: nexus-pulse 1.8s ease-in-out infinite;
+}
+.topbar .field .v.transmitting,
+.topbar .field .v.receiving {
+  color: var(--bronze);
+}
+.topbar .field .v.offline {
+  color: var(--fg-muted);
+  text-shadow: none;
+}
+
+/* ─── Main grid ─── */
+.nexus-main {
+  display: grid;
+  grid-template-columns: 60px 1fr 320px;
+  min-height: 0;
+  overflow: hidden;
+}
+.nexus-main.no-ledger { grid-template-columns: 60px 1fr; }
+
+/* ─── Left icon rail ─── */
+.rail-left {
+  background: var(--bg-elev-1);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  padding: 12px 0;
+  gap: 4px;
+  align-items: center;
+}
+.rail-btn {
+  position: relative;
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--fg-muted);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.rail-btn:hover {
+  color: var(--brass-bright);
+  border-color: var(--border);
+}
+.rail-btn.on {
+  color: var(--brass-bright);
+  border-color: var(--brass);
+  background: hsl(320 55% 50% / .12);
+  text-shadow: var(--glow-soft);
+}
+/* Active tab: 3 x 22 px magenta marker bar + glow. */
+.rail-btn.on::before {
+  content: "";
+  position: absolute;
+  left: -12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 22px;
+  background: var(--brass);
+  box-shadow: var(--glow-soft);
+}
+.rail-btn .rail-tip {
+  position: absolute;
+  left: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--bg-elev-3);
+  border: 1px solid var(--border-strong);
+  color: var(--fg);
+  font-family: var(--font-menu);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  padding: 5px 9px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .15s;
+  z-index: 20;
+  text-transform: uppercase;
+}
+.rail-btn:hover .rail-tip { opacity: 1; }
+.rail-divider {
+  width: 22px;
+  height: 1px;
+  background: var(--border);
+  margin: 6px 0;
+}
+.rail-spacer { flex: 1; }
+/* Rail monogram — menu font, not the marquee. */
+.rail-monogram {
+  font-family: var(--font-menu);
+  font-size: 11px;
+  color: var(--fg-dim);
+  letter-spacing: 0.3em;
+  opacity: .55;
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+
+/* ─── Main content ─── */
+.nexus-content {
+  min-width: 0;
+  overflow-y: auto;
+  position: relative;
+  padding: 28px;
+  background:
+    radial-gradient(1200px 600px at 50% -10%, hsl(320 55% 40% / .07), transparent 60%),
+    var(--bg);
+}
+
+/* ═══ READER ═══ */
+.reader {
+  max-width: 920px;
+  margin: 0 auto;
+}
+.reader-frame {
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 8px 30px -8px hsl(320 45% 8% / .55);
+}
+.reader-inner { padding: 38px 60px 36px; }
+.scene-head { text-align: center; }
+.scene-head .eyebrow {
+  display: block;
+  margin-bottom: 10px;
+}
+/* Scene title is the menu font — never the marquee. */
+.scene-title {
+  font-family: var(--font-menu);
+  font-size: 38px;
+  letter-spacing: 0.18em;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--brass-bright);
+  text-shadow: var(--glow-soft);
+  margin: 0 0 12px;
+  line-height: 1.05;
+}
+.scene-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.scene-meta .dot { color: var(--bronze); opacity: .6; }
+
+/* ─── Chunk blocks ─── */
+.chunk-stream {
+  margin-top: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.chunk-block {
+  position: relative;
+  border-left: 3px solid transparent;
+  padding: 4px 24px 4px 29px;
+  opacity: 0.78;
+  transition: opacity .25s ease-in-out;
+}
+.chunk-block.current {
+  opacity: 1;
+  border-left-color: var(--brass);
+  background: hsl(320 55% 50% / .04);
+  box-shadow: -6px 0 18px -8px hsl(320 55% 50% / .35);
+}
+.prose-block {
+  max-width: 65ch;
+  margin: 0 auto;
+}
+.prose-block .line {
+  font-family: var(--font-body);
+  font-size: 18px;
+  line-height: 1.78;
+  margin: 0 0 20px;
+  text-wrap: pretty;
+  font-style: normal;
+  white-space: pre-wrap;
+}
+/* Voice colors — uniform per speaker; no italics, no prefix glyphs. */
+.prose-block .line.st { color: var(--fg); }
+.prose-block .line.you { color: var(--fg-muted); }
+
+/* Voice divider: thin centered rule on speaker change. */
+.voice-divider {
+  border: none;
+  height: 1px;
+  margin: 24px auto;
+  width: 40%;
+  background: linear-gradient(to right, transparent, var(--border-strong), transparent);
+}
+
+/* Typewriter caret while a chunk is revealing. */
+.type-caret {
+  display: inline-block;
+  width: 0.55em;
+  margin-left: 1px;
+  border-bottom: 2px solid var(--brass);
+  animation: nexus-pulse 0.9s ease-in-out infinite;
+}
+
+/* ─── Choices block ─── */
+.choices {
+  margin: 36px auto 0;
+  max-width: 65ch;
+}
+.choices-eyebrow {
+  display: block;
+  margin-bottom: 14px;
+  font-family: var(--font-menu);
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--brass);
+  text-align: center;
+  font-weight: 600;
+}
+.choice {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  padding: 14px 18px;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  font-family: var(--font-body);
+  font-size: 17px;
+  line-height: 1.4;
+  text-align: left;
+  border-radius: var(--radius-sm);
+  margin-bottom: 10px;
+  cursor: pointer;
+  transition: border-color .15s, color .15s, background .15s, box-shadow .15s;
+}
+.choice:hover:not(:disabled) {
+  border-color: var(--brass);
+  color: var(--brass-bright);
+  background: hsl(320 55% 50% / .05);
+  box-shadow: 0 0 14px hsl(320 55% 50% / .2);
+}
+.choice:disabled { opacity: .5; cursor: not-allowed; }
+.choice-key {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--brass);
+  color: var(--brass-bright);
+  background: var(--bg);
+  font-family: var(--font-menu);
+  font-size: 12px;
+  letter-spacing: 0.05em;
+  border-radius: var(--radius-sm);
+  text-shadow: var(--glow-soft);
+  font-weight: 600;
+}
+.choice-glyph {
+  color: var(--brass);
+  opacity: .55;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.choice-text { flex: 1; }
+
+/* Freeform slot 0: no key box, user-voice color, italic, indented to align
+   with the numbered choice text (56px). Focus glow but no chosen-highlight. */
+.choice.freeform {
+  padding: 0 18px 0 56px;
+  cursor: text;
+  min-height: 56px;
+  display: flex;
+  align-items: center;
+}
+.choice-input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  box-shadow: none;
+  resize: none;
+  color: var(--fg-muted);
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 17px;
+  line-height: 1.5;
+  padding: 16px 0;
+  min-height: 0;
+  border-radius: 0;
+  caret-color: var(--brass);
+}
+.choice-input:focus,
+.choice-input:focus-visible {
+  outline: none;
+  box-shadow: none;
+  border: none;
+}
+.choice-input::placeholder {
+  color: var(--fg-dim);
+  opacity: .85;
+  font-style: italic;
+}
+.choice.freeform:hover .choice-input::placeholder {
+  color: var(--brass-bright);
+  opacity: 1;
+}
+.choice.freeform:focus-within {
+  border-color: var(--brass);
+  box-shadow: 0 0 18px hsl(320 55% 50% / .25);
+}
+
+/* Pending-generation note inside the reader. */
+.reader-status {
+  margin: 28px auto 0;
+  max-width: 65ch;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-family: var(--font-menu);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.reader-status .glyph {
+  color: var(--brass);
+  animation: nexus-pulse 1.2s infinite;
+}
+
+/* ═══ RIGHT LEDGER ═══ */
+.rail-right {
+  background: var(--bg-elev-1);
+  border-left: 1px solid var(--border);
+  overflow-y: auto;
+  padding: 22px 18px 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.ledger-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.ledger-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+/* Phase stream */
+.phase-stream {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 13px 14px;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+.phase-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-family: var(--font-menu);
+  font-size: 11px;
+  color: var(--fg-dim);
+  letter-spacing: 0.05em;
+  transition: color .2s;
+}
+.phase-row .phase-glyph {
+  width: 12px;
+  text-align: center;
+  color: var(--bronze-dark);
+  font-family: var(--font-menu);
+}
+.phase-row.done { color: var(--fg-muted); }
+.phase-row.done .phase-glyph { color: var(--bronze); }
+.phase-row.active {
+  color: var(--brass-bright);
+  text-shadow: var(--glow-soft);
+}
+.phase-row.active .phase-glyph {
+  color: var(--brass);
+  animation: nexus-pulse 1.2s infinite;
+}
+.phase-strip {
+  height: 4px;
+  background: hsl(270 30% 14%);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.phase-strip-bar {
+  height: 100%;
+  background: linear-gradient(90deg, var(--brass), var(--brass-bright), var(--bronze));
+  background-size: 200% 100%;
+  animation: nexus-shimmer 2.4s linear infinite;
+  box-shadow: var(--glow-soft);
+  transition: width .4s ease-out;
+}
+.phase-stat {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.phase-clock {
+  font-family: var(--font-menu);
+  font-size: 16px;
+  color: var(--brass-bright);
+  letter-spacing: 0.1em;
+  text-shadow: var(--glow-soft);
+  font-weight: 600;
+}
+
+/* Scene cast */
+.cast-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.cast-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 7px 8px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  overflow: hidden;
+}
+.cast-row:hover {
+  border-color: var(--border);
+  background: hsl(270 30% 14% / .5);
+}
+.cast-row.off { opacity: .65; }
+/* Single-letter avatar — menu font, not the marquee. */
+.cast-glyph {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  font-family: var(--font-menu);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--brass);
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+.cast-glyph.dim { color: var(--fg-dim); }
+.cast-name {
+  font-family: var(--font-menu);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  color: var(--fg);
+  text-transform: uppercase;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cast-role {
+  font-family: var(--font-body);
+  font-size: 14px;
+  color: var(--fg-muted);
+  font-style: italic;
+}
+
+/* Hierarchy */
+.hier-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.hier-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.hier-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px;
+  font-family: var(--font-menu);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.hier-season > .hier-row {
+  color: var(--brass);
+  font-weight: 600;
+}
+.hier-season.open > .hier-row { text-shadow: var(--glow-soft); }
+.hier-ep { padding-left: 14px; }
+.hier-ep > .hier-row { color: var(--fg); }
+.hier-ep > ul {
+  margin: 4px 0 8px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.hier-chunk {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding: 4px 4px 4px 10px;
+  font-family: var(--font-menu);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--fg-muted);
+  border-left: 2px solid transparent;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.hier-chunk .hier-coord {
+  color: var(--bronze);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+.hier-chunk .hier-slug {
+  color: var(--fg);
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.hier-chunk.current {
+  border-left-color: var(--brass);
+  background: hsl(320 55% 50% / .1);
+}
+.hier-chunk.current .hier-coord {
+  color: var(--brass-bright);
+  text-shadow: var(--glow-soft);
+}
+.hier-chunk.current .hier-slug { color: var(--brass-bright); }
+
+/* ═══ CHARACTERS PANE ═══ */
+.charspane {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 18px;
+  height: 100%;
+  min-height: 0;
+}
+.charspane-list { padding: 8px 0; overflow-y: auto; }
+.charspane-list > .eyebrow {
+  display: block;
+  margin-bottom: 12px;
+}
+.charspane-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.charspane-list li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 11px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.charspane-list li:hover {
+  border-color: var(--border);
+  background: hsl(270 30% 14% / .5);
+}
+.charspane-list li.on {
+  border-color: var(--brass);
+  background: hsl(320 55% 50% / .12);
+}
+.char-glyph {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  font-family: var(--font-menu);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--brass);
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  text-shadow: var(--glow-soft);
+  flex-shrink: 0;
+}
+.char-name {
+  font-family: var(--font-menu);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  color: var(--fg);
+  text-transform: uppercase;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.char-role {
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--fg-muted);
+  white-space: nowrap;
+}
+.charspane-detail {
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 8px 30px -8px hsl(320 45% 8% / .55);
+  overflow: hidden;
+  min-height: 0;
+}
+.charspane-detail-inner {
+  padding: 28px 34px;
+  height: 100%;
+  overflow-y: auto;
+}
+.char-head {
+  display: flex;
+  gap: 22px;
+  align-items: flex-end;
+  margin-bottom: 16px;
+}
+/* Portraits: dark surface, thin violet border, light sepia + cool rotate. */
+.char-portrait {
+  width: 104px;
+  height: 136px;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elev-3);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  overflow: hidden;
+  filter: sepia(.25) contrast(1.05) saturate(.8) hue-rotate(-10deg);
+  box-shadow: 0 0 18px hsl(320 55% 50% / .15);
+}
+.char-portrait img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.char-portrait .char-portrait-empty {
+  color: var(--fg-dim);
+}
+/* The character's NAME is a heading — menu font, not the marquee. */
+.char-title {
+  font-family: var(--font-menu);
+  font-size: 30px;
+  letter-spacing: 0.18em;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--brass-bright);
+  text-shadow: var(--glow-soft);
+  margin: 0 0 4px;
+  line-height: 1.1;
+}
+.char-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  margin-top: 22px;
+}
+.char-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.char-section p {
+  font-family: var(--font-body);
+  font-size: 17px;
+  line-height: 1.7;
+  color: var(--fg);
+  text-wrap: pretty;
+  margin: 0;
+  max-width: 60ch;
+}
+
+/* ═══ MAP PANE (styled shell — the real map is U4) ═══ */
+.mappane-shell {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.mappane-canvas {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 8px 30px -8px hsl(320 45% 8% / .55);
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+}
+.mappane-grid {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+.mappane-placeholder {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  text-align: center;
+  padding: 24px;
+}
+.mappane-placeholder .map-title {
+  font-family: var(--font-menu);
+  font-size: 24px;
+  letter-spacing: 0.18em;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--brass-bright);
+  text-shadow: var(--glow-soft);
+  margin: 0;
+}
+.mappane-placeholder .map-sub {
+  font-family: var(--font-body);
+  font-size: 16px;
+  font-style: italic;
+  color: var(--fg-muted);
+  max-width: 44ch;
+  margin: 0;
+}
+
+/* ═══ SETTINGS PANE (placeholder — full wiring is U5) ═══ */
+.settings-pane {
+  max-width: 720px;
+  margin: 0 auto;
+}
+.settings-card {
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 8px 30px -8px hsl(320 45% 8% / .55);
+  margin-bottom: 22px;
+}
+.settings-inner { padding: 30px 38px 26px; }
+.settings-inner > .eyebrow {
+  display: block;
+  margin-bottom: 6px;
+}
+.settings-title {
+  font-family: var(--font-menu);
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--brass);
+  text-shadow: var(--glow-soft);
+  margin: 0 0 18px;
+}
+.set-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 18px;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--border-faint);
+}
+.set-row:last-child { border-bottom: none; }
+.set-label {
+  font-family: var(--font-menu);
+  font-size: 10px;
+  letter-spacing: 0.24em;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  font-weight: 600;
+}
+.set-val {
+  font-family: var(--font-menu);
+  font-size: 13px;
+  color: var(--fg);
+  letter-spacing: 0.06em;
+  text-align: right;
+}
+.theme-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-top: 6px;
+}
+.theme-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px;
+  background: var(--bg-elev-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color .15s, box-shadow .15s;
+}
+.theme-card:hover {
+  border-color: var(--brass);
+  box-shadow: 0 0 14px hsl(320 55% 50% / .2);
+}
+.theme-card.on {
+  border-color: var(--brass);
+  box-shadow: 0 0 0 1px var(--brass) inset, 0 0 18px hsl(320 55% 50% / .3);
+}
+.theme-card .theme-name {
+  font-family: var(--font-menu);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg);
+}
+.theme-card.on .theme-name {
+  color: var(--brass-bright);
+  text-shadow: var(--glow-soft);
+}
+.theme-card .theme-motto {
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-style: italic;
+  color: var(--fg-muted);
+}
+.theme-swatches { display: flex; gap: 4px; }
+.theme-swatches span {
+  width: 18px;
+  height: 10px;
+  border: 1px solid var(--border);
+  border-radius: 1px;
+}
+
+/* Pane fallback (loading / error states share one look). */
+.pane-notice {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 60px 24px;
+  text-align: center;
+}
+.pane-notice .notice-text {
+  font-family: var(--font-menu);
+  font-size: 12px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.pane-notice .notice-detail {
+  font-family: var(--font-body);
+  font-size: 14px;
+  font-style: italic;
+  color: var(--fg-dim);
+  max-width: 52ch;
+}
+
+/* ─── Responsive collapse ─── */
+@media (max-width: 1280px) {
+  .nexus-main { grid-template-columns: 60px 1fr 280px; }
+  .nexus-main.no-ledger { grid-template-columns: 60px 1fr; }
+}
+@media (max-width: 1100px) {
+  .nexus-main,
+  .nexus-main.no-ledger { grid-template-columns: 60px 1fr; }
+  .rail-right { display: none; }
+}
+@media (max-width: 760px) {
+  .nexus-shell { grid-template-rows: 40px 1fr; }
+  .topbar { padding: 0 12px; }
+  .topbar-left .wordmark { font-size: 20px; }
+  .slot-label em { display: none; }
+  .nexus-content { padding: 14px; }
+  .reader-inner { padding: 24px 20px; }
+  .scene-title { font-size: 26px; }
+  .charspane { grid-template-columns: 1fr; }
+}

--- a/ui/client/src/hooks/useNarrativeEngine.ts
+++ b/ui/client/src/hooks/useNarrativeEngine.ts
@@ -99,6 +99,20 @@ export function useNarrativeEngine(slot: number | null): NarrativeEngine {
     }
   }, [slotState?.session_id]);
 
+  // Refetch slot state + narrative reads. Needed after `complete` (a new
+  // pending chunk exists) AND after `error`: submitting from a pending chunk
+  // auto-approves it before generation runs, so even a failed turn can leave
+  // the previously displayed state stale (chunk now committed, choices gone).
+  const invalidateNarrativeQueries = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["/api/slot/state", slot] });
+    queryClient.invalidateQueries({
+      predicate: (query) =>
+        Array.isArray(query.queryKey) &&
+        typeof query.queryKey[0] === "string" &&
+        query.queryKey[0].startsWith("/api/narrative"),
+    });
+  }, [queryClient, slot]);
+
   const handleProgress = useCallback(
     (payload: NarrativeProgressPayload) => {
       const { session_id: sessionId, status } = payload;
@@ -127,19 +141,17 @@ export function useNarrativeEngine(slot: number | null): NarrativeEngine {
         sessionRef.current = null;
         setCompletedGenerations((n) => n + 1);
         // The new pending chunk lives in slot state + incubator.
-        queryClient.invalidateQueries({ queryKey: ["/api/slot/state", slot] });
-        queryClient.invalidateQueries({
-          predicate: (query) =>
-            Array.isArray(query.queryKey) &&
-            typeof query.queryKey[0] === "string" &&
-            query.queryKey[0].startsWith("/api/narrative"),
-        });
+        invalidateNarrativeQueries();
       } else if (nextPhase === "error") {
         stopClock();
         const message =
           (payload.data?.error as string) || "Narrative generation failed";
         setGenerationError(message);
         sessionRef.current = null;
+        // The submitted chunk may already be committed (auto-approval runs
+        // before generation) - resync so the reader doesn't show it as
+        // pending with stale choices.
+        invalidateNarrativeQueries();
         toast({
           title: "Generation Failed",
           description: message,
@@ -149,7 +161,7 @@ export function useNarrativeEngine(slot: number | null): NarrativeEngine {
         setGenerationError(null);
       }
     },
-    [queryClient, slot, stopClock],
+    [invalidateNarrativeQueries, stopClock],
   );
 
   const handleProgressRef = useRef(handleProgress);
@@ -238,6 +250,9 @@ export function useNarrativeEngine(slot: number | null): NarrativeEngine {
         const message =
           error instanceof Error ? error.message : "Failed to start turn";
         setGenerationError(message);
+        // A mid-endpoint failure can still land after the server-side
+        // auto-approve - resync rather than trust the cached state.
+        invalidateNarrativeQueries();
         toast({
           title: "Generation Failed",
           description: message,
@@ -245,7 +260,7 @@ export function useNarrativeEngine(slot: number | null): NarrativeEngine {
         });
       }
     },
-    [slot, startClock, stopClock],
+    [slot, startClock, stopClock, invalidateNarrativeQueries],
   );
 
   let skaldStatus: SkaldStatus = "READY";

--- a/ui/client/src/hooks/useNarrativeEngine.ts
+++ b/ui/client/src/hooks/useNarrativeEngine.ts
@@ -1,0 +1,276 @@
+/**
+ * useNarrativeEngine - generation lifecycle for the narrative reading surface.
+ *
+ * Owns:
+ * - the /ws/narrative WebSocket (phase telemetry, auto-reconnect)
+ * - slot state polling via react-query (pending chunk + choices)
+ * - turn submission through POST /api/narrative/continue
+ * - the elapsed-time clock while a generation is in flight
+ * - SKALD operator status derivation (READY / TRANSMITTING / GENERATING /
+ *   RECEIVING / OFFLINE)
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "@/hooks/use-toast";
+import { continueNarrative, getSlotState } from "@/lib/narrative-api";
+import {
+  ACTIVE_GENERATION_PHASES,
+  type NarrativePhase,
+  type NarrativeProgressPayload,
+  type SkaldStatus,
+  type SlotState,
+} from "@/types/narrative";
+
+const RECEIVING_HOLD_MS = 1200;
+const WS_RECONNECT_MS = 3000;
+const CONNECTIVITY_POLL_MS = 10000;
+
+const isActivePhase = (phase: NarrativePhase | null): boolean =>
+  phase !== null && ACTIVE_GENERATION_PHASES.includes(phase);
+
+export interface NarrativeEngine {
+  slotState: SlotState | undefined;
+  slotStateError: Error | null;
+  isSlotStateLoading: boolean;
+  phase: NarrativePhase | null;
+  skaldStatus: SkaldStatus;
+  elapsedMs: number;
+  generationError: string | null;
+  isGenerating: boolean;
+  /** Increments each time a generation completes; keys the typewriter reveal. */
+  completedGenerations: number;
+  submitTurn: (params: { choice?: number; userText?: string }) => Promise<void>;
+}
+
+export function useNarrativeEngine(slot: number | null): NarrativeEngine {
+  const queryClient = useQueryClient();
+
+  const [phase, setPhase] = useState<NarrativePhase | null>(null);
+  const [generationError, setGenerationError] = useState<string | null>(null);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [backendReachable, setBackendReachable] = useState(true);
+  const [receiving, setReceiving] = useState(false);
+  const [completedGenerations, setCompletedGenerations] = useState(0);
+
+  const sessionRef = useRef<string | null>(null);
+  const phaseRef = useRef<NarrativePhase | null>(null);
+  const timerRef = useRef<number | null>(null);
+  const receivingTimeoutRef = useRef<number | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    phaseRef.current = phase;
+  }, [phase]);
+
+  const stopClock = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const startClock = useCallback(() => {
+    stopClock();
+    const startedAt = Date.now();
+    setElapsedMs(0);
+    timerRef.current = window.setInterval(() => {
+      setElapsedMs(Date.now() - startedAt);
+    }, 200);
+  }, [stopClock]);
+
+  // Slot state: the single source of truth for pending chunk + choices.
+  const {
+    data: slotState,
+    error: slotStateError,
+    isLoading: isSlotStateLoading,
+  } = useQuery<SlotState, Error>({
+    queryKey: ["/api/slot/state", slot],
+    queryFn: () => getSlotState(slot as number),
+    enabled: slot !== null,
+  });
+
+  // Adopt an in-flight session after a page reload: the slot state carries
+  // the live session id while incubator content is pending.
+  useEffect(() => {
+    if (slotState?.session_id && !sessionRef.current) {
+      sessionRef.current = slotState.session_id;
+    }
+  }, [slotState?.session_id]);
+
+  const handleProgress = useCallback(
+    (payload: NarrativeProgressPayload) => {
+      const { session_id: sessionId, status } = payload;
+      if (!sessionId || !status) return;
+
+      // Ignore telemetry from sessions other than ours (but adopt the
+      // session if we don't have one - e.g. generation started elsewhere).
+      if (sessionRef.current && sessionRef.current !== sessionId) return;
+      if (!sessionRef.current) sessionRef.current = sessionId;
+
+      const nextPhase = status as NarrativePhase;
+      setPhase(nextPhase);
+
+      if (nextPhase === "complete") {
+        stopClock();
+        setGenerationError(null);
+        setReceiving(true);
+        if (receivingTimeoutRef.current !== null) {
+          window.clearTimeout(receivingTimeoutRef.current);
+        }
+        receivingTimeoutRef.current = window.setTimeout(() => {
+          if (!mountedRef.current) return;
+          setReceiving(false);
+          setPhase(null);
+        }, RECEIVING_HOLD_MS);
+        sessionRef.current = null;
+        setCompletedGenerations((n) => n + 1);
+        // The new pending chunk lives in slot state + incubator.
+        queryClient.invalidateQueries({ queryKey: ["/api/slot/state", slot] });
+        queryClient.invalidateQueries({
+          predicate: (query) =>
+            Array.isArray(query.queryKey) &&
+            typeof query.queryKey[0] === "string" &&
+            query.queryKey[0].startsWith("/api/narrative"),
+        });
+      } else if (nextPhase === "error") {
+        stopClock();
+        const message =
+          (payload.data?.error as string) || "Narrative generation failed";
+        setGenerationError(message);
+        sessionRef.current = null;
+        toast({
+          title: "Generation Failed",
+          description: message,
+          variant: "destructive",
+        });
+      } else {
+        setGenerationError(null);
+      }
+    },
+    [queryClient, slot, stopClock],
+  );
+
+  const handleProgressRef = useRef(handleProgress);
+  useEffect(() => {
+    handleProgressRef.current = handleProgress;
+  }, [handleProgress]);
+
+  // WebSocket lifecycle with auto-reconnect.
+  useEffect(() => {
+    mountedRef.current = true;
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const url = `${protocol}//${window.location.host}/ws/narrative`;
+
+    const connect = () => {
+      if (!mountedRef.current) return;
+      const ws = new WebSocket(url);
+      wsRef.current = ws;
+      ws.onmessage = (event) => {
+        try {
+          handleProgressRef.current(JSON.parse(event.data));
+        } catch (error) {
+          console.error("[NarrativeWS] Failed to parse message:", error);
+        }
+      };
+      ws.onclose = () => {
+        wsRef.current = null;
+        if (mountedRef.current) {
+          reconnectRef.current = window.setTimeout(connect, WS_RECONNECT_MS);
+        }
+      };
+    };
+
+    connect();
+    return () => {
+      mountedRef.current = false;
+      if (reconnectRef.current !== null) window.clearTimeout(reconnectRef.current);
+      if (receivingTimeoutRef.current !== null) {
+        window.clearTimeout(receivingTimeoutRef.current);
+      }
+      stopClock();
+      wsRef.current?.close();
+    };
+  }, [stopClock]);
+
+  // Backend connectivity probe - drives the OFFLINE status.
+  useEffect(() => {
+    let cancelled = false;
+    const check = async () => {
+      try {
+        const res = await fetch("/api/settings", { method: "HEAD" });
+        if (!cancelled) setBackendReachable(res.ok);
+      } catch {
+        if (!cancelled) setBackendReachable(false);
+      }
+    };
+    check();
+    const interval = window.setInterval(check, CONNECTIVITY_POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  const submitTurn = useCallback(
+    async (params: { choice?: number; userText?: string }) => {
+      if (slot === null) throw new Error("No active slot");
+      if (isActivePhase(phaseRef.current)) {
+        toast({
+          title: "Generation Active",
+          description: "Wait for the current turn to finish.",
+        });
+        return;
+      }
+
+      setPhase("initiated");
+      setGenerationError(null);
+      sessionRef.current = null;
+      startClock();
+
+      try {
+        const result = await continueNarrative({ slot, ...params });
+        sessionRef.current = result.session_id;
+      } catch (error) {
+        stopClock();
+        setPhase("error");
+        const message =
+          error instanceof Error ? error.message : "Failed to start turn";
+        setGenerationError(message);
+        toast({
+          title: "Generation Failed",
+          description: message,
+          variant: "destructive",
+        });
+      }
+    },
+    [slot, startClock, stopClock],
+  );
+
+  let skaldStatus: SkaldStatus = "READY";
+  if (!backendReachable) {
+    skaldStatus = "OFFLINE";
+  } else if (receiving) {
+    skaldStatus = "RECEIVING";
+  } else if (phase === "calling_llm" || phase === "processing_response") {
+    skaldStatus = "GENERATING";
+  } else if (isActivePhase(phase)) {
+    skaldStatus = "TRANSMITTING";
+  } else if (phase === "error") {
+    skaldStatus = "OFFLINE";
+  }
+
+  return {
+    slotState,
+    slotStateError: slotStateError ?? null,
+    isSlotStateLoading,
+    phase,
+    skaldStatus,
+    elapsedMs,
+    generationError,
+    isGenerating: isActivePhase(phase),
+    completedGenerations,
+    submitTurn,
+  };
+}

--- a/ui/client/src/lib/narrative-api.ts
+++ b/ui/client/src/lib/narrative-api.ts
@@ -1,0 +1,110 @@
+/**
+ * Typed fetchers for the narrative reading surface.
+ *
+ * Read routes are served by the Express layer (direct Postgres);
+ * generation/slot routes are proxied through Express to FastAPI :8002.
+ * Errors surface as thrown exceptions — no silent fallbacks.
+ */
+import type { Season, Episode, Character, CharacterImage } from "@shared/schema";
+import type {
+  ChunkContext,
+  ChunkWithMetadata,
+  ContinueNarrativeResponse,
+  IncubatorPayload,
+  SlotState,
+} from "@/types/narrative";
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    const text = (await res.text()) || res.statusText;
+    throw new Error(`${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+export function getSlotState(slot: number): Promise<SlotState> {
+  return getJson(`/api/slot/${slot}/state`);
+}
+
+/** Returns null when the slot has no committed chunks yet (404 = new story). */
+export async function getLatestChunk(slot: number): Promise<ChunkWithMetadata | null> {
+  const res = await fetch(`/api/narrative/latest-chunk?slot=${slot}`);
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    const text = (await res.text()) || res.statusText;
+    throw new Error(`${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+export function getSeasons(slot: number): Promise<Season[]> {
+  return getJson(`/api/narrative/seasons?slot=${slot}`);
+}
+
+export function getEpisodes(seasonId: number, slot: number): Promise<Episode[]> {
+  return getJson(`/api/narrative/episodes/${seasonId}?slot=${slot}`);
+}
+
+export function getEpisodeChunks(
+  seasonId: number,
+  episodeId: number,
+  slot: number,
+  limit = 200,
+): Promise<{ chunks: ChunkWithMetadata[]; total: number }> {
+  return getJson(
+    `/api/narrative/chunks/${seasonId}/${episodeId}?limit=${limit}&slot=${slot}`,
+  );
+}
+
+export function getChunkContext(chunkId: number, slot: number): Promise<ChunkContext> {
+  return getJson(`/api/narrative/chunks/${chunkId}/context?slot=${slot}`);
+}
+
+export function getCharacters(slot: number): Promise<Character[]> {
+  return getJson(`/api/characters?slot=${slot}`);
+}
+
+export function getCharacterImages(
+  characterId: number,
+  slot: number,
+): Promise<CharacterImage[]> {
+  return getJson(`/api/characters/${characterId}/images?slot=${slot}`);
+}
+
+export function getUserCharacter(slot: number): Promise<{ name: string } | null> {
+  return getJson(`/api/user-character?slot=${slot}`);
+}
+
+export function getIncubator(slot: number): Promise<IncubatorPayload> {
+  return getJson(`/api/narrative/incubator?slot=${slot}`);
+}
+
+/**
+ * Submit a player turn through the unified continue endpoint.
+ *
+ * The backend resolves the current chunk from slot state, records the
+ * player's response on the pending chunk (auto-approving incubator content),
+ * and kicks off generation of the next chunk. Exactly one of `choice`
+ * (1-indexed) or `userText` (freeform, slot 0) should be provided.
+ */
+export async function continueNarrative(params: {
+  slot: number;
+  choice?: number;
+  userText?: string;
+}): Promise<ContinueNarrativeResponse> {
+  const body: Record<string, unknown> = { slot: params.slot };
+  if (params.choice !== undefined) body.choice = params.choice;
+  if (params.userText !== undefined) body.user_text = params.userText;
+
+  const res = await fetch("/api/narrative/continue", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = (await res.text()) || res.statusText;
+    throw new Error(`${res.status}: ${text}`);
+  }
+  return res.json();
+}

--- a/ui/client/src/types/narrative.ts
+++ b/ui/client/src/types/narrative.ts
@@ -1,0 +1,123 @@
+/**
+ * TypeScript types for the narrative reading surface.
+ *
+ * Mirrors the FastAPI Pydantic schemas in `nexus/api/narrative_schemas.py`
+ * and the Express read routes in `ui/server/routes.ts`.
+ */
+import type { NarrativeChunk, ChunkMetadata } from "@shared/schema";
+
+/** A committed chunk joined with its metadata row (Express read routes). */
+export type ChunkWithMetadata = Omit<NarrativeChunk, "choiceObject"> & {
+  choiceObject?: ChoiceObject | null;
+  metadata?: ChunkMetadata;
+};
+
+/**
+ * Choice object structure from the chunk / incubator JSONB column.
+ * `presented`: choice strings from the storyteller.
+ * `selected`: the user's recorded selection (after a choice is made).
+ */
+export interface ChoiceObject {
+  presented: string[];
+  selected?: ChoiceSelection;
+}
+
+/** Matches backend `ChoiceSelection` (label 0/freeform = custom input). */
+export interface ChoiceSelection {
+  label: number | "freeform";
+  text: string;
+  edited: boolean;
+}
+
+/** Response model for GET /api/slot/{slot}/state (SlotStateResponse). */
+export interface SlotState {
+  slot: number;
+  is_empty: boolean;
+  is_wizard_mode: boolean;
+  phase: string | null;
+  subphase: string | null;
+  thread_id: string | null;
+  current_chunk_id: number | null;
+  has_pending: boolean;
+  storyteller_text: string | null;
+  choices: string[];
+  session_id: string | null;
+  model: string | null;
+}
+
+/** Response from POST /api/narrative/continue. */
+export interface ContinueNarrativeResponse {
+  session_id: string;
+  status: string;
+  message: string;
+}
+
+/** WebSocket progress payload from /ws/narrative. */
+export interface NarrativeProgressPayload {
+  session_id: string;
+  status: string;
+  message?: string;
+  data?: {
+    error?: string;
+    phase?: string;
+    [key: string]: unknown;
+  };
+}
+
+export type NarrativePhase =
+  | "initiated"
+  | "loading_chunk"
+  | "building_context"
+  | "calling_llm"
+  | "processing_response"
+  | "complete"
+  | "error";
+
+/** Phases that indicate generation is actively in progress. */
+export const ACTIVE_GENERATION_PHASES: NarrativePhase[] = [
+  "initiated",
+  "loading_chunk",
+  "building_context",
+  "calling_llm",
+  "processing_response",
+];
+
+/** Operator-strip status derived from the generation phase. */
+export type SkaldStatus =
+  | "OFFLINE"
+  | "READY"
+  | "TRANSMITTING"
+  | "GENERATING"
+  | "RECEIVING";
+
+/** GET /api/narrative/chunks/:chunkId/context (Express). */
+export interface ChunkContext {
+  characters: Array<{
+    id: number;
+    name: string;
+    reference: "present" | "mentioned";
+  }>;
+  places: Array<{
+    id: number;
+    name: string;
+    referenceType: "setting" | "mentioned" | "transit";
+  }>;
+}
+
+/** GET /api/narrative/incubator (FastAPI incubator_view). */
+export interface IncubatorPayload {
+  chunk_id: number;
+  parent_chunk_id: number;
+  parent_chunk_text?: string | null;
+  user_text?: string | null;
+  storyteller_text?: string | null;
+  choice_object?: ChoiceObject | null;
+  episode_transition?: string | null;
+  time_delta?: string | null;
+  world_layer?: string | null;
+  status?: string;
+  session_id?: string;
+  created_at?: string;
+  /** Sentinel from the API when the incubator table is empty. */
+  message?: string;
+}

--- a/ui/client/src/types/settings.ts
+++ b/ui/client/src/types/settings.ts
@@ -1,0 +1,15 @@
+/**
+ * Shape of the GET /api/settings payload (the Express layer serves
+ * nexus.toml plus the legacy "Agent Settings" aliases it constructs).
+ * Single source of truth for the client - extend here, not locally.
+ */
+export interface SettingsPayload {
+  ["Agent Settings"]?: {
+    global?: {
+      model?: { default_model?: string };
+      narrative?: { test_mode?: boolean };
+    };
+  };
+  /** Mirrors `[ui]` in nexus.toml (UISettings in settings_models.py). */
+  ui?: { typewriter_ms_per_char?: number };
+}

--- a/ui/server/index.ts
+++ b/ui/server/index.ts
@@ -1,5 +1,6 @@
 import express, { type Request, Response, NextFunction } from "express";
-import { registerRoutes, registerProxyRoutes } from "./routes";
+import type { Socket } from "net";
+import { registerRoutes, registerProxyRoutes, getNarrativeWsProxy } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
@@ -42,6 +43,18 @@ app.use((req, res, next) => {
 
 (async () => {
   const server = await registerRoutes(app);
+
+  // Forward /ws/narrative upgrade requests to the FastAPI backend. Scoped by
+  // URL so Vite's HMR websocket (any other path) is left untouched.
+  const wsProxy = getNarrativeWsProxy();
+  if (wsProxy?.upgrade) {
+    server.on("upgrade", (req, socket, head) => {
+      if (req.url?.startsWith("/ws/narrative")) {
+        // Node types the upgrade socket as Duplex; it is a net.Socket at runtime.
+        wsProxy.upgrade(req, socket as Socket, head);
+      }
+    });
+  }
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;

--- a/ui/server/routes.ts
+++ b/ui/server/routes.ts
@@ -9,6 +9,17 @@ import { parse as parseToml } from "toml";
 import * as Toml from "@iarna/toml";
 import sharp from "sharp";
 
+// WebSocket proxy instance for /ws/narrative. http-proxy-middleware only
+// attaches its upgrade listener lazily (after the first plain HTTP request
+// through the same middleware), which never happens on a WS-only path - so
+// the HTTP server must wire `upgrade` events to this instance explicitly
+// (see server/index.ts).
+let narrativeWsProxy: ReturnType<typeof createProxyMiddleware> | null = null;
+
+export function getNarrativeWsProxy() {
+  return narrativeWsProxy;
+}
+
 // Register proxy BEFORE body parsing middleware
 export function registerProxyRoutes(app: Express): void {
   const narrativePort = process.env.NARRATIVE_API_PORT || "8002";
@@ -48,6 +59,12 @@ export function registerProxyRoutes(app: Express): void {
     pathRewrite: (path) => `/api/story${path}`,
   }));
 
+  // Proxy for Slot endpoints (slot state, undo, model, lock)
+  app.use("/api/slot", createProxyMiddleware({
+    ...narrativeProxyOptions,
+    pathRewrite: (path) => `/api/slot${path}`,
+  }));
+
   // Proxy for Chunk Workflow endpoints
   app.use("/api/chunks", createProxyMiddleware({
     ...narrativeProxyOptions,
@@ -66,7 +83,8 @@ export function registerProxyRoutes(app: Express): void {
     pathRewrite: (path) => `/api/config${path}`,
   }));
 
-  app.use("/ws/narrative", createProxyMiddleware({ ...narrativeProxyOptions, ws: true }));
+  narrativeWsProxy = createProxyMiddleware({ ...narrativeProxyOptions, ws: true });
+  app.use("/ws/narrative", narrativeWsProxy);
 }
 
 export async function registerRoutes(app: Express): Promise<Server> {
@@ -135,6 +153,24 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Error fetching adjacent chunks:", error);
       res.status(500).json({ error: "Failed to fetch adjacent chunks" });
+    }
+  });
+
+  // GET /api/narrative/chunks/:chunkId/context - Get character/place references for a chunk
+  // (must register before the :seasonId/:episodeId route, which would otherwise shadow it)
+  app.get("/api/narrative/chunks/:chunkId/context", async (req, res) => {
+    try {
+      const chunkId = parseInt(req.params.chunkId);
+      if (isNaN(chunkId)) {
+        return res.status(400).json({ error: "Invalid chunk ID" });
+      }
+
+      const slot = req.query.slot ? parseInt(req.query.slot as string) : undefined;
+      const context = await storage.getChunkContext(chunkId, slot);
+      res.json(context);
+    } catch (error) {
+      console.error("Error fetching chunk context:", error);
+      res.status(500).json({ error: "Failed to fetch chunk context" });
     }
   });
 

--- a/ui/server/storage.ts
+++ b/ui/server/storage.ts
@@ -32,6 +32,16 @@ import {
 import { db, getDb } from "./db";
 import { eq, and, gte, lte, sql } from "drizzle-orm";
 
+/**
+ * Entity references for a single narrative chunk: the characters in (or
+ * mentioned by) the scene and the places it is set in. Powers the reader's
+ * location header and the Session Ledger's scene cast.
+ */
+export interface ChunkContext {
+  characters: Array<{ id: number; name: string; reference: "present" | "mentioned" }>;
+  places: Array<{ id: number; name: string; referenceType: "setting" | "mentioned" | "transit" }>;
+}
+
 export interface IStorage {
   // Season methods
   getAllSeasons(slot?: number | null): Promise<Season[]>;
@@ -49,6 +59,7 @@ export interface IStorage {
     previous: (NarrativeChunk & { metadata?: ChunkMetadata }) | null;
     next: (NarrativeChunk & { metadata?: ChunkMetadata }) | null;
   }>;
+  getChunkContext(chunkId: number, slot?: number | null): Promise<ChunkContext>;
 
   // Character methods
   getCharacters(startId?: number, endId?: number, slot?: number | null): Promise<Character[]>;
@@ -318,6 +329,38 @@ export class PostgresStorage implements IStorage {
     return {
       previous: mapRow(previousResult.rows?.[0]),
       next: mapRow(nextResult.rows?.[0]),
+    };
+  }
+
+  async getChunkContext(chunkId: number, slot?: number | null): Promise<ChunkContext> {
+    const db = getDb(slot) || this.db;
+    const characterResult = await db.execute(sql`
+      SELECT c.id, c.name, ccr.reference
+      FROM chunk_character_references ccr
+      JOIN characters c ON c.id = ccr.character_id
+      WHERE ccr.chunk_id = ${chunkId}
+      ORDER BY (ccr.reference = 'present') DESC, c.id ASC
+    `);
+
+    const placeResult = await db.execute(sql`
+      SELECT p.id, p.name, pcr.reference_type
+      FROM place_chunk_references pcr
+      JOIN places p ON p.id = pcr.place_id
+      WHERE pcr.chunk_id = ${chunkId}
+      ORDER BY (pcr.reference_type = 'setting') DESC, p.id ASC
+    `);
+
+    return {
+      characters: (characterResult.rows as any[]).map((row) => ({
+        id: Number(row.id),
+        name: row.name,
+        reference: row.reference,
+      })),
+      places: (placeResult.rows as any[]).map((row) => ({
+        id: Number(row.id),
+        name: row.name,
+        referenceType: row.reference_type,
+      })),
     };
   }
 
@@ -773,6 +816,11 @@ class MemStorage implements IStorage {
       .sort((a, b) => a.id - b.id)[0] || null;
 
     return { previous, next };
+  }
+
+  async getChunkContext(_chunkId: number): Promise<ChunkContext> {
+    // The in-memory fixture store has no entity reference tables.
+    return { characters: [], places: [] };
   }
 
   async getCharacters(startId?: number, endId?: number): Promise<Character[]> {


### PR DESCRIPTION
## Summary

Rebuilds the long-lived "reading the story" surface per the NEXUS IRIS design kit (`design_handoff/project/`), restoring the `/nexus` route demolished in #341 and wiring every pane to the live backend — no mock data in shipped components.

### Component Inventory (Built)

| Component | Notes |
|---|---|
| `components/nexus/NexusLayout.tsx` | Shell: 52px top bar / 60px icon rail / pane router / 320px ledger (narrative tab only), responsive collapse |
| `components/nexus/TopBar.tsx` | Wordmark (marquee font, 27px) + slot label left; SKALD status right. No cartouche, no MODEL field |
| `components/nexus/LeftRail.tsx` | Home + 4 tabs, 3×22px magenta active marker + glow, CSS tooltips |
| `components/nexus/NarrativePane.tsx` | Chunk stream + pending incubator chunk, voice-by-color, choices 1–3 + freeform slot 0, typewriter reveal, number-key shortcuts |
| `components/nexus/RightLedger.tsx` | Phase telemetry stream + elapsed, live scene cast, narrative hierarchy |
| `components/nexus/CharactersPane.tsx` | Roster + dossier card, portrait treatment per README imagery rules |
| `components/nexus/MapPane.tsx` | Styled shell only (U4 owns the real map; zero map libraries) |
| `components/nexus/SettingsPane.tsx` | Kit-fidelity placeholder: live theme picker + read-only readout (U5 owns full wiring) |
| `components/nexus/TypewriterText.tsx` | 30–50ms/char reveal, speed via `nexus.toml [ui] typewriter_ms_per_char` |
| `hooks/useNarrativeEngine.ts` | WS telemetry + slot state + unified continue + SKALD status |
| `lib/narrative-api.ts`, `types/narrative.ts` | Typed fetchers / schema mirrors |
| `components/deco/DecoDivider.tsx` | Extended with theme-aware glyph variant (Veil ⟡ / Gilded ◆ / Vector ▮) |

### Installed from shadcn

None needed — the full shadcn registry was already vendored in `ui/client/src/components/ui/` (verified against ui.shadcn.com/docs/components: textarea, scroll-area, tooltip, toast, collapsible, separator, skeleton all present). The freeform input reuses the vendored `Textarea` skinned with brand tokens.

### API Endpoints Wired

- `GET /api/slot/{slot}/state` (new Express→FastAPI proxy) — pending chunk, choices, session
- `POST /api/narrative/continue` — unified turn submission (choice 1–3 or freeform), auto-approves pending incubator content
- `WS /ws/narrative` — phase telemetry (**fixed**: http-proxy-middleware never attached its upgrade listener on a WS-only path, so this proxy had never actually connected; the HTTP server now forwards scoped upgrade events explicitly)
- `GET /api/narrative/latest-chunk`, `/chunks/{s}/{e}`, `/seasons`, `/episodes/{s}` — committed narrative reads
- `GET /api/narrative/chunks/{id}/context` (**new Express route**) — joins `chunk_character_references` + `place_chunk_references` for the location header and scene cast
- `GET /api/characters`, `/characters/{id}/images`, `/api/user-character`, `/api/settings`

### Validation (slot 5, read-only)

```
npm run check        # tsc clean
npm run build        # vite + esbuild clean
# dev smoke: FastAPI :8002 + Express :5050
GET /api/slot/5/state                      → 200 (proxied)
GET /api/narrative/chunks/55/context?slot=5 → 200 (live cast + setting)
GET /api/settings                          → ui.typewriter_ms_per_char: 35
GET /nexus                                 → app shell serves
ws://localhost:5050/ws/narrative           → connects (was TIMEOUT before fix)
POST /api/narrative/continue (malformed)   → 422 naming exact fields, pre-execution
```

Choice submission was exercised **non-destructively**: schema verified against `/openapi.json` and two intentionally invalid bodies returned 422 through the full proxy chain (FastAPI rejects before the endpoint body runs — zero side effects). Per the lane rules no real turn was submitted against slots 2/5.

### Remaining for Conductor QA

- One real end-to-end turn: submit a choice → WS phases animate the ledger → typewriter reveals the new pending chunk → choices re-render. (Destructive; needs a sanctioned slot.)
- Visual QA across all three themes (screenshots N/A — no browser in this lane).
- Bootstrap flow on a fresh slot (Begin-the-story button → first chunk).

### Deferred

- **U4**: real Map pane (see `docs/maptab_rebuild_spec.md`); MapPane here is a themed shell.
- **U5**: settings wiring (model picker, test mode toggle, font controls); SettingsPane here is a placeholder with a working theme picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)