### PR TITLE
[codex] Restore native strict structured output schemas

### DIFF
--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -15,6 +15,7 @@ Key improvements over legacy schema:
 All models use Pydantic v2 for validation and serialization.
 """
 
+import json
 import logging
 from typing import List, Optional, Dict, Any, Union, Literal
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
@@ -113,6 +114,14 @@ class CharacterTraits(BaseModel):
     domain: Optional[str] = Field(
         default=None, description="Place or area you control or claim"
     )
+    role: Optional[str] = Field(
+        default=None,
+        description="Legacy freeform role note for partially introduced characters",
+    )
+    asset: Optional[str] = Field(
+        default=None,
+        description="Legacy freeform asset note for partially introduced characters",
+    )
 
     # Liabilities
     enemies: Optional[str] = Field(
@@ -132,7 +141,29 @@ class CharacterTraits(BaseModel):
         description="What this trait means - capability, possession, relationship, or curse",
     )
 
-    model_config = ConfigDict(extra="allow")
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_legacy_extra_trait_keys(cls, data: Any) -> Any:
+        """Fold legacy arbitrary extra_data keys into strict wildcard prose."""
+
+        if not isinstance(data, dict):
+            return data
+        field_names = set(cls.model_fields)
+        extras = {key: value for key, value in data.items() if key not in field_names}
+        if not extras:
+            return data
+
+        normalized = {
+            key: value for key, value in data.items() if key in field_names
+        }
+        normalized.setdefault("wildcard_name", "legacy_extra_data")
+        normalized.setdefault(
+            "wildcard_description",
+            json.dumps(extras, ensure_ascii=False, sort_keys=True),
+        )
+        return normalized
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class PlaceDetails(BaseModel):
@@ -190,7 +221,7 @@ class PlaceDetails(BaseModel):
         default_factory=list, description="Current rumors or gossip (max 3)"
     )
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class FactionDetails(BaseModel):
@@ -215,7 +246,35 @@ class FactionDetails(BaseModel):
         default=None, description="Key traditions or rituals"
     )
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
+
+
+class NamedObservation(BaseModel):
+    """Strict key/value observation entry for JSONB-style side notes."""
+
+    key: str = Field(min_length=1, description="Observation key or label")
+    value: str = Field(description="Observation value as concise prose")
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
+class FactionStanceChange(BaseModel):
+    """Strict faction stance change entry."""
+
+    target: str = Field(min_length=1, description="Faction, group, or entity target")
+    stance: str = Field(description="Updated stance toward the target")
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
+def _stringify_structured_value(value: Any) -> str:
+    """Render arbitrary legacy observation values into strict-schema prose."""
+
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
 
 
 # ============================================================================
@@ -700,8 +759,12 @@ class CharacterStateUpdate(BaseModel):
     emotional_state: Optional[str] = Field(
         default=None, description="Character's emotional state"
     )
-    extra_observations: Optional[Dict[str, Any]] = Field(
-        default=None, description="Additional observations stored in extra_data JSONB"
+    extra_observations: List[NamedObservation] = Field(
+        default_factory=list,
+        description=(
+            "Additional observations for extra_data JSONB as strict key/value "
+            "entries."
+        ),
     )
     orrery_tags: Optional[OrreryTagBestowal] = Field(
         default=None,
@@ -712,6 +775,20 @@ class CharacterStateUpdate(BaseModel):
             "Use only registered tag names."
         ),
     )
+
+    @field_validator("extra_observations", mode="before")
+    @classmethod
+    def normalize_extra_observations(cls, value: Any) -> Any:
+        """Accept legacy dict observations while emitting strict list schema."""
+
+        if value is None or isinstance(value, list):
+            return value
+        if isinstance(value, dict):
+            return [
+                {"key": str(key), "value": _stringify_structured_value(item)}
+                for key, item in value.items()
+            ]
+        return value
 
     model_config = ConfigDict(extra="forbid")
 
@@ -790,8 +867,9 @@ class FactionStateUpdate(BaseModel):
             "facts through world_events or accepted Orrery tags."
         ),
     )
-    stance_changes: Optional[Dict[str, str]] = Field(
-        default=None, description="Changes in stance toward other entities"
+    stance_changes: List[FactionStanceChange] = Field(
+        default_factory=list,
+        description="Changes in stance toward other entities as strict entries",
     )
     orrery_tags: Optional[OrreryTagBestowal] = Field(
         default=None,
@@ -802,6 +880,20 @@ class FactionStateUpdate(BaseModel):
             "tags_to_clear to retire active tags that no longer apply."
         ),
     )
+
+    @field_validator("stance_changes", mode="before")
+    @classmethod
+    def normalize_stance_changes(cls, value: Any) -> Any:
+        """Accept legacy stance-change dicts while emitting strict list schema."""
+
+        if value is None or isinstance(value, list):
+            return value
+        if isinstance(value, dict):
+            return [
+                {"target": str(target), "stance": _stringify_structured_value(stance)}
+                for target, stance in value.items()
+            ]
+        return value
 
     model_config = ConfigDict(extra="forbid")
 

--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -153,9 +153,7 @@ class CharacterTraits(BaseModel):
         if not extras:
             return data
 
-        normalized = {
-            key: value for key, value in data.items() if key in field_names
-        }
+        normalized = {key: value for key, value in data.items() if key in field_names}
         normalized.setdefault("wildcard_name", "legacy_extra_data")
         normalized.setdefault(
             "wildcard_description",
@@ -916,7 +914,135 @@ class StateUpdates(BaseModel):
         default_factory=list, description="Faction state updates"
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def expand_compact_updates(cls, data: Any) -> Any:
+        """Accept Anthropic's compact scalar wire shape for state updates."""
+
+        if not isinstance(data, dict) or "updates" not in data:
+            return data
+
+        expanded = {
+            "characters": list(data.get("characters") or []),
+            "relationships": list(data.get("relationships") or []),
+            "locations": list(data.get("locations") or []),
+            "factions": list(data.get("factions") or []),
+        }
+        for raw_update in data.get("updates") or []:
+            if not isinstance(raw_update, dict):
+                continue
+            kind = raw_update.get("kind")
+            if kind == "character":
+                update = _compact_character_state_update(raw_update)
+                if update:
+                    expanded["characters"].append(update)
+            elif kind == "place":
+                update = _compact_location_state_update(raw_update)
+                if update:
+                    expanded["locations"].append(update)
+            elif kind == "faction":
+                update = _compact_faction_state_update(raw_update)
+                if update:
+                    expanded["factions"].append(update)
+            elif kind == "relationship":
+                update = _compact_relationship_update(raw_update)
+                if update:
+                    expanded["relationships"].append(update)
+        return expanded
+
     model_config = ConfigDict(extra="forbid")
+
+
+def _compact_character_state_update(row: Dict[str, Any]) -> Dict[str, Any]:
+    update: Dict[str, Any] = {}
+    _copy_if_present(row, update, "entity_id", "character_id")
+    name = row.get("name") or row.get("character_name")
+    if name:
+        update["character_name"] = str(name)
+    status = row.get("status")
+    if status and "current_activity" not in row:
+        update["current_activity"] = str(status)
+    _copy_if_present(row, update, "current_location")
+    _copy_if_present(row, update, "current_activity")
+    _copy_if_present(row, update, "emotional_state")
+    _apply_compact_orrery_tags(row, update)
+    return update
+
+
+def _compact_location_state_update(row: Dict[str, Any]) -> Dict[str, Any]:
+    update: Dict[str, Any] = {}
+    _copy_if_present(row, update, "entity_id", "place_id")
+    name = row.get("name") or row.get("place_name")
+    if name:
+        update["place_name"] = str(name)
+    status = row.get("status")
+    if status and "current_conditions" not in row:
+        update["current_conditions"] = str(status)
+    _copy_if_present(row, update, "current_conditions")
+    notable_change = row.get("notable_change") or row.get("status")
+    if notable_change:
+        update["notable_changes"] = [str(notable_change)]
+    _apply_compact_orrery_tags(row, update)
+    return update
+
+
+def _compact_faction_state_update(row: Dict[str, Any]) -> Dict[str, Any]:
+    update: Dict[str, Any] = {}
+    _copy_if_present(row, update, "entity_id", "faction_id")
+    name = row.get("name") or row.get("faction_name")
+    if name:
+        update["faction_name"] = str(name)
+    recent_action = row.get("recent_action") or row.get("status")
+    if recent_action:
+        update["recent_actions"] = [str(recent_action)]
+    target = row.get("stance_target")
+    stance = row.get("stance")
+    if target and stance:
+        update["stance_changes"] = [{"target": str(target), "stance": str(stance)}]
+    _apply_compact_orrery_tags(row, update)
+    return update
+
+
+def _compact_relationship_update(row: Dict[str, Any]) -> Dict[str, Any]:
+    update: Dict[str, Any] = {}
+    _copy_if_present(row, update, "entity_id", "character1_id")
+    _copy_if_present(row, update, "other_entity_id", "character2_id")
+    name = row.get("name") or row.get("character1_name")
+    other_name = row.get("other_name") or row.get("character2_name")
+    if name:
+        update["character1_name"] = str(name)
+    if other_name:
+        update["character2_name"] = str(other_name)
+    _copy_if_present(row, update, "relationship_type")
+    _copy_if_present(row, update, "emotional_valence")
+    _copy_if_present(row, update, "dynamic")
+    _copy_if_present(row, update, "recent_events")
+    return update
+
+
+def _apply_compact_orrery_tags(
+    row: Dict[str, Any],
+    update: Dict[str, Any],
+) -> None:
+    tag_add = row.get("tag_add")
+    tag_clear = row.get("tag_clear")
+    if not tag_add and not tag_clear:
+        return
+    update["orrery_tags"] = {
+        "applied_tags": [str(tag_add)] if tag_add else [],
+        "tags_to_clear": [str(tag_clear)] if tag_clear else [],
+    }
+
+
+def _copy_if_present(
+    source: Dict[str, Any],
+    target: Dict[str, Any],
+    key: str,
+    target_key: Optional[str] = None,
+) -> None:
+    value = source.get(key)
+    if value is not None and value != "":
+        target[target_key or key] = value
 
 
 class OrreryReplacementStateDelta(BaseModel):

--- a/nexus/agents/logon/orrery_tag_schema.py
+++ b/nexus/agents/logon/orrery_tag_schema.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from copy import deepcopy
 import logging
-from typing import Any, Dict, Mapping, Optional, Type
+import os
+from typing import Any, Dict, Mapping, Optional, Sequence, Type
 
+import psycopg2
+from psycopg2.extras import RealDictCursor
 from pydantic import BaseModel
 
 from nexus.agents.orrery.tag_library import read_tag_library
@@ -49,10 +52,79 @@ def storyteller_anthropic_output_config(
 ) -> Optional[Dict[str, Any]]:
     """Build an Anthropic output_config with live tag enums for LOGON responses."""
 
+    compact_schema = storyteller_anthropic_compact_schema(schema_model, dbname)
+    if compact_schema is not None:
+        return anthropic_output_config(schema_model, schema=compact_schema)
+
     schema = storyteller_schema_with_runtime_tag_enums(schema_model, dbname)
     if schema is None:
         return None
     return anthropic_output_config(schema_model, schema=schema)
