### PR TITLE
Restart stale desktop runtime services

### DIFF
--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -62,9 +62,10 @@ Poetry from the repo root. Packaged or globally installed environments can set
   the runtime on quit.
 - If the shell runs the start command, it records ownership and runs the stop
   command on quit.
-- If `up` reports an existing managed service pid but `/runtime/status` is not
-  healthy, the shell runs `restartArgs`, waits for readiness, and then treats
-  the restarted runtime as shell-owned.
+- If the first `/runtime/status` probe is unhealthy, `up` reports an existing
+  managed service pid, and follow-up probes still cannot attach, the shell
+  runs `restartArgs`, waits for readiness, and then treats the restarted
+  runtime as shell-owned.
 - The shell talks only to the runtime contract: origin, status surface, auth
   header, and CLI entrypoint.
 - If startup fails before a window can be shown, the shell writes

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -42,6 +42,7 @@ It defines the runtime origin, status path, auth header, and CLI command:
   "authTokenEnv": "NEXUS_AUTH",
   "runtimeCommand": ["poetry", "run", "nexus"],
   "startArgs": ["--json", "up"],
+  "restartArgs": ["--json", "restart"],
   "stopArgs": ["--json", "down"],
   "workingDirectory": "../..",
   "commandTimeoutSeconds": 120
@@ -61,6 +62,9 @@ Poetry from the repo root. Packaged or globally installed environments can set
   the runtime on quit.
 - If the shell runs the start command, it records ownership and runs the stop
   command on quit.
+- If `up` reports an existing managed service pid but `/runtime/status` is not
+  healthy, the shell runs `restartArgs`, waits for readiness, and then treats
+  the restarted runtime as shell-owned.
 - The shell talks only to the runtime contract: origin, status surface, auth
   header, and CLI entrypoint.
 - If startup fails before a window can be shown, the shell writes

--- a/ui/src-tauri/nexus.desktop.json
+++ b/ui/src-tauri/nexus.desktop.json
@@ -5,6 +5,7 @@
   "authTokenEnv": "NEXUS_AUTH",
   "runtimeCommand": ["poetry", "run", "nexus"],
   "startArgs": ["--json", "up"],
+  "restartArgs": ["--json", "restart"],
   "stopArgs": ["--json", "down"],
   "workingDirectory": "../..",
   "startupTimeoutSeconds": 90,

--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -21,6 +21,8 @@ const DEFAULT_AUTH_TOKEN_ENV: &str = "NEXUS_AUTH";
 const DEFAULT_COMMAND_TIMEOUT_SECONDS: u64 = 120;
 const MIN_STARTUP_TIMEOUT_SECONDS: u64 = 5;
 const MIN_COMMAND_TIMEOUT_SECONDS: u64 = 5;
