### PR TITLE
M9: Golden-Path Release Gate — Live E2E Proven, Nine Bugs Fixed, Gate Codified

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -110,6 +110,16 @@ max_retries = 2
 max_tokens = 4096
 enable_streaming = true
 
+[wizard.trait_inputs]
+# Transition-time derivation of typed trait-compiler inputs (M9). The wizard
+# chat records trait selections and prose rationales only; when the character
+# sheet reaches the wizard -> narrative transition without TraitCompileInputs,
+# one structured Skald call derives them so the M5 compilers can write
+# mechanical state (relationship rows, pair-tags, stub entities) instead of
+# leaving every trait a prose-only remainder. Skipped for the mock TEST model.
+derive_at_transition = true
+max_tokens = 4096
+
 # =============================================================================
 # API Settings
 # =============================================================================

--- a/nexus.toml
+++ b/nexus.toml
@@ -707,6 +707,7 @@ provider = "openai"           # API provider: "openai" or "anthropic"
 model = "@openai.default"     # Resolved via api_models registry; edit roles to migrate
 reasoning_effort = "medium"   # Reasoning effort level (low/medium/high)
 max_output_tokens = 25000     # Maximum tokens for generated narrative
+structured_output_retries = 3 # Validation retry budget for structured story turns
 
 # =============================================================================
 # IR Evaluation V2 Settings

--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -262,9 +262,11 @@ class NewCharacter(BaseModel):
         default=None,
         description=(
             "Semantic Orrery tags for this character (bodyform, capacity, "
-            "disposition, role, state, etc.). Apply registered tags by name; "
-            "omit tags when the closed registry has no exact fit. See the "
-            "Orrery Awareness section of your system prompt for category guidance."
+            "disposition, role, state, etc.). This is an OBJECT whose "
+            '"applied_tags" key holds the list of registered tag names — '
+            "never a bare list of strings. Omit tags when the closed "
+            "registry has no exact fit. See the Orrery Awareness section of "
+            "your system prompt for category guidance."
         ),
     )
 
@@ -312,9 +314,10 @@ class NewPlace(BaseModel):
         default=None,
         description=(
             "Semantic place tags for this location (e.g., commerce, dwelling, "
-            "haven, transit, place_hidden, place_open, wilderness). Apply "
-            "registered tags by name; omit tags when the closed registry has "
-            "no exact fit."
+            "haven, transit, place_hidden, place_open, wilderness). This is "
+            'an OBJECT whose "applied_tags" key holds the list of registered '
+            "tag names — never a bare list of strings. Omit tags when the "
+            "closed registry has no exact fit."
         ),
     )
 
@@ -386,8 +389,10 @@ class NewFaction(BaseModel):
     orrery_tags: Optional[OrreryTagBestowal] = Field(
         default=None,
         description=(
-            "Closed-vocabulary Orrery tags for this faction. Use registered "
-            "tags from ideology, resource_base, legitimacy, operational_mode, "
+            "Closed-vocabulary Orrery tags for this faction. This is an "
+            'OBJECT whose "applied_tags" key holds the list of registered '
+            "tag names — never a bare list of strings. Use registered tags "
+            "from ideology, resource_base, legitimacy, operational_mode, "
             "power_status, and agenda; omit tags when prose is more accurate."
         ),
     )

--- a/nexus/agents/logon/orrery_tag_validation.py
+++ b/nexus/agents/logon/orrery_tag_validation.py
@@ -1,0 +1,133 @@
+"""Generation-time registry validation for storyteller Orrery tag bestowals.
+
+Skald freely invents tag names (often ``category:name`` composites) when
+introducing entities or updating state. The closed-vocabulary tag writers
+hard-error on unknown names -- but they run inside the chunk COMMIT
+transaction, where the only outcome is a dead player turn (M9 gate finding).
+
+This module walks a parsed storyteller response and validates every
+``orrery_tags`` bestowal against the live registry, so LOGON's structured
+output validator can hand the issues back to the model as a retry while the
+model still owns the turn.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional, Tuple
+
+from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
+from nexus.agents.orrery.tag_writer import validate_tag_bestowal
+
+logger = logging.getLogger("nexus.logon.orrery_tag_validation")
+
+
+def _bestowal_sites(response: Any) -> List[Tuple[str, str, OrreryTagBestowal]]:
+    """Yield (path, entity_kind, bestowal) triples from a parsed response."""
+
+    sites: List[Tuple[str, str, OrreryTagBestowal]] = []
+
+    referenced = getattr(response, "referenced_entities", None)
+    if referenced is not None:
+        for index, ref in enumerate(getattr(referenced, "characters", []) or []):
+            new_entity = getattr(ref, "new_character", None)
+            bestowal = getattr(new_entity, "orrery_tags", None)
+            if bestowal is not None:
+                sites.append(
+                    (
+                        f"referenced_entities.characters[{index}].new_character",
+                        "character",
+                        bestowal,
+                    )
+                )
+        for index, ref in enumerate(getattr(referenced, "places", []) or []):
+            new_entity = getattr(ref, "new_place", None)
+            bestowal = getattr(new_entity, "orrery_tags", None)
+            if bestowal is not None:
+                sites.append(
+                    (
+                        f"referenced_entities.places[{index}].new_place",
+                        "place",
+                        bestowal,
+                    )
+                )
+        for index, ref in enumerate(getattr(referenced, "factions", []) or []):
+            new_entity = getattr(ref, "new_faction", None)
+            bestowal = getattr(new_entity, "orrery_tags", None)
+            if bestowal is not None:
+                sites.append(
+                    (
+                        f"referenced_entities.factions[{index}].new_faction",
+                        "faction",
+                        bestowal,
+                    )
+                )
+
+    state_updates = getattr(response, "state_updates", None)
+    if state_updates is not None:
+        for index, update in enumerate(getattr(state_updates, "characters", []) or []):
+            bestowal = getattr(update, "orrery_tags", None)
+            if bestowal is not None:
+                sites.append(
+                    (f"state_updates.characters[{index}]", "character", bestowal)
+                )
+        for index, update in enumerate(getattr(state_updates, "locations", []) or []):
+            bestowal = getattr(update, "orrery_tags", None)
+            if bestowal is not None:
+                sites.append((f"state_updates.locations[{index}]", "place", bestowal))
+        for index, update in enumerate(getattr(state_updates, "factions", []) or []):
+            bestowal = getattr(update, "orrery_tags", None)
+            if bestowal is not None:
+                sites.append((f"state_updates.factions[{index}]", "faction", bestowal))
+
+    return sites
+
+
+def collect_orrery_tag_issues(response: Any, cur: Any) -> List[str]:
+    """Validate every bestowal in the response against the live registry."""
+
+    issues: List[str] = []
+    for path, entity_kind, bestowal in _bestowal_sites(response):
+        for issue in validate_tag_bestowal(
+            cur, entity_kind=entity_kind, bestowal=bestowal
+        ):
+            issues.append(f"{path}: {issue}")
+    return issues
+
+
+def build_storyteller_tag_validator(dbname: Optional[str]) -> Optional[Any]:
+    """Return an async pydantic_ai output validator bound to ``dbname``.
+
+    Returns ``None`` when no slot database is in scope (nothing to validate
+    against). The validator opens a short-lived pooled connection per
+    generation attempt and raises ``ModelRetry`` listing every invalid tag so
+    the model repairs the bestowal instead of killing the commit later.
+    """
+
+    if not dbname:
+        return None
+
+    async def _validate(ctx: Any, output: Any) -> Any:
+        from pydantic_ai import ModelRetry
+
+        from nexus.api.db_pool import get_connection
+
+        with get_connection(dbname) as conn:
+            with conn.cursor() as cur:
+                issues = collect_orrery_tag_issues(output, cur)
+        if issues:
+            formatted = "\n".join(f"- {issue}" for issue in issues)
+            logger.info(
+                "Storyteller orrery_tags failed registry validation (%s issues); "
+                "requesting model retry",
+                len(issues),
+            )
+            raise ModelRetry(
+                "Your orrery_tags failed closed-registry validation. Use bare "
+                "registered tag names only (e.g. 'comfortable'), never "
+                "'category:name' composites; drop any tag with no registered "
+                f"equivalent. Fix these and resubmit:\n{formatted}"
+            )
+        return output
+
+    return _validate

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -287,9 +287,14 @@ class LogonUtility:
         )
         from nexus.api.slot_utils import require_slot_dbname
 
-        output_validator = build_storyteller_tag_validator(
-            require_slot_dbname(dbname=self.dbname)
-        )
+        # Slotless LOGON usage (model_override without dbname or NEXUS_SLOT)
+        # has no registry to validate against; skip the validator rather
+        # than failing provider initialization (Codex review on PR #383).
+        try:
+            validation_dbname: Optional[str] = require_slot_dbname(dbname=self.dbname)
+        except Exception:
+            validation_dbname = None
+        output_validator = build_storyteller_tag_validator(validation_dbname)
 
         if provider_type in {"openai", "test"}:
             self.provider = OpenAIProvider(

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -278,6 +278,19 @@ class LogonUtility:
         self._provider_bootstrap_mode = provider_bootstrap_mode
 
         structured_output_retries = apex_settings.get("structured_output_retries", 3)
+
+        # Generation-time registry validation for Skald's orrery_tags: invalid
+        # names become a ModelRetry while the model still owns the turn,
+        # instead of a dead commit later (M9 gate finding).
+        from nexus.agents.logon.orrery_tag_validation import (
+            build_storyteller_tag_validator,
+        )
+        from nexus.api.slot_utils import require_slot_dbname
+
+        output_validator = build_storyteller_tag_validator(
+            require_slot_dbname(dbname=self.dbname)
+        )
+
         if provider_type in {"openai", "test"}:
             self.provider = OpenAIProvider(
                 model=model,
@@ -288,6 +301,7 @@ class LogonUtility:
                 base_url=base_url,
                 api_key=api_key,
                 structured_output_retries=structured_output_retries,
+                output_validator=output_validator,
             )
         elif provider_type == "anthropic":
             self.provider = AnthropicProvider(
@@ -297,6 +311,7 @@ class LogonUtility:
                 ),
                 system_prompt=system_prompt,
                 structured_output_retries=structured_output_retries,
+                output_validator=output_validator,
             )
         else:
             raise ValueError(f"Unsupported provider type: {provider_type}")

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -277,6 +277,7 @@ class LogonUtility:
         self._system_prompt = system_prompt
         self._provider_bootstrap_mode = provider_bootstrap_mode
 
+        structured_output_retries = apex_settings.get("structured_output_retries", 3)
         if provider_type in {"openai", "test"}:
             self.provider = OpenAIProvider(
                 model=model,
@@ -286,6 +287,7 @@ class LogonUtility:
                 system_prompt=system_prompt,
                 base_url=base_url,
                 api_key=api_key,
+                structured_output_retries=structured_output_retries,
             )
         elif provider_type == "anthropic":
             self.provider = AnthropicProvider(
@@ -294,6 +296,7 @@ class LogonUtility:
                     "max_output_tokens", apex_settings.get("max_tokens", 4000)
                 ),
                 system_prompt=system_prompt,
+                structured_output_retries=structured_output_retries,
             )
         else:
             raise ValueError(f"Unsupported provider type: {provider_type}")

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable as IterableABC
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping, Optional, Tuple
 
@@ -65,6 +65,10 @@ class OrreryResolutionDraft:
     event_type: Optional[str] = None
     changed_fields: Tuple[str, ...] = ()
     magnitude: float = 0.0
+    # Slot name -> entity display name. Skald adjudicates these proposals;
+    # without names it cannot tell WHO an off-screen resolution is about and
+    # may misattribute it to an on-screen character (M9 gate finding).
+    binding_names: Mapping[str, str] = field(default_factory=dict)
 
     @property
     def proposal_id(self) -> str:
@@ -81,6 +85,7 @@ class OrreryResolutionDraft:
             "priority": self.priority,
             "binding_hash": self.binding_hash,
             "bindings": dict(self.bindings),
+            "binding_names": dict(self.binding_names),
             "branch_label": self.branch_label,
             "narrative_stub": self.narrative_stub,
             "state_delta": dict(self.state_delta),
@@ -117,6 +122,7 @@ class OrreryResolutionDraft:
             event_type=data.get("event_type"),
             changed_fields=tuple(data.get("changed_fields") or ()),
             magnitude=float(data.get("magnitude") or 0.0),
+            binding_names=dict(data.get("binding_names") or {}),
         )
 
 
@@ -869,6 +875,32 @@ def resolve_dry_run(
                 resolution = evaluate_stack(pressure_templates, state, bindings)
                 if resolution is not None and resolution.passes:
                     scene_pressure_results.append(resolution)
+
+    # Resolve binding entity names so Skald's adjudication payload says WHO
+    # each off-screen proposal is about; bare entity ids invite misattribution
+    # to on-screen characters (M9 gate finding).
+    draft_entity_ids: set[int] = set()
+    for draft in drafts:
+        for value in draft.bindings.values():
+            if isinstance(value, int):
+                draft_entity_ids.add(value)
+    draft_entity_names = _load_entity_names(session, draft_entity_ids)
+    drafts = [
+        replace(
+            draft,
+            binding_names={
+                slot: _entity_label(value, draft_entity_names)
+                for slot, value in draft.bindings.items()
+            },
+            narrative_stub=_render_bound_text(
+                draft.narrative_stub,
+                draft.bindings,
+                draft_entity_names,
+                template_id=draft.template_id,
+            ),
+        )
+        for draft in drafts
+    ]
 
     present_need_pressure_specs = _present_need_pressure_specs(
         state,

--- a/nexus/agents/orrery/retrograde_orchestrator.py
+++ b/nexus/agents/orrery/retrograde_orchestrator.py
@@ -145,6 +145,7 @@ def generate_retrograde_history(
     weird_level: Optional[str] = None,
     weird_raw: Optional[float] = None,
     progress: Optional[ProgressCallback] = None,
+    trait_compile_inputs: Optional[Mapping[str, Any]] = None,
 ) -> RetrogradeGenerationBundle:
     """Run the non-mutating Retrograde stages from a wizard cache snapshot.
 
