### PR TITLE
design-sync: rescue data-bound cards + apply review findings

### DIFF
--- a/ui/.design-sync/NOTES.md
+++ b/ui/.design-sync/NOTES.md
@@ -101,16 +101,22 @@ Full-screen compositions (splash/*, ErrorBoundary fallback): size the wrapper to
 
 Screenshot groups: `ai/*` → `ai`; shadcn primitives + loose → `general`; deco/veil/splash → own dirs.
 
-## Deferred components (floor cards — authorable later)
+## Data-bound rescues (fetch stub) — no floor cards remain
 
-- **CharactersPane**, **SettingsPane** — data-bound panes gated on live `useQuery`
-  fetches; render blank / an error-state notice statically, so they ship as floor
-  cards. To author them, extend the `DesignThemeRoot` fetch stub (in
-  `ds-provider.tsx`) to mock their endpoints (`/api/characters*`, `/api/settings`).
-  Caution: `/api/settings` also drives the Theme/Font providers — a mock must return
-  `ui.theme: "veil"` or it changes every card's theme.
-- SlotSelector / SeedPhase / LocationPhase were rescued: SlotSelector via the
-  `/api/story/new/slots` stub; the two phases card their on-brand generating states.
+All 95 components ship as authored cards. The data-bound panes render populated via
+the GET-only `DesignThemeRoot` fetch stub (`ds-provider.tsx`):
+
+- **CharactersPane** — mocks `/api/characters` (cast roster) + `/api/characters/<id>/images`
+  (→ `[]`). The images route MUST match the `<id>` segment; a stub that only matches
+  `/api/characters/images` falls through to the cast mock and crashes on
+  `portraitSrc(undefined)` — that was the original blank-card cause.
+- **SettingsPane** — mocks `/api/settings` with a full payload (model roles, slider
+  bounds, keeper fonts). The theme it returns ECHOES the preview's own
+  `localStorage["nexus-theme"]`, NOT a hardcoded `"veil"` — otherwise the Theme/Font
+  providers adopt the mock's theme and override every deco/splash card. Per-component
+  capture isolation keeps this from bleeding across cards.
+- SlotSelector via `/api/story/new/slots`; SeedPhase / LocationPhase card their
+  on-brand generating states.
 
 ## ds-provider QueryClient
 

--- a/ui/.design-sync/NOTES.md
+++ b/ui/.design-sync/NOTES.md
@@ -114,7 +114,10 @@ the GET-only `DesignThemeRoot` fetch stub (`ds-provider.tsx`):
   bounds, keeper fonts). The theme it returns ECHOES the preview's own
   `localStorage["nexus-theme"]`, NOT a hardcoded `"veil"` — otherwise the Theme/Font
   providers adopt the mock's theme and override every deco/splash card. Per-component
-  capture isolation keeps this from bleeding across cards.
+  capture isolation keeps this from bleeding across cards. Its preview wrapper keeps
+  the `nexus-shell` class (overriding 100vh + the 52px TopBar grid row) so the
+  RESET/COMMIT footer buttons get their shell-scoped `.btn-soft`/`.btn-primary`
+  styling — a bare flex wrapper renders them as default browser buttons (Codex review).
 - SlotSelector via `/api/story/new/slots`; SeedPhase / LocationPhase card their
   on-brand generating states.
 

--- a/ui/.design-sync/build.mjs
+++ b/ui/.design-sync/build.mjs
@@ -19,7 +19,7 @@ const CSS = ".design-sync/.cache/lib-dist/style.css";
 if (!existsSync(CSS)) {
   throw new Error(
     `[build] expected Vite stylesheet at ${CSS} but it's missing — did the lib build emit CSS? ` +
-      `Check cssCodeSplit:false in vite.lib.config.mts. (Claude review)`,
+      `Check cssCodeSplit:false in vite.lib.config.mts.`,
   );
 }
 let css = readFileSync(CSS, "utf8");

--- a/ui/.design-sync/build.mjs
+++ b/ui/.design-sync/build.mjs
@@ -8,7 +8,7 @@
 // — but config.json's committed componentSrcMap is static; on a component add,
 // re-merge it (see .design-sync/NOTES.md).
 import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 
 const run = (cmd, args) => execFileSync(cmd, args, { stdio: "inherit" });
 
@@ -16,6 +16,12 @@ run("node", [".design-sync/gen-entry.mjs"]);
 run("npx", ["vite", "build", "--config", ".design-sync/vite.lib.config.mts"]);
 
 const CSS = ".design-sync/.cache/lib-dist/style.css";
+if (!existsSync(CSS)) {
+  throw new Error(
+    `[build] expected Vite stylesheet at ${CSS} but it's missing — did the lib build emit CSS? ` +
+      `Check cssCodeSplit:false in vite.lib.config.mts. (Claude review)`,
+  );
+}
 let css = readFileSync(CSS, "utf8");
 // "/fonts/X.ttf" -> "../../../client/public/fonts/X.ttf" (relative to the css dir
 // ui/.design-sync/.cache/lib-dist/ -> ui/client/public/fonts/)

--- a/ui/.design-sync/conventions.md
+++ b/ui/.design-sync/conventions.md
@@ -60,8 +60,9 @@ custom layout glue, reference tokens directly: `hsl(var(--primary))`,
 
 ## Where the truth lives
 
-- `styles.css` — the token + font + component-style closure every design
-  receives. Read it before styling.
+- `styles.css` (in this synced project) — the token + font + component-style
+  closure every design receives. Read it before styling. Upstream source:
+  `client/src/index.css` + `tailwind.config.ts`, compiled by the design-sync build.
 - `components/<group>/<Name>/<Name>.prompt.md` — per-component usage notes.
 - `components/<group>/<Name>/<Name>.d.ts` — the prop contract (`<Name>Props`).
 

--- a/ui/.design-sync/ds-provider.tsx
+++ b/ui/.design-sync/ds-provider.tsx
@@ -66,11 +66,11 @@ if (typeof window !== "undefined" && !(window as any).__dsFetchStubbed) {
     const url = typeof input === "string" ? input : input?.url ?? "";
     if (method === "GET") {
       if (url.includes("/api/settings")) {
-        const theme = window.localStorage?.getItem("nexus-theme") || "veil";
+        const theme = window.localStorage.getItem("nexus-theme") || "veil";
         return Promise.resolve(json(SETTINGS(theme)));
       }
       if (url.includes("/api/story/new/slots")) return Promise.resolve(json(SLOTS));
-      if (url.includes("/api/characters/") && url.includes("/images")) return Promise.resolve(json([]));
+      if (/\/api\/characters\/[^/]+\/images(\?|$)/.test(url)) return Promise.resolve(json([]));
       if (url.includes("/api/characters")) return Promise.resolve(json(CAST));
     }
     return realFetch(input as any, init);

--- a/ui/.design-sync/ds-provider.tsx
+++ b/ui/.design-sync/ds-provider.tsx
@@ -1,8 +1,8 @@
 // DesignThemeRoot — the preview wrapper for design-sync cards (cfg.provider).
 // Mounts the app's real providers so components that call useTheme/useFonts/
 // useSettings render instead of throwing, and applies the Veil (.dark) theme +
-// fonts. The /api/settings query fails harmlessly in headless (no server) and
-// falls back to the Veil keeper defaults; retries are off so the render settles
+// fonts. The fetch stub below mocks /api/settings (theme echoes each preview's
+// localStorage) and the character endpoints; retries are off so the render settles
 // immediately. Exported through the Vite lib entry → window.NexusIris.DesignThemeRoot.
 import React from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -11,10 +11,10 @@ import { ThemeProvider } from "@/contexts/ThemeContext";
 import { FontProvider } from "@/contexts/FontContext";
 
 // Headless preview fetch stub: feed the data-bound panes realistic mock data so
-// they render populated instead of their empty state. Intercepts ONLY the
-// endpoints below; everything else — notably /api/settings, which also drives
-// Theme/Font providers and must keep failing → Veil fallback so every other
-// card's theme is unchanged — passes through to the real fetch.
+// they render populated instead of their empty state. GET-only — mutations fall
+// through to the real fetch. /api/settings is mocked too (it drives the Theme/Font
+// providers), but its theme echoes each preview's own localStorage, so deco/splash
+// cards keep their theme and Veil cards stay Veil; everything else passes through.
 if (typeof window !== "undefined" && !(window as any).__dsFetchStubbed) {
   (window as any).__dsFetchStubbed = true;
   const realFetch = window.fetch.bind(window);
@@ -32,11 +32,47 @@ if (typeof window !== "undefined" && !(window as any).__dsFetchStubbed) {
     { id: 2, name: "Cassius Brenn", summary: "A dock-warden who runs more than he guards.", appearance: "Broad, scarred, a brass warden's pin he no longer has the right to wear.", personality: "Affable, calculating, loyal to whoever paid last.", emotionalState: "Restless.", currentActivity: "Counting debts in the lantern-light.", currentLocationName: "Harbor Steps", portraitPath: null },
     { id: 3, name: "The Archivist", summary: "Keeper of the Spire's flooded records; speaks in retrieved fragments.", appearance: "Robed, ageless, eyes like wet glass.", personality: "Patient, oblique, unnervingly precise.", emotionalState: "Serene.", currentActivity: "Cataloguing what the water took.", currentLocationName: "The Spire Vaults", portraitPath: null },
   ];
+  // Full settings payload; theme echoes the preview's own localStorage so the
+  // Theme/Font providers don't override a deco/splash card's intended theme.
+  const SETTINGS = (theme: string) => ({
+    ui: {
+      theme,
+      fonts: {
+        veil: { body: "Spectral", menu: "Cinzel", display: "Megrim" },
+        gilded: { body: "Cormorant Garamond", menu: "Space Mono", display: "Monoton" },
+        vector: { body: "Rajdhani", menu: "Source Code Pro", display: "Sixtyfour" },
+      },
+      lore_budget_slider: { min: 8000, max: 200000, step: 1000, stops: [8000, 32000, 64000, 128000, 200000] },
+      typewriter_ms_per_char: 18,
+    },
+    apex: { model: "@anthropic.apex", provider: "anthropic" },
+    lore: { token_budget: { apex_context_window: 128000 } },
+    global: { narrative: { test_mode: false } },
+    settings_meta: {
+      model_roles: [
+        { provider: "anthropic", role: "apex", ref: "@anthropic.apex", label: "Claude Opus 4.8" },
+        { provider: "anthropic", role: "fast", ref: "@anthropic.fast", label: "Claude Sonnet 4.6" },
+        { provider: "openai", role: "apex", ref: "@openai.apex", label: "GPT-5" },
+      ],
+      apex_allowed_providers: ["anthropic", "openai"],
+      typewriter: { min: 0, max: 60 },
+    },
+  });
+  // GET-only: mutations (POST/PATCH/DELETE) fall through to the real fetch so a
+  // preview that wires an interactive write fails visibly instead of silently
+  // succeeding with mock data (Claude review).
   window.fetch = ((input: any, init?: any) => {
+    const method = (init?.method ?? "GET").toUpperCase();
     const url = typeof input === "string" ? input : input?.url ?? "";
-    if (url.includes("/api/story/new/slots")) return Promise.resolve(json(SLOTS));
-    if (url.includes("/api/characters/images")) return Promise.resolve(json([]));
-    if (url.includes("/api/characters")) return Promise.resolve(json(CAST));
+    if (method === "GET") {
+      if (url.includes("/api/settings")) {
+        const theme = window.localStorage?.getItem("nexus-theme") || "veil";
+        return Promise.resolve(json(SETTINGS(theme)));
+      }
+      if (url.includes("/api/story/new/slots")) return Promise.resolve(json(SLOTS));
+      if (url.includes("/api/characters/") && url.includes("/images")) return Promise.resolve(json([]));
+      if (url.includes("/api/characters")) return Promise.resolve(json(CAST));
+    }
     return realFetch(input as any, init);
   }) as typeof window.fetch;
 }

--- a/ui/.design-sync/gen-entry.mjs
+++ b/ui/.design-sync/gen-entry.mjs
@@ -21,7 +21,7 @@ try {
   console.error(
     "[gen-entry] ts-morph not found under .ds-sync/ — run the design-sync setup first:\n" +
       "  (cd .ds-sync && npm i esbuild ts-morph @types/react)\n" +
-      "See .design-sync/NOTES.md. (Claude review)",
+      "See .design-sync/NOTES.md.",
   );
   process.exit(1);
 }
@@ -63,13 +63,15 @@ for (const f of files) {
       if (Node.isVariableDeclaration(d)) {
         const init = d.getInitializer?.();
         if (!init) return false;
-        // Keep functions/arrows, forwardRef|memo calls, and re-exports
-        // (const X = Primitive.Root); exclude PascalCase primitive constants
-        // (string/number) that merely pass isComp (Claude review).
-        return !(
-          Node.isStringLiteral(init) ||
-          Node.isNoSubstitutionTemplateLiteral(init) ||
-          Node.isNumericLiteral(init)
+        // Allowlist of component-shaped initializers: functions/arrows,
+        // forwardRef|memo|cva calls, and `const X = Ns.Root` re-exports. An
+        // allowlist (vs excluding known scalar literals) can't silently admit a
+        // PascalCase `= {}` / `= true` / `= null` constant as a component.
+        return (
+          Node.isArrowFunction(init) ||
+          Node.isFunctionExpression(init) ||
+          Node.isCallExpression(init) ||
+          Node.isPropertyAccessExpression(init)
         );
       }
       return false;

--- a/ui/.design-sync/gen-entry.mjs
+++ b/ui/.design-sync/gen-entry.mjs
@@ -14,7 +14,17 @@ import { execSync } from "node:child_process";
 const UI = fileURLToPath(new URL("..", import.meta.url)); // ui/
 const SRC = resolve(UI, "client/src");
 const require = createRequire(resolve(UI, ".ds-sync/package.json"));
-const { Project, Node, ts } = require("ts-morph");
+let Project, Node, ts;
+try {
+  ({ Project, Node, ts } = require("ts-morph"));
+} catch {
+  console.error(
+    "[gen-entry] ts-morph not found under .ds-sync/ — run the design-sync setup first:\n" +
+      "  (cd .ds-sync && npm i esbuild ts-morph @types/react)\n" +
+      "See .design-sync/NOTES.md. (Claude review)",
+  );
+  process.exit(1);
+}
 
 const files = execSync(
   `find "${SRC}/components" "${SRC}/pages" -type f \\( -name '*.tsx' -o -name '*.jsx' \\)`,
@@ -48,15 +58,23 @@ for (const f of files) {
         ? decls.map((d) => d.getName?.()).find((n) => n && n !== "default")
         : name;
     if (!real || !isComp(real)) continue;
-    if (
-      !decls.some(
-        (d) =>
-          Node.isVariableDeclaration(d) ||
-          Node.isFunctionDeclaration(d) ||
-          Node.isClassDeclaration(d),
-      )
-    )
-      continue;
+    const isComponentDecl = decls.some((d) => {
+      if (Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d)) return true;
+      if (Node.isVariableDeclaration(d)) {
+        const init = d.getInitializer?.();
+        if (!init) return false;
+        // Keep functions/arrows, forwardRef|memo calls, and re-exports
+        // (const X = Primitive.Root); exclude PascalCase primitive constants
+        // (string/number) that merely pass isComp (Claude review).
+        return !(
+          Node.isStringLiteral(init) ||
+          Node.isNoSubstitutionTemplateLiteral(init) ||
+          Node.isNumericLiteral(init)
+        );
+      }
+      return false;
+    });
+    if (!isComponentDecl) continue;
     if (name === "default") def = real;
     else named.add(real);
   }

--- a/ui/.design-sync/previews/Avatar.tsx
+++ b/ui/.design-sync/previews/Avatar.tsx
@@ -1,42 +1,34 @@
-import { Avatar, AvatarImage, AvatarFallback } from "nexus-ui";
+import { Avatar, AvatarFallback } from "nexus-ui";
+
+// Initials-only — no external portrait fetch, so captures are reproducible
+// (Claude review: pravatar.cc made these environment-dependent). NEXUS
+// characters frequently have no uploaded portrait, so the glyph fallback is
+// the common real-world state (see CharactersPane).
 
 export const Cast = () => (
   <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
-    <Avatar>
-      <AvatarImage src="https://i.pravatar.cc/80?img=47" alt="Mira" />
-      <AvatarFallback>MI</AvatarFallback>
-    </Avatar>
-    <Avatar>
-      <AvatarImage src="https://i.pravatar.cc/80?img=12" alt="Cassius" />
-      <AvatarFallback>CA</AvatarFallback>
-    </Avatar>
-    <Avatar>
-      <AvatarImage src="https://i.pravatar.cc/80?img=32" alt="The Archivist" />
-      <AvatarFallback>AR</AvatarFallback>
-    </Avatar>
+    <Avatar><AvatarFallback>MI</AvatarFallback></Avatar>
+    <Avatar><AvatarFallback>CA</AvatarFallback></Avatar>
+    <Avatar><AvatarFallback>AR</AvatarFallback></Avatar>
   </div>
 );
 
-export const Fallbacks = () => (
+export const Sizes = () => (
   <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
-    <Avatar>
-      <AvatarFallback>MI</AvatarFallback>
-    </Avatar>
-    <Avatar>
-      <AvatarFallback>CA</AvatarFallback>
-    </Avatar>
-    <Avatar>
-      <AvatarFallback>AR</AvatarFallback>
-    </Avatar>
+    <Avatar style={{ width: 32, height: 32 }}><AvatarFallback>MI</AvatarFallback></Avatar>
+    <Avatar style={{ width: 44, height: 44 }}><AvatarFallback>CA</AvatarFallback></Avatar>
+    <Avatar style={{ width: 60, height: 60 }}><AvatarFallback>AR</AvatarFallback></Avatar>
   </div>
 );
 
 export const PartyStack = () => (
   <div style={{ display: "flex", alignItems: "center" }}>
-    {[47, 12, 32, 5].map((img, i) => (
-      <Avatar key={img} style={{ marginLeft: i === 0 ? 0 : -12 }}>
-        <AvatarImage src={`https://i.pravatar.cc/80?img=${img}`} alt="" />
-        <AvatarFallback>{["MI", "CA", "AR", "VE"][i]}</AvatarFallback>
+    {["MI", "CA", "AR", "VE"].map((ini, i) => (
+      <Avatar
+        key={ini}
+        style={{ marginLeft: i === 0 ? 0 : -12, border: "2px solid hsl(var(--background))" }}
+      >
+        <AvatarFallback>{ini}</AvatarFallback>
       </Avatar>
     ))}
   </div>

--- a/ui/.design-sync/previews/CharactersPane.tsx
+++ b/ui/.design-sync/previews/CharactersPane.tsx
@@ -3,9 +3,11 @@ import { CharactersPane } from "nexus-ui";
 // Data-bound cast roster + dossier. The DesignThemeRoot fetch stub feeds
 // GET /api/characters?slot, so the pane renders populated (list on the left,
 // dossier on the right). Plain sized flex container — the nexus shell's 100vh
-// grid would clip a lone pane (see NOTES.md).
+// grid would clip a lone pane (see NOTES.md). Unlike SettingsPane, CharactersPane
+// has no shell-scoped controls, so it needs no `nexus-shell` wrapper.
 export const Roster = () => (
   <div style={{ width: 820, height: 460, display: "flex", overflow: "hidden" }}>
+    {/* slot is cosmetic — the stub matches on URL substring, not the query param */}
     <CharactersPane slot={2} />
   </div>
 );

