### PR TITLE
Slot Manager: Visual Empty/Occupied/Bound States

### DIFF
--- a/ui/client/src/components/NewStoryWizard/SlotSelector.tsx
+++ b/ui/client/src/components/NewStoryWizard/SlotSelector.tsx
@@ -164,6 +164,13 @@ export function SlotSelector({ onSlotSelected, onSlotResumed }: SlotSelectorProp
                         <Card
                             key={slotData.slot}
                             onClick={() => handleSelect(slotData.slot, slotData)}
+                            onKeyDown={(e) => {
+                                if (e.target === e.currentTarget && (e.key === "Enter" || e.key === " ")) {
+                                    e.preventDefault();
+                                    handleSelect(slotData.slot, slotData);
+                                }
+                            }}
+                            tabIndex={0}
                             role="group"
                             aria-label={visuals.ariaLabel}
                             title={visuals.ariaLabel}
@@ -240,6 +247,10 @@ export function SlotSelector({ onSlotSelected, onSlotResumed }: SlotSelectorProp
                                         <Button
                                             variant="ghost"
                                             aria-label={`Initialize empty Memory Slot ${slotData.slot}`}
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                handleSelect(slotData.slot, slotData);
+                                            }}
                                             className={cn(
                                                 "font-mono text-xs border border-transparent group-hover:border-primary/30",
                                                 selectedSlot === slotData.slot && "bg-primary text-primary-foreground hover:bg-primary/90"

--- a/ui/client/src/components/NewStoryWizard/SlotSelector.tsx
+++ b/ui/client/src/components/NewStoryWizard/SlotSelector.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from "react";
-import { Save, AlertTriangle, Loader2, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { AlertTriangle, Loader2, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { getSlotVisuals, readBoundSlot } from "./slotVisualState";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "@/hooks/use-toast";
 import {
@@ -58,6 +59,8 @@ interface SlotSelectorProps {
 
 export function SlotSelector({ onSlotSelected, onSlotResumed }: SlotSelectorProps) {
     const [selectedSlot, setSelectedSlot] = useState<number | null>(null);
+    // Currently-bound story slot (localStorage 'activeSlot') — gets the beacon.
+    const [boundSlot] = useState<number | null>(readBoundSlot);
     const queryClient = useQueryClient();
 
     // Fetch status of all 5 slots
@@ -72,8 +75,7 @@ export function SlotSelector({ onSlotSelected, onSlotResumed }: SlotSelectorProp
             return data.map((slot: any) => ({
                 slot: slot.slot_number,
                 is_active: slot.is_active,
-                character_name: slot.character_name,
-                last_played: slot.last_played,
+                is_locked: slot.is_locked,
                 // Wizard resume state
                 wizard_in_progress: slot.wizard_in_progress,
                 wizard_thread_id: slot.wizard_thread_id,
@@ -153,44 +155,57 @@ export function SlotSelector({ onSlotSelected, onSlotResumed }: SlotSelectorProp
                 <SlotFrameCorner position="br" />
 
                 <div className="grid gap-4 md:grid-cols-1">
-                    {slots.map((slotData) => (
+                    {slots.map((slotData) => {
+                        const visuals = getSlotVisuals(slotData, {
+                            selected: selectedSlot === slotData.slot,
+                            boundSlot,
+                        });
+                        return (
                         <Card
                             key={slotData.slot}
                             onClick={() => handleSelect(slotData.slot, slotData)}
-                            className={cn(
-                                "p-4 cursor-pointer transition-all duration-300 border-border bg-card/50 hover:bg-card hover:border-primary/50 group relative overflow-hidden",
-                                selectedSlot === slotData.slot && "border-primary bg-primary/5 ring-1 ring-primary",
-                                slotData.is_locked && "opacity-80 cursor-not-allowed hover:border-destructive/50 hover:bg-destructive/5"
-                            )}
+                            role="group"
+                            aria-label={visuals.ariaLabel}
+                            title={visuals.ariaLabel}
+                            data-occupancy={visuals.occupancy}
+                            className={visuals.card}
                         >
                             {/* Scanline effect */}
                             <div className="absolute inset-0 pointer-events-none bg-[linear-gradient(rgba(18,16,16,0)_50%,rgba(0,0,0,0.25)_50%),linear-gradient(90deg,rgba(255,0,0,0.06),rgba(0,255,0,0.02),rgba(0,0,255,0.06))] z-0 bg-[length:100%_2px,3px_100%] opacity-20" />
 
-                            <div className="relative z-10 flex items-center justify-between">
+                            {/* Currently-bound story: glowing left edge-marker (same
+                                vocabulary as the nexus current-chunk marker) */}
+                            {visuals.bound && (
+                                <div
+                                    aria-hidden="true"
+                                    className="absolute left-0 top-0 bottom-0 w-[3px] bg-primary shadow-[0_0_10px_2px_hsl(var(--primary)/0.6)]"
+                                />
+                            )}
+
+                            <div className={cn("relative z-10 flex items-center justify-between", visuals.content)}>
                                 <div className="flex items-center gap-4">
-                                    <div className={cn(
-                                        "h-12 w-12 rounded-sm flex items-center justify-center font-mono text-lg font-bold border",
-                                        slotData.is_locked
-                                            ? "border-destructive/50 text-destructive bg-destructive/10"
-                                            : slotData.is_active
-                                                ? "border-primary text-primary bg-primary/10 terminal-glow"
-                                                : "border-muted text-muted-foreground bg-muted/10"
-                                    )}>
+                                    <div className={visuals.tile}>
                                         {slotData.slot}
+                                        {/* Wizard-in-progress: pulsing corner mote */}
+                                        {visuals.occupancy === "wizard" && (
+                                            <span
+                                                aria-hidden="true"
+                                                className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-primary animate-pulse motion-reduce:animate-none shadow-[0_0_6px_1px_hsl(var(--primary)/0.8)]"
+                                            />
+                                        )}
                                     </div>
 
                                     <div className="flex items-center gap-2">
                                         <span className={cn(
                                             "font-mono text-sm font-bold",
-                                            slotData.is_locked ? "text-destructive" : "text-foreground"
+                                            slotData.is_locked
+                                                ? "text-destructive"
+                                                : visuals.occupancy === "empty"
+                                                    ? "text-muted-foreground"
+                                                    : "text-foreground"
                                         )}>
                                             {slotData.is_locked ? "PROTECTED ARCHIVE" : `MEMORY SLOT ${slotData.slot}`}
                                         </span>
-                                        {slotData.is_active && (
-                                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-primary/20 text-primary font-mono">
-                                                ACTIVE
-                                            </span>
-                                        )}
                                     </div>
                                 </div>
 
@@ -205,6 +220,7 @@ export function SlotSelector({ onSlotSelected, onSlotResumed }: SlotSelectorProp
                                             <Button
                                                 variant="ghost"
                                                 size="sm"
+                                                aria-label={`Clear Memory Slot ${slotData.slot}`}
                                                 onClick={(e) => handleReset(e, slotData)}
                                                 className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 font-mono text-xs"
                                             >
@@ -213,6 +229,7 @@ export function SlotSelector({ onSlotSelected, onSlotResumed }: SlotSelectorProp
                                             </Button>
                                             <Button
                                                 variant="default"
+                                                aria-label={`Resume story in Memory Slot ${slotData.slot}`}
                                                 className="font-mono text-xs bg-primary text-primary-foreground hover:bg-primary/90 terminal-glow"
                                                 onClick={(e) => handleResume(e, slotData)}
                                             >
@@ -222,6 +239,7 @@ export function SlotSelector({ onSlotSelected, onSlotResumed }: SlotSelectorProp
                                     ) : (
                                         <Button
                                             variant="ghost"
+                                            aria-label={`Initialize empty Memory Slot ${slotData.slot}`}
                                             className={cn(
                                                 "font-mono text-xs border border-transparent group-hover:border-primary/30",
                                                 selectedSlot === slotData.slot && "bg-primary text-primary-foreground hover:bg-primary/90"
@@ -233,7 +251,8 @@ export function SlotSelector({ onSlotSelected, onSlotResumed }: SlotSelectorProp
                                 </div>
                             </div>
                         </Card>
-                    ))}
+                        );
+                    })}
                 </div>
             </div>
 

--- a/ui/client/src/components/NewStoryWizard/slotVisualState.test.ts
+++ b/ui/client/src/components/NewStoryWizard/slotVisualState.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for the slot manager's visual-state classification
+ * (slot API data -> visual state classes), per the empty/occupied/
+ * wizard/locked/selected/bound vocabulary in slotVisualState.ts.
+ */
+import { describe, expect, it } from "vitest";
+import {
+    classifySlot,
+    getSlotVisuals,
+    readBoundSlot,
+    slotAriaLabel,
+} from "./slotVisualState";
+
+const emptySlot = { slot: 3, is_active: false };
+const occupiedSlot = { slot: 1, is_active: true };
+const wizardSlot = {
+    slot: 2,
+    is_active: true,
+    wizard_in_progress: true,
+    wizard_phase: "character",
+};
+const lockedSlot = { slot: 4, is_active: true, is_locked: true };
+
+const noSelection = { selected: false, boundSlot: null };
+
+describe("classifySlot", () => {
+    it("classifies slots without data as empty", () => {
+        expect(classifySlot(emptySlot)).toBe("empty");
+        expect(classifySlot({ slot: 5 })).toBe("empty");
+    });
+
+    it("classifies slots with data as occupied", () => {
+        expect(classifySlot(occupiedSlot)).toBe("occupied");
+    });
+
+    it("ranks wizard-in-progress above plain occupancy", () => {
+        expect(classifySlot(wizardSlot)).toBe("wizard");
+        expect(
+            classifySlot({ slot: 5, is_active: false, wizard_in_progress: true }),
+        ).toBe("wizard");
+    });
+});
+
+describe("getSlotVisuals card classes", () => {
+    it("renders empty slots hollow: dashed faint border, recessed surface", () => {
+        const { card, tile, content } = getSlotVisuals(emptySlot, noSelection);
+        expect(card).toContain("border-dashed");
+        expect(card).toContain("bg-card/20");
+        expect(tile).toContain("border-dashed");
+        expect(tile).not.toContain("terminal-glow");
+        expect(content).toContain("opacity-50");
+    });
+
+    it("renders occupied slots lit: solid border, full surface, glowing tile", () => {
+        const { card, tile, content } = getSlotVisuals(occupiedSlot, noSelection);
+        expect(card).toContain("border-solid");
+        expect(card).toContain("border-primary/30");
+        expect(card).not.toContain("border-dashed");
+        expect(tile).toContain("terminal-glow");
+        expect(content).toBe("");
+    });
+
+    it("renders wizard slots with the lit treatment", () => {
+        const { card, tile } = getSlotVisuals(wizardSlot, noSelection);
+        expect(card).toContain("border-solid");
+        expect(tile).toContain("terminal-glow");
+    });
+
+    it("keeps the selection ring and forces a solid border on empty slots", () => {
+        const { card } = getSlotVisuals(emptySlot, {
+            selected: true,
+            boundSlot: null,
+        });
+        expect(card).toContain("ring-1");
+        expect(card).toContain("ring-primary");
+        // tailwind-merge resolves the dashed/solid conflict to the later class
+        expect(card).toContain("border-solid");
+        expect(card).not.toContain("border-dashed");
+    });
+
+    it("lifts the hollow dimming when an empty slot is selected", () => {
+        const { content } = getSlotVisuals(emptySlot, {
+            selected: true,
+            boundSlot: null,
+        });
+        expect(content).toBe("");
+    });
+
+    it("applies the destructive locked treatment over occupancy", () => {
+        const { card, tile } = getSlotVisuals(lockedSlot, noSelection);
+        expect(card).toContain("cursor-not-allowed");
+        expect(tile).toContain("border-destructive/50");
+        expect(tile).not.toContain("terminal-glow");
+    });
+});
+
+describe("bound-slot beacon", () => {
+    it("marks the slot matching the bound slot", () => {
+        const visuals = getSlotVisuals(occupiedSlot, {
+            selected: false,
+            boundSlot: 1,
+        });
+        expect(visuals.bound).toBe(true);
+    });
+
+    it("does not mark other slots", () => {
+        const visuals = getSlotVisuals(occupiedSlot, {
+            selected: false,
+            boundSlot: 2,
+        });
+        expect(visuals.bound).toBe(false);
+    });
+
+    it("marks nothing when no slot is bound", () => {
+        const visuals = getSlotVisuals(occupiedSlot, noSelection);
+        expect(visuals.bound).toBe(false);
+    });
+});
+
+describe("readBoundSlot", () => {
+    it("parses the localStorage activeSlot value", () => {
+        localStorage.setItem("activeSlot", "4");
+        expect(readBoundSlot()).toBe(4);
+        localStorage.removeItem("activeSlot");
+    });
+
+    it("returns null when unset", () => {
+        localStorage.removeItem("activeSlot");
+        expect(readBoundSlot()).toBeNull();
+    });
+
+    it("returns null for non-numeric garbage", () => {
+        localStorage.setItem("activeSlot", "banana");
+        expect(readBoundSlot()).toBeNull();
+        localStorage.removeItem("activeSlot");
+    });
+});
+
+describe("slotAriaLabel", () => {
+    it("describes empty slots", () => {
+        expect(slotAriaLabel(emptySlot, "empty", { selected: false, bound: false }))
+            .toBe("Memory Slot 3: empty");
+    });
+
+    it("describes occupied slots", () => {
+        expect(
+            slotAriaLabel(occupiedSlot, "occupied", { selected: false, bound: false }),
+        ).toBe("Memory Slot 1: occupied");
+    });
+
+    it("describes wizard slots with phase", () => {
+        expect(
+            slotAriaLabel(wizardSlot, "wizard", { selected: false, bound: false }),
+        ).toBe("Memory Slot 2: story setup in progress (character phase)");
+    });
+
+    it("appends locked, current story, and selected modifiers", () => {
+        expect(
+            slotAriaLabel(lockedSlot, "occupied", { selected: true, bound: true }),
+        ).toBe("Memory Slot 4: occupied, locked, current story, selected");
+    });
+});

--- a/ui/client/src/components/NewStoryWizard/slotVisualState.test.ts
+++ b/ui/client/src/components/NewStoryWizard/slotVisualState.test.ts
@@ -86,6 +86,13 @@ describe("getSlotVisuals card classes", () => {
         expect(content).toBe("");
     });
 
+    it("keeps a keyboard focus ring on every card", () => {
+        for (const slot of [emptySlot, occupiedSlot, wizardSlot, lockedSlot]) {
+            const { card } = getSlotVisuals(slot, noSelection);
+            expect(card).toContain("focus-visible:ring-primary");
+        }
+    });
+
     it("applies the destructive locked treatment over occupancy", () => {
         const { card, tile } = getSlotVisuals(lockedSlot, noSelection);
         expect(card).toContain("cursor-not-allowed");
@@ -114,6 +121,15 @@ describe("bound-slot beacon", () => {
     it("marks nothing when no slot is bound", () => {
         const visuals = getSlotVisuals(occupiedSlot, noSelection);
         expect(visuals.bound).toBe(false);
+    });
+
+    it("never marks an empty slot, even with a stale activeSlot match", () => {
+        const visuals = getSlotVisuals(emptySlot, {
+            selected: false,
+            boundSlot: emptySlot.slot,
+        });
+        expect(visuals.bound).toBe(false);
+        expect(visuals.ariaLabel).not.toContain("current story");
     });
 });
 

--- a/ui/client/src/components/NewStoryWizard/slotVisualState.ts
+++ b/ui/client/src/components/NewStoryWizard/slotVisualState.ts
@@ -39,7 +39,15 @@ export interface SlotVisualSpec {
     ariaLabel: string;
 }
 
-/** Classify occupancy. Wizard-in-progress outranks plain occupancy. */
+/**
+ * Classify occupancy. Wizard-in-progress outranks plain occupancy.
+ *
+ * The API guarantees wizard_in_progress implies is_active: slot_state.py
+ * derives both from data presence and only reports wizard mode when a
+ * wizard cache row exists (is_empty=False, hence is_active=True). The
+ * precedence here is also correct defensively: a slot with resumable
+ * wizard data is not hollow, whatever is_active claims.
+ */
 export function classifySlot(slot: SlotVisualInput): SlotOccupancy {
     if (slot.wizard_in_progress) return "wizard";
     return slot.is_active ? "occupied" : "empty";
@@ -61,12 +69,18 @@ export function readBoundSlot(): number | null {
 }
 
 const CARD_BASE =
-    "p-4 cursor-pointer transition-all duration-300 group relative overflow-hidden";
+    "p-4 cursor-pointer transition-all duration-300 group relative overflow-hidden focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary";
+
+/* Shared "lit" treatment. Wizard slots are lit plus the pulsing mote
+   (rendered by the component), so both occupancies share these classes. */
+const CARD_LIT =
+    "border-solid border-primary/30 bg-card hover:border-primary/60";
+const TILE_LIT = "border-primary text-primary bg-primary/10 terminal-glow";
 
 const CARD_BY_OCCUPANCY: Record<SlotOccupancy, string> = {
     empty: "border-dashed border-muted-foreground/30 bg-card/20 hover:bg-card/40 hover:border-primary/40",
-    occupied: "border-solid border-primary/30 bg-card hover:border-primary/60",
-    wizard: "border-solid border-primary/30 bg-card hover:border-primary/60",
+    occupied: CARD_LIT,
+    wizard: CARD_LIT,
 };
 
 const TILE_BASE =
@@ -74,8 +88,8 @@ const TILE_BASE =
 
 const TILE_BY_OCCUPANCY: Record<SlotOccupancy, string> = {
     empty: "border-dashed border-muted-foreground/40 text-muted-foreground/60 bg-transparent",
-    occupied: "border-primary text-primary bg-primary/10 terminal-glow",
-    wizard: "border-primary text-primary bg-primary/10 terminal-glow",
+    occupied: TILE_LIT,
+    wizard: TILE_LIT,
 };
 
 const TILE_LOCKED = "border-destructive/50 text-destructive bg-destructive/10";
@@ -110,7 +124,13 @@ export function getSlotVisuals(
     opts: { selected: boolean; boundSlot: number | null },
 ): SlotVisualSpec {
     const occupancy = classifySlot(slot);
-    const bound = opts.boundSlot !== null && opts.boundSlot === slot.slot;
+    // An empty slot can never be the current story, even if a stale
+    // localStorage activeSlot still points at it (e.g. the bound slot
+    // was just cleared and the list refetched).
+    const bound =
+        occupancy !== "empty" &&
+        opts.boundSlot !== null &&
+        opts.boundSlot === slot.slot;
 
     const card = cn(
         CARD_BASE,

--- a/ui/client/src/components/NewStoryWizard/slotVisualState.ts
+++ b/ui/client/src/components/NewStoryWizard/slotVisualState.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure visual-state classification for the slot manager.
+ *
+ * Maps slot API data (GET /api/story/new/slots) onto the IRIS/Veil visual
+ * vocabulary with zero text labels:
+ *   - occupied  -> "lit": full-opacity surface, solid primary-tinted border
+ *   - empty     -> "hollow": recessed surface, faint dashed border, dimmed
+ *   - wizard    -> lit + a pulsing corner mote on the slot-number tile
+ *   - bound     -> 3px glowing left edge-marker (the same "you are here"
+ *                  cue nexus-layout.css uses for the current chunk)
+ *   - selected  -> existing primary ring, forced solid so it stays legible
+ *                  on top of a hollow (dashed) slot
+ *   - locked    -> existing destructive tint, takes precedence on the tile
+ *
+ * Kept free of React so the classification logic is unit-testable.
+ */
+import { cn } from "@/lib/utils";
+
+export type SlotOccupancy = "empty" | "occupied" | "wizard";
+
+export interface SlotVisualInput {
+    slot: number;
+    is_active?: boolean;
+    is_locked?: boolean;
+    wizard_in_progress?: boolean;
+    wizard_phase?: string;
+}
+
+export interface SlotVisualSpec {
+    occupancy: SlotOccupancy;
+    bound: boolean;
+    /** Card (outer button surface) classes. */
+    card: string;
+    /** Slot-number tile classes. */
+    tile: string;
+    /** Inner content-row classes (dimming for hollow slots). */
+    content: string;
+    /** Screen-reader description of the full visual state. */
+    ariaLabel: string;
+}
+
+/** Classify occupancy. Wizard-in-progress outranks plain occupancy. */
+export function classifySlot(slot: SlotVisualInput): SlotOccupancy {
+    if (slot.wizard_in_progress) return "wizard";
+    return slot.is_active ? "occupied" : "empty";
+}
+
+/**
+ * Read the currently-bound story slot from localStorage ('activeSlot').
+ * Same safe-access pattern as pages/splash/shared.tsx getActiveSlot().
+ */
+export function readBoundSlot(): number | null {
+    try {
+        const raw = localStorage.getItem("activeSlot");
+        if (raw === null) return null;
+        const parsed = Number.parseInt(raw, 10);
+        return Number.isNaN(parsed) ? null : parsed;
+    } catch {
+        return null;
+    }
+}
+
+const CARD_BASE =
+    "p-4 cursor-pointer transition-all duration-300 group relative overflow-hidden";
+
+const CARD_BY_OCCUPANCY: Record<SlotOccupancy, string> = {
+    empty: "border-dashed border-muted-foreground/30 bg-card/20 hover:bg-card/40 hover:border-primary/40",
+    occupied: "border-solid border-primary/30 bg-card hover:border-primary/60",
+    wizard: "border-solid border-primary/30 bg-card hover:border-primary/60",
+};
+
+const TILE_BASE =
+    "relative h-12 w-12 rounded-sm flex items-center justify-center font-mono text-lg font-bold border";
+
+const TILE_BY_OCCUPANCY: Record<SlotOccupancy, string> = {
+    empty: "border-dashed border-muted-foreground/40 text-muted-foreground/60 bg-transparent",
+    occupied: "border-primary text-primary bg-primary/10 terminal-glow",
+    wizard: "border-primary text-primary bg-primary/10 terminal-glow",
+};
+
+const TILE_LOCKED = "border-destructive/50 text-destructive bg-destructive/10";
+
+const CONTENT_DIMMED =
+    "opacity-50 group-hover:opacity-90 transition-opacity duration-300";
+
+const OCCUPANCY_DESCRIPTION: Record<SlotOccupancy, string> = {
+    empty: "empty",
+    occupied: "occupied",
+    wizard: "story setup in progress",
+};
+
+export function slotAriaLabel(
+    slot: SlotVisualInput,
+    occupancy: SlotOccupancy,
+    opts: { selected: boolean; bound: boolean },
+): string {
+    let label = `Memory Slot ${slot.slot}: ${OCCUPANCY_DESCRIPTION[occupancy]}`;
+    if (occupancy === "wizard" && slot.wizard_phase) {
+        label += ` (${slot.wizard_phase} phase)`;
+    }
+    if (slot.is_locked) label += ", locked";
+    if (opts.bound) label += ", current story";
+    if (opts.selected) label += ", selected";
+    return label;
+}
+
+/** Resolve the complete visual spec for one slot card. */
+export function getSlotVisuals(
+    slot: SlotVisualInput,
+    opts: { selected: boolean; boundSlot: number | null },
+): SlotVisualSpec {
+    const occupancy = classifySlot(slot);
+    const bound = opts.boundSlot !== null && opts.boundSlot === slot.slot;
+
+    const card = cn(
+        CARD_BASE,
+        CARD_BY_OCCUPANCY[occupancy],
+        opts.selected &&
+            "border-solid border-primary bg-primary/5 ring-1 ring-primary",
+        slot.is_locked &&
+            "opacity-80 cursor-not-allowed hover:border-destructive/50 hover:bg-destructive/5",
+    );
+
+    const tile = cn(
+        TILE_BASE,
+        slot.is_locked ? TILE_LOCKED : TILE_BY_OCCUPANCY[occupancy],
+    );
+
+    const content = cn(
+        occupancy === "empty" && !opts.selected && CONTENT_DIMMED,
+    );
+
+    return {
+        occupancy,
+        bound,
+        card,
+        tile,
+        content,
+        ariaLabel: slotAriaLabel(slot, occupancy, { selected: opts.selected, bound }),
+    };
+}


### PR DESCRIPTION
## Summary

User feedback: the slot manager gave no visual indication of which slots are empty vs occupied, and the only occupancy signal was an "ACTIVE" text badge — exactly the label clutter the user did not want. This PR replaces text-based state signaling with a purely visual vocabulary built from the vendored IRIS/Veil theme tokens.

## Visual Vocabulary

| State | Treatment | Why |
| --- | --- | --- |
| Occupied | "Lit": solid `--primary`-tinted border, full-opacity `bg-card` surface, glowing slot-number tile (`terminal-glow`) | Presence reads as light/energy, consistent with the terminal aesthetic |
| Empty | "Hollow": faint dashed border on card and tile, recessed `bg-card/20` surface, content dimmed to 50% with a hover lift | Dashed outline is the established idiom for a vacant receptacle; dimming makes it visually recessive at a glance |
| Wizard-in-progress | Lit treatment plus a small pulsing primary mote on the tile corner (`animate-pulse`, `motion-reduce:animate-none`) | "In motion, incomplete" without text |
| Currently-bound story (`localStorage activeSlot`) | 3px glowing left edge-marker | The same "you are here" cue nexus-layout.css uses for the current chunk — vocabulary reuse, not invention |
| Selected | Existing primary ring, now forced `border-solid` so it stays legible over a hollow slot's dashed border | Unchanged semantics |
| Locked | Existing destructive tint | Unchanged, and now actually reachable (see bug fix) |

The "ACTIVE" text badge is removed. All colors are theme tokens, so the treatment tracks Gilded/Vector/Veil automatically.

## Bug Fixed in Passing

The queryFn dropped `is_locked` from the API response, so the locked styling and the locked-slot click guard were dead code. It is mapped again (the two never-returned fields `character_name`/`last_played` were dropped from the mapping).

## Accessibility

States are visual-only on screen, but every slot card carries `aria-label` + `title` describing the full state (e.g. "Memory Slot 2: story setup in progress (character phase), current story"), and the CLEAR/RESUME/INITIALIZE buttons get descriptive aria-labels.

## Architecture

Classification logic (slot API data -> visual spec) lives in a pure module, `ui/client/src/components/NewStoryWizard/slotVisualState.ts`, kept free of React so it is unit-testable. `SlotSelector.tsx` consumes the spec and adds `data-occupancy` for test/automation hooks.

## Verification

- `npm test`: 41/41 passing (19 new tests covering classification precedence, class output per state, tailwind-merge dashed/solid resolution, bound-slot matching, localStorage parsing, aria labels).
- `npx tsc --noEmit` and production build (`npm run build`) clean.
- Real-browser screenshots (puppeteer + system Chrome) against a worktree dev server on :5022 proxying the live API (read-only):
  - Live state (all five slots currently occupied, slot 1 bound): occupied slots lit, beacon on slot 1.
  - Mixed state via request interception serving a modified copy of the real endpoint response (no database mutation): slot 1 occupied+bound, slot 2 wizard-in-progress, slot 3 empty, slot 4 locked, slot 5 occupied — all six visual states distinguishable side by side with zero added text.
  - Hover over the empty slot confirms the hover lift.
  - Rendered aria labels confirmed via DOM inspection in the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)