### PR TITLE
Package Self-Awareness: Branch Selection Reads the Acting Entity (M7, #282)

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -49,7 +49,20 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} slips off a Rootline platform into a flooded service corridor and kills every transmitter on their person.
 
-### Branch 2 — Reach a safe house through contacts  *(mag 0.58)*
+### Branch 2 — Buy a discreet extraction  *(mag 0.64)*
+
+**When:**
+
+- **AND:**
+  - actor's own fame is `renowned` or wider
+  - actor's own resources are `wealthy` or better
+
+**Does:** activity → "buying a discreet extraction"
+**Event:** `evade_pursuit`
+
+> {actor} knows their face does half the pursuers' work for them, so they pay for the kind of exit that never touches public flow: a closed vehicle, a bought route, a driver whose business is not remembering.
+
+### Branch 3 — Reach a safe house through contacts  *(mag 0.58)*
 
 **When:** actor has outbound `contact:lodging` pair tag
 
@@ -58,16 +71,20 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} pings a broker through a low-bandwidth dead-drop and takes a four-hop route to a safe house.
 
-### Branch 3 — Keep moving, blend into public flow  *(mag 0.42)*
+### Branch 4 — Keep moving, blend into public flow  *(mag 0.42)*
 
-**When:** actor can plausibly move through public flow
+**When:**
+
+- **AND:**
+  - actor can plausibly move through public flow
+  - actor's own fame is narrower than `renowned`
 
 **Does:** activity → "blending into public flow"
 **Event:** `evade_pursuit`
 
 > {actor} joins the densest pedestrian current nearby, never stopping long enough to make a clean pattern.
 
-### Branch 4 — Break line of sight without a clean route  *(mag 0.28)*
+### Branch 5 — Break line of sight without a clean route  *(mag 0.28)*
 
 **When:** *(always)*
 
@@ -325,7 +342,46 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - ≥ 6 ticks since last `signal_exposure_reduced` event for actor
   - ≥ 6 ticks since last `counter_surveillance_sweep` event for actor
 
-### Branch 1 — Harden or sanitize a safehouse  *(mag 0.4)*
+### Branch 1 — Erase the identity and vanish completely  *(mag 0.62)*
+
+**When:**
+
+- **AND:**
+  - actor's own fame is `legendary` or wider
+  - actor's own resources are `magnate` or better
+
+**Does:** activity → "erasing their identity"
+**Event:** `hideout_maintained`
+
+> {actor} is too widely known to be hidden by walls or habits, so they spend what almost no one can spend: the records, the debts, the face in the right databases — an identity dismantled piece by piece until there is nothing left to recognize.
+
+### Branch 2 — Relocate to safer ground  *(mag 0.52)*
+
+**When:**
+
+- **AND:**
+  - actor's own fame is `renowned` or wider
+  - actor's own resources are `wealthy` or better
+
+**Does:** activity → "relocating to safer ground"
+**Event:** `hideout_maintained`
+
+> {actor} accepts that a recognizable face cannot outlast the neighborhood that recognizes it, and pays for the quiet logistics of being somewhere else entirely before anyone thinks to look.
+
+### Branch 3 — Change the face they show the street  *(mag 0.44)*
+
+**When:**
+
+- **AND:**
+  - actor's own fame is `known` or wider
+  - actor's own resources are `comfortable` or better
+
+**Does:** activity → "altering their appearance"
+**Event:** `hideout_maintained`
+
+> {actor} is recognizable enough that habit alone will not protect them, so they spend on the cosmetic arithmetic of not being noticed: hair, clothes, gait, the small paid alterations that make a familiar face unfamiliar.
+
+### Branch 4 — Harden or sanitize a safehouse  *(mag 0.4)*
 
 **When:**
 
@@ -340,7 +396,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} spends the turn making the safe place safer: cleaning traces, changing habits, checking exits, and removing the small comforts that become evidence.
 
-### Branch 2 — Go dark and reduce signal exposure  *(mag 0.36)*
+### Branch 5 — Go dark and reduce signal exposure  *(mag 0.36)*
 
 **When:**
 
@@ -353,7 +409,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} trims their signal down to almost nothing — no unnecessary pings, no sentimental check-ins, no pattern that would let a watcher say yes, there.
 
-### Branch 3 — Run a counter-surveillance sweep  *(mag 0.34)*
+### Branch 6 — Run a counter-surveillance sweep  *(mag 0.34)*
 
 **When:**
 
@@ -366,7 +422,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} checks whether anyone has learned the shape of their absence: doubled-back routes, watcher positions, unusual queries, and the tiny repetitions that turn hiding into a map.
 
-### Branch 4 — Shift a mobile route without surfacing  *(mag 0.3)*
+### Branch 7 — Shift a mobile route without surfacing  *(mag 0.3)*
 
 **When:**
 
@@ -381,7 +437,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} changes the route without making the change look like a change, letting timing and terrain do what panic would ruin.
 
-### Branch 5 — Preserve the silence another day  *(mag 0.22)*
+### Branch 8 — Preserve the silence another day  *(mag 0.22)*
 
 **When:** *(always)*
 
@@ -1463,7 +1519,39 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} keeps moving: transfers, crossings, service corridors, streets whose names matter less than the fact that each one puts the destination a little closer.
 
-### Branch 5 — Depart toward the planned destination  *(mag 0.28)*
+### Branch 5 — Charter private transport  *(mag 0.3)*
+
+**When:**
+
+- **AND:**
+  - actor has a planned travel destination
+  - **NOT:** actor is in transit
+  - actor's own resources are `wealthy` or better
+
+**Does:** activity → "departing by chartered transport"; starts planned travel
+**Event:** `travel_departed`
+
+> {actor} does not queue, transfer, or wait. Money turns the journey into a closed door and a window: a private vehicle, a paid schedule, a route that exists because they asked for it.
+
+### Branch 6 — Slip out along covert routes  *(mag 0.32)*
+
+**When:**
+
+- **AND:**
+  - actor has a planned travel destination
+  - **NOT:** actor is in transit
+  - actor's own fame is `renowned` or wider
+  - **OR:**
+    - actor has `travel_ready` tag
+    - actor has `travel_provisioned` tag
+    - actor has `route_familiar` tag
+
+**Does:** activity → "departing along covert routes"; starts planned travel
+**Event:** `travel_departed`
+
+> {actor} cannot ride public flow without being a sighting, so the route runs through the city's blind spots: service levels, freight corridors, the hours and angles where a recognizable face passes unwitnessed.
+
+### Branch 7 — Depart toward the planned destination  *(mag 0.28)*
 
 **When:**
 
@@ -1481,7 +1569,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} starts the journey with enough of a route in mind to make the first leg real. The exact path can change; the destination no longer can.
 
-### Branch 6 — Prepare the journey rather than starting badly  *(mag 0.12)*
+### Branch 8 — Prepare the journey rather than starting badly  *(mag 0.12)*
 
 **When:** *(always)*
 
@@ -1510,7 +1598,20 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **NOT:** actor has `grieving` ephemeral
   - **NOT:** actor has `wounded` ephemeral
 
-### Branch 1 — Seek company after extended isolation  *(mag 0.54)*
+### Branch 1 — Host chosen company on their own ground  *(mag 0.24)*
+
+**When:**
+
+- **AND:**
+  - actor's own fame is `renowned` or wider
+  - actor has outbound `contact:social` pair tag
+
+**Does:** activity → "hosting chosen company privately"; fulfills `socialize` need, quality `private_company`, discharge 9999
+**Event:** `socialized`
+
+> {actor} does not go looking for company in rooms that would turn to watch them enter. They summon it instead: a few chosen people, a door that closes, an evening where nobody performs recognition.
+
+### Branch 2 — Seek company after extended isolation  *(mag 0.54)*
 
 **When:**
 
@@ -1524,6 +1625,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
       - actor is in `meeting` place class
       - actor is in `place_open` place class
   - actor can plausibly move through public flow
+  - actor's own fame is narrower than `renowned`
   - actor can resolve a destination with place class `commerce,entertainment,meeting,place_open`
 
 **Does:** activity → "seeking company after isolation"; starts travel toward a `commerce`, `entertainment`, `meeting`, `place_open` destination
@@ -1531,7 +1633,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} feels the particular pressure that comes from going too long without other people in their life, and moves toward somewhere there will be voices, even if those voices are not for them.
 
-### Branch 2 — Engage with company already present  *(mag 0.22)*
+### Branch 3 — Engage with company already present  *(mag 0.22)*
 
 **When:** 1+ other entities co-located with actor
 
@@ -1540,7 +1642,20 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} spends real attention on the people around them — not transactional attention, the other kind — for long enough that the social need is briefly met without anyone naming it as such.
 
-### Branch 3 — Set out toward public company  *(mag 0.26)*
+### Branch 4 — Seek a trusted voice rather than a crowd  *(mag 0.22)*
+
+**When:**
+
+- **AND:**
+  - actor has any of [`solitary`, `reserved`]
+  - actor has outbound `contact:social` pair tag
+
+**Does:** activity → "talking with a trusted contact"; fulfills `socialize` need, quality `trusted_contact`, discharge 72
+**Event:** `socialized`
+
+> {actor} weighs the noise of a public room against the particular relief of one familiar voice, and chooses the voice — a long, unhurried exchange with someone who does not need anything explained.
+
+### Branch 5 — Set out toward public company  *(mag 0.26)*
 
 **When:**
 
@@ -1553,6 +1668,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
       - actor is in `meeting` place class
       - actor is in `place_open` place class
   - actor can plausibly move through public flow
+  - actor's own fame is narrower than `renowned`
   - actor can resolve a destination with place class `commerce,entertainment,meeting,place_open`
 
 **Does:** activity → "seeking public company"; starts travel toward a `commerce`, `entertainment`, `meeting`, `place_open` destination
@@ -1560,22 +1676,24 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} chooses movement over more empty time and sets out toward a place where other people can be encountered without requiring the story to pre-name them.
 
-### Branch 4 — Go where people are  *(mag 0.2)*
+### Branch 6 — Go where people are  *(mag 0.2)*
 
 **When:**
 
