### PR TITLE
Settings: Visual Minimalism Pass — One Label per Section, Plain Functional Names

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -34,6 +34,7 @@ models = [
 ]
 
 [global.model.api_models.test]
+ui_visible = false  # Backend/CLI-only mock server; hidden from UI model pickers
 roles = { default = "TEST" }
 models = [
     { id = "TEST", label = "TEST", description = "Mock server with cached data (dev)" },

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -468,12 +468,17 @@ async def health_check():
 
 @app.get("/api/config/models")
 async def get_config_models():
-    """Get available API models with provider info from nexus.toml."""
+    """Get UI-visible API models with provider info from nexus.toml.
+
+    Providers flagged ``ui_visible = false`` in the api_models registry
+    (the TEST mock server) are omitted here; backend and CLI callers use
+    the unfiltered loader functions directly.
+    """
     from nexus.config.loader import get_all_api_models, get_api_models_by_provider
 
     return {
-        "models": get_all_api_models(),
-        "by_provider": get_api_models_by_provider(),
+        "models": get_all_api_models(ui_only=True),
+        "by_provider": get_api_models_by_provider(ui_only=True),
     }
 
 

--- a/nexus/api/settings_endpoints.py
+++ b/nexus/api/settings_endpoints.py
@@ -126,15 +126,28 @@ _TYPEWRITER_BOUNDS: Dict[str, int] = {
 
 
 def _build_settings_meta(raw: Dict[str, Any]) -> Dict[str, Any]:
-    """Derive the client-facing metadata block from config + Pydantic models."""
+    """Derive the client-facing metadata block from config + Pydantic models.
+
+    Providers flagged ``ui_visible = false`` in the api_models registry (the
+    TEST mock server) are excluded from every list served here - the settings
+    pane is a UI-facing model surface. The ``True`` default mirrors
+    ``ProviderModels.ui_visible``; backend/CLI callers read the registry
+    through the loader and are unaffected.
+    """
     api_models = raw.get("global", {}).get("model", {}).get("api_models", {})
+    visible = {
+        provider: cfg
+        for provider, cfg in api_models.items()
+        if cfg.get("ui_visible", True)
+    }
+
     labels_by_id: Dict[str, str] = {}
-    for provider_cfg in api_models.values():
+    for provider_cfg in visible.values():
         for entry in provider_cfg.get("models", []):
             labels_by_id[entry["id"]] = entry.get("label", entry["id"])
 
     model_roles: List[Dict[str, str]] = []
-    for provider, provider_cfg in api_models.items():
+    for provider, provider_cfg in visible.items():
         for role, model_id in provider_cfg.get("roles", {}).items():
             model_roles.append(
                 {
@@ -148,7 +161,7 @@ def _build_settings_meta(raw: Dict[str, Any]) -> Dict[str, Any]:
 
     apex_allowed_providers = [
         provider
-        for provider in api_models
+        for provider in visible
         if re.fullmatch(_APEX_PROVIDER_PATTERN, provider)
     ]
 

--- a/nexus/config/loader.py
+++ b/nexus/config/loader.py
@@ -141,9 +141,15 @@ def get_available_api_models() -> List[str]:
     return [m["id"] for m in get_all_api_models()]
 
 
-def get_api_models_by_provider() -> Dict[str, List[dict]]:
+def get_api_models_by_provider(ui_only: bool = False) -> Dict[str, List[dict]]:
     """
     Get API models grouped by provider, sourced from nexus.toml.
+
+    Args:
+        ui_only: When True, drop providers whose registry entry sets
+            ``ui_visible = false`` (e.g., the TEST mock server). UI-facing
+            endpoints pass True; backend/CLI validation paths keep the
+            default and always see the full registry.
 
     Returns:
         Dictionary mapping provider name to list of model dicts.
@@ -153,19 +159,23 @@ def get_api_models_by_provider() -> Dict[str, List[dict]]:
     return {
         provider: [m.model_dump() for m in config.models]
         for provider, config in settings.global_.model.api_models.items()
-        if config.models
+        if config.models and (config.ui_visible or not ui_only)
     }
 
 
-def get_all_api_models() -> List[dict]:
+def get_all_api_models(ui_only: bool = False) -> List[dict]:
     """
     Get flat list of all API models with provider info.
+
+    Args:
+        ui_only: When True, drop providers whose registry entry sets
+            ``ui_visible = false`` (see ``get_api_models_by_provider``).
 
     Returns:
         List of model dicts, each containing: id, label, description, provider
     """
     result = []
-    for provider, models in get_api_models_by_provider().items():
+    for provider, models in get_api_models_by_provider(ui_only=ui_only).items():
         for model in models:
             result.append({**model, "provider": provider})
     return result

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -69,6 +69,14 @@ class ProviderModels(BaseModel):
     models: List[APIModelEntry] = Field(
         default_factory=list, description="List of models available from this provider"
     )
+    ui_visible: bool = Field(
+        default=True,
+        description=(
+            "Expose this provider's models in UI-facing pickers "
+            "(/api/config/models, /api/settings settings_meta). Backend and "
+            "CLI callers always see the full registry regardless of this flag."
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_roles_reference_known_models(self) -> "ProviderModels":

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -102,3 +102,29 @@ def test_resolve_model_ref_resolves_roles_and_validates_literals():
         resolve_model_ref("@anthropic.bogus")
     with pytest.raises(ValueError, match="not declared"):
         resolve_model_ref("model-that-does-not-exist")
+
+
+def test_ui_visible_filters_ui_model_lists_but_not_registry():
+    """ui_visible = false hides a provider from UI lists, not the registry.
+
+    The TEST mock server stays fully functional for backend/CLI callers
+    (unfiltered loader calls, role resolution) while every UI-facing model
+    list - /api/config/models and the settings pane metadata - omits it.
+    """
+    from nexus.config.loader import get_all_api_models, get_api_models_by_provider
+
+    settings = load_settings("nexus.toml")
+    assert settings.global_.model.api_models["test"].ui_visible is False
+    assert settings.global_.model.api_models["anthropic"].ui_visible is True
+
+    all_ids = {m["id"] for m in get_all_api_models()}
+    ui_ids = {m["id"] for m in get_all_api_models(ui_only=True)}
+    assert "TEST" in all_ids
+    assert "TEST" not in ui_ids
+    assert ui_ids == all_ids - {"TEST"}
+
+    assert "test" not in get_api_models_by_provider(ui_only=True)
+    assert "test" in get_api_models_by_provider()
+
+    # Backend role resolution is untouched by UI visibility.
+    assert resolve_model_ref("@test.default") == "TEST"

--- a/tests/test_api/test_settings_endpoints.py
+++ b/tests/test_api/test_settings_endpoints.py
@@ -89,13 +89,30 @@ class TestBuildPayload:
         payload = _build_payload(raw_settings)
         assert payload["apex"]["model"].startswith("@")
 
-    def test_meta_roles_cover_registry(self, raw_settings: dict) -> None:
+    def test_meta_roles_cover_ui_visible_registry(self, raw_settings: dict) -> None:
         payload = _build_payload(raw_settings)
         meta = payload["settings_meta"]
         refs = {r["ref"] for r in meta["model_roles"]}
         for provider, cfg in raw_settings["global"]["model"]["api_models"].items():
             for role in cfg.get("roles", {}):
-                assert f"@{provider}.{role}" in refs
+                if cfg.get("ui_visible", True):
+                    assert f"@{provider}.{role}" in refs
+                else:
+                    assert f"@{provider}.{role}" not in refs
+
+    def test_meta_roles_exclude_ui_hidden_test_provider(
+        self, raw_settings: dict
+    ) -> None:
+        # The TEST mock server is flagged ui_visible = false in nexus.toml:
+        # it must stay in the backend registry but never reach UI model lists.
+        api_models = raw_settings["global"]["model"]["api_models"]
+        assert "test" in api_models, "TEST provider must remain in the registry"
+        assert api_models["test"]["ui_visible"] is False
+
+        meta = _build_payload(raw_settings)["settings_meta"]
+        providers = {r["provider"] for r in meta["model_roles"]}
+        assert "test" not in providers
+        assert {"openai", "anthropic"} <= providers
 
     def test_apex_allowlist_excludes_test_provider(self, raw_settings: dict) -> None:
         meta = _build_payload(raw_settings)["settings_meta"]

--- a/ui/client/src/components/nexus/SettingsPane.tsx
+++ b/ui/client/src/components/nexus/SettingsPane.tsx
@@ -1,28 +1,19 @@
 /**
- * SettingsPane - the operator's calibration console (NEXUS IRIS, U5).
+ * SettingsPane - the operator's settings console (NEXUS IRIS, U5).
  *
- * Seven sections: Theme, Typography, Narrative Mode, Model, LORE Budget,
+ * Seven sections: Theme, Typography, Test Mode, Model, Context Length,
  * Typewriter, App Icon. Every dial writes back to PATCH /api/settings
  * (FastAPI -> nexus.config.loader.save_settings -> nexus.toml) with
  * optimistic cache updates and server confirmation - no local draft state.
  * Theme and font writes flow through ThemeContext/FontContext, which share
  * the same settings query + mutation.
  *
- * Read-only by design (would break a running story or is derived):
- * - the active retrieval embedder (memnon.models.*)
- * - the test database suffix (global.narrative.test_database_suffix)
- * - apex.provider (derived from the @provider.role reference)
+ * Presentation follows the visual minimalism principle (PR #388): one label
+ * per section matching its rail name, no explanatory prose in persistent
+ * chrome, no internal module names in UI copy.
  */
 import { useEffect, useRef, useState } from "react";
-import {
-  AlertTriangle,
-  Check,
-  ChevronRight,
-  Circle,
-  CircleDot,
-  RefreshCw,
-  Save,
-} from "lucide-react";
+import { AlertTriangle, Circle, CircleDot, RefreshCw, Save } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
 import { useFonts } from "@/contexts/FontContext";
 import { useSettingsMutation, useSettingsQuery } from "@/hooks/useSettings";
@@ -30,83 +21,50 @@ import { themeIconPath } from "@/lib/themeIcons";
 import { FONT_CATALOG } from "./fontCatalog";
 import type {
   FontSlotId,
-  ModelRoleOption,
+  FontSlots,
   SettingsPayload,
   ThemeId,
 } from "@/types/settings";
 
 // ──────────────────────────────────────────────────────────────────────────
-// Design copy (presentation only - all values come from the settings API)
+// Section index (rail names double as the one label per card)
 // ──────────────────────────────────────────────────────────────────────────
 
 const SECTION_INDEX = [
   { id: "theme", label: "Theme" },
   { id: "type", label: "Typography" },
-  { id: "narrative", label: "Narrative Mode" },
+  { id: "narrative", label: "Test Mode" },
   { id: "model", label: "Model" },
-  { id: "lore", label: "LORE Budget" },
+  { id: "lore", label: "Context Length" },
   { id: "reveal", label: "Typewriter" },
   { id: "pwa", label: "App Icon" },
 ] as const;
 
 type SectionId = (typeof SECTION_INDEX)[number]["id"];
 
-const THEME_PALETTES: Record<
-  ThemeId,
-  { eyebrow: string; motto: string; swatches: string[]; wordmarkFont: string }
-> = {
-  veil: {
-    eyebrow: "ART NOUVEAU",
-    motto: "Magenta rain on blue-black",
-    swatches: ["#09101c", "#b83d7a", "#e86a4a", "#e1cd97"],
-    wordmarkFont: "Megrim, serif",
-  },
-  gilded: {
-    eyebrow: "ART DECO",
-    motto: "Brass engraved on midnight",
-    swatches: ["#0a0a0a", "#c9a227", "#7b5524", "#ece2c1"],
-    wordmarkFont: "Monoton, fantasy",
-  },
-  vector: {
-    eyebrow: "PHOSPHOR CRT",
-    motto: "Scanline void · on the wire",
-    swatches: ["#031414", "#00e5ff", "#3aa1ff", "#a3f0ff"],
-    wordmarkFont: "Sixtyfour, monospace",
-  },
-};
-
 const THEME_IDS: ThemeId[] = ["veil", "gilded", "vector"];
 
+const LOREM_SNIPPET =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.";
+
 const TYPE_SAMPLES: Record<FontSlotId, string> = {
-  body: "The night air shimmered with possibility as the lanterns cast warm halos through the mist-laden gardens — and you stepped out into the wet, counting windows.",
-  menu: "STATUS: READY  //  CHAPTER: S01·E01·S002  //  SKALD: GENERATING",
+  body: "The night air shimmered with possibility as the lanterns cast warm halos through the mist.",
+  menu: "STATUS: READY  //  CHAPTER 01  //  SCENE 02",
   display: "NEXUS",
 };
 
-/** Ladder copy applied to ui.lore_budget_slider.stops by index. */
-const LADDER_COPY = [
-  { label: "COMPACT", note: "fast · tighter context" },
-  { label: "BALANCED", note: "default · recommended" },
-  { label: "EXPANDED", note: "long-arc · slower" },
-  { label: "MAX", note: "ceiling · use sparingly" },
-];
-
 // ──────────────────────────────────────────────────────────────────────────
-// Card chrome
+// Card chrome - one label, body, optional footer
 // ──────────────────────────────────────────────────────────────────────────
 
 function SettingsCard({
   id,
-  eyebrow,
-  title,
-  sub,
+  label,
   children,
   footer,
 }: {
   id: SectionId;
-  eyebrow: string;
-  title: string;
-  sub?: React.ReactNode;
+  label: string;
   children: React.ReactNode;
   footer?: React.ReactNode;
 }) {
@@ -114,9 +72,7 @@ function SettingsCard({
     <section className="set-card" id={`set-${id}`}>
       <div className="set-card-frame">
         <header className="set-card-head">
-          <div className="set-card-eyebrow brass-glow">[ {eyebrow} ]</div>
-          <h3 className="set-card-title">{title}</h3>
-          {sub && <p className="set-card-sub">{sub}</p>}
+          <div className="set-card-eyebrow brass-glow">[ {label} ]</div>
         </header>
         <hr className="set-card-rule" />
         <div className="set-card-body">{children}</div>
@@ -127,20 +83,18 @@ function SettingsCard({
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// 1. Theme
+// 1. Theme - each card is the theme's own type specimen: name in its
+// marquee font, "menu" in its menu font, lorem ipsum in its body font.
 // ──────────────────────────────────────────────────────────────────────────
 
 function ThemeSection({ active, onPick }: { active: ThemeId; onPick: (t: ThemeId) => void }) {
+  const { fonts } = useFonts();
+
   return (
-    <SettingsCard
-      id="theme"
-      eyebrow="THEME · STAGE DRESSING"
-      title="Three Theatres, One Stage"
-      sub="Switching the theme rewrites every chrome surface in the operator's view and persists across sessions. Story content is untouched."
-    >
+    <SettingsCard id="theme" label="THEME">
       <div className="theme-grid">
         {THEME_IDS.map((id) => {
-          const palette = THEME_PALETTES[id];
+          const slots: FontSlots = fonts[id];
           const on = active === id;
           return (
             <button
@@ -152,30 +106,22 @@ function ThemeSection({ active, onPick }: { active: ThemeId; onPick: (t: ThemeId
             >
               <div
                 className="theme-card-wordmark"
-                style={{ fontFamily: palette.wordmarkFont }}
+                style={{ fontFamily: `"${slots.display}"` }}
               >
-                NEXUS
+                {id}
               </div>
-              <div className="theme-card-meta">
-                <span className="theme-card-name">{id}</span>
-                <span className="theme-card-eye">· {palette.eyebrow}</span>
+              <div
+                className="theme-card-menuline"
+                style={{ fontFamily: `"${slots.menu}"` }}
+              >
+                menu
               </div>
-              <p className="theme-card-motto">{palette.motto}</p>
-              <div className="theme-card-swatches">
-                {palette.swatches.map((color) => (
-                  <span
-                    key={color}
-                    className="theme-swatch"
-                    style={{ background: color }}
-                    title={color}
-                  />
-                ))}
-              </div>
-              {on && (
-                <span className="theme-card-active">
-                  <Check size={11} /> ACTIVE
-                </span>
-              )}
+              <p
+                className="theme-card-lorem"
+                style={{ fontFamily: `"${slots.body}"` }}
+              >
+                {LOREM_SNIPPET}
+              </p>
             </button>
           );
         })}
@@ -191,7 +137,6 @@ function ThemeSection({ active, onPick }: { active: ThemeId; onPick: (t: ThemeId
 function FontSlot({
   slotKey,
   label,
-  hint,
   theme,
   value,
   onPick,
@@ -199,7 +144,6 @@ function FontSlot({
 }: {
   slotKey: FontSlotId;
   label: string;
-  hint: string;
   theme: ThemeId;
   value: string;
   onPick: (font: string) => void;
@@ -210,7 +154,6 @@ function FontSlot({
     <div className="font-slot">
       <div className="font-slot-head">
         <span className="font-slot-label">[ {label} ]</span>
-        <span className="font-slot-hint">{hint}</span>
       </div>
       <div
         className="font-slot-preview"
@@ -232,7 +175,6 @@ function FontSlot({
             >
               {opt.label}
             </span>
-            <span className="font-chip-note">{opt.note}</span>
           </button>
         ))}
       </div>
@@ -249,33 +191,23 @@ function TypographySection() {
   return (
     <SettingsCard
       id="type"
-      eyebrow="TYPOGRAPHY · TYPE CARRIAGES"
-      title="Font Matrix — Keepers per Slot"
-      sub={`Active theme is ${themeId.toUpperCase()}. Choices persist per theme. The marquee font is reserved for the NEXUS wordmark — it appears on theme cards but cannot be substituted within chrome.`}
+      label="TYPOGRAPHY"
       footer={
-        <>
-          <span className="caption dim">
-            Slots bind to CSS custom properties — narrative prose, chrome
-            labels, and the marquee wordmark.
-          </span>
-          <button className="btn-soft" onClick={resetToKeepers}>
-            <RefreshCw size={12} /> RESET TO KEEPERS
-          </button>
-        </>
+        <button className="btn-soft" onClick={resetToKeepers}>
+          <RefreshCw size={12} /> RESET
+        </button>
       }
     >
       <FontSlot
         slotKey="body"
-        label="BODY · NARRATIVE PROSE"
-        hint="--font-narrative · 15–18px · line 1.78"
+        label="BODY"
         theme={themeId}
         value={slots.body}
         onPick={(font) => setFont(themeId, "body", font)}
       />
       <FontSlot
         slotKey="menu"
-        label="MENU · CHROME LABELS"
-        hint="--font-mono · 10–28px · tracking 0.18em · uppercase"
+        label="MENU"
         theme={themeId}
         value={slots.menu}
         onPick={(font) => setFont(themeId, "menu", font)}
@@ -283,8 +215,7 @@ function TypographySection() {
       />
       <FontSlot
         slotKey="display"
-        label="DISPLAY · MARQUEE (LOCKED SLOT)"
-        hint="--font-display · NEXUS wordmark only"
+        label="MARQUEE"
         theme={themeId}
         value={slots.display}
         onPick={(font) => setFont(themeId, "display", font)}
@@ -299,57 +230,19 @@ function TypographySection() {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// 3. Narrative Mode
+// 3. Test Mode
 // ──────────────────────────────────────────────────────────────────────────
 
-function NarrativeSection({
+function TestModeSection({
   on,
-  suffix,
   onToggle,
 }: {
   on: boolean;
-  suffix: string;
   onToggle: (value: boolean) => void;
 }) {
   return (
-    <SettingsCard
-      id="narrative"
-      eyebrow="NARRATIVE MODE · WRITE ROUTING"
-      title="Test Routing for Provisional Turns"
-      sub={
-        <>
-          When the test lever is thrown, new turns are committed to tables
-          suffixed <code className="code-inline">{suffix}</code> so production
-          stays untouched. The suffix itself is fixed — renaming it mid-story
-          would orphan existing test tables.
-        </>
-      }
-    >
+    <SettingsCard id="narrative" label="TEST MODE">
       <div className="lever-row">
-        <div className="lever-readout">
-          <div className="lever-status">
-            <span className={`lever-pip ${on ? "on" : ""}`} />
-            <span className={`lever-state ${on ? "danger" : ""}`}>
-              {on ? "TEST MODE · ENGAGED" : "NOMINAL · LIVE WRITE"}
-            </span>
-          </div>
-          <div className="lever-detail caption dim">
-            {on ? (
-              <>
-                Routing to{" "}
-                <code className="code-inline danger">narrative{suffix}</code>,{" "}
-                <code className="code-inline danger">chunks{suffix}</code>,{" "}
-                <code className="code-inline danger">choices{suffix}</code>
-              </>
-            ) : (
-              <>
-                Routing to <code className="code-inline">narrative</code>,{" "}
-                <code className="code-inline">chunks</code>,{" "}
-                <code className="code-inline">choices</code>
-              </>
-            )}
-          </div>
-        </div>
         <button
           className={`lever ${on ? "on" : ""}`}
           onClick={() => onToggle(!on)}
@@ -362,181 +255,69 @@ function NarrativeSection({
           <span className="lever-tick r">TEST</span>
         </button>
       </div>
-      {on && (
-        <div className="alert danger">
-          <AlertTriangle size={14} />
-          <div>
-            <div className="alert-title">TEST MODE ON</div>
-            <div className="alert-body">
-              New narrative turns will divert to the isolated test tables until
-              you flip the lever back. Generation otherwise proceeds normally.
-            </div>
-          </div>
-        </div>
-      )}
     </SettingsCard>
   );
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// 4. Model (role-level bindings only - never raw model IDs)
+// 4. Model - one picker; selection binds both narrative turns and the
+// new-story wizard to the same @provider.role reference in nexus.toml.
 // ──────────────────────────────────────────────────────────────────────────
-
-function RoleBinding({
-  caption,
-  currentRef,
-  roles,
-  onPick,
-}: {
-  caption: string;
-  currentRef: string;
-  roles: ModelRoleOption[];
-  onPick: (ref: string) => void;
-}) {
-  const active = roles.find((r) => r.ref === currentRef);
-  const providers = Array.from(new Set(roles.map((r) => r.provider)));
-  const [open, setOpen] = useState<Set<string>>(
-    () => new Set(active ? [active.provider] : []),
-  );
-  const toggle = (provider: string) => {
-    setOpen((prev) => {
-      const next = new Set(prev);
-      if (next.has(provider)) {
-        next.delete(provider);
-      } else {
-        next.add(provider);
-      }
-      return next;
-    });
-  };
-
-  return (
-    <div className="model-binding">
-      <div className="model-active">
-        <div className="model-active-mark">
-          {(active?.provider ?? currentRef.replace(/^@/, ""))[0]?.toUpperCase() ?? "?"}
-        </div>
-        <div className="model-active-body">
-          <span className="caption">{caption}</span>
-          <div className="model-active-name">{currentRef}</div>
-          <div className="model-active-meta">
-            {active ? (
-              <>
-                <span className="chip-meta">{active.label}</span>
-                <span className="chip-meta">{active.provider.toUpperCase()}</span>
-                <span className="chip-meta accent">{active.role.toUpperCase()}</span>
-              </>
-            ) : (
-              <span className="chip-meta accent">LITERAL ID · EDIT NEXUS.TOML TO REBIND</span>
-            )}
-          </div>
-        </div>
-        <Check size={16} className="model-active-check" />
-      </div>
-
-      <ul className="model-providers">
-        {providers.map((provider) => {
-          const providerRoles = roles.filter((r) => r.provider === provider);
-          const isOpen = open.has(provider);
-          return (
-            <li key={provider} className={`model-provider ${isOpen ? "open" : ""}`}>
-              <button className="model-provider-head" onClick={() => toggle(provider)}>
-                <ChevronRight size={11} className="model-caret" />
-                <span className="model-provider-name">{provider}</span>
-                <span className="model-provider-count">{providerRoles.length}</span>
-              </button>
-              {isOpen && (
-                <ul className="model-list">
-                  {providerRoles.map((role) => {
-                    const on = role.ref === currentRef;
-                    return (
-                      <li
-                        key={role.ref}
-                        className={`model-row ${on ? "on" : ""}`}
-                        onClick={() => onPick(role.ref)}
-                      >
-                        <span className="model-radio">
-                          {on ? <CircleDot size={12} /> : <Circle size={12} />}
-                        </span>
-                        <span className="model-name">{role.ref}</span>
-                        <span className="model-ctx">{role.label}</span>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-            </li>
-          );
-        })}
-      </ul>
-    </div>
-  );
-}
 
 function ModelSection({
   settings,
-  onPickApex,
-  onPickWizard,
+  onPick,
 }: {
   settings: SettingsPayload;
-  onPickApex: (ref: string) => void;
-  onPickWizard: (ref: string) => void;
+  onPick: (ref: string) => void;
 }) {
   const meta = settings.settings_meta;
   const roles = meta?.model_roles ?? [];
   const apexAllowed = new Set(meta?.apex_allowed_providers ?? []);
-  const apexRoles = roles.filter((r) => apexAllowed.has(r.provider));
-
-  const embedders = Object.entries(settings.memnon?.models ?? {}).filter(
-    ([, cfg]) => cfg.is_active,
-  );
+  const options = roles.filter((r) => apexAllowed.has(r.provider));
+  const providers = Array.from(new Set(options.map((r) => r.provider)));
+  const current = settings.apex?.model ?? "";
 
   return (
-    <SettingsCard
-      id="model"
-      eyebrow="MODEL · ROLE BINDINGS"
-      title="LORE / LOGON Binding"
-      sub="Bindings are role references resolved through the api_models registry in nexus.toml — edit a role there and every consumer migrates at once. Raw model IDs are never entered here."
-    >
-      <RoleBinding
-        caption="NARRATIVE TURNS · APEX"
-        currentRef={settings.apex?.model ?? "—"}
-        roles={apexRoles}
-        onPick={onPickApex}
-      />
-      <RoleBinding
-        caption="NEW STORY WIZARD"
-        currentRef={settings.wizard?.default_model ?? "—"}
-        roles={roles}
-        onPick={onPickWizard}
-      />
-
-      <div className="model-locked">
-        <div className="model-locked-head">
-          <span className="font-slot-label">[ RETRIEVAL EMBEDDER · LOCKED ]</span>
-        </div>
-        {embedders.map(([name, cfg]) => (
-          <div key={name} className="model-locked-row">
-            <span className="model-locked-name">{name}</span>
-            <span className="chip-meta">{cfg.dimensions} DIM</span>
-            <span className="chip-meta accent">ACTIVE</span>
-          </div>
+    <SettingsCard id="model" label="MODEL">
+      <ul className="model-providers">
+        {providers.map((provider) => (
+          <li key={provider} className="model-provider open">
+            <div className="model-provider-head">
+              <span className="model-provider-name">{provider}</span>
+            </div>
+            <ul className="model-list">
+              {options
+                .filter((r) => r.provider === provider)
+                .map((role) => {
+                  const on = role.ref === current;
+                  return (
+                    <li
+                      key={role.ref}
+                      className={`model-row ${on ? "on" : ""}`}
+                      onClick={() => onPick(role.ref)}
+                      data-testid={`model-${role.provider}-${role.role}`}
+                    >
+                      <span className="model-radio">
+                        {on ? <CircleDot size={12} /> : <Circle size={12} />}
+                      </span>
+                      <span className="model-name">{role.label}</span>
+                    </li>
+                  );
+                })}
+            </ul>
+          </li>
         ))}
-        <p className="model-locked-copy">
-          Every stored memory is encoded with this model. Switching it
-          mid-story orphans the archive — change requires a re-embedding
-          campaign, not a settings toggle.
-        </p>
-      </div>
+      </ul>
     </SettingsCard>
   );
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// 5. LORE Budget
+// 5. Context Length
 // ──────────────────────────────────────────────────────────────────────────
 
-function LoreSection({
+function ContextLengthSection({
   settings,
   onCommit,
 }: {
@@ -545,7 +326,6 @@ function LoreSection({
 }) {
   const slider = settings.ui?.lore_budget_slider;
   const saved = settings.lore?.token_budget?.apex_context_window ?? 0;
-  const reserve = settings.lore?.token_budget?.system_prompt_tokens;
   const [draft, setDraft] = useState<number | null>(null);
   const value = draft ?? saved;
   const dirty = draft !== null && draft !== saved;
@@ -560,23 +340,15 @@ function LoreSection({
   if (!slider) return null;
 
   const stopTolerance = slider.step * 5;
-  const ladderLabel =
-    LADDER_COPY[slider.stops.findIndex((s) => Math.abs(s - value) < stopTolerance)]
-      ?.label ?? "CUSTOM";
 
   return (
     <SettingsCard
       id="lore"
-      eyebrow="LORE · TOKEN BUDGETS"
-      title="Apex Context Window"
-      sub="The maximum token allotment for context assembly before each LORE / LOGON call. Smaller is faster; larger lets the agent reach further back."
+      label="CONTEXT LENGTH"
       footer={
         <>
           <span className={`caption ${dirty ? "warning" : "dim"}`}>
-            {dirty ? "● UNSAVED · " : ""}
-            saved: {saved.toLocaleString()} tok
-            {reserve !== undefined &&
-              ` · system prompt reserve: ${reserve.toLocaleString()} tok`}
+            {dirty ? "● UNSAVED" : ""}
           </span>
           <button
             className="btn-primary"
@@ -597,12 +369,10 @@ function LoreSection({
           {value.toLocaleString()}
           <span className="lore-unit">tok</span>
         </div>
-        <div className="lore-label">{ladderLabel}</div>
       </div>
       <div className="lore-stops">
-        {slider.stops.map((stop, i) => {
+        {slider.stops.map((stop) => {
           const isSel = Math.abs(stop - value) < stopTolerance;
-          const copy = LADDER_COPY[i] ?? { label: `${stop / 1000}K`, note: "" };
           return (
             <button
               key={stop}
@@ -614,8 +384,6 @@ function LoreSection({
                 style={{ height: `${(stop / slider.max) * 60 + 12}px` }}
               />
               <span className="lore-stop-num">{stop / 1000}K</span>
-              <span className="lore-stop-label">{copy.label}</span>
-              <span className="lore-stop-note caption dim">{copy.note}</span>
             </button>
           );
         })}
@@ -657,7 +425,8 @@ function TypewriterSection({
   const value = draft ?? saved;
   const dirty = draft !== null && draft !== saved;
 
-  // Same staleness rule as LoreSection: server movement invalidates the draft.
+  // Same staleness rule as ContextLengthSection: server movement invalidates
+  // the draft.
   useEffect(() => {
     setDraft(null);
   }, [saved]);
@@ -667,14 +436,11 @@ function TypewriterSection({
   return (
     <SettingsCard
       id="reveal"
-      eyebrow="REVEAL · TYPE SPEED"
-      title="Typewriter Cadence"
-      sub="Milliseconds per character for incoming narrative chunks. The design system recommends 30–50 ms/char; the next generated chunk picks the change up immediately."
+      label="TYPEWRITER"
       footer={
         <>
           <span className={`caption ${dirty ? "warning" : "dim"}`}>
-            {dirty ? "● UNSAVED · " : ""}
-            saved: {saved} ms/char
+            {dirty ? "● UNSAVED" : ""}
           </span>
           <button
             className="btn-primary"
@@ -694,9 +460,6 @@ function TypewriterSection({
         <div className="lore-value">
           {value}
           <span className="lore-unit">ms/char</span>
-        </div>
-        <div className="lore-label">
-          {value >= 30 && value <= 50 ? "DESIGN RANGE" : "CUSTOM"}
         </div>
       </div>
       <div className="lore-slider-row">
@@ -728,12 +491,7 @@ function PwaSection() {
   const { theme } = useTheme();
 
   return (
-    <SettingsCard
-      id="pwa"
-      eyebrow="PWA · HOME-SCREEN GLYPH"
-      title="App Icon"
-      sub="One mark, three liveries. The favicon and home-screen glyph follow the active theme; the PWA install icon is baked at build time on the default theme (Veil)."
-    >
+    <SettingsCard id="pwa" label="APP ICON">
       <div className="pwa-icon-row">
         {THEME_IDS.map((id) => (
           <div
@@ -762,7 +520,7 @@ function SectionRail({
 }) {
   return (
     <aside className="set-rail">
-      <div className="eyebrow brass-glow">CALIBRATION</div>
+      <div className="eyebrow brass-glow">SETTINGS</div>
       <ul>
         {SECTION_INDEX.map((s) => (
           <li key={s.id}>
@@ -776,10 +534,6 @@ function SectionRail({
           </li>
         ))}
       </ul>
-      <div className="set-rail-foot">
-        <span className="caption dim">/ AGENT SETTINGS</span>
-        <span className="caption dim">NEXUS.TOML · LIVE</span>
-      </div>
     </aside>
   );
 }
@@ -841,45 +595,34 @@ function SettingsConsole({ settings }: { settings: SettingsPayload }) {
   }, []);
 
   const testMode = settings.global?.narrative?.test_mode ?? false;
-  const testSuffix = settings.global?.narrative?.test_database_suffix ?? "_test";
 
   return (
     <div className="settings-pane-v2" data-testid="settings-pane">
       <SectionRail active={active} onPick={jumpTo} />
       <div className="set-scroller" ref={scrollerRef}>
-        <header className="set-header">
-          <div className="eyebrow brass-glow">[ AGENT CALIBRATION ]</div>
-          <h2 className="set-headline">Configuration</h2>
-          <p className="set-headline-sub">
-            Every dial on this console writes back to{" "}
-            <code className="code-inline">nexus.toml</code> through the
-            settings API. The agent picks up changes on the next narrative
-            turn — no restart, no incantations.
-          </p>
-          {mutation.isError && (
-            <div className="alert danger">
-              <AlertTriangle size={14} />
-              <div>
-                <div className="alert-title">WRITE REJECTED</div>
-                <div className="alert-body">{mutation.error.message}</div>
-              </div>
+        {mutation.isError && (
+          <div className="alert danger">
+            <AlertTriangle size={14} />
+            <div>
+              <div className="alert-title">WRITE REJECTED</div>
+              <div className="alert-body">{mutation.error.message}</div>
             </div>
-          )}
-        </header>
+          </div>
+        )}
 
         <ThemeSection active={theme as ThemeId} onPick={(t) => setTheme(t)} />
         <TypographySection />
-        <NarrativeSection
+        <TestModeSection
           on={testMode}
-          suffix={testSuffix}
           onToggle={(value) => mutation.mutate({ test_mode: value })}
         />
         <ModelSection
           settings={settings}
-          onPickApex={(ref) => mutation.mutate({ apex_model_ref: ref })}
-          onPickWizard={(ref) => mutation.mutate({ wizard_model_ref: ref })}
+          onPick={(ref) =>
+            mutation.mutate({ apex_model_ref: ref, wizard_model_ref: ref })
+          }
         />
-        <LoreSection
+        <ContextLengthSection
           settings={settings}
           onCommit={(value) => mutation.mutate({ apex_context_window: value })}
         />
@@ -888,11 +631,6 @@ function SettingsConsole({ settings }: { settings: SettingsPayload }) {
           onCommit={(value) => mutation.mutate({ typewriter_ms_per_char: value })}
         />
         <PwaSection />
-
-        <div className="set-foot">
-          <div className="set-foot-rule" />
-          <div className="caption dim">END OF CONSOLE</div>
-        </div>
       </div>
     </div>
   );

--- a/ui/client/src/components/nexus/SettingsPane.tsx
+++ b/ui/client/src/components/nexus/SettingsPane.tsx
@@ -15,7 +15,7 @@
 import { useEffect, useRef, useState } from "react";
 import { AlertTriangle, Circle, CircleDot, RefreshCw, Save } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
-import { useFonts } from "@/contexts/FontContext";
+import { KEEPERS, useFonts } from "@/contexts/FontContext";
 import { useSettingsMutation, useSettingsQuery } from "@/hooks/useSettings";
 import { themeIconPath } from "@/lib/themeIcons";
 import { FONT_CATALOG } from "./fontCatalog";
@@ -94,7 +94,10 @@ function ThemeSection({ active, onPick }: { active: ThemeId; onPick: (t: ThemeId
     <SettingsCard id="theme" label="THEME">
       <div className="theme-grid">
         {THEME_IDS.map((id) => {
-          const slots: FontSlots = fonts[id];
+          // GET /api/settings serves raw nexus.toml, so a hand-edited
+          // [ui.fonts] could arrive partial; guard with the keeper matrix
+          // exactly as FontContext does for the active theme.
+          const slots: FontSlots = fonts[id] ?? KEEPERS[id];
           const on = active === id;
           return (
             <button

--- a/ui/client/src/components/nexus/nexus-layout.css
+++ b/ui/client/src/components/nexus/nexus-layout.css
@@ -1187,11 +1187,12 @@
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   SETTINGS PANE V2 — the operator's calibration console (U5).
-   Ported from design_handoff/project/ui_kits/nexus_iris/styles.css.
-   Two-column layout: anchor rail (240px) + scrolling content. Every card
-   uses a framed eyebrow + menu-font title. Tokens only — the kit's --danger
-   and --warning map to hsl(var(--destructive)) and --bronze respectively.
+   SETTINGS PANE V2 — the operator's settings console (U5).
+   Ported from design_handoff/project/ui_kits/nexus_iris/styles.css, then
+   stripped to one label per card (visual minimalism pass, PR #388).
+   Two-column layout: anchor rail (240px) + scrolling content. Tokens only —
+   the kit's --danger and --warning map to hsl(var(--destructive)) and
+   --bronze respectively.
    ═══════════════════════════════════════════════════════════════════════════ */
 
 .nexus-content:has(> .settings-pane-v2) { padding: 0; overflow: hidden; }
@@ -1272,41 +1273,12 @@
   background: var(--brass);
   box-shadow: var(--glow-soft);
 }
-.set-rail-foot {
-  display: flex; flex-direction: column; gap: 2px;
-  padding: 12px 8px 0;
-  border-top: 1px solid var(--border-faint);
-  margin-top: 8px;
-}
-
 /* ─── Scroller ─── */
 .set-scroller {
   overflow: auto;
   padding: 36px 48px 60px;
   display: flex; flex-direction: column; gap: 28px;
   min-height: 0;
-}
-
-.set-header { padding: 0 0 8px; display: flex; flex-direction: column; gap: 8px; align-items: flex-start; }
-.set-headline {
-  font-family: var(--font-menu);
-  font-size: 36px;
-  letter-spacing: 0.16em;
-  font-weight: 600;
-  text-transform: uppercase;
-  color: var(--brass-bright);
-  text-shadow: var(--glow-soft);
-  margin: 0 0 4px;
-  line-height: 1.05;
-}
-.set-headline-sub {
-  font-family: var(--font-body);
-  font-size: 17px;
-  line-height: 1.65;
-  color: var(--fg-muted);
-  max-width: 64ch;
-  margin: 0;
-  text-wrap: pretty;
 }
 
 /* ─── Card chrome ─── */
@@ -1318,33 +1290,14 @@
   border-radius: var(--radius-sm);
   box-shadow: 0 8px 30px -8px hsl(320 45% 8% / .55);
 }
-.set-card-head { padding: 22px 28px 16px; }
+.set-card-head { padding: 18px 28px 14px; }
 .set-card-eyebrow {
   font-family: var(--font-menu);
-  font-size: 10px;
+  font-size: 12px;
   letter-spacing: 0.3em;
   text-transform: uppercase;
   color: var(--brass);
   font-weight: 600;
-  margin-bottom: 8px;
-}
-.set-card-title {
-  font-family: var(--font-menu);
-  font-size: 22px;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--fg);
-  margin: 0 0 6px;
-}
-.set-card-sub {
-  font-family: var(--font-body);
-  font-size: 15px;
-  line-height: 1.6;
-  color: var(--fg-muted);
-  max-width: 68ch;
-  margin: 0;
-  text-wrap: pretty;
 }
 .set-card-frame > .set-card-rule {
   margin: 0 28px;
@@ -1363,19 +1316,6 @@
   flex-wrap: wrap;
 }
 
-/* Inline code chip — routing readouts, paths, etc. */
-.code-inline {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  letter-spacing: 0.04em;
-  padding: 1px 6px;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 2px;
-  color: var(--brass-bright);
-}
-.code-inline.danger { color: var(--danger); border-color: hsl(var(--destructive) / .5); }
-
 /* ─── 1. Theme picker cards ─── */
 .theme-grid {
   display: grid;
@@ -1389,11 +1329,11 @@
   border-radius: var(--radius-sm);
   padding: 22px 18px 18px;
   text-align: left;
-  display: flex; flex-direction: column; align-items: flex-start; gap: 12px;
+  display: flex; flex-direction: column; align-items: flex-start; gap: 14px;
   cursor: pointer;
   transition: border-color .15s, background .15s, box-shadow .15s;
   overflow: hidden;
-  min-height: 200px;
+  min-height: 170px;
 }
 .theme-card:hover { border-color: var(--brass); background: hsl(320 55% 50% / .04); }
 .theme-card.on {
@@ -1405,6 +1345,7 @@
   font-size: 38px;
   letter-spacing: 0.14em;
   line-height: 1;
+  text-transform: uppercase;
   color: var(--brass-bright);
   text-shadow: var(--glow-soft);
   margin-bottom: 2px;
@@ -1412,44 +1353,17 @@
 .theme-card-veil .theme-card-wordmark { color: hsl(320 65% 70%); text-shadow: 0 0 10px hsl(320 55% 50% / .9), 0 0 24px hsl(15 75% 60% / .35); }
 .theme-card-gilded .theme-card-wordmark { color: hsl(45 60% 65%); text-shadow: 0 0 8px hsl(43 74% 47% / .7), 0 0 18px hsl(43 74% 47% / .35); font-size: 34px; }
 .theme-card-vector .theme-card-wordmark { color: hsl(185 100% 70%); text-shadow: 0 0 8px hsl(185 100% 50% / .9), 0 0 16px hsl(185 100% 50% / .5); font-size: 28px; }
-.theme-card-meta {
-  display: flex; align-items: baseline; gap: 6px;
-  font-family: var(--font-menu);
-  font-size: 11px;
+.theme-card-menuline {
+  font-size: 13px;
   letter-spacing: 0.18em;
-  text-transform: uppercase;
+  color: var(--fg);
 }
-.theme-card-name { color: var(--brass); font-weight: 600; text-shadow: var(--glow-soft); }
-.theme-card-eye { color: var(--fg-muted); font-size: 10px; }
-.theme-card-motto {
-  font-family: var(--font-body);
+.theme-card-lorem {
   font-size: 14px;
-  line-height: 1.4;
+  line-height: 1.5;
   color: var(--fg-muted);
-  font-style: italic;
   margin: 0;
   text-wrap: pretty;
-}
-.theme-card-swatches { display: flex; gap: 4px; margin-top: auto; }
-.theme-swatch {
-  width: 22px; height: 22px;
-  border: 1px solid hsl(270 30% 30% / .8);
-  border-radius: 2px;
-}
-.theme-card-active {
-  position: absolute;
-  top: 12px; right: 12px;
-  display: inline-flex; align-items: center; gap: 4px;
-  font-family: var(--font-menu);
-  font-size: 9px;
-  letter-spacing: 0.22em;
-  color: var(--brass-bright);
-  background: var(--bg);
-  border: 1px solid var(--brass);
-  padding: 3px 6px;
-  border-radius: var(--radius-sm);
-  text-shadow: var(--glow-soft);
-  font-weight: 600;
 }
 
 /* ─── 2. Typography slot picker ─── */
@@ -1468,13 +1382,6 @@
   color: var(--brass);
   font-weight: 600;
   text-shadow: var(--glow-soft);
-}
-.font-slot-hint {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.02em;
-  color: var(--fg-muted);
-  opacity: .8;
 }
 .font-slot-preview {
   padding: 16px 18px;
@@ -1511,46 +1418,15 @@
   letter-spacing: 0.02em;
 }
 .font-chip.on .font-chip-name { color: var(--brass-bright); text-shadow: var(--glow-soft); }
-.font-chip-note {
-  font-family: var(--font-menu);
-  font-size: 9px;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--fg-dim);
-}
 
 /* ─── 3. Lever toggle (test mode) ─── */
 .lever-row {
-  display: flex; align-items: center; justify-content: space-between; gap: 24px;
+  display: flex; align-items: center; gap: 24px;
   padding: 14px 18px;
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
 }
-.lever-readout { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
-.lever-status { display: flex; align-items: center; gap: 10px; }
-.lever-pip {
-  width: 9px; height: 9px;
-  background: var(--bg-elev-3);
-  border: 1px solid var(--border-strong);
-  border-radius: 50%;
-}
-.lever-pip.on {
-  background: var(--danger);
-  border-color: var(--danger);
-  box-shadow: 0 0 8px var(--danger), 0 0 14px hsl(var(--destructive) / .5);
-  animation: nexus-pulse 2s ease-in-out infinite;
-}
-.lever-state {
-  font-family: var(--font-menu);
-  font-size: 12px;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: var(--fg);
-  font-weight: 600;
-}
-.lever-state.danger { color: var(--danger); text-shadow: 0 0 6px hsl(var(--destructive) / .55); }
-.lever-detail { font-family: var(--font-body); font-size: 13px; }
 
 .lever {
   position: relative;
@@ -1617,56 +1493,7 @@
 }
 .alert-body { font-family: var(--font-body); font-size: 14px; line-height: 1.5; color: var(--fg); }
 
-/* ─── 4. Model role bindings ─── */
-.model-binding { display: flex; flex-direction: column; gap: 12px; }
-.model-active {
-  display: grid;
-  grid-template-columns: 56px 1fr auto;
-  align-items: center;
-  gap: 16px;
-  padding: 14px 18px;
-  background: var(--bg);
-  border: 1px solid var(--brass);
-  border-radius: var(--radius-sm);
-  box-shadow: 0 0 0 1px var(--brass) inset, 0 0 18px hsl(320 55% 50% / .2);
-}
-.model-active-mark {
-  width: 56px; height: 56px;
-  display: grid; place-items: center;
-  font-family: var(--font-menu);
-  font-size: 26px;
-  font-weight: 600;
-  color: var(--brass-bright);
-  background: hsl(320 55% 50% / .12);
-  border: 1px solid var(--brass);
-  border-radius: var(--radius-sm);
-  text-shadow: var(--glow-soft);
-}
-.model-active-body { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
-.model-active-body > .caption { font-size: 9px; }
-.model-active-name {
-  font-family: var(--font-mono);
-  font-size: 15px;
-  color: var(--brass-bright);
-  text-shadow: var(--glow-soft);
-  letter-spacing: 0.02em;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-.model-active-meta { display: flex; gap: 6px; flex-wrap: wrap; }
-.chip-meta {
-  font-family: var(--font-menu);
-  font-size: 9px;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  padding: 2px 7px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  color: var(--fg-muted);
-  background: var(--bg-elev-2);
-}
-.chip-meta.accent { color: var(--bronze); border-color: hsl(15 75% 50% / .5); }
-.model-active-check { color: var(--brass); }
-
+/* ─── 4. Model picker ─── */
 .model-providers {
   list-style: none; padding: 0; margin: 0;
   display: flex; flex-direction: column; gap: 4px;
@@ -1681,8 +1508,6 @@
   display: flex; align-items: center; gap: 10px;
   width: 100%;
   padding: 10px 14px;
-  background: transparent;
-  border: none;
   font-family: var(--font-menu);
   font-size: 11px;
   letter-spacing: 0.22em;
@@ -1690,24 +1515,10 @@
   color: var(--fg);
   font-weight: 600;
   text-align: left;
-  cursor: pointer;
 }
-.model-provider-head:hover { color: var(--brass-bright); }
-.model-caret { transition: transform .2s; color: var(--brass); }
-.model-provider.open .model-caret { transform: rotate(90deg); }
 .model-provider-name { flex: 1; }
-.model-provider-count {
-  font-size: 9px;
-  letter-spacing: 0.18em;
-  color: var(--fg-muted);
-  padding: 2px 6px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  background: var(--bg-elev-2);
-  font-weight: 400;
-}
 .model-list {
-  list-style: none; padding: 4px 8px 10px 32px; margin: 0;
+  list-style: none; padding: 4px 8px 10px 20px; margin: 0;
   display: flex; flex-direction: column; gap: 1px;
   border-top: 1px solid var(--border-faint);
 }
@@ -1731,42 +1542,8 @@
 }
 .model-row .model-radio { color: var(--brass); display: inline-flex; }
 .model-name { flex: 1; }
-.model-ctx {
-  font-family: var(--font-menu);
-  font-size: 10px;
-  letter-spacing: 0.18em;
-  color: var(--fg-muted);
-}
 
-/* Read-only embedder block */
-.model-locked {
-  display: flex; flex-direction: column; gap: 10px;
-  padding: 14px 18px;
-  background: var(--bg);
-  border: 1px dashed var(--border-strong);
-  border-radius: var(--radius-sm);
-}
-.model-locked-row {
-  display: flex; align-items: center; gap: 10px;
-}
-.model-locked-name {
-  font-family: var(--font-mono);
-  font-size: 13px;
-  color: var(--fg);
-  letter-spacing: 0.02em;
-  flex: 1;
-}
-.model-locked-copy {
-  font-family: var(--font-body);
-  font-size: 13px;
-  font-style: italic;
-  line-height: 1.5;
-  color: var(--fg-muted);
-  margin: 0;
-  max-width: 64ch;
-}
-
-/* ─── 5. LORE token budget + typewriter cadence ─── */
+/* ─── 5. Context length + typewriter readouts ─── */
 .lore-readout {
   display: flex; align-items: baseline; gap: 18px;
   padding: 18px 22px;
@@ -1791,16 +1568,6 @@
   margin-left: 6px;
   text-transform: uppercase;
 }
-.lore-label {
-  font-family: var(--font-menu);
-  font-size: 12px;
-  letter-spacing: 0.26em;
-  text-transform: uppercase;
-  color: var(--bronze);
-  margin-left: auto;
-  font-weight: 600;
-}
-
 .lore-stops {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -1815,7 +1582,7 @@
   cursor: pointer;
   text-align: left;
   transition: border-color .15s, background .15s;
-  min-height: 130px;
+  min-height: 110px;
 }
 .lore-stop:hover { border-color: var(--brass); background: hsl(320 55% 50% / .04); }
 .lore-stop.on {
@@ -1840,15 +1607,6 @@
   letter-spacing: 0.06em;
 }
 .lore-stop.on .lore-stop-num { color: var(--brass-bright); text-shadow: var(--glow-soft); }
-.lore-stop-label {
-  font-family: var(--font-menu);
-  font-size: 10px;
-  letter-spacing: 0.24em;
-  text-transform: uppercase;
-  color: var(--brass);
-  font-weight: 600;
-}
-.lore-stop-note { font-family: var(--font-body); font-size: 12px; font-style: italic; line-height: 1.3; text-transform: none; letter-spacing: 0; }
 
 /* Native range slider — restyled */
 .lore-slider-row { display: flex; flex-direction: column; gap: 6px; }
@@ -1922,23 +1680,6 @@
   opacity: 1;
   border-color: var(--brass);
   box-shadow: 0 0 0 1px var(--brass) inset, 0 0 18px hsl(320 55% 50% / .2);
-}
-
-/* ─── End-of-console footer ─── */
-.set-foot {
-  display: flex; flex-direction: column; align-items: center; gap: 8px;
-  padding: 24px 0 8px;
-  opacity: .65;
-}
-.set-foot-rule {
-  width: 240px;
-  height: 1px;
-  background: linear-gradient(to right,
-    transparent 0%,
-    var(--border-strong) 30%,
-    var(--brass) 50%,
-    var(--border-strong) 70%,
-    transparent 100%);
 }
 
 /* Pane fallback (loading / error states share one look). */

--- a/ui/client/src/contexts/FontContext.tsx
+++ b/ui/client/src/contexts/FontContext.tsx
@@ -12,8 +12,10 @@ import type { FontMatrix, FontSlotId, ThemeId } from '@/types/settings';
 /**
  * The NEXUS IRIS keeper matrix - first-paint seed only. The persisted
  * defaults live in UISettings (settings_models.py) and nexus.toml [ui.fonts].
+ * Exported so theme-card specimens can apply the same partial-matrix guard
+ * this provider uses for the active theme.
  */
-const KEEPERS: FontMatrix = {
+export const KEEPERS: FontMatrix = {
   veil: { body: 'Spectral', menu: 'Cinzel', display: 'Megrim' },
   gilded: { body: 'Cormorant Garamond', menu: 'Space Mono', display: 'Monoton' },
   vector: { body: 'Rajdhani', menu: 'Source Code Pro', display: 'Sixtyfour' },

--- a/ui/client/src/contexts/ModelContext.tsx
+++ b/ui/client/src/contexts/ModelContext.tsx
@@ -28,9 +28,12 @@ interface ModelContextType {
 const ModelContext = createContext<ModelContextType | undefined>(undefined);
 
 const STORAGE_KEY = 'nexus-model';
+// Offline-only seed; should track @openai.default in the nexus.toml
+// api_models registry. Reached only when /api/config/models is unreachable,
+// and replaced by registry truth on the first successful fetch.
 const DEFAULT_MODEL = 'gpt-5.2';
 
-// Fallback models if API fails (matches nexus.toml defaults). UI-visible
+// Fallback models if API fails (see DEFAULT_MODEL note above). UI-visible
 // providers only - the TEST mock server is backend/CLI-only (ui_visible =
 // false in the api_models registry) and never appears in UI model lists.
 const FALLBACK_MODELS: ModelInfo[] = [

--- a/ui/client/src/contexts/ModelContext.tsx
+++ b/ui/client/src/contexts/ModelContext.tsx
@@ -30,10 +30,11 @@ const ModelContext = createContext<ModelContextType | undefined>(undefined);
 const STORAGE_KEY = 'nexus-model';
 const DEFAULT_MODEL = 'gpt-5.2';
 
-// Fallback models if API fails (matches nexus.toml defaults)
+// Fallback models if API fails (matches nexus.toml defaults). UI-visible
+// providers only - the TEST mock server is backend/CLI-only (ui_visible =
+// false in the api_models registry) and never appears in UI model lists.
 const FALLBACK_MODELS: ModelInfo[] = [
   { id: 'gpt-5.2', label: 'GPT-5.2', provider: 'openai' },
-  { id: 'TEST', label: 'TEST', provider: 'test' },
   { id: 'claude', label: 'Claude', provider: 'anthropic' },
 ];
 


### PR DESCRIPTION
## Summary

Presentation surgery on the settings pane per the visual minimalism principle (PR #388): one label per section matching its rail name, zero explanatory prose in persistent chrome, no internal module names in UI copy. All persistence wiring is untouched and verified live.

## Label Collapses (Old → New)

| Old (eyebrow + title + subtitle) | New |
| --- | --- |
| `[ THEME · STAGE DRESSING ]` / "Three Theatres, One Stage" + subtitle | `[ THEME ]` |
| `[ TYPOGRAPHY · TYPE CARRIAGES ]` / "Font Matrix — Keepers per Slot" + subtitle | `[ TYPOGRAPHY ]` |
| `[ NARRATIVE MODE · WRITE ROUTING ]` / "Test Routing for Provisional Turns" + subtitle | `[ TEST MODE ]` |
| `[ MODEL · ROLE BINDINGS ]` / "LORE / LOGON Binding" + subtitle | `[ MODEL ]` |
| `[ LORE · TOKEN BUDGETS ]` / "Apex Context Window" + subtitle | `[ CONTEXT LENGTH ]` |
| `[ REVEAL · TYPE SPEED ]` / "Typewriter Cadence" + subtitle | `[ TYPEWRITER ]` |
| `[ PWA · HOME-SCREEN GLYPH ]` / "App Icon" + subtitle | `[ APP ICON ]` |
| `[ AGENT CALIBRATION ]` / "Configuration" headline + paragraph | removed (rail header is now `SETTINGS`, matching the left-nav name) |
| Font slot labels `BODY · NARRATIVE PROSE`, `MENU · CHROME LABELS`, `DISPLAY · MARQUEE (LOCKED SLOT)` + CSS-variable hints | `BODY`, `MENU`, `MARQUEE` |
| `RESET TO KEEPERS` | `RESET` |
| Rail names `Narrative Mode` / `LORE Budget` | `Test Mode` / `Context Length` |

## Prose Excised

- Header paragraph ("Every dial on this console writes back to nexus.toml…")
- Every per-section subtitle (theme persistence explainer, font matrix explainer, test-routing table explainer, role-binding registry explainer, context-window explainer, typewriter ms/char recommendation, app-icon liveries explainer)
- Test-mode routing readout (`narrative_test`/`chunks_test`/`choices_test` chips), status line, and the engaged-state warning alert — the lever's OFF/TEST ticks and color state carry it
- Read-only embedder block and its re-embedding-campaign paragraph
- Context-length ladder copy (`COMPACT / BALANCED / EXPANDED / MAX` + italic notes) — stops are now bar + number
- Footer captions ("Slots bind to CSS custom properties…", "saved: N tok · system prompt reserve…", "NEXUS.TOML · LIVE", "END OF CONSOLE")
- Font-chip notes ("default · serif", "marquee · locked")
- `SKALD` removed from the menu-font specimen text

## Theme Cards

Each card is now exactly three elements, all drawn from that theme's persisted font matrix: the theme name in its marquee font (Megrim / Monoton / Sixtyfour — replacing the "NEXUS" specimen), the word "menu" in its menu font (Cinzel / Space Mono / Source Code Pro), and a lorem ipsum snippet in its body font (Spectral / Cormorant Garamond / Rajdhani). Eyebrows, mottos, swatches, and the ACTIVE badge are gone; the active state is the existing border treatment.

## Model Picker

One picker labeled `MODEL`, provider-grouped, human labels only (no raw `@provider.role` refs in copy). A selection PATCHes both `apex_model_ref` and `wizard_model_ref` in a single request, so narrative turns and the new-story wizard follow the one visible model setting (the wizard's command-bar picker is being retired by another lane). Options are `settings_meta.model_roles` ∩ `apex_allowed_providers` — OpenAI + Anthropic per the M8.5 registry.

## TEST Server Filter (Config-Driven)

New `ui_visible` flag on the provider registry (`ProviderModels.ui_visible`, default `true`); `nexus.toml` sets `ui_visible = false` on `[global.model.api_models.test]`.

- `GET /api/config/models` now serves `get_all_api_models(ui_only=True)` / `get_api_models_by_provider(ui_only=True)`
- `GET /api/settings` `settings_meta` (model_roles, apex_allowed_providers, labels) filters on the same flag
- ModelContext's offline fallback list drops its TEST entry
- Backend/CLI surfaces are untouched: unfiltered loader calls, slot-model validation, `default_slot_model = "TEST"`, and `resolve_model_ref("@test.default")` all still work (covered by new tests)

## Persistence Verification

- `pytest -m "not live and not live_llm and not integration"`: **790 passed** (includes new `ui_visible` loader/meta tests and the existing tomlkit round-trip suite)
- `vitest`: 86 passed; `npm run build` clean; `tsc --noEmit` clean
- Real-browser drive (puppeteer + system Chrome) against a worktree-isolated API on port 8023 / UI on 5021:
  - theme → gilded → verified `ui.theme` via API → restored
  - model → `@anthropic.deep` → verified `apex.model`, `apex.provider`, **and** `wizard.default_model` all updated → restored
  - context length → different stop + COMMIT → verified `lore.token_budget.apex_context_window` → restored
  - forbidden-copy sweep over the rendered pane: no `LORE`, `LOGON`, `SKALD`, `MEMNON`, `APEX`, `@test.default` (word-boundary match)
  - worktree `nexus.toml` restored byte-exact from snapshot after the drive; the live dev stack on 5001/8002 was never touched (read-only before-screenshots only)

Net: −440 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)