### PR TITLE
[codex] Make agent package exports lazy

### DIFF
--- a/nexus/agents/lore/__init__.py
+++ b/nexus/agents/lore/__init__.py
@@ -4,6 +4,25 @@ LORE Agent Module
 Central orchestration agent for the NEXUS narrative intelligence system.
 """
 
-from .lore import LORE, TurnPhase
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .lore import LORE, TurnPhase
 
 __all__ = ["LORE", "TurnPhase"]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve package-level LORE exports only when callers request them."""
+    if name in __all__:
+        from .lore import LORE, TurnPhase
+
+        exports = {"LORE": LORE, "TurnPhase": TurnPhase}
+        globals().update(exports)
+        return exports[name]
+    raise AttributeError(f"module 'nexus.agents.lore' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return discoverable package exports without importing the agent stack."""
+    return sorted({*globals(), *__all__})

--- a/nexus/agents/memnon/__init__.py
+++ b/nexus/agents/memnon/__init__.py
@@ -6,4 +6,25 @@ for memory management, embedding generation, and cross-reference retrieval
 across both structured database storage and semantic vector search.
 """
 
-from .memnon import MEMNON
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .memnon import MEMNON
+
+__all__ = ["MEMNON"]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve package-level MEMNON export only when callers request it."""
+    if name in __all__:
+        from .memnon import MEMNON
+
+        exports = {"MEMNON": MEMNON}
+        globals().update(exports)
+        return exports[name]
+    raise AttributeError(f"module 'nexus.agents.memnon' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return discoverable package exports without importing the agent stack."""
+    return sorted({*globals(), *__all__})

--- a/tests/test_api/test_import_side_effects.py
+++ b/tests/test_api/test_import_side_effects.py
@@ -25,11 +25,21 @@ _UNREACHABLE_DB_ENV = {
     "NEXUS_SLOT": "1",
 }
 
-_FORBIDDEN_APP_IMPORT_MODULES = {
-    "nexus.agents.memnon.memnon",
+_FORBIDDEN_ML_IMPORT_MODULES = {
     "sentence_transformers",
     "torch",
     "transformers",
+}
+
+_FORBIDDEN_APP_IMPORT_MODULES = {
+    *_FORBIDDEN_ML_IMPORT_MODULES,
+    "nexus.agents.memnon.memnon",
+}
+
+_FORBIDDEN_AGENT_UTILITY_IMPORT_MODULES = {
+    *_FORBIDDEN_ML_IMPORT_MODULES,
+    "nexus.agents.lore.lore",
+    "nexus.agents.memnon.memnon",
 }
 
 
@@ -102,6 +112,61 @@ def test_orrery_worker_import_does_not_touch_postgres() -> None:
         "import nexus.agents.orrery.retrograde_embedding\n"
         "from nexus.api import db_pool\n"
         "assert db_pool._pools == {}, db_pool._pools\n"
+        "print('OK')\n"
+    )
+    _assert_clean(_run_fresh_import(code))
+
+
+def test_agent_utility_imports_do_not_import_agent_or_ml_stack() -> None:
+    """Utility imports must not load LORE, MEMNON, or ML dependencies."""
+    for target in [
+        "nexus.agents.lore.utils.chunk_operations",
+        "nexus.agents.memnon.utils.db_access",
+        "nexus.agents.memnon.utils.embedding_tables",
+        "nexus.agents.memnon.utils.query_analysis",
+    ]:
+        module_list = repr(sorted(_FORBIDDEN_AGENT_UTILITY_IMPORT_MODULES))
+        code = (
+            "import importlib\n"
+            "import sys\n"
+            f"target = {target!r}\n"
+            f"forbidden = {module_list}\n"
+            "importlib.import_module(target)\n"
+            "loaded = [module for module in forbidden if module in sys.modules]\n"
+            "assert loaded == [], {target: loaded}\n"
+            "print('OK')\n"
+        )
+        _assert_clean(_run_fresh_import(code))
+
+
+def test_agent_package_level_imports_still_work() -> None:
+    """Lazy package exports must preserve the documented compatibility imports."""
+    code = (
+        "from nexus.agents.lore import LORE, TurnPhase\n"
+        "from nexus.agents.memnon import MEMNON\n"
+        "assert LORE.__name__ == 'LORE'\n"
+        "assert TurnPhase.IDLE.value == 'idle'\n"
+        "assert MEMNON.__name__ == 'MEMNON'\n"
+        "print('OK')\n"
+    )
+    _assert_clean(_run_fresh_import(code))
+
+
+def test_agent_package_dir_exports_are_unique_after_lazy_load() -> None:
+    """Lazy export caching must not duplicate package names in dir()."""
+    code = (
+        "import importlib\n"
+        "packages = {\n"
+        "    'nexus.agents.lore': ('LORE', 'TurnPhase'),\n"
+        "    'nexus.agents.memnon': ('MEMNON',),\n"
+        "}\n"
+        "for package_name, exports in packages.items():\n"
+        "    package = importlib.import_module(package_name)\n"
+        "    for export in exports:\n"
+        "        getattr(package, export)\n"
+        "    names = dir(package)\n"
+        "    duplicates = [name for name in exports if names.count(name) != 1]\n"
+        "    assert duplicates == [], {package_name: duplicates}\n"
         "print('OK')\n"
     )
     _assert_clean(_run_fresh_import(code))


### PR DESCRIPTION
## Summary

Closes #417.

- Make `nexus.agents.lore` and `nexus.agents.memnon` package exports lazy via module-level `__getattr__`.
- Preserve compatibility for `from nexus.agents.lore import LORE, TurnPhase` and `from nexus.agents.memnon import MEMNON`.
- Add fresh-subprocess import-hygiene coverage for utility imports so `chunk_operations` and MEMNON DB/query helpers do not load LORE, MEMNON, `sentence_transformers`, `torch`, or `transformers`.
- Address Claude review feedback by keeping MEMNON aligned with `__all__`, deduplicating `__dir__`, making utility-import failures target-specific, and sharing the forbidden ML module set.

## Impact

Utility-only imports no longer pay the agent/ML cold-start tax. On the amended branch, fresh utility imports stayed clean: `nexus.agents.lore.utils.chunk_operations` imported in about `0.0139s`, and MEMNON utility imports stayed below about `0.11s`, with no forbidden modules loaded.

## Validation

- `poetry run black nexus/agents/lore/__init__.py nexus/agents/memnon/__init__.py tests/test_api/test_import_side_effects.py`
- `poetry run flake8 nexus/agents/lore/__init__.py nexus/agents/memnon/__init__.py tests/test_api/test_import_side_effects.py`
- `git diff --check`
- `poetry run pytest tests/test_api/test_import_side_effects.py -q --durations=20 --durations-min=0.001` -> `7 passed in 7.13s`
- `poetry run pytest tests/test_lore/test_chunk_operations.py -q --durations=30 --durations-min=0.001` -> `24 passed in 0.32s`
- `poetry run pytest tests/test_memnon_db_access.py -q --durations=20 --durations-min=0.001` -> `2 passed in 2.30s`
- `poetry run pytest -q --durations=30 --durations-min=0.05` -> `843 passed, 137 skipped, 16 warnings in 12.73s`

Schema/config/data impact: none.