--- a/ui/.design-sync/previews/CharactersPane.tsx
+++ b/ui/.design-sync/previews/CharactersPane.tsx
@@ -1,0 +1,11 @@
+import { CharactersPane } from "nexus-ui";
+
+// Data-bound cast roster + dossier. The DesignThemeRoot fetch stub feeds
+// GET /api/characters?slot, so the pane renders populated (list on the left,
+// dossier on the right). Plain sized flex container — the nexus shell's 100vh
+// grid would clip a lone pane (see NOTES.md).
+export const Roster = () => (
+  <div style={{ width: 820, height: 460, display: "flex", overflow: "hidden" }}>
+    <CharactersPane slot={2} />
+  </div>
+);

--- a/ui/.design-sync/previews/SettingsPane.tsx
+++ b/ui/.design-sync/previews/SettingsPane.tsx
@@ -4,8 +4,17 @@ import { SettingsPane } from "nexus-ui";
 // theme, keeper fonts, model roles, slider bounds), so all seven sections
 // render — the anchor rail plus Theme / Typography / Test Mode / Model /
 // Context Length / Typewriter / App Icon cards.
+//
+// Wrapper keeps the `nexus-shell` class (not a bare flex box) so the console's
+// RESET / COMMIT footer buttons — styled by shell-scoped `.nexus-shell .btn-soft`
+// / `.nexus-shell .btn-primary` rules — render correctly instead of as default
+// browser buttons. The shell's 100vh height and 52px TopBar grid row are
+// overridden locally so the lone pane fills the card.
 export const Console = () => (
-  <div style={{ width: 900, height: 680, display: "flex", overflow: "hidden" }}>
+  <div
+    className="nexus-shell"
+    style={{ width: 900, height: 680, gridTemplateRows: "1fr", overflow: "hidden" }}
+  >
     <SettingsPane />
   </div>
 );

