### PR TITLE
Managed Runtime and Model Registry Fixes (#396, #401)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ nexus-tui-temp/
 /archive/
 prompt.md
 format_strip.md
+
+# Managed runtime state (pidfiles, captured logs)
+.nexus/

--- a/README.md
+++ b/README.md
@@ -90,9 +90,12 @@ conversational new-story wizard (setting, character traits, story seed).
 
 One origin serves everything: the FastAPI gateway
 (`nexus.api.narrative:app`, port 8002) owns every API route, the
-`/ws/narrative` websocket, and static serving of the built PWA
-(`ui/dist/public`) plus runtime image uploads. Node is build-time only —
-there is no Express layer. For development with HMR, the Vite dev server
+`/ws/narrative` websocket, `/runtime/status`, and static serving of the
+built PWA (`ui/dist/public`) plus runtime image uploads. Node is build-time
+only — there is no Express layer. The managed runtime (`nexus up` / `down`
+/ `restart` / `status` / `logs`, configured in `nexus.toml` `[runtime]`)
+starts and observes the whole system as one unit; `docs/runtime.md` is the
+client/runtime contract. For development with HMR, the Vite dev server
 (`npm --prefix ui run dev`, port 5001) serves the client and proxies
 `/api`, `/ws`, and upload routes to the gateway.
 
@@ -111,8 +114,14 @@ poetry run pre-commit install
 python scripts/migrate.py --status
 python scripts/migrate.py --all
 
-# Single-origin gateway (port 8002): APIs, websocket, and the built PWA
-./iris
+# Start the runtime: gateway (port 8002) + enabled services, detached
+nexus up
+nexus status          # health, processes, slot, version
+nexus logs gateway -f # follow the captured gateway log
+nexus down            # stop everything, no orphans
+
+# Or stay attached (./iris is an alias for this); Ctrl+C tears down
+nexus up --foreground
 
 # UI development with HMR: Vite dev server (port 5001) proxying to the gateway
 npm --prefix ui run dev
@@ -150,5 +159,6 @@ Formatting and linting: `poetry run black .`, `poetry run flake8`,
 - `docs/orrery_design_plan.md` — world engine stages, schema, and workers
 - `docs/orrery_retrograde_spec.md` — deep-history generation
 - `docs/hybrid_search.md`, `docs/vector_embeddings.md` — retrieval stack
+- `docs/runtime.md` — the client/runtime contract (profiles, auth header)
 - `docs/agent_workflow.md` — branch, PR, and review workflow for agents
 - `CLAUDE.md`, `AGENTS.md` — repository conventions for coding agents

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,0 +1,213 @@
+# The NEXUS Runtime Contract
+
+This document defines the boundary between NEXUS clients and the NEXUS
+runtime. It is written for the author of a future client — a desktop shell
+(Electron/Tauri/native), a hosted web client, or any other front end — so
+that targeting NEXUS never requires knowledge of its internal process
+topology. Issues #396 (managed runtime) and the gateway consolidation in
+PR #400 are the provenance.
+
+## One Origin
+
+A NEXUS runtime is **one HTTP(S) origin**. That origin serves:
+
+- every API route (`/api/...`),
+- the narrative websocket (`/ws/narrative`),
+- liveness (`/health`) and the runtime status aggregate (`/runtime/status`),
+- the built PWA and runtime image uploads (static routes, registered last).
+
+Single-ASGI-origin is the converged end state, achieved in PR #400: the
+FastAPI gateway (`nexus.api.narrative:app`) is the entire serving surface.
+There is no Express layer, no sidecar API process, and no UNIX socket —
+everything a client needs is loopback or remote TCP against one base URL.
+A client that works against `http://127.0.0.1:8002` works against
+`https://nexus.example.com` by changing its base URL and nothing else.
+
+## The Runtime Endpoint
+
+`GET /runtime/status` is the runtime's self-description. Clients use it for
+"is my backend alive and what am I talking to" — not just process liveness
+(`/health` answers that) but aggregate health:
+
+```json
+{
+  "profile": "local",
+  "version": "0.1.0",
+  "slot": 5,
+  "database": {"ok": true, "slot": 5, "dbname": "save_05"},
+  "services": {
+    "gateway": {"ok": true, "port": 8002},
+    "mock_openai": {"ok": true, "port": 5102}
+  },
+  "auth": {"header": "X-Nexus-Auth", "enforced": false},
+  "ok": true
+}
+```
+
+Field semantics:
+
+- `profile` — how this runtime is operated (see Profiles below).
+- `version` — the installed `nexus` package version.
+- `slot` / `database` — the active save slot and a live `SELECT 1` against
+  its database; `database.ok == false` carries an `error` string.
+- `services` — per-service health. `gateway` is always present (it answered
+  the request). Model-backend services appear when enabled; absence means
+  "not part of this runtime", not failure.
+- `auth` — the reserved auth header name and whether this runtime enforces
+  it.
+- `ok` — conjunction of everything above; a client can gate its "connected"
+  indicator on this single bit.
+
+The canonical path and header names live in `nexus/runtime/contract.py`.
+
+## Reserved Auth Header: `X-Nexus-Auth`
+
+Every client request SHOULD carry the header
+
+```
+X-Nexus-Auth: <opaque credential>
+```
+
+Semantics, fixed now so clients never need retrofitting:
+
+- The value is an **opaque bearer credential** issued by the runtime
+  operator. Clients store and transmit it; they never parse it.
+- **Local profile (today): the header is a no-op.** The runtime ignores it
+  and `auth.enforced` is `false` in `/runtime/status`. Sending it anyway is
+  the contract — a client built today must already have the plumbing.
+- **Hosted runtimes (future): the header is required.** Requests without a
+  valid credential are rejected; `auth.enforced` will be `true`.
+- Browsers cannot attach custom headers to native `WebSocket` connects, so
+  hosted runtimes will accept the same credential for the websocket via the
+  first client message or a query token at connect time; the header remains
+  authoritative for all HTTP routes.
+
+## Profiles
+
+The runtime is operated in one of three profiles, configured in
+`nexus.toml` under `[runtime]` and reported in `/runtime/status`:
+
+| Profile    | Who runs the processes | What `nexus up` does | What `nexus status` does |
+|------------|------------------------|----------------------|--------------------------|
+| `local`    | The supervisor (`nexus/runtime/`): spawns services detached with pidfiles and captured logs under `[runtime].state_dir` | Spawns enabled services, waits for health, fails loud with log excerpts | Merges supervisor process state (pid, port, uptime) with `/runtime/status` |
+| `external` | You (or an IDE, a debugger, another orchestrator) | Health-checks the configured URLs; **spawns nothing**; nonzero exit if anything is down | Reads `/runtime/status` from `external.gateway_url` |
+| `remote`   | A hosted operator | Confirms `<remote.base_url>/runtime/status` answers | Reads the remote runtime's status |
+
+`nexus down`, `restart`, and `logs` are local-profile verbs: they manage or
+read state that only exists when this machine's supervisor owns the
+processes, and they fail loudly in other profiles.
+
+### Local profile mechanics
+
+- Services are declared in `[runtime.services.<name>]`: an argv `command`
+  template (`{python}`, `{host}`, `{port}` placeholders — no shell), `port`,
+  `health_path`, extra `env`, an `enabled` mode, and an `autorestart`
+  policy.
+- The supervisor is pure Python and cross-platform by construction: process
+  spawning uses `subprocess` with platform-appropriate detach flags,
+  liveness checks never signal the process, and all observation is loopback
+  TCP. Linux and Windows hosts are intended targets; nothing in the runtime
+  path shells out or touches UNIX sockets.
+- State lives under `[runtime].state_dir` (default `.nexus/runtime`):
+  `<service>.pid.json` records pid/port/slot/start time; `<service>.log`
+  captures stdout+stderr. Logs survive `nexus down` for postmortems.
+- `nexus up --foreground` keeps the supervisor attached: it streams
+  prefixed service logs to the console, honors `autorestart = "on-failure"`
+  (bounded by `autorestart_max_retries`), and tears everything down on
+  Ctrl+C. `./iris` is a thin alias for exactly this.
+- `nexus up` refuses ports held by unmanaged processes and refuses to
+  double-start; partial startups are rolled back so `up` is all-or-nothing.
+
+## CLI Surface
+
+```
+nexus up [--slot N] [--foreground] [--config PATH]
+nexus down [service] [--config PATH]
+nexus restart [service] [--slot N] [--config PATH]
+nexus status [--config PATH]
+nexus logs [service] [-n LINES] [-f] [--config PATH]
+```
+
+All verbs honor the global `--json` flag for machine-readable output.
+`--config` points at an alternate `nexus.toml` (test harnesses, parallel
+checkouts); spawned services receive its absolute path in the
+`NEXUS_RUNTIME_CONFIG` environment variable so their `/runtime/status`
+describes the config that actually launched them.
+
+## Model Backends Are Runtime Services
+
+Remote model providers (OpenAI, Anthropic) are reached through their native
+SDKs. **Every other model backend is an OpenAI-compatible server registered
+in config, not in code**: a provider section in
+`[global.model.api_models.<name>]` with a `base_url` is the complete
+integration. The mock TEST server is one such row; a local
+Ollama/vLLM-served model (e.g. a hermes-class model) is another — add the
+provider section, list its models, point `base_url` at the server, and
+every request builder routes to it.
+
+The supervisor treats these the same way: `[runtime.services.mock_openai]`
+spawns the mock server only while the TEST provider is registered
+(`enabled = "auto"`), and config load cross-validates that the service port
+and the registry `base_url` agree. A future local-LLM service follows the
+same pattern.
+
+Per-model request-parameter capability also lives in the registry: an
+entry's `unsupported_params` lists parameters its API rejects (e.g.
+`temperature` on reasoning-class models), and configuration that sets such
+a parameter for that model is refused at config load. Request builders only
+send explicitly configured parameters, so a provider can never receive a
+parameter it rejects.
+
+## Embedder and Reranker Run Host-Side
+
+MEMNON's embedding model (Octen-Embedding-4B) and cross-encoder reranker
+load **inside the gateway process** from local weights (paths in
+`nexus.toml` `[memnon]`). They use MPS on Apple Silicon and CUDA on Linux
+hosts. Consequences for deployment:
+
+- The runtime host needs the model weights and a supported accelerator (or
+  tolerable CPU latency); clients never see this — retrieval is behind the
+  API boundary.
+- A hosted runtime carries its own weights; nothing model-related crosses
+  the client contract.
+
+## Secrets per Profile
+
+- **Local (macOS):** API keys live in the macOS Keychain (service
+  `nexus-api`), read by `nexus.util.secret_manager.get_secret()` via the
+  system `security` CLI — silent, no prompts in unattended runs. 1Password
+  is the rotation source of truth (`scripts/sync_secrets.py`).
+- **Non-Mac hosts (Linux/Windows/CI):** set `NEXUS_KEYRING_DISABLE=1` and
+  provide `<PROVIDER>_API_KEY` environment variables. This is the supported
+  seam, not a workaround — a hosted runtime injects env vars through its
+  platform's secret store.
+- **Clients never handle provider keys.** Model calls happen runtime-side;
+  the only credential a client holds is its `X-Nexus-Auth` value.
+- Keyless local model servers (mock, Ollama) need no secret; a base_url
+  provider that does need one names a Keychain account via
+  `api_key_secret`.
+
+## Development Workflows (unchanged)
+
+- `npm --prefix ui run dev` — Vite dev server with HMR on :5001, proxying
+  `/api`, `/ws`, and uploads to the gateway on :8002. Start the gateway
+  with `nexus up` (or point Vite at an `external`-profile stack).
+- `npm --prefix ui run build` — produces `ui/dist/public`, which the
+  gateway serves statically. `nexus up` warns if the build is missing.
+- Test harnesses run parallel runtimes by passing `--config` with their own
+  ports and state dirs; the golden-path gate and agent worktrees use
+  8030+/5130+ to stay clear of a developer's stack.
+
+## What a Desktop Shell Needs to Know
+
+The entire integration surface for a future macOS/Windows/Linux shell:
+
+1. Run `nexus up` (or link `nexus/runtime/` and call
+   `Supervisor.from_config().up()`); the runtime owns its processes.
+2. Point a webview at the gateway origin.
+3. Poll `GET /runtime/status`; gate the UI on `ok`.
+4. Send `X-Nexus-Auth` on every request (empty locally is fine today).
+5. Run `nexus down` on quit.
+
+Nothing else about NEXUS internals — slots, databases, model processes,
+embedders — leaks across this boundary.

--- a/iris
+++ b/iris
@@ -2,39 +2,15 @@
 #
 # IRIS - Integrated Runtime for Interactive Stories
 #
-# Interim single-origin launcher (issue #396, part 1): the FastAPI gateway
-# serves the built PWA, every API route, and the narrative websocket from
-# one origin. Node/Express is retired; the UI is built once and served
-# statically. Lane C2 replaces this script with `nexus up`.
+# Thin alias for the managed runtime (issue #396). All process management
+# lives in pure Python (nexus/runtime/); this script only forwards to it.
+#
+#   ./iris            == nexus up --foreground
+#   ./iris --slot 3   == nexus up --foreground --slot 3
 #
 # For HMR development, run the Vite dev server alongside the gateway:
-#   npm --prefix ui run dev    # serves the client on $APP_PORT (5001),
-#                              # proxying /api, /ws, and uploads here
-#
+#   npm --prefix ui run dev    # proxies /api, /ws, and uploads to :8002
 
 set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$ROOT_DIR"
-
-NEXUS_SLOT="${NEXUS_SLOT:-1}"
-GATEWAY_PORT="${NARRATIVE_API_PORT:-8002}"
-MOCK_OPENAI_PORT="${MOCK_OPENAI_PORT:-5102}"
-
-# Build the PWA if missing (first run). Rebuild manually after UI changes:
-#   npm --prefix ui run build
-if [ ! -f ui/dist/public/index.html ]; then
-  echo "Building UI (first run)..."
-  [ -d ui/node_modules ] || npm --prefix ui install
-  npm --prefix ui run build
-fi
-
-# Mock OpenAI server for the TEST model (cached responses).
-poetry run uvicorn nexus.api.mock_openai:app --host 127.0.0.1 \
-  --port "$MOCK_OPENAI_PORT" &
-MOCK_PID=$!
-trap 'kill "$MOCK_PID" 2>/dev/null || true' EXIT
-
-echo "Starting NEXUS gateway on port ${GATEWAY_PORT} (slot ${NEXUS_SLOT})..."
-NEXUS_SLOT="$NEXUS_SLOT" poetry run uvicorn nexus.api.narrative:app \
-  --host 127.0.0.1 --port "$GATEWAY_PORT"
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec poetry run nexus up --foreground "$@"

--- a/nexus.toml
+++ b/nexus.toml
@@ -19,22 +19,31 @@ default_slot_model = "TEST"
 # Each provider section lists models available for that API backend AND named
 # roles that downstream consumers reference via "@provider.role" syntax.
 # Editing a role here (e.g., openai.default) propagates everywhere automatically.