@@ -174,6 +175,7 @@ def generate_retrograde_history(
         settings=settings,
         weird_level=weird_level,
         weird_raw=weird_raw,
+        trait_compile_inputs=trait_compile_inputs,
     )
     timings.append(
         RetrogradeStageTiming(stage="packet", seconds=time.monotonic() - started)

--- a/nexus/agents/orrery/retrograde_packet.py
+++ b/nexus/agents/orrery/retrograde_packet.py
@@ -67,8 +67,16 @@ def build_retrograde_dry_run_packet(
     settings: Settings,
     weird_level: Optional[str] = None,
     weird_raw: Optional[float] = None,
+    trait_compile_inputs: Optional[Mapping[str, Any]] = None,
 ) -> dict[str, Any]:
-    """Build a non-mutating Retrograde packet from wizard cache and vocabulary."""
+    """Build a non-mutating Retrograde packet from wizard cache and vocabulary.
+
+    ``trait_compile_inputs`` carries the typed trait-compiler inputs (derived
+    or wizard-collected) so trait-declared people, places, and factions become
+    first-class core entities: Skald must reuse their exact names, keeping
+    Retrograde refs aligned with the canonical rows the trait compiler creates
+    in the same transition transaction.
+    """
 
     setting = _require_cache_section(cache, "get_setting_dict", "setting")
     character = _require_cache_section(cache, "get_character_dict", "character")
@@ -89,6 +97,7 @@ def build_retrograde_dry_run_packet(
         layer=layer,
         zone=zone,
         initial_location=initial_location,
+        trait_compile_inputs=trait_compile_inputs,
     )
     if settings.orrery is None:
         raise ValueError("settings.orrery is required for Retrograde budgets")
@@ -366,6 +375,76 @@ def _seed_prompt_sections(
     ]
 
 
+def _trait_target_cards(
+    trait_compile_inputs: Optional[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return core-entity cards for trait-declared people, places, factions.
+
+    The trait compiler creates canonical rows for these names inside the same
+    transition transaction, before Retrograde persistence resolves expansion
+    refs. Exposing them as core entities makes Skald reuse the exact names,
+    so refs resolve as already_present instead of minting duplicate stubs.
+    """
+
+    if not trait_compile_inputs:
+        return []
+
+    cards: list[dict[str, Any]] = []
+    ref_rule = "Canonical name: refer to this entity with exactly this name."
+
+    def add(kind: str, role: str, target: Mapping[str, Any]) -> None:
+        name = target.get("name")
+        if not name:
+            return
+        summary = (
+            target.get("history")
+            or target.get("dynamic")
+            or f"Trait-declared {role} of the protagonist."
+        )
+        cards.append(
+            _compact_card(
+                kind=kind,
+                role=f"trait_target:{role}",
+                name=name,
+                summary=summary,
+                details={"ref_rule": ref_rule},
+            )
+        )
+
+    patron = _mapping(trait_compile_inputs.get("patron"))
+    if patron:
+        add("character", "patron", patron)
+    for target in _mapping(trait_compile_inputs.get("dependents")).get("targets") or []:
+        add("character", "dependent", _mapping(target))
+    for target in (
+        _mapping(trait_compile_inputs.get("obligations")).get("targets") or []
+    ):
+        target_map = _mapping(target)
+        kind = (
+            "faction"
+            if target_map.get("counterparty_kind") == "faction"
+            else "character"
+        )
+        add(kind, "obligation_counterparty", target_map)
+    relationship_roles = {"allies": "ally", "contacts": "contact", "enemies": "enemy"}
+    for trait_name, role in relationship_roles.items():
+        for target in (
+            _mapping(trait_compile_inputs.get(trait_name)).get("targets") or []
+        ):
+            add("character", role, _mapping(target))
+    domain = _mapping(trait_compile_inputs.get("domain"))
+    if domain:
+        add("place", "domain", domain)
+    status = _mapping(trait_compile_inputs.get("status"))
+    if status and status.get("scope_faction_name"):
+        add(
+            "faction",
+            "status_scope",
+            {"name": status.get("scope_faction_name")},
+        )
+    return cards
+
+
 def _candidate_scaffolds(
     *,
     character: Mapping[str, Any],
@@ -373,6 +452,7 @@ def _candidate_scaffolds(
     layer: Optional[Mapping[str, Any]],
     zone: Optional[Mapping[str, Any]],
     initial_location: Optional[Mapping[str, Any]],
+    trait_compile_inputs: Optional[Mapping[str, Any]] = None,
 ) -> dict[str, Any]:
     """Return deterministic R2/R3 scaffold cards for later seed generation."""
 
@@ -415,6 +495,7 @@ def _candidate_scaffolds(
                 summary=_mapping(layer).get("description"),
                 details=_mapping(layer),
             ),
+            *_trait_target_cards(trait_compile_inputs),
         ],
         "named_seed_npcs": [
             {"kind": "character", "role": "seed_npc", "name": name}

--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -144,6 +144,50 @@ def apply_tag_bestowal(
     return counters
 
 
+def validate_tag_bestowal(
+    cur: Any,
+    *,
+    entity_kind: str,
+    bestowal: Optional[OrreryTagBestowal],
+) -> list[str]:
+    """Validate a bestowal against the live registry without writing.
+
+    Returns issue strings for unknown, deprecated, or entity-kind-incompatible
+    tag names. Used by wizard tools to reject bad bestowals at submission time
+    (via ModelRetry) instead of exploding later inside the transition
+    transaction.
+    """
+
+    if bestowal is None:
+        return []
+    if entity_kind not in VALID_ENTITY_KINDS:
+        raise ValueError(
+            f"Unknown entity_kind={entity_kind!r}; expected one of "
+            f"{sorted(VALID_ENTITY_KINDS)}"
+        )
+
+    allowed = _lookup_allowed_categories(cur, entity_kind)
+    if not allowed:
+        raise ValueError(
+            f"No Orrery tag categories registered for entity_kind={entity_kind!r}"
+        )
+
+    issues: list[str] = []
+    for field_name in ("applied_tags", "tags_to_clear"):
+        for tag_name in getattr(bestowal, field_name):
+            try:
+                canonical_name, tag_row = _lookup_canonical_tag(cur, tag_name)
+                _validate_allowed_category(
+                    category=_row_value(tag_row, "category", 1),
+                    allowed=allowed,
+                    tag_name=canonical_name,
+                    entity_kind=entity_kind,
+                )
+            except ValueError as exc:
+                issues.append(f"{field_name}: {exc}")
+    return issues
+
+
 async def apply_tag_bestowal_async(
     conn: Any,
     *,

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -290,16 +290,18 @@ async def apply_state_updates(
                     bestowal=bestowal,
                 )
 
-    # Update place states
+    # Update place states. The schema field is current_conditions
+    # (LocationStateUpdate); it persists to the places.current_status
+    # column (M9 gate finding: the old attribute read crashed commits).
     for place_update in state_updates.locations:
-        if place_update.place_id and place_update.current_status:
+        if place_update.place_id and place_update.current_conditions:
             await conn.execute(
                 """
                 UPDATE places
                 SET current_status = $1
                 WHERE id = $2
                 """,
-                place_update.current_status,
+                place_update.current_conditions,
                 place_update.place_id,
             )
             logger.info(f"Updated place {place_update.place_id}")

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -651,12 +651,14 @@ def apply_state_updates_sync(conn, state_updates: StateUpdates):
                         bestowal=bestowal,
                     )
 
-        # Update place states
+        # Update place states. The schema field is current_conditions
+        # (LocationStateUpdate); it persists to the places.current_status
+        # column (M9 gate finding: the old attribute read crashed commits).
         for place_update in state_updates.locations:
-            if place_update.place_id and place_update.current_status:
+            if place_update.place_id and place_update.current_conditions:
                 cur.execute(
                     "UPDATE places SET current_status = %s WHERE id = %s",
-                    (place_update.current_status, place_update.place_id),
+                    (place_update.current_conditions, place_update.place_id),
                 )
                 logger.info(f"Updated place {place_update.place_id}")
 

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -377,72 +377,83 @@ def _trigger_locked_chunk_embedding(
     *, slot: Optional[int], parent_chunk_id: int
 ) -> None:
     """
-    Embed the chunk that becomes locked when starting from parent_chunk_id.
+    Embed every locked chunk older than parent_chunk_id.
 
-    Continuing from chunk n-1 creates provisional chunk n. That leaves chunk
-    n-1 undoable, while chunk n-2 is now locked and eligible for embeddings.
+    Continuing from chunk N creates a provisional successor, leaving chunk N
+    undoable while every committed chunk before it is locked and must be
+    embedded ("embedded == ironman"). Chunk ids are NOT contiguous: regens
+    burn ids and Retrograde/maturation summary chunks interleave with played
+    chunks, so the old single-id ``parent - 1`` arithmetic silently skipped
+    played chunks whenever a summary chunk sat in between (M9 gate finding).
+    This catch-up form embeds every unembedded locked chunk except the
+    intentionally unembedded Retrograde prologue anchor, healing any
+    previously skipped chunk on the next turn.
     """
-    locked_chunk_id = parent_chunk_id - 1
-    if locked_chunk_id < 1:
+    if parent_chunk_id <= 1:
         return
 
     try:
         dbname = require_slot_dbname(slot=slot)
     except Exception as exc:
         logger.warning(
-            "Skipping locked chunk embedding for chunk %s: %s",
-            locked_chunk_id,
+            "Skipping locked chunk embedding before chunk %s: %s",
+            parent_chunk_id,
             exc,
         )
         return
 
     try:
+        from nexus.agents.orrery.retrograde_markers import (
+            RETROGRADE_PROLOGUE_MARKER,
+        )
+
         with get_connection(dbname, dict_cursor=True) as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    SELECT embedding_generated_at
+                    SELECT id
                     FROM narrative_chunks
-                    WHERE id = %s
+                    WHERE id < %s
+                      AND embedding_generated_at IS NULL
+                      AND NOT (
+                          COALESCE(authorial_directives, '[]'::jsonb)
+                          @> %s::jsonb
+                      )
+                    ORDER BY id
                     """,
-                    (locked_chunk_id,),
+                    (parent_chunk_id, json.dumps([RETROGRADE_PROLOGUE_MARKER])),
                 )
-                row = cur.fetchone()
+                locked_chunk_ids = [row["id"] for row in cur.fetchall()]
 
-        if not row:
-            logger.warning(
-                "Skipping locked chunk embedding: chunk %s not found in %s",
-                locked_chunk_id,
-                dbname,
-            )
-            return
-
-        if row.get("embedding_generated_at"):
+        if not locked_chunk_ids:
             logger.info(
-                "Skipping locked chunk embedding: chunk %s already embedded",
-                locked_chunk_id,
+                "No locked chunks pending embedding before chunk %s in %s",
+                parent_chunk_id,
+                dbname,
             )
             return
 
         workflow = ChunkWorkflow(dbname)
-        job_id = workflow.trigger_embedding_generation(locked_chunk_id)
-        if job_id:
-            logger.info(
-                "Generated embeddings for locked chunk %s in %s (%s)",
-                locked_chunk_id,
-                dbname,
-                job_id,
-            )
-        else:
-            logger.warning(
-                "Embedding generation did not complete for locked chunk %s in %s",
-                locked_chunk_id,
-                dbname,
-            )
+        for locked_chunk_id in locked_chunk_ids:
+            job_id = workflow.trigger_embedding_generation(locked_chunk_id)
+            if job_id:
+                logger.info(
+                    "Generated embeddings for locked chunk %s in %s (%s)",
+                    locked_chunk_id,
+                    dbname,
+                    job_id,
+                )
+            else:
+                logger.warning(
+                    "Embedding generation did not complete for locked chunk %s "
+                    "in %s",
+                    locked_chunk_id,
+                    dbname,
+                )
     except Exception as exc:
         logger.error(
-            "Error embedding locked chunk %s for slot %s: %s",
-            locked_chunk_id,
+            "Error embedding locked chunks before %s for slot %s: %s",
+            parent_chunk_id,
             slot,
             exc,
         )

--- a/nexus/api/narrative_schemas.py
+++ b/nexus/api/narrative_schemas.py
@@ -328,3 +328,11 @@ class TransitionResponse(BaseModel):
             "withheld from this response."
         ),
     )
+    trait_inputs: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Transition-time trait input derivation outcome: whether typed "
+            "TraitCompileInputs were derived, with which model, and for "
+            "which canonical traits."
+        ),
+    )

