### PR TITLE
UI: Full Minimalism Audit Pass, Fading Scrollbars, Guarded Slot Initialization

### DIFF
--- a/ui/client/src/components/ErrorBoundary.tsx
+++ b/ui/client/src/components/ErrorBoundary.tsx
@@ -60,13 +60,8 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
               <AlertCircle className="h-5 w-5" />
               <AlertTitle className="text-lg font-semibold">Application Error</AlertTitle>
               <AlertDescription className="mt-2">
-                <p className="mb-4">
-                  The NEXUS interface encountered an unexpected error. This has been logged and can be
-                  reported to the development team.
-                </p>
                 {this.state.error && (
                   <div className="mt-4 p-4 bg-background/50 rounded border border-destructive/20 font-mono text-xs overflow-auto max-h-48">
-                    <div className="font-semibold mb-2 text-destructive">Error Details:</div>
                     <div className="text-muted-foreground">{this.state.error.toString()}</div>
                     {this.state.errorInfo && (
                       <details className="mt-2">
@@ -82,10 +77,10 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
                 )}
                 <div className="mt-6 flex gap-3">
                   <Button onClick={this.handleReload} variant="default">
-                    Reload Application
+                    Reload
                   </Button>
                   <Button onClick={this.handleReset} variant="outline">
-                    Try to Recover
+                    Recover
                   </Button>
                 </div>
               </AlertDescription>

--- a/ui/client/src/components/NewStoryWizard/ArtifactSidePanel.tsx
+++ b/ui/client/src/components/NewStoryWizard/ArtifactSidePanel.tsx
@@ -299,14 +299,9 @@ function AccordionSection({
           </button>
         </CollapsibleTrigger>
         <CollapsibleContent>
+          {/* An empty open section stays quiet - no placeholder copy. */}
           <div className="p-4 border-t border-primary/20 space-y-4">
-            {hasContent ? (
-              children
-            ) : (
-              <p className="text-muted-foreground text-sm italic">
-                Waiting for data...
-              </p>
-            )}
+            {hasContent ? children : null}
           </div>
         </CollapsibleContent>
       </div>
@@ -455,16 +450,7 @@ function CharacterContent({
   const { concept, traitSelection, wildcard, isComplete, completeSheet } =
     charView;
 
-  if (!data && !showTraitSelector) return null;
-
-  // M3: Fallback when trait selector is shown but no character concept exists yet
-  if (!data && showTraitSelector) {
-    return (
-      <div className="text-muted-foreground text-sm italic">
-        Waiting for character concept...
-      </div>
-    );
-  }
+  if (!data) return null;
 
   if (isComplete && completeSheet) {
     return (

--- a/ui/client/src/components/NewStoryWizard/ArtifactSidePanel.tsx
+++ b/ui/client/src/components/NewStoryWizard/ArtifactSidePanel.tsx
@@ -450,6 +450,12 @@ function CharacterContent({
   const { concept, traitSelection, wildcard, isComplete, completeSheet } =
     charView;
 
+  // showTraitSelector can flip true before any concept data exists (the
+  // keyword heuristic in InteractiveWizard.sendMessage fires on message
+  // text alone). The old "Waiting for character concept..." placeholder
+  // returned early in that window too - the trait chips have never
+  // rendered without data. The deliberate treatment now is a quiet empty
+  // section; the conversation itself carries the trait discussion.
   if (!data) return null;
 
   if (isComplete && completeSheet) {

--- a/ui/client/src/components/NewStoryWizard/InteractiveWizard.tsx
+++ b/ui/client/src/components/NewStoryWizard/InteractiveWizard.tsx
@@ -337,11 +337,9 @@ export function InteractiveWizard({
             // - Connect to WebSocket for real-time updates
             // - Detect incubator data when generation completes
             // - Show approval modal automatically
+            // No "generation started" toast: the reader the user lands on
+            // shows the live generation telemetry already (tenet 3).
             setWaitScreenActive(false);
-            toast({
-                title: "Generation Started",
-                description: "Your story is being created...",
-            });
             localStorage.setItem("activeSlot", slot.toString());
             onComplete();
 
@@ -353,10 +351,7 @@ export function InteractiveWizard({
                 processingRef.current = false;
                 setWaitScreenActive(false);
                 setIsLoading(false);
-                toast({
-                    title: "Operation cancelled",
-                    description: "You can restart when ready.",
-                });
+                toast({ title: "Cancelled" });
                 return;
             }
             console.error("Transition/bootstrap error:", e);

--- a/ui/client/src/components/NewStoryWizard/SlotSelector.test.tsx
+++ b/ui/client/src/components/NewStoryWizard/SlotSelector.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * SlotSelector interaction tests - the guarded occupied-slot initialization
+ * (tenet 9: a single click/Enter must not silently wipe an occupied slot).
+ *
+ * The query cache is pre-seeded with rows in the shape the component's
+ * queryFn produces from GET /api/story/new/slots (slot_number -> slot,
+ * is_active, is_locked, wizard_*), mirroring the live five-slot layout:
+ * occupied slots, an empty dev slot, and a locked archive. No fetch fires.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SlotSelector } from "./SlotSelector";
+
+interface SeedSlot {
+    slot: number;
+    is_active?: boolean;
+    is_locked?: boolean;
+    wizard_in_progress?: boolean;
+    wizard_phase?: "setting" | "character" | "seed";
+}
+
+function renderSelector(slots: SeedSlot[]) {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    queryClient.setQueryData(["/api/story/new/slots"], slots);
+    const onSlotSelected = vi.fn();
+    const onSlotResumed = vi.fn();
+    render(
+        <QueryClientProvider client={queryClient}>
+            <SlotSelector
+                onSlotSelected={onSlotSelected}
+                onSlotResumed={onSlotResumed}
+            />
+        </QueryClientProvider>,
+    );
+    return { onSlotSelected, onSlotResumed };
+}
+
+const FIVE_SLOTS: SeedSlot[] = [
+    { slot: 1, is_active: true },
+    { slot: 2, is_active: true },
+    { slot: 3, is_active: true },
+    { slot: 4, is_active: false, is_locked: true },
+    { slot: 5, is_active: false },
+];
+
+const card = (n: number) =>
+    screen.getByRole("group", { name: new RegExp(`Memory Slot ${n}`) });
+
+describe("SlotSelector occupied-slot guard", () => {
+    it("clicking an occupied slot opens the overwrite confirmation instead of initializing", () => {
+        const { onSlotSelected } = renderSelector(FIVE_SLOTS);
+        fireEvent.click(card(2));
+        expect(onSlotSelected).not.toHaveBeenCalled();
+        expect(screen.getByTestId("overwrite-confirm")).toBeInTheDocument();
+        expect(screen.getByText(/Overwrite Slot 2/)).toBeInTheDocument();
+    });
+
+    it("confirming the overwrite proceeds with initialization", () => {
+        const { onSlotSelected } = renderSelector(FIVE_SLOTS);
+        fireEvent.click(card(2));
+        fireEvent.click(screen.getByTestId("overwrite-confirm-action"));
+        expect(onSlotSelected).toHaveBeenCalledTimes(1);
+        expect(onSlotSelected).toHaveBeenCalledWith(2);
+    });
+
+    it("cancelling the overwrite leaves the slot untouched", () => {
+        const { onSlotSelected } = renderSelector(FIVE_SLOTS);
+        fireEvent.click(card(2));
+        fireEvent.click(screen.getByTestId("overwrite-cancel"));
+        expect(onSlotSelected).not.toHaveBeenCalled();
+        expect(screen.queryByTestId("overwrite-confirm")).not.toBeInTheDocument();
+    });
+
+    it("gates the keyboard path: Enter on an occupied card opens the confirmation", () => {
+        const { onSlotSelected } = renderSelector(FIVE_SLOTS);
+        fireEvent.keyDown(card(3), { key: "Enter" });
+        expect(onSlotSelected).not.toHaveBeenCalled();
+        expect(screen.getByTestId("overwrite-confirm")).toBeInTheDocument();
+    });
+
+    it("gates Space on an occupied card too", () => {
+        const { onSlotSelected } = renderSelector(FIVE_SLOTS);
+        fireEvent.keyDown(card(1), { key: " " });
+        expect(onSlotSelected).not.toHaveBeenCalled();
+        expect(screen.getByTestId("overwrite-confirm")).toBeInTheDocument();
+    });
+
+    it("a wizard-in-progress slot (occupied) is gated as well", () => {
+        const { onSlotSelected } = renderSelector([
+            {
+                slot: 2,
+                is_active: true,
+                wizard_in_progress: true,
+                wizard_phase: "character",
+            },
+            { slot: 5, is_active: false },
+        ]);
+        fireEvent.click(card(2));
+        expect(onSlotSelected).not.toHaveBeenCalled();
+        expect(screen.getByTestId("overwrite-confirm")).toBeInTheDocument();
+    });
+});
+
+describe("SlotSelector empty and locked slots", () => {
+    it("an empty slot initializes on a single click, no confirmation", () => {
+        const { onSlotSelected } = renderSelector(FIVE_SLOTS);
+        fireEvent.click(card(5));
+        expect(onSlotSelected).toHaveBeenCalledTimes(1);
+        expect(onSlotSelected).toHaveBeenCalledWith(5);
+        expect(screen.queryByTestId("overwrite-confirm")).not.toBeInTheDocument();
+    });
+
+    it("an empty slot initializes on a single Enter as well", () => {
+        const { onSlotSelected } = renderSelector(FIVE_SLOTS);
+        fireEvent.keyDown(card(5), { key: "Enter" });
+        expect(onSlotSelected).toHaveBeenCalledWith(5);
+        expect(screen.queryByTestId("overwrite-confirm")).not.toBeInTheDocument();
+    });
+
+    it("a locked slot neither initializes nor confirms", () => {
+        const { onSlotSelected } = renderSelector(FIVE_SLOTS);
+        fireEvent.click(card(4));
+        expect(onSlotSelected).not.toHaveBeenCalled();
+        expect(screen.queryByTestId("overwrite-confirm")).not.toBeInTheDocument();
+    });
+});

--- a/ui/client/src/components/NewStoryWizard/SlotSelector.tsx
+++ b/ui/client/src/components/NewStoryWizard/SlotSelector.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { AlertTriangle, Loader2, Trash2 } from "lucide-react";
+import { AlertTriangle, Loader2, Lock, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
@@ -96,24 +96,40 @@ export function SlotSelector({ onSlotSelected, onSlotResumed }: SlotSelectorProp
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["/api/story/new/slots"] });
-            toast({
-                title: "Slot Reset",
-                description: "Save slot has been cleared.",
-            });
+            toast({ title: "Slot cleared" });
         },
     });
 
-    const handleSelect = (slot: number, slotData: SlotData) => {
-        if (slotData.is_locked) {
-            toast({
-                title: "Slot Locked",
-                description: `Save Slot ${slot} is protected and cannot be overwritten.`,
-                variant: "destructive",
-            });
-            return;
-        }
+    // Occupied slot awaiting overwrite confirmation (tenet 9: wiping an
+    // occupied slot earns explicit friction; empty slots stay single-click).
+    const [slotToOverwrite, setSlotToOverwrite] = useState<number | null>(null);
+
+    const proceedToWizard = (slot: number) => {
         setSelectedSlot(slot);
         onSlotSelected(slot);
+    };
+
+    const handleSelect = (slot: number, slotData: SlotData) => {
+        if (slotData.is_locked) {
+            toast({ title: "Slot locked", variant: "destructive" });
+            return;
+        }
+        if (slotData.is_active) {
+            // Initializing an occupied slot destroys its story; gate it
+            // behind an explicit confirmation. Mouse and keyboard activation
+            // both route through here, so both paths are gated.
+            setSlotToOverwrite(slot);
+            return;
+        }
+        proceedToWizard(slot);
+    };
+
+    const confirmOverwrite = () => {
+        if (slotToOverwrite !== null) {
+            const slot = slotToOverwrite;
+            setSlotToOverwrite(null);
+            proceedToWizard(slot);
+        }
     };
 
     const handleResume = (e: React.MouseEvent, slotData: SlotData) => {
@@ -138,9 +154,8 @@ export function SlotSelector({ onSlotSelected, onSlotResumed }: SlotSelectorProp
 
     if (isLoading) {
         return (
-            <div className="flex flex-col items-center justify-center h-64 space-y-4">
+            <div className="flex flex-col items-center justify-center h-64">
                 <Loader2 className="h-8 w-8 animate-spin text-primary" />
-                <p className="font-mono text-sm text-muted-foreground">Scanning memory banks...</p>
             </div>
         );
     }
@@ -211,16 +226,19 @@ export function SlotSelector({ onSlotSelected, onSlotResumed }: SlotSelectorProp
                                                     ? "text-muted-foreground"
                                                     : "text-foreground"
                                         )}>
-                                            {slotData.is_locked ? "PROTECTED ARCHIVE" : `MEMORY SLOT ${slotData.slot}`}
+                                            MEMORY SLOT {slotData.slot}
                                         </span>
                                     </div>
                                 </div>
 
                                 <div className="flex items-center gap-2 ml-auto">
                                     {slotData.is_locked ? (
-                                        <div className="flex items-center gap-2 text-destructive text-xs font-mono px-3 py-1.5 border border-destructive/30 bg-destructive/5 rounded">
-                                            <AlertTriangle className="h-3 w-3" />
-                                            LOCKED
+                                        <div
+                                            className="flex items-center text-destructive px-3 py-1.5 border border-destructive/30 bg-destructive/5 rounded"
+                                            role="img"
+                                            aria-label="Locked"
+                                        >
+                                            <Lock className="h-3 w-3" />
                                         </div>
                                     ) : slotData.is_active ? (
                                         <>
@@ -272,10 +290,10 @@ export function SlotSelector({ onSlotSelected, onSlotResumed }: SlotSelectorProp
                     <AlertDialogHeader>
                         <AlertDialogTitle className="text-destructive font-mono uppercase tracking-wider flex items-center gap-2">
                             <AlertTriangle className="h-5 w-5" />
-                            Confirm Deletion
+                            Clear Slot {slotToDelete}
                         </AlertDialogTitle>
                         <AlertDialogDescription className="text-muted-foreground font-mono">
-                            Are you sure you want to clear Memory Slot {slotToDelete}? This action cannot be undone and all progress will be lost.
+                            The story in this slot will be erased.
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
@@ -284,7 +302,41 @@ export function SlotSelector({ onSlotSelected, onSlotResumed }: SlotSelectorProp
                             onClick={confirmReset}
                             className="bg-destructive text-destructive-foreground hover:bg-destructive/90 font-mono"
                         >
-                            DELETE DATA
+                            ERASE
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+
+            {/* Overwrite confirmation: shown only when initialization targets
+                an occupied slot (the destructive path). */}
+            <AlertDialog
+                open={slotToOverwrite !== null}
+                onOpenChange={(open) => !open && setSlotToOverwrite(null)}
+            >
+                <AlertDialogContent
+                    className="border-destructive/50 bg-background/95 backdrop-blur-xl"
+                    data-testid="overwrite-confirm"
+                >
+                    <AlertDialogHeader>
+                        <AlertDialogTitle className="text-destructive font-mono uppercase tracking-wider flex items-center gap-2">
+                            <AlertTriangle className="h-5 w-5" />
+                            Overwrite Slot {slotToOverwrite}
+                        </AlertDialogTitle>
+                        <AlertDialogDescription className="text-muted-foreground font-mono">
+                            Starting a new story here erases the existing one.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel className="font-mono" data-testid="overwrite-cancel">
+                            CANCEL
+                        </AlertDialogCancel>
+                        <AlertDialogAction
+                            onClick={confirmOverwrite}
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90 font-mono"
+                            data-testid="overwrite-confirm-action"
+                        >
+                            OVERWRITE
                         </AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>

--- a/ui/client/src/components/NewStoryWizard/WaitScreen.tsx
+++ b/ui/client/src/components/NewStoryWizard/WaitScreen.tsx
@@ -64,11 +64,6 @@ export function WaitScreen({
           <h2 className="text-2xl font-medium tracking-wide text-foreground mb-2">
             {hasError ? 'Generation Failed' : statusText}
           </h2>
-          {!hasError && (
-            <p className="text-muted-foreground text-sm">
-              This may take several minutes for complex scenarios
-            </p>
-          )}
         </div>
 
         {/* Error message if present */}
@@ -83,15 +78,12 @@ export function WaitScreen({
           {formatTime(elapsedSeconds)}
         </div>
 
-        {/* Progress bar */}
+        {/* Progress bar (the strip carries the proportion; no caption) */}
         <div className="w-full max-w-xs">
           <Progress
             value={progressPercent}
             className="h-2 bg-muted"
           />
-          <p className="text-center text-muted-foreground text-xs mt-2">
-            {hasError ? 'Ready to retry' : `${Math.round(progressPercent)}% of expected time`}
-          </p>
         </div>
 
         {/* Action buttons */}
@@ -110,17 +102,9 @@ export function WaitScreen({
             variant={hasError ? 'default' : 'outline'}
           >
             <RotateCcw className="h-4 w-4" />
-            {hasError ? 'Retry' : 'Retry Now'}
+            Retry
           </Button>
         </div>
-
-        {/* Hint text */}
-        {!hasError && (
-          <p className="text-muted-foreground/60 text-xs text-center max-w-xs">
-            Reasoning models like GPT-5.1 may need extra time for complex world-building.
-            You can retry if the request seems stuck.
-          </p>
-        )}
       </div>
     </div>
   );

--- a/ui/client/src/components/NewStoryWizard/WizardChoices.test.tsx
+++ b/ui/client/src/components/NewStoryWizard/WizardChoices.test.tsx
@@ -140,8 +140,12 @@ describe("WizardChoices", () => {
             />,
         );
         const button = screen.getByTestId("wizard-choice-1");
-        expect(button.querySelector("em")!.textContent).toBe("quiet");
-        expect(button.querySelector("strong")!.textContent).toBe("lower stacks");
+        const em = button.querySelector("em");
+        const strong = button.querySelector("strong");
+        expect(em).not.toBeNull();
+        expect(em!.textContent).toBe("quiet");
+        expect(strong).not.toBeNull();
+        expect(strong!.textContent).toBe("lower stacks");
         expect(button.textContent).not.toContain("*");
     });
 

--- a/ui/client/src/components/NewStoryWizard/WizardChoices.test.tsx
+++ b/ui/client/src/components/NewStoryWizard/WizardChoices.test.tsx
@@ -131,4 +131,25 @@ describe("WizardChoices", () => {
         expect(screen.getByTestId("wizard-choice-1")).toBeDisabled();
         expect(screen.getByTestId("wizard-freeform")).toBeDisabled();
     });
+
+    it("renders inline markdown in choice labels instead of literal markers", () => {
+        render(
+            <WizardChoices
+                choices={["A *quiet* start in the **lower stacks**"]}
+                onSubmit={() => {}}
+            />,
+        );
+        const button = screen.getByTestId("wizard-choice-1");
+        expect(button.querySelector("em")!.textContent).toBe("quiet");
+        expect(button.querySelector("strong")!.textContent).toBe("lower stacks");
+        expect(button.textContent).not.toContain("*");
+    });
+
+    it("submits the raw choice string even when the label is marked up", () => {
+        const onSubmit = vi.fn();
+        const marked = "A *quiet* start";
+        render(<WizardChoices choices={[marked]} onSubmit={onSubmit} />);
+        fireEvent.click(screen.getByTestId("wizard-choice-1"));
+        expect(onSubmit).toHaveBeenCalledWith(marked);
+    });
 });

--- a/ui/client/src/components/NewStoryWizard/WizardChoices.tsx
+++ b/ui/client/src/components/NewStoryWizard/WizardChoices.tsx
@@ -12,6 +12,7 @@ import {
     type KeyboardEvent,
 } from "react";
 import { cn } from "@/lib/utils";
+import { InlineMarkdown } from "@/components/nexus/ProseMarkdown";
 import { Textarea } from "@/components/ui/textarea";
 
 /**
@@ -133,7 +134,7 @@ export function WizardChoices({
                         {i + 1}.
                     </span>
                     <span className="flex-1 font-serif text-sm leading-relaxed text-muted-foreground">
-                        {text}
+                        <InlineMarkdown text={text} />
                     </span>
                 </button>
             ))}

--- a/ui/client/src/components/nexus/CharactersPane.tsx
+++ b/ui/client/src/components/nexus/CharactersPane.tsx
@@ -110,9 +110,6 @@ export function CharactersPane({ slot }: CharactersPaneProps) {
     return (
       <div className="pane-notice">
         <span className="notice-text">[ NO CAST RECORDED ]</span>
-        <span className="notice-detail">
-          Characters appear here as the story introduces them.
-        </span>
       </div>
     );
   }

--- a/ui/client/src/components/nexus/LeftRail.tsx
+++ b/ui/client/src/components/nexus/LeftRail.tsx
@@ -25,12 +25,9 @@ interface LeftRailProps {
 export function LeftRail({ tab, onTabChange, onHome }: LeftRailProps) {
   return (
     <nav className="rail-left" aria-label="Primary navigation">
-      <button
-        className="rail-btn"
-        onClick={onHome}
-        title="Home"
-        data-testid="rail-home"
-      >
+      {/* No title attributes: the styled .rail-tip is the hover label, and
+          a native tooltip on top of it would restate it (tenet 3). */}
+      <button className="rail-btn" onClick={onHome} data-testid="rail-home">
         <Home size={18} />
         <span className="rail-tip">HOME</span>
       </button>
@@ -40,7 +37,6 @@ export function LeftRail({ tab, onTabChange, onHome }: LeftRailProps) {
           key={id}
           className={`rail-btn ${tab === id ? "on" : ""}`}
           onClick={() => onTabChange(id)}
-          title={label}
           aria-pressed={tab === id}
           data-testid={`rail-${id}`}
         >

--- a/ui/client/src/components/nexus/LeftRail.tsx
+++ b/ui/client/src/components/nexus/LeftRail.tsx
@@ -26,10 +26,20 @@ export function LeftRail({ tab, onTabChange, onHome }: LeftRailProps) {
   return (
     <nav className="rail-left" aria-label="Primary navigation">
       {/* No title attributes: the styled .rail-tip is the hover label, and
-          a native tooltip on top of it would restate it (tenet 3). */}
-      <button className="rail-btn" onClick={onHome} data-testid="rail-home">
+          a native tooltip on top of it would restate it (tenet 3). The tip
+          hides via opacity (so it never left the accessibility tree), but
+          each button also carries an explicit aria-label so its accessible
+          name does not depend on a presentation class. */}
+      <button
+        className="rail-btn"
+        onClick={onHome}
+        aria-label="Home"
+        data-testid="rail-home"
+      >
         <Home size={18} />
-        <span className="rail-tip">HOME</span>
+        <span className="rail-tip" aria-hidden="true">
+          HOME
+        </span>
       </button>
       <div className="rail-divider" />
       {RAIL_TABS.map(({ id, label, Icon }) => (
@@ -37,11 +47,14 @@ export function LeftRail({ tab, onTabChange, onHome }: LeftRailProps) {
           key={id}
           className={`rail-btn ${tab === id ? "on" : ""}`}
           onClick={() => onTabChange(id)}
+          aria-label={label}
           aria-pressed={tab === id}
           data-testid={`rail-${id}`}
         >
           <Icon size={18} />
-          <span className="rail-tip">{label.toUpperCase()}</span>
+          <span className="rail-tip" aria-hidden="true">
+            {label.toUpperCase()}
+          </span>
         </button>
       ))}
       <div className="rail-spacer" />

--- a/ui/client/src/components/nexus/MapPane.tsx
+++ b/ui/client/src/components/nexus/MapPane.tsx
@@ -350,11 +350,11 @@ export function MapPane({ slot }: MapPaneProps) {
 
   return (
     <div className="mappane" data-testid="map-pane">
-      {/* ── Location index ─────────────────────────────────────────── */}
+      {/* ── Location index ─────────────────────────────────────────────
+          No header: the rail's Map tab already names this surface, and a
+          place count would restate the visible list (tenets 3/5; same
+          rationale as the cast roster's removed "CAST · N" header). */}
       <div className="mappane-list">
-        <span className="eyebrow brass-glow">
-          ATLAS · {places.length} {places.length === 1 ? "PLACE" : "PLACES"}
-        </span>
         <ul>
           {placesByZone.map(([zoneId, zonePlaces]) => {
             const zone = zoneById.get(zoneId);

--- a/ui/client/src/components/nexus/NarrativePane.tsx
+++ b/ui/client/src/components/nexus/NarrativePane.tsx
@@ -33,7 +33,7 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { DecoDivider } from "@/components/deco";
 import { Textarea } from "@/components/ui/textarea";
-import { ProseMarkdown } from "./ProseMarkdown";
+import { InlineMarkdown, ProseMarkdown } from "./ProseMarkdown";
 import { TypewriterText } from "./TypewriterText";
 import {
   getChunk,
@@ -334,7 +334,7 @@ export function NarrativePane({
   if (!slotState) {
     return (
       <div className="pane-notice">
-        <span className="notice-text">LOADING SLOT STATE…</span>
+        <span className="notice-text">LOADING…</span>
       </div>
     );
   }
@@ -343,10 +343,6 @@ export function NarrativePane({
     return (
       <div className="pane-notice">
         <span className="notice-text">[ SETUP INCOMPLETE ]</span>
-        <span className="notice-detail">
-          This slot is still in the New Story wizard. Finish setup to begin
-          reading.
-        </span>
       </div>
     );
   }
@@ -355,9 +351,6 @@ export function NarrativePane({
     return (
       <div className="pane-notice">
         <span className="notice-text">[ EMPTY SLOT ]</span>
-        <span className="notice-detail">
-          No story lives here yet. Start a new story from the splash menu.
-        </span>
       </div>
     );
   }
@@ -527,7 +520,9 @@ export function NarrativePane({
                 >
                   <span className="choice-key">{i + 1}</span>
                   <span className="choice-glyph">◆</span>
-                  <span className="choice-text">{text}</span>
+                  <span className="choice-text">
+                    <InlineMarkdown text={text} />
+                  </span>
                 </button>
               ))}
               <label className="choice freeform">

--- a/ui/client/src/components/nexus/NexusLayout.tsx
+++ b/ui/client/src/components/nexus/NexusLayout.tsx
@@ -98,10 +98,6 @@ export function NexusLayout() {
             (slot === null ? (
               <div className="pane-notice">
                 <span className="notice-text">[ NO ACTIVE SLOT ]</span>
-                <span className="notice-detail">
-                  Choose Continue or start a New Story from the splash menu to
-                  bind a save slot.
-                </span>
               </div>
             ) : engine.slotStateError ? (
               <div className="pane-notice">

--- a/ui/client/src/components/nexus/ProseMarkdown.test.tsx
+++ b/ui/client/src/components/nexus/ProseMarkdown.test.tsx
@@ -13,7 +13,11 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { ProseMarkdown, prepareRevealSource } from "./ProseMarkdown";
+import {
+  InlineMarkdown,
+  ProseMarkdown,
+  prepareRevealSource,
+} from "./ProseMarkdown";
 import { TypewriterText } from "./TypewriterText";
 
 const LEGACY_CHUNK_1425_EXCERPT = `<!-- SCENE BREAK: S05E06_001 (episode heading) -->
@@ -427,5 +431,68 @@ describe("typewriter reveal", () => {
     expect(ems[0].textContent).toContain("Brena.");
     expect(container.textContent).not.toContain("*");
     expect(container.querySelector(".type-caret")).not.toBeNull();
+  });
+});
+
+describe("InlineMarkdown (choice labels)", () => {
+  // No live chunk carries marked-up choices as of 2026-06-12 (verified
+  // across save_01..save_05 choice_object->'presented'), so these fixtures
+  // are pinned in the dialect the PR #386 survey documented for fresh Skald
+  // output: sentence emphasis via single asterisks (the real chunk strings
+  // `*Brena.*` / `*Before first bell. Come alone. Last favor.*`) and
+  // `**bold**`.
+  it("renders *emphasis* as <em> with no literal asterisks", () => {
+    const { container } = render(
+      <InlineMarkdown text="Answer her: *Before first bell. Come alone. Last favor.*" />,
+    );
+    const em = container.querySelector("em");
+    expect(em).not.toBeNull();
+    expect(em!.textContent).toBe("Before first bell. Come alone. Last favor.");
+    expect(container.textContent).not.toContain("*");
+  });
+
+  it("renders **bold** as <strong> with no literal asterisks", () => {
+    const { container } = render(
+      <InlineMarkdown text="Refuse. **Walk away** before first bell." />,
+    );
+    const strong = container.querySelector("strong");
+    expect(strong).not.toBeNull();
+    expect(strong!.textContent).toBe("Walk away");
+    expect(container.textContent).not.toContain("*");
+  });
+
+  it("handles mixed emphasis exactly like prose rendering", () => {
+    const { container } = render(
+      <InlineMarkdown text="Hold the line while *Brena.* watches — **do not blink**." />,
+    );
+    expect(container.querySelector("em")!.textContent).toBe("Brena.");
+    expect(container.querySelector("strong")!.textContent).toBe(
+      "do not blink",
+    );
+    expect(container.textContent).not.toMatch(/[*_]/);
+  });
+
+  it("emits no block elements - paragraphs unwrap, headings flatten to text", () => {
+    const { container } = render(<InlineMarkdown text="## Storm the gate" />);
+    expect(
+      container.querySelector("p, h1, h2, h3, ul, ol, blockquote, hr"),
+    ).toBeNull();
+    expect(container.textContent).toBe("Storm the gate");
+  });
+
+  it("unwraps links to their text - no navigation surface inside a choice", () => {
+    const { container } = render(
+      <InlineMarkdown text="Ask [Pete](https://example.com) to run the decoy." />,
+    );
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toBe("Ask Pete to run the decoy.");
+  });
+
+  it("passes plain choices through untouched", () => {
+    // Real choice string from save_02 (latest committed choice set).
+    const real =
+      "Disconnect the hard-line cleanly now and withdraw through the crawlspace before the technician reaches the annex door.";
+    const { container } = render(<InlineMarkdown text={real} />);
+    expect(container.textContent).toBe(real);
   });
 });

--- a/ui/client/src/components/nexus/ProseMarkdown.tsx
+++ b/ui/client/src/components/nexus/ProseMarkdown.tsx
@@ -188,6 +188,37 @@ function rehypeCaret() {
 const REMARK_PLUGINS = [remarkGfm];
 const REVEAL_REHYPE_PLUGINS = [rehypeCaret];
 
+/* Inline-only rendering for single-line labels (choice buttons). Emphasis
+   and strong render as real <em>/<strong>; every other construct is
+   unwrapped to its text (unwrapDisallowed), so a stray heading marker or
+   link in a choice can never produce block layout inside a button. */
+const INLINE_ALLOWED_ELEMENTS = ["p", "em", "strong"];
+const INLINE_COMPONENTS: Options["components"] = {
+  // The paragraph wrapper would be block-level inside the button; choices
+  // are single-line labels, so unwrap it.
+  p: ({ children }) => <>{children}</>,
+};
+
+/**
+ * InlineMarkdown - emphasis/strong only, no block elements. For choice
+ * button labels, which the storyteller marks up with the same `*italic*` /
+ * `**bold**` dialect as prose (PR #386 dialect survey) but which previously
+ * rendered the markers as literal asterisks.
+ */
+export function InlineMarkdown({ text }: { text: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={REMARK_PLUGINS}
+      components={INLINE_COMPONENTS}
+      allowedElements={INLINE_ALLOWED_ELEMENTS}
+      unwrapDisallowed
+      skipHtml
+    >
+      {text}
+    </ReactMarkdown>
+  );
+}
+
 interface ProseMarkdownProps {
   text: string;
   /**

--- a/ui/client/src/components/nexus/TopBar.tsx
+++ b/ui/client/src/components/nexus/TopBar.tsx
@@ -2,8 +2,13 @@
  * TopBar - the 52px operator strip across the top of the NexusLayout.
  *
  * Left: NEXUS wordmark (the single marquee-font element on this surface)
- * plus the slot label. Right: SKALD status field. Per the locked design
- * decisions there is no scene cartouche and no MODEL field.
+ * plus the slot label. Right: nothing at rest. Per the visual minimalism
+ * doctrine the old persistent `SKALD <status>` field is gone - it carried
+ * an internal module name, sat on screen while idle, and during generation
+ * restated the in-reader status line and the ledger telemetry. The one
+ * state with no other surface is backend unreachability, which renders as
+ * a plain OFFLINE flag only while true. Per the locked design decisions
+ * there is no scene cartouche and no MODEL field.
  */
 import type { SkaldStatus } from "@/types/narrative";
 
@@ -31,15 +36,13 @@ export function TopBar({ slot, characterName, skaldStatus }: TopBarProps) {
       </div>
 
       <div className="topbar-right">
-        <span className="field">
-          <span className="k">SKALD</span>
-          <span
-            className={`v ${skaldStatus.toLowerCase()}`}
-            data-testid="text-skald-status"
-          >
-            {skaldStatus}
+        {skaldStatus === "OFFLINE" && (
+          <span className="field">
+            <span className="v offline" data-testid="text-skald-status">
+              OFFLINE
+            </span>
           </span>
-        </span>
+        )}
       </div>
     </header>
   );

--- a/ui/client/src/index.css
+++ b/ui/client/src/index.css
@@ -186,6 +186,66 @@ html {
   background-color: #09101c;
 }
 
+/* ═══════════════════════════════════════════════════════════════════════════
+   FADING SCROLLBARS
+   Global overlay-style scrollbars: invisible at rest, fading in while
+   scrolling (lib/fading-scrollbars.ts toggles .scrollbar-active) and when
+   the pointer rests on the gutter. Styling ::-webkit-scrollbar reserves a
+   constant gutter, so the fade never shifts layout. The thumb color rides
+   each theme's --primary token, so Veil/Gilded/Vector inherit their own
+   palette. The fade itself animates the registered custom property
+   --scrollbar-alpha on the scrolling element; the scrollbar pseudo-elements
+   (which cannot transition) re-resolve the inherited var() every frame.
+   ═══════════════════════════════════════════════════════════════════════════ */
+@property --scrollbar-alpha {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0;
+}
+
+:root {
+  /* Tunables (consumed below and by lib/fading-scrollbars.ts). */
+  --scrollbar-size: 10px;
+  --scrollbar-fade-ms: 450ms;
+  --scrollbar-idle-ms: 1000;
+}
+
+/* Zero-specificity transition: fills in only where nothing else declares
+   one, so element/utility transitions are never disturbed. */
+* {
+  transition: --scrollbar-alpha var(--scrollbar-fade-ms) ease;
+}
+
+*::-webkit-scrollbar {
+  width: var(--scrollbar-size);
+  height: var(--scrollbar-size);
+  background: transparent;
+}
+
+*::-webkit-scrollbar-track,
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: hsl(var(--primary) / calc(var(--scrollbar-alpha) * 0.45));
+  border-radius: calc(var(--scrollbar-size) / 2);
+  /* Transparent border + padding-box clip = a slim inset thumb. */
+  border: 3px solid transparent;
+  background-clip: padding-box;
+}
+
+/* Hovering the gutter reveals the thumb regardless of scroll state (the
+   hit area exists even while the paint is transparent). */
+*::-webkit-scrollbar-thumb:hover,
+*::-webkit-scrollbar-thumb:active {
+  background-color: hsl(var(--primary) / 0.6);
+}
+
+.scrollbar-active {
+  --scrollbar-alpha: 1;
+}
+
 /* LIGHT MODE */
 :root {
   --button-outline: rgba(0, 0, 0, .10);

--- a/ui/client/src/index.css
+++ b/ui/client/src/index.css
@@ -211,7 +211,16 @@ html {
 }
 
 /* Zero-specificity transition: fills in only where nothing else declares
-   one, so element/utility transitions are never disturbed. */
+   one, so element/utility transitions are never disturbed. Interactions to
+   know about when adding transitions elsewhere:
+   - A higher-specificity `transition: none` (or any explicit transition
+     list) on a scroll container drops the fade there - the alpha still
+     switches, just instantly.
+   - A higher-specificity `transition: all` covers --scrollbar-alpha too,
+     so the fade runs at THAT rule's duration, not --scrollbar-fade-ms.
+     Prefer explicit property lists over `all` on scroll containers.
+   - On engines without ::-webkit-scrollbar (Firefox) this whole block is
+     visually inert; the property still animates but paints nothing. */
 * {
   transition: --scrollbar-alpha var(--scrollbar-fade-ms) ease;
 }

--- a/ui/client/src/lib/fading-scrollbars.test.ts
+++ b/ui/client/src/lib/fading-scrollbars.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Fading-scrollbars module tests: the scroll listener marks the scrolled
+ * element active and clears the mark after the idle delay. (The visual
+ * fade itself is CSS - covered by the real-browser verification pass.)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  installFadingScrollbars,
+  readScrollbarIdleMs,
+  SCROLLBAR_ACTIVE_CLASS,
+} from "./fading-scrollbars";
+
+const IDLE_MS = 40;
+
+describe("readScrollbarIdleMs", () => {
+  afterEach(() => {
+    document.documentElement.style.removeProperty("--scrollbar-idle-ms");
+  });
+
+  it("reads the pinned idle delay", () => {
+    document.documentElement.style.setProperty("--scrollbar-idle-ms", "1000");
+    expect(readScrollbarIdleMs(document)).toBe(1000);
+  });
+
+  it("fails loud when the tunable is missing", () => {
+    expect(() => readScrollbarIdleMs(document)).toThrow(/--scrollbar-idle-ms/);
+  });
+});
+
+describe("installFadingScrollbars", () => {
+  let uninstall: () => void;
+  let pane: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.documentElement.style.setProperty(
+      "--scrollbar-idle-ms",
+      String(IDLE_MS),
+    );
+    pane = document.createElement("div");
+    document.body.appendChild(pane);
+    uninstall = installFadingScrollbars(document);
+  });
+
+  afterEach(() => {
+    uninstall();
+    pane.remove();
+    document.documentElement.style.removeProperty("--scrollbar-idle-ms");
+    document.documentElement.classList.remove(SCROLLBAR_ACTIVE_CLASS);
+    vi.useRealTimers();
+  });
+
+  it("marks a scrolled element active, then clears it after the idle delay", () => {
+    pane.dispatchEvent(new Event("scroll"));
+    expect(pane.classList.contains(SCROLLBAR_ACTIVE_CLASS)).toBe(true);
+
+    vi.advanceTimersByTime(IDLE_MS - 1);
+    expect(pane.classList.contains(SCROLLBAR_ACTIVE_CLASS)).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(pane.classList.contains(SCROLLBAR_ACTIVE_CLASS)).toBe(false);
+  });
+
+  it("keeps the mark alive while scrolling continues", () => {
+    pane.dispatchEvent(new Event("scroll"));
+    vi.advanceTimersByTime(IDLE_MS - 5);
+    pane.dispatchEvent(new Event("scroll"));
+    vi.advanceTimersByTime(IDLE_MS - 5);
+    expect(pane.classList.contains(SCROLLBAR_ACTIVE_CLASS)).toBe(true);
+    vi.advanceTimersByTime(5);
+    expect(pane.classList.contains(SCROLLBAR_ACTIVE_CLASS)).toBe(false);
+  });
+
+  it("tracks independent scrollers independently", () => {
+    const other = document.createElement("div");
+    document.body.appendChild(other);
+
+    pane.dispatchEvent(new Event("scroll"));
+    vi.advanceTimersByTime(IDLE_MS / 2);
+    other.dispatchEvent(new Event("scroll"));
+
+    vi.advanceTimersByTime(IDLE_MS / 2);
+    expect(pane.classList.contains(SCROLLBAR_ACTIVE_CLASS)).toBe(false);
+    expect(other.classList.contains(SCROLLBAR_ACTIVE_CLASS)).toBe(true);
+
+    other.remove();
+  });
+
+  it("routes document-level scrolls to the root element", () => {
+    document.dispatchEvent(new Event("scroll"));
+    expect(
+      document.documentElement.classList.contains(SCROLLBAR_ACTIVE_CLASS),
+    ).toBe(true);
+    vi.advanceTimersByTime(IDLE_MS);
+    expect(
+      document.documentElement.classList.contains(SCROLLBAR_ACTIVE_CLASS),
+    ).toBe(false);
+  });
+
+  it("stops listening after uninstall", () => {
+    uninstall();
+    pane.dispatchEvent(new Event("scroll"));
+    expect(pane.classList.contains(SCROLLBAR_ACTIVE_CLASS)).toBe(false);
+    // Re-install so afterEach uninstall stays valid.
+    uninstall = installFadingScrollbars(document);
+  });
+});

--- a/ui/client/src/lib/fading-scrollbars.ts
+++ b/ui/client/src/lib/fading-scrollbars.ts
@@ -1,0 +1,73 @@
+/**
+ * Fading scrollbars - the JS half of the global overlay-scrollbar treatment.
+ *
+ * The CSS half lives in index.css ("FADING SCROLLBARS"): every scroll
+ * surface gets a custom ::-webkit-scrollbar whose thumb alpha is driven by
+ * the registered custom property `--scrollbar-alpha` (0 at rest). CSS cannot
+ * observe scrolling, so this module listens for scroll events in the capture
+ * phase (scroll does not bubble, but capture still visits ancestors) and
+ * toggles `.scrollbar-active` on the scrolled element; the property
+ * transition on the element produces the fade in both directions.
+ *
+ * The idle delay is a stylesheet tunable (`--scrollbar-idle-ms` on :root)
+ * so all scrollbar tuning lives in one CSS block. A missing or malformed
+ * value throws - fail loud, no silent default.
+ */
+
+/** Class toggled on actively scrolling elements (styled in index.css). */
+export const SCROLLBAR_ACTIVE_CLASS = "scrollbar-active";
+
+/** Read the idle delay from the stylesheet; loud failure if absent. */
+export function readScrollbarIdleMs(doc: Document): number {
+  // Inline value first (lets tests pin it without a stylesheet), then the
+  // cascaded :root value from index.css.
+  const raw =
+    doc.documentElement.style.getPropertyValue("--scrollbar-idle-ms") ||
+    doc.defaultView
+      ?.getComputedStyle(doc.documentElement)
+      .getPropertyValue("--scrollbar-idle-ms");
+  const parsed = Number.parseFloat(raw ?? "");
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(
+      `--scrollbar-idle-ms missing or invalid on :root (got ${JSON.stringify(raw)})`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Install the global scroll listener. Returns an uninstall function
+ * (used by tests; the app installs once for its lifetime in main.tsx).
+ */
+export function installFadingScrollbars(doc: Document = document): () => void {
+  const idleMs = readScrollbarIdleMs(doc);
+  const timers = new Map<Element, number>();
+
+  const onScroll = (event: Event) => {
+    // A document-level scroll targets the document itself; the scrollbar
+    // belongs to the root element.
+    const target =
+      event.target instanceof Element
+        ? event.target
+        : doc.scrollingElement ?? doc.documentElement;
+    if (!target) return;
+
+    target.classList.add(SCROLLBAR_ACTIVE_CLASS);
+    const pending = timers.get(target);
+    if (pending !== undefined) window.clearTimeout(pending);
+    timers.set(
+      target,
+      window.setTimeout(() => {
+        target.classList.remove(SCROLLBAR_ACTIVE_CLASS);
+        timers.delete(target);
+      }, idleMs),
+    );
+  };
+
+  doc.addEventListener("scroll", onScroll, { capture: true, passive: true });
+  return () => {
+    doc.removeEventListener("scroll", onScroll, { capture: true });
+    timers.forEach((id) => window.clearTimeout(id));
+    timers.clear();
+  };
+}

--- a/ui/client/src/main.tsx
+++ b/ui/client/src/main.tsx
@@ -1,5 +1,8 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { installFadingScrollbars } from "./lib/fading-scrollbars";
 import "./index.css";
+
+installFadingScrollbars();
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/ui/client/src/pages/not-found.tsx
+++ b/ui/client/src/pages/not-found.tsx
@@ -1,21 +1,22 @@
-import { Card, CardContent } from "@/components/ui/card";
-import { AlertCircle } from "lucide-react";
+/**
+ * 404 surface. Theme-consistent and quiet: the code, and a way home.
+ * (The previous version was unthemed template scaffolding with dev-facing
+ * copy - "Did you forget to add the page to the router?".)
+ */
+import { Link } from "wouter";
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
-      <Card className="w-full max-w-md mx-4">
-        <CardContent className="pt-6">
-          <div className="flex mb-4 gap-2">
-            <AlertCircle className="h-8 w-8 text-red-500" />
-            <h1 className="text-2xl font-bold text-gray-900">404 Page Not Found</h1>
-          </div>
-
-          <p className="mt-4 text-sm text-gray-600">
-            Did you forget to add the page to the router?
-          </p>
-        </CardContent>
-      </Card>
+    <div className="dark min-h-screen w-full flex flex-col items-center justify-center gap-6 bg-background">
+      <span className="font-mono text-sm tracking-[0.22em] text-muted-foreground">
+        [ 404 ]
+      </span>
+      <Link
+        href="/"
+        className="font-mono text-xs tracking-[0.22em] text-primary hover:underline underline-offset-4"
+      >
+        NEXUS
+      </Link>
     </div>
   );
 }

--- a/ui/client/src/pages/not-found.tsx
+++ b/ui/client/src/pages/not-found.tsx
@@ -1,5 +1,7 @@
 /**
  * 404 surface. Theme-consistent and quiet: the code, and a way home.
+ * Theme classes (dark + per-theme overrides) come from ThemeContext on the
+ * document root, exactly like every other surface - nothing stamped here.
  * (The previous version was unthemed template scaffolding with dev-facing
  * copy - "Did you forget to add the page to the router?".)
  */
@@ -7,7 +9,7 @@ import { Link } from "wouter";
 
 export default function NotFound() {
   return (
-    <div className="dark min-h-screen w-full flex flex-col items-center justify-center gap-6 bg-background">
+    <div className="min-h-screen w-full flex flex-col items-center justify-center gap-6 bg-background">
       <span className="font-mono text-sm tracking-[0.22em] text-muted-foreground">
         [ 404 ]
       </span>


### PR DESCRIPTION
## Summary

The post-merge audit lane: a walk of every IRIS surface in a real browser against the nine visual-minimalism tenets (CLAUDE.md, PR #388), fixing the gaps between the seven minimalism lanes' territories (#389-#395), plus the three conductor mandates. Nothing the seven lanes shipped is undone; PR #384's slot visual-state work is built on, not regressed.

## Violations Table (Audit Sweep)

| Surface | Tenet | Before -> After |
| --- | --- | --- |
| Top bar (reader chrome) | 6, 8, 3 | Persistent `SKALD READY/LIVE` field at idle -> removed; generation already shows in the reader status line + ledger telemetry; the only state with no other surface (backend unreachable) renders a plain `OFFLINE` flag while true |
| Left rail | 3 | Native `title` tooltip on every icon button duplicated the styled hover `.rail-tip` (double tooltip) -> `title` removed, hover tip kept |
| Reader empty/wizard notices | 4 | `[ EMPTY SLOT ]` + "No story lives here yet. Start a new story from the splash menu." (and the SETUP INCOMPLETE equivalent) -> bracketed label only, matching the map's `[ UNCHARTED ]` idiom; `LOADING SLOT STATE…` -> `LOADING…` |
| Reader shell (no slot) | 4, 3 | `[ NO ACTIVE SLOT ]` + two-line explainer (the characters tab version already had none) -> label only |
| Characters empty state | 4 | `[ NO CAST RECORDED ]` + "Characters appear here as the story introduces them." -> label only |
| Map place list | 5, 3 | `ATLAS · N PLACES` header restated the rail's Map tab and the visible list (same rationale as #390's removed `CAST · N`) -> removed |
| Slot manager loader | 2 | Spinner + "Scanning memory banks..." -> spinner only (matches #391's loader treatment) |
| Slot manager locked slot | 3, 2 | Triple signal: "PROTECTED ARCHIVE" name + `⚠ LOCKED` chip + destructive tint -> name stays `MEMORY SLOT N`, chip is a lock glyph (aria-label "Locked"), tint unchanged |
| Slot manager clear dialog | 1 | "Confirm Deletion" / "Are you sure you want to clear Memory Slot N? This action cannot be undone and all progress will be lost." / `DELETE DATA` -> "Clear Slot N" / "The story in this slot will be erased." / `ERASE` |
| Slot manager toasts | 3 | Title+description pairs restating each other ("Slot Reset" + "Save slot has been cleared.") -> single-line toasts |
| Wizard wait screen | 4, 2, 6-adjacent | "This may take several minutes for complex scenarios", "N% of expected time" caption under the progress bar, and the "Reasoning models like GPT-5.1 may need extra time..." paragraph (model-name leak) -> removed; `Retry Now` -> `Retry` |
| Wizard artifact panel | audit brief: stray placeholder copy | "Waiting for data..." / "Waiting for character concept..." -> quiet empty sections |
| Wizard toasts | 3, 8 | "Generation Started / Your story is being created..." fired right before landing on the reader that shows live telemetry -> removed; "Operation cancelled / You can restart when ready." -> "Cancelled" |
| Error boundary | 4 | "The NEXUS interface encountered an unexpected error. This has been logged and can be reported to the development team." (false logging claim) + "Error Details:" label -> dropped; the error text, component stack, and Reload/Recover actions remain (fail-loud preserved) |
| 404 page | audit brief: leftover dev copy, theming | Light-gray template card with "Did you forget to add the page to the router?" -> themed `[ 404 ]` + NEXUS link home |

Judgment calls noted: the map rows' `UNCHARTED` badge and the zone place-count chips were left (state data, not label restatement); `[ABORT]`/`EXIT` wizard chrome left (per-theme deliberate); dead components (StoryChoices, old phase components) left for other lanes per #391's note.

## Mandate A — Fading Scrollbars

Global, in the shared stylesheet (`index.css`): every scroll surface gets a custom `::-webkit-scrollbar` with a transparent track and a constant gutter, so the fade never shifts layout. The thumb's color is `hsl(var(--primary) / calc(alpha * 0.45))`, so Veil/Gilded/Vector each inherit their own palette. The fade animates the registered (`@property`) custom property `--scrollbar-alpha` on the scrolling element — scrollbar pseudo-elements cannot transition, but they re-resolve the inherited var() every frame. `lib/fading-scrollbars.ts` (installed once in main.tsx) listens for scroll in the capture phase and toggles `.scrollbar-active`, clearing it after `--scrollbar-idle-ms` (a stylesheet tunable; missing value throws). Hovering the gutter reveals the thumb for grabbing even at rest.

## Mandate B — Guarded Slot Initialization

Selecting an occupied (`is_active`) slot in the slot manager no longer starts the wizard directly: it opens a theme-consistent destructive AlertDialog ("Overwrite Slot N — Starting a new story here erases the existing one." CANCEL / OVERWRITE). The existing AlertDialog primitive already in the tree was reused — no new shadcn install needed. Empty slots stay single-click. The gate lives in the one `handleSelect` shared by pointer and keyboard activation, so Enter/Space on a focused card is gated identically. Wizard-in-progress slots (also `is_active`) are gated too.

## Mandate C — Inline Markdown in Choice Labels

New `InlineMarkdown` in `ProseMarkdown.tsx`: react-markdown with `allowedElements: [p, em, strong]` + `unwrapDisallowed` and the paragraph unwrapped to a fragment — emphasis and strong render as real elements, every block construct (headings, lists, links, rules) flattens to its text, raw HTML is skipped. Consumed by the reader's choice buttons (NarrativePane) and the wizard's (WizardChoices); the submitted choice string stays the raw text. **No live chunk currently carries marked-up choices** (verified across `save_01..save_05` `choice_object->'presented'`), so per the brief the test fixtures are pinned from the PR #386 dialect survey, including the real chunk strings `*Brena.*` and `*Before first bell. Come alone. Last favor.*`.

## Verification

- `vitest`: **166/166** (24 new: 7 fading-scrollbars, 9 SlotSelector guard incl. keyboard + locked paths, 6 InlineMarkdown, 2 WizardChoices markdown)
- `tsc --noEmit` clean; production build green
- **Real browser** (puppeteer-core + system Chrome headless, worktree dev server on :5028 proxying the live API read-only): **20/20 checks**
  - A: `--scrollbar-alpha` measured 0 -> ~0.47 mid-fade on scroll -> 0 after idle on both the reader pane and the settings scroller; class toggling confirmed; during/idle screenshot pair captured
  - B: occupied slot click -> dialog, zero POSTs; CANCEL -> zero POSTs; Enter on occupied card -> dialog; Escape -> zero POSTs; OVERWRITE -> wizard start POST observed and **aborted at the network layer**; empty slot 5 -> single click, no dialog, start POST likewise aborted. **All non-GET/HEAD /api requests were intercepted for the entire drive — `/api/story/new/slots` re-queried afterward: slot 2 still occupied, slot 5 still empty, no wizard rows.** No initialization ever reached any backend.
  - C: with a modified copy of the real slot-2 state response (PR #384's interception pattern) carrying the dialect fixtures, all three choice buttons rendered `<em>`/`<strong>` with computed `font-style: italic` and zero literal asterisks
  - D: walk of splash (three themes), slot manager, wizard entry, reader live (slots 1 and 2), historical chunk via the tree, story tree, characters, map (three themes + place dialog + slot 5 `[ UNCHARTED ]`), settings (forbidden-copy sweep: no LORE/LOGON/SKALD/MEMNON), empty states, 404, `document.title === "NEXUS"`; before-screenshots taken read-only from the live main stack on :5001 (the before reader shows the idle `SKALD READY` field this PR removes)
  - The live dev stack on 5001/8002 was never restarted, killed, or written to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