+const SERVICE_ALREADY_RUNNING_FRAGMENT: &str = "is already running";
+const SERVICE_RESTART_SUGGESTION_FRAGMENT: &str = "nexus restart";
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(default, rename_all = "camelCase")]
@@ -152,6 +154,16 @@ fn ensure_runtime_ready(
                 }
             }
             if service_already_running_error(&error) {
+                if let Ok(status) = fetch_runtime_status(config) {
+                    if status.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+                        set_loading_status(
+                            window,
+                            "Attached before restart",
+                            &runtime_summary(&status),
+                        );
+                        return Ok(status);
+                    }
+                }
                 set_loading_status(
                     window,
                     "Restarting managed runtime",
@@ -159,10 +171,17 @@ fn ensure_runtime_ready(
                 );
                 match run_runtime_command(config, &config.config.restart_args) {
                     Ok(output) => {
+                        // A successful restart means this shell created the
+                        // replacement process. Keep ownership even if the
+                        // readiness probe times out, so closing the shell can
+                        // still clean up the process it restarted.
                         runtime_owned_by_shell.store(true, Ordering::SeqCst);
-                        if !output.trim().is_empty() {
-                            set_loading_status(window, "Runtime restarted", output.trim());
-                        }
+                        let detail = if output.trim().is_empty() {
+                            "(no output)"
+                        } else {
+                            output.trim()
+                        };
+                        set_loading_status(window, "Runtime restarted", detail);
                     }
                     Err(restart_error) => {
                         return Err(format!(
@@ -233,7 +252,18 @@ fn fetch_runtime_status(config: &ResolvedDesktopConfig) -> Result<Value, String>
 }
 
 fn service_already_running_error(error: &str) -> bool {
-    error.contains("is already running") && error.contains("nexus restart")
+    let message = runtime_command_json_error(error).unwrap_or_else(|| error.to_string());
+    message.contains(SERVICE_ALREADY_RUNNING_FRAGMENT)
+        && message.contains(SERVICE_RESTART_SUGGESTION_FRAGMENT)
+}
+
+fn runtime_command_json_error(error: &str) -> Option<String> {
+    let start = error.find('{')?;
+    let value = serde_json::from_str::<Value>(&error[start..]).ok()?;
+    value
+        .get("error")
+        .and_then(Value::as_str)
+        .map(str::to_string)
 }
 
 fn run_runtime_command(config: &ResolvedDesktopConfig, args: &[String]) -> Result<String, String> {
@@ -748,6 +778,15 @@ mod tests {
             already running (pid 56729). Use 'nexus restart' or 'nexus down' first.\"}";
 
         assert!(service_already_running_error(error));
+        assert_eq!(
+            runtime_command_json_error(error).as_deref(),
+            Some("Service 'gateway' is already running (pid 56729). Use 'nexus restart' or 'nexus down' first.")
+        );
+        assert!(!service_already_running_error(""));
+        assert!(!service_already_running_error("   "));
+        assert!(!service_already_running_error(
+            "Service 'gateway' is already running"
+        ));
         assert!(!service_already_running_error(
             "Poetry could not find pyproject.toml"
         ));

--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -31,6 +31,7 @@ pub struct DesktopConfig {
     pub auth_token_env: String,
     pub runtime_command: Vec<String>,
     pub start_args: Vec<String>,
+    pub restart_args: Vec<String>,
     pub stop_args: Vec<String>,
     pub working_directory: Option<PathBuf>,
     pub startup_timeout_seconds: u64,
@@ -47,6 +48,7 @@ impl Default for DesktopConfig {
             auth_token_env: DEFAULT_AUTH_TOKEN_ENV.to_string(),
             runtime_command: vec!["nexus".to_string()],
             start_args: vec!["--json".to_string(), "up".to_string()],
+            restart_args: vec!["--json".to_string(), "restart".to_string()],
             stop_args: vec!["--json".to_string(), "down".to_string()],
             working_directory: None,
             startup_timeout_seconds: 90,
@@ -149,6 +151,28 @@ fn ensure_runtime_ready(
                     return Ok(status);
                 }
             }
+            if service_already_running_error(&error) {
+                set_loading_status(
+                    window,
+                    "Restarting managed runtime",
+                    "Existing service pid was stale or unhealthy",
+                );
+                match run_runtime_command(config, &config.config.restart_args) {
+                    Ok(output) => {
+                        runtime_owned_by_shell.store(true, Ordering::SeqCst);
+                        if !output.trim().is_empty() {
+                            set_loading_status(window, "Runtime restarted", output.trim());
+                        }
+                    }
+                    Err(restart_error) => {
+                        return Err(format!(
+                            "startup found an existing runtime service, but restart failed:\n\
+                             initial up error:\n{error}\n\nrestart error:\n{restart_error}"
+                        ));
+                    }
+                }
+                return wait_for_runtime_ready(config, window);
+            }
             return Err(error);
         }
     }
@@ -206,6 +230,10 @@ fn fetch_runtime_status(config: &ResolvedDesktopConfig) -> Result<Value, String>
     response
         .json::<Value>()
         .map_err(|error| format!("{url}: invalid JSON: {error}"))
+}
+
+fn service_already_running_error(error: &str) -> bool {
+    error.contains("is already running") && error.contains("nexus restart")
 }
 
 fn run_runtime_command(config: &ResolvedDesktopConfig, args: &[String]) -> Result<String, String> {
@@ -663,6 +691,7 @@ mod tests {
         assert_eq!(config.status_path, "/runtime/status");
         assert_eq!(config.auth_header, "X-Nexus-Auth");
         assert_eq!(config.start_args, vec!["--json", "up"]);
+        assert_eq!(config.restart_args, vec!["--json", "restart"]);
         assert_eq!(config.stop_args, vec!["--json", "down"]);
     }
 
@@ -710,6 +739,18 @@ mod tests {
         assert!(summary.contains("database ok"));
         assert!(summary.contains("gateway:ok"));
         assert!(summary.contains("mock_openai:down"));
+    }
+
+    #[test]
+    fn service_already_running_error_matches_json_cli_failure() {
+        let error = "/Users/pythagor/.local/bin/poetry run nexus --json up \
+            exited with exit status: 1: {\"error\": \"Service 'gateway' is \
+            already running (pid 56729). Use 'nexus restart' or 'nexus down' first.\"}";
+
+        assert!(service_already_running_error(error));
+        assert!(!service_already_running_error(
+            "Poetry could not find pyproject.toml"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add configurable desktop `restartArgs` defaulting to `["--json", "restart"]`.
- If the desktop shell cannot attach and `nexus up` reports an existing managed service pid, run `restartArgs` and wait for runtime readiness.
- Document the conditional restart ownership behavior.

## Why
After the cwd fix, the packaged app correctly runs `poetry run nexus --json up` from the repo root. The next startup edge case is a stale or unhealthy managed runtime pid:

`Service 'gateway' is already running (pid 56729). Use 'nexus restart' or 'nexus down' first.`

The shell should repair that state by restarting the managed runtime instead of surfacing the raw `up` failure.

## Validation
- `cargo fmt --manifest-path ui/src-tauri/Cargo.toml --check`
- `cargo test --manifest-path ui/src-tauri/Cargo.toml` -> 9 passed
- `npm --prefix ui run desktop:build`
- Verified the rebuilt app binary contains the restart fallback strings.

Fresh bundle: `/Users/pythagor/nexus/ui/src-tauri/target/release/bundle/macos/NEXUS.app`