--- a/nexus/api/new_story_flow.py
+++ b/nexus/api/new_story_flow.py
@@ -195,6 +195,26 @@ def perform_transition_with_retrograde(
     orrery_settings = settings.orrery
 
     effective_model = model or get_slot_model(slot_number, dbname=dbname)
+
+    # Derive typed trait-compiler inputs before any world writes so the
+    # compiler can create stub entities and relationship rows (M9). Runs for
+    # real models only; the mock TEST wizard stays hermetic.
+    trait_inputs_outcome: Optional[Dict[str, Any]] = None
+    trait_inputs_settings = settings.wizard.trait_inputs
+    if (
+        effective_model != MOCK_WIZARD_MODEL
+        and trait_inputs_settings.derive_at_transition
+    ):
+        from nexus.api.trait_input_derivation import ensure_trait_compile_inputs
+
+        trait_inputs_outcome = ensure_trait_compile_inputs(
+            transition_data,
+            slot=slot_number,
+            model_name=effective_model or get_new_story_model(),
+            max_tokens=trait_inputs_settings.max_tokens,
+            retries=settings.wizard.max_retries,
+        )
+
     if orrery_settings is None or not orrery_settings.enabled:
         skip_reason = "orrery_disabled"
     elif not orrery_settings.retrograde.wizard.enabled:
@@ -212,6 +232,7 @@ def perform_transition_with_retrograde(
         )
         result: Dict[str, Any] = dict(mapper.perform_transition(transition_data))
         result["retrograde"] = {"enabled": False, "skip_reason": skip_reason}
+        result["trait_inputs"] = trait_inputs_outcome or {"derived": False}
         return result
 
     # Narrowing only: orrery_settings None always sets skip_reason above.
@@ -287,6 +308,7 @@ def perform_transition_with_retrograde(
         "embedded_chunk_ids": [entry["chunk_id"] for entry in embedding_results],
         "timings": [timing.model_dump() for timing in bundle.timings],
     }
+    result["trait_inputs"] = trait_inputs_outcome or {"derived": False}
     return result
 
 

--- a/nexus/api/new_story_flow.py
+++ b/nexus/api/new_story_flow.py
@@ -207,10 +207,18 @@ def perform_transition_with_retrograde(
     ):
         from nexus.api.trait_input_derivation import ensure_trait_compile_inputs
 
+        if effective_model is None:
+            raise ValueError(
+                f"Slot {slot_number} has no configured model; cannot derive "
+                "trait compile inputs at the transition"
+            )
+        # Sync context only: the transition endpoint runs this whole
+        # function via asyncio.to_thread, and the deriver uses
+        # agent.run_sync, which would deadlock inside a running event loop.
         trait_inputs_outcome = ensure_trait_compile_inputs(
             transition_data,
             slot=slot_number,
-            model_name=effective_model or get_new_story_model(),
+            model_name=effective_model,
             max_tokens=trait_inputs_settings.max_tokens,
             retries=settings.wizard.max_retries,
         )

--- a/nexus/api/new_story_flow.py
+++ b/nexus/api/new_story_flow.py
@@ -250,6 +250,7 @@ def perform_transition_with_retrograde(
     def _progress(stage: str, detail: Dict[str, Any]) -> None:
         record_retrograde_progress(slot_number, stage, detail)
 
+    derived_inputs = transition_data.character.trait_compile_inputs
     bundle = generate_retrograde_history(
         slot=slot_number,
         dbname=dbname,
@@ -258,6 +259,11 @@ def perform_transition_with_retrograde(
         model_name=effective_model,
         max_tokens=orrery_settings.retrograde.wizard.max_tokens,
         progress=_progress,
+        trait_compile_inputs=(
+            derived_inputs.model_dump(mode="json", exclude_none=True)
+            if derived_inputs is not None
+            else None
+        ),
     )
 
     manifest_holder: Dict[str, Any] = {}

--- a/nexus/api/summary_triggers.py
+++ b/nexus/api/summary_triggers.py
@@ -172,6 +172,16 @@ def _run_single_task(
                 task.episode,
             )
             return
+        # The Storyteller may open play mid-numbering (e.g., the first played
+        # chunk lands in S01E02 while S01E01 holds no chunks); an episode
+        # with nothing in it has nothing to summarize (M9 gate finding).
+        if db_manager.get_episode_chunk_span(task.season, task.episode) is None:
+            logger.info(
+                "Skipping summary for S%02dE%02d because the episode has no " "chunks",
+                task.season,
+                task.episode,
+            )
+            return
         runner: Callable[[SummaryGenerator], Optional[dict]] = (
             lambda gen: gen.generate_episode_summary(task.season, task.episode)
         )

--- a/nexus/api/summary_triggers.py
+++ b/nexus/api/summary_triggers.py
@@ -130,20 +130,24 @@ def _run_summary_generation(
                 password = os.environ.get("DB_PASSWORD", "")
                 host = os.environ.get("DB_HOST", "localhost")
                 port = os.environ.get("DB_PORT", "5432")
-                
+
                 if password:
                     db_url = f"postgresql://{user}:{password}@{host}:{port}/{dbname}"
                 else:
                     db_url = f"postgresql://{user}@{host}:{port}/{dbname}"
-            
+
             db_manager = DatabaseManager(db_url=db_url)
     except Exception as exc:  # pragma: no cover - defensive logging
-        logger.error("Unable to start summary generation; database init failed: %s", exc)
+        logger.error(
+            "Unable to start summary generation; database init failed: %s", exc
+        )
         return
 
     for task in tasks:
         try:
-            _run_single_task(task, db_manager, model_candidates, overwrite, generator_cls)
+            _run_single_task(
+                task, db_manager, model_candidates, overwrite, generator_cls
+            )
         except Exception as exc:  # pragma: no cover - defensive logging
             logger.error("Summary generation failed for %s: %s", task, exc)
 
@@ -159,7 +163,9 @@ def _run_single_task(
         if task.episode is None:
             logger.warning("Episode summary task missing episode value: %s", task)
             return
-        if not overwrite and db_manager.episode_summary_exists(task.season, task.episode):
+        if not overwrite and db_manager.episode_summary_exists(
+            task.season, task.episode
+        ):
             logger.info(
                 "Skipping summary for S%02dE%02d because one already exists",
                 task.season,
@@ -193,10 +199,14 @@ def _run_single_task(
         if summary:
             if index > 0:
                 logger.info(
-                    "Generated %s summary using fallback model %s", target_label, model_name
+                    "Generated %s summary using fallback model %s",
+                    target_label,
+                    model_name,
                 )
             else:
-                logger.info("Generated %s summary using model %s", target_label, model_name)
+                logger.info(
+                    "Generated %s summary using model %s", target_label, model_name
+                )
             return
 
         if index < len(model_candidates) - 1:
@@ -213,6 +223,12 @@ def _run_single_task(
 
 
 def _coalesce_models(model_candidates: Optional[Sequence[str]]) -> List[str]:
+    # scripts/summarize_narrative resolves its module-level DEFAULT_MODEL /
+    # FALLBACK_MODEL constants at argparse time, so they are None when
+    # imported here (M9 gate finding: every API-triggered episode summary
+    # failed with zero model candidates). Resolve the default from the live
+    # apex config instead, keeping the legacy constants as extra candidates
+    # for older callers that still set them.
     models = (
         list(model_candidates) if model_candidates else [DEFAULT_MODEL, FALLBACK_MODEL]
     )
@@ -221,5 +237,10 @@ def _coalesce_models(model_candidates: Optional[Sequence[str]]) -> List[str]:
     for candidate in models:
         if candidate and candidate not in deduped:
             deduped.append(candidate)
+
+    if not deduped:
+        from nexus.config import load_settings
+
+        deduped.append(load_settings().apex.model)
 
     return deduped

--- a/nexus/api/trait_input_derivation.py
+++ b/nexus/api/trait_input_derivation.py
@@ -1,0 +1,308 @@
+"""Transition-time derivation of typed trait-compiler inputs.
+
+The wizard's conversational character phase records trait selections and
+prose rationales, but it never gathers the typed ``TraitCompileInputs`` the
+M5 trait compilers consume. Without them every selected trait falls to a
+prose-only remainder and Patron/Dependents/Obligations/Domain never create
+their stub entities -- breaking the "compiled relationships get cold-start
+history" promise.
+
+This module closes the gap at the wizard -> narrative transition: one
+structured-output Skald call reads the finished character sheet plus the
+setting card and emits ``TraitCompileInputs`` for exactly the selected
+traits. The derived inputs are validated (no database ids, closed
+vocabularies, named targets) before the trait compiler runs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, List, Optional
+
+from nexus.agents.orrery.status_family import STATUS_LEVELS
+from nexus.api.trait_compiler import FAME_TAGS, RESOURCE_TAGS
+from nexus.api.trait_compiler_schemas import (
+    TraitCompileInputs,
+    canonical_trait_name,
+)
+
+if TYPE_CHECKING:
+    from nexus.api.new_story_schemas import CharacterSheet, SettingCard
+
+logger = logging.getLogger("nexus.api.trait_input_derivation")
+
+PROMPT_PATH = Path(__file__).parent.parent.parent / "prompts" / "trait_input_deriver.md"
+
+# Patron functions mirror trait_compiler_schemas.PatronFunction.
+PATRON_FUNCTIONS = ("mentors", "sponsors", "protects", "authority_over")
+
+# Trait fields on TraitCompileInputs that target other entities by name.
+_RELATIONSHIP_TRAITS = ("allies", "contacts", "enemies")
+
+
+def selected_canonical_traits(character: "CharacterSheet") -> List[str]:
+    """Return the canonical names of the character's three selected traits."""
+
+    return [
+        canonical_trait_name(str(trait.name)) for trait in character.get_trait_entries()
+    ]
+
+
+def derived_input_issues(
+    inputs: TraitCompileInputs, *, selected: List[str]
+) -> List[str]:
+    """Validate derived inputs against the hard rules; return issue strings."""
+
+    issues: List[str] = []
+    selected_set = set(selected)
+
+    if inputs.reputation is not None:
+        issues.append("use the canonical 'fame' field, not 'reputation'")
+
+    provided = {
+        trait
+        for trait in (
+            "resources",
+            "fame",
+            "status",
+            "allies",
+            "contacts",
+            "enemies",
+            "domain",
+            "patron",
+            "dependents",
+            "obligations",
+        )
+        if getattr(inputs, trait) is not None
+    }
+    for extra in sorted(provided - selected_set):
+        issues.append(f"input provided for non-selected trait '{extra}'")
+    for missing in sorted(selected_set - provided):
+        issues.append(f"missing input for selected trait '{missing}'")
+
+    if inputs.resources is not None and inputs.resources.level not in RESOURCE_TAGS:
+        issues.append(
+            f"resources.level {inputs.resources.level!r} not in "
+            f"{sorted(RESOURCE_TAGS)}"
+        )
+    if inputs.fame is not None and inputs.fame.level not in FAME_TAGS:
+        issues.append(f"fame.level {inputs.fame.level!r} not in {sorted(FAME_TAGS)}")
+
+    if inputs.status is not None:
+        if inputs.status.level not in STATUS_LEVELS:
+            issues.append(
+                f"status.level {inputs.status.level!r} not in {sorted(STATUS_LEVELS)}"
+            )
+        if inputs.status.scope_faction_entity_id is not None:
+            issues.append("status.scope_faction_entity_id must be null")
+        if not inputs.status.scope_faction_name:
+            issues.append("status.scope_faction_name is required")
+
+    if inputs.domain is not None:
+        if inputs.domain.place_id is not None or inputs.domain.place_entity_id:
+            issues.append("domain place ids must be null")
+        if not inputs.domain.name:
+            issues.append("domain.name is required")
+
+    if inputs.patron is not None:
+        if inputs.patron.character_id is not None or inputs.patron.character_entity_id:
+            issues.append("patron character ids must be null")
+        if not inputs.patron.name:
+            issues.append("patron.name is required")
+
+    if inputs.dependents is not None:
+        if not inputs.dependents.targets:
+            issues.append("dependents requires at least one target")
+        for index, target in enumerate(inputs.dependents.targets):
+            if target.character_id is not None or target.character_entity_id:
+                issues.append(f"dependents.targets[{index}] ids must be null")
+            if not target.name:
+                issues.append(f"dependents.targets[{index}].name is required")
+
+    if inputs.obligations is not None:
+        if not inputs.obligations.targets:
+            issues.append("obligations requires at least one target")
+        for index, obligation in enumerate(inputs.obligations.targets):
+            if (
+                obligation.counterparty_id is not None
+                or obligation.counterparty_entity_id is not None
+            ):
+                issues.append(f"obligations.targets[{index}] ids must be null")
+            if not obligation.name:
+                issues.append(f"obligations.targets[{index}].name is required")
+
+    for trait in _RELATIONSHIP_TRAITS:
+        trait_input = getattr(inputs, trait)
+        if trait_input is None:
+            continue
+        if not trait_input.targets:
+            issues.append(f"{trait} requires at least one target")
+        for index, relation in enumerate(trait_input.targets):
+            if relation.character_id is not None or relation.character_entity_id:
+                issues.append(f"{trait}.targets[{index}] ids must be null")
+            if not relation.name:
+                issues.append(f"{trait}.targets[{index}].name is required")
+            if relation.apply_pair_tag:
+                issues.append(
+                    f"{trait}.targets[{index}].apply_pair_tag must be false in "
+                    "a fresh world"
+                )
+
+    return issues
+
+
+def render_trait_input_prompt(
+    *, character: "CharacterSheet", setting: "SettingCard"
+) -> str:
+    """Render the deterministic derivation prompt for the Skald call."""
+
+    if not PROMPT_PATH.exists():
+        raise FileNotFoundError(f"Trait input deriver prompt not found: {PROMPT_PATH}")
+    instructions = PROMPT_PATH.read_text()
+
+    payload = {
+        "selected_traits": selected_canonical_traits(character),
+        "character": {
+            "name": character.name,
+            "summary": character.summary,
+            "background": character.background,
+            "personality": character.personality,
+            "traits": [
+                {
+                    "name": canonical_trait_name(str(trait.name)),
+                    "description": trait.description,
+                }
+                for trait in character.get_trait_entries()
+            ],
+            "wildcard": {
+                "name": character.wildcard_name,
+                "description": character.wildcard_description,
+            },
+        },
+        "setting": {
+            "genre": setting.genre.value,
+            "world_name": setting.world_name,
+            "time_period": setting.time_period,
+        },
+        "vocabulary": {
+            "resource_levels": sorted(RESOURCE_TAGS),
+            "fame_levels": sorted(FAME_TAGS),
+            "status_levels": sorted(STATUS_LEVELS),
+            "patron_functions": list(PATRON_FUNCTIONS),
+        },
+    }
+    return (
+        f"{instructions}\n\n"
+        "TRAIT_INPUT_DERIVATION_REQUEST:\n"
+        f"{json.dumps(payload, indent=2, sort_keys=True)}"
+    )
+
+
+def derive_trait_compile_inputs(
+    *,
+    character: "CharacterSheet",
+    setting: "SettingCard",
+    model_name: str,
+    max_tokens: int,
+    retries: int,
+) -> TraitCompileInputs:
+    """Make the structured-output Skald call that derives trait inputs."""
+
+    from pydantic_ai import Agent, ModelRetry, RunContext
+    from pydantic_ai.settings import ModelSettings
+
+    from nexus.api.pydantic_ai_utils import build_pydantic_ai_model
+
+    selected = selected_canonical_traits(character)
+    prompt = render_trait_input_prompt(character=character, setting=setting)
+
+    agent: Any = Agent(
+        model=build_pydantic_ai_model(model_name),
+        output_type=TraitCompileInputs,
+        system_prompt=(
+            "You convert finished NEXUS character-wizard prose into typed "
+            "trait compiler inputs. Follow the hard rules exactly."
+        ),
+        model_settings=ModelSettings(max_tokens=max_tokens),
+        retries=retries,
+    )
+
+    async def _validate_output(
+        _ctx: RunContext[None], output: TraitCompileInputs
+    ) -> TraitCompileInputs:
+        issues = derived_input_issues(output, selected=selected)
+        if issues:
+            formatted = "\n".join(f"- {issue}" for issue in issues)
+            raise ModelRetry(
+                "Derived trait inputs violate the hard rules. Fix every "
+                f"issue and resubmit:\n{formatted}"
+            )
+        return output
+
+    agent.output_validator(_validate_output)
+    result = agent.run_sync(prompt)
+    output = result.output
+    if not isinstance(output, TraitCompileInputs):
+        raise TypeError(
+            "Trait input derivation returned "
+            f"{type(output).__name__}, expected TraitCompileInputs"
+        )
+    return output
+
+
+def ensure_trait_compile_inputs(
+    transition_data: Any,
+    *,
+    slot: int,
+    model_name: str,
+    max_tokens: int,
+    retries: int,
+) -> Optional[dict[str, Any]]:
+    """Derive and attach trait inputs to the transition's character sheet.
+
+    Returns an outcome block for the transition result, or ``None`` when the
+    sheet already carries typed inputs (a future wizard may collect them
+    conversationally; derivation never overwrites).
+    """
+
+    character = transition_data.character
+    if character.trait_compile_inputs is not None:
+        logger.info(
+            "Slot %s character already has trait_compile_inputs; skipping "
+            "derivation",
+            slot,
+        )
+        return None
+
+    derived = derive_trait_compile_inputs(
+        character=character,
+        setting=transition_data.setting,
+        model_name=model_name,
+        max_tokens=max_tokens,
+        retries=retries,
+    )
+    character.trait_compile_inputs = derived
+    derived_traits = sorted(
+        trait
+        for trait in (
+            "resources",
+            "fame",
+            "status",
+            "allies",
+            "contacts",
+            "enemies",
+            "domain",
+            "patron",
+            "dependents",
+            "obligations",
+        )
+        if getattr(derived, trait) is not None
+    )
+    logger.info("Derived trait compile inputs for slot %s: %s", slot, derived_traits)
+    return {
+        "derived": True,
+        "model": model_name,
+        "traits": derived_traits,
+    }

--- a/nexus/api/trait_input_derivation.py
+++ b/nexus/api/trait_input_derivation.py
@@ -268,6 +268,12 @@ def ensure_trait_compile_inputs(
 ) -> Optional[dict[str, Any]]:
     """Derive and attach trait inputs to the transition's character sheet.
 
+    MUTATES ``transition_data.character`` in place: the derived
+    ``TraitCompileInputs`` are assigned to ``trait_compile_inputs``, and the
+    caller (``perform_transition_with_retrograde``) depends on that
+    assignment when it later forwards the inputs to Retrograde generation
+    and the trait compiler.
+
     Returns an outcome block for the transition result, or ``None`` when the
     sheet already carries typed inputs (a future wizard may collect them
     conversationally; derivation never overwrites).

--- a/nexus/api/trait_input_derivation.py
+++ b/nexus/api/trait_input_derivation.py
@@ -79,7 +79,13 @@ def derived_input_issues(
     }
     for extra in sorted(provided - selected_set):
         issues.append(f"input provided for non-selected trait '{extra}'")
-    for missing in sorted(selected_set - provided):
+    # Relationship traits (allies/contacts/enemies) are optional: the M5
+    # compiler deliberately does not stub-create their targets, so name-only
+    # inputs compile to structured remainders regardless. Derived targets
+    # still feed Retrograde core-entity coverage when provided, but their
+    # absence is not an error.
+    required = selected_set - set(_RELATIONSHIP_TRAITS)
+    for missing in sorted(required - provided):
         issues.append(f"missing input for selected trait '{missing}'")
 
     if inputs.resources is not None and inputs.resources.level not in RESOURCE_TAGS:

--- a/nexus/api/wizard_agent.py
+++ b/nexus/api/wizard_agent.py
@@ -443,6 +443,29 @@ async def _submit_wildcard_impl(
         ctx, "wildcard", "submit_wildcard_trait"
     )
 
+    # Validate bestowed Orrery tags against the live registry now, while
+    # Skald can still repair them; an invalid name would otherwise explode
+    # later inside the transition transaction (M9 gate finding).
+    if wildcard.orrery_tags is not None:
+        from nexus.agents.orrery.tag_writer import validate_tag_bestowal
+        from nexus.api.db_pool import get_connection
+
+        with get_connection(slot_dbname(ctx.deps.slot)) as conn:
+            with conn.cursor() as cur:
+                tag_issues = validate_tag_bestowal(
+                    cur,
+                    entity_kind="character",
+                    bestowal=wildcard.orrery_tags,
+                )
+        if tag_issues:
+            formatted = "\n".join(f"- {issue}" for issue in tag_issues)
+            raise ModelRetry(
+                "submit_wildcard_trait rejected: orrery_tags failed registry "
+                "validation. Use bare registered tag names from the Tag "
+                "Reference (e.g. 'comfortable'), never 'category:name' "
+                f"composites. Issues:\n{formatted}"
+            )
+
     updated_state = CharacterCreationState.model_validate(
         {**creation_state.model_dump(), "wildcard": wildcard.model_dump()}
     )

--- a/nexus/api/wizard_chat.py
+++ b/nexus/api/wizard_chat.py
@@ -958,6 +958,7 @@ async def transition_to_narrative_endpoint(request: TransitionRequest):
             zone_id=result["zone_id"],
             message=f"Welcome to {transition_data.setting.world_name}. Your story begins.",
             retrograde=result.get("retrograde"),
+            trait_inputs=result.get("trait_inputs"),
         )
     except ValueError as e:
         # Includes RetrogradePersistenceBlockedError: the transaction rolled

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1010,6 +1010,26 @@ class APEXSettings(BaseModel):
 # =============================================================================
 
 
+class WizardTraitInputsSettings(BaseModel):
+    """Transition-time derivation of typed trait-compiler inputs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    derive_at_transition: bool = Field(
+        default=True,
+        description=(
+            "Derive TraitCompileInputs via one structured Skald call at the "
+            "wizard -> narrative transition when the wizard did not collect "
+            "them conversationally"
+        ),
+    )
+    max_tokens: int = Field(
+        default=4096,
+        ge=1,
+        description="Max output tokens for the trait input derivation call",
+    )
+
+
 class WizardSettings(BaseModel):
     """Wizard configuration for new story setup and structured responses."""
 
@@ -1031,6 +1051,10 @@ class WizardSettings(BaseModel):
     )
     enable_streaming: bool = Field(
         default=True, description="Enable wizard streaming endpoint"
+    )
+    trait_inputs: WizardTraitInputsSettings = Field(
+        default_factory=WizardTraitInputsSettings,
+        description="Transition-time trait input derivation settings",
     )
 
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1003,6 +1003,14 @@ class APEXSettings(BaseModel):
     model: str
     reasoning_effort: str = Field(..., pattern="^(low|medium|high)$")
     max_output_tokens: int = Field(..., ge=1)
+    structured_output_retries: int = Field(
+        default=3,
+        ge=0,
+        description=(
+            "Validation retry budget for apex structured-output calls. Each "
+            "retry feeds the validation error back to the model."
+        ),
+    )
 
 
 # =============================================================================

--- a/prompts/trait_input_deriver.md
+++ b/prompts/trait_input_deriver.md
@@ -15,9 +15,12 @@ mechanical state (relationship rows, pair-tags, stub entities).
    `scope_faction_entity_id`). This is a brand-new world: there are no existing
    rows to reference. Identify people, places, and factions by `name` only.
 3. Reuse proper names that already appear in the character sheet or trait
-   descriptions. Invent a fitting in-world name only when the prose names
-   nobody. Names must be concrete ("Doctor Imari Voss"), never generic
-   placeholders ("the patron", "a friend").
+   descriptions, and always use the FULLEST form of the name found anywhere
+   in the prose (given name plus family name, plus title or honorific when
+   the prose uses one). These names become canonical database rows that
+   later passes must match exactly. Invent a fitting in-world name only when
+   the prose names nobody. Names must be concrete ("Doctor Imari Voss"),
+   never generic placeholders ("the patron", "a friend").
 4. Use the canonical `fame` field, never the legacy `reputation` alias.
 5. Closed vocabularies are exhaustive. `resources.level` and `fame.level` must
    come from the levels in the request vocabulary. `status.level` must come

--- a/prompts/trait_input_deriver.md
+++ b/prompts/trait_input_deriver.md
@@ -1,0 +1,39 @@
+# Trait Input Deriver
+
+You are Skald-as-archivist for a NEXUS new-story transition. The player has
+finished the character wizard. Their three selected traits exist only as prose
+rationales; your job is to convert that prose into the typed
+`TraitCompileInputs` structure so the deterministic trait compiler can write
+mechanical state (relationship rows, pair-tags, stub entities).
+
+## Hard Rules
+
+1. Provide an input for EVERY selected trait listed in the request, and for NO
+   other trait. Leave every non-selected trait field null.
+2. Never set any database id field (`character_id`, `character_entity_id`,
+   `place_id`, `place_entity_id`, `counterparty_id`, `counterparty_entity_id`,
+   `scope_faction_entity_id`). This is a brand-new world: there are no existing
+   rows to reference. Identify people, places, and factions by `name` only.
+3. Reuse proper names that already appear in the character sheet or trait
+   descriptions. Invent a fitting in-world name only when the prose names
+   nobody. Names must be concrete ("Doctor Imari Voss"), never generic
+   placeholders ("the patron", "a friend").
+4. Use the canonical `fame` field, never the legacy `reputation` alias.
+5. Closed vocabularies are exhaustive. `resources.level` and `fame.level` must
+   come from the levels in the request vocabulary. `status.level` must come
+   from the status levels. `patron.functions` may only contain the listed
+   patron functions, and must include only functions the trait description
+   actually supports.
+6. For relationship-bearing inputs (patron, dependents, obligations, allies,
+   contacts, enemies), fill `dynamic`, `recent_events`, and `history` with
+   one or two compact sentences grounded in the trait description. Leave
+   `relationship_type` and `emotional_valence` null unless the prose clearly
+   demands a non-default valence (format: `<signed integer>|<word>`, e.g.
+   `+2|deferential`).
+7. Do not set `apply_pair_tag` on ally/contact/enemy targets: in a fresh world
+   those targets have no canonical rows yet, so pair-tag application cannot
+   resolve. Name the people anyway; the prose remainder is expected.
+8. `obligations` counterparties must be bound to a character or faction
+   (`counterparty_kind`). An obligation to a pure concept must be bound to the
+   entity that enforces or benefits from it.
+9. Return JSON only, matching the response schema exactly.

--- a/prompts/trait_input_deriver.md
+++ b/prompts/trait_input_deriver.md
@@ -8,8 +8,12 @@ mechanical state (relationship rows, pair-tags, stub entities).
 
 ## Hard Rules
 
-1. Provide an input for EVERY selected trait listed in the request, and for NO
-   other trait. Leave every non-selected trait field null.
+1. Provide an input for EVERY selected trait listed in the request, and for
+   NO other trait. Leave every non-selected trait field null. Exception:
+   allies, contacts, and enemies are OPTIONAL -- in a brand-new world their
+   targets have no database rows, so the compiler records them as prose
+   remainders either way. Provide named targets for them only when the
+   prose names concrete people (the names seed world-history coverage).
 2. Never set any database id field (`character_id`, `character_entity_id`,
    `place_id`, `place_entity_id`, `counterparty_id`, `counterparty_entity_id`,
    `scope_faction_entity_id`). This is a brand-new world: there are no existing

--- a/scripts/api_anthropic.py
+++ b/scripts/api_anthropic.py
@@ -257,7 +257,8 @@ class AnthropicProvider(LLMProvider):
                 timeout: int = 120,
                 thinking_enabled: bool = False,
                 thinking_budget_tokens: Optional[int] = None,
-                structured_output_retries: Optional[int] = None):
+                structured_output_retries: Optional[int] = None,
+                output_validator: Optional[Any] = None):
         """
         Initialize Anthropic provider.
 
@@ -274,6 +275,8 @@ class AnthropicProvider(LLMProvider):
             thinking_budget_tokens: Thinking token budget (typically 32000)
             structured_output_retries: Validation retry budget for structured
                 output agents (apex.structured_output_retries in nexus.toml)
+            output_validator: Optional async pydantic_ai output validator
+                registered on structured agents (may raise ModelRetry)
         """
         self.top_p = top_p
         self.top_k = top_k
@@ -285,6 +288,7 @@ class AnthropicProvider(LLMProvider):
             if structured_output_retries is not None
             else self.STRUCTURED_OUTPUT_RETRIES
         )
+        self.output_validator = output_validator
 
         # Validate thinking configuration
         if thinking_enabled and thinking_budget_tokens is None:
@@ -536,6 +540,8 @@ class AnthropicProvider(LLMProvider):
             model_settings=model_settings,
             retries=self.structured_output_retries,
         )
+        if self.output_validator is not None:
+            agent.output_validator(self.output_validator)
 
         return agent
 

--- a/scripts/api_anthropic.py
+++ b/scripts/api_anthropic.py
@@ -256,7 +256,8 @@ class AnthropicProvider(LLMProvider):
                 top_k: Optional[int] = None,
                 timeout: int = 120,
                 thinking_enabled: bool = False,
-                thinking_budget_tokens: Optional[int] = None):
+                thinking_budget_tokens: Optional[int] = None,
+                structured_output_retries: Optional[int] = None):
         """
         Initialize Anthropic provider.
 
@@ -271,12 +272,19 @@ class AnthropicProvider(LLMProvider):
             timeout: Request timeout in seconds
             thinking_enabled: Enable extended thinking (requires Claude 4+ models)
             thinking_budget_tokens: Thinking token budget (typically 32000)
+            structured_output_retries: Validation retry budget for structured
+                output agents (apex.structured_output_retries in nexus.toml)
         """
         self.top_p = top_p
         self.top_k = top_k
         self.timeout = timeout
         self.thinking_enabled = thinking_enabled
         self.thinking_budget_tokens = thinking_budget_tokens
