### PR TITLE
U5: Settings Pane Wiring — the Calibration Console

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -68,6 +68,34 @@ test_database_suffix = "_test"
 # system specifies 30-50 ms/char).
 typewriter_ms_per_char = 35
 
+# Active NEXUS IRIS theme, persisted across sessions via PATCH /api/settings.
+theme = "veil"
+
+[ui.lore_budget_slider]
+# Bounds, step, and preset ladder stops for the LORE budget slider in the
+# settings pane. Values are token counts for lore.token_budget.apex_context_window.
+min = 10_000
+max = 200_000
+step = 1000
+stops = [75_000, 100_000, 150_000, 200_000]
+
+# Per-theme font slot choices (NEXUS IRIS keeper matrix). The display slot is
+# the marquee font — reserved for the NEXUS wordmark and locked in the UI.
+[ui.fonts.veil]
+body = "Spectral"
+menu = "Cinzel"
+display = "Megrim"
+
+[ui.fonts.gilded]
+body = "Cormorant Garamond"
+menu = "Space Mono"
+display = "Monoton"
+
+[ui.fonts.vector]
+body = "Rajdhani"
+menu = "Source Code Pro"
+display = "Sixtyfour"
+
 # =============================================================================
 # Wizard Settings (New Story Setup)
 # =============================================================================

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -61,6 +61,7 @@ from nexus.api.narrative_generation import (
     generate_bootstrap_narrative,
 )
 from nexus.api.config_utils import get_max_choice_text_length
+from nexus.api.settings_endpoints import router as settings_router
 from nexus.api.slot_endpoints import router as slot_router
 from nexus.api.setup_endpoints import router as setup_router
 from nexus.api.wizard_chat import router as wizard_chat_router
@@ -80,6 +81,7 @@ app.add_middleware(
 
 
 # Include modular routers
+app.include_router(settings_router)
 app.include_router(slot_router)
 app.include_router(setup_router)
 app.include_router(wizard_chat_router)

--- a/nexus/api/settings_endpoints.py
+++ b/nexus/api/settings_endpoints.py
@@ -1,0 +1,229 @@
+"""
+FastAPI endpoints for the operator settings surface (GET/PATCH /api/settings).
+
+GET serves the raw nexus.toml contents (with @provider.role references left
+unresolved so the client can show role-level bindings), plus the legacy
+"Agent Settings"/"API Settings" aliases the React client predates, plus a
+derived ``settings_meta`` block (model role options, apex provider allowlist,
+typewriter bounds) so the client never hardcodes config semantics.
+
+PATCH accepts a typed subset of safe-to-edit keys and persists them through
+``nexus.config.loader.save_settings``, which validates the merged document
+against the Pydantic Settings model and preserves comments/formatting via
+tomlkit. Keys outside this subset (active embedding model, test database
+suffix, reranker paths, ...) are intentionally not writable from the UI.
+"""
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+# Python 3.11+ ships tomllib; mirror the loader's fallback for older runtimes.
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised only on Python <3.11
+    import tomli as tomllib  # type: ignore
+
+from nexus.config.loader import save_settings
+from nexus.config.settings_models import (
+    MODEL_ROLE_PREFIX,
+    APEXSettings,
+    UISettings,
+)
+
+logger = logging.getLogger("nexus.api.settings_endpoints")
+
+router = APIRouter(prefix="/api/settings", tags=["settings"])
+
+# Resolved relative to the process CWD, matching every other load_settings()
+# caller in the API layer (the narrative service runs from the repo root).
+NEXUS_TOML = Path("nexus.toml")
+
+ThemeId = Literal["veil", "gilded", "vector"]
+
+
+class FontSlotsPatch(BaseModel):
+    """Partial font slot update for one theme."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    body: Optional[str] = None
+    menu: Optional[str] = None
+    display: Optional[str] = None
+
+
+class SettingsPatchRequest(BaseModel):
+    """The safe-to-edit settings subset accepted by PATCH /api/settings."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    theme: Optional[ThemeId] = Field(
+        default=None, description="Active NEXUS IRIS theme (ui.theme)"
+    )
+    fonts: Optional[Dict[ThemeId, FontSlotsPatch]] = Field(
+        default=None, description="Per-theme font slot choices (ui.fonts.*)"
+    )
+    typewriter_ms_per_char: Optional[int] = Field(
+        default=None, description="Typewriter reveal speed (ui.typewriter_ms_per_char)"
+    )
+    test_mode: Optional[bool] = Field(
+        default=None, description="Test write routing (global.narrative.test_mode)"
+    )
+    apex_model_ref: Optional[str] = Field(
+        default=None,
+        description=(
+            "Role reference for live narrative turns, e.g. '@anthropic.deep' "
+            "(apex.model; apex.provider is derived from the reference)"
+        ),
+    )
+    wizard_model_ref: Optional[str] = Field(
+        default=None,
+        description="Role reference for the new-story wizard (wizard.default_model)",
+    )
+    apex_context_window: Optional[int] = Field(
+        default=None,
+        description="LORE context budget (lore.token_budget.apex_context_window)",
+    )
+
+
+def _read_raw_settings() -> Dict[str, Any]:
+    """Load nexus.toml as a plain dict without resolving model references."""
+    if not NEXUS_TOML.exists():
+        raise FileNotFoundError(f"Configuration file not found: {NEXUS_TOML}")
+    with open(NEXUS_TOML, "rb") as f:
+        return tomllib.load(f)
+
+
+def _field_constraint(model: type[BaseModel], field: str, attr: str) -> Any:
+    """Extract a constraint value (pattern/ge/le) from a Pydantic field."""
+    for meta in model.model_fields[field].metadata:
+        value = getattr(meta, attr, None)
+        if value is not None:
+            return value
+    raise RuntimeError(
+        f"{model.__name__}.{field} is missing the expected '{attr}' constraint"
+    )
+
+
+def _build_settings_meta(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Derive the client-facing metadata block from config + Pydantic models."""
+    api_models = raw.get("global", {}).get("model", {}).get("api_models", {})
+    labels_by_id: Dict[str, str] = {}
+    for provider_cfg in api_models.values():
+        for entry in provider_cfg.get("models", []):
+            labels_by_id[entry["id"]] = entry.get("label", entry["id"])
+
+    model_roles: List[Dict[str, str]] = []
+    for provider, provider_cfg in api_models.items():
+        for role, model_id in provider_cfg.get("roles", {}).items():
+            model_roles.append(
+                {
+                    "ref": f"{MODEL_ROLE_PREFIX}{provider}.{role}",
+                    "provider": provider,
+                    "role": role,
+                    "model_id": model_id,
+                    "label": labels_by_id.get(model_id, model_id),
+                }
+            )
+
+    provider_pattern = _field_constraint(APEXSettings, "provider", "pattern")
+    apex_allowed_providers = [
+        provider for provider in api_models if re.fullmatch(provider_pattern, provider)
+    ]
+
+    return {
+        "model_roles": model_roles,
+        "apex_allowed_providers": apex_allowed_providers,
+        "typewriter": {
+            "min": _field_constraint(UISettings, "typewriter_ms_per_char", "ge"),
+            "max": _field_constraint(UISettings, "typewriter_ms_per_char", "le"),
+        },
+    }
+
+
+def _build_payload(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Raw settings + legacy aliases + derived metadata, minus secrets refs."""
+    payload = dict(raw)
+    # 1Password reference strings are bootstrap-only config; the browser has
+    # no business seeing them even though they contain no secret material.
+    payload.pop("secrets", None)
+    payload["Agent Settings"] = {
+        "global": raw.get("global", {}),
+        "LORE": raw.get("lore", {}),
+        "MEMNON": raw.get("memnon", {}),
+    }
+    payload["API Settings"] = {"apex": raw.get("apex", {})}
+    payload["settings_meta"] = _build_settings_meta(raw)
+    return payload
+
+
+def _provider_from_ref(ref: str, source: str) -> str:
+    """Extract the provider from an '@provider.role' reference or raise 422."""
+    if not ref.startswith(MODEL_ROLE_PREFIX) or "." not in ref:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"{source}: expected an '@provider.role' reference "
+                f"(e.g., '@openai.default'), got '{ref}'"
+            ),
+        )
+    provider, _, _ = ref[len(MODEL_ROLE_PREFIX) :].partition(".")
+    return provider
+
+
+def _updates_from_patch(patch: SettingsPatchRequest) -> Dict[str, Any]:
+    """Map the typed patch onto dot-notation save_settings updates."""
+    updates: Dict[str, Any] = {}
+    if patch.theme is not None:
+        updates["ui.theme"] = patch.theme
+    if patch.fonts is not None:
+        for theme_id, slots in patch.fonts.items():
+            for slot in ("body", "menu", "display"):
+                value = getattr(slots, slot)
+                if value is not None:
+                    updates[f"ui.fonts.{theme_id}.{slot}"] = value
+    if patch.typewriter_ms_per_char is not None:
+        updates["ui.typewriter_ms_per_char"] = patch.typewriter_ms_per_char
+    if patch.test_mode is not None:
+        updates["global.narrative.test_mode"] = patch.test_mode
+    if patch.apex_model_ref is not None:
+        updates["apex.model"] = patch.apex_model_ref
+        updates["apex.provider"] = _provider_from_ref(
+            patch.apex_model_ref, "apex_model_ref"
+        )
+    if patch.wizard_model_ref is not None:
+        # Format check up front; provider/role existence is validated by the
+        # Settings model's resolution pass inside save_settings.
+        _provider_from_ref(patch.wizard_model_ref, "wizard_model_ref")
+        updates["wizard.default_model"] = patch.wizard_model_ref
+    if patch.apex_context_window is not None:
+        updates["lore.token_budget.apex_context_window"] = patch.apex_context_window
+    return updates
+
+
+@router.get("")
+async def get_settings() -> Dict[str, Any]:
+    """Serve the full settings payload for the React client."""
+    return _build_payload(_read_raw_settings())
+
+
+@router.patch("")
+async def patch_settings(patch: SettingsPatchRequest) -> Dict[str, Any]:
+    """Persist a safe-subset settings update and return the fresh payload."""
+    updates = _updates_from_patch(patch)
+    if not updates:
+        raise HTTPException(status_code=400, detail="No supported settings provided")
+
+    try:
+        save_settings(updates, path=NEXUS_TOML)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    logger.info("Applied settings update: %s", sorted(updates))
+    return _build_payload(_read_raw_settings())

--- a/nexus/api/settings_endpoints.py
+++ b/nexus/api/settings_endpoints.py
@@ -47,7 +47,14 @@ ThemeId = Literal["veil", "gilded", "vector"]
 
 
 class FontSlotsPatch(BaseModel):