-- **OR:**
-  - actor is in `commerce` place class
-  - actor is in `entertainment` place class
-  - actor is in `meeting` place class
-  - actor is in `place_open` place class
+- **AND:**
+  - **OR:**
+    - actor is in `commerce` place class
+    - actor is in `entertainment` place class
+    - actor is in `meeting` place class
+    - actor is in `place_open` place class
+  - actor's own fame is narrower than `renowned`
 
 **Does:** activity → "passing time in a populated place"; fulfills `socialize` need, quality `public_company`, discharge 9999
 **Event:** `socialized`
 
 > {actor} goes to one of the places built around the fact that people gather there, and stays long enough to become part of the room's ordinary texture.
 
-### Branch 5 — Reach out to a contact for no urgent reason  *(mag 0.24)*
+### Branch 7 — Reach out to a contact for no urgent reason  *(mag 0.24)*
 
 **When:** actor has outbound `contact:social` pair tag
 
@@ -1584,7 +1702,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} thinks of someone they have not spoken with in too long and reaches out for no urgent reason, which is its own kind of reason.
 
-### Branch 6 — Practice parasocial company  *(mag 0.16)*
+### Branch 8 — Practice parasocial company  *(mag 0.16)*
 
 **When:** *(always)*
 
@@ -1705,7 +1823,16 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **NOT:** actor has `wounded` ephemeral
   - **NOT:** actor has `grieving` ephemeral
 
-### Branch 1 — Make the weapon ready for what comes next  *(mag 0.18)*
+### Branch 1 — Put real money into the craft  *(mag 0.18)*
+
+**When:** actor's own resources are `wealthy` or better
+
+**Does:** activity → "investing in the craft"; adds `recently_tended_craft` to actor
+**Event:** `craft_tended`
+
+> {actor} spends on the work the way only someone with money can: the proper materials instead of the workable ones, the commissioned part instead of the salvaged one, the bought afternoon of uninterrupted attention.
+
+### Branch 2 — Make the weapon ready for what comes next  *(mag 0.18)*
 
 **When:** actor has any of [`combat_trained`, `soldier`, `warrior`, `fighter`]
 
@@ -1714,7 +1841,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} takes the weapon apart with the slow patience of someone who has done this enough times to know the geometry of each piece by feel, and puts it back together the same way, attentive to small things only they will notice.
 
-### Branch 2 — Lay hands on the arcane work-in-progress  *(mag 0.18)*
+### Branch 3 — Lay hands on the arcane work-in-progress  *(mag 0.18)*
 
 **When:** actor has `arcane_caster` tag
 
@@ -1723,7 +1850,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} spends an unhurried hour with whatever is currently between their hands and the world's underlying grammar — checking small things, adjusting smaller things, letting the work tell them what it still needs.
 
-### Branch 3 — Maintain and improve the tools of the trade  *(mag 0.18)*
+### Branch 4 — Maintain and improve the tools of the trade  *(mag 0.18)*
 
 **When:** actor has any of [`engineer`, `mechanic`, `tinkerer`, `hacker`, `artificer`]
 
@@ -1732,7 +1859,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} attends to the equipment — the part that's been annoying them for weeks, the upgrade they keep meaning to install, the calibration that's been just slightly off — and emerges with the tools a small degree better than they were.
 
-### Branch 4 — Run through the work that keeps the work possible  *(mag 0.18)*
+### Branch 5 — Run through the work that keeps the work possible  *(mag 0.18)*
 
 **When:** actor has any of [`musician`, `dancer`, `performer`, `artist`, `writer`, `artisan`]
 
@@ -1741,7 +1868,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} works through the practice that no one will ever see — the scales, the exercises, the small motions that the public version of the art rests on — for an hour, the way the practice has to be done if the work is to stay alive.
 
-### Branch 5 — Move the body through its daily reckoning  *(mag 0.18)*
+### Branch 6 — Move the body through its daily reckoning  *(mag 0.18)*
 
 **When:** actor has any of [`athlete`, `martial_artist`, `ranger`, `scout`, `monk`]
 
@@ -1750,7 +1877,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} puts the body through its daily reckoning — the run, the forms, the small punishments that keep the body ready for whatever the next demand will be — and finishes marginally sharper than they began.
 
-### Branch 6 — Tend the small shop's quiet machinery  *(mag 0.18)*
+### Branch 7 — Tend the small shop's quiet machinery  *(mag 0.18)*
 
 **When:** actor has any of [`keeps_shop`, `merchant`, `innkeeper`, `trader`]
 
@@ -1759,7 +1886,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} does the things a place of business needs in order to keep being a place of business: the count, the ledger, the small repairs, the conversations with regulars who came in for something other than the thing they actually bought.
 
-### Branch 7 — Keep the household running  *(mag 0.18)*
+### Branch 8 — Keep the household running  *(mag 0.18)*
 
 **When:** actor has any of [`domestic_role`, `cares_for_household`, `matriarch`, `patriarch`]
 
@@ -1768,7 +1895,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} does the work that holds a household together — the meals, the cleaning, the small attentions no one particularly thanks anyone for but whose absence would be felt immediately. It is enough work for a full day, every day, by itself.
 
-### Branch 8 — Return to the unfinished study  *(mag 0.18)*
+### Branch 9 — Return to the unfinished study  *(mag 0.18)*
 
 **When:** actor has any of [`scholar`, `researcher`, `academic`, `loremaster`]
 
@@ -1777,7 +1904,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} returns to the long work that is always almost but never finished — reading carefully, taking notes that may yet matter, following a thread that may yet lead somewhere — and gives the work another quiet evening of the only thing it really needs.
 
-### Branch 9 — Take a small action of care for the work that is theirs  *(mag 0.12)*
+### Branch 10 — Take a small action of care for the work that is theirs  *(mag 0.12)*
 
 **When:** *(always)*
 
@@ -1812,7 +1939,25 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **NOT:** actor has `wounded` ephemeral
   - **NOT:** actor has `grieving` ephemeral
 
-### Branch 1 — Work a public-facing shift  *(mag 0.18)*
+### Branch 1 — Take whatever paying work the day offers  *(mag 0.2)*
+
+**When:** actor's own resources are below `poor`
+
+**Does:** activity → "scraping together day labor"
+**Event:** `work_performed`
+
+> {actor} cannot afford the luxury of work that matches who they are. They take what the day pays for — hauling, queueing, standing in for someone luckier — and count the result in meals, not meaning.
+
+### Branch 2 — Direct the work rather than perform it  *(mag 0.16)*
+
+**When:** actor's own resources are `wealthy` or better
+
+**Does:** activity → "directing the work of others"
+**Event:** `work_performed`
+
+> {actor} does not stand a shift; they decide what the shifts are for. An hour of instructions, approvals, and quiet corrections moves more value than a day at any counter would.
+
+### Branch 3 — Work a public-facing shift  *(mag 0.18)*
 
 **When:**
 
@@ -1831,7 +1976,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} gives the day to work that other people can see: the counter, the ledger, the bargaining, the small maintenance of trust that keeps trade from becoming chaos.
 
-### Branch 2 — Handle field or maintenance work  *(mag 0.2)*
+### Branch 4 — Handle field or maintenance work  *(mag 0.2)*
 
 **When:**
 
@@ -1847,20 +1992,21 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} spends the hour in practical labor: repairs, inspection, hauling, checking systems whose importance only becomes visible when they fail.
 
-### Branch 3 — Keep administrative obligations moving  *(mag 0.16)*
+### Branch 5 — Keep administrative obligations moving  *(mag 0.16)*
 
 **When:**
 
 - **OR:**
   - actor is in `administration` place class
   - actor has any of [`researcher`, `academic`, `soldier`]
+  - actor holds `status:senior`+ toward any faction
 
 **Does:** activity → "handling administrative work"
 **Event:** `work_performed`
 
 > {actor} moves necessary work through the quiet machinery: forms, messages, rosters, notes, approvals, the kind of paper trail that decides what can happen tomorrow.
 
-### Branch 4 — Do the labor that holds a household together  *(mag 0.18)*
+### Branch 6 — Do the labor that holds a household together  *(mag 0.18)*
 
 **When:** actor has any of [`domestic_role`, `cares_for_household`]
 
@@ -1869,7 +2015,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} does household work with the competence of someone who knows that ordinary life is not self-maintaining: food, cleaning, repairs, care, the small logistics of everyone getting through the day.
 
-### Branch 5 — Keep the obligation from slipping  *(mag 0.1)*
+### Branch 7 — Keep the obligation from slipping  *(mag 0.1)*
 
 **When:** *(always)*
 
@@ -1904,7 +2050,16 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
     - actor is in `meeting` place class
   - ≥ 6 ticks since last `maintain_cover` event for actor
 
-### Branch 1 — Run a low-level courier job  *(mag 0.16)*
+### Branch 1 — Be seen exactly where they are expected  *(mag 0.14)*
+
+**When:** actor's own fame is `renowned` or wider
+
+**Does:** activity → "performing the expected public pattern"
+**Event:** `maintain_cover`
+
+> {actor} cannot be nobody, so they are conspicuously, boringly themselves: the usual table, the usual hours, the usual complaints — a public pattern so consistent that nobody thinks to ask what it covers.
+
+### Branch 2 — Run a low-level courier job  *(mag 0.16)*
 
 **When:**
 
@@ -1916,13 +2071,14 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
     - actor is in `commerce` place class
     - actor is in `meeting` place class
   - actor can plausibly move through public flow
+  - actor's own fame is narrower than `renowned`
 
 **Does:** activity → "running low-level cover work"
 **Event:** `maintain_cover`
 
 > {actor} picks up a benign data packet, walks it across the district, and earns just enough to register as ordinary.
 
-### Branch 2 — Maintain a specific cover identity  *(mag 0.14)*
+### Branch 3 — Maintain a specific cover identity  *(mag 0.14)*
 
 **When:** actor has any current tag of [`cover_identity`, `public_role`, `undercover`]
 
@@ -1931,7 +2087,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} services the identity that keeps questions from forming: one believable errand, one ordinary exchange, one small proof that the mask has a life of its own.
 
-### Branch 3 — Keep a public role legible  *(mag 0.12)*
+### Branch 4 — Keep a public role legible  *(mag 0.12)*
 
 **When:** actor has any current tag of [`broker`, `fixer`, `operative`]
 