+        self.structured_output_retries = (
+            structured_output_retries
+            if structured_output_retries is not None
+            else self.STRUCTURED_OUTPUT_RETRIES
+        )
 
         # Validate thinking configuration
         if thinking_enabled and thinking_budget_tokens is None:
@@ -526,7 +534,7 @@ class AnthropicProvider(LLMProvider):
             output_type=schema_model,
             system_prompt=self.system_prompt,
             model_settings=model_settings,
-            retries=self.STRUCTURED_OUTPUT_RETRIES,
+            retries=self.structured_output_retries,
         )
 
         return agent

--- a/scripts/api_openai.py
+++ b/scripts/api_openai.py
@@ -259,7 +259,8 @@ class OpenAIProvider(LLMProvider):
                 system_prompt: Optional[str] = None,
                 reasoning_effort: Optional[str] = None,
                 base_url: Optional[str] = None,
-                structured_output_retries: Optional[int] = None):
+                structured_output_retries: Optional[int] = None,
+                output_validator: Optional[Any] = None):
         """
         Initialize OpenAI provider with additional reasoning parameter.
 
@@ -276,6 +277,8 @@ class OpenAIProvider(LLMProvider):
             base_url: Optional base URL for API (e.g., for mock servers)
             structured_output_retries: Validation retry budget for structured
                 output agents (apex.structured_output_retries in nexus.toml)
+            output_validator: Optional async pydantic_ai output validator
+                registered on structured agents (may raise ModelRetry)
         """
         self.reasoning_effort = reasoning_effort
         self.max_output_tokens = max_output_tokens or max_tokens
@@ -285,6 +288,7 @@ class OpenAIProvider(LLMProvider):
             if structured_output_retries is not None
             else self.STRUCTURED_OUTPUT_RETRIES
         )
+        self.output_validator = output_validator
 
         # Validate reasoning effort if provided
         if reasoning_effort is not None and reasoning_effort not in self.VALID_REASONING_EFFORTS:
@@ -442,6 +446,8 @@ class OpenAIProvider(LLMProvider):
             model_settings=model_settings,
             retries=self.structured_output_retries,
         )
+        if self.output_validator is not None:
+            agent.output_validator(self.output_validator)
 
         return agent
 

--- a/scripts/api_openai.py
+++ b/scripts/api_openai.py
@@ -258,7 +258,8 @@ class OpenAIProvider(LLMProvider):
                 max_output_tokens: Optional[int] = None,
                 system_prompt: Optional[str] = None,
                 reasoning_effort: Optional[str] = None,
-                base_url: Optional[str] = None):
+                base_url: Optional[str] = None,
+                structured_output_retries: Optional[int] = None):
         """
         Initialize OpenAI provider with additional reasoning parameter.
 
@@ -273,10 +274,17 @@ class OpenAIProvider(LLMProvider):
                 - GPT-5: 'minimal', 'medium', 'high'
                 - o3: 'low', 'medium', 'high'
             base_url: Optional base URL for API (e.g., for mock servers)
+            structured_output_retries: Validation retry budget for structured
+                output agents (apex.structured_output_retries in nexus.toml)
         """
         self.reasoning_effort = reasoning_effort
         self.max_output_tokens = max_output_tokens or max_tokens
         self.base_url = base_url
+        self.structured_output_retries = (
+            structured_output_retries
+            if structured_output_retries is not None
+            else self.STRUCTURED_OUTPUT_RETRIES
+        )
 
         # Validate reasoning effort if provided
         if reasoning_effort is not None and reasoning_effort not in self.VALID_REASONING_EFFORTS:
@@ -432,7 +440,7 @@ class OpenAIProvider(LLMProvider):
             output_type=schema_model,
             system_prompt=self.system_prompt,
             model_settings=model_settings,
-            retries=self.STRUCTURED_OUTPUT_RETRIES,
+            retries=self.structured_output_retries,
         )
 
         return agent

