### PR TITLE
App Icons: Per-Theme Set, Locked; Retire Dead Upload Path

### DIFF
--- a/ui/client/index.html
+++ b/ui/client/index.html
@@ -28,7 +28,7 @@
     <link rel="manifest" href="/manifest.json" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/veil/icon-32.png?v=20260612" />
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/veil/icon-16.png?v=20260612" />
-    <link rel="apple-touch-icon" href="/icons/veil/icon-180.png?v=20260612" />
+    <link rel="apple-touch-icon" type="image/png" href="/icons/veil/icon-180.png?v=20260612" />
 
     <!-- Apple PWA Meta Tags -->
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/ui/client/index.html
+++ b/ui/client/index.html
@@ -21,19 +21,23 @@
     <title>NEXUS IRIS - Narrative Intelligence System</title>
     <meta name="description" content="AI-driven interactive storytelling interface with advanced memory architecture and immersive cyberpunk terminal aesthetic" />
 
-    <!-- PWA Icons and Manifest -->
+    <!-- PWA Icons and Manifest. The static hrefs are the Veil (default
+         theme) set; ThemeContext retargets them per theme at runtime via
+         applyThemeIcons (src/lib/themeIcons.ts). Keep ?v= in sync with
+         ICON_VERSION there. -->
     <link rel="manifest" href="/manifest.json" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/icons/veil/icon-32.png?v=20260612" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/icons/veil/icon-16.png?v=20260612" />
+    <link rel="apple-touch-icon" href="/icons/veil/icon-180.png?v=20260612" />
 
     <!-- Apple PWA Meta Tags -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="NEXUS" />
 
-    <!-- Theme Colors -->
-    <meta name="theme-color" content="#0d9488" />
-    <meta name="msapplication-TileColor" content="#0d9488" />
+    <!-- Theme Colors (Veil blue-black, the default theme) -->
+    <meta name="theme-color" content="#09101c" />
+    <meta name="msapplication-TileColor" content="#09101c" />
 
     <!-- All brand fonts are self-hosted keepers served from /fonts/ via
          @font-face in src/index.css — no CDN dependency. -->

--- a/ui/client/public/favicon.ico
+++ b/ui/client/public/favicon.ico
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4df16a1d42e70a2af00d07fa4a83e4cac23222f712e1f67d145aee25fd308a31
-size 3952
+oid sha256:0c2d3933df98271f4eb7633e995802cee336d66650be7d4ef8b7b741db92947d
+size 2813

--- a/ui/client/public/icons/apple-touch-icon.png
+++ b/ui/client/public/icons/apple-touch-icon.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6051237c097ff8f33a8f02b089a5314eb3c369103ad6b1bb98e9ca6285ff5011
-size 49638

--- a/ui/client/public/icons/favicon-32.png
+++ b/ui/client/public/icons/favicon-32.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7846f19fccafac09cfcdd1438e747f0ac354aed4c592dd56ea9c4839be6f66d9
-size 3927

--- a/ui/client/public/icons/gilded/icon-16.png
+++ b/ui/client/public/icons/gilded/icon-16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:209318e396124abe0af38555a82afd5345731cb56d027a55cae09ca1d54e847b
+size 811

--- a/ui/client/public/icons/gilded/icon-180.png
+++ b/ui/client/public/icons/gilded/icon-180.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93ca16a9d2b766c661f48bb6a7394770673a11bbab7369e829226bbf9c7e5e63
+size 47028

--- a/ui/client/public/icons/gilded/icon-192.png
+++ b/ui/client/public/icons/gilded/icon-192.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07ea551f8a758a939147004c82efb87bc57c120dd50e9be5b0842c1d4affadf6
+size 52886

--- a/ui/client/public/icons/gilded/icon-32.png
+++ b/ui/client/public/icons/gilded/icon-32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c0efe57f3594194d929f79a54e3e131f376bbfcb01652b5ce48d8c572c50558
+size 2363

--- a/ui/client/public/icons/gilded/icon-512.png
+++ b/ui/client/public/icons/gilded/icon-512.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2f2cb715a3ff16f75b2b34020384fd4c25afbbf9194d5390c54c4c7b7d3711e
+size 346768

--- a/ui/client/public/icons/icon-192.png
+++ b/ui/client/public/icons/icon-192.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:25a962c91b084b2e8e4323c6f3e8e73b7d4cdadcd8fdcf9d8c03651e6fcafa97
-size 55691