+# Per-model `unsupported_params` lists request parameters the provider rejects
+# outright for that model (e.g. temperature on reasoning-class models).
+# Config load refuses any consumer section that configures one of them.
 [global.model.api_models.openai]
 roles = { default = "gpt-5.5" }
 models = [
-    { id = "gpt-5.5", label = "GPT-5.5" },
+    { id = "gpt-5.5", label = "GPT-5.5", unsupported_params = ["temperature", "top_p"] },
 ]
 
 [global.model.api_models.anthropic]
 roles = { default = "claude-opus-4-8", deep = "claude-fable-5", fast = "claude-sonnet-4-6" }
 models = [
     { id = "claude-sonnet-4-6", label = "Sonnet 4.6" },
-    { id = "claude-opus-4-8", label = "Opus 4.8" },
-    { id = "claude-fable-5", label = "Fable 5" },
+    { id = "claude-opus-4-8", label = "Opus 4.8", unsupported_params = ["temperature", "top_p", "top_k"] },
+    { id = "claude-fable-5", label = "Fable 5", unsupported_params = ["temperature", "top_p", "top_k"] },
 ]
 
+# Non-native providers are OpenAI-compatible servers: `base_url` is where the
+# OpenAI client points. Any local server (Ollama, vLLM, ...) is registered the
+# same way — a new provider section with its own base_url and model list.
+# `api_key_secret` names a Keychain account (service "nexus-api") when the
+# server needs a key; leave unset for keyless servers like this mock.
 [global.model.api_models.test]
 ui_visible = false  # Backend/CLI-only mock server; hidden from UI model pickers
