### PR TITLE
Add Orrery audit dashboard backend v1 (/api/dev/orrery)

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -206,6 +206,12 @@ enabled = true
 [orrery.binding]
 window_chunks = 30
 
+[orrery.dashboard]
+# Registers the read-only /api/dev/orrery/* audit router on the gateway.
+# Server-side gate (import.meta.env.DEV only hides the client bundle) — flip
+# to false before exposing the gateway beyond localhost (issue #415).
+enabled = true
+
 [orrery.route_graph]
 max_edges_per_query = 5000
 

--- a/nexus.toml
+++ b/nexus.toml
@@ -208,9 +208,10 @@ window_chunks = 30
 
 [orrery.dashboard]
 # Registers the read-only /api/dev/orrery/* audit router on the gateway.
-# Server-side gate (import.meta.env.DEV only hides the client bundle) — flip
-# to false before exposing the gateway beyond localhost (issue #415).
-enabled = true
+# Server-side gate (import.meta.env.DEV only hides the client bundle): the
+# gateway has no auth and binds 0.0.0.0, so this ships off — flip to true
+# locally while working on the audit dashboard (issue #415).
+enabled = false
 
 [orrery.route_graph]
 max_edges_per_query = 5000

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -1,0 +1,918 @@
+"""Slot-backed explained resolution for the Orrery audit dashboard.
+
+This module is the read-only bridge between the explain layer
+(:mod:`nexus.agents.orrery.explain`) and real slot databases. It mirrors
+:func:`nexus.agents.orrery.resolver.resolve_dry_run` **exactly** — the same
+hydration, the same actor-only / two-party stack split, the same binding
+composition (including threading the actor set through
+``compose_actor_target_bindings``), and the same present-target pressure pass —
+but runs :func:`explain_stack` per binding set so every template's gate and
+branch trace is retained, not just the winner.
+
+The stack-split fidelity matters: tracing a two-party template with only
+``ACTOR`` bound would make every ``@target`` leaf read ``None`` and report
+``False``, rendering "not applicable, no target bound" indistinguishable from a
+genuine gate failure. Here two-party templates are only ever explained against
+composed (actor, target) bindings; an actor with no composed pair gets an
+explicit not-applicable marker instead (scoped to the off-screen two-party
+stack — the present-target pressure pass depends on scene composition, not on
+a per-actor binding decision).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterable, List, Mapping, Optional, Tuple
+
+from sqlalchemy import text
+
+from nexus.agents.orrery.explain import StackExplanation, explain_stack
+from nexus.agents.orrery.needs import (
+    NEED_SEVERITY_PREFIX,
+    coerce_need_tuning,
+    severity_for_debt,
+)
+from nexus.agents.orrery.resolver import (
+    _LOCATION_CLASS_CATEGORY_SQL,
+    OrreryScenePressureDraft,
+    _entity_label,
+    _load_entity_names,
+    _load_need_debt_scores,
+    _load_routine_anchors,
+    _load_travel_states,
+    _load_world_time,
+    _present_actor_ids_at_anchor,
+    _present_need_pressure_specs,
+    _render_bound_text,
+    _scene_pressure_from_need_spec,
+    compose_actor_bindings,
+    compose_actor_target_bindings,
+    hydrate_world_state,
+)
+from nexus.agents.orrery.substrate import (
+    CONSTRAINED_TAGS,
+    DRAMATIC_CONTACT_TAGS,
+    DRIVE_BAND_ORDER,
+    ESTABLISHED_PARTNER_RELATIONSHIP_TYPES,
+    HIDDEN_TAGS,
+    INTIMACY_SUPPRESSOR_TAGS,
+    PUBLIC_MOBILITY_TAGS,
+    PUBLIC_PLACE_CLASSES,
+    PresentTargetPolicy,
+    Slot,
+    Template,
+    _condition_tree_leaves,
+    drive_band_priority_warnings,
+)
+
+_ACTOR_ONLY_SLOTS: Tuple[Slot, ...] = (Slot.ACTOR,)
+_ACTOR_TARGET_SLOTS: Tuple[Slot, ...] = (Slot.ACTOR, Slot.TARGET)
+
+NOT_APPLICABLE_REASON = "no_target_bound"
+
+
+@dataclass(frozen=True, slots=True)
+class ActorGroupExplanation:
+    """All explained stacks for one off-screen actor in one tick."""
+
+    actor_entity_id: int
+    actor_stack: StackExplanation
+    two_party_stacks: Tuple[StackExplanation, ...] = ()
+    scene_pressure_stacks: Tuple[StackExplanation, ...] = ()
+    not_applicable: Tuple[Mapping[str, Any], ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ExplainedTickReport:
+    """Full audit record for one dry-run tick against a real slot."""
+
+    anchor_chunk_id: Optional[int]
+    window_chunks: int
+    world_time: Optional[datetime]
+    time_of_day: str
+    weather: str
+    actor_count: int
+    actors: Tuple[ActorGroupExplanation, ...]
+    need_pressures: Tuple[OrreryScenePressureDraft, ...]
+    entity_names: Mapping[int, str]
+    locations: Mapping[int, Any]
+    location_names: Mapping[int, str]
+    activities: Mapping[int, str]
+    generated_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "anchor_chunk_id": self.anchor_chunk_id,
+            "window_chunks": self.window_chunks,
+            "world_time": (
+                self.world_time.isoformat() if self.world_time is not None else None
+            ),
+            "time_of_day": self.time_of_day,
+            "weather": self.weather,
+            "actor_count": self.actor_count,
+            "generated_at": self.generated_at,
+            "actors": [self._group_payload(group) for group in self.actors],
+            "need_pressures": [draft.to_dict() for draft in self.need_pressures],
+            "entity_names": {
+                str(entity_id): name for entity_id, name in self.entity_names.items()
+            },
+        }
+
+    def _group_payload(self, group: ActorGroupExplanation) -> dict[str, Any]:
+        actor_id = group.actor_entity_id
+        place_id = self.locations.get(actor_id)
+        location: Optional[dict[str, Any]] = None
+        if place_id is not None:
+            location = {
+                "place_id": place_id,
+                "name": self.location_names.get(place_id),
+            }
+        return {
+            "actor_entity_id": actor_id,
+            "actor_name": _entity_label(actor_id, self.entity_names),
+            "location": location,
+            "activity": self.activities.get(actor_id),
+            "actor_stack": self._stack_payload(group.actor_stack),
+            "two_party_stacks": [
+                self._stack_payload(stack) for stack in group.two_party_stacks
+            ],
+            "scene_pressure_stacks": [
+                self._stack_payload(stack) for stack in group.scene_pressure_stacks
+            ],
+            "not_applicable": [dict(item) for item in group.not_applicable],
+        }
+
+    def _stack_payload(self, stack: StackExplanation) -> dict[str, Any]:
+        payload = stack.to_dict()
+        payload["binding_names"] = {
+            slot: _entity_label(value, self.entity_names)
+            for slot, value in stack.bindings.items()
+        }
+        for item in payload["templates"]:
+            stub = item["narrative_stub"] if item["fired"] else None
+            item["narrative_stub_rendered"] = (
+                _render_bound_text(
+                    stub,
+                    stack.bindings,
+                    self.entity_names,
+                    template_id=item["template_id"],
+                )
+                if stub
+                else None
+            )
+            pressure_stub = item["scene_pressure_stub"] if item["fired"] else None
+            item["scene_pressure_prompt_rendered"] = (
+                _render_bound_text(
+                    pressure_stub,
+                    stack.bindings,
+                    self.entity_names,
+                    template_id=item["template_id"],
+                )
+                if pressure_stub
+                else None
+            )
+        return payload
+
+
+def explain_dry_run(
+    session: Any,
+    templates: Iterable[Template],
+    *,
+    anchor_chunk_id: Optional[int],
+    window_chunks: int,
+    sunhelm_settings: Optional[Any] = None,
+    world_time_override: Optional[datetime] = None,
+) -> ExplainedTickReport:
+    """Hydrate, bind, and explain Orrery packages without database writes.
+
+    Every step below has a line-for-line counterpart in ``resolve_dry_run``;
+    keep them in lockstep. Winner/branch parity with production is enforced
+    per template by ``explain_template``'s cross-check against ``evaluate``.
+    """
+
+    need_tuning = coerce_need_tuning(sunhelm_settings)
+    state = hydrate_world_state(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        window_chunks=window_chunks,
+        need_tuning=need_tuning,
+        world_time_override=world_time_override,
+    )
+
+    templates_list = list(templates)
+    actor_only_templates = [
+        t for t in templates_list if t.required_slots == _ACTOR_ONLY_SLOTS
+    ]
+    actor_target_templates = [
+        t for t in templates_list if t.required_slots == _ACTOR_TARGET_SLOTS
+    ]
+    unsupported = [
+        t
+        for t in templates_list
+        if t.required_slots not in (_ACTOR_ONLY_SLOTS, _ACTOR_TARGET_SLOTS)
+    ]
+    if unsupported:
+        raise ValueError(
+            "Orrery audit resolver does not yet compose bindings for "
+            "required_slots="
+            + ", ".join(
+                f"{t.id}:{tuple(s.value for s in t.required_slots)}"
+                for t in unsupported
+            )
+        )
+
+    actor_bindings = compose_actor_bindings(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        window_chunks=window_chunks,
+    )
+    actor_stacks: dict[int, StackExplanation] = {}
+    for bindings in actor_bindings:
+        actor_stacks[bindings[Slot.ACTOR]] = explain_stack(
+            actor_only_templates, state, bindings
+        )
+    actor_ids = set(actor_stacks)
+
+    two_party_stacks: dict[int, List[StackExplanation]] = {}
+    pressure_stacks: dict[int, List[StackExplanation]] = {}
+    if actor_target_templates:
+        offscreen_pair_bindings = compose_actor_target_bindings(
+            session,
+            anchor_chunk_id=anchor_chunk_id,
+            window_chunks=window_chunks,
+            actor_ids=actor_ids,
+            target_presence="offscreen",
+        )
+        for bindings in offscreen_pair_bindings:
+            two_party_stacks.setdefault(bindings[Slot.ACTOR], []).append(
+                explain_stack(actor_target_templates, state, bindings)
+            )
+
+        pressure_templates = [
+            template
+            for template in actor_target_templates
+            if template.present_target_policy
+            is PresentTargetPolicy.STORYTELLER_PRESSURE
+        ]
+        if pressure_templates:
+            present_pair_bindings = compose_actor_target_bindings(
+                session,
+                anchor_chunk_id=anchor_chunk_id,
+                window_chunks=window_chunks,
+                actor_ids=actor_ids,
+                target_presence="present",
+            )
+            for bindings in present_pair_bindings:
+                pressure_stacks.setdefault(bindings[Slot.ACTOR], []).append(
+                    explain_stack(pressure_templates, state, bindings)
+                )
+
+    present_actor_ids = _present_actor_ids_at_anchor(
+        session, anchor_chunk_id=anchor_chunk_id
+    )
+    need_pressure_specs = _present_need_pressure_specs(
+        state,
+        present_actor_ids=present_actor_ids,
+        need_tuning=need_tuning,
+    )
+
+    entity_ids: set[int] = {spec["actor_entity_id"] for spec in need_pressure_specs}
+    all_stacks: list[StackExplanation] = list(actor_stacks.values())
+    for stacks in two_party_stacks.values():
+        all_stacks.extend(stacks)
+    for stacks in pressure_stacks.values():
+        all_stacks.extend(stacks)
+    for stack in all_stacks:
+        for value in stack.bindings.values():
+            if isinstance(value, int):
+                entity_ids.add(value)
+    place_entity_ids = {
+        state.location_entity_ids[place_id]
+        for actor_id in actor_ids
+        if (place_id := state.locations.get(actor_id)) is not None
+        and place_id in state.location_entity_ids
+    }
+    entity_names = _load_entity_names(session, entity_ids | place_entity_ids)
+    location_names = {
+        place_id: entity_names[entity_id]
+        for place_id, entity_id in state.location_entity_ids.items()
+        if entity_id in entity_names
+    }
+
+    need_pressures = tuple(
+        _scene_pressure_from_need_spec(
+            spec,
+            entity_names,
+            need_tuning=need_tuning,
+        )
+        for spec in need_pressure_specs
+    )
+
+    not_applicable_markers = tuple(
+        {
+            "template_id": template.id,
+            "priority": template.priority,
+            "drive_band": template.drive_band.value,
+            "reason": NOT_APPLICABLE_REASON,
+        }
+        for template in actor_target_templates
+    )
+    groups = tuple(
+        ActorGroupExplanation(
+            actor_entity_id=actor_id,
+            actor_stack=actor_stacks[actor_id],
+            two_party_stacks=tuple(two_party_stacks.get(actor_id, ())),
+            scene_pressure_stacks=tuple(pressure_stacks.get(actor_id, ())),
+            not_applicable=(
+                not_applicable_markers if not two_party_stacks.get(actor_id) else ()
+            ),
+        )
+        for actor_id in sorted(actor_ids)
+    )
+
+    return ExplainedTickReport(
+        anchor_chunk_id=anchor_chunk_id,
+        window_chunks=window_chunks,
+        world_time=state.world_time,
+        time_of_day=state.time_of_day,
+        weather=state.weather,
+        actor_count=len(actor_ids),
+        actors=groups,
+        need_pressures=need_pressures,
+        entity_names=entity_names,
+        locations=dict(state.locations),
+        location_names=location_names,
+        activities=dict(state.activities),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Static catalog introspection
+# ---------------------------------------------------------------------------
+
+# Curated coupling families from substrate. `kind` says what vocabulary the
+# members belong to, so consumers don't try to match relationship types or
+# place classes against tag chips.
+TAG_FAMILIES: Mapping[str, Mapping[str, Any]] = {
+    "intimacy_suppressor_tags": {
+        "kind": "tags",
+        "members": INTIMACY_SUPPRESSOR_TAGS,
+    },
+    "hidden_tags": {"kind": "tags", "members": HIDDEN_TAGS},
+    "dramatic_contact_tags": {"kind": "tags", "members": DRAMATIC_CONTACT_TAGS},
+    "constrained_tags": {"kind": "tags", "members": CONSTRAINED_TAGS},
+    "public_mobility_tags": {"kind": "tags", "members": PUBLIC_MOBILITY_TAGS},
+    "public_place_classes": {
+        "kind": "place_classes",
+        "members": PUBLIC_PLACE_CLASSES,
+    },
+    "established_partner_relationship_types": {
+        "kind": "relationship_types",
+        "members": ESTABLISHED_PARTNER_RELATIONSHIP_TYPES,
+    },
+}
+
+_TAG_FAMILY_TAG_SETS: Mapping[str, frozenset[str]] = {
+    name: spec["members"]
+    for name, spec in TAG_FAMILIES.items()
+    if spec["kind"] == "tags"
+}
+
+# Same event-consumption grammar the catalog's vocabulary collector matches
+# against predicate __name__s (catalog._VOCAB_PATTERNS); the wildcard
+# `recent_event(*)` form is deliberately excluded — it consumes no specific
+# event type.
+_EVENT_CONSUMER_PATTERNS: Tuple[re.Pattern[str], ...] = (
+    re.compile(r"recent_event\(([^,*()]+),"),
+    re.compile(r"since_last_event_at_least\(([^,()]+),"),
+)
+
+
+def _consumed_event_types(condition: Any) -> set[str]:
+    consumed: set[str] = set()
+    for leaf in _condition_tree_leaves(condition):
+        name = getattr(leaf, "__name__", "")
+        for pattern in _EVENT_CONSUMER_PATTERNS:
+            match = pattern.search(name)
+            if match:
+                consumed.add(match.group(1))
+    return consumed
+
+
+def build_catalog(
+    templates: Iterable[Template],
+    *,
+    sunhelm_settings: Optional[Any] = None,
+    promote_settings: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    """Return the static template catalog payload for the audit dashboard.
+
+    Pure introspection over the template tuple plus config-derived
+    pseudo-template metadata; no database access. Tuple index is included
+    because ``evaluate_stack``'s stable sort makes authored order the
+    tie-breaker between equal priorities.
+    """
+
+    templates_tuple = tuple(templates)
+    need_tuning = coerce_need_tuning(sunhelm_settings)
+
+    template_payloads: list[dict[str, Any]] = []
+    event_map: dict[str, dict[str, list[str]]] = {}
+
+    def _event_entry(event_type: str) -> dict[str, list[str]]:
+        return event_map.setdefault(
+            event_type,
+            {"consumed_by_gate": [], "consumed_by_branch": [], "emitted_by": []},
+        )
+
+    for tuple_index, template in enumerate(templates_tuple):
+        gate_consumed = _consumed_event_types(template.package_gate)
+        branch_consumed: set[str] = set()
+        emitted: set[str] = set()
+        branch_payloads: list[dict[str, Any]] = []
+        for branch in template.branches:
+            branch_consumed |= _consumed_event_types(branch.conditions)
+            if branch.event_type:
+                emitted.add(branch.event_type)
+            branch_payloads.append(
+                {
+                    "label": branch.label,
+                    "magnitude": branch.magnitude,
+                    "event_type": branch.event_type,
+                    "has_scene_pressure_stub": branch.scene_pressure_stub is not None,
+                }
+            )
+        for event_type in sorted(gate_consumed):
+            _event_entry(event_type)["consumed_by_gate"].append(template.id)
+        for event_type in sorted(branch_consumed):
+            _event_entry(event_type)["consumed_by_branch"].append(template.id)
+        for event_type in sorted(emitted):
+            _event_entry(event_type)["emitted_by"].append(template.id)
+
+        arity = (
+            "two_party"
+            if template.required_slots == _ACTOR_TARGET_SLOTS
+            else "actor_only"
+        )
+        template_payloads.append(
+            {
+                "template_id": template.id,
+                "priority": template.priority,
+                "tuple_index": tuple_index,
+                "drive_band": template.drive_band.value,
+                "blurb": template.blurb,
+                "required_slots": [slot.value for slot in template.required_slots],
+                "arity": arity,
+                "present_target_policy": template.present_target_policy.value,
+                "drive_band_priority_exempt": template.drive_band_priority_exempt,
+                "priority_override_rationale": template.priority_override_rationale,
+                "branches": branch_payloads,
+                "consumed_event_types": {
+                    "gate": sorted(gate_consumed),
+                    "branch": sorted(branch_consumed),
+                },
+                "emitted_event_types": sorted(emitted),
+            }
+        )
+
+    bands = [
+        {
+            "band": band.value,
+            "urgency_rank": rank,
+            "templates": [
+                payload
+                for payload in template_payloads
+                if payload["drive_band"] == band.value
+            ],
+        }
+        for band, rank in sorted(DRIVE_BAND_ORDER.items(), key=lambda item: item[1])
+    ]
+
+    for entry in event_map.values():
+        entry_any: dict[str, Any] = entry  # widen for the derived flag
+        entry_any["exogenous_only"] = not entry["emitted_by"] and bool(
+            entry["consumed_by_gate"] or entry["consumed_by_branch"]
+        )
+
+    pseudo_templates = [
+        {
+            "template_id": f"{need_type}_need_pressure",
+            "kind": "need_pressure",
+            "need_type": need_type,
+            "priority": need_tuning.priorities[need_type],
+            "min_severity_level": need_tuning.pressure.min_severity_level,
+        }
+        for need_type in NEED_SEVERITY_PREFIX
+    ]
+
+    priority_ties: list[dict[str, Any]] = []
+    for arity, slots in (
+        ("actor_only", _ACTOR_ONLY_SLOTS),
+        ("two_party", _ACTOR_TARGET_SLOTS),
+    ):
+        partition = [t for t in templates_tuple if t.required_slots == slots]
+        by_priority: dict[int, list[str]] = {}
+        for template in partition:
+            by_priority.setdefault(template.priority, []).append(template.id)
+        for priority, ids in sorted(by_priority.items(), reverse=True):
+            if len(ids) > 1:
+                priority_ties.append(
+                    {
+                        "arity": arity,
+                        "priority": priority,
+                        # Tuple order — the actual tie-breaker.
+                        "template_ids": ids,
+                    }
+                )
+
+    promotion: Optional[dict[str, Any]] = None
+    if promote_settings is not None:
+        promotion = {
+            "priority_threshold": promote_settings["priority_threshold"],
+            "magnitude_threshold": promote_settings["magnitude_threshold"],
+        }
+
+    return {
+        "drive_bands": bands,
+        "pseudo_templates": pseudo_templates,
+        "tag_families": {
+            name: {"kind": spec["kind"], "members": sorted(spec["members"])}
+            for name, spec in TAG_FAMILIES.items()
+        },
+        "event_map": event_map,
+        "priority_ties": priority_ties,
+        "drive_band_priority_warnings": list(
+            drive_band_priority_warnings(templates_tuple)
+        ),
+        "promotion": promotion,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Entity hover/context hydration
+# ---------------------------------------------------------------------------
+
+
+def _tag_provenance(applied_at_world_time: Optional[datetime]) -> str:
+    # "exact" is reserved for rows carrying a source_chunk_id bestowal key,
+    # which does not exist pre-migration (see the reconstruction-sufficiency
+    # notes in docs/orrery_audit_dashboard_notes.md).
+    return "approximate" if applied_at_world_time is not None else "unknowable"
+
+
+def _iso(value: Optional[datetime]) -> Optional[str]:
+    return value.isoformat() if value is not None else None
+
+
+def entity_context(
+    session: Any,
+    entity_ids: Iterable[int],
+    *,
+    anchor_chunk_id: Optional[int],
+    recent_events_limit: int = 5,
+    sunhelm_settings: Optional[Any] = None,
+) -> dict[str, Any]:
+    """Return the hover-audit payload for a set of entity ids.
+
+    Everything the dashboard's HoverCard renders: name, place (with classes),
+    activity, effective need debt, tags with per-row provenance and family
+    membership, pair tags, relationships (explicitly labeled unversioned),
+    travel state, routine anchors, and recent events. Read-only.
+    """
+
+    ids = sorted(set(entity_ids))
+    if not ids:
+        return {"anchor_chunk_id": anchor_chunk_id, "entities": []}
+
+    need_tuning = coerce_need_tuning(sunhelm_settings)
+    world_time = _load_world_time(session, anchor_chunk_id=anchor_chunk_id)
+
+    kinds = {
+        row["id"]: row["kind"]
+        for row in session.execute(
+            text(
+                """
+                /* orrery_audit:entity_kinds */
+                SELECT id, kind::text AS kind
+                FROM entities
+                WHERE id = ANY(:ids)
+                """
+            ),
+            {"ids": ids},
+        ).mappings()
+    }
+
+    tags_by_entity: dict[int, list[dict[str, Any]]] = {}
+    tag_sets: dict[int, set[str]] = {}
+    for row in session.execute(
+        text(
+            """
+            /* orrery_audit:entity_tags */
+            SELECT entity_id, tag, category, is_ephemeral, source_kind::text
+                   AS source_kind, template_id, applied_at,
+                   applied_at_world_time
+            FROM entity_tags_current
+            WHERE entity_id = ANY(:ids)
+            ORDER BY entity_id, tag
+            """
+        ),
+        {"ids": ids},
+    ).mappings():
+        tag = row["tag"]
+        tags_by_entity.setdefault(row["entity_id"], []).append(
+            {
+                "tag": tag,
+                "category": row["category"],
+                "is_ephemeral": row["is_ephemeral"],
+                "source_kind": row["source_kind"],
+                "template_id": row["template_id"],
+                "applied_at": _iso(row["applied_at"]),
+                "applied_at_world_time": _iso(row["applied_at_world_time"]),
+                "provenance": _tag_provenance(row["applied_at_world_time"]),
+                "families": [
+                    name
+                    for name, members in _TAG_FAMILY_TAG_SETS.items()
+                    if tag in members
+                ],
+            }
+        )
+        # Production hydration feeds only durable tags into the need-immunity
+        # check (hydrate_world_state's `tags` excludes ephemerals); match it.
+        if not row["is_ephemeral"]:
+            tag_sets.setdefault(row["entity_id"], set()).add(tag)
+
+    pair_tags_by_entity: dict[int, list[dict[str, Any]]] = {}
+    referenced_ids: set[int] = set(ids)
+    for row in session.execute(
+        text(
+            """
+            /* orrery_audit:entity_pair_tags */
+            SELECT ept.subject_entity_id,
+                   ept.object_entity_id,
+                   pt.tag,
+                   ept.source_kind::text AS source_kind,
+                   ept.template_id,
+                   ept.applied_at,
+                   ept.applied_at_world_time
+            FROM entity_pair_tags ept
+            JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+            WHERE ept.cleared_at IS NULL
+              AND NOT pt.deprecated
+              AND (ept.subject_entity_id = ANY(:ids)
+                   OR ept.object_entity_id = ANY(:ids))
+            ORDER BY ept.subject_entity_id, ept.object_entity_id, pt.tag
+            """
+        ),
+        {"ids": ids},
+    ).mappings():
+        subject_id = row["subject_entity_id"]
+        object_id = row["object_entity_id"]
+        referenced_ids.update((subject_id, object_id))
+        base = {
+            "tag": row["tag"],
+            "source_kind": row["source_kind"],
+            "template_id": row["template_id"],
+            "applied_at": _iso(row["applied_at"]),
+            "applied_at_world_time": _iso(row["applied_at_world_time"]),
+            "provenance": _tag_provenance(row["applied_at_world_time"]),
+        }
+        if subject_id in kinds:
+            pair_tags_by_entity.setdefault(subject_id, []).append(
+                {**base, "direction": "outbound", "other_entity_id": object_id}
+            )
+        if object_id in kinds:
+            pair_tags_by_entity.setdefault(object_id, []).append(
+                {**base, "direction": "inbound", "other_entity_id": subject_id}
+            )
+
+    relationships_by_entity: dict[int, list[dict[str, Any]]] = {}
+    for row in session.execute(
+        text(
+            """
+            /* orrery_audit:entity_relationships */
+            SELECT source_entity_id,
+                   target_entity_id,
+                   relationship_type,
+                   valence_magnitude
+            FROM entity_relationships_v
+            WHERE relationship_scope = 'character'
+              AND source_entity_id IS NOT NULL
+              AND target_entity_id IS NOT NULL
+              AND relationship_type IS NOT NULL
+              AND (source_entity_id = ANY(:ids)
+                   OR target_entity_id = ANY(:ids))
+            """
+        ),
+        {"ids": ids},
+    ).mappings():
+        source_id = row["source_entity_id"]
+        target_id = row["target_entity_id"]
+        referenced_ids.update((source_id, target_id))
+        base = {
+            "relationship_type": row["relationship_type"],
+            "valence_magnitude": row["valence_magnitude"],
+            # No versioned relationship storage exists; the UI renders this
+            # as the "unversioned" watermark.
+            "versioned": False,
+        }
+        if source_id in kinds:
+            relationships_by_entity.setdefault(source_id, []).append(
+                {**base, "direction": "outbound", "other_entity_id": target_id}
+            )
+        if target_id in kinds:
+            relationships_by_entity.setdefault(target_id, []).append(
+                {**base, "direction": "inbound", "other_entity_id": source_id}
+            )
+
+    place_rows = {
+        row["entity_id"]: row
+        for row in session.execute(
+            text(
+                """
+                /* orrery_audit:character_places */
+                SELECT c.entity_id,
+                       c.current_location,
+                       c.current_activity,
+                       p.type::text AS place_type,
+                       p.entity_id AS place_entity_id
+                FROM characters c
+                LEFT JOIN places p ON p.id = c.current_location
+                WHERE c.entity_id = ANY(:ids)
+                """
+            ),
+            {"ids": ids},
+        ).mappings()
+    }
+    place_ids = sorted(
+        {
+            row["current_location"]
+            for row in place_rows.values()
+            if row["current_location"] is not None
+        }
+    )
+    place_classes: dict[int, set[str]] = {}
+    if place_ids:
+        for row in session.execute(
+            text(
+                f"""
+                /* orrery_audit:place_classes */
+                SELECT p.id AS place_id, etc.tag
+                FROM places p
+                JOIN entity_tags_current etc ON etc.entity_id = p.entity_id
+                WHERE p.id = ANY(:place_ids)
+                  AND etc.entity_kind = 'place'
+                  AND etc.category IN ({_LOCATION_CLASS_CATEGORY_SQL})
+                """
+            ),
+            {"place_ids": place_ids},
+        ).mappings():
+            place_classes.setdefault(row["place_id"], set()).add(row["tag"])
+    for row in place_rows.values():
+        if row["place_entity_id"] is not None:
+            referenced_ids.add(row["place_entity_id"])
+
+    need_scores = _load_need_debt_scores(
+        session,
+        current_world_time=world_time,
+        need_tuning=need_tuning,
+        tags_by_entity={
+            entity_id: frozenset(values) for entity_id, values in tag_sets.items()
+        },
+    )
+    needs_by_entity: dict[int, list[dict[str, Any]]] = {}
+    for (entity_id, need_type), score in sorted(need_scores.items()):
+        if entity_id not in kinds:
+            continue
+        severity = severity_for_debt(need_type, score, tuning=need_tuning)
+        needs_by_entity.setdefault(entity_id, []).append(
+            {
+                "need_type": need_type,
+                "debt_score": score,
+                "severity_level": severity[0] if severity else None,
+                "severity_name": severity[1] if severity else None,
+            }
+        )
+
+    travel_states = _load_travel_states(session)
+    routine_anchors = _load_routine_anchors(session)
+
+    events_by_entity: dict[int, list[dict[str, Any]]] = {}
+    # Anchor-bound like production _load_recent_events: a historical anchor
+    # must not surface events from its own future next to the anchor's clock.
+    anchor_bound = (
+        "AND tick_chunk_id <= :anchor_chunk_id" if anchor_chunk_id is not None else ""
+    )
+    for entity_id in ids:
+        event_params: dict[str, Any] = {
+            "entity_id": entity_id,
+            "limit": recent_events_limit,
+        }
+        if anchor_chunk_id is not None:
+            event_params["anchor_chunk_id"] = anchor_chunk_id
+        rows = session.execute(
+            text(
+                f"""
+                /* orrery_audit:entity_recent_events */
+                SELECT event_type,
+                       tick_chunk_id,
+                       actor_entity_id,
+                       target_entity_id,
+                       location_id
+                FROM world_events
+                WHERE (actor_entity_id = :entity_id
+                       OR target_entity_id = :entity_id)
+                  AND (world_layer IS NULL OR world_layer = 'primary')
+                  AND superseded_by_event_id IS NULL
+                  {anchor_bound}
+                ORDER BY tick_chunk_id DESC, id DESC
+                LIMIT :limit
+                """
+            ),
+            event_params,
+        ).mappings()
+        events = []
+        for row in rows:
+            events.append(dict(row))
+            for key in ("actor_entity_id", "target_entity_id"):
+                if row[key] is not None:
+                    referenced_ids.add(row[key])
+        events_by_entity[entity_id] = events
+
+    entity_names = _load_entity_names(session, referenced_ids)
+
+    def _named(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        for row in rows:
+            if "other_entity_id" in row:
+                row["other_name"] = _entity_label(row["other_entity_id"], entity_names)
+        return rows
+
+    for events in events_by_entity.values():
+        for event in events:
+            for key, name_key in (
+                ("actor_entity_id", "actor_name"),
+                ("target_entity_id", "target_name"),
+            ):
+                event[name_key] = (
+                    _entity_label(event[key], entity_names)
+                    if event[key] is not None
+                    else None
+                )
+
+    entities: list[dict[str, Any]] = []
+    for entity_id in ids:
+        place_row = place_rows.get(entity_id)
+        place: Optional[dict[str, Any]] = None
+        activity: Optional[str] = None
+        if place_row is not None:
+            activity = place_row["current_activity"]
+            if place_row["current_location"] is not None:
+                place = {
+                    "place_id": place_row["current_location"],
+                    "name": (
+                        entity_names.get(place_row["place_entity_id"])
+                        if place_row["place_entity_id"] is not None
+                        else None
+                    ),
+                    "place_type": place_row["place_type"],
+                    "classes": sorted(
+                        place_classes.get(place_row["current_location"], set())
+                    ),
+                }
+        tag_rows = tags_by_entity.get(entity_id, [])
+        travel = travel_states.get(entity_id)
+        anchors = [
+            asdict(anchor)
+            for (anchor_entity_id, _), anchor in sorted(
+                routine_anchors.items(), key=lambda item: item[0]
+            )
+            if anchor_entity_id == entity_id
+        ]
+        entities.append(
+            {
+                "entity_id": entity_id,
+                "name": _entity_label(entity_id, entity_names),
+                "kind": kinds.get(entity_id),
+                "place": place,
+                "activity": activity,
+                "needs": needs_by_entity.get(entity_id, []),
+                "tags": {
+                    "durable": [t for t in tag_rows if not t["is_ephemeral"]],
+                    "ephemeral": [t for t in tag_rows if t["is_ephemeral"]],
+                },
+                "pair_tags": _named(pair_tags_by_entity.get(entity_id, [])),
+                "relationships": _named(relationships_by_entity.get(entity_id, [])),
+                "travel_state": asdict(travel) if travel is not None else None,
+                "routine_anchors": anchors,
+                "recent_events": events_by_entity.get(entity_id, []),
+            }
+        )
+
+    return {
+        "anchor_chunk_id": anchor_chunk_id,
+        "world_time": _iso(world_time),
+        "entities": entities,
+    }

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -799,6 +799,11 @@ def entity_context(
 
     travel_states = _load_travel_states(session)
     routine_anchors = _load_routine_anchors(session)
+    anchors_by_entity: dict[int, list[dict[str, Any]]] = {}
+    for (anchor_entity_id, _), anchor in sorted(
+        routine_anchors.items(), key=lambda item: item[0]
+    ):
+        anchors_by_entity.setdefault(anchor_entity_id, []).append(asdict(anchor))
 
     events_by_entity: dict[int, list[dict[str, Any]]] = {}
     # Anchor-bound like production _load_recent_events: a historical anchor
@@ -884,13 +889,7 @@ def entity_context(
                 }
         tag_rows = tags_by_entity.get(entity_id, [])
         travel = travel_states.get(entity_id)
-        anchors = [
-            asdict(anchor)
-            for (anchor_entity_id, _), anchor in sorted(
-                routine_anchors.items(), key=lambda item: item[0]
-            )
-            if anchor_entity_id == entity_id
-        ]
+        anchors = anchors_by_entity.get(entity_id, [])
         entities.append(
             {
                 "entity_id": entity_id,

--- a/nexus/agents/orrery/explain.py
+++ b/nexus/agents/orrery/explain.py
@@ -115,9 +115,15 @@ class TemplateExplanation:
     magnitude: float
     event_type: Optional[str]
     narrative_stub: Optional[str]
+    binding_hash: str
     state_delta: Mapping[str, Any] = field(default_factory=dict)
+    changed_fields: Tuple[str, ...] = ()
+    scene_pressure_stub: Optional[str] = None
 
     def to_dict(self) -> dict[str, Any]:
+        # Payload hygiene: a non-fired template's magnitude/event_type are
+        # Resolution defaults (0.0 / None), not observations — null them so a
+        # consumer can't render them as meaningful.
         return {
             "template_id": self.template_id,
             "priority": self.priority,
@@ -130,10 +136,13 @@ class TemplateExplanation:
             "fired": self.fired,
             "chosen_branch": self.chosen_branch,
             "branches": [branch.to_dict() for branch in self.branches],
-            "magnitude": self.magnitude,
-            "event_type": self.event_type,
+            "magnitude": self.magnitude if self.fired else None,
+            "event_type": self.event_type if self.fired else None,
             "narrative_stub": self.narrative_stub,
+            "binding_hash": self.binding_hash,
             "state_delta": dict(self.state_delta),
+            "changed_fields": list(self.changed_fields),
+            "scene_pressure_stub": self.scene_pressure_stub,
         }
 
 
@@ -273,7 +282,10 @@ def explain_template(
         magnitude=truth.magnitude,
         event_type=truth.event_type,
         narrative_stub=truth.narrative_stub,
+        binding_hash=truth.binding_hash,
         state_delta=dict(truth.state_delta),
+        changed_fields=truth.changed_fields,
+        scene_pressure_stub=truth.scene_pressure_stub,
     )
 
 

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -94,6 +94,30 @@ app.include_router(reader_router)
 app.include_router(asset_router)
 
 
+def _include_orrery_dev_router(target_app: FastAPI, settings: Any = None) -> None:
+    """Register the audit-dashboard router iff [orrery.dashboard] enabled.
+
+    Server-side gate: the client bundle's import.meta.env.DEV check cannot
+    protect the API once the gateway is exposed beyond localhost (issue
+    #415). Evaluated once at import — flag changes need a gateway restart.
+    ``settings`` is injectable so both arms of the gate are testable.
+    """
+
+    if settings is None:
+        from nexus.config import load_settings as _load_typed_settings
+
+        settings = _load_typed_settings()
+
+    orrery_settings = settings.orrery
+    if orrery_settings is not None and orrery_settings.dashboard.enabled:
+        from nexus.api.orrery_dev_endpoints import router as orrery_dev_router
+
+        target_app.include_router(orrery_dev_router)
+
+
+_include_orrery_dev_router(app)
+
+
 # WebSocket connection manager
 class ConnectionManager:
     def __init__(self):

--- a/nexus/api/orrery_dev_endpoints.py
+++ b/nexus/api/orrery_dev_endpoints.py
@@ -1,0 +1,170 @@
+"""Dev-only FastAPI endpoints backing the Orrery audit dashboard.
+
+Registered on the gateway only when ``[orrery.dashboard] enabled`` is true in
+nexus.toml (see the conditional ``include_router`` in
+:mod:`nexus.api.narrative`). All endpoints are read-only against slot
+databases; payload assembly lives in :mod:`nexus.agents.orrery.audit` so it
+can be exercised directly in tests.
+
+Unexpected failures are allowed to propagate (500 with the real traceback in
+the server log) — this is a development surface and errors should be loud.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import Any, Iterator, List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+from nexus.agents.orrery.audit import build_catalog, entity_context, explain_dry_run
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+from nexus.api.slot_utils import get_slot_db_url
+
+logger = logging.getLogger("nexus.api.orrery_dev_endpoints")
+
+router = APIRouter(prefix="/api/dev/orrery", tags=["orrery-dev"])
+
+
+class OrreryResolveRequest(BaseModel):
+    """Parameters for one explained dry-run tick."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    slot: Optional[int] = Field(
+        default=None,
+        description="Save slot (1-5); falls back to NEXUS_SLOT when omitted.",
+    )
+    anchor_chunk_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "Tick anchor chunk. Defaults to the slot's latest narrative chunk, "
+            "matching the turn cycle's fallback."
+        ),
+    )
+    window_chunks: Optional[int] = Field(
+        default=None,
+        description="Binding window; defaults to [orrery.binding] window_chunks.",
+    )
+
+
+class OrreryEntityContextRequest(BaseModel):
+    """Parameters for the entity hover/context payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    slot: Optional[int] = Field(default=None)
+    entity_ids: List[int] = Field(min_length=1)
+    anchor_chunk_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "Tick anchor for need-debt accrual and world-time readout. "
+            "Defaults to the slot's latest narrative chunk."
+        ),
+    )
+    recent_events_limit: int = Field(default=5, ge=1, le=50)
+
+
+def _orrery_settings() -> dict[str, Any]:
+    from nexus.config import load_settings_as_dict
+
+    settings = load_settings_as_dict()
+    orrery = settings.get("orrery")
+    if not orrery:
+        raise RuntimeError(
+            "nexus.toml has no [orrery] section; the audit dashboard cannot "
+            "resolve without binding/sunhelm configuration"
+        )
+    return orrery
+
+
+@contextmanager
+def _slot_session(slot: Optional[int]) -> Iterator[Session]:
+    try:
+        db_url = get_slot_db_url(slot=slot)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    engine = create_engine(db_url)
+    try:
+        with Session(engine) as session:
+            yield session
+    finally:
+        engine.dispose()
+
+
+def _default_anchor_chunk_id(session: Session) -> Optional[int]:
+    # Same fallback the turn cycle uses when no target chunk is in play.
+    row = (
+        session.execute(text("SELECT max(id) AS max_id FROM narrative_chunks"))
+        .mappings()
+        .first()
+    )
+    return row["max_id"] if row else None
+
+
+@router.get("/catalog")
+async def get_catalog() -> dict[str, Any]:
+    """Static template catalog: bands, pseudo-templates, families, event map."""
+
+    orrery = _orrery_settings()
+    return build_catalog(
+        BUILTIN_TEMPLATES,
+        sunhelm_settings=orrery.get("sunhelm"),
+        promote_settings=orrery.get("promote"),
+    )
+
+
+@router.post("/resolve")
+async def post_resolve(request: OrreryResolveRequest) -> dict[str, Any]:
+    """Explained dry-run tick against a real slot. Read-only."""
+
+    orrery = _orrery_settings()
+    window_chunks = (
+        request.window_chunks
+        if request.window_chunks is not None
+        else int(orrery["binding"]["window_chunks"])
+    )
+    with _slot_session(request.slot) as session:
+        anchor_chunk_id = (
+            request.anchor_chunk_id
+            if request.anchor_chunk_id is not None
+            else _default_anchor_chunk_id(session)
+        )
+        report = explain_dry_run(
+            session,
+            BUILTIN_TEMPLATES,
+            anchor_chunk_id=anchor_chunk_id,
+            window_chunks=window_chunks,
+            sunhelm_settings=orrery.get("sunhelm"),
+        )
+    payload = report.to_dict()
+    payload["mode"] = "current"
+    return payload
+
+
+@router.post("/context/entities")
+async def post_entity_context(
+    request: OrreryEntityContextRequest,
+) -> dict[str, Any]:
+    """Hover-audit payload for a set of entity ids. Read-only."""
+
+    orrery = _orrery_settings()
+    with _slot_session(request.slot) as session:
+        anchor_chunk_id = (
+            request.anchor_chunk_id
+            if request.anchor_chunk_id is not None
+            else _default_anchor_chunk_id(session)
+        )
+        return entity_context(
+            session,
+            request.entity_ids,
+            anchor_chunk_id=anchor_chunk_id,
+            recent_events_limit=request.recent_events_limit,
+            sunhelm_settings=orrery.get("sunhelm"),
+        )

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -987,6 +987,23 @@ class OrreryRetrogradeSettings(BaseModel):
     )
 
 