--- a/tests/fixtures/golden_path_wizard_cache.json
+++ b/tests/fixtures/golden_path_wizard_cache.json
@@ -1,0 +1,181 @@
+{
+ "thread_id": "thread_kXPR4jDfqfHXpGP1x40347ze",
+ "setting_draft": {
+  "genre": "fantasy",
+  "secondary_genres": [
+   "noir",
+   "mystery"
+  ],
+  "world_name": "Veyport",
+  "time_period": "Late medieval maritime city-state era",
+  "tech_level": "medieval",
+  "magic_exists": true,
+  "magic_description": "Magic is old, scarce, distrusted, and mostly maritime or warding in nature. It survives in lighthouse rites, salt-oaths, charms against drowning, guild-kept alchemical tricks, and half-forgotten signals used to keep an ancient presence asleep beyond the breakwater. Open sorcery is rare enough to be scandalous and dangerous enough to draw knives, contracts, or bells.",
+  "political_structure": "Independent harbor city ruled by a Merchant-Guild Compact, with competing guild councils, dock syndicates, ward bosses, old noble remnants, smuggler fraternities, and the semi-sacred Lighthouse Order all claiming pieces of authority.",
+  "major_conflict": "Veyport\u2019s prosperity depends on sea trade, smuggling, and fragile civic bargains, but the ancient Lighthouse Order\u2019s weakening vigil keeps something vast asleep beyond the breakwater. Guild ambition, criminal profit, political sabotage, and maritime superstition all threaten to disturb it.",
+  "tone": "dark",
+  "themes": [
+   "The city as a living organism",
+   "Commerce versus sacred duty",
+   "Corruption and survival",
+   "Old promises coming due",
+   "Class tension and civic rot",
+   "Secrets buried under routine"
+  ],
+  "cultural_notes": "Veyport is a city of tides, ledgers, bells, and knives. Reputation is currency; oaths sworn over saltwater are feared; guild colors mark status and danger; funeral coins are nailed beneath doorframes for those lost at sea. Common folk navigate neighborhood loyalties, protection rents, market feasts, fog curfews, and the constant rumor-mill of taverns, countinghouses, shrines, and dock cranes. The Lighthouse Order is treated with a blend of reverence, resentment, and unease.",
+  "language_notes": "Names favor hard consonants, brine-worn syllables, and occupational bynames: Mara Kest, Orven Tallow, Sella Grig, Dock-Saint Harl, Bellwarden Voss. Veyport slang is nautical and transactional: debts are 'anchors,' secrets are 'sealed cargo,' betrayal is 'cutting the moorline,' and death at sea is 'going under the gray.'",
+  "geographic_scope": "local",
+  "diegetic_artifact": "EXTRACT FROM THE BELLWARDEN\u2019S REGISTER, KEPT IN THE THIRD LANTERN ROOM OF SAINT ORVEN\u2019S LIGHT\nCopied under fog-seal for the instruction of junior keepers, harbor magistrates, and such guild factors as have paid the old fee and sworn not to laugh.\n\nKnow first that Veyport is not built beside the sea. Veyport is built in argument with it.\n\nThe city lies curled around the black-water harbor like a fist around a coin. Its outer arms are stone moles, chain piers, tide-gates, wrecking cranes, and the long teeth of the breakwater where the gulls go silent at dusk. Inland it rises in crowded tiers: tarred dock roofs and sail-lofts below; chandlers, fishwives, coopers, ropewalks, debt-houses, and cheap shrines above; then the counting stairs, guild halls, charter courts, and rain-polished mansions of those who own ships they never board. Every street remembers water. Every cellar has tasted brine. Every family keeps at least one story of a door opened during a storm and someone beloved never standing there again.\n\nThe city\u2019s heart is the harbor, though the guilds will tell you it is the Ledger House, the smugglers will tell you it is the Moon Quay, and the priests will tell you a city has no heart until it is dying. All are wrong. Veyport\u2019s heart is the tide-bell. It hangs green with age in the low tower over Chainmarket, and it is rung for fog, fire, riot, plague-ship, royal envoy, guild judgment, drowned children, and once\u2014only once in living memory\u2014for the thing beyond the breakwater turning in its sleep.\n\nDo not write its name. Do not ask the old keepers for its shape. The sea is full of things that were never meant to be believed in by daylight.\n\nThe Merchant-Guild Compact governs Veyport in the way a net governs fish: by catching some, missing many, and tearing under strain. The Compact\u2019s public face is respectable. The Salt Factors regulate cargo rights. The Red Ropemakers hold half the labor contracts below Hook Street. The Lampwrights maintain whale-oil quotas and public lanterns. The Chandlers\u2019 Confraternity owns more debt than any noble house ever owned land. The Shipwrights speak softly because every wall in the city depends on their hands. Lesser guilds swarm beneath them\u2014guttersmiths, eelmongers, bellfounders, sail-inkers, corpse washers, lime burners, oyster-lawyers, ratcatchers with hereditary badges and excellent memories.\n\nNo guild acts alone if it can act through a cousin, a bonded apprentice, a drinking club, a charity kitchen, a dockside preacher, or a knife hired under another man\u2019s seal. Veyport\u2019s politics are conducted in votes, bribes, marriages, warehouse fires, tariff amendments, missing cargo, and rumors placed carefully enough to ruin a family by breakfast.\n\nBeneath the Compact swim the unlicensed powers. The Marsh Eels run night cargo through the reed channels west of the city. The Grayhook Brotherhood owns three fish markets, two orphanages, and more honest magistrates than is considered decent. The Lanternless are not a gang, whatever the watch claims, but a habit of the city: men and women who know which postern is unwatched in rain, which customs clerk fears debt, which widow will hide a fugitive for coin, pity, or revenge. Smuggling in Veyport is less a crime than a second weather. Everyone condemns it. Everyone budgets for it.\n\nAbove all this stands Saint Orven\u2019s Light on the outer rock, older than the Compact, older than the south wall, older than the language in which its first vows were carved. The Lighthouse Order keeps the lamps, charts the fog banks, blesses departures, records wrecks, and performs the night rites no guild auditor is permitted to witness. Its members are called bellwardens, wick-sisters, lens-brothers, storm-novices, and, by those who have lost cargo to their interdictions, salt-mad frauds. They own little land and command no army. Yet when the Light\u2019s black bell sounds across the harbor, even guildmasters stop speaking.\n\nThe Order\u2019s doctrine is simple in public: the Light guides ships home and warns ships away. Its private doctrine is older and less comforting: the Light is not for ships.\n\nPast the breakwater the seabed drops sheer into a trench the charts mark only as Saint\u2019s Mercy. Nets lowered there come up cut, frozen, or full of pale weed that bleeds blue when burned. On windless nights, fishermen report a pressure in the bones, as if the world is holding its breath. The oldest account says something was lured there before Veyport had walls, bound beneath stone, song, lamp-glass, and tide. The Order does not keep it dead. It keeps it asleep.\n\nMagic, if that word must be used, is not a scholar\u2019s toy in Veyport. It is not fire from fingers or gold from mud. It is the inherited fear of doing a precise thing at the precise hour because your grandmother did it and her grandmother survived. It is salt thrown over a ledger before a dangerous contract. It is a bell struck underwater to call back the nearly drowned. It is blue flame in the lighthouse lens when no oil has been poured. It is a smuggler\u2019s charm that fails if bought with clean money. It is the way certain debts seem to find heirs.\n\nThe city tolerates such practices so long as they remain useful, private, and deniable. Public sorcery brings crowds. Crowds bring panic. Panic brings the watch, the guild courts, the Order, or worse, ambitious men who believe the old rites are merely technology without patents.\n\nFor Veyport is changing. The western warehouses are sinking by inches though no engineer will admit it. The Fishgut Steps flood now under a moon that once left them dry. Three guilds have petitioned to audit the Lighthouse Order\u2019s sealed accounts. Two bellwardens have vanished. The tide-bell has developed a hairline crack shaped, if viewed by candlelight, like an open eye. Ships from the south bring spices, plague rumors, and coin clipped so thin it sings wrong when dropped. Apprentices whisper that the old guildmasters are selling harbor rights to foreign crowns. Smugglers whisper that the Order has been dumping chained coffins beyond the breakwater. The Order whispers nothing.\n\nTo live in Veyport is to understand that the city is alive, and like all living things it hungers. It eats timber, coin, fish, secrets, labor, names, sons, daughters, and ships painted bright with hope. It rewards those who learn its pulses: fog hour, watch change, market surge, bell silence, funeral tide, riot weather. It punishes those who mistake its corruption for weakness. Every alley belongs to someone. Every roof hears something. Every lantern casts both guidance and shadow.\n\nIf you are new to the city, learn the first laws:\n\nNever mock a salt-oath.\nNever count another crew\u2019s dead aloud.\nNever bring an unhooded flame onto Moon Quay after midnight.\nNever ask what the Light is watching.\nNever stand on the seaward breakwater when the tide is going out and the gulls have stopped crying.\n\nAnd if the tide-bell rings three times with no hand on the rope, find stone beneath your feet, close your eyes, and pray the old bargains still remember your blood."
+ },
+ "character_draft": {
+  "concept": {
+   "name": "Brena Tideloft",
+   "archetype": "fever-marked salvage diver and tide-canal fixer",
+   "background": "Brena Tideloft survived Veyport's fever year and came out of it with a life built from salvage, favors, and grudges. She works the tide canals from her patched dory, the Gullwise, retrieving drowned cargo, inconvenient evidence, and things the Harbor Council would rather forget. Magistra Odile Sorrenwick, an aging Council archivist, quietly sponsors and shields her in exchange for discreet recoveries. At home, Brena supports her too-clever twelve-year-old brother Pim and half-blind Nan Cesska, the woman who raised them after the fever year. Practical, dry-humored, and careful with her hidden savings, Brena knows Veyport from the waterline down.",
+   "appearance": "Brena is in her mid-thirties, weather-browned and wiry from years of hauling rope, diving cold channels, and sleeping poorly when the foghorns call. She dresses in patched oilcloth, canal boots, and layered wool that always smells faintly of brine, lamp-smoke, and old copper. Her hands are scarred from barnacles and salvage hooks; her eyes have the narrowed patience of someone who has learned to listen before speaking. She carries herself plainly, with a fixer\u2019s economy\u2014nothing ornamental unless it hides a use.",
+   "suggested_traits": [
+    "patron",
+    "dependents",
+    "resources"
+   ],
+   "trait_rationales": {
+    "patron": "Magistra Odile Sorrenwick sponsors and protects Brena, but that protection comes tied to Council secrets and dangerous retrievals.",
+    "dependents": "Pim Tideloft and Nan Cesska give Brena a household to protect, making her choices personal whenever Veyport applies pressure.",
+    "resources": "Brena\u2019s modest hidden savings and working dory matter in a city where a little money, gear, and mobility can decide whether someone survives the tide."
+   }
+  },
+  "trait_selection": {
+   "selected_traits": [
+    "patron",
+    "dependents",
+    "resources"
+   ],
+   "trait_rationales": {
+    "patron": "Magistra Odile Sorrenwick sponsors and protects Brena, but that protection comes tied to Council secrets and dangerous retrievals.",
+    "dependents": "Pim Tideloft and Nan Cesska give Brena a household to protect, making her choices personal whenever Veyport applies pressure.",
+    "resources": "Brena\u2019s modest hidden savings and working dory matter in a city where a little money, gear, and mobility can decide whether someone survives the tide."
+   }
+  },
+  "wildcard": {
+   "wildcard_name": "Fever-Born Tide-Sense",
+   "wildcard_description": "Since surviving the fever year, Brena can read Veyport\u2019s tides, canals, submerged rooms, and hidden currents as if they were alleys under a dim moon. In the water she senses disturbances, drowned passages, and things moving before they surface\u2014but deep harbor pressure can stir memories that are not hers, and the sleeper beyond the breakwater may sometimes sense her in return.",
+   "orrery_tags": {
+    "applied_tags": [
+     "human",
+     "perceptive",
+     "resourceful",
+     "survivalist",
+     "urban",
+     "cautious",
+     "cynical",
+     "dutiful",
+     "kin_protector",
+     "reserved",
+     "fixer",
+     "salvager",
+     "broker",
+     "trauma_survivor",
+     "route_familiar",
+     "travel_ready",
+     "work_obligation",
+     "field_worker"
+    ],
+    "tags_to_clear": []
+   }
+  }
+ },
+ "selected_seed": {
+  "seed_type": "meeting",
+  "title": "Odile\u2019s Last Favor",
+  "situation": "Brena Tideloft arrives before dawn at the Lanternward Annex, a half-flooded Harbor Council archive built into Veyport\u2019s old seawall, where Magistra Odile Sorrenwick has summoned her for one last retrieval: a sealed bell-casket taken from beneath the outer breakwater and misfiled under plague-dead property. Odile insists it must be moved quietly to the Gullwise before the morning guild clerks arrive, but the archive doors have already been opened from the inside and someone has left wet footprints leading down into the forbidden lower stacks.",
+  "hook": "The job begins as a discreet favor between patron and fixer, but immediately turns into a tense search through drowned records, guild secrets, and old lighthouse taboos. Brena\u2019s fever-born tide-sense reacts to the bell-casket as if the harbor itself is breathing around it, and Odile\u2019s apology-laden urgency suggests this favor is less an errand than a farewell.",
+  "immediate_goal": "Get inside the Lanternward Annex, find Odile, secure the sealed bell-casket, and decide whether to carry out the retrieval before guild agents, Council rivals, or the old lighthouse order intervene.",
+  "stakes": "If Brena refuses or fails, Odile\u2019s protection may collapse, exposing Brena, Pim, and Nan to guild debt collectors and Council inquiry. If she succeeds blindly, she may help bury\u2014or awaken\u2014something tied to the old order\u2019s watch beyond the breakwater.",
+  "tension_source": "Brena owes Odile trust but has every reason to suspect she is being used. The archive is physically unsafe at the predawn flood, politically dangerous because rival Council hands are already moving, and supernaturally wrong because Brena\u2019s tide-sense recognizes a current where no water should be flowing.",
+  "base_timestamp": {
+   "year": 2026,
+   "month": 6,
+   "day": 11,
+   "hour": 3,
+   "minute": 21
+  },
+  "weather": "Cold predawn fog, steady harbor drizzle, and a rising tide pressing black water up through the archive drains.",
+  "key_npcs": [
+   "Magistra Odile Sorrenwick, aging Harbor Council archivist and Brena\u2019s patron, frightened but composed and hiding how little time she has left",
+   "Pim Tideloft, Brena\u2019s twelve-year-old brother, not present at the opening but vulnerable if Brena\u2019s protection network fails",
+   "Nan Cesska, half-blind household elder, asleep at home near the tide canals and dependent on Brena\u2019s income",
+   "Brother Edran Vell, a severe emissary of the old lighthouse order who believes the bell-casket must never leave consecrated watch",
+   "Marra Kest, a guild clerk-thief selling access to Council records to whoever pays fastest"
+  ],
+  "secrets": "Odile is dying from a slow poison administered through Council supper wine after she discovered that several Harbor Council families secretly profit from smuggling offerings past the breakwater to keep the sleeper quiescent. The bell-casket does not contain treasure or documents but a cracked tongue from one of the original lighthouse bells; when near Brena, it resonates with her fever-born tide-sense because the same fever that killed her parents was caused by a diluted outbreak of the sleeper\u2019s dream leaking into the canals. Odile intends Brena to take the casket not to the Council vault, as she will claim, but to a hidden channel only Brena can find. Brother Edran is not an enemy at first: he has orders to recover the casket, but he also knows Odile\u2019s poisoner sits on the Council. Marra Kest opened the Annex for a rival guild, then panicked after seeing a dead clerk walking and whispering below the waterline. The immediate corpse in the lower stacks is animated only by echo and current, not true life, and it may speak with the voice of someone Brena lost in the fever year."
+ },
+ "layer_draft": {
+  "name": "Veyport",
+  "type": "planet",
+  "description": "A dark late-medieval maritime world centered on a rain-lashed city-state of canals, guild law, sea walls, relics, and old harbor magic."
+ },
+ "zone_draft": {
+  "name": "Lanternward Quays",
+  "summary": "The old lighthouse quarter of Veyport, where seawalls, rope bridges, fish markets, signal towers, council offices, and flooded prison-stores crowd the fogbound harbor edge."
+ },
+ "initial_location": {
+  "name": "Lanternward Annex",
+  "history": "The Annex began as a tide-prison and signal storehouse for the old lighthouse order, later seized by the Harbor Council and converted into a restricted archive for salvage liens, plague-year inventories, guild charters, harbor claims, and misfiled property of the dead.",
+  "secrets": "The sealed bell-casket was not merely recovered from beneath the outer breakwater; it was deliberately placed there as a warding weight tied to the sleeper below the harbor. Odile knows the Council\u2019s official catalog has been altered by someone with access to plague-dead property records. The wet footprints may belong to a drowned agent using the culverts, a living clerk possessed by bell-metal resonance, or an old lighthouse-order remnant seeking to return the casket before the tide turns. Odile\u2019s private catalog room behind false tax rolls contains evidence that several Harbor Council archives were built over sealed channels leading to the same submerged thing.",
+  "summary": "A narrow, leaning Harbor Council archive built into Veyport\u2019s old seawall near the lighthouse quay. Its upper rooms hold warped oak shelves, brass catalog rails, locked map cages, clerk desks, and mildew-stained civic seals, while lower levels descend below the tide mark into flooded stacks, barred culverts, forgotten cells, and bricked-up lighthouse passages.",
+  "latitude": 60.392,
+  "longitude": 5.322,
+  "extra_data": {
+   "ruler": "Veyport Harbor Council",
+   "rumors": [
+    "Some records in the lower stacks whisper different names after they swell with seawater.",
+    "A smugglers\u2019 grate beneath the Annex opens only when the tide is nearly high.",
+    "Odile keeps a second index that contradicts the Council\u2019s official ledgers."
+   ],
+   "culture": "Austere civic secrecy governs the Annex: ledgers are treated like legal weapons, access is controlled by stamps and favors, and everyone understands that some drowned records are safer left misfiled.",
+   "dangers": [
+    "rising tide flooding the lower stacks",
+    "rotten stairs and collapsing shelves",
+    "barred culverts that trap the unwary",
+    "watchmen open to bribes or panic",
+    "bell-metal relics that stir old things under the breakwater"
+   ],
+   "economy": "The Annex underpins Veyport\u2019s harbor economy by recording salvage rights, shipping disputes, guild charters, plague inheritances, and claims on goods pulled from wrecks or tidewater graves.",
+   "factions": [
+    "Harbor Council clerks",
+    "Lanternward watchmen",
+    "dockside smugglers",
+    "old lighthouse-order remnants",
+    "guild salvage interests"
+   ],
+   "resources": [
+    "harbor claims and salvage records",
+    "locked map cages",
+    "Odile\u2019s private catalog room",
+    "culvert routes",
+    "Council seals and filing warrants"
+   ],
+   "atmosphere": "Bureaucratic, haunted, damp, and claustrophobic, with salt fog muffling bells and the smell of lamp oil, wet paper, rusted chain, mildew, and cold ashes.",
+   "nearby_landmarks": [
+    "the lighthouse quay",
+    "the outer breakwater",
+    "the old seawall",
+    "pre-dawn fish market",
+    "Gullwise mooring"
+   ]
+  },
+  "place_type": "fixed_location",
+  "inhabitants": [
+   "Magistra Odile Sorrenwick",
+   "exhausted junior clerks",
+   "bribed harbor watchmen",
+   "night smugglers",
+   "council record-keepers",
+   "rats and tide-crabs"
+  ],
+  "orrery_tags": null,
+  "current_status": "Before dawn, cold fog and harbor drizzle press against the building as the rising tide forces black water up through floor drains. Magistra Odile Sorrenwick has summoned Brena Tideloft to retrieve a sealed bell-casket, but the archive doors stand opened from within and wet footprints lead toward the forbidden lower stacks."
+ },
+ "base_timestamp": null,
+ "target_slot": 5
+}

--- a/tests/test_commit_handler_sync.py
+++ b/tests/test_commit_handler_sync.py
@@ -140,3 +140,31 @@ def test_sync_faction_state_updates_do_not_write_legacy_activity():
     )
 
     assert all("UPDATE factions" not in sql for sql in conn.cursor_instance.statements)
+
+
+def test_sync_location_state_updates_map_conditions_to_status_column():
+    """LocationStateUpdate.current_conditions persists to places.current_status.
+
+    M9 gate finding: the handler previously read a nonexistent
+    ``current_status`` attribute and crashed every commit that carried a
+    location state update.
+    """
+
+    from nexus.agents.logon.apex_schema import LocationStateUpdate
+
+    conn = RecordingStateUpdateConnection()
+
+    apply_state_updates_sync(
+        conn,
+        StateUpdates(
+            locations=[
+                LocationStateUpdate(
+                    place_id=4,
+                    current_conditions="Flooded to the second stair",
+                )
+            ]
+        ),
+    )
+
+    statements = conn.cursor_instance.statements
+    assert any("UPDATE places SET current_status" in sql for sql in statements)

--- a/tests/test_golden_path_live.py
+++ b/tests/test_golden_path_live.py
@@ -38,9 +38,10 @@ Stages (ordered; each test asserts one category against the shared run):
 Gating: NEXUS_RUN_LIVE_LLM=1, NEXUS_RUN_POSTGRES=1, and the destructive
 opt-in NEXUS_GOLDEN_PATH_E2E=1.
 
-Cost and wall clock: roughly 30-60 frontier calls (transition ~4-7 min;
-each turn ~2-4 min; plus embeddings); expect 25-50 minutes total at
-2026-06 gpt-5.5 latencies. Budget accordingly before wiring into CI.
+Cost and wall clock: measured green run (2026-06-11, gpt-5.5 +
+@anthropic.default narration): 20 frontier calls, 14m30s end to end.
+Budget ~20-35 calls / 15-30 minutes; the adaptive tail adds turns only
+when promotion/bleed/maturation lag. Budget accordingly before CI.
 
 Cleanup: the API server subprocess is terminated on teardown. Slot 5 is
 deliberately left with the run's data for post-mortem inspection; rerun

--- a/tests/test_golden_path_live.py
+++ b/tests/test_golden_path_live.py
@@ -562,12 +562,26 @@ def test_stage7_runtime_maturation(golden_path: GoldenPathRun) -> None:
 
 
 def test_stage8_server_log_clean(golden_path: GoldenPathRun) -> None:
-    """The full run produced no tracebacks and no ERROR lines."""
+    """The full run produced no tracebacks and no ERROR lines.
+
+    The level matcher is coupled to the standard ``- LEVEL -`` log format,
+    so a format-detection canary guards against the assertion silently
+    becoming a no-op if the logging format ever changes.
+    """
 
     assert golden_path.log_path is not None
     log_text = golden_path.log_path.read_text()
+    assert " - INFO - " in log_text, (
+        "Log format canary failed: no ' - INFO - ' lines found, so the "
+        "ERROR matcher below cannot be trusted. Update both matchers to "
+        "the current logging format."
+    )
     assert "Traceback (most recent call last)" not in log_text
-    error_lines = [line for line in log_text.splitlines() if " - ERROR - " in line]
+    error_lines = [
+        line
+        for line in log_text.splitlines()
+        if " - ERROR - " in line or " - CRITICAL - " in line
+    ]
     assert not error_lines, "Server log contains errors:\n" + "\n".join(
         error_lines[:20]
     )

