### PR TITLE
Add what-if override/sandbox layer to the Orrery audit resolver

### DIFF
--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -17,6 +17,14 @@ composed (actor, target) bindings; an actor with no composed pair gets an
 explicit not-applicable marker instead (scoped to the off-screen two-party
 stack — the present-target pressure pass depends on scene composition, not on
 a per-actor binding decision).
+
+What-if mode: :func:`explain_dry_run` optionally takes a
+:class:`~nexus.agents.orrery.overrides.WorldStateOverrides` set. Hydration and
+binding composition run once (SQL); the tick is then explained twice — against
+the hydrated state and against a copy with the overrides applied — and every
+sandbox stack carries a compact diff against its baseline twin. Overrides edit
+world state only: the actor roster and pair composition come from SQL, so the
+payload's override echo carries the ``world_state_only`` scope marker.
 """
 
 from __future__ import annotations
@@ -24,11 +32,16 @@ from __future__ import annotations
 import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Iterable, List, Mapping, Optional, Tuple
+from typing import Any, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from sqlalchemy import text
 
 from nexus.agents.orrery.explain import StackExplanation, explain_stack
+from nexus.agents.orrery.overrides import (
+    OverrideValidationError,
+    WorldStateOverrides,
+    apply_overrides,
+)
 from nexus.agents.orrery.needs import (
     NEED_SEVERITY_PREFIX,
     coerce_need_tuning,
@@ -75,13 +88,21 @@ NOT_APPLICABLE_REASON = "no_target_bound"
 
 @dataclass(frozen=True, slots=True)
 class ActorGroupExplanation:
-    """All explained stacks for one off-screen actor in one tick."""
+    """All explained stacks for one off-screen actor in one tick.
+
+    In what-if mode the ``*_diff`` fields align positionally with their stack
+    fields (same binding composition on both sides of the diff); in current
+    mode they stay ``None``/empty.
+    """
 
     actor_entity_id: int
     actor_stack: StackExplanation
     two_party_stacks: Tuple[StackExplanation, ...] = ()
     scene_pressure_stacks: Tuple[StackExplanation, ...] = ()
     not_applicable: Tuple[Mapping[str, Any], ...] = ()
+    actor_stack_diff: Optional[Mapping[str, Any]] = None
+    two_party_stack_diffs: Tuple[Optional[Mapping[str, Any]], ...] = ()
+    scene_pressure_stack_diffs: Tuple[Optional[Mapping[str, Any]], ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -100,6 +121,9 @@ class ExplainedTickReport:
     locations: Mapping[int, Any]
     location_names: Mapping[int, str]
     activities: Mapping[int, str]
+    mode: str = "current"
+    overrides: Optional[Mapping[str, Any]] = None
+    need_pressures_diff: Optional[Mapping[str, Any]] = None
     generated_at: str = field(
         default_factory=lambda: datetime.now(timezone.utc).isoformat()
     )
@@ -114,9 +138,16 @@ class ExplainedTickReport:
             "time_of_day": self.time_of_day,
             "weather": self.weather,
             "actor_count": self.actor_count,
+            "mode": self.mode,
+            "overrides": dict(self.overrides) if self.overrides is not None else None,
             "generated_at": self.generated_at,
             "actors": [self._group_payload(group) for group in self.actors],
             "need_pressures": [draft.to_dict() for draft in self.need_pressures],
+            "need_pressures_diff": (
+                dict(self.need_pressures_diff)
+                if self.need_pressures_diff is not None
+                else None
+            ),
             "entity_names": {
                 str(entity_id): name for entity_id, name in self.entity_names.items()
             },
@@ -131,23 +162,37 @@ class ExplainedTickReport:
                 "place_id": place_id,
                 "name": self.location_names.get(place_id),
             }
+        two_party_diffs: Tuple[Optional[Mapping[str, Any]], ...] = (
+            group.two_party_stack_diffs or (None,) * len(group.two_party_stacks)
+        )
+        pressure_diffs: Tuple[Optional[Mapping[str, Any]], ...] = (
+            group.scene_pressure_stack_diffs
+            or (None,) * len(group.scene_pressure_stacks)
+        )
         return {
             "actor_entity_id": actor_id,
             "actor_name": _entity_label(actor_id, self.entity_names),
             "location": location,
             "activity": self.activities.get(actor_id),
-            "actor_stack": self._stack_payload(group.actor_stack),
+            "actor_stack": self._stack_payload(
+                group.actor_stack, group.actor_stack_diff
+            ),
             "two_party_stacks": [
-                self._stack_payload(stack) for stack in group.two_party_stacks
+                self._stack_payload(stack, diff)
+                for stack, diff in zip(group.two_party_stacks, two_party_diffs)
             ],
             "scene_pressure_stacks": [
-                self._stack_payload(stack) for stack in group.scene_pressure_stacks
+                self._stack_payload(stack, diff)
+                for stack, diff in zip(group.scene_pressure_stacks, pressure_diffs)
             ],
             "not_applicable": [dict(item) for item in group.not_applicable],
         }
 
-    def _stack_payload(self, stack: StackExplanation) -> dict[str, Any]:
+    def _stack_payload(
+        self, stack: StackExplanation, diff: Optional[Mapping[str, Any]] = None
+    ) -> dict[str, Any]:
         payload = stack.to_dict()
+        payload["diff"] = dict(diff) if diff is not None else None
         payload["binding_names"] = {
             slot: _entity_label(value, self.entity_names)
             for slot, value in stack.bindings.items()
@@ -178,6 +223,240 @@ class ExplainedTickReport:
         return payload
 
 
+@dataclass(frozen=True, slots=True)
+class _TickStacks:
+    """One state's explained stacks — the unit the what-if diff compares."""
+
+    actor_stacks: Mapping[int, StackExplanation]
+    two_party_stacks: Mapping[int, List[StackExplanation]]
+    pressure_stacks: Mapping[int, List[StackExplanation]]
+    need_pressure_specs: Sequence[Mapping[str, Any]]
+
+
+def _stack_diff(
+    baseline: StackExplanation, sandbox: StackExplanation
+) -> dict[str, Any]:
+    """Compact outcome diff between the same stack under two states.
+
+    ``changed`` tracks the *card-level* outcome (winner or its branch);
+    ``changed_template_ids`` tracks every template whose fired flag or chosen
+    branch moved, so shadowed/ghost rows can carry diff markers too.
+    """
+
+    if dict(baseline.bindings) != dict(sandbox.bindings):
+        raise AssertionError(
+            "what-if diff misalignment: baseline and sandbox stacks carry "
+            f"different bindings ({dict(baseline.bindings)} vs "
+            f"{dict(sandbox.bindings)})"
+        )
+    baseline_by_id = {item.template_id: item for item in baseline.templates}
+    changed_template_ids = [
+        item.template_id
+        for item in sandbox.templates
+        if baseline_by_id[item.template_id].fired != item.fired
+        or baseline_by_id[item.template_id].chosen_branch != item.chosen_branch
+    ]
+    baseline_winner = (
+        baseline_by_id[baseline.winner_id] if baseline.winner_id is not None else None
+    )
+    sandbox_winner = next(
+        (item for item in sandbox.templates if item.template_id == sandbox.winner_id),
+        None,
+    )
+    changed = baseline.winner_id != sandbox.winner_id or (
+        baseline_winner is not None
+        and sandbox_winner is not None
+        and baseline_winner.chosen_branch != sandbox_winner.chosen_branch
+    )
+    return {
+        "changed": changed,
+        "baseline_winner_id": baseline.winner_id,
+        "baseline_chosen_branch": (
+            baseline_winner.chosen_branch if baseline_winner is not None else None
+        ),
+        "baseline_magnitude": (
+            baseline_winner.magnitude
+            if baseline_winner is not None and baseline_winner.fired
+            else None
+        ),
+        "changed_template_ids": changed_template_ids,
+    }
+
+
+def _need_pressure_diff(
+    baseline: Tuple[OrreryScenePressureDraft, ...],
+    sandbox: Tuple[OrreryScenePressureDraft, ...],
+) -> dict[str, Any]:
+    """Added/removed/changed need pressures keyed by (template, binding)."""
+
+    def _key(draft: OrreryScenePressureDraft) -> Tuple[str, str]:
+        return (draft.template_id, draft.binding_hash)
+
+    baseline_by_key = {_key(draft): draft for draft in baseline}
+    sandbox_by_key = {_key(draft): draft for draft in sandbox}
+    added = sorted(sandbox_by_key.keys() - baseline_by_key.keys())
+    removed = sorted(baseline_by_key.keys() - sandbox_by_key.keys())
+    changed = [
+        {
+            "current": sandbox_by_key[key].to_dict(),
+            "baseline": baseline_by_key[key].to_dict(),
+        }
+        for key in sorted(sandbox_by_key.keys() & baseline_by_key.keys())
+        if sandbox_by_key[key].to_dict() != baseline_by_key[key].to_dict()
+    ]
+    return {
+        "added": [sandbox_by_key[key].to_dict() for key in added],
+        "removed": [baseline_by_key[key].to_dict() for key in removed],
+        "changed": changed,
+    }
+
+
+def _override_entity_ids(overrides: WorldStateOverrides) -> set[int]:
+    """Every entity id an override set references, for validation and naming."""
+
+    entity_ids: set[int] = set()
+    for tag_override in overrides.tags:
+        entity_ids.add(tag_override.entity_id)
+    for pair_override in overrides.pair_tags:
+        entity_ids.add(pair_override.subject_entity_id)
+        entity_ids.add(pair_override.object_entity_id)
+    for need_override in overrides.needs:
+        entity_ids.add(need_override.entity_id)
+    for location_override in overrides.locations:
+        entity_ids.add(location_override.entity_id)
+    for event_override in overrides.events:
+        for value in (
+            event_override.actor_entity_id,
+            event_override.target_entity_id,
+        ):
+            if value is not None:
+                entity_ids.add(value)
+    return entity_ids
+
+
+def _validate_overrides(session: Any, overrides: WorldStateOverrides) -> None:
+    """Validate an override set against the slot's live vocabularies.
+
+    State-independent checks only — the state-dependent toggle checks (add an
+    already-present tag, remove an absent one) live in ``apply_overrides``.
+    Raises ``ValueError`` with a message naming every offending value.
+    """
+
+    entity_ids = _override_entity_ids(overrides)
+    if entity_ids:
+        known_entities = set(
+            session.execute(
+                text(
+                    """
+                    /* orrery_audit:override_entities */
+                    SELECT id FROM entities WHERE id = ANY(:ids)
+                    """
+                ),
+                {"ids": sorted(entity_ids)},
+            ).scalars()
+        )
+        missing_entities = entity_ids - known_entities
+        if missing_entities:
+            raise OverrideValidationError(
+                "Override references unknown entity ids: " f"{sorted(missing_entities)}"
+            )
+
+    if overrides.tags:
+        requested = {item.tag for item in overrides.tags}
+        vocab = {
+            row["tag"]: row["is_ephemeral"]
+            for row in session.execute(
+                text(
+                    """
+                    /* orrery_audit:override_tag_vocab */
+                    SELECT tag, is_ephemeral FROM tags
+                    WHERE tag = ANY(:tags) AND NOT deprecated
+                    """
+                ),
+                {"tags": sorted(requested)},
+            ).mappings()
+        }
+        unknown_tags = requested - vocab.keys()
+        if unknown_tags:
+            raise OverrideValidationError(
+                f"Override references unknown or deprecated tags: "
+                f"{sorted(unknown_tags)}"
+            )
+        for item in overrides.tags:
+            if vocab[item.tag] != item.ephemeral:
+                actual = "ephemeral" if vocab[item.tag] else "durable"
+                requested_layer = "ephemeral" if item.ephemeral else "durable"
+                raise OverrideValidationError(
+                    f"Tag {item.tag!r} is {actual} in the vocabulary but the "
+                    f"override targets the {requested_layer} layer — predicates "
+                    "read the two layers separately, so the override would "
+                    "fabricate unreachable state"
+                )
+
+    if overrides.pair_tags:
+        requested = {item.tag for item in overrides.pair_tags}
+        known_pair_tags = set(
+            session.execute(
+                text(
+                    """
+                    /* orrery_audit:override_pair_tag_vocab */
+                    SELECT tag FROM pair_tags
+                    WHERE tag = ANY(:tags) AND NOT deprecated
+                    """
+                ),
+                {"tags": sorted(requested)},
+            ).scalars()
+        )
+        unknown_pair_tags = requested - known_pair_tags
+        if unknown_pair_tags:
+            raise OverrideValidationError(
+                f"Override references unknown or deprecated pair tags: "
+                f"{sorted(unknown_pair_tags)}"
+            )
+
+    if overrides.events:
+        requested = {item.event_type for item in overrides.events}
+        known_events = set(
+            session.execute(
+                text(
+                    """
+                    /* orrery_audit:override_event_vocab */
+                    SELECT type FROM event_types
+                    WHERE type = ANY(:types) AND NOT deprecated
+                    """
+                ),
+                {"types": sorted(requested)},
+            ).scalars()
+        )
+        unknown_events = requested - known_events
+        if unknown_events:
+            raise OverrideValidationError(
+                f"Override references unknown or deprecated event types: "
+                f"{sorted(unknown_events)}"
+            )
+
+    place_ids = {item.place_id for item in overrides.locations} | {
+        item.location_id for item in overrides.events if item.location_id is not None
+    }
+    if place_ids:
+        known_places = set(
+            session.execute(
+                text(
+                    """
+                    /* orrery_audit:override_places */
+                    SELECT id FROM places WHERE id = ANY(:ids)
+                    """
+                ),
+                {"ids": sorted(place_ids)},
+            ).scalars()
+        )
+        missing_places = place_ids - known_places
+        if missing_places:
+            raise OverrideValidationError(
+                f"Override references unknown place ids: {sorted(missing_places)}"
+            )
+
+
 def explain_dry_run(
     session: Any,
     templates: Iterable[Template],
@@ -186,12 +465,19 @@ def explain_dry_run(
     window_chunks: int,
     sunhelm_settings: Optional[Any] = None,
     world_time_override: Optional[datetime] = None,
+    overrides: Optional[WorldStateOverrides] = None,
 ) -> ExplainedTickReport:
     """Hydrate, bind, and explain Orrery packages without database writes.
 
     Every step below has a line-for-line counterpart in ``resolve_dry_run``;
     keep them in lockstep. Winner/branch parity with production is enforced
     per template by ``explain_template``'s cross-check against ``evaluate``.
+
+    With a non-empty ``overrides`` set the report switches to what-if mode:
+    hydration and binding composition still run once, the overrides are
+    validated against the slot's vocabularies and applied to a copy of the
+    state, and both the baseline and sandbox states are explained so each
+    sandbox stack carries a diff against its baseline twin.
     """
 
     need_tuning = coerce_need_tuning(sunhelm_settings)
@@ -230,15 +516,15 @@ def explain_dry_run(
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
     )
-    actor_stacks: dict[int, StackExplanation] = {}
-    for bindings in actor_bindings:
-        actor_stacks[bindings[Slot.ACTOR]] = explain_stack(
-            actor_only_templates, state, bindings
-        )
-    actor_ids = set(actor_stacks)
+    actor_ids = {bindings[Slot.ACTOR] for bindings in actor_bindings}
 
-    two_party_stacks: dict[int, List[StackExplanation]] = {}
-    pressure_stacks: dict[int, List[StackExplanation]] = {}
+    pressure_templates = [
+        template
+        for template in actor_target_templates
+        if template.present_target_policy is PresentTargetPolicy.STORYTELLER_PRESSURE
+    ]
+    offscreen_pair_bindings: Sequence[dict[Slot, Any]] = ()
+    present_pair_bindings: Sequence[dict[Slot, Any]] = ()
     if actor_target_templates:
         offscreen_pair_bindings = compose_actor_target_bindings(
             session,
@@ -247,17 +533,6 @@ def explain_dry_run(
             actor_ids=actor_ids,
             target_presence="offscreen",
         )
-        for bindings in offscreen_pair_bindings:
-            two_party_stacks.setdefault(bindings[Slot.ACTOR], []).append(
-                explain_stack(actor_target_templates, state, bindings)
-            )
-
-        pressure_templates = [
-            template
-            for template in actor_target_templates
-            if template.present_target_policy
-            is PresentTargetPolicy.STORYTELLER_PRESSURE
-        ]
         if pressure_templates:
             present_pair_bindings = compose_actor_target_bindings(
                 session,
@@ -266,51 +541,96 @@ def explain_dry_run(
                 actor_ids=actor_ids,
                 target_presence="present",
             )
-            for bindings in present_pair_bindings:
-                pressure_stacks.setdefault(bindings[Slot.ACTOR], []).append(
-                    explain_stack(pressure_templates, state, bindings)
-                )
 
     present_actor_ids = _present_actor_ids_at_anchor(
         session, anchor_chunk_id=anchor_chunk_id
     )
-    need_pressure_specs = _present_need_pressure_specs(
-        state,
-        present_actor_ids=present_actor_ids,
-        need_tuning=need_tuning,
-    )
 
-    entity_ids: set[int] = {spec["actor_entity_id"] for spec in need_pressure_specs}
-    all_stacks: list[StackExplanation] = list(actor_stacks.values())
-    for stacks in two_party_stacks.values():
+    def _explain_tick(tick_state: Any) -> _TickStacks:
+        """Explain every composed binding set against one state snapshot."""
+
+        actor_stacks: dict[int, StackExplanation] = {}
+        for bindings in actor_bindings:
+            actor_stacks[bindings[Slot.ACTOR]] = explain_stack(
+                actor_only_templates, tick_state, bindings
+            )
+        two_party_stacks: dict[int, List[StackExplanation]] = {}
+        for pair_bindings in offscreen_pair_bindings:
+            two_party_stacks.setdefault(pair_bindings[Slot.ACTOR], []).append(
+                explain_stack(actor_target_templates, tick_state, pair_bindings)
+            )
+        pressure_stacks: dict[int, List[StackExplanation]] = {}
+        for pair_bindings in present_pair_bindings:
+            pressure_stacks.setdefault(pair_bindings[Slot.ACTOR], []).append(
+                explain_stack(pressure_templates, tick_state, pair_bindings)
+            )
+        need_pressure_specs = _present_need_pressure_specs(
+            tick_state,
+            present_actor_ids=present_actor_ids,
+            need_tuning=need_tuning,
+        )
+        return _TickStacks(
+            actor_stacks=actor_stacks,
+            two_party_stacks=two_party_stacks,
+            pressure_stacks=pressure_stacks,
+            need_pressure_specs=need_pressure_specs,
+        )
+
+    baseline = _explain_tick(state)
+    what_if = overrides is not None and not overrides.is_empty
+    if what_if:
+        assert overrides is not None  # narrowed by what_if
+        _validate_overrides(session, overrides)
+        active_state = apply_overrides(state, overrides)
+        active = _explain_tick(active_state)
+    else:
+        active_state = state
+        active = baseline
+
+    entity_ids: set[int] = {
+        spec["actor_entity_id"]
+        for tick in (baseline, active)
+        for spec in tick.need_pressure_specs
+    }
+    all_stacks: list[StackExplanation] = list(active.actor_stacks.values())
+    for stacks in active.two_party_stacks.values():
         all_stacks.extend(stacks)
-    for stacks in pressure_stacks.values():
+    for stacks in active.pressure_stacks.values():
         all_stacks.extend(stacks)
     for stack in all_stacks:
         for value in stack.bindings.values():
             if isinstance(value, int):
                 entity_ids.add(value)
+    if what_if:
+        assert overrides is not None
+        entity_ids |= _override_entity_ids(overrides)
     place_entity_ids = {
-        state.location_entity_ids[place_id]
+        active_state.location_entity_ids[place_id]
         for actor_id in actor_ids
-        if (place_id := state.locations.get(actor_id)) is not None
-        and place_id in state.location_entity_ids
+        if (place_id := active_state.locations.get(actor_id)) is not None
+        and place_id in active_state.location_entity_ids
     }
     entity_names = _load_entity_names(session, entity_ids | place_entity_ids)
     location_names = {
         place_id: entity_names[entity_id]
-        for place_id, entity_id in state.location_entity_ids.items()
+        for place_id, entity_id in active_state.location_entity_ids.items()
         if entity_id in entity_names
     }
 
-    need_pressures = tuple(
-        _scene_pressure_from_need_spec(
-            spec,
-            entity_names,
-            need_tuning=need_tuning,
+    def _pressures(tick: _TickStacks) -> Tuple[OrreryScenePressureDraft, ...]:
+        return tuple(
+            _scene_pressure_from_need_spec(
+                spec,
+                entity_names,
+                need_tuning=need_tuning,
+            )
+            for spec in tick.need_pressure_specs
         )
-        for spec in need_pressure_specs
-    )
+
+    need_pressures = _pressures(active)
+    need_pressures_diff: Optional[dict[str, Any]] = None
+    if what_if:
+        need_pressures_diff = _need_pressure_diff(_pressures(baseline), need_pressures)
 
     not_applicable_markers = tuple(
         {
@@ -321,32 +641,62 @@ def explain_dry_run(
         }
         for template in actor_target_templates
     )
-    groups = tuple(
-        ActorGroupExplanation(
+
+    def _group(actor_id: int) -> ActorGroupExplanation:
+        two_party = tuple(active.two_party_stacks.get(actor_id, ()))
+        pressures = tuple(active.pressure_stacks.get(actor_id, ()))
+        actor_stack_diff: Optional[Mapping[str, Any]] = None
+        two_party_diffs: Tuple[Optional[Mapping[str, Any]], ...] = ()
+        pressure_diffs: Tuple[Optional[Mapping[str, Any]], ...] = ()
+        if what_if:
+            actor_stack_diff = _stack_diff(
+                baseline.actor_stacks[actor_id], active.actor_stacks[actor_id]
+            )
+            two_party_diffs = tuple(
+                _stack_diff(base_stack, sandbox_stack)
+                for base_stack, sandbox_stack in zip(
+                    baseline.two_party_stacks.get(actor_id, ()),
+                    two_party,
+                    strict=True,
+                )
+            )
+            pressure_diffs = tuple(
+                _stack_diff(base_stack, sandbox_stack)
+                for base_stack, sandbox_stack in zip(
+                    baseline.pressure_stacks.get(actor_id, ()),
+                    pressures,
+                    strict=True,
+                )
+            )
+        return ActorGroupExplanation(
             actor_entity_id=actor_id,
-            actor_stack=actor_stacks[actor_id],
-            two_party_stacks=tuple(two_party_stacks.get(actor_id, ())),
-            scene_pressure_stacks=tuple(pressure_stacks.get(actor_id, ())),
-            not_applicable=(
-                not_applicable_markers if not two_party_stacks.get(actor_id) else ()
-            ),
+            actor_stack=active.actor_stacks[actor_id],
+            two_party_stacks=two_party,
+            scene_pressure_stacks=pressures,
+            not_applicable=(not_applicable_markers if not two_party else ()),
+            actor_stack_diff=actor_stack_diff,
+            two_party_stack_diffs=two_party_diffs,
+            scene_pressure_stack_diffs=pressure_diffs,
         )
-        for actor_id in sorted(actor_ids)
-    )
+
+    groups = tuple(_group(actor_id) for actor_id in sorted(actor_ids))
 
     return ExplainedTickReport(
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
-        world_time=state.world_time,
-        time_of_day=state.time_of_day,
-        weather=state.weather,
+        world_time=active_state.world_time,
+        time_of_day=active_state.time_of_day,
+        weather=active_state.weather,
         actor_count=len(actor_ids),
         actors=groups,
         need_pressures=need_pressures,
         entity_names=entity_names,
-        locations=dict(state.locations),
+        locations=dict(active_state.locations),
         location_names=location_names,
-        activities=dict(state.activities),
+        activities=dict(active_state.activities),
+        mode="what_if" if what_if else "current",
+        overrides=overrides.to_dict() if what_if and overrides is not None else None,
+        need_pressures_diff=need_pressures_diff,
     )
 
 

--- a/nexus/agents/orrery/overrides.py
+++ b/nexus/agents/orrery/overrides.py
@@ -1,0 +1,231 @@
+"""What-if overrides over a hydrated Orrery :class:`WorldState`.
+
+The audit dashboard's sandbox mode ("what-if") re-resolves a tick against a
+copy of the hydrated world state with developer edits applied — toggle a tag,
+set a need, move an actor, inject a recent event — without any database
+writes. :class:`WorldState` is a frozen dataclass, so the copy-with-edits is
+a :func:`dataclasses.replace` over rebuilt mappings.
+
+Scope: overrides edit **world state only**. Actor roster and binding
+composition are derived from SQL (`compose_actor_bindings` /
+`compose_actor_target_bindings`), not from ``WorldState``, so a moved actor
+changes how location predicates evaluate but does not recompose pairs or the
+roster. The payload echo carries this scope marker so the UI's honesty label
+can render it.
+
+Validation split: this module performs the *state-dependent* checks (a tag
+toggle must actually change state; need types must be real needs). Vocabulary
+and existence checks that require the database — tag/pair-tag/event-type
+vocabularies, entity and place ids — belong to the caller
+(:func:`nexus.agents.orrery.audit.explain_dry_run`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Optional, Tuple
+
+from nexus.agents.orrery.needs import NEED_SEVERITY_PREFIX
+from nexus.agents.orrery.substrate import EventRecord, WorldState
+
+OVERRIDE_SCOPE = "world_state_only"
+
+_TAG_OPS = ("add", "remove")
+
+
+class OverrideValidationError(ValueError):
+    """A what-if override is invalid: unknown vocabulary or a no-op toggle.
+
+    Distinct from plain ``ValueError`` so the API layer can map caller
+    mistakes to 400 without swallowing genuine server-side failures.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class TagOverride:
+    """Toggle a durable or ephemeral tag on one entity."""
+
+    entity_id: int
+    tag: str
+    op: str
+    ephemeral: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class PairTagOverride:
+    """Toggle a directed pair tag between two entities."""
+
+    subject_entity_id: int
+    object_entity_id: int
+    tag: str
+    op: str
+
+
+@dataclass(frozen=True, slots=True)
+class NeedOverride:
+    """Set one entity's debt score for one need type."""
+
+    entity_id: int
+    need_type: str
+    debt_score: float
+
+
+@dataclass(frozen=True, slots=True)
+class LocationOverride:
+    """Move one entity to a place."""
+
+    entity_id: int
+    place_id: int
+
+
+@dataclass(frozen=True, slots=True)
+class EventOverride:
+    """Inject a recent event, ``ticks_ago`` ticks before the current tick."""
+
+    event_type: str
+    actor_entity_id: Optional[int] = None
+    target_entity_id: Optional[int] = None
+    location_id: Optional[int] = None
+    ticks_ago: int = 0
+    changed_fields: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class WorldStateOverrides:
+    """The full override set for one what-if re-resolve."""
+
+    tags: Tuple[TagOverride, ...] = ()
+    pair_tags: Tuple[PairTagOverride, ...] = ()
+    needs: Tuple[NeedOverride, ...] = ()
+    locations: Tuple[LocationOverride, ...] = ()
+    events: Tuple[EventOverride, ...] = ()
+
+    @property
+    def is_empty(self) -> bool:
+        return not (
+            self.tags or self.pair_tags or self.needs or self.locations or self.events
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serializable echo of the applied overrides, with scope label."""
+
+        return {
+            "scope": OVERRIDE_SCOPE,
+            "tags": [asdict(item) for item in self.tags],
+            "pair_tags": [asdict(item) for item in self.pair_tags],
+            "needs": [asdict(item) for item in self.needs],
+            "locations": [asdict(item) for item in self.locations],
+            "events": [
+                {**asdict(item), "changed_fields": list(item.changed_fields)}
+                for item in self.events
+            ],
+        }
+
+
+def _toggle(members: set[str], tag: str, op: str, *, subject: str) -> None:
+    if op not in _TAG_OPS:
+        raise OverrideValidationError(
+            f"Unknown tag override op {op!r} for {subject}; expected one of {_TAG_OPS}"
+        )
+    if op == "add":
+        if tag in members:
+            raise OverrideValidationError(
+                f"Override asked to add tag {tag!r} to {subject}, "
+                "which already carries it — the override would be a no-op"
+            )
+        members.add(tag)
+    else:
+        if tag not in members:
+            raise OverrideValidationError(
+                f"Override asked to remove tag {tag!r} from {subject}, "
+                "which does not carry it — the override would be a no-op"
+            )
+        members.remove(tag)
+
+
+def apply_overrides(state: WorldState, overrides: WorldStateOverrides) -> WorldState:
+    """Return a copy of ``state`` with the override set applied.
+
+    Tag and pair-tag toggles are state-dependent and raise
+    :class:`OverrideValidationError` when they would be no-ops; need,
+    location, and event overrides are set/append operations. Never mutates
+    ``state``.
+    """
+
+    changes: dict[str, Any] = {}
+
+    if overrides.tags:
+        durable = {key: set(value) for key, value in state.tags.items()}
+        ephemeral = {key: set(value) for key, value in state.ephemeral_tags.items()}
+        for item in overrides.tags:
+            target = ephemeral if item.ephemeral else durable
+            layer = "ephemeral" if item.ephemeral else "durable"
+            _toggle(
+                target.setdefault(item.entity_id, set()),
+                item.tag,
+                item.op,
+                subject=f"entity {item.entity_id} ({layer})",
+            )
+        changes["tags"] = {key: frozenset(value) for key, value in durable.items()}
+        changes["ephemeral_tags"] = {
+            key: frozenset(value) for key, value in ephemeral.items()
+        }
+
+    if overrides.pair_tags:
+        pair_tags = {key: set(value) for key, value in state.pair_tags.items()}
+        for pair in overrides.pair_tags:
+            key = (pair.subject_entity_id, pair.object_entity_id)
+            _toggle(
+                pair_tags.setdefault(key, set()),
+                pair.tag,
+                pair.op,
+                subject=f"pair {key[0]}->{key[1]}",
+            )
+        changes["pair_tags"] = {
+            key: frozenset(value) for key, value in pair_tags.items()
+        }
+
+    if overrides.needs:
+        need_debt_scores = dict(state.need_debt_scores)
+        for need in overrides.needs:
+            if need.need_type not in NEED_SEVERITY_PREFIX:
+                raise OverrideValidationError(
+                    f"Unknown need type {need.need_type!r} in override; "
+                    f"expected one of {sorted(NEED_SEVERITY_PREFIX)}"
+                )
+            if need.debt_score < 0:
+                raise OverrideValidationError(
+                    f"Need debt override for entity {need.entity_id} must be "
+                    f">= 0, got {need.debt_score}"
+                )
+            need_debt_scores[(need.entity_id, need.need_type)] = need.debt_score
+        changes["need_debt_scores"] = need_debt_scores
+
+    if overrides.locations:
+        locations = dict(state.locations)
+        for move in overrides.locations:
+            locations[move.entity_id] = move.place_id
+        changes["locations"] = locations
+
+    if overrides.events:
+        injected = []
+        for event in overrides.events:
+            if event.ticks_ago < 0:
+                raise OverrideValidationError(
+                    f"Event override ticks_ago must be >= 0, got {event.ticks_ago}"
+                )
+            injected.append(
+                EventRecord(
+                    event_type=event.event_type,
+                    tick=state.current_tick - event.ticks_ago,
+                    actor_entity_id=event.actor_entity_id,
+                    target_entity_id=event.target_entity_id,
+                    location_id=event.location_id,
+                    changed_fields=event.changed_fields,
+                )
+            )
+        changes["recent_events"] = state.recent_events + tuple(injected)
+
+    if not changes:
+        return state
+    return replace(state, **changes)

--- a/nexus/api/orrery_dev_endpoints.py
+++ b/nexus/api/orrery_dev_endpoints.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
-from typing import Any, Iterator, List, Optional
+from typing import Any, Iterator, List, Literal, Optional
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict, Field
@@ -22,12 +22,138 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
 from nexus.agents.orrery.audit import build_catalog, entity_context, explain_dry_run
+from nexus.agents.orrery.overrides import (
+    EventOverride,
+    LocationOverride,
+    NeedOverride,
+    OverrideValidationError,
+    PairTagOverride,
+    TagOverride,
+    WorldStateOverrides,
+)
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 from nexus.api.slot_utils import get_slot_db_url
 
 logger = logging.getLogger("nexus.api.orrery_dev_endpoints")
 
 router = APIRouter(prefix="/api/dev/orrery", tags=["orrery-dev"])
+
+
+class OrreryTagOverrideModel(BaseModel):
+    """Toggle one durable or ephemeral tag on one entity."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    entity_id: int
+    tag: str
+    op: Literal["add", "remove"]
+    ephemeral: bool = Field(
+        default=False,
+        description=(
+            "Layer to edit; must match the tag vocabulary's is_ephemeral flag "
+            "(validated server-side)."
+        ),
+    )
+
+
+class OrreryPairTagOverrideModel(BaseModel):
+    """Toggle one directed pair tag between two entities."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    subject_entity_id: int
+    object_entity_id: int
+    tag: str
+    op: Literal["add", "remove"]
+
+
+class OrreryNeedOverrideModel(BaseModel):
+    """Set one entity's debt score for one need type."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    entity_id: int
+    need_type: str
+    debt_score: float = Field(ge=0)
+
+
+class OrreryLocationOverrideModel(BaseModel):
+    """Move one entity to a place."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    entity_id: int
+    place_id: int
+
+
+class OrreryEventOverrideModel(BaseModel):
+    """Inject a recent event ticks_ago ticks before the anchor tick."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    event_type: str
+    actor_entity_id: Optional[int] = None
+    target_entity_id: Optional[int] = None
+    location_id: Optional[int] = None
+    ticks_ago: int = Field(default=0, ge=0)
+    changed_fields: List[str] = Field(default_factory=list)
+
+
+class OrreryOverridesModel(BaseModel):
+    """What-if override set applied to a copy of the hydrated world state."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    tags: List[OrreryTagOverrideModel] = Field(default_factory=list)
+    pair_tags: List[OrreryPairTagOverrideModel] = Field(default_factory=list)
+    needs: List[OrreryNeedOverrideModel] = Field(default_factory=list)
+    locations: List[OrreryLocationOverrideModel] = Field(default_factory=list)
+    events: List[OrreryEventOverrideModel] = Field(default_factory=list)
+
+    def to_overrides(self) -> WorldStateOverrides:
+        return WorldStateOverrides(
+            tags=tuple(
+                TagOverride(
+                    entity_id=item.entity_id,
+                    tag=item.tag,
+                    op=item.op,
+                    ephemeral=item.ephemeral,
+                )
+                for item in self.tags
+            ),
+            pair_tags=tuple(
+                PairTagOverride(
+                    subject_entity_id=item.subject_entity_id,
+                    object_entity_id=item.object_entity_id,
+                    tag=item.tag,
+                    op=item.op,
+                )
+                for item in self.pair_tags
+            ),
+            needs=tuple(
+                NeedOverride(
+                    entity_id=item.entity_id,
+                    need_type=item.need_type,
+                    debt_score=item.debt_score,
+                )
+                for item in self.needs
+            ),
+            locations=tuple(
+                LocationOverride(entity_id=item.entity_id, place_id=item.place_id)
+                for item in self.locations
+            ),
+            events=tuple(
+                EventOverride(
+                    event_type=item.event_type,
+                    actor_entity_id=item.actor_entity_id,
+                    target_entity_id=item.target_entity_id,
+                    location_id=item.location_id,
+                    ticks_ago=item.ticks_ago,
+                    changed_fields=tuple(item.changed_fields),
+                )
+                for item in self.events
+            ),
+        )
 
 
 class OrreryResolveRequest(BaseModel):
@@ -49,6 +175,16 @@ class OrreryResolveRequest(BaseModel):
     window_chunks: Optional[int] = Field(
         default=None,
         description="Binding window; defaults to [orrery.binding] window_chunks.",
+    )
+    overrides: Optional[OrreryOverridesModel] = Field(
+        default=None,
+        description=(
+            "What-if override set. When present and non-empty the response "
+            "switches to what_if mode: the tick is explained against a copy "
+            "of the world state with these edits applied, and every stack "
+            "carries a diff against the un-overridden baseline. Overrides "
+            "never touch the database."
+        ),
     )
 
 
@@ -130,22 +266,29 @@ async def post_resolve(request: OrreryResolveRequest) -> dict[str, Any]:
         if request.window_chunks is not None
         else int(orrery["binding"]["window_chunks"])
     )
+    overrides = (
+        request.overrides.to_overrides() if request.overrides is not None else None
+    )
     with _slot_session(request.slot) as session:
         anchor_chunk_id = (
             request.anchor_chunk_id
             if request.anchor_chunk_id is not None
             else _default_anchor_chunk_id(session)
         )
-        report = explain_dry_run(
-            session,
-            BUILTIN_TEMPLATES,
-            anchor_chunk_id=anchor_chunk_id,
-            window_chunks=window_chunks,
-            sunhelm_settings=orrery.get("sunhelm"),
-        )
-    payload = report.to_dict()
-    payload["mode"] = "current"
-    return payload
+        try:
+            report = explain_dry_run(
+                session,
+                BUILTIN_TEMPLATES,
+                anchor_chunk_id=anchor_chunk_id,
+                window_chunks=window_chunks,
+                sunhelm_settings=orrery.get("sunhelm"),
+                overrides=overrides,
+            )
+        except OverrideValidationError as exc:
+            # Override validation (unknown vocab, no-op toggles) is caller
+            # error, not a server fault; anything else propagates as 500.
+            raise HTTPException(status_code=400, detail=str(exc))
+    return report.to_dict()
 
 
 @router.post("/context/entities")

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -27,7 +27,11 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
 from nexus.agents.orrery.needs import NEED_SEVERITY_PREFIX
-from nexus.agents.orrery.resolver import OrreryTickProposal, resolve_dry_run
+from nexus.agents.orrery.resolver import (
+    OrreryTickProposal,
+    _present_actor_ids_at_anchor,
+    resolve_dry_run,
+)
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 from nexus.api.orrery_dev_endpoints import router as orrery_dev_router
 from nexus.api.slot_utils import get_slot_db_url
@@ -304,6 +308,261 @@ def test_entity_context_recent_events_respect_anchor(client: TestClient) -> None
     assert at_genesis.status_code == 200
     for entity in at_genesis.json()["entities"]:
         assert entity["recent_events"] == []
+
+
+# ---------------------------------------------------------------------------
+# What-if (override/sandbox) mode
+# ---------------------------------------------------------------------------
+
+
+def _resolve(client: TestClient, slot: int, **extra) -> dict:
+    response = client.post("/api/dev/orrery/resolve", json={"slot": slot, **extra})
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def _not_hunted_winners(payload: dict) -> Iterator[tuple[int, dict]]:
+    """Actor-only winners whose gate passed through a top-level
+    NOT(has_inbound_pair_tag(hunting)) leg — the injection kill switch."""
+
+    for group in payload["actors"]:
+        stack = group["actor_stack"]
+        if stack["winner_id"] is None:
+            continue
+        winner = _winner(stack)
+        root = winner["gate_trace"]
+        if root.get("op") != "AND":
+            continue
+        for child in root["children"]:
+            if (
+                child.get("op") == "NOT"
+                and child["result"] is True
+                and child["children"][0]["raw"].startswith(
+                    "has_inbound_pair_tag(hunting"
+                )
+            ):
+                yield group["actor_entity_id"], winner
+                break
+
+
+@pytest.mark.requires_postgres
+def test_current_mode_carries_no_what_if_payload(client: TestClient) -> None:
+    payload = _resolve(client, 2)
+    assert payload["mode"] == "current"
+    assert payload["overrides"] is None
+    assert payload["need_pressures_diff"] is None
+    for _, stack in _all_stacks(payload):
+        assert stack["diff"] is None
+
+    # An explicitly empty override set is still current mode.
+    empty = _resolve(client, 2, overrides={})
+    assert empty["mode"] == "current"
+    assert empty["overrides"] is None
+
+
+@pytest.mark.requires_postgres
+def test_what_if_pair_tag_injection_kills_a_winner(client: TestClient) -> None:
+    """The guaranteed flip: a winner that required NOT(inbound hunting) at the
+    top of its AND gate cannot survive the tag's injection, so the diff must
+    record both the fired flip and the winner change."""
+
+    candidates: list[tuple[int, int, int, str]] = []
+    for slot in AUDIT_SLOTS:
+        payload = _resolve(client, slot)
+        actor_ids = [group["actor_entity_id"] for group in payload["actors"]]
+        for actor_id, winner in _not_hunted_winners(payload):
+            subjects = [other for other in actor_ids if other != actor_id]
+            if subjects:
+                candidates.append((slot, actor_id, subjects[0], winner["template_id"]))
+                break
+    assert candidates, (
+        "no audited slot yields an actor-only winner gated on "
+        "NOT(has_inbound_pair_tag(hunting)) — the what-if kill test is "
+        "vacuous; repoint AUDIT_SLOTS at a slot with routine/concealment "
+        "winners"
+    )
+
+    for slot, actor_id, subject_id, winner_id in candidates:
+        payload = _resolve(
+            client,
+            slot,
+            overrides={
+                "pair_tags": [
+                    {
+                        "subject_entity_id": subject_id,
+                        "object_entity_id": actor_id,
+                        "tag": "hunting",
+                        "op": "add",
+                    }
+                ]
+            },
+        )
+        assert payload["mode"] == "what_if"
+        assert payload["overrides"]["scope"] == "world_state_only"
+        group = next(g for g in payload["actors"] if g["actor_entity_id"] == actor_id)
+        stack = group["actor_stack"]
+        diff = stack["diff"]
+        assert diff is not None
+        assert diff["baseline_winner_id"] == winner_id
+        assert winner_id in diff["changed_template_ids"]
+        assert diff["changed"] is True
+        assert stack["winner_id"] != winner_id
+        killed = next(t for t in stack["templates"] if t["template_id"] == winner_id)
+        assert killed["fired"] is False
+
+
+@pytest.mark.requires_postgres
+def test_what_if_need_override_reaches_stacks_and_pressures(
+    client: TestClient,
+) -> None:
+    """Setting sleep debt sky-high must surface both in off-screen stacks
+    (the sleep template firing somewhere) and, for present actors, in the
+    need-pressure diff."""
+
+    flipped_stacks = 0
+    pressure_changes = 0
+    for slot in AUDIT_SLOTS:
+        baseline = _resolve(client, slot)
+        offscreen_ids = [group["actor_entity_id"] for group in baseline["actors"]]
+
+        engine = create_engine(get_slot_db_url(slot=slot))
+        try:
+            with Session(engine) as session:
+                present_ids = _present_actor_ids_at_anchor(
+                    session, anchor_chunk_id=baseline["anchor_chunk_id"]
+                )
+        finally:
+            engine.dispose()
+
+        overrides = {
+            "needs": [
+                {"entity_id": entity_id, "need_type": "sleep", "debt_score": 500.0}
+                for entity_id in sorted(set(offscreen_ids) | set(present_ids))
+            ]
+        }
+        if not overrides["needs"]:
+            continue
+        payload = _resolve(client, slot, overrides=overrides)
+        assert payload["mode"] == "what_if"
+        for group in payload["actors"]:
+            diff = group["actor_stack"]["diff"]
+            if "sleep" in diff["changed_template_ids"]:
+                flipped_stacks += 1
+        pressures_diff = payload["need_pressures_diff"]
+        assert pressures_diff is not None
+        pressure_changes += len(pressures_diff["added"]) + len(
+            pressures_diff["changed"]
+        )
+        for draft in pressures_diff["added"]:
+            assert draft["template_id"] == "sleep_need_pressure"
+
+    assert flipped_stacks > 0, (
+        "sleep debt 500 flipped no off-screen actor's sleep template on any "
+        "audited slot — the stack-side what-if assertion is vacuous; repoint "
+        "AUDIT_SLOTS"
+    )
+    assert pressure_changes > 0, (
+        "sleep debt 500 changed no present actor's need pressure on any "
+        "audited slot — the pressure-side what-if assertion is vacuous; "
+        "repoint AUDIT_SLOTS at a slot with on-screen characters"
+    )
+
+
+@pytest.mark.requires_postgres
+def test_what_if_validation_rejections(client: TestClient) -> None:
+    payload = _resolve(client, 2)
+    actor_id = payload["actors"][0]["actor_entity_id"]
+
+    def _post(overrides: dict) -> tuple[int, str]:
+        response = client.post(
+            "/api/dev/orrery/resolve", json={"slot": 2, "overrides": overrides}
+        )
+        return response.status_code, response.json().get("detail", "")
+
+    status, detail = _post(
+        {"tags": [{"entity_id": actor_id, "tag": "definitely_not_a_tag", "op": "add"}]}
+    )
+    assert status == 400 and "unknown or deprecated tags" in detail
+
+    status, detail = _post(
+        {
+            "pair_tags": [
+                {
+                    "subject_entity_id": actor_id,
+                    "object_entity_id": actor_id,
+                    "tag": "definitely_not_a_pair_tag",
+                    "op": "add",
+                }
+            ]
+        }
+    )
+    assert status == 400 and "unknown or deprecated pair tags" in detail
+
+    status, detail = _post({"events": [{"event_type": "definitely_not_an_event"}]})
+    assert status == 400 and "unknown or deprecated event types" in detail
+
+    status, detail = _post(
+        {"needs": [{"entity_id": 999_999_999, "need_type": "sleep", "debt_score": 1.0}]}
+    )
+    assert status == 400 and "unknown entity ids" in detail
+
+    status, detail = _post(
+        {"locations": [{"entity_id": actor_id, "place_id": 999_999_999}]}
+    )
+    assert status == 400 and "unknown place ids" in detail
+
+    # Layer mismatch and no-op toggles need a real tag the actor carries.
+    context = client.post(
+        "/api/dev/orrery/context/entities",
+        json={
+            "slot": 2,
+            "entity_ids": [g["actor_entity_id"] for g in payload["actors"]],
+        },
+    ).json()
+    carried = next(
+        (
+            (entity["entity_id"], row["tag"])
+            for entity in context["entities"]
+            for row in entity["tags"]["durable"]
+        ),
+        None,
+    )
+    assert carried is not None, (
+        "no audited actor on save_02 carries a durable tag — layer-mismatch "
+        "and no-op rejection checks are vacuous; repoint the test"
+    )
+    tagged_entity, durable_tag = carried
+
+    status, detail = _post(
+        {
+            "tags": [
+                {
+                    "entity_id": tagged_entity,
+                    "tag": durable_tag,
+                    "op": "add",
+                    "ephemeral": True,
+                }
+            ]
+        }
+    )
+    assert status == 400 and "layer" in detail
+
+    status, detail = _post(
+        {"tags": [{"entity_id": tagged_entity, "tag": durable_tag, "op": "add"}]}
+    )
+    assert status == 400 and "already carries it" in detail
+
+    # Shape errors (unknown op) are Pydantic's to reject, before any DB work.
+    response = client.post(
+        "/api/dev/orrery/resolve",
+        json={
+            "slot": 2,
+            "overrides": {
+                "tags": [{"entity_id": actor_id, "tag": "x", "op": "toggle"}]
+            },
+        },
+    )
+    assert response.status_code == 422
 
 
 def test_catalog_endpoint_over_http(client: TestClient) -> None:

--- a/tests/test_orrery/test_overrides.py
+++ b/tests/test_orrery/test_overrides.py
@@ -1,0 +1,284 @@
+"""Real-engine tests for the what-if override layer.
+
+These apply overrides to the deterministic demo presets and re-run the
+production ``evaluate_stack`` — no mocks, no database. Each flip below was
+chosen because the preset makes the outcome fully deterministic: the
+``hiding`` preset's winner (``hide``) gates on the absence of an inbound
+``hunting`` pair tag, on the ``off_grid`` hidden tag, and on three event
+cooldowns, so each override category can kill or redirect it through a
+different door. Slot-backed what-if behavior (validation against live
+vocabularies, diff payloads) is covered in
+tests/test_api/test_orrery_dev_endpoints.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.agents.orrery.demo import _resolve_preset
+from nexus.agents.orrery.explain import explain_stack
+from nexus.agents.orrery.overrides import (
+    EventOverride,
+    LocationOverride,
+    NeedOverride,
+    OverrideValidationError,
+    PairTagOverride,
+    TagOverride,
+    WorldStateOverrides,
+    apply_overrides,
+)
+from nexus.agents.orrery.substrate import evaluate_stack
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+
+ACTOR_ID = 1
+TARGET_ID = 2
+
+
+def _winner(state, bindings):
+    resolution = evaluate_stack(BUILTIN_TEMPLATES, state, bindings)
+    return resolution.template_id if resolution is not None else None
+
+
+def test_pair_tag_add_redirects_hide_to_evade() -> None:
+    """Injecting an inbound `hunting` pair tag turns concealment into flight."""
+
+    state, bindings = _resolve_preset("hiding")
+    assert _winner(state, bindings) == "hide"
+
+    hunted = apply_overrides(
+        state,
+        WorldStateOverrides(
+            pair_tags=(
+                PairTagOverride(
+                    subject_entity_id=TARGET_ID,
+                    object_entity_id=ACTOR_ID,
+                    tag="hunting",
+                    op="add",
+                ),
+            )
+        ),
+    )
+    assert _winner(hunted, bindings) == "evade_pursuers"
+    # The original state is untouched.
+    assert _winner(state, bindings) == "hide"
+    assert (TARGET_ID, ACTOR_ID) not in state.pair_tags
+
+
+def test_event_injection_respects_tick_arithmetic() -> None:
+    """ticks_ago maps onto the cooldown window exactly.
+
+    ``hide`` requires >= 6 ticks since the last ``hideout_maintained``; an
+    injection at ticks_ago=0 kills it, the same injection at ticks_ago=10
+    leaves it standing.
+    """
+
+    state, bindings = _resolve_preset("hiding")
+
+    fresh = apply_overrides(
+        state,
+        WorldStateOverrides(
+            events=(
+                EventOverride(
+                    event_type="hideout_maintained",
+                    actor_entity_id=ACTOR_ID,
+                    ticks_ago=0,
+                ),
+            )
+        ),
+    )
+    assert _winner(fresh, bindings) is None
+
+    stale = apply_overrides(
+        state,
+        WorldStateOverrides(
+            events=(
+                EventOverride(
+                    event_type="hideout_maintained",
+                    actor_entity_id=ACTOR_ID,
+                    ticks_ago=10,
+                ),
+            )
+        ),
+    )
+    assert _winner(stale, bindings) == "hide"
+    # Injected events append after the hydrated ones with the derived tick.
+    assert stale.recent_events[-1].tick == state.current_tick - 10
+
+
+def test_tag_removal_kills_hidden_state() -> None:
+    state, bindings = _resolve_preset("hiding")
+
+    exposed = apply_overrides(
+        state,
+        WorldStateOverrides(
+            tags=(TagOverride(entity_id=ACTOR_ID, tag="off_grid", op="remove"),)
+        ),
+    )
+    assert _winner(exposed, bindings) is None
+    assert "off_grid" in state.tags[ACTOR_ID]
+
+
+def test_need_override_fires_sleep_over_maintain_cover() -> None:
+    state, bindings = _resolve_preset("quiet")
+    assert _winner(state, bindings) == "maintain_cover"
+
+    tired = apply_overrides(
+        state,
+        WorldStateOverrides(
+            needs=(
+                NeedOverride(entity_id=ACTOR_ID, need_type="sleep", debt_score=20.0),
+            )
+        ),
+    )
+    assert _winner(tired, bindings) == "sleep"
+    assert (ACTOR_ID, "sleep") not in state.need_debt_scores
+
+
+def test_location_override_moves_actor() -> None:
+    state, _ = _resolve_preset("quiet")
+    moved = apply_overrides(
+        state,
+        WorldStateOverrides(
+            locations=(LocationOverride(entity_id=ACTOR_ID, place_id=104),)
+        ),
+    )
+    assert moved.locations[ACTOR_ID] == 104
+    assert state.locations[ACTOR_ID] != 104
+
+
+def test_explain_cross_check_holds_on_overridden_state() -> None:
+    """explain_stack's per-template evaluate() cross-check runs on the
+    sandbox state too — sandbox parity is enforced by construction."""
+
+    state, bindings = _resolve_preset("hiding")
+    hunted = apply_overrides(
+        state,
+        WorldStateOverrides(
+            pair_tags=(
+                PairTagOverride(
+                    subject_entity_id=TARGET_ID,
+                    object_entity_id=ACTOR_ID,
+                    tag="hunting",
+                    op="add",
+                ),
+            )
+        ),
+    )
+    explanation = explain_stack(BUILTIN_TEMPLATES, hunted, bindings)
+    assert explanation.winner_id == "evade_pursuers"
+    hide = next(item for item in explanation.templates if item.template_id == "hide")
+    assert hide.gate_passed is False
+
+
+def test_empty_override_set_returns_state_unchanged() -> None:
+    state, _ = _resolve_preset("quiet")
+    overrides = WorldStateOverrides()
+    assert overrides.is_empty
+    assert apply_overrides(state, overrides) is state
+
+
+def test_no_op_tag_toggles_raise() -> None:
+    state, _ = _resolve_preset("hiding")
+
+    with pytest.raises(OverrideValidationError, match="already carries it"):
+        apply_overrides(
+            state,
+            WorldStateOverrides(
+                tags=(TagOverride(entity_id=ACTOR_ID, tag="off_grid", op="add"),)
+            ),
+        )
+    with pytest.raises(OverrideValidationError, match="does not carry it"):
+        apply_overrides(
+            state,
+            WorldStateOverrides(
+                tags=(TagOverride(entity_id=ACTOR_ID, tag="public_role", op="remove"),)
+            ),
+        )
+    # Layers are separate vocabularies: off_grid lives on the durable layer,
+    # so an ephemeral-layer removal is a no-op and must refuse.
+    with pytest.raises(OverrideValidationError, match="does not carry it"):
+        apply_overrides(
+            state,
+            WorldStateOverrides(
+                tags=(
+                    TagOverride(
+                        entity_id=ACTOR_ID,
+                        tag="off_grid",
+                        op="remove",
+                        ephemeral=True,
+                    ),
+                )
+            ),
+        )
+
+
+def test_unknown_inputs_raise() -> None:
+    state, _ = _resolve_preset("quiet")
+
+    with pytest.raises(OverrideValidationError, match="Unknown tag override op"):
+        apply_overrides(
+            state,
+            WorldStateOverrides(
+                tags=(TagOverride(entity_id=ACTOR_ID, tag="off_grid", op="toggle"),)
+            ),
+        )
+    with pytest.raises(OverrideValidationError, match="Unknown need type"):
+        apply_overrides(
+            state,
+            WorldStateOverrides(
+                needs=(
+                    NeedOverride(
+                        entity_id=ACTOR_ID, need_type="caffeine", debt_score=1.0
+                    ),
+                )
+            ),
+        )
+    with pytest.raises(OverrideValidationError, match="must be >= 0"):
+        apply_overrides(
+            state,
+            WorldStateOverrides(
+                needs=(
+                    NeedOverride(
+                        entity_id=ACTOR_ID, need_type="sleep", debt_score=-1.0
+                    ),
+                )
+            ),
+        )
+    with pytest.raises(OverrideValidationError, match="ticks_ago must be >= 0"):
+        apply_overrides(
+            state,
+            WorldStateOverrides(
+                events=(EventOverride(event_type="contact_made", ticks_ago=-1),)
+            ),
+        )
+
+
+def test_override_echo_round_trips_through_json() -> None:
+    import json
+
+    overrides = WorldStateOverrides(
+        tags=(TagOverride(entity_id=1, tag="off_grid", op="remove"),),
+        pair_tags=(
+            PairTagOverride(
+                subject_entity_id=2, object_entity_id=1, tag="hunting", op="add"
+            ),
+        ),
+        needs=(NeedOverride(entity_id=1, need_type="sleep", debt_score=20.0),),
+        locations=(LocationOverride(entity_id=1, place_id=104),),
+        events=(
+            EventOverride(
+                event_type="hideout_maintained", actor_entity_id=1, ticks_ago=3
+            ),
+        ),
+    )
+    echo = json.loads(json.dumps(overrides.to_dict()))
+    assert echo["scope"] == "world_state_only"
+    assert {key for key in echo} == {
+        "scope",
+        "tags",
+        "pair_tags",
+        "needs",
+        "locations",
+        "events",
+    }
+    assert echo["events"][0]["ticks_ago"] == 3


### PR DESCRIPTION
## Summary

Step 3 of the audit-dashboard sequence in `docs/orrery_audit_dashboard_notes.md` — the override/sandbox ("what-if") layer the spec calls the highest-value, cheapest-to-build mode. `POST /api/dev/orrery/resolve` now takes an optional `overrides` object; the tick is re-explained against a copy of the hydrated `WorldState` with the edits applied, with zero database writes.

**Override vocabulary** (all five edit categories): toggle durable/ephemeral entity tag, toggle directed pair tag, set need debt, move actor, inject recent event (`ticks_ago` maps onto cooldown tick arithmetic).

**Design points**

- `nexus/agents/orrery/overrides.py` is pure: frozen dataclasses + `apply_overrides()` via `dataclasses.replace`, rebuilding only the mappings actually touched. No-op toggles (add a tag already present, remove one absent) raise `OverrideValidationError` — on an audit surface, an override that silently does nothing is the worst failure mode.
- `explain_dry_run()` runs hydration and SQL binding composition **once**, then explains baseline + sandbox states. Each sandbox stack carries a compact diff (`changed`, baseline winner/branch/magnitude, `changed_template_ids`), and need pressures get an added/removed/changed diff.
- DB-backed validation checks entity ids, place ids, and the `tags` / `pair_tags` / `event_types` vocabularies — including a tag-layer check: the override's durable/ephemeral flag must match the vocabulary's `is_ephemeral`, since predicates read the two layers separately.
- Honesty labeling per the spec: payload `mode` (`current` / `what_if`), override echo with `scope: world_state_only` (actor roster and pair composition come from SQL and are not overridden — the UI's sandbox frame can say so). `OverrideValidationError` → 400; anything else stays a loud 500.
- Sandbox parity is enforced by construction: `explain_template`'s cross-check against production `evaluate()` runs on the overridden state too.

**Tests** (no mocks; live DBs on slots 2 & 5 plus deterministic demo presets)

- Pure preset flips: `hide` → `evade_pursuers` via inbound `hunting` pair-tag injection; cooldown tick arithmetic (`hideout_maintained` at `ticks_ago=0` kills `hide`, at `10` leaves it standing); need override firing `sleep` over `maintain_cover`; immutability, JSON echo, and the full error matrix.
- Live endpoint: a **guaranteed-by-construction winner kill** — scan baseline winners for a top-level `NOT(has_inbound_pair_tag(hunting))` leg, inject the tag, the winner cannot survive; joint stack+pressure need-override assertion across both slots with loud repoint messages; 400 rejections for unknown tag/pair-tag/event-type/entity/place, layer mismatch, and no-op toggles; 422 for shape errors; current-mode payloads carry no what-if keys.

Known pre-existing failure (untouched, reproduces on origin/main): `tests/test_orrery/test_pair_tag_writer.py::test_polymorphic_subject_kind_character_path`.

Next in sequence: step 4 (evidence layer — parse-and-recompute observed values in leaf traces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY