### PR TITLE
M8.5: Wizard Multi-Model Support — Registry-Routed Models, Anthropic Proven Live

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -6,9 +6,10 @@
 # =============================================================================
 
 [global.model]
-# Display-only model ID for legacy settings consumers.
+# Display-only model reference for legacy settings consumers, resolved to a
+# concrete ID at config load via the api_models registry below.
 # Inference callers must use role-resolved agent fields such as @openai.default.
-default_model = "gpt-5.5"
+default_model = "@openai.default"
 
 # Default model for newly created/reset slots
 # Use "TEST" for development (mock responses, no API key needed)

--- a/nexus/api/wizard_chat.py
+++ b/nexus/api/wizard_chat.py
@@ -497,11 +497,15 @@ async def new_story_chat_endpoint(request: ChatRequest):
                         # Production: Call set designer to generate location data
                         logger.info("Running set designer for slot %s", request.slot)
                         try:
+                            # selected_model, not request.model: the request
+                            # may omit the model (it is persisted on the slot),
+                            # and the effective model is locked after the first
+                            # user message regardless of provider.
                             layer, zone, place = await generate_set_design(
                                 location_sketch=location_sketch,
                                 setting=setting,
                                 seed=seed,
-                                model=request.model,
+                                model=selected_model,
                             )
 
                             # Record the generated location data
@@ -799,11 +803,13 @@ async def new_story_chat_stream_endpoint(request: ChatRequest):
                                 request.slot,
                             )
                             try:
+                                # selected_model, not request.model (see the
+                                # non-streaming endpoint for rationale).
                                 layer, zone, place = await generate_set_design(
                                     location_sketch=location_sketch,
                                     setting=setting,
                                     seed=seed,
-                                    model=request.model,
+                                    model=selected_model,
                                 )
 
                                 record_drafts(

--- a/nexus/config/__init__.py
+++ b/nexus/config/__init__.py
@@ -1,6 +1,19 @@
 """NEXUS configuration loading and validation."""
 
 from .settings_models import Settings
-from .loader import load_settings, load_settings_as_dict, get_available_api_models, save_settings
+from .loader import (
+    load_settings,
+    load_settings_as_dict,
+    get_available_api_models,
+    resolve_model_ref,
+    save_settings,
+)
 
-__all__ = ["Settings", "load_settings", "load_settings_as_dict", "get_available_api_models", "save_settings"]
+__all__ = [
+    "Settings",
+    "load_settings",
+    "load_settings_as_dict",
+    "get_available_api_models",
+    "resolve_model_ref",
+    "save_settings",
+]

--- a/nexus/config/loader.py
+++ b/nexus/config/loader.py
@@ -187,6 +187,28 @@ def get_provider_for_model(model_id: str) -> Optional[str]:
     return None
 
 
+def resolve_model_ref(ref: str, path: Union[str, Path] = "nexus.toml") -> str:
+    """
+    Resolve an "@provider.role" reference to a concrete model ID.
+
+    Literal model IDs are validated against the registry and returned
+    unchanged. Convenience wrapper for callers that take role references at
+    runtime (live tests, env overrides) rather than at config-load time.
+
+    Args:
+        ref: "@provider.role" reference or literal registry model ID
+        path: Path to configuration file (default: nexus.toml)
+
+    Returns:
+        Concrete model ID from the api_models registry
+
+    Raises:
+        ValueError: If the reference is malformed, names an unknown
+            provider/role, or a literal ID is not in the registry
+    """
+    return load_settings(path).resolve_model_ref(ref)
+
+
 def load_settings(path: Union[str, Path] = "nexus.toml") -> Settings:
     """
     Load and validate NEXUS configuration.

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -107,7 +107,12 @@ class ModelConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_defaults_reference_known_models(self) -> "ModelConfig":
-        """Legacy/default UI fields must stay anchored to registered model IDs."""
+        """Legacy/default UI fields must stay anchored to registered model IDs.
+
+        "@provider.role" references are skipped here: they are resolved (and
+        validated) by ``Settings._resolve_model_references`` once the full
+        registry is available on the root model.
+        """
         known_ids = {
             entry.id
             for provider in self.api_models.values()
@@ -115,6 +120,8 @@ class ModelConfig(BaseModel):
         }
         for field_name in ("default_model", "default_slot_model"):
             model_id = getattr(self, field_name)
+            if model_id.startswith(MODEL_ROLE_PREFIX):
+                continue
             if model_id not in known_ids:
                 raise ValueError(
                     f"{field_name} references unknown model id '{model_id}'. "
@@ -1267,6 +1274,8 @@ class Settings(BaseModel):
         # Each tuple is (container, attribute_name, optional_flag). When the
         # value is None on an optional field, skip resolution silently.
         targets: List[Tuple[Any, str, bool]] = [
+            (self.global_.model, "default_model", False),
+            (self.global_.model, "default_slot_model", False),
             (self.apex, "model", False),
             (self.wizard, "default_model", False),
             (self.wizard, "fallback_model", True),
@@ -1303,6 +1312,19 @@ class Settings(BaseModel):
             object.__setattr__(container, attr, resolved)
 
         return self
+
+    def resolve_model_ref(self, ref: str) -> str:
+        """Resolve an "@provider.role" reference against the api_models registry.
+
+        Literal model IDs are validated against the registry and returned
+        unchanged. Intended for callers outside the load-time resolution pass
+        (live tests, env overrides) that accept role references at runtime.
+        """
+        return _resolve_model_reference(
+            ref,
+            registry=self._build_model_registry(),
+            source="Settings.resolve_model_ref",
+        )
 
     def _build_model_registry(self) -> _ModelRegistry:
         """Index [global.model.api_models] for fast role / literal-ID lookup.

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -1,9 +1,22 @@
 """Tests for configuration schema validation."""
 
+import tomllib
+
 import pytest
 from pydantic import ValidationError
 
-from nexus.config.settings_models import APIModelEntry, ModelConfig, ProviderModels
+from nexus.config import load_settings, resolve_model_ref
+from nexus.config.settings_models import (
+    APIModelEntry,
+    ModelConfig,
+    ProviderModels,
+    Settings,
+)
+
+
+def _nexus_toml_dict() -> dict:
+    with open("nexus.toml", "rb") as handle:
+        return tomllib.load(handle)
 
 
 def test_model_config_rejects_unknown_default_model():
@@ -19,3 +32,56 @@ def test_model_config_rejects_unknown_default_model():
                 )
             },
         )
+
+
+def test_model_config_defers_role_references_to_settings_resolution():
+    """ "@provider.role" defaults pass ModelConfig and resolve on the root model."""
+    config = ModelConfig(
+        default_model="@test.default",
+        default_slot_model="TEST",
+        api_models={
+            "test": ProviderModels(
+                roles={"default": "TEST"},
+                models=[APIModelEntry(id="TEST", label="TEST")],
+            )
+        },
+    )
+    assert config.default_model == "@test.default"
+
+
+def test_global_default_model_resolves_at_load():
+    """nexus.toml's display default is a role reference resolved at load."""
+    raw = _nexus_toml_dict()
+    raw_default = raw["global"]["model"]["default_model"]
+    assert raw_default.startswith("@"), (
+        "global.model.default_model should be an @provider.role reference in "
+        f"nexus.toml, found literal '{raw_default}'"
+    )
+
+    settings = load_settings("nexus.toml")
+    openai_default = settings.global_.model.api_models["openai"].roles["default"]
+    assert settings.global_.model.default_model == openai_default
+
+
+def test_global_default_model_unknown_role_rejected():
+    """An unknown role in the global display default fails Settings validation."""
+    raw = _nexus_toml_dict()
+    raw["global"]["model"]["default_model"] = "@openai.nonexistent_role"
+    with pytest.raises(ValidationError, match="no role 'nonexistent_role'"):
+        Settings(**raw)
+
+
+def test_resolve_model_ref_resolves_roles_and_validates_literals():
+    """The public resolver maps roles to concrete IDs and validates literals."""
+    settings = load_settings("nexus.toml")
+    anthropic_default = settings.global_.model.api_models["anthropic"].roles["default"]
+
+    assert resolve_model_ref("@anthropic.default") == anthropic_default
+    assert settings.resolve_model_ref("@anthropic.default") == anthropic_default
+    # Literal registry IDs pass through unchanged.
+    assert resolve_model_ref(anthropic_default) == anthropic_default
+
+    with pytest.raises(ValueError, match="no role 'bogus'"):
+        resolve_model_ref("@anthropic.bogus")
+    with pytest.raises(ValueError, match="not declared"):
+        resolve_model_ref("model-that-does-not-exist")

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -71,6 +71,23 @@ def test_global_default_model_unknown_role_rejected():
         Settings(**raw)
 
 
+def test_global_default_slot_model_unknown_role_rejected():
+    """An unknown role in the slot default fails Settings validation too."""
+    raw = _nexus_toml_dict()
+    raw["global"]["model"]["default_slot_model"] = "@test.nonexistent_role"
+    with pytest.raises(ValidationError, match="no role 'nonexistent_role'"):
+        Settings(**raw)
+
+
+def test_global_default_slot_model_role_ref_resolves_at_load():
+    """A valid role ref in default_slot_model resolves to the concrete ID."""
+    raw = _nexus_toml_dict()
+    raw["global"]["model"]["default_slot_model"] = "@test.default"
+    settings = Settings(**raw)
+    test_default = settings.global_.model.api_models["test"].roles["default"]
+    assert settings.global_.model.default_slot_model == test_default
+
+
 def test_resolve_model_ref_resolves_roles_and_validates_literals():
     """The public resolver maps roles to concrete IDs and validates literals."""
     settings = load_settings("nexus.toml")

--- a/tests/live_seed_schema_test.py
+++ b/tests/live_seed_schema_test.py
@@ -43,6 +43,7 @@ logging.getLogger("openai").setLevel(logging.WARNING)
 from nexus.api.wizard_agent import WizardContext, get_wizard_agent
 from nexus.api.pydantic_ai_utils import build_pydantic_ai_model
 from nexus.api.new_story_schemas import StorySeedSubmission, WizardResponse
+from nexus.config import resolve_model_ref
 
 
 # Test context data - minimal setting and character to enable seed phase
@@ -202,8 +203,6 @@ async def main():
     logger.info("LIVE SEED SCHEMA TEST")
     logger.info("Testing StorySeedSubmission against real LLMs")
     logger.info("=" * 60)
-
-    from nexus.config import resolve_model_ref
 
     results = []
     for model_name in [resolve_model_ref(ref) for ref in TEST_MODEL_REFS]:

--- a/tests/live_seed_schema_test.py
+++ b/tests/live_seed_schema_test.py
@@ -69,7 +69,8 @@ TEST_CONTEXT = {
     },
 }
 
-TEST_MODELS = ["gpt-5.1", "claude-sonnet-4-5"]
+# Model role references, resolved against the nexus.toml registry at run time.
+TEST_MODEL_REFS = ["@openai.default", "@anthropic.default"]
 
 SEED_PROMPT = """Create a compelling story opening for this cyberpunk setting and character.
 
@@ -163,14 +164,22 @@ async def test_model(model_name: str) -> Dict[str, Any]:
                 logger.info(f"{sketch[:500]}...")
 
                 logger.info(f"\n--- VALIDATION ---")
-                logger.info(f"requires_set_design: {context.last_tool_result.get('requires_set_design')}")
-                logger.info(f"phase_complete: {context.last_tool_result.get('phase_complete')}")
+                logger.info(
+                    f"requires_set_design: {context.last_tool_result.get('requires_set_design')}"
+                )
+                logger.info(
+                    f"phase_complete: {context.last_tool_result.get('phase_complete')}"
+                )
             else:
                 result["error"] = f"Wrong tool called: {context.last_tool_name}"
-                logger.error(f"Wrong tool: expected submit_starting_scenario, got {context.last_tool_name}")
+                logger.error(
+                    f"Wrong tool: expected submit_starting_scenario, got {context.last_tool_name}"
+                )
 
         elif isinstance(output, WizardResponse):
-            result["error"] = "Got WizardResponse instead of tool call (accept_fate should force tool)"
+            result["error"] = (
+                "Got WizardResponse instead of tool call (accept_fate should force tool)"
+            )
             logger.error(f"WizardResponse returned instead of tool call:")
             logger.error(f"Message: {output.message[:200]}...")
             logger.error(f"Choices: {output.choices}")
@@ -194,8 +203,10 @@ async def main():
     logger.info("Testing StorySeedSubmission against real LLMs")
     logger.info("=" * 60)
 
+    from nexus.config import resolve_model_ref
+
     results = []
-    for model_name in TEST_MODELS:
+    for model_name in [resolve_model_ref(ref) for ref in TEST_MODEL_REFS]:
         result = await test_model(model_name)
         results.append(result)
         logger.info(f"\n{model_name}: {'PASS' if result['success'] else 'FAIL'}")

--- a/tests/live_set_designer_test.py
+++ b/tests/live_set_designer_test.py
@@ -76,7 +76,10 @@ TEST_SEED = StorySeed(
     tension_source="Corporate drones tracking from above, unknown allies signaling from below.",
     base_timestamp=StoryTimestamp(year=2087, month=11, day=3, hour=0, minute=15),
     weather="Hard sideways rain, visibility near zero",
-    key_npcs=["Pursuing corporate security team", "Mysterious figure signaling from below"],
+    key_npcs=[
+        "Pursuing corporate security team",
+        "Mysterious figure signaling from below",
+    ],
     secrets="The data core is bait planted by a Ghost faction testing if Kade can be reactivated as an asset.",
 )
 
@@ -114,8 +117,9 @@ The air tastes of rust, recycled coolant, and the ozone snap of failing electron
     },
 ]
 
-# Models to test (testing defaults per CLAUDE.md)
-TEST_MODELS = ["gpt-5.1", "claude-sonnet-4-5"]
+# Model role references to test, resolved against the nexus.toml registry at
+# run time (testing defaults per CLAUDE.md).
+TEST_MODEL_REFS = ["@openai.default", "@anthropic.default"]
 
 
 async def test_set_designer(model: str, sketch_info: Dict[str, str]) -> Dict[str, Any]:
@@ -145,7 +149,11 @@ async def test_set_designer(model: str, sketch_info: Dict[str, str]) -> Dict[str
         )
 
         result["success"] = True
-        result["layer"] = {"name": layer.name, "type": layer.type.value, "description": layer.description[:100]}
+        result["layer"] = {
+            "name": layer.name,
+            "type": layer.type.value,
+            "description": layer.description[:100],
+        }
         result["zone"] = {"name": zone.name, "summary": zone.summary[:100]}
         result["place"] = {
             "name": place.name,
@@ -165,7 +173,9 @@ async def test_set_designer(model: str, sketch_info: Dict[str, str]) -> Dict[str
         if "Hong Kong" in sketch or "Yokohama" in sketch:
             # Should be East Asia region (lat 20-40, lon 100-145)
             if not (15 < place.latitude < 45 and 100 < place.longitude < 150):
-                logger.warning(f"  ⚠ Coordinates don't match Hong Kong/Yokohama region!")
+                logger.warning(
+                    f"  ⚠ Coordinates don't match Hong Kong/Yokohama region!"
+                )
         elif "Kowloon" in sketch or "Manchester" in sketch:
             # Could be either HK or UK depending on interpretation
             pass
@@ -189,9 +199,12 @@ async def main():
     logger.info("Testing location_sketch → structured location data translation")
     logger.info("=" * 70)
 
-    results = []
+    from nexus.config import resolve_model_ref
 
-    for model in TEST_MODELS:
+    results = []
+    models = [resolve_model_ref(ref) for ref in TEST_MODEL_REFS]
+
+    for model in models:
         logger.info(f"\n{'='*70}")
         logger.info(f"MODEL: {model}")
         logger.info(f"{'='*70}")
@@ -206,7 +219,7 @@ async def main():
     logger.info("=" * 70)
 
     # Group by model
-    for model in TEST_MODELS:
+    for model in models:
         model_results = [r for r in results if r["model"] == model]
         passed = sum(1 for r in model_results if r["success"])
         logger.info(f"\n{model}: {passed}/{len(model_results)} passed")
@@ -215,7 +228,9 @@ async def main():
             status = "✓" if r["success"] else "✗"
             if r["success"]:
                 coords = r["coordinates"]
-                logger.info(f"  {status} {r['sketch']}: {r['place']['name']} @ ({coords['lat']:.2f}, {coords['lon']:.2f})")
+                logger.info(
+                    f"  {status} {r['sketch']}: {r['place']['name']} @ ({coords['lat']:.2f}, {coords['lon']:.2f})"
+                )
             else:
                 logger.info(f"  {status} {r['sketch']}: {r['error'][:50]}...")
 

--- a/tests/live_set_designer_test.py
+++ b/tests/live_set_designer_test.py
@@ -46,6 +46,7 @@ from nexus.api.new_story_schemas import (
     Genre,
     TechLevel,
 )
+from nexus.config import resolve_model_ref
 
 
 # Test setting (cyberpunk Neon Palimpsest)
@@ -198,8 +199,6 @@ async def main():
     logger.info("LIVE SET DESIGNER TEST")
     logger.info("Testing location_sketch → structured location data translation")
     logger.info("=" * 70)
-
-    from nexus.config import resolve_model_ref
 
     results = []
     models = [resolve_model_ref(ref) for ref in TEST_MODEL_REFS]

--- a/tests/test_api/test_settings_endpoints.py
+++ b/tests/test_api/test_settings_endpoints.py
@@ -178,3 +178,15 @@ class TestRoundTripOnCopy:
         assert "# Typewriter reveal speed" in updated
         assert "# Resolved via api_models registry" in updated
         assert original != updated
+
+    def test_anthropic_wizard_selection_round_trips(self, tmp_path: Path) -> None:
+        """Selecting an Anthropic wizard model through the API surface works."""
+        toml_copy = tmp_path / "nexus.toml"
+        shutil.copy2(REPO_ROOT / "nexus.toml", toml_copy)
+
+        patch = SettingsPatchRequest(wizard_model_ref="@anthropic.default")
+        save_settings(_updates_from_patch(patch), path=toml_copy, backup=False)
+
+        settings = load_settings(toml_copy)
+        anthropic = settings.global_.model.api_models["anthropic"]
+        assert settings.wizard.default_model == anthropic.roles["default"]

--- a/tests/test_orrery/test_retrograde_live.py
+++ b/tests/test_orrery/test_retrograde_live.py
@@ -19,14 +19,13 @@ from nexus.agents.orrery.retrograde_vocabulary import (
     SeedEligibleVocabulary,
     enumerate_seed_eligible_vocabulary,
 )
+from nexus.config import resolve_model_ref
 
 
 @pytest.mark.live
 @pytest.mark.live_llm
 def test_live_retrograde_seed_and_expansion_round_trip() -> None:
     """Real Skald calls can generate seeds and weave a dry-run R6 plan."""
-
-    from nexus.config import resolve_model_ref
 
     packet = _compact_live_packet()
     model_name = resolve_model_ref(

--- a/tests/test_orrery/test_retrograde_live.py
+++ b/tests/test_orrery/test_retrograde_live.py
@@ -26,8 +26,12 @@ from nexus.agents.orrery.retrograde_vocabulary import (
 def test_live_retrograde_seed_and_expansion_round_trip() -> None:
     """Real Skald calls can generate seeds and weave a dry-run R6 plan."""
 
+    from nexus.config import resolve_model_ref
+
     packet = _compact_live_packet()
-    model_name = os.environ.get("NEXUS_RETROGRADE_LIVE_MODEL", "gpt-5.1")
+    model_name = resolve_model_ref(
+        os.environ.get("NEXUS_RETROGRADE_LIVE_MODEL", "@openai.default")
+    )
     max_tokens = int(os.environ.get("NEXUS_RETROGRADE_LIVE_MAX_TOKENS", "8000"))
 
     seed_generation = generate_seed_candidates_with_skald(

--- a/tests/test_orrery/test_retrograde_wizard_live.py
+++ b/tests/test_orrery/test_retrograde_wizard_live.py
@@ -73,9 +73,10 @@ def test_wizard_transition_cold_starts_retrograde_history() -> None:
 
     retrograde = result["retrograde"]
     assert retrograde["enabled"] is True, retrograde
-    assert retrograde["model"] == _live_run_model(), (
+    expected_model = _live_run_model()
+    assert retrograde["model"] == expected_model, (
         "Retrograde ran with an unexpected model: "
-        f"got {retrograde['model']!r}, expected {_live_run_model()!r}"
+        f"got {retrograde['model']!r}, expected {expected_model!r}"
     )
 
     # Canonical history landed with source='retrograde'.

--- a/tests/test_orrery/test_retrograde_wizard_live.py
+++ b/tests/test_orrery/test_retrograde_wizard_live.py
@@ -7,6 +7,10 @@ and expansion calls, real persistence, real embedding, real MEMNON retrieval.
 
 Gating: requires ``NEXUS_RUN_LIVE_LLM=1``, ``NEXUS_RUN_POSTGRES=1``, and the
 explicit destructive opt-in ``NEXUS_RETROGRADE_WIZARD_E2E=1``.
+
+Model selection: defaults to the wizard default model (wizard.default_model in
+nexus.toml). Set ``NEXUS_RETROGRADE_WIZARD_MODEL`` to an ``@provider.role``
+reference (e.g. ``@anthropic.default``) to prove the run on another provider.
 """
 
 from __future__ import annotations