+base_url = "http://127.0.0.1:5102/v1"
 roles = { default = "TEST" }
 models = [
     { id = "TEST", label = "TEST", description = "Mock server with cached data (dev)" },
@@ -204,6 +213,13 @@ max_edges_per_query = 5000
 mode = "async"
 provider = "anthropic"
 model_ref = "@anthropic.default"
+# Optional sampling/queue knobs (defaults in OrreryNarrationSettings):
+#   temperature        — omitted from the request entirely when unset; setting
+#                        it for a model whose registry entry lists it in
+#                        unsupported_params is a config-load error (#401)
+#   max_output_tokens  — narration output ceiling (default 1200)
+#   max_attempts       — narration job attempts before failure (default 3)
+#   retry_delay_seconds — backoff between attempts (default 300)
 
 [orrery.bleed]
 max_candidates = 3
@@ -727,9 +743,6 @@ reasoning_effort = "high"     # Reasoning effort level (low/medium/high)
 # =============================================================================
 # API Settings
 # =============================================================================
-
-[global.api]
-test_mock_server_url = "http://localhost:5102/v1"  # Mock server for TEST model
 
 [api.constraints]
 max_choice_text_length = 1000  # Maximum length of choice text

--- a/nexus.toml
+++ b/nexus.toml
@@ -746,3 +746,49 @@ reasoning_effort = "high"     # Reasoning effort level (low/medium/high)
 
 [api.constraints]
 max_choice_text_length = 1000  # Maximum length of choice text
+
+# =============================================================================
+# Managed Runtime (issue #396) — nexus up / down / restart / status / logs
+# =============================================================================
+
+[runtime]
+# local    — spawn and manage services (pidfiles + captured logs in state_dir)
+# external — attach to already-running services: health-check + status only
+# remote   — hosted runtime; status hits <remote.base_url>/runtime/status
+profile = "local"
+state_dir = ".nexus/runtime"  # relative paths resolve against the repo root
+default_slot = 1              # NEXUS_SLOT for spawned services (--slot/env override)
+
+[runtime.health]
+timeout_seconds = 2.0            # per HTTP health probe
+startup_deadline_seconds = 30.0  # nexus up waits this long per service
+poll_interval_seconds = 0.25
+stop_grace_seconds = 10.0        # terminate -> kill escalation on nexus down
+
+[runtime.logs]
+tail_lines = 100          # default for `nexus logs`
+follow_poll_seconds = 0.5 # poll interval for `nexus logs -f`
+
+[runtime.services.gateway]
+# argv template — {python} is the current interpreter; no shell in the path
+command = ["{python}", "-m", "uvicorn", "nexus.api.narrative:app", "--host", "{host}", "--port", "{port}"]
+host = "127.0.0.1"
+port = 8002
+health_path = "/health"
+autorestart = "on-failure"  # honored by the foreground supervisor only
+
+[runtime.services.mock_openai]
+command = ["{python}", "-m", "uvicorn", "nexus.api.mock_openai:app", "--host", "{host}", "--port", "{port}"]
+host = "127.0.0.1"
+port = 5102  # must match [global.model.api_models.test] base_url (validated)
+health_path = "/health"
+enabled = "auto"  # spawn only while the TEST provider is registered above
+
+# Attach targets for profile = "external" (uncomment to use):
+# [runtime.external]
+# gateway_url = "http://127.0.0.1:8002"
+# mock_openai_url = "http://127.0.0.1:5102"
+
+# Hosted runtime for profile = "remote" (uncomment to use):
+# [runtime.remote]
+# base_url = "https://nexus.example.com"

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -78,9 +78,6 @@ def _labeled_lines(rows: list[tuple[str, Any]]) -> list[str]:
 class LogonUtility:
     """Wrapper for Apex AI API calls using existing providers"""
 
-    # Mock server URL for TEST model
-    TEST_MODEL_BASE_URL = "http://localhost:5102/v1"
-
     def __init__(
         self,
         settings: Dict[str, Any],
@@ -264,13 +261,15 @@ class LogonUtility:
             "provider", "openai"
         )
 
-        # Determine base_url for TEST model routing
-        base_url = None
-        api_key = None
-        if model == "TEST":
-            base_url = self.TEST_MODEL_BASE_URL
-            api_key = "test-dummy-key"  # Avoid 1Password lookup for TEST
-            logger.info(f"TEST model: routing to mock server at {base_url}")
+        # OpenAI-compatible base_url routing (mock TEST server, local servers):
+        # the endpoint lives in the [global.model.api_models] registry (#401).
+        from nexus.config import get_openai_compatible_endpoint
+
+        endpoint = get_openai_compatible_endpoint(model)
+        base_url = endpoint["base_url"] if endpoint else None
+        api_key = endpoint["api_key"] if endpoint else None
+        if base_url:
+            logger.info(f"Model {model}: routing to base_url {base_url}")
 
         # Load system prompt
         system_prompt = self._load_system_prompt(provider_bootstrap_mode)
@@ -296,7 +295,19 @@ class LogonUtility:
             validation_dbname = None
         output_validator = build_storyteller_tag_validator(validation_dbname)
 
-        if provider_type in {"openai", "test"}:
+        if provider_type == "anthropic":
+            self.provider = AnthropicProvider(
+                model=model,
+                max_tokens=apex_settings.get(
+                    "max_output_tokens", apex_settings.get("max_tokens", 4000)
+                ),
+                system_prompt=system_prompt,
+                structured_output_retries=structured_output_retries,
+                output_validator=output_validator,
+            )
+        elif provider_type == "openai" or base_url:
+            # Native OpenAI, or any OpenAI-compatible server registered with a
+            # base_url in [global.model.api_models] (mock TEST, Ollama, vLLM).
             self.provider = OpenAIProvider(
                 model=model,
                 temperature=apex_settings.get("temperature", 0.7),
@@ -305,16 +316,6 @@ class LogonUtility:
                 system_prompt=system_prompt,
                 base_url=base_url,
                 api_key=api_key,
-                structured_output_retries=structured_output_retries,
-                output_validator=output_validator,
-            )
-        elif provider_type == "anthropic":
-            self.provider = AnthropicProvider(
-                model=model,
-                max_tokens=apex_settings.get(
-                    "max_output_tokens", apex_settings.get("max_tokens", 4000)
-                ),
-                system_prompt=system_prompt,
                 structured_output_retries=structured_output_retries,
                 output_validator=output_validator,
             )

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -17,13 +17,11 @@ from nexus.agents.orrery.retrograde_maturation import (
     load_maturation_status_sync,
 )
 from nexus.config import load_settings_as_dict
-from nexus.config.settings_models import OrreryPromoteSettings
+from nexus.config.settings_models import OrreryNarrationSettings, OrreryPromoteSettings
 
 logger = logging.getLogger("nexus.orrery.worker")
 
 
-DEFAULT_NARRATION_MAX_ATTEMPTS = 3
-DEFAULT_NARRATION_RETRY_DELAY_SECONDS = 300
 DEFAULT_SEMANTIC_CLEARANCE_LIMIT = 20
 DEFAULT_SEMANTIC_CLEARANCE_RECENT_CHUNKS = 10
 DEFAULT_SEMANTIC_CLEARANCE_EVIDENCE_CHUNKS = 5
@@ -632,44 +630,59 @@ def _perceptual_descriptor(row: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _narration_settings(settings: Mapping[str, Any]) -> OrreryNarrationSettings:
+    raw_settings = (settings.get("orrery") or {}).get("narration") or {}
+    if isinstance(raw_settings, OrreryNarrationSettings):
+        return raw_settings
+    return OrreryNarrationSettings.model_validate(raw_settings)
+
+
 def _narration_provider(settings: Mapping[str, Any]) -> Any:
+    from nexus.config import get_openai_compatible_endpoint
     from nexus.config.loader import get_provider_for_model
     from scripts.api_anthropic import AnthropicProvider
     from scripts.api_openai import OpenAIProvider
 
-    narration_settings = (settings.get("orrery") or {}).get("narration") or {}
-    provider_name = narration_settings.get("provider")
-    model = narration_settings.get("model_ref")
-    provider_name = provider_name or get_provider_for_model(model)
+    narration = _narration_settings(settings)
+    model = narration.model_ref
+    provider_name = narration.provider or get_provider_for_model(model)
 
-    if provider_name in {"openai", "test"}:
-        return OpenAIProvider(
-            model=model,
-            temperature=0.4,
-            max_output_tokens=1200,
-            system_prompt=NARRATION_SYSTEM_PROMPT,
-        )
+    # Sampling params come from [orrery.narration]; anything left unset is
+    # omitted from the request entirely. Config load already rejected any
+    # configured param the model declares unsupported (#401), so nothing sent
+    # here can be refused by the provider.
     if provider_name == "anthropic":
         return AnthropicProvider(
             model=model,
-            temperature=0.4,
-            max_tokens=1200,
+            temperature=narration.temperature,
+            max_tokens=narration.max_output_tokens,
             system_prompt=NARRATION_SYSTEM_PROMPT,
+        )
+    if provider_name == "openai":
+        return OpenAIProvider(
+            model=model,
+            temperature=narration.temperature,
+            max_output_tokens=narration.max_output_tokens,
+            system_prompt=NARRATION_SYSTEM_PROMPT,
+        )
+    # Any other provider must be the model's own registry provider with an
+    # OpenAI-compatible base_url (mock TEST server, Ollama, vLLM, ...).
+    endpoint = get_openai_compatible_endpoint(model)
+    if endpoint and get_provider_for_model(model) == provider_name:
+        return OpenAIProvider(
+            model=model,
+            temperature=narration.temperature,
+            max_output_tokens=narration.max_output_tokens,
+            system_prompt=NARRATION_SYSTEM_PROMPT,
+            base_url=endpoint["base_url"],
+            api_key=endpoint["api_key"],
         )
     raise ValueError(f"Unsupported Orrery narration provider: {provider_name}")
 
 
 def _narration_retry_settings(settings: Mapping[str, Any]) -> tuple[int, int]:
-    narration_settings = (settings.get("orrery") or {}).get("narration") or {}
-    max_attempts = int(
-        narration_settings.get("max_attempts", DEFAULT_NARRATION_MAX_ATTEMPTS)
-    )
-    retry_delay_seconds = int(
-        narration_settings.get(
-            "retry_delay_seconds", DEFAULT_NARRATION_RETRY_DELAY_SECONDS
-        )
-    )
-    return max(1, max_attempts), max(0, retry_delay_seconds)
+    narration = _narration_settings(settings)
+    return max(1, narration.max_attempts), max(0, narration.retry_delay_seconds)
 
 
 def _connect_for_slot(slot: Optional[int]) -> Any:

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -67,6 +67,7 @@ from nexus.api.reader_endpoints import router as reader_router
 from nexus.api.settings_endpoints import router as settings_router
 from nexus.api.slot_endpoints import router as slot_router
 from nexus.api.setup_endpoints import router as setup_router
+from nexus.api.runtime_status import register_runtime_status
 from nexus.api.static_ui import mount_ui
 from nexus.api.wizard_chat import router as wizard_chat_router
 
@@ -1185,6 +1186,10 @@ async def get_user_character(slot: Optional[int] = None):
         if "conn" in locals():
             conn.close()
 
+
+# Runtime status endpoint (issue #396): aggregate health beside /health.
+# Must register BEFORE mount_ui below - the SPA mount is a catch-all.
+register_runtime_status(app)
 
 # Static serving for the built PWA and runtime uploads. Registered last:
 # the dist mount at "/" is a catch-all and Starlette matches in order.

--- a/nexus/api/pydantic_ai_utils.py
+++ b/nexus/api/pydantic_ai_utils.py
@@ -48,6 +48,8 @@ def build_pydantic_ai_model(model: str) -> Model:
     # Any other provider is an OpenAI-compatible server registered via
     # base_url in [global.model.api_models] (mock TEST server, Ollama, vLLM).
     endpoint = get_openai_compatible_endpoint(model)
+    if endpoint is None:
+        raise ValueError(f"No base_url registry entry for model {model!r}")
     pyd_provider = PydanticOpenAIProvider(
         api_key=endpoint["api_key"], base_url=endpoint["base_url"]
     )

--- a/nexus/api/pydantic_ai_utils.py
+++ b/nexus/api/pydantic_ai_utils.py
@@ -15,31 +15,28 @@ from pydantic_ai.messages import (
 from pydantic_ai.models import Model
 from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.models.openai import OpenAIResponsesModel
-from pydantic_ai.providers.anthropic import AnthropicProvider as PydanticAnthropicProvider
+from pydantic_ai.providers.anthropic import (
+    AnthropicProvider as PydanticAnthropicProvider,
+)
 from pydantic_ai.providers.openai import OpenAIProvider as PydanticOpenAIProvider
 
-from nexus.config import load_settings
+from nexus.config import get_openai_compatible_endpoint
 from nexus.config.loader import get_provider_for_model
 from scripts.api_anthropic import AnthropicProvider as LegacyAnthropicProvider
 from scripts.api_openai import OpenAIProvider as LegacyOpenAIProvider
 
 
 def get_base_url_for_model(model: str) -> Optional[str]:
-    """Return a base URL override for the model, if configured."""
-    provider = get_provider_for_model(model)
-    if provider == "test":
-        settings = load_settings()
-        if settings.global_.api:
-            return settings.global_.api.test_mock_server_url
-        return "http://localhost:5102/v1"
-    if provider in {"openai", "anthropic"}:
-        return None
-    raise ValueError(f"Unknown provider for model {model!r}")
+    """Return the registry base_url for the model (None for native providers)."""
+    endpoint = get_openai_compatible_endpoint(model)
+    return endpoint["base_url"] if endpoint else None
 
 
 def build_pydantic_ai_model(model: str) -> Model:
     """Create a Pydantic AI model with the correct provider and credentials."""
     provider = get_provider_for_model(model)
+    if provider is None:
+        raise ValueError(f"Unknown provider for model {model!r}")
     if provider == "openai":
         legacy_provider = LegacyOpenAIProvider(model=model)
         pyd_provider = PydanticOpenAIProvider(api_key=legacy_provider.api_key)
@@ -48,13 +45,13 @@ def build_pydantic_ai_model(model: str) -> Model:
         legacy_provider = LegacyAnthropicProvider(model=model)
         pyd_provider = PydanticAnthropicProvider(api_key=legacy_provider.api_key)
         return AnthropicModel(model_name=model, provider=pyd_provider)
-    if provider == "test":
-        base_url = get_base_url_for_model(model)
-        pyd_provider = PydanticOpenAIProvider(
-            api_key="test-dummy-key", base_url=base_url
-        )
-        return OpenAIResponsesModel(model_name=model, provider=pyd_provider)
-    raise ValueError(f"Unknown provider for model {model!r}")
+    # Any other provider is an OpenAI-compatible server registered via
+    # base_url in [global.model.api_models] (mock TEST server, Ollama, vLLM).
+    endpoint = get_openai_compatible_endpoint(model)
+    pyd_provider = PydanticOpenAIProvider(
+        api_key=endpoint["api_key"], base_url=endpoint["base_url"]
+    )
+    return OpenAIResponsesModel(model_name=model, provider=pyd_provider)
 
 
 def build_message_history(

--- a/nexus/api/runtime_status.py
+++ b/nexus/api/runtime_status.py
@@ -12,6 +12,7 @@ SPA mount registers a catch-all route and must come last.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Dict
@@ -108,4 +109,4 @@ def register_runtime_status(app: FastAPI) -> None:
 
     @app.get(RUNTIME_STATUS_PATH)
     async def runtime_status() -> Dict[str, Any]:
-        return build_runtime_status()
+        return await asyncio.to_thread(build_runtime_status)

--- a/nexus/api/runtime_status.py
+++ b/nexus/api/runtime_status.py
@@ -1,0 +1,119 @@
+"""Gateway-side runtime status endpoint (issue #396).
+
+The gateway IS the runtime endpoint: ``GET /runtime/status`` aggregates the
+health of everything a client needs — the gateway itself, the active slot's
+database, and the mock model server when enabled — plus the runtime profile
+and version. ``nexus status`` renders this beside supervisor-side process
+state; remote clients hit it directly.
+
+Registered in ``nexus.api.narrative`` BEFORE ``mount_ui(app)`` — the static
+SPA mount registers a catch-all route and must come last.
+"""
+
+from __future__ import annotations
+
+import os
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any, Dict
+
+import requests
+from fastapi import FastAPI
+
+from nexus.config import load_settings
+from nexus.runtime.contract import (
+    NEXUS_AUTH_HEADER,
+    RUNTIME_CONFIG_ENV,
+    RUNTIME_STATUS_PATH,
+)
+
+
+def _database_status() -> Dict[str, Any]:
+    """SELECT 1 against the active slot's database."""
+    import psycopg2
+
+    from nexus.api.db_pool import get_connect_timeout_seconds
+    from nexus.api.slot_utils import get_active_slot, require_slot_dbname
+
+    try:
+        slot = get_active_slot()
+        dbname = require_slot_dbname(slot=slot)
+    except (RuntimeError, ValueError) as exc:
+        return {"ok": False, "error": str(exc)}
+    try:
+        conn = psycopg2.connect(
+            host="localhost",
+            dbname=dbname,
+            user="pythagor",
+            connect_timeout=get_connect_timeout_seconds(),
+        )
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+                cur.fetchone()
+        finally:
+            conn.close()
+        return {"ok": True, "slot": slot, "dbname": dbname}
+    except psycopg2.Error as exc:
+        return {"ok": False, "slot": slot, "dbname": dbname, "error": str(exc)}
+
+
+def build_runtime_status() -> Dict[str, Any]:
+    """Aggregate runtime health (sync; called from the async endpoint)."""
+    config_path = os.environ.get(RUNTIME_CONFIG_ENV, "nexus.toml")
+    settings = load_settings(config_path)
+    runtime = settings.runtime
+
+    try:
+        nexus_version = version("nexus")
+    except PackageNotFoundError:
+        nexus_version = "unknown"
+
+    database = _database_status()
+    status: Dict[str, Any] = {
+        "profile": runtime.profile if runtime else None,
+        "version": nexus_version,
+        "slot": database.get("slot"),
+        "database": database,
+        # The gateway answered this request, so it is healthy by construction.
+        "services": {"gateway": {"ok": True}},
+        "auth": {"header": NEXUS_AUTH_HEADER, "enforced": False},
+    }
+
+    if runtime and runtime.profile == "local":
+        gateway = runtime.services.get("gateway")
+        if gateway:
+            status["services"]["gateway"]["port"] = gateway.port
+        mock = runtime.services.get("mock_openai")
+        test_provider = settings.global_.model.api_models.get("test")
+        mock_enabled = (
+            mock is not None
+            and mock.enabled != "never"
+            and not (
+                mock.enabled == "auto" and not (test_provider and test_provider.models)
+            )
+        )
+        if mock_enabled:
+            url = f"http://{mock.host}:{mock.port}{mock.health_path}"
+            try:
+                ok = (
+                    requests.get(
+                        url, timeout=runtime.health.timeout_seconds
+                    ).status_code
+                    == 200
+                )
+            except requests.RequestException:
+                ok = False
+            status["services"]["mock_openai"] = {"ok": ok, "port": mock.port}
+
+    status["ok"] = database["ok"] and all(
+        service.get("ok", False) for service in status["services"].values()
+    )
+    return status
+
+
+def register_runtime_status(app: FastAPI) -> None:
+    """Attach GET /runtime/status to the gateway app."""
+
+    @app.get(RUNTIME_STATUS_PATH)
+    async def runtime_status() -> Dict[str, Any]:
+        return build_runtime_status()

--- a/nexus/api/runtime_status.py
+++ b/nexus/api/runtime_status.py
@@ -31,7 +31,7 @@ def _database_status() -> Dict[str, Any]:
     """SELECT 1 against the active slot's database."""
     import psycopg2
 
-    from nexus.api.db_pool import get_connect_timeout_seconds
+    from nexus.api.db_pool import get_connection
     from nexus.api.slot_utils import get_active_slot, require_slot_dbname
 
     try:
@@ -40,18 +40,10 @@ def _database_status() -> Dict[str, Any]:
     except (RuntimeError, ValueError) as exc:
         return {"ok": False, "error": str(exc)}
     try:
-        conn = psycopg2.connect(
-            host="localhost",
-            dbname=dbname,
-            user="pythagor",
-            connect_timeout=get_connect_timeout_seconds(),
-        )
-        try:
+        with get_connection(dbname=dbname) as conn:
             with conn.cursor() as cur:
                 cur.execute("SELECT 1")
                 cur.fetchone()
-        finally:
-            conn.close()
         return {"ok": True, "slot": slot, "dbname": dbname}
     except psycopg2.Error as exc:
         return {"ok": False, "slot": slot, "dbname": dbname, "error": str(exc)}

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -2553,6 +2553,176 @@ def run_unlock(args: argparse.Namespace) -> Dict[str, Any]:
         return {"success": False, "error": str(e)}
 
 
+# =============================================================================
+# Managed runtime verbs (issue #396): up / down / restart / status / logs
+# =============================================================================
+
+
+def _runtime_supervisor(args: argparse.Namespace):
+    from nexus.runtime import Supervisor
+
+    return Supervisor.from_config(getattr(args, "config", None))
+
+
+def run_up(args: argparse.Namespace) -> Dict[str, Any]:
+    """Start the runtime per the configured profile."""
+    from nexus.runtime import RuntimeError_
+
+    try:
+        supervisor = _runtime_supervisor(args)
+        return supervisor.up(
+            slot=args.slot,
+            foreground=args.foreground,
+            echo=not args.json,
+        )
+    except (RuntimeError_, FileNotFoundError, requests.RequestException) as exc:
+        return {"success": False, "error": str(exc)}
+
+
+def run_down(args: argparse.Namespace) -> Dict[str, Any]:
+    """Stop managed services and remove pidfiles."""
+    from nexus.runtime import RuntimeError_
+
+    try:
+        supervisor = _runtime_supervisor(args)
+        result = supervisor.down(service=args.service)
+        if not args.json:
+            stopped = result.get("stopped", {})
+            if stopped:
+                for name, info in stopped.items():
+                    print(f"stopped {name} (pid {info['pid']})")
+            else:
+                print("nothing running")
+        return result
+    except (RuntimeError_, FileNotFoundError) as exc:
+        return {"success": False, "error": str(exc)}
+
+
+def run_restart(args: argparse.Namespace) -> Dict[str, Any]:
+    """Restart all managed services, or one by name."""
+    from nexus.runtime import RuntimeError_
+
+    try:
+        supervisor = _runtime_supervisor(args)
+        result = supervisor.restart(service=args.service, slot=args.slot)
+        if not args.json:
+            for name, record in result.get("services", {}).items():
+                print(f"restarted {name} (pid {record['pid']})")
+        return result
+    except (RuntimeError_, FileNotFoundError, requests.RequestException) as exc:
+        return {"success": False, "error": str(exc)}
+
+
+def _format_uptime(seconds: float) -> str:
+    total = int(seconds)
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    return f"{hours}:{minutes:02d}:{secs:02d}"
+
+
+def _print_runtime_status(result: Dict[str, Any]) -> None:
+    runtime = result.get("runtime") or {}
+    print(f"NEXUS runtime - profile {result['profile']} - {result['gateway_url']}")
+    rows = []
+    health_by_service = runtime.get("services", {})
+    for name, proc in (result.get("processes") or {}).items():
+        health = health_by_service.get(name, {})
+        rows.append(
+            (
+                name,
+                proc.get("state", "-"),
+                str(proc.get("pid", "-")),
+                str(proc.get("port", "-")),
+                (
+                    _format_uptime(proc["uptime_seconds"])
+                    if proc.get("uptime_seconds") is not None
+                    else "-"
+                ),
+                "ok" if health.get("ok") else ("fail" if health else "-"),
+            )
+        )
+    if not rows:
+        # external/remote: render gateway health from the runtime endpoint
+        for name, health in health_by_service.items():
+            rows.append(
+                (
+                    name,
+                    "-",
+                    "-",
+                    str(health.get("port", "-")),
+                    "-",
+                    "ok" if health.get("ok") else "fail",
+                )
+            )
+    database = runtime.get("database") or {}
+    rows.append(
+        (
+            "database",
+            "-",
+            "-",
+            "-",
+            "-",
+            (
+                f"ok ({database.get('dbname')})"
+                if database.get("ok")
+                else f"fail ({database.get('error', 'unknown')})"
+            ),
+        )
+    )
+    header = ("SERVICE", "STATE", "PID", "PORT", "UPTIME", "HEALTH")
+    widths = [
+        max(len(str(row[i])) for row in [header] + rows) for i in range(len(header))
+    ]
+    for row in [header] + rows:
+        print("  ".join(str(cell).ljust(widths[i]) for i, cell in enumerate(row)))
+    if runtime.get("error"):
+        print(f"runtime endpoint: {runtime['error']}")
+    else:
+        auth = runtime.get("auth", {})
+        print(
+            f"version {runtime.get('version', '?')} - slot "
+            f"{runtime.get('slot', '?')} - auth {auth.get('header', '?')}"
+            f"{'' if auth.get('enforced') else ' (not enforced)'}"
+        )
+
+
+def run_status(args: argparse.Namespace) -> Dict[str, Any]:
+    """Render supervisor process state plus the gateway's /runtime/status."""
+    from nexus.runtime import RuntimeError_
+
+    try:
+        supervisor = _runtime_supervisor(args)
+        result = supervisor.status()
+        if not args.json:
+            _print_runtime_status(result)
+        return result
+    except (RuntimeError_, FileNotFoundError) as exc:
+        return {"success": False, "error": str(exc)}
+
+
+def run_logs(args: argparse.Namespace) -> Dict[str, Any]:
+    """Tail captured service logs; -f follows."""
+    from nexus.runtime import RuntimeError_
+
+    if args.json and args.follow:
+        return {"success": False, "error": "--json cannot be combined with -f"}
+    try:
+        supervisor = _runtime_supervisor(args)
+        stream = supervisor.logs(
+            service=args.service, lines=args.lines, follow=args.follow
+        )
+        if args.json:
+            return {"success": True, "service": args.service, "lines": list(stream)}
+        try:
+            for line in stream:
+                print(line)
+        except KeyboardInterrupt:
+            pass
+        return {"success": True}
+    except (RuntimeError_, FileNotFoundError) as exc:
+        return {"success": False, "error": str(exc)}
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build CLI argument parser with subcommands."""
     parser = argparse.ArgumentParser(
@@ -2560,6 +2730,11 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
+  nexus up                      Start the runtime (gateway + enabled services)
+  nexus up --foreground         Stay attached; Ctrl+C tears down
+  nexus status                  Runtime health, processes, slot, version
+  nexus logs gateway -f         Follow the gateway log
+  nexus down                    Stop the runtime
   nexus load --slot 5           Show current state of slot 5
   nexus continue --slot 5       Advance the story
   nexus continue --slot 5 --choice 1   Select choice #1
@@ -2598,6 +2773,60 @@ Examples:
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Managed runtime verbs (issue #396)
+    def _add_config_arg(p: argparse.ArgumentParser) -> None:
+        p.add_argument(
+            "--config",
+            help="Path to nexus.toml (default: the repository's nexus.toml)",
+        )
+
+    up_parser = subparsers.add_parser(
+        "up", help="Start the NEXUS runtime (gateway + enabled services)"
+    )
+    up_parser.add_argument("--slot", type=int, help="Active slot (1-5)")
+    up_parser.add_argument(
+        "--foreground",
+        action="store_true",
+        help="Stay attached: stream logs, supervise, tear down on Ctrl+C",
+    )
+    _add_config_arg(up_parser)
+
+    down_parser = subparsers.add_parser("down", help="Stop managed runtime services")
+    down_parser.add_argument(
+        "service", nargs="?", default=None, help="Stop a single service by name"
+    )
+    _add_config_arg(down_parser)
+
+    restart_parser = subparsers.add_parser(
+        "restart", help="Restart managed runtime services"
+    )
+    restart_parser.add_argument(
+        "service", nargs="?", default=None, help="Restart a single service by name"
+    )
+    restart_parser.add_argument("--slot", type=int, help="Active slot (1-5)")
+    _add_config_arg(restart_parser)
+
+    status_parser = subparsers.add_parser(
+        "status", help="Show runtime health, processes, slot, and version"
+    )
+    _add_config_arg(status_parser)
+
+    logs_parser = subparsers.add_parser("logs", help="Tail captured service logs")
+    logs_parser.add_argument(
+        "service", nargs="?", default="gateway", help="Service name (default: gateway)"
+    )
+    logs_parser.add_argument(
+        "-n",
+        "--lines",
+        type=int,
+        default=None,
+        help="Line count (default: runtime.logs.tail_lines)",
+    )
+    logs_parser.add_argument(
+        "-f", "--follow", action="store_true", help="Follow the log"
+    )
+    _add_config_arg(logs_parser)
 
     # load command
     load_parser = subparsers.add_parser("load", help="Display current slot state")
@@ -3137,8 +3366,23 @@ def main() -> int:
             emit_error("Slot must be between 1 and 5", args.json)
             return 1
 
+    if args.command in ("up", "restart") and args.slot is not None:
+        if args.slot < 1 or args.slot > 5:
+            emit_error("Slot must be between 1 and 5", args.json)
+            return 1
+
     # Execute command
-    if args.command == "load":
+    if args.command == "up":
+        result = run_up(args)
+    elif args.command == "down":
+        result = run_down(args)
+    elif args.command == "restart":
+        result = run_restart(args)
+    elif args.command == "status":
+        result = run_status(args)
+    elif args.command == "logs":
+        result = run_logs(args)
+    elif args.command == "load":
         result = run_load(args)
     elif args.command == "continue":
         result = run_continue(args)

--- a/nexus/config/__init__.py
+++ b/nexus/config/__init__.py
@@ -5,6 +5,7 @@ from .loader import (
     load_settings,
     load_settings_as_dict,
     get_available_api_models,
+    get_openai_compatible_endpoint,
     resolve_model_ref,
     save_settings,
 )
@@ -14,6 +15,7 @@ __all__ = [
     "load_settings",
     "load_settings_as_dict",
     "get_available_api_models",
+    "get_openai_compatible_endpoint",
     "resolve_model_ref",
     "save_settings",
 ]

--- a/nexus/config/loader.py
+++ b/nexus/config/loader.py
@@ -197,6 +197,44 @@ def get_provider_for_model(model_id: str) -> Optional[str]:
     return None
 
 
+def get_openai_compatible_endpoint(model_id: str) -> Optional[Dict[str, str]]:
+    """
+    Resolve the OpenAI-compatible endpoint for a registry model, if any.
+
+    Native SDK providers (openai, anthropic) return None — their requests use
+    the provider SDK's own endpoint and Keychain credentials. Every other
+    provider in [global.model.api_models] is an OpenAI-compatible server whose
+    `base_url` lives in the registry (issue #401); the mock TEST server and any
+    future local server (Ollama, vLLM, ...) route through here.
+
+    Args:
+        model_id: Concrete model ID from the api_models registry
+
+    Returns:
+        ``{"base_url": ..., "api_key": ...}`` for base_url providers, or None
+        for native providers and for models absent from the registry (callers
+        that accept ad-hoc model overrides treat those as native-SDK models).
+        ``api_key`` is read from Keychain when the provider declares
+        ``api_key_secret``; otherwise a placeholder is returned because OpenAI
+        clients require a non-empty key.
+    """
+    from nexus.config.settings_models import NATIVE_API_PROVIDERS
+
+    settings = load_settings()
+    provider = get_provider_for_model(model_id)
+    if provider is None or provider in NATIVE_API_PROVIDERS:
+        return None
+    entry = settings.global_.model.api_models[provider]
+    # base_url presence is enforced at config load for non-native providers.
+    if entry.api_key_secret:
+        from nexus.util.secret_manager import get_secret
+
+        api_key = get_secret(entry.api_key_secret)
+    else:
+        api_key = "nexus-local-no-key"
+    return {"base_url": entry.base_url, "api_key": api_key}
+
+
 def resolve_model_ref(ref: str, path: Union[str, Path] = "nexus.toml") -> str:
     """
     Resolve an "@provider.role" reference to a concrete model ID.

--- a/nexus/config/loader.py
+++ b/nexus/config/loader.py
@@ -9,6 +9,7 @@ to nexus.toml; explicitly passed .json paths remain supported only for
 legacy ir_eval V1 tooling that synthesizes temporary settings files.
 """
 
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -33,6 +34,8 @@ except ModuleNotFoundError:
 from .settings_models import Settings
 
 logger = logging.getLogger("nexus.config.loader")
+
+RUNTIME_CONFIG_ENV = "NEXUS_RUNTIME_CONFIG"
 
 
 def save_settings(
@@ -235,7 +238,7 @@ def get_openai_compatible_endpoint(model_id: str) -> Optional[Dict[str, str]]:
     return {"base_url": entry.base_url, "api_key": api_key}
 
 
-def resolve_model_ref(ref: str, path: Union[str, Path] = "nexus.toml") -> str:
+def resolve_model_ref(ref: str, path: Union[str, Path, None] = None) -> str:
     """
     Resolve an "@provider.role" reference to a concrete model ID.
 
@@ -245,7 +248,8 @@ def resolve_model_ref(ref: str, path: Union[str, Path] = "nexus.toml") -> str:
 
     Args:
         ref: "@provider.role" reference or literal registry model ID
-        path: Path to configuration file (default: nexus.toml)
+        path: Path to configuration file (default: active runtime config, then
+            nexus.toml)
 
     Returns:
         Concrete model ID from the api_models registry
@@ -257,13 +261,15 @@ def resolve_model_ref(ref: str, path: Union[str, Path] = "nexus.toml") -> str:
     return load_settings(path).resolve_model_ref(ref)
 
 
-def load_settings(path: Union[str, Path] = "nexus.toml") -> Settings:
+def load_settings(path: Union[str, Path, None] = None) -> Settings:
     """
     Load and validate NEXUS configuration.
 
     Args:
-        path: Path to configuration file (nexus.toml; explicit .json paths
-              are accepted only for legacy ir_eval V1 tooling)
+        path: Path to configuration file. When omitted, services spawned by
+              the managed runtime honor NEXUS_RUNTIME_CONFIG; otherwise
+              nexus.toml is used. Explicit .json paths are accepted only for
+              legacy ir_eval V1 tooling.
 
     Returns:
         Validated Settings object with type-safe access to configuration
@@ -280,6 +286,8 @@ def load_settings(path: Union[str, Path] = "nexus.toml") -> Settings:
         >>> # settings.apex.model resolves to a concrete ID from the api_models
         >>> # registry (e.g. whatever openai.default points at).
     """
+    if path is None:
+        path = os.environ.get(RUNTIME_CONFIG_ENV, "nexus.toml")
     path = Path(path)
 
     if not path.exists():
@@ -369,7 +377,7 @@ def _load_from_json(path: Path) -> Settings:
         raise
 
 
-def load_settings_as_dict(path: Union[str, Path] = "nexus.toml") -> Dict[str, Any]:
+def load_settings_as_dict(path: Union[str, Path, None] = None) -> Dict[str, Any]:
     """
     Load settings and return as dict for backward compatibility.
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -14,6 +14,11 @@ from pydantic import BaseModel, Field, ConfigDict, model_validator
 # Example: "@openai.default" resolves via api_models.openai.roles.default
 MODEL_ROLE_PREFIX = "@"
 
+# Providers with native SDK request paths. Every other provider in
+# [global.model.api_models] is an OpenAI-compatible server and must declare a
+# `base_url` (enforced by ``ModelConfig._validate_non_native_providers``).
+NATIVE_API_PROVIDERS = frozenset({"openai", "anthropic"})
+
 
 @dataclass
 class _ModelRegistry:
@@ -46,6 +51,17 @@ class APIModelEntry(BaseModel):
     description: Optional[str] = Field(
         default=None, description="Human-readable description (optional)"
     )
+    unsupported_params: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Request parameters this model's API rejects outright (e.g. "
+            "'temperature' on reasoning-class models). Config load refuses any "
+            "consumer field that configures one of these params for this model "
+            "(see Settings._validate_param_capabilities); request builders only "
+            "send explicitly configured params, so a rejected parameter can "
+            "never reach the provider."
+        ),
+    )
 
 
 class ProviderModels(BaseModel):
@@ -75,6 +91,25 @@ class ProviderModels(BaseModel):
             "Expose this provider's models in UI-facing pickers "
             "(/api/config/models, /api/settings settings_meta). Backend and "
             "CLI callers always see the full registry regardless of this flag."
+        ),
+    )
+    base_url: Optional[str] = Field(
+        default=None,
+        description=(
+            "OpenAI-compatible server base URL (e.g. 'http://127.0.0.1:5102/v1' "
+            "for the mock server, or an Ollama/vLLM endpoint). Required for "
+            "every provider outside NATIVE_API_PROVIDERS; requests for this "
+            "provider's models are sent to this URL with the OpenAI client."
+        ),
+    )
+    api_key_secret: Optional[str] = Field(
+        default=None,
+        description=(
+            "Keychain account name (service 'nexus-api') holding the API key "
+            "for a base_url provider, resolved via "
+            "nexus.util.secret_manager.get_secret. Leave unset for servers "
+            "that need no key (mock server, local Ollama/vLLM); a placeholder "
+            "key is sent because OpenAI clients require a non-empty key."
         ),
     )
 
@@ -137,6 +172,32 @@ class ModelConfig(BaseModel):
                 )
         return self
 
+    @model_validator(mode="after")
+    def _validate_non_native_providers(self) -> "ModelConfig":
+        """Every provider without a native SDK path must declare a base_url.
+
+        OpenAI and Anthropic requests go through their own SDK clients; any
+        other provider section (test mock server, Ollama, vLLM, ...) is an
+        OpenAI-compatible server whose endpoint lives in the registry, not in
+        code.
+        """
+        for provider, config in self.api_models.items():
+            if provider in NATIVE_API_PROVIDERS:
+                if config.base_url is not None:
+                    raise ValueError(
+                        f"Provider '{provider}' uses its native SDK endpoint; "
+                        f"base_url is not allowed here. Register a proxy or "
+                        f"local server as its own provider section instead."
+                    )
+                continue
+            if config.models and not config.base_url:
+                raise ValueError(
+                    f"Provider '{provider}' in [global.model.api_models] is not "
+                    f"a native SDK provider ({sorted(NATIVE_API_PROVIDERS)}) and "
+                    f"must declare a base_url for its OpenAI-compatible server."
+                )
+        return self
+
 
 class NarrativeConfig(BaseModel):
     """Narrative test mode settings."""
@@ -147,16 +208,6 @@ class NarrativeConfig(BaseModel):
     test_database_suffix: str = Field(..., description="Database suffix for testing")
 
 
-class GlobalAPIConfig(BaseModel):
-    """Global API configuration."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    test_mock_server_url: str = Field(
-        default="http://localhost:5102/v1", description="Mock server URL for TEST model"
-    )
-
-
 class GlobalSettings(BaseModel):
     """Global configuration settings."""
 
@@ -164,9 +215,6 @@ class GlobalSettings(BaseModel):
 
     model: ModelConfig
     narrative: NarrativeConfig
-    api: Optional[GlobalAPIConfig] = Field(
-        default=None, description="API configuration"
-    )
 
 
 # =============================================================================
@@ -277,6 +325,26 @@ class OrreryNarrationSettings(BaseModel):
     mode: Literal["async", "sync"] = "async"
     provider: str = "anthropic"
     model_ref: str = Field(..., description="Model ID or @provider.role reference")
+    temperature: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=2.0,
+        description=(
+            "Sampling temperature for narration calls. Unset means the "
+            "parameter is omitted entirely (API default). Configuring it for "
+            "a model that lists 'temperature' in unsupported_params is a "
+            "config-load error."
+        ),
+    )
+    max_output_tokens: int = Field(
+        default=1200, ge=1, description="Output-token ceiling for narration calls"
+    )
+    max_attempts: int = Field(
+        default=3, ge=1, description="Narration job attempts before marked failed"
+    )
+    retry_delay_seconds: int = Field(
+        default=300, ge=0, description="Delay before a failed narration job retries"
+    )
 
 
 class OrreryBleedSettings(BaseModel):
@@ -1372,6 +1440,68 @@ class Settings(BaseModel):
             object.__setattr__(container, attr, resolved)
 
         return self
+
+    @model_validator(mode="after")
+    def _validate_param_capabilities(self) -> "Settings":
+        """Refuse configured request params that the resolved model rejects.
+
+        This is the single enforcement boundary for per-model parameter
+        capability (issue #401): consumer sections in nexus.toml may only
+        configure a sampling parameter when the model they resolve to does not
+        list it in `unsupported_params`. Request builders send only explicitly
+        configured params, so passing this validator guarantees no provider
+        ever receives a parameter it rejects.
+
+        Runs after ``_resolve_model_references`` (Pydantic executes model
+        validators in definition order), so every model field holds a concrete
+        registry ID by the time this checks it.
+        """
+        # Each tuple: (concrete model id, {param name: configured value}, source)
+        checks: List[Tuple[str, Dict[str, Any], str]] = []
+        if self.orrery is not None:
+            checks.append(
+                (
+                    self.orrery.narration.model_ref,
+                    {"temperature": self.orrery.narration.temperature},
+                    "[orrery.narration]",
+                )
+            )
+
+        for model_id, params, source in checks:
+            entry = self.model_entry(model_id)
+            for param, value in params.items():
+                if value is None:
+                    continue
+                if param in entry.unsupported_params:
+                    raise ValueError(
+                        f"{source} configures {param}={value!r}, but model "
+                        f"'{model_id}' declares '{param}' unsupported "
+                        f"(unsupported_params in [global.model.api_models]). "
+                        f"Remove the setting or choose a model that accepts it."
+                    )
+        return self
+
+    def model_entry(self, model_id: str) -> APIModelEntry:
+        """Return the registry entry for a concrete model ID (raises if absent)."""
+        for provider_models in self.global_.model.api_models.values():
+            for entry in provider_models.models:
+                if entry.id == model_id:
+                    return entry
+        raise ValueError(
+            f"Model ID '{model_id}' is not declared in "
+            f"[global.model.api_models.*].models"
+        )
+
+    def provider_for_model(self, model_id: str) -> str:
+        """Return the provider name owning a concrete model ID (raises if absent)."""
+        for provider, provider_models in self.global_.model.api_models.items():
+            for entry in provider_models.models:
+                if entry.id == model_id:
+                    return provider
+        raise ValueError(
+            f"Model ID '{model_id}' is not declared in "
+            f"[global.model.api_models.*].models"
+        )
 
     def resolve_model_ref(self, ref: str) -> str:
         """Resolve an "@provider.role" reference against the api_models registry.

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1614,12 +1614,12 @@ class Settings(BaseModel):
     def _validate_param_capabilities(self) -> "Settings":
         """Refuse configured request params that the resolved model rejects.
 
-        This is the single enforcement boundary for per-model parameter
-        capability (issue #401): consumer sections in nexus.toml may only
-        configure a sampling parameter when the model they resolve to does not
-        list it in `unsupported_params`. Request builders send only explicitly
-        configured params, so passing this validator guarantees no provider
-        ever receives a parameter it rejects.
+        This is the enforcement boundary for Orrery narration sampling
+        capability (issue #401): [orrery.narration] may only configure a
+        sampling parameter when its resolved model does not list it in
+        `unsupported_params`. Request builders send only explicitly configured
+        params, so passing this validator guarantees Orrery never sends a
+        narration parameter its provider rejects.
 
         Runs after ``_resolve_model_references`` (Pydantic executes model
         validators in definition order), so every model field holds a concrete

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -218,6 +218,171 @@ class GlobalSettings(BaseModel):
 
 
 # =============================================================================
+# Managed Runtime Settings Models (issue #396)
+# =============================================================================
+
+
+class RuntimeServiceSettings(BaseModel):
+    """One supervised service in the local runtime profile."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    command: List[str] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "argv template for spawning the service. Placeholders: {python} "
+            "(current interpreter), {host}, {port}. No shell is involved."
+        ),
+    )
+    host: str = Field(default="127.0.0.1", description="Bind host (loopback TCP)")
+    port: int = Field(..., ge=1, le=65535, description="Service port")
+    health_path: str = Field(
+        default="/health", description="HTTP path probed for liveness"
+    )
+    env: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Extra environment variables set on the spawned process",
+    )
+    enabled: Literal["always", "never", "auto"] = Field(
+        default="always",
+        description=(
+            "'always' spawns the service in the local profile; 'never' skips "
+            "it; 'auto' spawns only when the TEST provider is registered in "
+            "[global.model.api_models] (the mock server's condition)."
+        ),
+    )
+    autorestart: Literal["never", "on-failure"] = Field(
+        default="never",
+        description=(
+            "'on-failure' respawns the service when it exits nonzero while a "
+            "foreground supervisor (nexus up --foreground) is attached. "
+            "Detached mode has no supervising process, so it is effectively "
+            "'never' there."
+        ),
+    )
+    autorestart_max_retries: int = Field(
+        default=3,
+        ge=0,
+        description="Foreground autorestart attempts before giving up",
+    )
+
+
+class RuntimeHealthSettings(BaseModel):
+    """HTTP health-probe and process lifecycle timing."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    timeout_seconds: float = Field(
+        default=2.0, gt=0, description="Per-probe HTTP timeout"
+    )
+    startup_deadline_seconds: float = Field(
+        default=30.0, gt=0, description="How long nexus up waits per service"
+    )
+    poll_interval_seconds: float = Field(
+        default=0.25, gt=0, description="Delay between startup health probes"
+    )
+    stop_grace_seconds: float = Field(
+        default=10.0,
+        gt=0,
+        description="SIGTERM-to-SIGKILL escalation window on nexus down",
+    )
+
+
+class RuntimeLogsSettings(BaseModel):
+    """Captured-log presentation settings for nexus logs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    tail_lines: int = Field(
+        default=100, ge=1, description="Default line count for nexus logs"
+    )
+    follow_poll_seconds: float = Field(
+        default=0.5, gt=0, description="Poll interval for nexus logs -f"
+    )
+
+
+class RuntimeExternalSettings(BaseModel):
+    """Attach targets for the external profile (spawn nothing)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    gateway_url: str = Field(..., description="Base URL of the already-running gateway")
+    mock_openai_url: Optional[str] = Field(
+        default=None,
+        description="Base URL of an already-running mock server (optional)",
+    )
+
+
+class RuntimeRemoteSettings(BaseModel):
+    """A hosted NEXUS runtime reached purely over HTTP."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    base_url: str = Field(
+        ..., min_length=1, description="Base URL of the remote runtime origin"
+    )
+
+
+class RuntimeSettings(BaseModel):
+    """Managed runtime configuration (nexus up / down / status / logs)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    profile: Literal["local", "external", "remote"] = Field(
+        default="local",
+        description=(
+            "'local' spawns and manages services; 'external' attaches to "
+            "already-running services (health/status only); 'remote' targets "
+            "a hosted runtime via remote.base_url."
+        ),
+    )
+    state_dir: str = Field(
+        default=".nexus/runtime",
+        description=(
+            "Directory for pidfiles and captured service logs. Relative paths "
+            "resolve against the repository root."
+        ),
+    )
+    default_slot: int = Field(
+        default=1,
+        ge=1,
+        le=5,
+        description=(
+            "Slot exported as NEXUS_SLOT to spawned services when neither "
+            "--slot nor the NEXUS_SLOT environment variable is set."
+        ),
+    )
+    services: Dict[str, RuntimeServiceSettings] = Field(
+        default_factory=dict,
+        description="Supervised services for the local profile, by name",
+    )
+    health: RuntimeHealthSettings = Field(default_factory=RuntimeHealthSettings)
+    logs: RuntimeLogsSettings = Field(default_factory=RuntimeLogsSettings)
+    external: Optional[RuntimeExternalSettings] = None
+    remote: Optional[RuntimeRemoteSettings] = None
+
+    @model_validator(mode="after")
+    def _validate_profile_requirements(self) -> "RuntimeSettings":
+        if self.profile == "local" and "gateway" not in self.services:
+            raise ValueError(
+                "[runtime] profile 'local' requires a [runtime.services.gateway] "
+                "section"
+            )
+        if self.profile == "external" and self.external is None:
+            raise ValueError(
+                "[runtime] profile 'external' requires a [runtime.external] "
+                "section with gateway_url"
+            )
+        if self.profile == "remote" and self.remote is None:
+            raise ValueError(
+                "[runtime] profile 'remote' requires a [runtime.remote] section "
+                "with base_url"
+            )
+        return self
+
+
+# =============================================================================
 # LORE Agent Settings Models
 # =============================================================================
 
@@ -1389,6 +1554,10 @@ class Settings(BaseModel):
         default=None,
         description="IR evaluation subsystem settings",
     )
+    runtime: Optional[RuntimeSettings] = Field(
+        default=None,
+        description="Managed runtime settings (nexus up/down/status/logs)",
+    )
 
     @model_validator(mode="after")
     def _resolve_model_references(self) -> "Settings":
@@ -1479,6 +1648,34 @@ class Settings(BaseModel):
                         f"(unsupported_params in [global.model.api_models]). "
                         f"Remove the setting or choose a model that accepts it."
                     )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_runtime_mock_port_consistency(self) -> "Settings":
+        """The mock service port and the test provider base_url must agree.
+
+        The TEST registry entry's base_url is where clients send requests; the
+        [runtime.services.mock_openai] port is where the supervisor binds the
+        server. Drift between the two produces a runtime that "works" while
+        every TEST call connection-refuses, so it is rejected at load.
+        """
+        if self.runtime is None:
+            return self
+        mock = self.runtime.services.get("mock_openai")
+        test_provider = self.global_.model.api_models.get("test")
+        if mock is None or mock.enabled == "never":
+            return self
+        if test_provider is None or not test_provider.base_url:
+            return self
+        from urllib.parse import urlparse
+
+        base_port = urlparse(test_provider.base_url).port
+        if base_port != mock.port:
+            raise ValueError(
+                f"[runtime.services.mock_openai] port {mock.port} does not match "
+                f"the test provider base_url port {base_port} "
+                f"({test_provider.base_url}). Keep them in sync."
+            )
         return self
 
     def model_entry(self, model_id: str) -> APIModelEntry:

--- a/nexus/runtime/__init__.py
+++ b/nexus/runtime/__init__.py
@@ -1,0 +1,17 @@
+"""NEXUS managed runtime: supervisor, profiles, and runtime contract."""
+
+from nexus.runtime.contract import (
+    NEXUS_AUTH_HEADER,
+    RUNTIME_CONFIG_ENV,
+    RUNTIME_STATUS_PATH,
+)
+from nexus.runtime.supervisor import RuntimeError_, Supervisor, repo_root
+
+__all__ = [
+    "NEXUS_AUTH_HEADER",
+    "RUNTIME_CONFIG_ENV",
+    "RUNTIME_STATUS_PATH",
+    "RuntimeError_",
+    "Supervisor",
+    "repo_root",
+]

--- a/nexus/runtime/contract.py
+++ b/nexus/runtime/contract.py
@@ -1,0 +1,24 @@
+"""Runtime contract constants shared by the gateway, supervisor, and clients.
+
+These values are part of the client/runtime boundary documented in
+docs/runtime.md. Clients (PWA, CLI, future desktop shells or hosted clients)
+should import or mirror these rather than hardcoding strings.
+"""
+
+from __future__ import annotations
+
+# Reserved auth header for every client -> runtime request. Semantics:
+# an opaque bearer credential issued by the runtime operator. The local
+# profile ignores it entirely (no-op), but clients must send it from day one
+# so that pointing the same client at a remote runtime is a base-URL change,
+# not a code change. Hosted runtimes reject requests without it.
+NEXUS_AUTH_HEADER = "X-Nexus-Auth"
+
+# The runtime status endpoint, served by the gateway beside /health.
+RUNTIME_STATUS_PATH = "/runtime/status"
+
+# Environment seam: absolute path of the nexus.toml the runtime was started
+# from. The supervisor sets it on every spawned service so the gateway's
+# /runtime/status reports the profile/ports of the config that actually
+# launched it (test harnesses point this at temp configs).
+RUNTIME_CONFIG_ENV = "NEXUS_RUNTIME_CONFIG"

--- a/nexus/runtime/supervisor.py
+++ b/nexus/runtime/supervisor.py
@@ -435,6 +435,15 @@ class Supervisor:
             _signal_pid(pid, kill_sig)
             time.sleep(0.2)
 
+    def _wait_port_closed(self, host: str, port: int) -> bool:
+        """Return true once a stopped service's TCP port is closed."""
+        deadline = time.monotonic() + self.runtime.health.stop_grace_seconds
+        while time.monotonic() < deadline:
+            if not _port_open(host, port):
+                return True
+            time.sleep(0.1)
+        return not _port_open(host, port)
+
     def _stop_service(self, name: str) -> Optional[int]:
         record = self._read_pidfile(name)
         if record is None:
@@ -465,7 +474,9 @@ class Supervisor:
             if pid is None:
                 continue
             stopped[name] = {"pid": pid}
-            if record and _port_open(record.get("host", "127.0.0.1"), record["port"]):
+            if record and not self._wait_port_closed(
+                record.get("host", "127.0.0.1"), record["port"]
+            ):
                 raise RuntimeError_(
                     f"Service '{name}' was signaled but port {record['port']} is "
                     f"still open - a process outlived shutdown."
@@ -624,7 +635,7 @@ class Supervisor:
                         with open(path, "rb") as handle:
                             handle.seek(offsets[name])
                             data = handle.read()
-                        offsets[name] = size
+                            offsets[name] = handle.tell()
                         if echo:
                             text = data.decode("utf-8", errors="replace")
                             for line in text.splitlines():
@@ -645,22 +656,29 @@ class Supervisor:
         restarts: Dict[str, int],
         echo: bool,
     ) -> None:
+        exited: list[tuple[str, RuntimeServiceSettings, Dict[str, Any]]] = []
         for name, service in services.items():
             record = self._read_pidfile(name)
             if record is None or _pid_alive(int(record["pid"])):
                 continue
             self._pidfile(name).unlink(missing_ok=True)
+            exited.append((name, service, record))
+
+        failures: list[str] = []
+        for name, service, record in exited:
             if service.autorestart != "on-failure":
-                raise RuntimeError_(
+                failures.append(
                     f"Service '{name}' (pid {record['pid']}) exited and "
                     f"autorestart is 'never'."
                 )
+                continue
             attempts = restarts.get(name, 0)
             if attempts >= service.autorestart_max_retries:
-                raise RuntimeError_(
+                failures.append(
                     f"Service '{name}' exceeded autorestart_max_retries "
                     f"({service.autorestart_max_retries})."
                 )
+                continue
             restarts[name] = attempts + 1
             if echo:
                 print(
@@ -668,3 +686,5 @@ class Supervisor:
                     f"({restarts[name]}/{service.autorestart_max_retries})"
                 )
             self._start_service(name, service, slot, detached=False)
+        if failures:
+            raise RuntimeError_(" ".join(failures))

--- a/nexus/runtime/supervisor.py
+++ b/nexus/runtime/supervisor.py
@@ -165,6 +165,26 @@ class Supervisor:
             return None
         return json.loads(path.read_text())
 
+    def _running_slot(self) -> Optional[int]:
+        """Return the slot recorded by running services, if any.
+
+        A full restart should preserve the slot chosen by ``nexus up --slot N``;
+        once ``down()`` removes pidfiles that information is gone.
+        """
+        slots = {
+            int(record["slot"])
+            for path in self.state_dir.glob("*.pid.json")
+            if (record := json.loads(path.read_text()))
+            and _pid_alive(int(record["pid"]))
+            and record.get("slot") is not None
+        }
+        if len(slots) > 1:
+            raise RuntimeError_(
+                f"Running services disagree about active slot: {sorted(slots)}. "
+                "Pass --slot explicitly."
+            )
+        return next(iter(slots), None)
+
     def _write_pidfile(self, name: str, record: Dict[str, Any]) -> None:
         self._pidfile(name).write_text(json.dumps(record, indent=2))
 
@@ -476,8 +496,11 @@ class Supervisor:
                 service, services[service], resolved_slot, detached=True
             )
             return {"success": True, "services": {service: record}}
+        resolved_slot = self._resolve_slot(
+            slot if slot is not None else self._running_slot()
+        )
         self.down()
-        return self.up(slot=slot, echo=False)
+        return self.up(slot=resolved_slot, echo=False)
 
     # ------------------------------------------------------------------
     # Status

--- a/nexus/runtime/supervisor.py
+++ b/nexus/runtime/supervisor.py
@@ -1,0 +1,647 @@
+"""Managed runtime supervisor: nexus up / down / restart / status / logs.
+
+Pure-Python, cross-platform process management (issue #396). No bash in the
+runtime path, no UNIX sockets — services are spawned directly from argv
+templates and observed over loopback TCP. Process state lives in JSON
+pidfiles and captured log files under [runtime].state_dir.
+
+Profiles (configured in nexus.toml [runtime]):
+
+- ``local``    — spawn and manage the services in [runtime.services.*]
+- ``external`` — attach to already-running services: health-check and status
+                 only; never spawns or stops anything
+- ``remote``   — a hosted runtime; status hits <base_url>/runtime/status
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+import requests
+
+from nexus.config import load_settings
+from nexus.config.settings_models import (
+    RuntimeServiceSettings,
+    RuntimeSettings,
+    Settings,
+)
+from nexus.runtime.contract import (
+    NEXUS_AUTH_HEADER,
+    RUNTIME_CONFIG_ENV,
+    RUNTIME_STATUS_PATH,
+)
+
+
+class RuntimeError_(Exception):
+    """Supervisor-level failure with a user-facing message."""
+
+
+def repo_root() -> Path:
+    """The repository root, derived from the nexus package location."""
+    return Path(__file__).resolve().parents[2]
+
+
+def _pid_alive(pid: int) -> bool:
+    """Cross-platform process liveness check (never signals the process)."""
+    if os.name == "nt":  # pragma: no cover - exercised on Windows hosts only
+        import ctypes
+
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        STILL_ACTIVE = 259
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return False
+        try:
+            exit_code = ctypes.c_ulong()
+            ok = kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code))
+            return bool(ok) and exit_code.value == STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _signal_pid(pid: int, sig: int) -> None:
+    """Deliver a signal to the service's process group (POSIX) or process."""
+    if os.name == "nt":  # pragma: no cover - Windows: TerminateProcess semantics
+        os.kill(pid, sig)
+        return
+    try:
+        # Detached services run in their own session (start_new_session=True),
+        # so the group id equals the pid; signaling the group reaches any
+        # workers the service forked.
+        os.killpg(pid, sig)
+    except (ProcessLookupError, PermissionError):
+        os.kill(pid, sig)
+
+
+def _port_open(host: str, port: int, timeout: float = 0.5) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(timeout)
+        return sock.connect_ex((host, port)) == 0
+
+
+def _tail_lines(path: Path, count: int) -> List[str]:
+    if not path.exists():
+        return []
+    with open(path, "rb") as handle:
+        try:
+            handle.seek(-min(path.stat().st_size, 256 * 1024), os.SEEK_END)
+        except OSError:
+            handle.seek(0)
+        text = handle.read().decode("utf-8", errors="replace")
+    lines = text.splitlines()
+    return lines[-count:]
+
+
+class Supervisor:
+    """Process supervisor for the configured runtime profile."""
+
+    def __init__(self, settings: Settings, config_path: Path):
+        if settings.runtime is None:
+            raise RuntimeError_(
+                "nexus.toml has no [runtime] section; the managed runtime "
+                "requires one (see docs/runtime.md)."
+            )
+        self.settings = settings
+        self.runtime: RuntimeSettings = settings.runtime
+        self.config_path = config_path.resolve()
+        self.root = repo_root()
+        state_dir = Path(self.runtime.state_dir)
+        self.state_dir = state_dir if state_dir.is_absolute() else self.root / state_dir
+
+    @classmethod
+    def from_config(cls, config_path: Optional[Path] = None) -> "Supervisor":
+        path = Path(config_path) if config_path else repo_root() / "nexus.toml"
+        return cls(load_settings(path), path)
+
+    # ------------------------------------------------------------------
+    # Service selection
+    # ------------------------------------------------------------------
+
+    def enabled_services(self) -> Dict[str, RuntimeServiceSettings]:
+        """Services the local profile should spawn, honoring 'auto' gating."""
+        test_registered = bool(
+            self.settings.global_.model.api_models.get("test")
+            and self.settings.global_.model.api_models["test"].models
+        )
+        selected: Dict[str, RuntimeServiceSettings] = {}
+        for name, service in self.runtime.services.items():
+            if service.enabled == "never":
+                continue
+            if service.enabled == "auto" and not test_registered:
+                continue
+            selected[name] = service
+        return selected
+
+    # ------------------------------------------------------------------
+    # State files
+    # ------------------------------------------------------------------
+
+    def _pidfile(self, name: str) -> Path:
+        return self.state_dir / f"{name}.pid.json"
+
+    def log_path(self, name: str) -> Path:
+        return self.state_dir / f"{name}.log"
+
+    def _read_pidfile(self, name: str) -> Optional[Dict[str, Any]]:
+        path = self._pidfile(name)
+        if not path.exists():
+            return None
+        return json.loads(path.read_text())
+
+    def _write_pidfile(self, name: str, record: Dict[str, Any]) -> None:
+        self._pidfile(name).write_text(json.dumps(record, indent=2))
+
+    # ------------------------------------------------------------------
+    # Spawning
+    # ------------------------------------------------------------------
+
+    def _resolve_slot(self, slot: Optional[int]) -> int:
+        if slot is not None:
+            return slot
+        env_slot = os.environ.get("NEXUS_SLOT")
+        if env_slot:
+            return int(env_slot)
+        return self.runtime.default_slot
+
+    def _service_argv(self, service: RuntimeServiceSettings) -> List[str]:
+        substitutions = {
+            "python": sys.executable,
+            "host": service.host,
+            "port": str(service.port),
+        }
+        return [part.format(**substitutions) for part in service.command]
+
+    def _service_env(
+        self, service: RuntimeServiceSettings, slot: int
+    ) -> Dict[str, str]:
+        env = dict(os.environ)
+        env.update(service.env)
+        env["NEXUS_SLOT"] = str(slot)
+        env[RUNTIME_CONFIG_ENV] = str(self.config_path)
+        # Spawned services must import this checkout's nexus package even when
+        # an editable install of another checkout exists in the environment.
+        env["PYTHONPATH"] = os.pathsep.join(
+            [str(self.root)] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])
+        )
+        return env
+
+    def _spawn(
+        self,
+        name: str,
+        service: RuntimeServiceSettings,
+        slot: int,
+        detached: bool,
+    ) -> int:
+        argv = self._service_argv(service)
+        log_path = self.log_path(name)
+        popen_kwargs: Dict[str, Any] = {}
+        if detached:
+            if os.name == "posix":
+                popen_kwargs["start_new_session"] = True
+            else:  # pragma: no cover - Windows host path
+                popen_kwargs["creationflags"] = (
+                    subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
+                )
+        elif os.name == "posix":
+            # Foreground children still get their own session so a group
+            # signal on teardown reaches forked workers without hitting the
+            # supervisor itself.
+            popen_kwargs["start_new_session"] = True
+        with open(log_path, "ab") as log_handle:
+            process = subprocess.Popen(
+                argv,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                cwd=self.root,
+                env=self._service_env(service, slot),
+                **popen_kwargs,
+            )
+        return process.pid
+
+    def _await_healthy(self, name: str, service: RuntimeServiceSettings, pid: int):
+        health = self.runtime.health
+        url = f"http://{service.host}:{service.port}{service.health_path}"
+        deadline = time.monotonic() + health.startup_deadline_seconds
+        while True:
+            if not _pid_alive(pid):
+                excerpt = "\n".join(_tail_lines(self.log_path(name), 30))
+                raise RuntimeError_(
+                    f"Service '{name}' exited during startup. Last log lines:\n"
+                    f"{excerpt}"
+                )
+            try:
+                if requests.get(url, timeout=health.timeout_seconds).status_code == 200:
+                    return
+            except requests.RequestException:
+                pass
+            if time.monotonic() > deadline:
+                excerpt = "\n".join(_tail_lines(self.log_path(name), 30))
+                self._stop_pid(pid)
+                raise RuntimeError_(
+                    f"Service '{name}' failed to become healthy at {url} within "
+                    f"{health.startup_deadline_seconds}s. Last log lines:\n"
+                    f"{excerpt}"
+                )
+            time.sleep(health.poll_interval_seconds)
+
+    def _start_service(
+        self,
+        name: str,
+        service: RuntimeServiceSettings,
+        slot: int,
+        detached: bool,
+    ) -> Dict[str, Any]:
+        existing = self._read_pidfile(name)
+        if existing and _pid_alive(int(existing["pid"])):
+            raise RuntimeError_(
+                f"Service '{name}' is already running (pid {existing['pid']}). "
+                f"Use 'nexus restart' or 'nexus down' first."
+            )
+        if existing:
+            self._pidfile(name).unlink()  # stale pidfile from a dead process
+        if _port_open(service.host, service.port):
+            raise RuntimeError_(
+                f"Port {service.port} is already in use by an unmanaged process; "
+                f"refusing to spawn '{name}'. Adjust [runtime.services.{name}] "
+                f"port or stop the other process."
+            )
+        pid = self._spawn(name, service, slot, detached=detached)
+        self._await_healthy(name, service, pid)
+        record = {
+            "pid": pid,
+            "service": name,
+            "port": service.port,
+            "host": service.host,
+            "slot": slot,
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "command": self._service_argv(service),
+            "log": str(self.log_path(name)),
+        }
+        self._write_pidfile(name, record)
+        return record
+
+    # ------------------------------------------------------------------
+    # Public verbs
+    # ------------------------------------------------------------------
+
+    def up(
+        self,
+        slot: Optional[int] = None,
+        foreground: bool = False,
+        echo: bool = True,
+    ) -> Dict[str, Any]:
+        """Start the runtime per the configured profile."""
+        profile = self.runtime.profile
+        if profile == "external":
+            return self._attach_external()
+        if profile == "remote":
+            return self._check_remote()
+
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        resolved_slot = self._resolve_slot(slot)
+        ui_index = self.root / "ui" / "dist" / "public" / "index.html"
+        if echo and not ui_index.exists():
+            print(
+                "warning: ui/dist/public/index.html is missing - the gateway "
+                "will serve 503 for UI routes. Build it with: "
+                "npm --prefix ui run build",
+                file=sys.stderr,
+            )
+
+        started: Dict[str, Any] = {}
+        try:
+            for name, service in self.enabled_services().items():
+                record = self._start_service(
+                    name, service, resolved_slot, detached=not foreground
+                )
+                started[name] = record
+                if echo:
+                    print(
+                        f"started {name} (pid {record['pid']}) on "
+                        f"http://{service.host}:{service.port}"
+                    )
+        except Exception:
+            # Partial starts are torn down so up() is all-or-nothing.
+            for name in started:
+                self._stop_service(name)
+            raise
+
+        gateway = self.runtime.services.get("gateway")
+        if echo and gateway:
+            print(
+                f"NEXUS is up: http://{gateway.host}:{gateway.port} "
+                f"(slot {resolved_slot}, profile local)"
+            )
+
+        if foreground:
+            self._foreground_loop(resolved_slot, echo=echo)
+            return {"success": True, "profile": profile, "stopped": True}
+        return {
+            "success": True,
+            "profile": profile,
+            "slot": resolved_slot,
+            "services": started,
+        }
+
+    def _attach_external(self) -> Dict[str, Any]:
+        external = self.runtime.external
+        targets = {"gateway": external.gateway_url.rstrip("/") + "/health"}
+        if external.mock_openai_url:
+            targets["mock_openai"] = external.mock_openai_url.rstrip("/") + "/health"
+        results: Dict[str, Any] = {}
+        failures = []
+        for name, url in targets.items():
+            ok = self._probe(url)
+            results[name] = {"ok": ok, "url": url}
+            if not ok:
+                failures.append(f"{name} ({url})")
+        if failures:
+            raise RuntimeError_(
+                "External profile attach failed; unhealthy services: "
+                + ", ".join(failures)
+            )
+        return {"success": True, "profile": "external", "services": results}
+
+    def _check_remote(self) -> Dict[str, Any]:
+        remote = self.runtime.remote
+        url = remote.base_url.rstrip("/") + RUNTIME_STATUS_PATH
+        response = requests.get(
+            url,
+            timeout=self.runtime.health.timeout_seconds,
+            headers={NEXUS_AUTH_HEADER: os.environ.get("NEXUS_AUTH", "")},
+        )
+        response.raise_for_status()
+        return {"success": True, "profile": "remote", "runtime": response.json()}
+
+    def _probe(self, url: str) -> bool:
+        try:
+            return (
+                requests.get(
+                    url, timeout=self.runtime.health.timeout_seconds
+                ).status_code
+                == 200
+            )
+        except requests.RequestException:
+            return False
+
+    def _stop_pid(self, pid: int) -> None:
+        grace = self.runtime.health.stop_grace_seconds
+        if not _pid_alive(pid):
+            return
+        _signal_pid(pid, signal.SIGTERM)
+        deadline = time.monotonic() + grace
+        while _pid_alive(pid) and time.monotonic() < deadline:
+            time.sleep(0.1)
+        if _pid_alive(pid):
+            kill_sig = signal.SIGKILL if os.name == "posix" else signal.SIGTERM
+            _signal_pid(pid, kill_sig)
+            time.sleep(0.2)
+
+    def _stop_service(self, name: str) -> Optional[int]:
+        record = self._read_pidfile(name)
+        if record is None:
+            return None
+        pid = int(record["pid"])
+        self._stop_pid(pid)
+        self._pidfile(name).unlink(missing_ok=True)
+        return pid
+
+    def down(self, service: Optional[str] = None) -> Dict[str, Any]:
+        """Stop managed services and remove their pidfiles (local only)."""
+        if self.runtime.profile != "local":
+            raise RuntimeError_(
+                f"'nexus down' manages local processes; profile is "
+                f"'{self.runtime.profile}'."
+            )
+        names = (
+            [service]
+            if service
+            else [
+                p.name[: -len(".pid.json")] for p in self.state_dir.glob("*.pid.json")
+            ]
+        )
+        stopped: Dict[str, Any] = {}
+        for name in names:
+            record = self._read_pidfile(name)
+            pid = self._stop_service(name)
+            if pid is None:
+                continue
+            stopped[name] = {"pid": pid}
+            if record and _port_open(record.get("host", "127.0.0.1"), record["port"]):
+                raise RuntimeError_(
+                    f"Service '{name}' was signaled but port {record['port']} is "
+                    f"still open - a process outlived shutdown."
+                )
+        return {"success": True, "stopped": stopped}
+
+    def restart(
+        self, service: Optional[str] = None, slot: Optional[int] = None
+    ) -> Dict[str, Any]:
+        if self.runtime.profile != "local":
+            raise RuntimeError_(
+                f"'nexus restart' manages local processes; profile is "
+                f"'{self.runtime.profile}'."
+            )
+        if service:
+            services = self.enabled_services()
+            if service not in services:
+                raise RuntimeError_(
+                    f"Unknown or disabled service '{service}'. Enabled: "
+                    f"{sorted(services)}"
+                )
+            previous = self._read_pidfile(service)
+            self._stop_service(service)
+            resolved_slot = self._resolve_slot(
+                slot if slot is not None else (previous or {}).get("slot")
+            )
+            record = self._start_service(
+                service, services[service], resolved_slot, detached=True
+            )
+            return {"success": True, "services": {service: record}}
+        self.down()
+        return self.up(slot=slot, echo=False)
+
+    # ------------------------------------------------------------------
+    # Status
+    # ------------------------------------------------------------------
+
+    def _gateway_url(self) -> str:
+        if self.runtime.profile == "external":
+            return self.runtime.external.gateway_url.rstrip("/")
+        if self.runtime.profile == "remote":
+            return self.runtime.remote.base_url.rstrip("/")
+        gateway = self.runtime.services["gateway"]
+        return f"http://{gateway.host}:{gateway.port}"
+
+    def _fetch_runtime_status(self) -> Dict[str, Any]:
+        url = self._gateway_url() + RUNTIME_STATUS_PATH
+        try:
+            response = requests.get(
+                url,
+                timeout=self.runtime.health.timeout_seconds,
+                headers={NEXUS_AUTH_HEADER: os.environ.get("NEXUS_AUTH", "")},
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as exc:
+            return {"error": f"runtime status unreachable at {url}: {exc}"}
+
+    def status(self) -> Dict[str, Any]:
+        """Supervisor-side process state merged with /runtime/status."""
+        result: Dict[str, Any] = {
+            "success": True,
+            "profile": self.runtime.profile,
+            "config": str(self.config_path),
+            "gateway_url": self._gateway_url(),
+        }
+        if self.runtime.profile == "local":
+            processes: Dict[str, Any] = {}
+            for name, service in self.runtime.services.items():
+                record = self._read_pidfile(name)
+                if record and _pid_alive(int(record["pid"])):
+                    started = datetime.fromisoformat(record["started_at"])
+                    uptime = (datetime.now(timezone.utc) - started).total_seconds()
+                    processes[name] = {
+                        "state": "running",
+                        "pid": record["pid"],
+                        "port": record["port"],
+                        "slot": record.get("slot"),
+                        "uptime_seconds": round(uptime, 1),
+                    }
+                else:
+                    processes[name] = {"state": "stopped", "port": service.port}
+            result["processes"] = processes
+        result["runtime"] = self._fetch_runtime_status()
+        return result
+
+    # ------------------------------------------------------------------
+    # Logs
+    # ------------------------------------------------------------------
+
+    def logs(
+        self,
+        service: str = "gateway",
+        lines: Optional[int] = None,
+        follow: bool = False,
+    ) -> Iterator[str]:
+        """Yield captured log lines for a service; generator so -f can stream."""
+        if self.runtime.profile != "local":
+            raise RuntimeError_(
+                f"'nexus logs' reads captured local logs; profile is "
+                f"'{self.runtime.profile}'."
+            )
+        log_path = self.log_path(service)
+        if not log_path.exists():
+            raise RuntimeError_(
+                f"No captured log for service '{service}' at {log_path}. "
+                f"Known services: {sorted(self.runtime.services)}"
+            )
+        count = lines if lines is not None else self.runtime.logs.tail_lines
+        for line in _tail_lines(log_path, count):
+            yield line
+        if not follow:
+            return
+        with open(log_path, "rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            while True:
+                chunk = handle.readline()
+                if chunk:
+                    yield chunk.decode("utf-8", errors="replace").rstrip("\n")
+                else:
+                    time.sleep(self.runtime.logs.follow_poll_seconds)
+
+    # ------------------------------------------------------------------
+    # Foreground supervision
+    # ------------------------------------------------------------------
+
+    def _foreground_loop(self, slot: int, echo: bool = True) -> None:
+        """Tail service logs to the console and supervise until interrupted."""
+        offsets: Dict[str, int] = {}
+        restarts: Dict[str, int] = {}
+        services = self.enabled_services()
+        for name in services:
+            path = self.log_path(name)
+            offsets[name] = path.stat().st_size if path.exists() else 0
+
+        interrupted = {"flag": False}
+
+        def _handle_signal(_signum, _frame):
+            interrupted["flag"] = True
+
+        previous_handlers = {
+            sig: signal.signal(sig, _handle_signal)
+            for sig in (signal.SIGINT, signal.SIGTERM)
+        }
+        try:
+            while not interrupted["flag"]:
+                for name in services:
+                    path = self.log_path(name)
+                    if not path.exists():
+                        continue
+                    size = path.stat().st_size
+                    if size > offsets[name]:
+                        with open(path, "rb") as handle:
+                            handle.seek(offsets[name])
+                            data = handle.read()
+                        offsets[name] = size
+                        if echo:
+                            text = data.decode("utf-8", errors="replace")
+                            for line in text.splitlines():
+                                print(f"[{name}] {line}")
+                self._check_children(services, slot, restarts, echo=echo)
+                time.sleep(self.runtime.logs.follow_poll_seconds)
+        finally:
+            for sig, handler in previous_handlers.items():
+                signal.signal(sig, handler)
+            if echo:
+                print("shutting down...")
+            self.down()
+
+    def _check_children(
+        self,
+        services: Dict[str, RuntimeServiceSettings],
+        slot: int,
+        restarts: Dict[str, int],
+        echo: bool,
+    ) -> None:
+        for name, service in services.items():
+            record = self._read_pidfile(name)
+            if record is None or _pid_alive(int(record["pid"])):
+                continue
+            self._pidfile(name).unlink(missing_ok=True)
+            if service.autorestart != "on-failure":
+                raise RuntimeError_(
+                    f"Service '{name}' (pid {record['pid']}) exited and "
+                    f"autorestart is 'never'."
+                )
+            attempts = restarts.get(name, 0)
+            if attempts >= service.autorestart_max_retries:
+                raise RuntimeError_(
+                    f"Service '{name}' exceeded autorestart_max_retries "
+                    f"({service.autorestart_max_retries})."
+                )
+            restarts[name] = attempts + 1
+            if echo:
+                print(
+                    f"[{name}] exited; restarting "
+                    f"({restarts[name]}/{service.autorestart_max_retries})"
+                )
+            self._start_service(name, service, slot, detached=False)

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -29,6 +29,7 @@ def test_model_config_rejects_unknown_default_model():
                 "test": ProviderModels(
                     roles={"default": "TEST"},
                     models=[APIModelEntry(id="TEST", label="TEST")],
+                    base_url="http://127.0.0.1:5102/v1",
                 )
             },
         )
@@ -43,6 +44,7 @@ def test_model_config_defers_role_references_to_settings_resolution():
             "test": ProviderModels(
                 roles={"default": "TEST"},
                 models=[APIModelEntry(id="TEST", label="TEST")],
+                base_url="http://127.0.0.1:5102/v1",
             )
         },
     )
@@ -128,3 +130,78 @@ def test_ui_visible_filters_ui_model_lists_but_not_registry():
 
     # Backend role resolution is untouched by UI visibility.
     assert resolve_model_ref("@test.default") == "TEST"
+
+
+# =============================================================================
+# Registry base_url + per-model parameter capability (#401)
+# =============================================================================
+
+
+def test_non_native_provider_requires_base_url():
+    """Providers outside the native SDK set must declare an endpoint."""
+    raw = _nexus_toml_dict()
+    del raw["global"]["model"]["api_models"]["test"]["base_url"]
+    with pytest.raises(ValidationError, match="must declare a base_url"):
+        Settings(**raw)
+
+
+def test_native_provider_rejects_base_url():
+    """Native SDK providers use their own endpoints; base_url is a config error."""
+    raw = _nexus_toml_dict()
+    raw["global"]["model"]["api_models"]["openai"]["base_url"] = "http://x/v1"
+    with pytest.raises(ValidationError, match="base_url is not allowed"):
+        Settings(**raw)
+
+
+def test_configured_param_rejected_when_model_declares_it_unsupported():
+    """[orrery.narration] temperature on a temperature-rejecting model fails load.
+
+    This is the #401 proving instance: the narration model resolves to a model
+    whose registry entry lists 'temperature' in unsupported_params, so setting
+    temperature in nexus.toml must be refused at config load, not at request
+    time.
+    """
+    raw = _nexus_toml_dict()
+    narration_model = Settings(**raw).orrery.narration.model_ref
+    assert "temperature" in {
+        p
+        for provider in Settings(**raw).global_.model.api_models.values()
+        for entry in provider.models
+        if entry.id == narration_model
+        for p in entry.unsupported_params
+    }, f"expected nexus.toml to declare temperature unsupported for {narration_model}"
+
+    raw["orrery"]["narration"]["temperature"] = 0.4
+    with pytest.raises(ValidationError, match="declares 'temperature' unsupported"):
+        Settings(**raw)
+
+
+def test_configured_param_allowed_when_model_supports_it():
+    """A supporting model (Sonnet 4.6) accepts a configured temperature."""
+    raw = _nexus_toml_dict()
+    raw["orrery"]["narration"]["model_ref"] = "claude-sonnet-4-6"
+    raw["orrery"]["narration"]["temperature"] = 0.4
+    settings = Settings(**raw)
+    assert settings.orrery.narration.temperature == 0.4
+
+
+def test_narration_temperature_unset_by_default():
+    """Shipped config omits narration temperature so the param is never sent."""
+    settings = load_settings("nexus.toml")
+    assert settings.orrery.narration.temperature is None
+
+
+def test_get_openai_compatible_endpoint_routing():
+    """Registry base_url providers resolve to an endpoint; native ones do not."""
+    from nexus.config import get_openai_compatible_endpoint
+
+    settings = load_settings("nexus.toml")
+    endpoint = get_openai_compatible_endpoint("TEST")
+    assert endpoint == {
+        "base_url": settings.global_.model.api_models["test"].base_url,
+        "api_key": "nexus-local-no-key",
+    }
+    assert get_openai_compatible_endpoint("gpt-5.5") is None
+    assert get_openai_compatible_endpoint("claude-opus-4-8") is None
+    # Models absent from the registry are treated as native/legacy overrides.
+    assert get_openai_compatible_endpoint("unregistered-model") is None

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -3,6 +3,7 @@
 import tomllib
 
 import pytest
