### PR TITLE
Characters: Natural-Case Names, Place Names, Working Portraits

### DIFF
--- a/ui/client/src/components/nexus/CharactersPane.test.tsx
+++ b/ui/client/src/components/nexus/CharactersPane.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * CharactersPane tests - cast roster minimalism and portrait resolution.
+ *
+ * The legacy file path below is the real save_01 assets.character_images row
+ * for Alex (id 1) as of 2026-06-12: stored WITH a leading slash, which the
+ * old `/${filePath}` interpolation turned into a protocol-relative URL
+ * ("//character_portraits/...") and a broken image. These tests pin the fix.
+ *
+ * Component tests render against pre-seeded react-query caches built from
+ * real row shapes (no fetch interception): data drawn from save_01.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+import { CharactersPane, portraitSrc } from "./CharactersPane";
+import type { CharacterImage, CharacterListEntry } from "@shared/schema";
+
+const ALEX_LEGACY_PATH = "/character_portraits/1/1759852333889_9jangr.png";
+
+function makeCharacter(
+  overrides: Partial<CharacterListEntry> & { id: number; name: string },
+): CharacterListEntry {
+  return {
+    summary: null,
+    appearance: null,
+    background: null,
+    personality: null,
+    emotionalState: null,
+    currentActivity: null,
+    currentLocation: null,
+    extraData: null,
+    createdAt: new Date("2025-10-07T15:52:13Z"),
+    updatedAt: new Date("2025-10-07T15:52:13Z"),
+    currentLocationName: null,
+    portraitPath: null,
+    ...overrides,
+  };
+}
+
+function renderPane(
+  characters: CharacterListEntry[],
+  imagesByCharacter: Record<number, CharacterImage[]> = {},
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  const slot = 1;
+  queryClient.setQueryData(["/api/characters", slot], characters);
+  for (const character of characters) {
+    queryClient.setQueryData(
+      ["/api/characters/images", character.id, slot],
+      imagesByCharacter[character.id] ?? [],
+    );
+  }
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <CharactersPane slot={slot} />
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("portraitSrc", () => {
+  it("roots a clean relative path", () => {
+    expect(portraitSrc("character_portraits/5/abc.png")).toBe(
+      "/character_portraits/5/abc.png",
+    );
+  });
+
+  it("collapses the legacy leading slash instead of emitting a protocol-relative URL", () => {
+    expect(portraitSrc(ALEX_LEGACY_PATH)).toBe(ALEX_LEGACY_PATH);
+    expect(portraitSrc(ALEX_LEGACY_PATH)).not.toMatch(/^\/\//);
+  });
+});
+
+describe("CharactersPane", () => {
+  it("lists names in natural case with no location or id suffix", () => {
+    renderPane([
+      makeCharacter({
+        id: 1,
+        name: "Alex",
+        currentLocation: "2",
+        currentLocationName: "The Crucible",
+      }),
+    ]);
+    const row = screen.getByTestId("cast-member-1");
+    expect(row).toHaveTextContent(/^A\s*Alex$/);
+    expect(within(row).queryByText(/2/)).not.toBeInTheDocument();
+  });
+
+  it("shows no CAST MEMBER eyebrow and no roster header label", () => {
+    renderPane([makeCharacter({ id: 1, name: "Alex" })]);
+    expect(screen.queryByText(/cast member/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^CAST\b/)).not.toBeInTheDocument();
+  });
+
+  it("renders the resolved place name as 'at {place}'", () => {
+    renderPane([
+      makeCharacter({
+        id: 1,
+        name: "Alex",
+        currentLocation: "2",
+        currentLocationName: "The Crucible",
+      }),
+    ]);
+    expect(screen.getByText("at The Crucible")).toBeInTheDocument();
+    expect(screen.queryByText(/currently in/i)).not.toBeInTheDocument();
+  });
+
+  it("renders no location line when the place is unknown", () => {
+    renderPane([makeCharacter({ id: 2, name: "Emilia" })]);
+    expect(screen.queryByText(/^at /)).not.toBeInTheDocument();
+    expect(screen.queryByText(/null/)).not.toBeInTheDocument();
+  });
+
+  it("resolves Alex's legacy leading-slash portrait to a working src in list and detail", () => {
+    renderPane(
+      [
+        makeCharacter({
+          id: 1,
+          name: "Alex",
+          portraitPath: ALEX_LEGACY_PATH,
+        }),
+      ],
+      {
+        1: [
+          {
+            id: 1,
+            characterId: 1,
+            filePath: ALEX_LEGACY_PATH,
+            isMain: 1,
+            displayOrder: 0,
+            uploadedAt: new Date("2025-10-07T15:52:13Z"),
+          },
+        ],
+      },
+    );
+    const detailImg = screen.getByAltText("Alex");
+    expect(detailImg).toHaveAttribute("src", ALEX_LEGACY_PATH);
+    const row = screen.getByTestId("cast-member-1");
+    const thumb = row.querySelector("img");
+    expect(thumb).not.toBeNull();
+    expect(thumb!.getAttribute("src")).toBe(ALEX_LEGACY_PATH);
+  });
+
+  it("falls back to the letter glyph in the list and offers the upload affordance", () => {
+    renderPane([makeCharacter({ id: 3, name: "Pete" })]);
+    const row = screen.getByTestId("cast-member-3");
+    expect(within(row).getByText("P")).toBeInTheDocument();
+    expect(row.querySelector("img")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Upload portrait" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/client/src/components/nexus/CharactersPane.tsx
+++ b/ui/client/src/components/nexus/CharactersPane.tsx
@@ -1,21 +1,37 @@
 /**
  * CharactersPane - cast roster + dossier card.
  *
- * List on the left (single-letter glyph avatars, menu-font names), dossier
- * detail on the right: portrait on a dark surface behind a thin violet
- * border (lightly sepia + cool-rotated per the README imagery rules),
- * name as a menu-font heading, and prose sections from the live
- * characters table.
+ * List on the left (portrait thumbnails when uploaded, single-letter glyph
+ * avatars otherwise), dossier detail on the right: portrait on a dark
+ * surface behind a thin violet border (lightly sepia + cool-rotated per the
+ * README imagery rules), name as a menu-font heading in natural case, and
+ * prose sections from the live characters table. Hovering the portrait
+ * reveals an icon-only upload affordance; uploads fail loud.
  */
-import { useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { User } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ImagePlus, Loader2, User } from "lucide-react";
 import { DecoDivider } from "@/components/deco";
-import { getCharacterImages, getCharacters } from "@/lib/narrative-api";
-import type { Character, CharacterImage } from "@shared/schema";
+import {
+  getCharacterImages,
+  getCharacters,
+  setMainCharacterImage,
+  uploadCharacterPortrait,
+} from "@/lib/narrative-api";
+import type { CharacterImage, CharacterListEntry } from "@shared/schema";
 
 interface CharactersPaneProps {
   slot: number;
+}
+
+/**
+ * Root a stored portrait path as a site-absolute URL. Legacy rows stored the
+ * path with a leading slash; naively prefixing "/" turned those into
+ * protocol-relative URLs ("//character_portraits/...") that resolve against a
+ * bogus host and render as broken images.
+ */
+export function portraitSrc(filePath: string): string {
+  return `/${filePath.replace(/^\/+/, "")}`;
 }
 
 function DossierSection({ title, body }: { title: string; body: string | null }) {
@@ -30,8 +46,10 @@ function DossierSection({ title, body }: { title: string; body: string | null })
 
 export function CharactersPane({ slot }: CharactersPaneProps) {
   const [selectedId, setSelectedId] = useState<number | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const queryClient = useQueryClient();
 
-  const { data: characters, isLoading, error } = useQuery<Character[]>({
+  const { data: characters, isLoading, error } = useQuery<CharacterListEntry[]>({
     queryKey: ["/api/characters", slot],
     queryFn: () => getCharacters(slot),
   });
@@ -45,6 +63,30 @@ export function CharactersPane({ slot }: CharactersPaneProps) {
     queryKey: ["/api/characters/images", selected?.id, slot],
     queryFn: () => getCharacterImages(selected!.id, slot),
     enabled: !!selected,
+  });
+
+  const upload = useMutation({
+    mutationFn: async ({
+      characterId,
+      file,
+    }: {
+      characterId: number;
+      file: File;
+    }) => {
+      const hadImages = (images?.length ?? 0) > 0;
+      const image = await uploadCharacterPortrait(characterId, slot, file);
+      // The POST only marks the very first image as main; promoting each new
+      // upload keeps the visible portrait in sync with what was just chosen.
+      if (hadImages) {
+        await setMainCharacterImage(characterId, image.id, slot);
+      }
+    },
+    onSuccess: (_data, { characterId }) => {
+      queryClient.invalidateQueries({
+        queryKey: ["/api/characters/images", characterId, slot],
+      });
+      queryClient.invalidateQueries({ queryKey: ["/api/characters", slot] });
+    },
   });
 
   if (isLoading) {
@@ -81,7 +123,6 @@ export function CharactersPane({ slot }: CharactersPaneProps) {
   return (
     <div className="charspane" data-testid="characters-pane">
       <div className="charspane-list">
-        <span className="eyebrow brass-glow">CAST · {characters.length}</span>
         <ul>
           {characters.map((character) => (
             <li
@@ -90,13 +131,18 @@ export function CharactersPane({ slot }: CharactersPaneProps) {
               onClick={() => setSelectedId(character.id)}
               data-testid={`cast-member-${character.id}`}
             >
-              <span className="char-glyph">
-                {character.name.charAt(0).toUpperCase()}
-              </span>
-              <span className="char-name">{character.name}</span>
-              {character.currentLocation && (
-                <span className="char-role">· {character.currentLocation}</span>
+              {character.portraitPath ? (
+                <img
+                  className="char-glyph-img"
+                  src={portraitSrc(character.portraitPath)}
+                  alt=""
+                />
+              ) : (
+                <span className="char-glyph">
+                  {character.name.charAt(0).toUpperCase()}
+                </span>
               )}
+              <span className="char-name">{character.name}</span>
             </li>
           ))}
         </ul>
@@ -108,19 +154,50 @@ export function CharactersPane({ slot }: CharactersPaneProps) {
             <header className="char-head">
               <div className="char-portrait">
                 {mainImage ? (
-                  <img src={`/${mainImage.filePath}`} alt={selected.name} />
+                  <img src={portraitSrc(mainImage.filePath)} alt={selected.name} />
                 ) : (
                   <User className="char-portrait-empty" size={40} />
                 )}
+                <button
+                  type="button"
+                  className="char-portrait-upload"
+                  aria-label="Upload portrait"
+                  disabled={upload.isPending}
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  {upload.isPending ? (
+                    <Loader2 className="char-upload-spin" size={22} />
+                  ) : (
+                    <ImagePlus size={22} />
+                  )}
+                </button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/png,image/jpeg"
+                  hidden
+                  data-testid="input-portrait-file"
+                  onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    if (file) {
+                      upload.mutate({ characterId: selected.id, file });
+                    }
+                    event.target.value = "";
+                  }}
+                />
               </div>
               <div>
-                <span className="eyebrow">CAST MEMBER</span>
                 <h2 className="char-title" data-testid="text-dossier-name">
                   {selected.name}
                 </h2>
-                {selected.currentLocation && (
-                  <span className="caption">
-                    currently in {selected.currentLocation}
+                {selected.currentLocationName && (
+                  <span className="char-where">
+                    at {selected.currentLocationName}
+                  </span>
+                )}
+                {upload.isError && (
+                  <span className="char-upload-error" role="alert">
+                    {(upload.error as Error).message}
                   </span>
                 )}
               </div>

--- a/ui/client/src/components/nexus/CharactersPane.tsx
+++ b/ui/client/src/components/nexus/CharactersPane.tsx
@@ -73,15 +73,15 @@ export function CharactersPane({ slot }: CharactersPaneProps) {
       characterId: number;
       file: File;
     }) => {
-      const hadImages = (images?.length ?? 0) > 0;
       const image = await uploadCharacterPortrait(characterId, slot, file);
-      // The POST only marks the very first image as main; promoting each new
-      // upload keeps the visible portrait in sync with what was just chosen.
-      if (hadImages) {
-        await setMainCharacterImage(characterId, image.id, slot);
-      }
+      // Promote unconditionally: the POST only marks a slot's very first
+      // image as main, and gating the promote on the client's images query
+      // would race its async settle. Promoting every upload is idempotent.
+      await setMainCharacterImage(characterId, image.id, slot);
     },
-    onSuccess: (_data, { characterId }) => {
+    onSettled: (_data, _error, { characterId }) => {
+      // Invalidate even on failure so a partially completed upload (image
+      // row created, promote rejected) still surfaces without a reload.
       queryClient.invalidateQueries({
         queryKey: ["/api/characters/images", characterId, slot],
       });

--- a/ui/client/src/components/nexus/nexus-layout.css
+++ b/ui/client/src/components/nexus/nexus-layout.css
@@ -787,10 +787,6 @@
   min-height: 0;
 }
 .charspane-list { padding: 8px 0; overflow-y: auto; }
-.charspane-list > .eyebrow {
-  display: block;
-  margin-bottom: 12px;
-}
 .charspane-list ul {
   list-style: none;
   padding: 0;
@@ -831,22 +827,25 @@
   text-shadow: var(--glow-soft);
   flex-shrink: 0;
 }
+/* Uploaded-portrait thumbnail; same footprint as the letter glyph. */
+.char-glyph-img {
+  width: 30px;
+  height: 30px;
+  object-fit: cover;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+/* Names are content — natural case in the body face (the menu face has no
+   true lowercase in every theme). */
 .char-name {
-  font-family: var(--font-menu);
-  font-size: 12px;
-  letter-spacing: 0.18em;
+  font-family: var(--font-body);
+  font-size: 15px;
+  letter-spacing: 0.02em;
   color: var(--fg);
-  text-transform: uppercase;
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.char-role {
-  font-family: var(--font-body);
-  font-style: italic;
-  font-size: 14px;
-  color: var(--fg-muted);
   white-space: nowrap;
 }
 .charspane-detail {
@@ -870,6 +869,7 @@
 }
 /* Portraits: dark surface, thin violet border, light sepia + cool rotate. */
 .char-portrait {
+  position: relative;
   width: 104px;
   height: 136px;
   border: 1px solid var(--border-strong);
@@ -889,17 +889,59 @@
 .char-portrait .char-portrait-empty {
   color: var(--fg-dim);
 }
-/* The character's NAME is a heading — menu font, not the marquee. */
+/* Icon-only upload affordance: hidden until the portrait is hovered or the
+   control is focused; stays visible while an upload is in flight. */
+.char-portrait-upload {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  border: 0;
+  padding: 0;
+  background: hsl(270 30% 8% / .65);
+  color: var(--brass);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+.char-portrait:hover .char-portrait-upload,
+.char-portrait-upload:focus-visible,
+.char-portrait-upload:disabled {
+  opacity: 1;
+}
+.char-upload-spin {
+  animation: char-upload-rotate 0.9s linear infinite;
+}
+@keyframes char-upload-rotate {
+  to { transform: rotate(360deg); }
+}
+/* The character's NAME is a heading, but it is content — body face so it
+   renders in natural case in every theme. */
 .char-title {
-  font-family: var(--font-menu);
+  font-family: var(--font-body);
   font-size: 30px;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.02em;
   font-weight: 600;
-  text-transform: uppercase;
   color: var(--brass-bright);
   text-shadow: var(--glow-soft);
   margin: 0 0 4px;
   line-height: 1.1;
+}
+/* Location line: place names are content, not chrome — no uppercasing. */
+.char-where {
+  display: block;
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 15px;
+  color: var(--fg-muted);
+}
+.char-upload-error {
+  display: block;
+  margin-top: 6px;
+  font-family: var(--font-menu);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: hsl(var(--destructive));
 }
 .char-sections {
   display: flex;

--- a/ui/client/src/lib/narrative-api.ts
+++ b/ui/client/src/lib/narrative-api.ts
@@ -8,8 +8,8 @@
 import type {
   Season,
   Episode,
-  Character,
   CharacterImage,
+  CharacterListEntry,
   CurrentPlace,
   Place,
   PlaceImage,
@@ -70,7 +70,7 @@ export function getChunkContext(chunkId: number, slot: number): Promise<ChunkCon
   return getJson(`/api/narrative/chunks/${chunkId}/context?slot=${slot}`);
 }
 
-export function getCharacters(slot: number): Promise<Character[]> {
+export function getCharacters(slot: number): Promise<CharacterListEntry[]> {
   return getJson(`/api/characters?slot=${slot}`);
 }
 
@@ -79,6 +79,43 @@ export function getCharacterImages(
   slot: number,
 ): Promise<CharacterImage[]> {
   return getJson(`/api/characters/${characterId}/images?slot=${slot}`);
+}
+
+export async function uploadCharacterPortrait(
+  characterId: number,
+  slot: number,
+  file: File,
+): Promise<CharacterImage> {
+  const form = new FormData();
+  form.append("images", file);
+  const res = await fetch(`/api/characters/${characterId}/images?slot=${slot}`, {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    const text = (await res.text()) || res.statusText;
+    throw new Error(`${res.status}: ${text}`);
+  }
+  const data: { images: CharacterImage[] } = await res.json();
+  if (!data.images?.length) {
+    throw new Error("Upload returned no image record");
+  }
+  return data.images[0];
+}
+
+export async function setMainCharacterImage(
+  characterId: number,
+  imageId: number,
+  slot: number,
+): Promise<void> {
+  const res = await fetch(
+    `/api/characters/${characterId}/images/${imageId}/main?slot=${slot}`,
+    { method: "PUT" },
+  );
+  if (!res.ok) {
+    const text = (await res.text()) || res.statusText;
+    throw new Error(`${res.status}: ${text}`);
+  }
 }
 
 export function getUserCharacter(slot: number): Promise<{ name: string } | null> {

--- a/ui/server/routes.ts
+++ b/ui/server/routes.ts
@@ -1,4 +1,4 @@
-import type { Express } from "express";
+import express, { type Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { createProxyMiddleware } from "http-proxy-middleware";
@@ -341,6 +341,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
     },
   });
 
+  // Serve uploaded portraits straight from the runtime upload directory.
+  // Vite only mirrors client/public in dev; a production bundle serves the
+  // frozen dist copy, which predates any runtime upload. This route makes
+  // portrait files resolvable in both modes.
+  app.use(
+    "/character_portraits",
+    express.static(path.join(import.meta.dirname, "..", "client", "public", "character_portraits")),
+  );
+
   // Character image routes
   app.get("/api/characters/:id/images", async (req, res) => {
     try {
@@ -369,11 +378,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ error: "No files uploaded" });
       }
 
+      const slot = req.query.slot ? parseInt(req.query.slot as string) : undefined;
+
       const characterDir = path.join(import.meta.dirname, "..", "client", "public", "character_portraits", String(characterId));
       await fs.mkdir(characterDir, { recursive: true });
 
-      // Get current max display order
-      const existingImages = await storage.getCharacterImages(characterId);
+      // Get current max display order (in the same slot the rows are written
+      // to — omitting the slot here used to consult the default database and
+      // mis-flag a slot's first portrait as non-main).
+      const existingImages = await storage.getCharacterImages(characterId, slot);
       let maxOrder = existingImages.reduce((max, img) => Math.max(max, img.displayOrder), -1);
 
       const uploadedImages = [];
@@ -394,8 +407,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const isMain = existingImages.length === 0 && uploadedImages.length === 0 ? 1 : 0;
         maxOrder++;
 
-        const slot = req.query.slot ? parseInt(req.query.slot as string) : undefined;
-        const image = await storage.addCharacterImage(characterId, relativePath, isMain, maxOrder, slot);
+        let image;
+        try {
+          image = await storage.addCharacterImage(characterId, relativePath, isMain, maxOrder, slot);
+        } catch (insertError) {
+          // Don't leave an orphaned file behind when the row insert fails;
+          // the error still propagates to the client.
+          await fs.unlink(destPath).catch(() => {});
+          throw insertError;
+        }
         uploadedImages.push(image);
       }
 
@@ -438,8 +458,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ error: "Invalid IDs" });
       }
 
-      // Get image info to delete file
-      const images = await storage.getCharacterImages(characterId);
+      const slot = req.query.slot ? parseInt(req.query.slot as string) : undefined;
+
+      // Get image info to delete file (from the same slot the row lives in)
+      const images = await storage.getCharacterImages(characterId, slot);
       const image = images.find(img => img.id === imageId);
 
       if (image) {
@@ -451,7 +473,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
         }
       }
 
-      const slot = req.query.slot ? parseInt(req.query.slot as string) : undefined;
       await storage.deleteCharacterImage(imageId, slot);
       res.json({ success: true });
     } catch (error) {

--- a/ui/server/storage.ts
+++ b/ui/server/storage.ts
@@ -9,6 +9,7 @@ import {
   type NarrativeChunk,
   type ChunkMetadata,
   type Character,
+  type CharacterListEntry,
   type CharacterRelationship,
   type CharacterPsychology,
   type CharacterImage,
@@ -31,7 +32,7 @@ import {
   factions
 } from "@shared/schema";
 import { db, getDb } from "./db";
-import { eq, and, gte, lte, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 /**
  * Entity references for a single narrative chunk: the characters in (or
@@ -63,7 +64,7 @@ export interface IStorage {
   getChunkContext(chunkId: number, slot?: number | null): Promise<ChunkContext>;
 
   // Character methods
-  getCharacters(startId?: number, endId?: number, slot?: number | null): Promise<Character[]>;
+  getCharacters(startId?: number, endId?: number, slot?: number | null): Promise<CharacterListEntry[]>;
   getCharacterById(id: number, slot?: number | null): Promise<Character | undefined>;
 
   // Character relationship methods
@@ -367,31 +368,57 @@ export class PostgresStorage implements IStorage {
   }
 
   // Character methods
-  async getCharacters(startId?: number, endId?: number, slot?: number | null): Promise<Character[]> {
+  async getCharacters(startId?: number, endId?: number, slot?: number | null): Promise<CharacterListEntry[]> {
     const db = getDb(slot) || this.db;
-    if (startId !== undefined && endId !== undefined) {
-      return await db.select()
-        .from(characters)
-        .where(and(
-          gte(characters.id, startId),
-          lte(characters.id, endId)
-        ))
-        .orderBy(characters.id);
-    } else if (startId !== undefined) {
-      return await db.select()
-        .from(characters)
-        .where(gte(characters.id, startId))
-        .orderBy(characters.id);
-    } else if (endId !== undefined) {
-      return await db.select()
-        .from(characters)
-        .where(lte(characters.id, endId))
-        .orderBy(characters.id);
-    }
+    // Raw SQL (getAllPlaces precedent): resolve current_location to the place
+    // name server-side and pick each character's display portrait (main first,
+    // then display order) so the cast pane needs no second fetch per row.
+    const startCond = startId !== undefined ? sql` AND c.id >= ${startId}` : sql``;
+    const endCond = endId !== undefined ? sql` AND c.id <= ${endId}` : sql``;
+    const result = await db.execute(sql`
+      SELECT
+        c.id,
+        c.name,
+        c.summary,
+        c.appearance,
+        c.background,
+        c.personality,
+        c.emotional_state,
+        c.current_activity,
+        c.current_location,
+        c.extra_data,
+        c.created_at,
+        c.updated_at,
+        p.name AS current_location_name,
+        (
+          SELECT ci.file_path
+          FROM assets.character_images ci
+          WHERE ci.character_id = c.id
+          ORDER BY ci.is_main DESC, ci.display_order ASC
+          LIMIT 1
+        ) AS portrait_path
+      FROM characters c
+      LEFT JOIN places p ON p.id = c.current_location
+      WHERE TRUE${startCond}${endCond}
+      ORDER BY c.id
+    `);
 
-    return await db.select()
-      .from(characters)
-      .orderBy(characters.id);
+    return (result.rows as any[]).map((row) => ({
+      id: Number(row.id),
+      name: row.name as string,
+      summary: row.summary ?? null,
+      appearance: row.appearance ?? null,
+      background: row.background ?? null,
+      personality: row.personality ?? null,
+      emotionalState: row.emotional_state ?? null,
+      currentActivity: row.current_activity ?? null,
+      currentLocation: row.current_location != null ? String(row.current_location) : null,
+      extraData: row.extra_data ?? null,
+      createdAt: new Date(row.created_at),
+      updatedAt: new Date(row.updated_at),
+      currentLocationName: row.current_location_name ?? null,
+      portraitPath: row.portrait_path ?? null,
+    })) as CharacterListEntry[];
   }
 
   async getCharacterById(id: number, slot?: number | null): Promise<Character | undefined> {
@@ -850,16 +877,32 @@ class MemStorage implements IStorage {
     return { characters: [], places: [] };
   }
 
-  async getCharacters(startId?: number, endId?: number): Promise<Character[]> {
-    return this.characters.filter((character) => {
-      if (startId !== undefined && character.id < startId) {
-        return false;
-      }
-      if (endId !== undefined && character.id > endId) {
-        return false;
-      }
-      return true;
-    });
+  async getCharacters(startId?: number, endId?: number): Promise<CharacterListEntry[]> {
+    return this.characters
+      .filter((character) => {
+        if (startId !== undefined && character.id < startId) {
+          return false;
+        }
+        if (endId !== undefined && character.id > endId) {
+          return false;
+        }
+        return true;
+      })
+      .map((character) => {
+        // Mirror the Postgres join: resolve the place name and pick the
+        // display portrait (main first, then display order).
+        const portrait = this.characterImages
+          .filter((img) => img.characterId === character.id)
+          .sort((a, b) => b.isMain - a.isMain || a.displayOrder - b.displayOrder)[0];
+        const place = this.places.find(
+          (p) => String(p.id) === character.currentLocation,
+        );
+        return {
+          ...character,
+          currentLocationName: place?.name ?? null,
+          portraitPath: portrait?.filePath ?? null,
+        };
+      });
   }
 
   async getCharacterById(id: number): Promise<Character | undefined> {

--- a/ui/shared/schema.ts
+++ b/ui/shared/schema.ts
@@ -200,6 +200,14 @@ export interface CurrentPlace {
 }
 
 export type Character = typeof characters.$inferSelect;
+
+// Character row plus presentation context for the cast pane: the resolved
+// current-location place name and the main portrait path (both null when
+// unknown). Served by GET /api/characters.
+export type CharacterListEntry = Character & {
+  currentLocationName: string | null;
+  portraitPath: string | null;
+};
 export type CharacterRelationship = typeof characterRelationships.$inferSelect;
 export type CharacterPsychology = typeof characterPsychology.$inferSelect;
 export type CharacterImage = typeof characterImages.$inferSelect;


### PR DESCRIPTION
## Summary

Cast pane cleanup per the visual-minimalism doctrine (PR #388), plus a full repair of the half-broken portrait feature.

## Root Cause of Alex's Broken Portrait

The save_01 `assets.character_images` row for Alex stores `file_path` **with a leading slash** (`/character_portraits/1/1759852333889_9jangr.png`); current upload code writes paths without one. The client rendered `src={`/${filePath}`}`, which turned the legacy row into `//character_portraits/...` — a **protocol-relative URL** that resolves against host `character_portraits` and renders as a broken image. The file itself was intact on disk the whole time, so per the brief the fix is resolution logic, not data: a `portraitSrc()` helper collapses leading slashes before rooting the path. **No save_01 write was needed or performed.**

## Storage and Serving Design

- Files: `ui/client/public/character_portraits/<characterId>/<timestamped name>` (gitignored), written by the existing multer route.
- Rows: per-slot `assets.character_images` (`file_path`, `is_main`, `display_order`).
- Serving: added an explicit Express static route for `/character_portraits` so runtime uploads resolve in production builds too (previously only Vite dev mirrored `client/public`; a prod bundle serves the frozen `dist` copy, which predates any upload).
- `GET /api/characters` now LEFT JOINs `places` (location name) and subselects each character's display portrait (main first, then display order) — list thumbnails need no per-row second fetch. New shared type `CharacterListEntry = Character & { currentLocationName, portraitPath }`.

## Slot Bugs Found and Fixed in the Image Routes

- `POST /api/characters/:id/images` computed `existingImages` **without passing the slot**, consulting the default database — uploading a slot's first portrait could mis-flag it `is_main = 0` (reproduced live against save_05 before the fix).
- `DELETE /api/characters/:id/images/:imageId` looked up the file path the same wrong way.
- A failed row insert used to leak the already-copied file; it is now unlinked before the error propagates (still fail-loud).

## Label Removals (Minimalism Sweep)

- "CAST MEMBER" eyebrow above the dossier name: removed.
- "CAST · N" roster header (restated the rail's Characters tab): removed.
- List rows read "A ALEX · 2" (glyph + uppercased name + raw `places.id`): now just the avatar and "Alex". Names render in natural case via the body face — the veil theme's menu face is Cinzel, a small-caps design with no true lowercase, so dropping `text-transform` alone could not satisfy "names render in natural case".
- "currently in 2" caption: now "at The Land Rig" (server-resolved place name, body face, never uppercased); nothing renders when the location is unknown — no "at null", no placeholder.
- Dossier title likewise natural case.

## Upload Affordance

Icon-only hover overlay on the dossier portrait (also keyboard-focusable, `aria-label` only — no visible label text). Picks PNG/JPEG, posts to the existing route, promotes the new image to main so the visible portrait tracks the latest choice, invalidates both queries so list thumbnail and detail update together. Errors render loud beside the name (`role="alert"`).

## Verification

- `npm test`: 94 passed, including 8 new `CharactersPane` tests pinning the legacy leading-slash fix, the label removals, the "at {place}" line, and the upload affordance (pre-seeded query caches built from real save_01 row shapes; no fetch interception).
- `npm run check` (tsc) clean; `npm run build` green.
- Real browser (puppeteer + system Chrome, dev server on :5024):
  - Slot 1: Alex's portrait renders (`naturalWidth` 1856), her row shows the thumbnail, all names natural case with no id badges, "at The Land Rig" / "at Data-Barge Okami" lines correct, hover overlay appears.
  - Slot 5: end-to-end upload of a real PNG through the UI affordance — row landed `is_main = 1, display_order = 0` (post-fix) and the portrait rendered in both list and detail (`naturalWidth > 0` checked). Test row and file removed afterward; save_05 was concurrently reset by another lane, which is unrelated.
- save_01 was touched read-only throughout; no data writes performed anywhere except the save_05 upload test (cleaned up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)