--- a/tests/test_golden_path_live.py
+++ b/tests/test_golden_path_live.py
@@ -1,0 +1,570 @@
+"""Golden-Path Release Gate (M9): one live end-to-end run proves the MVP.
+
+DESTRUCTIVE, EXPENSIVE, SLOW. This is the backend v1.0 release gate: it drops
+and recreates the save_05 database (slot 5, the designated dev slot), boots
+the real API server as a subprocess, runs the wizard -> narrative transition
+with a real Retrograde cold start, then plays live turns through the
+production HTTP surface -- every model call is a real frontier call.
+
+Reduced-path note: the wizard CHAT phases are staged from a canned cache
+captured from a full manual CLI wizard run (the conversational wizard is
+covered by its own live suites); everything from the transition onward --
+trait-input derivation, Retrograde generation/persistence/embedding, the
+bootstrap, and all play turns -- runs live. The companion full ~10-turn
+manual run is documented on the M9 PR.
+
+Stages (ordered; each test asserts one category against the shared run):
+  1. Retrograde cold start fired at the transition (world_events
+     source='retrograde', embedded per-event summary chunks, derived trait
+     inputs, trait-compiler stubs, decision-8 caps, no duplicate entities).
+  2. Live play: scripted turns including one freeform directive, one
+     entity-eliciting input, and one explicit time skip (sunhelm needs accrue
+     on world time; a fresh world's Orrery wakes through them), then
+     adaptive eventful turns until promotion + bleed-offer + maturation have
+     all occurred (bounded by GOLDEN_PATH_MAX_TURNS).
+  3. Chunk persistence + incubator lifecycle (one pending chunk, committed
+     chunks finalized).
+  4. Embedding lifecycle: every locked chunk embedded except the Retrograde
+     prologue anchor (intentionally unembedded) and the newest committed
+     chunk (the undo buffer).
+  5. MEMNON retrieves Retrograde-sourced history for an event-specific query.
+  6. Orrery promotions occurred, narrations landed, and at least one
+     narrated off-screen event was offered to (and surfaced for) a
+     subsequent chunk's generation (Bleed).
+  7. Runtime maturation fired for a Skald-declared entity; its generated
+     history persisted, embedded, and became retrievable.
+  8. Server log scan: no tracebacks, no ERROR lines.
+
+Gating: NEXUS_RUN_LIVE_LLM=1, NEXUS_RUN_POSTGRES=1, and the destructive
+opt-in NEXUS_GOLDEN_PATH_E2E=1.
+
+Cost and wall clock: roughly 30-60 frontier calls (transition ~4-7 min;
+each turn ~2-4 min; plus embeddings); expect 25-50 minutes total at
+2026-06 gpt-5.5 latencies. Budget accordingly before wiring into CI.
+
+Cleanup: the API server subprocess is terminated on teardown. Slot 5 is
+deliberately left with the run's data for post-mortem inspection; rerun
+``python scripts/new_story_setup.py --slot 5 --force`` to reset it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import psycopg2  # type: ignore[import-untyped]
+import pytest
+import requests
+from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
+
+SLOT = 5
+DBNAME = "save_05"
+DSN = f"postgresql://pythagor@localhost:5432/{DBNAME}"
+API = "http://localhost:8002"
+FIXTURE = Path(__file__).parent / "fixtures" / "golden_path_wizard_cache.json"
+
+# Hard ceiling on play turns; the run goes adaptive after the scripted
+# opening if promotion/bleed/maturation have not all occurred yet.
+GOLDEN_PATH_MAX_TURNS = 10
+SCRIPTED_OPENING: List[Dict[str, Any]] = [
+    {"choice": 1},
+    {
+        "user_text": (
+            "Before anything else, I find the nearest bystander who saw what "
+            "happened, ask their name, who they work for, and what they saw "
+            "tonight - everyone in this city has a story, and I want theirs."
+        )
+    },
+    {"choice": 1},
+    {
+        "user_text": (
+            "I disengage and go home the long way. I check on my people, hide "
+            "what I am carrying, and sleep until the next evening tide. I want "
+            "a full day to pass in the world before I act again - everyone in "
+            "this story needs food, water, and rest, and so do I."
+        )
+    },
+]
+ADAPTIVE_INPUT = {"choice": 1}
+
+GENERATION_POLL_SECONDS = 360
+TRANSITION_TIMEOUT_SECONDS = 900
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.live_llm,
+    pytest.mark.requires_postgres,
+    pytest.mark.skipif(
+        os.environ.get("NEXUS_GOLDEN_PATH_E2E") != "1",
+        reason=(
+            "Set NEXUS_GOLDEN_PATH_E2E=1 to run the destructive slot-5 "
+            "golden-path release gate (30-60 live frontier calls)."
+        ),
+    ),
+]
+
+
+def _query(sql: str, params: Any = None) -> List[Dict[str, Any]]:
+    conn = psycopg2.connect(DSN)
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(sql, params)
+            return list(cur.fetchall())
+    finally:
+        conn.close()
+
+
+def _scalar(sql: str, params: Any = None) -> Any:
+    rows = _query(sql, params)
+    return next(iter(rows[0].values())) if rows else None
+
+
+class GoldenPathRun:
+    """Shared state captured by the staged run for the assertion tests."""
+
+    def __init__(self) -> None:
+        self.server: Optional[subprocess.Popen] = None
+        self.log_path: Optional[Path] = None
+        self.transition: Dict[str, Any] = {}
+        self.turns: List[Dict[str, Any]] = []
+        self.turn_seconds: List[float] = []
+        self.prologue_chunk_id: Optional[int] = None
+        self.failures: List[str] = []
+
+
+def _port_free(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        return sock.connect_ex(("127.0.0.1", port)) != 0
+
+
+def _wait_health(timeout: float = 60.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if requests.get(f"{API}/health", timeout=3).ok:
+                return
+        except requests.RequestException:
+            pass
+        time.sleep(1)
+    raise RuntimeError("Stage server-boot: API server never became healthy")
+
+
+def _stage_reset_slot() -> None:
+    from nexus.api.db_pool import close_pool
+    from nexus.api.save_slots import upsert_slot
+    from nexus.api.new_story_cache import write_cache
+    from scripts.new_story_setup import create_slot_schema_only
+
+    close_pool(DBNAME)
+    create_slot_schema_only(SLOT, source_db="NEXUS_template", force=True)
+
+    cache = json.loads(FIXTURE.read_text())
+    write_cache(
+        thread_id=cache["thread_id"],
+        setting_draft=cache["setting_draft"],
+        character_draft=cache["character_draft"],
+        selected_seed=cache["selected_seed"],
+        layer_draft=cache["layer_draft"],
+        zone_draft=cache["zone_draft"],
+        initial_location=cache["initial_location"],
+        target_slot=SLOT,
+        dbname=DBNAME,
+    )
+    # Fresh slots default to the mock TEST model; a real wizard run persists
+    # the real model in start_setup. Mirror that so the transition engages
+    # Retrograde + trait derivation with real frontier calls.
+    from nexus.api.config_utils import get_new_story_model
+
+    upsert_slot(SLOT, model=get_new_story_model(), dbname=DBNAME)
+    close_pool(DBNAME)
+
+
+def _stage_run_transition(run: GoldenPathRun) -> None:
+    response = requests.post(
+        f"{API}/api/story/new/transition",
+        json={"slot": SLOT},
+        timeout=TRANSITION_TIMEOUT_SECONDS,
+    )
+    if not response.ok:
+        raise RuntimeError(f"Stage transition: {response.status_code} {response.text}")
+    run.transition = response.json()
+
+
+def _poll_generation(session_id: str) -> None:
+    deadline = time.monotonic() + GENERATION_POLL_SECONDS
+    while time.monotonic() < deadline:
+        status = requests.get(
+            f"{API}/api/narrative/status/{session_id}",
+            params={"slot": SLOT},
+            timeout=30,
+        )
+        if status.ok:
+            state = status.json().get("status")
+            if state in {
+                "complete",
+                "completed",
+                "provisional",
+                "approved",
+                "committed",
+            }:
+                return
+            if state == "error":
+                raise RuntimeError(
+                    f"Stage play: generation session {session_id} errored: "
+                    f"{status.json()}"
+                )
+        time.sleep(2)
+    raise RuntimeError(f"Stage play: generation session {session_id} timed out")
+
+
+def _continue_turn(payload: Dict[str, Any]) -> Dict[str, Any]:
+    body: Dict[str, Any] = {"slot": SLOT, "user_text": payload.get("user_text", "")}
+    if payload.get("choice") is not None:
+        body["choice"] = payload["choice"]
+    response = requests.post(f"{API}/api/narrative/continue", json=body, timeout=120)
+    if not response.ok:
+        raise RuntimeError(
+            f"Stage play: continue failed {response.status_code}: {response.text}"
+        )
+    data = response.json()
+    session_id = data.get("session_id")
+    if session_id:
+        _poll_generation(session_id)
+    return data
+
+
+def _goal_state() -> Dict[str, bool]:
+    promoted = int(
+        _scalar(
+            "SELECT count(*) FROM orrery_resolutions "
+            "WHERE promotion_status = 'promoted'"
+        )
+        or 0
+    )
+    narrated = int(_scalar("SELECT count(*) FROM offscreen_narrations") or 0)
+    offered = int(
+        _scalar("SELECT count(*) FROM orrery_resolutions WHERE offer_count > 0") or 0
+    )
+    matured = int(
+        _scalar(
+            "SELECT count(*) FROM orrery_maturation_jobs "
+            "WHERE state::text = 'succeeded'"
+        )
+        or 0
+    )
+    return {
+        "promotion": promoted > 0,
+        "narration": narrated > 0,
+        "bleed_offer": offered > 0,
+        "maturation": matured > 0,
+    }
+
+
+def _stage_play_turns(run: GoldenPathRun) -> None:
+    # Bootstrap chunk 1 of play.
+    run.turns.append({"input": "bootstrap"})
+    started = time.monotonic()
+    _continue_turn({"user_text": ""})
+    run.turn_seconds.append(time.monotonic() - started)
+
+    scripted = list(SCRIPTED_OPENING)
+    for turn_index in range(GOLDEN_PATH_MAX_TURNS):
+        payload = scripted.pop(0) if scripted else dict(ADAPTIVE_INPUT)
+        run.turns.append({"input": payload})
+        started = time.monotonic()
+        _continue_turn(payload)
+        run.turn_seconds.append(time.monotonic() - started)
+        if not scripted and all(_goal_state().values()):
+            break
+
+    # Let detached work settle: the maturation drain and the embedding
+    # catch-up both run after the last commit.
+    deadline = time.monotonic() + 300
+    while time.monotonic() < deadline:
+        goals = _goal_state()
+        pending_jobs = int(
+            _scalar(
+                "SELECT count(*) FROM orrery_maturation_jobs "
+                "WHERE state::text IN ('pending', 'leased')"
+            )
+            or 0
+        )
+        if all(goals.values()) and pending_jobs == 0:
+            break
+        time.sleep(5)
+
+
+@pytest.fixture(scope="module")
+def golden_path(tmp_path_factory: pytest.TempPathFactory) -> Any:
+    """Execute the staged golden-path run once; yield shared evidence."""
+
+    if not _port_free(8002):
+        raise RuntimeError(
+            "Port 8002 is occupied; stop the running NEXUS API server before "
+            "the golden-path gate (it boots its own instance)."
+        )
+
+    from nexus.config import load_settings
+
+    settings = load_settings()
+    assert settings.orrery is not None and settings.orrery.enabled
+    assert settings.orrery.retrograde.wizard.enabled
+    assert settings.orrery.retrograde.maturation.enabled
+
+    run = GoldenPathRun()
+    _stage_reset_slot()
+
+    run.log_path = tmp_path_factory.mktemp("golden_path") / "server.log"
+    log_handle = run.log_path.open("w")
+    run.server = subprocess.Popen(
+        [sys.executable, "-m", "nexus.api.narrative"],
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
+        env=os.environ.copy(),
+    )
+    try:
+        _wait_health()
+        _stage_run_transition(run)
+        run.prologue_chunk_id = _scalar(
+            "SELECT id FROM narrative_chunks "
+            "WHERE authorial_directives @> %s::jsonb",
+            (json.dumps(["orrery:retrograde_prologue_anchor"]),),
+        )
+        _stage_play_turns(run)
+        yield run
+    finally:
+        if run.server is not None:
+            run.server.terminate()
+            try:
+                run.server.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                run.server.kill()
+        log_handle.close()
+
+
+def test_stage1_retrograde_cold_start(golden_path: GoldenPathRun) -> None:
+    """The transition ran Retrograde with derived trait inputs and stubs."""
+
+    retro = golden_path.transition.get("retrograde") or {}
+    assert retro.get("enabled") is True, retro
+
+    trait_inputs = golden_path.transition.get("trait_inputs") or {}
+    assert trait_inputs.get("derived") is True, trait_inputs
+    assert "patron" in trait_inputs.get("traits", []), trait_inputs
+    assert "dependents" in trait_inputs.get("traits", []), trait_inputs
+
+    events = _query(
+        "SELECT id, payload ->> 'retrograde_summary_chunk_id' AS cid "
+        "FROM world_events WHERE source = 'retrograde'"
+    )
+    assert events, "No retrograde world_events were persisted"
+    assert all(row["cid"] is not None for row in events)
+
+    # Trait-compiler stubs exist for the fixture's patron and dependents.
+    trait_stubs = _query(
+        "SELECT name FROM characters "
+        "WHERE extra_data ->> 'stub_kind' = 'trait_compiler_target_ref'"
+    )
+    assert len(trait_stubs) >= 3, trait_stubs
+
+    # Decision-8 cap: retrograde expansion stubs stay within configuration.
+    from nexus.config import load_settings
+
+    settings = load_settings()
+    assert settings.orrery is not None
+    cap = settings.orrery.retrograde.wizard.max_new_entity_stubs
+    expansion_stubs = _scalar(
+        "SELECT count(*) FROM ("
+        "  SELECT name FROM characters "
+        "  WHERE extra_data ->> 'stub_kind' = 'retrograde_expansion_ref'"
+        "  UNION ALL SELECT name FROM places "
+        "  WHERE extra_data ->> 'stub_kind' = 'retrograde_expansion_ref'"
+        "  UNION ALL SELECT name FROM factions "
+        "  WHERE extra_data ->> 'stub_kind' = 'retrograde_expansion_ref'"
+        ") stubs"
+    )
+    assert int(expansion_stubs) <= cap
+
+    # The duplicate-stub regression: one canonical row per character name.
+    duplicates = _query(
+        "SELECT lower(name) AS name, count(*) AS n FROM characters "
+        "GROUP BY lower(name) HAVING count(*) > 1"
+    )
+    assert not duplicates, f"Duplicate canonical characters: {duplicates}"
+
+
+def test_stage2_turns_played(golden_path: GoldenPathRun) -> None:
+    """The scripted opening plus adaptive turns all completed."""
+
+    assert len(golden_path.turns) >= len(SCRIPTED_OPENING) + 1
+    assert all(seconds > 0 for seconds in golden_path.turn_seconds)
+
+
+def test_stage3_chunk_persistence_and_incubator(golden_path: GoldenPathRun) -> None:
+    """Committed chunks exist and exactly one provisional chunk is pending."""
+
+    committed = int(_scalar("SELECT count(*) FROM narrative_chunks"))
+    summary_chunks = int(
+        _scalar(
+            "SELECT count(*) FROM narrative_chunks "
+            "WHERE authorial_directives @> %s::jsonb",
+            (json.dumps(["orrery:retrograde_event_summary"]),),
+        )
+    )
+    played = committed - summary_chunks - 1  # minus prologue anchor
+    assert played >= len(golden_path.turns) - 1, (
+        f"Expected at least {len(golden_path.turns) - 1} committed played "
+        f"chunks, found {played} (committed={committed}, "
+        f"summaries={summary_chunks})"
+    )
+    pending = _query("SELECT chunk_id FROM incubator")
+    assert len(pending) == 1, pending
+
+
+def test_stage4_embedding_lifecycle(golden_path: GoldenPathRun) -> None:
+    """Locked == embedded; only the prologue and the undo buffer stay raw.
+
+    The undo buffer is the newest committed played chunk: it stays mutable
+    (and unembedded) until the next turn locks it. The Retrograde prologue
+    anchor is intentionally never embedded. Everything else must embed --
+    including played chunks separated from their successor by interleaved
+    summary chunks (the M9 id-arithmetic regression).
+    """
+
+    deadline = time.monotonic() + 180
+    pending: List[int] = []
+    while time.monotonic() < deadline:
+        unembedded = [
+            row["id"]
+            for row in _query(
+                "SELECT id FROM narrative_chunks "
+                "WHERE embedding_generated_at IS NULL ORDER BY id"
+            )
+        ]
+        pending = [
+            chunk_id
+            for chunk_id in unembedded
+            if chunk_id != golden_path.prologue_chunk_id
+        ]
+        if len(pending) <= 1:
+            break
+        time.sleep(5)
+    assert len(pending) <= 1, (
+        f"Locked chunks missing embeddings: {pending[:-1]} "
+        "(embedded == ironman is the contract; only the newest committed "
+        "chunk may remain unembedded)"
+    )
+
+
+def test_stage5_retrograde_history_retrievable(golden_path: GoldenPathRun) -> None:
+    """MEMNON returns Retrograde history for an event-specific query."""
+
+    from nexus.agents.memnon.memnon import MEMNON
+
+    events = _query(
+        "SELECT payload ->> 'summary' AS summary, "
+        "payload ->> 'retrograde_summary_chunk_id' AS cid "
+        "FROM world_events WHERE source = 'retrograde' "
+        "AND payload ->> 'retrograde_summary_chunk_id' IS NOT NULL"
+    )
+    target = max(events, key=lambda row: len(row["summary"] or ""))
+    memnon = MEMNON(interface=None, db_url=DSN)
+    search = memnon.query_memory(query=target["summary"], k=10, use_hybrid=True)
+    returned = {
+        int(chunk.get("chunk_id") or chunk["id"]) for chunk in search["results"]
+    }
+    assert int(target["cid"]) in returned, (
+        f"MEMNON missed retrograde summary chunk {target['cid']}; "
+        f"returned={sorted(returned)}"
+    )
+
+
+def test_stage6_orrery_promotion_narration_bleed(golden_path: GoldenPathRun) -> None:
+    """Off-screen resolutions promoted, narrated, and offered as Bleed."""
+
+    promoted = _query(
+        "SELECT id, template_id, first_surfaced_chunk_id, offer_count "
+        "FROM orrery_resolutions WHERE promotion_status = 'promoted'"
+    )
+    assert promoted, "No Orrery resolution promoted during the run"
+
+    narrations = _query("SELECT resolution_id, text FROM offscreen_narrations")
+    assert narrations, "Promotion occurred but no narration landed"
+
+    offered = [row for row in promoted if (row["offer_count"] or 0) > 0]
+    assert offered, "No narrated resolution was offered to the Storyteller"
+
+    # Bleed-into-prose heuristic: a committed chunk at or after the first
+    # surfacing references the offered resolution's actor by name. (The
+    # definitive prose-weave reading is part of the manual gate evidence.)
+    surfaced = [row for row in offered if row["first_surfaced_chunk_id"]]
+    assert surfaced, "Offered resolutions never recorded a surfacing chunk"
+    woven = _query(
+        """
+        SELECT r.id
+        FROM orrery_resolutions r
+        JOIN entity_names_v en ON en.id = r.actor_entity_id
+        JOIN narrative_chunks nc ON nc.id >= r.first_surfaced_chunk_id
+        WHERE r.offer_count > 0
+          AND position(
+              en.name IN COALESCE(nc.raw_text, nc.storyteller_text, '')
+          ) > 0
+        LIMIT 1
+        """
+    )
+    assert woven, "No offered off-screen actor surfaced in subsequent prose"
+
+
+def test_stage7_runtime_maturation(golden_path: GoldenPathRun) -> None:
+    """A Skald-declared entity matured and its history is retrievable."""
+
+    jobs = _query(
+        "SELECT entity_name, state::text AS state, result_manifest "
+        "FROM orrery_maturation_jobs"
+    )
+    succeeded = [job for job in jobs if job["state"] == "succeeded"]
+    assert succeeded, f"No maturation job succeeded; jobs={jobs}"
+
+    job = succeeded[0]
+    manifest = job["result_manifest"]
+    assert manifest["persisted"] is True
+    event_ids = list(manifest["world_event_ids"].values())
+    assert event_ids, "Maturation persisted no world events"
+    count = _scalar(
+        "SELECT count(*) FROM world_events "
+        "WHERE id = ANY(%s) AND source = 'retrograde'::event_source_kind",
+        (event_ids,),
+    )
+    assert int(count) == len(event_ids)
+
+    from nexus.agents.memnon.memnon import MEMNON
+
+    pending = manifest.get("embedding_pending_chunk_ids") or []
+    assert pending, "Maturation produced no summary chunks"
+    memnon = MEMNON(interface=None, db_url=DSN)
+    search = memnon.query_memory(query=job["entity_name"], k=15, use_hybrid=True)
+    returned = {
+        int(chunk.get("chunk_id") or chunk["id"]) for chunk in search["results"]
+    }
+    assert returned & set(map(int, pending)), (
+        f"MEMNON did not retrieve matured history for {job['entity_name']}: "
+        f"chunks={pending} returned={sorted(returned)}"
+    )
+
+
+def test_stage8_server_log_clean(golden_path: GoldenPathRun) -> None:
+    """The full run produced no tracebacks and no ERROR lines."""
+
+    assert golden_path.log_path is not None
+    log_text = golden_path.log_path.read_text()
+    assert "Traceback (most recent call last)" not in log_text
+    error_lines = [line for line in log_text.splitlines() if " - ERROR - " in line]
+    assert not error_lines, "Server log contains errors:\n" + "\n".join(
+        error_lines[:20]
+    )

--- a/tests/test_golden_path_live.py
+++ b/tests/test_golden_path_live.py
@@ -373,23 +373,17 @@ def test_stage1_retrograde_cold_start(golden_path: GoldenPathRun) -> None:
     )
     assert len(trait_stubs) >= 3, trait_stubs
 
-    # Decision-8 cap: retrograde expansion stubs stay within configuration.
+    # Decision-8 cap: the wizard-time expansion stayed within its stub
+    # budget. Assert the transition's own counter -- runtime maturations
+    # later in the run legitimately add their own expansion stubs, so an
+    # end-of-run table count would conflate the two.
     from nexus.config import load_settings
 
     settings = load_settings()
     assert settings.orrery is not None
     cap = settings.orrery.retrograde.wizard.max_new_entity_stubs
-    expansion_stubs = _scalar(
-        "SELECT count(*) FROM ("
-        "  SELECT name FROM characters "
-        "  WHERE extra_data ->> 'stub_kind' = 'retrograde_expansion_ref'"
-        "  UNION ALL SELECT name FROM places "
-        "  WHERE extra_data ->> 'stub_kind' = 'retrograde_expansion_ref'"
-        "  UNION ALL SELECT name FROM factions "
-        "  WHERE extra_data ->> 'stub_kind' = 'retrograde_expansion_ref'"
-        ") stubs"
-    )
-    assert int(expansion_stubs) <= cap
+    counters = retro.get("counters") or {}
+    assert int(counters.get("entity_stubs_inserted", 0)) <= cap, counters
 
     # The duplicate-stub regression: one canonical row per character name.
     duplicates = _query(

--- a/tests/test_golden_path_live.py
+++ b/tests/test_golden_path_live.py
@@ -199,11 +199,19 @@ def _stage_run_transition(run: GoldenPathRun) -> None:
 def _poll_generation(session_id: str) -> None:
     deadline = time.monotonic() + GENERATION_POLL_SECONDS
     while time.monotonic() < deadline:
-        status = requests.get(
-            f"{API}/api/narrative/status/{session_id}",
-            params={"slot": SLOT},
-            timeout=30,
-        )
+        try:
+            status = requests.get(
+                f"{API}/api/narrative/status/{session_id}",
+                params={"slot": SLOT},
+                timeout=60,
+            )
+        except requests.RequestException:
+            # The single-worker server shares its host with in-process
+            # embedding inference; a slow status read is expected under
+            # load. The status GET is idempotent -- keep polling until the
+            # overall deadline.
+            time.sleep(2)
+            continue
         if status.ok:
             state = status.json().get("status")
             if state in {

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -8,6 +8,7 @@ from nexus.agents.lore.utils.turn_context import TurnContext
 from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
 from nexus.agents.orrery.resolver import (
     LOCATION_CLASS_TAG_CATEGORIES,
+    OrreryResolutionDraft,
     _need_pressure_stub,
     compose_actor_target_bindings,
     hydrate_world_state,
@@ -2118,3 +2119,43 @@ def test_resolve_dry_run_produces_multi_slot_resolution() -> None:
     )
     assert protect_kin_drafts[0].bindings == {"actor": 1, "target": 2}
     assert proposal.pressure_count == 0
+
+
+def test_resolution_drafts_carry_binding_names_for_skald() -> None:
+    """Imminent-activity drafts name their actors and render their stubs.
+
+    M9 gate finding: Skald received bare entity ids and misattributed an
+    off-screen sleep resolution to the on-screen protagonist.
+    """
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            world_time=datetime(2073, 10, 31, 23, tzinfo=timezone.utc),
+            entity_name_rows=[{"id": 1, "name": "Brother Edran Vell"}],
+            need_debt_rows=[
+                {
+                    "character_entity_id": 1,
+                    "need_type": "sleep",
+                    "debt_score": 10,
+                    "last_evaluated_at": datetime(
+                        2073, 10, 31, 23, tzinfo=timezone.utc
+                    ),
+                }
+            ],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    draft = proposal.resolutions[0]
+    assert draft.binding_names == {"actor": "Brother Edran Vell"}
+    assert "{actor}" not in draft.narrative_stub
+    assert "Brother Edran Vell" in draft.narrative_stub
+
+    # The Skald-facing dict and the incubator round-trip both keep names.
+    data = draft.to_dict()
+    assert data["binding_names"] == {"actor": "Brother Edran Vell"}
+    rehydrated = OrreryResolutionDraft.from_dict(data)
+    assert rehydrated.binding_names == {"actor": "Brother Edran Vell"}

--- a/tests/test_orrery/test_retrograde_packet.py
+++ b/tests/test_orrery/test_retrograde_packet.py
@@ -256,3 +256,85 @@ def test_retrograde_weird_raw_override_stays_in_dev_range() -> None:
             setting={"genre": "cyberpunk"},
             weird_raw=999,
         )
+
+
+def test_trait_compile_inputs_become_first_class_core_entities() -> None:
+    """Trait-declared targets join core entities so Skald reuses their names.
+
+    Without this, the trait compiler and Retrograde expansion mint separate
+    rows for the same person under different name forms (the M9 golden-path
+    duplicate-stub bug).
+    """
+
+    trait_compile_inputs = {
+        "patron": {
+            "name": "Magistra Odile Sorrenwick",
+            "functions": ["sponsors", "protects"],
+            "history": "Quiet Council sponsorship in exchange for retrievals.",
+        },
+        "dependents": {
+            "targets": [
+                {"name": "Pim Tideloft", "dynamic": "Kid brother, too clever."},
+                {"name": "Nan Cesska"},
+            ]
+        },
+        "resources": {"level": "comfortable"},
+    }
+
+    packet = build_retrograde_dry_run_packet(
+        slot=5,
+        dbname="save_05",
+        cache=FakeRetrogradeCache(),
+        vocabulary=enumerate_seed_eligible_vocabulary(),
+        settings=load_settings(),
+        trait_compile_inputs=trait_compile_inputs,
+    )
+
+    core = packet["candidate_scaffolds"]["core_entities"]
+    by_name = {card["name"]: card for card in core if card.get("name")}
+
+    patron_card = by_name["Magistra Odile Sorrenwick"]
+    assert patron_card["kind"] == "character"
+    assert patron_card["role"] == "trait_target:patron"
+    assert "exactly this name" in patron_card["details"]["ref_rule"]
+
+    assert by_name["Pim Tideloft"]["role"] == "trait_target:dependent"
+    assert by_name["Nan Cesska"]["role"] == "trait_target:dependent"
+
+    # The seed prompt section carries the same cards (expansion reads the
+    # first four prompt sections, so trait targets reach both Skald calls).
+    sections = {
+        section["heading"]: section
+        for section in packet["seed_generation_request"]["prompt_sections"]
+    }
+    core_section_names = {
+        item.get("name") for item in sections["Core entities"]["items"]
+    }
+    assert {"Magistra Odile Sorrenwick", "Pim Tideloft", "Nan Cesska"} <= (
+        core_section_names
+    )
+
+    # Resources is protagonist-level state, never a separate entity card.
+    assert all(
+        not str(card.get("role", "")).startswith("trait_target:resources")
+        for card in core
+    )
+
+
+def test_packet_without_trait_inputs_keeps_legacy_core_entities() -> None:
+    """No trait inputs -> exactly the four legacy core entity cards."""
+
+    packet = build_retrograde_dry_run_packet(
+        slot=5,
+        dbname="save_05",
+        cache=FakeRetrogradeCache(),
+        vocabulary=enumerate_seed_eligible_vocabulary(),
+        settings=load_settings(),
+    )
+    roles = [card["role"] for card in packet["candidate_scaffolds"]["core_entities"]]
+    assert roles == [
+        "protagonist",
+        "starting_location",
+        "starting_zone",
+        "starting_layer",
+    ]

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -1,0 +1,140 @@
+"""Offline tests for generation-time storyteller Orrery tag validation."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Tuple
+
+from nexus.agents.logon.apex_schema import (
+    CharacterReference,
+    CharacterStateUpdate,
+    LocationStateUpdate,
+    NewCharacter,
+    ReferencedEntities,
+    ReferenceType,
+    StateUpdates,
+)
+from nexus.agents.logon.orrery_tag_validation import (
+    build_storyteller_tag_validator,
+    collect_orrery_tag_issues,
+)
+from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
+
+
+class FakeRegistryCursor:
+    """Cursor stand-in serving a tiny in-memory tag registry."""
+
+    def __init__(self) -> None:
+        # tag -> (id, category, is_ephemeral, reapplication_policy)
+        self.tags = {
+            "human": (1, "bodyform", False, None),
+            "perceptive": (2, "disposition", False, None),
+            "haven": (3, "place_class", False, None),
+        }
+        self.categories_by_kind = {
+            "character": {"bodyform", "disposition"},
+            "place": {"place_class"},
+            "faction": {"ideology"},
+        }
+        self._result: List[Tuple[Any, ...]] = []
+        self._one: Optional[Tuple[Any, ...]] = None
+
+    def execute(self, sql: str, params: Tuple[Any, ...] = ()) -> None:
+        if "tag_category_registry" in sql:
+            kind = params[0]
+            self._result = [
+                (category,) for category in sorted(self.categories_by_kind[kind])
+            ]
+            self._one = None
+        elif "FROM tags" in sql:
+            row = self.tags.get(params[0])
+            self._one = row
+            self._result = [row] if row else []
+        else:
+            raise AssertionError(f"Unexpected query: {sql}")
+
+    def fetchall(self) -> List[Tuple[Any, ...]]:
+        return self._result
+
+    def fetchone(self) -> Optional[Tuple[Any, ...]]:
+        return self._one
+
+
+def _response(**kwargs: Any) -> Any:
+    class _FakeResponse:
+        referenced_entities = kwargs.get("referenced_entities")
+        state_updates = kwargs.get("state_updates")
+
+    return _FakeResponse()
+
+
+def test_valid_bestowals_produce_no_issues() -> None:
+    response = _response(
+        referenced_entities=ReferencedEntities(
+            characters=[
+                CharacterReference(
+                    reference_type=ReferenceType.PRESENT,
+                    new_character=NewCharacter(
+                        name="Joryn Peale",
+                        summary="A frightened junior copyist.",
+                        orrery_tags=OrreryTagBestowal(
+                            applied_tags=["human", "perceptive"]
+                        ),
+                    ),
+                )
+            ]
+        ),
+    )
+    assert collect_orrery_tag_issues(response, FakeRegistryCursor()) == []
+
+
+def test_composite_tag_names_are_flagged_with_paths() -> None:
+    response = _response(
+        state_updates=StateUpdates(
+            characters=[
+                CharacterStateUpdate(
+                    character_id=1,
+                    character_name="Brena Tideloft",
+                    orrery_tags=OrreryTagBestowal(
+                        applied_tags=["role.resources:comfortable"]
+                    ),
+                )
+            ],
+            locations=[
+                LocationStateUpdate(
+                    place_id=4,
+                    orrery_tags=OrreryTagBestowal(
+                        applied_tags=["place_affordance:neutral_ground"]
+                    ),
+                )
+            ],
+        ),
+    )
+    issues = collect_orrery_tag_issues(response, FakeRegistryCursor())
+    assert len(issues) == 2
+    assert any(issue.startswith("state_updates.characters[0]") for issue in issues)
+    assert any(issue.startswith("state_updates.locations[0]") for issue in issues)
+    assert all("Unknown or deprecated" in issue for issue in issues)
+
+
+def test_kind_incompatible_tags_are_flagged() -> None:
+    # 'haven' is a place tag; bestowing it on a character must fail.
+    response = _response(
+        state_updates=StateUpdates(
+            characters=[
+                CharacterStateUpdate(
+                    character_id=1,
+                    character_name="Brena Tideloft",
+                    orrery_tags=OrreryTagBestowal(applied_tags=["haven"]),
+                )
+            ],
+        ),
+    )
+    issues = collect_orrery_tag_issues(response, FakeRegistryCursor())
+    assert len(issues) == 1
+    assert "haven" in issues[0]
+
+
+def test_validator_skipped_without_slot_database() -> None:
+    assert build_storyteller_tag_validator(None) is None
+    assert build_storyteller_tag_validator("") is None
+    assert build_storyteller_tag_validator("save_05") is not None