+import tomlkit
 from pydantic import ValidationError
 
 from nexus.config import load_settings, resolve_model_ref
@@ -205,3 +206,36 @@ def test_get_openai_compatible_endpoint_routing():
     assert get_openai_compatible_endpoint("claude-opus-4-8") is None
     # Models absent from the registry are treated as native/legacy overrides.
     assert get_openai_compatible_endpoint("unregistered-model") is None
+
+
+def test_default_load_honors_runtime_config_env(tmp_path, monkeypatch):
+    """Managed services use the config path exported by the supervisor."""
+    from nexus.config import get_openai_compatible_endpoint
+    from nexus.config.loader import get_provider_for_model
+
+    raw = _nexus_toml_dict()
+    raw["global"]["model"]["default_slot_model"] = "TEMPTEST"
+    raw["global"]["model"]["api_models"]["test"]["roles"]["default"] = "TEMPTEST"
+    raw["global"]["model"]["api_models"]["test"]["models"][0]["id"] = "TEMPTEST"
+    raw["global"]["model"]["api_models"]["test"][
+        "base_url"
+    ] = "http://127.0.0.1:5999/v1"
+    raw["runtime"]["services"]["mock_openai"]["port"] = 5999
+    config = tmp_path / "runtime.toml"
+    config.write_text(tomlkit.dumps(raw))
+
+    monkeypatch.setenv("NEXUS_RUNTIME_CONFIG", str(config))
+
+    assert (
+        load_settings().global_.model.api_models["test"].models[0].id == "TEMPTEST"
+    )
+    assert get_provider_for_model("TEMPTEST") == "test"
+    assert get_openai_compatible_endpoint("TEMPTEST") == {
+        "base_url": "http://127.0.0.1:5999/v1",
+        "api_key": "nexus-local-no-key",
+    }
+    assert (
+        load_settings("nexus.toml")
+        .global_.model.api_models["test"]
+        .base_url.endswith(":5102/v1")
+    )