@@ -1940,16 +2096,20 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} keeps their visible role legible to the people who expect to see it — enough routine, enough responsiveness, enough plausible friction to look like a life.
 
-### Branch 4 — Drift through public space  *(mag 0.1)*
+### Branch 5 — Drift through public space  *(mag 0.1)*
 
-**When:** actor can plausibly move through public flow
+**When:**
+
+- **AND:**
+  - actor can plausibly move through public flow
+  - actor's own fame is narrower than `renowned`
 
 **Does:** activity → "maintaining public cover"
 **Event:** `maintain_cover`
 
 > {actor} moves through public space at the pace of someone with somewhere to be, generating forgettable civilian noise.
 
-### Branch 5 — Keep the ledger plausible from a fixed post  *(mag 0.08)*
+### Branch 6 — Keep the ledger plausible from a fixed post  *(mag 0.08)*
 
 **When:** *(always)*
 
@@ -2038,12 +2198,14 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `ranger`
 - `religiously_abstinent`
 - `researcher`
+- `reserved`
 - `ritual_practitioner`
 - `route_familiar`
 - `scholar`
 - `scout`
 - `seeking_identity`
 - `soldier`
+- `solitary`
 - `surgical_training`
 - `survivalist`
 - `tinkerer`

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -180,6 +180,38 @@ _register(
     ),
 )
 
