### PR TITLE
M10 Follow-Up: Complete the get_default_workflow() Migration

### DIFF
--- a/nexus/api/db_pool.py
+++ b/nexus/api/db_pool.py
@@ -177,7 +177,13 @@ def get_connection(dbname: Optional[str] = None, dict_cursor: bool = False):
 
 
 def close_all_pools():
-    """Close all connection pools. Call this on application shutdown."""
+    """Close all connection pools and reset cached connection config.
+
+    Call this on application shutdown or after a nexus.toml edit: pools
+    rebuilt afterwards re-read the configured connect timeout, because the
+    ``get_connect_timeout_seconds`` cache is cleared here — the two resets
+    are semantically coupled whenever a config reload is the motivation.
+    """
     for db_key, conn_pool in _pools.items():
         try:
             conn_pool.closeall()
@@ -186,6 +192,7 @@ def close_all_pools():
             logger.error("Error closing pool for %s: %s", db_key, e)
 
     _pools.clear()
+    get_connect_timeout_seconds.cache_clear()
 
 
 def close_pool(dbname: Optional[str] = None) -> None:

--- a/nexus/api/db_pool.py
+++ b/nexus/api/db_pool.py
@@ -11,6 +11,7 @@ or can be explicitly passed to connection functions.
 
 from __future__ import annotations
 
+import functools
 import logging
 import os
 from contextlib import contextmanager
@@ -32,19 +33,22 @@ MIN_CONNECTIONS = 1
 MAX_CONNECTIONS = 10
 
 
+@functools.lru_cache(maxsize=None)
 def get_connect_timeout_seconds() -> int:
     """Read the configured Postgres connect timeout from nexus.toml.
 
-    Loaded lazily at connection time (never at import) so that importing
-    this module stays free of configuration and database side effects.
+    Loaded lazily on first connection (never at import) so that importing
+    this module stays free of configuration and database side effects. The
+    value is static config, so it is cached after the first read; call
+    ``get_connect_timeout_seconds.cache_clear()`` to force a re-read.
     """
     from nexus.config import load_settings
 
     settings = load_settings()
     if settings.api is None:
         raise RuntimeError(
-            "nexus.toml is missing the [api.database] section; "
-            "connect_timeout_seconds is required"
+            "nexus.toml is missing the [api] section; "
+            "[api.database] connect_timeout_seconds is required"
         )
     return settings.api.database.connect_timeout_seconds
 

--- a/nexus/api/storyteller.py
+++ b/nexus/api/storyteller.py
@@ -38,7 +38,6 @@ from nexus.api.new_story_flow import (
     activate_slot as activate_new_story_slot,
 )
 from nexus.api.chunk_workflow import (
-    ChunkWorkflow,
     ChunkAcceptRequest,
     ChunkAcceptResponse,
     ChunkRejectRequest,
@@ -838,8 +837,7 @@ def reject_chunk(request: ChunkRejectRequest) -> ChunkRejectResponse:
     - edit_previous: Enable editing of the user's previous input
     """
     try:
-        workflow = ChunkWorkflow()
-        return workflow.reject_chunk(
+        return get_default_workflow().reject_chunk(
             request.chunk_id, request.session_id, request.action
         )
     except ValueError as e:
@@ -864,8 +862,7 @@ def edit_previous_input(
         if chunk_id != request.chunk_id:
             raise ValueError("Chunk ID mismatch")
 
-        workflow = ChunkWorkflow()
-        return workflow.edit_previous_input(
+        return get_default_workflow().edit_previous_input(
             chunk_id, request.new_user_input, request.session_id
         )
     except ValueError as e:
@@ -891,8 +888,7 @@ def get_chunk_states(
         )
 
     try:
-        workflow = ChunkWorkflow()
-        return workflow.get_chunk_states(start, end)
+        return get_default_workflow().get_chunk_states(start, end)
     except Exception as e:
         logger.error(f"Error getting chunk states: {e}")
         raise HTTPException(status_code=500, detail="Failed to get chunk states")

--- a/tests/test_api/test_chunk_workflow_integration.py
+++ b/tests/test_api/test_chunk_workflow_integration.py
@@ -132,9 +132,12 @@ def test_default_workflow_singleton_reuses_one_pool() -> None:
         second = chunk_workflow.get_default_workflow()
         assert first is second
 
-        # A real read through the workflow must reuse the existing pool.
+        # Any real query forces pool creation; (1, 1) is an arbitrary
+        # one-chunk range, not a boundary assertion.
         first.get_chunk_states(1, 1)
         assert list(db_pool._pools) == [first.dbname]
     finally:
+        # close_all_pools() also clears the connect-timeout cache, so this
+        # fully resets pool-related state for subsequent tests.
         chunk_workflow._default_workflow = None
         db_pool.close_all_pools()

--- a/tests/test_api/test_chunk_workflow_integration.py
+++ b/tests/test_api/test_chunk_workflow_integration.py
@@ -113,3 +113,28 @@ def test_accept_chunk_queues_background_embedding_with_real_slot_db(
     assert rows[1][0] == current_id
     assert rows[1][1] == ChunkState.FINALIZED.value
     assert rows[1][2] is not None
+
+
+def test_default_workflow_singleton_reuses_one_pool() -> None:
+    """get_default_workflow() must hand every caller one workflow and one pool.
+
+    Guards the lazy-singleton invariant from issue #369: endpoint handlers
+    (accept/reject/edit/states) all route through get_default_workflow(), so
+    repeated access must never construct a fresh ChunkWorkflow or open an
+    additional connection pool per request.
+    """
+    from nexus.api import db_pool
+
+    chunk_workflow._default_workflow = None
+    db_pool.close_all_pools()
+    try:
+        first = chunk_workflow.get_default_workflow()
+        second = chunk_workflow.get_default_workflow()
+        assert first is second
+
+        # A real read through the workflow must reuse the existing pool.
+        first.get_chunk_states(1, 1)
+        assert list(db_pool._pools) == [first.dbname]
+    finally:
+        chunk_workflow._default_workflow = None
+        db_pool.close_all_pools()


### PR DESCRIPTION
Follow-up to PR #380, addressing the Claude review that landed after merge (one critical, two minors, one coverage gap). Fresh PR with only the new commit per repo review conventions.

## Critical: Per-Request ChunkWorkflow() Constructions

`reject_chunk`, `edit_previous_input`, and `get_chunk_states` in `nexus/api/storyteller.py` were pre-existing offenders that constructed `ChunkWorkflow()` on every request — re-running `_ensure_schema()` per call and bypassing the lazy singleton #380 introduced (the migration sweep only matched `default_workflow` references, not direct constructions). All three now route through `get_default_workflow()`, matching `accept_chunk` and the narrative.py endpoint set. The unused `ChunkWorkflow` import is removed.

## Minors

- `get_connect_timeout_seconds()` is now cached with `functools.lru_cache` — static config, no TOML re-parse per connection; `cache_clear()` documented for forced re-reads.
- Its missing-section error message now correctly names `[api]` (a present `[api]` with missing `[api.database]` fails earlier at Pydantic validation).

## Coverage

New `requires_postgres` regression test in `tests/test_api/test_chunk_workflow_integration.py`: `get_default_workflow()` returns the identical instance across calls, and a real read through the workflow leaves exactly one connection pool (read-only against the default slot).

## Validation

- Full offline sweep: 758 passed, 96 skipped.
- Postgres tier under `NEXUS_RUN_POSTGRES=1`: chunk workflow integration (incl. new singleton test), import side-effect tests, fresh-slot baseline test — 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)