### PR TITLE
Fix Gilded splash and lazy API imports

### DIFF
--- a/nexus/agents/lore/lore.py
+++ b/nexus/agents/lore/lore.py
@@ -35,7 +35,7 @@ import asyncio
 import logging
 import json
 import time
-from typing import Dict, Optional, Any, List, Union
+from typing import Any, Dict, List, Optional, Union
 from pathlib import Path
 
 # Import NEXUS configuration loader
@@ -58,15 +58,6 @@ from nexus.agents.lore.logon_utility import LogonUtility
 
 from nexus.memory import ContextMemoryManager
 from nexus.memory.user_confirmation import request_input
-
-# Import MEMNON if available
-try:
-    from nexus.agents.memnon.memnon import MEMNON
-
-    MEMNON_AVAILABLE = True
-except ImportError:
-    MEMNON_AVAILABLE = False
-    logging.warning("MEMNON not available. Memory retrieval will be limited.")
 
 # Configure logger
 logger = logging.getLogger("nexus.lore")
@@ -211,11 +202,6 @@ class LORE:
             "MEMNON search."
         )
 
-        # MEMNON is REQUIRED
-        if not MEMNON_AVAILABLE:
-            raise RuntimeError(
-                "FATAL: MEMNON module not available! Cannot proceed without memory retrieval."
-            )
         self._initialize_memnon()
         if not self.memnon:
             raise RuntimeError(
@@ -244,6 +230,14 @@ class LORE:
 
     def _initialize_memnon(self):
         """Initialize MEMNON utility for memory retrieval"""
+        try:
+            from nexus.agents.memnon.memnon import MEMNON
+        except ImportError as e:
+            logger.error("MEMNON module not available: %s", e)
+            raise RuntimeError(
+                "FATAL: MEMNON module not available! Cannot proceed without memory retrieval."
+            ) from e
+
         try:
             # Create a minimal interface for MEMNON
             class MinimalInterface:

--- a/nexus/agents/lore/lore.py
+++ b/nexus/agents/lore/lore.py
@@ -233,7 +233,6 @@ class LORE:
         try:
             from nexus.agents.memnon.memnon import MEMNON
         except ImportError as e:
-            logger.error("MEMNON module not available: %s", e)
             raise RuntimeError(
                 "FATAL: MEMNON module not available! Cannot proceed without memory retrieval."
             ) from e

--- a/nexus/api/storyteller.py
+++ b/nexus/api/storyteller.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from fastapi import (
     BackgroundTasks,
@@ -20,7 +20,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
 from nexus.api.session_manager import SessionManager, SessionNotFoundError, SessionTurn
-from nexus.agents.lore.lore import LORE
 from nexus.agents.logon.apex_schema import (
     StoryTurnResponse,
     StorytellerResponseBootstrap,
@@ -56,6 +55,9 @@ from nexus.api.retry_handler import (
     FallbackChain,
 )
 from nexus.api.config_utils import get_new_story_model
+
+if TYPE_CHECKING:
+    from nexus.agents.lore.lore import LORE
 
 logger = logging.getLogger("nexus.api.storyteller")
 
@@ -263,10 +265,10 @@ class LoreProvider:
     """Lazily instantiate the LORE agent for request handling."""
 
     def __init__(self) -> None:
-        self._instance: Optional[LORE] = None
+        self._instance: Optional["LORE"] = None
         self._lock = asyncio.Lock()
 
-    async def get(self) -> LORE:
+    async def get(self) -> "LORE":
         """Return a cached LORE instance, creating it if necessary."""
 
         if self._instance is not None:
@@ -275,6 +277,8 @@ class LoreProvider:
         async with self._lock:
             if self._instance is None:
                 loop = asyncio.get_running_loop()
+                from nexus.agents.lore.lore import LORE
+
                 self._instance = await loop.run_in_executor(None, LORE)
         return self._instance
 
@@ -339,7 +343,7 @@ def get_session_manager() -> SessionManager:
     return session_manager
 
 
-async def get_lore() -> LORE:
+async def get_lore() -> Any:
     """FastAPI dependency returning the LORE agent."""
 
     return await lore_provider.get()
@@ -478,7 +482,7 @@ async def story_turn(
     request: StoryTurnRequest,
     background_tasks: BackgroundTasks,
     manager: SessionManager = Depends(get_session_manager),
-    lore: LORE = Depends(get_lore),
+    lore: Any = Depends(get_lore),
 ) -> StoryTurnResponse:
     """Execute a full story turn and persist the results."""
 
@@ -601,7 +605,7 @@ async def regenerate_turn(
     request: RegenerateRequest,
     background_tasks: BackgroundTasks,
     manager: SessionManager = Depends(get_session_manager),
-    lore: LORE = Depends(get_lore),
+    lore: Any = Depends(get_lore),
 ) -> StoryTurnResponse:
     """Regenerate the last turn with updated options."""
 

--- a/nexus/api/storyteller.py
+++ b/nexus/api/storyteller.py
@@ -58,6 +58,8 @@ from nexus.api.config_utils import get_new_story_model
 
 if TYPE_CHECKING:
     from nexus.agents.lore.lore import LORE
+else:
+    LORE = Any
 
 logger = logging.getLogger("nexus.api.storyteller")
 
@@ -343,7 +345,7 @@ def get_session_manager() -> SessionManager:
     return session_manager
 
 
-async def get_lore() -> Any:
+async def get_lore() -> "LORE":
     """FastAPI dependency returning the LORE agent."""
 
     return await lore_provider.get()
@@ -482,7 +484,7 @@ async def story_turn(
     request: StoryTurnRequest,
     background_tasks: BackgroundTasks,
     manager: SessionManager = Depends(get_session_manager),
-    lore: Any = Depends(get_lore),
+    lore: "LORE" = Depends(get_lore),
 ) -> StoryTurnResponse:
     """Execute a full story turn and persist the results."""
 
@@ -605,7 +607,7 @@ async def regenerate_turn(
     request: RegenerateRequest,
     background_tasks: BackgroundTasks,
     manager: SessionManager = Depends(get_session_manager),
-    lore: Any = Depends(get_lore),
+    lore: "LORE" = Depends(get_lore),
 ) -> StoryTurnResponse:
     """Regenerate the last turn with updated options."""
 

--- a/tests/test_api/test_import_side_effects.py
+++ b/tests/test_api/test_import_side_effects.py
@@ -25,6 +25,13 @@ _UNREACHABLE_DB_ENV = {
     "NEXUS_SLOT": "1",
 }
 
+_FORBIDDEN_APP_IMPORT_MODULES = {
+    "nexus.agents.memnon.memnon",
+    "sentence_transformers",
+    "torch",
+    "transformers",
+}
+
 
 def _run_fresh_import(code: str) -> "subprocess.CompletedProcess[str]":
     env = {**os.environ, **_UNREACHABLE_DB_ENV}
@@ -68,6 +75,21 @@ def test_storyteller_app_export_does_not_touch_postgres() -> None:
         "from nexus.api import db_pool\n"
         "assert app.title is not None\n"
         "assert db_pool._pools == {}, db_pool._pools\n"
+        "print('OK')\n"
+    )
+    _assert_clean(_run_fresh_import(code))
+
+
+def test_storyteller_app_export_does_not_import_ml_stack() -> None:
+    """Resolving nexus.api.app must not import LORE's MEMNON/ML dependencies."""
+    module_list = repr(sorted(_FORBIDDEN_APP_IMPORT_MODULES))
+    code = (
+        "import sys\n"
+        "from nexus.api import app\n"
+        f"forbidden = {module_list}\n"
+        "loaded = [module for module in forbidden if module in sys.modules]\n"
+        "assert app.title is not None\n"
+        "assert loaded == [], loaded\n"
         "print('OK')\n"
     )
     _assert_clean(_run_fresh_import(code))

--- a/ui/client/src/pages/splash/GildedDeco.tsx
+++ b/ui/client/src/pages/splash/GildedDeco.tsx
@@ -179,6 +179,12 @@ const getRequiredNumber = (value: number | null | undefined): number => {
   return value;
 };
 
+const assertFixedTerminator = (stretchFlags: boolean[], nextIndex: number): void => {
+  if (nextIndex >= stretchFlags.length || stretchFlags[nextIndex]) {
+    throw new Error('Deco frame metadata must terminate each stretch band with a fixed ink band.');
+  }
+};
+
 function layoutAxis(
   bounds: number[],
   stretchFlags: boolean[],
@@ -225,6 +231,7 @@ function layoutAxis(
       }
 
       const nextIndex = index + 1;
+      assertFixedTerminator(stretchFlags, nextIndex);
       const nextInkCenter = getRequiredNumber(inkCenters[nextIndex]);
       const nextFraction = getRequiredNumber(fractions[nextIndex]);
       const inkOffset = (nextInkCenter - bounds[nextIndex]) * scale;
@@ -256,6 +263,7 @@ function layoutAxis(
       }
 
       const nextIndex = index + 1;
+      assertFixedTerminator(stretchFlags, nextIndex);
       const nextInkCenter = getRequiredNumber(inkCenters[nextIndex]);
       const nextFraction = getRequiredNumber(fractions[nextIndex]);
       const inkOffset = (nextInkCenter - bounds[nextIndex]) * scale;
@@ -302,8 +310,9 @@ export function DecoFrameSliced({
 
     let animationFrame = 0;
     let tries = 0;
+    let cancelled = false;
     const pollUntilSized = () => {
-      if (!ref.current) return;
+      if (cancelled || !ref.current) return;
       if (ref.current.clientWidth > 0 && ref.current.clientHeight > 0) {
         measure();
         return;
@@ -325,6 +334,7 @@ export function DecoFrameSliced({
     }
 
     return () => {
+      cancelled = true;
       window.removeEventListener('resize', measure);
       resizeObserver?.disconnect();
       if (animationFrame) cancelAnimationFrame(animationFrame);

--- a/ui/client/src/pages/splash/GildedDeco.tsx
+++ b/ui/client/src/pages/splash/GildedDeco.tsx
@@ -1,0 +1,402 @@
+/**
+ * Gilded splash ornament helpers, ported from the NEXUS IRIS design handoff.
+ *
+ * DecoFrameSliced uses measured multi-band slicing for the licensed r1c1 Art
+ * Deco frame. Do not replace it with a simple CSS border-image: the fixed
+ * tracks preserve the corner and center ornaments while the straight bands
+ * stretch to the viewport.
+ */
+import { useId, useLayoutEffect, useRef, useState } from 'react';
+
+import type { DecoFrameMeta } from '@/assets/ArtDecoFrames-549888080/frames-meta';
+
+interface DecoRaysProps {
+  sourceXvw?: number;
+  sourceYvh?: number;
+  rayCount?: number;
+  spinSeconds?: number;
+  reverse?: boolean;
+  reachVmax?: number;
+  spreadDeg?: number;
+  color?: string;
+  accentColor?: string;
+  accentEvery?: number;
+  thickness?: number;
+  intensity?: number;
+  falloff?: number;
+  pulse?: number;
+  rings?: boolean;
+  ringCount?: number;
+  zIndex?: number;
+}
+
+export function DecoRays({
+  sourceXvw = 50,
+  sourceYvh = -32,
+  rayCount = 96,
+  spinSeconds = 160,
+  reverse = false,
+  reachVmax = 1.15,
+  spreadDeg = 360,
+  color = '#c9a227',
+  accentColor = '#e8c766',
+  accentEvery = 4,
+  thickness = 2,
+  intensity = 0.5,
+  falloff = 0.65,
+  pulse = 0,
+  rings = true,
+  ringCount = 3,
+  zIndex = 0,
+}: DecoRaysProps) {
+  const rayId = useId().replace(/[:]/g, '');
+  const containerHalf = reachVmax * 92 + Math.abs(sourceYvh) + 54;
+  const sizeVmax = containerHalf * 2;
+  const viewBox = 1000;
+  const center = viewBox / 2;
+  const rayLength = (viewBox / 2) * 0.99;
+  const innerRadius = viewBox * 0.01;
+  const halfSpread = spreadDeg / 2;
+
+  const lines = Array.from({ length: rayCount }, (_, index) => {
+    const fraction = rayCount === 1 ? 0.5 : index / rayCount;
+    const degrees =
+      spreadDeg >= 360
+        ? fraction * 360
+        : 90 - halfSpread + (index / Math.max(1, rayCount - 1)) * spreadDeg;
+    const angle = (degrees * Math.PI) / 180;
+    const isAccent = index % accentEvery === 0;
+    const isMid = !isAccent && index % 2 === 0;
+
+    return (
+      <line
+        key={index}
+        x1={center + Math.cos(angle) * innerRadius}
+        y1={center + Math.sin(angle) * innerRadius}
+        x2={center + Math.cos(angle) * rayLength}
+        y2={center + Math.sin(angle) * rayLength}
+        stroke={isAccent ? accentColor : color}
+        strokeWidth={isAccent ? thickness * 1.8 : isMid ? thickness * 1.1 : thickness * 0.6}
+        strokeLinecap="butt"
+        opacity={isAccent ? 0.95 : isMid ? 0.7 : 0.5}
+      />
+    );
+  });
+
+  const spin =
+    spinSeconds > 0
+      ? `decoRaySpin_${rayId} ${spinSeconds}s linear infinite${reverse ? ' reverse' : ''}`
+      : 'none';
+
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: 'absolute',
+        left: `${sourceXvw}vw`,
+        top: `${sourceYvh}vh`,
+        width: `min(${sizeVmax}vmax, 7600px)`,
+        height: `min(${sizeVmax}vmax, 7600px)`,
+        transform: 'translate(-50%, -50%)',
+        WebkitMaskImage: `radial-gradient(circle closest-side, #000 0%, #000 ${Math.round(
+          (1 - falloff) * 70,
+        )}%, transparent 100%)`,
+        maskImage: `radial-gradient(circle closest-side, #000 0%, #000 ${Math.round(
+          (1 - falloff) * 70,
+        )}%, transparent 100%)`,
+        pointerEvents: 'none',
+        zIndex,
+        opacity: intensity,
+        animation:
+          pulse > 0
+            ? `decoRayPulse_${rayId} ${(6 / pulse).toFixed(2)}s ease-in-out infinite`
+            : 'none',
+      }}
+    >
+      <style>{`
+        @keyframes decoRaySpin_${rayId} { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+        @keyframes decoRayPulse_${rayId} { 0%,100% { opacity: ${intensity}; } 50% { opacity: ${Math.min(
+          1,
+          intensity * 1.35,
+        ).toFixed(3)}; } }
+      `}</style>
+      <svg
+        viewBox={`0 0 ${viewBox} ${viewBox}`}
+        width="100%"
+        height="100%"
+        style={{
+          display: 'block',
+          transformOrigin: '50% 50%',
+          animation: spin,
+          willChange: spinSeconds > 0 ? 'transform' : 'auto',
+        }}
+      >
+        <g>
+          {lines}
+          {rings &&
+            Array.from({ length: ringCount }, (_, index) => {
+              const radius = rayLength * (0.16 + index * (0.5 / Math.max(1, ringCount)));
+
+              return (
+                <circle
+                  key={`ring-${index}`}
+                  cx={center}
+                  cy={center}
+                  r={radius}
+                  fill="none"
+                  stroke={index % 2 === 1 ? accentColor : color}
+                  strokeWidth={index % 2 === 1 ? thickness * 0.9 : thickness * 0.5}
+                  opacity={0.18 + index * 0.04}
+                />
+              );
+            })}
+        </g>
+      </svg>
+    </div>
+  );
+}
+
+interface DecoFrameSlicedProps {
+  src: string;
+  meta: DecoFrameMeta;
+  scale?: number;
+  margin?: number;
+  tint?: number;
+  zIndex?: number;
+}
+
+interface AxisLayout {
+  srcSizes: number[];
+  dstSizes: number[];
+  offsets: number[];
+}
+
+const getRequiredNumber = (value: number | null | undefined): number => {
+  if (value == null) {
+    throw new Error('Deco frame metadata has a missing fixed-band ink center.');
+  }
+
+  return value;
+};
+
+function layoutAxis(
+  bounds: number[],
+  stretchFlags: boolean[],
+  inkCenters: Array<number | null>,
+  total: number,
+  requestedScale: number,
+): AxisLayout {
+  const bandCount = stretchFlags.length;
+  const sourceWidth = bounds[bandCount];
+  const srcSizes = bounds.slice(1).map((bound, index) => bound - bounds[index]);
+  const fixedSourceSize = srcSizes.reduce(
+    (sum, size, index) => sum + (stretchFlags[index] ? 0 : size),
+    0,
+  );
+  const palindromic = stretchFlags.every(
+    (flag, index) => flag === stretchFlags[bandCount - 1 - index],
+  );
+  const fractions = inkCenters.map((centerValue, index) => {
+    if (centerValue == null) return null;
+
+    const mirrored = inkCenters[bandCount - 1 - index];
+    return palindromic && mirrored != null
+      ? ((centerValue + (sourceWidth - mirrored)) / 2) / sourceWidth
+      : centerValue / sourceWidth;
+  });
+
+  let scale = Math.min(requestedScale, (total * 0.96) / fixedSourceSize);
+  let dstSizes: number[] = [];
+
+  for (let iteration = 0; iteration < 24; iteration += 1) {
+    dstSizes = new Array<number>(bandCount);
+    for (let index = 0; index < bandCount; index += 1) {
+      if (!stretchFlags[index]) {
+        dstSizes[index] = srcSizes[index] * scale;
+      }
+    }
+
+    let position = 0;
+    let ok = true;
+    for (let index = 0; index < bandCount; index += 1) {
+      if (!stretchFlags[index]) {
+        position += dstSizes[index];
+        continue;
+      }
+
+      const nextIndex = index + 1;
+      const nextInkCenter = getRequiredNumber(inkCenters[nextIndex]);
+      const nextFraction = getRequiredNumber(fractions[nextIndex]);
+      const inkOffset = (nextInkCenter - bounds[nextIndex]) * scale;
+      const nextStart =
+        nextIndex === bandCount - 1
+          ? total - dstSizes[nextIndex]
+          : nextFraction * total - inkOffset;
+      const stretchSize = nextStart - position;
+
+      if (stretchSize < 2) {
+        ok = false;
+        break;
+      }
+
+      dstSizes[index] = stretchSize;
+      position = nextStart;
+    }
+
+    if (ok) break;
+    scale *= 0.94;
+  }
+
+  if (dstSizes.some((value) => value === undefined)) {
+    let position = 0;
+    for (let index = 0; index < bandCount; index += 1) {
+      if (!stretchFlags[index]) {
+        position += dstSizes[index];
+        continue;
+      }
+
+      const nextIndex = index + 1;
+      const nextInkCenter = getRequiredNumber(inkCenters[nextIndex]);
+      const nextFraction = getRequiredNumber(fractions[nextIndex]);
+      const inkOffset = (nextInkCenter - bounds[nextIndex]) * scale;
+      const nextStart =
+        nextIndex === bandCount - 1
+          ? total - dstSizes[nextIndex]
+          : nextFraction * total - inkOffset;
+
+      dstSizes[index] = Math.max(2, nextStart - position);
+      position += dstSizes[index];
+    }
+  }
+
+  const offsets = [0];
+  dstSizes.forEach((size) => offsets.push(offsets[offsets.length - 1] + size));
+
+  return { srcSizes, dstSizes, offsets };
+}
+
+export function DecoFrameSliced({
+  src,
+  meta,
+  scale = 1,
+  margin = 16,
+  tint = 0,
+  zIndex = 2,
+}: DecoFrameSlicedProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [box, setBox] = useState({ width: 0, height: 0 });
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) return undefined;
+
+    const measure = () => {
+      setBox((current) => {
+        const width = element.clientWidth;
+        const height = element.clientHeight;
+        return current.width === width && current.height === height ? current : { width, height };
+      });
+    };
+
+    measure();
+
+    let animationFrame = 0;
+    let tries = 0;
+    const pollUntilSized = () => {
+      if (!ref.current) return;
+      if (ref.current.clientWidth > 0 && ref.current.clientHeight > 0) {
+        measure();
+        return;
+      }
+      tries += 1;
+      if (tries < 600) animationFrame = requestAnimationFrame(pollUntilSized);
+    };
+
+    if (element.clientWidth === 0 || element.clientHeight === 0) {
+      animationFrame = requestAnimationFrame(pollUntilSized);
+    }
+
+    window.addEventListener('resize', measure);
+
+    let resizeObserver: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(measure);
+      resizeObserver.observe(element);
+    }
+
+    return () => {
+      window.removeEventListener('resize', measure);
+      resizeObserver?.disconnect();
+      if (animationFrame) cancelAnimationFrame(animationFrame);
+    };
+  }, [margin]);
+
+  const cells = [];
+  if (box.width > 4 && box.height > 4) {
+    const fit = Math.min(box.width / meta.w, box.height / meta.h);
+    const requestedScale = fit * scale;
+    const xLayout = layoutAxis(
+      meta.cols,
+      meta.colStretch,
+      meta.colInkC,
+      box.width,
+      requestedScale,
+    );
+    const yLayout = layoutAxis(
+      meta.rows,
+      meta.rowStretch,
+      meta.rowInkC,
+      box.height,
+      requestedScale,
+    );
+    const lastColumn = xLayout.dstSizes.length - 1;
+    const lastRow = yLayout.dstSizes.length - 1;
+
+    for (let row = 0; row <= lastRow; row += 1) {
+      for (let column = 0; column <= lastColumn; column += 1) {
+        if (row !== 0 && row !== lastRow && column !== 0 && column !== lastColumn) continue;
+
+        const width = xLayout.dstSizes[column];
+        const height = yLayout.dstSizes[row];
+        if (width < 0.5 || height < 0.5) continue;
+
+        const scaleX = width / xLayout.srcSizes[column];
+        const scaleY = height / yLayout.srcSizes[row];
+        cells.push(
+          <div
+            key={`${row}-${column}`}
+            style={{
+              position: 'absolute',
+              left: `${xLayout.offsets[column]}px`,
+              top: `${yLayout.offsets[row]}px`,
+              width: `${width}px`,
+              height: `${height}px`,
+              backgroundImage: `url("${src}")`,
+              backgroundRepeat: 'no-repeat',
+              backgroundSize: `${meta.w * scaleX}px ${meta.h * scaleY}px`,
+              backgroundPosition: `${-meta.cols[column] * scaleX}px ${
+                -meta.rows[row] * scaleY
+              }px`,
+            }}
+          />,
+        );
+      }
+    }
+  }
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden="true"
+      style={{
+        position: 'absolute',
+        inset: `${margin}px`,
+        pointerEvents: 'none',
+        zIndex,
+        filter: tint ? `hue-rotate(${tint}deg)` : 'none',
+      }}
+    >
+      {cells}
+    </div>
+  );
+}

--- a/ui/client/src/pages/splash/GildedSplash.tsx
+++ b/ui/client/src/pages/splash/GildedSplash.tsx
@@ -1,231 +1,156 @@
 /**
- * Gilded theme splash page - Art Deco home screen with animated sunburst.
- * Showcases the Monoton display font and brass/gold color palette.
+ * Gilded theme splash page - the approved Art Deco home screen.
+ *
+ * The composition comes from the NEXUS IRIS design handoff: an off-screen brass
+ * ray field behind the marquee and the licensed r1c1 Deco frame dynamically
+ * sliced around the whole viewport. The marquee font appears exactly once.
  */
-import { useState } from 'react';
+import { CSSProperties, ReactNode, useState } from 'react';
+
+import decoFrameR1C1 from '@/assets/ArtDecoFrames-549888080/r1c1.png';
+import { DECO_FRAME_META } from '@/assets/ArtDecoFrames-549888080/frames-meta';
+import { DecoFrameSliced, DecoRays } from './GildedDeco';
 import { useSplashNavigation, SplashThemeMenu } from './shared';
 
-// CSS variable references for theme-aware colors
-const themeColors = {
-  bg: 'hsl(var(--background))',
-  primary: 'hsl(var(--primary))',
-  accent: 'hsl(var(--accent))',
-  foreground: 'hsl(var(--foreground))',
-  mutedForeground: 'hsl(var(--muted-foreground))',
-  bronze: 'hsl(var(--chart-2))',
-  darkBronze: 'hsl(var(--chart-4))',
-};
+const gilded = {
+  bg: 'hsl(0 0% 4%)',
+  brass: '#c9a227',
+  brassBright: '#e8c766',
+  bronze: 'hsl(30 50% 45%)',
+  cream: 'hsl(45 20% 93%)',
+  panelHover: 'hsl(43 45% 12%)',
+} as const;
 
-const HeroSunburst = () => {
-  const rays = 72;
-  const size = 1600;
-  const pulseGroups = 6;
+const GILDED_SPLASH_FRAME = {
+  scale: 0.75,
+  margin: 16,
+  tint: 2,
+} as const;
 
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox={`0 0 ${size} ${size}`}
-      className="absolute overflow-visible"
-      style={{
-        top: -size/2,
-        left: '50%',
-        transform: 'translateX(-50%)',
-      }}
-    >
-      <style>{`
-        @keyframes rotateSunburst {
-          from { transform: rotate(0deg); }
-          to { transform: rotate(-360deg); }
-        }
-        @keyframes rayPulse {
-          0%, 100% { opacity: 0.15; }
-          50% { opacity: 0.5; }
-        }
-        @keyframes rayPulseAccent {
-          0%, 100% { opacity: 0.25; }
-          50% { opacity: 0.7; }
-        }
-        @keyframes rayPulseBronze {
-          0%, 100% { opacity: 0.2; }
-          50% { opacity: 0.6; }
-        }
-      `}</style>
+const GILDED_SPLASH_RAYS = {
+  sourceXvw: 50,
+  sourceYvh: -34,
+  rayCount: 50,
+  spinSeconds: 160,
+  reachVmax: 1.15,
+  spreadDeg: 360,
+  color: '#c9a227',
+  accentColor: '#e8c766',
+  thickness: 1,
+  intensity: 0.5,
+  falloff: 0.65,
+  pulse: 1.5,
+  rings: false,
+} as const;
 
-      <g style={{
-        transformOrigin: `${size/2}px ${size/2}px`,
-        animation: 'rotateSunburst 120s linear infinite',
-      }}>
-        {[...Array(rays)].map((_, i) => {
-          const angle = (i * (360 / rays)) * Math.PI / 180;
-          const isAccent = i % 4 === 0;
-          const isBronze = i % 6 === 2;
-          const isMajor = i % 2 === 0;
-          const groupIndex = Math.floor(i / (rays / pulseGroups));
-          const pulseDelay = (groupIndex / pulseGroups) * 8;
-
-          let rayColor, rayWidth, animName;
-          if (isAccent) {
-            rayColor = themeColors.primary;
-            rayWidth = 2.5;
-            animName = 'rayPulseAccent';
-          } else if (isBronze) {
-            rayColor = themeColors.bronze;
-            rayWidth = 2;
-            animName = 'rayPulseBronze';
-          } else {
-            rayColor = isMajor ? themeColors.darkBronze : themeColors.mutedForeground;
-            rayWidth = isMajor ? 1.5 : 0.75;
-            animName = 'rayPulse';
-          }
-
-          return (
-            <line
-              key={i}
-              x1={size / 2}
-              y1={size / 2}
-              x2={size / 2 + Math.cos(angle) * size}
-              y2={size / 2 + Math.sin(angle) * size}
-              stroke={rayColor}
-              strokeWidth={rayWidth}
-              style={{
-                animation: `${animName} 8s ease-in-out infinite`,
-                animationDelay: `${pulseDelay}s`,
-              }}
-            />
-          );
-        })}
-      </g>
-
-      {/* Concentric circles */}
-      {[150, 250, 380].map((r, i) => (
-        <circle
-          key={r}
-          cx={size / 2}
-          cy={size / 2}
-          r={r}
-          fill="none"
-          stroke={i === 1 ? themeColors.bronze : themeColors.primary}
-          strokeWidth={i === 1 ? 2 : 1}
-          opacity={0.12 + i * 0.04}
-        />
-      ))}
-    </svg>
-  );
-};
-
-// Corner component for the Art Deco frame
-const Corner = ({ position }: { position: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' }) => {
-  const isLeft = position.includes('left');
-  const isTop = position.includes('top');
-
-  return (
-    <div
-      className="absolute w-2 h-2 border border-primary"
-      style={{
-        [isTop ? 'top' : 'bottom']: -8,
-        [isLeft ? 'left' : 'right']: -8,
-      }}
-    >
-      {/* Horizontal extension */}
-      <div
-        className="absolute w-8 h-[15px]"
-        style={{
-          [isTop ? 'top' : 'bottom']: -1,
-          [isLeft ? 'left' : 'right']: 14,
-          [isTop ? 'borderTop' : 'borderBottom']: '1px solid hsl(var(--primary))',
-        }}
-      />
-      {/* Vertical extension */}
-      <div
-        className="absolute w-[15px] h-8"
-        style={{
-          [isTop ? 'top' : 'bottom']: 14,
-          [isLeft ? 'left' : 'right']: -1,
-          [isLeft ? 'borderLeft' : 'borderRight']: '1px solid hsl(var(--primary))',
-        }}
-      />
-    </div>
-  );
-};
-
-// Art Deco frame
-const DecoFrame = () => {
-  return (
-    <div className="absolute inset-5 border border-primary pointer-events-none">
-      <Corner position="top-left" />
-      <Corner position="top-right" />
-      <Corner position="bottom-left" />
-      <Corner position="bottom-right" />
-
-      {/* Horizontal bars extending beyond frame */}
-      <div
-        className="absolute top-[10px] bottom-[10px] -left-5 -right-5 border-t border-b border-primary pointer-events-none"
-      />
-
-      {/* Vertical bars extending beyond frame */}
-      <div
-        className="absolute -top-5 -bottom-5 left-[10px] right-[10px] border-l border-r border-primary pointer-events-none"
-      />
-    </div>
-  );
-};
-
-interface MenuButtonProps {
-  children: React.ReactNode;
+interface GildedButtonProps {
+  children: ReactNode;
   onClick: () => void;
-  primary?: boolean;
   animationClass?: string;
+  primary?: boolean;
 }
 
-const MenuButton = ({ children, onClick, primary = false, animationClass = '' }: MenuButtonProps) => {
-  const [hover, setHover] = useState(false);
-  const label = typeof children === 'string' ? children : 'Menu button';
+const cornerBase: CSSProperties = {
+  position: 'absolute',
+  width: 12,
+  height: 12,
+  borderStyle: 'solid',
+  borderColor: gilded.bronze,
+  transition: 'border-color .2s',
+};
+
+const GildedButton = ({
+  children,
+  onClick,
+  animationClass = '',
+  primary = false,
+}: GildedButtonProps) => {
+  const [hovered, setHovered] = useState(false);
+
+  const base: CSSProperties = {
+    position: 'relative',
+    width: 280,
+    padding: '16px 28px',
+    fontFamily: 'var(--font-menu)',
+    fontSize: 14,
+    letterSpacing: '0.3em',
+    textTransform: 'uppercase',
+    fontWeight: 600,
+    background: gilded.bg,
+    border: `2px solid ${hovered ? gilded.brass : gilded.bronze}`,
+    color: hovered ? gilded.brassBright : gilded.cream,
+    borderRadius: 2,
+    cursor: 'pointer',
+    transition: 'background .2s, color .2s, border-color .2s, box-shadow .2s',
+  };
+
+  const primaryStyle: CSSProperties = {
+    background: hovered ? gilded.brassBright : gilded.brass,
+    border: 'none',
+    color: gilded.bg,
+    boxShadow: 'none',
+  };
+
+  const hoverStyle: CSSProperties = {
+    background: gilded.panelHover,
+    boxShadow: primary ? 'none' : '0 0 18px hsl(43 74% 47% / 0.28)',
+  };
+
+  const cornerColor = hovered ? gilded.brass : gilded.bronze;
 
   return (
     <button
+      type="button"
       onClick={onClick}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      aria-label={`${label}${primary ? ' - Primary action' : ''}`}
-      className={`relative w-[280px] py-[18px] px-8 font-mono text-lg tracking-[0.25em] uppercase cursor-pointer transition-all duration-200 ${animationClass}`}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      className={animationClass}
       style={{
-        background: primary
-          ? (hover ? themeColors.accent : themeColors.primary)
-          : (hover ? 'hsla(var(--primary) / 0.15)' : 'transparent'),
-        border: primary ? 'none' : `2px solid ${hover ? themeColors.primary : themeColors.bronze}`,
-        color: primary ? themeColors.bg : (hover ? themeColors.accent : themeColors.foreground),
+        ...base,
+        ...(hovered ? hoverStyle : {}),
+        ...(primary ? primaryStyle : {}),
       }}
     >
       {!primary && (
         <>
-          {/* Corner accents */}
           <span
-            className="absolute -top-0.5 -left-0.5 w-3 h-3 transition-colors duration-200"
+            aria-hidden="true"
             style={{
-              borderTop: `2px solid ${hover ? themeColors.primary : themeColors.bronze}`,
-              borderLeft: `2px solid ${hover ? themeColors.primary : themeColors.bronze}`,
+              ...cornerBase,
+              top: -2,
+              left: -2,
+              borderWidth: '2px 0 0 2px',
+              borderColor: cornerColor,
             }}
           />
           <span
-            className="absolute -top-0.5 -right-0.5 w-3 h-3 transition-colors duration-200"
+            aria-hidden="true"
             style={{
-              borderTop: `2px solid ${hover ? themeColors.primary : themeColors.bronze}`,
-              borderRight: `2px solid ${hover ? themeColors.primary : themeColors.bronze}`,
+              ...cornerBase,
+              top: -2,
+              right: -2,
+              borderWidth: '2px 2px 0 0',
+              borderColor: cornerColor,
             }}
           />
           <span
-            className="absolute -bottom-0.5 -left-0.5 w-3 h-3 transition-colors duration-200"
+            aria-hidden="true"
             style={{
-              borderBottom: `2px solid ${hover ? themeColors.primary : themeColors.bronze}`,
-              borderLeft: `2px solid ${hover ? themeColors.primary : themeColors.bronze}`,
+              ...cornerBase,
+              bottom: -2,
+              left: -2,
+              borderWidth: '0 0 2px 2px',
+              borderColor: cornerColor,
             }}
           />
           <span
-            className="absolute -bottom-0.5 -right-0.5 w-3 h-3 transition-colors duration-200"
+            aria-hidden="true"
             style={{
-              borderBottom: `2px solid ${hover ? themeColors.primary : themeColors.bronze}`,
-              borderRight: `2px solid ${hover ? themeColors.primary : themeColors.bronze}`,
+              ...cornerBase,
+              right: -2,
+              bottom: -2,
+              borderWidth: '0 2px 2px 0',
+              borderColor: cornerColor,
             }}
           />
         </>
@@ -236,42 +161,95 @@ const MenuButton = ({ children, onClick, primary = false, animationClass = '' }:
 };
 
 export function GildedSplash() {
-  const { isExiting, handleContinue, handleLoad, handleSettings, getAnimationClass } = useSplashNavigation();
+  const { isExiting, handleContinue, handleLoad, handleSettings, getAnimationClass } =
+    useSplashNavigation();
 
   return (
-    <div className="min-h-screen bg-background relative overflow-hidden flex flex-col items-center">
-      {/* Theme switcher menu */}
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: gilded.bg,
+        overflow: 'hidden',
+      }}
+    >
       <SplashThemeMenu />
 
-      {/* DecoFrame fades out fast (not the clicked element) */}
-      <div className={isExiting ? 'animate-fade-out-fast' : ''}>
-        <DecoFrame />
+      <div
+        className={isExiting ? 'animate-fade-out-fast' : ''}
+        style={{ position: 'absolute', inset: 0, zIndex: 0, pointerEvents: 'none' }}
+      >
+        <DecoRays {...GILDED_SPLASH_RAYS} zIndex={0} />
+        <DecoFrameSliced
+          src={decoFrameR1C1}
+          meta={DECO_FRAME_META.r1c1}
+          scale={GILDED_SPLASH_FRAME.scale}
+          margin={GILDED_SPLASH_FRAME.margin}
+          tint={GILDED_SPLASH_FRAME.tint}
+          zIndex={2}
+        />
       </div>
 
-      {/* Hero section with sunburst */}
-      <div className={`relative w-full h-[200px] flex items-start justify-center overflow-visible ${isExiting ? 'animate-fade-out-fast' : ''}`}>
-        <HeroSunburst />
-
+      <div
+        className={isExiting ? 'animate-fade-out-fast' : ''}
+        style={{
+          position: 'relative',
+          zIndex: 4,
+          width: '100%',
+          height: 280,
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'center',
+          overflow: 'visible',
+          marginTop: 60,
+          pointerEvents: 'none',
+        }}
+      >
         <h1
-          className={`font-display text-[112px] font-normal tracking-[0.1em] text-accent m-0 mt-9 relative z-10 deco-glow ${isExiting ? 'animate-fade-out-fast' : ''}`}
+          className="deco-glow"
+          style={{
+            position: 'relative',
+            zIndex: 4,
+            margin: '30px 0 0',
+            fontFamily: 'var(--font-display)',
+            fontSize: 128,
+            fontWeight: 400,
+            letterSpacing: '0.1em',
+            lineHeight: 1,
+            color: gilded.brassBright,
+            textShadow:
+              '0 0 12px hsl(43 74% 47% / .6), 0 0 24px hsl(43 74% 47% / .35)',
+          }}
         >
           NEXUS
         </h1>
       </div>
 
-      {/* Menu buttons */}
-      <div className="flex flex-col items-center gap-5 mt-10">
-        <MenuButton primary onClick={handleContinue} animationClass={getAnimationClass('continue')}>
+      <div
+        style={{
+          position: 'relative',
+          zIndex: 5,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 14,
+          marginTop: 36,
+        }}
+      >
+        <GildedButton primary onClick={handleContinue} animationClass={getAnimationClass('continue')}>
           Continue
-        </MenuButton>
-
-        <MenuButton onClick={handleLoad} animationClass={getAnimationClass('load')}>
+        </GildedButton>
+        <GildedButton onClick={handleLoad} animationClass={getAnimationClass('load')}>
           Load
-        </MenuButton>
-
-        <MenuButton onClick={handleSettings} animationClass={getAnimationClass('settings')}>
+        </GildedButton>
+        <GildedButton onClick={handleSettings} animationClass={getAnimationClass('settings')}>
           Settings
-        </MenuButton>
+        </GildedButton>
       </div>
     </div>
   );

--- a/ui/client/src/pages/splash/GildedSplash.tsx
+++ b/ui/client/src/pages/splash/GildedSplash.tsx
@@ -174,7 +174,7 @@ export function GildedSplash() {
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        background: gilded.bg,
+        background: 'hsl(var(--background))',
         overflow: 'hidden',
       }}
     >


### PR DESCRIPTION
## Summary
- Port the approved Gilded splash composition from the design handoff into the live app using the tracked `r1c1` Art Deco frame asset.
- Add reusable Gilded ornament helpers for the sliced frame and off-screen brass ray field, with button plates adjusted so labels stay clear over the frame.
- Defer LORE and MEMNON/ML imports until first narrative use instead of importing them during `from nexus.api import app`.
- Add a fresh-process import-side-effect regression guard for the API app export.

## Validation
- `poetry run pytest tests/test_api/test_import_side_effects.py -q -s --durations=10 --durations-min=0.001` (`4 passed`)
- `poetry run python -c "import sys; from nexus.api import app; mods=['sentence_transformers','torch','transformers','nexus.agents.memnon.memnon']; loaded={m: m in sys.modules for m in mods}; print(loaded); assert not any(loaded.values()), loaded; assert app.title"`
- `poetry run pytest -q --durations=30 --durations-min=0.05` (`819 passed, 136 skipped`)
- `npm --prefix ui run check`
- `npm --prefix ui run build`
- Local Vite render at `http://127.0.0.1:5176/`: switched to Gilded via the app theme menu, confirmed `dark theme-gilded`, `NEXUS`, 16 sliced frame cells, 53 SVG ray lines, and visually inspected the screenshot.

## Notes
- No schema, database, or runtime config changes.
- The unrelated untracked `design_handoff/` and `whats_new_v1.0.0.html` files remain untouched.
- The UI build still emits pre-existing warnings for stale Browserslist/Baseline data, PostCSS `from`, Arwes `eval`, and large chunks.

Closes #405
Closes #406