--- a/tests/test_api/test_pydantic_ai_utils.py
+++ b/tests/test_api/test_pydantic_ai_utils.py
@@ -1,0 +1,19 @@
+"""Pydantic-AI wiring regressions."""
+
+import pytest
+
+from nexus.api import pydantic_ai_utils
+
+
+def test_build_pydantic_ai_model_requires_base_url_for_non_native(monkeypatch):
+    """Non-native providers must resolve to an OpenAI-compatible endpoint."""
+
+    monkeypatch.setattr(
+        pydantic_ai_utils, "get_provider_for_model", lambda model: "local"
+    )
+    monkeypatch.setattr(
+        pydantic_ai_utils, "get_openai_compatible_endpoint", lambda model: None
+    )
+
+    with pytest.raises(ValueError, match="No base_url registry entry"):
+        pydantic_ai_utils.build_pydantic_ai_model("LOCAL")

--- a/tests/test_api/test_runtime_status.py
+++ b/tests/test_api/test_runtime_status.py
@@ -1,0 +1,44 @@
+"""Runtime status endpoint regressions."""
+
+from contextlib import contextmanager
+
+from nexus.api import db_pool
+from nexus.api import runtime_status
+
+
+def test_database_status_uses_api_connection_path(monkeypatch):
+    """The status probe must reuse API DB connection settings."""
+
+    calls: list[str] = []
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def execute(self, sql: str) -> None:
+            assert sql == "SELECT 1"
+
+        def fetchone(self) -> tuple[int]:
+            return (1,)
+
+    class FakeConnection:
+        def cursor(self) -> FakeCursor:
+            return FakeCursor()
+
+    @contextmanager
+    def fake_get_connection(dbname: str):
+        calls.append(dbname)
+        yield FakeConnection()
+
+    monkeypatch.setenv("NEXUS_SLOT", "5")
+    monkeypatch.setattr(db_pool, "get_connection", fake_get_connection)
+
+    assert runtime_status._database_status() == {
+        "ok": True,
+        "slot": 5,
+        "dbname": "save_05",
+    }
+    assert calls == ["save_05"]

