### PR TITLE
Map: Click+Drag Panning; Rail: Retire Inert Monogram

### DIFF
--- a/docs/maptab_rebuild_spec.md
+++ b/docs/maptab_rebuild_spec.md
@@ -161,10 +161,19 @@ visible.
 ### 4.1 Pan (pointer drag)
 
 - `onPointerDown` on the `<svg>`: capture pointer ID, store start point,
-  set `isDragging = true`.
+  begin a drag session.
 - `onPointerMove`: compute delta from start, scale by current `viewBox.width
   / svgClientWidth`, subtract from `viewBox.x/y`. Call `clampViewBox`.
 - `onPointerUp`: release pointer capture, clear drag state.
+
+**Click-vs-drag threshold** (June 2026 rework): a press is not a drag
+until the pointer moves a few px (`DRAG_THRESHOLD_PX`, straight-line
+from pointerdown). Below the threshold the map must not move and the
+release counts as a click (pin selection); at or above it the press is
+a pan and the release must never fire a selection — even if the pointer
+returns to its origin before release. The session logic is pure and
+unit-tested (`beginDragSession` / `applyDragMove` / `endDragSession` in
+`lib/map-geometry.ts`).
 
 **Pointer capture is mandatory**, not optional:
 `svgRef.current.setPointerCapture(e.pointerId)` ensures `pointermove`
@@ -212,16 +221,27 @@ Zoom range: 0.2× to 100×. Don't allow negative or zero.
 ### 4.3 ViewBox clamping
 
 After every pan or zoom, run `clampViewBox(viewBox)` to ensure the world
-outline stays at least partially visible. The exact bounds depend on the
-projected world bounds — the current implementation uses the result of
-`fitSize` to define a "fully zoomed out" viewBox and never lets the user
-pan beyond it.
+outline stays at least partially visible.
+
+**The mistake to avoid** (shipped in the U4 rebuild): clamping the
+window to the initially *fitted* region. At 1.00× zoom the window
+exactly equals the fit box, the clamp range collapses to zero on both
+axes, and every drag is silently clamped back — pan handlers that look
+correct but do nothing. Clamp against the **whole projected world**
+instead (for equirectangular, the two projected corners of
+[-180..180, -90..90]), requiring some minimum fraction of the viewport
+(`MIN_WORLD_VISIBLE_FRACTION`) to still overlap the world box, so the
+map can roam anywhere but never be dragged fully off-screen.
 
 ### 4.4 Place selection / details modal
 
 - Click a pin → set `selectedLocation = place.id`, open details dialog.
-  Use `e.stopPropagation()` and an `isDragging` check to prevent the
-  click from firing at the end of a drag.
+  NOTE: with pointer capture on the `<svg>`, the browser retargets the
+  derived `click` event to the capture element, so a pin `onClick` never
+  fires once the svg captures on pointerdown. Select on the svg's
+  `pointerup` instead, keyed off the original pointerdown target (the
+  release target is retargeted too), and only when the drag session
+  stayed below the click-vs-drag threshold (§4.1).
 - Click a place in the sidebar → set `selectedLocation` AND programmatically
   reposition the viewBox so the place sits at the canvas center
   (manually compute new viewBox.x/y from `placeCoordinates.get(id)`).

--- a/ui/client/src/components/nexus/LeftRail.tsx
+++ b/ui/client/src/components/nexus/LeftRail.tsx
@@ -57,10 +57,6 @@ export function LeftRail({ tab, onTabChange, onHome }: LeftRailProps) {
           </span>
         </button>
       ))}
-      <div className="rail-spacer" />
-      <div className="rail-monogram" aria-hidden="true">
-        N·I
-      </div>
     </nav>
   );
 }

