### PR TITLE
Wizard: Structured Choices + Freeform Input, Command Bar Retired

### DIFF
--- a/nexus/api/narrative_schemas.py
+++ b/nexus/api/narrative_schemas.py
@@ -257,25 +257,16 @@ class SlotLockResponse(BaseModel):
 # =============================================================================
 
 
-def _wizard_default_model_factory() -> str:
-    """Return the resolved wizard default model from nexus.toml.
-
-    Used as the field default when an HTTP client doesn't specify a model.
-    Reading at request time keeps the value in sync with config edits.
-    """
-    from nexus.config import load_settings
-
-    return load_settings().wizard.default_model
-
-
 class ChatRequest(BaseModel):
     slot: int
     message: str
     # thread_id and current_phase are optional - resolved from slot state if not provided
     thread_id: Optional[str] = None
     current_phase: Optional[Literal["setting", "character", "seed"]] = None
-    # Defaults to the resolved wizard.default_model from nexus.toml
-    model: str = Field(default_factory=_wizard_default_model_factory)
+    # Optional explicit override. When omitted, the endpoint resolves the
+    # slot's stamped model (locked at setup start), then the configured
+    # wizard default from nexus.toml.
+    model: Optional[str] = None
     context_data: Optional[Dict[str, Any]] = None  # Accumulated wizard state
     accept_fate: bool = False  # Force tool call without adding user message
     dev: bool = Field(
@@ -288,8 +279,10 @@ class ChatRequest(BaseModel):
 
     @field_validator("model")
     @classmethod
-    def validate_model(cls, v: str) -> str:
+    def validate_model(cls, v: Optional[str]) -> Optional[str]:
         """Validate model against available models from nexus.toml."""
+        if v is None:
+            return v
         from nexus.config import get_available_api_models
 
         available = get_available_api_models()

--- a/nexus/api/new_story_flow.py
+++ b/nexus/api/new_story_flow.py
@@ -37,7 +37,11 @@ def start_setup(slot_number: int, model: Optional[str] = None) -> str:
 
     Args:
         slot_number: Target save slot (1-5)
-        model: Optional model name (defaults to settings.json new_story.model)
+        model: Optional model name. The HTTP setup endpoint resolves the
+            model before calling (explicit override or the configured
+            wizard default), so it always passes a concrete ID; direct
+            callers (e.g., scripts/new_story_cli.py) may pass None to get
+            the nexus.toml wizard.default_model fallback here.
 
     Returns:
         Thread ID for the new conversation

--- a/nexus/api/setup_endpoints.py
+++ b/nexus/api/setup_endpoints.py
@@ -42,7 +42,14 @@ router = APIRouter(prefix="/api/story/new", tags=["setup"])
 async def start_setup_endpoint(request: StartSetupRequest) -> Dict[str, Any]:
     """Start a new setup conversation"""
     try:
-        thread_id = start_setup(request.slot, request.model)
+        # Resolve the effective model once: an explicit request override
+        # (backend/CLI test flows may pass TEST here) or the configured
+        # wizard default from nexus.toml. The resolved model is stamped on
+        # the slot by start_setup, overriding any pre-wizard slot stamp such
+        # as the dev reset default; the mock TEST server is never selected
+        # implicitly.
+        model_to_use = request.model or get_new_story_model()
+        thread_id = start_setup(request.slot, model_to_use)
 
         # Load welcome message and choices from frontmatter
         prompt_path = (
@@ -58,8 +65,6 @@ async def start_setup_endpoint(request: StartSetupRequest) -> Dict[str, Any]:
 
         # Seed welcome message if exists (without choices - UI renders those)
         if welcome_message:
-            # Use request model (enables TEST mode) or fall back to settings
-            model_to_use = request.model or get_new_story_model()
             client = ConversationsClient(model=model_to_use)
             client.add_message(thread_id, "assistant", welcome_message)
 
@@ -71,6 +76,7 @@ async def start_setup_endpoint(request: StartSetupRequest) -> Dict[str, Any]:
             "status": "started",
             "thread_id": thread_id,
             "slot": request.slot,
+            "model": model_to_use,
             "welcome_message": welcome_message,
             "welcome_choices": welcome_choices,
         }
@@ -174,7 +180,9 @@ async def get_slots_status_endpoint():
         except (psycopg2.OperationalError, psycopg2.DatabaseError) as e:
             # Expected: DB doesn't exist or connection failed
             logger.warning(f"Could not connect to slot {slot} database: {e}")
-            results.append({"slot_number": slot, "is_active": False, "wizard_in_progress": False})
+            results.append(
+                {"slot_number": slot, "is_active": False, "wizard_in_progress": False}
+            )
         except Exception as e:
             # Unexpected errors should surface during development
             logger.error(f"Unexpected error fetching slot {slot}: {e}")

--- a/nexus/api/wizard_chat.py
+++ b/nexus/api/wizard_chat.py
@@ -69,6 +69,33 @@ logger = logging.getLogger("nexus.api.wizard_chat")
 router = APIRouter(prefix="/api/story/new", tags=["wizard"])
 
 
+def resolve_wizard_model(
+    request_model: Optional[str], slot_model: Optional[str]
+) -> str:
+    """Resolve the effective wizard model for a turn.
+
+    Precedence: explicit request override -> the slot's stamped model
+    (locked at setup start) -> the configured wizard default from
+    nexus.toml. The mock TEST model is never introduced here; it can only
+    arrive as an explicit request override or a deliberate slot stamp.
+    """
+    return request_model or slot_model or get_new_story_model()
+
+
+def wizard_model_lock_candidate(
+    request_model: Optional[str], slot_model: Optional[str]
+) -> bool:
+    """Whether a request may violate the wizard model lock.
+
+    Only an explicit request override that differs from the slot's stamped
+    model can conflict; an omitted model always resolves to the stamped
+    model and is therefore never a lock violation. The caller still checks
+    message history before raising 409 (the lock engages after the first
+    user message).
+    """
+    return bool(request_model and slot_model and request_model != slot_model)
+
+
 def _hydrate_character_context(request: ChatRequest) -> Optional[Dict[str, Any]]:
     """Load character_state from cache if in character phase and no context provided."""
     if request.current_phase != "character" or request.context_data is not None:
@@ -310,9 +337,9 @@ async def new_story_chat_endpoint(request: ChatRequest):
         history_limit = get_wizard_history_limit()
 
         slot_model = state.model
-        selected_model = request.model or slot_model or get_new_story_model()
+        selected_model = resolve_wizard_model(request.model, slot_model)
 
-        if request.model and slot_model and request.model != slot_model:
+        if wizard_model_lock_candidate(request.model, slot_model):
             history_client = ConversationsClient(model=slot_model)
             history = history_client.list_messages(
                 request.thread_id, limit=history_limit
@@ -625,9 +652,9 @@ async def new_story_chat_stream_endpoint(request: ChatRequest):
 
     history_limit = get_wizard_history_limit()
     slot_model = state.model
-    selected_model = request.model or slot_model or get_new_story_model()
+    selected_model = resolve_wizard_model(request.model, slot_model)
 
-    if request.model and slot_model and request.model != slot_model:
+    if wizard_model_lock_candidate(request.model, slot_model):
         history_client = ConversationsClient(model=slot_model)
         history = history_client.list_messages(request.thread_id, limit=history_limit)
         if any(msg["role"] == "user" for msg in history):

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -1047,11 +1047,14 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
         state = state_response.json()
 
         if state.get("is_empty"):
-            # Initialize via setup/start endpoint
-            # Use CLI-provided model, slot's configured model, or backend default.
+            # Initialize via setup/start endpoint. Forward only an explicit
+            # --model override; otherwise the backend resolves the configured
+            # wizard default. The empty slot's pre-wizard model stamp (the
+            # dev reset default) is deliberately NOT forwarded so the mock
+            # TEST server is never selected implicitly.
             setup_url = f"{get_api_url()}/api/story/new/setup/start"
             setup_payload = {"slot": args.slot}
-            model_to_use = getattr(args, "model", None) or state.get("model")
+            model_to_use = getattr(args, "model", None)
             if model_to_use:
                 setup_payload["model"] = model_to_use
             setup_response = requests.post(setup_url, json=setup_payload, timeout=30)
@@ -1069,6 +1072,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                 or f"Wizard initialized for slot {args.slot}.",
                 "choices": setup_data.get("welcome_choices", []),
                 "phase": "setting",
+                "model": setup_data.get("model"),
             }
 
         if state.get("is_wizard_mode"):

--- a/tests/test_api/test_wizard_model_resolution.py
+++ b/tests/test_api/test_wizard_model_resolution.py
@@ -1,0 +1,41 @@
+"""
+Regression tests for wizard default-model resolution.
+
+The wizard UI no longer carries a model picker; clients omit `model` and the
+backend resolves it: explicit request override -> slot's stamped model
+(locked at setup start) -> configured wizard default from nexus.toml. The
+mock TEST server must never be selected implicitly.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from nexus.api.config_utils import get_new_story_model
+from nexus.api.narrative_schemas import ChatRequest, StartSetupRequest
+
+
+def test_chat_request_model_defaults_to_none() -> None:
+    """Omitted model stays None so the slot's stamped model can win."""
+    request = ChatRequest(slot=5, message="hello")
+    assert request.model is None
+
+
+def test_chat_request_rejects_unknown_model() -> None:
+    with pytest.raises(ValidationError, match="Invalid model"):
+        ChatRequest(slot=5, message="hello", model="not-a-registry-id")
+
+
+def test_chat_request_accepts_explicit_test_model() -> None:
+    """TEST stays available as an explicit, backend-only override."""
+    request = ChatRequest(slot=5, message="hello", model="TEST")
+    assert request.model == "TEST"
+
+
+def test_start_setup_request_model_defaults_to_none() -> None:
+    request = StartSetupRequest(slot=5)
+    assert request.model is None
+
+
+def test_configured_wizard_default_is_not_the_mock() -> None:
+    """The resolved wizard.default_model must be a real model, never TEST."""
+    assert get_new_story_model() != "TEST"

--- a/tests/test_api/test_wizard_model_resolution.py
+++ b/tests/test_api/test_wizard_model_resolution.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 
 from nexus.api.config_utils import get_new_story_model
 from nexus.api.narrative_schemas import ChatRequest, StartSetupRequest
+from nexus.api.wizard_chat import resolve_wizard_model, wizard_model_lock_candidate
 
 
 def test_chat_request_model_defaults_to_none() -> None:
@@ -26,7 +27,11 @@ def test_chat_request_rejects_unknown_model() -> None:
 
 
 def test_chat_request_accepts_explicit_test_model() -> None:
-    """TEST stays available as an explicit, backend-only override."""
+    """TEST stays available as an explicit, backend-only override.
+
+    Requires the test provider entry in nexus.toml's api_models registry;
+    validate_model checks against get_available_api_models().
+    """
     request = ChatRequest(slot=5, message="hello", model="TEST")
     assert request.model == "TEST"
 
@@ -39,3 +44,32 @@ def test_start_setup_request_model_defaults_to_none() -> None:
 def test_configured_wizard_default_is_not_the_mock() -> None:
     """The resolved wizard.default_model must be a real model, never TEST."""
     assert get_new_story_model() != "TEST"
+
+
+def test_resolve_wizard_model_explicit_override_wins() -> None:
+    assert resolve_wizard_model("explicit-model", "slot-model") == "explicit-model"
+
+
+def test_resolve_wizard_model_falls_back_to_slot_stamp() -> None:
+    """Omitted request model resolves to the slot's stamped (locked) model."""
+    assert resolve_wizard_model(None, "slot-model") == "slot-model"
+
+
+def test_resolve_wizard_model_falls_back_to_configured_default() -> None:
+    resolved = resolve_wizard_model(None, None)
+    assert resolved == get_new_story_model()
+    assert resolved != "TEST"
+
+
+def test_omitted_model_is_never_a_lock_conflict() -> None:
+    """Normal UI requests (no model) can never trip the 409 model lock."""
+    assert wizard_model_lock_candidate(None, "slot-model") is False
+    assert wizard_model_lock_candidate(None, None) is False
+
+
+def test_matching_override_is_not_a_lock_conflict() -> None:
+    assert wizard_model_lock_candidate("slot-model", "slot-model") is False
+
+
+def test_differing_override_is_a_lock_conflict_candidate() -> None:
+    assert wizard_model_lock_candidate("other-model", "slot-model") is True

--- a/ui/client/src/components/NewStoryWizard/InteractiveWizard.tsx
+++ b/ui/client/src/components/NewStoryWizard/InteractiveWizard.tsx
@@ -44,6 +44,8 @@ interface InteractiveWizardProps {
 
 type Phase = "setting" | "character" | "seed";
 
+// User-facing phase titles; the seed phase is presented as "Introduction"
+// throughout the wizard (see WizardShell's PHASES and the artifact modal).
 const PHASE_TITLES: Record<Phase, string> = {
     setting: "Setting",
     character: "Character",

--- a/ui/client/src/components/NewStoryWizard/InteractiveWizard.tsx
+++ b/ui/client/src/components/NewStoryWizard/InteractiveWizard.tsx
@@ -1,14 +1,12 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from "react";
-import { Sparkles, ChevronDown, Check } from "lucide-react";
-import { getProviderIcon, getProviderWordmark, getModelIcon } from "@/lib/model-icons";
+import { Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { motion, AnimatePresence } from "framer-motion";
 import { useToast } from "@/hooks/use-toast";
-import { StoryChoices, ChoiceSelection } from "@/components/StoryChoices";
+import { WizardChoices, normalizeChoices } from "./WizardChoices";
 import { WaitScreen } from "./WaitScreen";
 import { ArtifactSidePanel } from "./ArtifactSidePanel";
-import { useModel } from "@/contexts/ModelContext";
 import {
     ResizablePanelGroup,
     ResizablePanel,
@@ -16,24 +14,9 @@ import {
 } from "@/components/ui/resizable";
 import type { ImperativePanelGroupHandle } from "react-resizable-panels";
 import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuPortal,
-    DropdownMenuSub,
-    DropdownMenuSubContent,
-    DropdownMenuSubTrigger,
-    DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
     Conversation,
     ConversationContent,
     ConversationScrollButton,
-    PromptInput,
-    PromptInputTextarea,
-    PromptInputToolbar,
-    PromptInputTools,
-    PromptInputSubmit,
     Loader,
     Response,
 } from "@/components/ai";
@@ -60,6 +43,12 @@ interface InteractiveWizardProps {
 }
 
 type Phase = "setting" | "character" | "seed";
+
+const PHASE_TITLES: Record<Phase, string> = {
+    setting: "Setting",
+    character: "Character",
+    seed: "Introduction",
+};
 
 // Panel size constants (percentages of container width)
 const PANEL_SIZE_COLLAPSED = 5;
@@ -117,18 +106,15 @@ export function InteractiveWizard({
     initialPhase,
 }: InteractiveWizardProps) {
     const [messages, setMessages] = useState<Message[]>([]);
-    const [input, setInput] = useState("");
     const [isLoading, setIsLoading] = useState(false);
     const [threadId, setThreadId] = useState<string | null>(null);
     const [currentPhase, setCurrentPhase] = useState<Phase>(initialPhase || "setting");
     const [pendingArtifact, setPendingArtifact] = useState<any>(null);
-    const [displayChoices, setDisplayChoices] = useState<string[] | null>(null);
+    const [displayChoices, setDisplayChoices] = useState<string[]>([]);
     const [showTraitSelector, setShowTraitSelector] = useState(false);
     const [suggestedTraits, setSuggestedTraits] = useState<string[]>([]);
     const [selectedTraits, setSelectedTraits] = useState<string[]>([]);
-    const [modelLocked, setModelLocked] = useState(false);
     const { toast } = useToast();
-    const { model, setModel, availableModels, modelsByProvider, isTestMode } = useModel();
 
     // Side panel state
     const [panelExpanded, setPanelExpanded] = useState(false);
@@ -167,20 +153,21 @@ export function InteractiveWizard({
 
                 // Reset local UI state when starting/resuming a session
                 setMessages([]);
-                setDisplayChoices(null);
+                setDisplayChoices([]);
                 setPendingArtifact(null);
                 setShowTraitSelector(false);
-                setModelLocked(false);
 
                 if (resumeThreadId) {
                     setThreadId(resumeThreadId);
                     return;
                 }
 
+                // No model in the payload: the backend resolves the
+                // configured wizard default and stamps it on the slot.
                 const startRes = await fetch("/api/story/new/setup/start", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ slot, model }),  // Include model for TEST mode support
+                    body: JSON.stringify({ slot }),
                 });
 
                 if (!startRes.ok) throw new Error("Failed to start setup");
@@ -190,9 +177,7 @@ export function InteractiveWizard({
                 if (welcome_message) {
                     addMessage("assistant", welcome_message);
                 }
-                if (welcome_choices && welcome_choices.length > 0) {
-                    setDisplayChoices(welcome_choices);
-                }
+                setDisplayChoices(normalizeChoices(welcome_choices));
             } catch (error) {
                 console.error("Failed to init chat:", error);
                 toast({
@@ -319,6 +304,8 @@ export function InteractiveWizard({
             // Step 2: Trigger bootstrap (generate first narrative chunk)
             setWaitScreenStatusText("Starting narrative generation...");
 
+            // No model override: bootstrap uses the model stamped on the
+            // slot when the wizard session started.
             const bootstrapRes = await fetch("/api/narrative/continue", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
@@ -326,8 +313,6 @@ export function InteractiveWizard({
                     chunk_id: 0,  // Bootstrap signal
                     slot,
                     user_text: "Begin the story.",
-                    test_mode: isTestMode,  // Pass TEST mode for mock bootstrap
-                    model,
                 }),
                 signal: abortController.signal,
             });
@@ -407,9 +392,6 @@ export function InteractiveWizard({
         content: string,
         artifact?: { type: string; data: any }
     ) => {
-        if (role === "user") {
-            setModelLocked(true);
-        }
         setMessages((prev) => [
             ...prev,
             {
@@ -434,7 +416,7 @@ export function InteractiveWizard({
     const triggerSubphaseContinuation = async (artifactType: string, contextData: any) => {
         if (isLoading) return;
         setIsLoading(true);
-        setDisplayChoices(null);  // Clear stale choices immediately to prevent flash
+        setDisplayChoices([]);  // Clear stale choices immediately to prevent flash
         try {
             const res = await fetch("/api/story/new/chat", {
                 method: "POST",
@@ -443,7 +425,6 @@ export function InteractiveWizard({
                     slot,
                     thread_id: threadId,
                     message: `[SYSTEM] Artifact ${artifactType} confirmed. Proceed to next step.`,
-                    model,
                     current_phase: currentPhase,
                     context_data: contextData
                 }),
@@ -454,12 +435,12 @@ export function InteractiveWizard({
 
             if (data.phase_complete) {
                 setPendingArtifact(normalizePendingArtifact(data.phase, data.artifact_type, data.data));
-                setDisplayChoices(null);
+                setDisplayChoices([]);
             } else if (data.subphase_complete) {
                 handleSubphaseCompletion(data.artifact_type, data.data);
             } else {
                 addMessage("assistant", data.message);
-                setDisplayChoices(data.choices ? normalizeChoices(data.choices) : null);
+                setDisplayChoices(normalizeChoices(data.choices));
                 if (currentPhase === "character" && shouldShowTraitSelector(data.message)) {
                     setShowTraitSelector(true);
                     extractSuggestedTraits(data.message);
@@ -521,7 +502,7 @@ export function InteractiveWizard({
                 console.error("Failed to build trait intro message:", error);
                 addMessage("assistant", TRAIT_INTRODUCTION + "\n\nPlease select your traits from the menu.");
             }
-            setDisplayChoices(null);  // No structured choices - TraitSelector handles it
+            setDisplayChoices([]);  // No structured choices - TraitSelector handles it
             return;  // Early return - no API call needed
         }
 
@@ -536,33 +517,15 @@ export function InteractiveWizard({
         triggerSubphaseContinuation(artifactType, updatedWizardData);
     };
 
-    const normalizeChoices = (choices: any): string[] | null => {
-        if (!choices || !Array.isArray(choices) || choices.length === 0) {
-            return null;
-        }
-        // Already string array
-        if (typeof choices[0] === "string") {
-            return (choices as string[]).map((c) => c.trim()).filter(Boolean);
-        }
-        // Handle structured {label, description}
-        if (choices[0]?.label && choices[0]?.description) {
-            return (choices as Array<{ label: string; description: string }>).map(
-                (c) => `${c.label}: ${c.description}`
-            );
-        }
-        // Fallback: coerce to strings
-        return (choices as Array<any>).map((c) => String(c).trim()).filter(Boolean);
-    };
-
-    const handleSend = async () => {
+    // Unified turn submission for structured choices and freeform input.
+    const sendMessage = async (text: string) => {
         // Synchronous ref-based guard for double-click prevention
-        if (processingRef.current || !input.trim() || isLoading || !threadId) return;
+        if (processingRef.current || !text.trim() || isLoading || !threadId) return;
         processingRef.current = true;
 
-        const userMsg = input.trim();
-        setInput("");
+        const userMsg = text.trim();
         addMessage("user", userMsg);
-        setDisplayChoices(null);  // Clear choices while loading
+        setDisplayChoices([]);  // Clear choices while loading
         setIsLoading(true);
 
         try {
@@ -573,7 +536,6 @@ export function InteractiveWizard({
                     slot,
                     thread_id: threadId,
                     message: userMsg,
-                    model,
                     current_phase: currentPhase,
                     context_data: wizardData
                 }),
@@ -585,13 +547,13 @@ export function InteractiveWizard({
 
             if (data.phase_complete) {
                 setPendingArtifact(normalizePendingArtifact(data.phase, data.artifact_type, data.data));
-                setDisplayChoices(null);
+                setDisplayChoices([]);
             } else if (data.subphase_complete) {
                 handleSubphaseCompletion(data.artifact_type, data.data);
             } else {
                 addMessage("assistant", data.message);
                 // Set choices if returned by backend
-                setDisplayChoices(data.choices ? normalizeChoices(data.choices) : null);
+                setDisplayChoices(normalizeChoices(data.choices));
                 // Check if LLM is prompting for trait selection
                 if (currentPhase === "character" && shouldShowTraitSelector(data.message)) {
                     setShowTraitSelector(true);
@@ -611,61 +573,6 @@ export function InteractiveWizard({
             processingRef.current = false;
             setIsLoading(false);
         }
-    };
-
-    const handleChoiceSelect = (selection: ChoiceSelection) => {
-        // Synchronous ref-based guard for double-click prevention
-        if (processingRef.current || isLoading) return;
-        processingRef.current = true;
-
-        // Clear choices while loading
-        setDisplayChoices(null);
-        const inputToSend = selection.text;
-        addMessage("user", inputToSend);
-        setIsLoading(true);
-
-        fetch("/api/story/new/chat", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                slot,
-                thread_id: threadId,
-                message: inputToSend,
-                model,
-                current_phase: currentPhase,
-                context_data: wizardData
-            }),
-        })
-            .then(async (res) => {
-                if (!res.ok) throw new Error("Failed to send message");
-                const data = await res.json();
-                if (data.phase_complete) {
-                    setPendingArtifact(normalizePendingArtifact(data.phase, data.artifact_type, data.data));
-                    setDisplayChoices(null);
-                } else if (data.subphase_complete) {
-                    handleSubphaseCompletion(data.artifact_type, data.data);
-                } else {
-                    addMessage("assistant", data.message);
-                    // Set choices if returned by backend
-                    setDisplayChoices(data.choices ? normalizeChoices(data.choices) : null);
-                    // Check if LLM is prompting for trait selection
-                    if (currentPhase === "character" && shouldShowTraitSelector(data.message)) {
-                        setShowTraitSelector(true);
-                    }
-                }
-            })
-            .catch((error) => {
-                console.error("Chat error:", error);
-                toast({
-                    title: "Transmission Error",
-                    description: "Failed to send message. Please try again.",
-                    variant: "destructive",
-                });
-            })
-            .finally(() => {
-                processingRef.current = false;
-                setIsLoading(false);
-            });
     };
 
     // Detect if LLM message is prompting for trait selection
@@ -713,9 +620,8 @@ export function InteractiveWizard({
 
         // Don't close selector yet - keep it open with spinner while processing
         const traitMessage = `I'll take: ${traits.join(", ")}`;
-        setInput("");
         addMessage("user", traitMessage);
-        setDisplayChoices(null);  // Clear choices while loading
+        setDisplayChoices([]);  // Clear choices while loading
         setIsLoading(true);
 
         fetch("/api/story/new/chat", {
@@ -725,7 +631,6 @@ export function InteractiveWizard({
                 slot,
                 thread_id: threadId,
                 message: traitMessage,
-                model,
                 current_phase: currentPhase,
                 context_data: wizardData
             }),
@@ -737,12 +642,12 @@ export function InteractiveWizard({
                 setShowTraitSelector(false);
                 if (data.phase_complete) {
                     setPendingArtifact(normalizePendingArtifact(data.phase, data.artifact_type, data.data));
-                    setDisplayChoices(null);
+                    setDisplayChoices([]);
                 } else if (data.subphase_complete) {
                     handleSubphaseCompletion(data.artifact_type, data.data);
                 } else {
                     addMessage("assistant", data.message);
-                    setDisplayChoices(data.choices ? normalizeChoices(data.choices) : null);
+                    setDisplayChoices(normalizeChoices(data.choices));
                 }
             })
             .catch((error) => {
@@ -780,7 +685,6 @@ export function InteractiveWizard({
                 slot,
                 thread_id: threadId,
                 message: traitMessage,
-                model,
                 current_phase: currentPhase,
                 context_data: wizardData
             }),
@@ -890,7 +794,6 @@ export function InteractiveWizard({
                     slot,
                     thread_id: threadId,
                     message: `[SYSTEM] Phase ${currentPhase} complete. Proceeding to ${nextPhase}. Please introduce the next phase.`,
-                    model,
                     current_phase: nextPhase,
                     context_data: wizardData
                 }),
@@ -901,7 +804,7 @@ export function InteractiveWizard({
             addMessage("assistant", data.message);
 
             // Set new choices (or clear if none)
-            setDisplayChoices(data.choices ? normalizeChoices(data.choices) : null);
+            setDisplayChoices(normalizeChoices(data.choices));
         } catch (error) {
             console.error("Next phase trigger error:", error);
         } finally {
@@ -967,7 +870,7 @@ export function InteractiveWizard({
                 <div className="flex items-center gap-2">
                     <Sparkles className="w-5 h-5 text-primary" />
                     <h3 className="font-mono text-foreground">
-                        SKALD // {currentPhase.toUpperCase()} PROTOCOL
+                        {PHASE_TITLES[currentPhase]}
                     </h3>
                 </div>
                 <Button
@@ -988,7 +891,6 @@ export function InteractiveWizard({
                                     slot,
                                     thread_id: threadId,
                                     message: "",  // No message needed
-                                    model,
                                     current_phase: currentPhase,
                                     context_data: wizardData,
                                     accept_fate: true,  // Backend forces tool call
@@ -1004,7 +906,7 @@ export function InteractiveWizard({
                                 handleSubphaseCompletion(data.artifact_type, data.data);
                             } else {
                                 addMessage("assistant", data.message);
-                                setDisplayChoices(data.choices?.length > 0 ? normalizeChoices(data.choices) : null);
+                                setDisplayChoices(normalizeChoices(data.choices));
                             }
                         } catch (e) {
                             console.error(e);
@@ -1046,14 +948,8 @@ export function InteractiveWizard({
                                         )}
                                     >
                                         {msg.role === "assistant" ? (
-                                            <div>
-                                                <div className="flex items-center gap-1.5 mb-2 pb-1 border-b border-primary/20">
-                                                    <Sparkles className="w-3 h-3 text-primary" />
-                                                    <span className="text-[10px] font-mono text-primary uppercase tracking-widest">Skald</span>
-                                                </div>
-                                                <div className="prose prose-invert max-w-none prose-p:leading-relaxed">
-                                                    <Response>{msg.content}</Response>
-                                                </div>
+                                            <div className="prose prose-invert max-w-none prose-p:leading-relaxed">
+                                                <Response>{msg.content}</Response>
                                             </div>
                                         ) : msg.role === "system" && msg.artifactData ? (
                                             <button
@@ -1074,17 +970,17 @@ export function InteractiveWizard({
                                 </motion.div>
                             ))}
                         </AnimatePresence>
-                        {/* Structured choices */}
-                        {displayChoices && displayChoices.length > 0 && !isLoading && (
+                        {/* Structured choices + freeform slot */}
+                        {!isLoading && (
                             <motion.div
                                 initial={{ opacity: 0, y: 10 }}
                                 animate={{ opacity: 1, y: 0 }}
                                 className="mt-4"
                             >
-                                <StoryChoices
+                                <WizardChoices
                                     choices={displayChoices}
-                                    onSelect={handleChoiceSelect}
-                                    disabled={isLoading}
+                                    onSubmit={sendMessage}
+                                    disabled={isLoading || !!pendingArtifact || !threadId}
                                 />
                             </motion.div>
                         )}
@@ -1096,100 +992,12 @@ export function InteractiveWizard({
                             >
                                 <div className="bg-muted/60 border border-accent/30 p-3 rounded-lg flex items-center gap-2">
                                     <Loader size={16} className="text-accent" />
-                                    <span className="text-xs text-muted-foreground font-mono">PROCESSING...</span>
                                 </div>
                             </motion.div>
                         )}
                     </ConversationContent>
                     <ConversationScrollButton />
                 </Conversation>
-
-                {/* Input Area - shadcn AI PromptInput */}
-                <div className="p-4 border-t border-primary/30 bg-background/60">
-                    <PromptInput
-                        onSubmit={(e) => {
-                            e.preventDefault();
-                            handleSend();
-                        }}
-                        className="border-primary/30 bg-background/40"
-                    >
-                        <PromptInputTextarea
-                            value={input}
-                            onChange={(e) => setInput(e.target.value)}
-                            placeholder={displayChoices && displayChoices.length > 0 ? "or something else?" : `Input for ${currentPhase} phase...`}
-                            disabled={isLoading || !!pendingArtifact}
-                            className="font-mono bg-transparent"
-                        />
-                        <PromptInputToolbar>
-                            <PromptInputTools>
-                                {/* Model Picker - Nested Dropdown */}
-                                <DropdownMenu>
-                                    <DropdownMenuTrigger asChild>
-                                        <Button
-                                            variant="ghost"
-                                            size="sm"
-                                            disabled={modelLocked}
-                                            className="h-7 px-2 font-mono text-xs text-muted-foreground hover:text-foreground"
-                                        >
-                                            <div className="flex items-center gap-1.5">
-                                                {getModelIcon(model, modelsByProvider, 'w-3.5 h-3.5')}
-                                                <span>{availableModels.find(m => m.id === model)?.label || model}</span>
-                                            </div>
-                                            <ChevronDown className="h-3 w-3 ml-1 opacity-50" />
-                                        </Button>
-                                    </DropdownMenuTrigger>
-                                    <DropdownMenuContent className="font-mono text-xs" align="start">
-                                        {Object.entries(modelsByProvider).map(([provider, models]) => (
-                                            models.length === 1 ? (
-                                                <DropdownMenuItem
-                                                    key={models[0].id}
-                                                    onClick={() => setModel(models[0].id)}
-                                                    className="flex items-center justify-between gap-2 text-xs"
-                                                >
-                                                    <div className="flex items-center gap-1.5">
-                                                        {getProviderIcon(provider, 'w-3.5 h-3.5')}
-                                                        <span>{models[0].label}</span>
-                                                    </div>
-                                                    {model === models[0].id && <Check className="h-3 w-3 shrink-0" />}
-                                                </DropdownMenuItem>
-                                            ) : (
-                                                <DropdownMenuSub key={provider}>
-                                                    <DropdownMenuSubTrigger className="gap-1.5 text-xs">
-                                                        {getProviderWordmark(provider, true) || (
-                                                            <span>{provider.charAt(0).toUpperCase() + provider.slice(1)}</span>
-                                                        )}
-                                                    </DropdownMenuSubTrigger>
-                                                    <DropdownMenuPortal>
-                                                        <DropdownMenuSubContent className="font-mono text-xs">
-                                                            {models.map(m => (
-                                                                <DropdownMenuItem
-                                                                    key={m.id}
-                                                                    onClick={() => setModel(m.id)}
-                                                                    className="flex items-center justify-between gap-2 text-xs"
-                                                                >
-                                                                    <div className="flex items-center gap-1.5">
-                                                                        {getProviderIcon(provider, 'w-3.5 h-3.5')}
-                                                                        <span>{m.label}</span>
-                                                                    </div>
-                                                                    {model === m.id && <Check className="h-3 w-3 shrink-0" />}
-                                                                </DropdownMenuItem>
-                                                            ))}
-                                                        </DropdownMenuSubContent>
-                                                    </DropdownMenuPortal>
-                                                </DropdownMenuSub>
-                                            )
-                                        ))}
-                                    </DropdownMenuContent>
-                                </DropdownMenu>
-                            </PromptInputTools>
-                            <PromptInputSubmit
-                                disabled={isLoading || !input.trim() || !!pendingArtifact}
-                                status={isLoading ? "submitted" : "ready"}
-                                className="bg-primary/20 border border-primary/50 text-primary hover:bg-primary/30"
-                            />
-                        </PromptInputToolbar>
-                    </PromptInput>
-                </div>
             </div>
         </div>
             </ResizablePanel>

--- a/ui/client/src/components/NewStoryWizard/WizardChoices.test.tsx
+++ b/ui/client/src/components/NewStoryWizard/WizardChoices.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Tests for the wizard's structured-choices + freeform composition:
+ * normalization of backend turn payloads and the click/type/keyboard
+ * interaction surface that replaced the wizard command bar.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { normalizeChoices, WizardChoices } from "./WizardChoices";
+
+describe("normalizeChoices", () => {
+    it("passes through string arrays, trimmed and filtered", () => {
+        expect(normalizeChoices(["  A cyberpunk city ", "", "High fantasy"])).toEqual([
+            "A cyberpunk city",
+            "High fantasy",
+        ]);
+    });
+
+    it("flattens structured {label, description} objects", () => {
+        expect(
+            normalizeChoices([{ label: "Noir", description: "Rain and neon" }]),
+        ).toEqual(["Noir: Rain and neon"]);
+    });
+
+    it("returns an empty list for null, undefined, and non-arrays", () => {
+        expect(normalizeChoices(null)).toEqual([]);
+        expect(normalizeChoices(undefined)).toEqual([]);
+        expect(normalizeChoices("not-an-array")).toEqual([]);
+    });
+
+    it("coerces unexpected member types to strings", () => {
+        expect(normalizeChoices([42, " yes "])).toEqual(["42", "yes"]);
+    });
+});
+
+describe("WizardChoices", () => {
+    const choices = ["Build a floating city", "Start in the underdark"];
+
+    it("renders one numbered button per choice", () => {
+        render(<WizardChoices choices={choices} onSubmit={() => {}} />);
+        expect(screen.getByTestId("wizard-choice-1")).toHaveTextContent(
+            "Build a floating city",
+        );
+        expect(screen.getByTestId("wizard-choice-2")).toHaveTextContent(
+            "Start in the underdark",
+        );
+    });
+
+    it("submits the choice text on click", () => {
+        const onSubmit = vi.fn();
+        render(<WizardChoices choices={choices} onSubmit={onSubmit} />);
+        fireEvent.click(screen.getByTestId("wizard-choice-2"));
+        expect(onSubmit).toHaveBeenCalledWith("Start in the underdark");
+    });
+
+    it("always renders the freeform slot, even with no choices", () => {
+        render(<WizardChoices choices={[]} onSubmit={() => {}} />);
+        expect(screen.queryByRole("button")).toBeNull();
+        expect(screen.getByTestId("wizard-freeform")).toBeInTheDocument();
+    });
+
+    it("submits trimmed freeform text on Enter and clears the field", () => {
+        const onSubmit = vi.fn();
+        render(<WizardChoices choices={choices} onSubmit={onSubmit} />);
+        const freeform = screen.getByTestId("wizard-freeform");
+        fireEvent.change(freeform, { target: { value: "  a haunted lighthouse  " } });
+        fireEvent.keyDown(freeform, { key: "Enter" });
+        expect(onSubmit).toHaveBeenCalledWith("a haunted lighthouse");
+        expect(freeform).toHaveValue("");
+    });
+
+    it("does not submit empty freeform text", () => {
+        const onSubmit = vi.fn();
+        render(<WizardChoices choices={choices} onSubmit={onSubmit} />);
+        const freeform = screen.getByTestId("wizard-freeform");
+        fireEvent.change(freeform, { target: { value: "   " } });
+        fireEvent.keyDown(freeform, { key: "Enter" });
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("inserts a newline instead of submitting on Shift+Enter", () => {
+        const onSubmit = vi.fn();
+        render(<WizardChoices choices={choices} onSubmit={onSubmit} />);
+        const freeform = screen.getByTestId("wizard-freeform");
+        fireEvent.change(freeform, { target: { value: "line one" } });
+        fireEvent.keyDown(freeform, { key: "Enter", shiftKey: true });
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("selects a choice via number key when focus is outside the field", () => {
+        const onSubmit = vi.fn();
+        render(<WizardChoices choices={choices} onSubmit={onSubmit} />);
+        fireEvent.keyDown(window, { key: "1" });
+        expect(onSubmit).toHaveBeenCalledWith("Build a floating city");
+    });
+
+    it("ignores number keys typed inside the freeform field", () => {
+        const onSubmit = vi.fn();
+        render(<WizardChoices choices={choices} onSubmit={onSubmit} />);
+        const freeform = screen.getByTestId("wizard-freeform");
+        freeform.focus();
+        fireEvent.keyDown(freeform, { key: "1" });
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("disables all interaction when disabled", () => {
+        const onSubmit = vi.fn();
+        render(<WizardChoices choices={choices} onSubmit={onSubmit} disabled />);
+        fireEvent.keyDown(window, { key: "1" });
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(screen.getByTestId("wizard-choice-1")).toBeDisabled();
+        expect(screen.getByTestId("wizard-freeform")).toBeDisabled();
+    });
+});

--- a/ui/client/src/components/NewStoryWizard/WizardChoices.test.tsx
+++ b/ui/client/src/components/NewStoryWizard/WizardChoices.test.tsx
@@ -52,6 +52,27 @@ describe("WizardChoices", () => {
         expect(onSubmit).toHaveBeenCalledWith("Start in the underdark");
     });
 
+    it("clears a freeform draft when a choice is clicked", () => {
+        const onSubmit = vi.fn();
+        render(<WizardChoices choices={choices} onSubmit={onSubmit} />);
+        const freeform = screen.getByTestId("wizard-freeform");
+        fireEvent.change(freeform, { target: { value: "abandoned draft" } });
+        fireEvent.click(screen.getByTestId("wizard-choice-1"));
+        expect(onSubmit).toHaveBeenCalledWith("Build a floating city");
+        expect(freeform).toHaveValue("");
+    });
+
+    it("clears a freeform draft when a choice is selected by number key", () => {
+        const onSubmit = vi.fn();
+        render(<WizardChoices choices={choices} onSubmit={onSubmit} />);
+        const freeform = screen.getByTestId("wizard-freeform");
+        fireEvent.change(freeform, { target: { value: "abandoned draft" } });
+        (document.activeElement as HTMLElement | null)?.blur?.();
+        fireEvent.keyDown(window, { key: "2" });
+        expect(onSubmit).toHaveBeenCalledWith("Start in the underdark");
+        expect(freeform).toHaveValue("");
+    });
+
     it("always renders the freeform slot, even with no choices", () => {
         render(<WizardChoices choices={[]} onSubmit={() => {}} />);
         expect(screen.queryByRole("button")).toBeNull();

--- a/ui/client/src/components/NewStoryWizard/WizardChoices.tsx
+++ b/ui/client/src/components/NewStoryWizard/WizardChoices.tsx
@@ -63,6 +63,17 @@ export function WizardChoices({
     const [freeform, setFreeform] = useState("");
     const freeformRef = useRef<HTMLTextAreaElement>(null);
 
+    // Choice selection clears any freeform draft so it cannot leak into the
+    // next turn's input.
+    const submitChoice = useCallback(
+        (text: string) => {
+            if (disabled) return;
+            setFreeform("");
+            onSubmit(text);
+        },
+        [disabled, onSubmit],
+    );
+
     const submitFreeform = useCallback(() => {
         const text = freeform.trim();
         if (!text || disabled) return;
@@ -95,12 +106,12 @@ export function WizardChoices({
             }
             const n = parseInt(e.key, 10);
             if (!isNaN(n) && n >= 1 && n <= choices.length) {
-                onSubmit(choices[n - 1]);
+                submitChoice(choices[n - 1]);
             }
         };
         window.addEventListener("keydown", onKey);
         return () => window.removeEventListener("keydown", onKey);
-    }, [choices, disabled, onSubmit]);
+    }, [choices, disabled, submitChoice]);
 
     return (
         <div className="space-y-1.5" data-testid="wizard-choices">
@@ -108,7 +119,7 @@ export function WizardChoices({
                 <button
                     key={`${i}-${text}`}
                     type="button"
-                    onClick={() => onSubmit(text)}
+                    onClick={() => submitChoice(text)}
                     disabled={disabled}
                     data-testid={`wizard-choice-${i + 1}`}
                     className={cn(

--- a/ui/client/src/components/NewStoryWizard/WizardChoices.tsx
+++ b/ui/client/src/components/NewStoryWizard/WizardChoices.tsx
@@ -1,0 +1,152 @@
+/**
+ * WizardChoices - Structured choices plus an always-present freeform input
+ * for the new-story wizard, mirroring the narrative reader's interaction
+ * pattern (numbered choice buttons + freeform slot 0). The wizard composes
+ * its own markup; reader-owned files are untouched.
+ */
+import {
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+    type KeyboardEvent,
+} from "react";
+import { cn } from "@/lib/utils";
+import { Textarea } from "@/components/ui/textarea";
+
+/**
+ * Normalize backend choice payloads into display strings.
+ *
+ * The wizard turn contract returns `choices: string[]`, but older cached
+ * turns may carry structured `{label, description}` objects.
+ */
+export function normalizeChoices(choices: unknown): string[] {
+    if (!Array.isArray(choices)) {
+        return [];
+    }
+    return choices
+        .map((choice) => {
+            if (typeof choice === "string") {
+                return choice.trim();
+            }
+            if (
+                choice !== null &&
+                typeof choice === "object" &&
+                "label" in choice &&
+                "description" in choice
+            ) {
+                const { label, description } = choice as {
+                    label: unknown;
+                    description: unknown;
+                };
+                return `${String(label)}: ${String(description)}`.trim();
+            }
+            return String(choice ?? "").trim();
+        })
+        .filter(Boolean);
+}
+
+interface WizardChoicesProps {
+    /** Structured choices from the wizard turn contract (may be empty). */
+    choices: string[];
+    /** Called with the chosen or typed text; the parent sends it as the turn. */
+    onSubmit: (text: string) => void;
+    /** Disable interaction while a turn is in flight or an artifact is pending. */
+    disabled?: boolean;
+}
+
+export function WizardChoices({
+    choices,
+    onSubmit,
+    disabled = false,
+}: WizardChoicesProps) {
+    const [freeform, setFreeform] = useState("");
+    const freeformRef = useRef<HTMLTextAreaElement>(null);
+
+    const submitFreeform = useCallback(() => {
+        const text = freeform.trim();
+        if (!text || disabled) return;
+        setFreeform("");
+        onSubmit(text);
+    }, [freeform, disabled, onSubmit]);
+
+    const handleFreeformKeyDown = useCallback(
+        (e: KeyboardEvent<HTMLTextAreaElement>) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                submitFreeform();
+            }
+        },
+        [submitFreeform],
+    );
+
+    // Number keys 1-N select choices when focus is outside any text field.
+    useEffect(() => {
+        const onKey = (e: globalThis.KeyboardEvent) => {
+            if (disabled) return;
+            const active = document.activeElement;
+            if (
+                active instanceof HTMLElement &&
+                (active.tagName === "TEXTAREA" ||
+                    active.tagName === "INPUT" ||
+                    active.isContentEditable)
+            ) {
+                return;
+            }
+            const n = parseInt(e.key, 10);
+            if (!isNaN(n) && n >= 1 && n <= choices.length) {
+                onSubmit(choices[n - 1]);
+            }
+        };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [choices, disabled, onSubmit]);
+
+    return (
+        <div className="space-y-1.5" data-testid="wizard-choices">
+            {choices.map((text, i) => (
+                <button
+                    key={`${i}-${text}`}
+                    type="button"
+                    onClick={() => onSubmit(text)}
+                    disabled={disabled}
+                    data-testid={`wizard-choice-${i + 1}`}
+                    className={cn(
+                        "flex w-full items-start gap-3 px-4 py-3 text-left",
+                        "border border-border/30 transition-colors duration-150",
+                        "hover:border-primary/40 hover:bg-primary/5",
+                        "disabled:pointer-events-none disabled:opacity-50",
+                    )}
+                >
+                    <span className="min-w-[1.5rem] text-sm font-semibold text-primary">
+                        {i + 1}.
+                    </span>
+                    <span className="flex-1 font-serif text-sm leading-relaxed text-muted-foreground">
+                        {text}
+                    </span>
+                </button>
+            ))}
+            {/* Freeform slot 0: unboxed italic input indented to the
+                choice-text line, always present. */}
+            <div className="flex items-start gap-3 px-4 py-3">
+                <span className="min-w-[1.5rem]" aria-hidden="true" />
+                <Textarea
+                    ref={freeformRef}
+                    rows={1}
+                    value={freeform}
+                    placeholder="…or something else"
+                    onChange={(e) => setFreeform(e.target.value)}
+                    onKeyDown={handleFreeformKeyDown}
+                    disabled={disabled}
+                    data-testid="wizard-freeform"
+                    className={cn(
+                        "min-h-0 flex-1 resize-none border-0 bg-transparent p-0",
+                        "font-serif text-sm italic leading-relaxed shadow-none",
+                        "placeholder:text-muted-foreground/60",
+                        "focus-visible:ring-0 focus-visible:ring-offset-0",
+                    )}
+                />
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Implements the wizard input redesign: the command bar is gone, replaced by the reader's established interaction pattern — structured choice buttons plus an always-present freeform slot. Model selection leaves the wizard entirely; the backend resolves the configured default, and the TEST mock can no longer be selected implicitly.

## Turn Contract: Was vs Is

No schema change was needed. The wizard turn contract already carried structured choices end to end:

- `WizardResponse` (nexus/api/new_story_schemas.py) enforces `message` + 2-4 `choices` via strict structured output on every conversational turn.
- `/api/story/new/setup/start` already returned `welcome_choices`.

What changed in the contract is **model resolution**, not choices:

- **Was:** `ChatRequest.model` default-factory-filled the wizard default on every request, which made the slot's stamped model dead code in `request.model or slot_model or get_new_story_model()`, and the UI separately injected a model from localStorage on every call.
- **Is:** `model` is an optional explicit override. Omitted -> the slot's stamped model (locked at setup start) -> the configured `wizard.default_model` (`@openai.default`). `/setup/start` resolves the effective model once, stamps it on the slot, and now reports it in the response (`"model": ...`) for verification.

## Root Cause of the TEST Default

Two compounding defaults:

1. **DB stamp:** `nexus.toml [global.model] default_slot_model = "TEST"` stamps fresh/reset slots with `model = TEST` in `global_variables` (via `scripts/new_story_setup.py`). The CLI's empty-slot init forwarded that stamp (`args.model or state.get("model")`) into `/setup/start`, so a plain `nexus continue --slot N` on a fresh slot silently started a TEST wizard. slot 5 was in exactly this state (`model = TEST`).
2. **UI persistence:** the wizard's command-bar model picker read `localStorage["nexus-model"]` (sticky from any prior TEST session; TEST is also in the ModelContext fallback list) and sent it with every request, persisting TEST onto the slot via `upsert_slot`.

Fixes: the wizard UI has no picker and sends no model anywhere (start/chat/bootstrap; the dead `test_mode` flag on bootstrap is also gone); `/setup/start` stamps the resolved real default over the reset stamp; the CLI forwards only an explicit `--model`. TEST remains available as an explicit, backend-only override (`--model TEST`), per the contract that the settings lane owns UI-facing list filtering.

## Visual Minimalism

- Header: phase title ("Setting" / "Character" / "Introduction") replaces "SKALD // SETTING PROTOCOL"; the phase dock in the side panel already carries progress.
- Per-bubble "Skald" label chrome removed; voice is carried by bubble alignment/color.
- Loader text ("PROCESSING...") dropped; spinner only.
- Freeform placeholder matches the reader: "…or something else".

## Verification (Real API Calls, Slot 5)

Worktree backend on :8022, worktree UI on :5022, real `gpt-5.5` turns throughout (no mocks).

CLI (roleplaying a user):
- `nexus continue --slot 5` on the TEST-stamped slot -> wizard started, slot model flipped `TEST -> gpt-5.5`; server log: `Started setup for slot 5 with thread thread_zR9z... (model=gpt-5.5)`.
- `nexus continue --slot 5 --choice 1` -> real frontier turn, 4 new structured choices.
- `nexus continue --slot 5 --user-text "biopunk megacity..."` -> real freeform turn answered in-theme.

Browser (puppeteer-core + system Chrome, headless):
- Slot 5 card -> fresh wizard; welcome renders 4 numbered choice buttons + freeform slot; **no command bar remnant** (asserted).
- Clicking choice 1 advanced the flow (real turn; new choices rendered).
- Typing freeform + Enter advanced the flow (real turn; user text visible in conversation).
- Server log for the UI-driven session (no model in any request): `Started setup for slot 5 ... (model=gpt-5.5)` — resolution proof that the configured default served the turns.

Tests/build:
- `vitest`: 99 passed (incl. 13 new for choice normalization/rendering/interaction).
- `pytest`: 782 passed (incl. new model-resolution contract tests: omitted model stays None; TEST accepted only as explicit override; configured wizard default is never the mock).
- `tsc` clean; `npm run build` green.

## Notes

- `components/StoryChoices.tsx` is now unconsumed (the wizard was its only importer) but is left in place for other lanes.
- `ModelContext` is no longer consumed by the wizard; the settings lane owns its future.
- Reader-owned files (NarrativePane, RightLedger, SettingsPane) untouched; SlotSelector's PR #384 visual-state work preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)