+# Self-awareness predicates (issue #282): stage-2 reads of the acting
+# entity's own fame / resources tiers and self-scoped status edges.
+_register(
+    r"fame_at_or_above\((?P<tier>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: (f"{_slot(m.group('slot'))}'s own fame is `{m.group('tier')}` or wider"),
+)
+_register(
+    r"fame_below\((?P<tier>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('slot'))}'s own fame is narrower than `{m.group('tier')}`"
+    ),
+)
+_register(
+    r"resources_at_or_above\((?P<tier>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('slot'))}'s own resources are `{m.group('tier')}` or better"
+    ),
+)
+_register(
+    r"resources_below\((?P<tier>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('slot'))}'s own resources are below `{m.group('tier')}`"
+    ),
+)
+_register(
+    r"has_any_status_at_or_above\((?P<level>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('slot'))} holds `status:{m.group('level')}`+ "
+        "toward any faction"
+    ),
+)
+
 # Location predicates
 _register(
     r"in_location_class\((?P<lc>[^@()]+)@(?P<slot>\w+)\)",

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -471,14 +471,25 @@ def _tier_rank(
     entity_id: int,
     ranks: Mapping[str, int],
     default_tier: str,
+    ladder: str,
 ) -> int:
-    """Return an entity's rank on an exclusive tier ladder (durable tags)."""
+    """Return an entity's rank on an exclusive tier ladder (durable tags).
 
-    present = [
-        ranks[tag] for tag in state.tags.get(entity_id, frozenset()) if tag in ranks
-    ]
+    Tier ladders are exclusive-cardinality registry categories: an entity
+    carrying more than one tier tag on the same ladder is corrupt state, and
+    corrupt state must surface loudly rather than be quietly resolved.
+    """
+
+    present = sorted(
+        tag for tag in state.tags.get(entity_id, frozenset()) if tag in ranks
+    )
+    if len(present) > 1:
+        raise ValueError(
+            f"Entity {entity_id} holds multiple {ladder} tier tags {present}; "
+            f"{ladder} is an exclusive ladder"
+        )
     if present:
-        return max(present)
+        return ranks[present[0]]
     return ranks[default_tier]
 
 
@@ -507,7 +518,7 @@ def fame_at_or_above(tier: str, slot: Slot = Slot.ACTOR) -> Condition:
         if entity_id is None:
             return False
         return (
-            _tier_rank(state, entity_id, FAME_TIER_RANKS, DEFAULT_FAME_TIER)
+            _tier_rank(state, entity_id, FAME_TIER_RANKS, DEFAULT_FAME_TIER, "fame")
             >= threshold
         )
 
@@ -528,7 +539,8 @@ def fame_below(tier: str, slot: Slot = Slot.ACTOR) -> Condition:
         if entity_id is None:
             return False
         return (
-            _tier_rank(state, entity_id, FAME_TIER_RANKS, DEFAULT_FAME_TIER) < threshold
+            _tier_rank(state, entity_id, FAME_TIER_RANKS, DEFAULT_FAME_TIER, "fame")
+            < threshold
         )
 
     return _named(_condition, f"fame_below({normalized}@{slot.value})")
@@ -549,7 +561,13 @@ def resources_at_or_above(tier: str, slot: Slot = Slot.ACTOR) -> Condition:
         if entity_id is None:
             return False
         return (
-            _tier_rank(state, entity_id, RESOURCES_TIER_RANKS, DEFAULT_RESOURCES_TIER)
+            _tier_rank(
+                state,
+                entity_id,
+                RESOURCES_TIER_RANKS,
+                DEFAULT_RESOURCES_TIER,
+                "resources",
+            )
             >= threshold
         )
 
@@ -567,7 +585,13 @@ def resources_below(tier: str, slot: Slot = Slot.ACTOR) -> Condition:
         if entity_id is None:
             return False
         return (
-            _tier_rank(state, entity_id, RESOURCES_TIER_RANKS, DEFAULT_RESOURCES_TIER)
+            _tier_rank(
+                state,
+                entity_id,
+                RESOURCES_TIER_RANKS,
+                DEFAULT_RESOURCES_TIER,
+                "resources",
+            )
             < threshold
         )
 
@@ -590,6 +614,11 @@ def has_any_status_at_or_above(threshold: str, slot: Slot = Slot.ACTOR) -> Condi
         entity_id = _slot_entity(bindings, slot)
         if entity_id is None:
             return False
+        # Known cost: O(total pair-tag relationships) per evaluation, the
+        # same shape as _has_outbound_pair_tag / _has_inbound_pair_tag.
+        # WorldState.pair_tags is keyed by (subject, object) with no subject
+        # index; if stage-3 encounter rolls make this measurable, add a
+        # derived pair_tags_by_subject map at hydration rather than here.
         for (subject_id, _object_id), tags in state.pair_tags.items():
             if subject_id != entity_id:
                 continue

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -10,6 +10,11 @@ import json
 from typing import Any, Callable, Dict, Iterable, Literal, Mapping, Optional, Tuple
 
 from nexus.agents.orrery.needs import normalize_need_type
+from nexus.agents.orrery.status_family import (
+    STATUS_LEVEL_RANKS,
+    STATUS_TAG_PREFIX,
+    normalize_status_level,
+)
 
 
 class EntityKind(str, Enum):
@@ -145,6 +150,33 @@ CONTACT_PAIR_TAGS: Mapping[ContactKind, str] = {
 }
 LOADED_TRUST_FORWARD_MIN = 2
 LOADED_TRUST_REVERSE_MAX = -1
+
+# Package self-awareness (issue #282): exclusive single-entity tier ladders the
+# acting entity reads about *itself* during stage-2 branch selection. Ranks are
+# vocabulary semantics (registry tag ordering), not tunable weights. Absence of
+# a tier tag IS the default tier — the registry's documented default-absent
+# pattern (`role.fame:obscure`, `role.resources:comfortable`).
+FAME_TIER_RANKS: Mapping[str, int] = {
+    "obscure": 0,
+    "known": 1,
+    "renowned": 2,
+    "legendary": 3,
+}
+DEFAULT_FAME_TIER = "obscure"
+RESOURCES_TIER_RANKS: Mapping[str, int] = {
+    "destitute": 0,
+    "poor": 1,
+    "comfortable": 2,
+    "wealthy": 3,
+    "magnate": 4,
+}
+DEFAULT_RESOURCES_TIER = "comfortable"
+# Fame predicates are stage-2/stage-3 vocabulary ONLY. Entry gating (stage 1)
+# must never read fame; validate_no_fame_in_entry_gates enforces this.
+_FAME_PREDICATE_NAME_PREFIXES: Tuple[str, ...] = (
+    "fame_at_or_above(",
+    "fame_below(",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -432,6 +464,148 @@ def has_any_current_tag(*tags: str, slot: Slot = Slot.ACTOR) -> Condition:
         return bool(candidates & current_tags)
 
     return _named(_condition, f"has_any_current_tag({','.join(tags)}@{slot.value})")
+
+
+def _tier_rank(
+    state: WorldState,
+    entity_id: int,
+    ranks: Mapping[str, int],
+    default_tier: str,
+) -> int:
+    """Return an entity's rank on an exclusive tier ladder (durable tags)."""
+
+    present = [
+        ranks[tag] for tag in state.tags.get(entity_id, frozenset()) if tag in ranks
+    ]
+    if present:
+        return max(present)
+    return ranks[default_tier]
+
+
+def _validate_tier(tier: str, ranks: Mapping[str, int], ladder: str) -> str:
+    normalized = str(tier).strip()
+    if normalized not in ranks:
+        raise ValueError(
+            f"Unknown {ladder} tier {tier!r}; expected one of {sorted(ranks)}"
+        )
+    return normalized
+
+
+def fame_at_or_above(tier: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound entity's own fame meets a tier threshold.
+
+    Fame is an unvalenced ambient detection radius (inverse stealth); absence
+    of a ``role.fame`` tag reads as ``obscure``. Stage-2/3 vocabulary only —
+    never use this in a package gate (stage 1 entry gating).
+    """
+
+    normalized = _validate_tier(tier, FAME_TIER_RANKS, "fame")
+    threshold = FAME_TIER_RANKS[normalized]
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        return (
+            _tier_rank(state, entity_id, FAME_TIER_RANKS, DEFAULT_FAME_TIER)
+            >= threshold
+        )
+
+    return _named(_condition, f"fame_at_or_above({normalized}@{slot.value})")
+
+
+def fame_below(tier: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound entity's own fame is below a tier threshold.
+
+    Same stage discipline as :func:`fame_at_or_above`: stage-2/3 only.
+    """
+
+    normalized = _validate_tier(tier, FAME_TIER_RANKS, "fame")
+    threshold = FAME_TIER_RANKS[normalized]
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        return (
+            _tier_rank(state, entity_id, FAME_TIER_RANKS, DEFAULT_FAME_TIER) < threshold
+        )
+
+    return _named(_condition, f"fame_below({normalized}@{slot.value})")
+
+
+def resources_at_or_above(tier: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound entity's own wealth meets a tier threshold.
+
+    Absence of a ``role.resources`` tag reads as ``comfortable`` per the
+    registry's default-absent pattern.
+    """
+
+    normalized = _validate_tier(tier, RESOURCES_TIER_RANKS, "resources")
+    threshold = RESOURCES_TIER_RANKS[normalized]
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        return (
+            _tier_rank(state, entity_id, RESOURCES_TIER_RANKS, DEFAULT_RESOURCES_TIER)
+            >= threshold
+        )
+
+    return _named(_condition, f"resources_at_or_above({normalized}@{slot.value})")
+
+
+def resources_below(tier: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound entity's own wealth is below a tier threshold."""
+
+    normalized = _validate_tier(tier, RESOURCES_TIER_RANKS, "resources")
+    threshold = RESOURCES_TIER_RANKS[normalized]
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        return (
+            _tier_rank(state, entity_id, RESOURCES_TIER_RANKS, DEFAULT_RESOURCES_TIER)
+            < threshold
+        )
+
+    return _named(_condition, f"resources_below({normalized}@{slot.value})")
+
+
+def has_any_status_at_or_above(threshold: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether the entity holds outbound status at a rank, in any scope.
+
+    Status is scope-bound (``status:<level>`` pair tags, subject → faction);
+    this is the self-scoped read: does the acting entity hold standing at or
+    above ``threshold`` toward *any* scope faction. Negative levels never
+    satisfy a positive threshold because ranks are ordered.
+    """
+
+    normalized = normalize_status_level(threshold)
+    threshold_rank = STATUS_LEVEL_RANKS[normalized]
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        for (subject_id, _object_id), tags in state.pair_tags.items():
+            if subject_id != entity_id:
+                continue
+            for tag in tags:
+                if not tag.startswith(STATUS_TAG_PREFIX):
+                    continue
+                level = tag.removeprefix(STATUS_TAG_PREFIX)
+                rank = STATUS_LEVEL_RANKS.get(level)
+                if rank is not None and rank >= threshold_rank:
+                    return True
+        return False
+
+    return _named(
+        _condition,
+        f"has_any_status_at_or_above({normalized}@{slot.value})",
+    )
 
 
 def has_ephemeral(tag: str, slot: Slot = Slot.ACTOR) -> Condition:
@@ -1594,6 +1768,38 @@ def validate_always_fallbacks(templates: Iterable[Template]) -> None:
         raise ValueError(
             "Orrery templates missing terminal ALWAYS branch: "
             + ", ".join(sorted(missing))
+        )
+
+
+def _condition_tree_leaves(condition: Condition) -> Iterable[Condition]:
+    """Yield leaf predicates of a (possibly compound) condition tree."""
+
+    if isinstance(condition, CompoundCondition):
+        for child in condition.children:
+            yield from _condition_tree_leaves(child)
+    else:
+        yield condition
+
+
+def validate_no_fame_in_entry_gates(templates: Iterable[Template]) -> None:
+    """Enforce the issue #282 stage contract: fame never gates package entry.
+
+    Fame is stage-2 (branch selection) and stage-3 (outcome) vocabulary only.
+    A package gate that reads the actor's fame would make recognizability
+    decide *whether* a behavior fires instead of *how* it is performed, which
+    the locked design forbids.
+    """
+
+    offenders: list[str] = []
+    for template in templates:
+        for leaf in _condition_tree_leaves(template.package_gate):
+            name = getattr(leaf, "__name__", "")
+            if name.startswith(_FAME_PREDICATE_NAME_PREFIXES):
+                offenders.append(f"{template.id}: {name}")
+    if offenders:
+        raise ValueError(
+            "Fame predicates are stage-2/3 only and must not appear in "
+            "package gates (issue #282 stage contract): " + ", ".join(sorted(offenders))
         )
 
 

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -56,6 +56,7 @@ from nexus.agents.orrery.substrate import (
     travel_risk_is,
     trust_at_least,
     trust_below,
+    validate_no_fame_in_entry_gates,
     weather_is,
 )
 
@@ -3192,7 +3193,10 @@ SOCIALIZE = Template(
         # Self-awareness: a renowned-or-better actor cannot get casual
         # anonymous company from a public room — the room reorganizes
         # around them. Their socializing happens on ground they control,
-        # with people they already know.
+        # with people they already know. Listed before the disposition
+        # branch below deliberately: fame structurally constrains WHERE
+        # company can happen, so it outranks disposition (which only
+        # shapes the medium) when both match.
         Branch(
             label="Host chosen company on their own ground",
             conditions=AND(
@@ -3609,3 +3613,9 @@ BUILTIN_TEMPLATES = (
     INTIMACY,
     MAINTAIN_COVER,
 )
+
+# Enforce the issue #282 stage contract at import time: fame predicates are
+# stage-2/3 vocabulary and must never appear in stage-1 entry gating. A
+# fame-gated template added to this catalog raises immediately rather than
+# relying on test coverage.
+validate_no_fame_in_entry_gates(BUILTIN_TEMPLATES)

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -17,8 +17,11 @@ from nexus.agents.orrery.substrate import (
     co_located,
     count_co_located,
     direct_contact_is_dramatic,
+    fame_at_or_above,
+    fame_below,
     has_any_intimacy_suppressor,
     has_any_current_tag,
+    has_any_status_at_or_above,
     has_any_tag,
     has_contact_of_kind,
     has_ephemeral,
@@ -40,6 +43,8 @@ from nexus.agents.orrery.substrate import (
     recent_event,
     relationship_is_asymmetric,
     relationship_is_mutual_warm,
+    resources_at_or_above,
+    resources_below,
     at_routine_anchor,
     away_from_routine_anchor,
     routine_anchor_due,
@@ -130,6 +135,25 @@ EVADE_PURSUERS = Template(
             magnitude=0.72,
         ),
         Branch(
+            label="Buy a discreet extraction",
+            conditions=AND(
+                fame_at_or_above("renowned"),
+                resources_at_or_above("wealthy"),
+            ),
+            narrative_stub=(
+                "{actor} knows their face does half the pursuers' work for "
+                "them, so they pay for the kind of exit that never touches "
+                "public flow: a closed vehicle, a bought route, a driver "
+                "whose business is not remembering."
+            ),
+            state_delta={
+                "character.current_activity": "buying a discreet extraction",
+            },
+            event_type="evade_pursuit",
+            changed_fields=("character.current_activity",),
+            magnitude=0.64,
+        ),
+        Branch(
             label="Reach a safe house through contacts",
             conditions=has_contact_of_kind("lodging"),
             narrative_stub=(
@@ -145,7 +169,11 @@ EVADE_PURSUERS = Template(
         ),
         Branch(
             label="Keep moving, blend into public flow",
-            conditions=can_move_publicly(),
+            # Self-awareness: blending into a crowd only works for actors
+            # whose ambient detection radius is narrow. Renowned-or-better
+            # actors cannot disappear into pedestrian flow; without funds
+            # for an extraction they fall through to breaking line of sight.
+            conditions=AND(can_move_publicly(), fame_below("renowned")),
             narrative_stub=(
                 "{actor} joins the densest pedestrian current nearby, never "
                 "stopping long enough to make a clean pattern."
@@ -188,6 +216,70 @@ HIDE = Template(
         since_last_event_at_least("counter_surveillance_sweep", minimum_ticks=6),
     ),
     branches=(
+        # Stage-2 self-awareness (issue #282 worked example): concealment
+        # escalates with the actor's own fame because a wide detection radius
+        # makes laying low ineffective. Each escalation tier must also be
+        # affordable; an actor who cannot pay for their tier falls through to
+        # the cheaper measure below it. Obscure actors ride out concealment
+        # with the lay-low maintenance branches further down.
+        Branch(
+            label="Erase the identity and vanish completely",
+            conditions=AND(
+                fame_at_or_above("legendary"),
+                resources_at_or_above("magnate"),
+            ),
+            narrative_stub=(
+                "{actor} is too widely known to be hidden by walls or "
+                "habits, so they spend what almost no one can spend: the "
+                "records, the debts, the face in the right databases — an "
+                "identity dismantled piece by piece until there is nothing "
+                "left to recognize."
+            ),
+            state_delta={
+                "character.current_activity": "erasing their identity",
+            },
+            event_type="hideout_maintained",
+            changed_fields=("character.current_activity",),
+            magnitude=0.62,
+        ),
+        Branch(
+            label="Relocate to safer ground",
+            conditions=AND(
+                fame_at_or_above("renowned"),
+                resources_at_or_above("wealthy"),
+            ),
+            narrative_stub=(
+                "{actor} accepts that a recognizable face cannot outlast "
+                "the neighborhood that recognizes it, and pays for the "
+                "quiet logistics of being somewhere else entirely before "
+                "anyone thinks to look."
+            ),
+            state_delta={
+                "character.current_activity": "relocating to safer ground",
+            },
+            event_type="hideout_maintained",
+            changed_fields=("character.current_activity",),
+            magnitude=0.52,
+        ),
+        Branch(
+            label="Change the face they show the street",
+            conditions=AND(
+                fame_at_or_above("known"),
+                resources_at_or_above("comfortable"),
+            ),
+            narrative_stub=(
+                "{actor} is recognizable enough that habit alone will not "
+                "protect them, so they spend on the cosmetic arithmetic of "
+                "not being noticed: hair, clothes, gait, the small paid "
+                "alterations that make a familiar face unfamiliar."
+            ),
+            state_delta={
+                "character.current_activity": "altering their appearance",
+            },
+            event_type="hideout_maintained",
+            changed_fields=("character.current_activity",),
+            magnitude=0.44,
+        ),
         Branch(
             label="Harden or sanitize a safehouse",
             conditions=AND(
@@ -452,9 +544,33 @@ MAINTAIN_COVER = Template(
         since_last_event_at_least("maintain_cover", minimum_ticks=6),
     ),
     branches=(
+        # Self-awareness inversion: a recognizable actor cannot maintain
+        # cover by generating anonymous civilian noise — their cover IS the
+        # public pattern people expect to see. Fame is unvalenced detection
+        # radius; here visibility composes into an asset.
+        Branch(
+            label="Be seen exactly where they are expected",
+            conditions=fame_at_or_above("renowned"),
+            narrative_stub=(
+                "{actor} cannot be nobody, so they are conspicuously, "
+                "boringly themselves: the usual table, the usual hours, the "
+                "usual complaints — a public pattern so consistent that "
+                "nobody thinks to ask what it covers."
+            ),
+            state_delta={
+                "character.current_activity": "performing the expected public pattern",
+            },
+            event_type="maintain_cover",
+            changed_fields=("character.current_activity",),
+            magnitude=0.14,
+        ),
         Branch(
             label="Run a low-level courier job",
-            conditions=AND(URBAN_PUBLIC_FLOW_PLACE, can_move_publicly()),
+            conditions=AND(
+                URBAN_PUBLIC_FLOW_PLACE,
+                can_move_publicly(),
+                fame_below("renowned"),
+            ),
             narrative_stub=(
                 "{actor} picks up a benign data packet, walks it across the "
                 "district, and earns just enough to register as ordinary."
@@ -496,7 +612,7 @@ MAINTAIN_COVER = Template(
         ),
         Branch(
             label="Drift through public space",
-            conditions=can_move_publicly(),
+            conditions=AND(can_move_publicly(), fame_below("renowned")),
             narrative_stub=(
                 "{actor} moves through public space at the pace of someone "
                 "with somewhere to be, generating forgettable civilian noise."
@@ -1655,6 +1771,66 @@ TRAVEL = Template(
             ),
             magnitude=0.18,
         ),
+        # Self-awareness route styles: the actor's own wealth and fame shape
+        # HOW they depart before the generic departure logic applies. Wealth
+        # substitutes for preparation (a charter is bought, not packed);
+        # fame forces recognizable travelers off public flow onto covert
+        # routings, which still demand real preparation.
+        Branch(
+            label="Charter private transport",
+            conditions=AND(
+                has_travel_destination(),
+                NOT(is_in_transit()),
+                resources_at_or_above("wealthy"),
+            ),
+            narrative_stub=(
+                "{actor} does not queue, transfer, or wait. Money turns the "
+                "journey into a closed door and a window: a private vehicle, "
+                "a paid schedule, a route that exists because they asked "
+                "for it."
+            ),
+            state_delta={
+                "character.current_activity": "departing by chartered transport",
+                "travel.start": {"mode": "vehicle", "initial_progress": 0.05},
+            },
+            event_type="travel_departed",
+            changed_fields=(
+                "character.current_activity",
+                "character_travel_states.status",
+                "character_travel_states.progress_ratio",
+            ),
+            magnitude=0.30,
+        ),
+        Branch(
+            label="Slip out along covert routes",
+            conditions=AND(
+                has_travel_destination(),
+                NOT(is_in_transit()),
+                fame_at_or_above("renowned"),
+                OR(
+                    has_tag("travel_ready"),
+                    has_tag("travel_provisioned"),
+                    has_tag("route_familiar"),
+                ),
+            ),
+            narrative_stub=(
+                "{actor} cannot ride public flow without being a sighting, "
+                "so the route runs through the city's blind spots: service "
+                "levels, freight corridors, the hours and angles where a "
+                "recognizable face passes unwitnessed."
+            ),
+            state_delta={
+                "character.current_activity": "departing along covert routes",
+                "travel.start": {"mode": "covert", "initial_progress": 0.05},
+            },
+            event_type="travel_departed",
+            changed_fields=(
+                "character.current_activity",
+                "character_travel_states.status",
+                "character_travel_states.progress_ratio",
+            ),
+            magnitude=0.32,
+        ),
         Branch(
             label="Depart toward the planned destination",
             conditions=AND(
@@ -1731,6 +1907,41 @@ WORK = Template(
         NOT(has_ephemeral("grieving")),
     ),
     branches=(
+        # Self-awareness: the actor's own wealth tier shapes what "work"
+        # means before role or place do. Destitution makes work a matter of
+        # survival; magnate-tier wealth makes it a matter of direction.
+        Branch(
+            label="Take whatever paying work the day offers",
+            conditions=resources_below("poor"),
+            narrative_stub=(
+                "{actor} cannot afford the luxury of work that matches who "
+                "they are. They take what the day pays for — hauling, "
+                "queueing, standing in for someone luckier — and count the "
+                "result in meals, not meaning."
+            ),
+            state_delta={
+                "character.current_activity": "scraping together day labor",
+            },
+            event_type="work_performed",
+            changed_fields=("character.current_activity",),
+            magnitude=0.20,
+        ),
+        Branch(
+            label="Direct the work rather than perform it",
+            conditions=resources_at_or_above("wealthy"),
+            narrative_stub=(
+                "{actor} does not stand a shift; they decide what the "
+                "shifts are for. An hour of instructions, approvals, and "
+                "quiet corrections moves more value than a day at any "
+                "counter would."
+            ),
+            state_delta={
+                "character.current_activity": "directing the work of others",
+            },
+            event_type="work_performed",
+            changed_fields=("character.current_activity",),
+            magnitude=0.16,
+        ),
         Branch(
             label="Work a public-facing shift",
             conditions=OR(
@@ -1767,9 +1978,13 @@ WORK = Template(
         ),
         Branch(
             label="Keep administrative obligations moving",
+            # Self-scoped status read: senior-or-better standing toward any
+            # faction means the actor's work is rosters, approvals, and
+            # institutional upkeep even away from an administration place.
             conditions=OR(
                 ADMINISTRATION_PLACE,
                 has_any_tag("researcher", "academic", "soldier"),
+                has_any_status_at_or_above("senior"),
             ),
             narrative_stub=(
                 "{actor} moves necessary work through the quiet machinery: "
@@ -1883,6 +2098,26 @@ TEND_CRAFT = Template(
         NOT(has_ephemeral("grieving")),
     ),
     branches=(
+        # Self-awareness: wealth changes how craft is tended — money buys
+        # materials, commissions, and time that poorer practitioners must
+        # improvise around (the improvisation IS the branches below).
+        Branch(
+            label="Put real money into the craft",
+            conditions=resources_at_or_above("wealthy"),
+            narrative_stub=(
+                "{actor} spends on the work the way only someone with money "
+                "can: the proper materials instead of the workable ones, "
+                "the commissioned part instead of the salvaged one, the "
+                "bought afternoon of uninterrupted attention."
+            ),
+            state_delta={
+                "character.current_activity": "investing in the craft",
+                "entity_tags.add": ["recently_tended_craft"],
+            },
+            event_type="craft_tended",
+            changed_fields=("character.current_activity", "entity_tags"),
+            magnitude=0.18,
+        ),
         Branch(
             label="Make the weapon ready for what comes next",
             conditions=has_any_tag("combat_trained", "soldier", "warrior", "fighter"),
@@ -2954,6 +3189,37 @@ SOCIALIZE = Template(
         NOT(has_ephemeral("wounded")),
     ),
     branches=(
+        # Self-awareness: a renowned-or-better actor cannot get casual
+        # anonymous company from a public room — the room reorganizes
+        # around them. Their socializing happens on ground they control,
+        # with people they already know.
+        Branch(
+            label="Host chosen company on their own ground",
+            conditions=AND(
+                fame_at_or_above("renowned"),
+                has_contact_of_kind("social"),
+            ),
+            narrative_stub=(
+                "{actor} does not go looking for company in rooms that "
+                "would turn to watch them enter. They summon it instead: a "
+                "few chosen people, a door that closes, an evening where "
+                "nobody performs recognition."
+            ),
+            state_delta={
+                "character.current_activity": "hosting chosen company privately",
+                "need.fulfill": {
+                    "type": "socialize",
+                    "quality": "private_company",
+                    "discharge_debt": 9999,
+                },
+            },
+            event_type="socialized",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.24,
+        ),
         Branch(
             label="Seek company after extended isolation",
             conditions=AND(
@@ -2961,6 +3227,7 @@ SOCIALIZE = Template(
                 NOT(count_co_located(1)),
                 NOT(SOCIAL_VENUE_PLACE),
                 can_move_publicly(),
+                fame_below("renowned"),
                 has_location_class_destination(
                     "commerce", "entertainment", "meeting", "place_open"
                 ),
@@ -3018,12 +3285,43 @@ SOCIALIZE = Template(
             ),
             magnitude=0.22,
         ),
+        # Self-awareness: dispositionally private actors with someone to
+        # call prefer a trusted voice over an anonymous crowd, even when a
+        # public venue is reachable.
+        Branch(
+            label="Seek a trusted voice rather than a crowd",
+            conditions=AND(
+                has_any_tag("solitary", "reserved"),
+                has_contact_of_kind("social"),
+            ),
+            narrative_stub=(
+                "{actor} weighs the noise of a public room against the "
+                "particular relief of one familiar voice, and chooses the "
+                "voice — a long, unhurried exchange with someone who does "
+                "not need anything explained."
+            ),
+            state_delta={
+                "character.current_activity": "talking with a trusted contact",
+                "need.fulfill": {
+                    "type": "socialize",
+                    "quality": "trusted_contact",
+                    "discharge_debt": 72,
+                },
+            },
+            event_type="socialized",
+            changed_fields=(
+                "character.current_activity",
+                "character_need_states.debt_score",
+            ),
+            magnitude=0.22,
+        ),
         Branch(
             label="Set out toward public company",
             conditions=AND(
                 NOT(count_co_located(1)),
                 NOT(SOCIAL_VENUE_PLACE),
                 can_move_publicly(),
+                fame_below("renowned"),
                 has_location_class_destination(
                     "commerce", "entertainment", "meeting", "place_open"
                 ),
@@ -3058,7 +3356,7 @@ SOCIALIZE = Template(
         ),
         Branch(
             label="Go where people are",
-            conditions=SOCIAL_VENUE_PLACE,
+            conditions=AND(SOCIAL_VENUE_PLACE, fame_below("renowned")),
             narrative_stub=(
                 "{actor} goes to one of the places built around the fact "
                 "that people gather there, and stays long enough to become "

--- a/tests/test_orrery/test_self_awareness.py
+++ b/tests/test_orrery/test_self_awareness.py
@@ -1,0 +1,457 @@
+"""Tests for package self-awareness (issue #282): stage-2 self-property reads."""
+
+from typing import Optional
+
+import pytest
+
+from nexus.agents.orrery.substrate import (
+    ALWAYS,
+    AND,
+    NOT,
+    Branch,
+    DriveBand,
+    Slot,
+    Template,
+    TravelState,
+    WorldState,
+    evaluate,
+    fame_at_or_above,
+    fame_below,
+    has_any_status_at_or_above,
+    resources_at_or_above,
+    resources_below,
+    validate_no_fame_in_entry_gates,
+)
+from nexus.agents.orrery.templates import (
+    BUILTIN_TEMPLATES,
+    EVADE_PURSUERS,
+    HIDE,
+    MAINTAIN_COVER,
+    SOCIALIZE,
+    TEND_CRAFT,
+    TRAVEL,
+    WORK,
+)
+
+ACTOR = 1
+PURSUER = 2
+CONTACT = 3
+FACTION = 40
+PLACE = 7
+
+ACTOR_BINDINGS = {Slot.ACTOR: ACTOR}
+
+
+def _state(
+    *,
+    actor_tags: frozenset[str] = frozenset(),
+    pair_tags: Optional[dict] = None,
+    locations: Optional[dict] = None,
+    location_classes: Optional[dict] = None,
+    need_debt_scores: Optional[dict] = None,
+    travel_states: Optional[dict] = None,
+) -> WorldState:
+    return WorldState(
+        tags={ACTOR: actor_tags},
+        pair_tags=pair_tags or {},
+        locations=locations or {},
+        location_classes=location_classes or {},
+        need_debt_scores=need_debt_scores or {},
+        travel_states=travel_states or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Predicate semantics
+# ---------------------------------------------------------------------------
+
+
+def test_fame_tiers_order_and_default_absent_reads_as_obscure() -> None:
+    """Absence of a role.fame tag IS the obscure tier (default-absent)."""
+
+    untagged = _state(actor_tags=frozenset({"fixer"}))
+    assert fame_at_or_above("obscure")(untagged, ACTOR_BINDINGS)
+    assert not fame_at_or_above("known")(untagged, ACTOR_BINDINGS)
+    assert fame_below("known")(untagged, ACTOR_BINDINGS)
+    assert not fame_below("obscure")(untagged, ACTOR_BINDINGS)
+
+    renowned = _state(actor_tags=frozenset({"renowned"}))
+    assert fame_at_or_above("known")(renowned, ACTOR_BINDINGS)
+    assert fame_at_or_above("renowned")(renowned, ACTOR_BINDINGS)
+    assert not fame_at_or_above("legendary")(renowned, ACTOR_BINDINGS)
+    assert fame_below("legendary")(renowned, ACTOR_BINDINGS)
+    assert not fame_below("renowned")(renowned, ACTOR_BINDINGS)
+
+
+def test_resources_tiers_order_and_default_absent_reads_as_comfortable() -> None:
+    """Absence of a role.resources tag IS the comfortable tier."""
+
+    untagged = _state(actor_tags=frozenset({"fixer"}))
+    assert resources_at_or_above("comfortable")(untagged, ACTOR_BINDINGS)
+    assert not resources_at_or_above("wealthy")(untagged, ACTOR_BINDINGS)
+    assert resources_below("wealthy")(untagged, ACTOR_BINDINGS)
+    assert not resources_below("poor")(untagged, ACTOR_BINDINGS)
+
+    destitute = _state(actor_tags=frozenset({"destitute"}))
+    assert resources_below("poor")(destitute, ACTOR_BINDINGS)
+    assert not resources_at_or_above("poor")(destitute, ACTOR_BINDINGS)
+
+    magnate = _state(actor_tags=frozenset({"magnate"}))
+    assert resources_at_or_above("magnate")(magnate, ACTOR_BINDINGS)
+    assert not resources_below("magnate")(magnate, ACTOR_BINDINGS)
+
+
+def test_tier_predicates_reject_unknown_tiers() -> None:
+    with pytest.raises(ValueError, match="Unknown fame tier"):
+        fame_at_or_above("celebrity")
+    with pytest.raises(ValueError, match="Unknown fame tier"):
+        fame_below("famous")
+    with pytest.raises(ValueError, match="Unknown resources tier"):
+        resources_at_or_above("rich")
+    with pytest.raises(ValueError, match="Unknown resources tier"):
+        resources_below("broke")
+
+
+def test_tier_predicates_require_bound_entity() -> None:
+    state = _state(actor_tags=frozenset({"legendary", "magnate"}))
+    empty: dict = {}
+    assert not fame_at_or_above("obscure")(state, empty)
+    assert not fame_below("legendary")(state, empty)
+    assert not resources_at_or_above("destitute")(state, empty)
+    assert not resources_below("magnate")(state, empty)
+
+
+def test_self_scoped_status_reads_outbound_edges_in_any_scope() -> None:
+    """Status is scope-bound; the self read is outbound-any-scope."""
+
+    senior = _state(
+        pair_tags={(ACTOR, FACTION): frozenset({"status:senior"})},
+    )
+    assert has_any_status_at_or_above("senior")(senior, ACTOR_BINDINGS)
+    assert has_any_status_at_or_above("junior")(senior, ACTOR_BINDINGS)
+    assert not has_any_status_at_or_above("elite")(senior, ACTOR_BINDINGS)
+
+    inbound_only = _state(
+        pair_tags={(FACTION, ACTOR): frozenset({"status:senior"})},
+    )
+    assert not has_any_status_at_or_above("junior")(inbound_only, ACTOR_BINDINGS)
+
+    negative = _state(
+        pair_tags={(ACTOR, FACTION): frozenset({"status:pariah"})},
+    )
+    assert not has_any_status_at_or_above("junior")(negative, ACTOR_BINDINGS)
+
+    with pytest.raises(ValueError, match="Unknown status level"):
+        has_any_status_at_or_above("vip")
+
+
+# ---------------------------------------------------------------------------
+# Stage-1 guardrail: fame never gates package entry
+# ---------------------------------------------------------------------------
+
+
+def test_builtin_package_gates_never_read_fame() -> None:
+    """The locked #282 stage contract holds for the whole built-in catalog."""
+
+    validate_no_fame_in_entry_gates(BUILTIN_TEMPLATES)
+
+
+def test_fame_in_entry_gate_is_rejected_even_when_nested() -> None:
+    offender = Template(
+        id="fame_gated_offender",
+        priority=1,
+        drive_band=DriveBand.PROJECT_IDENTITY,
+        blurb="Illegally gates entry on the actor's fame.",
+        required_slots=(Slot.ACTOR,),
+        package_gate=AND(NOT(fame_below("renowned"))),
+        branches=(
+            Branch(
+                label="noop",
+                conditions=ALWAYS,
+                narrative_stub="{actor} does nothing.",
+            ),
+        ),
+    )
+    with pytest.raises(ValueError, match="stage-2/3 only"):
+        validate_no_fame_in_entry_gates((offender,))
+
+
+# ---------------------------------------------------------------------------
+# HIDE: the issue #282 worked example
+# ---------------------------------------------------------------------------
+
+_HIDDEN_BASE = frozenset({"fugitive"})
+
+
+@pytest.mark.parametrize(
+    ("profile_tags", "expected_branch"),
+    (
+        # The worked-example table from issue #282. The lay_low row maps to
+        # HIDE's existing low-drama maintenance fallback.
+        (
+            frozenset({"cautious"}),
+            "Preserve the silence another day",
+        ),
+        (
+            frozenset({"known"}),
+            "Change the face they show the street",
+        ),
+        (
+            frozenset({"renowned", "wealthy"}),
+            "Relocate to safer ground",
+        ),
+        (
+            frozenset({"legendary", "magnate"}),
+            "Erase the identity and vanish completely",
+        ),
+    ),
+)
+def test_hide_branch_selection_matches_issue_282_worked_example(
+    profile_tags: frozenset[str], expected_branch: str
+) -> None:
+    state = _state(actor_tags=_HIDDEN_BASE | profile_tags)
+    resolution = evaluate(HIDE, state, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == expected_branch
+
+
+def test_hide_escalation_requires_affordability() -> None:
+    """A famous actor who cannot pay for their tier takes a cheaper measure."""
+
+    legendary_destitute = _state(
+        actor_tags=_HIDDEN_BASE | frozenset({"legendary", "destitute"})
+    )
+    resolution = evaluate(HIDE, legendary_destitute, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Preserve the silence another day"
+
+    legendary_wealthy = _state(
+        actor_tags=_HIDDEN_BASE | frozenset({"legendary", "wealthy"})
+    )
+    resolution = evaluate(HIDE, legendary_wealthy, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Relocate to safer ground"
+
+
+def test_hide_entry_gate_ignores_fame() -> None:
+    """Stage 1: a legendary actor qualifies for HIDE exactly like an obscure one."""
+
+    for fame_tag in ((), ("legendary",)):
+        state = _state(actor_tags=_HIDDEN_BASE | frozenset(fame_tag))
+        assert evaluate(HIDE, state, ACTOR_BINDINGS).passes
+
+
+# ---------------------------------------------------------------------------
+# EVADE_PURSUERS: the famous fixer no longer strolls into a crowd
+# ---------------------------------------------------------------------------
+
+
+def _pursued_state(actor_tags: frozenset[str]) -> WorldState:
+    return _state(
+        actor_tags=actor_tags,
+        pair_tags={(PURSUER, ACTOR): frozenset({"hunting"})},
+    )
+
+
+def test_obscure_actor_still_blends_into_public_flow() -> None:
+    state = _pursued_state(frozenset({"fixer"}))
+    resolution = evaluate(EVADE_PURSUERS, state, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Keep moving, blend into public flow"
+
+
+def test_renowned_actor_cannot_blend_and_scrambles_without_funds() -> None:
+    state = _pursued_state(frozenset({"fixer", "renowned"}))
+    resolution = evaluate(EVADE_PURSUERS, state, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Break line of sight without a clean route"
+
+
+def test_renowned_wealthy_actor_buys_a_discreet_extraction() -> None:
+    state = _pursued_state(frozenset({"fixer", "renowned", "wealthy"}))
+    resolution = evaluate(EVADE_PURSUERS, state, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Buy a discreet extraction"
+
+
+# ---------------------------------------------------------------------------
+# MAINTAIN_COVER: visibility as cover for recognizable actors
+# ---------------------------------------------------------------------------
+
+
+def _cover_state(actor_tags: frozenset[str]) -> WorldState:
+    return _state(
+        actor_tags=actor_tags,
+        locations={ACTOR: PLACE},
+        location_classes={PLACE: frozenset({"urban_dense"})},
+    )
+
+
+def test_obscure_operative_runs_anonymous_courier_cover() -> None:
+    state = _cover_state(frozenset({"fixer"}))
+    resolution = evaluate(MAINTAIN_COVER, state, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Run a low-level courier job"
+
+
+def test_renowned_operative_performs_the_expected_public_pattern() -> None:
+    state = _cover_state(frozenset({"fixer", "renowned"}))
+    resolution = evaluate(MAINTAIN_COVER, state, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Be seen exactly where they are expected"
+
+
+# ---------------------------------------------------------------------------
+# SOCIALIZE: fame and disposition shape where company is sought
+# ---------------------------------------------------------------------------
+
+
+def _social_state(
+    actor_tags: frozenset[str],
+    *,
+    with_contact: bool = False,
+    at_venue: bool = False,
+) -> WorldState:
+    pair_tags = (
+        {(ACTOR, CONTACT): frozenset({"contact:social"})} if with_contact else {}
+    )
+    return _state(
+        actor_tags=actor_tags,
+        pair_tags=pair_tags,
+        locations={ACTOR: PLACE},
+        location_classes={PLACE: frozenset({"meeting" if at_venue else "dwelling"})},
+        need_debt_scores={(ACTOR, "socialize"): 200.0},
+    )
+
+
+def test_obscure_actor_at_a_venue_still_goes_where_people_are() -> None:
+    state = _social_state(frozenset({"gregarious"}), at_venue=True)
+    resolution = evaluate(SOCIALIZE, state, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Go where people are"
+
+
+def test_renowned_actor_hosts_chosen_company_instead_of_a_crowd() -> None:
+    state = _social_state(frozenset({"renowned"}), with_contact=True, at_venue=True)
+    resolution = evaluate(SOCIALIZE, state, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Host chosen company on their own ground"
+
+
+def test_renowned_actor_without_contacts_falls_to_parasocial_company() -> None:
+    state = _social_state(frozenset({"renowned"}), at_venue=True)
+    resolution = evaluate(SOCIALIZE, state, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Practice parasocial company"
+
+
+def test_solitary_actor_with_a_contact_prefers_a_trusted_voice() -> None:
+    state = _social_state(frozenset({"solitary"}), with_contact=True, at_venue=True)
+    resolution = evaluate(SOCIALIZE, state, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Seek a trusted voice rather than a crowd"
+
+
+# ---------------------------------------------------------------------------
+# WORK / TEND_CRAFT: resource-gated branches
+# ---------------------------------------------------------------------------
+
+
+def _work_state(actor_tags: frozenset[str]) -> WorldState:
+    return _state(
+        actor_tags=actor_tags | frozenset({"work_obligation"}),
+        locations={ACTOR: PLACE},
+        location_classes={PLACE: frozenset({"commerce"})},
+    )
+
+
+def test_destitute_actor_takes_whatever_paying_work_exists() -> None:
+    resolution = evaluate(WORK, _work_state(frozenset({"destitute"})), ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Take whatever paying work the day offers"
+
+
+def test_wealthy_actor_directs_rather_than_performs() -> None:
+    resolution = evaluate(WORK, _work_state(frozenset({"magnate"})), ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Direct the work rather than perform it"
+
+
+def test_comfortable_default_actor_still_works_the_shift() -> None:
+    resolution = evaluate(WORK, _work_state(frozenset()), ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Work a public-facing shift"
+
+
+def test_senior_status_anywhere_routes_work_to_administration() -> None:
+    state = _state(
+        actor_tags=frozenset({"work_obligation"}),
+        pair_tags={(ACTOR, FACTION): frozenset({"status:senior"})},
+        locations={ACTOR: PLACE},
+        location_classes={PLACE: frozenset({"dwelling"})},
+    )
+    resolution = evaluate(WORK, state, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Keep administrative obligations moving"
+
+
+def test_wealthy_crafter_puts_money_into_the_craft() -> None:
+    state = _state(actor_tags=frozenset({"soldier", "wealthy"}))
+    resolution = evaluate(TEND_CRAFT, state, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Put real money into the craft"
+
+
+def test_comfortable_crafter_keeps_existing_craft_branch() -> None:
+    state = _state(actor_tags=frozenset({"soldier"}))
+    resolution = evaluate(TEND_CRAFT, state, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Make the weapon ready for what comes next"
+
+
+# ---------------------------------------------------------------------------
+# TRAVEL: route style follows the traveler's own wealth and fame
+# ---------------------------------------------------------------------------
+
+
+def _travel_state(actor_tags: frozenset[str]) -> WorldState:
+    return _state(
+        actor_tags=actor_tags,
+        travel_states={
+            ACTOR: TravelState(status="at_place", destination_place_id=PLACE)
+        },
+    )
+
+
+def test_wealthy_traveler_charters_private_transport() -> None:
+    resolution = evaluate(TRAVEL, _travel_state(frozenset({"wealthy"})), ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Charter private transport"
+    assert resolution.state_delta["travel.start"]["mode"] == "vehicle"
+
+
+def test_renowned_prepared_traveler_takes_covert_routes() -> None:
+    resolution = evaluate(
+        TRAVEL,
+        _travel_state(frozenset({"renowned", "travel_ready"})),
+        ACTOR_BINDINGS,
+    )
+    assert resolution.passes
+    assert resolution.branch_label == "Slip out along covert routes"
+    assert resolution.state_delta["travel.start"]["mode"] == "covert"
+
+
+def test_renowned_unprepared_traveler_prepares_before_going_covert() -> None:
+    resolution = evaluate(
+        TRAVEL, _travel_state(frozenset({"renowned"})), ACTOR_BINDINGS
+    )
+    assert resolution.passes
+    assert resolution.branch_label == "Prepare the journey rather than starting badly"
+
+
+def test_ordinary_prepared_traveler_departs_normally() -> None:
+    resolution = evaluate(
+        TRAVEL, _travel_state(frozenset({"travel_ready"})), ACTOR_BINDINGS
+    )
+    assert resolution.passes
+    assert resolution.branch_label == "Depart toward the planned destination"

--- a/tests/test_orrery/test_self_awareness.py
+++ b/tests/test_orrery/test_self_awareness.py
@@ -112,6 +112,23 @@ def test_tier_predicates_reject_unknown_tiers() -> None:
         resources_below("broke")
 
 
+def test_multiple_tier_tags_on_one_ladder_raise_loudly() -> None:
+    """Exclusive ladders treat multiple tier tags as corrupt state, no fallback."""
+
+    corrupt_fame = _state(actor_tags=frozenset({"known", "legendary"}))
+    with pytest.raises(ValueError, match="multiple fame tier tags"):
+        fame_at_or_above("obscure")(corrupt_fame, ACTOR_BINDINGS)
+
+    corrupt_resources = _state(actor_tags=frozenset({"poor", "wealthy"}))
+    with pytest.raises(ValueError, match="multiple resources tier tags"):
+        resources_below("magnate")(corrupt_resources, ACTOR_BINDINGS)
+
+    # One tag per ladder across DIFFERENT ladders is fine.
+    cross_ladder = _state(actor_tags=frozenset({"legendary", "magnate"}))
+    assert fame_at_or_above("legendary")(cross_ladder, ACTOR_BINDINGS)
+    assert resources_at_or_above("magnate")(cross_ladder, ACTOR_BINDINGS)
+
+
 def test_tier_predicates_require_bound_entity() -> None:
     state = _state(actor_tags=frozenset({"legendary", "magnate"}))
     empty: dict = {}
@@ -352,6 +369,22 @@ def test_solitary_actor_with_a_contact_prefers_a_trusted_voice() -> None:
     assert resolution.branch_label == "Seek a trusted voice rather than a crowd"
 
 
+def test_renowned_solitary_actor_hosts_rather_than_calls() -> None:
+    """Branch-order pin: fame outranks disposition when both branches match.
+
+    Fame is a structural constraint on WHERE company can happen (public rooms
+    reorganize around a renowned actor); disposition only shapes the medium.
+    The hosting branch is intentionally listed first.
+    """
+
+    state = _social_state(
+        frozenset({"renowned", "solitary"}), with_contact=True, at_venue=True
+    )
+    resolution = evaluate(SOCIALIZE, state, ACTOR_BINDINGS)
+    assert resolution.passes
+    assert resolution.branch_label == "Host chosen company on their own ground"
+
+
 # ---------------------------------------------------------------------------
 # WORK / TEND_CRAFT: resource-gated branches
 # ---------------------------------------------------------------------------
@@ -447,6 +480,20 @@ def test_renowned_unprepared_traveler_prepares_before_going_covert() -> None:
     )
     assert resolution.passes
     assert resolution.branch_label == "Prepare the journey rather than starting badly"
+
+
+def test_renowned_wealthy_prepared_traveler_charters_over_covert_routes() -> None:
+    """Branch-order pin: wealth precedence — a chartered private route is
+    already discreet, so the charter branch is intentionally listed before
+    covert routing and wins when both are satisfied."""
+
+    resolution = evaluate(
+        TRAVEL,
+        _travel_state(frozenset({"renowned", "wealthy", "travel_ready"})),
+        ACTOR_BINDINGS,
+    )
+    assert resolution.passes
+    assert resolution.branch_label == "Charter private transport"
 
 
 def test_ordinary_prepared_traveler_departs_normally() -> None:


### PR DESCRIPTION
## Summary

Implements package self-awareness per the locked design in #282: Orrery stage-2 branch selection now reads the **acting entity's own properties** — fame, resources, disposition, and self-scoped status edges — so a firing package chooses *how* it acts based on who the actor is. Fixes the absurd-choice class the design targets (the famous fixer strolling into a crowd; the destitute NPC picking the luxury branch).

## Engine Design (How Self-Predicates Evaluate)

New deterministic, config-free condition factories in `nexus/agents/orrery/substrate.py`, same closure shape as every existing predicate:

- **`fame_at_or_above(tier)` / `fame_below(tier)`** — compare the actor's own `role.fame` tier on the ladder `obscure < known < renowned < legendary`. Fame stays an unvalenced ambient detection radius; valence emerges only from composition with other predicates in each branch (e.g., in MAINTAIN_COVER high fame composes into an *asset*).
- **`resources_at_or_above(tier)` / `resources_below(tier)`** — same shape over `role.resources` (`destitute < poor < comfortable < wealthy < magnate`).
- **Default-absent semantics**: no `role.fame` tag reads as `obscure`, no `role.resources` tag reads as `comfortable` — exactly the registry's documented default-absent pattern (`docs/orrery_tag_vocabulary.md`). This is what makes the change backward compatible: untagged actors take identical branches to main (verified below).
- **`has_any_status_at_or_above(level)`** — the self-scoped status read: does the actor hold an outbound `status:<level>` pair tag at/above the rank toward *any* scope faction. Status stays an edge property; this composes the existing `entity_pair_tags` substrate and `status_family` ranks. Negative levels never satisfy positive thresholds.
- **Disposition** needed no new engine code — `has_tag` / `has_any_tag` already read the actor's own disposition tags; templates now actually use them for branch selection (SOCIALIZE).
- **Stage contract enforced structurally**: `validate_no_fame_in_entry_gates(templates)` walks every package gate's condition tree and raises if a fame predicate appears. Fame is stage-2/3 vocabulary ONLY, never stage-1 entry gating — a `legendary` actor qualifies for HIDE exactly like an `obscure` one (tested). The whole built-in catalog is validated in the test suite.

Unknown tiers/levels raise `ValueError` at template-construction time (no graceful fallbacks). No tunable weights were introduced — tier ranks are vocabulary semantics, so nothing new in `nexus.toml`.

## Templates Touched (and Why)

Only the packages the #282 design and worked example justify — no carpet-bombing:

| Template | Change |
|---|---|
| **HIDE** | The issue's worked example, as affordability-composed escalation tiers above the existing lay-low maintenance branches: `known`+`comfortable` → change appearance; `renowned`+`wealthy` → relocate; `legendary`+`magnate` → erase identity. An actor who cannot afford their fame tier falls through to cheaper measures (stage 3 encounter pressure is where that becomes dangerous — see Deferred). |
| **EVADE_PURSUERS** | "Blend into public flow" is now gated `fame_below(renowned)` — wide detection radii cannot disappear into pedestrian current. New "Buy a discreet extraction" branch for `renowned`+`wealthy`. Famous-but-poor actors fall to the line-of-sight scramble fallback. |
| **MAINTAIN_COVER** | New top branch: `renowned`+ actors maintain cover by *being seen exactly where expected* (visibility-as-cover inversion). The anonymous-noise branches (courier job, drift through public space) are fame-gated. |
| **SOCIALIZE** | `renowned`+ actors with a social contact host chosen company on their own ground instead of seeking anonymous crowds; famous actors with no contacts land on the parasocial fallback (fame isolates). `solitary`/`reserved` actors with a contact prefer a trusted voice over a venue (disposition read). Public-crowd branches fame-gated. |
| **WORK** | Resource-gated: `destitute` actors take whatever paying work exists (survival precedes role); `wealthy`+ actors direct the work rather than perform it. The administrative branch additionally fires on `has_any_status_at_or_above(senior)` — the self-scoped status read. |
| **TEND_CRAFT** | `wealthy`+ practitioners put money into the craft (proper materials, commissions); poorer tiers keep the existing improvisation branches. |
| **TRAVEL** | Route-style departures: `wealthy`+ charters private transport (`travel_mode=vehicle`, wealth substitutes for preparation); `renowned`+ prepared travelers slip out on covert routes (`travel_mode=covert`); unprepared famous travelers prepare first. |

## Behavioral Evidence

### Read-Only Corpus Replay (save_05, anchor chunk 78, window 30)

`resolve_dry_run` with main's templates vs this branch over the same hydrated state: **14 actors, 12 resolutions, 0 branch diffs** (distribution: drink 5, tend_craft 3, check_on_dependent 2, hide 1, honor_debt 1). save_05 carries no fame/resources tier tags, so the default-absent semantics reproduce main's choices exactly — self-awareness is purely additive until the trait compiler writes tier tags.

### Profile Grid (corpus template shapes × self-property tiers)

Same `WorldState` scaffold per row; only the actor's own tags vary. ⬅ marks a shift.

### HIDE (gate: fugitive, no pursuit)

| actor profile | before (main) | after (M7) |
|---|---|---|
| obscure + cautious (lay_low row) | Preserve the silence another day | Preserve the silence another day |
| known + comfortable | Preserve the silence another day | Change the face they show the street ⬅ |
| renowned + wealthy | Preserve the silence another day | Relocate to safer ground ⬅ |
| legendary + magnate | Preserve the silence another day | Erase the identity and vanish completely ⬅ |
| legendary + destitute (affordability fall-through) | Preserve the silence another day | Preserve the silence another day |

### EVADE_PURSUERS (gate: inbound hunting, public mobility)

| actor profile | before (main) | after (M7) |
|---|---|---|
| obscure fixer | Keep moving, blend into public flow | Keep moving, blend into public flow |
| renowned fixer, comfortable | Keep moving, blend into public flow | Break line of sight without a clean route ⬅ |
| renowned fixer, wealthy | Keep moving, blend into public flow | Buy a discreet extraction ⬅ |
| legendary fixer, magnate | Keep moving, blend into public flow | Buy a discreet extraction ⬅ |

### MAINTAIN_COVER (gate: fixer in urban_dense)

| actor profile | before (main) | after (M7) |
|---|---|---|
| obscure fixer | Run a low-level courier job | Run a low-level courier job |
| known fixer | Run a low-level courier job | Run a low-level courier job |
| renowned fixer | Run a low-level courier job | Be seen exactly where they are expected ⬅ |
| legendary fixer | Run a low-level courier job | Be seen exactly where they are expected ⬅ |

### SOCIALIZE (gate: socialize debt 200, at a meeting venue)

| actor profile | before (main) | after (M7) |
|---|---|---|
| obscure, at venue | Go where people are | Go where people are |
| renowned, at venue, has contact | Go where people are | Host chosen company on their own ground ⬅ |
| renowned, at venue, no contacts | Go where people are | Practice parasocial company ⬅ |
| solitary, at venue, has contact | Go where people are | Seek a trusted voice rather than a crowd ⬅ |

### WORK (gate: work_obligation)

| actor profile | before (main) | after (M7) |
|---|---|---|
| comfortable (untagged default), at commerce | Work a public-facing shift | Work a public-facing shift |
| destitute, at commerce | Work a public-facing shift | Take whatever paying work the day offers ⬅ |
| wealthy, at commerce | Work a public-facing shift | Direct the work rather than perform it ⬅ |
| magnate, at commerce | Work a public-facing shift | Direct the work rather than perform it ⬅ |
| status:senior(→faction), at dwelling | Keep the obligation from slipping | Keep administrative obligations moving ⬅ |

### TEND_CRAFT (gate: soldier craft identity)

| actor profile | before (main) | after (M7) |
|---|---|---|
| comfortable soldier | Make the weapon ready for what comes next | Make the weapon ready for what comes next |
| wealthy soldier | Make the weapon ready for what comes next | Put real money into the craft ⬅ |
| destitute soldier | Make the weapon ready for what comes next | Make the weapon ready for what comes next |

### TRAVEL (gate: planned destination, not in transit)

| actor profile | before (main) | after (M7) |
|---|---|---|
| comfortable, travel_ready | Depart toward the planned destination | Depart toward the planned destination |
| wealthy, unprepared | Prepare the journey rather than starting badly | Charter private transport ⬅ |
| renowned, travel_ready | Depart toward the planned destination | Slip out along covert routes ⬅ |
| renowned, unprepared | Prepare the journey rather than starting badly | Prepare the journey rather than starting badly |
| renowned + wealthy, travel_ready | Depart toward the planned destination | Charter private transport ⬅ |

## Vocabulary Additions

**None.** Zero new tags, zero new event types, zero new pair tags, zero migrations (slot 064 unused). Every new branch reuses registered event types (`hideout_maintained`, `evade_pursuit`, `maintain_cover`, `socialized`, `work_performed`, `craft_tended`, `travel_departed`) and existing `orrery_travel_mode` enum values (`vehicle`, `covert`). The #282 design composes existing substrate, and it held.

## Test Output

```
poetry run python -m pytest tests/test_orrery/test_self_awareness.py -q   # 32 passed
poetry run python -m pytest tests/test_orrery/ -q                         # 370 passed, 43 skipped
poetry run python -m pytest -q --ignore=tests/test_ir_eval_v2             # 677 passed, 88 skipped
```

New suite covers: tier ordering + default-absent semantics, unknown-tier `ValueError`s, self-scoped status (outbound-only, any-scope, negative-level exclusion), the #282 worked example as a parametrized HIDE table, affordability fall-through, stage-1 fame-gate rejection (including nested compounds), and per-template branch-shift cases for all seven touched packages. Black/flake8 clean; mypy introduces no new errors (11 preexisting baseline errors in untouched files).

`docs/orrery_packages.md` regenerated via the pre-commit catalog hook.

## Deferred

- **Stage 3 (outcome / encounter rolls)**: the fame-weighted per-tick detection layer (ambient fame radius + targeted `pursuing` sensitivity, chunk-seeded PRNG) is out of M7 scope, which covers resolve-stage branch selection. The affordability fall-through (famous-but-poor actors laying low badly) is where stage 3 will bite when it lands.
- **Live behavioral validation** folds into the M9 golden path per the milestone plan (slots 2/5 owned by concurrent lanes; this PR is offline + read-only-postgres validated).
- **NEGOTIATE / SURVEIL / FLEE-specific adoption** beyond the touched set: #282 names them as the broader pattern; the predicates are now available for any future template work without further engine changes.

Closes nothing automatically; #282 remains the design anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
