### PR TITLE
Fix packaged desktop runtime working directory

### DIFF
--- a/ui/src-tauri/build.rs
+++ b/ui/src-tauri/build.rs
@@ -1,3 +1,8 @@
 fn main() {
+    println!("cargo:rerun-if-changed=nexus.desktop.json");
+    println!(
+        "cargo:rustc-env=NEXUS_BUILD_CONFIG_DIR={}",
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set")
+    );
     tauri_build::build()
 }

--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -441,6 +441,18 @@ fn resolve_working_directory(
     config: &DesktopConfig,
     source_path: Option<&Path>,
 ) -> Result<PathBuf, String> {
+    resolve_working_directory_with_bundled_config_dir(
+        config,
+        source_path,
+        bundled_config_dir().as_deref(),
+    )
+}
+
+fn resolve_working_directory_with_bundled_config_dir(
+    config: &DesktopConfig,
+    source_path: Option<&Path>,
+    bundled_config_dir: Option<&Path>,
+) -> Result<PathBuf, String> {
     if let Some(path) = &config.working_directory {
         let resolved = if path.is_absolute() {
             path.clone()
@@ -449,20 +461,32 @@ fn resolve_working_directory(
                 .parent()
                 .unwrap_or_else(|| Path::new("."))
                 .join(path)
-        } else if let Some(repo_root) = discover_repo_root() {
-            repo_root.join(path)
+        } else if let Some(config_dir) = bundled_config_dir {
+            config_dir.join(path)
         } else {
-            env::current_dir()
-                .map_err(|error| format!("failed to resolve current directory: {error}"))?
-                .join(path)
+            return Err(format!(
+                "relative workingDirectory {} has no config file anchor; set \
+                 NEXUS_DESKTOP_CONFIG or use an absolute workingDirectory",
+                path.display()
+            ));
         };
-        return Ok(resolved);
+        return Ok(canonicalize_if_possible(resolved));
     }
     discover_repo_root()
         .or_else(|| env::current_dir().ok())
         .ok_or_else(|| {
             "failed to resolve desktop runtime working directory; set workingDirectory".to_string()
         })
+}
+
+fn bundled_config_dir() -> Option<PathBuf> {
+    option_env!("NEXUS_BUILD_CONFIG_DIR")
+        .map(PathBuf::from)
+        .filter(|path| path.exists())
+}
+
+fn canonicalize_if_possible(path: PathBuf) -> PathBuf {
+    path.canonicalize().unwrap_or(path)
 }
 
 fn discover_repo_root() -> Option<PathBuf> {
@@ -662,5 +686,38 @@ mod tests {
         assert!(summary.contains("database ok"));
         assert!(summary.contains("gateway:ok"));
         assert!(summary.contains("mock_openai:down"));
+    }
+
+    #[test]
+    fn bundled_config_relative_working_directory_uses_build_config_dir() {
+        let temp_root = env::temp_dir().join(format!("nexus-desktop-test-{}", std::process::id()));
+        let config_dir = temp_root.join("ui/src-tauri");
+        fs::create_dir_all(&config_dir).unwrap();
+
+        let config = DesktopConfig {
+            working_directory: Some(PathBuf::from("../..")),
+            ..DesktopConfig::default()
+        };
+
+        let working_directory =
+            resolve_working_directory_with_bundled_config_dir(&config, None, Some(&config_dir))
+                .unwrap();
+
+        assert_eq!(working_directory, temp_root.canonicalize().unwrap());
+        let _ = fs::remove_dir_all(temp_root);
+    }
+
+    #[test]
+    fn bundled_config_relative_working_directory_requires_anchor() {
+        let config = DesktopConfig {
+            working_directory: Some(PathBuf::from("../..")),
+            ..DesktopConfig::default()
+        };
+
+        let error =
+            resolve_working_directory_with_bundled_config_dir(&config, None, None).unwrap_err();
+
+        assert!(error.contains("relative workingDirectory"));
+        assert!(error.contains("NEXUS_DESKTOP_CONFIG"));
     }
 }

--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -441,10 +441,15 @@ fn resolve_working_directory(
     config: &DesktopConfig,
     source_path: Option<&Path>,
 ) -> Result<PathBuf, String> {
+    let baked_config_dir = if source_path.is_none() {
+        bundled_config_dir()
+    } else {
+        None
+    };
     resolve_working_directory_with_bundled_config_dir(
         config,
         source_path,
-        bundled_config_dir().as_deref(),
+        baked_config_dir.as_deref(),
     )
 }
 
@@ -474,6 +479,7 @@ fn resolve_working_directory_with_bundled_config_dir(
     }
     discover_repo_root()
         .or_else(|| env::current_dir().ok())
+        .map(canonicalize_if_possible)
         .ok_or_else(|| {
             "failed to resolve desktop runtime working directory; set workingDirectory".to_string()
         })
@@ -632,6 +638,24 @@ fn applescript_string(value: &str) -> String {
 mod tests {
     use super::*;
 
+    struct TempRoot {
+        path: PathBuf,
+    }
+
+    impl TempRoot {
+        fn new(name: &str) -> Self {
+            let path = env::temp_dir().join(format!("{name}-{}", std::process::id()));
+            let _ = fs::remove_dir_all(&path);
+            Self { path }
+        }
+    }
+
+    impl Drop for TempRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
     #[test]
     fn desktop_config_defaults_to_runtime_contract() {
         let config = DesktopConfig::default();
@@ -690,8 +714,8 @@ mod tests {
 
     #[test]
     fn bundled_config_relative_working_directory_uses_build_config_dir() {
-        let temp_root = env::temp_dir().join(format!("nexus-desktop-test-{}", std::process::id()));
-        let config_dir = temp_root.join("ui/src-tauri");
+        let temp_root = TempRoot::new("nexus-desktop-test-bundled-cwd");
+        let config_dir = temp_root.path.join("ui/src-tauri");
         fs::create_dir_all(&config_dir).unwrap();
 
         let config = DesktopConfig {
@@ -703,8 +727,34 @@ mod tests {
             resolve_working_directory_with_bundled_config_dir(&config, None, Some(&config_dir))
                 .unwrap();
 
-        assert_eq!(working_directory, temp_root.canonicalize().unwrap());
-        let _ = fs::remove_dir_all(temp_root);
+        assert_eq!(working_directory, temp_root.path.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn source_config_path_takes_priority_over_bundled_config_dir() {
+        let temp_root = TempRoot::new("nexus-desktop-test-source-priority");
+        let source_dir = temp_root.path.join("source");
+        let bundled_dir = temp_root.path.join("bundled");
+        fs::create_dir_all(source_dir.join("subdir")).unwrap();
+        fs::create_dir_all(bundled_dir.join("subdir")).unwrap();
+        let source_path = source_dir.join("nexus.desktop.json");
+
+        let config = DesktopConfig {
+            working_directory: Some(PathBuf::from("subdir")),
+            ..DesktopConfig::default()
+        };
+
+        let working_directory = resolve_working_directory_with_bundled_config_dir(
+            &config,
+            Some(&source_path),
+            Some(&bundled_dir),
+        )
+        .unwrap();
+
+        assert_eq!(
+            working_directory,
+            source_dir.join("subdir").canonicalize().unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Capture the Tauri desktop config directory at build time.
- Resolve bundled relative `workingDirectory` values from that captured source directory instead of Finder's launch cwd.
- Fail loudly if a bundled relative working directory has no anchor instead of letting Poetry run from `/`.

## Why
A dev-built `.app` launched from Finder was running `poetry run nexus --json up` with cwd `/`, producing:

`Poetry could not find a pyproject.toml file in / or its parents`

The bundled config contains `"workingDirectory": "../.."`, which is correct relative to `ui/src-tauri/nexus.desktop.json` but lost its anchor once embedded into the binary.

## Validation
- `cargo fmt --manifest-path ui/src-tauri/Cargo.toml --check`
- `cargo test --manifest-path ui/src-tauri/Cargo.toml`
- `npm --prefix ui run desktop:build`
- Verified the built binary contains the captured config anchor: `/Users/pythagor/nexus/ui/src-tauri`

Fresh bundle: `/Users/pythagor/nexus/ui/src-tauri/target/release/bundle/macos/NEXUS.app`