--- a/ui/client/public/icons/icon-512.png
+++ b/ui/client/public/icons/icon-512.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d7417f72b3840286e353cfdabcdc9df57e8bf4927199c0a88d65efe90e142a3
-size 335228

--- a/ui/client/public/icons/icon-source.png
+++ b/ui/client/public/icons/icon-source.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9616bea043da5c8c451305d5649b76d9418a2ab5f7e1bc0166a915a6dee4762a
-size 3350578

--- a/ui/client/public/icons/vector/icon-16.png
+++ b/ui/client/public/icons/vector/icon-16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce17c35d111bcc77a32994a8f16ee482262a363131c1052b2d83bb81ac6de82a
+size 727

--- a/ui/client/public/icons/vector/icon-180.png
+++ b/ui/client/public/icons/vector/icon-180.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edf58dc7497df07c91113c41c0cfec74ae163d38def2d7d2f50261f736ade6ed
+size 44039

--- a/ui/client/public/icons/vector/icon-192.png
+++ b/ui/client/public/icons/vector/icon-192.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c5994b6c801f71594b32cf6dcab60b566ffaec22d72b50c2ba50f1287fb5ce5
+size 41734

--- a/ui/client/public/icons/vector/icon-32.png
+++ b/ui/client/public/icons/vector/icon-32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90f16e37a130151ef569fc26e5b0aeca842d3031c055d0e5821f5f7303ec858e
+size 2229

--- a/ui/client/public/icons/vector/icon-512.png
+++ b/ui/client/public/icons/vector/icon-512.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc1988b4aa2d7703e9e8cede2405adec83818142b6819b3013fcaa8b588e7096
+size 340014

--- a/ui/client/public/icons/veil/icon-16.png
+++ b/ui/client/public/icons/veil/icon-16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a5da8cf769dc75fd63010e51e21f3a2816237bd0a88f3dda5229e85937b8df2
+size 789

--- a/ui/client/public/icons/veil/icon-180.png
+++ b/ui/client/public/icons/veil/icon-180.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:523ab2a7487e2d15981a722e9a9524497c268b26f9dd21051e2e5ab2ccc1f6aa
+size 39550

--- a/ui/client/public/icons/veil/icon-192.png
+++ b/ui/client/public/icons/veil/icon-192.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec3b5484d7ce12ad9973f1368b48ad679a11ddd4727220fdbc90cad1dc02f140
+size 44848

--- a/ui/client/public/icons/veil/icon-32.png
+++ b/ui/client/public/icons/veil/icon-32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7e83c06a9c42c733c01d309b4ccb1980512ec42e135acaf741922e02a7b88f3
+size 2349

--- a/ui/client/public/icons/veil/icon-512.png
+++ b/ui/client/public/icons/veil/icon-512.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:912e8d7db0f6fa175aa45dd1b72104695471350286d82f31e462b2efff715382
+size 340466

--- a/ui/client/public/manifest.json
+++ b/ui/client/public/manifest.json
@@ -4,23 +4,27 @@
   "description": "AI-driven interactive storytelling interface with advanced memory architecture",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#0a0a0a",
-  "theme_color": "#0d9488",
+  "background_color": "#09101c",
+  "theme_color": "#09101c",
   "orientation": "any",
   "icons": [
     {
-      "src": "/icons/icon-192.png?v=1729645200000",
+      "src": "/icons/veil/icon-192.png?v=20260612",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-512.png?v=1729645200000",
+      "src": "/icons/veil/icon-512.png?v=20260612",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
     }
   ],
-  "categories": ["entertainment", "productivity", "utilities"],
+  "categories": [
+    "entertainment",
+    "productivity",
+    "utilities"
+  ],
   "screenshots": []
 }

--- a/ui/client/src/components/nexus/SettingsPane.tsx
+++ b/ui/client/src/components/nexus/SettingsPane.tsx
@@ -2,7 +2,7 @@
  * SettingsPane - the operator's calibration console (NEXUS IRIS, U5).
  *
  * Seven sections: Theme, Typography, Narrative Mode, Model, LORE Budget,