@@ -21,6 +25,19 @@ from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
 SAVE_05_DSN = "postgresql://pythagor@localhost:5432/save_05"
 SAVE_05_DBNAME = "save_05"
 SLOT = 5
+MODEL_OVERRIDE_ENV = "NEXUS_RETROGRADE_WIZARD_MODEL"
+
+
+def _live_run_model() -> str:
+    """Wizard default model, or the @provider.role env override if set."""
+    from nexus.api.config_utils import get_new_story_model
+    from nexus.config import resolve_model_ref
+
+    override = os.environ.get(MODEL_OVERRIDE_ENV)
+    if override:
+        return resolve_model_ref(override)
+    return get_new_story_model()
+
 
 pytestmark = [
     pytest.mark.live,
@@ -56,6 +73,10 @@ def test_wizard_transition_cold_starts_retrograde_history() -> None:
 
     retrograde = result["retrograde"]
     assert retrograde["enabled"] is True, retrograde
+    assert retrograde["model"] == _live_run_model(), (
+        "Retrograde ran with an unexpected model: "
+        f"got {retrograde['model']!r}, expected {_live_run_model()!r}"
+    )
 
     # Canonical history landed with source='retrograde'.
     rows = _query(
@@ -135,7 +156,6 @@ def _install_fixture_world() -> Any:
 
     from datetime import datetime, timezone
 
-    from nexus.api.config_utils import get_new_story_model
     from nexus.api.db_pool import close_pool
     from nexus.api.new_story_cache import write_cache
     from nexus.api.new_story_schemas import (
@@ -158,7 +178,7 @@ def _install_fixture_world() -> Any:
     # Fresh slots default to the mock TEST model (global.model.
     # default_slot_model); a real wizard run overrides it in start_setup.
     # Mirror that here so the transition engages real Retrograde generation.
-    upsert_slot(SLOT, model=get_new_story_model(), dbname=SAVE_05_DBNAME)
+    upsert_slot(SLOT, model=_live_run_model(), dbname=SAVE_05_DBNAME)
 
     cache = load_cache()
     write_cache(

--- a/tests/test_wizard_live.py
+++ b/tests/test_wizard_live.py
@@ -92,11 +92,19 @@ PHASE_CONFIGS: Dict[str, Dict[str, Any]] = {
     },
 }
 
-# Models to test
-TEST_MODELS = [
-    "gpt-5.1",
-    "claude-sonnet-4-5",
+# Model role references to test (resolved against the nexus.toml registry at
+# run time so this file never drifts from the live model lineup).
+TEST_MODEL_REFS = [
+    "@openai.default",
+    "@anthropic.default",
 ]
+
+
+def _build_model_for_ref(model_ref: str):
+    """Resolve a role reference and build the Pydantic AI model for it."""
+    from nexus.config import resolve_model_ref
+
+    return build_pydantic_ai_model(resolve_model_ref(model_ref))
 
 
 def make_test_context(
@@ -134,8 +142,12 @@ def mock_db_functions(monkeypatch):
     monkeypatch.setattr(wizard_module, "record_drafts", lambda *args, **kwargs: None)
 
     # Mock suggested traits functions (called by concept tool)
-    monkeypatch.setattr(wizard_module, "write_suggested_traits", lambda *args, **kwargs: None)
-    monkeypatch.setattr(wizard_module, "clear_suggested_traits", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        wizard_module, "write_suggested_traits", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        wizard_module, "clear_suggested_traits", lambda *args, **kwargs: None
+    )
 
     # Mock trait menu functions (called by concept tool)
     class DummyTrait:
@@ -159,8 +171,10 @@ def mock_db_functions(monkeypatch):
 @pytest.mark.live
 @pytest.mark.asyncio
 @pytest.mark.parametrize("phase_name", ["setting", "concept", "wildcard", "seed"])
-@pytest.mark.parametrize("model_name", TEST_MODELS)
-async def test_accept_fate_forces_tool_call(phase_name: str, model_name: str, mock_db_functions):
+@pytest.mark.parametrize("model_name", TEST_MODEL_REFS)
+async def test_accept_fate_forces_tool_call(
+    phase_name: str, model_name: str, mock_db_functions
+):
     """
     Live test: accept_fate=True should result in a tool call, not WizardResponse.
 
@@ -175,7 +189,7 @@ async def test_accept_fate_forces_tool_call(phase_name: str, model_name: str, mo
     )
 
     agent = get_wizard_agent(context)
-    model = build_pydantic_ai_model(model_name)
+    model = _build_model_for_ref(model_name)
 
     logger.info(f"Testing {phase_name} phase with {model_name}, accept_fate=True")
 
@@ -193,9 +207,9 @@ async def test_accept_fate_forces_tool_call(phase_name: str, model_name: str, mo
     )
 
     # Verify the correct tool was called
-    assert context.last_tool_name == config["expected_tool"], (
-        f"Expected tool {config['expected_tool']}, got {context.last_tool_name}"
-    )
+    assert (
+        context.last_tool_name == config["expected_tool"]
+    ), f"Expected tool {config['expected_tool']}, got {context.last_tool_name}"
 
     logger.info(
         f"✓ {phase_name}/{model_name}: Tool '{context.last_tool_name}' called successfully"
@@ -209,7 +223,7 @@ async def test_normal_flow_allows_wizard_response(phase_name: str, mock_db_funct
     """
     Sanity check: accept_fate=False should allow WizardResponse.
 
-    Uses gpt-5.1 only to minimize API calls for sanity check.
+    Uses the OpenAI default role only to minimize API calls for sanity check.
     """
     config = PHASE_CONFIGS[phase_name]
     context = make_test_context(
@@ -219,7 +233,7 @@ async def test_normal_flow_allows_wizard_response(phase_name: str, mock_db_funct
     )
 
     agent = get_wizard_agent(context)
-    model = build_pydantic_ai_model("gpt-5.1")
+    model = _build_model_for_ref("@openai.default")
 
     logger.info(f"Testing {phase_name} phase with accept_fate=False")
 
@@ -262,7 +276,11 @@ def setup_db_mocks():
             self.is_selected = False
             self.rationale = ""
 
-    dummy_traits = [DummyTrait(1, "allies"), DummyTrait(2, "contacts"), DummyTrait(3, "patron")]
+    dummy_traits = [
+        DummyTrait(1, "allies"),
+        DummyTrait(2, "contacts"),
+        DummyTrait(3, "patron"),
+    ]
     wizard_module.get_trait_menu = lambda _: dummy_traits
     wizard_module.get_selected_trait_count = lambda _: 0
     wizard_module.slot_dbname = lambda slot: f"save_0{slot}"
@@ -283,7 +301,7 @@ async def quick_test():
 
     results = []
 
-    for model_name in TEST_MODELS:
+    for model_name in TEST_MODEL_REFS:
         print(f"\n--- Testing with {model_name} ---")
 
         for phase_name, config in PHASE_CONFIGS.items():
@@ -294,7 +312,7 @@ async def quick_test():
             )
 
             agent = get_wizard_agent(context)
-            model = build_pydantic_ai_model(model_name)
+            model = _build_model_for_ref(model_name)
 
             try:
                 result = await agent.run(
@@ -311,26 +329,34 @@ async def quick_test():
                         print(f"  {phase_name}: {status} - Called {tool_name}")
                     else:
                         status = "✗ WRONG TOOL"
-                        print(f"  {phase_name}: {status} - Expected {expected}, got {tool_name}")
+                        print(
+                            f"  {phase_name}: {status} - Expected {expected}, got {tool_name}"
+                        )
                 else:
                     status = "✗ FAIL"
                     output_type = type(result.output).__name__
-                    print(f"  {phase_name}: {status} - Got {output_type} instead of tool call")
+                    print(
+                        f"  {phase_name}: {status} - Got {output_type} instead of tool call"
+                    )
 
-                results.append({
-                    "model": model_name,
-                    "phase": phase_name,
-                    "status": status,
-                })
+                results.append(
+                    {
+                        "model": model_name,
+                        "phase": phase_name,
+                        "status": status,
+                    }
+                )
 
             except Exception as e:
                 status = "✗ ERROR"
                 print(f"  {phase_name}: {status} - {e}")
-                results.append({
-                    "model": model_name,
-                    "phase": phase_name,
-                    "status": f"ERROR: {e}",
-                })
+                results.append(
+                    {
+                        "model": model_name,
+                        "phase": phase_name,
+                        "status": f"ERROR: {e}",
+                    }
+                )
 
     # Summary
     print("\n" + "=" * 60)

--- a/tests/test_wizard_live.py
+++ b/tests/test_wizard_live.py
@@ -26,6 +26,7 @@ from nexus.api.wizard_agent import (
 )
 from nexus.api.new_story_schemas import WizardResponse
 from nexus.api.pydantic_ai_utils import build_pydantic_ai_model
+from nexus.config import resolve_model_ref
 
 logger = logging.getLogger(__name__)
 
@@ -102,8 +103,6 @@ TEST_MODEL_REFS = [
 
 def _build_model_for_ref(model_ref: str):
     """Resolve a role reference and build the Pydantic AI model for it."""
-    from nexus.config import resolve_model_ref
-
     return build_pydantic_ai_model(resolve_model_ref(model_ref))
 
 


### PR DESCRIPTION
M8.5: Wizard Multi-Model Support. The wizard, set designer, and Retrograde R4/R6 paths already shared the provider-agnostic Pydantic AI layer (`build_pydantic_ai_model`, which wraps `scripts/api_openai.py` / `scripts/api_anthropic.py` for credentials), but the path was OpenAI-pinned in practice: a literal model default in config, a bug that broke any run not driven by per-request model params, and live tests pinned to model IDs that no longer exist in the registry. This PR unroutes every pin and proves both providers live, end to end, on slot 5. `@openai.default` (gpt-5.5) remains the wizard default; Anthropic models are selectable through the same `@provider.role` registry syntax everywhere.

## Pins Found and Unrouted

| Pin | Where | Fix |
| --- | --- | --- |
| Literal `default_model = "gpt-5.5"` | `nexus.toml:11` (`[global.model]`, display-only legacy field) | Now `"@openai.default"`, resolved at config load: `ModelConfig` defers `@`-refs to the root resolution pass, and `Settings._resolve_model_references` gains `global.model.default_model` / `default_slot_model` targets |
| Set designer called with `request.model` | `nexus/api/wizard_chat.py` (both `/chat` and `/chat/stream`) | Now uses `selected_model` (the request → slot → wizard-default precedence). `request.model` is `None` whenever the client relies on the slot-persisted model, which crashed `build_pydantic_ai_model(None)` at the seed phase — and it bypassed the post-first-message model lock |
| `TEST_MODELS = ["gpt-5.1", "claude-sonnet-4-5"]` (neither in the registry — these suites could not run) | `tests/test_wizard_live.py`, `tests/live_set_designer_test.py`, `tests/live_seed_schema_test.py` | `@openai.default` / `@anthropic.default` role refs resolved at run time via the new `nexus.config.resolve_model_ref` |
| Env default `"gpt-5.1"` | `tests/test_orrery/test_retrograde_live.py` | Defaults to `@openai.default`; env override now accepts role refs |
| No model override in the destructive E2E harness | `tests/test_orrery/test_retrograde_wizard_live.py` | New `NEXUS_RETROGRADE_WIZARD_MODEL` env override (role-ref syntax) + assertion that Retrograde ran on the expected model |

## What Was Already Provider-Agnostic (Verified, Not Changed)

- Wizard chat agents, debug agent, accept-fate flows (`wizard_agent.py` / `wizard_chat.py`) — model built per request via `build_pydantic_ai_model`
- `ConversationsClient` — OpenAI Threads for OpenAI, file-backed store for Anthropic, in-memory for TEST
- `new_story_generator.py` (structured generation + set designer)
- R4 `generate_seed_candidates_with_skald` / R6 `generate_expansion_with_skald` and the runtime maturation path (PR #379) via `[orrery.retrograde.maturation].model_ref`
- U5 settings surface: `wizard_model_ref` PATCH accepts any `@provider.role` (new round-trip test for `@anthropic.default`); the UI dropdown renders all registry providers — no OpenAI filter to extend

## New Public Surface

`nexus.config.resolve_model_ref(ref)` / `Settings.resolve_model_ref(ref)` — runtime resolution of `@provider.role` references (validates literal IDs against the registry), for live tests and env overrides. Load-time consumer fields keep using the existing resolution pass.

## Live Validation (Slot 5, Real API Calls)

**Run 1 — default `gpt-5.5`** (`tests/test_orrery/test_retrograde_wizard_live.py`, destructive slot-5 reset):
- 1 passed in 188.67s; R4 seed-candidate + R6 expansion Skald calls, persistence, embedding, MEMNON retrieval all green
- 4 `world_events` with `source='retrograde'` (intel_acquired ×2, circumstance_reversed, signal_exposure_reduced), summary chunks 2–5 all embedded, MEMNON hybrid retrieval returned them

**Run 2 — `@anthropic.default` (claude-sonnet-4-6)** (same harness, `NEXUS_RETROGRADE_WIZARD_MODEL=@anthropic.default`):
- 1 passed in 786.29s; in-test assertion confirms Retrograde ran on `claude-sonnet-4-6`
- R4 produced 9 candidates / 4 selected; persistence wrote 9 `world_events` (work_performed ×2, faction_realignment ×2, intel_acquired ×2, exposed, hideout_maintained, threat_issued), 5 entity stubs, 1 relationship, 24 tags; summary chunks 2–10 all embedded; MEMNON hybrid retrieval returned them
- Honesty note: the *first* Anthropic attempt failed after 15:27 with zero rows persisted — the transaction rolled back exactly as designed (wizard cache intact, transition retryable, failure loud). The rerun passed cleanly, and the non-destructive R4/R6 round-trip (`test_retrograde_live.py` with `NEXUS_RETROGRADE_LIVE_MODEL=@anthropic.default`) also passed in 120s, so this is frontier contract-adherence flakiness bounded by the existing `wizard.max_retries` budget, not a provider-routing defect. See Deferred.

**Wizard-agent live canaries** (real accept-fate calls through the agent + tool layer, structured output on both providers):
- `test_accept_fate_forces_tool_call[@anthropic.default-setting]` — passed (64.4s)
- `test_accept_fate_forces_tool_call[@openai.default-setting]` — passed (63.2s)

## Offline Validation

- Full suite: 760 passed, 94 skipped (live/postgres-gated)
- `scripts/check_model_drift.py`: OK, no drift
- black clean; flake8/mypy introduce zero new findings (pre-existing debt in `wizard_chat.py`/`loader.py` untouched: baseline 15 flake8 / 43 mypy, after 13 / 43)

## Preserved Semantics

- `wizard.fallback_model = "@anthropic.fast"` stays manual-use-only (documented "no automatic failover") — no graceful fallback added
- Wizard model lock after the first user message unchanged
- TEST/mock model short-circuits unchanged

## Deferred

- `nexus/api/resilient_openai.py` has zero importers (dead code) — left for the M10 hygiene lane (#380) rather than widening this diff
- `ConversationsClient` uses the OpenAI beta Threads API for OpenAI-model history; works today (proven in run 1) but is a legacy API surface worth migrating eventually
- Worker-driven runtime maturation on Anthropic: the executors it shares with R4/R6 are proven on both providers here; a full worker-loop live run on Anthropic was not separately exercised
- Anthropic R4/R6 contract-adherence flakiness: 1-of-2 cold-start attempts exhausted the retry budget (rollback was clean and loud). If Anthropic runs prove consistently flakier, consider a Retrograde-specific retry budget in `[orrery.retrograde.wizard]` rather than raising the global `wizard.max_retries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