+
+
+def storyteller_anthropic_compact_schema(
+    schema_model: Type[BaseModel],
+    dbname: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Return a compact Anthropic wire schema for extended storyteller turns."""
+
+    if schema_model.__name__ != "StorytellerResponseExtended":
+        return None
+    tag_names, pair_tag_names = _compact_new_entity_vocabulary(dbname)
+
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "narrative": {
+                "type": "string",
+                "description": "The narrative prose.",
+            },
+            "choices": _string_array_schema(
+                "Player choices, each as a complete actionable option."
+            ),
+            "authorial_directives": _string_array_schema(
+                "Focused retrieval priorities for the next turn."
+            ),
+            "chunk_metadata": _empty_object_schema(
+                "Default chunk metadata; runtime fills normal chronology."
+            ),
+            "referenced_entities": _empty_object_schema(
+                "Default referenced entity set; leave empty in compact Anthropic wire."
+            ),
+            "state_updates": _empty_object_schema(
+                "Default state updates; leave empty unless using full provider schema."
+            ),
+            "operations": _nullable_schema(_empty_object_schema("No operations.")),
+            "orrery_adjudications": {
+                "type": "array",
+                "items": _compact_orrery_adjudication_schema(),
+                "description": "Optional defer/replace/void rulings.",
+            },
+            "new_entities": {
+                "type": "array",
+                "items": _compact_new_entity_schema(tag_names, pair_tag_names),
+                "description": (
+                    "Sparing declarations for newly introduced persistent entities."
+                ),
+            },
+            "reasoning": _nullable_schema(
+                {"type": "string", "description": "Optional debug reasoning."}
+            ),
+        },
+        "required": [
+            "narrative",
+            "choices",
+            "authorial_directives",
+            "chunk_metadata",
+            "referenced_entities",
+            "state_updates",
+            "operations",
+            "orrery_adjudications",
+            "new_entities",
+            "reasoning",
+        ],
+    }
 
 
 def storyteller_schema_with_runtime_tag_enums(
@@ -103,6 +175,160 @@ def storyteller_schema_with_runtime_tag_enums(
     return schema if replaced else None
 
 
+def _string_array_schema(description: str) -> Dict[str, Any]:
+    return {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": description,
+    }
+
+
+def _enum_string_array_schema(
+    description: str,
+    values: Sequence[str],
+) -> Dict[str, Any]:
+    items: Dict[str, Any] = {"type": "string"}
+    if values:
+        items["enum"] = list(values)
+    return {
+        "type": "array",
+        "items": items,
+        "description": description,
+    }
+
+
+def _enum_string_schema(values: Sequence[str]) -> Dict[str, Any]:
+    schema: Dict[str, Any] = {"type": "string"}
+    if values:
+        schema["enum"] = list(values)
+    return schema
+
+
+def _empty_object_schema(description: str) -> Dict[str, Any]:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {},
+        "description": description,
+    }
+
+
+def _nullable_schema(schema: Mapping[str, Any]) -> Dict[str, Any]:
+    return {"anyOf": [dict(schema), {"type": "null"}]}
+
+
+def _compact_new_entity_schema(
+    tag_names: Sequence[str],
+    pair_tag_names: Sequence[str],
+) -> Dict[str, Any]:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "kind": {"type": "string", "enum": ["character", "place", "faction"]},
+            "name": {"type": "string"},
+            "summary": {"type": "string"},
+            "tag_hints": _enum_string_array_schema(
+                "Registered single-entity tag names.",
+                tag_names,
+            ),
+            "pair_tag_hints": {
+                "type": "array",
+                "items": _compact_pair_tag_hint_schema(pair_tag_names),
+            },
+        },
+        "required": [
+            "kind",
+            "name",
+            "summary",
+            "tag_hints",
+            "pair_tag_hints",
+        ],
+    }
+
+
+def _compact_pair_tag_hint_schema(pair_tag_names: Sequence[str]) -> Dict[str, Any]:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "tag": _enum_string_schema(pair_tag_names),
+            "other_entity_name": {"type": "string"},
+            "declared_entity_role": {
+                "type": "string",
+                "enum": ["subject", "object"],
+            },
+        },
+        "required": ["tag", "other_entity_name", "declared_entity_role"],
+    }
+
+
+def _compact_orrery_adjudication_schema() -> Dict[str, Any]:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "proposal_id": {"type": "string"},
+            "action": {"type": "string", "enum": ["defer", "replace", "void"]},
+            "note": _nullable_schema({"type": "string"}),
+            "replacement_state_delta": _nullable_schema(
+                _compact_replacement_state_delta_schema()
+            ),
+            "replacement_event_type": _nullable_schema({"type": "string"}),
+        },
+        "required": [
+            "proposal_id",
+            "action",
+            "note",
+            "replacement_state_delta",
+            "replacement_event_type",
+        ],
+    }
+
+
+def _compact_replacement_state_delta_schema() -> Dict[str, Any]:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "character_current_activity": _nullable_schema({"type": "string"}),
+            "entity_tags_add": _string_array_schema("Actor tags to add."),
+            "entity_tags_remove": _string_array_schema("Actor tags to clear."),
+            "entity_tags_target_add": _string_array_schema("Target tags to add."),
+            "entity_tags_target_remove": _string_array_schema("Target tags to clear."),
+            "entity_pair_tags_target_clear_inbound": _string_array_schema(
+                "Inbound target pair-tags to clear."
+            ),
+        },
+        "required": [
+            "character_current_activity",
+            "entity_tags_add",
+            "entity_tags_remove",
+            "entity_tags_target_add",
+            "entity_tags_target_remove",
+            "entity_pair_tags_target_clear_inbound",
+        ],
+    }
+
+
+def _compact_new_entity_vocabulary(
+    dbname: Optional[str],
+) -> tuple[list[str], list[str]]:
+    if not dbname:
+        return [], []
+    try:
+        tags_by_kind = _read_tags_by_kind(dbname)
+        tag_names = sorted({tag for tags in tags_by_kind.values() for tag in tags})
+        pair_tag_names = _read_pair_tags(dbname)
+    except Exception as exc:
+        logger.warning(
+            "Failed to load compact Anthropic storyteller vocab enums: %s",
+            exc,
+        )
+        return [], []
+    return tag_names, pair_tag_names
+
+
 def _read_tags_by_kind(dbname: str) -> dict[str, list[str]]:
     tags_by_kind = {kind: [] for kind in _KIND_DEF_NAMES}
     for entry in read_tag_library(dbname):
@@ -112,6 +338,29 @@ def _read_tags_by_kind(dbname: str) -> dict[str, list[str]]:
         for kind, tags in tags_by_kind.items()
         if kind in _KIND_DEF_NAMES
     }
+
+
+def _read_pair_tags(dbname: str) -> list[str]:
+    conn = psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+        cursor_factory=RealDictCursor,
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT tag
+                FROM pair_tags
+                WHERE deprecated = FALSE
+                ORDER BY tag
+                """
+            )
+            return [str(row["tag"]) for row in cur.fetchall()]
+    finally:
+        conn.close()
 
 
 def _bestowal_def_with_tag_enum(

--- a/nexus/agents/logon/orrery_tag_schema.py
+++ b/nexus/agents/logon/orrery_tag_schema.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 from copy import deepcopy
 import logging
-import os
 from typing import Any, Dict, Mapping, Optional, Sequence, Type
 
-import psycopg2
-from psycopg2.extras import RealDictCursor
 from pydantic import BaseModel
 
-from nexus.agents.orrery.tag_library import read_tag_library
+from nexus.agents.orrery.tag_library import (
+    read_event_types,
+    read_pair_tag_library,
+    read_tag_library,
+)
 from nexus.api.native_structured_output import (
     anthropic_output_config,
     openai_response_text_format,
@@ -70,7 +71,7 @@ def storyteller_anthropic_compact_schema(
 
     if schema_model.__name__ != "StorytellerResponseExtended":
         return None
-    tag_names, pair_tag_names = _compact_new_entity_vocabulary(dbname)
+    tag_names, pair_tag_names, event_types = _compact_storyteller_vocabulary(dbname)
 
     return {
         "type": "object",
@@ -92,13 +93,11 @@ def storyteller_anthropic_compact_schema(
             "referenced_entities": _empty_object_schema(
                 "Default referenced entity set; leave empty in compact Anthropic wire."
             ),
-            "state_updates": _empty_object_schema(
-                "Default state updates; leave empty unless using full provider schema."
-            ),
-            "operations": _nullable_schema(_empty_object_schema("No operations.")),
+            "state_updates": _compact_state_updates_schema(),
+            "operations": _empty_object_schema("No operations."),
             "orrery_adjudications": {
                 "type": "array",
-                "items": _compact_orrery_adjudication_schema(),
+                "items": _compact_orrery_adjudication_schema(event_types),
                 "description": "Optional defer/replace/void rulings.",
             },
             "new_entities": {
@@ -108,9 +107,7 @@ def storyteller_anthropic_compact_schema(
                     "Sparing declarations for newly introduced persistent entities."
                 ),
             },
-            "reasoning": _nullable_schema(
-                {"type": "string", "description": "Optional debug reasoning."}
-            ),
+            "reasoning": {"type": "string", "description": "Optional debug reasoning."},
         },
         "required": [
             "narrative",
@@ -204,6 +201,10 @@ def _enum_string_schema(values: Sequence[str]) -> Dict[str, Any]:
     return schema
 
 
+def _optional_string_schema(description: str) -> Dict[str, Any]:
+    return {"type": "string", "description": description}
+
+
 def _empty_object_schema(description: str) -> Dict[str, Any]:
     return {
         "type": "object",
@@ -215,6 +216,41 @@ def _empty_object_schema(description: str) -> Dict[str, Any]:
 
 def _nullable_schema(schema: Mapping[str, Any]) -> Dict[str, Any]:
     return {"anyOf": [dict(schema), {"type": "null"}]}
+
+
+def _compact_state_updates_schema() -> Dict[str, Any]:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "updates": {
+                "type": "array",
+                "items": _compact_state_update_entry_schema(),
+            }
+        },
+        "required": ["updates"],
+        "description": "Compact per-turn entity state updates expanded by runtime.",
+    }
+
+
+def _compact_state_update_entry_schema() -> Dict[str, Any]:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "kind": {
+                "type": "string",
+                "enum": ["character", "place", "faction"],
+            },
+            "name": _optional_string_schema("Subject entity name."),
+            "status": _optional_string_schema(
+                "Current activity, condition, or faction action."
+            ),
+            "tag_add": _optional_string_schema("Registered tag name to apply."),
+            "tag_clear": _optional_string_schema("Registered tag name to clear."),
+        },
+        "required": ["kind"],
+    }
 
 
 def _compact_new_entity_schema(
@@ -263,70 +299,45 @@ def _compact_pair_tag_hint_schema(pair_tag_names: Sequence[str]) -> Dict[str, An
     }
 
 
-def _compact_orrery_adjudication_schema() -> Dict[str, Any]:
+def _compact_orrery_adjudication_schema(
+    event_types: Sequence[str],
+) -> Dict[str, Any]:
+    properties: Dict[str, Any] = {
+        "proposal_id": {"type": "string"},
+        "action": {"type": "string", "enum": ["defer", "replace", "void"]},
+        "note": {"type": "string"},
+    }
+    if event_types:
+        properties["replacement_event_type"] = _enum_string_schema(event_types)
+
     return {
         "type": "object",
         "additionalProperties": False,
-        "properties": {
-            "proposal_id": {"type": "string"},
-            "action": {"type": "string", "enum": ["defer", "replace", "void"]},
-            "note": _nullable_schema({"type": "string"}),
-            "replacement_state_delta": _nullable_schema(
-                _compact_replacement_state_delta_schema()
-            ),
-            "replacement_event_type": _nullable_schema({"type": "string"}),
-        },
+        "properties": properties,
         "required": [
             "proposal_id",
             "action",
-            "note",
-            "replacement_state_delta",
-            "replacement_event_type",
         ],
     }
 
 
-def _compact_replacement_state_delta_schema() -> Dict[str, Any]:
-    return {
-        "type": "object",
-        "additionalProperties": False,
-        "properties": {
-            "character_current_activity": _nullable_schema({"type": "string"}),
-            "entity_tags_add": _string_array_schema("Actor tags to add."),
-            "entity_tags_remove": _string_array_schema("Actor tags to clear."),
-            "entity_tags_target_add": _string_array_schema("Target tags to add."),
-            "entity_tags_target_remove": _string_array_schema("Target tags to clear."),
-            "entity_pair_tags_target_clear_inbound": _string_array_schema(
-                "Inbound target pair-tags to clear."
-            ),
-        },
-        "required": [
-            "character_current_activity",
-            "entity_tags_add",
-            "entity_tags_remove",
-            "entity_tags_target_add",
-            "entity_tags_target_remove",
-            "entity_pair_tags_target_clear_inbound",
-        ],
-    }
-
-
-def _compact_new_entity_vocabulary(
+def _compact_storyteller_vocabulary(
     dbname: Optional[str],
-) -> tuple[list[str], list[str]]:
+) -> tuple[list[str], list[str], list[str]]:
     if not dbname:
-        return [], []
+        return [], [], []
     try:
         tags_by_kind = _read_tags_by_kind(dbname)
         tag_names = sorted({tag for tags in tags_by_kind.values() for tag in tags})
         pair_tag_names = _read_pair_tags(dbname)
+        event_types = _read_event_types(dbname)
     except Exception as exc:
         logger.warning(
             "Failed to load compact Anthropic storyteller vocab enums: %s",
             exc,
         )
-        return [], []
-    return tag_names, pair_tag_names
+        return [], [], []
+    return tag_names, pair_tag_names, event_types
 
 
 def _read_tags_by_kind(dbname: str) -> dict[str, list[str]]:
@@ -341,26 +352,11 @@ def _read_tags_by_kind(dbname: str) -> dict[str, list[str]]:
 
 
 def _read_pair_tags(dbname: str) -> list[str]:
-    conn = psycopg2.connect(
-        dbname=dbname,
-        user=os.environ.get("PGUSER", "pythagor"),
-        host=os.environ.get("PGHOST", "localhost"),
-        port=os.environ.get("PGPORT", "5432"),
-        cursor_factory=RealDictCursor,
-    )
-    try:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT tag
-                FROM pair_tags
-                WHERE deprecated = FALSE
-                ORDER BY tag
-                """
-            )
-            return [str(row["tag"]) for row in cur.fetchall()]
-    finally:
-        conn.close()
+    return read_pair_tag_library(dbname)
+
+
+def _read_event_types(dbname: str) -> list[str]:
+    return read_event_types(dbname)
 
 
 def _bestowal_def_with_tag_enum(

--- a/nexus/agents/logon/orrery_tag_schema.py
+++ b/nexus/agents/logon/orrery_tag_schema.py
@@ -1,0 +1,167 @@
+"""Runtime JSON Schema constraints for storyteller Orrery tag bestowals."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import logging
+from typing import Any, Dict, Mapping, Optional, Type
+
+from pydantic import BaseModel
+
+from nexus.agents.orrery.tag_library import read_tag_library
+from nexus.api.native_structured_output import (
+    anthropic_output_format,
+    openai_response_text_format,
+    strict_json_schema,
+)
+
+logger = logging.getLogger("nexus.logon.orrery_tag_schema")
+
+_KIND_DEF_NAMES = {
+    "character": "OrreryTagBestowalCharacter",
+    "place": "OrreryTagBestowalPlace",
+    "faction": "OrreryTagBestowalFaction",
+}
+
+_OWNER_KINDS = {
+    "CharacterStateUpdate": "character",
+    "NewCharacter": "character",
+    "LocationStateUpdate": "place",
+    "NewPlace": "place",
+    "FactionStateUpdate": "faction",
+    "NewFaction": "faction",
+}
+
+
+def storyteller_openai_text_format(
+    schema_model: Type[BaseModel], dbname: Optional[str]
+) -> Optional[Dict[str, Any]]:
+    """Build an OpenAI text.format with live tag enums for LOGON responses."""
+
+    schema = storyteller_schema_with_runtime_tag_enums(schema_model, dbname)
+    if schema is None:
+        return None
+    return openai_response_text_format(schema_model, schema=schema)
+
+
+def storyteller_anthropic_output_format(
+    schema_model: Type[BaseModel], dbname: Optional[str]
+) -> Optional[Dict[str, Any]]:
+    """Build an Anthropic output_format with live tag enums for LOGON responses."""
+
+    schema = storyteller_schema_with_runtime_tag_enums(schema_model, dbname)
+    if schema is None:
+        return None
+    return anthropic_output_format(schema_model, schema=schema)
+
+
+def storyteller_schema_with_runtime_tag_enums(
+    schema_model: Type[BaseModel], dbname: Optional[str]
+) -> Optional[Dict[str, Any]]:
+    """Specialize LOGON's JSON Schema with slot-specific Orrery tag enums."""
+
+    if not dbname:
+        return None
+    try:
+        tags_by_kind = _read_tags_by_kind(dbname)
+    except Exception as exc:
+        logger.warning(
+            "Failed to load runtime Orrery tag enums for storyteller schema: %s",
+            exc,
+        )
+        return None
+    if not any(tags_by_kind.values()):
+        return None
+
+    schema = deepcopy(strict_json_schema(schema_model))
+    defs = schema.get("$defs")
+    if not isinstance(defs, dict) or "OrreryTagBestowal" not in defs:
+        return None
+
+    base_bestowal = defs["OrreryTagBestowal"]
+    for entity_kind, tags in tags_by_kind.items():
+        if not tags:
+            continue
+        def_name = _KIND_DEF_NAMES[entity_kind]
+        defs[def_name] = _bestowal_def_with_tag_enum(
+            base_bestowal,
+            tags,
+            entity_kind=entity_kind,
+        )
+
+    replaced = False
+    for owner_def, entity_kind in _OWNER_KINDS.items():
+        if not tags_by_kind.get(entity_kind):
+            continue
+        if _replace_owner_bestowal_ref(
+            defs,
+            owner_def=owner_def,
+            target_def=_KIND_DEF_NAMES[entity_kind],
+        ):
+            replaced = True
+
+    return schema if replaced else None
+
+
+def _read_tags_by_kind(dbname: str) -> dict[str, list[str]]:
+    tags_by_kind = {kind: [] for kind in _KIND_DEF_NAMES}
+    for entry in read_tag_library(dbname):
+        tags_by_kind.setdefault(entry.entity_kind, []).append(entry.tag)
+    return {
+        kind: sorted(dict.fromkeys(tags))
+        for kind, tags in tags_by_kind.items()
+        if kind in _KIND_DEF_NAMES
+    }
+
+
+def _bestowal_def_with_tag_enum(
+    base_bestowal: Mapping[str, Any], tags: list[str], *, entity_kind: str
+) -> Dict[str, Any]:
+    bestowal = deepcopy(dict(base_bestowal))
+    bestowal["title"] = _KIND_DEF_NAMES[entity_kind]
+    bestowal["description"] = (
+        f"{base_bestowal.get('description', '')}\n\n"
+        f"Runtime constraint: tag names must be registered {entity_kind} tags "
+        "from this slot."
+    ).strip()
+    properties = bestowal.get("properties", {})
+    if isinstance(properties, dict):
+        for field_name in ("applied_tags", "tags_to_clear"):
+            field_schema = properties.get(field_name)
+            if isinstance(field_schema, dict):
+                items = field_schema.setdefault("items", {})
+                if isinstance(items, dict):
+                    items["type"] = "string"
+                    items["enum"] = tags
+    return bestowal
+
+
+def _replace_owner_bestowal_ref(
+    defs: Dict[str, Any], *, owner_def: str, target_def: str
+) -> bool:
+    owner_schema = defs.get(owner_def)
+    if not isinstance(owner_schema, dict):
+        return False
+    properties = owner_schema.get("properties")
+    if not isinstance(properties, dict):
+        return False
+    bestowal_field = properties.get("orrery_tags")
+    if not isinstance(bestowal_field, dict):
+        return False
+    return _replace_bestowal_ref(bestowal_field, target_def=target_def)
+
+
+def _replace_bestowal_ref(schema: Any, *, target_def: str) -> bool:
+    if isinstance(schema, dict):
+        if schema.get("$ref") == "#/$defs/OrreryTagBestowal":
+            schema["$ref"] = f"#/$defs/{target_def}"
+            return True
+        return any(
+            _replace_bestowal_ref(value, target_def=target_def)
+            for value in schema.values()
+        )
+    if isinstance(schema, list):
+        return any(
+            _replace_bestowal_ref(item, target_def=target_def) for item in schema
+        )
+    return False

--- a/nexus/agents/logon/orrery_tag_schema.py
+++ b/nexus/agents/logon/orrery_tag_schema.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from nexus.agents.orrery.tag_library import read_tag_library
 from nexus.api.native_structured_output import (
-    anthropic_output_format,
+    anthropic_output_config,
     openai_response_text_format,
     strict_json_schema,
 )
@@ -44,15 +44,15 @@ def storyteller_openai_text_format(
     return openai_response_text_format(schema_model, schema=schema)
 
 
-def storyteller_anthropic_output_format(
+def storyteller_anthropic_output_config(
     schema_model: Type[BaseModel], dbname: Optional[str]
 ) -> Optional[Dict[str, Any]]:
-    """Build an Anthropic output_format with live tag enums for LOGON responses."""
+    """Build an Anthropic output_config with live tag enums for LOGON responses."""
 
     schema = storyteller_schema_with_runtime_tag_enums(schema_model, dbname)
     if schema is None:
         return None
-    return anthropic_output_format(schema_model, schema=schema)
+    return anthropic_output_config(schema_model, schema=schema)
 
 
 def storyteller_schema_with_runtime_tag_enums(

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -103,6 +103,9 @@ class LogonUtility:
         self.provider: Optional[object] = None
         self._system_prompt: Optional[str] = None
         self._provider_bootstrap_mode: Optional[bool] = None
+        self._provider_wire_type: Optional[str] = None
+        self._validation_dbname: Optional[str] = None
+        self._schema_format_cache: Dict[type, Dict[str, Any]] = {}
 
     def _load_system_prompt(self, is_bootstrap: Optional[bool] = None) -> str:
         """Load and combine storyteller instructions with live slot context."""
@@ -294,8 +297,11 @@ class LogonUtility:
         except Exception:
             validation_dbname = None
         output_validator = build_storyteller_tag_validator(validation_dbname)
+        self._validation_dbname = validation_dbname
+        self._schema_format_cache = {}
 
         if provider_type == "anthropic":
+            self._provider_wire_type = "anthropic"
             self.provider = AnthropicProvider(
                 model=model,
                 max_tokens=apex_settings.get(
@@ -308,6 +314,7 @@ class LogonUtility:
         elif provider_type == "openai" or base_url:
             # Native OpenAI, or any OpenAI-compatible server registered with a
             # base_url in [global.model.api_models] (mock TEST, Ollama, vLLM).
+            self._provider_wire_type = "openai"
             self.provider = OpenAIProvider(
                 model=model,
                 temperature=apex_settings.get("temperature", 0.7),
@@ -365,6 +372,7 @@ class LogonUtility:
         # Format the context into a prompt
         prompt = self._format_context_prompt(context_payload)
         schema_model = self._select_response_schema(context_payload)
+        schema_kwargs = self._schema_format_kwargs(schema_model)
 
         # Get structured completion from provider
         # This returns a tuple of (parsed_object, llm_response)
@@ -372,6 +380,7 @@ class LogonUtility:
             parsed_response, _llm_response = self.provider.get_structured_completion(
                 prompt,
                 schema_model,
+                **schema_kwargs,
             )
             logger.debug(
                 "Received structured response with narrative length: %s",
@@ -389,12 +398,14 @@ class LogonUtility:
         self._ensure_provider(context_payload)
         prompt = self._format_context_prompt(context_payload)
         schema_model = self._select_response_schema(context_payload)
+        schema_kwargs = self._schema_format_kwargs(schema_model)
 
         try:
             parsed_response, _llm_response = (
                 await self.provider.get_structured_completion_async(
                     prompt,
                     schema_model,
+                    **schema_kwargs,
                 )
             )
             logger.debug(
@@ -414,6 +425,42 @@ class LogonUtility:
             return StorytellerResponseBootstrap
 
         return StorytellerResponseExtended
+
+    def _schema_format_kwargs(self, schema_model: type) -> Dict[str, Any]:
+        """Return provider-specific native schema overrides for LOGON."""
+
+        if not self._validation_dbname or not self._provider_wire_type:
+            return {}
+        if schema_model in self._schema_format_cache:
+            return self._schema_format_cache[schema_model]
+
+        kwargs: Dict[str, Any] = {}
+        try:
+            from nexus.agents.logon.orrery_tag_schema import (
+                storyteller_anthropic_output_format,
+                storyteller_openai_text_format,
+            )
+
+            if self._provider_wire_type == "anthropic":
+                output_format = storyteller_anthropic_output_format(
+                    schema_model, self._validation_dbname
+                )
+                if output_format is not None:
+                    kwargs = {"output_format": output_format}
+            else:
+                text_format = storyteller_openai_text_format(
+                    schema_model, self._validation_dbname
+                )
+                if text_format is not None:
+                    kwargs = {"text_format": text_format}
+        except Exception as exc:
+            logger.warning(
+                "Failed to build runtime storyteller schema constraints: %s",
+                exc,
+            )
+
+        self._schema_format_cache[schema_model] = kwargs
+        return kwargs
 
     @staticmethod
     def _is_bootstrap_context(context_payload: Optional[Mapping[str, Any]]) -> bool:

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -679,7 +679,9 @@ class LogonUtility:
             sections.append(
                 "These are optional ambient peripherals from off-screen events. "
                 "Ignore freely, render subtly, or use them at any density that "
-                "fits the current scene. Do not explain Orrery."
+                "fits the current scene. If you use one with an actor name, "
+                "include that exact name at least once in the prose. Do not "
+                "explain Orrery."
             )
             for item in bleed_menu[:5]:
                 channel = item.get("channel") or "ambient"

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -437,16 +437,16 @@ class LogonUtility:
         kwargs: Dict[str, Any] = {}
         try:
             from nexus.agents.logon.orrery_tag_schema import (
-                storyteller_anthropic_output_format,
+                storyteller_anthropic_output_config,
                 storyteller_openai_text_format,
             )
 
             if self._provider_wire_type == "anthropic":
-                output_format = storyteller_anthropic_output_format(
+                output_config = storyteller_anthropic_output_config(
                     schema_model, self._validation_dbname
                 )
-                if output_format is not None:
-                    kwargs = {"output_format": output_format}
+                if output_config is not None:
+                    kwargs = {"output_config": output_config}
             else:
                 text_format = storyteller_openai_text_format(
                     schema_model, self._validation_dbname

--- a/nexus/agents/orrery/retrograde_expansion.py
+++ b/nexus/agents/orrery/retrograde_expansion.py
@@ -56,6 +56,25 @@ class RetrogradeExpansionValidationError(ValueError):
     """Raised when an R6 expansion plan is shaped correctly but illegal."""
 
 
+class RetrogradePayloadEntry(BaseModel):
+    """Strict key/value entry for future world_events.payload sketches."""
+
+    key: str = Field(min_length=1)
+    value: str = Field(description="Payload value rendered as concise prose or JSON.")
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
+def _stringify_payload_value(value: Any) -> str:
+    """Render arbitrary legacy payload values into strict-schema strings."""
+
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
 class RetrogradeExpansionParticipant(BaseModel):
     """One entity reference participating in a planned Retrograde event."""
 
@@ -110,10 +129,28 @@ class RetrogradeExpansionEventPlan(BaseModel):
         le=1,
         description="Optional future world_events.magnitude value.",
     )
-    payload: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Small future world_events.payload sketch.",
+    payload: list[RetrogradePayloadEntry] = Field(
+        default_factory=list,
+        description="Small future world_events.payload sketch as key/value entries.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_legacy_payload(cls, data: Any) -> Any:
+        """Accept legacy payload dicts while emitting strict list schema."""
+
+        if not isinstance(data, dict):
+            return data
+        payload = data.get("payload")
+        if payload is None or isinstance(payload, list):
+            return data
+        if isinstance(payload, Mapping):
+            data = dict(data)
+            data["payload"] = [
+                {"key": str(key), "value": _stringify_payload_value(value)}
+                for key, value in payload.items()
+            ]
+        return data
 
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
@@ -353,34 +390,32 @@ def generate_expansion_with_skald(
 ) -> dict[str, Any]:
     """Make a non-mutating Skald call to weave selected seeds into an R6 plan."""
 
-    from pydantic_ai import Agent, ModelRetry, RunContext
-    from pydantic_ai.settings import ModelSettings
+    from pydantic_ai import ModelRetry
 
     from nexus.api.config_utils import (
         get_new_story_model,
         get_wizard_max_tokens,
         get_wizard_retry_budget,
     )
-    from nexus.api.pydantic_ai_utils import build_pydantic_ai_model
+    from nexus.api.native_structured_output import build_native_structured_provider
 
     prompt = render_expansion_prompt(
         packet=packet,
         seed_candidate_response=seed_candidate_response,
     )
     selected_model = model_name or get_new_story_model()
-    agent = Agent(
-        model=build_pydantic_ai_model(selected_model),
-        output_type=RetrogradeExpansionPlanResponse,
+    provider = build_native_structured_provider(
+        model=selected_model,
+        max_tokens=max_tokens or get_wizard_max_tokens(),
         system_prompt=(
             "You are Skald-as-weaver for a NEXUS Retrograde expansion pass. "
             "Return a non-mutating expansion plan only."
         ),
-        model_settings=ModelSettings(max_tokens=max_tokens or get_wizard_max_tokens()),
-        retries=get_wizard_retry_budget(),
+        structured_output_retries=get_wizard_retry_budget(),
     )
 
     async def _validate_output(
-        _ctx: RunContext[None],
+        _ctx: Any,
         output: RetrogradeExpansionPlanResponse,
     ) -> RetrogradeExpansionPlanResponse:
         try:
@@ -396,9 +431,11 @@ def generate_expansion_with_skald(
                 f"seed, or adding required refs:\n{exc}"
             ) from exc
 
-    agent.output_validator(_validate_output)
-    result = agent.run_sync(prompt)
-    response = result.output
+    provider.output_validator = _validate_output
+    response, _llm_response = provider.get_structured_completion(
+        prompt,
+        RetrogradeExpansionPlanResponse,
+    )
     if not isinstance(response, RetrogradeExpansionPlanResponse):
         raise TypeError(
             "Skald expansion call returned "

--- a/nexus/agents/orrery/retrograde_expansion.py
+++ b/nexus/agents/orrery/retrograde_expansion.py
@@ -239,6 +239,85 @@ class RetrogradeExpansionCommitReadiness(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
 
+class RetrogradeExpansionWireEventPlan(BaseModel):
+    """Provider-facing event plan with absence represented as empty strings."""
+
+    event_ref: str = Field(min_length=1)
+    seed_ids: list[str] = Field(default_factory=list)
+    event_type: str = Field(min_length=1)
+    summary: str = Field(min_length=1)
+    chronology: Literal["deep_past", "recent_past", "opening_pressure"]
+    participants: list[RetrogradeExpansionParticipant] = Field(default_factory=list)
+    location_ref: str = Field(
+        default="",
+        description="Prompt-local place name, or empty string when absent.",
+    )
+    changed_fields: list[str] = Field(default_factory=list)
+    magnitude: str = Field(
+        default="",
+        description="0..1 as text, or empty string when absent.",
+    )
+    payload: list[RetrogradePayloadEntry] = Field(default_factory=list)
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
+class RetrogradeExpansionWireMechanicPlan(BaseModel):
+    """Provider-facing generic mechanics row expanded by runtime."""
+
+    plan: Literal["entity_tag", "pair_tag", "relationship"]
+    subject_ref: EntityRef
+    subject_kind: str = Field(min_length=1)
+    tag: str = Field(
+        default="",
+        description="Single-entity or pair tag; empty for relationship rows.",
+    )
+    object_ref: str = Field(
+        default="",
+        description="Object entity ref for pair tags/relationships; empty otherwise.",
+    )
+    object_kind: str = Field(
+        default="",
+        description="Object entity kind for pair tags/relationships; empty otherwise.",
+    )
+    relationship_type: str = Field(
+        default="",
+        description="Relationship type for relationship rows; empty otherwise.",
+    )
+    source_event_ref: str = Field(
+        default="",
+        description="Planned event_ref source, or empty string when absent.",
+    )
+    rationale: str = Field(default="")
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
+class RetrogradeExpansionWireThreadPlan(BaseModel):
+    """Provider-facing thread accounting with absence represented as strings."""
+
+    seed_id: str = Field(min_length=1)
+    status: Literal["woven", "deferred", "rejected"]
+    event_refs: list[str] = Field(default_factory=list)
+    present_leaf_anchor: str = Field(min_length=1)
+    note: str = Field(default="")
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
+class RetrogradeExpansionWireResponse(BaseModel):
+    """Provider-facing R6 response with deterministic fields omitted."""
+
+    event_plan: list[RetrogradeExpansionWireEventPlan] = Field(default_factory=list)
+    mechanical_plan: list[RetrogradeExpansionWireMechanicPlan] = Field(
+        default_factory=list
+    )
+    thread_plan: list[RetrogradeExpansionWireThreadPlan] = Field(default_factory=list)
+    coverage_notes: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
 class RetrogradeExpansionPlanResponse(BaseModel):
     """Structured R6 response from Skald-as-weaver."""
 
@@ -291,6 +370,104 @@ def expansion_response_schema() -> dict[str, Any]:
     """Return the Pydantic JSON schema for R6 expansion responses."""
 
     return RetrogradeExpansionPlanResponse.model_json_schema()
+
+
+def coerce_expansion_response_payload(
+    payload: Mapping[str, Any],
+    *,
+    selected_seed_ids: list[str],
+) -> RetrogradeExpansionPlanResponse:
+    """Fill deterministic R6 fields and return the full app contract."""
+
+    data = _expand_wire_payload(payload)
+    data.setdefault("schema_version", RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION)
+    data.setdefault("selected_seed_ids", list(selected_seed_ids))
+    data.setdefault("commit_readiness", {})
+    return RetrogradeExpansionPlanResponse.model_validate(data)
+
+
+def _none_if_empty(value: Any) -> Any:
+    if value == "":
+        return None
+    return value
+
+
+def _float_if_present(value: Any) -> Optional[float]:
+    if value in {"", None}:
+        return None
+    return float(value)
+
+
+def _expand_wire_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Expand compact provider mechanics into the full persistence plan shape."""
+
+    data = dict(payload)
+    if "mechanical_plan" not in data:
+        return data
+
+    event_plan = []
+    for event in data.get("event_plan") or []:
+        row = dict(event)
+        row["location_ref"] = _none_if_empty(row.get("location_ref"))
+        row["magnitude"] = _float_if_present(row.get("magnitude"))
+        event_plan.append(row)
+
+    entity_tag_plan = []
+    pair_tag_plan = []
+    relationship_plan = []
+    for mechanic in data.get("mechanical_plan") or []:
+        plan = str(mechanic.get("plan"))
+        source_event_ref = _none_if_empty(mechanic.get("source_event_ref"))
+        rationale = _none_if_empty(mechanic.get("rationale"))
+        if plan == "entity_tag":
+            entity_tag_plan.append(
+                {
+                    "entity_ref": mechanic.get("subject_ref"),
+                    "entity_kind": mechanic.get("subject_kind"),
+                    "tag": mechanic.get("tag"),
+                    "source_event_ref": source_event_ref,
+                    "rationale": rationale,
+                }
+            )
+        elif plan == "pair_tag":
+            pair_tag_plan.append(
+                {
+                    "subject_ref": mechanic.get("subject_ref"),
+                    "subject_kind": mechanic.get("subject_kind"),
+                    "tag": mechanic.get("tag"),
+                    "object_ref": mechanic.get("object_ref"),
+                    "object_kind": mechanic.get("object_kind"),
+                    "source_event_ref": source_event_ref,
+                    "rationale": rationale,
+                }
+            )
+        elif plan == "relationship":
+            relationship_plan.append(
+                {
+                    "subject_ref": mechanic.get("subject_ref"),
+                    "subject_kind": mechanic.get("subject_kind"),
+                    "relationship_type": mechanic.get("relationship_type"),
+                    "object_ref": mechanic.get("object_ref"),
+                    "object_kind": mechanic.get("object_kind"),
+                    "source_event_ref": source_event_ref,
+                    "rationale": rationale,
+                }
+            )
+
+    thread_plan = []
+    for thread in data.get("thread_plan") or []:
+        row = dict(thread)
+        row["note"] = _none_if_empty(row.get("note"))
+        thread_plan.append(row)
+
+    return {
+        "event_plan": event_plan,
+        "entity_tag_plan": entity_tag_plan,
+        "pair_tag_plan": pair_tag_plan,
+        "relationship_plan": relationship_plan,
+        "thread_plan": thread_plan,
+        "coverage_notes": data.get("coverage_notes") or [],
+    }
 
 
 def render_expansion_prompt(
@@ -367,7 +544,10 @@ def validate_expansion_plan(
         seed_generation_request=seed_generation_request,
         vocabulary=vocabulary,
     )
-    response = RetrogradeExpansionPlanResponse.model_validate(payload)
+    response = coerce_expansion_response_payload(
+        payload,
+        selected_seed_ids=list(candidates.selected_seed_ids),
+    )
     issues = _expansion_contract_issues(
         response=response,
         selected_seed_ids=set(candidates.selected_seed_ids),
@@ -416,7 +596,7 @@ def generate_expansion_with_skald(
 
     async def _validate_output(
         _ctx: Any,
-        output: RetrogradeExpansionPlanResponse,
+        output: RetrogradeExpansionWireResponse,
     ) -> RetrogradeExpansionPlanResponse:
         try:
             return validate_expansion_plan(
@@ -434,7 +614,7 @@ def generate_expansion_with_skald(
     provider.output_validator = _validate_output
     response, _llm_response = provider.get_structured_completion(
         prompt,
-        RetrogradeExpansionPlanResponse,
+        RetrogradeExpansionWireResponse,
     )
     if not isinstance(response, RetrogradeExpansionPlanResponse):
         raise TypeError(
@@ -844,10 +1024,15 @@ def _hard_validation_rules() -> list[str]:
         "Every selected seed must appear once in thread_plan.",
         "Woven threads must reference planned event_ref values.",
         (
-            "Event-anchored single-entity tags require source_event_ref that "
+            "mechanical_plan rows use plan='entity_tag', 'pair_tag', or "
+            "'relationship'. Leave fields irrelevant to that plan as empty "
+            "strings."
+        ),
+        (
+            "Event-anchored entity_tag mechanics require source_event_ref that "
             "matches event_plan.event_ref."
         ),
-        "Prompt-visible-only tags must not appear in entity_tag_plan.",
+        "Prompt-visible-only tags must not appear in mechanical_plan.",
         "Pair tags must obey registered subject/object kind constraints.",
         (
             "Single-entity tags must be registered for the tagged entity_kind "
@@ -855,18 +1040,14 @@ def _hard_validation_rules() -> list[str]:
             "kind is illegal."
         ),
         (
-            "relationship_plan currently supports only character->character "
+            "relationship mechanics currently support only character->character "
             "rows; express faction/place pressure through events or pair tags."
         ),
         (
-            "Entity refs (entity_ref, subject_ref, object_ref, location_ref) "
+            "Entity refs (subject_ref, object_ref, location_ref) "
             f"are proper names of at most {ENTITY_REF_MAX_LENGTH} characters "
             "-- never sentences or descriptive phrases. New implied entities "
             "get a short invented name, not a description."
-        ),
-        (
-            "commit_readiness must keep writes='none' and include both current "
-            "commit blockers."
         ),
     ]
 
@@ -875,16 +1056,22 @@ def _prompt_response_contract() -> dict[str, Any]:
     """Return a compact prompt-facing R6 response contract."""
 
     return {
-        "schema_version": RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION,
         "top_level_fields": [
-            "schema_version",
-            "selected_seed_ids",
             "event_plan",
-            "entity_tag_plan",
-            "pair_tag_plan",
-            "relationship_plan",
+            "mechanical_plan",
             "thread_plan",
             "coverage_notes",
+        ],
+        "mechanical_plan_fields": {
+            "common": ["plan", "subject_ref", "subject_kind", "source_event_ref"],
+            "entity_tag": ["tag"],
+            "pair_tag": ["tag", "object_ref", "object_kind"],
+            "relationship": ["relationship_type", "object_ref", "object_kind"],
+            "unused_fields": "Use empty strings for fields irrelevant to the plan.",
+        },
+        "deterministic_fields_filled_by_runtime": [
+            "schema_version",
+            "selected_seed_ids",
             "commit_readiness",
         ],
     }

--- a/nexus/agents/orrery/retrograde_persistence.py
+++ b/nexus/agents/orrery/retrograde_persistence.py
@@ -1028,7 +1028,7 @@ def _insert_world_event(
             if result.get("resolution") == "resolved"
         ],
         "location_ref": event.location_ref,
-        "payload": event.payload,
+        "payload": {entry.key: entry.value for entry in event.payload},
     }
     cur.execute(
         """

--- a/nexus/agents/orrery/retrograde_seed_candidates.py
+++ b/nexus/agents/orrery/retrograde_seed_candidates.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Annotated, Any, Literal, Mapping, Optional, cast
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, create_model, model_validator
 
 from nexus.agents.orrery.retrograde_vocabulary import (
     ENTITY_REF_MAX_LENGTH,
@@ -130,6 +130,95 @@ class RetrogradeMechanicalHints(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
 
+class RetrogradeWireSingleEntityTagHint(BaseModel):
+    """Provider-facing tag hint using a grammar-safe kind/tag enum ref."""
+
+    entity_ref: EntityRef
+    tag_ref: str = Field(
+        min_length=1,
+        description="Exact single-entity tag ref in the form entity_kind|tag.",
+    )
+    supporting_event_ref: str = Field(
+        default="",
+        description="Event ref for event-anchored tags, or empty string.",
+    )
+    rationale: str = Field(default="")
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
+class RetrogradeWirePairTagHint(BaseModel):
+    """Provider-facing pair tag hint using a grammar-safe kind/tag enum ref."""
+
+    subject_ref: EntityRef
+    tag_ref: str = Field(
+        min_length=1,
+        description="Exact pair tag ref in the form subject_kind|object_kind|tag.",
+    )
+    object_ref: EntityRef
+    rationale: str = Field(default="")
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
+class RetrogradeWireRelationshipHint(BaseModel):
+    """Provider-facing relationship hint using a grammar-safe kind/type ref."""
+
+    subject_ref: EntityRef
+    relationship_ref: str = Field(
+        min_length=1,
+        description=(
+            "Exact relationship ref in the form "
+            "subject_kind|object_kind|relationship_type."
+        ),
+    )
+    object_ref: EntityRef
+    rationale: str = Field(default="")
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
+class RetrogradeWireMechanicalHints(BaseModel):
+    """Provider-facing hints with dynamic enum fields injected at runtime."""
+
+    events: list[RetrogradeSeedEventHint] = Field(default_factory=list)
+    single_entity_tags: list[RetrogradeWireSingleEntityTagHint] = Field(
+        default_factory=list
+    )
+    pair_tags: list[RetrogradeWirePairTagHint] = Field(default_factory=list)
+    relationships: list[RetrogradeWireRelationshipHint] = Field(default_factory=list)
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
+class RetrogradeWireSeedCandidate(BaseModel):
+    """Provider-facing seed candidate with compact mechanical refs."""
+
+    seed_id: str = Field(min_length=1)
+    summary: str = Field(min_length=1, max_length=1200)
+    origin_friction: Literal["low", "medium", "high"]
+    present_leaf_anchor: str = Field(min_length=1, max_length=800)
+    coverage_functions: list[str] = Field(default_factory=list)
+    mechanical_hints: RetrogradeWireMechanicalHints = Field(
+        default_factory=RetrogradeWireMechanicalHints
+    )
+    defer_or_reject_if: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
+class RetrogradeWireSeedCandidateResponse(BaseModel):
+    """Provider-facing seed response with compact mechanical refs."""
+
+    schema_version: SeedCandidateSchemaVersion = SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION
+    candidates: list[RetrogradeWireSeedCandidate] = Field(default_factory=list)
+    selected_seed_ids: list[str] = Field(default_factory=list)
+    rejected_seed_ids: list[str] = Field(default_factory=list)
+    selection_notes: str = Field(default="")
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
 class RetrogradeSeedCandidate(BaseModel):
     """One over-generated Retrograde seed candidate."""
 
@@ -222,6 +311,94 @@ def seed_candidate_response_schema() -> dict[str, Any]:
     return RetrogradeSeedCandidateResponse.model_json_schema()
 
 
+def seed_candidate_wire_response_model(
+    *,
+    seed_generation_request: Mapping[str, Any],
+    vocabulary: SeedEligibleVocabulary,
+) -> type[BaseModel]:
+    """Build the provider-facing R4/R5 schema from live Orrery vocabulary."""
+
+    event_hint_model = create_model(
+        "RetrogradeWireSeedEventHintRuntime",
+        __base__=RetrogradeSeedEventHint,
+        event_type=(
+            _literal_or_str(vocabulary["event_types"]),
+            Field(description="Registered Orrery event type."),
+        ),
+    )
+    single_tag_model = create_model(
+        "RetrogradeWireSingleEntityTagHintRuntime",
+        __base__=RetrogradeWireSingleEntityTagHint,
+        tag_ref=(
+            _literal_or_str(_single_entity_tag_refs(vocabulary)),
+            Field(
+                description=(
+                    "Exact single-entity tag ref from "
+                    "allowed_vocabulary.single_entity_tag_refs."
+                )
+            ),
+        ),
+    )
+    pair_tag_model = create_model(
+        "RetrogradeWirePairTagHintRuntime",
+        __base__=RetrogradeWirePairTagHint,
+        tag_ref=(
+            _literal_or_str(_pair_tag_refs(vocabulary)),
+            Field(
+                description=(
+                    "Exact pair tag ref from allowed_vocabulary.pair_tag_refs."
+                )
+            ),
+        ),
+    )
+    relationship_model = create_model(
+        "RetrogradeWireRelationshipHintRuntime",
+        __base__=RetrogradeWireRelationshipHint,
+        relationship_ref=(
+            _literal_or_str(_relationship_refs(vocabulary)),
+            Field(
+                description=(
+                    "Exact relationship ref from "
+                    "allowed_vocabulary.relationship_refs."
+                )
+            ),
+        ),
+    )
+    mechanical_hints_model = create_model(
+        "RetrogradeWireMechanicalHintsRuntime",
+        __base__=RetrogradeWireMechanicalHints,
+        events=(list[event_hint_model], Field(default_factory=list)),
+        single_entity_tags=(list[single_tag_model], Field(default_factory=list)),
+        pair_tags=(list[pair_tag_model], Field(default_factory=list)),
+        relationships=(list[relationship_model], Field(default_factory=list)),
+    )
+    coverage_type = _literal_or_str(_coverage_function_ids(seed_generation_request))
+    candidate_model = create_model(
+        "RetrogradeWireSeedCandidateRuntime",
+        __base__=RetrogradeWireSeedCandidate,
+        coverage_functions=(list[coverage_type], Field(default_factory=list)),
+        mechanical_hints=(
+            mechanical_hints_model,
+            Field(default_factory=mechanical_hints_model),
+        ),
+    )
+    return create_model(
+        "RetrogradeWireSeedCandidateResponseRuntime",
+        __base__=RetrogradeWireSeedCandidateResponse,
+        candidates=(list[candidate_model], Field(default_factory=list)),
+    )
+
+
+def coerce_seed_candidate_response_payload(
+    payload: Mapping[str, Any],
+) -> RetrogradeSeedCandidateResponse:
+    """Expand provider-facing mechanical refs into the full app contract."""
+
+    data = _expand_wire_seed_candidate_payload(payload)
+    data.setdefault("schema_version", SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION)
+    return RetrogradeSeedCandidateResponse.model_validate(data)
+
+
 def render_seed_generation_prompt(
     *,
     seed_generation_request: Mapping[str, Any],
@@ -267,7 +444,7 @@ def validate_seed_candidate_response(
 ) -> RetrogradeSeedCandidateResponse:
     """Validate a Skald seed response against request budgets and vocabulary."""
 
-    response = RetrogradeSeedCandidateResponse.model_validate(payload)
+    response = coerce_seed_candidate_response_payload(payload)
     issues = _response_contract_issues(
         response=response,
         seed_generation_request=seed_generation_request,
@@ -307,6 +484,10 @@ def generate_seed_candidates_with_skald(
             seed_generation_request=seed_generation_request,
             vocabulary=vocabulary,
         )
+    schema_model = seed_candidate_wire_response_model(
+        seed_generation_request=seed_generation_request,
+        vocabulary=vocabulary,
+    )
 
     selected_model = model_name or get_new_story_model()
     provider = build_native_structured_provider(
@@ -322,11 +503,14 @@ def generate_seed_candidates_with_skald(
 
     async def _validate_output(
         _ctx: Any,
-        output: RetrogradeSeedCandidateResponse,
+        output: BaseModel,
     ) -> RetrogradeSeedCandidateResponse:
         try:
+            payload = coerce_seed_candidate_response_payload(
+                output.model_dump(mode="json")
+            )
             return validate_seed_candidate_response(
-                payload=output.model_dump(mode="json"),
+                payload=payload.model_dump(mode="json"),
                 seed_generation_request=seed_generation_request,
                 vocabulary=vocabulary,
             )
@@ -340,7 +524,7 @@ def generate_seed_candidates_with_skald(
     provider.output_validator = _validate_output
     response, _llm_response = provider.get_structured_completion(
         prompt,
-        RetrogradeSeedCandidateResponse,
+        schema_model,
     )
     if not isinstance(response, RetrogradeSeedCandidateResponse):
         raise TypeError(
@@ -353,6 +537,168 @@ def generate_seed_candidates_with_skald(
         "prompt_chars": len(prompt),
         "seed_candidate_response": response.model_dump(mode="json"),
     }
+
+
+def _expand_wire_seed_candidate_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    data = dict(payload)
+    candidates = data.get("candidates")
+    if not isinstance(candidates, list):
+        return data
+
+    expanded_candidates = []
+    for candidate in candidates:
+        candidate_row = dict(candidate)
+        hints = candidate_row.get("mechanical_hints")
+        if isinstance(hints, Mapping):
+            candidate_row["mechanical_hints"] = _expand_wire_mechanical_hints(hints)
+        expanded_candidates.append(candidate_row)
+
+    data["candidates"] = expanded_candidates
+    if data.get("selection_notes") == "":
+        data["selection_notes"] = None
+    return data
+
+
+def _expand_wire_mechanical_hints(hints: Mapping[str, Any]) -> dict[str, Any]:
+    data = dict(hints)
+    data["single_entity_tags"] = [
+        _expand_wire_single_entity_tag(tag)
+        for tag in data.get("single_entity_tags") or []
+    ]
+    data["pair_tags"] = [
+        _expand_wire_pair_tag(tag) for tag in data.get("pair_tags") or []
+    ]
+    data["relationships"] = [
+        _expand_wire_relationship(relationship)
+        for relationship in data.get("relationships") or []
+    ]
+    return data
+
+
+def _expand_wire_single_entity_tag(tag: Mapping[str, Any]) -> dict[str, Any]:
+    if "tag_ref" not in tag:
+        return dict(tag)
+
+    entity_kind, tag_name = _split_ref(str(tag.get("tag_ref", "")), parts=2)
+    return {
+        "entity_ref": tag.get("entity_ref"),
+        "entity_kind": entity_kind,
+        "tag": tag_name,
+        "supporting_event_ref": _none_if_empty(tag.get("supporting_event_ref")),
+        "rationale": _none_if_empty(tag.get("rationale")),
+    }
+
+
+def _expand_wire_pair_tag(tag: Mapping[str, Any]) -> dict[str, Any]:
+    if "tag_ref" not in tag:
+        return dict(tag)
+
+    subject_kind, object_kind, tag_name = _split_ref(
+        str(tag.get("tag_ref", "")),
+        parts=3,
+    )
+    return {
+        "subject_ref": tag.get("subject_ref"),
+        "subject_kind": subject_kind,
+        "tag": tag_name,
+        "object_ref": tag.get("object_ref"),
+        "object_kind": object_kind,
+        "rationale": _none_if_empty(tag.get("rationale")),
+    }
+
+
+def _expand_wire_relationship(relationship: Mapping[str, Any]) -> dict[str, Any]:
+    if "relationship_ref" not in relationship:
+        return dict(relationship)
+
+    subject_kind, object_kind, relationship_type = _split_ref(
+        str(relationship.get("relationship_ref", "")),
+        parts=3,
+    )
+    return {
+        "subject_ref": relationship.get("subject_ref"),
+        "subject_kind": subject_kind,
+        "relationship_type": relationship_type,
+        "object_ref": relationship.get("object_ref"),
+        "object_kind": object_kind,
+        "rationale": _none_if_empty(relationship.get("rationale")),
+    }
+
+
+def _split_ref(value: str, *, parts: int) -> tuple[str, ...]:
+    split = value.split("|", parts - 1)
+    if len(split) != parts:
+        return tuple("" for _ in range(parts))
+    return tuple(split)
+
+
+def _none_if_empty(value: Any) -> Any:
+    if value == "":
+        return None
+    return value
+
+
+def _literal_or_str(values: list[str]) -> Any:
+    unique_values = tuple(dict.fromkeys(str(value) for value in values if value))
+    if not unique_values:
+        return str
+    return Literal.__getitem__(unique_values)
+
+
+def _coverage_function_ids(seed_generation_request: Mapping[str, Any]) -> list[str]:
+    return [
+        str(function.get("id"))
+        for function in seed_generation_request.get("coverage_functions", [])
+        if isinstance(function, Mapping) and function.get("id")
+    ]
+
+
+def _single_entity_tag_refs(vocabulary: SeedEligibleVocabulary) -> list[str]:
+    tags_by_entity_kind = {
+        kind: set(tags)
+        for kind, tags in vocabulary.get("registered_tags_by_entity_kind", {}).items()
+    }
+    allowed_mechanical_tags = set(
+        vocabulary.get("registered_tags_by_seed_policy", {}).get("stable_seed", [])
+    ) | set(
+        vocabulary.get("registered_tags_by_seed_policy", {}).get("event_anchored", [])
+    )
+    if not tags_by_entity_kind:
+        tags_by_entity_kind = {
+            kind: set(vocabulary.get("registered_single_entity_tags", []))
+            for kind in vocabulary["entity_kinds"]
+        }
+
+    refs: list[str] = []
+    for kind in vocabulary["entity_kinds"]:
+        for tag in sorted(
+            tags_by_entity_kind.get(kind, set()) & allowed_mechanical_tags
+        ):
+            refs.append(_join_ref(kind, tag))
+    return refs
+
+
+def _pair_tag_refs(vocabulary: SeedEligibleVocabulary) -> list[str]:
+    refs: list[str] = []
+    for definition in vocabulary["multi_entity_tag_definitions"]:
+        tag = str(definition["tag"])
+        for subject_kind in definition["subject_kinds"]:
+            for object_kind in definition["object_kinds"]:
+                refs.append(_join_ref(subject_kind, object_kind, tag))
+    return refs
+
+
+def _relationship_refs(vocabulary: SeedEligibleVocabulary) -> list[str]:
+    refs: list[str] = []
+    for subject_kind in vocabulary["entity_kinds"]:
+        for object_kind in vocabulary["entity_kinds"]:
+            for relationship_type in vocabulary["relationship_types"]:
+                refs.append(_join_ref(subject_kind, object_kind, relationship_type))
+    return refs
+
+
+def _join_ref(*parts: str) -> str:
+    return "|".join(str(part) for part in parts)
 
 
 def _response_contract_issues(
@@ -656,6 +1002,9 @@ def _prompt_vocabulary(vocabulary: SeedEligibleVocabulary) -> dict[str, Any]:
             "registered_tags_by_entity_kind", {}
         ),
         "multi_entity_tag_definitions": vocabulary["multi_entity_tag_definitions"],
+        "single_entity_tag_refs": _single_entity_tag_refs(vocabulary),
+        "pair_tag_refs": _pair_tag_refs(vocabulary),
+        "relationship_refs": _relationship_refs(vocabulary),
     }
 
 
@@ -686,10 +1035,18 @@ def _prompt_response_contract() -> dict[str, Any]:
         ],
         "mechanical_hint_fields": [
             "events",
-            "single_entity_tags",
-            "pair_tags",
-            "relationships",
+            "single_entity_tags: entity_ref, tag_ref, supporting_event_ref, rationale",
+            "pair_tags: subject_ref, tag_ref, object_ref, rationale",
+            "relationships: subject_ref, relationship_ref, object_ref, rationale",
         ],
+        "compact_ref_format": {
+            "single_entity_tags.tag_ref": "entity_kind|tag",
+            "pair_tags.tag_ref": "subject_kind|object_kind|tag",
+            "relationships.relationship_ref": (
+                "subject_kind|object_kind|relationship_type"
+            ),
+            "absence": "Use empty strings for absent supporting_event_ref/rationale.",
+        },
     }
 
 
@@ -703,12 +1060,18 @@ def _hard_validation_rules() -> list[str]:
             "inside the same candidate."
         ),
         (
+            "single_entity_tags use tag_ref values from "
+            "allowed_vocabulary.single_entity_tag_refs; this encodes the legal "
+            "entity_kind|tag pair."
+        ),
+        (
             "Prompt-visible-only tags may influence prose but must not appear in "
             "mechanical_hints.single_entity_tags."
         ),
         (
-            "Pair tags must use the exact subject_kind/object_kind constraints "
-            "from multi_entity_tag_definitions."
+            "Pair tags use tag_ref values from allowed_vocabulary.pair_tag_refs; "
+            "relationships use relationship_ref values from "
+            "allowed_vocabulary.relationship_refs."
         ),
         (
             "Single-entity tags must be registered for the tagged entity_kind "

--- a/nexus/agents/orrery/retrograde_seed_candidates.py
+++ b/nexus/agents/orrery/retrograde_seed_candidates.py
@@ -626,9 +626,12 @@ def _expand_wire_relationship(relationship: Mapping[str, Any]) -> dict[str, Any]
 
 
 def _split_ref(value: str, *, parts: int) -> tuple[str, ...]:
-    split = value.split("|", parts - 1)
-    if len(split) != parts:
-        return tuple("" for _ in range(parts))
+    split = value.split("|")
+    if len(split) != parts or any(part == "" for part in split):
+        raise ValueError(
+            f"Malformed compact Retrograde ref {value!r}; expected {parts} "
+            "non-empty pipe-delimited parts"
+        )
     return tuple(split)
 
 

--- a/nexus/agents/orrery/retrograde_seed_candidates.py
+++ b/nexus/agents/orrery/retrograde_seed_candidates.py
@@ -287,15 +287,14 @@ def generate_seed_candidates_with_skald(
 ) -> dict[str, Any]:
     """Make a non-mutating Skald call to generate Retrograde seed candidates."""
 
-    from pydantic_ai import Agent, ModelRetry, RunContext
-    from pydantic_ai.settings import ModelSettings
+    from pydantic_ai import ModelRetry
 
     from nexus.api.config_utils import (
         get_new_story_model,
         get_wizard_max_tokens,
         get_wizard_retry_budget,
     )
-    from nexus.api.pydantic_ai_utils import build_pydantic_ai_model
+    from nexus.api.native_structured_output import build_native_structured_provider
 
     seed_generation_request = _required_mapping(
         packet.get("seed_generation_request"),
@@ -310,20 +309,19 @@ def generate_seed_candidates_with_skald(
         )
 
     selected_model = model_name or get_new_story_model()
-    agent = Agent(
-        model=build_pydantic_ai_model(selected_model),
-        output_type=RetrogradeSeedCandidateResponse,
+    provider = build_native_structured_provider(
+        model=selected_model,
+        max_tokens=max_tokens or get_wizard_max_tokens(),
         system_prompt=(
             "You are Skald-as-weaver for a NEXUS Retrograde seed pass. "
             "Generate candidate history seeds, select a subset, and do not "
             "claim any canonical write has occurred."
         ),
-        model_settings=ModelSettings(max_tokens=max_tokens or get_wizard_max_tokens()),
-        retries=get_wizard_retry_budget(),
+        structured_output_retries=get_wizard_retry_budget(),
     )
 
     async def _validate_output(
-        _ctx: RunContext[None],
+        _ctx: Any,
         output: RetrogradeSeedCandidateResponse,
     ) -> RetrogradeSeedCandidateResponse:
         try:
@@ -339,9 +337,11 @@ def generate_seed_candidates_with_skald(
                 f"the required refs:\n{exc}"
             ) from exc
 
-    agent.output_validator(_validate_output)
-    result = agent.run_sync(prompt)
-    response = result.output
+    provider.output_validator = _validate_output
+    response, _llm_response = provider.get_structured_completion(
+        prompt,
+        RetrogradeSeedCandidateResponse,
+    )
     if not isinstance(response, RetrogradeSeedCandidateResponse):
         raise TypeError(
             "Skald seed candidate call returned "

--- a/nexus/agents/orrery/tag_library.py
+++ b/nexus/agents/orrery/tag_library.py
@@ -103,6 +103,25 @@ def read_event_types(dbname: Optional[str] = None) -> list[str]:
         conn.close()
 
 
+def read_pair_tag_library(dbname: Optional[str] = None) -> list[str]:
+    """Read active Orrery pair-tag names from the target slot database."""
+
+    conn = _connect(dbname)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT tag
+                FROM pair_tags
+                WHERE deprecated = FALSE
+                ORDER BY tag
+                """
+            )
+            return [str(row["tag"]) for row in cur.fetchall()]
+    finally:
+        conn.close()
+
+
 def format_tag_library_for_prompt(
     dbname: Optional[str] = None,
     *,

--- a/nexus/api/mock_openai.py
+++ b/nexus/api/mock_openai.py
@@ -612,12 +612,38 @@ class ResponsesRequest(BaseModel):
     max_output_tokens: Optional[int] = None
     temperature: Optional[float] = None
     reasoning: Optional[Dict[str, Any]] = None
+    text: Optional[Dict[str, Any]] = None  # OpenAI native strict text.format
     text_format: Optional[Any] = None  # Pydantic schema for structured output
     tools: Optional[Any] = None  # pydantic_ai output tool ("final_result")
 
 
+def _schema_property_names(payload: Any) -> set[str]:
+    """Return top-level property names from OpenAI structured-output payloads."""
+
+    if not isinstance(payload, dict):
+        return set()
+    if "format" in payload:
+        return _schema_property_names(payload.get("format"))
+    if payload.get("type") == "json_schema":
+        schema = payload.get("schema")
+        if schema is None and isinstance(payload.get("json_schema"), dict):
+            schema = payload["json_schema"].get("schema")
+        if isinstance(schema, dict):
+            return set((schema.get("properties") or {}).keys())
+    return set((payload.get("properties") or {}).keys())
+
+
+def _requested_output_uses_final_result_tool(request: "ResponsesRequest") -> bool:
+    """Return whether the request expects a Pydantic-AI final_result call."""
+
+    for tool in request.tools or []:
+        if isinstance(tool, dict) and tool.get("name") == "final_result":
+            return True
+    return False
+
+
 def _requested_output_properties(request: "ResponsesRequest") -> set[str]:
-    """Return the property names of the structured-output tool, if present.
+    """Return the property names of the requested structured output, if present.
 
     pydantic_ai delivers the caller's output schema as a ``final_result``
     function tool with ``tool_choice: required``; the schema's top-level
@@ -625,11 +651,20 @@ def _requested_output_properties(request: "ResponsesRequest") -> set[str]:
     against. Routing on this is exact, where the legacy keyword sniffing of
     the prompt text was not (a turn request without Orrery proposals used to
     fall through to the bootstrap-shaped payload and fail validation).
+
+    Native OpenAI structured output arrives as ``text.format`` with the same
+    top-level schema properties.
     """
+    fields = _schema_property_names(request.text)
+    if fields:
+        return fields
+    fields = _schema_property_names(request.text_format)
+    if fields:
+        return fields
     for tool in request.tools or []:
         if isinstance(tool, dict) and tool.get("name") == "final_result":
             params = tool.get("parameters") or {}
-            return set((params.get("properties") or {}).keys())
+            return _schema_property_names(params)
     return set()
 
 
@@ -866,17 +901,19 @@ async def responses_create(request: ResponsesRequest):
     # (StorytellerResponseBootstrap) do not.
     output_fields = _requested_output_properties(request)
     if output_fields:
+        final_result_tool = _requested_output_uses_final_result_tool(request)
         if "state_updates" in output_fields:
             logger.info(
                 "[MOCK] Extended turn schema requested (%d Orrery proposals)",
                 len(proposal_ids),
             )
             return _responses_payload(
-                _mock_storyteller_response(input_text), final_result_tool=True
+                _mock_storyteller_response(input_text),
+                final_result_tool=final_result_tool,
             )
         logger.info("[MOCK] Bootstrap schema requested, returning cached bootstrap")
         return _responses_payload(
-            get_cached_bootstrap_narrative(), final_result_tool=True
+            get_cached_bootstrap_narrative(), final_result_tool=final_result_tool
         )
 
     # Legacy keyword routing for callers without a structured-output tool.
@@ -897,7 +934,7 @@ async def responses_create(request: ResponsesRequest):
         return _responses_payload(get_cached_bootstrap_narrative())
 
     # Default fallback for non-narrative requests
-    logger.warning(f"[MOCK] Unknown responses request type")
+    logger.warning("[MOCK] Unknown responses request type")
     return {
         "id": f"resp-mock-{uuid.uuid4().hex[:8]}",
         "object": "response",

--- a/nexus/api/native_structured_output.py
+++ b/nexus/api/native_structured_output.py
@@ -1,0 +1,176 @@
+"""Provider-native structured-output helpers.
+
+Pydantic models remain the NEXUS app contract, but provider requests should
+use native strict schema controls where available. This module keeps the wire
+schema and the boundary validation helpers in one place.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional, Type
+
+from pydantic import BaseModel
+
+
+ANTHROPIC_UNSUPPORTED_SCHEMA_KEYS = {
+    "default",
+    "exclusiveMaximum",
+    "exclusiveMinimum",
+    "format",
+    "maxItems",
+    "maxLength",
+    "maximum",
+    "minItems",
+    "minLength",
+    "minimum",
+    "multipleOf",
+    "pattern",
+}
+
+
+@dataclass
+class NativeValidationContext:
+    """Small context object for validators that were written for Pydantic AI."""
+
+    retry: int = 0
+
+
+def strict_json_schema(schema_model: Type[BaseModel]) -> Dict[str, Any]:
+    """Return the strict JSON schema OpenAI's native parser sends on the wire."""
+
+    try:
+        from openai.lib._pydantic import to_strict_json_schema
+    except ImportError:
+        return schema_model.model_json_schema()
+
+    return to_strict_json_schema(schema_model)
+
+
+def openai_response_text_format(schema_model: Type[BaseModel]) -> Dict[str, Any]:
+    """Build the OpenAI Responses API native strict text format payload."""
+
+    try:
+        from openai.lib._parsing._responses import type_to_text_format_param
+    except ImportError:
+        schema = strict_json_schema(schema_model)
+        return {
+            "type": "json_schema",
+            "strict": True,
+            "name": schema_model.__name__,
+            "schema": schema,
+        }
+
+    return type_to_text_format_param(schema_model)
+
+
+def _strip_anthropic_unsupported_schema_keys(value: Any) -> Any:
+    """Remove JSON Schema constraints not accepted by Anthropic structured output."""
+
+    if isinstance(value, list):
+        return [_strip_anthropic_unsupported_schema_keys(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    return {
+        key: _strip_anthropic_unsupported_schema_keys(item)
+        for key, item in value.items()
+        if key not in ANTHROPIC_UNSUPPORTED_SCHEMA_KEYS
+    }
+
+
+def anthropic_json_schema(schema_model: Type[BaseModel]) -> Dict[str, Any]:
+    """Return a schema suitable for Anthropic native JSON output."""
+
+    return _strip_anthropic_unsupported_schema_keys(strict_json_schema(schema_model))
+
+
+def anthropic_output_format(schema_model: Type[BaseModel]) -> Dict[str, Any]:
+    """Build the Anthropic beta Messages native JSON schema output format."""
+
+    return {"type": "json_schema", "schema": anthropic_json_schema(schema_model)}
+
+
+def anthropic_strict_tool(
+    schema_model: Type[BaseModel], *, name: str = "submit_structured_response"
+) -> Dict[str, Any]:
+    """Build an Anthropic strict tool definition for schema-constrained calls."""
+
+    return {
+        "name": name,
+        "description": (
+            "Return the complete structured response for the current NEXUS "
+            "generation request."
+        ),
+        "input_schema": anthropic_json_schema(schema_model),
+        "strict": True,
+    }
+
+
+def build_native_structured_provider(
+    *,
+    model: str,
+    max_tokens: int,
+    system_prompt: str,
+    structured_output_retries: int,
+    output_validator: Optional[Callable[..., Any]] = None,
+) -> Any:
+    """Build the repo's native strict structured-output provider wrapper."""
+
+    from nexus.config import get_openai_compatible_endpoint
+    from nexus.config.loader import get_provider_for_model
+    from scripts.api_anthropic import AnthropicProvider
+    from scripts.api_openai import OpenAIProvider
+
+    endpoint = get_openai_compatible_endpoint(model)
+    provider_type = get_provider_for_model(model)
+    if provider_type == "anthropic" and endpoint is None:
+        return AnthropicProvider(
+            model=model,
+            max_tokens=max_tokens,
+            system_prompt=system_prompt,
+            structured_output_retries=structured_output_retries,
+            output_validator=output_validator,
+        )
+    if provider_type == "openai" or endpoint is not None:
+        return OpenAIProvider(
+            model=model,
+            max_output_tokens=max_tokens,
+            system_prompt=system_prompt,
+            base_url=endpoint["base_url"] if endpoint else None,
+            api_key=endpoint["api_key"] if endpoint else None,
+            structured_output_retries=structured_output_retries,
+            output_validator=output_validator,
+        )
+    raise ValueError(f"Unsupported provider type for model {model!r}: {provider_type}")
+
+
+def retry_prompt(prompt: str, message: str) -> str:
+    """Append a bounded repair instruction for semantic validation retries."""
+
+    return (
+        f"{prompt}\n\n"
+        "=== STRUCTURED OUTPUT RETRY ===\n"
+        "Your previous structured response failed validation before commit.\n"
+        f"{message}\n"
+        "Return a complete response satisfying the same schema. Use null or "
+        "empty arrays for absent optional values instead of omitting required "
+        "strict-schema keys."
+    )
+
+
+async def run_output_validator(
+    validator: Optional[Callable[..., Any]],
+    output: Any,
+    *,
+    retry: int = 0,
+) -> Any:
+    """Run an optional Pydantic-AI-style output validator."""
+
+    if validator is None:
+        return output
+
+    result = validator(NativeValidationContext(retry=retry), output)
+    if inspect.isawaitable(result):
+        result = await result
+    return output if result is None else result

--- a/nexus/api/native_structured_output.py
+++ b/nexus/api/native_structured_output.py
@@ -48,8 +48,18 @@ def strict_json_schema(schema_model: Type[BaseModel]) -> Dict[str, Any]:
     return to_strict_json_schema(schema_model)
 
 
-def openai_response_text_format(schema_model: Type[BaseModel]) -> Dict[str, Any]:
+def openai_response_text_format(
+    schema_model: Type[BaseModel], *, schema: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
     """Build the OpenAI Responses API native strict text format payload."""
+
+    if schema is not None:
+        return {
+            "type": "json_schema",
+            "strict": True,
+            "name": schema_model.__name__,
+            "schema": schema,
+        }
 
     try:
         from openai.lib._parsing._responses import type_to_text_format_param
@@ -85,10 +95,17 @@ def anthropic_json_schema(schema_model: Type[BaseModel]) -> Dict[str, Any]:
     return _strip_anthropic_unsupported_schema_keys(strict_json_schema(schema_model))
 
 
-def anthropic_output_format(schema_model: Type[BaseModel]) -> Dict[str, Any]:
+def anthropic_output_format(
+    schema_model: Type[BaseModel], *, schema: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
     """Build the Anthropic beta Messages native JSON schema output format."""
 
-    return {"type": "json_schema", "schema": anthropic_json_schema(schema_model)}
+    schema_payload = (
+        _strip_anthropic_unsupported_schema_keys(schema)
+        if schema is not None
+        else anthropic_json_schema(schema_model)
+    )
+    return {"type": "json_schema", "schema": schema_payload}
 
 
 def anthropic_strict_tool(

--- a/nexus/api/native_structured_output.py
+++ b/nexus/api/native_structured_output.py
@@ -98,7 +98,7 @@ def anthropic_json_schema(schema_model: Type[BaseModel]) -> Dict[str, Any]:
 def anthropic_output_format(
     schema_model: Type[BaseModel], *, schema: Optional[Dict[str, Any]] = None
 ) -> Dict[str, Any]:
-    """Build the Anthropic beta Messages native JSON schema output format."""
+    """Build the Anthropic native JSON schema format payload."""
 
     schema_payload = (
         _strip_anthropic_unsupported_schema_keys(schema)
@@ -106,6 +106,14 @@ def anthropic_output_format(
         else anthropic_json_schema(schema_model)
     )
     return {"type": "json_schema", "schema": schema_payload}
+
+
+def anthropic_output_config(
+    schema_model: Type[BaseModel], *, schema: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Build the Anthropic Messages output_config wrapper for native JSON output."""
+
+    return {"format": anthropic_output_format(schema_model, schema=schema)}
 
 
 def anthropic_strict_tool(

--- a/nexus/api/new_story_generator.py
+++ b/nexus/api/new_story_generator.py
@@ -14,10 +14,9 @@ from typing import Dict, List, Optional, Type
 
 import frontmatter
 from pydantic import BaseModel, Field, ConfigDict
-from pydantic_ai import Agent
-from pydantic_ai.settings import ModelSettings
 
 from nexus.api.config_utils import get_wizard_max_tokens, get_wizard_retry_budget
+from nexus.api.native_structured_output import build_native_structured_provider
 from nexus.api.new_story_schemas import (
     SettingCard,
     CharacterSheet,
@@ -27,7 +26,6 @@ from nexus.api.new_story_schemas import (
     PlaceProfile,
     TransitionData,
 )
-from nexus.api.pydantic_ai_utils import build_message_history, build_pydantic_ai_model
 
 logger = logging.getLogger("nexus.api.new_story_generator")
 
@@ -48,9 +46,31 @@ class StoryComponentGenerator:
             model: Concrete model ID to use (must appear in the api_models registry).
         """
         self.model = model
-        self._model = build_pydantic_ai_model(model)
-        self._model_settings = ModelSettings(max_tokens=get_wizard_max_tokens())
+        self._max_tokens = get_wizard_max_tokens()
         self._retry_budget = get_wizard_retry_budget()
+
+    @staticmethod
+    def _prompt_with_history(
+        user_prompt: str, message_history: Optional[List[Dict[str, str]]]
+    ) -> str:
+        """Render optional prior chat messages into a native-provider prompt."""
+
+        if not message_history:
+            return user_prompt
+        rendered_history = []
+        for message in message_history:
+            role = message.get("role")
+            content = message.get("content")
+            if role in {"user", "assistant", "system"} and content:
+                rendered_history.append(f"{role.upper()}: {content}")
+        if not rendered_history:
+            return user_prompt
+        return (
+            "Conversation so far:\n"
+            + "\n\n".join(rendered_history)
+            + "\n\nCurrent request:\n"
+            + user_prompt
+        )
 
     def _run_structured(
         self,
@@ -59,16 +79,17 @@ class StoryComponentGenerator:
         schema_model: Type[BaseModel],
         message_history: Optional[List[Dict[str, str]]] = None,
     ) -> BaseModel:
-        agent = Agent(
-            model=self._model,
-            output_type=schema_model,
+        provider = build_native_structured_provider(
+            model=self.model,
+            max_tokens=self._max_tokens,
             system_prompt=system_prompt,
-            model_settings=self._model_settings,
-            retries=self._retry_budget,
+            structured_output_retries=self._retry_budget,
         )
-        history = build_message_history(message_history or [])
-        result = agent.run_sync(user_prompt, message_history=history)
-        return result.output
+        result, _llm_response = provider.get_structured_completion(
+            self._prompt_with_history(user_prompt, message_history),
+            schema_model,
+        )
+        return result
 
     def generate_setting_card(
         self,
@@ -508,12 +529,8 @@ class SetDesignerOutput(BaseModel):
     Contains the complete location hierarchy generated from a freeform sketch.
     """
 
-    layer: LayerDefinition = Field(
-        ..., description="World layer (planet/dimension)"
-    )
-    zone: ZoneDefinition = Field(
-        ..., description="Geographic zone/region"
-    )
+    layer: LayerDefinition = Field(..., description="World layer (planet/dimension)")
+    zone: ZoneDefinition = Field(..., description="Geographic zone/region")
     location: PlaceProfile = Field(
         ..., description="The specific starting place with latitude/longitude"
     )
@@ -521,7 +538,9 @@ class SetDesignerOutput(BaseModel):
 
 def _load_set_designer_prompt() -> str:
     """Load the set designer prompt from the prompts directory."""
-    prompt_path = Path(__file__).parent.parent.parent / "prompts" / "storyteller_set_designer.md"
+    prompt_path = (
+        Path(__file__).parent.parent.parent / "prompts" / "storyteller_set_designer.md"
+    )
     if not prompt_path.exists():
         raise FileNotFoundError(
             f"Set designer prompt not found at {prompt_path}. "
@@ -587,20 +606,17 @@ For latitude/longitude, use Earth coordinates that match any Earth-analog hints 
 or choose coordinates appropriate for the described environment (e.g., northern latitudes for
 cold climates, coastal coordinates for harbors, etc.)."""
 
-    pydantic_model = build_pydantic_ai_model(model)
-    model_settings = ModelSettings(max_tokens=get_wizard_max_tokens())
-    retry_budget = get_wizard_retry_budget()
-
-    agent = Agent(
-        model=pydantic_model,
-        output_type=SetDesignerOutput,
+    provider = build_native_structured_provider(
+        model=model,
+        max_tokens=get_wizard_max_tokens(),
         system_prompt=system_prompt,
-        model_settings=model_settings,
-        retries=retry_budget,
+        structured_output_retries=get_wizard_retry_budget(),
     )
 
-    result = await agent.run(user_prompt)
-    output = result.output
+    output, _llm_response = await provider.get_structured_completion_async(
+        user_prompt,
+        SetDesignerOutput,
+    )
 
     logger.info(
         "Set designer generated: %s -> %s -> %s at (%.2f, %.2f)",

--- a/nexus/api/trait_input_derivation.py
+++ b/nexus/api/trait_input_derivation.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional, Type
+
+from pydantic import BaseModel, ConfigDict, create_model
 
 from nexus.agents.orrery.status_family import STATUS_LEVELS
 from nexus.api.trait_compiler import FAME_TAGS, RESOURCE_TAGS
@@ -40,6 +42,18 @@ PATRON_FUNCTIONS = ("mentors", "sponsors", "protects", "authority_over")
 
 # Trait fields on TraitCompileInputs that target other entities by name.
 _RELATIONSHIP_TRAITS = ("allies", "contacts", "enemies")
+_DERIVABLE_TRAITS = (
+    "resources",
+    "fame",
+    "status",
+    "allies",
+    "contacts",
+    "enemies",
+    "domain",
+    "patron",
+    "dependents",
+    "obligations",
+)
 
 
 def selected_canonical_traits(character: "CharacterSheet") -> List[str]:
@@ -48,6 +62,35 @@ def selected_canonical_traits(character: "CharacterSheet") -> List[str]:
     return [
         canonical_trait_name(str(trait.name)) for trait in character.get_trait_entries()
     ]
+
+
+def selected_trait_compile_inputs_model(selected: List[str]) -> Type[BaseModel]:
+    """Return a compact schema model containing only selected trait fields."""
+
+    fields: dict[str, tuple[Any, None]] = {}
+    for trait in selected:
+        canonical = canonical_trait_name(trait)
+        if canonical not in _DERIVABLE_TRAITS:
+            raise ValueError(f"Cannot derive unknown trait input field: {trait!r}")
+        source_field = TraitCompileInputs.model_fields[canonical]
+        fields[canonical] = (source_field.annotation, None)
+
+    suffix = "".join(part.title() for part in fields) or "Empty"
+    return create_model(
+        f"TraitCompileInputsSelected{suffix}",
+        __config__=ConfigDict(str_strip_whitespace=True, extra="forbid"),
+        **fields,
+    )
+
+
+def coerce_selected_trait_inputs(output: BaseModel) -> TraitCompileInputs:
+    """Convert a selected-trait schema response into the full app contract."""
+
+    if isinstance(output, TraitCompileInputs):
+        return output
+    return TraitCompileInputs.model_validate(
+        output.model_dump(mode="json", exclude_none=True)
+    )
 
 
 def derived_input_issues(
@@ -222,6 +265,7 @@ def derive_trait_compile_inputs(
 
     selected = selected_canonical_traits(character)
     prompt = render_trait_input_prompt(character=character, setting=setting)
+    schema_model = selected_trait_compile_inputs_model(selected)
 
     provider: Any = build_native_structured_provider(
         model=model_name,
@@ -233,22 +277,21 @@ def derive_trait_compile_inputs(
         structured_output_retries=retries,
     )
 
-    async def _validate_output(
-        _ctx: Any, output: TraitCompileInputs
-    ) -> TraitCompileInputs:
-        issues = derived_input_issues(output, selected=selected)
+    async def _validate_output(_ctx: Any, output: BaseModel) -> TraitCompileInputs:
+        trait_inputs = coerce_selected_trait_inputs(output)
+        issues = derived_input_issues(trait_inputs, selected=selected)
         if issues:
             formatted = "\n".join(f"- {issue}" for issue in issues)
             raise ModelRetry(
                 "Derived trait inputs violate the hard rules. Fix every "
                 f"issue and resubmit:\n{formatted}"
             )
-        return output
+        return trait_inputs
 
     provider.output_validator = _validate_output
     output, _llm_response = provider.get_structured_completion(
         prompt,
-        TraitCompileInputs,
+        schema_model,
     )
     if not isinstance(output, TraitCompileInputs):
         raise TypeError(

--- a/nexus/api/trait_input_derivation.py
+++ b/nexus/api/trait_input_derivation.py
@@ -216,27 +216,25 @@ def derive_trait_compile_inputs(
 ) -> TraitCompileInputs:
     """Make the structured-output Skald call that derives trait inputs."""
 
-    from pydantic_ai import Agent, ModelRetry, RunContext
-    from pydantic_ai.settings import ModelSettings
+    from pydantic_ai import ModelRetry
 
-    from nexus.api.pydantic_ai_utils import build_pydantic_ai_model
+    from nexus.api.native_structured_output import build_native_structured_provider
 
     selected = selected_canonical_traits(character)
     prompt = render_trait_input_prompt(character=character, setting=setting)
 
-    agent: Any = Agent(
-        model=build_pydantic_ai_model(model_name),
-        output_type=TraitCompileInputs,
+    provider: Any = build_native_structured_provider(
+        model=model_name,
+        max_tokens=max_tokens,
         system_prompt=(
             "You convert finished NEXUS character-wizard prose into typed "
             "trait compiler inputs. Follow the hard rules exactly."
         ),
-        model_settings=ModelSettings(max_tokens=max_tokens),
-        retries=retries,
+        structured_output_retries=retries,
     )
 
     async def _validate_output(
-        _ctx: RunContext[None], output: TraitCompileInputs
+        _ctx: Any, output: TraitCompileInputs
     ) -> TraitCompileInputs:
         issues = derived_input_issues(output, selected=selected)
         if issues:
@@ -247,9 +245,11 @@ def derive_trait_compile_inputs(
             )
         return output
 
-    agent.output_validator(_validate_output)
-    result = agent.run_sync(prompt)
-    output = result.output
+    provider.output_validator = _validate_output
+    output, _llm_response = provider.get_structured_completion(
+        prompt,
+        TraitCompileInputs,
+    )
     if not isinstance(output, TraitCompileInputs):
         raise TypeError(
             "Trait input derivation returned "

--- a/nexus/api/wizard_agent.py
+++ b/nexus/api/wizard_agent.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import frontmatter
-from pydantic_ai import Agent, CallDeferred, ModelRetry
+from pydantic_ai import Agent, CallDeferred, ModelRetry, NativeOutput
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import DeferredToolRequests, RunContext
 
@@ -563,6 +563,7 @@ _wizard_retries = get_wizard_retry_budget()
 
 # Type alias for agent output
 AgentOutput = WizardResponse | DeferredToolRequests
+_wizard_response_output = NativeOutput(WizardResponse, strict=True)
 
 
 def _make_accept_fate_validator(tool_name: str):
@@ -592,7 +593,7 @@ def _make_accept_fate_validator(tool_name: str):
 
 # Config 1: Setting phase, normal flow (WizardResponse + submit_world_document)
 _setting_agent = Agent(
-    output_type=(WizardResponse, DeferredToolRequests),
+    output_type=(_wizard_response_output, DeferredToolRequests),
     instructions=build_wizard_prompt,
     deps_type=WizardContext,
     model_settings=_wizard_model_settings,
@@ -602,7 +603,7 @@ _setting_agent.tool(retries=_wizard_retries)(_submit_world_impl)
 
 # Config 2: Setting phase, accept_fate (forces submit_world_document)
 _setting_accept_agent = Agent(
-    output_type=(WizardResponse, DeferredToolRequests),
+    output_type=(_wizard_response_output, DeferredToolRequests),
     instructions=build_wizard_prompt,
     deps_type=WizardContext,
     model_settings=_wizard_model_settings,
@@ -619,7 +620,7 @@ _setting_accept_agent.output_validator(
 
 # Config 3: Character/concept, normal flow
 _concept_agent = Agent(
-    output_type=(WizardResponse, DeferredToolRequests),
+    output_type=(_wizard_response_output, DeferredToolRequests),
     instructions=build_wizard_prompt,
     deps_type=WizardContext,
     model_settings=_wizard_model_settings,
@@ -629,7 +630,7 @@ _concept_agent.tool(retries=_wizard_retries)(_submit_concept_impl)
 
 # Config 4: Character/concept, accept_fate (forces submit_character_concept)
 _concept_accept_agent = Agent(
-    output_type=(WizardResponse, DeferredToolRequests),
+    output_type=(_wizard_response_output, DeferredToolRequests),
     instructions=build_wizard_prompt,
     deps_type=WizardContext,
     model_settings=_wizard_model_settings,
@@ -647,7 +648,7 @@ _concept_accept_agent.output_validator(
 # Config 5: Character/traits, normal flow only
 # (accept_fate for traits is handled deterministically in wizard_chat.py)
 _traits_agent = Agent(
-    output_type=(WizardResponse, DeferredToolRequests),
+    output_type=(_wizard_response_output, DeferredToolRequests),
     instructions=build_wizard_prompt,
     deps_type=WizardContext,
     model_settings=_wizard_model_settings,
@@ -661,7 +662,7 @@ _traits_agent.tool(retries=_wizard_retries)(_submit_traits_impl)
 
 # Config 7: Character/wildcard, normal flow
 _wildcard_agent = Agent(
-    output_type=(WizardResponse, DeferredToolRequests),
+    output_type=(_wizard_response_output, DeferredToolRequests),
     instructions=build_wizard_prompt,
     deps_type=WizardContext,
     model_settings=_wizard_model_settings,
@@ -671,7 +672,7 @@ _wildcard_agent.tool(retries=_wizard_retries)(_submit_wildcard_impl)
 
 # Config 8: Character/wildcard, accept_fate (forces submit_wildcard_trait)
 _wildcard_accept_agent = Agent(
-    output_type=(WizardResponse, DeferredToolRequests),
+    output_type=(_wizard_response_output, DeferredToolRequests),
     instructions=build_wizard_prompt,
     deps_type=WizardContext,
     model_settings=_wizard_model_settings,
@@ -688,7 +689,7 @@ _wildcard_accept_agent.output_validator(
 
 # Config 9: Seed phase, normal flow
 _seed_agent = Agent(
-    output_type=(WizardResponse, DeferredToolRequests),
+    output_type=(_wizard_response_output, DeferredToolRequests),
     instructions=build_wizard_prompt,
     deps_type=WizardContext,
     model_settings=_wizard_model_settings,
@@ -698,7 +699,7 @@ _seed_agent.tool(retries=_wizard_retries)(_submit_scenario_impl)
 
 # Config 10: Seed phase, accept_fate (forces submit_starting_scenario)
 _seed_accept_agent = Agent(
-    output_type=(WizardResponse, DeferredToolRequests),
+    output_type=(_wizard_response_output, DeferredToolRequests),
     instructions=build_wizard_prompt,
     deps_type=WizardContext,
     model_settings=_wizard_model_settings,

--- a/scripts/api_anthropic.py
+++ b/scripts/api_anthropic.py
@@ -49,6 +49,7 @@ from datetime import datetime, timedelta
 # Try to import keyboard module for abort functionality
 try:
     import keyboard
+
     KEYBOARD_AVAILABLE = True
 except ImportError:
     KEYBOARD_AVAILABLE = False
@@ -58,7 +59,7 @@ try:
     import anthropic
 except ImportError:
     anthropic = None
-    
+
 # For token counting
 try:
     import tiktoken
@@ -71,7 +72,7 @@ from sqlalchemy import create_engine
 from pydantic import ValidationError
 
 from nexus.api.native_structured_output import (
-    anthropic_output_format,
+    anthropic_output_config,
     retry_prompt,
     run_output_validator,
 )
@@ -80,32 +81,26 @@ from nexus.api.native_structured_output import (
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler("metadata_processing.log"),
-        logging.StreamHandler()
-    ]
+    handlers=[logging.FileHandler("metadata_processing.log"), logging.StreamHandler()],
 )
 logger = logging.getLogger("nexus.metadata")
 
 # Default TPM limits if settings file is not available
-DEFAULT_TPM_LIMITS = {
-    "anthropic": 30000
-}
+DEFAULT_TPM_LIMITS = {"anthropic": 30000}
 
-DEFAULT_COOLDOWNS = {
-    "individual": 15,
-    "batch": 30,
-    "rate_limit": 300
-}
+DEFAULT_COOLDOWNS = {"individual": 15, "batch": 30, "rate_limit": 300}
 
 # Load settings using centralized config loader
 try:
     from nexus.config import load_settings_as_dict
+
     SETTINGS = load_settings_as_dict()
     TPM_LIMITS = SETTINGS.get("API Settings", {}).get("TPM", DEFAULT_TPM_LIMITS)
     COOLDOWNS = SETTINGS.get("API Settings", {}).get("cooldowns", DEFAULT_COOLDOWNS)
 except Exception as e:
-    logger.warning(f"Failed to load settings via config loader: {str(e)}. Using defaults.")
+    logger.warning(
+        f"Failed to load settings via config loader: {str(e)}. Using defaults."
+    )
     TPM_LIMITS = DEFAULT_TPM_LIMITS
     COOLDOWNS = DEFAULT_COOLDOWNS
 
@@ -113,14 +108,16 @@ except Exception as e:
 class LLMResponse:
     """Standardized response object from any LLM provider."""
 
-    def __init__(self,
-                content: str,
-                input_tokens: int,
-                output_tokens: int,
-                model: str,
-                raw_response: Any = None,
-                cache_creation_tokens: int = 0,
-                cache_read_tokens: int = 0):
+    def __init__(
+        self,
+        content: str,
+        input_tokens: int,
+        output_tokens: int,
+        model: str,
+        raw_response: Any = None,
+        cache_creation_tokens: int = 0,
+        cache_read_tokens: int = 0,
+    ):
         self.content = content
         self.input_tokens = input_tokens
         self.output_tokens = output_tokens
@@ -142,11 +139,11 @@ class LLMResponse:
 def get_token_count(text: str, model: str) -> int:
     """
     Get an approximate token count.
-    
+
     Args:
         text: The text to count tokens for
         model: The model name to use for tokenization
-        
+
     Returns:
         The number of tokens in the text
     """
@@ -157,16 +154,20 @@ def get_token_count(text: str, model: str) -> int:
             token_count = client.count_tokens(text)
             return token_count
         except Exception as e:
-            logger.warning(f"Failed to get token count using anthropic library: {str(e)}. Falling back to approximation.")
-    
+            logger.warning(
+                f"Failed to get token count using anthropic library: {str(e)}. Falling back to approximation."
+            )
+
     # If anthropic not available, use tiktoken with cl100k_base which is similar to Claude's tokenizer
     if tiktoken:
         try:
             encoding = tiktoken.get_encoding("cl100k_base")
             return len(encoding.encode(text))
         except Exception as e:
-            logger.warning(f"Failed to get token count using tiktoken: {str(e)}. Falling back to character-based estimation.")
-    
+            logger.warning(
+                f"Failed to get token count using tiktoken: {str(e)}. Falling back to character-based estimation."
+            )
+
     # Fallback to character-based estimation if all else fails
     # Claude's tokenization is roughly 4 characters per token
     logger.warning(
@@ -177,13 +178,15 @@ def get_token_count(text: str, model: str) -> int:
 
 class LLMProvider(abc.ABC):
     """Abstract base class for LLM providers."""
-    
-    def __init__(self, 
-                api_key: Optional[str] = None, 
-                model: Optional[str] = None,
-                temperature: Optional[float] = None,
-                max_tokens: int = 4000,
-                system_prompt: Optional[str] = None):
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        max_tokens: int = 4000,
+        system_prompt: Optional[str] = None,
+    ):
         self.api_key = api_key
         self.model = model
         self.temperature = temperature
@@ -191,12 +194,12 @@ class LLMProvider(abc.ABC):
         self.system_prompt = system_prompt
         self.provider_name = None  # Will be set by subclasses
         self.initialize()
-    
+
     @abc.abstractmethod
     def initialize(self) -> None:
         """Initialize the provider client."""
         pass
-        
+
     @abc.abstractmethod
     def get_completion(self, prompt: str) -> LLMResponse:
         """Get a completion from the LLM."""
@@ -205,44 +208,52 @@ class LLMProvider(abc.ABC):
     def count_tokens(self, text: str) -> int:
         """Count tokens for the provider's model."""
         return get_token_count(text, self.model)
-    
-    def check_tpm_limit(self, prompt: str, estimated_output_tokens: Optional[int] = None) -> Tuple[bool, int, int]:
+
+    def check_tpm_limit(
+        self, prompt: str, estimated_output_tokens: Optional[int] = None
+    ) -> Tuple[bool, int, int]:
         """
         Check if the request would exceed TPM limits from settings.json.
-        
+
         Args:
             prompt: The prompt text to be sent
             estimated_output_tokens: Optional estimate of output tokens (calculated if not provided)
-            
+
         Returns:
             Tuple of (within_limit, input_tokens, total_tokens)
         """
         if not self.provider_name or self.provider_name.lower() not in TPM_LIMITS:
             # No provider name or no limit defined - assume it's safe
-            logger.warning(f"No TPM limit found for provider {self.provider_name}. Proceeding without limits.")
+            logger.warning(
+                f"No TPM limit found for provider {self.provider_name}. Proceeding without limits."
+            )
             return True, 0, 0
-        
+
         # Count input tokens
         input_tokens = self.count_tokens(prompt)
-        
+
         # Estimate output tokens if not provided
         if estimated_output_tokens is None:
             # Default estimation
             estimated_output_tokens = max(400, input_tokens // 5)
-                
+
         # Get total tokens
         total_tokens = input_tokens + estimated_output_tokens
-        
+
         # Get TPM limit for this provider
         tpm_limit = TPM_LIMITS.get(self.provider_name.lower(), 0)
-        
+
         # Check if we're within the limit
         within_limit = total_tokens <= tpm_limit
-        
+
         if not within_limit:
-            logger.warning(f"TPM limit exceeded: Request would use {total_tokens} tokens but limit is {tpm_limit}")
-            logger.warning(f"This exceeds the {self.provider_name} TPM limit set in settings.json")
-        
+            logger.warning(
+                f"TPM limit exceeded: Request would use {total_tokens} tokens but limit is {tpm_limit}"
+            )
+            logger.warning(
+                f"This exceeds the {self.provider_name} TPM limit set in settings.json"
+            )
+
         return within_limit, input_tokens, total_tokens
 
 
@@ -253,19 +264,21 @@ class AnthropicProvider(LLMProvider):
     DEFAULT_MODEL = "claude-3-haiku-20240307"
     STRUCTURED_OUTPUT_RETRIES = 1
 
-    def __init__(self,
-                api_key: Optional[str] = None,
-                model: Optional[str] = None,
-                temperature: Optional[float] = None,
-                max_tokens: int = 4000,
-                system_prompt: Optional[str] = None,
-                top_p: Optional[float] = None,
-                top_k: Optional[int] = None,
-                timeout: int = 120,
-                thinking_enabled: bool = False,
-                thinking_budget_tokens: Optional[int] = None,
-                structured_output_retries: Optional[int] = None,
-                output_validator: Optional[Any] = None):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        max_tokens: int = 4000,
+        system_prompt: Optional[str] = None,
+        top_p: Optional[float] = None,
+        top_k: Optional[int] = None,
+        timeout: int = 120,
+        thinking_enabled: bool = False,
+        thinking_budget_tokens: Optional[int] = None,
+        structured_output_retries: Optional[int] = None,
+        output_validator: Optional[Any] = None,
+    ):
         """
         Initialize Anthropic provider.
 
@@ -299,7 +312,9 @@ class AnthropicProvider(LLMProvider):
 
         # Validate thinking configuration
         if thinking_enabled and thinking_budget_tokens is None:
-            raise ValueError("thinking_budget_tokens must be specified when thinking_enabled=True")
+            raise ValueError(
+                "thinking_budget_tokens must be specified when thinking_enabled=True"
+            )
 
         # Call parent init
         super().__init__(
@@ -307,13 +322,15 @@ class AnthropicProvider(LLMProvider):
             model=model,
             temperature=temperature,
             max_tokens=max_tokens,
-            system_prompt=system_prompt
+            system_prompt=system_prompt,
         )
-    
+
     def initialize(self) -> None:
         """Initialize the Anthropic client."""
         if not anthropic:
-            raise ImportError("The 'anthropic' package is required for AnthropicProvider. Install with 'pip install anthropic'.")
+            raise ImportError(
+                "The 'anthropic' package is required for AnthropicProvider. Install with 'pip install anthropic'."
+            )
 
         self.provider_name = "anthropic"
         self.api_key = self.api_key or self._get_api_key()
@@ -325,19 +342,27 @@ class AnthropicProvider(LLMProvider):
         # Log the model type and thinking status
         if self.thinking_enabled:
             if self.temperature is None:
-                logger.info(f"Using Anthropic model: {self.model} with default temperature, "
-                           f"extended thinking enabled (budget: {self.thinking_budget_tokens} tokens, "
-                           f"total max_tokens: {self.max_tokens})")
+                logger.info(
+                    f"Using Anthropic model: {self.model} with default temperature, "
+                    f"extended thinking enabled (budget: {self.thinking_budget_tokens} tokens, "
+                    f"total max_tokens: {self.max_tokens})"
+                )
             else:
-                logger.info(f"Using Anthropic model: {self.model} with temperature: {self.temperature}, "
-                           f"extended thinking enabled (budget: {self.thinking_budget_tokens} tokens, "
-                           f"total max_tokens: {self.max_tokens})")
+                logger.info(
+                    f"Using Anthropic model: {self.model} with temperature: {self.temperature}, "
+                    f"extended thinking enabled (budget: {self.thinking_budget_tokens} tokens, "
+                    f"total max_tokens: {self.max_tokens})"
+                )
         else:
             if self.temperature is None:
-                logger.info(f"Using Anthropic model: {self.model} with default temperature")
+                logger.info(
+                    f"Using Anthropic model: {self.model} with default temperature"
+                )
             else:
-                logger.info(f"Using Anthropic model: {self.model} with temperature: {self.temperature}")
-        
+                logger.info(
+                    f"Using Anthropic model: {self.model} with temperature: {self.temperature}"
+                )
+
     def get_completion(self, prompt: str, enable_cache: bool = False) -> LLMResponse:
         """
         Get a completion from Anthropic Claude.
@@ -384,7 +409,7 @@ class AnthropicProvider(LLMProvider):
         if self.thinking_enabled:
             extra_body["thinking"] = {
                 "type": "enabled",
-                "budget_tokens": self.thinking_budget_tokens
+                "budget_tokens": self.thinking_budget_tokens,
             }
 
         try:
@@ -398,15 +423,19 @@ class AnthropicProvider(LLMProvider):
             content = ""
             if response.content:
                 for block in response.content:
-                    if hasattr(block, 'type') and block.type == 'thinking':
+                    if hasattr(block, "type") and block.type == "thinking":
                         continue  # Skip thinking blocks
-                    if hasattr(block, 'text') and block.text:
+                    if hasattr(block, "text") and block.text:
                         content = block.text
                         break
 
             # Extract cache usage if available
-            cache_creation_tokens = getattr(response.usage, 'cache_creation_input_tokens', 0) or 0
-            cache_read_tokens = getattr(response.usage, 'cache_read_input_tokens', 0) or 0
+            cache_creation_tokens = (
+                getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+            )
+            cache_read_tokens = (
+                getattr(response.usage, "cache_read_input_tokens", 0) or 0
+            )
 
             # Create and return a standardized response
             return LLMResponse(
@@ -416,65 +445,72 @@ class AnthropicProvider(LLMProvider):
                 model=self.model,
                 raw_response=response,
                 cache_creation_tokens=cache_creation_tokens,
-                cache_read_tokens=cache_read_tokens
+                cache_read_tokens=cache_read_tokens,
             )
         except Exception as e:
             # Handle API errors
             logger.error(f"Error calling Anthropic API: {str(e)}")
-            
+
             # Check for rate limit errors
             if hasattr(e, "status_code") and e.status_code == 429:
                 # Get retry information if available
                 retry_after = None
                 if hasattr(e, "response") and hasattr(e.response, "headers"):
                     retry_after = e.response.headers.get("retry-after")
-                
-                logger.warning(f"Rate limit exceeded. Retry after: {retry_after or 'unknown'}")
-                
+
+                logger.warning(
+                    f"Rate limit exceeded. Retry after: {retry_after or 'unknown'}"
+                )
+
                 # Implement exponential backoff retry
-                retry_wait = int(retry_after) if retry_after and retry_after.isdigit() else COOLDOWNS["rate_limit"]
+                retry_wait = (
+                    int(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else COOLDOWNS["rate_limit"]
+                )
                 logger.info(f"Waiting {retry_wait} seconds before retrying...")
                 time.sleep(retry_wait)
-                
+
                 # Retry the request
                 return self.get_completion(prompt)
-            
+
             # Re-raise other exceptions
             raise
-    
+
     def get_structured_completion(
         self,
         prompt: str,
         schema_model: Type,
         *,
+        output_config: Optional[Dict[str, Any]] = None,
         output_format: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, LLMResponse]:
         """
         Get a structured completion using Anthropic native JSON schema output.
-        
+
         Args:
             prompt: The input prompt
             schema_model: A Pydantic BaseModel class defining the output schema
-            
+
         Returns:
             A tuple of (parsed_object, LLMResponse)
-            
+
         Example:
             ```python
             from pydantic import BaseModel, Field
-            
+
             # Define your output schema
             class SentimentAnalysis(BaseModel):
                 sentiment: str = Field(description="Sentiment of the text (positive, negative, neutral)")
                 score: float = Field(description="Confidence score (0-1)")
-                
+
             # Get structured completion
             provider = AnthropicProvider(model="claude-3-sonnet-20240229")
             result, response = provider.get_structured_completion(
                 "Analyze this text: 'I love this product!'",
                 SentimentAnalysis
             )
-            
+
             # Access the structured data directly
             print(f"Sentiment: {result.sentiment}, Score: {result.score}")
             ```
@@ -484,7 +520,10 @@ class AnthropicProvider(LLMProvider):
             "get_structured_completion_async",
         )
         return self._get_structured_completion_native_sync(
-            prompt, schema_model, output_format=output_format
+            prompt,
+            schema_model,
+            output_config=output_config,
+            output_format=output_format,
         )
 
     async def get_structured_completion_async(
@@ -492,6 +531,7 @@ class AnthropicProvider(LLMProvider):
         prompt: str,
         schema_model: Type,
         *,
+        output_config: Optional[Dict[str, Any]] = None,
         output_format: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, LLMResponse]:
         """Get a structured completion without blocking an existing event loop."""
@@ -499,6 +539,7 @@ class AnthropicProvider(LLMProvider):
             self._get_structured_completion_native_sync,
             prompt,
             schema_model,
+            output_config=output_config,
             output_format=output_format,
         )
 
@@ -519,6 +560,7 @@ class AnthropicProvider(LLMProvider):
         prompt: str,
         schema_model: Type,
         *,
+        output_config: Optional[Dict[str, Any]] = None,
         output_format: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, LLMResponse]:
         """Run a native JSON-schema Messages request with bounded repair."""
@@ -531,7 +573,10 @@ class AnthropicProvider(LLMProvider):
             try:
                 response = self.client.beta.messages.create(
                     **self._build_native_structured_request_params(
-                        active_prompt, schema_model, output_format=output_format
+                        active_prompt,
+                        schema_model,
+                        output_config=output_config,
+                        output_format=output_format,
                     )
                 )
                 parsed_output = self._extract_native_parsed_output(
@@ -563,15 +608,23 @@ class AnthropicProvider(LLMProvider):
         prompt: str,
         schema_model: Type,
         *,
+        output_config: Optional[Dict[str, Any]] = None,
         output_format: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Build Anthropic Messages params for native JSON schema output."""
+
+        if output_config is None:
+            output_config = (
+                {"format": output_format}
+                if output_format is not None
+                else anthropic_output_config(schema_model)
+            )
 
         params: Dict[str, Any] = {
             "model": self.model,
             "messages": [{"role": "user", "content": prompt}],
             "max_tokens": self.max_tokens,
-            "output_format": output_format or anthropic_output_format(schema_model),
+            "output_config": output_config,
         }
         if self.system_prompt:
             params["system"] = self.system_prompt
@@ -640,10 +693,10 @@ class AnthropicProvider(LLMProvider):
     def count_tokens(self, text: str) -> int:
         """
         Count tokens for Anthropic models.
-        
+
         Args:
             text: The text to count tokens for
-            
+
         Returns:
             The number of tokens in the text
         """
@@ -652,7 +705,9 @@ class AnthropicProvider(LLMProvider):
             return self.client.count_tokens(text)
         except Exception as e:
             # Fall back to base implementation if Anthropic's counter fails
-            logger.warning(f"Error using Anthropic token counter: {str(e)}. Falling back to approximation.")
+            logger.warning(
+                f"Error using Anthropic token counter: {str(e)}. Falling back to approximation."
+            )
             return super().count_tokens(text)
 
     def _format_system_with_cache(self) -> List[Dict[str, Any]]:
@@ -669,7 +724,7 @@ class AnthropicProvider(LLMProvider):
             {
                 "type": "text",
                 "text": self.system_prompt,
-                "cache_control": {"type": "ephemeral"}
+                "cache_control": {"type": "ephemeral"},
             }
         ]
 
@@ -709,17 +764,17 @@ class AnthropicProvider(LLMProvider):
             current_section = []
             current_name = None
 
-            for line in prompt.split('\n'):
-                if line.startswith('===') and line.endswith('==='):
+            for line in prompt.split("\n"):
+                if line.startswith("===") and line.endswith("==="):
                     if current_section:
-                        sections.append((current_name, '\n'.join(current_section)))
-                    current_name = line.strip('= ')
+                        sections.append((current_name, "\n".join(current_section)))
+                    current_name = line.strip("= ")
                     current_section = []
                 else:
                     current_section.append(line)
 
             if current_section:
-                sections.append((current_name, '\n'.join(current_section)))
+                sections.append((current_name, "\n".join(current_section)))
 
             # Add sections as content blocks, marking large ones for caching
             for section_name, section_text in sections:
@@ -743,7 +798,7 @@ class AnthropicProvider(LLMProvider):
                     "RECENT STORYTELLER CONTEXT",
                     "ENTITY DOSSIER",
                     "HISTORICAL PASSAGES",
-                    "STRUCTURED SUMMARIES"
+                    "STRUCTURED SUMMARIES",
                 ]:
                     block["cache_control"] = {"type": "ephemeral"}
 
@@ -769,32 +824,36 @@ class AnthropicProvider(LLMProvider):
 def get_db_connection_string() -> str:
     """
     Get the database connection string from environment variables or defaults.
-    
+
     By default, connects to NEXUS database on localhost with the current user.
     Override with DB_* environment variables or custom URL.
     """
-    DB_USER = os.environ.get("DB_USER", "pythagor") 
+    DB_USER = os.environ.get("DB_USER", "pythagor")
     DB_PASSWORD = os.environ.get("DB_PASSWORD", "")
     DB_HOST = os.environ.get("DB_HOST", "localhost")
     DB_PORT = os.environ.get("DB_PORT", "5432")
     DB_NAME = os.environ.get("DB_NAME", "NEXUS")
-    
+
     # Build connection string (with password if provided)
     if DB_PASSWORD:
-        connection_string = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+        connection_string = (
+            f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+        )
     else:
         connection_string = f"postgresql://{DB_USER}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
-        
-    logger.info(f"Using database connection: {connection_string.replace(DB_PASSWORD, '********' if DB_PASSWORD else '')}")
+
+    logger.info(
+        f"Using database connection: {connection_string.replace(DB_PASSWORD, '********' if DB_PASSWORD else '')}"
+    )
     return connection_string
+
 
 def to_json(obj):
     """Convert an object to a JSON-serializable format."""
     if isinstance(obj, (datetime, timedelta)):
         return str(obj)
-    elif hasattr(obj, '__dict__'):
-        return {k: to_json(v) for k, v in obj.__dict__.items() 
-                if not k.startswith('_')}
+    elif hasattr(obj, "__dict__"):
+        return {k: to_json(v) for k, v in obj.__dict__.items() if not k.startswith("_")}
     elif isinstance(obj, dict):
         return {k: to_json(v) for k, v in obj.items()}
     elif isinstance(obj, (list, tuple)):
@@ -806,99 +865,128 @@ def to_json(obj):
 def get_default_llm_argument_parser():
     """
     Returns an argument parser with common LLM-related arguments pre-configured.
-    
+
     This is a helper function for scripts that want to use this library.
     It sets up the standard arguments for LLM options.
-    
+
     Returns:
         argparse.ArgumentParser: An argument parser with common LLM-related arguments
     """
     parser = argparse.ArgumentParser(
         description="Process with Anthropic Claude API.",
-        formatter_class=argparse.RawDescriptionHelpFormatter
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    
+
     # Anthropic options
     llm_group = parser.add_argument_group("Anthropic API Options")
-    llm_group.add_argument("--model", default=AnthropicProvider.DEFAULT_MODEL,
-                         help=f"Model name to use (default: {AnthropicProvider.DEFAULT_MODEL})")
+    llm_group.add_argument(
+        "--model",
+        default=AnthropicProvider.DEFAULT_MODEL,
+        help=f"Model name to use (default: {AnthropicProvider.DEFAULT_MODEL})",
+    )
     llm_group.add_argument("--api-key", help="API key (optional)")
-    llm_group.add_argument("--temperature", type=float, default=None,
-                         help="Model temperature (0.0-1.0, omit for API default)")
-    llm_group.add_argument("--max-tokens", type=int, default=4000,
-                         help="Maximum tokens to generate in response (default: 4000)")
-    llm_group.add_argument("--system-prompt", 
-                         help="Optional system prompt to use")
-    llm_group.add_argument("--top-p", type=float,
-                         help="Top-p sampling parameter (0.0-1.0)")
-    llm_group.add_argument("--top-k", type=int,
-                         help="Top-k sampling parameter")
-    llm_group.add_argument("--timeout", type=int, default=120,
-                         help="Request timeout in seconds (default: 120)")
-    
+    llm_group.add_argument(
+        "--temperature",
+        type=float,
+        default=None,
+        help="Model temperature (0.0-1.0, omit for API default)",
+    )
+    llm_group.add_argument(
+        "--max-tokens",
+        type=int,
+        default=4000,
+        help="Maximum tokens to generate in response (default: 4000)",
+    )
+    llm_group.add_argument("--system-prompt", help="Optional system prompt to use")
+    llm_group.add_argument(
+        "--top-p", type=float, help="Top-p sampling parameter (0.0-1.0)"
+    )
+    llm_group.add_argument("--top-k", type=int, help="Top-k sampling parameter")
+    llm_group.add_argument(
+        "--timeout",
+        type=int,
+        default=120,
+        help="Request timeout in seconds (default: 120)",
+    )
+
     # Common processing options
     process_group = parser.add_argument_group("Processing Options")
-    process_group.add_argument("--batch-size", type=int, default=10,
-                             help="Number of items to process before prompting to continue (default: 10)")
-    process_group.add_argument("--dry-run", action="store_true", 
-                             help="Don't actually save results to the database")
-    process_group.add_argument("--db-url", 
-                        help="Database connection URL (optional, defaults to environment variables)")
-    
+    process_group.add_argument(
+        "--batch-size",
+        type=int,
+        default=10,
+        help="Number of items to process before prompting to continue (default: 10)",
+    )
+    process_group.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Don't actually save results to the database",
+    )
+    process_group.add_argument(
+        "--db-url",
+        help="Database connection URL (optional, defaults to environment variables)",
+    )
+
     return parser
 
 
 def validate_llm_requirements(api_key: Optional[str] = None) -> None:
     """
     Validate that the required packages are installed for Anthropic.
-    
+
     Args:
         api_key: Optional API key to validate
-        
+
     Raises:
         ImportError: If the required package is not installed
         ValueError: If the configuration is invalid
     """
     if anthropic is None:
-        raise ImportError("The 'anthropic' package is required. Install with 'pip install anthropic'")
+        raise ImportError(
+            "The 'anthropic' package is required. Install with 'pip install anthropic'"
+        )
 
 
 # Abort functionality
 # Global abort flag
 ABORT_REQUESTED = False
 
-def setup_abort_handler(abort_message: str = "Abort requested! Will finish current operation and stop."):
+
+def setup_abort_handler(
+    abort_message: str = "Abort requested! Will finish current operation and stop.",
+):
     """
     Set up handlers to catch abort requests (Esc key or Ctrl+C)
-    
+
     Args:
         abort_message: Custom message to display when abort is requested
-        
+
     Returns:
         True if handlers were successfully set up, False otherwise
     """
     global ABORT_REQUESTED
-    
+
     # Setup keyboard handler if available
     if KEYBOARD_AVAILABLE:
+
         def on_escape_press(event):
             global ABORT_REQUESTED
-            if event.name == 'esc':
+            if event.name == "esc":
                 print(f"\n{abort_message}")
                 logger.info("Abort requested via ESC key")
                 ABORT_REQUESTED = True
-                
+
         # Register escape key handler
         keyboard.on_press(on_escape_press)
         logger.info("Keyboard abort handler active - Press ESC to abort processing")
-    
+
     # Setup signal handler for Ctrl+C
     def signal_handler(sig, frame):
         global ABORT_REQUESTED
         print(f"\n{abort_message}")
         logger.info("Abort requested via Ctrl+C")
         ABORT_REQUESTED = True
-        
+
     try:
         signal.signal(signal.SIGINT, signal_handler)
         logger.info("Signal handler active - Press Ctrl+C to abort processing")
@@ -907,21 +995,24 @@ def setup_abort_handler(abort_message: str = "Abort requested! Will finish curre
         logger.warning(f"Failed to set up signal handler: {e}")
         return False
 
+
 def is_abort_requested() -> bool:
     """
     Check if abort has been requested
-    
+
     Returns:
         True if abort has been requested, False otherwise
     """
     global ABORT_REQUESTED
     return ABORT_REQUESTED
 
+
 def reset_abort_flag():
     """Reset the abort flag to False"""
     global ABORT_REQUESTED
     ABORT_REQUESTED = False
     logger.info("Abort flag has been reset")
+
 
 # This file is now meant to be imported as a library, not run directly
 if __name__ == "__main__":

--- a/scripts/api_anthropic.py
+++ b/scripts/api_anthropic.py
@@ -443,7 +443,11 @@ class AnthropicProvider(LLMProvider):
             raise
     
     def get_structured_completion(
-        self, prompt: str, schema_model: Type
+        self,
+        prompt: str,
+        schema_model: Type,
+        *,
+        output_format: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, LLMResponse]:
         """
         Get a structured completion using Anthropic native JSON schema output.
@@ -479,14 +483,23 @@ class AnthropicProvider(LLMProvider):
             "get_structured_completion",
             "get_structured_completion_async",
         )
-        return self._get_structured_completion_native_sync(prompt, schema_model)
+        return self._get_structured_completion_native_sync(
+            prompt, schema_model, output_format=output_format
+        )
 
     async def get_structured_completion_async(
-        self, prompt: str, schema_model: Type
+        self,
+        prompt: str,
+        schema_model: Type,
+        *,
+        output_format: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, LLMResponse]:
         """Get a structured completion without blocking an existing event loop."""
         return await asyncio.to_thread(
-            self._get_structured_completion_native_sync, prompt, schema_model
+            self._get_structured_completion_native_sync,
+            prompt,
+            schema_model,
+            output_format=output_format,
         )
 
     def _raise_if_running_loop(self, method_name: str, async_method_name: str) -> None:
@@ -502,7 +515,11 @@ class AnthropicProvider(LLMProvider):
         )
 
     def _get_structured_completion_native_sync(
-        self, prompt: str, schema_model: Type
+        self,
+        prompt: str,
+        schema_model: Type,
+        *,
+        output_format: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, LLMResponse]:
         """Run a native JSON-schema Messages request with bounded repair."""
 
@@ -514,7 +531,7 @@ class AnthropicProvider(LLMProvider):
             try:
                 response = self.client.beta.messages.create(
                     **self._build_native_structured_request_params(
-                        active_prompt, schema_model
+                        active_prompt, schema_model, output_format=output_format
                     )
                 )
                 parsed_output = self._extract_native_parsed_output(
@@ -542,7 +559,11 @@ class AnthropicProvider(LLMProvider):
         raise RuntimeError("Structured completion failed") from last_error
 
     def _build_native_structured_request_params(
-        self, prompt: str, schema_model: Type
+        self,
+        prompt: str,
+        schema_model: Type,
+        *,
+        output_format: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Build Anthropic Messages params for native JSON schema output."""
 
@@ -550,7 +571,7 @@ class AnthropicProvider(LLMProvider):
             "model": self.model,
             "messages": [{"role": "user", "content": prompt}],
             "max_tokens": self.max_tokens,
-            "output_format": anthropic_output_format(schema_model),
+            "output_format": output_format or anthropic_output_format(schema_model),
         }
         if self.system_prompt:
             params["system"] = self.system_prompt

--- a/scripts/api_anthropic.py
+++ b/scripts/api_anthropic.py
@@ -68,6 +68,13 @@ except ImportError:
 # For database connection (utilities only, no ORM)
 import sqlalchemy as sa
 from sqlalchemy import create_engine
+from pydantic import ValidationError
+
+from nexus.api.native_structured_output import (
+    anthropic_output_format,
+    retry_prompt,
+    run_output_validator,
+)
 
 # Configure logging
 logging.basicConfig(
@@ -439,7 +446,7 @@ class AnthropicProvider(LLMProvider):
         self, prompt: str, schema_model: Type
     ) -> Tuple[Any, LLMResponse]:
         """
-        Get a structured completion using a Pydantic model.
+        Get a structured completion using Anthropic native JSON schema output.
         
         Args:
             prompt: The input prompt
@@ -472,17 +479,15 @@ class AnthropicProvider(LLMProvider):
             "get_structured_completion",
             "get_structured_completion_async",
         )
-        agent = self._build_structured_agent(schema_model)
-        result = agent.run_sync(prompt)
-        return self._structured_result_to_response(result)
+        return self._get_structured_completion_native_sync(prompt, schema_model)
 
     async def get_structured_completion_async(
         self, prompt: str, schema_model: Type
     ) -> Tuple[Any, LLMResponse]:
         """Get a structured completion without blocking an existing event loop."""
-        agent = self._build_structured_agent(schema_model)
-        result = await agent.run(prompt)
-        return self._structured_result_to_response(result)
+        return await asyncio.to_thread(
+            self._get_structured_completion_native_sync, prompt, schema_model
+        )
 
     def _raise_if_running_loop(self, method_name: str, async_method_name: str) -> None:
         """Reject sync structured calls from async contexts with a clear error."""
@@ -496,94 +501,121 @@ class AnthropicProvider(LLMProvider):
             f"event loop; use AnthropicProvider.{async_method_name}() instead."
         )
 
-    def _build_structured_agent(self, schema_model: Type) -> Any:
-        """Build the Pydantic AI agent for structured output."""
-        try:
-            from pydantic_ai import Agent
-            from pydantic_ai.models.anthropic import AnthropicModel
-            from pydantic_ai.providers.anthropic import AnthropicProvider as PydanticAnthropicProvider
-            from pydantic_ai.settings import ModelSettings
-        except ImportError as exc:
-            raise ImportError(
-                "Pydantic AI is required for structured completions. "
-                "Install with 'pip install pydantic-ai'."
-            ) from exc
+    def _get_structured_completion_native_sync(
+        self, prompt: str, schema_model: Type
+    ) -> Tuple[Any, LLMResponse]:
+        """Run a native JSON-schema Messages request with bounded repair."""
 
-        logger.info(
-            "Using Pydantic AI structured output with model %s and schema %s",
-            self.model,
-            schema_model.__name__,
-        )
+        from pydantic_ai import ModelRetry
 
-        provider = PydanticAnthropicProvider(api_key=self.api_key)
-        model = AnthropicModel(model_name=self.model, provider=provider)
+        active_prompt = prompt
+        last_error: Optional[BaseException] = None
+        for attempt in range(self.structured_output_retries + 1):
+            try:
+                response = self.client.beta.messages.create(
+                    **self._build_native_structured_request_params(
+                        active_prompt, schema_model
+                    )
+                )
+                parsed_output = self._extract_native_parsed_output(
+                    response, schema_model
+                )
+                parsed_output = asyncio.run(
+                    run_output_validator(
+                        self.output_validator, parsed_output, retry=attempt
+                    )
+                )
+                return parsed_output, self._native_response_to_llm_response(
+                    parsed_output, response
+                )
+            except ModelRetry as exc:
+                last_error = exc
+                if attempt >= self.structured_output_retries:
+                    raise
+                active_prompt = retry_prompt(prompt, exc.message)
+            except (ValidationError, json.JSONDecodeError, ValueError) as exc:
+                last_error = exc
+                if attempt >= self.structured_output_retries:
+                    raise
+                active_prompt = retry_prompt(prompt, str(exc))
 
-        settings_kwargs = {"max_tokens": self.max_tokens}
-        model_fields = getattr(ModelSettings, "model_fields", None) or getattr(ModelSettings, "__fields__", {})
-        if (
-            "temperature" in model_fields
-            and self.temperature is not None
-            and not self.model.lower().startswith("claude-")
-        ):
-            settings_kwargs["temperature"] = self.temperature
-        if "top_p" in model_fields and self.top_p is not None:
-            settings_kwargs["top_p"] = self.top_p
-        if "top_k" in model_fields and self.top_k is not None:
-            settings_kwargs["top_k"] = self.top_k
+        raise RuntimeError("Structured completion failed") from last_error
 
-        model_settings = ModelSettings(**settings_kwargs)
+    def _build_native_structured_request_params(
+        self, prompt: str, schema_model: Type
+    ) -> Dict[str, Any]:
+        """Build Anthropic Messages params for native JSON schema output."""
 
-        agent = Agent(
-            model=model,
-            output_type=schema_model,
-            system_prompt=self.system_prompt,
-            model_settings=model_settings,
-            retries=self.structured_output_retries,
-        )
-        if self.output_validator is not None:
-            agent.output_validator(self.output_validator)
+        params: Dict[str, Any] = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": self.max_tokens,
+            "output_format": anthropic_output_format(schema_model),
+        }
+        if self.system_prompt:
+            params["system"] = self.system_prompt
+        if self.temperature is not None:
+            params["temperature"] = self.temperature
+        if self.top_p is not None:
+            params["top_p"] = self.top_p
+        if self.top_k is not None:
+            params["top_k"] = self.top_k
+        if self.thinking_enabled:
+            params["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": self.thinking_budget_tokens,
+            }
+        return params
 
-        return agent
+    @staticmethod
+    def _extract_native_parsed_output(response: Any, schema_model: Type) -> Any:
+        """Extract and validate Anthropic native JSON output."""
 
-    def _structured_result_to_response(self, result: Any) -> Tuple[Any, LLMResponse]:
-        """Convert a Pydantic AI run result into the local response tuple."""
-        parsed_output = result.output
+        text_parts: List[str] = []
+        for block in getattr(response, "content", []) or []:
+            block_type = getattr(block, "type", None)
+            if block_type == "tool_use" and getattr(block, "input", None):
+                return schema_model.model_validate(block.input)
+            text = getattr(block, "text", None)
+            if block_type == "text" and text:
+                text_parts.append(text)
+
+        output_text = "".join(text_parts).strip()
+        if output_text:
+            return schema_model.model_validate_json(output_text)
+
+        raise ValueError("Anthropic structured response did not include JSON output")
+
+    def _native_response_to_llm_response(
+        self, parsed_output: Any, response: Any
+    ) -> LLMResponse:
+        """Convert an Anthropic native structured response into LLMResponse."""
 
         content = (
             parsed_output.model_dump_json()
             if hasattr(parsed_output, "model_dump_json")
             else json.dumps(parsed_output)
         )
+        usage = getattr(response, "usage", None)
+        input_tokens = getattr(usage, "input_tokens", 0) if usage else 0
+        output_tokens = getattr(usage, "output_tokens", 0) if usage else 0
+        cache_creation_tokens = (
+            getattr(usage, "cache_creation_input_tokens", 0) if usage else 0
+        ) or 0
+        cache_read_tokens = (
+            getattr(usage, "cache_read_input_tokens", 0) if usage else 0
+        ) or 0
 
-        usage = result.usage() if callable(getattr(result, "usage", None)) else getattr(result, "usage", None)
-        input_tokens = 0
-        output_tokens = 0
-        if usage:
-            if isinstance(usage, dict):
-                input_tokens = usage.get("input_tokens") or usage.get("request_tokens") or 0
-                output_tokens = usage.get("output_tokens") or usage.get("response_tokens") or 0
-            else:
-                input_tokens = (
-                    getattr(usage, "input_tokens", None)
-                    or getattr(usage, "request_tokens", None)
-                    or 0
-                )
-                output_tokens = (
-                    getattr(usage, "output_tokens", None)
-                    or getattr(usage, "response_tokens", None)
-                    or 0
-                )
-
-        llm_response = LLMResponse(
+        return LLMResponse(
             content=content,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             model=self.model,
-            raw_response=result,
+            raw_response=response,
+            cache_creation_tokens=cache_creation_tokens,
+            cache_read_tokens=cache_read_tokens,
         )
 
-        return parsed_output, llm_response
-    
     def count_tokens(self, text: str) -> int:
         """
         Count tokens for Anthropic models.

--- a/scripts/api_openai.py
+++ b/scripts/api_openai.py
@@ -343,7 +343,11 @@ class OpenAIProvider(LLMProvider):
         return self._get_completion_unified(prompt, cache_key=cache_key)
     
     def get_structured_completion(
-        self, prompt: str, schema_model: Type
+        self,
+        prompt: str,
+        schema_model: Type,
+        *,
+        text_format: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, LLMResponse]:
         """
         Get a structured completion using OpenAI native strict schema output.
@@ -379,14 +383,23 @@ class OpenAIProvider(LLMProvider):
             "get_structured_completion",
             "get_structured_completion_async",
         )
-        return self._get_structured_completion_native_sync(prompt, schema_model)
+        return self._get_structured_completion_native_sync(
+            prompt, schema_model, text_format=text_format
+        )
 
     async def get_structured_completion_async(
-        self, prompt: str, schema_model: Type
+        self,
+        prompt: str,
+        schema_model: Type,
+        *,
+        text_format: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, LLMResponse]:
         """Get a structured completion without blocking an existing event loop."""
         return await asyncio.to_thread(
-            self._get_structured_completion_native_sync, prompt, schema_model
+            self._get_structured_completion_native_sync,
+            prompt,
+            schema_model,
+            text_format=text_format,
         )
 
     def _raise_if_running_loop(self, method_name: str, async_method_name: str) -> None:
@@ -402,7 +415,11 @@ class OpenAIProvider(LLMProvider):
         )
 
     def _get_structured_completion_native_sync(
-        self, prompt: str, schema_model: Type
+        self,
+        prompt: str,
+        schema_model: Type,
+        *,
+        text_format: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, LLMResponse]:
         """Run a native strict-schema Responses request with bounded repair."""
 
@@ -414,7 +431,7 @@ class OpenAIProvider(LLMProvider):
             try:
                 response = self.client.responses.parse(
                     **self._build_native_structured_request_params(
-                        active_prompt, schema_model
+                        active_prompt, schema_model, text_format=text_format
                     )
                 )
                 parsed_output = self._extract_native_parsed_output(
@@ -442,7 +459,11 @@ class OpenAIProvider(LLMProvider):
         raise RuntimeError("Structured completion failed") from last_error
 
     def _build_native_structured_request_params(
-        self, prompt: str, schema_model: Type
+        self,
+        prompt: str,
+        schema_model: Type,
+        *,
+        text_format: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Build OpenAI Responses params for native strict structured output."""
 
@@ -454,8 +475,11 @@ class OpenAIProvider(LLMProvider):
             "model": self.model,
             "input": input_messages,
             "max_output_tokens": self.max_output_tokens,
-            "text_format": schema_model,
         }
+        if text_format is None:
+            request_params["text_format"] = schema_model
+        else:
+            request_params["text"] = {"format": text_format}
         if self.supports_temperature and self.temperature is not None:
             request_params["temperature"] = self.temperature
         if self.reasoning_effort:

--- a/scripts/api_openai.py
+++ b/scripts/api_openai.py
@@ -67,6 +67,9 @@ except ImportError:
 # For database connection (utilities only, no ORM)
 import sqlalchemy as sa
 from sqlalchemy import create_engine
+from pydantic import ValidationError
+
+from nexus.api.native_structured_output import retry_prompt, run_output_validator
 
 # Configure logging
 logging.basicConfig(
@@ -343,7 +346,7 @@ class OpenAIProvider(LLMProvider):
         self, prompt: str, schema_model: Type
     ) -> Tuple[Any, LLMResponse]:
         """
-        Get a structured completion using the Responses API with a Pydantic model.
+        Get a structured completion using OpenAI native strict schema output.
         
         Args:
             prompt: The input prompt
@@ -376,17 +379,15 @@ class OpenAIProvider(LLMProvider):
             "get_structured_completion",
             "get_structured_completion_async",
         )
-        agent = self._build_structured_agent(schema_model)
-        result = agent.run_sync(prompt)
-        return self._structured_result_to_response(result)
+        return self._get_structured_completion_native_sync(prompt, schema_model)
 
     async def get_structured_completion_async(
         self, prompt: str, schema_model: Type
     ) -> Tuple[Any, LLMResponse]:
         """Get a structured completion without blocking an existing event loop."""
-        agent = self._build_structured_agent(schema_model)
-        result = await agent.run(prompt)
-        return self._structured_result_to_response(result)
+        return await asyncio.to_thread(
+            self._get_structured_completion_native_sync, prompt, schema_model
+        )
 
     def _raise_if_running_loop(self, method_name: str, async_method_name: str) -> None:
         """Reject sync structured calls from async contexts with a clear error."""
@@ -400,96 +401,103 @@ class OpenAIProvider(LLMProvider):
             f"event loop; use OpenAIProvider.{async_method_name}() instead."
         )
 
-    def _build_structured_agent(self, schema_model: Type) -> Any:
-        """Build the Pydantic AI agent for structured output."""
-        try:
-            from pydantic_ai import Agent
-            from pydantic_ai.models.openai import OpenAIResponsesModel
-            from pydantic_ai.providers.openai import OpenAIProvider as PydanticOpenAIProvider
-            from pydantic_ai.settings import ModelSettings
-        except ImportError as exc:
-            raise ImportError(
-                "Pydantic AI is required for structured completions. "
-                "Install with 'pip install pydantic-ai'."
-            ) from exc
+    def _get_structured_completion_native_sync(
+        self, prompt: str, schema_model: Type
+    ) -> Tuple[Any, LLMResponse]:
+        """Run a native strict-schema Responses request with bounded repair."""
 
-        logger.info(
-            "Using Pydantic AI structured output with model %s and schema %s",
-            self.model,
-            schema_model.__name__,
-        )
+        from pydantic_ai import ModelRetry
 
-        provider = PydanticOpenAIProvider(api_key=self.api_key, base_url=self.base_url)
-        model = OpenAIResponsesModel(model_name=self.model, provider=provider)
+        active_prompt = prompt
+        last_error: Optional[BaseException] = None
+        for attempt in range(self.structured_output_retries + 1):
+            try:
+                response = self.client.responses.parse(
+                    **self._build_native_structured_request_params(
+                        active_prompt, schema_model
+                    )
+                )
+                parsed_output = self._extract_native_parsed_output(
+                    response, schema_model
+                )
+                parsed_output = asyncio.run(
+                    run_output_validator(
+                        self.output_validator, parsed_output, retry=attempt
+                    )
+                )
+                return parsed_output, self._native_response_to_llm_response(
+                    parsed_output, response
+                )
+            except ModelRetry as exc:
+                last_error = exc
+                if attempt >= self.structured_output_retries:
+                    raise
+                active_prompt = retry_prompt(prompt, exc.message)
+            except (ValidationError, json.JSONDecodeError, ValueError) as exc:
+                last_error = exc
+                if attempt >= self.structured_output_retries:
+                    raise
+                active_prompt = retry_prompt(prompt, str(exc))
 
-        settings_kwargs = {"max_tokens": self.max_output_tokens}
-        model_fields = getattr(ModelSettings, "model_fields", None) or getattr(ModelSettings, "__fields__", {})
-        if (
-            "temperature" in model_fields
-            and self.supports_temperature
-            and self.temperature is not None
-            and not self.model.lower().startswith("gpt-5")  # pin: family-prefix feature detection
-        ):
-            settings_kwargs["temperature"] = self.temperature
+        raise RuntimeError("Structured completion failed") from last_error
+
+    def _build_native_structured_request_params(
+        self, prompt: str, schema_model: Type
+    ) -> Dict[str, Any]:
+        """Build OpenAI Responses params for native strict structured output."""
+
+        input_messages = [{"role": "user", "content": prompt}]
+        if self.system_prompt:
+            input_messages.insert(0, {"role": "system", "content": self.system_prompt})
+
+        request_params: Dict[str, Any] = {
+            "model": self.model,
+            "input": input_messages,
+            "max_output_tokens": self.max_output_tokens,
+            "text_format": schema_model,
+        }
+        if self.supports_temperature and self.temperature is not None:
+            request_params["temperature"] = self.temperature
         if self.reasoning_effort:
-            if "reasoning_effort" in model_fields:
-                settings_kwargs["reasoning_effort"] = self.reasoning_effort
-            elif "reasoning" in model_fields:
-                settings_kwargs["reasoning"] = {"effort": self.reasoning_effort}
+            request_params["reasoning"] = {"effort": self.reasoning_effort}
+        return request_params
 
-        model_settings = ModelSettings(**settings_kwargs)
+    @staticmethod
+    def _extract_native_parsed_output(response: Any, schema_model: Type) -> Any:
+        """Extract the parsed model from an OpenAI parsed response."""
 
-        agent = Agent(
-            model=model,
-            output_type=schema_model,
-            system_prompt=self.system_prompt,
-            model_settings=model_settings,
-            retries=self.structured_output_retries,
-        )
-        if self.output_validator is not None:
-            agent.output_validator(self.output_validator)
+        parsed_output = getattr(response, "output_parsed", None)
+        if parsed_output is not None:
+            return parsed_output
 
-        return agent
+        output_text = getattr(response, "output_text", "")
+        if output_text:
+            return schema_model.model_validate_json(output_text)
 
-    def _structured_result_to_response(self, result: Any) -> Tuple[Any, LLMResponse]:
-        """Convert a Pydantic AI run result into the local response tuple."""
-        parsed_output = result.output
+        raise ValueError("OpenAI structured response did not include parsed output")
+
+    def _native_response_to_llm_response(
+        self, parsed_output: Any, response: Any
+    ) -> LLMResponse:
+        """Convert an OpenAI native structured response into LLMResponse."""
 
         content = (
             parsed_output.model_dump_json()
             if hasattr(parsed_output, "model_dump_json")
             else json.dumps(parsed_output)
         )
+        usage = getattr(response, "usage", None)
+        input_tokens = getattr(usage, "input_tokens", 0) if usage else 0
+        output_tokens = getattr(usage, "output_tokens", 0) if usage else 0
 
-        usage = result.usage() if callable(getattr(result, "usage", None)) else getattr(result, "usage", None)
-        input_tokens = 0
-        output_tokens = 0
-        if usage:
-            if isinstance(usage, dict):
-                input_tokens = usage.get("input_tokens") or usage.get("request_tokens") or 0
-                output_tokens = usage.get("output_tokens") or usage.get("response_tokens") or 0
-            else:
-                input_tokens = (
-                    getattr(usage, "input_tokens", None)
-                    or getattr(usage, "request_tokens", None)
-                    or 0
-                )
-                output_tokens = (
-                    getattr(usage, "output_tokens", None)
-                    or getattr(usage, "response_tokens", None)
-                    or 0
-                )
-
-        llm_response = LLMResponse(
+        return LLMResponse(
             content=content,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             model=self.model,
-            raw_response=result,
+            raw_response=response,
         )
 
-        return parsed_output, llm_response
-    
     def _get_completion_unified(self, prompt: str, cache_key: Optional[str] = None) -> LLMResponse:
         """Get a completion using the unified /v1/responses API.
 

--- a/tests/test_golden_path_live.py
+++ b/tests/test_golden_path_live.py
@@ -20,8 +20,8 @@ Stages (ordered; each test asserts one category against the shared run):
   2. Live play: scripted turns including one freeform directive, one
      entity-eliciting input, and one explicit time skip (sunhelm needs accrue
      on world time; a fresh world's Orrery wakes through them), then
-     adaptive eventful turns until promotion + bleed-offer + maturation have
-     all occurred (bounded by GOLDEN_PATH_MAX_TURNS).
+     adaptive eventful turns until promotion + bleed-offer/prose weave +
+     persisted maturation have all occurred (bounded by GOLDEN_PATH_MAX_TURNS).
   3. Chunk persistence + incubator lifecycle (one pending chunk, committed
      chunks finalized).
   4. Embedding lifecycle: every locked chunk embedded except the Retrograde
@@ -41,7 +41,7 @@ opt-in NEXUS_GOLDEN_PATH_E2E=1.
 Cost and wall clock: measured green run (2026-06-11, gpt-5.5 +
 @anthropic.default narration): 20 frontier calls, 14m30s end to end.
 Budget ~20-35 calls / 15-30 minutes; the adaptive tail adds turns only
-when promotion/bleed/maturation lag. Budget accordingly before CI.
+when promotion/bleed-weave/persisted maturation lag. Budget accordingly before CI.
 
 Cleanup: the API server subprocess is terminated on teardown. Slot 5 is
 deliberately left with the run's data for post-mortem inspection; rerun
@@ -62,6 +62,7 @@ from typing import Any, Dict, List, Optional
 import psycopg2  # type: ignore[import-untyped]
 import pytest
 import requests
+import tomlkit
 from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
 
 SLOT = 5
@@ -71,9 +72,11 @@ DSN = f"postgresql://pythagor@localhost:5432/{DBNAME}"
 # (agent worktrees); the spawned server subprocess inherits it via env.
 API = f"http://localhost:{os.environ.get('NARRATIVE_API_PORT', '8002')}"
 FIXTURE = Path(__file__).parent / "fixtures" / "golden_path_wizard_cache.json"
+MODEL_OVERRIDE_ENV = "NEXUS_GOLDEN_MODEL_REF"
+RUNTIME_CONFIG_ENV = "NEXUS_RUNTIME_CONFIG"
 
 # Hard ceiling on play turns; the run goes adaptive after the scripted
-# opening if promotion/bleed/maturation have not all occurred yet.
+# opening if promotion/bleed-weave/persisted maturation have not all occurred yet.
 GOLDEN_PATH_MAX_TURNS = 10
 SCRIPTED_OPENING: List[Dict[str, Any]] = [
     {"choice": 1},
@@ -95,6 +98,14 @@ SCRIPTED_OPENING: List[Dict[str, Any]] = [
     },
 ]
 ADAPTIVE_INPUT = {"choice": 1}
+ADAPTIVE_ENTITY_INPUT = {
+    "user_text": (
+        "I slow down and ask the nearest unnamed witness for their name, "
+        "trade, and what they risk by helping. If there is a new helper, "
+        "informer, guard, or neighbor who matters, bring that person "
+        "on-screen by name now so I can remember them."
+    )
+}
 
 GENERATION_POLL_SECONDS = 360
 TRANSITION_TIMEOUT_SECONDS = 900
@@ -265,7 +276,8 @@ def _goal_state() -> Dict[str, bool]:
     matured = int(
         _scalar(
             "SELECT count(*) FROM orrery_maturation_jobs "
-            "WHERE state::text = 'succeeded'"
+            "WHERE state::text = 'succeeded' "
+            "AND COALESCE((result_manifest ->> 'persisted')::boolean, false)"
         )
         or 0
     )
@@ -273,8 +285,78 @@ def _goal_state() -> Dict[str, bool]:
         "promotion": promoted > 0,
         "narration": narrated > 0,
         "bleed_offer": offered > 0,
+        "bleed_weave": bool(_bleed_woven_rows()),
         "maturation": matured > 0,
     }
+
+
+def _bleed_woven_rows() -> List[Dict[str, Any]]:
+    return _query(
+        """
+        SELECT r.id, en.name
+        FROM orrery_resolutions r
+        JOIN entity_names_v en ON en.id = r.actor_entity_id
+        JOIN narrative_chunks nc ON nc.id >= r.first_surfaced_chunk_id
+        WHERE r.offer_count > 0
+          AND r.first_surfaced_chunk_id IS NOT NULL
+          AND position(
+              lower(en.name) IN lower(COALESCE(nc.raw_text, nc.storyteller_text, ''))
+          ) > 0
+        LIMIT 1
+        """
+    )
+
+
+def _offered_bleed_actor_needing_weave() -> Optional[str]:
+    rows = _query(
+        """
+        SELECT en.name
+        FROM orrery_resolutions r
+        JOIN entity_names_v en ON en.id = r.actor_entity_id
+        WHERE r.offer_count > 0
+          AND r.first_surfaced_chunk_id IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1
+              FROM narrative_chunks nc
+              WHERE nc.id >= r.first_surfaced_chunk_id
+                AND position(
+                    lower(en.name)
+                    IN lower(COALESCE(nc.raw_text, nc.storyteller_text, ''))
+                ) > 0
+          )
+        ORDER BY r.first_surfaced_chunk_id, r.id
+        LIMIT 1
+        """
+    )
+    if not rows:
+        return None
+    return str(rows[0]["name"])
+
+
+def _has_persisted_maturation() -> bool:
+    return bool(
+        _scalar(
+            "SELECT 1 FROM orrery_maturation_jobs "
+            "WHERE state::text = 'succeeded' "
+            "AND COALESCE((result_manifest ->> 'persisted')::boolean, false) "
+            "LIMIT 1"
+        )
+    )
+
+
+def _adaptive_payload() -> Dict[str, Any]:
+    actor_name = _offered_bleed_actor_needing_weave()
+    if actor_name:
+        return {
+            "user_text": (
+                f"Before leaving this thread, I look for any sign of {actor_name}. "
+                f"If {actor_name} is not present, name the trace, rumor, or "
+                f"consequence of {actor_name} that reaches me now."
+            )
+        }
+    if not _has_persisted_maturation():
+        return dict(ADAPTIVE_ENTITY_INPUT)
+    return dict(ADAPTIVE_INPUT)
 
 
 def _stage_play_turns(run: GoldenPathRun) -> None:
@@ -286,7 +368,7 @@ def _stage_play_turns(run: GoldenPathRun) -> None:
 
     scripted = list(SCRIPTED_OPENING)
     for turn_index in range(GOLDEN_PATH_MAX_TURNS):
-        payload = scripted.pop(0) if scripted else dict(ADAPTIVE_INPUT)
+        payload = scripted.pop(0) if scripted else _adaptive_payload()
         run.turns.append({"input": payload})
         started = time.monotonic()
         _continue_turn(payload)
@@ -311,54 +393,98 @@ def _stage_play_turns(run: GoldenPathRun) -> None:
         time.sleep(5)
 
 
+def _configure_model_override(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Create a temporary runtime config for an explicit golden model override."""
+
+    model_ref = os.environ.get(MODEL_OVERRIDE_ENV)
+    if not model_ref:
+        return
+    if not model_ref.startswith("@") or "." not in model_ref:
+        raise RuntimeError(
+            f"{MODEL_OVERRIDE_ENV} must be an @provider.role reference, got "
+            f"{model_ref!r}"
+        )
+
+    provider = model_ref[1:].split(".", 1)[0]
+    if provider not in {"openai", "anthropic"}:
+        raise RuntimeError(
+            f"{MODEL_OVERRIDE_ENV} provider must be openai or anthropic, got "
+            f"{provider!r}"
+        )
+
+    source = Path(os.environ.get(RUNTIME_CONFIG_ENV, "nexus.toml"))
+    document = tomlkit.parse(source.read_text())
+    document["global"]["model"]["default_model"] = model_ref
+    document["wizard"]["default_model"] = model_ref
+    document["apex"]["provider"] = provider
+    document["apex"]["model"] = model_ref
+    if "orrery" in document:
+        document["orrery"]["narration"]["provider"] = provider
+        document["orrery"]["narration"]["model_ref"] = model_ref
+        document["orrery"]["retrograde"]["maturation"]["model_ref"] = model_ref
+
+    path = tmp_path_factory.mktemp("golden_config") / "nexus.toml"
+    path.write_text(tomlkit.dumps(document))
+    os.environ[RUNTIME_CONFIG_ENV] = str(path)
+
+
 @pytest.fixture(scope="module")
 def golden_path(tmp_path_factory: pytest.TempPathFactory) -> Any:
     """Execute the staged golden-path run once; yield shared evidence."""
 
-    api_port = int(os.environ.get("NARRATIVE_API_PORT", "8002"))
-    if not _port_free(api_port):
-        raise RuntimeError(
-            f"Port {api_port} is occupied; stop the running NEXUS API server "
-            "before the golden-path gate (it boots its own instance), or set "
-            "NARRATIVE_API_PORT to a free port."
-        )
-
-    from nexus.config import load_settings
-
-    settings = load_settings()
-    assert settings.orrery is not None and settings.orrery.enabled
-    assert settings.orrery.retrograde.wizard.enabled
-    assert settings.orrery.retrograde.maturation.enabled
-
-    run = GoldenPathRun()
-    _stage_reset_slot()
-
-    run.log_path = tmp_path_factory.mktemp("golden_path") / "server.log"
-    log_handle = run.log_path.open("w")
-    run.server = subprocess.Popen(
-        [sys.executable, "-m", "nexus.api.narrative"],
-        stdout=log_handle,
-        stderr=subprocess.STDOUT,
-        env=os.environ.copy(),
-    )
+    original_runtime_config = os.environ.get(RUNTIME_CONFIG_ENV)
     try:
-        _wait_health()
-        _stage_run_transition(run)
-        run.prologue_chunk_id = _scalar(
-            "SELECT id FROM narrative_chunks "
-            "WHERE authorial_directives @> %s::jsonb",
-            (json.dumps(["orrery:retrograde_prologue_anchor"]),),
+        _configure_model_override(tmp_path_factory)
+
+        api_port = int(os.environ.get("NARRATIVE_API_PORT", "8002"))
+        if not _port_free(api_port):
+            raise RuntimeError(
+                f"Port {api_port} is occupied; stop the running NEXUS API server "
+                "before the golden-path gate (it boots its own instance), or set "
+                "NARRATIVE_API_PORT to a free port."
+            )
+
+        from nexus.config import load_settings
+
+        settings = load_settings()
+        assert settings.orrery is not None and settings.orrery.enabled
+        assert settings.orrery.retrograde.wizard.enabled
+        assert settings.orrery.retrograde.maturation.enabled
+
+        run = GoldenPathRun()
+        _stage_reset_slot()
+
+        run.log_path = tmp_path_factory.mktemp("golden_path") / "server.log"
+        log_handle = run.log_path.open("w")
+        run.server = subprocess.Popen(
+            [sys.executable, "-m", "nexus.api.narrative"],
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            env=os.environ.copy(),
         )
-        _stage_play_turns(run)
-        yield run
+        try:
+            _wait_health()
+            _stage_run_transition(run)
+            run.prologue_chunk_id = _scalar(
+                "SELECT id FROM narrative_chunks "
+                "WHERE authorial_directives @> %s::jsonb",
+                (json.dumps(["orrery:retrograde_prologue_anchor"]),),
+            )
+            _stage_play_turns(run)
+            yield run
+        finally:
+            if run.server is not None:
+                run.server.terminate()
+                try:
+                    run.server.wait(timeout=15)
+                except subprocess.TimeoutExpired:
+                    run.server.kill()
+            log_handle.close()
     finally:
-        if run.server is not None:
-            run.server.terminate()
-            try:
-                run.server.wait(timeout=15)
-            except subprocess.TimeoutExpired:
-                run.server.kill()
-        log_handle.close()
+        if original_runtime_config is None:
+            os.environ.pop(RUNTIME_CONFIG_ENV, None)
+        else:
+            os.environ[RUNTIME_CONFIG_ENV] = original_runtime_config
 
 
 def test_stage1_retrograde_cold_start(golden_path: GoldenPathRun) -> None:
@@ -512,19 +638,7 @@ def test_stage6_orrery_promotion_narration_bleed(golden_path: GoldenPathRun) -> 
     # definitive prose-weave reading is part of the manual gate evidence.)
     surfaced = [row for row in offered if row["first_surfaced_chunk_id"]]
     assert surfaced, "Offered resolutions never recorded a surfacing chunk"
-    woven = _query(
-        """
-        SELECT r.id
-        FROM orrery_resolutions r
-        JOIN entity_names_v en ON en.id = r.actor_entity_id
-        JOIN narrative_chunks nc ON nc.id >= r.first_surfaced_chunk_id
-        WHERE r.offer_count > 0
-          AND position(
-              en.name IN COALESCE(nc.raw_text, nc.storyteller_text, '')
-          ) > 0
-        LIMIT 1
-        """
-    )
+    woven = _bleed_woven_rows()
     assert woven, "No offered off-screen actor surfaced in subsequent prose"
 
 
@@ -535,8 +649,13 @@ def test_stage7_runtime_maturation(golden_path: GoldenPathRun) -> None:
         "SELECT entity_name, state::text AS state, result_manifest "
         "FROM orrery_maturation_jobs"
     )
-    succeeded = [job for job in jobs if job["state"] == "succeeded"]
-    assert succeeded, f"No maturation job succeeded; jobs={jobs}"
+    succeeded = [
+        job
+        for job in jobs
+        if job["state"] == "succeeded"
+        and (job["result_manifest"] or {}).get("persisted") is True
+    ]
+    assert succeeded, f"No persisted maturation job succeeded; jobs={jobs}"
 
     job = succeeded[0]
     manifest = job["result_manifest"]

--- a/tests/test_logon_mock_integration.py
+++ b/tests/test_logon_mock_integration.py
@@ -65,7 +65,11 @@ def test_provider_routes_to_mock_server():
         "Generate narrative for the story protagonist",
         StorytellerResponseExtended,
     )
-    
+
     assert len(response.narrative) > 100, "Narrative too short"
-    assert len(response.choices) == 3, f"Expected 3 choices, got {len(response.choices)}"
-    assert "tram" in response.narrative.lower() or "satchel" in response.narrative.lower()
+    assert len(response.choices) == 3, (
+        f"Expected 3 choices, got {len(response.choices)}"
+    )
+    assert response.narrative.startswith("[TEST MODE]")
+    assert response.orrery_adjudications == []
+    assert "deterministic mock control" in response.narrative

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -269,6 +269,7 @@ def test_context_prompt_includes_orrery_bleed_menu_controls() -> None:
     assert "=== ORRERY AMBIENT PERIPHERALS ===" in prompt
     assert "optional ambient peripherals from off-screen events" in prompt
     assert "Ignore freely, render subtly" in prompt
+    assert "include that exact name at least once" in prompt
     assert "[digital] Mara: street cameras briefly lose Mara" in prompt
 
 

--- a/tests/test_mock_openai.py
+++ b/tests/test_mock_openai.py
@@ -14,6 +14,7 @@ from nexus.api.mock_openai import (
     _requested_output_properties,
     responses_create,
 )
+from nexus.api.native_structured_output import openai_response_text_format
 
 
 def _final_result_tool(schema_model) -> dict:
@@ -24,6 +25,12 @@ def _final_result_tool(schema_model) -> dict:
         "parameters": schema_model.model_json_schema(),
         "strict": True,
     }
+
+
+def _native_text_format(schema_model) -> dict:
+    """Build the OpenAI native Responses text.format payload."""
+
+    return {"format": openai_response_text_format(schema_model)}
 
 
 @pytest.mark.asyncio
@@ -169,6 +176,27 @@ async def test_mock_responses_routes_turn_schema_without_orrery_proposals() -> N
 
 
 @pytest.mark.asyncio
+async def test_mock_responses_routes_turn_schema_as_native_text_format() -> None:
+    """Native OpenAI strict schemas should route without a final_result tool."""
+
+    response = await responses_create(
+        ResponsesRequest(
+            model="TEST",
+            input=[{"role": "user", "content": "Continue the protagonist story."}],
+            text=_native_text_format(StorytellerResponseExtended),
+        )
+    )
+
+    message = response["output"][0]
+    assert message["type"] == "message"
+
+    payload = json.loads(response["output_text"])
+    parsed = StorytellerResponseExtended.model_validate(payload)
+    assert parsed.narrative.startswith("[TEST MODE]")
+    assert parsed.orrery_adjudications == []
+
+
+@pytest.mark.asyncio
 async def test_mock_responses_routes_bootstrap_schema_as_final_result_tool() -> None:
     """Bootstrap structured output must also call the required output tool."""
 
@@ -187,6 +215,23 @@ async def test_mock_responses_routes_bootstrap_schema_as_final_result_tool() -> 
     StorytellerResponseBootstrap.model_validate(payload)
 
 
+@pytest.mark.asyncio
+async def test_mock_responses_routes_bootstrap_schema_as_native_text_format() -> None:
+    """Bootstrap native structured output should return message JSON."""
+
+    response = await responses_create(
+        ResponsesRequest(
+            model="TEST",
+            input=[{"role": "user", "content": "Bootstrap the protagonist story."}],
+            text=_native_text_format(StorytellerResponseBootstrap),
+        )
+    )
+
+    message = response["output"][0]
+    assert message["type"] == "message"
+    StorytellerResponseBootstrap.model_validate_json(response["output_text"])
+
+
 def test_requested_output_properties_extracts_schema_fields() -> None:
     """The output-tool discriminator sees the schema's top-level properties."""
 
@@ -199,6 +244,15 @@ def test_requested_output_properties_extracts_schema_fields() -> None:
     assert "narrative" in fields
     assert "choices" in fields
     assert "state_updates" not in fields
+
+    native_request = ResponsesRequest(
+        model="TEST",
+        input=[],
+        text=_native_text_format(StorytellerResponseExtended),
+    )
+    native_fields = _requested_output_properties(native_request)
+    assert "state_updates" in native_fields
+    assert "referenced_entities" in native_fields
 
     bare = ResponsesRequest(model="TEST", input=[])
     assert _requested_output_properties(bare) == set()

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -106,6 +106,44 @@ def test_openai_provider_uses_responses_parse_text_format() -> None:
     assert captured["max_output_tokens"] == 1234
 
 
+def test_openai_provider_accepts_native_text_format_override() -> None:
+    """Runtime-mutated schemas ride text.format and still parse to Pydantic."""
+
+    expected = _bootstrap_response()
+    captured = {}
+    text_format = {
+        "type": "json_schema",
+        "name": "RuntimeBootstrap",
+        "strict": True,
+        "schema": StorytellerResponseBootstrap.model_json_schema(),
+    }
+
+    class FakeResponses:
+        def parse(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                output_parsed=None,
+                output_text=expected.model_dump_json(),
+                usage=SimpleNamespace(input_tokens=11, output_tokens=22),
+            )
+
+    provider = OpenAIProvider(
+        model="gpt-4.1",
+        api_key="test-key",
+        system_prompt="System prompt",
+        max_output_tokens=1234,
+    )
+    provider.client = SimpleNamespace(responses=FakeResponses())
+
+    parsed, _llm_response = provider.get_structured_completion(
+        "Prompt", StorytellerResponseBootstrap, text_format=text_format
+    )
+
+    assert parsed == expected
+    assert captured["text"]["format"] is text_format
+    assert "text_format" not in captured
+
+
 def test_anthropic_provider_uses_native_output_format() -> None:
     """Anthropic provider should call beta Messages with JSON schema output."""
 
@@ -116,9 +154,7 @@ def test_anthropic_provider_uses_native_output_format() -> None:
         def create(self, **kwargs):
             captured.update(kwargs)
             return SimpleNamespace(
-                content=[
-                    SimpleNamespace(type="text", text=expected.model_dump_json())
-                ],
+                content=[SimpleNamespace(type="text", text=expected.model_dump_json())],
                 usage=SimpleNamespace(input_tokens=33, output_tokens=44),
             )
 
@@ -142,3 +178,35 @@ def test_anthropic_provider_uses_native_output_format() -> None:
     assert "tools" not in captured
     assert captured["system"] == "System prompt"
     assert captured["max_tokens"] == 5678
+
+
+def test_anthropic_provider_accepts_native_output_format_override() -> None:
+    expected = _bootstrap_response()
+    captured = {}
+    output_format = {
+        "type": "json_schema",
+        "schema": StorytellerResponseBootstrap.model_json_schema(),
+    }
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                content=[SimpleNamespace(type="text", text=expected.model_dump_json())],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        system_prompt="System prompt",
+        max_tokens=5678,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    parsed, _llm_response = provider.get_structured_completion(
+        "Prompt", StorytellerResponseBootstrap, output_format=output_format
+    )
+
+    assert parsed == expected
+    assert captured["output_format"] is output_format

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -1,0 +1,144 @@
+"""Tests for provider-native structured output request construction."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nexus.agents.logon.apex_schema import (
+    StorytellerResponseBootstrap,
+    StorytellerResponseExtended,
+)
+from nexus.api.native_structured_output import (
+    anthropic_output_format,
+    anthropic_strict_tool,
+    openai_response_text_format,
+)
+from scripts.api_anthropic import AnthropicProvider
+from scripts.api_openai import OpenAIProvider
+
+
+def _bootstrap_response() -> StorytellerResponseBootstrap:
+    return StorytellerResponseBootstrap(
+        narrative="[TEST MODE] Native structured output.",
+        choices=["Continue", "Wait"],
+        authorial_directives=["Retrieve recent context."],
+    )
+
+
+def _contains_key(value: object, key: str) -> bool:
+    if isinstance(value, dict):
+        return key in value or any(_contains_key(item, key) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_key(item, key) for item in value)
+    return False
+
+
+def test_openai_response_text_format_is_native_strict_json_schema() -> None:
+    """OpenAI schema payload uses native strict text.format, not a tool."""
+
+    text_format = openai_response_text_format(StorytellerResponseExtended)
+
+    assert text_format["type"] == "json_schema"
+    assert text_format["strict"] is True
+    assert text_format["name"] == "StorytellerResponseExtended"
+    schema = text_format["schema"]
+    assert schema["additionalProperties"] is False
+    assert "state_updates" in schema["required"]
+    assert "state_updates" in schema["properties"]
+
+
+def test_anthropic_output_format_uses_native_json_schema_shape() -> None:
+    """Anthropic receives schema output_format and leaves validation to Pydantic."""
+
+    output_format = anthropic_output_format(StorytellerResponseExtended)
+
+    assert output_format["type"] == "json_schema"
+    schema = output_format["schema"]
+    assert schema["additionalProperties"] is False
+    assert "state_updates" in schema["required"]
+    assert not _contains_key(schema, "minLength")
+    assert not _contains_key(schema, "maximum")
+
+
+def test_anthropic_strict_tool_helper_sets_strict_true() -> None:
+    """The helper can produce strict Anthropic tool schemas when needed."""
+
+    tool = anthropic_strict_tool(StorytellerResponseBootstrap)
+
+    assert tool["name"] == "submit_structured_response"
+    assert tool["strict"] is True
+    assert tool["input_schema"]["additionalProperties"] is False
+
+
+def test_openai_provider_uses_responses_parse_text_format() -> None:
+    """OpenAI provider should call native parse with the Pydantic model."""
+
+    expected = _bootstrap_response()
+    captured = {}
+
+    class FakeResponses:
+        def parse(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                output_parsed=expected,
+                output_text=expected.model_dump_json(),
+                usage=SimpleNamespace(input_tokens=11, output_tokens=22),
+            )
+
+    provider = OpenAIProvider(
+        model="gpt-4.1",
+        api_key="test-key",
+        system_prompt="System prompt",
+        max_output_tokens=1234,
+    )
+    provider.client = SimpleNamespace(responses=FakeResponses())
+
+    parsed, llm_response = provider.get_structured_completion(
+        "Prompt", StorytellerResponseBootstrap
+    )
+
+    assert parsed == expected
+    assert llm_response.input_tokens == 11
+    assert llm_response.output_tokens == 22
+    assert captured["text_format"] is StorytellerResponseBootstrap
+    assert "tools" not in captured
+    assert captured["input"][0] == {"role": "system", "content": "System prompt"}
+    assert captured["max_output_tokens"] == 1234
+
+
+def test_anthropic_provider_uses_native_output_format() -> None:
+    """Anthropic provider should call beta Messages with JSON schema output."""
+
+    expected = _bootstrap_response()
+    captured = {}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                content=[
+                    SimpleNamespace(type="text", text=expected.model_dump_json())
+                ],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        system_prompt="System prompt",
+        max_tokens=5678,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    parsed, llm_response = provider.get_structured_completion(
+        "Prompt", StorytellerResponseBootstrap
+    )
+
+    assert parsed == expected
+    assert llm_response.input_tokens == 33
+    assert llm_response.output_tokens == 44
+    assert captured["output_format"]["type"] == "json_schema"
+    assert captured["output_format"]["schema"]["additionalProperties"] is False
+    assert "tools" not in captured
+    assert captured["system"] == "System prompt"
+    assert captured["max_tokens"] == 5678

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -9,6 +9,7 @@ from nexus.agents.logon.apex_schema import (
     StorytellerResponseExtended,
 )
 from nexus.api.native_structured_output import (
+    anthropic_output_config,
     anthropic_output_format,
     anthropic_strict_tool,
     openai_response_text_format,
@@ -48,7 +49,7 @@ def test_openai_response_text_format_is_native_strict_json_schema() -> None:
 
 
 def test_anthropic_output_format_uses_native_json_schema_shape() -> None:
-    """Anthropic receives schema output_format and leaves validation to Pydantic."""
+    """Anthropic receives a schema format and leaves validation to Pydantic."""
 
     output_format = anthropic_output_format(StorytellerResponseExtended)
 
@@ -58,6 +59,15 @@ def test_anthropic_output_format_uses_native_json_schema_shape() -> None:
     assert "state_updates" in schema["required"]
     assert not _contains_key(schema, "minLength")
     assert not _contains_key(schema, "maximum")
+
+
+def test_anthropic_output_config_wraps_native_schema_format() -> None:
+    """Anthropic Messages receives structured output through output_config.format."""
+
+    output_config = anthropic_output_config(StorytellerResponseBootstrap)
+
+    assert output_config["format"]["type"] == "json_schema"
+    assert output_config["format"]["schema"]["additionalProperties"] is False
 
 
 def test_anthropic_strict_tool_helper_sets_strict_true() -> None:
@@ -145,7 +155,7 @@ def test_openai_provider_accepts_native_text_format_override() -> None:
 
 
 def test_anthropic_provider_uses_native_output_format() -> None:
-    """Anthropic provider should call beta Messages with JSON schema output."""
+    """Anthropic provider should call beta Messages with output_config.format."""
 
     expected = _bootstrap_response()
     captured = {}
@@ -173,14 +183,52 @@ def test_anthropic_provider_uses_native_output_format() -> None:
     assert parsed == expected
     assert llm_response.input_tokens == 33
     assert llm_response.output_tokens == 44
-    assert captured["output_format"]["type"] == "json_schema"
-    assert captured["output_format"]["schema"]["additionalProperties"] is False
+    assert captured["output_config"]["format"]["type"] == "json_schema"
+    assert (
+        captured["output_config"]["format"]["schema"]["additionalProperties"] is False
+    )
+    assert "output_format" not in captured
     assert "tools" not in captured
     assert captured["system"] == "System prompt"
     assert captured["max_tokens"] == 5678
 
 
-def test_anthropic_provider_accepts_native_output_format_override() -> None:
+def test_anthropic_provider_accepts_native_output_config_override() -> None:
+    expected = _bootstrap_response()
+    captured = {}
+    output_config = {
+        "format": {
+            "type": "json_schema",
+            "schema": StorytellerResponseBootstrap.model_json_schema(),
+        }
+    }
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                content=[SimpleNamespace(type="text", text=expected.model_dump_json())],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        system_prompt="System prompt",
+        max_tokens=5678,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    parsed, _llm_response = provider.get_structured_completion(
+        "Prompt", StorytellerResponseBootstrap, output_config=output_config
+    )
+
+    assert parsed == expected
+    assert captured["output_config"] is output_config
+    assert "output_format" not in captured
+
+
+def test_anthropic_provider_wraps_legacy_output_format_override() -> None:
     expected = _bootstrap_response()
     captured = {}
     output_format = {
@@ -209,4 +257,5 @@ def test_anthropic_provider_accepts_native_output_format_override() -> None:
     )
 
     assert parsed == expected
-    assert captured["output_format"] is output_format
+    assert captured["output_config"] == {"format": output_format}
+    assert "output_format" not in captured

--- a/tests/test_orrery/test_retrograde_expansion.py
+++ b/tests/test_orrery/test_retrograde_expansion.py
@@ -10,10 +10,13 @@ from pydantic import ValidationError
 
 from nexus.agents.orrery.retrograde_expansion import (
     RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION,
+    RetrogradeExpansionWireResponse,
     RetrogradeExpansionValidationError,
+    coerce_expansion_response_payload,
     render_expansion_prompt,
     validate_expansion_plan,
 )
+from nexus.api.native_structured_output import anthropic_json_schema
 from nexus.agents.orrery.retrograde_packet import build_seed_generation_request
 from nexus.agents.orrery.retrograde_seed_candidates import (
     SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION,
@@ -43,6 +46,91 @@ def test_expansion_plan_accepts_row_shaped_dry_run_output() -> None:
     assert response.event_plan[0].event_type == vocabulary["event_types"][0]
 
 
+def test_wire_expansion_response_omits_deterministic_fields() -> None:
+    """Provider grammar excludes fields the runtime already knows."""
+
+    schema = anthropic_json_schema(RetrogradeExpansionWireResponse)
+
+    assert set(schema["properties"]) == {
+        "event_plan",
+        "mechanical_plan",
+        "thread_plan",
+        "coverage_notes",
+    }
+    assert "selected_seed_ids" not in schema["properties"]
+    assert "commit_readiness" not in schema["properties"]
+
+
+def test_wire_expansion_response_coerces_to_full_contract() -> None:
+    vocabulary = _expansion_test_vocabulary()
+    payload = _valid_expansion(vocabulary)
+    wire_payload = {
+        "event_plan": [
+            {
+                **payload["event_plan"][0],
+                "location_ref": "",
+                "magnitude": "",
+            }
+        ],
+        "mechanical_plan": [
+            {
+                "plan": "entity_tag",
+                "subject_ref": payload["entity_tag_plan"][0]["entity_ref"],
+                "subject_kind": payload["entity_tag_plan"][0]["entity_kind"],
+                "tag": payload["entity_tag_plan"][0]["tag"],
+                "object_ref": "",
+                "object_kind": "",
+                "relationship_type": "",
+                "source_event_ref": payload["entity_tag_plan"][0]["source_event_ref"],
+                "rationale": payload["entity_tag_plan"][0].get("rationale", ""),
+            },
+            {
+                "plan": "pair_tag",
+                "subject_ref": payload["pair_tag_plan"][0]["subject_ref"],
+                "subject_kind": payload["pair_tag_plan"][0]["subject_kind"],
+                "tag": payload["pair_tag_plan"][0]["tag"],
+                "object_ref": payload["pair_tag_plan"][0]["object_ref"],
+                "object_kind": payload["pair_tag_plan"][0]["object_kind"],
+                "relationship_type": "",
+                "source_event_ref": "",
+                "rationale": payload["pair_tag_plan"][0].get("rationale", ""),
+            },
+            {
+                "plan": "relationship",
+                "subject_ref": payload["relationship_plan"][0]["subject_ref"],
+                "subject_kind": payload["relationship_plan"][0]["subject_kind"],
+                "tag": "",
+                "object_ref": payload["relationship_plan"][0]["object_ref"],
+                "object_kind": payload["relationship_plan"][0]["object_kind"],
+                "relationship_type": payload["relationship_plan"][0][
+                    "relationship_type"
+                ],
+                "source_event_ref": payload["relationship_plan"][0]["source_event_ref"],
+                "rationale": payload["relationship_plan"][0].get("rationale", ""),
+            },
+        ],
+        "thread_plan": [
+            {
+                **payload["thread_plan"][0],
+                "note": "",
+            }
+        ],
+        "coverage_notes": payload["coverage_notes"],
+    }
+
+    response = coerce_expansion_response_payload(
+        wire_payload,
+        selected_seed_ids=["seed_001"],
+    )
+
+    assert response.schema_version == RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION
+    assert response.selected_seed_ids == ["seed_001"]
+    assert response.commit_readiness.writes == "none"
+    assert len(response.entity_tag_plan) == 1
+    assert len(response.pair_tag_plan) == 1
+    assert len(response.relationship_plan) == 1
+
+
 def test_expansion_prompt_includes_selected_seeds_and_commit_blockers() -> None:
     """R6 prompt rendering names the dry-run boundary and selected seed surface."""
 
@@ -55,9 +143,11 @@ def test_expansion_prompt_includes_selected_seeds_and_commit_blockers() -> None:
     assert "RETROGRADE_EXPANSION_REQUEST" in prompt
     assert "seed_001" in prompt
     assert "pre_game_tick_chunk_id" in prompt
-    assert "relationship_plan currently supports only character->character" in prompt
+    assert (
+        "relationship mechanics currently support only character->character" in prompt
+    )
     assert "registered_tags_by_entity_kind" in prompt
-    assert RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION in prompt
+    assert "deterministic_fields_filled_by_runtime" in prompt
 
 
 def test_expansion_plan_rejects_non_selected_event_seed() -> None:

--- a/tests/test_orrery/test_retrograde_seed_candidates.py
+++ b/tests/test_orrery/test_retrograde_seed_candidates.py
@@ -154,6 +154,22 @@ def test_seed_candidate_wire_payload_coerces_to_full_contract() -> None:
     assert response.selection_notes is None
 
 
+def test_seed_candidate_wire_payload_rejects_malformed_ref() -> None:
+    """Malformed compact refs stay retryable instead of becoming empty hints."""
+
+    vocabulary = _seed_test_vocabulary()
+    payload = _valid_response_payload(vocabulary)
+    payload["candidates"][0]["mechanical_hints"]["single_entity_tags"][0] = {
+        "entity_ref": "Mara",
+        "tag_ref": "character",
+        "supporting_event_ref": "event_001",
+        "rationale": "",
+    }
+
+    with pytest.raises(ValueError, match="Malformed compact Retrograde ref"):
+        coerce_seed_candidate_response_payload(payload)
+
+
 def test_seed_candidate_response_rejects_prompt_visible_mechanics() -> None:
     """Prompt-visible-only tags may guide prose but cannot become writes."""
 

--- a/tests/test_orrery/test_retrograde_seed_candidates.py
+++ b/tests/test_orrery/test_retrograde_seed_candidates.py
@@ -13,7 +13,9 @@ from nexus.agents.orrery.retrograde_seed_candidates import (
     SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION,
     RetrogradeSeedCandidateResponse,
     RetrogradeSeedCandidateValidationError,
+    coerce_seed_candidate_response_payload,
     render_seed_generation_prompt,
+    seed_candidate_wire_response_model,
     validate_seed_candidate_response,
 )
 from nexus.agents.orrery.retrograde_vocabulary import (
@@ -21,6 +23,7 @@ from nexus.agents.orrery.retrograde_vocabulary import (
     SeedEligibleVocabulary,
     enumerate_seed_eligible_vocabulary,
 )
+from nexus.api.native_structured_output import anthropic_json_schema
 
 
 def test_seed_candidate_response_accepts_registered_mechanics() -> None:
@@ -59,6 +62,96 @@ def test_seed_candidate_prompt_embeds_schema_and_allowed_vocabulary() -> None:
     assert "registered_tags_by_entity_kind" in prompt
     assert "scholar" in prompt
     assert "knows_location" in prompt
+    assert "single_entity_tag_refs" in prompt
+    assert "character|scholar" in prompt
+
+
+def test_seed_candidate_wire_schema_constrains_kind_tag_refs() -> None:
+    """Native grammar sees legal kind/tag pairs as enum values."""
+
+    vocabulary = _seed_test_vocabulary()
+    schema_model = seed_candidate_wire_response_model(
+        seed_generation_request=_seed_request(vocabulary),
+        vocabulary=vocabulary,
+    )
+    schema = anthropic_json_schema(schema_model)
+    enum_values = _schema_enum_values(schema)
+
+    assert "character|scholar" in enum_values
+    assert "character|grieving" in enum_values
+    assert "faction|scholar" not in enum_values
+    assert "character|place|knows_location" in enum_values
+
+
+def test_seed_candidate_wire_payload_coerces_to_full_contract() -> None:
+    """Provider-facing compact refs expand back into the app response model."""
+
+    vocabulary = _seed_test_vocabulary()
+    event_type = vocabulary["event_types"][0]
+    relationship_type = vocabulary["relationship_types"][0]
+    payload = {
+        "schema_version": SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION,
+        "candidates": [
+            {
+                "seed_id": "seed_001",
+                "summary": "Mara inherited a debt from a dead handler.",
+                "origin_friction": "medium",
+                "present_leaf_anchor": "The debt returns in the opening hook.",
+                "coverage_functions": ["hidden_truth", "unresolved_ledger"],
+                "mechanical_hints": {
+                    "events": [
+                        {
+                            "event_ref": "event_001",
+                            "event_type": event_type,
+                            "summary": "The handler died before clearing the debt.",
+                            "participating_entities": ["Mara", "Vale"],
+                        }
+                    ],
+                    "single_entity_tags": [
+                        {
+                            "entity_ref": "Mara",
+                            "tag_ref": "character|grieving",
+                            "supporting_event_ref": "event_001",
+                            "rationale": "",
+                        }
+                    ],
+                    "pair_tags": [
+                        {
+                            "subject_ref": "Mara",
+                            "tag_ref": "character|place|knows_location",
+                            "object_ref": "Shutter Hall",
+                            "rationale": "",
+                        }
+                    ],
+                    "relationships": [
+                        {
+                            "subject_ref": "Mara",
+                            "relationship_ref": (
+                                f"character|character|{relationship_type}"
+                            ),
+                            "object_ref": "Vale",
+                            "rationale": "",
+                        }
+                    ],
+                },
+                "defer_or_reject_if": [],
+            }
+        ],
+        "selected_seed_ids": ["seed_001"],
+        "rejected_seed_ids": [],
+        "selection_notes": "",
+    }
+
+    response = coerce_seed_candidate_response_payload(payload)
+
+    hints = response.candidates[0].mechanical_hints
+    assert hints.single_entity_tags[0].entity_kind == "character"
+    assert hints.single_entity_tags[0].tag == "grieving"
+    assert hints.single_entity_tags[0].rationale is None
+    assert hints.pair_tags[0].subject_kind == "character"
+    assert hints.pair_tags[0].object_kind == "place"
+    assert hints.relationships[0].relationship_type == relationship_type
+    assert response.selection_notes is None
 
 
 def test_seed_candidate_response_rejects_prompt_visible_mechanics() -> None:
@@ -222,6 +315,11 @@ def _seed_test_vocabulary() -> SeedEligibleVocabulary:
         "event_anchored": ["grieving"],
         "prompt_visible_only": ["untested_signal"],
     }
+    vocabulary["registered_tags_by_entity_kind"] = {
+        "character": ["scholar", "grieving", "untested_signal"],
+        "place": [],
+        "faction": [],
+    }
     vocabulary["registered_category_seed_policies"] = [
         {
             "category": "role.function",
@@ -243,6 +341,20 @@ def _seed_test_vocabulary() -> SeedEligibleVocabulary:
         },
     ]
     return vocabulary
+
+
+def _schema_enum_values(value: object) -> set[str]:
+    values: set[str] = set()
+    if isinstance(value, dict):
+        enum = value.get("enum")
+        if isinstance(enum, list):
+            values.update(str(item) for item in enum)
+        for item in value.values():
+            values.update(_schema_enum_values(item))
+    elif isinstance(value, list):
+        for item in value:
+            values.update(_schema_enum_values(item))
+    return values
 
 
 def _seed_request(vocabulary: SeedEligibleVocabulary) -> dict[str, Any]:

--- a/tests/test_orrery/test_tag_library.py
+++ b/tests/test_orrery/test_tag_library.py
@@ -52,6 +52,13 @@ def test_format_tag_library_rejects_unknown_entity_kind() -> None:
         )
 
 
+def test_read_pair_tag_library_uses_shared_connection(monkeypatch) -> None:
+    rows = [{"tag": "hiding"}, {"tag": "shelters"}]
+    monkeypatch.setattr(tag_library, "_connect", lambda _dbname: _Conn(rows))
+
+    assert tag_library.read_pair_tag_library("save_05") == ["hiding", "shelters"]
+
+
 class _Conn:
     def __init__(self, rows: list[dict[str, Any]]) -> None:
         self.rows = rows
@@ -80,7 +87,7 @@ class _Cursor:
     def __exit__(self, *_exc: object) -> None:
         return None
 
-    def execute(self, _sql: str, params: tuple[object, ...]) -> None:
+    def execute(self, _sql: str, params: tuple[object, ...] = ()) -> None:
         self.params = params
 
     def fetchall(self) -> list[dict[str, Any]]:

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -244,6 +244,11 @@ def test_storyteller_anthropic_output_config_uses_compact_extended_schema(
         "_read_pair_tags",
         lambda _dbname: ["hiding", "shelters"],
     )
+    monkeypatch.setattr(
+        orrery_tag_schema,
+        "_read_event_types",
+        lambda _dbname: ["evade_pursuit", "slept"],
+    )
 
     output_config = storyteller_anthropic_output_config(
         StorytellerResponseExtended,
@@ -265,7 +270,20 @@ def test_storyteller_anthropic_output_config_uses_compact_extended_schema(
         "new_entities",
         "reasoning",
     }
-    assert schema["properties"]["state_updates"]["properties"] == {}
+    state_update_schema = schema["properties"]["state_updates"]
+    assert set(state_update_schema["properties"]) == {
+        "updates",
+    }
+    update_schema = state_update_schema["properties"]["updates"]["items"]
+    assert update_schema["properties"]["kind"]["enum"] == [
+        "character",
+        "place",
+        "faction",
+    ]
+    assert update_schema["properties"]["tag_add"] == {
+        "type": "string",
+        "description": "Registered tag name to apply.",
+    }
     entity_schema = schema["properties"]["new_entities"]["items"]
     assert entity_schema["properties"]["tag_hints"]["items"]["enum"] == [
         "haven",
@@ -275,6 +293,11 @@ def test_storyteller_anthropic_output_config_uses_compact_extended_schema(
     ]
     pair_tag_schema = entity_schema["properties"]["pair_tag_hints"]["items"]
     assert pair_tag_schema["properties"]["tag"]["enum"] == ["hiding", "shelters"]
+    adjudication_schema = schema["properties"]["orrery_adjudications"]["items"]
+    assert adjudication_schema["properties"]["replacement_event_type"]["enum"] == [
+        "evade_pursuit",
+        "slept",
+    ]
 
     response = StorytellerResponseExtended.model_validate(
         {
@@ -283,8 +306,17 @@ def test_storyteller_anthropic_output_config_uses_compact_extended_schema(
             "authorial_directives": ["Retrieve the lower stacks layout."],
             "chunk_metadata": {},
             "referenced_entities": {},
-            "state_updates": {},
-            "operations": None,
+            "state_updates": {
+                "updates": [
+                    {
+                        "kind": "character",
+                        "name": "Brena Tideloft",
+                        "status": "following a wet bell-sound",
+                        "tag_add": "perceptive",
+                    }
+                ]
+            },
+            "operations": {},
             "orrery_adjudications": [],
             "new_entities": [
                 {
@@ -295,11 +327,19 @@ def test_storyteller_anthropic_output_config_uses_compact_extended_schema(
                     "pair_tag_hints": [],
                 }
             ],
-            "reasoning": None,
+            "reasoning": "",
         }
     )
 
-    assert response.state_updates.characters == []
+    assert response.state_updates.characters[0].character_name == "Brena Tideloft"
+    assert (
+        response.state_updates.characters[0].current_activity
+        == "following a wet bell-sound"
+    )
+    assert response.state_updates.characters[0].orrery_tags is not None
+    assert response.state_updates.characters[0].orrery_tags.applied_tags == [
+        "perceptive"
+    ]
     assert response.new_entities[0].name == "Marra Kest"
 
 

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -14,6 +14,7 @@ from nexus.agents.logon.apex_schema import (
     StateUpdates,
 )
 from nexus.agents.logon.orrery_tag_schema import (
+    storyteller_anthropic_output_config,
     storyteller_openai_text_format,
     storyteller_schema_with_runtime_tag_enums,
 )
@@ -217,6 +218,89 @@ def test_storyteller_openai_text_format_wraps_runtime_schema(monkeypatch) -> Non
     assert text_format["schema"]["$defs"]["OrreryTagBestowalCharacter"]["properties"][
         "applied_tags"
     ]["items"]["enum"] == ["human"]
+
+
+def test_storyteller_anthropic_output_config_uses_compact_extended_schema(
+    monkeypatch,
+) -> None:
+    """Anthropic extended turns avoid the full DB-mirroring grammar."""
+
+    from nexus.agents.logon import orrery_tag_schema
+    from nexus.agents.logon.apex_schema import StorytellerResponseExtended
+
+    entries = [
+        _tag_entry("character", "bodyform", "human"),
+        _tag_entry("character", "disposition", "perceptive"),
+        _tag_entry("place", "place_class", "haven"),
+        _tag_entry("faction", "ideology", "loyalist"),
+    ]
+    monkeypatch.setattr(
+        orrery_tag_schema,
+        "read_tag_library",
+        lambda _dbname: entries,
+    )
+    monkeypatch.setattr(
+        orrery_tag_schema,
+        "_read_pair_tags",
+        lambda _dbname: ["hiding", "shelters"],
+    )
+
+    output_config = storyteller_anthropic_output_config(
+        StorytellerResponseExtended,
+        "save_05",
+    )
+
+    assert output_config is not None
+    schema = output_config["format"]["schema"]
+    assert "$defs" not in schema
+    assert set(schema["properties"]) == {
+        "narrative",
+        "choices",
+        "authorial_directives",
+        "chunk_metadata",
+        "referenced_entities",
+        "state_updates",
+        "operations",
+        "orrery_adjudications",
+        "new_entities",
+        "reasoning",
+    }
+    assert schema["properties"]["state_updates"]["properties"] == {}
+    entity_schema = schema["properties"]["new_entities"]["items"]
+    assert entity_schema["properties"]["tag_hints"]["items"]["enum"] == [
+        "haven",
+        "human",
+        "loyalist",
+        "perceptive",
+    ]
+    pair_tag_schema = entity_schema["properties"]["pair_tag_hints"]["items"]
+    assert pair_tag_schema["properties"]["tag"]["enum"] == ["hiding", "shelters"]
+
+    response = StorytellerResponseExtended.model_validate(
+        {
+            "narrative": "Brena follows the wet bell-sound into the stacks.",
+            "choices": ["Follow the footprints.", "Call for Odile."],
+            "authorial_directives": ["Retrieve the lower stacks layout."],
+            "chunk_metadata": {},
+            "referenced_entities": {},
+            "state_updates": {},
+            "operations": None,
+            "orrery_adjudications": [],
+            "new_entities": [
+                {
+                    "kind": "character",
+                    "name": "Marra Kest",
+                    "summary": "A drowned clerk animated by echo and current.",
+                    "tag_hints": [],
+                    "pair_tag_hints": [],
+                }
+            ],
+            "reasoning": None,
+        }
+    )
+
+    assert response.state_updates.characters == []
+    assert response.new_entities[0].name == "Marra Kest"
 
 
 def _tag_entry(entity_kind: str, category: str, tag: str) -> TagLibraryEntry:

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -13,10 +13,15 @@ from nexus.agents.logon.apex_schema import (
     ReferenceType,
     StateUpdates,
 )
+from nexus.agents.logon.orrery_tag_schema import (
+    storyteller_openai_text_format,
+    storyteller_schema_with_runtime_tag_enums,
+)
 from nexus.agents.logon.orrery_tag_validation import (
     build_storyteller_tag_validator,
     collect_orrery_tag_issues,
 )
+from nexus.agents.orrery.tag_library import TagLibraryEntry
 from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
 
 
@@ -138,3 +143,89 @@ def test_validator_skipped_without_slot_database() -> None:
     assert build_storyteller_tag_validator(None) is None
     assert build_storyteller_tag_validator("") is None
     assert build_storyteller_tag_validator("save_05") is not None
+
+
+def test_storyteller_schema_uses_runtime_tag_enums(monkeypatch) -> None:
+    """Native LOGON schema constrains Orrery tags by live entity kind."""
+
+    from nexus.agents.logon import orrery_tag_schema
+    from nexus.agents.logon.apex_schema import StorytellerResponseExtended
+
+    entries = [
+        _tag_entry("character", "bodyform", "human"),
+        _tag_entry("character", "disposition", "perceptive"),
+        _tag_entry("place", "place_class", "haven"),
+        _tag_entry("faction", "ideology", "loyalist"),
+    ]
+    monkeypatch.setattr(
+        orrery_tag_schema,
+        "read_tag_library",
+        lambda _dbname: entries,
+    )
+
+    schema = storyteller_schema_with_runtime_tag_enums(
+        StorytellerResponseExtended,
+        "save_05",
+    )
+
+    assert schema is not None
+    defs = schema["$defs"]
+    character_tags = defs["OrreryTagBestowalCharacter"]["properties"]["applied_tags"][
+        "items"
+    ]["enum"]
+    place_tags = defs["OrreryTagBestowalPlace"]["properties"]["applied_tags"]["items"][
+        "enum"
+    ]
+    faction_tags = defs["OrreryTagBestowalFaction"]["properties"]["tags_to_clear"][
+        "items"
+    ]["enum"]
+    assert character_tags == ["human", "perceptive"]
+    assert place_tags == ["haven"]
+    assert faction_tags == ["loyalist"]
+    assert (
+        defs["NewCharacter"]["properties"]["orrery_tags"]["anyOf"][0]["$ref"]
+        == "#/$defs/OrreryTagBestowalCharacter"
+    )
+    assert (
+        defs["LocationStateUpdate"]["properties"]["orrery_tags"]["anyOf"][0]["$ref"]
+        == "#/$defs/OrreryTagBestowalPlace"
+    )
+    assert (
+        defs["FactionStateUpdate"]["properties"]["orrery_tags"]["anyOf"][0]["$ref"]
+        == "#/$defs/OrreryTagBestowalFaction"
+    )
+
+
+def test_storyteller_openai_text_format_wraps_runtime_schema(monkeypatch) -> None:
+    from nexus.agents.logon import orrery_tag_schema
+    from nexus.agents.logon.apex_schema import StorytellerResponseExtended
+
+    monkeypatch.setattr(
+        orrery_tag_schema,
+        "read_tag_library",
+        lambda _dbname: [_tag_entry("character", "bodyform", "human")],
+    )
+
+    text_format = storyteller_openai_text_format(
+        StorytellerResponseExtended,
+        "save_05",
+    )
+
+    assert text_format is not None
+    assert text_format["type"] == "json_schema"
+    assert text_format["strict"] is True
+    assert text_format["schema"]["$defs"]["OrreryTagBestowalCharacter"]["properties"][
+        "applied_tags"
+    ]["items"]["enum"] == ["human"]
+
+
+def _tag_entry(entity_kind: str, category: str, tag: str) -> TagLibraryEntry:
+    return TagLibraryEntry(
+        entity_kind=entity_kind,
+        category=category,
+        tag=tag,
+        is_ephemeral=False,
+        description=f"{tag} description",
+        category_description=f"{category} description",
+        prompt_order=10,
+    )

--- a/tests/test_trait_input_derivation.py
+++ b/tests/test_trait_input_derivation.py
@@ -26,9 +26,11 @@ from nexus.api.trait_compiler_schemas import (
     TraitCompileInputs,
 )
 from nexus.api.trait_input_derivation import (
+    coerce_selected_trait_inputs,
     derived_input_issues,
     render_trait_input_prompt,
     selected_canonical_traits,
+    selected_trait_compile_inputs_model,
 )
 
 
@@ -78,6 +80,38 @@ def _setting() -> SettingCard:
 def test_selected_canonical_traits_maps_reputation_to_fame() -> None:
     character = _character(["patron", "reputation", "dependents"])
     assert selected_canonical_traits(character) == ["patron", "fame", "dependents"]
+
+
+def test_selected_trait_schema_contains_only_selected_fields() -> None:
+    schema_model = selected_trait_compile_inputs_model(
+        ["patron", "dependents", "resources"]
+    )
+    schema = schema_model.model_json_schema()
+
+    assert set(schema["properties"]) == {"patron", "dependents", "resources"}
+    assert "status" not in schema["properties"]
+    assert "obligations" not in schema["properties"]
+
+
+def test_selected_trait_schema_coerces_to_full_contract() -> None:
+    schema_model = selected_trait_compile_inputs_model(
+        ["patron", "dependents", "resources"]
+    )
+    selected_output = schema_model(
+        patron=PatronTraitInput(name="Doctor Imari Voss"),
+        dependents=DependentsTraitInput(
+            targets=[DependentTargetInput(name="Juno Reyes")]
+        ),
+        resources=SingleEntityTraitInput(level="comfortable"),
+    )
+
+    coerced = coerce_selected_trait_inputs(selected_output)
+
+    assert isinstance(coerced, TraitCompileInputs)
+    assert coerced.patron is not None
+    assert coerced.dependents is not None
+    assert coerced.resources is not None
+    assert coerced.status is None
 
 
 def test_valid_inputs_produce_no_issues() -> None:

--- a/tests/test_wizard_agent.py
+++ b/tests/test_wizard_agent.py
@@ -326,6 +326,7 @@ from nexus.api.wizard_agent import (
     _seed_accept_agent,
 )
 from nexus.api.new_story_schemas import WizardResponse
+from pydantic_ai import NativeOutput
 from pydantic_ai.tools import DeferredToolRequests
 
 
@@ -342,10 +343,12 @@ class TestAgentFactoryStructure:
             _seed_agent,
         ]
         for agent in normal_agents:
-            # output_type should be a tuple containing WizardResponse
-            assert (
-                WizardResponse in agent.output_type
-            ), f"Agent {agent} should allow WizardResponse"
+            native_outputs = [
+                item for item in agent.output_type if isinstance(item, NativeOutput)
+            ]
+            assert native_outputs, f"Agent {agent} should allow WizardResponse"
+            assert native_outputs[0].outputs is WizardResponse
+            assert native_outputs[0].strict is True
 
     def test_accept_fate_agents_have_validators(self):
         """Accept-fate agents should have output validators to reject WizardResponse."""


### PR DESCRIPTION
Closes #404.

## Summary

- Replace PydanticAI-managed structured completion loops in LOGON providers with provider-native strict structured output: OpenAI now uses native Responses structured output, and Anthropic uses the beta Messages `output_config.format` JSON schema harness.
- Add a central `native_structured_output` helper for strict OpenAI schema generation, Anthropic schema adaptation, native provider construction, retry prompt handling, and PydanticAI-style semantic validator compatibility.
- Move the direct schema-output agent calls onto the native provider path: LOGON narrative/bootstrap, Retrograde seed candidates, Retrograde expansion, trait input derivation, new-story component generation, and set design.
- Add a LOGON runtime schema layer that reads the slot's live Orrery tag registry and injects character/place/faction-specific `enum` constraints into the native schema for `orrery_tags.applied_tags` and `tags_to_clear`.
- Keep wizard tool orchestration on PydanticAI, but wrap `WizardResponse` with `NativeOutput(..., strict=True)` so the schema response side uses the provider-native path while deferred tools remain available.
- Close loose schema pockets that native strict decoding rejects, including LOGON partial-context extras and Retrograde expansion event payloads, with compatibility validators for legacy dict-shaped data.
- Teach TEST/mock OpenAI routing to understand native `text.format` schemas while retaining compatibility with old `final_result` tool-style calls.

## Notes

Native strict schema decoding now covers both JSON shape and the dynamic Orrery single-entity tag vocabulary for LOGON storyteller responses when a slot database is available. Pydantic and the existing LOGON validator still remain as the in-process boundary for cross-field rules and commit-time semantics that cannot be expressed as static JSON Schema.

## Validation

- `poetry run pytest tests/test_orrery/test_retrograde_seed_candidates.py tests/test_orrery/test_retrograde_expansion.py tests/test_orrery/test_retrograde_persistence.py tests/test_trait_input_derivation.py tests/test_new_story_schemas.py tests/test_wizard_agent.py tests/test_native_structured_output.py tests/test_mock_openai.py -q` -> 98 passed, 4 skipped
- `poetry run pytest tests/test_native_structured_output.py tests/test_orrery_tag_validation.py tests/test_lore/test_logon_prompt_formatting.py tests/test_mock_openai.py tests/test_lore/test_apex_schema.py -q` -> 40 passed
- `poetry run pytest tests/test_logon_mock_integration.py tests/test_lore/test_logon_lazy_init.py tests/test_api/test_narrative_generation.py -q` -> 5 passed, 4 skipped
- `poetry run pytest` -> 830 passed, 136 skipped
- `NEXUS_RUN_LIVE_LLM=1 poetry run python -m pytest tests/test_model_registry_live.py -q` -> 4 passed
- `npm --prefix ui run build` -> passed with existing Vite/browser-data warnings
- `poetry run black --check nexus/api/native_structured_output.py nexus/agents/orrery/retrograde_seed_candidates.py nexus/agents/orrery/retrograde_expansion.py nexus/agents/orrery/retrograde_persistence.py nexus/api/trait_input_derivation.py nexus/api/new_story_generator.py nexus/api/wizard_agent.py tests/test_wizard_agent.py` -> passed
- Tiny live OpenAI custom `text.format` enum probe on `gpt-5.5` -> 200 OK, parsed `{'tag': 'blue'}`
- Full LOGON runtime enum schema acceptance probe against `gpt-5.5` -> 200 OK with expected `max_output_tokens` truncation at 16 tokens
- Full-path certification after the runtime-enum follow-up: `NARRATIVE_API_PORT=8032 NEXUS_RUN_LIVE_LLM=1 NEXUS_RUN_POSTGRES=1 NEXUS_GOLDEN_PATH_E2E=1 poetry run python -m pytest tests/test_golden_path_live.py -q` -> 8 passed, 4 warnings in 785.81s; server log audit found no validation/ModelRetry/registry-repair/error signatures
- `poetry run pytest tests/test_native_structured_output.py tests/test_orrery_tag_validation.py tests/test_lore/test_logon_prompt_formatting.py -q` -> 25 passed, 5 warnings after the Anthropic `output_config.format` follow-up
- Live `@anthropic.default` native structured enum probe after the `output_config.format` follow-up -> 200 OK on `claude-opus-4-8`, parsed tag=blue