### PR TITLE
Fix Golden Gate Turn-8 Hang (#401)

### DIFF
--- a/nexus/agents/lore/lore.py
+++ b/nexus/agents/lore/lore.py
@@ -304,6 +304,30 @@ class LORE:
         if self.logon is None:
             self._initialize_logon()
 
+    def close(self) -> None:
+        """Deterministically release this turn-stack's per-instance resources.
+
+        The narrative API constructs a fresh LORE per turn; the resulting
+        object graph is a reference-cycle island (LORE <-> TurnCycleManager,
+        MEMNON <-> ContentProcessor bound method) that plain refcounting
+        cannot reclaim, and CPython's throttled full GC effectively never
+        runs mid-session (issue #401's turn-8 hang). Callers that build a
+        LORE per request MUST close it when the turn finishes.
+
+        Closes MEMNON (disposing its engine/pool) and drops the component
+        back-references so the island collapses under refcounting alone.
+        The shared embedding-model cache is untouched by design.
+        """
+        if self.memnon is not None:
+            self.memnon.close()
+        # Break the cycles: these components hold back-references to self
+        # (directly or via bound methods). After close() the LORE instance
+        # is dead; any late access should fail loudly with AttributeError.
+        self.turn_manager = None
+        self.memory_manager = None
+        self.memnon = None
+        logger.info("LORE turn stack closed")
+
     async def process_turn(
         self,
         user_input: str,

--- a/nexus/agents/lore/lore.py
+++ b/nexus/agents/lore/lore.py
@@ -326,6 +326,8 @@ class LORE:
         self.turn_manager = None
         self.memory_manager = None
         self.memnon = None
+        self.logon = None
+        self._logon_initialized = False
         logger.info("LORE turn stack closed")
 
     async def process_turn(

--- a/nexus/agents/memnon/memnon.py
+++ b/nexus/agents/memnon/memnon.py
@@ -414,6 +414,16 @@ class MEMNON:
 
         logger.info("MEMNON agent initialized (Headless Mode - No LLM)")
 
+    def close(self) -> None:
+        """Release per-instance resources deterministically.
+
+        Disposes this instance's SQLAlchemy engine (returning pooled Postgres
+        connections). Embedding models are deliberately NOT released: they
+        live in the process-level cache in embedding_manager and are shared
+        by every MEMNON in this process (issue #401).
+        """
+        self.db_manager.close()
+
     def get_schema_summary(self, tables: Optional[List[str]] = None) -> str:
         """
         Return a concise schema summary for non-empty, relevant tables.

--- a/nexus/agents/memnon/utils/db_schema.py
+++ b/nexus/agents/memnon/utils/db_schema.py
@@ -194,6 +194,17 @@ class DatabaseManager:
         """
         return self.Session()
 
+    def close(self) -> None:
+        """Dispose the engine, returning all pooled connections to Postgres.
+
+        The narrative API builds a fresh MEMNON (and therefore a fresh
+        engine) per turn; without explicit disposal those pools sit in
+        reference-cycle garbage holding server-side connections until a full
+        GC that rarely arrives (issue #401). Deterministic teardown instead.
+        """
+        self.engine.dispose()
+        logger.info("DatabaseManager engine disposed")
+
     def get_model_classes(self) -> Dict[str, Any]:
         """
         Get dictionary of model classes defined in this module.

--- a/nexus/agents/memnon/utils/db_schema.py
+++ b/nexus/agents/memnon/utils/db_schema.py
@@ -99,6 +99,7 @@ class DatabaseManager:
         """
         self.db_url = db_url
         self.settings = settings or {}
+        self._closed = False
         self.engine = self._initialize_database_connection()
         self.Session = sessionmaker(bind=self.engine)
 
@@ -192,6 +193,8 @@ class DatabaseManager:
         Returns:
             SQLAlchemy session
         """
+        if self._closed:
+            raise RuntimeError("DatabaseManager is closed")
         return self.Session()
 
     def close(self) -> None:
@@ -203,6 +206,7 @@ class DatabaseManager:
         GC that rarely arrives (issue #401). Deterministic teardown instead.
         """
         self.engine.dispose()
+        self._closed = True
         logger.info("DatabaseManager engine disposed")
 
     def get_model_classes(self) -> Dict[str, Any]:

--- a/nexus/agents/memnon/utils/embedding_manager.py
+++ b/nexus/agents/memnon/utils/embedding_manager.py
@@ -4,6 +4,7 @@ Embedding Manager Utility for MEMNON Agent
 Handles initialization and usage of sentence transformer embedding models.
 """
 import logging
+import threading
 from pathlib import Path
 from typing import Dict, List, Any, Optional
 from sentence_transformers import SentenceTransformer
@@ -20,6 +21,40 @@ from sentence_transformers import SentenceTransformer
 #     print("Warning: Could not import MEMNON_SETTINGS. Using empty defaults.")
 
 logger = logging.getLogger("nexus.memnon.embedding_manager")
+
+# Process-level cache of loaded SentenceTransformer models, keyed by the
+# path string actually passed to the constructor. Mirrors _RERANKER_CACHE in
+# cross_encoder.py.
+#
+# This cache is load-bearing, not an optimization: the production embedder
+# (Octen-Embedding-4B) materializes ~15.5 GB of unified (MPS) memory per
+# instance, and the narrative API constructs a fresh LORE -> MEMNON ->
+# EmbeddingManager stack for every turn. Those per-turn stacks are reference
+# -cycle islands that CPython's throttled full GC does not reclaim mid-run,
+# so without sharing, each turn permanently ratchets the server's Metal
+# footprint by one full model copy -- exhausting a 128 GB machine at ~8
+# turns and hanging the event loop inside Metal allocation (issue #401).
+_MODEL_CACHE: Dict[str, SentenceTransformer] = {}
+_MODEL_CACHE_LOCK = threading.Lock()
+
+
+def _get_or_load_sentence_transformer(path: str) -> SentenceTransformer:
+    """Return the process-wide SentenceTransformer for ``path``.
+
+    Loads on first request and reuses the same instance for every subsequent
+    EmbeddingManager in this process. The lock is held across the load so
+    concurrent first requests cannot race two copies of a multi-gigabyte
+    model into memory.
+    """
+    with _MODEL_CACHE_LOCK:
+        model = _MODEL_CACHE.get(path)
+        if model is None:
+            model = SentenceTransformer(path)
+            _MODEL_CACHE[path] = model
+        else:
+            logger.info(f"Reusing process-cached SentenceTransformer: {path}")
+        return model
+
 
 class EmbeddingManager:
     """Manages embedding models for MEMNON."""
@@ -73,7 +108,7 @@ class EmbeddingManager:
                 local_path_obj = Path(local_path)
                 if local_path_obj.exists() and local_path_obj.is_dir():
                     try:
-                        model = SentenceTransformer(str(local_path_obj))
+                        model = _get_or_load_sentence_transformer(str(local_path_obj))
                         self.models[model_name] = model
                         logger.info(f"Loaded {model_name} from local path: {local_path}")
                         loaded = True
@@ -86,7 +121,7 @@ class EmbeddingManager:
             if not loaded and remote_path:
                 try:
                     logger.info(f"Attempting to load {model_name} from remote path: {remote_path}")
-                    model = SentenceTransformer(remote_path)
+                    model = _get_or_load_sentence_transformer(remote_path)
                     self.models[model_name] = model
                     logger.info(f"Loaded {model_name} from remote path: {remote_path}")
                     loaded = True
@@ -123,7 +158,7 @@ class EmbeddingManager:
             if name not in self.models and self.model_active_status.get(name, True): # Check active status
                 try:
                     logger.info(f"Loading default model {name} from {path}")
-                    self.models[name] = SentenceTransformer(path)
+                    self.models[name] = _get_or_load_sentence_transformer(path)
                     logger.info(f"Successfully loaded default {name}")
                 except Exception as e:
                     logger.warning(f"Failed to load default model {name}: {e}")

--- a/nexus/agents/memnon/utils/embedding_manager.py
+++ b/nexus/agents/memnon/utils/embedding_manager.py
@@ -3,6 +3,7 @@ Embedding Manager Utility for MEMNON Agent
 
 Handles initialization and usage of sentence transformer embedding models.
 """
+
 import logging
 import threading
 from pathlib import Path
@@ -13,17 +14,17 @@ from sentence_transformers import SentenceTransformer
 # For standalone testing, provide a default or load manually
 # REMOVED try...except block for top-level import
 # try:
-#     from ..memnon import MEMNON_SETTINGS 
+#     from ..memnon import MEMNON_SETTINGS
 # except ImportError:
 #     # Fallback for direct execution or testing
 #     # In a real scenario, settings should be loaded more robustly
-#     MEMNON_SETTINGS = {} 
+#     MEMNON_SETTINGS = {}
 #     print("Warning: Could not import MEMNON_SETTINGS. Using empty defaults.")
 
 logger = logging.getLogger("nexus.memnon.embedding_manager")
 
-# Process-level cache of loaded SentenceTransformer models, keyed by the
-# path string actually passed to the constructor. Mirrors _RERANKER_CACHE in
+# Process-level cache of loaded SentenceTransformer models, keyed by resolved
+# local paths or by remote model identifiers. Mirrors _RERANKER_CACHE in
 # cross_encoder.py.
 #
 # This cache is load-bearing, not an optimization: the production embedder
@@ -38,6 +39,14 @@ _MODEL_CACHE: Dict[str, SentenceTransformer] = {}
 _MODEL_CACHE_LOCK = threading.Lock()
 
 
+def _cache_key_for_path(path: str) -> str:
+    """Normalize local filesystem paths without rewriting remote model IDs."""
+    path_obj = Path(path)
+    if path_obj.exists():
+        return str(path_obj.resolve())
+    return path
+
+
 def _get_or_load_sentence_transformer(path: str) -> SentenceTransformer:
     """Return the process-wide SentenceTransformer for ``path``.
 
@@ -46,20 +55,21 @@ def _get_or_load_sentence_transformer(path: str) -> SentenceTransformer:
     concurrent first requests cannot race two copies of a multi-gigabyte
     model into memory.
     """
+    cache_key = _cache_key_for_path(path)
     with _MODEL_CACHE_LOCK:
-        model = _MODEL_CACHE.get(path)
+        model = _MODEL_CACHE.get(cache_key)
         if model is None:
             model = SentenceTransformer(path)
-            _MODEL_CACHE[path] = model
+            _MODEL_CACHE[cache_key] = model
         else:
-            logger.info(f"Reusing process-cached SentenceTransformer: {path}")
+            logger.info(f"Reusing process-cached SentenceTransformer: {cache_key}")
         return model
 
 
 class EmbeddingManager:
     """Manages embedding models for MEMNON."""
 
-    def __init__(self, settings: Dict[str, Any]): # Changed settings to be non-optional
+    def __init__(self, settings: Dict[str, Any]):  # Changed settings to be non-optional
         """
         Initialize the EmbeddingManager.
 
@@ -67,12 +77,12 @@ class EmbeddingManager:
             settings: MEMNON agent settings dictionary. Must be provided.
         """
         if settings is None:
-             # This case should ideally not happen if instantiated correctly from MEMNON
-             logger.error("EmbeddingManager initialized without settings!")
-             self.settings = {}
+            # This case should ideally not happen if instantiated correctly from MEMNON
+            logger.error("EmbeddingManager initialized without settings!")
+            self.settings = {}
         else:
-             self.settings = settings
-             
+            self.settings = settings
+
         self.models: Dict[str, SentenceTransformer] = {}
         self.model_active_status: Dict[str, bool] = {}
         self._initialize_models()
@@ -80,24 +90,28 @@ class EmbeddingManager:
     def _initialize_models(self):
         """Initialize embedding models based on settings."""
         model_configs = self.settings.get("models", {})
-        
+
         if not model_configs:
-             logger.warning("No embedding models defined in MEMNON settings. Vector search might be unavailable.")
-             # Attempt to load defaults if no config provided
-             self._load_default_models()
-             return
+            logger.warning(
+                "No embedding models defined in MEMNON settings. Vector search might be unavailable."
+            )
+            # Attempt to load defaults if no config provided
+            self._load_default_models()
+            return
 
         # Load each model defined in settings
         for model_name, model_config in model_configs.items():
             # Added: Check if model is explicitly set to active
-            is_active = model_config.get("is_active", True) # Default to True if flag is missing
+            is_active = model_config.get(
+                "is_active", True
+            )  # Default to True if flag is missing
             self.model_active_status[model_name] = is_active
             if not is_active:
                 logger.info(f"Skipping initialization for inactive model: {model_name}")
-                continue # Skip loading if not active
+                continue  # Skip loading if not active
 
             logger.info(f"Initializing active model {model_name}...")
-            
+
             local_path = model_config.get("local_path")
             remote_path = model_config.get("remote_path")
             # dimensions = model_config.get("dimensions") # Dimension info not directly used by ST library here
@@ -110,52 +124,72 @@ class EmbeddingManager:
                     try:
                         model = _get_or_load_sentence_transformer(str(local_path_obj))
                         self.models[model_name] = model
-                        logger.info(f"Loaded {model_name} from local path: {local_path}")
+                        logger.info(
+                            f"Loaded {model_name} from local path: {local_path}"
+                        )
                         loaded = True
                     except Exception as e:
-                        logger.warning(f"Failed to load {model_name} from local path '{local_path}': {e}")
+                        logger.warning(
+                            f"Failed to load {model_name} from local path '{local_path}': {e}"
+                        )
                 else:
-                    logger.warning(f"Local path for {model_name} does not exist or is not a directory: {local_path}")
-            
+                    logger.warning(
+                        f"Local path for {model_name} does not exist or is not a directory: {local_path}"
+                    )
+
             # Fall back to remote path if local failed or wasn't specified
             if not loaded and remote_path:
                 try:
-                    logger.info(f"Attempting to load {model_name} from remote path: {remote_path}")
+                    logger.info(
+                        f"Attempting to load {model_name} from remote path: {remote_path}"
+                    )
                     model = _get_or_load_sentence_transformer(remote_path)
                     self.models[model_name] = model
                     logger.info(f"Loaded {model_name} from remote path: {remote_path}")
                     loaded = True
                 except Exception as e:
-                    logger.warning(f"Failed to load {model_name} from remote path '{remote_path}': {e}")
-            
+                    logger.warning(
+                        f"Failed to load {model_name} from remote path '{remote_path}': {e}"
+                    )
+
             if not loaded:
-                 logger.error(f"Could not load embedding model '{model_name}' from either local or remote paths.")
+                logger.error(
+                    f"Could not load embedding model '{model_name}' from either local or remote paths."
+                )
 
         # If absolutely no models were loaded after checking config, try defaults as last resort
         if not self.models:
-            logger.warning("No active models loaded from settings, attempting to load hardcoded defaults...")
+            logger.warning(
+                "No active models loaded from settings, attempting to load hardcoded defaults..."
+            )
             # Defaults are assumed active if loaded
             self._load_default_models()
             # Update active status for defaults that were loaded
             for name in self.models:
-                 if name not in self.model_active_status:
-                      self.model_active_status[name] = True
+                if name not in self.model_active_status:
+                    self.model_active_status[name] = True
 
-        active_models = self.get_available_models() # Get filtered list
+        active_models = self.get_available_models()  # Get filtered list
         if not active_models:
-            logger.error("CRITICAL: No ACTIVE embedding models could be loaded. Vector search will be unavailable.")
+            logger.error(
+                "CRITICAL: No ACTIVE embedding models could be loaded. Vector search will be unavailable."
+            )
         else:
-            logger.info(f"EmbeddingManager initialized with {len(active_models)} active models: {', '.join(active_models)}")
+            logger.info(
+                f"EmbeddingManager initialized with {len(active_models)} active models: {', '.join(active_models)}"
+            )
 
     def _load_default_models(self):
         """Loads hardcoded default models as a fallback."""
         defaults = {
             "bge-large": "BAAI/bge-large-en",
-            "e5-large": "intfloat/e5-large-v2"
+            "e5-large": "intfloat/e5-large-v2",
         }
         for name, path in defaults.items():
             # Only load if not present AND not explicitly marked inactive in config
-            if name not in self.models and self.model_active_status.get(name, True): # Check active status
+            if name not in self.models and self.model_active_status.get(
+                name, True
+            ):  # Check active status
                 try:
                     logger.info(f"Loading default model {name} from {path}")
                     self.models[name] = _get_or_load_sentence_transformer(path)
@@ -166,13 +200,17 @@ class EmbeddingManager:
     def get_model(self, model_key: str) -> Optional[SentenceTransformer]:
         """Get a specific embedding model by key."""
         if not self.model_active_status.get(model_key, False):
-             logger.warning(f"Attempted to get inactive model: '{model_key}'")
-             return None
+            logger.warning(f"Attempted to get inactive model: '{model_key}'")
+            return None
         return self.models.get(model_key)
 
     def get_available_models(self) -> List[str]:
         """Return a list of keys for the loaded models."""
-        return [name for name, model in self.models.items() if self.model_active_status.get(name, False)]
+        return [
+            name
+            for name, model in self.models.items()
+            if self.model_active_status.get(name, False)
+        ]
 
     def generate_embedding(self, text: str, model_key: str) -> Optional[List[float]]:
         """
@@ -190,22 +228,27 @@ class EmbeddingManager:
             # get_model already logged warning if inactive
             # logger.error(f"Model '{model_key}' not found or not active.") # Simplified log message
             return None
-        
+
         try:
             # Ensure text is not empty
             if not text or not isinstance(text, str) or not text.strip():
-                 logger.warning(f"Attempted to generate embedding for empty or invalid text with model {model_key}. Returning None.")
-                 return None
+                logger.warning(
+                    f"Attempted to generate embedding for empty or invalid text with model {model_key}. Returning None."
+                )
+                return None
 
             embedding = model.encode(text)
             return embedding.tolist()
         except Exception as e:
             logger.error(f"Error generating embedding with model '{model_key}': {e}")
             import traceback
+
             logger.debug(f"Traceback: {traceback.format_exc()}")
             return None
 
-    def generate_embeddings_batch(self, texts: List[str], model_key: str) -> Optional[List[List[float]]]:
+    def generate_embeddings_batch(
+        self, texts: List[str], model_key: str
+    ) -> Optional[List[List[float]]]:
         """
         Generate embeddings for a batch of texts using the specified model.
 
@@ -221,48 +264,58 @@ class EmbeddingManager:
             # get_model already logged warning if inactive
             # logger.error(f"Model '{model_key}' not found or not active for batch generation.")
             return None
-            
+
         # Filter out empty texts before sending to model
-        valid_texts = [text for text in texts if text and isinstance(text, str) and text.strip()]
+        valid_texts = [
+            text for text in texts if text and isinstance(text, str) and text.strip()
+        ]
         if not valid_texts:
-             logger.warning(f"generate_embeddings_batch called with no valid texts for model {model_key}. Returning empty list.")
-             return []
+            logger.warning(
+                f"generate_embeddings_batch called with no valid texts for model {model_key}. Returning empty list."
+            )
+            return []
         if len(valid_texts) < len(texts):
-             logger.warning(f"Filtered out {len(texts) - len(valid_texts)} empty/invalid texts from batch for model {model_key}.")
+            logger.warning(
+                f"Filtered out {len(texts) - len(valid_texts)} empty/invalid texts from batch for model {model_key}."
+            )
 
         try:
             embeddings = model.encode(valid_texts)
             return [emb.tolist() for emb in embeddings]
         except Exception as e:
-            logger.error(f"Error generating batch embeddings with model '{model_key}': {e}")
+            logger.error(
+                f"Error generating batch embeddings with model '{model_key}': {e}"
+            )
             import traceback
+
             logger.debug(f"Traceback: {traceback.format_exc()}")
             return None
+
 
 # Example usage (for testing purposes)
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     logger.info("Testing EmbeddingManager...")
-    
+
     # Create dummy settings if needed (since top-level import was removed)
     # In a real test setup, you might load settings from a file here.
     test_settings = {
         "models": {
-             "bge-small-test": {
-                 "remote_path": "BAAI/bge-small-en-v1.5", # Use a real small model for testing
-                 "local_path": None,
-                 "is_active": True
-             },
-              "nonexistent-model": {
-                  "local_path": "/path/does/not/exist",
-                   "remote_path": "fake/model-path",
-                   "is_active": False
-              }
+            "bge-small-test": {
+                "remote_path": "BAAI/bge-small-en-v1.5",  # Use a real small model for testing
+                "local_path": None,
+                "is_active": True,
+            },
+            "nonexistent-model": {
+                "local_path": "/path/does/not/exist",
+                "remote_path": "fake/model-path",
+                "is_active": False,
+            },
         }
     }
 
     manager = EmbeddingManager(settings=test_settings)
-    
+
     print(f"Available models: {manager.get_available_models()}")
 
     test_text = "This is a test sentence."
@@ -276,24 +329,30 @@ if __name__ == "__main__":
             print(f"  First 5 values: {embedding[:5]}")
         else:
             print(f"Failed to generate embedding for {model_to_use}.")
-            
+
         # Test batch embedding
         batch_texts = ["First sentence.", "", "Third sentence.", "Another test."]
         batch_embeddings = manager.generate_embeddings_batch(batch_texts, model_to_use)
         if batch_embeddings is not None:
-             print(f"\nGenerated batch embeddings using {model_to_use}:")
-             print(f"  Requested: {len(batch_texts)}, Generated: {len(batch_embeddings)}")
-             if batch_embeddings:
-                 print(f"  Dimensions of first embedding: {len(batch_embeddings[0])}")
+            print(f"\nGenerated batch embeddings using {model_to_use}:")
+            print(
+                f"  Requested: {len(batch_texts)}, Generated: {len(batch_embeddings)}"
+            )
+            if batch_embeddings:
+                print(f"  Dimensions of first embedding: {len(batch_embeddings[0])}")
         else:
-             print(f"\nFailed to generate batch embeddings for {model_to_use}.")
+            print(f"\nFailed to generate batch embeddings for {model_to_use}.")
 
     else:
-         print(f"Model {model_to_use} not available for testing.")
+        print(f"Model {model_to_use} not available for testing.")
 
     # Test getting a non-existent model
     print(f"\nAttempting to get non-existent model: {manager.get_model('invalid-key')}")
-    print(f"Attempting to generate embedding with non-existent model: {manager.generate_embedding(test_text, 'invalid-key')}")
-    
+    print(
+        f"Attempting to generate embedding with non-existent model: {manager.generate_embedding(test_text, 'invalid-key')}"
+    )
+
     # Test generating embedding for empty text
-    print(f"Attempting to generate embedding for empty text: {manager.generate_embedding('', model_to_use)}") 
+    print(
+        f"Attempting to generate embedding for empty text: {manager.generate_embedding('', model_to_use)}"
+    )

--- a/nexus/api/mock_openai.py
+++ b/nexus/api/mock_openai.py
@@ -766,17 +766,25 @@ def _mock_storyteller_response(prompt: str) -> Dict[str, Any]:
     }
 
 
-def _responses_payload(output_data: Dict[str, Any]) -> Dict[str, Any]:
+def _responses_payload(
+    output_data: Dict[str, Any], *, final_result_tool: bool = False
+) -> Dict[str, Any]:
     """Format structured JSON as an OpenAI Responses-compatible payload."""
 
     output_json = json.dumps(output_data)
-    return {
-        "id": f"resp-mock-{uuid.uuid4().hex[:8]}",
-        "object": "response",
-        "created_at": int(datetime.now().timestamp()),
-        "model": "TEST",
-        "status": "completed",
-        "output": [
+    if final_result_tool:
+        output = [
+            {
+                "type": "function_call",
+                "id": f"fc-mock-{uuid.uuid4().hex[:8]}",
+                "call_id": f"call-mock-{uuid.uuid4().hex[:8]}",
+                "name": "final_result",
+                "arguments": output_json,
+                "status": "completed",
+            }
+        ]
+    else:
+        output = [
             {
                 "type": "message",
                 "id": f"msg-mock-{uuid.uuid4().hex[:8]}",
@@ -790,7 +798,14 @@ def _responses_payload(output_data: Dict[str, Any]) -> Dict[str, Any]:
                     }
                 ],
             }
-        ],
+        ]
+    return {
+        "id": f"resp-mock-{uuid.uuid4().hex[:8]}",
+        "object": "response",
+        "created_at": int(datetime.now().timestamp()),
+        "model": "TEST",
+        "status": "completed",
+        "output": output,
         "output_text": output_json,
         "usage": {
             "input_tokens": 1000,
@@ -856,9 +871,13 @@ async def responses_create(request: ResponsesRequest):
                 "[MOCK] Extended turn schema requested (%d Orrery proposals)",
                 len(proposal_ids),
             )
-            return _responses_payload(_mock_storyteller_response(input_text))
+            return _responses_payload(
+                _mock_storyteller_response(input_text), final_result_tool=True
+            )
         logger.info("[MOCK] Bootstrap schema requested, returning cached bootstrap")
-        return _responses_payload(get_cached_bootstrap_narrative())
+        return _responses_payload(
+            get_cached_bootstrap_narrative(), final_result_tool=True
+        )
 
     # Legacy keyword routing for callers without a structured-output tool.
     is_narrative = any(

--- a/nexus/api/mock_openai.py
+++ b/nexus/api/mock_openai.py
@@ -613,6 +613,24 @@ class ResponsesRequest(BaseModel):
     temperature: Optional[float] = None
     reasoning: Optional[Dict[str, Any]] = None
     text_format: Optional[Any] = None  # Pydantic schema for structured output
+    tools: Optional[Any] = None  # pydantic_ai output tool ("final_result")
+
+
+def _requested_output_properties(request: "ResponsesRequest") -> set:
+    """Return the property names of the structured-output tool, if present.
+
+    pydantic_ai delivers the caller's output schema as a ``final_result``
+    function tool with ``tool_choice: required``; the schema's top-level
+    properties identify WHICH Storyteller schema the caller will validate
+    against. Routing on this is exact, where the legacy keyword sniffing of
+    the prompt text was not (a turn request without Orrery proposals used to
+    fall through to the bootstrap-shaped payload and fail validation).
+    """
+    for tool in request.tools or []:
+        if isinstance(tool, dict) and tool.get("name") == "final_result":
+            params = tool.get("parameters") or {}
+            return set((params.get("properties") or {}).keys())
+    return set()
 
 
 def _collect_text(value: Any) -> str:
@@ -786,8 +804,11 @@ def get_cached_bootstrap_narrative() -> Dict[str, Any]:
     """
     Get bootstrap narrative from mock database.
 
-    Queries incubator and transforms to StorytellerResponseExtended format.
-    Must match the exact schema in nexus/agents/logon/apex_schema.py.
+    Queries incubator and transforms to StorytellerResponseBootstrap format
+    (narrative + choices + authorial_directives, extra fields forbidden).
+    Must match the exact schema in nexus/agents/logon/apex_schema.py: the
+    bootstrap path validates StorytellerResponseBootstrap, which rejects the
+    Extended-shaped payload this function used to emit.
     """
     row = query_bootstrap_narrative()
 
@@ -803,57 +824,11 @@ def get_cached_bootstrap_narrative() -> Dict[str, Any]:
     choice_obj = row.get("choice_object") or {}
     choices = choice_obj.get("presented", [])
 
-    # Extract metadata
-    metadata = row.get("metadata_updates") or {}
-    chronology = metadata.get("chronology", {})
-
-    # Extract references
-    refs = row.get("reference_updates") or {}
-
-    # Build response matching StorytellerResponseExtended schema exactly
     return {
         "narrative": row.get("storyteller_text", ""),
         "choices": choices,
         "authorial_directives": row.get("authorial_directives")
         or ["Retrieve the immediate prior scene."],
-        # ChunkMetadataUpdate: has chronology (nested) and world_layer
-        "chunk_metadata": {
-            "chronology": {
-                "episode_transition": chronology.get("episode_transition", "continue"),
-                "time_delta_minutes": chronology.get("time_delta_minutes"),
-                "time_delta_hours": chronology.get("time_delta_hours"),
-                "time_delta_days": chronology.get("time_delta_days"),
-                "time_delta_description": chronology.get("time_delta_description"),
-            },
-            "world_layer": metadata.get("world_layer", "primary"),
-        },
-        # ReferencedEntities: characters, places, factions (no items field!)
-        "referenced_entities": {
-            "characters": [
-                {
-                    "character_id": c.get("character_id"),
-                    "reference_type": "present",  # Valid: present, mentioned, protagonist, antagonist
-                }
-                for c in refs.get("characters", [])
-            ],
-            "places": [
-                {
-                    "place_id": p.get("place_id"),
-                    "reference_type": "setting",  # Valid: setting, mentioned, transit
-                }
-                for p in refs.get("places", [])
-            ],
-            "factions": [],
-        },
-        # StateUpdates: characters, relationships, locations, factions
-        "state_updates": {
-            "characters": [],
-            "relationships": [],
-            "locations": [],
-            "factions": [],
-        },
-        "operations": None,
-        "reasoning": "[TEST MODE] Returning cached bootstrap narrative",
     }
 
 
@@ -867,11 +842,25 @@ async def responses_create(request: ResponsesRequest):
     """
     logger.info(f"[MOCK] Responses request for model: {request.model}")
 
-    # Check if this is a bootstrap/narrative request (vs wizard)
-    # by looking for storyteller-related content in the messages
     input_text = _collect_text(request.input)
     proposal_ids = _extract_orrery_proposal_ids(input_text)
 
+    # Exact routing: the structured-output tool's schema says which
+    # Storyteller response the caller validates against. Turn requests
+    # (StorytellerResponseExtended) carry state_updates; bootstrap requests
+    # (StorytellerResponseBootstrap) do not.
+    output_fields = _requested_output_properties(request)
+    if output_fields:
+        if "state_updates" in output_fields:
+            logger.info(
+                "[MOCK] Extended turn schema requested (%d Orrery proposals)",
+                len(proposal_ids),
+            )
+            return _responses_payload(_mock_storyteller_response(input_text))
+        logger.info("[MOCK] Bootstrap schema requested, returning cached bootstrap")
+        return _responses_payload(get_cached_bootstrap_narrative())
+
+    # Legacy keyword routing for callers without a structured-output tool.
     is_narrative = any(
         kw in input_text.lower()
         for kw in ["narrative", "story", "protagonist", "bootstrap", "user input"]

--- a/nexus/api/mock_openai.py
+++ b/nexus/api/mock_openai.py
@@ -616,7 +616,7 @@ class ResponsesRequest(BaseModel):
     tools: Optional[Any] = None  # pydantic_ai output tool ("final_result")
 
 
-def _requested_output_properties(request: "ResponsesRequest") -> set:
+def _requested_output_properties(request: "ResponsesRequest") -> set[str]:
     """Return the property names of the structured-output tool, if present.
 
     pydantic_ai delivers the caller's output schema as a ``final_result``

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -164,45 +164,54 @@ async def generate_narrative_async(
             # Initialize LORE with LOGON enabled for API calls
             lore = LORE(enable_logon=True, debug=True, slot=slot)
 
-            # Send progress: calling LLM
-            await manager.send_progress(session_id, "calling_llm")
-
-            # Process the turn with LORE (builds context and generates narrative)
+            # The per-turn LORE stack MUST be closed when the turn finishes:
+            # it is a reference-cycle island holding an engine pool, and
+            # without deterministic teardown those islands accumulate across
+            # turns (issue #401). The shared embedding model survives close()
+            # in the process-level cache.
             try:
-                response = await lore.process_turn(
-                    user_text, parent_chunk_id=parent_chunk_id, note=note
-                )
-                logger.info(f"LORE response received for session {session_id}")
-            except Exception as e:
-                error_detail = _exception_detail(e)
-                logger.error(f"LORE process_turn failed: {error_detail}")
-                raise HTTPException(
-                    status_code=500,
-                    detail=f"Failed to generate narrative: {error_detail}",
-                )
+                # Send progress: calling LLM
+                await manager.send_progress(session_id, "calling_llm")
 
-            # Send progress: processing response
-            await manager.send_progress(session_id, "processing_response")
+                # Process the turn with LORE (builds context and generates
+                # narrative)
+                try:
+                    response = await lore.process_turn(
+                        user_text, parent_chunk_id=parent_chunk_id, note=note
+                    )
+                    logger.info(f"LORE response received for session {session_id}")
+                except Exception as e:
+                    error_detail = _exception_detail(e)
+                    logger.error(f"LORE process_turn failed: {error_detail}")
+                    raise HTTPException(
+                        status_code=500,
+                        detail=f"Failed to generate narrative: {error_detail}",
+                    )
 
-            failure_detail = _describe_lore_failure(lore, response)
-            if failure_detail:
-                logger.error(
-                    "Narrative turn failed for session %s: %s",
-                    session_id,
-                    failure_detail,
+                # Send progress: processing response
+                await manager.send_progress(session_id, "processing_response")
+
+                failure_detail = _describe_lore_failure(lore, response)
+                if failure_detail:
+                    logger.error(
+                        "Narrative turn failed for session %s: %s",
+                        session_id,
+                        failure_detail,
+                    )
+                    raise HTTPException(status_code=500, detail=failure_detail)
+
+                # Transform LORE response to incubator format
+                incubator_data = response_to_incubator(
+                    response=response,
+                    parent_chunk_id=parent_chunk_id,
+                    user_text=user_text,
+                    session_id=session_id,
+                    orrery_proposal=(
+                        lore.turn_context.orrery_proposal if lore.turn_context else None
+                    ),
                 )
-                raise HTTPException(status_code=500, detail=failure_detail)
-
-            # Transform LORE response to incubator format
-            incubator_data = response_to_incubator(
-                response=response,
-                parent_chunk_id=parent_chunk_id,
-                user_text=user_text,
-                session_id=session_id,
-                orrery_proposal=(
-                    lore.turn_context.orrery_proposal if lore.turn_context else None
-                ),
-            )
+            finally:
+                lore.close()
 
             # Validate the data before writing
             validate_incubator_data(incubator_data)

--- a/tests/test_api/test_narrative_generation.py
+++ b/tests/test_api/test_narrative_generation.py
@@ -63,6 +63,10 @@ async def test_lore_phase_failure_is_reported_before_adapter_coercion(
             """Return the legacy failure string from LORE.process_turn."""
             return "Error processing turn: FATAL: No warm slice chunks retrieved."
 
+        def close(self) -> None:
+            """Match LORE's per-turn teardown contract (issue #401)."""
+            self.closed = True
+
     async def fake_get_chunk_info(
         conn: DummyConnection, chunk_id: int
     ) -> dict[str, Any]:

--- a/tests/test_memnon_embedding_cache.py
+++ b/tests/test_memnon_embedding_cache.py
@@ -1,0 +1,138 @@
+"""Regression tests for the turn-8 session hang (issue #401).
+
+The narrative API constructs a fresh LORE -> MEMNON -> EmbeddingManager stack
+per turn. Before the process-level model cache, every construction loaded its
+own copy of the production embedder (~15.5 GB of MPS unified memory each),
+and the per-turn stacks are reference-cycle islands that CPython's throttled
+full GC never reclaimed mid-run -- ratcheting the server's footprint by one
+model copy per turn until Metal allocation stalled at ~turn 8 on a 128 GB
+machine.
+
+These tests use a real local model (bge-large-en, ~1.3 GB) so they exercise
+the genuine SentenceTransformer load path without the production model's
+cost. They skip when the local model directory is absent (e.g. bare CI).
+"""
+
+from __future__ import annotations
+
+import gc
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from nexus.agents.memnon.utils import embedding_manager as em
+from nexus.config import load_settings_as_dict
+
+
+def _bge_large_path() -> Path:
+    """Resolve bge-large's local path from the nexus.toml model registry."""
+    models = (
+        load_settings_as_dict()
+        .get("Agent Settings", {})
+        .get("MEMNON", {})
+        .get("models", {})
+    )
+    return Path(models.get("bge-large", {}).get("local_path", "/nonexistent"))
+
+
+MODEL_DIR = _bge_large_path()
+
+pytestmark = pytest.mark.skipif(
+    not MODEL_DIR.is_dir(),
+    reason="bge-large local model from nexus.toml registry not present",
+)
+
+
+def _settings() -> Dict[str, Any]:
+    return {
+        "models": {
+            "bge-large": {
+                "local_path": str(MODEL_DIR),
+                "is_active": True,
+            }
+        }
+    }
+
+
+def test_embedding_manager_shares_one_model_per_process() -> None:
+    """Two EmbeddingManagers must hand out the SAME model object.
+
+    Identity (not equality) is the contract: a second in-process copy of the
+    production embedder is exactly the defect that exhausted unified memory.
+    """
+    first = em.EmbeddingManager(settings=_settings())
+    second = em.EmbeddingManager(settings=_settings())
+    assert first.models["bge-large"] is second.models["bge-large"]
+
+
+def test_cached_model_survives_manager_teardown() -> None:
+    """Dropping a manager must not evict (or duplicate) the cached model."""
+    manager = em.EmbeddingManager(settings=_settings())
+    model = manager.models["bge-large"]
+    del manager
+    gc.collect()
+
+    again = em.EmbeddingManager(settings=_settings())
+    assert again.models["bge-large"] is model
+
+    # The shared instance stays usable after a sibling manager's teardown.
+    embedding = again.generate_embedding("the bell under the lintel", "bge-large")
+    assert embedding is not None and len(embedding) > 0
+
+
+@pytest.mark.requires_postgres
+def test_memnon_close_disposes_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MEMNON.close() must return its pooled Postgres connections.
+
+    Pre-fix, each per-turn MEMNON's SQLAlchemy engine sat in cyclic garbage
+    holding server-side connections until a full GC that effectively never
+    ran mid-session.
+    """
+    import sqlalchemy as sa
+
+    from nexus.agents.memnon import memnon as memnon_module
+
+    monkeypatch.setitem(memnon_module.MEMNON_SETTINGS, "models", _settings()["models"])
+
+    instance = memnon_module.MEMNON(
+        interface=None,
+        db_url="postgresql://pythagor@localhost:5432/save_05",
+    )
+    session = instance.db_manager.create_session()
+    session.execute(sa.text("SELECT 1"))
+    session.close()
+
+    pool = instance.db_manager.engine.pool
+    assert pool.checkedin() >= 1, "expected a pooled connection before close()"
+
+    instance.close()
+    assert pool.checkedin() == 0, "close() must dispose pooled connections"
+
+
+@pytest.mark.requires_postgres
+def test_per_turn_lore_stacks_share_embedder_and_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successive per-turn LORE stacks reuse ONE embedder and tear down cleanly.
+
+    This is the turn-loop shape of the issue #401 regression: the narrative
+    API builds LORE fresh per turn; without the process cache each build
+    added a full embedder copy.
+    """
+    from nexus.agents.memnon import memnon as memnon_module
+
+    monkeypatch.setitem(memnon_module.MEMNON_SETTINGS, "models", _settings()["models"])
+
+    from nexus.agents.lore.lore import LORE
+
+    first = LORE(enable_logon=False, debug=False, slot=5)
+    first_model = first.memnon.embedding_manager.models["bge-large"]
+    first.close()
+    assert first.memnon is None, "close() must break the component back-refs"
+
+    second = LORE(enable_logon=False, debug=False, slot=5)
+    try:
+        assert second.memnon.embedding_manager.models["bge-large"] is first_model
+    finally:
+        second.close()

--- a/tests/test_memnon_embedding_cache.py
+++ b/tests/test_memnon_embedding_cache.py
@@ -44,6 +44,15 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+@pytest.fixture(autouse=True)
+def isolated_model_cache(monkeypatch: pytest.MonkeyPatch):
+    """Keep process-global model cache assertions scoped to each test."""
+    monkeypatch.setattr(em, "_MODEL_CACHE", {})
+    yield
+    em._MODEL_CACHE.clear()
+    gc.collect()
+
+
 def _settings() -> Dict[str, Any]:
     return {
         "models": {
@@ -64,6 +73,31 @@ def test_embedding_manager_shares_one_model_per_process() -> None:
     first = em.EmbeddingManager(settings=_settings())
     second = em.EmbeddingManager(settings=_settings())
     assert first.models["bge-large"] is second.models["bge-large"]
+
+
+def test_model_cache_normalizes_local_path_aliases(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Filesystem aliases for one model directory must share one cache key."""
+
+    target = tmp_path / "model"
+    target.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(target, target_is_directory=True)
+
+    loads = []
+
+    class FakeSentenceTransformer:
+        def __init__(self, path: str):
+            loads.append(path)
+
+    monkeypatch.setattr(em, "SentenceTransformer", FakeSentenceTransformer)
+
+    first = em._get_or_load_sentence_transformer(str(alias))
+    second = em._get_or_load_sentence_transformer(str(target))
+
+    assert first is second
+    assert loads == [str(alias)]
 
 
 def test_cached_model_survives_manager_teardown() -> None:
@@ -108,6 +142,8 @@ def test_memnon_close_disposes_engine(monkeypatch: pytest.MonkeyPatch) -> None:
 
     instance.close()
     assert pool.checkedin() == 0, "close() must dispose pooled connections"
+    with pytest.raises(RuntimeError, match="DatabaseManager is closed"):
+        instance.db_manager.create_session()
 
 
 @pytest.mark.requires_postgres
@@ -127,9 +163,13 @@ def test_per_turn_lore_stacks_share_embedder_and_close(
     from nexus.agents.lore.lore import LORE
 
     first = LORE(enable_logon=False, debug=False, slot=5)
+    first.logon = object()
+    first._logon_initialized = True
     first_model = first.memnon.embedding_manager.models["bge-large"]
     first.close()
     assert first.memnon is None, "close() must break the component back-refs"
+    assert first.logon is None
+    assert not first._logon_initialized
 
     second = LORE(enable_logon=False, debug=False, slot=5)
     try:

--- a/tests/test_mock_openai.py
+++ b/tests/test_mock_openai.py
@@ -157,10 +157,34 @@ async def test_mock_responses_routes_turn_schema_without_orrery_proposals() -> N
         )
     )
 
+    tool_call = response["output"][0]
+    assert tool_call["type"] == "function_call"
+    assert tool_call["name"] == "final_result"
+
     payload = json.loads(response["output_text"])
+    assert json.loads(tool_call["arguments"]) == payload
     parsed = StorytellerResponseExtended.model_validate(payload)
     assert parsed.narrative.startswith("[TEST MODE]")
     assert parsed.orrery_adjudications == []
+
+
+@pytest.mark.asyncio
+async def test_mock_responses_routes_bootstrap_schema_as_final_result_tool() -> None:
+    """Bootstrap structured output must also call the required output tool."""
+
+    response = await responses_create(
+        ResponsesRequest(
+            model="TEST",
+            input=[{"role": "user", "content": "Bootstrap the protagonist story."}],
+            tools=[_final_result_tool(StorytellerResponseBootstrap)],
+        )
+    )
+
+    tool_call = response["output"][0]
+    assert tool_call["type"] == "function_call"
+    assert tool_call["name"] == "final_result"
+    payload = json.loads(tool_call["arguments"])
+    StorytellerResponseBootstrap.model_validate(payload)
 
 
 def test_requested_output_properties_extracts_schema_fields() -> None:

--- a/tests/test_mock_openai.py
+++ b/tests/test_mock_openai.py
@@ -4,8 +4,26 @@ import json
 
 import pytest
 
-from nexus.agents.logon.apex_schema import StorytellerResponseExtended
-from nexus.api.mock_openai import ResponsesRequest, _collect_text, responses_create
+from nexus.agents.logon.apex_schema import (
+    StorytellerResponseBootstrap,
+    StorytellerResponseExtended,
+)
+from nexus.api.mock_openai import (
+    ResponsesRequest,
+    _collect_text,
+    _requested_output_properties,
+    responses_create,
+)
+
+
+def _final_result_tool(schema_model) -> dict:
+    """Build the pydantic_ai-style output tool for a Storyteller schema."""
+    return {
+        "name": "final_result",
+        "type": "function",
+        "parameters": schema_model.model_json_schema(),
+        "strict": True,
+    }
 
 
 @pytest.mark.asyncio
@@ -120,6 +138,46 @@ async def test_mock_responses_prioritizes_orrery_fixture_over_cached_story() -> 
     payload = json.loads(response["output_text"])
     assert payload["narrative"].startswith("[TEST MODE]")
     assert payload["orrery_adjudications"][0]["proposal_id"] == "honor_debt:aaa"
+
+
+@pytest.mark.asyncio
+async def test_mock_responses_routes_turn_schema_without_orrery_proposals() -> None:
+    """A turn request with no Orrery section still gets an Extended payload.
+
+    Regression for the issue #401 reproduction blocker: keyword routing sent
+    proposal-free turn requests to the bootstrap-shaped payload, which fails
+    StorytellerResponseExtended validation and stalls TEST-mode turn loops.
+    """
+
+    response = await responses_create(
+        ResponsesRequest(
+            model="TEST",
+            input=[{"role": "user", "content": "Continue the protagonist story."}],
+            tools=[_final_result_tool(StorytellerResponseExtended)],
+        )
+    )
+
+    payload = json.loads(response["output_text"])
+    parsed = StorytellerResponseExtended.model_validate(payload)
+    assert parsed.narrative.startswith("[TEST MODE]")
+    assert parsed.orrery_adjudications == []
+
+
+def test_requested_output_properties_extracts_schema_fields() -> None:
+    """The output-tool discriminator sees the schema's top-level properties."""
+
+    request = ResponsesRequest(
+        model="TEST",
+        input=[],
+        tools=[_final_result_tool(StorytellerResponseBootstrap)],
+    )
+    fields = _requested_output_properties(request)
+    assert "narrative" in fields
+    assert "choices" in fields
+    assert "state_updates" not in fields
+
+    bare = ResponsesRequest(model="TEST", input=[])
+    assert _requested_output_properties(bare) == set()
 
 
 def test_collect_text_uses_first_prompt_like_key() -> None:


### PR DESCRIPTION
Refs #401.

## Summary

This is the C3 lane from the YOLO-at-C campaign, built on the merged gateway consolidation in #400.

- Adds a process-level `SentenceTransformer` cache so every per-turn MEMNON stack shares one embedder instance per process instead of loading another multi-GB model copy.
- Adds deterministic teardown through `LORE.close()`, `MEMNON.close()`, and `DatabaseManager.close()`, and closes the per-turn LORE stack in `generate_narrative_async` via `finally`.
- Breaks the LORE/MEMNON reference-cycle islands that were pinning SQLAlchemy engines and model-bearing object graphs until a full GC.
- Fixes TEST-mode `mock_openai` routing to use the `pydantic_ai` structured-output tool schema, so bootstrap and ordinary turn requests receive the right response shapes.

## Root Cause

Every `/api/narrative/continue` turn built a fresh LORE -> MEMNON -> EmbeddingManager stack in the gateway process. Each stack loaded its own production embedder copy, and the object graph formed reference cycles that normal refcounting could not reclaim mid-session. Memory ratcheted by one embedder copy per turn until the gate silently stalled around turn 8.

## Validation

Self-verified in the C3 lane before handoff:

- 12 consecutive live TEST-model turns on slot 5 with the real in-process embedder, flat ~2 seconds per turn, one model load plus cache reuses, and stable post-run footprint.
- Regression tests for model sharing, cached-model survival, MEMNON engine disposal, per-turn LORE teardown, schema-based mock routing, and the narrative-generation close contract.

## Integration Note

This PR intentionally does not close #401. The final close criterion is a green destructive slot-5 golden path gate after this PR and the managed-runtime/model-registry PR both land on `main`.