--- a/tests/test_api/test_runtime_status.py
+++ b/tests/test_api/test_runtime_status.py
@@ -2,6 +2,9 @@
 
 from contextlib import contextmanager
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
 from nexus.api import db_pool
 from nexus.api import runtime_status
 
@@ -42,3 +45,30 @@ def test_database_status_uses_api_connection_path(monkeypatch):
         "dbname": "save_05",
     }
     assert calls == ["save_05"]
+
+
+def test_runtime_status_endpoint_offloads_sync_builder(monkeypatch):
+    """The async endpoint must not run sync health probes on the event loop."""
+
+    calls = []
+
+    def fake_build_runtime_status():
+        return {"ok": True}
+
+    async def fake_to_thread(func):
+        calls.append(func)
+        return func()
+
+    monkeypatch.setattr(
+        runtime_status, "build_runtime_status", fake_build_runtime_status
+    )
+    monkeypatch.setattr(runtime_status.asyncio, "to_thread", fake_to_thread)
+
+    app = FastAPI()
+    runtime_status.register_runtime_status(app)
+
+    response = TestClient(app).get("/runtime/status")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert calls == [fake_build_runtime_status]

--- a/tests/test_model_registry_live.py
+++ b/tests/test_model_registry_live.py
@@ -1,0 +1,151 @@
+"""Live verification for the model registry endpoint/param-capability work (#401).
+
+These tests make REAL calls:
+
+- the Orrery narration provider built from shipped nexus.toml settings must
+  succeed against the configured Anthropic narration model (the golden-gate
+  failure case was ``temperature=0.4`` hardcoded into the request);
+- the rejection itself is reproduced live, proving the registry's
+  ``unsupported_params`` declaration matches provider behavior;
+- an ``@openai.default`` role call still works through the OpenAI provider;
+- the TEST model works through an OpenAI-compatible server registered via the
+  first-class ``base_url`` registry field (a real mock_openai process).
+
+Run with: NEXUS_RUN_LIVE_LLM=1 python -m pytest tests/test_model_registry_live.py
+"""
+
+from __future__ import annotations
+
+import copy
+import subprocess
+import sys
+import time
+import tomllib
+from pathlib import Path
+
+import pytest
+import requests
+
+from nexus.config import load_settings
+from nexus.config.settings_models import Settings
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MOCK_PORT = 5133  # lane-assigned test port; never the dev stack's 5102
+
+pytestmark = pytest.mark.live_llm
+
+
+def _nexus_toml_dict() -> dict:
+    with open(REPO_ROOT / "nexus.toml", "rb") as handle:
+        return tomllib.load(handle)
+
+
+def test_narration_provider_succeeds_against_configured_anthropic_model():
+    """The exact failing call from issue #401, rebuilt from shipped config.
+
+    ``_narration_provider`` previously hardcoded ``temperature=0.4``, which the
+    Anthropic model selected in commit 2a1f15d4 rejects with a 400. With
+    sampling params sourced from [orrery.narration] (unset by default), the
+    real call must succeed.
+    """
+    from nexus.agents.orrery.worker import _narration_provider
+
+    settings = load_settings(REPO_ROOT / "nexus.toml")
+    narration = settings.orrery.narration.model_copy(
+        update={"max_output_tokens": 64}  # keep the live call cheap
+    )
+    provider = _narration_provider({"orrery": {"narration": narration}})
+
+    response = provider.get_completion(
+        "Write one sentence describing a courier crossing a rainy plaza."
+    )
+    assert response.content.strip(), "narration provider returned empty text"
+    assert provider.temperature is None, "no temperature configured, none sent"
+
+
+def test_temperature_rejected_live_matches_registry_declaration():
+    """Prove unsupported_params is true: temperature really 400s on the model."""
+    import anthropic
+
+    from scripts.api_anthropic import AnthropicProvider
+
+    settings = load_settings(REPO_ROOT / "nexus.toml")
+    model = settings.orrery.narration.model_ref
+    assert "temperature" in settings.model_entry(model).unsupported_params
+
+    provider = AnthropicProvider(model=model, temperature=0.4, max_tokens=16)
+    with pytest.raises(anthropic.BadRequestError, match="temperature"):
+        provider.get_completion("Say OK.")
+
+
+def test_openai_default_role_still_works():
+    """An @openai role resolves and completes through the OpenAI provider."""
+    from scripts.api_openai import OpenAIProvider
+
+    settings = load_settings(REPO_ROOT / "nexus.toml")
+    model = settings.resolve_model_ref("@openai.default")
+
+    provider = OpenAIProvider(model=model, max_output_tokens=64)
+    # The provider's reasoning-model detection must suppress temperature for
+    # models whose registry entry rejects it.
+    if "temperature" in settings.model_entry(model).unsupported_params:
+        assert provider.supports_temperature is False
+
+    response = provider.get_completion("Reply with the single word: ready")
+    assert response.content.strip(), "OpenAI provider returned empty text"
+
+
+def test_test_model_via_registry_base_url_against_real_mock_server():
+    """The TEST model routes through a registry base_url to a real local server."""
+    from scripts.api_openai import OpenAIProvider
+
+    raw = copy.deepcopy(_nexus_toml_dict())
+    raw["global"]["model"]["api_models"]["test"][
+        "base_url"
+    ] = f"http://127.0.0.1:{MOCK_PORT}/v1"
+    settings = Settings(**raw)
+    entry = settings.global_.model.api_models["test"]
+
+    server = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "nexus.api.mock_openai:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(MOCK_PORT),
+        ],
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        deadline = time.monotonic() + 30
+        while True:
+            try:
+                if (
+                    requests.get(
+                        f"http://127.0.0.1:{MOCK_PORT}/health", timeout=1
+                    ).status_code
+                    == 200
+                ):
+                    break
+            except requests.ConnectionError:
+                pass
+            if time.monotonic() > deadline:
+                raise TimeoutError("mock_openai did not become healthy in 30s")
+            time.sleep(0.25)
+
+        provider = OpenAIProvider(
+            model="TEST",
+            base_url=entry.base_url,
+            api_key="nexus-local-no-key",
+            max_output_tokens=64,
+        )
+        response = provider.get_completion("ping")
+        assert response.content.strip(), "mock server returned empty text"
+    finally:
+        server.terminate()
+        server.wait(timeout=10)