- * Typewriter, PWA Icon. Every dial writes back to PATCH /api/settings
+ * Typewriter, App Icon. Every dial writes back to PATCH /api/settings
  * (FastAPI -> nexus.config.loader.save_settings -> nexus.toml) with
  * optimistic cache updates and server confirmation - no local draft state.
  * Theme and font writes flow through ThemeContext/FontContext, which share
@@ -22,12 +22,11 @@ import {
   CircleDot,
   RefreshCw,
   Save,
-  Upload,
-  X,
 } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
 import { useFonts } from "@/contexts/FontContext";
 import { useSettingsMutation, useSettingsQuery } from "@/hooks/useSettings";
+import { themeIconPath } from "@/lib/themeIcons";
 import { FONT_CATALOG } from "./fontCatalog";
 import type {
   FontSlotId,
@@ -47,7 +46,7 @@ const SECTION_INDEX = [
   { id: "model", label: "Model" },
   { id: "lore", label: "LORE Budget" },
   { id: "reveal", label: "Typewriter" },
-  { id: "pwa", label: "PWA Icon" },
+  { id: "pwa", label: "App Icon" },
 ] as const;
 
 type SectionId = (typeof SECTION_INDEX)[number]["id"];
@@ -722,133 +721,30 @@ function TypewriterSection({
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// 7. PWA Icon
+// 7. App Icon (Per-Theme, Locked)
 // ──────────────────────────────────────────────────────────────────────────
 
 function PwaSection() {
-  const [drag, setDrag] = useState(false);
-  const [preview, setPreview] = useState<string | null>(null);
-  const [file, setFile] = useState<File | null>(null);
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [cacheBust, setCacheBust] = useState(0);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const onFile = (candidate: File | null | undefined) => {
-    if (!candidate || !candidate.type.startsWith("image/")) return;
-    setFile(candidate);
-    setError(null);
-    const reader = new FileReader();
-    reader.onload = (e) => setPreview(e.target?.result as string);
-    reader.readAsDataURL(candidate);
-  };
-
-  const discard = () => {
-    setPreview(null);
-    setFile(null);
-    setError(null);
-    if (inputRef.current) inputRef.current.value = "";
-  };
-
-  const commit = async () => {
-    if (!file) return;
-    setBusy(true);
-    setError(null);
-    try {
-      const form = new FormData();
-      form.append("icon", file);
-      const res = await fetch("/api/settings/pwa-icon", {
-        method: "POST",
-        body: form,
-        credentials: "include",
-      });
-      if (!res.ok) {
-        const text = (await res.text()) || res.statusText;
-        throw new Error(`${res.status}: ${text}`);
-      }
-      discard();
-      setCacheBust(Date.now());
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const currentSrc = `/icons/icon-192.png${cacheBust ? `?v=${cacheBust}` : ""}`;
+  const { theme } = useTheme();
 
   return (
     <SettingsCard
       id="pwa"
       eyebrow="PWA · HOME-SCREEN GLYPH"
-      title="Installable Icon"
-      sub="The icon stamped onto the home screen, dock, or splash when NEXUS is installed as a PWA. PNG or JPEG, at least 512 px — all sizes and the manifest are regenerated server-side."
+      title="App Icon"
+      sub="One mark, three liveries. The favicon and home-screen glyph follow the active theme; the PWA install icon is baked at build time on the default theme (Veil)."
     >
-      <div className="pwa-row">
-        <div className="pwa-current">
-          <div className="caption dim">CURRENT · 192PX</div>
-          <div className="pwa-icon-box">
-            <img src={currentSrc} alt="Current PWA icon" />
+      <div className="pwa-icon-row">
+        {THEME_IDS.map((id) => (
+          <div
+            key={id}
+            className={`pwa-icon-tile ${theme === id ? "on" : ""}`}
+            data-testid={`pwa-icon-${id}`}
+          >
+            <img src={themeIconPath(id, 192)} alt={`${id} app icon`} />
           </div>
-          <div className="pwa-icon-coord">/icons/icon-192.png</div>
-        </div>
-
-        <div
-          className={`pwa-drop ${drag ? "drag" : ""} ${preview ? "has-preview" : ""}`}
-          onDragOver={(e) => {
-            e.preventDefault();
-            setDrag(true);
-          }}
-          onDragLeave={() => setDrag(false)}
-          onDrop={(e) => {
-            e.preventDefault();
-            setDrag(false);
-            onFile(e.dataTransfer.files?.[0]);
-          }}
-          onClick={() => inputRef.current?.click()}
-          data-testid="pwa-drop"
-        >
-          {preview ? (
-            <img src={preview} alt="Staged icon preview" className="pwa-drop-img" />
-          ) : (
-            <>
-              <Upload size={22} />
-              <div className="pwa-drop-title">DROP NEW GLYPH</div>
-              <div className="caption dim">
-                or click to choose · PNG / JPEG · 512px or larger
-              </div>
-            </>
-          )}
-          <input
-            ref={inputRef}
-            type="file"
-            accept="image/png,image/jpeg,image/jpg"
-            style={{ display: "none" }}
-            onChange={(e) => onFile(e.target.files?.[0])}
-          />
-        </div>
+        ))}
       </div>
-
-      {error && (
-        <div className="alert danger">
-          <AlertTriangle size={14} />
-          <div>
-            <div className="alert-title">UPLOAD FAILED</div>
-            <div className="alert-body">{error}</div>
-          </div>
-        </div>
-      )}
-
-      {preview && (
-        <div className="pwa-actions">
-          <button className="btn-soft" onClick={discard} disabled={busy}>
-            <X size={11} /> DISCARD
-          </button>
-          <button className="btn-primary" onClick={commit} disabled={busy}>
-            <Upload size={12} /> {busy ? "TRANSMITTING" : "COMMIT GLYPH"}
-          </button>
-        </div>
-      )}
     </SettingsCard>
   );
 }

--- a/ui/client/src/components/nexus/nexus-layout.css
+++ b/ui/client/src/components/nexus/nexus-layout.css
@@ -1836,64 +1836,30 @@
 
 .settings-pane-v2 .caption.warning { color: var(--warning); }
 
-/* ─── 7. PWA icon ─── */
-.pwa-row {
-  display: grid;
-  grid-template-columns: 200px 1fr;
-  gap: 24px;
-  align-items: stretch;
+/* ─── 7. App icon (per-theme, locked) ─── */
+.pwa-icon-row {
+  display: flex;
+  gap: 18px;
 }
-.pwa-current { display: flex; flex-direction: column; gap: 8px; }
-.pwa-icon-box {
-  width: 144px; height: 144px;
+.pwa-icon-tile {
+  width: 96px; height: 96px;
+  padding: 10px;
   border: 1px solid var(--border-strong);
-  background: var(--bg);
-  display: grid; place-items: center;
-  overflow: hidden;
-  border-radius: var(--radius-sm);
-  box-shadow: 0 0 0 1px hsl(320 55% 50% / .15) inset, 0 0 18px hsl(320 55% 50% / .12);
-}
-.pwa-icon-box img { width: 100%; height: 100%; object-fit: cover; }
-.pwa-icon-coord {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--fg-muted);
-  letter-spacing: 0.02em;
-}
-.pwa-drop {
-  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px;
-  border: 1px dashed var(--border-strong);
   border-radius: var(--radius-sm);
   background: var(--bg);
-  color: var(--fg-muted);
-  padding: 28px 22px;
-  cursor: pointer;
-  text-align: center;
-  transition: border-color .15s, background .15s, color .15s;
-  min-height: 144px;
+  opacity: .45;
+  transition: opacity .15s, border-color .15s, box-shadow .15s;
 }
-.pwa-drop:hover { border-color: var(--brass); color: var(--brass-bright); background: hsl(320 55% 50% / .04); }
-.pwa-drop.drag {
+.pwa-icon-tile img {
+  width: 100%; height: 100%;
+  object-fit: contain;
+  border-radius: 2px;
+  display: block;
+}
+.pwa-icon-tile.on {
+  opacity: 1;
   border-color: var(--brass);
-  border-style: solid;
-  background: hsl(320 55% 50% / .08);
-  color: var(--brass-bright);
-  box-shadow: 0 0 0 1px var(--brass) inset, 0 0 20px hsl(320 55% 50% / .25);
-}
-.pwa-drop.has-preview { padding: 0; border-style: solid; }
-.pwa-drop-img { width: 100%; height: 100%; min-height: 144px; object-fit: cover; }
-.pwa-drop-title {
-  font-family: var(--font-menu);
-  font-size: 11px;
-  letter-spacing: 0.26em;
-  text-transform: uppercase;
-  color: var(--brass);
-  text-shadow: var(--glow-soft);
-  font-weight: 600;
-}
-.pwa-actions {
-  display: flex; justify-content: flex-end; gap: 10px;
-  padding-top: 4px;
+  box-shadow: 0 0 0 1px var(--brass) inset, 0 0 18px hsl(320 55% 50% / .2);
 }
 
 /* ─── End-of-console footer ─── */

--- a/ui/client/src/contexts/ThemeContext.tsx
+++ b/ui/client/src/contexts/ThemeContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { useSettingsMutation, useSettingsQuery } from '@/hooks/useSettings';
+import { applyThemeIcons } from '@/lib/themeIcons';
 
 export type Theme = 'gilded' | 'vector' | 'veil';
 
@@ -58,6 +59,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       root.classList.add('theme-vector');
     }
     localStorage.setItem(STORAGE_KEY, theme);
+    // Favicon + apple-touch icons follow the active theme (one mark, three
+    // liveries). PWA manifest icons are bake-time and stay on Veil.
+    applyThemeIcons(theme);
   }, [theme]);
 
   const setTheme = (newTheme: Theme) => {

--- a/ui/client/src/lib/themeIcons.test.ts
+++ b/ui/client/src/lib/themeIcons.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { ICON_VERSION, applyThemeIcons, themeIconPath } from "./themeIcons";
+
+describe("themeIconPath", () => {
+  it("builds per-theme cache-busted icon paths", () => {
+    expect(themeIconPath("veil", 32)).toBe(
+      `/icons/veil/icon-32.png?v=${ICON_VERSION}`,
+    );
+    expect(themeIconPath("gilded", 512)).toBe(
+      `/icons/gilded/icon-512.png?v=${ICON_VERSION}`,
+    );
+    expect(themeIconPath("vector", 180)).toBe(
+      `/icons/vector/icon-180.png?v=${ICON_VERSION}`,
+    );
+  });
+});
+
+describe("applyThemeIcons", () => {
+  beforeEach(() => {
+    document.head
+      .querySelectorAll('link[rel="icon"], link[rel="apple-touch-icon"]')
+      .forEach((link) => link.remove());
+  });
+
+  const href = (selector: string) =>
+    document.head.querySelector<HTMLLinkElement>(selector)?.getAttribute("href");
+
+  it("creates favicon and apple-touch links when none exist", () => {
+    applyThemeIcons("veil");
+
+    expect(href('link[rel="icon"][sizes="32x32"]')).toBe(
+      themeIconPath("veil", 32),
+    );
+    expect(href('link[rel="icon"][sizes="16x16"]')).toBe(
+      themeIconPath("veil", 16),
+    );
+    expect(href('link[rel="apple-touch-icon"]')).toBe(
+      themeIconPath("veil", 180),
+    );
+  });
+
+  it("retargets existing links on theme change without duplicating them", () => {
+    applyThemeIcons("veil");
+    applyThemeIcons("vector");
+
+    expect(href('link[rel="icon"][sizes="32x32"]')).toBe(
+      themeIconPath("vector", 32),
+    );
+    expect(href('link[rel="icon"][sizes="16x16"]')).toBe(
+      themeIconPath("vector", 16),
+    );
+    expect(href('link[rel="apple-touch-icon"]')).toBe(
+      themeIconPath("vector", 180),
+    );
+    expect(document.head.querySelectorAll('link[rel="icon"]')).toHaveLength(2);
+    expect(
+      document.head.querySelectorAll('link[rel="apple-touch-icon"]'),
+    ).toHaveLength(1);
+  });
+});

--- a/ui/client/src/lib/themeIcons.ts
+++ b/ui/client/src/lib/themeIcons.ts
@@ -35,9 +35,9 @@ export function applyThemeIcons(theme: ThemeId): void {
       link = document.createElement("link");
       link.rel = rel;
       if (sizes) link.setAttribute("sizes", sizes);
-      link.type = "image/png";
       document.head.appendChild(link);
     }
+    link.type = "image/png";
     link.href = themeIconPath(theme, size);
   }
 }

--- a/ui/client/src/lib/themeIcons.ts
+++ b/ui/client/src/lib/themeIcons.ts
@@ -1,0 +1,43 @@
+/**
+ * Per-theme app icon wiring.
+ *
+ * One circuit-tree mark, three liveries (design handoff, brand-favicons
+ * preview): Veil magenta tree / violet river, Gilded amber tree / teal
+ * river, Vector blue tree / green river. The favicon and apple-touch link
+ * tags follow the active theme at runtime; the PWA manifest icons are
+ * bake-time and stay on the default theme (Veil).
+ */
+import type { ThemeId } from "@/types/settings";
+
+export type ThemeIconSize = 16 | 32 | 180 | 192 | 512;
+
+/** Cache-bust token for the icon set; bump when the PNGs change. */
+export const ICON_VERSION = "20260612";
+
+export function themeIconPath(theme: ThemeId, size: ThemeIconSize): string {
+  return `/icons/${theme}/icon-${size}.png?v=${ICON_VERSION}`;
+}
+
+const HEAD_LINKS: Array<{ rel: string; sizes?: string; size: ThemeIconSize }> = [
+  { rel: "icon", sizes: "32x32", size: 32 },
+  { rel: "icon", sizes: "16x16", size: 16 },
+  { rel: "apple-touch-icon", size: 180 },
+];
+
+/** Point the favicon + apple-touch link tags at the active theme's set. */
+export function applyThemeIcons(theme: ThemeId): void {
+  for (const { rel, sizes, size } of HEAD_LINKS) {
+    const selector = sizes
+      ? `link[rel="${rel}"][sizes="${sizes}"]`
+      : `link[rel="${rel}"]`;
+    let link = document.head.querySelector<HTMLLinkElement>(selector);
+    if (!link) {
+      link = document.createElement("link");
+      link.rel = rel;
+      if (sizes) link.setAttribute("sizes", sizes);
+      link.type = "image/png";
+      document.head.appendChild(link);
+    }
+    link.href = themeIconPath(theme, size);
+  }
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -72,7 +72,6 @@
         "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
-        "sharp": "^0.33.5",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "toml": "^3.0.0",
@@ -1988,16 +1987,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
@@ -2923,367 +2912,6 @@
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "license": "ISC"
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -7427,19 +7055,6 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7457,16 +7072,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -8047,6 +7652,9 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9761,12 +9369,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -13739,57 +13341,6 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
-    "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
-      }
-    },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -13900,15 +13451,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/smob": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -75,7 +75,6 @@
     "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
-    "sharp": "^0.33.5",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "toml": "^3.0.0",

--- a/ui/server/routes.ts
+++ b/ui/server/routes.ts
@@ -5,7 +5,6 @@ import { createProxyMiddleware } from "http-proxy-middleware";
 import multer from "multer";
 import fs from "fs/promises";
 import path from "path";
-import sharp from "sharp";
 
 // WebSocket proxy instance for /ws/narrative. http-proxy-middleware only
 // attaches its upgrade listener lazily (after the first plain HTTP request
@@ -83,18 +82,12 @@ export function registerProxyRoutes(app: Express): void {
 
   // Settings GET/PATCH live on the FastAPI service (typed, Pydantic-validated,
   // formatting-preserving writes through nexus.config.loader.save_settings).
-  // Only the exact /api/settings path proxies — /api/settings/pwa-icon stays a
-  // local Express route (multer + sharp asset pipeline in registerRoutes).
-  const settingsProxy = createProxyMiddleware({
+  // All /api/settings paths proxy through; there are no Express-local settings
+  // routes (the PWA icon upload was retired — icons are per-theme and locked).
+  app.use("/api/settings", createProxyMiddleware({
     ...narrativeProxyOptions,
     pathRewrite: (path) => (path === "/" ? "/api/settings" : `/api/settings${path}`),
-  });
-  app.use("/api/settings", (req, res, next) => {
-    if (req.path === "/" || req.path === "") {
-      return settingsProxy(req, res, next);
-    }
-    next();
-  });
+  }));
 
   narrativeWsProxy = createProxyMiddleware({ ...narrativeProxyOptions, ws: true });
   app.use("/ws/narrative", narrativeWsProxy);
@@ -325,7 +318,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Settings GET/PATCH are proxied to the FastAPI service (registerProxyRoutes).
-  // Only the PWA icon upload below remains an Express-local settings route.
 
   // Multer configuration for file uploads
   const upload = multer({
@@ -584,70 +576,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Error deleting place image:", error);
       res.status(500).json({ error: "Failed to delete image" });
-    }
-  });
-
-  // PWA Icon upload route
-  app.post("/api/settings/pwa-icon", upload.single("icon"), async (req, res) => {
-    try {
-      if (!req.file) {
-        return res.status(400).json({ error: "No file uploaded" });
-      }
-
-      const tempPath = req.file.path;
-      const iconsDir = path.join(import.meta.dirname, "..", "client", "public", "icons");
-
-      // Generate all required icon sizes using sharp (safe, no shell execution)
-      const sizes = [
-        { size: 512, name: "icon-512.png" },
-        { size: 192, name: "icon-192.png" },
-        { size: 180, name: "apple-touch-icon.png" },
-        { size: 32, name: "favicon-32.png" },
-      ];
-
-      for (const { size, name } of sizes) {
-        const outputPath = path.join(iconsDir, name);
-        await sharp(tempPath)
-          .resize(size, size, { fit: "contain", background: { r: 0, g: 0, b: 0, alpha: 0 } })
-          .png()
-          .toFile(outputPath);
-      }
-
-      // Generate favicon.ico using sharp
-      const faviconPath = path.join(import.meta.dirname, "..", "client", "public", "favicon.ico");
-
-      // Sharp doesn't natively support ICO, so create a 32x32 PNG as favicon
-      // Modern browsers support PNG favicons via <link rel="icon">
-      await sharp(tempPath)
-        .resize(32, 32, { fit: "contain", background: { r: 0, g: 0, b: 0, alpha: 0 } })
-        .png()
-        .toFile(faviconPath.replace('.ico', '.png'));
-
-      // Copy source file for future reference
-      const sourcePath = path.join(iconsDir, "icon-source.png");
-      await fs.copyFile(tempPath, sourcePath);
-
-      // Clean up temp file
-      await fs.unlink(tempPath);
-
-      // Update manifest.json with cache-busting timestamp
-      const manifestPath = path.join(import.meta.dirname, "..", "client", "public", "manifest.json");
-      const manifestData = await fs.readFile(manifestPath, "utf-8");
-      const manifest = JSON.parse(manifestData);
-      const timestamp = Date.now();
-
-      // Add timestamp query parameter to all icon URLs
-      manifest.icons = manifest.icons.map((icon: any) => ({
-        ...icon,
-        src: icon.src.split('?')[0] + `?v=${timestamp}` // Remove old timestamp if exists, add new one
-      }));
-
-      await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf-8");
-
-      res.json({ success: true, message: "PWA icon updated successfully" });
-    } catch (error) {
-      console.error("Error uploading PWA icon:", error);
-      res.status(500).json({ error: "Failed to upload icon" });
     }
   });
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -8,30 +8,33 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: 'autoUpdate',
-      includeAssets: ['favicon.ico', 'icons/apple-touch-icon.png'],
+      // PWA install icons are bake-time and follow the default theme (Veil).
+      // Runtime favicon/apple-touch swapping per theme happens in
+      // client/src/lib/themeIcons.ts.
+      includeAssets: ['favicon.ico', 'icons/veil/icon-180.png'],
       manifest: {
         name: 'NEXUS',
         short_name: 'NEXUS',
         description: 'NEXUS - Narrative exploration and analysis',
-        theme_color: '#0d9488',
-        background_color: '#09090b',
+        theme_color: '#09101c',
+        background_color: '#09101c',
         display: 'standalone',
         orientation: 'any',
         icons: [
           {
-            src: '/icons/icon-192.png',
+            src: '/icons/veil/icon-192.png',
             sizes: '192x192',
             type: 'image/png',
             purpose: 'any'
           },
           {
-            src: '/icons/icon-512.png',
+            src: '/icons/veil/icon-512.png',
             sizes: '512x512',
             type: 'image/png',
             purpose: 'any'
           },
           {
-            src: '/icons/apple-touch-icon.png',
+            src: '/icons/veil/icon-180.png',
             sizes: '180x180',
             type: 'image/png',
             purpose: 'any'
@@ -42,7 +45,6 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
         globIgnores: [
           '**/character_portraits/**',
-          '**/icons/icon-source.png',
         ],
         maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
         runtimeCaching: [

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -25,19 +25,19 @@ export default defineConfig({
             src: '/icons/veil/icon-192.png',
             sizes: '192x192',
             type: 'image/png',
-            purpose: 'any'
+            purpose: 'any maskable'
           },
           {
             src: '/icons/veil/icon-512.png',
             sizes: '512x512',
             type: 'image/png',
-            purpose: 'any'
+            purpose: 'any maskable'
           },
           {
             src: '/icons/veil/icon-180.png',
             sizes: '180x180',
             type: 'image/png',
-            purpose: 'any'
+            purpose: 'any maskable'
           }
         ]
       },
@@ -45,6 +45,11 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
         globIgnores: [
           '**/character_portraits/**',
+          // Non-default theme icons are fetched on demand at theme switch and
+          // cached by the NetworkFirst runtimeCaching rule below — keep them
+          // out of the install-time precache.
+          '**/icons/gilded/**',
+          '**/icons/vector/**',
         ],
         maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
         runtimeCaching: [


### PR DESCRIPTION
## Summary

The design handoff shipped three per-theme variants of the new circuit-tree app icon, but the PWA was still serving the old icon with a dead "upload your own" control in settings. This PR vendors the per-theme set, wires favicons to follow the active theme, and retires the upload path.

## Asset Provenance

Found, not generated. The handoff (`design_handoff/project/assets/`) contains finished per-theme sets at 512/192/180/32, confirmed against the kit's `preview/brand-favicons.html` and the chat record (the Vector icon is the corrected blue-tree/green-river version, per the "VECTOR and VECTOR ALT switched" exchange in chats/chat1.md):

- Veil: magenta tree, violet river (`icon-veil-*`)
- Gilded: amber tree, teal river (the kit's original `icon-*` set)
- Vector: blue tree, green river (`icon-vector-*`)

Vendored as `ui/client/public/icons/<theme>/icon-{512,192,180,32,16}.png`. Two derived assets were generated locally with Pillow:

- The 16px favicons: Lanczos downscale of each theme's designer-tuned 32px asset (the handoff preview renders the 32 at 16px for the 16 slot, so the 32 is the small-size master).
- The root `favicon.ico` legacy fallback: rebuilt as a 32+16 PNG-in-ICO from the Veil set (Veil is the default theme).

The old generic `/icons/icon-*.png` set (including `icon-source.png`, which existed only to serve the upload flow) is removed; per-theme master PNGs remain in the design handoff. Safe-zone margins of the new 512s match or improve on the old icon's, so the manifest keeps its existing `any maskable` purpose.

## Runtime Wiring

- `src/lib/themeIcons.ts` exports `themeIconPath()` and `applyThemeIcons()`, which retarget the `link[rel=icon]` (32/16) and `link[rel=apple-touch-icon]` tags; `ThemeContext`'s theme effect calls it on every theme change, using the existing `?v=` cache-bust pattern (`ICON_VERSION`).
- `index.html` static links point at the Veil set so the first paint matches the default theme; `meta theme-color` updated from the retired teal to Veil blue-black (`#09101c`).
- PWA install icons are bake-time and follow the default theme (Veil): both the static `manifest.json` and the VitePWA generated manifest now reference `/icons/veil/...`. No dynamic manifest route, by design.

## Removed

- The settings "upload your own icon" dropzone (drag-drop + commit/discard flow). Replaced with a compact non-interactive preview of the three theme icons; the active theme's tile is highlighted. Section relabeled "App Icon".
- The Express `POST /api/settings/pwa-icon` route and the settings-proxy carve-out that existed only for it (all `/api/settings` paths now proxy straight to FastAPI).
- The `sharp` dependency (the removed route was its only consumer). No `nexus.toml` or settings-model keys existed for the upload path.

## Verification

- `npm test` (vitest): 25 passed, including new `themeIcons.test.ts` covering link creation, per-theme retargeting, and no-duplication.
- `tsc --noEmit`: clean.
- Production build + `vite preview`: `/manifest.json`, `/manifest.webmanifest`, all 15 per-theme PNGs, and `favicon.ico` resolve 200 from build output.
- Headless Chrome (puppeteer-core) against a worktree dev server on port 5024: drove the settings UI through Gilded, Vector, Veil; asserted per theme that all three head links retarget to `/icons/<theme>/...?v=20260612`, each URL returns 200 `image/png`, no duplicate link tags accumulate, and the settings preview marks exactly one active tile. 27/27 checks passed; the persisted theme was restored to its original value (veil) afterwards.

Screenshot of the new settings section (Veil active):
the three-tile preview replaces the dropzone, active theme ringed, no text labels beyond the section heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)