--- a/ui/.design-sync/previews/SettingsPane.tsx
+++ b/ui/.design-sync/previews/SettingsPane.tsx
@@ -1,0 +1,11 @@
+import { SettingsPane } from "nexus-ui";
+
+// Data-bound settings console. The fetch stub feeds GET /api/settings (Veil
+// theme, keeper fonts, model roles, slider bounds), so all seven sections
+// render — the anchor rail plus Theme / Typography / Test Mode / Model /
+// Context Length / Typewriter / App Icon cards.
+export const Console = () => (
+  <div style={{ width: 900, height: 680, display: "flex", overflow: "hidden" }}>
+    <SettingsPane />
+  </div>
+);


### PR DESCRIPTION
Follow-up to #413 (NEXUS Iris design-system sync). A separate, smaller PR that rescues the two data-bound panes which shipped as floor cards in #413, and folds in the Claude review findings on the sync harness.

## Data-Bound Rescues

Both panes now render as authored cards (verified, render cleanly):

- **CharactersPane** — cast roster + dossier, fed by the `/api/characters` and `/api/characters/<id>/images` stubs. The blank card in #413 was an images-route mismatch: the stub matched only `/api/characters/images` (no `<id>` segment), fell through to the cast mock, and crashed on `portraitSrc(undefined)`. Now matches the `<id>` route → `[]`.
- **SettingsPane** — full settings console (Theme / Typography / Model / Context / Typewriter / …), fed by a `/api/settings` mock. The mock's theme **echoes each preview's `localStorage`** rather than hardcoding `"veil"`, so the Theme/Font providers don't override the deco/splash cards' themes.

## Review Findings

- ds-provider fetch stub is **GET-only** — mutations fall through to the real fetch (a preview that wires an interactive write fails visibly instead of getting mock data).
- `gen-entry`: actionable error when `ts-morph`/`.ds-sync` is missing; component discovery excludes PascalCase primitive constants while keeping re-exports (`const X = Primitive.Root`) — the strict form regressed `AspectRatio`/`Collapsible` until corrected.
- `build.mjs`: explicit error if the Vite stylesheet is missing.
- `Avatar` preview: dropped `pravatar.cc` (non-reproducible) → initials / sizes / stack cells.
- `conventions.md`: note `styles.css` is a build artifact + point to its source.

## Sync

The diff — 3 components + bundle + CSS + README + anchor — is **already synced** to the live NEXUS Iris project (verified: remote anchor matches local). The other 92 components are byte-identical and untouched (precise `deletes: []`, no reconciliation). Render check: **95/95 clean, 0 floor cards.**

Build artifacts (`ds-bundle/`, `.cache/`) are gitignored; this PR contains only the durable sync inputs under `ui/.design-sync/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015k5oReuL2TuGyVrKihVqAK