### PR TITLE
Keep Gilded splash buttons inside frame

### DIFF
--- a/ui/client/src/pages/splash/GildedSplash.tsx
+++ b/ui/client/src/pages/splash/GildedSplash.tsx
@@ -213,11 +213,9 @@ export function GildedSplash() {
         <h1
           className="deco-glow"
           style={{
-            position: 'relative',
-            zIndex: 4,
             margin: '8px 0 0',
             fontFamily: 'var(--font-display)',
-            fontSize: 128,
+            fontSize: 'clamp(96px, 18vh, 128px)',
             fontWeight: 400,
             letterSpacing: '0.1em',
             lineHeight: 1,

--- a/ui/client/src/pages/splash/GildedSplash.tsx
+++ b/ui/client/src/pages/splash/GildedSplash.tsx
@@ -70,7 +70,7 @@ const GildedButton = ({
   const base: CSSProperties = {
     position: 'relative',
     width: 280,
-    padding: '16px 28px',
+    padding: '14px 28px',
     fontFamily: 'var(--font-menu)',
     fontSize: 14,
     letterSpacing: '0.3em',
@@ -201,12 +201,12 @@ export function GildedSplash() {
           position: 'relative',
           zIndex: 4,
           width: '100%',
-          height: 280,
+          height: 'min(220px, 30vh)',
           display: 'flex',
           alignItems: 'flex-start',
           justifyContent: 'center',
           overflow: 'visible',
-          marginTop: 60,
+          marginTop: 0,
           pointerEvents: 'none',
         }}
       >
@@ -215,7 +215,7 @@ export function GildedSplash() {
           style={{
             position: 'relative',
             zIndex: 4,
-            margin: '30px 0 0',
+            margin: '8px 0 0',
             fontFamily: 'var(--font-display)',
             fontSize: 128,
             fontWeight: 400,
@@ -237,8 +237,8 @@ export function GildedSplash() {
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
-          gap: 14,
-          marginTop: 36,
+          gap: 12,
+          marginTop: 0,
         }}
       >
         <GildedButton primary onClick={handleContinue} animationClass={getAnimationClass('continue')}>


### PR DESCRIPTION
## Summary
- Tighten the Gilded splash vertical layout so the menu buttons sit inside the Art Deco frame instead of overlapping the lower frame band.
- Slightly slim the button plates and reduce the title/button vertical spacing while preserving the approved frame/ray composition.

## Validation
- `npm --prefix ui run check`
- `npm --prefix ui run build`
- Local render at `http://127.0.0.1:5176/` with Gilded theme, captured at 1280x720. The Settings button clears the lower frame band in `/tmp/nexus-gilded-splash-fit-2026-06-17.png`.

## Notes
- No schema, backend, or config changes.
- The local theme was restored to Veil after screenshot capture.
