### PR TITLE
Reader: Fix Single-Asterisk Emphasis

### DIFF
--- a/ui/client/src/components/nexus/ProseMarkdown.test.tsx
+++ b/ui/client/src/components/nexus/ProseMarkdown.test.tsx
@@ -35,6 +35,24 @@ The crew **moves through the quiet streets, recovering from the night before—s
 - **Pete** → _Surprisingly un-hungover, but moving with the energy of a man whose worldview permanently shifted overnight._
 `;
 
+/**
+ * Real Skald output captured from save_05 narrative_chunks id 6 on
+ * 2026-06-12. Fresh chunks italicize whole sentences with single asterisks,
+ * so the spans end in punctuation (`favor.*`) - the form that regressed
+ * during typewriter reveal when a sentinel character followed the closing
+ * delimiter and broke CommonMark's right-flanking rule.
+ */
+const SKALD_CHUNK_6_EXCERPT = `Odile’s summons is folded inside your coat, already soft from damp. Seven words in her cramped archive hand:
+
+*Before first bell. Come alone. Last favor.*
+
+Not *urgent*. Not *danger*. Odile Sorrenwick was born into a city where panic is taxed if spoken aloud.`;
+
+/** Real Skald output from save_05 narrative_chunks id 7 (same capture). */
+const SKALD_CHUNK_7_EXCERPT = `Somewhere below the Annex, below the seawall, below any lawful map of Veyport, a voice like water remembered under a door shapes your name with patient intimacy.
+
+*Brena.*`;
+
 describe("ProseMarkdown", () => {
   it("renders **bold** as <strong> with no literal asterisks", () => {
     const { container } = render(<ProseMarkdown text="A **bold** claim." />);
@@ -157,6 +175,21 @@ describe("ProseMarkdown", () => {
     expect(container.querySelector("hr.md-hr")).not.toBeNull();
     expect(container.querySelectorAll("ul li").length).toBe(2);
   });
+
+  it("renders real Skald sentence-italics (save_05 chunk 6) as <em>", () => {
+    const { container } = render(
+      <ProseMarkdown text={SKALD_CHUNK_6_EXCERPT} />,
+    );
+    const ems = Array.from(container.querySelectorAll("em")).map(
+      (em) => em.textContent,
+    );
+    expect(ems).toEqual([
+      "Before first bell. Come alone. Last favor.",
+      "urgent",
+      "danger",
+    ]);
+    expect(container.textContent).not.toContain("*");
+  });
 });
 
 describe("heading scale (nexus-layout.css)", () => {
@@ -269,6 +302,103 @@ describe("typewriter reveal", () => {
       <ProseMarkdown text="Mid-sentence revea" revealing />,
     );
     expect(container.textContent).not.toContain("\uE000");
+    expect(container.querySelector(".type-caret")).not.toBeNull();
+  });
+
+  // Regression (user report: "*italic* not rendering"): the frame whose
+  // last typed character is the closing `*` of a punctuation-final span.
+  // The old in-source caret sentinel (a word character to micromark) made
+  // that closing delimiter non-right-flanking, so the whole span flashed
+  // as literal asterisks at the exact moment it completed.
+  it("keeps a just-completed punctuation-final *italic* span italic mid-reveal", () => {
+    const end =
+      SKALD_CHUNK_6_EXCERPT.indexOf("Last favor.*") + "Last favor.*".length;
+    const { container } = render(
+      <ProseMarkdown text={SKALD_CHUNK_6_EXCERPT.slice(0, end)} revealing />,
+    );
+    const em = container.querySelector("em");
+    expect(em).not.toBeNull();
+    expect(em!.textContent).toContain("Before first bell. Come alone.");
+    expect(container.textContent).not.toContain("*");
+    expect(container.querySelector(".type-caret")).not.toBeNull();
+  });
+
+  it("keeps just-completed **bold.** and _italic._ spans styled mid-reveal", () => {
+    const bold = render(
+      <ProseMarkdown text={'He says **"Stop."**'} revealing />,
+    );
+    expect(bold.container.querySelector("strong")!.textContent).toBe(
+      '"Stop."',
+    );
+    expect(bold.container.textContent).not.toContain("*");
+    const under = render(
+      <ProseMarkdown
+        text="- **Pete** \u2192 _Surprisingly un-hungover, but moving with the energy of a man whose worldview permanently shifted overnight._"
+        revealing
+      />,
+    );
+    expect(under.container.querySelector("em")!.textContent).toContain(
+      "Surprisingly un-hungover",
+    );
+    expect(under.container.textContent).not.toContain("_");
+  });
+
+  it("renders a just-typed opener as plain text, not an empty emphasis", () => {
+    // Frame ends exactly on the opening `*` of mid-line `*urgent*`: closing
+    // it would yield the empty-emphasis literal `Not **`. The trailing run
+    // is stripped instead; the opener reappears with its first content char.
+    const opener = render(<ProseMarkdown text="Not *" revealing />, {});
+    expect(opener.container.textContent).not.toContain("*");
+    expect(opener.container.querySelector(".type-caret")).not.toBeNull();
+    const boldOpener = render(<ProseMarkdown text="the **" revealing />);
+    expect(boldOpener.container.textContent).not.toContain("*");
+  });
+
+  it("rebuilds a half-typed closing run instead of leaking stars", () => {
+    // One of the two closing stars typed: `**moves through...*`.
+    const { container } = render(
+      <ProseMarkdown text="The crew **moves through the quiet streets*" revealing />,
+    );
+    const strong = container.querySelector("strong");
+    expect(strong).not.toBeNull();
+    expect(strong!.textContent).toContain("moves through the quiet streets");
+    expect(container.textContent).not.toContain("*");
+  });
+
+  it("never flashes literal markers on any frame of a real reveal", () => {
+    // Sweeps every typewriter frame of real corpus text: fresh Skald
+    // sentence-italics (save_05), a bold legacy line, and the full legacy
+    // excerpt whose scene-break comment contains `_` (which must not count
+    // toward delimiter parity - skipHtml drops the comment, so a parity
+    // closer would ride the caret as a literal underscore forever).
+    const texts = [
+      `${SKALD_CHUNK_7_EXCERPT}\n\nThe lower stacks answer.`,
+      SKALD_CHUNK_6_EXCERPT,
+      "The crew **moves through the quiet streets, recovering from the night before—some more gracefully than others.**\n\nDone.",
+      LEGACY_CHUNK_1425_EXCERPT,
+    ];
+    for (const text of texts) {
+      for (let frontier = 1; frontier <= text.length; frontier += 1) {
+        const { container, unmount } = render(
+          <ProseMarkdown text={text.slice(0, frontier)} revealing />,
+        );
+        expect(
+          container.textContent,
+          `literal marker leaked at frame ${frontier} of ${JSON.stringify(text.slice(0, 30))}`,
+        ).not.toMatch(/[*_]/);
+        unmount();
+      }
+    }
+  });
+
+  it("renders the live *Brena.* paragraph italic with the caret inside", () => {
+    const { container } = render(
+      <ProseMarkdown text={SKALD_CHUNK_7_EXCERPT} revealing />,
+    );
+    const ems = container.querySelectorAll("em");
+    expect(ems).toHaveLength(1);
+    expect(ems[0].textContent).toContain("Brena.");
+    expect(container.textContent).not.toContain("*");
     expect(container.querySelector(".type-caret")).not.toBeNull();
   });
 });

--- a/ui/client/src/components/nexus/ProseMarkdown.test.tsx
+++ b/ui/client/src/components/nexus/ProseMarkdown.test.tsx
@@ -290,6 +290,33 @@ describe("typewriter reveal", () => {
     expect(prepareRevealSource("Before.\n\n------")).not.toContain("-");
   });
 
+  it("keeps the caret at the frontier after a just-completed rule", () => {
+    // A textless last block (the freshly revealed <hr>) must take the caret
+    // after itself; pulling it back into the previous paragraph's text made
+    // the typewriter position jump backward mid-chunk. The caret stands in
+    // its own paragraph so the markdown root keeps block-level children.
+    const { container } = render(
+      <ProseMarkdown text={"Before.\n\n---\n\n"} revealing />,
+    );
+    const caret = container.querySelector(".type-caret");
+    expect(caret).not.toBeNull();
+    const caretLine = caret!.closest("p");
+    expect(caretLine).not.toBeNull();
+    expect(caretLine!.previousElementSibling?.tagName).toBe("HR");
+    expect(caretLine!.textContent).toBe("");
+  });
+
+  it("attaches auto-closers to the last non-whitespace character", () => {
+    // A whitespace-preceded closer is not right-flanking and cannot close.
+    expect(prepareRevealSource("*Before ")).toBe("*Before*");
+    expect(prepareRevealSource("*Before first bell. ")).toBe(
+      "*Before first bell.*",
+    );
+    expect(prepareRevealSource("The crew **moves ")).toBe(
+      "The crew **moves**",
+    );
+  });
+
   it("trims bare heading hashes until their text arrives", () => {
     const { container } = render(
       <ProseMarkdown text={"Seen.\n\n##"} revealing />,

--- a/ui/client/src/components/nexus/ProseMarkdown.test.tsx
+++ b/ui/client/src/components/nexus/ProseMarkdown.test.tsx
@@ -347,7 +347,7 @@ describe("typewriter reveal", () => {
     // Frame ends exactly on the opening `*` of mid-line `*urgent*`: closing
     // it would yield the empty-emphasis literal `Not **`. The trailing run
     // is stripped instead; the opener reappears with its first content char.
-    const opener = render(<ProseMarkdown text="Not *" revealing />, {});
+    const opener = render(<ProseMarkdown text="Not *" revealing />);
     expect(opener.container.textContent).not.toContain("*");
     expect(opener.container.querySelector(".type-caret")).not.toBeNull();
     const boldOpener = render(<ProseMarkdown text="the **" revealing />);

--- a/ui/client/src/components/nexus/ProseMarkdown.tsx
+++ b/ui/client/src/components/nexus/ProseMarkdown.tsx
@@ -21,13 +21,17 @@
  * markdown renders correctly mid-reveal without flashing literal syntax, and
  * an inline caret element is injected at the reveal frontier via a tiny
  * rehype plugin.
+ *
+ * The caret is injected into the parsed tree (after the last text node), not
+ * embedded in the markdown source. An earlier sentinel-character approach
+ * (U+E000 appended to the source) broke CommonMark's right-flanking rule for
+ * any emphasis span ending in punctuation - micromark classifies a private-use
+ * char as a word character, so the frame that typed the closing `*` of
+ * `*Brena.*` rendered literal asterisks instead of an <em>.
  */
 import ReactMarkdown, { type Options } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import type { Element, ElementContent, Root, Text } from "hast";
-
-/** Private-use sentinel marking the reveal frontier; never user-visible. */
-const CARET_SENTINEL = "\uE000";
+import type { Element, Root } from "hast";
 
 const components: Options["components"] = {
   // Clamp: an in-chunk h1 gets the h2 treatment.
@@ -52,17 +56,23 @@ const components: Options["components"] = {
  * the typewriter shows `**bo` as bold-in-progress rather than literal stars.
  * Handles both the asterisk and underscore forms found in the corpus
  * (`**`/`*` from Skald, `__`/`_` in the legacy import). Returns the suffix
- * of closing markers to append (after the caret).
+ * of closing markers to append.
  */
 function emphasisClosers(partial: string): string {
+  // Markers inside HTML comments (legacy `<!-- SCENE BREAK: S05E06_001 -->`)
+  // never reach the renderer - skipHtml drops the whole node, dangling or
+  // closed - so they must not count toward delimiter parity. Before this
+  // exclusion, the `_` in a scene-break id flipped the underscore count odd
+  // and a literal `_` rode the caret for the rest of the reveal.
+  const counted = partial.replace(/<!--[\s\S]*?(-->|$)/g, "");
   let closers = "";
-  const boldTokens = (partial.match(/\*\*/g) ?? []).length;
+  const boldTokens = (counted.match(/\*\*/g) ?? []).length;
   if (boldTokens % 2 === 1) closers += "**";
-  const singleStars = (partial.replace(/\*\*/g, "").match(/\*/g) ?? []).length;
+  const singleStars = (counted.replace(/\*\*/g, "").match(/\*/g) ?? []).length;
   if (singleStars % 2 === 1) closers += "*";
-  const doubleUnderscores = (partial.match(/__/g) ?? []).length;
+  const doubleUnderscores = (counted.match(/__/g) ?? []).length;
   if (doubleUnderscores % 2 === 1) closers += "__";
-  const singleUnderscores = (partial.replace(/__/g, "").match(/_/g) ?? [])
+  const singleUnderscores = (counted.replace(/__/g, "").match(/_/g) ?? [])
     .length;
   if (singleUnderscores % 2 === 1) closers += "_";
   return closers;
@@ -71,56 +81,72 @@ function emphasisClosers(partial: string): string {
 /**
  * Build the markdown source for a mid-reveal frame: trim a trailing line
  * that is still just structural markers (`--` typing toward `---` and its
- * longer CommonMark variants, bare `##`, `>`), insert the caret sentinel at
- * the frontier, and close any dangling emphasis after it.
+ * longer CommonMark variants, bare `##`, `>`), strip a half-typed trailing
+ * emphasis run, and close any dangling emphasis. Stripping the trailing run
+ * before computing closers means the frame source never ends in a bare
+ * delimiter: a just-typed opener (`the *`) renders as `the ` instead of the
+ * empty-emphasis literal `the **`, and a half-typed closer (`**bold*`)
+ * rebuilds as `**bold**` instead of leaking stars.
+ *
+ * The source carries no caret marker - any in-source character would sit
+ * between an emphasis delimiter and what follows it and change how
+ * CommonMark's flanking rules resolve it (the single-asterisk regression:
+ * `*Brena.*` plus a trailing sentinel parsed as literal text because the
+ * private-use char counts as a word character, un-right-flanking the
+ * closer). The caret is injected into the parsed tree instead (rehypeCaret).
  */
 export function prepareRevealSource(partial: string): string {
-  const trimmed = partial.replace(/(^|\n)[-*_#>]{1,6}[ \t]*$/, "$1");
-  return trimmed + CARET_SENTINEL + emphasisClosers(trimmed);
+  const trimmed = partial
+    .replace(/(^|\n)[-*_#>]{1,6}[ \t]*$/, "$1")
+    .replace(/[*_]+$/, "");
+  const closers = emphasisClosers(trimmed);
+  if (!closers) return trimmed;
+  // A closer preceded by whitespace is not right-flanking and cannot close
+  // (`*Before ` + `*` would leak literal stars); attach it to the last
+  // non-whitespace character instead.
+  return trimmed.replace(/\s+$/, "") + closers;
 }
 
-/** Replace the caret sentinel text with an inline caret element. */
-function injectCaret(parent: Root | Element): boolean {
+function makeCaret(): Element {
+  return {
+    type: "element",
+    tagName: "span",
+    properties: { className: ["type-caret"], ariaHidden: "true" },
+    children: [],
+  };
+}
+
+/**
+ * Locate the last non-whitespace text node in tree order. The reveal
+ * frontier always sits at the end of the rendered prose (narrative reveals
+ * linearly), so the caret belongs immediately after this node - including
+ * inside an in-progress emphasis whose closer was auto-appended.
+ */
+function lastTextPosition(
+  parent: Root | Element,
+): { parent: Root | Element; index: number } | null {
   for (let i = parent.children.length - 1; i >= 0; i -= 1) {
     const child = parent.children[i];
-    if (child.type === "text" && child.value.includes(CARET_SENTINEL)) {
-      const before = child.value.slice(0, child.value.indexOf(CARET_SENTINEL));
-      const after = child.value.slice(
-        child.value.indexOf(CARET_SENTINEL) + CARET_SENTINEL.length,
-      );
-      const caret: Element = {
-        type: "element",
-        tagName: "span",
-        properties: { className: ["type-caret"], ariaHidden: "true" },
-        children: [],
-      };
-      const replacement: ElementContent[] = [];
-      if (before) replacement.push({ type: "text", value: before } as Text);
-      replacement.push(caret);
-      if (after) replacement.push({ type: "text", value: after } as Text);
-      parent.children.splice(i, 1, ...replacement);
-      return true;
-    }
-    if (child.type === "element" && injectCaret(child)) return true;
-  }
-  return false;
-}
-
-/** Strip any sentinel that survived in odd positions (defensive). */
-function stripSentinels(parent: Root | Element): void {
-  for (const child of parent.children) {
-    if (child.type === "text" && child.value.includes(CARET_SENTINEL)) {
-      child.value = child.value.split(CARET_SENTINEL).join("");
-    } else if (child.type === "element") {
-      stripSentinels(child);
+    if (child.type === "element") {
+      const found = lastTextPosition(child);
+      if (found) return found;
+    } else if (child.type === "text" && child.value.trim() !== "") {
+      return { parent, index: i };
     }
   }
+  return null;
 }
 
+/** Append the inline caret element at the reveal frontier. */
 function rehypeCaret() {
   return (tree: Root) => {
-    injectCaret(tree);
-    stripSentinels(tree);
+    const position = lastTextPosition(tree);
+    if (position) {
+      position.parent.children.splice(position.index + 1, 0, makeCaret());
+    } else {
+      // Nothing revealed yet (or only structure): caret stands alone.
+      tree.children.push(makeCaret());
+    }
   };
 }
 

--- a/ui/client/src/components/nexus/ProseMarkdown.tsx
+++ b/ui/client/src/components/nexus/ProseMarkdown.tsx
@@ -31,7 +31,7 @@
  */
 import ReactMarkdown, { type Options } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import type { Element, Root } from "hast";
+import type { Element, ElementContent, Root, Text } from "hast";
 
 const components: Options["components"] = {
   // Clamp: an in-chunk h1 gets the h2 treatment.
@@ -64,6 +64,13 @@ function emphasisClosers(partial: string): string {
   // closed - so they must not count toward delimiter parity. Before this
   // exclusion, the `_` in a scene-break id flipped the underscore count odd
   // and a literal `_` rode the caret for the rest of the reveal.
+  //
+  // The `$` alternative makes an unclosed `<!--` swallow everything to the
+  // end of the partial. That mirrors the renderer: micromark treats an
+  // unterminated `<!--` HTML block as running to end of input, and skipHtml
+  // drops it wholesale - so nothing after it is visible and nothing after it
+  // should count. (Corpus comments are block-level scene breaks; inline
+  // comments mid-paragraph do not occur.)
   const counted = partial.replace(/<!--[\s\S]*?(-->|$)/g, "");
   let closers = "";
   const boldTokens = (counted.match(/\*\*/g) ?? []).length;
@@ -140,13 +147,41 @@ function lastTextPosition(
 /** Append the inline caret element at the reveal frontier. */
 function rehypeCaret() {
   return (tree: Root) => {
-    const position = lastTextPosition(tree);
-    if (position) {
-      position.parent.children.splice(position.index + 1, 0, makeCaret());
-    } else {
-      // Nothing revealed yet (or only structure): caret stands alone.
-      tree.children.push(makeCaret());
+    // The frontier lives in the last rendered block, so the caret search is
+    // scoped to it: a block with no text node (a just-completed `---` rule)
+    // takes the caret after itself rather than pulling it backward into an
+    // earlier block's text.
+    let lastBlock: Element | null = null;
+    for (let i = tree.children.length - 1; i >= 0; i -= 1) {
+      const child = tree.children[i];
+      if (child.type === "element") {
+        lastBlock = child;
+        break;
+      }
     }
+    const position = lastBlock ? lastTextPosition(lastBlock) : null;
+    if (!position) {
+      // No text at the frontier yet (empty frame, or a textless last block
+      // such as a just-revealed rule): the caret stands on its own line, in
+      // a paragraph so the root keeps block-level children only.
+      tree.children.push({
+        type: "element",
+        tagName: "p",
+        properties: { className: ["line"] },
+        children: [makeCaret()],
+      });
+      return;
+    }
+    // Character-precise placement: the frontier is the last non-whitespace
+    // character, so trailing whitespace in the text node stays after the
+    // caret rather than pushing it forward.
+    const node = position.parent.children[position.index] as Text;
+    const kept = node.value.replace(/\s+$/, "");
+    const trailing = node.value.slice(kept.length);
+    node.value = kept;
+    const inserted: ElementContent[] = [makeCaret()];
+    if (trailing) inserted.push({ type: "text", value: trailing });
+    position.parent.children.splice(position.index + 1, 0, ...inserted);
   };
 }
 


### PR DESCRIPTION
## User Report

"Italics are displaying correctly when the text has wrapping underscores, but not rendering when wrapped with single asterisks."

## Where the Failure Actually Lives

Committed-chunk rendering was **not** broken: a scan of all 2,858 asterisk-bearing chunks across save_01/save_02/save_05 through the exact react-markdown pipeline found zero well-formed `*italic*` spans failing (the only stragglers are six legacy chunks with genuinely malformed nested emphasis in the source text). A live-browser check confirmed committed `em` elements render with computed `font-style: italic` and no literal asterisks.

The failure is in **typewriter-reveal rendering**. Fresh Skald output italicizes whole sentences with single asterisks, so the spans end in punctuation. Real failing strings from the live database:

- `*Brena.*` (save_05 chunks 7/8/9 + the slot 5 pending chunk)
- `*Before first bell. Come alone. Last favor.*` (save_05 chunk 6)

## Precise Mechanism

`prepareRevealSource` embedded the caret sentinel U+E000 in the markdown source at the reveal frontier. micromark classifies a private-use character as a **word character** (neither whitespace nor punctuation). CommonMark's right-flanking rule says a closing delimiter preceded by punctuation can only close if it is *followed by whitespace or punctuation*. So the frame that typed the closing `*` of `*Brena.*` produced `*Brena.*<U+E000>` — closer preceded by `.`, followed by a word character — no longer right-flanking — the whole span rendered as literal asterisks at the exact moment it completed. The same flank break hit `**bold.**` and `_italic._`; the user saw it on asterisks because fresh Skald output (which is what animates) uses `*italic*`, while legacy `_italic_` text is read as committed history and never reveals.

## Fix

The markdown source no longer carries any caret marker; the caret is injected into the parsed hast tree after the last non-whitespace text node. Removing the sentinel exposed two cases it had been accidentally papering over, both now handled explicitly:

1. **Just-typed opener** (`the *`): auto-closing it would produce the empty-emphasis literal `the **`. A trailing half-typed delimiter run is stripped before closers are computed (it also makes a half-typed closer `**bold*` rebuild as `**bold**`).
2. **Frontier after whitespace inside an open span** (`*Before ` + `*`): a whitespace-preceded closer is not right-flanking and cannot close. Closers attach to the last non-whitespace character.

Plus one pre-existing leak found while sweeping the legacy dialect: the `_` inside `<!-- SCENE BREAK: S05E06_001 -->` comments flipped underscore parity, so a literal `_` rode the caret for the entire reveal of legacy-style text. Markers inside HTML comments (which `skipHtml` drops wholesale) are now excluded from parity counting.

## Verification

- **Exhaustive frame sweep with real data**: every reveal frame of save_05 chunks 6-9, the live slot 5 pending chunk, and save_02 chunk 1425 — 39,824 frames, zero leaked markers (old code: thousands, including every punctuation-final span completion).
- **vitest**: 93/93 green (29 in ProseMarkdown, 7 new). The 4 new reveal regression tests fail against the old implementation and pin the real failing strings captured from the live DBs.
- **Real browser** (headless Chrome against a worktree dev server on :5026): reader shows 13 `em` elements all computed `font-style: italic` — including single-asterisk `*Le Chat Noir*` and `*The Ghost*` — with zero literal asterisks; live typewriter reveal sampled across 55 frames shows zero leaked-marker frames (2 before the fix), emphasis styled mid-reveal, caret riding and clearing at completion. Note: slot 5 was wiped by another process mid-task (it is the active dev slot), so the browser pass ran against the slot 2 legacy corpus; the slot 5 real text is pinned in the vitest cases.
- `tsc --noEmit` clean; production build clean.

## Scope

`ProseMarkdown.tsx` + its test file only. No changes to NarrativePane.tsx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)