--- a/tests/test_model_registry_live.py
+++ b/tests/test_model_registry_live.py
@@ -103,6 +103,7 @@ def test_test_model_via_registry_base_url_against_real_mock_server():
     raw["global"]["model"]["api_models"]["test"][
         "base_url"
     ] = f"http://127.0.0.1:{MOCK_PORT}/v1"
+    raw["runtime"]["services"]["mock_openai"]["port"] = MOCK_PORT
     settings = Settings(**raw)
     entry = settings.global_.model.api_models["test"]
 

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -331,7 +331,9 @@ def test_drain_narration_outbox_does_not_lease_before_provider_ready() -> None:
     with pytest.raises(ValueError, match="Unsupported Orrery narration provider"):
         drain_narration_outbox_sync(
             slot=5,
-            settings={"orrery": {"narration": {"provider": "missing"}}},
+            settings={
+                "orrery": {"narration": {"provider": "missing", "model_ref": "TEST"}}
+            },
             conn=WorkerConn(cursor),
         )
 

--- a/tests/test_runtime/test_supervisor_live.py
+++ b/tests/test_runtime/test_supervisor_live.py
@@ -141,6 +141,20 @@ def test_local_profile_full_lifecycle(tmp_path):
         assert _pid_alive(mock_pid)
         assert requests.get(f"{base}/health", timeout=5).status_code == 200
 
+        # A full restart without --slot preserves the running slot instead of
+        # falling back to runtime.default_slot.
+        full_restart = _cli("restart", config=config)
+        assert full_restart["slot"] == TEST_SLOT
+        full_gateway_pid = full_restart["services"]["gateway"]["pid"]
+        full_mock_pid = full_restart["services"]["mock_openai"]["pid"]
+        assert full_gateway_pid != new_pid
+        assert full_mock_pid != mock_pid
+        runtime_status = requests.get(f"{base}/runtime/status", timeout=5).json()
+        assert runtime_status["slot"] == TEST_SLOT
+        assert runtime_status["database"]["dbname"] == f"save_0{TEST_SLOT}"
+        new_pid = full_gateway_pid
+        mock_pid = full_mock_pid
+
         # down leaves no orphans: pids dead, ports closed, pidfiles gone.
         down = _cli("down", config=config)
         assert set(down["stopped"]) == {"gateway", "mock_openai"}

--- a/tests/test_runtime/test_supervisor_live.py
+++ b/tests/test_runtime/test_supervisor_live.py
@@ -1,0 +1,287 @@
+"""Real process lifecycle tests for the managed runtime (issue #396).
+
+No mocks: these spawn the actual gateway and mock_openai with uvicorn via the
+real CLI entrypoint (``python -m nexus.cli``), probe real HTTP health, and
+assert teardown by port and pid. They run on lane-assigned ports (8032+/5133)
+so a developer stack on :8002/:5102 is never touched.
+
+Run with: NEXUS_RUN_POSTGRES=1 python -m pytest tests/test_runtime
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import requests
+import tomlkit
+
+from nexus.config import load_settings
+from nexus.runtime import RUNTIME_CONFIG_ENV, Supervisor
+from nexus.runtime.supervisor import _pid_alive, _port_open
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GATEWAY_PORT = 8032
+MOCK_PORT = 5133
+EXTERNAL_GATEWAY_PORT = 8034
+TEST_SLOT = 5
+
+pytestmark = pytest.mark.requires_postgres
+
+
+def _write_config(
+    tmp_path: Path,
+    *,
+    profile: str = "local",
+    gateway_port: int = GATEWAY_PORT,
+    mock_port: int = MOCK_PORT,
+    include_test_provider: bool = True,
+    external_gateway_url: str | None = None,
+    remote_base_url: str | None = None,
+) -> Path:
+    doc = tomlkit.parse((REPO_ROOT / "nexus.toml").read_text())
+    doc["runtime"]["profile"] = profile
+    doc["runtime"]["state_dir"] = str(tmp_path / "state")
+    doc["runtime"]["services"]["gateway"]["port"] = gateway_port
+    doc["runtime"]["services"]["mock_openai"]["port"] = mock_port
+    if include_test_provider:
+        doc["global"]["model"]["api_models"]["test"][
+            "base_url"
+        ] = f"http://127.0.0.1:{mock_port}/v1"
+    else:
+        del doc["global"]["model"]["api_models"]["test"]
+        # default_slot_model = "TEST" would dangle without the registry entry
+        doc["global"]["model"]["default_slot_model"] = "@openai.default"
+    if external_gateway_url:
+        doc["runtime"]["external"] = {"gateway_url": external_gateway_url}
+    if remote_base_url:
+        doc["runtime"]["remote"] = {"base_url": remote_base_url}
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path = tmp_path / "nexus.toml"
+    path.write_text(tomlkit.dumps(doc))
+    return path
+
+
+def _cli(*args: str, config: Path, timeout: float = 120) -> dict:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    completed = subprocess.run(
+        [sys.executable, "-m", "nexus.cli", "--json", *args, "--config", str(config)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=env,
+        timeout=timeout,
+    )
+    output = completed.stdout or completed.stderr
+    payload = json.loads(output)
+    payload["_returncode"] = completed.returncode
+    return payload
+
+
+def _down(config: Path) -> None:
+    _cli("down", config=config)
+
+
+def test_local_profile_full_lifecycle(tmp_path):
+    """up -> status -> logs -> restart -> down against real processes."""
+    config = _write_config(tmp_path)
+    try:
+        up = _cli("up", "--slot", str(TEST_SLOT), config=config)
+        assert up["_returncode"] == 0, up
+        assert set(up["services"]) == {"gateway", "mock_openai"}
+        gateway_pid = up["services"]["gateway"]["pid"]
+        assert _pid_alive(gateway_pid)
+
+        # The gateway answers /health and the aggregate /runtime/status.
+        base = f"http://127.0.0.1:{GATEWAY_PORT}"
+        assert requests.get(f"{base}/health", timeout=5).status_code == 200
+        status_response = requests.get(f"{base}/runtime/status", timeout=5)
+        assert status_response.status_code == 200
+        runtime_status = status_response.json()
+        assert runtime_status["profile"] == "local"
+        assert runtime_status["slot"] == TEST_SLOT
+        assert runtime_status["database"]["ok"] is True
+        assert runtime_status["database"]["dbname"] == f"save_0{TEST_SLOT}"
+        assert runtime_status["services"]["gateway"]["ok"] is True
+        assert runtime_status["services"]["mock_openai"]["ok"] is True
+        assert runtime_status["auth"]["header"] == "X-Nexus-Auth"
+        assert runtime_status["ok"] is True
+
+        # nexus status merges supervisor process state with the endpoint.
+        status = _cli("status", config=config)
+        assert status["processes"]["gateway"]["state"] == "running"
+        assert status["processes"]["gateway"]["pid"] == gateway_pid
+        assert status["processes"]["gateway"]["port"] == GATEWAY_PORT
+        assert status["processes"]["gateway"]["uptime_seconds"] >= 0
+        assert status["runtime"]["ok"] is True
+
+        # Captured logs are readable through nexus logs.
+        logs = _cli("logs", "gateway", "-n", "50", config=config)
+        assert logs["_returncode"] == 0
+        assert any("Uvicorn running" in line for line in logs["lines"])
+
+        # A second up refuses while services run.
+        again = _cli("up", config=config)
+        assert again["_returncode"] == 1
+        assert "already running" in again["error"]
+
+        # Restarting the gateway yields a new pid; mock_openai is untouched.
+        mock_pid = up["services"]["mock_openai"]["pid"]
+        restart = _cli("restart", "gateway", config=config)
+        new_pid = restart["services"]["gateway"]["pid"]
+        assert new_pid != gateway_pid
+        assert _pid_alive(new_pid)
+        assert _pid_alive(mock_pid)
+        assert requests.get(f"{base}/health", timeout=5).status_code == 200
+
+        # down leaves no orphans: pids dead, ports closed, pidfiles gone.
+        down = _cli("down", config=config)
+        assert set(down["stopped"]) == {"gateway", "mock_openai"}
+        for pid in (new_pid, mock_pid):
+            assert not _pid_alive(pid)
+        assert not _port_open("127.0.0.1", GATEWAY_PORT)
+        assert not _port_open("127.0.0.1", MOCK_PORT)
+        state_dir = tmp_path / "state"
+        assert not list(state_dir.glob("*.pid.json"))
+        # Captured logs survive shutdown for postmortem reading.
+        assert (state_dir / "gateway.log").exists()
+    finally:
+        _down(config)
+
+
+def test_up_refuses_port_held_by_unmanaged_process(tmp_path):
+    """A foreign listener on the gateway port is a hard error, not a takeover."""
+    config = _write_config(tmp_path)
+    blocker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    blocker.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    blocker.bind(("127.0.0.1", GATEWAY_PORT))
+    blocker.listen(1)
+    try:
+        result = _cli("up", config=config)
+        assert result["_returncode"] == 1
+        assert "already in use by an unmanaged process" in result["error"]
+        state_dir = tmp_path / "state"
+        assert not list(state_dir.glob("*.pid.json"))
+    finally:
+        blocker.close()
+        _down(config)
+
+
+def test_mock_openai_auto_gating_follows_test_provider(tmp_path):
+    """enabled='auto' spawns the mock only while TEST is in the registry."""
+    with_test = _write_config(tmp_path, include_test_provider=True)
+    supervisor = Supervisor.from_config(with_test)
+    assert set(supervisor.enabled_services()) == {"gateway", "mock_openai"}
+
+    without_test = _write_config(tmp_path / "no-test", include_test_provider=False)
+    supervisor = Supervisor.from_config(without_test)
+    assert set(supervisor.enabled_services()) == {"gateway"}
+
+
+@pytest.fixture()
+def external_gateway(tmp_path_factory):
+    """A gateway this test suite does NOT manage - started out-of-band."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    env["NEXUS_SLOT"] = str(TEST_SLOT)
+    env[RUNTIME_CONFIG_ENV] = str(REPO_ROOT / "nexus.toml")
+    log_path = tmp_path_factory.mktemp("external") / "gateway.log"
+    with open(log_path, "wb") as log:
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "uvicorn",
+                "nexus.api.narrative:app",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(EXTERNAL_GATEWAY_PORT),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+    url = f"http://127.0.0.1:{EXTERNAL_GATEWAY_PORT}"
+    deadline = time.monotonic() + 60
+    while True:
+        try:
+            if requests.get(f"{url}/health", timeout=1).status_code == 200:
+                break
+        except requests.RequestException:
+            pass
+        if time.monotonic() > deadline:
+            process.terminate()
+            raise TimeoutError(f"external gateway never became healthy:\n{log_path}")
+        time.sleep(0.25)
+    yield url
+    process.terminate()
+    process.wait(timeout=15)
+
+
+def test_external_profile_attaches_and_never_spawns(tmp_path, external_gateway):
+    """profile=external health-checks the running stack and manages nothing."""
+    config = _write_config(
+        tmp_path, profile="external", external_gateway_url=external_gateway
+    )
+    up = _cli("up", config=config)
+    assert up["_returncode"] == 0
+    assert up["profile"] == "external"
+    assert up["services"]["gateway"]["ok"] is True
+    # Nothing was spawned: no pidfiles appear.
+    assert not list((tmp_path / "state").glob("*.pid.json"))
+
+    status = _cli("status", config=config)
+    assert status["runtime"]["services"]["gateway"]["ok"] is True
+    assert "processes" not in status
+
+    down = _cli("down", config=config)
+    assert down["_returncode"] == 1
+    assert "profile" in down["error"]
+
+    logs = _cli("logs", config=config)
+    assert logs["_returncode"] == 1
+
+
+def test_external_profile_fails_loud_when_target_is_down(tmp_path):
+    """Attaching to a dead stack is an error, not a silent success."""
+    config = _write_config(
+        tmp_path,
+        profile="external",
+        external_gateway_url="http://127.0.0.1:39999",
+    )
+    up = _cli("up", config=config)
+    assert up["_returncode"] == 1
+    assert "unhealthy" in up["error"]
+
+
+def test_remote_profile_status_hits_runtime_endpoint(tmp_path, external_gateway):
+    """profile=remote reports the hosted runtime's /runtime/status."""
+    config = _write_config(tmp_path, profile="remote", remote_base_url=external_gateway)
+    up = _cli("up", config=config)
+    assert up["_returncode"] == 0
+    assert up["profile"] == "remote"
+    assert up["runtime"]["services"]["gateway"]["ok"] is True
+
+    status = _cli("status", config=config)
+    assert status["gateway_url"] == external_gateway
+    assert status["runtime"]["profile"] == "local"  # the remote host's profile
+    assert status["runtime"]["version"]
+
+
+def test_mock_port_must_match_test_base_url(tmp_path):
+    """Config-load consistency: mock service port vs test provider base_url."""
+    doc = tomlkit.parse((REPO_ROOT / "nexus.toml").read_text())
+    doc["runtime"]["services"]["mock_openai"]["port"] = 5999
+    path = tmp_path / "drift.toml"
+    path.write_text(tomlkit.dumps(doc))
+    with pytest.raises(Exception, match="does not match"):
+        load_settings(path)


### PR DESCRIPTION
Closes #396.
Refs #401.

## Summary

This is the C2 lane from the YOLO-at-C campaign, built on the merged gateway consolidation in #400.

- Adds the managed runtime surface: `nexus up/down/restart/status/logs`, local/external/remote profiles in `nexus.toml [runtime]`, and supervisor state/log handling under `.nexus/runtime`.
- Adds `GET /runtime/status` to the FastAPI gateway, with runtime profile, active slot/database health, service health, version, and the reserved `X-Nexus-Auth` contract.
- Documents the client/runtime boundary in `docs/runtime.md`, including the future hosted-runtime seam and `NEXUS_RUNTIME_CONFIG`.
- Promotes OpenAI-compatible model backends to first-class `base_url` registry rows, removes the old TEST-only URL path, and adds per-model `unsupported_params` validation.
- Fixes #401 signature 1 by moving Orrery narration sampling out of hardcoded request params and rejecting unsupported model params at config load.

## Validation

Self-verified in the C2 lane before handoff:

- Real-process runtime lifecycle tests on lane ports `8032/5133`: up/status/logs/restart/down, orphan assertions, double-up refusal, unmanaged-port refusal, auto-gating, external attach, remote status, and mock-port consistency validation.
- Live model registry verification: configured Anthropic narration succeeds without temperature, `temperature=0.4` reproduces the provider 400, `@openai.default` completes, and TEST completes via registry `base_url` against a real mock server.

## Integration Note

This PR intentionally does not close #401. The registry fix covers signature 1, but #401 is only closeable after this PR and the turn-8 hang fix both merge and the destructive slot-5 golden path gate passes on the combined tree.