--- a/tests/test_summary_triggers.py
+++ b/tests/test_summary_triggers.py
@@ -29,12 +29,18 @@ def test_plan_summary_tasks():
 class _FakeDB:
     episode_summaries: Dict[str, bool]
     season_summaries: Dict[int, bool]
+    empty_episodes: Optional[List[str]] = None
 
     def episode_summary_exists(self, season: int, episode: int) -> bool:
         return self.episode_summaries.get(f"{season}-{episode}", False)
 
     def season_summary_exists(self, season: int) -> bool:
         return self.season_summaries.get(season, False)
+
+    def get_episode_chunk_span(self, season: int, episode: int):
+        if self.empty_episodes and f"{season}-{episode}" in self.empty_episodes:
+            return None
+        return (1, 2)
 
 
 @dataclass
@@ -108,3 +114,27 @@ def test_coalesce_models_resolves_apex_default_when_constants_are_none():
     models = _coalesce_models(None)
     assert models, "model candidate list must never be empty"
     assert all(isinstance(model, str) and model for model in models)
+
+
+def test_schedule_summary_generation_skips_chunkless_episodes():
+    """Episodes with no chunks are skipped instead of erroring.
+
+    M9 gate finding: the Storyteller opened play at S01E02, the bootstrap
+    commit scheduled a summary for S01E01, and the summarizer errored on an
+    episode that holds zero chunks.
+    """
+
+    recorder_calls: List[str] = []
+
+    def generator_factory(**kwargs):
+        return _RecorderGenerator(calls=recorder_calls, **kwargs)
+
+    schedule_summary_generation(
+        [SummaryTask(kind="episode", season=1, episode=1)],
+        model_candidates=["gpt-test"],
+        run_in_thread=False,
+        db_manager_factory=lambda: _FakeDB({}, {}, empty_episodes=["1-1"]),
+        generator_cls=generator_factory,
+    )
+
+    assert recorder_calls == []

--- a/tests/test_summary_triggers.py
+++ b/tests/test_summary_triggers.py
@@ -64,7 +64,9 @@ class _RecorderGenerator:
         (False, True, ["episode-5-1-gpt-5.1"]),  # skip season summary if present
     ],
 )
-def test_schedule_summary_generation_skips_existing(existing_episode, existing_season, expected_calls):
+def test_schedule_summary_generation_skips_existing(
+    existing_episode, existing_season, expected_calls
+):
     recorder_calls: List[str] = []
 
     def db_factory() -> _FakeDB:
@@ -91,3 +93,18 @@ def test_schedule_summary_generation_skips_existing(existing_episode, existing_s
     )
 
     assert recorder_calls == expected_calls
+
+
+def test_coalesce_models_resolves_apex_default_when_constants_are_none():
+    """Empty candidates resolve to the live apex model, never an empty list.
+
+    M9 gate finding: scripts/summarize_narrative resolves its module
+    constants at argparse time (both None on import), so API-triggered
+    episode summaries ran with zero model candidates and always failed.
+    """
+
+    from nexus.api.summary_triggers import _coalesce_models
+
+    models = _coalesce_models(None)
+    assert models, "model candidate list must never be empty"
+    assert all(isinstance(model, str) and model for model in models)