--- a/ui/client/src/components/nexus/MapPane.tsx
+++ b/ui/client/src/components/nexus/MapPane.tsx
@@ -57,6 +57,7 @@ import {
   clampZoom,
   computeLabelVisibility,
   computeMapBounds,
+  endDragSession,
   extractCoordinates,
   panViewBox,
   zoomViewBoxAtCursor,
@@ -273,6 +274,11 @@ export function MapPane({ slot }: MapPaneProps) {
     svgRef.current?.setPointerCapture?.(e.pointerId);
   };
 
+  // NOTE: these React handlers read `panBounds` from the render closure,
+  // which is safe — JSX-bound handlers are recreated every render, so the
+  // closure is never stale. Only the NATIVE wheel listener above (mounted
+  // once, empty deps) must go through panBoundsRef. Do not wrap these in
+  // useCallback without moving them onto the ref.
   const handlePointerMove = (e: ReactPointerEvent<SVGSVGElement>) => {
     const session = dragSessionRef.current;
     if (!session) return;
@@ -299,17 +305,20 @@ export function MapPane({ slot }: MapPaneProps) {
 
   const handlePointerUp = (e: ReactPointerEvent<SVGSVGElement>) => {
     const session = dragSessionRef.current;
-    if (!session || session.pointerId !== e.pointerId) return;
+    if (!session) return;
+
+    const end = endDragSession(session, e.pointerId);
+    if (!end) return; // foreign pointer's release: the drag survives
 
     dragSessionRef.current = null;
-    setIsDragging(false);
+    if (end.panned) setIsDragging(false);
     svgRef.current?.releasePointerCapture?.(e.pointerId);
 
     // Below the drag threshold this press was a click. Pointer capture
     // retargets the click event to the SVG itself, so pin selection lives
     // here — keyed off the original pointerdown target, never the (re-
     // targeted) release target.
-    if (!session.panned && downTargetRef.current instanceof Element) {
+    if (!end.panned && downTargetRef.current instanceof Element) {
       const pin = downTargetRef.current.closest("[data-place-id]");
       if (pin) {
         const placeId = Number(pin.getAttribute("data-place-id"));
@@ -326,7 +335,7 @@ export function MapPane({ slot }: MapPaneProps) {
     if (!session || session.pointerId !== e.pointerId) return;
     dragSessionRef.current = null;
     downTargetRef.current = null;
-    setIsDragging(false);
+    if (session.panned) setIsDragging(false);
   };
 
   // ── Selection ───────────────────────────────────────────────────────

--- a/ui/client/src/components/nexus/MapPane.tsx
+++ b/ui/client/src/components/nexus/MapPane.tsx
@@ -14,9 +14,14 @@
  *                       by a NATIVE non-passive wheel listener (React 17+
  *                       root wheel listeners are passive: preventDefault
  *                       would silently fail and scroll the page)
- *  3. Pointer capture → setPointerCapture on pointerdown + an
- *                       activePointerId ref that rejects events from any
- *                       other pointer (multi-touch / trackpad safety)
+ *  3. Pointer capture → setPointerCapture on pointerdown (drag keeps
+ *                       working across the pane edge, releases cleanly)
+ *                       + the pure drag-session machine in
+ *                       lib/map-geometry.ts: an owning-pointer guard that
+ *                       rejects events from any other pointer
+ *                       (multi-touch / trackpad safety) and a small
+ *                       movement threshold separating click from drag —
+ *                       pin selection fires only below it
  *  4. lng/lat order   → extractCoordinates is the only place the GeoJSON
  *                       [longitude, latitude] array is destructured
  *  5. Spherical fit winding → boundsToFitObject in lib/map-geometry.ts
@@ -36,7 +41,6 @@
  * across Veil / Gilded / Vector with zero map-specific colors.
  */
 import {
-  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -47,14 +51,18 @@ import { useQuery } from "@tanstack/react-query";
 import { ChevronDown, ChevronRight, MapPin } from "lucide-react";
 import { useGeoProjection } from "@/hooks/useGeoProjection";
 import {
+  applyDragMove,
+  beginDragSession,
   centerViewBoxOn,
-  clampViewBox,
   clampZoom,
   computeLabelVisibility,
   computeMapBounds,
   extractCoordinates,
+  panViewBox,
   zoomViewBoxAtCursor,
+  type DragSession,
   type LabelCandidate,
+  type PanBounds,
   type ViewBox,
 } from "@/lib/map-geometry";
 import { getCurrentPlace, getPlaces, getZones } from "@/lib/narrative-api";
@@ -111,8 +119,8 @@ export function MapPane({ slot }: MapPaneProps) {
 
   const svgRef = useRef<SVGSVGElement>(null);
   const canvasRef = useRef<HTMLDivElement>(null);
-  const activePointerId = useRef<number | null>(null);
-  const dragStartRef = useRef({ x: 0, y: 0 });
+  const dragSessionRef = useRef<DragSession | null>(null);
+  const downTargetRef = useRef<EventTarget | null>(null);
   const dimensionsRef = useRef(mapDimensions);
   dimensionsRef.current = mapDimensions;
 
@@ -149,6 +157,26 @@ export function MapPane({ slot }: MapPaneProps) {
     mapDimensions,
     mapBounds,
   });
+
+  // Pan bounds: the whole projected world, not the initially fitted
+  // region. The old clamp confined the window to the fit box, which at
+  // 1.00× zoom had zero slack — dragging was a silent no-op. Equirect
+  // projection is linear, so the two corners bound the projected globe.
+  const panBounds = useMemo<PanBounds>(() => {
+    const a = transformCoordinates(-180, 90);
+    const b = transformCoordinates(180, -90);
+    if (!a || !b) {
+      throw new Error("Map projection failed to project the world corners");
+    }
+    return {
+      minX: Math.min(a.x, b.x),
+      minY: Math.min(a.y, b.y),
+      maxX: Math.max(a.x, b.x),
+      maxY: Math.max(a.y, b.y),
+    };
+  }, [transformCoordinates]);
+  const panBoundsRef = useRef(panBounds);
+  panBoundsRef.current = panBounds;
 
   const worldCountries = useMemo(() => {
     return worldOutline.features
@@ -222,6 +250,7 @@ export function MapPane({ slot }: MapPaneProps) {
           newZoom,
           dims.width,
           dims.height,
+          panBoundsRef.current,
         );
       });
     };
@@ -230,57 +259,74 @@ export function MapPane({ slot }: MapPaneProps) {
     return () => svg.removeEventListener("wheel", onWheel);
   }, []);
 
-  // ── Pan (failure mode 3: pointer capture + active-pointer guard) ────
-  const isInteractiveTarget = (target: EventTarget | null) => {
-    if (!(target instanceof Element)) return false;
-    return Boolean(target.closest("[data-interactive='true']"));
-  };
-
-  const endDrag = useCallback(() => {
-    setIsDragging(false);
-    activePointerId.current = null;
-  }, []);
-
+  // ── Pan (failure mode 3: pointer capture + drag-session machine) ────
+  // Every press starts a session — including presses on pins, so a drag
+  // that begins on a pin pans the map. Selection happens on release,
+  // only when the session never crossed the drag threshold.
   const handlePointerDown = (e: ReactPointerEvent<SVGSVGElement>) => {
     if (e.button !== 0) return;
-    if (isInteractiveTarget(e.target)) return;
 
-    activePointerId.current = e.pointerId;
-    setIsDragging(true);
-    dragStartRef.current = { x: e.clientX, y: e.clientY };
-    // Mandatory: keeps pointermove firing when the cursor leaves the SVG
-    // mid-drag. Without capture, drag breaks on fast cursor movement.
+    dragSessionRef.current = beginDragSession(e.pointerId, e.clientX, e.clientY);
+    downTargetRef.current = e.target;
+    // Mandatory (spec §6.3): capture keeps pointermove firing when the
+    // cursor leaves the SVG mid-drag and guarantees a clean release.
     svgRef.current?.setPointerCapture?.(e.pointerId);
   };
 
   const handlePointerMove = (e: ReactPointerEvent<SVGSVGElement>) => {
-    // Reject any pointer that isn't the dragger (multi-touch safety).
-    if (!isDragging || activePointerId.current !== e.pointerId) return;
+    const session = dragSessionRef.current;
+    if (!session) return;
 
-    const deltaX = e.clientX - dragStartRef.current.x;
-    const deltaY = e.clientY - dragStartRef.current.y;
-    dragStartRef.current = { x: e.clientX, y: e.clientY };
+    const move = applyDragMove(session, e.pointerId, e.clientX, e.clientY);
+    if (!move) return; // foreign pointer (multi-touch safety)
+    dragSessionRef.current = move.session;
+
+    if (move.session.panned && !isDragging) setIsDragging(true);
+    if (move.deltaX === 0 && move.deltaY === 0) return;
 
     const dims = dimensionsRef.current;
-    setViewBox((prev) => {
-      const scaleX = prev.width / Math.max(dims.width, 1);
-      const scaleY = prev.height / Math.max(dims.height, 1);
-      return clampViewBox(
-        {
-          ...prev,
-          x: prev.x - deltaX * scaleX,
-          y: prev.y - deltaY * scaleY,
-        },
+    setViewBox((prev) =>
+      panViewBox(
+        prev,
+        move.deltaX,
+        move.deltaY,
         dims.width,
         dims.height,
-      );
-    });
+        panBounds,
+      ),
+    );
   };
 
-  const handlePointerEnd = (e: ReactPointerEvent<SVGSVGElement>) => {
-    if (activePointerId.current !== e.pointerId) return;
+  const handlePointerUp = (e: ReactPointerEvent<SVGSVGElement>) => {
+    const session = dragSessionRef.current;
+    if (!session || session.pointerId !== e.pointerId) return;
+
+    dragSessionRef.current = null;
+    setIsDragging(false);
     svgRef.current?.releasePointerCapture?.(e.pointerId);
-    endDrag();
+
+    // Below the drag threshold this press was a click. Pointer capture
+    // retargets the click event to the SVG itself, so pin selection lives
+    // here — keyed off the original pointerdown target, never the (re-
+    // targeted) release target.
+    if (!session.panned && downTargetRef.current instanceof Element) {
+      const pin = downTargetRef.current.closest("[data-place-id]");
+      if (pin) {
+        const placeId = Number(pin.getAttribute("data-place-id"));
+        if (Number.isFinite(placeId)) selectPlace(placeId, false);
+      }
+    }
+    downTargetRef.current = null;
+  };
+
+  // Aborted gestures (pointercancel, capture stolen/lost without a
+  // pointerup): reset drag state, never fire a selection.
+  const handlePointerAbort = (e: ReactPointerEvent<SVGSVGElement>) => {
+    const session = dragSessionRef.current;
+    if (!session || session.pointerId !== e.pointerId) return;
+    dragSessionRef.current = null;
+    downTargetRef.current = null;
+    setIsDragging(false);
   };
 
   // ── Selection ───────────────────────────────────────────────────────
@@ -290,10 +336,7 @@ export function MapPane({ slot }: MapPaneProps) {
     if (center) {
       const coords = placeCoordinates.get(placeId);
       if (coords) {
-        const dims = dimensionsRef.current;
-        setViewBox((prev) =>
-          centerViewBoxOn(coords, prev, dims.width, dims.height),
-        );
+        setViewBox((prev) => centerViewBoxOn(coords, prev, panBounds));
       }
     }
   };
@@ -422,15 +465,19 @@ export function MapPane({ slot }: MapPaneProps) {
           preserveAspectRatio="xMidYMid slice"
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
-          onPointerUp={handlePointerEnd}
-          onPointerLeave={handlePointerEnd}
-          onPointerCancel={handlePointerEnd}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerAbort}
+          onLostPointerCapture={handlePointerAbort}
           data-testid="map-svg"
         >
-          {/* Background + survey grid */}
+          {/* Background + survey grid track the window: the viewBox can
+              now roam beyond the initially fitted region, so a fixed
+              canvas-sized rect would run out from under the sea. */}
           <rect
-            width={mapDimensions.width}
-            height={mapDimensions.height}
+            x={viewBox.x}
+            y={viewBox.y}
+            width={viewBox.width}
+            height={viewBox.height}
             fill="var(--map-sea)"
           />
           <defs>
@@ -450,8 +497,10 @@ export function MapPane({ slot }: MapPaneProps) {
             </pattern>
           </defs>
           <rect
-            width={mapDimensions.width}
-            height={mapDimensions.height}
+            x={viewBox.x}
+            y={viewBox.y}
+            width={viewBox.width}
+            height={viewBox.height}
             fill="url(#nexus-map-grid)"
           />
 
@@ -485,18 +534,12 @@ export function MapPane({ slot }: MapPaneProps) {
               <g
                 key={place.id}
                 className="map-pin"
-                data-interactive="true"
+                data-place-id={place.id}
                 onPointerEnter={() => {
                   if (!isDragging) setHoveredId(place.id);
                 }}
                 onPointerLeave={() => {
                   if (!isDragging) setHoveredId(null);
-                }}
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={(e) => {
-                  if (isDragging) return;
-                  e.stopPropagation();
-                  selectPlace(place.id, false);
                 }}
                 data-testid={`map-pin-${place.id}`}
               >
@@ -555,8 +598,8 @@ export function MapPane({ slot }: MapPaneProps) {
           {/* Empty state: grid + world outline stay visible (spec §3.4) */}
           {!placesLoading && placeCoordinates.size === 0 && (
             <text
-              x="50%"
-              y="50%"
+              x={viewBox.x + viewBox.width / 2}
+              y={viewBox.y + viewBox.height / 2}
               textAnchor="middle"
               className="map-empty-text"
             >

--- a/ui/client/src/components/nexus/nexus-layout.css
+++ b/ui/client/src/components/nexus/nexus-layout.css
@@ -253,17 +253,6 @@
   background: var(--border);
   margin: 6px 0;
 }
-.rail-spacer { flex: 1; }
-/* Rail monogram — menu font, not the marquee. */
-.rail-monogram {
-  font-family: var(--font-menu);
-  font-size: 11px;
-  color: var(--fg-dim);
-  letter-spacing: 0.3em;
-  opacity: .55;
-  margin-bottom: 8px;
-  font-weight: 600;
-}
 
 /* ─── Main content ─── */
 .nexus-content {

--- a/ui/client/src/lib/map-geometry.test.ts
+++ b/ui/client/src/lib/map-geometry.test.ts
@@ -6,30 +6,62 @@
  *   - extractCoordinates  → §6.4 GeoJSON [lng, lat] ordering + validation
  *   - zoomViewBoxAtCursor → §6.2 cursor-anchored zoom
  *   - computeLabelVisibility → §6.1 priority + AABB label culling
- *   - clampViewBox / computeMapBounds → §4.3 pan clamping
- * (§6.3 pointer capture is DOM behavior — verified manually, see PR.)
+ *   - clampViewBox / panViewBox / computeMapBounds → §4.1/§4.3 pan + bounds
+ *   - beginDragSession / applyDragMove / endDragSession → §6.3 pointer
+ *     lifecycle (owning-pointer guard) + click-vs-drag threshold
+ * (The setPointerCapture / releasePointerCapture DOM calls themselves are
+ * verified in a real browser — see PR evidence.)
  */
 import { geoEquirectangular } from "d3-geo";
 import { describe, expect, it, vi } from "vitest";
 import type { Place } from "@shared/schema";
 import {
+  applyDragMove,
+  beginDragSession,
   boundsToFitObject,
   centerViewBoxOn,
   clampViewBox,
   clampZoom,
   computeLabelVisibility,
   computeMapBounds,
+  DRAG_THRESHOLD_PX,
+  endDragSession,
   extractCoordinates,
   MIN_BOUNDS_SPAN_DEG,
+  MIN_WORLD_VISIBLE_FRACTION,
+  panViewBox,
   shouldDisplayLabelByZoom,
   zoomViewBoxAtCursor,
   type LabelCandidate,
+  type PanBounds,
   type ViewBox,
 } from "./map-geometry";
 
 function makePlace(id: number, geometry: unknown): Place {
   return { id, name: `Place ${id}`, geometry } as unknown as Place;
 }
+
+/** SVG-space point under a client cursor position for a given viewBox. */
+function svgPointUnderCursor(
+  box: ViewBox,
+  cursorX: number,
+  cursorY: number,
+  rectW: number,
+  rectH: number,
+) {
+  return {
+    x: box.x + cursorX * (box.width / rectW),
+    y: box.y + cursorY * (box.height / rectH),
+  };
+}
+
+/** A projected world so large no clamp engages (regional-fit geometry). */
+const OPEN_WORLD: PanBounds = {
+  minX: -100000,
+  minY: -100000,
+  maxX: 100000,
+  maxY: 100000,
+};
 
 describe("extractCoordinates (failure mode 4: lng/lat ordering)", () => {
   it("reads GeoJSON Point as [longitude, latitude]", () => {
@@ -118,20 +150,6 @@ describe("zoomViewBoxAtCursor (failure mode 2: zoom anchoring)", () => {
   const MAP_W = 800;
   const MAP_H = 600;
 
-  /** SVG-space point under a client cursor position for a given viewBox. */
-  function svgPointUnderCursor(
-    box: ViewBox,
-    cursorX: number,
-    cursorY: number,
-    rectW: number,
-    rectH: number,
-  ) {
-    return {
-      x: box.x + cursorX * (box.width / rectW),
-      y: box.y + cursorY * (box.height / rectH),
-    };
-  }
-
   it("keeps the SVG point under the cursor invariant across a zoom-in", () => {
     const prev: ViewBox = { x: 100, y: 80, width: 400, height: 300 };
     const cursor = { x: 530, y: 190 };
@@ -154,6 +172,7 @@ describe("zoomViewBoxAtCursor (failure mode 2: zoom anchoring)", () => {
       2.2,
       MAP_W,
       MAP_H,
+      OPEN_WORLD,
     );
     const after = svgPointUnderCursor(next, cursor.x, cursor.y, rect.w, rect.h);
 
@@ -185,6 +204,7 @@ describe("zoomViewBoxAtCursor (failure mode 2: zoom anchoring)", () => {
       3.6,
       MAP_W,
       MAP_H,
+      OPEN_WORLD,
     );
     const after = svgPointUnderCursor(next, cursor.x, cursor.y, rect.w, rect.h);
 
@@ -197,7 +217,17 @@ describe("zoomViewBoxAtCursor (failure mode 2: zoom anchoring)", () => {
     // x/y zooms toward the top-left corner. With the cursor at the canvas
     // center, a correct zoom-in must move the origin down-right.
     const prev: ViewBox = { x: 0, y: 0, width: 800, height: 600 };
-    const next = zoomViewBoxAtCursor(prev, 400, 300, 800, 600, 2, MAP_W, MAP_H);
+    const next = zoomViewBoxAtCursor(
+      prev,
+      400,
+      300,
+      800,
+      600,
+      2,
+      MAP_W,
+      MAP_H,
+      OPEN_WORLD,
+    );
     expect(next.x).toBeGreaterThan(0);
     expect(next.y).toBeGreaterThan(0);
     expect(next.x).toBeCloseTo(200, 6);
@@ -211,46 +241,212 @@ describe("zoomViewBoxAtCursor (failure mode 2: zoom anchoring)", () => {
   });
 });
 
-describe("clampViewBox (§4.3 pan clamping)", () => {
-  it("clamps negative origins to zero", () => {
-    const box = clampViewBox(
-      { x: -50, y: -20, width: 400, height: 300 },
-      800,
-      600,
-    );
-    expect(box.x).toBe(0);
-    expect(box.y).toBe(0);
+describe("clampViewBox (§4.3 pan bounds: world never fully off-screen)", () => {
+  // A projected world that extends beyond the 800×600 canvas, as it does
+  // for any regional fit (the fitted region maps to the canvas, the rest
+  // of the globe projects outside it).
+  const world: PanBounds = { minX: -1000, minY: -800, maxX: 1800, maxY: 1400 };
+
+  it("leaves an interior window untouched", () => {
+    const box = clampViewBox({ x: 250, y: 130, width: 400, height: 300 }, world);
+    expect(box).toEqual({ x: 250, y: 130, width: 400, height: 300 });
   });
 
-  it("clamps the origin so the window stays inside the map", () => {
-    const box = clampViewBox(
-      { x: 700, y: 500, width: 400, height: 300 },
-      800,
-      600,
+  it("allows panning beyond the fitted region (the 1.00x pan-lock bug)", () => {
+    // REGRESSION: the old clamp confined the window to the fitted region
+    // [0, 0, mapW, mapH]; at zoom 1 the slack was zero on both axes and
+    // every drag was silently clamped back — "the map has no panning".
+    const box = clampViewBox({ x: 300, y: 200, width: 800, height: 600 }, world);
+    expect(box.x).toBe(300);
+    expect(box.y).toBe(200);
+
+    const negative = clampViewBox(
+      { x: -350, y: -250, width: 800, height: 600 },
+      world,
     );
-    expect(box.x).toBe(400); // 800 - 400
-    expect(box.y).toBe(300); // 600 - 300
+    expect(negative.x).toBe(-350);
+    expect(negative.y).toBe(-250);
   });
 
-  it("pins to origin when the window is larger than the map (zoom < 1)", () => {
+  it("keeps the minimum world fraction visible at the right/bottom edge", () => {
     const box = clampViewBox(
-      { x: 120, y: 90, width: 1600, height: 1200 },
-      800,
-      600,
+      { x: 99999, y: 99999, width: 800, height: 600 },
+      world,
     );
-    expect(box.x).toBe(0);
-    expect(box.y).toBe(0);
+    expect(box.x).toBe(world.maxX - 800 * MIN_WORLD_VISIBLE_FRACTION);
+    expect(box.y).toBe(world.maxY - 600 * MIN_WORLD_VISIBLE_FRACTION);
   });
 
-  it("centerViewBoxOn centers a point and respects clamping", () => {
+  it("keeps the minimum world fraction visible at the left/top edge", () => {
+    const box = clampViewBox(
+      { x: -99999, y: -99999, width: 800, height: 600 },
+      world,
+    );
+    expect(box.x).toBe(world.minX - 800 + 800 * MIN_WORLD_VISIBLE_FRACTION);
+    expect(box.y).toBe(world.minY - 600 + 600 * MIN_WORLD_VISIBLE_FRACTION);
+  });
+
+  it("keeps a small world inside a large window (deep zoom-out)", () => {
+    const tiny: PanBounds = { minX: 0, minY: 0, maxX: 100, maxY: 80 };
+    const big = { width: 4000, height: 3000 };
+
+    const right = clampViewBox({ x: 5000, y: 5000, ...big }, tiny);
+    expect(right.x).toBeLessThanOrEqual(tiny.minX);
+    expect(right.x + big.width).toBeGreaterThanOrEqual(tiny.maxX);
+    expect(right.y).toBeLessThanOrEqual(tiny.minY);
+    expect(right.y + big.height).toBeGreaterThanOrEqual(tiny.maxY);
+
+    const left = clampViewBox({ x: -5000, y: -5000, ...big }, tiny);
+    expect(left.x).toBeLessThanOrEqual(tiny.minX);
+    expect(left.x + big.width).toBeGreaterThanOrEqual(tiny.maxX);
+  });
+
+  it("centerViewBoxOn centers a point and respects the pan bounds", () => {
     const prev: ViewBox = { x: 0, y: 0, width: 400, height: 300 };
-    const centered = centerViewBoxOn({ x: 400, y: 300 }, prev, 800, 600);
+    const centered = centerViewBoxOn({ x: 400, y: 300 }, prev, world);
     expect(centered.x).toBe(200);
     expect(centered.y).toBe(150);
 
-    const nearEdge = centerViewBoxOn({ x: 790, y: 590 }, prev, 800, 600);
-    expect(nearEdge.x).toBe(400); // clamped to map edge
-    expect(nearEdge.y).toBe(300);
+    const farOut = centerViewBoxOn({ x: 99999, y: 99999 }, prev, world);
+    expect(farOut.x).toBe(world.maxX - 400 * MIN_WORLD_VISIBLE_FRACTION);
+    expect(farOut.y).toBe(world.maxY - 300 * MIN_WORLD_VISIBLE_FRACTION);
+  });
+});
+
+describe("panViewBox (§4.1 drag-to-pan + pan/zoom composition)", () => {
+  it("moves the window opposite the drag (content follows the cursor)", () => {
+    // Dragging right/down pulls the world right/down → window moves left/up.
+    const next = panViewBox(
+      { x: 0, y: 0, width: 800, height: 600 },
+      50,
+      30,
+      800,
+      600,
+      OPEN_WORLD,
+    );
+    expect(next.x).toBe(-50);
+    expect(next.y).toBe(-30);
+  });
+
+  it("maps the same px drag through the projection scale at every zoom", () => {
+    // zoom 1: viewBox width == rect width → 50 px ⇒ 50 SVG units.
+    const z1 = panViewBox(
+      { x: 0, y: 0, width: 800, height: 600 },
+      50,
+      -30,
+      800,
+      600,
+      OPEN_WORLD,
+    );
+    expect(z1.x).toBeCloseTo(-50, 6);
+    expect(z1.y).toBeCloseTo(30, 6);
+
+    // zoom 4: same 50 px covers a quarter of the SVG distance, which is
+    // the SAME distance on screen — pan feel is zoom-invariant.
+    const z4 = panViewBox(
+      { x: 100, y: 80, width: 200, height: 150 },
+      50,
+      -30,
+      800,
+      600,
+      OPEN_WORLD,
+    );
+    expect(z4.x).toBeCloseTo(100 - 12.5, 6);
+    expect(z4.y).toBeCloseTo(80 + 7.5, 6);
+  });
+
+  it("clamps a drag at the world edge", () => {
+    const world: PanBounds = { minX: 0, minY: 0, maxX: 1600, maxY: 1200 };
+    const next = panViewBox(
+      { x: 0, y: 0, width: 800, height: 600 },
+      99999, // hard fling right → window pushed far left of the world
+      0,
+      800,
+      600,
+      world,
+    );
+    expect(next.x).toBe(world.minX - 800 + 800 * MIN_WORLD_VISIBLE_FRACTION);
+  });
+
+  it("zoom anchoring still holds on a panned window (composition)", () => {
+    // Pan first…
+    const panned = panViewBox(
+      { x: 0, y: 0, width: 400, height: 300 },
+      -120,
+      90,
+      800,
+      600,
+      OPEN_WORLD,
+    );
+    expect(panned.x).toBeCloseTo(60, 6); // 120 px × (400/800)
+    expect(panned.y).toBeCloseTo(-45, 6);
+
+    // …then zoom at an off-center cursor: the SVG point under the cursor
+    // must survive the zoom exactly as it does on an unpanned window.
+    const cursor = { x: 250, y: 410 };
+    const before = svgPointUnderCursor(panned, cursor.x, cursor.y, 800, 600);
+    const next = zoomViewBoxAtCursor(
+      panned,
+      cursor.x,
+      cursor.y,
+      800,
+      600,
+      3,
+      800,
+      600,
+      OPEN_WORLD,
+    );
+    const after = svgPointUnderCursor(next, cursor.x, cursor.y, 800, 600);
+    expect(after.x).toBeCloseTo(before.x, 6);
+    expect(after.y).toBeCloseTo(before.y, 6);
+  });
+});
+
+describe("drag session (failure mode 3: pointer lifecycle + click-vs-drag)", () => {
+  it("ignores moves from a foreign pointer (multi-touch safety)", () => {
+    const session = beginDragSession(7, 100, 100);
+    expect(applyDragMove(session, 9, 300, 300)).toBeNull();
+  });
+
+  it("survives a foreign pointer's release", () => {
+    const session = beginDragSession(7, 100, 100);
+    expect(endDragSession(session, 9)).toBeNull();
+    expect(endDragSession(session, 7)).toEqual({ panned: false });
+  });
+
+  it("stays a click below the movement threshold (map must not move)", () => {
+    const session = beginDragSession(1, 100, 100);
+    const move = applyDragMove(session, 1, 102, 101); // ~2.2 px of jitter
+    expect(move).not.toBeNull();
+    expect(move!.deltaX).toBe(0);
+    expect(move!.deltaY).toBe(0);
+    expect(move!.session.panned).toBe(false);
+    expect(endDragSession(move!.session, 1)).toEqual({ panned: false });
+  });
+
+  it("becomes a pan at the threshold, applying the full accumulated delta", () => {
+    const session = beginDragSession(1, 100, 100);
+    const move = applyDragMove(session, 1, 100 + DRAG_THRESHOLD_PX + 2, 100);
+    expect(move!.session.panned).toBe(true);
+    expect(move!.deltaX).toBe(DRAG_THRESHOLD_PX + 2); // nothing swallowed
+    expect(move!.deltaY).toBe(0);
+  });
+
+  it("applies incremental deltas after the threshold", () => {
+    let session = beginDragSession(1, 100, 100);
+    session = applyDragMove(session, 1, 110, 100)!.session;
+    const move = applyDragMove(session, 1, 115, 103);
+    expect(move!.deltaX).toBe(5);
+    expect(move!.deltaY).toBe(3);
+  });
+
+  it("a pan stays a pan even when released back at the origin", () => {
+    // Drag out and back: total displacement is zero, but the session
+    // panned — the release must still be click-suppressed.
+    let session = beginDragSession(1, 100, 100);
+    session = applyDragMove(session, 1, 130, 100)!.session;
+    session = applyDragMove(session, 1, 100, 100)!.session;
+    expect(endDragSession(session, 1)).toEqual({ panned: true });
   });
 });
 

--- a/ui/client/src/lib/map-geometry.ts
+++ b/ui/client/src/lib/map-geometry.ts
@@ -7,8 +7,12 @@
  *  1. Label culling        → computeLabelVisibility (priority + AABB overlap)
  *  2. Zoom-cursor anchoring → zoomViewBoxAtCursor (solve for the new origin
  *                             so the SVG point under the cursor stays put)
- *  3. Pointer capture       → DOM-coupled; lives in MapPane.tsx (see the
- *                             pointer handlers there), not here
+ *  3. Pointer capture       → the capture calls are DOM-coupled and live in
+ *                             MapPane.tsx, but the drag lifecycle itself
+ *                             (active-pointer guard, click-vs-drag movement
+ *                             threshold, incremental deltas) is the pure
+ *                             drag-session machine here: beginDragSession /
+ *                             applyDragMove / endDragSession
  *  4. lng/lat ordering      → extractCoordinates (GeoJSON is [lng, lat])
  *  5. Spherical fit winding → boundsToFitObject (winding-free corner points
  *                             for fitSize; a bounding polygon ring wound
@@ -37,8 +41,35 @@ export interface MapBounds {
   maxLat: number;
 }
 
+/**
+ * The projected extent the pan/zoom window is allowed to roam, in SVG
+ * units (for MapPane this is the whole projected world, i.e. the Natural
+ * Earth box [-180..180, -90..90] pushed through the current projection).
+ */
+export interface PanBounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
 export const MIN_ZOOM = 0.2;
 export const MAX_ZOOM = 100;
+
+/**
+ * Pointer movement (client px, straight-line from pointerdown) below which
+ * a press-release is a click, at or above which it is a pan. Keeps
+ * click-to-select working: a click with a couple px of jitter still
+ * selects, while any real drag suppresses selection.
+ */
+export const DRAG_THRESHOLD_PX = 4;
+
+/**
+ * Fraction of the viewport (per axis) that must still overlap the world
+ * after clamping — the user can pan anywhere on the globe, but can never
+ * drag the world fully off-screen and get lost in the void.
+ */
+export const MIN_WORLD_VISIBLE_FRACTION = 0.2;
 
 /**
  * Minimum geographic span (degrees) for the projection fit. Without a
@@ -177,25 +208,62 @@ export function computeMapBounds(places: Place[]): MapBounds | null {
 }
 
 /**
- * Keep the viewBox inside the projected map area so the user can never
- * pan the world fully out of frame (spec §4.3).
+ * Pan-bounds clamp (spec §4.3, reworked).
+ *
+ * The original clamp confined the window to the initially fitted region
+ * ([0..mapWidth] × [0..mapHeight]) — at 1.00× zoom that range has zero
+ * slack, so dragging was a silent no-op and the map "had no panning".
+ *
+ * The window may now roam the entire projected world; the only rule is
+ * that at least MIN_WORLD_VISIBLE_FRACTION of the viewport (per axis)
+ * must still overlap the world box, so the map can never be dragged
+ * fully off-screen. When the window is larger than the world (deep
+ * zoom-out), the same arithmetic keeps the world inside the window.
  */
-export function clampViewBox(
-  box: ViewBox,
-  mapWidth: number,
-  mapHeight: number,
-): ViewBox {
-  const safeWidth = Math.max(mapWidth, 1);
-  const safeHeight = Math.max(mapHeight, 1);
-  const maxX = Math.max(0, safeWidth - box.width);
-  const maxY = Math.max(0, safeHeight - box.height);
+export function clampViewBox(box: ViewBox, world: PanBounds): ViewBox {
+  const keepX = box.width * MIN_WORLD_VISIBLE_FRACTION;
+  const keepY = box.height * MIN_WORLD_VISIBLE_FRACTION;
+
+  // Range is never inverted: maxX ≥ minX ⇔ worldWidth ≥ -(1 - 2f)·boxWidth,
+  // which holds for any fraction f ≤ 0.5.
+  const minX = world.minX - box.width + keepX;
+  const maxX = world.maxX - keepX;
+  const minY = world.minY - box.height + keepY;
+  const maxY = world.maxY - keepY;
 
   return {
-    x: Math.min(Math.max(box.x, 0), maxX),
-    y: Math.min(Math.max(box.y, 0), maxY),
+    x: Math.min(Math.max(box.x, minX), maxX),
+    y: Math.min(Math.max(box.y, minY), maxY),
     width: box.width,
     height: box.height,
   };
+}
+
+/**
+ * Drag-to-pan (spec §4.1): convert a pointer delta in client px into a
+ * viewBox translation in SVG units. The delta divides by the current
+ * zoom (prev.width / rectW), so a given mouse movement always moves the
+ * map the same distance ON SCREEN regardless of zoom level.
+ */
+export function panViewBox(
+  prev: ViewBox,
+  deltaXPx: number,
+  deltaYPx: number,
+  rectW: number,
+  rectH: number,
+  world: PanBounds,
+): ViewBox {
+  const scaleX = prev.width / Math.max(rectW, 1);
+  const scaleY = prev.height / Math.max(rectH, 1);
+
+  return clampViewBox(
+    {
+      ...prev,
+      x: prev.x - deltaXPx * scaleX,
+      y: prev.y - deltaYPx * scaleY,
+    },
+    world,
+  );
 }
 
 /**
@@ -211,6 +279,7 @@ export function clampViewBox(
  * @param cursorX/Y cursor position in client px, relative to the SVG rect
  * @param rectW/H   the SVG element's client size in px
  * @param newZoom   the already-clamped target zoom factor
+ * @param world     projected world extent for the pan-bounds clamp
  */
 export function zoomViewBoxAtCursor(
   prev: ViewBox,
@@ -221,6 +290,7 @@ export function zoomViewBoxAtCursor(
   newZoom: number,
   mapWidth: number,
   mapHeight: number,
+  world: PanBounds,
 ): ViewBox {
   // The SVG-space point currently under the cursor:
   const svgX = prev.x + cursorX * (prev.width / rectW);
@@ -238,8 +308,7 @@ export function zoomViewBoxAtCursor(
       width: newWidth,
       height: newHeight,
     },
-    mapWidth,
-    mapHeight,
+    world,
   );
 }
 
@@ -255,8 +324,7 @@ export function clampZoom(zoom: number): number {
 export function centerViewBoxOn(
   point: { x: number; y: number },
   prev: ViewBox,
-  mapWidth: number,
-  mapHeight: number,
+  world: PanBounds,
 ): ViewBox {
   return clampViewBox(
     {
@@ -265,9 +333,103 @@ export function centerViewBoxOn(
       width: prev.width,
       height: prev.height,
     },
-    mapWidth,
-    mapHeight,
+    world,
   );
+}
+
+// ─── Drag session (failure mode 3: pointer lifecycle + click-vs-drag) ──────
+//
+// The DOM half of failure mode 3 (setPointerCapture / releasePointerCapture)
+// lives in MapPane.tsx; everything decidable without a DOM lives here so it
+// can be unit-tested: which pointer owns the drag, when a press stops being
+// a click and becomes a pan, and what delta each move contributes.
+
+export interface DragSession {
+  /** The pointer that owns this drag — all others are ignored (§6.3). */
+  pointerId: number;
+  /** pointerdown position (client px) — anchor for the click-vs-drag test. */
+  originX: number;
+  originY: number;
+  /** Last applied position (client px) — anchor for incremental deltas. */
+  lastX: number;
+  lastY: number;
+  /** True once movement exceeded the threshold: this press is a pan, and
+   *  the release must not fire a click. Never resets within a session. */
+  panned: boolean;
+}
+
+export interface DragMoveResult {
+  session: DragSession;
+  /** Pan delta to apply, in client px. Zero until the threshold trips. */
+  deltaX: number;
+  deltaY: number;
+}
+
+export function beginDragSession(
+  pointerId: number,
+  clientX: number,
+  clientY: number,
+): DragSession {
+  return {
+    pointerId,
+    originX: clientX,
+    originY: clientY,
+    lastX: clientX,
+    lastY: clientY,
+    panned: false,
+  };
+}
+
+/**
+ * Advance the drag session for a pointermove.
+ *
+ * Returns null for a foreign pointer (multi-touch / stray trackpad
+ * contact — spec §6.3: ignore every pointer but the dragger). Below the
+ * movement threshold the press is still a potential click and the map
+ * must not move. The move that crosses the threshold applies the full
+ * displacement accumulated since pointerdown, so no pixels are swallowed.
+ */
+export function applyDragMove(
+  session: DragSession,
+  pointerId: number,
+  clientX: number,
+  clientY: number,
+  thresholdPx: number = DRAG_THRESHOLD_PX,
+): DragMoveResult | null {
+  if (pointerId !== session.pointerId) return null;
+
+  if (!session.panned) {
+    const dx = clientX - session.originX;
+    const dy = clientY - session.originY;
+    if (Math.hypot(dx, dy) < thresholdPx) {
+      return { session, deltaX: 0, deltaY: 0 };
+    }
+    return {
+      session: { ...session, lastX: clientX, lastY: clientY, panned: true },
+      deltaX: dx,
+      deltaY: dy,
+    };
+  }
+
+  return {
+    session: { ...session, lastX: clientX, lastY: clientY },
+    deltaX: clientX - session.lastX,
+    deltaY: clientY - session.lastY,
+  };
+}
+
+/**
+ * Close the drag session for a pointerup. Returns null for a foreign
+ * pointer (the drag survives another pointer's release); otherwise
+ * reports whether the session panned — a panned release must NOT count
+ * as a click on whatever the press started on.
+ */
+export function endDragSession(
+  session: DragSession,
+  pointerId: number,
+): { panned: boolean } | null {
+  if (pointerId !== session.pointerId) return null;
+  return { panned: session.panned };
 }
 
 export interface LabelCandidate {

--- a/ui/client/src/lib/map-geometry.ts
+++ b/ui/client/src/lib/map-geometry.ts
@@ -68,8 +68,19 @@ export const DRAG_THRESHOLD_PX = 4;
  * Fraction of the viewport (per axis) that must still overlap the world
  * after clamping — the user can pan anywhere on the globe, but can never
  * drag the world fully off-screen and get lost in the void.
+ *
+ * Must stay ≤ 0.5: above that, the clamp range in clampViewBox inverts
+ * whenever the world box is smaller than the window (deep zoom-out), and
+ * min/max clamping silently pins the view to one bound. Guarded below.
  */
 export const MIN_WORLD_VISIBLE_FRACTION = 0.2;
+
+if (MIN_WORLD_VISIBLE_FRACTION > 0.5) {
+  throw new Error(
+    "MIN_WORLD_VISIBLE_FRACTION must be <= 0.5: larger fractions invert " +
+      "the clampViewBox range when the world is smaller than the window",
+  );
+}
 
 /**
  * Minimum geographic span (degrees) for the projection fit. Without a


### PR DESCRIPTION
## Summary

Two cleanup items: working click+drag panning on the map, and removal of the inert rail monogram.

## Why the Map "Had No Panning"

The pointer handlers existed, but `clampViewBox` confined the window to the initially fitted region (`[0..mapWidth] x [0..mapHeight]`). At the default 1.00x zoom that range has zero slack on both axes, so every drag was silently clamped back to the origin — a structural no-op, not a missing handler.

## Pan Design

- **Capture** (spec 6.3): `setPointerCapture` on pointerdown; the gesture survives the cursor crossing the pane edge and releases cleanly. `pointercancel` / `lostpointercapture` abort the session without firing a selection. The owning-pointer guard (multi-touch safety) now lives in a pure, unit-tested drag-session machine in `lib/map-geometry.ts` (`beginDragSession` / `applyDragMove` / `endDragSession`).
- **Click-vs-drag threshold**: 4 px straight-line from pointerdown (`DRAG_THRESHOLD_PX`). Below it the press is a click and the map does not move; the move that crosses it applies the full accumulated displacement (no swallowed pixels), and a panned session permanently suppresses the release-click — even if released back at the origin. Presses on pins start sessions too (the old `stopPropagation` is gone), so a drag beginning on a pin pans the map. Because capture retargets the click event to the SVG, selection moved from pin `onClick` to the SVG `pointerup`, keyed off the original pointerdown target via `data-place-id`.
- **Bounds**: the window may now roam the entire projected world (Natural Earth box through the current projection — equirectangular is linear, so two corners suffice). `clampViewBox` guarantees at least 20% of the viewport per axis (`MIN_WORLD_VISIBLE_FRACTION`) still overlaps the world box, so the map can never be dragged fully off-screen and flings saturate at a recoverable bound. When the window is larger than the world (deep zoom-out) the same arithmetic keeps the world inside the window. The sea/grid background rects and empty-state text now track the viewBox so panning beyond the original fit doesn't run out from under the map.
- **Zoom composition**: pan deltas divide by the current zoom (`prev.width / rectW`), so a given mouse movement pans the same distance **on screen** at every zoom level. `zoomViewBoxAtCursor` is untouched math-wise (no regression to PR #395's `boundsToFitObject` work) and now clamps against the same world bounds; cursor anchoring verified on panned windows.
- **Cursor affordance only**: `grab` at rest, `grabbing` mid-drag (pre-existing CSS) — no labels or instruction text, per the minimalism doctrine. Touch rides the same pointer-event path (`touch-action: none` was already set); a second touch is ignored by the owning-pointer guard.

## Rail Monogram

Removed the decorative `N·I` element from `LeftRail.tsx` and its `.rail-monogram` CSS block. Grep confirmed no behavior or other references. Also removed `.rail-spacer`, whose only job was bottom-anchoring the monogram.

## Verification

- `npx vitest run`: **178 passed** (map-geometry suite grew to 38 tests: pan-bounds clamping incl. the 1.00x pan-lock regression, `panViewBox` screen-consistency, pan+zoom anchoring composition, drag-session lifecycle with foreign-pointer guards and threshold semantics).
- `npm run check` (tsc) and `npm run build`: clean.
- Real browser (headless system Chrome, slot 1, dev server on :5029) — **13/13 checks**:

```
PASS  rail monogram removed from DOM
PASS  cursor is grab at rest
PASS  cursor is grabbing mid-drag
PASS  drag pans the viewBox (1.00x zoom, the old pan-lock case) — delta=(180.0, 120.0) expected ~(180, 120)
PASS  sub-threshold jitter does not pan
PASS  click on a pin opens the place dialog
PASS  drag starting on a pin pans the map — delta=(-90.0, -50.0)
PASS  drag starting on a pin does NOT open the dialog
PASS  drag keeps panning after the cursor leaves the pane (capture) — x: 90 -> 210 -> 370
PASS  zoom after pan keeps the cursor point anchored — anchor error 0.103 SVG units; width 1026 -> 933
PASS  pan delta maps through the current zoom (screen-consistent) — moved 90.9 SVG units, expected ~90.9
PASS  repeated flings saturate at the pan bound (no runaway) — clamped at x=-1478 y=-717
PASS  dragging back recovers from the clamped corner — x -1478 -> -1059, y -717 -> -393
```

Screenshot evidence at `/tmp/map_pan_shots/` (initial fit, post-drag showing the world panned beyond the original fit toward Europe/Africa, pin-selected dialog, clamped corner, recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)