+class OrreryDashboardSettings(BaseModel):
+    """Audit-dashboard settings for the Orrery dev surface."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Register the /api/dev/orrery/* audit router on the gateway. "
+            "Server-side gate: import.meta.env.DEV only hides the client "
+            "bundle, so this flag is what keeps the dev surface off any "
+            "externally exposed gateway (issue #415). Default off; enable "
+            "explicitly for local development."
+        ),
+    )
+
+
 class OrrerySettings(BaseModel):
     """Orrery off-screen behavior settings.
 
@@ -1006,6 +1023,7 @@ class OrrerySettings(BaseModel):
     promote: OrreryPromoteSettings = Field(default_factory=OrreryPromoteSettings)
     sunhelm: OrrerySunhelmSettings = Field(default_factory=OrrerySunhelmSettings)
     retrograde: OrreryRetrogradeSettings
+    dashboard: OrreryDashboardSettings = Field(default_factory=OrreryDashboardSettings)
 
 
 # =============================================================================

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -1,0 +1,367 @@
+"""Live tests for the /api/dev/orrery/* audit endpoints.
+
+These exercise the real router over HTTP through a TestClient against real
+slot databases — no mocks (see CLAUDE.md testing philosophy). The central
+contract is parity: for the same anchor, the explained payload must name
+exactly the winners the production ``resolve_dry_run`` selects, stack by
+stack, including branch, magnitude, event type, binding hash, and the
+rendered narrative stub.
+
+save_02 is the dense retrograde-backfilled audit target; save_05 is the
+small live-runtime slot exhibiting the NULL-world-time bestowal pathology —
+running parity on both catches data-shape assumptions the other slot would
+hide, and a joint non-vacuity test guards against both slots drifting into
+a state where a parity block silently runs zero iterations. All endpoints
+are read-only, so no cleanup is needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator, Optional
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+from nexus.agents.orrery.needs import NEED_SEVERITY_PREFIX
+from nexus.agents.orrery.resolver import OrreryTickProposal, resolve_dry_run
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+from nexus.api.orrery_dev_endpoints import router as orrery_dev_router
+from nexus.api.slot_utils import get_slot_db_url
+from nexus.config import load_settings, load_settings_as_dict
+
+AUDIT_SLOTS = (2, 5)
+
+TWO_PARTY_TEMPLATE_IDS = {t.id for t in BUILTIN_TEMPLATES if len(t.required_slots) == 2}
+ACTOR_ONLY_TEMPLATE_IDS = {
+    t.id for t in BUILTIN_TEMPLATES if len(t.required_slots) == 1
+}
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(orrery_dev_router)
+    return TestClient(app)
+
+
+def _production_proposal(slot: int) -> tuple[Optional[int], OrreryTickProposal]:
+    """Run the production resolver directly — the parity oracle."""
+
+    orrery = load_settings_as_dict()["orrery"]
+    engine = create_engine(get_slot_db_url(slot=slot))
+    try:
+        with Session(engine) as session:
+            anchor_chunk_id = session.execute(
+                text("SELECT max(id) FROM narrative_chunks")
+            ).scalar()
+            proposal = resolve_dry_run(
+                session,
+                BUILTIN_TEMPLATES,
+                anchor_chunk_id=anchor_chunk_id,
+                window_chunks=int(orrery["binding"]["window_chunks"]),
+                sunhelm_settings=orrery.get("sunhelm"),
+            )
+    finally:
+        engine.dispose()
+    return anchor_chunk_id, proposal
+
+
+@pytest.fixture(scope="module")
+def production_proposals() -> dict[int, tuple[Optional[int], OrreryTickProposal]]:
+    return {slot: _production_proposal(slot) for slot in AUDIT_SLOTS}
+
+
+def _all_stacks(payload: dict) -> Iterator[tuple[dict, dict]]:
+    for group in payload["actors"]:
+        yield group, group["actor_stack"]
+        for stack in group["two_party_stacks"]:
+            yield group, stack
+        for stack in group["scene_pressure_stacks"]:
+            yield group, stack
+
+
+def _winner(stack: dict) -> dict:
+    return next(t for t in stack["templates"] if t["is_winner"])
+
+
+@pytest.mark.requires_postgres
+def test_slots_jointly_exercise_both_parity_contracts(
+    production_proposals: dict[int, tuple[Optional[int], OrreryTickProposal]],
+) -> None:
+    """Guard against the parity test going vacuous as slot data drifts.
+
+    Each parity block below iterates over whatever the production resolver
+    yields; if every audited slot stopped producing resolutions (or scene
+    pressures), that block would silently pass with zero iterations. This
+    test fails loudly instead, telling us to repoint AUDIT_SLOTS.
+    """
+
+    total_resolutions = sum(
+        len(proposal.resolutions) for _, proposal in production_proposals.values()
+    )
+    total_pressures = sum(
+        len(proposal.scene_pressures) for _, proposal in production_proposals.values()
+    )
+    assert total_resolutions > 0, (
+        "no audited slot produces resolutions — winner parity is vacuous; "
+        "repoint AUDIT_SLOTS at a slot with Orrery activity"
+    )
+    assert total_pressures > 0, (
+        "no audited slot produces scene pressures — pressure parity is "
+        "vacuous; repoint AUDIT_SLOTS at a slot with on-screen targets"
+    )
+
+
+@pytest.mark.requires_postgres
+@pytest.mark.parametrize("slot", AUDIT_SLOTS)
+def test_resolve_parity_with_production_resolver(
+    client: TestClient,
+    production_proposals: dict[int, tuple[Optional[int], OrreryTickProposal]],
+    slot: int,
+) -> None:
+    anchor_chunk_id, proposal = production_proposals[slot]
+
+    response = client.post(
+        "/api/dev/orrery/resolve",
+        json={"slot": slot, "anchor_chunk_id": anchor_chunk_id},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["anchor_chunk_id"] == anchor_chunk_id
+    assert payload["mode"] == "current"
+    assert payload["actor_count"] == proposal.actor_count
+    assert len(payload["actors"]) == proposal.actor_count
+
+    # --- Resolution parity: actor-only + off-screen two-party stacks -------
+    endpoint_winners: dict[tuple[str, str], dict] = {}
+    for group in payload["actors"]:
+        for stack in [group["actor_stack"], *group["two_party_stacks"]]:
+            if stack["winner_id"] is None:
+                continue
+            winner = _winner(stack)
+            key = (winner["template_id"], winner["binding_hash"])
+            assert key not in endpoint_winners, "duplicate winner stack"
+            endpoint_winners[key] = winner
+
+    production = {
+        (draft.template_id, draft.binding_hash): draft for draft in proposal.resolutions
+    }
+    assert set(endpoint_winners) == set(production)
+    for key, draft in production.items():
+        winner = endpoint_winners[key]
+        assert winner["chosen_branch"] == draft.branch_label
+        assert winner["magnitude"] == pytest.approx(draft.magnitude)
+        assert winner["event_type"] == draft.event_type
+        assert winner["changed_fields"] == list(draft.changed_fields)
+        assert winner["state_delta"] == dict(draft.state_delta)
+        # Production renders the stub through the entity-name table; the
+        # audit payload must reproduce it verbatim.
+        assert winner["narrative_stub_rendered"] == draft.narrative_stub
+
+    # --- Scene-pressure parity: template pressures + need pseudo-drafts ----
+    production_pressures = {
+        (draft.template_id, draft.binding_hash): draft
+        for draft in proposal.scene_pressures
+    }
+    endpoint_pressures: dict[tuple[str, str], dict] = {}
+    for group in payload["actors"]:
+        for stack in group["scene_pressure_stacks"]:
+            if stack["winner_id"] is None:
+                continue
+            winner = _winner(stack)
+            endpoint_pressures[(winner["template_id"], winner["binding_hash"])] = {
+                "magnitude": winner["magnitude"],
+                "prompt_text": winner["scene_pressure_prompt_rendered"],
+            }
+    for pressure in payload["need_pressures"]:
+        endpoint_pressures[(pressure["template_id"], pressure["binding_hash"])] = {
+            "magnitude": pressure["magnitude"],
+            "prompt_text": pressure["prompt_text"],
+        }
+
+    assert set(endpoint_pressures) == set(production_pressures)
+    for key, draft in production_pressures.items():
+        assert endpoint_pressures[key]["magnitude"] == pytest.approx(draft.magnitude)
+        assert endpoint_pressures[key]["prompt_text"] == draft.prompt_text
+
+
+@pytest.mark.requires_postgres
+def test_resolve_four_template_states_are_distinguishable(
+    client: TestClient,
+) -> None:
+    """Winner / shadowed / gate-failed / not-applicable must never blur."""
+
+    response = client.post("/api/dev/orrery/resolve", json={"slot": 2})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["actors"], "save_02 is expected to bind off-screen actors"
+
+    for group in payload["actors"]:
+        # Stack composition respects arity — the stack-split trap guard.
+        actor_stack_ids = {t["template_id"] for t in group["actor_stack"]["templates"]}
+        assert actor_stack_ids == ACTOR_ONLY_TEMPLATE_IDS
+        assert "target" not in group["actor_stack"]["bindings"]
+        for stack in group["two_party_stacks"] + group["scene_pressure_stacks"]:
+            stack_ids = {t["template_id"] for t in stack["templates"]}
+            assert stack_ids <= TWO_PARTY_TEMPLATE_IDS
+            assert stack["bindings"].get("target") is not None
+
+        # Not-applicable is exactly "no two-party binding composed", and is
+        # never conflated with an evaluated-and-refused gate.
+        if group["two_party_stacks"]:
+            assert group["not_applicable"] == []
+        else:
+            marked = {item["template_id"] for item in group["not_applicable"]}
+            assert marked == TWO_PARTY_TEMPLATE_IDS
+            assert all(
+                item["reason"] == "no_target_bound" for item in group["not_applicable"]
+            )
+
+    for _, stack in _all_stacks(payload):
+        shadowed = set(stack["shadowed_ids"])
+        for template in stack["templates"]:
+            # Payload hygiene: defaults on non-fired templates are nulled.
+            if not template["fired"]:
+                assert template["magnitude"] is None
+                assert template["event_type"] is None
+                assert template["chosen_branch"] is None
+            if not template["gate_passed"]:
+                assert template["fired"] is False
+            if template["is_winner"]:
+                assert template["template_id"] == stack["winner_id"]
+                assert template["fired"] is True
+            if template["template_id"] in shadowed:
+                assert template["fired"] is True
+                assert not template["is_winner"]
+
+
+@pytest.mark.requires_postgres
+def test_entity_context_hover_payload(client: TestClient) -> None:
+    resolve = client.post("/api/dev/orrery/resolve", json={"slot": 2})
+    assert resolve.status_code == 200
+    groups = resolve.json()["actors"]
+    assert groups
+    entity_ids = [groups[0]["actor_entity_id"], groups[1]["actor_entity_id"]]
+
+    response = client.post(
+        "/api/dev/orrery/context/entities",
+        json={"slot": 2, "entity_ids": entity_ids, "recent_events_limit": 3},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert [e["entity_id"] for e in payload["entities"]] == sorted(entity_ids)
+    for entity in payload["entities"]:
+        assert entity["name"]
+        assert entity["kind"] == "character"
+        for bucket in ("durable", "ephemeral"):
+            for tag_row in entity["tags"][bucket]:
+                assert tag_row["provenance"] in {"approximate", "unknowable"}
+                assert (tag_row["provenance"] == "approximate") == (
+                    tag_row["applied_at_world_time"] is not None
+                )
+                assert isinstance(tag_row["families"], list)
+        for relationship in entity["relationships"]:
+            assert relationship["versioned"] is False
+            assert relationship["direction"] in {"outbound", "inbound"}
+            assert relationship["other_name"]
+        for need in entity["needs"]:
+            assert need["need_type"] in set(NEED_SEVERITY_PREFIX)
+        assert len(entity["recent_events"]) <= 3
+        if entity["place"] is not None:
+            assert isinstance(entity["place"]["classes"], list)
+
+
+@pytest.mark.requires_postgres
+def test_entity_context_recent_events_respect_anchor(client: TestClient) -> None:
+    """A historical anchor must not surface events from its own future."""
+
+    resolve = client.post("/api/dev/orrery/resolve", json={"slot": 2})
+    assert resolve.status_code == 200
+    resolved = resolve.json()
+    head_anchor = resolved["anchor_chunk_id"]
+    entity_ids = [group["actor_entity_id"] for group in resolved["actors"][:3]]
+
+    at_head = client.post(
+        "/api/dev/orrery/context/entities",
+        json={"slot": 2, "entity_ids": entity_ids, "anchor_chunk_id": head_anchor},
+    )
+    assert at_head.status_code == 200
+    for entity in at_head.json()["entities"]:
+        for event in entity["recent_events"]:
+            assert event["tick_chunk_id"] <= head_anchor
+
+    # Anchor 0 predates every event; the honest answer is "none yet".
+    at_genesis = client.post(
+        "/api/dev/orrery/context/entities",
+        json={"slot": 2, "entity_ids": entity_ids, "anchor_chunk_id": 0},
+    )
+    assert at_genesis.status_code == 200
+    for entity in at_genesis.json()["entities"]:
+        assert entity["recent_events"] == []
+
+
+def test_catalog_endpoint_over_http(client: TestClient) -> None:
+    """Route wiring for GET /catalog; payload content is covered offline."""
+
+    response = client.get("/api/dev/orrery/catalog")
+    assert response.status_code == 200
+    payload = response.json()
+    assert {band["band"] for band in payload["drive_bands"]} == {
+        "crisis_constraint",
+        "embodied_maintenance",
+        "anchored_routine",
+        "affiliation",
+        "project_identity",
+    }
+    assert len(payload["pseudo_templates"]) == len(NEED_SEVERITY_PREFIX)
+    assert payload["promotion"] is not None
+
+
+def test_resolve_rejects_invalid_slot(client: TestClient) -> None:
+    # Slot validation fails inside get_slot_db_url before any engine or
+    # database connection exists, so no postgres marker is needed.
+    response = client.post("/api/dev/orrery/resolve", json={"slot": 9})
+    assert response.status_code == 400
+
+
+def test_dashboard_flag_gates_router_registration(tmp_path: Path) -> None:
+    """Both arms of the server-side gate, exercised on real parsed config."""
+
+    import tomlkit
+
+    import nexus.api.narrative as narrative
+
+    document = tomlkit.parse(Path("nexus.toml").read_text())
+
+    document["orrery"]["dashboard"]["enabled"] = False  # type: ignore[index]
+    off_path = tmp_path / "nexus_dashboard_off.toml"
+    off_path.write_text(tomlkit.dumps(document))
+    app_off = FastAPI()
+    narrative._include_orrery_dev_router(app_off, load_settings(str(off_path)))
+    assert not [
+        route
+        for route in app_off.routes
+        if str(getattr(route, "path", "")).startswith("/api/dev/orrery")
+    ]
+
+    document["orrery"]["dashboard"]["enabled"] = True  # type: ignore[index]
+    on_path = tmp_path / "nexus_dashboard_on.toml"
+    on_path.write_text(tomlkit.dumps(document))
+    app_on = FastAPI()
+    narrative._include_orrery_dev_router(app_on, load_settings(str(on_path)))
+    registered = {
+        str(getattr(route, "path", ""))
+        for route in app_on.routes
+        if str(getattr(route, "path", "")).startswith("/api/dev/orrery")
+    }
+    assert registered == {
+        "/api/dev/orrery/catalog",
+        "/api/dev/orrery/resolve",
+        "/api/dev/orrery/context/entities",
+    }

--- a/tests/test_orrery/test_audit.py
+++ b/tests/test_orrery/test_audit.py
@@ -1,0 +1,158 @@
+"""Offline tests for the Orrery audit payload builders.
+
+The slot-backed explained resolver is exercised against real databases in
+tests/test_api/test_orrery_dev_endpoints.py; everything here is pure
+introspection over the builtin templates and the checked-in nexus.toml —
+no mocks, no database.
+"""
+
+from __future__ import annotations
+
+import json
+
+from nexus.agents.orrery.audit import (
+    NOT_APPLICABLE_REASON,
+    build_catalog,
+)
+from nexus.agents.orrery.substrate import (
+    CONSTRAINED_TAGS,
+    DRAMATIC_CONTACT_TAGS,
+    DRIVE_BAND_ORDER,
+    ESTABLISHED_PARTNER_RELATIONSHIP_TYPES,
+    HIDDEN_TAGS,
+    INTIMACY_SUPPRESSOR_TAGS,
+    PUBLIC_MOBILITY_TAGS,
+    PUBLIC_PLACE_CLASSES,
+)
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+from nexus.config import load_settings_as_dict
+
+
+def _catalog() -> dict:
+    orrery = load_settings_as_dict()["orrery"]
+    return build_catalog(
+        BUILTIN_TEMPLATES,
+        sunhelm_settings=orrery.get("sunhelm"),
+        promote_settings=orrery.get("promote"),
+    )
+
+
+def test_catalog_covers_every_template_exactly_once() -> None:
+    catalog = _catalog()
+
+    bands = catalog["drive_bands"]
+    assert [band["band"] for band in bands] == [
+        band.value
+        for band, _ in sorted(DRIVE_BAND_ORDER.items(), key=lambda item: item[1])
+    ]
+    template_ids = [
+        template["template_id"] for band in bands for template in band["templates"]
+    ]
+    assert sorted(template_ids) == sorted(t.id for t in BUILTIN_TEMPLATES)
+    assert len(template_ids) == len(set(template_ids)) == len(BUILTIN_TEMPLATES)
+
+
+def test_catalog_pseudo_templates_carry_configured_priorities() -> None:
+    catalog = _catalog()
+    sunhelm = load_settings_as_dict()["orrery"]["sunhelm"]
+
+    pseudo = {item["template_id"]: item for item in catalog["pseudo_templates"]}
+    assert set(pseudo) == {f"{need}_need_pressure" for need in sunhelm["priorities"]}
+    for need, priority in sunhelm["priorities"].items():
+        assert pseudo[f"{need}_need_pressure"]["priority"] == priority
+        assert pseudo[f"{need}_need_pressure"]["kind"] == "need_pressure"
+
+
+def test_catalog_surfaces_priority_ties_in_tuple_order() -> None:
+    """Tuple order is the invisible tie-breaker; the catalog must expose it."""
+
+    catalog = _catalog()
+    ties = {
+        (tie["arity"], tie["priority"]): tie["template_ids"]
+        for tie in catalog["priority_ties"]
+    }
+
+    assert ties[("two_party", 50)] == ["cultivate_informant", "keep_vigil"]
+    assert ties[("actor_only", 25)] == ["mourn_loss", "sleep"]
+
+
+def test_catalog_flags_exogenous_only_event_types() -> None:
+    """The four gate-consumed, never-emitted event types are dead gate arms."""
+
+    catalog = _catalog()
+    exogenous = {
+        event_type
+        for event_type, entry in catalog["event_map"].items()
+        if entry["exogenous_only"]
+    }
+
+    assert {
+        "threat_issued",
+        "compliance_alert",
+        "faction_realignment",
+        "encoded_message",
+    } <= exogenous
+    for event_type in exogenous:
+        assert not catalog["event_map"][event_type]["emitted_by"]
+
+
+def test_catalog_event_map_includes_genuinely_emitted_types() -> None:
+    catalog = _catalog()
+
+    emitted = {
+        event_type
+        for event_type, entry in catalog["event_map"].items()
+        if entry["emitted_by"]
+    }
+    assert emitted, "builtin templates emit at least some event types"
+    for event_type in emitted:
+        assert not catalog["event_map"][event_type]["exogenous_only"]
+
+
+def test_catalog_tag_families_match_substrate() -> None:
+    """Family payloads must track the substrate frozensets, not a local copy."""
+
+    catalog = _catalog()
+
+    expected = {
+        "intimacy_suppressor_tags": ("tags", INTIMACY_SUPPRESSOR_TAGS),
+        "hidden_tags": ("tags", HIDDEN_TAGS),
+        "dramatic_contact_tags": ("tags", DRAMATIC_CONTACT_TAGS),
+        "constrained_tags": ("tags", CONSTRAINED_TAGS),
+        "public_mobility_tags": ("tags", PUBLIC_MOBILITY_TAGS),
+        "public_place_classes": ("place_classes", PUBLIC_PLACE_CLASSES),
+        "established_partner_relationship_types": (
+            "relationship_types",
+            ESTABLISHED_PARTNER_RELATIONSHIP_TYPES,
+        ),
+    }
+    assert set(catalog["tag_families"]) == set(expected)
+    for name, (kind, members) in expected.items():
+        payload = catalog["tag_families"][name]
+        assert payload["kind"] == kind
+        assert payload["members"] == sorted(members)
+    # DRAMATIC_CONTACT_TAGS is composed from HIDDEN_TAGS; keep that visible.
+    assert set(catalog["tag_families"]["dramatic_contact_tags"]["members"]) > set(
+        catalog["tag_families"]["hidden_tags"]["members"]
+    )
+
+
+def test_catalog_promotion_thresholds_come_from_config() -> None:
+    catalog = _catalog()
+    promote = load_settings_as_dict()["orrery"]["promote"]
+
+    assert catalog["promotion"] == {
+        "priority_threshold": promote["priority_threshold"],
+        "magnitude_threshold": promote["magnitude_threshold"],
+    }
+
+
+def test_catalog_is_json_serializable() -> None:
+    payload = json.loads(json.dumps(_catalog()))
+    assert payload["drive_bands"]
+
+
+def test_not_applicable_reason_is_stable() -> None:
+    """The UI keys ghost-row styling off this marker; treat it as contract."""
+
+    assert NOT_APPLICABLE_REASON == "no_target_bound"

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -9,6 +9,7 @@ from nexus.config import load_settings
 from nexus.api.new_story_schemas import Genre
 from nexus.config.settings_models import (
     OrreryBleedSettings,
+    OrreryDashboardSettings,
     OrreryPromoteSettings,
     OrreryRetrogradeMaturationSettings,
     OrreryRetrogradeWeirdGenreBands,
@@ -48,6 +49,7 @@ def test_orrery_settings_resolve_model_reference() -> None:
         "intimacy": 16,
     }
     assert settings.orrery.sunhelm.pressure.min_severity_level == 2
+    assert settings.orrery.dashboard.enabled is True
     weird = settings.orrery.retrograde.weird
     assert weird.default_level == "medium"
     assert weird.dev.cli_flag == "--weird"
@@ -56,6 +58,12 @@ def test_orrery_settings_resolve_model_reference() -> None:
     assert set(weird.bands_by_genre) == {genre.value for genre in Genre}
     assert weird.bands_by_genre["cyberpunk"].medium.min == 0.36
     assert weird.bands_by_genre["historical"].medium.min == 0.12
+
+
+def test_orrery_dashboard_defaults_to_disabled() -> None:
+    """Fresh checkouts must not expose the dev audit router implicitly."""
+
+    assert OrreryDashboardSettings().enabled is False
 
 
 def test_orrery_bleed_accepts_deprecated_selection_keys() -> None:

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -49,7 +49,7 @@ def test_orrery_settings_resolve_model_reference() -> None:
         "intimacy": 16,
     }
     assert settings.orrery.sunhelm.pressure.min_severity_level == 2
-    assert settings.orrery.dashboard.enabled is True
+    assert settings.orrery.dashboard.enabled is False
     weird = settings.orrery.retrograde.weird
     assert weird.default_level == "medium"
     assert weird.dev.cli_flag == "--weird"

--- a/tests/test_orrery/test_explain.py
+++ b/tests/test_orrery/test_explain.py
@@ -49,6 +49,9 @@ def test_explain_stack_matches_evaluate_stack(preset_name: str) -> None:
     assert winner.chosen_branch == truth.branch_label
     assert winner.magnitude == truth.magnitude
     assert winner.event_type == truth.event_type
+    assert winner.binding_hash == truth.binding_hash
+    assert winner.changed_fields == truth.changed_fields
+    assert winner.scene_pressure_stub == truth.scene_pressure_stub
 
 
 def test_every_template_is_explained_in_priority_order() -> None:
@@ -128,3 +131,25 @@ def test_explanation_is_json_serializable() -> None:
     assert payload["templates"]
     winner = next(t for t in payload["templates"] if t["is_winner"])
     assert winner["gate_trace"]["result"] is True
+    assert winner["binding_hash"]
+    assert isinstance(winner["changed_fields"], list)
+    assert "scene_pressure_stub" in winner
+
+
+def test_non_fired_templates_null_magnitude_and_event_in_payload() -> None:
+    """Resolution defaults on non-fired templates must not look like data."""
+
+    state, bindings = _resolve_preset("kin_danger")
+    explanation = explain_stack(BUILTIN_TEMPLATES, state, bindings)
+    payload = explanation.to_dict()
+
+    non_fired = [t for t in payload["templates"] if not t["fired"]]
+    assert non_fired, "preset expected to leave some templates un-fired"
+    for template in non_fired:
+        assert template["magnitude"] is None
+        assert template["event_type"] is None
+
+    fired = [t for t in payload["templates"] if t["fired"]]
+    assert fired
+    for template in fired:
+        assert template["magnitude"] is not None


### PR DESCRIPTION
## Summary

Backend step 1 of the audit-dashboard sequence in `docs/orrery_audit_dashboard_notes.md` (merged in #419): connect the existing explain layer to real slot hydration behind a dev-only, config-gated router. The Claude Design prototype (step 2) consumes these payloads.

## Changes

- **`nexus/agents/orrery/audit.py`** — the slot-backed explained resolver:
  - `explain_dry_run()` mirrors `resolve_dry_run`'s choreography exactly: actor-only stack per actor, two-party stack per composed (actor, target) pair with `actor_ids` threaded through, present-target pressure pass restricted to `STORYTELLER_PRESSURE` templates, and the `{need}_need_pressure` pseudo-drafts. Per-actor groups carry full gate/branch traces, entity names, rendered stubs, and explicit **not-applicable markers** (`no_target_bound`) so "no target composed" is never conflated with "gate refused".
  - `build_catalog()` — static introspection: drive-band grouping in urgency order, tuple-index tie surfacing (the invisible tie-breaker), tag families with kinds, and the event emit/consume map flagging **exogenous-only** event types (the four dead gate arms).
  - `entity_context()` — hover payload: tags with per-row provenance (`approximate`/`unknowable`; `exact` reserved for the post-migration `source_chunk_id` epoch), pair tags, relationships labeled unversioned, effective need debt (immunity-tag filtered, durable-only like production), travel state, routine anchors, anchor-bounded recent events.
- **`nexus/agents/orrery/explain.py`** — restores the three `Resolution` fields `to_dict()` dropped (`binding_hash`, `changed_fields`, `scene_pressure_stub`) and nulls `magnitude`/`event_type` on non-fired templates so Resolution defaults can't render as data.
- **`nexus/api/orrery_dev_endpoints.py`** — `GET /api/dev/orrery/catalog`, `POST /resolve`, `POST /context/entities`. Read-only; unexpected errors propagate loudly.
- **Server-side gate** — router registered iff `[orrery.dashboard] enabled` (new `OrrerySettings` subsection, **model default `false`**), closing the issue #415 tunnel hole; the checked-in nexus.toml ships `enabled = true` for local dev with a comment to flip before external exposure.

## Test Plan (no mocks)

- [x] **Parity**: live TestClient against save_02 and save_05 — endpoint winners must equal `resolve_dry_run` output per stack (template, branch, magnitude, event type, binding hash, changed fields, state delta, verbatim rendered stub), plus scene-pressure/need-pressure parity. A joint non-vacuity test fails loudly if both slots drift to zero resolutions/pressures.
- [x] Four-state invariants (winner / shadowed / gate-failed / not-applicable) + arity-respecting stack composition (the stack-split trap guard).
- [x] Anchor-bound regression: historical anchors never surface future events in the hover payload.
- [x] Both arms of the config gate on real parsed TOML copies.
- [x] Offline catalog suite (bands, ties, families vs substrate constants, exogenous-only events, config passthrough).
- [x] Full suite: 876 passed offline; live lane green. End-to-end verified via a real gateway process on a spare port (all three endpoints + 400 on invalid slot).
- [x] Multi-agent adversarial review (42 agents); all 7 confirmed findings fixed pre-commit.

Known pre-existing failure (untouched, reproduces on origin/main): `tests/test_orrery/test_pair_tag_writer.py::test_polymorphic_subject_kind_character_path` under `NEXUS_RUN_POSTGRES=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnUY3ui8W4shQjobjRosV2