-    """Partial font slot update for one theme."""
+    """Partial font slot update for one theme.
+
+    ``display`` (the marquee slot) is locked in the settings pane per the
+    design system's marquee rule, but stays writable here deliberately:
+    the pane's RESET TO KEEPERS action PATCHes the full keeper matrix
+    (display included), and the API remains the operator escape hatch for
+    rebinding the marquee without hand-editing nexus.toml.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
@@ -109,6 +116,15 @@ def _field_constraint(model: type[BaseModel], field: str, attr: str) -> Any:
     )
 
 
+# Resolved eagerly so a renamed/removed Pydantic constraint fails at import
+# (server startup) rather than on the first GET /api/settings request.
+_APEX_PROVIDER_PATTERN: str = _field_constraint(APEXSettings, "provider", "pattern")
+_TYPEWRITER_BOUNDS: Dict[str, int] = {
+    "min": _field_constraint(UISettings, "typewriter_ms_per_char", "ge"),
+    "max": _field_constraint(UISettings, "typewriter_ms_per_char", "le"),
+}
+
+
 def _build_settings_meta(raw: Dict[str, Any]) -> Dict[str, Any]:
     """Derive the client-facing metadata block from config + Pydantic models."""
     api_models = raw.get("global", {}).get("model", {}).get("api_models", {})
@@ -130,18 +146,16 @@ def _build_settings_meta(raw: Dict[str, Any]) -> Dict[str, Any]:
                 }
             )
 
-    provider_pattern = _field_constraint(APEXSettings, "provider", "pattern")
     apex_allowed_providers = [
-        provider for provider in api_models if re.fullmatch(provider_pattern, provider)
+        provider
+        for provider in api_models
+        if re.fullmatch(_APEX_PROVIDER_PATTERN, provider)
     ]
 
     return {
         "model_roles": model_roles,
         "apex_allowed_providers": apex_allowed_providers,
-        "typewriter": {
-            "min": _field_constraint(UISettings, "typewriter_ms_per_char", "ge"),
-            "max": _field_constraint(UISettings, "typewriter_ms_per_char", "le"),
-        },
+        "typewriter": dict(_TYPEWRITER_BOUNDS),
     }
 
 
@@ -226,7 +240,14 @@ async def get_settings() -> Dict[str, Any]:
 
 @router.patch("")
 async def patch_settings(patch: SettingsPatchRequest) -> Dict[str, Any]:
-    """Persist a safe-subset settings update and return the fresh payload."""
+    """Persist a safe-subset settings update and return the fresh payload.
+
+    Concurrency posture: save_settings does an unlocked read-merge-write on
+    nexus.toml. That is safe for the deployed shape - a single-operator app
+    on a single-worker uvicorn process, where the event loop serializes
+    handlers. Running this API with multiple workers would reintroduce a
+    lost-update race and would need file locking here first.
+    """
     updates = _updates_from_patch(patch)
     if not updates:
         raise HTTPException(status_code=400, detail="No supported settings provided")

--- a/nexus/api/settings_endpoints.py
+++ b/nexus/api/settings_endpoints.py
@@ -19,7 +19,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Response
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 # Python 3.11+ ships tomllib; mirror the loader's fallback for older runtimes.
@@ -203,6 +203,19 @@ def _updates_from_patch(patch: SettingsPatchRequest) -> Dict[str, Any]:
     if patch.apex_context_window is not None:
         updates["lore.token_budget.apex_context_window"] = patch.apex_context_window
     return updates
+
+
+@router.head("")
+async def head_settings() -> Response:
+    """Connectivity probe (useNarrativeEngine polls HEAD /api/settings).
+
+    FastAPI's APIRoute does not auto-serve HEAD from GET handlers (unlike
+    bare Starlette routes), so the probe needs this explicit handler.
+    Raises - and therefore returns 500 - if the config file is unreadable,
+    matching the retired Express behavior.
+    """
+    _read_raw_settings()
+    return Response(status_code=200)
 
 
 @router.get("")

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -929,11 +929,78 @@ class IREvalSettings(BaseModel):
     judgment: IREvalJudgmentConfig
 
 
+class UIFontSlots(BaseModel):
+    """Font choices for one theme's three slots (NEXUS IRIS keeper matrix).
+
+    ``display`` is the marquee slot — reserved for the NEXUS wordmark per the
+    design system's marquee rule. It is persisted for completeness but the
+    settings pane renders it locked.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    body: str = Field(..., description="Narrative prose font (--font-narrative)")
+    menu: str = Field(..., description="Chrome/menu font (--font-mono)")
+    display: str = Field(..., description="Marquee font (--font-display, locked)")
+
+
+def _default_veil_fonts() -> UIFontSlots:
+    return UIFontSlots(body="Spectral", menu="Cinzel", display="Megrim")
+
+
+def _default_gilded_fonts() -> UIFontSlots:
+    return UIFontSlots(body="Cormorant Garamond", menu="Space Mono", display="Monoton")
+
+
+def _default_vector_fonts() -> UIFontSlots:
+    return UIFontSlots(body="Rajdhani", menu="Source Code Pro", display="Sixtyfour")
+
+
+class UIFontMatrix(BaseModel):
+    """Per-theme font slot choices persisted from the settings pane."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    veil: UIFontSlots = Field(default_factory=_default_veil_fonts)
+    gilded: UIFontSlots = Field(default_factory=_default_gilded_fonts)
+    vector: UIFontSlots = Field(default_factory=_default_vector_fonts)
+
+
+def _default_lore_budget_stops() -> List[int]:
+    return [75_000, 100_000, 150_000, 200_000]
+
+
+class UILoreBudgetSlider(BaseModel):
+    """Bounds and ladder stops for the LORE budget slider in the settings pane."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    min: int = Field(default=10_000, ge=1000, description="Slider lower bound (tok)")
+    max: int = Field(default=200_000, ge=1000, description="Slider upper bound (tok)")
+    step: int = Field(default=1000, ge=1, description="Slider step size (tok)")
+    stops: List[int] = Field(
+        default_factory=_default_lore_budget_stops,
+        description="Preset ladder stops rendered above the slider",
+    )
+
+    @model_validator(mode="after")
+    def _validate_range(self) -> "UILoreBudgetSlider":
+        if self.min > self.max:
+            raise ValueError("lore_budget_slider min must be <= max")
+        for stop in self.stops:
+            if not self.min <= stop <= self.max:
+                raise ValueError(
+                    f"lore_budget_slider stop {stop} is outside "
+                    f"[{self.min}, {self.max}]"
+                )
+        return self
+
+
 class UISettings(BaseModel):
     """Settings consumed by the React client.
 
-    Served verbatim to the browser through the Express ``GET /api/settings``
-    endpoint (which reads nexus.toml); keep keys JSON-friendly.
+    Served to the browser through ``GET /api/settings`` (FastAPI, proxied by
+    Express; reads nexus.toml); keep keys JSON-friendly.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -946,6 +1013,18 @@ class UISettings(BaseModel):
             "Typewriter reveal speed for incoming narrative chunks in "
             "milliseconds per character (design system: 30-50 ms/char)"
         ),
+    )
+    theme: Literal["veil", "gilded", "vector"] = Field(
+        default="veil",
+        description="Active NEXUS IRIS theme, persisted across sessions",
+    )
+    fonts: UIFontMatrix = Field(
+        default_factory=UIFontMatrix,
+        description="Per-theme font slot choices (keeper matrix)",
+    )
+    lore_budget_slider: UILoreBudgetSlider = Field(
+        default_factory=UILoreBudgetSlider,
+        description="Bounds and ladder stops for the LORE budget slider",
     )
 
 

--- a/tests/test_api/test_settings_endpoints.py
+++ b/tests/test_api/test_settings_endpoints.py
@@ -1,16 +1,19 @@
 """Tests for the GET/PATCH /api/settings surface (nexus/api/settings_endpoints).
 
 These exercise the real nexus.toml in the repository root (payload assembly,
-metadata derivation) and real tomlkit writes against a temporary copy - no
-mocks. The HTTP layer itself is exercised by the live round-trip in the U5
-validation workflow (uvicorn + curl); these tests pin the pure logic.
+metadata derivation), real tomlkit writes against a temporary copy, and the
+HTTP layer through a TestClient mounting the real router - no mocks. Write
+paths over HTTP are limited to rejection cases so the repository config is
+never mutated; the full PATCH round-trip is covered on the temp copy and by
+the live uvicorn + curl validation in the U5 workflow.
 """
 
 import shutil
 from pathlib import Path
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 from nexus.api.settings_endpoints import (
     SettingsPatchRequest,
@@ -19,6 +22,7 @@ from nexus.api.settings_endpoints import (
     _provider_from_ref,
     _read_raw_settings,
     _updates_from_patch,
+    router,
 )
 from nexus.config.loader import save_settings, load_settings
 
@@ -28,6 +32,46 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 @pytest.fixture
 def raw_settings() -> dict:
     return _read_raw_settings()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+class TestHTTPSurface:
+    """The wire contract, including the HEAD connectivity probe."""
+
+    def test_head_probe_returns_200(self, client: TestClient) -> None:
+        # useNarrativeEngine polls HEAD /api/settings; FastAPI does not
+        # auto-serve HEAD from GET handlers, so this pins the explicit route.
+        response = client.head("/api/settings")
+        assert response.status_code == 200
+
+    def test_get_serves_payload(self, client: TestClient) -> None:
+        response = client.get("/api/settings")
+        assert response.status_code == 200
+        payload = response.json()
+        assert "settings_meta" in payload
+        assert "secrets" not in payload
+
+    def test_patch_empty_body_is_400(self, client: TestClient) -> None:
+        assert client.patch("/api/settings", json={}).status_code == 400
+
+    def test_patch_unknown_key_is_422(self, client: TestClient) -> None:
+        response = client.patch("/api/settings", json={"embedding_model": "x"})
+        assert response.status_code == 422
+
+    def test_patch_malformed_ref_is_422(self, client: TestClient) -> None:
+        response = client.patch(
+            "/api/settings",
+            json={
+                "apex_model_ref": "gpt-5.5"
+            },  # pin: malformed-ref fixture, never persisted
+        )
+        assert response.status_code == 422
 
 
 class TestBuildPayload:
@@ -109,9 +153,7 @@ class TestProviderFromRef:
 class TestRoundTripOnCopy:
     """Real tomlkit write of endpoint-shaped updates on a temp copy."""
 
-    def test_patch_updates_persist_and_preserve_comments(
-        self, tmp_path: Path
-    ) -> None:
+    def test_patch_updates_persist_and_preserve_comments(self, tmp_path: Path) -> None:
         toml_copy = tmp_path / "nexus.toml"
         shutil.copy2(REPO_ROOT / "nexus.toml", toml_copy)
         original = toml_copy.read_text()

--- a/tests/test_api/test_settings_endpoints.py
+++ b/tests/test_api/test_settings_endpoints.py
@@ -1,0 +1,138 @@
+"""Tests for the GET/PATCH /api/settings surface (nexus/api/settings_endpoints).
+
+These exercise the real nexus.toml in the repository root (payload assembly,
+metadata derivation) and real tomlkit writes against a temporary copy - no
+mocks. The HTTP layer itself is exercised by the live round-trip in the U5
+validation workflow (uvicorn + curl); these tests pin the pure logic.
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from nexus.api.settings_endpoints import (
+    SettingsPatchRequest,
+    FontSlotsPatch,
+    _build_payload,
+    _provider_from_ref,
+    _read_raw_settings,
+    _updates_from_patch,
+)
+from nexus.config.loader import save_settings, load_settings
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def raw_settings() -> dict:
+    return _read_raw_settings()
+
+
+class TestBuildPayload:
+    def test_strips_secrets(self, raw_settings: dict) -> None:
+        payload = _build_payload(raw_settings)
+        assert "secrets" not in payload
+
+    def test_legacy_aliases_present(self, raw_settings: dict) -> None:
+        payload = _build_payload(raw_settings)
+        assert payload["Agent Settings"]["global"] == raw_settings["global"]
+        assert payload["Agent Settings"]["LORE"] == raw_settings["lore"]
+        assert payload["API Settings"]["apex"] == raw_settings["apex"]
+
+    def test_role_refs_left_unresolved(self, raw_settings: dict) -> None:
+        payload = _build_payload(raw_settings)
+        assert payload["apex"]["model"].startswith("@")
+
+    def test_meta_roles_cover_registry(self, raw_settings: dict) -> None:
+        payload = _build_payload(raw_settings)
+        meta = payload["settings_meta"]
+        refs = {r["ref"] for r in meta["model_roles"]}
+        for provider, cfg in raw_settings["global"]["model"]["api_models"].items():
+            for role in cfg.get("roles", {}):
+                assert f"@{provider}.{role}" in refs
+
+    def test_apex_allowlist_excludes_test_provider(self, raw_settings: dict) -> None:
+        meta = _build_payload(raw_settings)["settings_meta"]
+        assert "test" not in meta["apex_allowed_providers"]
+        assert "openai" in meta["apex_allowed_providers"]
+        assert "anthropic" in meta["apex_allowed_providers"]
+
+    def test_typewriter_bounds_from_model(self, raw_settings: dict) -> None:
+        meta = _build_payload(raw_settings)["settings_meta"]
+        assert meta["typewriter"] == {"min": 1, "max": 500}
+
+
+class TestUpdatesFromPatch:
+    def test_full_patch_maps_dot_keys(self) -> None:
+        patch = SettingsPatchRequest(
+            theme="gilded",
+            fonts={"vector": FontSlotsPatch(menu="Monaco")},
+            typewriter_ms_per_char=42,
+            test_mode=True,
+            apex_model_ref="@anthropic.deep",
+            wizard_model_ref="@openai.default",
+            apex_context_window=100_000,
+        )
+        updates = _updates_from_patch(patch)
+        assert updates == {
+            "ui.theme": "gilded",
+            "ui.fonts.vector.menu": "Monaco",
+            "ui.typewriter_ms_per_char": 42,
+            "global.narrative.test_mode": True,
+            "apex.model": "@anthropic.deep",
+            "apex.provider": "anthropic",
+            "wizard.default_model": "@openai.default",
+            "lore.token_budget.apex_context_window": 100_000,
+        }
+
+    def test_empty_patch_yields_no_updates(self) -> None:
+        assert _updates_from_patch(SettingsPatchRequest()) == {}
+
+    def test_malformed_ref_raises_422(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _updates_from_patch(SettingsPatchRequest(apex_model_ref="gpt-5.5"))
+        assert exc_info.value.status_code == 422
+
+
+class TestProviderFromRef:
+    def test_extracts_provider(self) -> None:
+        assert _provider_from_ref("@anthropic.fast", "test") == "anthropic"
+
+    @pytest.mark.parametrize("ref", ["gpt-5.5", "@anthropic", "anthropic.fast"])
+    def test_rejects_malformed(self, ref: str) -> None:
+        with pytest.raises(HTTPException):
+            _provider_from_ref(ref, "test")
+
+
+class TestRoundTripOnCopy:
+    """Real tomlkit write of endpoint-shaped updates on a temp copy."""
+
+    def test_patch_updates_persist_and_preserve_comments(
+        self, tmp_path: Path
+    ) -> None:
+        toml_copy = tmp_path / "nexus.toml"
+        shutil.copy2(REPO_ROOT / "nexus.toml", toml_copy)
+        original = toml_copy.read_text()
+
+        patch = SettingsPatchRequest(
+            theme="vector",
+            apex_model_ref="@anthropic.deep",
+            typewriter_ms_per_char=42,
+        )
+        save_settings(_updates_from_patch(patch), path=toml_copy, backup=False)
+
+        settings = load_settings(toml_copy)
+        assert settings.ui.theme == "vector"
+        assert settings.ui.typewriter_ms_per_char == 42
+        assert settings.apex.provider == "anthropic"
+        # Role ref resolves to the registry's concrete ID at load time.
+        anthropic = settings.global_.model.api_models["anthropic"]
+        assert settings.apex.model == anthropic.roles["deep"]
+
+        # Comments survive the write.
+        updated = toml_copy.read_text()
+        assert "# Typewriter reveal speed" in updated
+        assert "# Resolved via api_models registry" in updated
+        assert original != updated

--- a/ui/client/src/App.tsx
+++ b/ui/client/src/App.tsx
@@ -24,21 +24,23 @@ function Router() {
 }
 
 function App() {
+  // QueryClientProvider wraps the theme/font contexts so they can hydrate
+  // from (and persist through) the GET/PATCH /api/settings query.
   return (
-    <ThemeProvider>
-      <FontProvider>
-        <ModelProvider>
-          <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <FontProvider>
+          <ModelProvider>
             <TooltipProvider>
               <ErrorBoundary>
                 <Toaster />
                 <Router />
               </ErrorBoundary>
             </TooltipProvider>
-          </QueryClientProvider>
-        </ModelProvider>
-      </FontProvider>
-    </ThemeProvider>
+          </ModelProvider>
+        </FontProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/ui/client/src/components/nexus/SettingsPane.tsx
+++ b/ui/client/src/components/nexus/SettingsPane.tsx
@@ -1,109 +1,982 @@
 /**
- * SettingsPane - kit-fidelity placeholder (full settings wiring is U5).
+ * SettingsPane - the operator's calibration console (NEXUS IRIS, U5).
  *
- * The theme picker is live (ThemeContext persists to localStorage today);
- * the remaining rows are read-only values from GET /api/settings so the
- * operator can verify configuration at a glance.
+ * Seven sections: Theme, Typography, Narrative Mode, Model, LORE Budget,
+ * Typewriter, PWA Icon. Every dial writes back to PATCH /api/settings
+ * (FastAPI -> nexus.config.loader.save_settings -> nexus.toml) with
+ * optimistic cache updates and server confirmation - no local draft state.
+ * Theme and font writes flow through ThemeContext/FontContext, which share
+ * the same settings query + mutation.
+ *
+ * Read-only by design (would break a running story or is derived):
+ * - the active retrieval embedder (memnon.models.*)
+ * - the test database suffix (global.narrative.test_database_suffix)
+ * - apex.provider (derived from the @provider.role reference)
  */
-import { useQuery } from "@tanstack/react-query";
-import { useTheme, type Theme } from "@/contexts/ThemeContext";
-import type { SettingsPayload } from "@/types/settings";
+import { useEffect, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  Check,
+  ChevronRight,
+  Circle,
+  CircleDot,
+  RefreshCw,
+  Save,
+  Upload,
+  X,
+} from "lucide-react";
+import { useTheme } from "@/contexts/ThemeContext";
+import { useFonts } from "@/contexts/FontContext";
+import { useSettingsMutation, useSettingsQuery } from "@/hooks/useSettings";
+import { FONT_CATALOG } from "./fontCatalog";
+import type {
+  FontSlotId,
+  ModelRoleOption,
+  SettingsPayload,
+  ThemeId,
+} from "@/types/settings";
 
-/** Palette swatches from the NEXUS IRIS theme matrix (display-only). */
-const THEME_CARDS: Array<{
-  id: Theme;
-  name: string;
-  motto: string;
-  swatches: string[];
-}> = [
-  {
-    id: "veil",
-    name: "Veil",
+// ──────────────────────────────────────────────────────────────────────────
+// Design copy (presentation only - all values come from the settings API)
+// ──────────────────────────────────────────────────────────────────────────
+
+const SECTION_INDEX = [
+  { id: "theme", label: "Theme" },
+  { id: "type", label: "Typography" },
+  { id: "narrative", label: "Narrative Mode" },
+  { id: "model", label: "Model" },
+  { id: "lore", label: "LORE Budget" },
+  { id: "reveal", label: "Typewriter" },
+  { id: "pwa", label: "PWA Icon" },
+] as const;
+
+type SectionId = (typeof SECTION_INDEX)[number]["id"];
+
+const THEME_PALETTES: Record<
+  ThemeId,
+  { eyebrow: string; motto: string; swatches: string[]; wordmarkFont: string }
+> = {
+  veil: {
+    eyebrow: "ART NOUVEAU",
     motto: "Magenta rain on blue-black",
     swatches: ["#09101c", "#b83d7a", "#e86a4a", "#e1cd97"],
+    wordmarkFont: "Megrim, serif",
   },
-  {
-    id: "gilded",
-    name: "Gilded",
+  gilded: {
+    eyebrow: "ART DECO",
     motto: "Brass engraved on midnight",
     swatches: ["#0a0a0a", "#c9a227", "#7b5524", "#ece2c1"],
+    wordmarkFont: "Monoton, fantasy",
   },
-  {
-    id: "vector",
-    name: "Vector",
+  vector: {
+    eyebrow: "PHOSPHOR CRT",
     motto: "Scanline void · on the wire",
     swatches: ["#031414", "#00e5ff", "#3aa1ff", "#a3f0ff"],
+    wordmarkFont: "Sixtyfour, monospace",
   },
+};
+
+const THEME_IDS: ThemeId[] = ["veil", "gilded", "vector"];
+
+const TYPE_SAMPLES: Record<FontSlotId, string> = {
+  body: "The night air shimmered with possibility as the lanterns cast warm halos through the mist-laden gardens — and you stepped out into the wet, counting windows.",
+  menu: "STATUS: READY  //  CHAPTER: S01·E01·S002  //  SKALD: GENERATING",
+  display: "NEXUS",
+};
+
+/** Ladder copy applied to ui.lore_budget_slider.stops by index. */
+const LADDER_COPY = [
+  { label: "COMPACT", note: "fast · tighter context" },
+  { label: "BALANCED", note: "default · recommended" },
+  { label: "EXPANDED", note: "long-arc · slower" },
+  { label: "MAX", note: "ceiling · use sparingly" },
 ];
 
-export function SettingsPane() {
-  const { theme, setTheme } = useTheme();
+// ──────────────────────────────────────────────────────────────────────────
+// Card chrome
+// ──────────────────────────────────────────────────────────────────────────
 
-  const { data: settings } = useQuery<SettingsPayload>({
-    queryKey: ["/api/settings"],
-  });
+function SettingsCard({
+  id,
+  eyebrow,
+  title,
+  sub,
+  children,
+  footer,
+}: {
+  id: SectionId;
+  eyebrow: string;
+  title: string;
+  sub?: React.ReactNode;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}) {
+  return (
+    <section className="set-card" id={`set-${id}`}>
+      <div className="set-card-frame">
+        <header className="set-card-head">
+          <div className="set-card-eyebrow brass-glow">[ {eyebrow} ]</div>
+          <h3 className="set-card-title">{title}</h3>
+          {sub && <p className="set-card-sub">{sub}</p>}
+        </header>
+        <hr className="set-card-rule" />
+        <div className="set-card-body">{children}</div>
+        {footer && <footer className="set-card-foot">{footer}</footer>}
+      </div>
+    </section>
+  );
+}
 
-  const defaultModel =
-    settings?.["Agent Settings"]?.global?.model?.default_model ?? "—";
-  const testMode = settings?.["Agent Settings"]?.global?.narrative?.test_mode;
-  const typeSpeed = settings?.ui?.typewriter_ms_per_char;
+// ──────────────────────────────────────────────────────────────────────────
+// 1. Theme
+// ──────────────────────────────────────────────────────────────────────────
+
+function ThemeSection({ active, onPick }: { active: ThemeId; onPick: (t: ThemeId) => void }) {
+  return (
+    <SettingsCard
+      id="theme"
+      eyebrow="THEME · STAGE DRESSING"
+      title="Three Theatres, One Stage"
+      sub="Switching the theme rewrites every chrome surface in the operator's view and persists across sessions. Story content is untouched."
+    >
+      <div className="theme-grid">
+        {THEME_IDS.map((id) => {
+          const palette = THEME_PALETTES[id];
+          const on = active === id;
+          return (
+            <button
+              key={id}
+              className={`theme-card theme-card-${id} ${on ? "on" : ""}`}
+              onClick={() => onPick(id)}
+              aria-pressed={on}
+              data-testid={`theme-${id}`}
+            >
+              <div
+                className="theme-card-wordmark"
+                style={{ fontFamily: palette.wordmarkFont }}
+              >
+                NEXUS
+              </div>
+              <div className="theme-card-meta">
+                <span className="theme-card-name">{id}</span>
+                <span className="theme-card-eye">· {palette.eyebrow}</span>
+              </div>
+              <p className="theme-card-motto">{palette.motto}</p>
+              <div className="theme-card-swatches">
+                {palette.swatches.map((color) => (
+                  <span
+                    key={color}
+                    className="theme-swatch"
+                    style={{ background: color }}
+                    title={color}
+                  />
+                ))}
+              </div>
+              {on && (
+                <span className="theme-card-active">
+                  <Check size={11} /> ACTIVE
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </SettingsCard>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 2. Typography
+// ──────────────────────────────────────────────────────────────────────────
+
+function FontSlot({
+  slotKey,
+  label,
+  hint,
+  theme,
+  value,
+  onPick,
+  sampleStyle,
+}: {
+  slotKey: FontSlotId;
+  label: string;
+  hint: string;
+  theme: ThemeId;
+  value: string;
+  onPick: (font: string) => void;
+  sampleStyle?: React.CSSProperties;
+}) {
+  const options = FONT_CATALOG[theme][slotKey];
+  return (
+    <div className="font-slot">
+      <div className="font-slot-head">
+        <span className="font-slot-label">[ {label} ]</span>
+        <span className="font-slot-hint">{hint}</span>
+      </div>
+      <div
+        className="font-slot-preview"
+        style={{ fontFamily: `"${value}", serif`, ...sampleStyle }}
+      >
+        {TYPE_SAMPLES[slotKey]}
+      </div>
+      <div className="font-slot-chips">
+        {options.map((opt) => (
+          <button
+            key={opt.id}
+            className={`font-chip ${opt.id === value ? "on" : ""} ${opt.locked ? "locked" : ""}`}
+            onClick={() => onPick(opt.id)}
+            disabled={Boolean(opt.locked) && opt.id !== value}
+          >
+            <span
+              className="font-chip-name"
+              style={{ fontFamily: `"${opt.id}", serif` }}
+            >
+              {opt.label}
+            </span>
+            <span className="font-chip-note">{opt.note}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TypographySection() {
+  const { theme } = useTheme();
+  const { fonts, setFont, resetToKeepers } = useFonts();
+  const themeId = theme as ThemeId;
+  const slots = fonts[themeId];
 
   return (
-    <div className="settings-pane" data-testid="settings-pane">
-      <div className="settings-card">
-        <div className="settings-inner">
-          <span className="eyebrow brass-glow">[ APPEARANCE ]</span>
-          <h2 className="settings-title">Theme</h2>
-          <div className="theme-cards">
-            {THEME_CARDS.map((card) => (
-              <button
-                key={card.id}
-                className={`theme-card ${theme === card.id ? "on" : ""}`}
-                onClick={() => setTheme(card.id)}
-                data-testid={`theme-${card.id}`}
-              >
-                <span className="theme-name">
-                  {card.name}
-                  {theme === card.id ? " ✓" : ""}
-                </span>
-                <span className="theme-motto">{card.motto}</span>
-                <span className="theme-swatches">
-                  {card.swatches.map((color) => (
-                    <span key={color} style={{ background: color }} />
-                  ))}
-                </span>
-              </button>
-            ))}
+    <SettingsCard
+      id="type"
+      eyebrow="TYPOGRAPHY · TYPE CARRIAGES"
+      title="Font Matrix — Keepers per Slot"
+      sub={`Active theme is ${themeId.toUpperCase()}. Choices persist per theme. The marquee font is reserved for the NEXUS wordmark — it appears on theme cards but cannot be substituted within chrome.`}
+      footer={
+        <>
+          <span className="caption dim">
+            Slots bind to CSS custom properties — narrative prose, chrome
+            labels, and the marquee wordmark.
+          </span>
+          <button className="btn-soft" onClick={resetToKeepers}>
+            <RefreshCw size={12} /> RESET TO KEEPERS
+          </button>
+        </>
+      }
+    >
+      <FontSlot
+        slotKey="body"
+        label="BODY · NARRATIVE PROSE"
+        hint="--font-narrative · 15–18px · line 1.78"
+        theme={themeId}
+        value={slots.body}
+        onPick={(font) => setFont(themeId, "body", font)}
+      />
+      <FontSlot
+        slotKey="menu"
+        label="MENU · CHROME LABELS"
+        hint="--font-mono · 10–28px · tracking 0.18em · uppercase"
+        theme={themeId}
+        value={slots.menu}
+        onPick={(font) => setFont(themeId, "menu", font)}
+        sampleStyle={{ letterSpacing: "0.18em", textTransform: "uppercase" }}
+      />
+      <FontSlot
+        slotKey="display"
+        label="DISPLAY · MARQUEE (LOCKED SLOT)"
+        hint="--font-display · NEXUS wordmark only"
+        theme={themeId}
+        value={slots.display}
+        onPick={(font) => setFont(themeId, "display", font)}
+        sampleStyle={{
+          fontSize: "44px",
+          letterSpacing: "0.18em",
+          textAlign: "center",
+        }}
+      />
+    </SettingsCard>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 3. Narrative Mode
+// ──────────────────────────────────────────────────────────────────────────
+
+function NarrativeSection({
+  on,
+  suffix,
+  onToggle,
+}: {
+  on: boolean;
+  suffix: string;
+  onToggle: (value: boolean) => void;
+}) {
+  return (
+    <SettingsCard
+      id="narrative"
+      eyebrow="NARRATIVE MODE · WRITE ROUTING"
+      title="Test Routing for Provisional Turns"
+      sub={
+        <>
+          When the test lever is thrown, new turns are committed to tables
+          suffixed <code className="code-inline">{suffix}</code> so production
+          stays untouched. The suffix itself is fixed — renaming it mid-story
+          would orphan existing test tables.
+        </>
+      }
+    >
+      <div className="lever-row">
+        <div className="lever-readout">
+          <div className="lever-status">
+            <span className={`lever-pip ${on ? "on" : ""}`} />
+            <span className={`lever-state ${on ? "danger" : ""}`}>
+              {on ? "TEST MODE · ENGAGED" : "NOMINAL · LIVE WRITE"}
+            </span>
           </div>
+          <div className="lever-detail caption dim">
+            {on ? (
+              <>
+                Routing to{" "}
+                <code className="code-inline danger">narrative{suffix}</code>,{" "}
+                <code className="code-inline danger">chunks{suffix}</code>,{" "}
+                <code className="code-inline danger">choices{suffix}</code>
+              </>
+            ) : (
+              <>
+                Routing to <code className="code-inline">narrative</code>,{" "}
+                <code className="code-inline">chunks</code>,{" "}
+                <code className="code-inline">choices</code>
+              </>
+            )}
+          </div>
+        </div>
+        <button
+          className={`lever ${on ? "on" : ""}`}
+          onClick={() => onToggle(!on)}
+          role="switch"
+          aria-checked={on}
+          data-testid="lever-test-mode"
+        >
+          <span className="lever-knob" />
+          <span className="lever-tick l">OFF</span>
+          <span className="lever-tick r">TEST</span>
+        </button>
+      </div>
+      {on && (
+        <div className="alert danger">
+          <AlertTriangle size={14} />
+          <div>
+            <div className="alert-title">TEST MODE ON</div>
+            <div className="alert-body">
+              New narrative turns will divert to the isolated test tables until
+              you flip the lever back. Generation otherwise proceeds normally.
+            </div>
+          </div>
+        </div>
+      )}
+    </SettingsCard>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 4. Model (role-level bindings only - never raw model IDs)
+// ──────────────────────────────────────────────────────────────────────────
+
+function RoleBinding({
+  caption,
+  currentRef,
+  roles,
+  onPick,
+}: {
+  caption: string;
+  currentRef: string;
+  roles: ModelRoleOption[];
+  onPick: (ref: string) => void;
+}) {
+  const active = roles.find((r) => r.ref === currentRef);
+  const providers = Array.from(new Set(roles.map((r) => r.provider)));
+  const [open, setOpen] = useState<Set<string>>(
+    () => new Set(active ? [active.provider] : []),
+  );
+  const toggle = (provider: string) => {
+    setOpen((prev) => {
+      const next = new Set(prev);
+      if (next.has(provider)) {
+        next.delete(provider);
+      } else {
+        next.add(provider);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="model-binding">
+      <div className="model-active">
+        <div className="model-active-mark">
+          {(active?.provider ?? currentRef.replace(/^@/, ""))[0]?.toUpperCase() ?? "?"}
+        </div>
+        <div className="model-active-body">
+          <span className="caption">{caption}</span>
+          <div className="model-active-name">{currentRef}</div>
+          <div className="model-active-meta">
+            {active ? (
+              <>
+                <span className="chip-meta">{active.label}</span>
+                <span className="chip-meta">{active.provider.toUpperCase()}</span>
+                <span className="chip-meta accent">{active.role.toUpperCase()}</span>
+              </>
+            ) : (
+              <span className="chip-meta accent">LITERAL ID · EDIT NEXUS.TOML TO REBIND</span>
+            )}
+          </div>
+        </div>
+        <Check size={16} className="model-active-check" />
+      </div>
+
+      <ul className="model-providers">
+        {providers.map((provider) => {
+          const providerRoles = roles.filter((r) => r.provider === provider);
+          const isOpen = open.has(provider);
+          return (
+            <li key={provider} className={`model-provider ${isOpen ? "open" : ""}`}>
+              <button className="model-provider-head" onClick={() => toggle(provider)}>
+                <ChevronRight size={11} className="model-caret" />
+                <span className="model-provider-name">{provider}</span>
+                <span className="model-provider-count">{providerRoles.length}</span>
+              </button>
+              {isOpen && (
+                <ul className="model-list">
+                  {providerRoles.map((role) => {
+                    const on = role.ref === currentRef;
+                    return (
+                      <li
+                        key={role.ref}
+                        className={`model-row ${on ? "on" : ""}`}
+                        onClick={() => onPick(role.ref)}
+                      >
+                        <span className="model-radio">
+                          {on ? <CircleDot size={12} /> : <Circle size={12} />}
+                        </span>
+                        <span className="model-name">{role.ref}</span>
+                        <span className="model-ctx">{role.label}</span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function ModelSection({
+  settings,
+  onPickApex,
+  onPickWizard,
+}: {
+  settings: SettingsPayload;
+  onPickApex: (ref: string) => void;
+  onPickWizard: (ref: string) => void;
+}) {
+  const meta = settings.settings_meta;
+  const roles = meta?.model_roles ?? [];
+  const apexAllowed = new Set(meta?.apex_allowed_providers ?? []);
+  const apexRoles = roles.filter((r) => apexAllowed.has(r.provider));
+
+  const embedders = Object.entries(settings.memnon?.models ?? {}).filter(
+    ([, cfg]) => cfg.is_active,
+  );
+
+  return (
+    <SettingsCard
+      id="model"
+      eyebrow="MODEL · ROLE BINDINGS"
+      title="LORE / LOGON Binding"
+      sub="Bindings are role references resolved through the api_models registry in nexus.toml — edit a role there and every consumer migrates at once. Raw model IDs are never entered here."
+    >
+      <RoleBinding
+        caption="NARRATIVE TURNS · APEX"
+        currentRef={settings.apex?.model ?? "—"}
+        roles={apexRoles}
+        onPick={onPickApex}
+      />
+      <RoleBinding
+        caption="NEW STORY WIZARD"
+        currentRef={settings.wizard?.default_model ?? "—"}
+        roles={roles}
+        onPick={onPickWizard}
+      />
+
+      <div className="model-locked">
+        <div className="model-locked-head">
+          <span className="font-slot-label">[ RETRIEVAL EMBEDDER · LOCKED ]</span>
+        </div>
+        {embedders.map(([name, cfg]) => (
+          <div key={name} className="model-locked-row">
+            <span className="model-locked-name">{name}</span>
+            <span className="chip-meta">{cfg.dimensions} DIM</span>
+            <span className="chip-meta accent">ACTIVE</span>
+          </div>
+        ))}
+        <p className="model-locked-copy">
+          Every stored memory is encoded with this model. Switching it
+          mid-story orphans the archive — change requires a re-embedding
+          campaign, not a settings toggle.
+        </p>
+      </div>
+    </SettingsCard>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 5. LORE Budget
+// ──────────────────────────────────────────────────────────────────────────
+
+function LoreSection({
+  settings,
+  onCommit,
+}: {
+  settings: SettingsPayload;
+  onCommit: (value: number) => void;
+}) {
+  const slider = settings.ui?.lore_budget_slider;
+  const saved = settings.lore?.token_budget?.apex_context_window ?? 0;
+  const reserve = settings.lore?.token_budget?.system_prompt_tokens;
+  const [draft, setDraft] = useState<number | null>(null);
+  const value = draft ?? saved;
+  const dirty = draft !== null && draft !== saved;
+
+  if (!slider) return null;
+
+  const stopTolerance = slider.step * 5;
+  const ladderLabel =
+    LADDER_COPY[slider.stops.findIndex((s) => Math.abs(s - value) < stopTolerance)]
+      ?.label ?? "CUSTOM";
+
+  return (
+    <SettingsCard
+      id="lore"
+      eyebrow="LORE · TOKEN BUDGETS"
+      title="Apex Context Window"
+      sub="The maximum token allotment for context assembly before each LORE / LOGON call. Smaller is faster; larger lets the agent reach further back."
+      footer={
+        <>
+          <span className={`caption ${dirty ? "warning" : "dim"}`}>
+            {dirty ? "● UNSAVED · " : ""}
+            saved: {saved.toLocaleString()} tok
+            {reserve !== undefined &&
+              ` · system prompt reserve: ${reserve.toLocaleString()} tok`}
+          </span>
+          <button
+            className="btn-primary"
+            disabled={!dirty}
+            onClick={() => {
+              onCommit(value);
+              setDraft(null);
+            }}
+            data-testid="lore-commit"
+          >
+            <Save size={12} /> COMMIT
+          </button>
+        </>
+      }
+    >
+      <div className="lore-readout">
+        <div className="lore-value">
+          {value.toLocaleString()}
+          <span className="lore-unit">tok</span>
+        </div>
+        <div className="lore-label">{ladderLabel}</div>
+      </div>
+      <div className="lore-stops">
+        {slider.stops.map((stop, i) => {
+          const isSel = Math.abs(stop - value) < stopTolerance;
+          const copy = LADDER_COPY[i] ?? { label: `${stop / 1000}K`, note: "" };
+          return (
+            <button
+              key={stop}
+              className={`lore-stop ${isSel ? "on" : ""}`}
+              onClick={() => setDraft(stop)}
+            >
+              <span
+                className="lore-stop-bar"
+                style={{ height: `${(stop / slider.max) * 60 + 12}px` }}
+              />
+              <span className="lore-stop-num">{stop / 1000}K</span>
+              <span className="lore-stop-label">{copy.label}</span>
+              <span className="lore-stop-note caption dim">{copy.note}</span>
+            </button>
+          );
+        })}
+      </div>
+      <div className="lore-slider-row">
+        <input
+          type="range"
+          min={slider.min}
+          max={slider.max}
+          step={slider.step}
+          value={value}
+          onChange={(e) => setDraft(parseInt(e.target.value, 10))}
+          className="lore-slider"
+        />
+        <div className="lore-slider-axis">
+          <span>{slider.min / 1000}K</span>
+          <span>{slider.max / 2000}K</span>
+          <span>{slider.max / 1000}K</span>
+        </div>
+      </div>
+    </SettingsCard>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 6. Typewriter
+// ──────────────────────────────────────────────────────────────────────────
+
+function TypewriterSection({
+  settings,
+  onCommit,
+}: {
+  settings: SettingsPayload;
+  onCommit: (value: number) => void;
+}) {
+  const saved = settings.ui?.typewriter_ms_per_char ?? 0;
+  const bounds = settings.settings_meta?.typewriter;
+  const [draft, setDraft] = useState<number | null>(null);
+  const value = draft ?? saved;
+  const dirty = draft !== null && draft !== saved;
+
+  if (!bounds) return null;
+
+  return (
+    <SettingsCard
+      id="reveal"
+      eyebrow="REVEAL · TYPE SPEED"
+      title="Typewriter Cadence"
+      sub="Milliseconds per character for incoming narrative chunks. The design system recommends 30–50 ms/char; the next generated chunk picks the change up immediately."
+      footer={
+        <>
+          <span className={`caption ${dirty ? "warning" : "dim"}`}>
+            {dirty ? "● UNSAVED · " : ""}
+            saved: {saved} ms/char
+          </span>
+          <button
+            className="btn-primary"
+            disabled={!dirty}
+            onClick={() => {
+              onCommit(value);
+              setDraft(null);
+            }}
+            data-testid="typewriter-commit"
+          >
+            <Save size={12} /> COMMIT
+          </button>
+        </>
+      }
+    >
+      <div className="lore-readout">
+        <div className="lore-value">
+          {value}
+          <span className="lore-unit">ms/char</span>
+        </div>
+        <div className="lore-label">
+          {value >= 30 && value <= 50 ? "DESIGN RANGE" : "CUSTOM"}
+        </div>
+      </div>
+      <div className="lore-slider-row">
+        <input
+          type="range"
+          min={bounds.min}
+          max={bounds.max}
+          step={1}
+          value={value}
+          onChange={(e) => setDraft(parseInt(e.target.value, 10))}
+          className="lore-slider"
+          data-testid="typewriter-slider"
+        />
+        <div className="lore-slider-axis">
+          <span>{bounds.min}</span>
+          <span>{Math.round((bounds.min + bounds.max) / 2)}</span>
+          <span>{bounds.max}</span>
+        </div>
+      </div>
+    </SettingsCard>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 7. PWA Icon
+// ──────────────────────────────────────────────────────────────────────────
+
+function PwaSection() {
+  const [drag, setDrag] = useState(false);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [cacheBust, setCacheBust] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const onFile = (candidate: File | null | undefined) => {
+    if (!candidate || !candidate.type.startsWith("image/")) return;
+    setFile(candidate);
+    setError(null);
+    const reader = new FileReader();
+    reader.onload = (e) => setPreview(e.target?.result as string);
+    reader.readAsDataURL(candidate);
+  };
+
+  const discard = () => {
+    setPreview(null);
+    setFile(null);
+    setError(null);
+    if (inputRef.current) inputRef.current.value = "";
+  };
+
+  const commit = async () => {
+    if (!file) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const form = new FormData();
+      form.append("icon", file);
+      const res = await fetch("/api/settings/pwa-icon", {
+        method: "POST",
+        body: form,
+        credentials: "include",
+      });
+      if (!res.ok) {
+        const text = (await res.text()) || res.statusText;
+        throw new Error(`${res.status}: ${text}`);
+      }
+      discard();
+      setCacheBust(Date.now());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const currentSrc = `/icons/icon-192.png${cacheBust ? `?v=${cacheBust}` : ""}`;
+
+  return (
+    <SettingsCard
+      id="pwa"
+      eyebrow="PWA · HOME-SCREEN GLYPH"
+      title="Installable Icon"
+      sub="The icon stamped onto the home screen, dock, or splash when NEXUS is installed as a PWA. PNG or JPEG, at least 512 px — all sizes and the manifest are regenerated server-side."
+    >
+      <div className="pwa-row">
+        <div className="pwa-current">
+          <div className="caption dim">CURRENT · 192PX</div>
+          <div className="pwa-icon-box">
+            <img src={currentSrc} alt="Current PWA icon" />
+          </div>
+          <div className="pwa-icon-coord">/icons/icon-192.png</div>
+        </div>
+
+        <div
+          className={`pwa-drop ${drag ? "drag" : ""} ${preview ? "has-preview" : ""}`}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDrag(true);
+          }}
+          onDragLeave={() => setDrag(false)}
+          onDrop={(e) => {
+            e.preventDefault();
+            setDrag(false);
+            onFile(e.dataTransfer.files?.[0]);
+          }}
+          onClick={() => inputRef.current?.click()}
+          data-testid="pwa-drop"
+        >
+          {preview ? (
+            <img src={preview} alt="Staged icon preview" className="pwa-drop-img" />
+          ) : (
+            <>
+              <Upload size={22} />
+              <div className="pwa-drop-title">DROP NEW GLYPH</div>
+              <div className="caption dim">
+                or click to choose · PNG / JPEG · 512px or larger
+              </div>
+            </>
+          )}
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/jpg"
+            style={{ display: "none" }}
+            onChange={(e) => onFile(e.target.files?.[0])}
+          />
         </div>
       </div>
 
-      <div className="settings-card">
-        <div className="settings-inner">
-          <span className="eyebrow brass-glow">[ CONFIGURATION ]</span>
-          <h2 className="settings-title">Readout</h2>
-          <div className="set-row">
-            <span className="set-label">Default Model</span>
-            <span className="set-val" data-testid="text-setting-model">
-              {defaultModel}
-            </span>
+      {error && (
+        <div className="alert danger">
+          <AlertTriangle size={14} />
+          <div>
+            <div className="alert-title">UPLOAD FAILED</div>
+            <div className="alert-body">{error}</div>
           </div>
-          <div className="set-row">
-            <span className="set-label">Test Mode</span>
-            <span className="set-val">
-              {testMode === undefined ? "—" : testMode ? "ENABLED" : "OFF"}
-            </span>
-          </div>
-          <div className="set-row">
-            <span className="set-label">Typewriter Speed</span>
-            <span className="set-val">
-              {typeSpeed !== undefined ? `${typeSpeed} ms/char` : "—"}
-            </span>
-          </div>
-          <div className="set-row">
-            <span className="set-label">Calibration Console</span>
-            <span className="set-val">ARRIVING · U5</span>
-          </div>
+        </div>
+      )}
+
+      {preview && (
+        <div className="pwa-actions">
+          <button className="btn-soft" onClick={discard} disabled={busy}>
+            <X size={11} /> DISCARD
+          </button>
+          <button className="btn-primary" onClick={commit} disabled={busy}>
+            <Upload size={12} /> {busy ? "TRANSMITTING" : "COMMIT GLYPH"}
+          </button>
+        </div>
+      )}
+    </SettingsCard>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Anchor rail + composed pane
+// ──────────────────────────────────────────────────────────────────────────
+
+function SectionRail({
+  active,
+  onPick,
+}: {
+  active: SectionId;
+  onPick: (id: SectionId) => void;
+}) {
+  return (
+    <aside className="set-rail">
+      <div className="eyebrow brass-glow">CALIBRATION</div>
+      <ul>
+        {SECTION_INDEX.map((s) => (
+          <li key={s.id}>
+            <button
+              className={`set-rail-btn ${active === s.id ? "on" : ""}`}
+              onClick={() => onPick(s.id)}
+            >
+              <span className="set-rail-label">{s.label}</span>
+              {active === s.id && <span className="set-rail-bar" />}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="set-rail-foot">
+        <span className="caption dim">/ AGENT SETTINGS</span>
+        <span className="caption dim">NEXUS.TOML · LIVE</span>
+      </div>
+    </aside>
+  );
+}
+
+export function SettingsPane() {
+  const { theme, setTheme } = useTheme();
+  const { data: settings, error } = useSettingsQuery();
+  const mutation = useSettingsMutation();
+
+  const [active, setActive] = useState<SectionId>("theme");
+  const scrollerRef = useRef<HTMLDivElement>(null);
+
+  const jumpTo = (id: SectionId) => {
+    setActive(id);
+    const root = scrollerRef.current;
+    const el = root?.querySelector<HTMLElement>(`#set-${id}`);
+    if (el && root) root.scrollTo({ top: el.offsetTop - 12, behavior: "smooth" });
+  };
+
+  // Track which section is in view as the operator scrolls.
+  useEffect(() => {
+    const root = scrollerRef.current;
+    if (!root) return;
+    const onScroll = () => {
+      const top = root.scrollTop + 80;
+      let current: SectionId = "theme";
+      for (const s of SECTION_INDEX) {
+        const el = root.querySelector<HTMLElement>(`#set-${s.id}`);
+        if (el && el.offsetTop <= top) current = s.id;
+      }
+      setActive(current);
+    };
+    root.addEventListener("scroll", onScroll, { passive: true });
+    return () => root.removeEventListener("scroll", onScroll);
+  }, [settings !== undefined]);
+
+  if (error) {
+    return (
+      <div className="pane-notice" data-testid="settings-pane">
+        <span className="notice-text">[ SETTINGS UNAVAILABLE ]</span>
+        <span className="notice-detail">{error.message}</span>
+      </div>
+    );
+  }
+
+  if (!settings) {
+    return (
+      <div className="pane-notice" data-testid="settings-pane">
+        <span className="notice-text">[ RECEIVING ]</span>
+      </div>
+    );
+  }
+
+  const testMode = settings.global?.narrative?.test_mode ?? false;
+  const testSuffix = settings.global?.narrative?.test_database_suffix ?? "_test";
+
+  return (
+    <div className="settings-pane-v2" data-testid="settings-pane">
+      <SectionRail active={active} onPick={jumpTo} />
+      <div className="set-scroller" ref={scrollerRef}>
+        <header className="set-header">
+          <div className="eyebrow brass-glow">[ AGENT CALIBRATION ]</div>
+          <h2 className="set-headline">Configuration</h2>
+          <p className="set-headline-sub">
+            Every dial on this console writes back to{" "}
+            <code className="code-inline">nexus.toml</code> through the
+            settings API. The agent picks up changes on the next narrative
+            turn — no restart, no incantations.
+          </p>
+          {mutation.isError && (
+            <div className="alert danger">
+              <AlertTriangle size={14} />
+              <div>
+                <div className="alert-title">WRITE REJECTED</div>
+                <div className="alert-body">{mutation.error.message}</div>
+              </div>
+            </div>
+          )}
+        </header>
+
+        <ThemeSection active={theme as ThemeId} onPick={(t) => setTheme(t)} />
+        <TypographySection />
+        <NarrativeSection
+          on={testMode}
+          suffix={testSuffix}
+          onToggle={(value) => mutation.mutate({ test_mode: value })}
+        />
+        <ModelSection
+          settings={settings}
+          onPickApex={(ref) => mutation.mutate({ apex_model_ref: ref })}
+          onPickWizard={(ref) => mutation.mutate({ wizard_model_ref: ref })}
+        />
+        <LoreSection
+          settings={settings}
+          onCommit={(value) => mutation.mutate({ apex_context_window: value })}
+        />
+        <TypewriterSection
+          settings={settings}
+          onCommit={(value) => mutation.mutate({ typewriter_ms_per_char: value })}
+        />
+        <PwaSection />
+
+        <div className="set-foot">
+          <div className="set-foot-rule" />
+          <div className="caption dim">END OF CONSOLE</div>
         </div>
       </div>
     </div>

--- a/ui/client/src/components/nexus/SettingsPane.tsx
+++ b/ui/client/src/components/nexus/SettingsPane.tsx
@@ -551,6 +551,13 @@ function LoreSection({
   const value = draft ?? saved;
   const dirty = draft !== null && draft !== saved;
 
+  // When the server value moves under the draft (optimistic commit applied,
+  // or a failed PATCH rolled the cache back), the draft is stale - drop it
+  // so the control always re-syncs to server truth.
+  useEffect(() => {
+    setDraft(null);
+  }, [saved]);
+
   if (!slider) return null;
 
   const stopTolerance = slider.step * 5;
@@ -650,6 +657,11 @@ function TypewriterSection({
   const [draft, setDraft] = useState<number | null>(null);
   const value = draft ?? saved;
   const dirty = draft !== null && draft !== saved;
+
+  // Same staleness rule as LoreSection: server movement invalidates the draft.
+  useEffect(() => {
+    setDraft(null);
+  }, [saved]);
 
   if (!bounds) return null;
 
@@ -877,8 +889,32 @@ function SectionRail({
 }
 
 export function SettingsPane() {
-  const { theme, setTheme } = useTheme();
   const { data: settings, error } = useSettingsQuery();
+
+  if (error) {
+    return (
+      <div className="pane-notice" data-testid="settings-pane">
+        <span className="notice-text">[ SETTINGS UNAVAILABLE ]</span>
+        <span className="notice-detail">{error.message}</span>
+      </div>
+    );
+  }
+
+  if (!settings) {
+    return (
+      <div className="pane-notice" data-testid="settings-pane">
+        <span className="notice-text">[ RECEIVING ]</span>
+      </div>
+    );
+  }
+
+  // The console only mounts once settings exist, so its scroll-tracking
+  // effect can bind on mount with the scroller guaranteed present.
+  return <SettingsConsole settings={settings} />;
+}
+
+function SettingsConsole({ settings }: { settings: SettingsPayload }) {
+  const { theme, setTheme } = useTheme();
   const mutation = useSettingsMutation();
 
   const [active, setActive] = useState<SectionId>("theme");
@@ -906,24 +942,7 @@ export function SettingsPane() {
     };
     root.addEventListener("scroll", onScroll, { passive: true });
     return () => root.removeEventListener("scroll", onScroll);
-  }, [settings !== undefined]);
-
-  if (error) {
-    return (
-      <div className="pane-notice" data-testid="settings-pane">
-        <span className="notice-text">[ SETTINGS UNAVAILABLE ]</span>
-        <span className="notice-detail">{error.message}</span>
-      </div>
-    );
-  }
-
-  if (!settings) {
-    return (
-      <div className="pane-notice" data-testid="settings-pane">
-        <span className="notice-text">[ RECEIVING ]</span>
-      </div>
-    );
-  }
+  }, []);
 
   const testMode = settings.global?.narrative?.test_mode ?? false;
   const testSuffix = settings.global?.narrative?.test_database_suffix ?? "_test";

--- a/ui/client/src/components/nexus/fontCatalog.ts
+++ b/ui/client/src/components/nexus/fontCatalog.ts
@@ -1,0 +1,51 @@
+/**
+ * Selectable fonts per theme per slot (NEXUS IRIS keeper matrix + approved
+ * alternates from the design system's FONT_CATALOG). This lives client-side
+ * because the option set is bounded by the fonts actually loaded by the
+ * bundle (@font-face / Google Fonts) - it is not runtime configuration.
+ * The *persisted choices* live in nexus.toml [ui.fonts.*].
+ *
+ * The display slot is the marquee font - reserved for the NEXUS wordmark
+ * (the design system's marquee rule) and locked to a single option.
+ */
+import type { FontSlotId, ThemeId } from "@/types/settings";
+
+export interface FontOption {
+  id: string;
+  label: string;
+  note: string;
+  locked?: boolean;
+}
+
+export const FONT_CATALOG: Record<ThemeId, Record<FontSlotId, FontOption[]>> = {
+  veil: {
+    body: [
+      { id: "Spectral", label: "Spectral", note: "default · serif" },
+      { id: "Cormorant Garamond", label: "Cormorant Garamond", note: "serif · alt" },
+    ],
+    menu: [{ id: "Cinzel", label: "Cinzel", note: "default · small-caps" }],
+    display: [
+      { id: "Megrim", label: "Megrim", note: "marquee · locked", locked: true },
+    ],
+  },
+  gilded: {
+    body: [
+      { id: "Cormorant Garamond", label: "Cormorant Garamond", note: "default · serif" },
+    ],
+    menu: [{ id: "Space Mono", label: "Space Mono", note: "default · mono" }],
+    display: [
+      { id: "Monoton", label: "Monoton", note: "marquee · locked", locked: true },
+    ],
+  },
+  vector: {
+    body: [{ id: "Rajdhani", label: "Rajdhani", note: "default · sans" }],
+    menu: [
+      { id: "Source Code Pro", label: "Source Code Pro", note: "default · mono" },
+      { id: "Monaco", label: "Monaco", note: "mono · system" },
+      { id: "Consolas", label: "Consolas", note: "mono · system" },
+    ],
+    display: [
+      { id: "Sixtyfour", label: "Sixtyfour", note: "marquee · locked", locked: true },
+    ],
+  },
+};

--- a/ui/client/src/components/nexus/nexus-layout.css
+++ b/ui/client/src/components/nexus/nexus-layout.css
@@ -914,107 +914,793 @@
   margin: 0;
 }
 
-/* ═══ SETTINGS PANE (placeholder — full wiring is U5) ═══ */
-.settings-pane {
-  max-width: 720px;
-  margin: 0 auto;
+/* ═══════════════════════════════════════════════════════════════════════════
+   SETTINGS PANE V2 — the operator's calibration console (U5).
+   Ported from design_handoff/project/ui_kits/nexus_iris/styles.css.
+   Two-column layout: anchor rail (240px) + scrolling content. Every card
+   uses a framed eyebrow + menu-font title. Tokens only — the kit's --danger
+   and --warning map to hsl(var(--destructive)) and --bronze respectively.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.nexus-content:has(> .settings-pane-v2) { padding: 0; overflow: hidden; }
+.settings-pane-v2 {
+  --danger: hsl(var(--destructive));
+  --warning: var(--bronze);
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 0;
+  height: 100%;
+  min-height: 0;
 }
-.settings-card {
+
+.nexus-shell .btn-primary {
+  background: var(--brass);
+  color: hsl(42 45% 95%);
+  border: none;
+  padding: 12px 24px;
+  font-family: var(--font-menu);
+  font-size: 11px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+.nexus-shell .btn-primary:hover:not(:disabled) {
+  background: var(--brass-bright);
+  box-shadow: 0 0 0 1px hsl(320 55% 70% / .5) inset, 0 0 18px hsl(320 55% 50% / .4);
+}
+.nexus-shell .btn-primary:disabled { opacity: .35; cursor: not-allowed; }
+
+/* ─── Anchor rail ─── */
+.set-rail {
+  position: sticky; top: 0;
+  align-self: start;
+  height: 100%;
+  background: var(--bg-elev-1);
+  border-right: 1px solid var(--border);
+  padding: 28px 18px 20px;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.set-rail > .eyebrow { display: block; margin-bottom: 18px; padding-left: 8px; }
+.set-rail ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 2px; flex: 1; }
+.set-rail-btn {
+  position: relative;
+  display: flex; align-items: center; gap: 10px;
+  width: 100%;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 8px 12px 8px 10px;
+  color: var(--fg-muted);
+  text-align: left;
+  font-family: var(--font-menu);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color .15s, background .15s, border-color .15s;
+}
+.set-rail-btn:hover { color: var(--brass-bright); background: hsl(320 55% 50% / .04); }
+.set-rail-btn.on {
+  color: var(--brass-bright);
+  background: hsl(320 55% 50% / .10);
+  border-color: var(--border);
+  text-shadow: var(--glow-soft);
+}
+.set-rail-label { flex: 1; }
+.set-rail-bar {
+  position: absolute;
+  right: -1px; top: 50%; transform: translateY(-50%);
+  width: 3px; height: 22px;
+  background: var(--brass);
+  box-shadow: var(--glow-soft);
+}
+.set-rail-foot {
+  display: flex; flex-direction: column; gap: 2px;
+  padding: 12px 8px 0;
+  border-top: 1px solid var(--border-faint);
+  margin-top: 8px;
+}
+
+/* ─── Scroller ─── */
+.set-scroller {
+  overflow: auto;
+  padding: 36px 48px 60px;
+  display: flex; flex-direction: column; gap: 28px;
+  min-height: 0;
+}
+
+.set-header { padding: 0 0 8px; display: flex; flex-direction: column; gap: 8px; align-items: flex-start; }
+.set-headline {
+  font-family: var(--font-menu);
+  font-size: 36px;
+  letter-spacing: 0.16em;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--brass-bright);
+  text-shadow: var(--glow-soft);
+  margin: 0 0 4px;
+  line-height: 1.05;
+}
+.set-headline-sub {
+  font-family: var(--font-body);
+  font-size: 17px;
+  line-height: 1.65;
+  color: var(--fg-muted);
+  max-width: 64ch;
+  margin: 0;
+  text-wrap: pretty;
+}
+
+/* ─── Card chrome ─── */
+.set-card { scroll-margin-top: 24px; }
+.set-card-frame {
+  padding: 0;
   background: var(--bg-elev-2);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
   box-shadow: 0 8px 30px -8px hsl(320 45% 8% / .55);
-  margin-bottom: 22px;
 }
-.settings-inner { padding: 30px 38px 26px; }
-.settings-inner > .eyebrow {
-  display: block;
-  margin-bottom: 6px;
-}
-.settings-title {
+.set-card-head { padding: 22px 28px 16px; }
+.set-card-eyebrow {
   font-family: var(--font-menu);
-  font-size: 26px;
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--brass);
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.set-card-title {
+  font-family: var(--font-menu);
+  font-size: 22px;
   font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--brass);
-  text-shadow: var(--glow-soft);
-  margin: 0 0 18px;
-}
-.set-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 18px;
-  padding: 13px 0;
-  border-bottom: 1px solid var(--border-faint);
-}
-.set-row:last-child { border-bottom: none; }
-.set-label {
-  font-family: var(--font-menu);
-  font-size: 10px;
-  letter-spacing: 0.24em;
-  color: var(--fg-muted);
-  text-transform: uppercase;
-  font-weight: 600;
-}
-.set-val {
-  font-family: var(--font-menu);
-  font-size: 13px;
   color: var(--fg);
-  letter-spacing: 0.06em;
-  text-align: right;
+  margin: 0 0 6px;
 }
-.theme-cards {
+.set-card-sub {
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--fg-muted);
+  max-width: 68ch;
+  margin: 0;
+  text-wrap: pretty;
+}
+.set-card-frame > .set-card-rule {
+  margin: 0 28px;
+  border: 0;
+  border-top: 1px solid var(--border-faint);
+}
+.set-card-body {
+  padding: 22px 28px 22px;
+  display: flex; flex-direction: column; gap: 24px;
+}
+.set-card-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 14px 28px 22px;
+  border-top: 1px solid var(--border-faint);
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+/* Inline code chip — routing readouts, paths, etc. */
+.code-inline {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  color: var(--brass-bright);
+}
+.code-inline.danger { color: var(--danger); border-color: hsl(var(--destructive) / .5); }
+
+/* ─── 1. Theme picker cards ─── */
+.theme-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
-  margin-top: 6px;
+  gap: 14px;
 }
 .theme-card {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 14px;
-  background: var(--bg-elev-1);
+  position: relative;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 22px 18px 18px;
+  text-align: left;
+  display: flex; flex-direction: column; align-items: flex-start; gap: 12px;
+  cursor: pointer;
+  transition: border-color .15s, background .15s, box-shadow .15s;
+  overflow: hidden;
+  min-height: 200px;
+}
+.theme-card:hover { border-color: var(--brass); background: hsl(320 55% 50% / .04); }
+.theme-card.on {
+  border-color: var(--brass);
+  box-shadow: 0 0 0 1px var(--brass) inset, 0 0 20px hsl(320 55% 50% / .25);
+  background: hsl(320 55% 50% / .08);
+}
+.theme-card-wordmark {
+  font-size: 38px;
+  letter-spacing: 0.14em;
+  line-height: 1;
+  color: var(--brass-bright);
+  text-shadow: var(--glow-soft);
+  margin-bottom: 2px;
+}
+.theme-card-veil .theme-card-wordmark { color: hsl(320 65% 70%); text-shadow: 0 0 10px hsl(320 55% 50% / .9), 0 0 24px hsl(15 75% 60% / .35); }
+.theme-card-gilded .theme-card-wordmark { color: hsl(45 60% 65%); text-shadow: 0 0 8px hsl(43 74% 47% / .7), 0 0 18px hsl(43 74% 47% / .35); font-size: 34px; }
+.theme-card-vector .theme-card-wordmark { color: hsl(185 100% 70%); text-shadow: 0 0 8px hsl(185 100% 50% / .9), 0 0 16px hsl(185 100% 50% / .5); font-size: 28px; }
+.theme-card-meta {
+  display: flex; align-items: baseline; gap: 6px;
+  font-family: var(--font-menu);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.theme-card-name { color: var(--brass); font-weight: 600; text-shadow: var(--glow-soft); }
+.theme-card-eye { color: var(--fg-muted); font-size: 10px; }
+.theme-card-motto {
+  font-family: var(--font-body);
+  font-size: 14px;
+  line-height: 1.4;
+  color: var(--fg-muted);
+  font-style: italic;
+  margin: 0;
+  text-wrap: pretty;
+}
+.theme-card-swatches { display: flex; gap: 4px; margin-top: auto; }
+.theme-swatch {
+  width: 22px; height: 22px;
+  border: 1px solid hsl(270 30% 30% / .8);
+  border-radius: 2px;
+}
+.theme-card-active {
+  position: absolute;
+  top: 12px; right: 12px;
+  display: inline-flex; align-items: center; gap: 4px;
+  font-family: var(--font-menu);
+  font-size: 9px;
+  letter-spacing: 0.22em;
+  color: var(--brass-bright);
+  background: var(--bg);
+  border: 1px solid var(--brass);
+  padding: 3px 6px;
+  border-radius: var(--radius-sm);
+  text-shadow: var(--glow-soft);
+  font-weight: 600;
+}
+
+/* ─── 2. Typography slot picker ─── */
+.font-slot {
+  display: flex; flex-direction: column; gap: 10px;
+  padding-bottom: 22px;
+  border-bottom: 1px solid var(--border-faint);
+}
+.font-slot:last-child { padding-bottom: 0; border-bottom: none; }
+.font-slot-head { display: flex; align-items: baseline; gap: 12px; justify-content: space-between; }
+.font-slot-label {
+  font-family: var(--font-menu);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--brass);
+  font-weight: 600;
+  text-shadow: var(--glow-soft);
+}
+.font-slot-hint {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--fg-muted);
+  opacity: .8;
+}
+.font-slot-preview {
+  padding: 16px 18px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--fg);
+  font-size: 17px;
+  line-height: 1.65;
+  text-wrap: pretty;
+}
+.font-slot-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.font-chip {
+  display: flex; align-items: baseline; gap: 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: border-color .15s, background .15s;
+}
+.font-chip:hover:not(:disabled) { border-color: var(--brass); background: hsl(320 55% 50% / .06); }
+.font-chip.on {
+  border-color: var(--brass);
+  background: hsl(320 55% 50% / .12);
+  box-shadow: 0 0 0 1px var(--brass) inset, 0 0 12px hsl(320 55% 50% / .25);
+}
+.font-chip.locked { opacity: .8; }
+.font-chip.locked:disabled { cursor: not-allowed; }
+.font-chip-name {
+  font-size: 14px;
+  color: var(--fg);
+  letter-spacing: 0.02em;
+}
+.font-chip.on .font-chip-name { color: var(--brass-bright); text-shadow: var(--glow-soft); }
+.font-chip-note {
+  font-family: var(--font-menu);
+  font-size: 9px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--fg-dim);
+}
+
+/* ─── 3. Lever toggle (test mode) ─── */
+.lever-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 24px;
+  padding: 14px 18px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+.lever-readout { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+.lever-status { display: flex; align-items: center; gap: 10px; }
+.lever-pip {
+  width: 9px; height: 9px;
+  background: var(--bg-elev-3);
+  border: 1px solid var(--border-strong);
+  border-radius: 50%;
+}
+.lever-pip.on {
+  background: var(--danger);
+  border-color: var(--danger);
+  box-shadow: 0 0 8px var(--danger), 0 0 14px hsl(var(--destructive) / .5);
+  animation: nexus-pulse 2s ease-in-out infinite;
+}
+.lever-state {
+  font-family: var(--font-menu);
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--fg);
+  font-weight: 600;
+}
+.lever-state.danger { color: var(--danger); text-shadow: 0 0 6px hsl(var(--destructive) / .55); }
+.lever-detail { font-family: var(--font-body); font-size: 13px; }
+
+.lever {
+  position: relative;
+  flex-shrink: 0;
+  width: 120px;
+  height: 44px;
+  background: var(--bg-elev-3);
+  border: 1px solid var(--border-strong);
+  border-radius: 22px;
+  cursor: pointer;
+  display: flex; align-items: center;
+  padding: 0;
+  transition: background .2s, border-color .2s;
+}
+.lever-knob {
+  position: absolute;
+  left: 4px;
+  width: 36px; height: 36px;
+  background: var(--brass);
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px hsl(320 55% 50% / .6), 0 2px 4px hsl(320 45% 6% / .6), 0 0 14px hsl(320 55% 50% / .3);
+  transition: left .25s ease-in-out, background .2s;
+  z-index: 2;
+}
+.lever.on .lever-knob {
+  left: calc(100% - 40px);
+  background: var(--danger);
+  box-shadow: 0 0 0 1px hsl(var(--destructive) / .6), 0 2px 4px hsl(320 45% 6% / .6), 0 0 16px hsl(var(--destructive) / .55);
+}
+.lever.on { background: hsl(var(--destructive) / .18); border-color: hsl(var(--destructive) / .65); }
+.lever-tick {
+  position: absolute;
+  top: 50%; transform: translateY(-50%);
+  font-family: var(--font-menu);
+  font-size: 9px;
+  letter-spacing: 0.22em;
+  color: var(--fg-dim);
+  font-weight: 600;
+}
+.lever-tick.l { left: 12px; }
+.lever-tick.r { right: 10px; }
+.lever.on .lever-tick.r { color: var(--danger); text-shadow: 0 0 8px hsl(var(--destructive) / .6); }
+.lever:not(.on) .lever-tick.l { color: var(--brass); text-shadow: var(--glow-soft); }
+
+/* Alert (danger flavor) */
+.alert {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 12px 16px;
+  background: hsl(var(--destructive) / .08);
+  border: 1px solid hsl(var(--destructive) / .4);
+  border-left: 3px solid var(--danger);
+  border-radius: var(--radius-sm);
+  color: var(--fg);
+}
+.alert > svg { color: var(--danger); flex-shrink: 0; margin-top: 2px; }
+.alert-title {
+  font-family: var(--font-menu);
+  font-size: 10px;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: var(--danger);
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+.alert-body { font-family: var(--font-body); font-size: 14px; line-height: 1.5; color: var(--fg); }
+
+/* ─── 4. Model role bindings ─── */
+.model-binding { display: flex; flex-direction: column; gap: 12px; }
+.model-active {
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 18px;
+  background: var(--bg);
+  border: 1px solid var(--brass);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 0 0 1px var(--brass) inset, 0 0 18px hsl(320 55% 50% / .2);
+}
+.model-active-mark {
+  width: 56px; height: 56px;
+  display: grid; place-items: center;
+  font-family: var(--font-menu);
+  font-size: 26px;
+  font-weight: 600;
+  color: var(--brass-bright);
+  background: hsl(320 55% 50% / .12);
+  border: 1px solid var(--brass);
+  border-radius: var(--radius-sm);
+  text-shadow: var(--glow-soft);
+}
+.model-active-body { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.model-active-body > .caption { font-size: 9px; }
+.model-active-name {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  color: var(--brass-bright);
+  text-shadow: var(--glow-soft);
+  letter-spacing: 0.02em;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.model-active-meta { display: flex; gap: 6px; flex-wrap: wrap; }
+.chip-meta {
+  font-family: var(--font-menu);
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--fg-muted);
+  background: var(--bg-elev-2);
+}
+.chip-meta.accent { color: var(--bronze); border-color: hsl(15 75% 50% / .5); }
+.model-active-check { color: var(--brass); }
+
+.model-providers {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.model-provider {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+.model-provider.open { border-color: var(--border-strong); }
+.model-provider-head {
+  display: flex; align-items: center; gap: 10px;
+  width: 100%;
+  padding: 10px 14px;
+  background: transparent;
+  border: none;
+  font-family: var(--font-menu);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--fg);
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+.model-provider-head:hover { color: var(--brass-bright); }
+.model-caret { transition: transform .2s; color: var(--brass); }
+.model-provider.open .model-caret { transform: rotate(90deg); }
+.model-provider-name { flex: 1; }
+.model-provider-count {
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  color: var(--fg-muted);
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elev-2);
+  font-weight: 400;
+}
+.model-list {
+  list-style: none; padding: 4px 8px 10px 32px; margin: 0;
+  display: flex; flex-direction: column; gap: 1px;
+  border-top: 1px solid var(--border-faint);
+}
+.model-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 7px 12px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.02em;
+}
+.model-row:hover { color: var(--brass-bright); background: hsl(320 55% 50% / .05); }
+.model-row.on {
+  color: var(--brass-bright);
+  background: hsl(320 55% 50% / .12);
+  border-color: var(--brass);
+  text-shadow: var(--glow-soft);
+}
+.model-row .model-radio { color: var(--brass); display: inline-flex; }
+.model-name { flex: 1; }
+.model-ctx {
+  font-family: var(--font-menu);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--fg-muted);
+}
+
+/* Read-only embedder block */
+.model-locked {
+  display: flex; flex-direction: column; gap: 10px;
+  padding: 14px 18px;
+  background: var(--bg);
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-sm);
+}
+.model-locked-row {
+  display: flex; align-items: center; gap: 10px;
+}
+.model-locked-name {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--fg);
+  letter-spacing: 0.02em;
+  flex: 1;
+}
+.model-locked-copy {
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-style: italic;
+  line-height: 1.5;
+  color: var(--fg-muted);
+  margin: 0;
+  max-width: 64ch;
+}
+
+/* ─── 5. LORE token budget + typewriter cadence ─── */
+.lore-readout {
+  display: flex; align-items: baseline; gap: 18px;
+  padding: 18px 22px;
+  background: var(--bg);
+  border: 1px solid var(--brass);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 0 0 1px var(--brass) inset, 0 0 18px hsl(320 55% 50% / .15);
+}
+.lore-value {
+  font-family: var(--font-menu);
+  font-size: 38px;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  color: var(--brass-bright);
+  text-shadow: var(--glow-soft);
+  line-height: 1;
+}
+.lore-unit {
+  font-size: 14px;
+  letter-spacing: 0.18em;
+  color: var(--fg-muted);
+  margin-left: 6px;
+  text-transform: uppercase;
+}
+.lore-label {
+  font-family: var(--font-menu);
+  font-size: 12px;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: var(--bronze);
+  margin-left: auto;
+  font-weight: 600;
+}
+
+.lore-stops {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+.lore-stop {
+  display: flex; flex-direction: column; align-items: flex-start; gap: 6px;
+  padding: 14px 14px 12px;
+  background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   cursor: pointer;
   text-align: left;
-  transition: border-color .15s, box-shadow .15s;
+  transition: border-color .15s, background .15s;
+  min-height: 130px;
 }
-.theme-card:hover {
+.lore-stop:hover { border-color: var(--brass); background: hsl(320 55% 50% / .04); }
+.lore-stop.on {
   border-color: var(--brass);
-  box-shadow: 0 0 14px hsl(320 55% 50% / .2);
+  background: hsl(320 55% 50% / .10);
+  box-shadow: 0 0 0 1px var(--brass) inset;
 }
-.theme-card.on {
-  border-color: var(--brass);
-  box-shadow: 0 0 0 1px var(--brass) inset, 0 0 18px hsl(320 55% 50% / .3);
+.lore-stop-bar {
+  display: block;
+  width: 6px;
+  background: linear-gradient(to top, var(--bronze), var(--brass));
+  border-radius: 1px;
+  opacity: .55;
+  margin-bottom: 6px;
 }
-.theme-card .theme-name {
+.lore-stop.on .lore-stop-bar { opacity: 1; box-shadow: 0 0 8px hsl(320 55% 50% / .6); }
+.lore-stop-num {
   font-family: var(--font-menu);
-  font-size: 13px;
+  font-size: 18px;
   font-weight: 600;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
   color: var(--fg);
+  letter-spacing: 0.06em;
 }
-.theme-card.on .theme-name {
-  color: var(--brass-bright);
-  text-shadow: var(--glow-soft);
+.lore-stop.on .lore-stop-num { color: var(--brass-bright); text-shadow: var(--glow-soft); }
+.lore-stop-label {
+  font-family: var(--font-menu);
+  font-size: 10px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--brass);
+  font-weight: 600;
 }
-.theme-card .theme-motto {
-  font-family: var(--font-body);
-  font-size: 13px;
-  font-style: italic;
+.lore-stop-note { font-family: var(--font-body); font-size: 12px; font-style: italic; line-height: 1.3; text-transform: none; letter-spacing: 0; }
+
+/* Native range slider — restyled */
+.lore-slider-row { display: flex; flex-direction: column; gap: 6px; }
+.lore-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 22px;
+  background: transparent;
+  cursor: pointer;
+}
+.lore-slider::-webkit-slider-runnable-track {
+  height: 4px;
+  background: linear-gradient(to right, var(--brass), var(--brass-bright), var(--bronze));
+  border-radius: 2px;
+  box-shadow: 0 0 8px hsl(320 55% 50% / .3);
+}
+.lore-slider::-moz-range-track {
+  height: 4px;
+  background: linear-gradient(to right, var(--brass), var(--brass-bright), var(--bronze));
+  border-radius: 2px;
+}
+.lore-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 16px; height: 16px;
+  margin-top: -6px;
+  background: var(--brass-bright);
+  border: 1px solid var(--brass);
+  border-radius: 2px;
+  box-shadow: 0 0 8px hsl(320 55% 50% / .6);
+  transform: rotate(45deg);
+}
+.lore-slider::-moz-range-thumb {
+  width: 16px; height: 16px;
+  background: var(--brass-bright);
+  border: 1px solid var(--brass);
+  border-radius: 2px;
+  box-shadow: 0 0 8px hsl(320 55% 50% / .6);
+}
+.lore-slider-axis {
+  display: flex; justify-content: space-between;
+  font-family: var(--font-menu);
+  font-size: 9px;
+  letter-spacing: 0.18em;
   color: var(--fg-muted);
 }
-.theme-swatches { display: flex; gap: 4px; }
-.theme-swatches span {
-  width: 18px;
-  height: 10px;
-  border: 1px solid var(--border);
-  border-radius: 1px;
+
+.settings-pane-v2 .caption.warning { color: var(--warning); }
+
+/* ─── 7. PWA icon ─── */
+.pwa-row {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 24px;
+  align-items: stretch;
+}
+.pwa-current { display: flex; flex-direction: column; gap: 8px; }
+.pwa-icon-box {
+  width: 144px; height: 144px;
+  border: 1px solid var(--border-strong);
+  background: var(--bg);
+  display: grid; place-items: center;
+  overflow: hidden;
+  border-radius: var(--radius-sm);
+  box-shadow: 0 0 0 1px hsl(320 55% 50% / .15) inset, 0 0 18px hsl(320 55% 50% / .12);
+}
+.pwa-icon-box img { width: 100%; height: 100%; object-fit: cover; }
+.pwa-icon-coord {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+  letter-spacing: 0.02em;
+}
+.pwa-drop {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--fg-muted);
+  padding: 28px 22px;
+  cursor: pointer;
+  text-align: center;
+  transition: border-color .15s, background .15s, color .15s;
+  min-height: 144px;
+}
+.pwa-drop:hover { border-color: var(--brass); color: var(--brass-bright); background: hsl(320 55% 50% / .04); }
+.pwa-drop.drag {
+  border-color: var(--brass);
+  border-style: solid;
+  background: hsl(320 55% 50% / .08);
+  color: var(--brass-bright);
+  box-shadow: 0 0 0 1px var(--brass) inset, 0 0 20px hsl(320 55% 50% / .25);
+}
+.pwa-drop.has-preview { padding: 0; border-style: solid; }
+.pwa-drop-img { width: 100%; height: 100%; min-height: 144px; object-fit: cover; }
+.pwa-drop-title {
+  font-family: var(--font-menu);
+  font-size: 11px;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: var(--brass);
+  text-shadow: var(--glow-soft);
+  font-weight: 600;
+}
+.pwa-actions {
+  display: flex; justify-content: flex-end; gap: 10px;
+  padding-top: 4px;
+}
+
+/* ─── End-of-console footer ─── */
+.set-foot {
+  display: flex; flex-direction: column; align-items: center; gap: 8px;
+  padding: 24px 0 8px;
+  opacity: .65;
+}
+.set-foot-rule {
+  width: 240px;
+  height: 1px;
+  background: linear-gradient(to right,
+    transparent 0%,
+    var(--border-strong) 30%,
+    var(--brass) 50%,
+    var(--border-strong) 70%,
+    transparent 100%);
 }
 
 /* Pane fallback (loading / error states share one look). */

--- a/ui/client/src/contexts/FontContext.tsx
+++ b/ui/client/src/contexts/FontContext.tsx
@@ -1,198 +1,110 @@
 /**
- * Font preferences context for managing typography across the application.
- * Theme-aware: Applies appropriate fonts for each theme (Gilded, Vector, Veil).
+ * Font preferences context. Theme-aware: applies the persisted font matrix
+ * (ui.fonts in nexus.toml, served via GET /api/settings) to the CSS custom
+ * properties for the active theme. Writes go through PATCH /api/settings -
+ * localStorage only seeds the first paint before the query resolves.
  */
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { useTheme } from './ThemeContext';
+import { useSettingsMutation, useSettingsQuery } from '@/hooks/useSettings';
+import type { FontMatrix, FontSlotId, ThemeId } from '@/types/settings';
 
-interface FontPreferences {
-  // Vector (Cyberpunk) theme fonts
-  vectorNarrativeFont: string;
-  vectorUIFont: string;
-  vectorDisplayFont: string;
-  // Gilded theme fonts
-  gildedBodyFont: string;
-  gildedMenuFont: string;
-  gildedDisplayFont: string;
-  // Veil theme fonts
-  veilBodyFont: string;
-  veilMenuFont: string;
-  veilDisplayFont: string;
-  // Legacy aliases (deprecated - use vector* instead)
-  cyberpunkNarrativeFont?: string;
-  cyberpunkUIFont?: string;
-  cyberpunkDisplayFont?: string;
-}
+/**
+ * The NEXUS IRIS keeper matrix - first-paint seed only. The persisted
+ * defaults live in UISettings (settings_models.py) and nexus.toml [ui.fonts].
+ */
+const KEEPERS: FontMatrix = {
+  veil: { body: 'Spectral', menu: 'Cinzel', display: 'Megrim' },
+  gilded: { body: 'Cormorant Garamond', menu: 'Space Mono', display: 'Monoton' },
+  vector: { body: 'Rajdhani', menu: 'Source Code Pro', display: 'Sixtyfour' },
+};
+
+const STORAGE_KEY = 'nexus-font-preferences-v5';
 
 interface FontContextType {
-  fonts: FontPreferences;
-  // Vector (Cyberpunk) setters
-  setVectorNarrativeFont: (font: string) => void;
-  setVectorUIFont: (font: string) => void;
-  setVectorDisplayFont: (font: string) => void;
-  // Gilded setters
-  setGildedBodyFont: (font: string) => void;
-  setGildedMenuFont: (font: string) => void;
-  setGildedDisplayFont: (font: string) => void;
-  // Veil setters
-  setVeilBodyFont: (font: string) => void;
-  setVeilMenuFont: (font: string) => void;
-  setVeilDisplayFont: (font: string) => void;
-  resetToDefaults: () => void;
-  // Convenience getters for current theme
+  fonts: FontMatrix;
+  setFont: (theme: ThemeId, slot: FontSlotId, font: string) => void;
+  resetToKeepers: () => void;
+  // Convenience getters for the active theme
   currentBodyFont: string;
   currentMenuFont: string;
   currentDisplayFont: string;
-  // Legacy aliases
-  setCyberpunkNarrativeFont: (font: string) => void;
-  setCyberpunkUIFont: (font: string) => void;
-  setCyberpunkDisplayFont: (font: string) => void;
 }
 
 const FontContext = createContext<FontContextType | undefined>(undefined);
 
-const DEFAULT_FONTS: FontPreferences = {
-  // Vector (Cyberpunk) theme
-  vectorNarrativeFont: 'Rajdhani',
-  vectorUIFont: 'Source Code Pro',
-  vectorDisplayFont: 'Sixtyfour',
-  // Gilded theme
-  gildedBodyFont: 'Cormorant Garamond',
-  gildedMenuFont: 'Space Mono',
-  gildedDisplayFont: 'Monoton',
-  // Veil theme (Art Nouveau)
-  veilBodyFont: 'Spectral',
-  veilMenuFont: 'Cinzel',
-  veilDisplayFont: 'Megrim',
-};
-
-const STORAGE_KEY = 'nexus-font-preferences-v4';
+function seedFromStorage(): FontMatrix {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored) as Partial<FontMatrix>;
+      return {
+        veil: { ...KEEPERS.veil, ...parsed.veil },
+        gilded: { ...KEEPERS.gilded, ...parsed.gilded },
+        vector: { ...KEEPERS.vector, ...parsed.vector },
+      };
+    } catch {
+      return KEEPERS;
+    }
+  }
+  return KEEPERS;
+}
 
 export function FontProvider({ children }: { children: ReactNode }) {
-  const { theme, isGilded, isVector, isVeil } = useTheme();
+  const { theme } = useTheme();
+  const { data: settings } = useSettingsQuery();
+  const mutation = useSettingsMutation();
 
-  const [fonts, setFonts] = useState<FontPreferences>(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      try {
-        return { ...DEFAULT_FONTS, ...JSON.parse(stored) };
-      } catch {
-        return DEFAULT_FONTS;
-      }
+  const [seed] = useState<FontMatrix>(seedFromStorage);
+  const fonts: FontMatrix = settings?.ui?.fonts ?? seed;
+
+  // Mirror the server matrix into localStorage so the next first paint
+  // matches the persisted state.
+  useEffect(() => {
+    if (settings?.ui?.fonts) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(settings.ui.fonts));
     }
-    return DEFAULT_FONTS;
-  });
+  }, [settings?.ui?.fonts]);
 
   useEffect(() => {
     const root = document.documentElement;
+    const slots = fonts[theme as ThemeId] ?? KEEPERS[theme as ThemeId];
 
-    if (isGilded) {
-      // Gilded theme: Art Deco aesthetic
-      root.style.setProperty('--font-narrative', fonts.gildedBodyFont);
-      root.style.setProperty('--font-sans', fonts.gildedBodyFont);
-      root.style.setProperty('--font-serif', fonts.gildedBodyFont);
-      root.style.setProperty('--font-mono', fonts.gildedMenuFont);
-      root.style.setProperty('--font-display', fonts.gildedDisplayFont);
-    } else if (isVector) {
-      // Vector theme: Cyberpunk/terminal aesthetic
-      root.style.setProperty('--font-narrative', fonts.vectorNarrativeFont);
-      root.style.setProperty('--font-sans', fonts.vectorUIFont);
-      root.style.setProperty('--font-serif', fonts.vectorUIFont);
-      root.style.setProperty('--font-mono', fonts.vectorUIFont);
-      root.style.setProperty('--font-display', fonts.vectorDisplayFont);
-    } else if (isVeil) {
-      // Veil theme: Art Nouveau aesthetic
-      root.style.setProperty('--font-narrative', fonts.veilBodyFont);
-      root.style.setProperty('--font-sans', fonts.veilBodyFont);
-      root.style.setProperty('--font-serif', fonts.veilBodyFont);
-      root.style.setProperty('--font-mono', fonts.veilMenuFont);
-      root.style.setProperty('--font-display', fonts.veilDisplayFont);
+    root.style.setProperty('--font-narrative', slots.body);
+    root.style.setProperty('--font-display', slots.display);
+    if (theme === 'vector') {
+      // Vector chrome is all-terminal: the menu font carries every UI face.
+      root.style.setProperty('--font-sans', slots.menu);
+      root.style.setProperty('--font-serif', slots.menu);
+      root.style.setProperty('--font-mono', slots.menu);
+    } else {
+      root.style.setProperty('--font-sans', slots.body);
+      root.style.setProperty('--font-serif', slots.body);
+      root.style.setProperty('--font-mono', slots.menu);
     }
+  }, [fonts, theme]);
 
-    // Save to localStorage
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(fonts));
-  }, [fonts, isGilded, isVector, isVeil, theme]);
-
-  // Vector setters
-  const setVectorNarrativeFont = (font: string) => {
-    setFonts(prev => ({ ...prev, vectorNarrativeFont: font }));
+  const setFont = (themeId: ThemeId, slot: FontSlotId, font: string) => {
+    mutation.mutate({ fonts: { [themeId]: { [slot]: font } } });
   };
 
-  const setVectorUIFont = (font: string) => {
-    setFonts(prev => ({ ...prev, vectorUIFont: font }));
+  const resetToKeepers = () => {
+    mutation.mutate({ fonts: KEEPERS });
   };
 
-  const setVectorDisplayFont = (font: string) => {
-    setFonts(prev => ({ ...prev, vectorDisplayFont: font }));
-  };
-
-  // Gilded setters
-  const setGildedBodyFont = (font: string) => {
-    setFonts(prev => ({ ...prev, gildedBodyFont: font }));
-  };
-
-  const setGildedMenuFont = (font: string) => {
-    setFonts(prev => ({ ...prev, gildedMenuFont: font }));
-  };
-
-  const setGildedDisplayFont = (font: string) => {
-    setFonts(prev => ({ ...prev, gildedDisplayFont: font }));
-  };
-
-  // Veil setters
-  const setVeilBodyFont = (font: string) => {
-    setFonts(prev => ({ ...prev, veilBodyFont: font }));
-  };
-
-  const setVeilMenuFont = (font: string) => {
-    setFonts(prev => ({ ...prev, veilMenuFont: font }));
-  };
-
-  const setVeilDisplayFont = (font: string) => {
-    setFonts(prev => ({ ...prev, veilDisplayFont: font }));
-  };
-
-  const resetToDefaults = () => {
-    setFonts(DEFAULT_FONTS);
-  };
-
-  // Convenience getters for current theme
-  const currentBodyFont = isGilded ? fonts.gildedBodyFont
-    : isVector ? fonts.vectorNarrativeFont
-    : fonts.veilBodyFont;
-  const currentMenuFont = isGilded ? fonts.gildedMenuFont
-    : isVector ? fonts.vectorUIFont
-    : fonts.veilMenuFont;
-  const currentDisplayFont = isGilded ? fonts.gildedDisplayFont
-    : isVector ? fonts.vectorDisplayFont
-    : fonts.veilDisplayFont;
-
-  // Legacy aliases for backwards compatibility
-  const setCyberpunkNarrativeFont = setVectorNarrativeFont;
-  const setCyberpunkUIFont = setVectorUIFont;
-  const setCyberpunkDisplayFont = setVectorDisplayFont;
+  const active = fonts[theme as ThemeId] ?? KEEPERS[theme as ThemeId];
 
   return (
-    <FontContext.Provider value={{
-      fonts,
-      setVectorNarrativeFont,
-      setVectorUIFont,
-      setVectorDisplayFont,
-      setGildedBodyFont,
-      setGildedMenuFont,
-      setGildedDisplayFont,
-      setVeilBodyFont,
-      setVeilMenuFont,
-      setVeilDisplayFont,
-      resetToDefaults,
-      currentBodyFont,
-      currentMenuFont,
-      currentDisplayFont,
-      // Legacy aliases
-      setCyberpunkNarrativeFont,
-      setCyberpunkUIFont,
-      setCyberpunkDisplayFont,
-    }}>
+    <FontContext.Provider
+      value={{
+        fonts,
+        setFont,
+        resetToKeepers,
+        currentBodyFont: active.body,
+        currentMenuFont: active.menu,
+        currentDisplayFont: active.display,
+      }}
+    >
       {children}
     </FontContext.Provider>
   );

--- a/ui/client/src/contexts/ThemeContext.tsx
+++ b/ui/client/src/contexts/ThemeContext.tsx
@@ -1,6 +1,9 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { useSettingsMutation, useSettingsQuery } from '@/hooks/useSettings';
 
 export type Theme = 'gilded' | 'vector' | 'veil';
+
+const THEMES: Theme[] = ['gilded', 'vector', 'veil'];
 
 interface ThemeContextType {
   theme: Theme;
@@ -21,12 +24,27 @@ const STORAGE_KEY = 'nexus-theme';
 const DEFAULT_THEME: Theme = 'veil';
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
+  // localStorage seeds the first paint only; the persisted source of truth
+  // is ui.theme in nexus.toml (GET/PATCH /api/settings).
   const [theme, setThemeState] = useState<Theme>(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
     // Handle migration from old 'cyberpunk' to 'vector'
     if (stored === 'cyberpunk') return 'vector';
-    return (stored === 'gilded' || stored === 'vector' || stored === 'veil') ? stored : DEFAULT_THEME;
+    return THEMES.includes(stored as Theme) ? (stored as Theme) : DEFAULT_THEME;
   });
+
+  const { data: settings } = useSettingsQuery();
+  const mutation = useSettingsMutation();
+  const serverTheme = settings?.ui?.theme;
+
+  // Adopt the server-persisted theme when it arrives or changes. Because
+  // setTheme() updates the query cache optimistically, this also reverts the
+  // chrome automatically if a PATCH fails and the cache rolls back.
+  useEffect(() => {
+    if (serverTheme && THEMES.includes(serverTheme) && serverTheme !== theme) {
+      setThemeState(serverTheme);
+    }
+  }, [serverTheme, theme]);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -42,7 +60,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     localStorage.setItem(STORAGE_KEY, theme);
   }, [theme]);
 
-  const setTheme = (newTheme: Theme) => setThemeState(newTheme);
+  const setTheme = (newTheme: Theme) => {
+    setThemeState(newTheme);
+    mutation.mutate({ theme: newTheme });
+  };
 
   const isGilded = theme === 'gilded';
   const isVector = theme === 'vector';

--- a/ui/client/src/hooks/useSettings.ts
+++ b/ui/client/src/hooks/useSettings.ts
@@ -9,6 +9,7 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import type {
+  FontMatrix,
   FontSlots,
   SettingsPatch,
   SettingsPayload,
@@ -34,14 +35,20 @@ export function applySettingsPatch(
   if (patch.theme !== undefined) {
     next.ui = { ...next.ui, theme: patch.theme };
   }
-  if (patch.fonts !== undefined && payload.ui?.fonts) {
-    const fonts = { ...payload.ui.fonts };
+  if (patch.fonts !== undefined) {
+    // Merge even when the cached payload predates ui.fonts (cold cache or a
+    // pre-U5 server) so the optimistic projection never silently drops a
+    // font change; the server response remains the authoritative matrix.
+    const fonts = { ...(payload.ui?.fonts ?? {}) } as Record<
+      ThemeId,
+      Partial<FontSlots>
+    >;
     for (const [themeId, slots] of Object.entries(patch.fonts) as Array<
       [ThemeId, Partial<FontSlots>]
     >) {
       fonts[themeId] = { ...fonts[themeId], ...slots };
     }
-    next.ui = { ...next.ui, fonts };
+    next.ui = { ...next.ui, fonts: fonts as FontMatrix };
   }
   if (patch.typewriter_ms_per_char !== undefined) {
     next.ui = { ...next.ui, typewriter_ms_per_char: patch.typewriter_ms_per_char };

--- a/ui/client/src/hooks/useSettings.ts
+++ b/ui/client/src/hooks/useSettings.ts
@@ -1,0 +1,119 @@
+/**
+ * Server-backed settings: GET /api/settings query + PATCH mutation with
+ * optimistic cache updates, rollback on error, and server confirmation
+ * (the PATCH response is the fresh payload and replaces the cache).
+ *
+ * All settings writes in the client flow through useSettingsMutation -
+ * there is no local draft state anywhere in the settings surface.
+ */
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { apiRequest, queryClient } from "@/lib/queryClient";
+import type {
+  FontSlots,
+  SettingsPatch,
+  SettingsPayload,
+  ThemeId,
+} from "@/types/settings";
+
+export const SETTINGS_QUERY_KEY = ["/api/settings"] as const;
+
+export function useSettingsQuery() {
+  return useQuery<SettingsPayload>({ queryKey: [...SETTINGS_QUERY_KEY] });
+}
+
+/** Pure optimistic projection of a patch onto the cached payload. */
+export function applySettingsPatch(
+  payload: SettingsPayload,
+  patch: SettingsPatch,
+): SettingsPayload {
+  const next: SettingsPayload = {
+    ...payload,
+    ui: { ...payload.ui },
+  };
+
+  if (patch.theme !== undefined) {
+    next.ui = { ...next.ui, theme: patch.theme };
+  }
+  if (patch.fonts !== undefined && payload.ui?.fonts) {
+    const fonts = { ...payload.ui.fonts };
+    for (const [themeId, slots] of Object.entries(patch.fonts) as Array<
+      [ThemeId, Partial<FontSlots>]
+    >) {
+      fonts[themeId] = { ...fonts[themeId], ...slots };
+    }
+    next.ui = { ...next.ui, fonts };
+  }
+  if (patch.typewriter_ms_per_char !== undefined) {
+    next.ui = { ...next.ui, typewriter_ms_per_char: patch.typewriter_ms_per_char };
+  }
+  if (patch.test_mode !== undefined) {
+    next.global = {
+      ...payload.global,
+      narrative: { ...payload.global?.narrative, test_mode: patch.test_mode },
+    };
+    next["Agent Settings"] = {
+      ...payload["Agent Settings"],
+      global: {
+        ...payload["Agent Settings"]?.global,
+        narrative: {
+          ...payload["Agent Settings"]?.global?.narrative,
+          test_mode: patch.test_mode,
+        },
+      },
+    };
+  }
+  if (patch.apex_model_ref !== undefined) {
+    const provider = patch.apex_model_ref.replace(/^@/, "").split(".")[0];
+    next.apex = { ...payload.apex, model: patch.apex_model_ref, provider };
+  }
+  if (patch.wizard_model_ref !== undefined) {
+    next.wizard = { ...payload.wizard, default_model: patch.wizard_model_ref };
+  }
+  if (patch.apex_context_window !== undefined) {
+    next.lore = {
+      ...payload.lore,
+      token_budget: {
+        ...payload.lore?.token_budget,
+        apex_context_window: patch.apex_context_window,
+      },
+    };
+  }
+  return next;
+}
+
+export function useSettingsMutation() {
+  return useMutation<
+    SettingsPayload,
+    Error,
+    SettingsPatch,
+    { previous: SettingsPayload | undefined }
+  >({
+    mutationFn: async (patch: SettingsPatch) => {
+      const res = await apiRequest("PATCH", "/api/settings", patch);
+      return (await res.json()) as SettingsPayload;
+    },
+    onMutate: async (patch) => {
+      await queryClient.cancelQueries({ queryKey: [...SETTINGS_QUERY_KEY] });
+      const previous = queryClient.getQueryData<SettingsPayload>([
+        ...SETTINGS_QUERY_KEY,
+      ]);
+      if (previous) {
+        queryClient.setQueryData(
+          [...SETTINGS_QUERY_KEY],
+          applySettingsPatch(previous, patch),
+        );
+      }
+      return { previous };
+    },
+    onError: (error, _patch, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData([...SETTINGS_QUERY_KEY], context.previous);
+      }
+      console.error("Settings update failed:", error);
+    },
+    onSuccess: (serverPayload) => {
+      // Server confirmation: the PATCH response is the authoritative state.
+      queryClient.setQueryData([...SETTINGS_QUERY_KEY], serverPayload);
+    },
+  });
+}

--- a/ui/client/src/types/settings.ts
+++ b/ui/client/src/types/settings.ts
@@ -1,15 +1,88 @@
 /**
- * Shape of the GET /api/settings payload (the Express layer serves
- * nexus.toml plus the legacy "Agent Settings" aliases it constructs).
- * Single source of truth for the client - extend here, not locally.
+ * Shapes for the GET/PATCH /api/settings surface (FastAPI, proxied by
+ * Express). GET serves raw nexus.toml (role references like
+ * "@openai.default" left unresolved) plus legacy "Agent Settings" aliases
+ * and a derived `settings_meta` block. Single source of truth for the
+ * client - extend here, not locally.
  */
+
+export type ThemeId = "veil" | "gilded" | "vector";
+export type FontSlotId = "body" | "menu" | "display";
+
+export interface FontSlots {
+  body: string;
+  menu: string;
+  display: string;
+}
+
+export type FontMatrix = Record<ThemeId, FontSlots>;
+
+/** One selectable @provider.role binding from [global.model.api_models]. */
+export interface ModelRoleOption {
+  ref: string;
+  provider: string;
+  role: string;
+  model_id: string;
+  label: string;
+}
+
+/** Derived metadata so the client never hardcodes config semantics. */
+export interface SettingsMeta {
+  model_roles: ModelRoleOption[];
+  /** Providers APEXSettings.provider accepts (the wizard accepts all). */
+  apex_allowed_providers: string[];
+  typewriter: { min: number; max: number };
+}
+
+export interface LoreBudgetSlider {
+  min: number;
+  max: number;
+  step: number;
+  stops: number[];
+}
+
 export interface SettingsPayload {
   ["Agent Settings"]?: {
     global?: {
       model?: { default_model?: string };
-      narrative?: { test_mode?: boolean };
+      narrative?: { test_mode?: boolean; test_database_suffix?: string };
     };
   };
+  global?: {
+    narrative?: { test_mode?: boolean; test_database_suffix?: string };
+  };
+  /** Raw role reference (e.g. "@openai.default"), not a resolved model ID. */
+  apex?: { provider?: string; model?: string };
+  wizard?: { default_model?: string; fallback_model?: string };
+  lore?: {
+    token_budget?: {
+      apex_context_window?: number;
+      system_prompt_tokens?: number;
+    };
+  };
+  memnon?: {
+    models?: Record<
+      string,
+      { is_active?: boolean; dimensions?: number; weight?: number }
+    >;
+  };
   /** Mirrors `[ui]` in nexus.toml (UISettings in settings_models.py). */
-  ui?: { typewriter_ms_per_char?: number };
+  ui?: {
+    typewriter_ms_per_char?: number;
+    theme?: ThemeId;
+    fonts?: FontMatrix;
+    lore_budget_slider?: LoreBudgetSlider;
+  };
+  settings_meta?: SettingsMeta;
+}
+
+/** The safe-to-edit subset accepted by PATCH /api/settings. */
+export interface SettingsPatch {
+  theme?: ThemeId;
+  fonts?: Partial<Record<ThemeId, Partial<FontSlots>>>;
+  typewriter_ms_per_char?: number;
+  test_mode?: boolean;
+  apex_model_ref?: string;
+  wizard_model_ref?: string;
+  apex_context_window?: number;
 }

--- a/ui/server/routes.ts
+++ b/ui/server/routes.ts
@@ -5,8 +5,6 @@ import { createProxyMiddleware } from "http-proxy-middleware";
 import multer from "multer";
 import fs from "fs/promises";
 import path from "path";
-import { parse as parseToml } from "toml";
-import * as Toml from "@iarna/toml";
 import sharp from "sharp";
 
 // WebSocket proxy instance for /ws/narrative. http-proxy-middleware only
@@ -82,6 +80,21 @@ export function registerProxyRoutes(app: Express): void {
     ...narrativeProxyOptions,
     pathRewrite: (path) => `/api/config${path}`,
   }));
+
+  // Settings GET/PATCH live on the FastAPI service (typed, Pydantic-validated,
+  // formatting-preserving writes through nexus.config.loader.save_settings).
+  // Only the exact /api/settings path proxies — /api/settings/pwa-icon stays a
+  // local Express route (multer + sharp asset pipeline in registerRoutes).
+  const settingsProxy = createProxyMiddleware({
+    ...narrativeProxyOptions,
+    pathRewrite: (path) => (path === "/" ? "/api/settings" : `/api/settings${path}`),
+  });
+  app.use("/api/settings", (req, res, next) => {
+    if (req.path === "/" || req.path === "") {
+      return settingsProxy(req, res, next);
+    }
+    next();
+  });
 
   narrativeWsProxy = createProxyMiddleware({ ...narrativeProxyOptions, ws: true });
   app.use("/ws/narrative", narrativeWsProxy);
@@ -287,157 +300,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  // Settings routes
-  const rootDir = path.join(process.cwd(), "..");
-  const tomlSettingsPath = path.join(rootDir, "nexus.toml");
-  const legacySettingsPath = path.join(rootDir, "settings.json");
-
-  const buildSettingsPayload = (rawSettings: any) => ({
-    ...rawSettings,
-    "Agent Settings": {
-      global: rawSettings?.global ?? {},
-      LORE: rawSettings?.lore ?? rawSettings?.LORE ?? {},
-      MEMNON: rawSettings?.memnon ?? rawSettings?.MEMNON ?? {},
-    },
-    "API Settings": {
-      apex: rawSettings?.apex ?? rawSettings?.API?.apex ?? {},
-    },
-  });
-
-  const readSettings = async () => {
-    try {
-      const tomlContent = await fs.readFile(tomlSettingsPath, "utf-8");
-      return parseToml(tomlContent);
-    } catch (error: any) {
-      if (error?.code === "ENOENT") {
-        console.warn("[settings] nexus.toml not found, falling back to legacy settings.json");
-        const legacyContent = await fs.readFile(legacySettingsPath, "utf-8");
-        return JSON.parse(legacyContent);
-      }
-      throw error;
-    }
-  };
-
-  const escapeForRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-  const serializeTomlValue = (value: unknown) => {
-    // Constrain supported types so we don't inject unsafe TOML fragments.
-    const isPrimitive = (val: unknown) => ["string", "number", "boolean"].includes(typeof val);
-    const isSupportedArray =
-      Array.isArray(value) && value.every((item) => isPrimitive(item));
-
-    if (!isPrimitive(value) && !isSupportedArray) {
-      throw new Error(
-        `Unsupported TOML value type: ${typeof value} (${JSON.stringify(value)})`,
-      );
-    }
-
-    try {
-      const serialized = Toml.stringify({ value } as Toml.JsonMap);
-      const match = serialized.match(/value\s*=\s*(.*)/);
-      if (!match || !match[1]) {
-        throw new Error(`Unable to extract serialized TOML literal for value: ${JSON.stringify(value)}`);
-      }
-      return match[1].trim();
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Unknown TOML serialization error";
-      throw new Error(`Failed to serialize TOML value (${JSON.stringify(value)}): ${message}`);
-    }
-  };
-
-  const replaceTomlValue = (content: string, section: string, key: string, value: unknown) => {
-    const rawValue = serializeTomlValue(value);
-    const sectionPattern = new RegExp(
-      `\\[${escapeForRegex(section)}\\]\\s*\\n([\\s\\S]*?)(?=\\n\\[|$)`,
-      "m",
-    );
-    const sectionMatch = content.match(sectionPattern);
-    if (!sectionMatch) {
-      throw new Error(`Section [${section}] not found in nexus.toml`);
-    }
-
-    const sectionBody = sectionMatch[1];
-    // Capture groups:
-    // 1: leading "key =" including whitespace
-    // 2: current value
-    // 3: trailing whitespace/comment (if present)
-    const keyPattern = new RegExp(`(^\\s*${escapeForRegex(key)}\\s*=\\s*)([^#\\n]*?)(\\s*(#.*)?)$`, "m");
-
-    let updatedBody: string;
-    if (keyPattern.test(sectionBody)) {
-      updatedBody = sectionBody.replace(keyPattern, (_match, prefix: string, _value: string, suffix: string) => {
-        const trailing = suffix ?? "";
-        return `${prefix}${rawValue}${trailing}`;
-      });
-    } else {
-      const trimmed = sectionBody.trimEnd();
-      const newline = trimmed.endsWith("\n") ? "" : "\n";
-      updatedBody = `${trimmed}${newline}${key} = ${rawValue}\n`;
-    }
-
-    return content.replace(sectionPattern, `[${section}]\n${updatedBody}`);
-  };
-
-  app.head("/api/settings", async (_req, res) => {
-    try {
-      await readSettings();
-      res.status(200).end();
-    } catch (error) {
-      console.error("Error fetching settings (HEAD):", error);
-      res.status(500).end();
-    }
-  });
-
-  app.get("/api/settings", async (_req, res) => {
-    try {
-      const settings = await readSettings();
-      res.json(buildSettingsPayload(settings));
-    } catch (error) {
-      console.error("Error fetching settings:", error);
-      res.status(500).json({ error: "Failed to fetch settings" });
-    }
-  });
-
-  app.patch("/api/settings", async (req, res) => {
-    try {
-      let tomlContent = await fs.readFile(tomlSettingsPath, "utf-8");
-      const updates = req.body;
-      let appliedUpdates = 0;
-
-      const narrativeUpdates = updates?.["Agent Settings"]?.global?.narrative ?? updates?.global?.narrative;
-      if (narrativeUpdates && typeof narrativeUpdates === "object" && "test_mode" in narrativeUpdates) {
-        const testMode = Boolean(narrativeUpdates.test_mode);
-        tomlContent = replaceTomlValue(tomlContent, "global.narrative", "test_mode", testMode);
-        appliedUpdates += 1;
-      }
-
-      const apexContextWindow =
-        updates?.["Agent Settings"]?.LORE?.token_budget?.apex_context_window ??
-        updates?.lore?.token_budget?.apex_context_window;
-      if (typeof apexContextWindow === "number") {
-        tomlContent = replaceTomlValue(
-          tomlContent,
-          "lore.token_budget",
-          "apex_context_window",
-          apexContextWindow,
-        );
-        appliedUpdates += 1;
-      }
-
-      if (!appliedUpdates) {
-        return res.status(400).json({ error: "No supported settings provided" });
-      }
-
-      await fs.writeFile(tomlSettingsPath, tomlContent, "utf-8");
-      const updatedSettings = await readSettings();
-
-      res.json({ success: true, settings: buildSettingsPayload(updatedSettings) });
-    } catch (error) {
-      console.error("Error updating settings:", error);
-      res.status(500).json({ error: "Failed to update settings" });
-    }
-  });
+  // Settings GET/PATCH are proxied to the FastAPI service (registerProxyRoutes).
+  // Only the PWA icon upload below remains an Express-local settings route.
 
   // Multer configuration for file uploads
   const upload = multer({


### PR DESCRIPTION
## Summary

The placeholder SettingsPane becomes the IRIS kit's calibration console (`design_handoff/project/ui_kits/nexus_iris/settings_pane.jsx`), wired to real persistence in `nexus.toml`. All writes flow through a new typed FastAPI surface and the config loader's formatting-preserving `save_settings` path — no local draft state, optimistic UI with rollback, server confirmation from the PATCH response.

## Sections

| Section | Status | Persistence |
| --- | --- | --- |
| Theme | **Wired** | `ui.theme` (new) — splash dropdown + ThemeMenu also persist now, since all theme changes flow through ThemeContext |
| Typography | **Wired** | `ui.fonts.<theme>.<slot>` (new) — keeper matrix per theme; display slot locked per the marquee rule |
| Narrative Mode | **Wired** | `global.narrative.test_mode` — kit lever + danger alert |
| Model | **Wired** (role-level only) | `apex.model` + derived `apex.provider`; `wizard.default_model`. Only `@provider.role` refs selectable — never raw model IDs |
| LORE Budget | **Wired** | `lore.token_budget.apex_context_window` — ladder + slider + COMMIT, bounds/stops from `ui.lore_budget_slider` (new) |
| Typewriter | **Wired** | `ui.typewriter_ms_per_char` — added as a seventh rail section (kit's data has `typeSpeed` but no section; the ask requires it) |
| PWA Icon | **Wired** | The Express multer + sharp pipeline (`POST /api/settings/pwa-icon`) already existed — dropzone + preview + COMMIT GLYPH per kit, cache-busted current icon |

## Read-Only by Design (Safety Judgments)

- **Active retrieval embedder** (`memnon.models.*`) — rendered in the Model card as a locked block with explanatory copy. Every stored embedding is encoded with this model; switching mid-story orphans the archive and requires a re-embedding campaign.
- **`global.narrative.test_database_suffix`** — displayed in the routing copy but not editable; renaming mid-flight orphans existing `_test` tables.
- **`apex.provider`** — derived from the role reference server-side, never directly editable.
- **`apex.reasoning_effort` / `max_output_tokens`, `lore.payload_percent_budget`, `wizard.fallback_model`** — not in the kit's six sections; left out rather than inventing UI without design.

## API Changes

- **New** `nexus/api/settings_endpoints.py`: `GET /api/settings` (raw TOML payload, role refs unresolved, `[secrets]` stripped, legacy `Agent Settings` aliases preserved, derived `settings_meta` block) and `PATCH /api/settings` (typed `SettingsPatchRequest`, `extra=forbid`, writes via `save_settings` with full-document Pydantic validation; 422 on rejection, file untouched).
- **`settings_meta`** carries the role catalog, the apex provider allowlist (derived from the `APEXSettings.provider` pattern — so TEST is excluded without hardcoding), and typewriter bounds (from `UISettings` field constraints). Components never hardcode config semantics.
- **Express** (`ui/server/routes.ts`): exact `/api/settings` now proxies to FastAPI :8002; the regex-based TOML writer (2 hardcoded keys, no validation) is deleted. `/api/settings/pwa-icon` falls through to the local multer + sharp route.
- **`UISettings`** gains `theme`, `fonts` (per-theme slot matrix), `lore_budget_slider`; all seeded with comments in `nexus.toml [ui]`.
- **Provider order** in `App.tsx`: `QueryClientProvider` now outermost so Theme/Font contexts hydrate from and persist through the settings query.

## Round-Trip Evidence (live API, throwaway value)

```
GET  ui.typewriter_ms_per_char        -> 35
PATCH {"typewriter_ms_per_char": 42}  -> 42 (response + file + fresh GET)
PATCH {"typewriter_ms_per_char": 35}  -> 35
diff nexus.toml.before nexus.toml     -> IDENTICAL (comments + formatting preserved)
```

Also exercised live: `apex_model_ref` `@openai.default -> @anthropic.deep -> back` (both `apex.model` and `apex.provider` rewritten, inline comments intact), `apex_context_window` 75000 <-> 100000 (inline comment intact; note tomlkit normalizes the `75_000` underscore literal to `75000` on write — value-identical), theme + fonts patch and restore, and the rejection paths: `@test.default` for apex -> 422 (provider pattern), unknown role -> 422, malformed ref -> 422, out-of-bounds typewriter -> 422, empty patch -> 400, unknown key -> 422. Rejected writes never touch the file.

## Validation

- `tsc` clean, `vite build` clean
- Dev-server smoke: Express :5189 -> FastAPI :8002 proxy GET/PATCH round-trip green; `pwa-icon` fall-through confirmed local (400 "No file uploaded", not 404)
- `black` / `flake8` / `mypy` clean on changed Python
- `pytest tests/test_api tests/config` -> 29 passed, 1 skipped (14 new endpoint tests, real file I/O, no mocks)
- No DB writes; persistence under test is the config file only

## Notes

- shadcn directive: the full primitive set (switch/select/slider) is already vendored under `ui/client/src/components/ui/`; the kit's lever/slider/chips are bespoke IRIS design elements implemented per kit CSS with proper ARIA (`role="switch"`), so nothing needed installing.
- Kit's "OPEN PALETTE COMPARISON" link omitted (no target surface in production).
- Kit `--danger`/`--warning` map to `hsl(var(--destructive))`/`--bronze` — tokens only, no invented hues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)