### PR TITLE
Reader: Real Markdown Rendering with Clamped Heading Scale

### DIFF
--- a/ui/client/src/App.tsx
+++ b/ui/client/src/App.tsx
@@ -10,6 +10,7 @@ import { ModelProvider } from "@/contexts/ModelContext";
 import NotFound from "@/pages/not-found";
 import SplashPage from "@/pages/SplashPage";
 import NewStoryPage from "@/pages/NewStoryPage";
+import DevMarkdownPreview from "@/pages/DevMarkdownPreview";
 import { NexusLayout } from "@/components/nexus";
 
 function Router() {
@@ -18,6 +19,10 @@ function Router() {
       <Route path="/" component={SplashPage} />
       <Route path="/new-story" component={NewStoryPage} />
       <Route path="/nexus" component={NexusLayout} />
+      {/* Dev-only harness for narrative markdown rendering. */}
+      {import.meta.env.DEV && (
+        <Route path="/dev/markdown" component={DevMarkdownPreview} />
+      )}
       <Route component={NotFound} />
     </Switch>
   );

--- a/ui/client/src/App.tsx
+++ b/ui/client/src/App.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from "react";
 import { Switch, Route } from "wouter";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -10,8 +11,13 @@ import { ModelProvider } from "@/contexts/ModelContext";
 import NotFound from "@/pages/not-found";
 import SplashPage from "@/pages/SplashPage";
 import NewStoryPage from "@/pages/NewStoryPage";
-import DevMarkdownPreview from "@/pages/DevMarkdownPreview";
 import { NexusLayout } from "@/components/nexus";
+
+// Dev-only markdown harness: lazy + DEV-guarded so the module (and its
+// embedded fixture text) never reaches the production bundle.
+const DevMarkdownPreview = import.meta.env.DEV
+  ? lazy(() => import("@/pages/DevMarkdownPreview"))
+  : null;
 
 function Router() {
   return (
@@ -19,9 +25,12 @@ function Router() {
       <Route path="/" component={SplashPage} />
       <Route path="/new-story" component={NewStoryPage} />
       <Route path="/nexus" component={NexusLayout} />
-      {/* Dev-only harness for narrative markdown rendering. */}
-      {import.meta.env.DEV && (
-        <Route path="/dev/markdown" component={DevMarkdownPreview} />
+      {DevMarkdownPreview && (
+        <Route path="/dev/markdown">
+          <Suspense fallback={null}>
+            <DevMarkdownPreview />
+          </Suspense>
+        </Route>
       )}
       <Route component={NotFound} />
     </Switch>

--- a/ui/client/src/components/nexus/NarrativePane.tsx
+++ b/ui/client/src/components/nexus/NarrativePane.tsx
@@ -2,7 +2,10 @@
  * NarrativePane - the typeset book-chapter reading surface.
  *
  * Renders the current episode's committed chunks plus the pending
- * (incubator) chunk from slot state. Voice is differentiated by color only:
+ * (incubator) chunk from slot state. Prose renders as real markdown via
+ * ProseMarkdown (committed path and typewriter reveal path alike), with the
+ * voice color carried by the .md-part wrapper.
+ * Voice is differentiated by color only:
  * storyteller prose in warm cream (--fg), player responses in muted cream
  * (--fg-muted), with a thin centered rule between speaker changes. The
  * current chunk carries a 3px magenta edge marker; earlier chunks read at
@@ -17,11 +20,11 @@ import {
   useRef,
   useState,
   type KeyboardEvent,
-  type ReactNode,
 } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { DecoDivider } from "@/components/deco";
 import { Textarea } from "@/components/ui/textarea";
+import { ProseMarkdown } from "./ProseMarkdown";
 import { TypewriterText } from "./TypewriterText";
 import {
   getChunkContext,
@@ -30,13 +33,6 @@ import {
 } from "@/lib/narrative-api";
 import type { NarrativeEngine } from "@/hooks/useNarrativeEngine";
 import type { ChunkContext, ChunkWithMetadata } from "@/types/narrative";
-
-/** Render *emphasis* spans without dangerouslySetInnerHTML. */
-function renderProse(text: string): ReactNode[] {
-  return text.split(/\*([^*]+)\*/g).map((segment, i) =>
-    i % 2 === 1 ? <em key={i}>{segment}</em> : <Fragment key={i}>{segment}</Fragment>,
-  );
-}
 
 interface NarrativePaneProps {
   slot: number;
@@ -251,9 +247,9 @@ export function NarrativePane({
                   {chunk.parts.map((part) => (
                     <Fragment key={part.voice}>
                       {part.divider && <hr className="voice-divider" />}
-                      <p className={`line ${part.voice}`}>
-                        {renderProse(part.text)}
-                      </p>
+                      <div className={`md-part ${part.voice}`}>
+                        <ProseMarkdown text={part.text} />
+                      </div>
                     </Fragment>
                   ))}
                 </div>
@@ -264,14 +260,15 @@ export function NarrativePane({
               <div className="chunk-block current" data-testid="chunk-pending">
                 <div className="prose-block">
                   {pendingDivider && <hr className="voice-divider" />}
-                  <p className="line st">
+                  <div className="md-part st">
                     <TypewriterText
                       key={completedGenerations}
                       text={pendingText}
                       msPerChar={typewriterMsPerChar}
                       animate={completedGenerations > 0}
+                      markdown
                     />
-                  </p>
+                  </div>
                 </div>
               </div>
             )}

--- a/ui/client/src/components/nexus/ProseMarkdown.test.tsx
+++ b/ui/client/src/components/nexus/ProseMarkdown.test.tsx
@@ -123,6 +123,19 @@ describe("ProseMarkdown", () => {
     expect(container.textContent).toContain("the ledger");
   });
 
+  it("never emits an <img>; image markdown renders alt text only", () => {
+    const { container } = render(
+      <ProseMarkdown text="Before ![a tracking pixel](https://example.com/p.png) after." />,
+    );
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toContain("a tracking pixel");
+    const { container: noAlt } = render(
+      <ProseMarkdown text="Bare ![](https://example.com/p.png) image." />,
+    );
+    expect(noAlt.querySelector("img")).toBeNull();
+    expect(noAlt.textContent).toContain("Bare");
+  });
+
   it("renders the real save_02 legacy excerpt cleanly", () => {
     const { container } = render(
       <ProseMarkdown text={LEGACY_CHUNK_1425_EXCERPT} />,
@@ -220,6 +233,16 @@ describe("typewriter reveal", () => {
     expect(strong!.querySelector(".type-caret")).not.toBeNull();
   });
 
+  it("closes dangling _italic_ mid-reveal (legacy underscore emphasis)", () => {
+    const { container } = render(
+      <ProseMarkdown text="Alex is _well-rest" revealing />,
+    );
+    const em = container.querySelector("em");
+    expect(em).not.toBeNull();
+    expect(em!.textContent).toContain("well-rest");
+    expect(container.textContent).not.toContain("_");
+  });
+
   it("trims a half-typed rule so `--` never flashes as text", () => {
     expect(prepareRevealSource("Before.\n\n--")).not.toContain("-");
     const { container } = render(
@@ -227,6 +250,11 @@ describe("typewriter reveal", () => {
     );
     expect(container.textContent).not.toContain("-");
     expect(container.querySelector(".type-caret")).not.toBeNull();
+  });
+
+  it("trims longer CommonMark rule variants up to six markers", () => {
+    expect(prepareRevealSource("Before.\n\n-----")).not.toContain("-");
+    expect(prepareRevealSource("Before.\n\n------")).not.toContain("-");
   });
 
   it("trims bare heading hashes until their text arrives", () => {

--- a/ui/client/src/components/nexus/ProseMarkdown.test.tsx
+++ b/ui/client/src/components/nexus/ProseMarkdown.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * ProseMarkdown tests - real markdown rendering for the narrative reader.
+ *
+ * The legacy-corpus fixture below is real text captured from save_02
+ * narrative_chunks id 1425 on 2026-06-12 (trailing hard-break spaces and
+ * list-continuation indentation normalized for source hygiene). It exercises
+ * the dialect the storyteller actually emits: h1 episode headings, h2 voice
+ * headings, h3 section headings with bold inside, **bold**, *italic*,
+ * _italic_, `---` rules, bullet lists, and HTML scene-break comments.
+ */
+import { render } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { ProseMarkdown, prepareRevealSource } from "./ProseMarkdown";
+import { TypewriterText } from "./TypewriterText";
+
+const LEGACY_CHUNK_1425_EXCERPT = `<!-- SCENE BREAK: S05E06_001 (episode heading) -->
+# S05E06: Extraction
+## Storyteller
+### **Sullivan Retrieval Mission**
+\u{1F4CD} The Morning After | *Le Chat Noir*
+
+The **morning air in New Orleans is thick with humidity, but it carries the scent of fresh beignets, chicory coffee, and the distant pulse of the river.**
+
+The crew **moves through the quiet streets, recovering from the night before—some more gracefully than others.**
+
+---
+
+### **Crew Status Update**
+
+- **Alex & Emilia** → _Well-rested, smug, and walking just a little too in sync._
+
+- **Pete** → _Surprisingly un-hungover, but moving with the energy of a man whose worldview permanently shifted overnight._
+`;
+
+describe("ProseMarkdown", () => {
+  it("renders **bold** as <strong> with no literal asterisks", () => {
+    const { container } = render(<ProseMarkdown text="A **bold** claim." />);
+    const strong = container.querySelector("strong");
+    expect(strong).not.toBeNull();
+    expect(strong!.textContent).toBe("bold");
+    expect(container.textContent).not.toContain("*");
+  });
+
+  it("renders *italic* and _italic_ as <em>", () => {
+    const { container } = render(
+      <ProseMarkdown text="The *Gullwise* knocks; _witnessed_ and sealed." />,
+    );
+    const ems = container.querySelectorAll("em");
+    expect(ems).toHaveLength(2);
+    expect(ems[0].textContent).toBe("Gullwise");
+    expect(ems[1].textContent).toBe("witnessed");
+    expect(container.textContent).not.toContain("*");
+    expect(container.textContent).not.toContain("_");
+  });
+
+  it("leaves body prose as plain text nodes (no italic-everything wrapper)", () => {
+    const { container } = render(
+      <ProseMarkdown text="Plain prose stays upright." />,
+    );
+    expect(container.querySelector("em")).toBeNull();
+    expect(container.querySelector("p.line")).not.toBeNull();
+  });
+
+  it("renders ## as h2.md-h2 and ### as h3.md-h3", () => {
+    const { container } = render(
+      <ProseMarkdown text={"## Storyteller\n\n### Section"} />,
+    );
+    expect(container.querySelector("h2.md-h2")!.textContent).toBe(
+      "Storyteller",
+    );
+    expect(container.querySelector("h3.md-h3")!.textContent).toBe("Section");
+    expect(container.textContent).not.toContain("#");
+  });
+
+  it("clamps an in-content h1 to the h2 treatment", () => {
+    const { container } = render(
+      <ProseMarkdown text="# S05E06: Extraction" />,
+    );
+    expect(container.querySelector("h1")).toBeNull();
+    const clamped = container.querySelector("h2.md-h2");
+    expect(clamped).not.toBeNull();
+    expect(clamped!.textContent).toBe("S05E06: Extraction");
+  });
+
+  it("floors h4-h6 at the h4 (body-size) treatment", () => {
+    const { container } = render(
+      <ProseMarkdown text={"#### Four\n\n##### Five\n\n###### Six"} />,
+    );
+    expect(container.querySelectorAll(".md-h4")).toHaveLength(3);
+  });
+
+  it("renders --- as a styled rule, lists, and blockquotes", () => {
+    const { container } = render(
+      <ProseMarkdown
+        text={"Before.\n\n---\n\n- one\n- two\n\n> a quiet aside"}
+      />,
+    );
+    expect(container.querySelector("hr.md-hr")).not.toBeNull();
+    expect(container.querySelectorAll("ul li")).toHaveLength(2);
+    expect(container.querySelector("blockquote")!.textContent).toContain(
+      "a quiet aside",
+    );
+  });
+
+  it("drops raw HTML (scene-break comments) without rendering it", () => {
+    const { container } = render(
+      <ProseMarkdown
+        text={"<!-- SCENE BREAK: S05E06_001 -->\nThe fog comes in low."}
+      />,
+    );
+    expect(container.textContent).not.toContain("SCENE BREAK");
+    expect(container.textContent).toContain("The fog comes in low.");
+  });
+
+  it("renders links as plain text without an anchor", () => {
+    const { container } = render(
+      <ProseMarkdown text="See [the ledger](https://example.com)." />,
+    );
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toContain("the ledger");
+  });
+
+  it("renders the real save_02 legacy excerpt cleanly", () => {
+    const { container } = render(
+      <ProseMarkdown text={LEGACY_CHUNK_1425_EXCERPT} />,
+    );
+    // Heading clamp + hierarchy.
+    expect(container.querySelector("h1")).toBeNull();
+    const h2s = container.querySelectorAll("h2.md-h2");
+    expect(h2s.length).toBe(2); // clamped episode heading + voice heading
+    expect(h2s[0].textContent).toBe("S05E06: Extraction");
+    expect(container.querySelectorAll("h3.md-h3").length).toBe(2);
+    // Bold and italics resolved, no leaked syntax.
+    expect(container.querySelectorAll("strong").length).toBeGreaterThan(3);
+    expect(container.querySelectorAll("em").length).toBeGreaterThan(1);
+    expect(container.textContent).not.toContain("*");
+    expect(container.textContent).not.toContain("##");
+    expect(container.textContent).not.toContain("SCENE BREAK");
+    expect(container.textContent).not.toContain("---");
+    // Structure: rule + list survived.
+    expect(container.querySelector("hr.md-hr")).not.toBeNull();
+    expect(container.querySelectorAll("ul li").length).toBe(2);
+  });
+});
+
+describe("heading scale (nexus-layout.css)", () => {
+  const css = readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), "nexus-layout.css"),
+    "utf-8",
+  );
+
+  function sizeOf(selector: string): number {
+    const pattern = new RegExp(
+      `${selector.replace(/[.\\]/g, "\\$&")}[^}]*font-size:\\s*(\\d+(?:\\.\\d+)?)px`,
+    );
+    const match = css.match(pattern);
+    expect(match, `font-size for ${selector}`).not.toBeNull();
+    return parseFloat(match![1]);
+  }
+
+  it("keeps body prose upright by stylesheet", () => {
+    const line = css.match(/\.prose-block \.line \{[^}]*\}/);
+    expect(line).not.toBeNull();
+    expect(line![0]).toContain("font-style: normal");
+  });
+
+  it("sizes h2 at ~1.25-1.4x body so chrome still dominates", () => {
+    const body = sizeOf(".prose-block .line");
+    const h2 = sizeOf(".prose-block .md-h2");
+    expect(h2 / body).toBeGreaterThanOrEqual(1.25);
+    expect(h2 / body).toBeLessThanOrEqual(1.4);
+  });
+
+  it("steps h3 down from h2 but never below body", () => {
+    const body = sizeOf(".prose-block .line");
+    const h2 = sizeOf(".prose-block .md-h2");
+    const h3 = sizeOf(".prose-block .md-h3");
+    expect(h3).toBeLessThan(h2);
+    expect(h3).toBeGreaterThanOrEqual(body);
+  });
+
+  it("floors h4 at exactly body size", () => {
+    const body = sizeOf(".prose-block .line");
+    const h3 = sizeOf(".prose-block .md-h3");
+    const h4 = sizeOf(".prose-block .md-h4");
+    expect(h4).toBeLessThanOrEqual(h3);
+    expect(h4).toBeGreaterThanOrEqual(body);
+  });
+});
+
+describe("typewriter reveal", () => {
+  it("renders the finished frame as full markdown (no swap needed)", () => {
+    const { container } = render(
+      <TypewriterText
+        text={"## Arrival\n\nA **bold** *entrance*."}
+        msPerChar={1}
+        animate={false}
+        markdown
+      />,
+    );
+    expect(container.querySelector("h2.md-h2")!.textContent).toBe("Arrival");
+    expect(container.querySelector("strong")!.textContent).toBe("bold");
+    expect(container.querySelector("em")!.textContent).toBe("entrance");
+    expect(container.textContent).not.toContain("*");
+    expect(container.querySelector(".type-caret")).toBeNull();
+  });
+
+  it("closes dangling bold mid-reveal and rides the caret inline", () => {
+    const { container } = render(
+      <ProseMarkdown text="The crew **moves thro" revealing />,
+    );
+    const strong = container.querySelector("strong");
+    expect(strong).not.toBeNull();
+    expect(strong!.textContent).toContain("moves thro");
+    expect(container.textContent).not.toContain("*");
+    // Caret is injected inside the in-progress emphasis, at the frontier.
+    expect(strong!.querySelector(".type-caret")).not.toBeNull();
+  });
+
+  it("trims a half-typed rule so `--` never flashes as text", () => {
+    expect(prepareRevealSource("Before.\n\n--")).not.toContain("-");
+    const { container } = render(
+      <ProseMarkdown text={"Before.\n\n--"} revealing />,
+    );
+    expect(container.textContent).not.toContain("-");
+    expect(container.querySelector(".type-caret")).not.toBeNull();
+  });
+
+  it("trims bare heading hashes until their text arrives", () => {
+    const { container } = render(
+      <ProseMarkdown text={"Seen.\n\n##"} revealing />,
+    );
+    expect(container.textContent).not.toContain("#");
+  });
+
+  it("never leaks the caret sentinel as text", () => {
+    const { container } = render(
+      <ProseMarkdown text="Mid-sentence revea" revealing />,
+    );
+    expect(container.textContent).not.toContain("\uE000");
+    expect(container.querySelector(".type-caret")).not.toBeNull();
+  });
+});

--- a/ui/client/src/components/nexus/ProseMarkdown.tsx
+++ b/ui/client/src/components/nexus/ProseMarkdown.tsx
@@ -1,0 +1,141 @@
+/**
+ * ProseMarkdown - real markdown rendering for narrative prose.
+ *
+ * Replaces the old single-asterisk regex in NarrativePane (which italicized
+ * whole passages and leaked literal `**` / `##` markers). Parses the dialect
+ * Skald and the imported legacy corpus actually emit: `**bold**`, `*italic*`
+ * and `_italic_`, `#`-`######` ATX headings, `---` rules, `-`/`1.` lists,
+ * `>` blockquotes, and hard line breaks (GFM).
+ *
+ * Safety: raw HTML is never rendered (react-markdown default) and is dropped
+ * entirely via `skipHtml` so legacy `<!-- SCENE BREAK -->` comments vanish
+ * instead of printing literally. Links render as plain styled text - no
+ * navigation surface inside narrative. No dangerouslySetInnerHTML anywhere.
+ *
+ * Heading clamp: `#` in chunk content renders with the h2 treatment, and
+ * h4-h6 floor at the h4 treatment (body size). Sizing lives in
+ * nexus-layout.css (.md-h2 / .md-h3 / .md-h4).
+ *
+ * Reveal mode (`revealing`) supports the typewriter: the partial text is
+ * stabilized (dangling `**` / `*` closed, half-typed marker lines trimmed) so
+ * markdown renders correctly mid-reveal without flashing literal syntax, and
+ * an inline caret element is injected at the reveal frontier via a tiny
+ * rehype plugin.
+ */
+import ReactMarkdown, { type Options } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { Element, ElementContent, Root, Text } from "hast";
+
+/** Private-use sentinel marking the reveal frontier; never user-visible. */
+const CARET_SENTINEL = "\uE000";
+
+const components: Options["components"] = {
+  // Clamp: an in-chunk h1 gets the h2 treatment.
+  h1: ({ children }) => <h2 className="md-heading md-h2">{children}</h2>,
+  h2: ({ children }) => <h2 className="md-heading md-h2">{children}</h2>,
+  h3: ({ children }) => <h3 className="md-heading md-h3">{children}</h3>,
+  // Floor: h4 and deeper never render smaller than body text.
+  h4: ({ children }) => <h4 className="md-heading md-h4">{children}</h4>,
+  h5: ({ children }) => <h5 className="md-heading md-h4">{children}</h5>,
+  h6: ({ children }) => <h6 className="md-heading md-h4">{children}</h6>,
+  p: ({ children }) => <p className="line">{children}</p>,
+  hr: () => <hr className="md-hr" />,
+  // Narrative carries no navigation: render link text, drop the href.
+  a: ({ children }) => <span className="md-link">{children}</span>,
+};
+
+/**
+ * Close dangling emphasis markers in a partially revealed markdown string so
+ * the typewriter shows `**bo` as bold-in-progress rather than literal stars.
+ * Returns the suffix of closing markers to append (after the caret).
+ */
+function emphasisClosers(partial: string): string {
+  let closers = "";
+  const boldTokens = (partial.match(/\*\*/g) ?? []).length;
+  if (boldTokens % 2 === 1) closers += "**";
+  const singleStars = (partial.replace(/\*\*/g, "").match(/\*/g) ?? []).length;
+  if (singleStars % 2 === 1) closers += "*";
+  return closers;
+}
+
+/**
+ * Build the markdown source for a mid-reveal frame: trim a trailing line
+ * that is still just structural markers (`--` typing toward `---`, bare
+ * `##`, `>`), insert the caret sentinel at the frontier, and close any
+ * dangling emphasis after it.
+ */
+export function prepareRevealSource(partial: string): string {
+  const trimmed = partial.replace(/(^|\n)[-*_#>]{1,4}[ \t]*$/, "$1");
+  return trimmed + CARET_SENTINEL + emphasisClosers(trimmed);
+}
+
+/** Replace the caret sentinel text with an inline caret element. */
+function injectCaret(parent: Root | Element): boolean {
+  for (let i = parent.children.length - 1; i >= 0; i -= 1) {
+    const child = parent.children[i];
+    if (child.type === "text" && child.value.includes(CARET_SENTINEL)) {
+      const before = child.value.slice(0, child.value.indexOf(CARET_SENTINEL));
+      const after = child.value.slice(
+        child.value.indexOf(CARET_SENTINEL) + CARET_SENTINEL.length,
+      );
+      const caret: Element = {
+        type: "element",
+        tagName: "span",
+        properties: { className: ["type-caret"], ariaHidden: "true" },
+        children: [],
+      };
+      const replacement: ElementContent[] = [];
+      if (before) replacement.push({ type: "text", value: before } as Text);
+      replacement.push(caret);
+      if (after) replacement.push({ type: "text", value: after } as Text);
+      parent.children.splice(i, 1, ...replacement);
+      return true;
+    }
+    if (child.type === "element" && injectCaret(child)) return true;
+  }
+  return false;
+}
+
+/** Strip any sentinel that survived in odd positions (defensive). */
+function stripSentinels(parent: Root | Element): void {
+  for (const child of parent.children) {
+    if (child.type === "text" && child.value.includes(CARET_SENTINEL)) {
+      child.value = child.value.split(CARET_SENTINEL).join("");
+    } else if (child.type === "element") {
+      stripSentinels(child);
+    }
+  }
+}
+
+function rehypeCaret() {
+  return (tree: Root) => {
+    injectCaret(tree);
+    stripSentinels(tree);
+  };
+}
+
+const REMARK_PLUGINS = [remarkGfm];
+const REVEAL_REHYPE_PLUGINS = [rehypeCaret];
+
+interface ProseMarkdownProps {
+  text: string;
+  /**
+   * When true the text is a partial typewriter frame: dangling emphasis is
+   * closed and an inline caret marks the reveal frontier.
+   */
+  revealing?: boolean;
+}
+
+export function ProseMarkdown({ text, revealing = false }: ProseMarkdownProps) {
+  const source = revealing ? prepareRevealSource(text) : text;
+  return (
+    <ReactMarkdown
+      remarkPlugins={REMARK_PLUGINS}
+      rehypePlugins={revealing ? REVEAL_REHYPE_PLUGINS : undefined}
+      components={components}
+      skipHtml
+    >
+      {source}
+    </ReactMarkdown>
+  );
+}

--- a/ui/client/src/components/nexus/ProseMarkdown.tsx
+++ b/ui/client/src/components/nexus/ProseMarkdown.tsx
@@ -42,12 +42,17 @@ const components: Options["components"] = {
   hr: () => <hr className="md-hr" />,
   // Narrative carries no navigation: render link text, drop the href.
   a: ({ children }) => <span className="md-link">{children}</span>,
+  // Never emit a real <img> (no outbound requests from narrative or
+  // freeform player text); render the alt text inert, like links.
+  img: ({ alt }) => (alt ? <span className="md-link">{alt}</span> : null),
 };
 
 /**
  * Close dangling emphasis markers in a partially revealed markdown string so
  * the typewriter shows `**bo` as bold-in-progress rather than literal stars.
- * Returns the suffix of closing markers to append (after the caret).
+ * Handles both the asterisk and underscore forms found in the corpus
+ * (`**`/`*` from Skald, `__`/`_` in the legacy import). Returns the suffix
+ * of closing markers to append (after the caret).
  */
 function emphasisClosers(partial: string): string {
   let closers = "";
@@ -55,17 +60,22 @@ function emphasisClosers(partial: string): string {
   if (boldTokens % 2 === 1) closers += "**";
   const singleStars = (partial.replace(/\*\*/g, "").match(/\*/g) ?? []).length;
   if (singleStars % 2 === 1) closers += "*";
+  const doubleUnderscores = (partial.match(/__/g) ?? []).length;
+  if (doubleUnderscores % 2 === 1) closers += "__";
+  const singleUnderscores = (partial.replace(/__/g, "").match(/_/g) ?? [])
+    .length;
+  if (singleUnderscores % 2 === 1) closers += "_";
   return closers;
 }
 
 /**
  * Build the markdown source for a mid-reveal frame: trim a trailing line
- * that is still just structural markers (`--` typing toward `---`, bare
- * `##`, `>`), insert the caret sentinel at the frontier, and close any
- * dangling emphasis after it.
+ * that is still just structural markers (`--` typing toward `---` and its
+ * longer CommonMark variants, bare `##`, `>`), insert the caret sentinel at
+ * the frontier, and close any dangling emphasis after it.
  */
 export function prepareRevealSource(partial: string): string {
-  const trimmed = partial.replace(/(^|\n)[-*_#>]{1,4}[ \t]*$/, "$1");
+  const trimmed = partial.replace(/(^|\n)[-*_#>]{1,6}[ \t]*$/, "$1");
   return trimmed + CARET_SENTINEL + emphasisClosers(trimmed);
 }
 

--- a/ui/client/src/components/nexus/TypewriterText.tsx
+++ b/ui/client/src/components/nexus/TypewriterText.tsx
@@ -5,8 +5,17 @@
  * (configurable via `[ui] typewriter_ms_per_char` in nexus.toml, surfaced
  * through GET /api/settings). Chunks loaded from history render instantly;
  * only freshly generated text animates (the parent decides via `animate`).
+ *
+ * Markdown mode (`markdown`) renders each frame's visible slice through
+ * ProseMarkdown instead of as plain text, so emphasis and headings appear
+ * correctly formatted mid-reveal and the finished frame is identical to the
+ * committed-chunk rendering - no end-of-reveal swap, no layout jump. The
+ * caret rides the reveal frontier inside the rendered markdown. Block
+ * content cannot live inside a span, so markdown mode ignores `className`
+ * and returns the bare block stream (wrap it in a styled container).
  */
 import { useEffect, useRef, useState } from "react";
+import { ProseMarkdown } from "./ProseMarkdown";
 
 interface TypewriterTextProps {
   text: string;
@@ -14,6 +23,8 @@ interface TypewriterTextProps {
   msPerChar: number;
   /** When false, render the full text immediately. */
   animate: boolean;
+  /** Render the visible slice as narrative markdown (block content). */
+  markdown?: boolean;
   className?: string;
   onDone?: () => void;
 }
@@ -22,6 +33,7 @@ export function TypewriterText({
   text,
   msPerChar,
   animate,
+  markdown = false,
   className,
   onDone,
 }: TypewriterTextProps) {
@@ -50,6 +62,12 @@ export function TypewriterText({
   }, [text, animate, msPerChar]);
 
   const revealing = animate && visibleChars < text.length;
+
+  if (markdown) {
+    return (
+      <ProseMarkdown text={text.slice(0, visibleChars)} revealing={revealing} />
+    );
+  }
 
   return (
     <span className={className}>

--- a/ui/client/src/components/nexus/nexus-layout.css
+++ b/ui/client/src/components/nexus/nexus-layout.css
@@ -348,9 +348,71 @@
   font-style: normal;
   white-space: pre-wrap;
 }
-/* Voice colors — uniform per speaker; no italics, no prefix glyphs. */
-.prose-block .line.st { color: var(--fg); }
-.prose-block .line.you { color: var(--fg-muted); }
+/* Voice colors — uniform per speaker; no italics, no prefix glyphs.
+   Color sits on the markdown part wrapper so every block element
+   (paragraphs, headings, lists, quotes) inherits its voice. */
+.prose-block .md-part.st { color: var(--fg); }
+.prose-block .md-part.you { color: var(--fg-muted); }
+.prose-block .md-part > :first-child { margin-top: 0; }
+
+/* ─── In-chunk markdown ───
+   Headings stay in the body serif and defer to the surrounding UI chrome:
+   h2 is the largest in-chunk heading (h1 in content clamps to it), h3 steps
+   down, and h4-h6 floor at body size — distinguished by size first, with
+   weight and a touch of tracking within the existing design language. */
+.prose-block .md-heading {
+  font-family: var(--font-body);
+  font-weight: 600;
+  line-height: 1.35;
+  letter-spacing: 0.02em;
+  color: inherit;
+  margin: 30px 0 14px;
+  text-wrap: pretty;
+}
+.prose-block .md-h2 { font-size: 24px; }
+.prose-block .md-h3 { font-size: 20px; }
+.prose-block .md-h4 { font-size: 18px; }
+
+/* Markdown scene rule (`---`) — kin to the voice divider, slightly wider. */
+.prose-block .md-hr {
+  border: none;
+  height: 1px;
+  margin: 26px auto;
+  width: 55%;
+  background: linear-gradient(to right, transparent, var(--border-strong), transparent);
+}
+
+/* list-style is explicit because the Tailwind preflight resets it. */
+.prose-block .md-part ul,
+.prose-block .md-part ol {
+  font-family: var(--font-body);
+  font-size: 18px;
+  line-height: 1.6;
+  margin: 0 0 20px;
+  padding-left: 1.6em;
+}
+.prose-block .md-part ul { list-style: disc outside; }
+.prose-block .md-part ol { list-style: decimal outside; }
+.prose-block .md-part li { margin: 0 0 10px; }
+.prose-block .md-part li:last-child { margin-bottom: 0; }
+.prose-block .md-part li::marker { color: var(--bronze); }
+.prose-block .md-part li > .line { margin: 0; }
+
+.prose-block .md-part blockquote {
+  margin: 0 0 20px;
+  padding: 2px 0 2px 18px;
+  border-left: 2px solid var(--border-strong);
+}
+.prose-block .md-part blockquote > .line:last-child { margin-bottom: 0; }
+
+.prose-block .md-part code {
+  font-family: var(--font-mono);
+  font-size: 15px;
+}
+.prose-block .md-part pre {
+  margin: 0 0 20px;
+  white-space: pre-wrap;
+}
 
 /* Voice divider: thin centered rule on speaker change. */
 .voice-divider {

--- a/ui/client/src/pages/DevMarkdownPreview.tsx
+++ b/ui/client/src/pages/DevMarkdownPreview.tsx
@@ -1,0 +1,93 @@
+/**
+ * DevMarkdownPreview - dev-only harness for narrative markdown rendering.
+ *
+ * Registered at /dev/markdown only when import.meta.env.DEV (see App.tsx).
+ * Feeds a real save_02 legacy-corpus excerpt (narrative_chunks id 1425) and a
+ * replayable typewriter reveal through the exact components and markup
+ * NarrativePane uses (.reader / .prose-block / .md-part), so heading scale,
+ * voice color, emphasis, and mid-reveal stabilization can be verified in a
+ * real browser without staging database state.
+ */
+import { useState } from "react";
+import { ProseMarkdown } from "@/components/nexus/ProseMarkdown";
+import { TypewriterText } from "@/components/nexus/TypewriterText";
+import "@/components/nexus/nexus-layout.css";
+
+const LEGACY_EXCERPT = `<!-- SCENE BREAK: S05E06_001 (episode heading) -->
+# S05E06: Extraction
+## Storyteller
+### **Sullivan Retrieval Mission**
+\u{1F4CD} The Morning After | *Le Chat Noir*
+
+The **morning air in New Orleans is thick with humidity, but it carries the scent of fresh beignets, chicory coffee, and the distant pulse of the river.**
+
+The crew **moves through the quiet streets, recovering from the night before—some more gracefully than others.**
+
+---
+
+### **Crew Status Update**
+
+- **Alex & Emilia** → _Well-rested, smug, and walking just a little too in sync._
+
+- **Pete** → _Surprisingly un-hungover, but moving with the energy of a man whose worldview permanently shifted overnight._
+
+> A quiet aside, the way the corpus actually quotes its asides.
+
+#### Deep Heading Floor Check
+
+Plain body prose stays upright; only *marked* spans italicize and only **marked** spans embolden.`;
+
+const REVEAL_TEXT = `## Arrival
+
+The dory knocks against the quay, the *Gullwise* riding low, and somewhere behind the fog a bell counts what the **harbor refuses to say out loud**.
+
+You hold the lamp steady.`;
+
+export default function DevMarkdownPreview() {
+  const [run, setRun] = useState(1);
+  return (
+    <div style={{ padding: 28, background: "var(--bg)", minHeight: "100vh" }}>
+      <article className="reader" data-testid="dev-markdown-reader">
+        <div className="reader-frame">
+          <div className="reader-inner">
+            <section className="chunk-stream">
+              <div className="chunk-block" data-testid="dev-md-committed">
+                <div className="prose-block">
+                  <div className="md-part st">
+                    <ProseMarkdown text={LEGACY_EXCERPT} />
+                  </div>
+                  <hr className="voice-divider" />
+                  <div className="md-part you">
+                    <ProseMarkdown text="You take the ring — *not* to wear it, just to **hold the proof**." />
+                  </div>
+                </div>
+              </div>
+              <div className="chunk-block current" data-testid="dev-md-reveal">
+                <div className="prose-block">
+                  <div className="md-part st">
+                    <TypewriterText
+                      key={run}
+                      text={REVEAL_TEXT}
+                      msPerChar={18}
+                      animate
+                      markdown
+                    />
+                  </div>
+                </div>
+              </div>
+            </section>
+            <button
+              type="button"
+              className="choice"
+              onClick={() => setRun((r) => r + 1)}
+              data-testid="button-replay-reveal"
+            >
+              <span className="choice-glyph">◆</span>
+              <span className="choice-text">Replay the reveal.</span>
+            </button>
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}


### PR DESCRIPTION
## Root Cause

`renderProse()` in `NarrativePane.tsx` was a naive regex — `text.split(/\*([^*]+)\*/g)` — that wrapped every single-asterisk span in `<em>` with no markdown parsing at all. `**bold**` therefore rendered as a literal `*`, an italicized "bold", and another literal `*`; `##` heading hashes passed through as text; and long asterisk-delimited spans italicized entire passages.

## Dialect Found in Real Chunks

Sampled `narrative_chunks` across save_01/save_02/save_05 plus the storyteller prompts. The legacy corpus (1,458 chunks in save_02) is heavily markdown:

| Feature | Chunks (save_02) |
| --- | --- |
| `**bold**` | 1,432 |
| `*italic*` / `_italic_` | 1,432 |
| `## ` h2 (voice headings) | 1,425 |
| `### ` h3 (section headings, often `### **Bold Title**`) | 1,275 |
| `---` rules | 1,160 |
| `> ` blockquotes | 164 |
| `- ` bullet lists / `1.` ordered lists | 129 / 308 |
| `# ` h1 (episode headings) | 62 |
| `<!-- SCENE BREAK: ... -->` HTML comments | pervasive |

Fresh Skald output (save_05) currently emits plain paragraphs with `*italic*`. No tables or strikethrough anywhere.

## Fix

New `ProseMarkdown` component (react-markdown + remark-gfm, both already in package.json):

- Raw HTML never rendered; `skipHtml` drops legacy scene-break comments instead of printing them. No `dangerouslySetInnerHTML` anywhere. Links render as plain styled text (no navigation surface inside narrative).
- Paragraphs map to the existing `p.line` typography (Spectral 18px/1.78, 20px rhythm, `white-space: pre-wrap` preserved so intra-paragraph newlines still break).
- Voice-by-color moved to the `.md-part` wrapper (`st` = `--fg`, `you` = `--fg-muted`) so headings, lists, and quotes inherit their speaker's color.
- Explicit `list-style` on ul/ol because the Tailwind preflight strips bullets (caught in browser verification).

## Heading Scale

Body 18px Spectral. In-chunk headings stay in the body serif, weight 600, distinguished primarily by size:

- **h2: 24px** (1.33x body) — largest in-chunk heading; UI chrome (38px scene title) still dominates
- **h1 in content: clamped to the h2 treatment** (no h1 element rendered)
- **h3: 20px** (1.11x body)
- **h4–h6: 18px floor** — never below body size
- Margins 30px/14px around headings, harmonious with the 20px paragraph rhythm

## Typewriter Approach

Progressive markdown rendering — each frame's visible slice renders through the same `ProseMarkdown` path as committed chunks, so the finished frame is byte-identical to the committed rendering: no end-of-reveal swap, no flash, no layout jump. Two stabilizers keep mid-reveal frames clean:

- dangling `**`/`*` are closed so bold-in-progress renders bold instead of leaking stars;
- a trailing line that is still bare structural markers (`--` typing toward `---`, bare `##`, `>`) is trimmed until its content arrives.

The caret rides the reveal frontier inline (a private-use sentinel char swapped for the `.type-caret` span by a tiny rehype plugin), even inside an in-progress emphasis.

## Verification

- `npm test`: 41 passed (19 new — bold/italic, heading clamp, h4 floor, literal-asterisk regression, hr/list/blockquote, raw-HTML drop, heading-scale relationships parsed from the actual stylesheet, reveal stabilization, caret injection, sentinel non-leak). The big fixture is real save_02 chunk 1425 text.
- `tsc --noEmit` clean; production build clean.
- Real-browser pass (headless Chrome via puppeteer-core against a worktree Vite server on :5021, proxying the live API): computed styles confirmed body `font-style: normal` 18px Spectral, h2/h3/h4 = 24/20/18px weight 600, `em` italic only on marked spans, zero literal `*`/`##`/`SCENE BREAK` in rendered text, `h1Count: 0`. Screenshots of the dev harness (`/dev/markdown`, dev-only route feeding the real save_02 excerpt plus a live reveal) show correct headings, bold/italic, bronze list bullets, blockquote, hr rules, voice colors, and the caret riding mid-paragraph during reveal. The live reader on slot 5 renders upright prose with `em` italics exactly where marked.

## Notes

- `/dev/markdown` harness route registers only under `import.meta.env.DEV`.
- Choice-button labels still render raw text (pre-existing; no emphasis markers observed in live choices) — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)