--- a/tests/test_trait_input_derivation.py
+++ b/tests/test_trait_input_derivation.py
@@ -1,0 +1,210 @@
+"""Offline tests for transition-time trait input derivation (pure functions).
+
+The live structured-output call is exercised by the golden-path release gate
+(``tests/test_golden_path_live.py``); these tests cover the deterministic
+validator and prompt renderer only.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from nexus.api.new_story_schemas import CharacterSheet, CharacterTrait, SettingCard
+from nexus.api.trait_compiler_schemas import (
+    DependentsTraitInput,
+    DependentTargetInput,
+    DomainTraitInput,
+    ObligationsTraitInput,
+    ObligationTargetInput,
+    PatronTraitInput,
+    RelationshipTargetInput,
+    RelationshipTraitInput,
+    SingleEntityTraitInput,
+    StatusTraitInput,
+    TraitCompileInputs,
+)
+from nexus.api.trait_input_derivation import (
+    derived_input_issues,
+    render_trait_input_prompt,
+    selected_canonical_traits,
+)
+
+
+def _character(trait_names: List[str]) -> CharacterSheet:
+    traits = [
+        CharacterTrait(name=name, description=f"{name} description for testing")
+        for name in trait_names
+    ]
+    return CharacterSheet(
+        name="Test Protagonist",
+        summary="A test character summary long enough to validate.",
+        appearance="A test appearance description long enough to validate.",
+        background=(
+            "A test background long enough to satisfy the minimum length "
+            "constraint on the character sheet."
+        ),
+        personality="Cautious, wry, loyal to a fault.",
+        wildcard_name="Echo Fragment",
+        wildcard_description="A memory that is not theirs.",
+        trait_1=traits[0],
+        trait_2=traits[1],
+        trait_3=traits[2],
+    )
+
+
+def _setting() -> SettingCard:
+    return SettingCard(
+        genre="cyberpunk",
+        world_name="Test World",
+        time_period="2120s",
+        tech_level="near_future",
+        political_structure="Corporate city-states",
+        major_conflict="Syndicates against the grid communes",
+        themes=["memory", "debt"],
+        description=(
+            "A coastal megacity where corporate enclaves float above flooded "
+            "districts and everyone owes someone something."
+        ),
+        cultural_notes="Debt is social currency; names are collateral.",
+        diegetic_artifact=(
+            "A laminated transit token stamped with a debt-ledger glyph, "
+            "carried as proof of standing."
+        ),
+    )
+
+
+def test_selected_canonical_traits_maps_reputation_to_fame() -> None:
+    character = _character(["patron", "reputation", "dependents"])
+    assert selected_canonical_traits(character) == ["patron", "fame", "dependents"]
+
+
+def test_valid_inputs_produce_no_issues() -> None:
+    inputs = TraitCompileInputs(
+        patron=PatronTraitInput(
+            name="Doctor Imari Voss", functions=["mentors", "protects"]
+        ),
+        dependents=DependentsTraitInput(
+            targets=[DependentTargetInput(name="Juno Reyes")]
+        ),
+        resources=SingleEntityTraitInput(level="comfortable"),
+    )
+    issues = derived_input_issues(
+        inputs, selected=["patron", "dependents", "resources"]
+    )
+    assert issues == []
+
+
+def test_missing_and_extra_traits_are_flagged() -> None:
+    inputs = TraitCompileInputs(
+        domain=DomainTraitInput(name="The Stacks"),
+    )
+    issues = derived_input_issues(inputs, selected=["patron", "dependents"])
+    assert "input provided for non-selected trait 'domain'" in issues
+    assert "missing input for selected trait 'patron'" in issues
+    assert "missing input for selected trait 'dependents'" in issues
+
+
+def test_database_ids_are_rejected_everywhere() -> None:
+    inputs = TraitCompileInputs(
+        patron=PatronTraitInput(name="Voss", character_id=3),
+        dependents=DependentsTraitInput(
+            targets=[DependentTargetInput(name="Juno", character_entity_id=9)]
+        ),
+        obligations=ObligationsTraitInput(
+            targets=[
+                ObligationTargetInput(
+                    counterparty_kind="faction", name="The Combine", counterparty_id=2
+                )
+            ]
+        ),
+    )
+    issues = derived_input_issues(
+        inputs, selected=["patron", "dependents", "obligations"]
+    )
+    assert "patron character ids must be null" in issues
+    assert "dependents.targets[0] ids must be null" in issues
+    assert "obligations.targets[0] ids must be null" in issues
+
+
+def test_closed_vocabulary_violations_are_flagged() -> None:
+    inputs = TraitCompileInputs(
+        resources=SingleEntityTraitInput(level="rich"),
+        fame=SingleEntityTraitInput(level="famous"),
+        status=StatusTraitInput(level="boss", scope_faction_name="The Combine"),
+    )
+    issues = derived_input_issues(inputs, selected=["resources", "fame", "status"])
+    assert any(i.startswith("resources.level 'rich'") for i in issues)
+    assert any(i.startswith("fame.level 'famous'") for i in issues)
+    assert any(i.startswith("status.level 'boss'") for i in issues)
+
+
+def test_reputation_alias_is_rejected() -> None:
+    inputs = TraitCompileInputs(
+        reputation=SingleEntityTraitInput(level="known"),
+        patron=PatronTraitInput(name="Voss"),
+        dependents=DependentsTraitInput(targets=[DependentTargetInput(name="Juno")]),
+    )
+    issues = derived_input_issues(inputs, selected=["fame", "patron", "dependents"])
+    assert "use the canonical 'fame' field, not 'reputation'" in issues
+
+
+def test_relationship_pair_tags_are_rejected_in_fresh_world() -> None:
+    inputs = TraitCompileInputs(
+        enemies=RelationshipTraitInput(
+            targets=[
+                RelationshipTargetInput(
+                    name="Sgt. Hale", apply_pair_tag=True, pair_tag="hostile_to"
+                )
+            ]
+        ),
+        patron=PatronTraitInput(name="Voss"),
+        dependents=DependentsTraitInput(targets=[DependentTargetInput(name="Juno")]),
+    )
+    issues = derived_input_issues(inputs, selected=["enemies", "patron", "dependents"])
+    assert "enemies.targets[0].apply_pair_tag must be false in a fresh world" in issues
+
+
+def test_empty_target_lists_are_flagged() -> None:
+    inputs = TraitCompileInputs(
+        dependents=DependentsTraitInput(targets=[]),
+        obligations=ObligationsTraitInput(targets=[]),
+        allies=RelationshipTraitInput(targets=[]),
+    )
+    issues = derived_input_issues(
+        inputs, selected=["dependents", "obligations", "allies"]
+    )
+    assert "dependents requires at least one target" in issues
+    assert "obligations requires at least one target" in issues
+    assert "allies requires at least one target" in issues
+
+
+def test_prompt_renders_selected_traits_and_vocabulary() -> None:
+    character = _character(["patron", "dependents", "resources"])
+    prompt = render_trait_input_prompt(character=character, setting=_setting())
+    assert "TRAIT_INPUT_DERIVATION_REQUEST" in prompt
+    assert '"patron"' in prompt
+    assert '"dependents"' in prompt
+    assert '"magnate"' in prompt  # resource vocabulary present
+    assert '"sovereign"' in prompt  # status vocabulary present
+    assert "Hard Rules" in prompt
+
+
+def test_prompt_requires_existing_prompt_file() -> None:
+    # The deriver must fail loudly if the prompt file is missing.
+    from nexus.api import trait_input_derivation
+
+    assert trait_input_derivation.PROMPT_PATH.exists()
+
+
+@pytest.mark.parametrize("missing_field", ["patron", "domain"])
+def test_named_target_required(missing_field: str) -> None:
+    if missing_field == "patron":
+        inputs = TraitCompileInputs(patron=PatronTraitInput(functions=["mentors"]))
+        issues = derived_input_issues(inputs, selected=["patron"])
+        assert "patron.name is required" in issues
+    else:
+        inputs = TraitCompileInputs(domain=DomainTraitInput())
+        issues = derived_input_issues(inputs, selected=["domain"])
+        assert "domain.name is required" in issues

--- a/tests/test_trait_input_derivation.py
+++ b/tests/test_trait_input_derivation.py
@@ -106,6 +106,19 @@ def test_missing_and_extra_traits_are_flagged() -> None:
     assert "missing input for selected trait 'dependents'" in issues
 
 
+def test_relationship_traits_are_optional() -> None:
+    """Allies/contacts/enemies may be omitted: the M5 compiler deliberately
+    does not stub-create their targets, so name-only inputs are prose
+    remainders regardless (Codex review on PR #383)."""
+
+    inputs = TraitCompileInputs(
+        patron=PatronTraitInput(name="Doctor Imari Voss"),
+        resources=SingleEntityTraitInput(level="comfortable"),
+    )
+    issues = derived_input_issues(inputs, selected=["patron", "resources", "enemies"])
+    assert issues == []
+
+
 def test_database_ids_are_rejected_everywhere() -> None:
     inputs = TraitCompileInputs(
         patron=PatronTraitInput(name="Voss", character_id=3),


### PR DESCRIPTION
## Summary

M9 of the backend v1.0 campaign: the Golden-Path Release Gate. One scripted, repeatable, live end-to-end run — fresh slot 5, real frontier calls throughout — proving wizard → Retrograde cold start → live turns with the Orrery on, codified as `tests/test_golden_path_live.py` so it can gate every future release. Passing this run is backend v1.0.

The gate did its job: the full manual run surfaced **nine real bugs**, all fixed in this branch with offline regression tests, before the codified gate went green.

## The Two Runs

1. **Full manual golden path** (CLI-driven, as a human player): complete wizard chat (setting → character with Patron + Dependents + Resources → wildcard → seed) on slot 5 with `gpt-5.5` (`@openai.default`), Retrograde cold start at the transition, then 11 live turns (9 numbered choices, 2 freeform — one entity-eliciting, one explicit day-skip). Evidence table below.
2. **Codified gate** (`tests/test_golden_path_live.py`, `NEXUS_RUN_LIVE_LLM=1 NEXUS_RUN_POSTGRES=1 NEXUS_GOLDEN_PATH_E2E=1`): reduced path per the milestone's allowance — wizard chat staged from a fixture captured off the manual run (`tests/fixtures/golden_path_wizard_cache.json`); everything from the transition onward live (trait derivation, Retrograde generation/persistence/embedding, bootstrap, scripted+adaptive turns). All eight stage assertions green: 

```
tests/test_golden_path_live.py — 8 passed in 870.16s (0:14:30)
```

Green-run telemetry: 20 frontier calls (17 gpt-5.5 + 3 `@anthropic.default` narrations); 13 chunks (11 embedded; prologue anchor + undo buffer raw by contract); 8 retrograde world_events; 3 promotions, 3 narrations, 3 bleed offers; 2 runtime maturations (Joryn Pell character, Lampwrights faction); **0 ERROR lines / 0 tracebacks** in the gate's server log.

It took three gate executions to go green, and the first two were the gate doing its job on the harness itself: run 1 (6/8) caught that `TransitionResponse` never serialized the trait-derivation outcome and that the decision-8 cap assertion conflated wizard-time stubs with runtime-maturation stubs; run 2 died on a brittle 30s status-poll timeout while the single-worker server ran in-process embedding inference. Both fixed; run 3 passed 8/8 with no retries.

## Manual Run Evidence (Slot 5, gpt-5.5)

| Stage | Evidence |
|---|---|
| Wizard (CLI, live chat) | Veyport (gritty maritime fantasy); Brena Tideloft; traits patron/dependents/resources confirmed via trait menu (`--choice 0`); wildcard "Fever-Born Tide-Sense"; seed "Odile's Last Favor". One undo/replay cycle after gate finding #3. |
| Trait input derivation (new) | 1 structured call; derived patron (Magistra Odile Sorrenwick, sponsors+protects), dependents (Pim Tideloft, Nan Cesska), resources (comfortable); 0 prose-only remainders; compile counters: 3 created entities, 4 pair-tags, 3 relationships, 1 single-entity tag |
| Retrograde cold start | transition+bootstrap 282s (seed candidates 117.2s, expansion 75.7s); 5 world_events `source='retrograde'`; 5 summary chunks embedded; weird=medium (fantasy); 12 tags, 7 pair-tags |
| Dedupe (finding #2 fix proven) | Odile/Pim/Nan/protagonist/starting location all resolved `already_present`; expansion stubs = Brother Edran Vell, Harbor Council, Lighthouse Order, Outer Breakwater (4 ≤ cap 6); 0 duplicate character rows |
| Live turns | 11 turns; per-turn wall clock 107–251s; one freeform entity-elicit (Skald declared Joryn Peale + Tide-Prison Lower Stacks on turn 1), one 23h day-skip (woke sunhelm needs) |
| Chunk/incubator lifecycle | 34 committed chunks + 1 pending incubator chunk at run end; auto-approve commit path exercised every turn |
| Embedding lifecycle | After finding #7 fix: 32/34 embedded; only unembedded = Retrograde prologue anchor (by design) + newest committed chunk (undo buffer) |
| MEMNON retrograde retrieval | Event-specific query (event 3, Odile's hidden plague-ledger docket) → its summary chunk **top hit**; Joryn Peale history query → matured summary chunk **top hit** |
| Orrery promotions | 7/7 resolutions promoted (4× sleep via magnitude 0.36 ≥ 0.35; 3× check_on_dependent via priority 55 ≥ 30); 7 real narrations; 5 offered as Bleed (offer_count > 0, first_surfaced recorded) |
| Bleed into prose | Off-screen narration (Odile, sleep): *"She finds a corner where the draft is least… sleeps in pieces"* → two chunks later, on-screen dialogue: *"'She's worse than she let me say… **She sleeps in pieces. Wakes angry.**'"* |
| Runtime maturation (M8) | 3 Skald-declared entities matured: Joryn Peale (character, 4 events), Lanternless (faction), Moon Quay (place); all jobs `succeeded`, attempt 1; history embedded + retrievable |
| world_events at end | 18 retrograde + 3 resolver |
| Log scan | 0 tracebacks; 9 ERROR lines, every one attributable to gate findings #3/#4/#6/#8 — all fixed in this branch; post-fix segments clean |

What it took for promotion in 10 turns (documented per the milestone): a fresh world's relational templates gate on recent events, and events come from resolutions — the bootstrap path is sunhelm need debt, which accrues on **world time**. A continuous crisis scene advances minutes per chunk; one explicit "a full day passes" freeform woke the needs (12 scene pressures, then sleep resolutions at magnitude 0.36) and the relational `check_on_dependent` promotions followed. No thresholds were touched.

## Gate Findings (all fixed here, each with offline regression tests)

1. **Wizard never gathers `TraitCompileInputs`** — every selected trait fell to a prose-only remainder; Patron/Dependents never created stubs. Fix: one structured Skald call at the transition derives typed inputs (validated: no DB ids, closed vocab, named targets); config `[wizard.trait_inputs]`.
2. **Duplicate entity stubs** — trait compiler and Retrograde expansion minted separate rows for the same people ("Magistra Odile Sorrenwick" vs "Odile Sorrenwick"). Fix: trait-declared targets join the Retrograde packet's core entities with an exact-name ref rule; refs now resolve `already_present`.
3. **Wizard wildcard accepted invalid Orrery tag** (`role.resources:comfortable`) that exploded later inside the transition transaction. Fix: registry validation + `ModelRetry` at `submit_wildcard_trait` (new no-write `tag_writer.validate_tag_bestowal`).
4. **`LocationStateUpdate.current_conditions` vs handler's `current_status`** — every commit carrying a location state update crashed (both sync and async handlers). Fix: correct field → column mapping.
5. **Skald misattributed off-screen resolutions** — adjudication payload carried bare entity ids and raw `{actor}` stubs; Skald rewrote Edran Vell's night onto the protagonist. Fix: `binding_names` + name-rendered stubs on resolution drafts (mirrors scene pressures).
6. **Storyteller `orrery_tags` invalid names killed turns at commit** (`place_affordance:neutral_ground`). Fix: generation-time registry validation via a pydantic_ai output validator on both providers — invalid tags become a `ModelRetry` while the model still owns the turn.
7. **N-1 embedding arithmetic broke on non-contiguous ids** — interleaved maturation summary chunks left five played chunks silently unembedded. Fix: embed every unembedded locked chunk older than the undo buffer (excluding the prologue anchor by marker); self-healing.
8. **API-triggered episode summaries always failed** — `scripts/summarize_narrative` constants resolve at argparse time (None on import), so the summary path ran with zero model candidates. Fix: resolve from live apex config.
9. **Chunk-less episode summaries** (exposed by fixing #8): the Storyteller opens play at S01E02, the bootstrap commit scheduled a summary for S01E01, and the summarizer errored on an episode holding zero chunks. Fix: the trigger checks the episode chunk span and skips empty episodes at INFO level.

Plus: the hardcoded storyteller structured-output retry budget (1) moved to `apex.structured_output_retries` in nexus.toml (default 3), and the three new-entity `orrery_tags` field descriptions now state the object shape (the list-shaped miss burned a turn).

## Documented, Not Fixed

- **Bidirectional patron relationship rows**: the trait compiler writes Brena→Odile (`+2|deferential`) and Retrograde writes Odile→Brena (`0|neutral`). Directional rows with per-side valences may be the data model working as intended — flagged for a design call rather than papered over.
- **`offscreen_narrations.embedding_status` stays `pending`** — the M6 decision to defer the offscreen-narrations embedding path is unchanged.
- The manual run's fixed bugs remain visible in that run's server log (the log-scan row above attributes them); the codified gate asserts a fully clean log on post-fix code.

## Cost

Total frontier calls across the campaign: **~178** (learning run 31; full manual run 89 = 79 gpt-5.5 + 10 Anthropic narrations; gate runs ~20 + 18 + 20). Wall clock: manual wizard + 11 turns ≈ 75 minutes of live API time spread over the evening's fix cycles; gate runs 16:16 / 15:09 / **14:30 (green)**.

## Validation

```bash
# Offline suite (includes all new regression tests)
PYTHONPATH=$PWD poetry run python -m pytest -q          # 786 passed, 104 skipped

# The gate itself (DESTRUCTIVE on slot 5; ~30-60 frontier calls)
NEXUS_RUN_LIVE_LLM=1 NEXUS_RUN_POSTGRES=1 NEXUS_GOLDEN_PATH_E2E=1 \
  PYTHONPATH=$PWD poetry run python -m pytest tests/test_golden_path_live.py -v
```

black/flake8/mypy clean on touched files (remaining findings pre-exist on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
