### PR TITLE
Add parse-and-recompute evidence layer to Orrery explain traces

### DIFF
--- a/nexus/agents/orrery/evidence.py
+++ b/nexus/agents/orrery/evidence.py
@@ -1,0 +1,1510 @@
+"""Parse-and-recompute evidence for Orrery leaf predicates.
+
+The explain layer records that a leaf predicate returned True or False; this
+module recovers *why* — the actual state values the predicate read — without
+touching the 53 predicate factories in :mod:`substrate`. Every factory stamps
+a machine-parseable ``__name__`` (``has_need_debt_at_or_above(sleep,16@actor)``),
+and the catalog's ``_PREDICATE_PARSERS`` regexes already parse all of them;
+this module reuses those exact patterns, so there is one grammar, defined once.
+
+Each resolver returns a uniform evidence payload::
+
+    {
+        "kind":     "has_any_tag",          # factory name
+        "params":   {...},                   # config parsed from __name__
+        "entities": {"actor": 5},            # slot -> resolved entity id
+        "observed": {...},                   # the state values actually read
+        "matched":  [...] | None,            # which members/ids satisfied it
+        "result":   True,                    # recomputed verdict
+    }
+
+``result`` is the drift tripwire: the caller (``explain.trace_condition``)
+compares it against the real predicate's return value and raises loudly on
+mismatch, the same discipline ``explain_template`` applies against
+``evaluate``. Recomputation deliberately reuses substrate's own helper
+functions (``_tier_rank``, ``_at_routine_anchor``, ...) where they exist —
+the goal is exposing the values production reads, not reimplementing them.
+
+Family predicates (``has_any_*``, ``is_hidden``, ``is_constrained``, ...)
+always name the specific member(s) that matched in ``matched`` — a bare bool
+cannot answer "which suppressor tag killed this package."
+
+The one name-unrecoverable input is ``recent_event``'s ``changed_fields``
+filter (the name carries only a ``,fields`` marker). No builtin template uses
+it; when it appears, ``result`` is ``None`` and the caller skips the
+cross-check rather than pretending to a verdict it cannot recompute.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict
+from typing import Any, Callable, Mapping, Optional
+
+from nexus.agents.orrery.catalog import _PREDICATE_PARSERS
+from nexus.agents.orrery.status_family import (
+    STATUS_LEVEL_RANKS,
+    STATUS_TAG_PREFIX,
+)
+from nexus.agents.orrery.substrate import (
+    CONSTRAINED_TAGS,
+    CONTACT_PAIR_TAGS,
+    DEFAULT_FAME_TIER,
+    DEFAULT_RESOURCES_TIER,
+    DRAMATIC_CONTACT_TAGS,
+    ESTABLISHED_PARTNER_RELATIONSHIP_TYPES,
+    FAME_TIER_RANKS,
+    HIDDEN_TAGS,
+    INTIMACY_SUPPRESSOR_TAGS,
+    LOADED_TRUST_FORWARD_MIN,
+    LOADED_TRUST_REVERSE_MAX,
+    PUBLIC_MOBILITY_TAGS,
+    PUBLIC_PLACE_CLASSES,
+    RESOURCES_TIER_RANKS,
+    Bindings,
+    Slot,
+    WorldState,
+    _at_routine_anchor,
+    _is_in_transit,
+    _routine_anchor,
+    _routine_anchor_destination_available,
+    _routine_schedule_due,
+    _trust_values_are_asymmetric,
+)
+
+
+class EvidenceResolutionError(RuntimeError):
+    """A leaf predicate name has no evidence resolver.
+
+    Raised loudly: on an audit surface, a leaf whose reasoning cannot be
+    shown is a coverage bug, not a degradation to tolerate silently.
+    """
+
+
+_Resolver = Callable[["re.Match[str]", WorldState, Bindings], "dict[str, Any]"]
+
+_RESOLVERS: dict[str, _Resolver] = {}
+
+
+def _resolver(kind: str) -> Callable[[_Resolver], _Resolver]:
+    def _register(func: _Resolver) -> _Resolver:
+        _RESOLVERS[kind] = func
+        return func
+
+    return _register
+
+
+def _entity(bindings: Bindings, slot_name: str) -> Optional[int]:
+    value = bindings.get(Slot(slot_name))
+    return value if isinstance(value, int) else None
+
+
+def _current_tags(state: WorldState, entity_id: Optional[int]) -> frozenset[str]:
+    if entity_id is None:
+        return frozenset()
+    return state.tags.get(entity_id, frozenset()) | state.ephemeral_tags.get(
+        entity_id, frozenset()
+    )
+
+
+def _evidence(
+    kind: str,
+    *,
+    params: Mapping[str, Any],
+    entities: Mapping[str, Optional[int]],
+    observed: Mapping[str, Any],
+    result: Optional[bool],
+    matched: Optional[list[Any]] = None,
+) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "params": dict(params),
+        "entities": dict(entities),
+        "observed": dict(observed),
+        "matched": matched,
+        "result": result,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tags (durable / ephemeral / union)
+# ---------------------------------------------------------------------------
+
+
+@_resolver("has_tag")
+def _has_tag(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot, tag = match["slot"], match["tag"]
+    entity_id = _entity(bindings, slot)
+    tags = (
+        state.tags.get(entity_id, frozenset()) if entity_id is not None else frozenset()
+    )
+    return _evidence(
+        "has_tag",
+        params={"tag": tag, "slot": slot},
+        entities={slot: entity_id},
+        observed={"durable_tags": sorted(tags)},
+        matched=[tag] if tag in tags else [],
+        result=entity_id is not None and tag in tags,
+    )
+
+
+@_resolver("lacks_tag")
+def _lacks_tag(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot, tag = match["slot"], match["tag"]
+    entity_id = _entity(bindings, slot)
+    tags = (
+        state.tags.get(entity_id, frozenset()) if entity_id is not None else frozenset()
+    )
+    return _evidence(
+        "lacks_tag",
+        params={"tag": tag, "slot": slot},
+        entities={slot: entity_id},
+        observed={"durable_tags": sorted(tags)},
+        matched=[tag] if tag in tags else [],
+        result=entity_id is None or tag not in tags,
+    )
+
+
+@_resolver("has_any_tag")
+def _has_any_tag(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot = match["slot"]
+    candidates = match["tags"].split(",")
+    entity_id = _entity(bindings, slot)
+    tags = (
+        state.tags.get(entity_id, frozenset()) if entity_id is not None else frozenset()
+    )
+    matched = sorted(frozenset(candidates) & tags)
+    return _evidence(
+        "has_any_tag",
+        params={"tags": candidates, "slot": slot},
+        entities={slot: entity_id},
+        observed={"durable_tags": sorted(tags)},
+        matched=matched,
+        result=entity_id is not None and bool(matched),
+    )
+
+
+@_resolver("has_any_current_tag")
+def _has_any_current_tag(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot = match["slot"]
+    candidates = match["tags"].split(",")
+    entity_id = _entity(bindings, slot)
+    tags = _current_tags(state, entity_id)
+    matched = sorted(frozenset(candidates) & tags)
+    return _evidence(
+        "has_any_current_tag",
+        params={"tags": candidates, "slot": slot},
+        entities={slot: entity_id},
+        observed={"current_tags": sorted(tags)},
+        matched=matched,
+        result=entity_id is not None and bool(matched),
+    )
+
+
+@_resolver("has_ephemeral")
+def _has_ephemeral(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot, tag = match["slot"], match["tag"]
+    entity_id = _entity(bindings, slot)
+    tags = (
+        state.ephemeral_tags.get(entity_id, frozenset())
+        if entity_id is not None
+        else frozenset()
+    )
+    return _evidence(
+        "has_ephemeral",
+        params={"tag": tag, "slot": slot},
+        entities={slot: entity_id},
+        observed={"ephemeral_tags": sorted(tags)},
+        matched=[tag] if tag in tags else [],
+        result=entity_id is not None and tag in tags,
+    )
+
+
+def _family_resolver(kind: str, family_name: str, family: frozenset[str]) -> None:
+    def _resolve(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+        slot = match["slot"]
+        entity_id = _entity(bindings, slot)
+        tags = _current_tags(state, entity_id)
+        matched = sorted(family & tags)
+        return _evidence(
+            kind,
+            params={
+                "family": family_name,
+                "family_members": sorted(family),
+                "slot": slot,
+            },
+            entities={slot: entity_id},
+            observed={"current_tags": sorted(tags)},
+            matched=matched,
+            result=entity_id is not None and bool(matched),
+        )
+
+    _RESOLVERS[kind] = _resolve
+
+
+_family_resolver("is_constrained", "constrained_tags", CONSTRAINED_TAGS)
+_family_resolver("is_hidden", "hidden_tags", HIDDEN_TAGS)
+_family_resolver(
+    "has_any_intimacy_suppressor",
+    "intimacy_suppressor_tags",
+    INTIMACY_SUPPRESSOR_TAGS,
+)
+
+
+@_resolver("has_severity_tag")
+def _has_severity_tag(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot, prefix = match["slot"], match["prefix"]
+    entity_id = _entity(bindings, slot)
+    tags = _current_tags(state, entity_id)
+    marker = f"{prefix}_"
+    matched = sorted(tag for tag in tags if tag.startswith(marker))
+    return _evidence(
+        "has_severity_tag",
+        params={"prefix": prefix, "slot": slot},
+        entities={slot: entity_id},
+        observed={"current_tags": sorted(tags)},
+        matched=matched,
+        result=entity_id is not None and bool(matched),
+    )
+
+
+@_resolver("has_severity_tag_at_or_above")
+def _has_severity_tag_at_or_above(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot, prefix = match["slot"], match["prefix"]
+    level = int(match["level"])
+    entity_id = _entity(bindings, slot)
+    tags = _current_tags(state, entity_id)
+    marker = f"{prefix}_"
+    track: list[dict[str, Any]] = []
+    matched: list[str] = []
+    for tag in sorted(tags):
+        if not tag.startswith(marker):
+            continue
+        numeric, _sep, _label = tag.removeprefix(marker).partition("_")
+        try:
+            parsed = int(numeric)
+        except ValueError:
+            track.append({"tag": tag, "level": None})
+            continue
+        track.append({"tag": tag, "level": parsed})
+        if parsed >= level:
+            matched.append(tag)
+    return _evidence(
+        "has_severity_tag_at_or_above",
+        params={"prefix": prefix, "level": level, "slot": slot},
+        entities={slot: entity_id},
+        observed={"severity_track": track},
+        matched=matched,
+        result=entity_id is not None and bool(matched),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Exclusive tier ladders (fame / resources)
+# ---------------------------------------------------------------------------
+
+
+def _tier_resolver(
+    kind: str,
+    ranks: Mapping[str, int],
+    default_tier: str,
+    at_or_above: bool,
+) -> None:
+    def _resolve(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+        slot, tier = match["slot"], match["tier"]
+        threshold_rank = ranks[tier]
+        entity_id = _entity(bindings, slot)
+        present = (
+            sorted(
+                tag for tag in state.tags.get(entity_id, frozenset()) if tag in ranks
+            )
+            if entity_id is not None
+            else []
+        )
+        if len(present) > 1:
+            # Mirror _tier_rank's corrupt-ladder refusal rather than guessing.
+            raise ValueError(
+                f"Entity {entity_id} holds multiple tier tags {present}; "
+                "exclusive ladder is corrupt"
+            )
+        resolved = present[0] if present else default_tier
+        resolved_rank = ranks[resolved]
+        satisfied = (
+            resolved_rank >= threshold_rank
+            if at_or_above
+            else resolved_rank < threshold_rank
+        )
+        return _evidence(
+            kind,
+            params={
+                "tier": tier,
+                "threshold_rank": threshold_rank,
+                "slot": slot,
+                "comparator": ">=" if at_or_above else "<",
+            },
+            entities={slot: entity_id},
+            observed={
+                "tier_tags_present": present,
+                "resolved_tier": resolved,
+                "resolved_rank": resolved_rank,
+                "defaulted": not present,
+            },
+            matched=present,
+            result=entity_id is not None and satisfied,
+        )
+
+    _RESOLVERS[kind] = _resolve
+
+
+_tier_resolver("fame_at_or_above", FAME_TIER_RANKS, DEFAULT_FAME_TIER, True)
+_tier_resolver("fame_below", FAME_TIER_RANKS, DEFAULT_FAME_TIER, False)
+_tier_resolver(
+    "resources_at_or_above", RESOURCES_TIER_RANKS, DEFAULT_RESOURCES_TIER, True
+)
+_tier_resolver("resources_below", RESOURCES_TIER_RANKS, DEFAULT_RESOURCES_TIER, False)
+
+
+# ---------------------------------------------------------------------------
+# Pair tags
+# ---------------------------------------------------------------------------
+
+
+def _edge_tags(
+    state: WorldState, subject_id: Optional[int], object_id: Optional[int]
+) -> frozenset[str]:
+    if subject_id is None or object_id is None:
+        return frozenset()
+    return state.pair_tags.get((subject_id, object_id), frozenset())
+
+
+@_resolver("has_pair_tag")
+def _has_pair_tag(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    subj, obj, tag = match["subj"], match["obj"], match["tag"]
+    subject_id = _entity(bindings, subj)
+    object_id = _entity(bindings, obj)
+    edge = _edge_tags(state, subject_id, object_id)
+    return _evidence(
+        "has_pair_tag",
+        params={"tag": tag, "subject_slot": subj, "object_slot": obj},
+        entities={subj: subject_id, obj: object_id},
+        observed={"edge_tags": sorted(edge)},
+        matched=[tag] if tag in edge else [],
+        result=subject_id is not None and object_id is not None and tag in edge,
+    )
+
+
+@_resolver("lacks_pair_tag")
+def _lacks_pair_tag(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    subj, obj, tag = match["subj"], match["obj"], match["tag"]
+    subject_id = _entity(bindings, subj)
+    object_id = _entity(bindings, obj)
+    edge = _edge_tags(state, subject_id, object_id)
+    return _evidence(
+        "lacks_pair_tag",
+        params={"tag": tag, "subject_slot": subj, "object_slot": obj},
+        entities={subj: subject_id, obj: object_id},
+        observed={"edge_tags": sorted(edge)},
+        matched=[tag] if tag in edge else [],
+        result=subject_id is None or object_id is None or tag not in edge,
+    )
+
+
+@_resolver("has_any_pair_tag")
+def _has_any_pair_tag(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    subj, obj = match["subj"], match["obj"]
+    candidates = match["tags"].split(",")
+    subject_id = _entity(bindings, subj)
+    object_id = _entity(bindings, obj)
+    edge = _edge_tags(state, subject_id, object_id)
+    matched = sorted(frozenset(candidates) & edge)
+    return _evidence(
+        "has_any_pair_tag",
+        params={"tags": candidates, "subject_slot": subj, "object_slot": obj},
+        entities={subj: subject_id, obj: object_id},
+        observed={"edge_tags": sorted(edge)},
+        matched=matched,
+        result=subject_id is not None and object_id is not None and bool(matched),
+    )
+
+
+@_resolver("has_pair_tag_to_current_location")
+def _has_pair_tag_to_current_location(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot, tag = match["slot"], match["tag"]
+    entity_id = _entity(bindings, slot)
+    place_id = state.locations.get(entity_id) if entity_id is not None else None
+    place_entity_id = (
+        state.location_entity_ids.get(place_id) if place_id is not None else None
+    )
+    edge = _edge_tags(state, entity_id, place_entity_id)
+    return _evidence(
+        "has_pair_tag_to_current_location",
+        params={"tag": tag, "slot": slot},
+        entities={slot: entity_id},
+        observed={
+            "place_id": place_id,
+            "place_entity_id": place_entity_id,
+            "edge_tags": sorted(edge),
+        },
+        matched=[tag] if tag in edge else [],
+        result=(entity_id is not None and place_entity_id is not None and tag in edge),
+    )
+
+
+@_resolver("has_inbound_pair_tag")
+def _has_inbound_pair_tag_evidence(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot, tag = match["slot"], match["tag"]
+    entity_id = _entity(bindings, slot)
+    matched = sorted(
+        subject_id
+        for (subject_id, object_id), tags in state.pair_tags.items()
+        if entity_id is not None and object_id == entity_id and tag in tags
+    )
+    return _evidence(
+        "has_inbound_pair_tag",
+        params={"tag": tag, "slot": slot},
+        entities={slot: entity_id},
+        observed={"inbound_subject_ids": matched},
+        matched=matched,
+        result=bool(matched),
+    )
+
+
+@_resolver("has_contact_of_kind")
+def _has_contact_of_kind(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot, kind = match["slot"], match["kind"]
+    pair_tag = CONTACT_PAIR_TAGS[kind]
+    entity_id = _entity(bindings, slot)
+    matched = sorted(
+        object_id
+        for (subject_id, object_id), tags in state.pair_tags.items()
+        if entity_id is not None and subject_id == entity_id and pair_tag in tags
+    )
+    return _evidence(
+        "has_contact_of_kind",
+        params={"kind": kind, "pair_tag": pair_tag, "slot": slot},
+        entities={slot: entity_id},
+        observed={"outbound_object_ids": matched},
+        matched=matched,
+        result=bool(matched),
+    )
+
+
+@_resolver("has_any_status_at_or_above")
+def _has_any_status_at_or_above(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot, level = match["slot"], match["level"]
+    threshold_rank = STATUS_LEVEL_RANKS[level]
+    entity_id = _entity(bindings, slot)
+    edges: list[dict[str, Any]] = []
+    matched: list[dict[str, Any]] = []
+    for (subject_id, object_id), tags in state.pair_tags.items():
+        if entity_id is None or subject_id != entity_id:
+            continue
+        for tag in sorted(tags):
+            if not tag.startswith(STATUS_TAG_PREFIX):
+                continue
+            status_level = tag.removeprefix(STATUS_TAG_PREFIX)
+            rank = STATUS_LEVEL_RANKS.get(status_level)
+            entry = {
+                "scope_entity_id": object_id,
+                "tag": tag,
+                "rank": rank,
+            }
+            edges.append(entry)
+            if rank is not None and rank >= threshold_rank:
+                matched.append(entry)
+    return _evidence(
+        "has_any_status_at_or_above",
+        params={"level": level, "threshold_rank": threshold_rank, "slot": slot},
+        entities={slot: entity_id},
+        observed={"status_edges": edges},
+        matched=matched,
+        result=bool(matched),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Composite context predicates
+# ---------------------------------------------------------------------------
+
+
+@_resolver("has_minimal_context")
+def _has_minimal_context(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot = match["slot"]
+    entity_id = _entity(bindings, slot)
+    sources = {
+        "tags": bool(
+            entity_id is not None
+            and (state.tags.get(entity_id) or state.ephemeral_tags.get(entity_id))
+        ),
+        "location_or_activity": bool(
+            entity_id is not None
+            and (entity_id in state.locations or entity_id in state.activities)
+        ),
+        "travel_state": entity_id in state.travel_states,
+        "recent_events": any(
+            entity_id is not None
+            and entity_id in (event.actor_entity_id, event.target_entity_id)
+            for event in state.recent_events
+        ),
+    }
+    matched = sorted(name for name, present in sources.items() if present)
+    return _evidence(
+        "has_minimal_context",
+        params={"slot": slot},
+        entities={slot: entity_id},
+        observed={"context_sources": sources},
+        matched=matched,
+        result=entity_id is not None and bool(matched),
+    )
+
+
+@_resolver("can_move_publicly")
+def _can_move_publicly(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot = match["slot"]
+    entity_id = _entity(bindings, slot)
+    in_transit = entity_id is not None and _is_in_transit(state, entity_id)
+    tags = _current_tags(state, entity_id)
+    constrained = sorted(CONSTRAINED_TAGS & tags)
+    mobility = sorted(PUBLIC_MOBILITY_TAGS & tags)
+    social_tag = CONTACT_PAIR_TAGS["social"]
+    social_contacts = sorted(
+        object_id
+        for (subject_id, object_id), edge in state.pair_tags.items()
+        if entity_id is not None and subject_id == entity_id and social_tag in edge
+    )
+    place_id = state.locations.get(entity_id) if entity_id is not None else None
+    semantic = (
+        state.location_classes.get(place_id, frozenset())
+        if place_id is not None
+        else frozenset()
+    )
+    legacy = state.location_class.get(place_id) if place_id is not None else None
+    public_classes = sorted(
+        (PUBLIC_PLACE_CLASSES & semantic)
+        | ({legacy} if legacy in PUBLIC_PLACE_CLASSES else set())
+    )
+    if entity_id is None or in_transit or constrained:
+        result = False
+        granted_by: Optional[str] = None
+    elif mobility:
+        result, granted_by = True, "public_mobility_tag"
+    elif social_contacts:
+        result, granted_by = True, "social_contact"
+    elif public_classes:
+        result, granted_by = True, "public_place_class"
+    else:
+        result, granted_by = False, None
+    return _evidence(
+        "can_move_publicly",
+        params={"slot": slot},
+        entities={slot: entity_id},
+        observed={
+            "in_transit": in_transit,
+            "constrained_tags": constrained,
+            "public_mobility_tags": mobility,
+            "social_contact_ids": social_contacts,
+            "place_id": place_id,
+            "public_place_classes": public_classes,
+            "granted_by": granted_by,
+        },
+        matched=mobility + public_classes,
+        result=result,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Needs
+# ---------------------------------------------------------------------------
+
+
+@_resolver("has_need_debt_at_or_above")
+def _has_need_debt_at_or_above(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot, need = match["slot"], match["need"]
+    threshold = float(match["threshold"])
+    entity_id = _entity(bindings, slot)
+    score = (
+        state.need_debt_scores.get((entity_id, need), 0.0)
+        if entity_id is not None
+        else 0.0
+    )
+    return _evidence(
+        "has_need_debt_at_or_above",
+        params={"need_type": need, "threshold": threshold, "slot": slot},
+        entities={slot: entity_id},
+        observed={"debt_score": score},
+        result=entity_id is not None and score >= threshold,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Locations
+# ---------------------------------------------------------------------------
+
+
+def _place_classes(state: WorldState, place_id: Optional[int]) -> dict[str, Any]:
+    if place_id is None:
+        return {"place_id": None, "semantic_classes": [], "legacy_class": None}
+    return {
+        "place_id": place_id,
+        "semantic_classes": sorted(state.location_classes.get(place_id, frozenset())),
+        "legacy_class": state.location_class.get(place_id),
+    }
+
+
+@_resolver("in_location_class")
+def _in_location_class(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot, location_class = match["slot"], match["lc"]
+    entity_id = _entity(bindings, slot)
+    in_transit = entity_id is not None and _is_in_transit(state, entity_id)
+    place_id = state.locations.get(entity_id) if entity_id is not None else None
+    place = _place_classes(state, place_id)
+    hit = location_class in place["semantic_classes"] or (
+        place["legacy_class"] == location_class
+    )
+    return _evidence(
+        "in_location_class",
+        params={"location_class": location_class, "slot": slot},
+        entities={slot: entity_id},
+        observed={"in_transit": in_transit, **place},
+        matched=[location_class] if hit else [],
+        result=(
+            entity_id is not None and not in_transit and place_id is not None and hit
+        ),
+    )
+
+
+@_resolver("has_location_class_destination")
+def _has_location_class_destination(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot = match["slot"]
+    classes = frozenset(match["lc"].split(","))
+    entity_id = _entity(bindings, slot)
+    in_transit = entity_id is not None and _is_in_transit(state, entity_id)
+    current_place_id = state.locations.get(entity_id) if entity_id is not None else None
+    matched_places: set[int] = set()
+    if entity_id is not None and not in_transit and current_place_id is not None:
+        for place_id, semantic_classes in state.location_classes.items():
+            if place_id != current_place_id and classes & semantic_classes:
+                matched_places.add(place_id)
+        for place_id, legacy_class in state.location_class.items():
+            if place_id != current_place_id and legacy_class in classes:
+                matched_places.add(place_id)
+    return _evidence(
+        "has_location_class_destination",
+        params={"location_classes": sorted(classes), "slot": slot},
+        entities={slot: entity_id},
+        observed={
+            "in_transit": in_transit,
+            "current_place_id": current_place_id,
+            "destination_count": len(matched_places),
+        },
+        matched=sorted(matched_places),
+        result=bool(matched_places),
+    )
+
+
+@_resolver("in_location")
+def _in_location(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot = match["slot"]
+    target_place = int(match["lid"])
+    entity_id = _entity(bindings, slot)
+    in_transit = entity_id is not None and _is_in_transit(state, entity_id)
+    place_id = state.locations.get(entity_id) if entity_id is not None else None
+    return _evidence(
+        "in_location",
+        params={"location_id": target_place, "slot": slot},
+        entities={slot: entity_id},
+        observed={"in_transit": in_transit, "place_id": place_id},
+        result=entity_id is not None and not in_transit and place_id == target_place,
+    )
+
+
+@_resolver("co_located")
+def _co_located(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot_a, slot_b = match["a"], match["b"]
+    left = _entity(bindings, slot_a)
+    right = _entity(bindings, slot_b)
+    left_transit = left is not None and _is_in_transit(state, left)
+    right_transit = right is not None and _is_in_transit(state, right)
+    left_place = state.locations.get(left) if left is not None else None
+    right_place = state.locations.get(right) if right is not None else None
+    return _evidence(
+        "co_located",
+        params={"slot_a": slot_a, "slot_b": slot_b},
+        entities={slot_a: left, slot_b: right},
+        observed={
+            "places": {slot_a: left_place, slot_b: right_place},
+            "in_transit": {slot_a: left_transit, slot_b: right_transit},
+        },
+        result=(
+            left is not None
+            and right is not None
+            and not left_transit
+            and not right_transit
+            and left_place is not None
+            and left_place == right_place
+        ),
+    )
+
+
+@_resolver("count_co_located")
+def _count_co_located(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot = match["slot"]
+    minimum = int(match["n"])
+    with_tag = match["tag"]
+    with_ephemeral = match["ephemeral"]
+    entity_id = _entity(bindings, slot)
+    in_transit = entity_id is not None and _is_in_transit(state, entity_id)
+    place_id = state.locations.get(entity_id) if entity_id is not None else None
+    matched: list[int] = []
+    if entity_id is not None and not in_transit and place_id is not None:
+        for other_id, other_place in state.locations.items():
+            if other_id == entity_id or other_place != place_id:
+                continue
+            if _is_in_transit(state, other_id):
+                continue
+            if with_tag and with_tag not in state.tags.get(other_id, frozenset()):
+                continue
+            if with_ephemeral and with_ephemeral not in state.ephemeral_tags.get(
+                other_id, frozenset()
+            ):
+                continue
+            matched.append(other_id)
+    matched.sort()
+    return _evidence(
+        "count_co_located",
+        params={
+            "minimum": minimum,
+            "with_tag": with_tag,
+            "with_ephemeral": with_ephemeral,
+            "slot": slot,
+        },
+        entities={slot: entity_id},
+        observed={
+            "in_transit": in_transit,
+            "place_id": place_id,
+            "count": len(matched),
+        },
+        matched=matched,
+        result=(
+            entity_id is not None
+            and not in_transit
+            and place_id is not None
+            and len(matched) >= minimum
+        ),
+    )
+
+
+@_resolver("has_established_partner_co_located")
+def _has_established_partner_co_located(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot = match["slot"]
+    entity_id = _entity(bindings, slot)
+    in_transit = entity_id is not None and _is_in_transit(state, entity_id)
+    place_id = state.locations.get(entity_id) if entity_id is not None else None
+    matched: list[dict[str, Any]] = []
+    if entity_id is not None and not in_transit and place_id is not None:
+        for (source, target), relationship_types in state.relationship_types.items():
+            if entity_id not in (source, target):
+                continue
+            partner_types = sorted(
+                ESTABLISHED_PARTNER_RELATIONSHIP_TYPES & relationship_types
+            )
+            if not partner_types:
+                continue
+            partner_id = target if source == entity_id else source
+            if (
+                not _is_in_transit(state, partner_id)
+                and state.locations.get(partner_id) == place_id
+            ):
+                matched.append(
+                    {
+                        "partner_entity_id": partner_id,
+                        "relationship_types": partner_types,
+                    }
+                )
+    return _evidence(
+        "has_established_partner_co_located",
+        params={
+            "slot": slot,
+            "family": "established_partner_relationship_types",
+            "family_members": sorted(ESTABLISHED_PARTNER_RELATIONSHIP_TYPES),
+        },
+        entities={slot: entity_id},
+        observed={"in_transit": in_transit, "place_id": place_id},
+        matched=matched,
+        result=bool(matched),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Travel
+# ---------------------------------------------------------------------------
+
+
+def _travel_state(state: WorldState, entity_id: Optional[int]) -> Optional[dict]:
+    if entity_id is None:
+        return None
+    travel = state.travel_states.get(entity_id)
+    return asdict(travel) if travel is not None else None
+
+
+@_resolver("is_in_transit")
+def _is_in_transit_evidence(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot = match["slot"]
+    entity_id = _entity(bindings, slot)
+    travel = _travel_state(state, entity_id)
+    return _evidence(
+        "is_in_transit",
+        params={"slot": slot},
+        entities={slot: entity_id},
+        observed={"travel_status": travel["status"] if travel else None},
+        result=entity_id is not None and _is_in_transit(state, entity_id),
+    )
+
+
+@_resolver("has_travel_destination")
+def _has_travel_destination(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot = match["slot"]
+    entity_id = _entity(bindings, slot)
+    travel = _travel_state(state, entity_id)
+    destination = travel["destination_place_id"] if travel else None
+    return _evidence(
+        "has_travel_destination",
+        params={"slot": slot},
+        entities={slot: entity_id},
+        observed={"destination_place_id": destination},
+        result=entity_id is not None and destination is not None,
+    )
+
+
+@_resolver("travel_progress_at_or_above")
+def _travel_progress_at_or_above(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot = match["slot"]
+    threshold = float(match["threshold"])
+    entity_id = _entity(bindings, slot)
+    travel = _travel_state(state, entity_id)
+    progress = travel["progress_ratio"] if travel else None
+    return _evidence(
+        "travel_progress_at_or_above",
+        params={"threshold": threshold, "slot": slot},
+        entities={slot: entity_id},
+        observed={"progress_ratio": progress},
+        result=(
+            entity_id is not None and progress is not None and progress >= threshold
+        ),
+    )
+
+
+@_resolver("travel_purpose_is")
+def _travel_purpose_is(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot = match["slot"]
+    candidates = match["purpose"].split(",")
+    entity_id = _entity(bindings, slot)
+    travel = _travel_state(state, entity_id)
+    raw_purpose = travel["route_purpose"] if travel else None
+    normalized = str(raw_purpose).strip().lower() if raw_purpose is not None else None
+    matched = [normalized] if normalized in candidates else []
+    return _evidence(
+        "travel_purpose_is",
+        params={"purposes": candidates, "slot": slot},
+        entities={slot: entity_id},
+        observed={"route_purpose": raw_purpose},
+        matched=matched,
+        result=entity_id is not None and bool(matched),
+    )
+
+
+@_resolver("travel_risk_is")
+def _travel_risk_is(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot = match["slot"]
+    candidates = match["values"].split(",")
+    entity_id = _entity(bindings, slot)
+    travel = _travel_state(state, entity_id)
+    risk = travel["risk"] if travel else None
+    matched = [risk] if risk in candidates else []
+    return _evidence(
+        "travel_risk_is",
+        params={"risks": candidates, "slot": slot},
+        entities={slot: entity_id},
+        observed={"risk": risk},
+        matched=matched,
+        result=entity_id is not None and travel is not None and bool(matched),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Routine anchors
+# ---------------------------------------------------------------------------
+
+
+def _anchor_observation(
+    state: WorldState, entity_id: Optional[int], anchor_type: str
+) -> tuple[Optional[Any], dict[str, Any]]:
+    anchor = (
+        _routine_anchor(state, entity_id, anchor_type)
+        if entity_id is not None
+        else None
+    )
+    observed: dict[str, Any] = {
+        "anchor": asdict(anchor) if anchor is not None else None,
+        "current_place_id": (
+            state.locations.get(entity_id) if entity_id is not None else None
+        ),
+    }
+    return anchor, observed
+
+
+def _anchor_active(anchor: Optional[Any]) -> bool:
+    return bool(anchor and anchor.mobility_policy not in {"none", "nomadic"})
+
+
+@_resolver("has_routine_anchor")
+def _has_routine_anchor(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot, anchor_type = match["slot"], match["anchor"]
+    entity_id = _entity(bindings, slot)
+    anchor, observed = _anchor_observation(state, entity_id, anchor_type)
+    return _evidence(
+        "has_routine_anchor",
+        params={"anchor_type": anchor_type, "slot": slot},
+        entities={slot: entity_id},
+        observed=observed,
+        result=entity_id is not None and _anchor_active(anchor),
+    )
+
+
+@_resolver("routine_anchor_due")
+def _routine_anchor_due(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot, anchor_type = match["slot"], match["anchor"]
+    entity_id = _entity(bindings, slot)
+    anchor, observed = _anchor_observation(state, entity_id, anchor_type)
+    observed["world_time"] = (
+        state.world_time.isoformat() if state.world_time is not None else None
+    )
+    due = (
+        anchor is not None
+        and _anchor_active(anchor)
+        and _routine_schedule_due(anchor.schedule, state.world_time)
+    )
+    return _evidence(
+        "routine_anchor_due",
+        params={"anchor_type": anchor_type, "slot": slot},
+        entities={slot: entity_id},
+        observed=observed,
+        result=entity_id is not None and due,
+    )
+
+
+@_resolver("at_routine_anchor")
+def _at_routine_anchor_evidence(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot, anchor_type = match["slot"], match["anchor"]
+    entity_id = _entity(bindings, slot)
+    _, observed = _anchor_observation(state, entity_id, anchor_type)
+    current_place = observed["current_place_id"]
+    observed["current_place_zone"] = (
+        state.location_zones.get(current_place) if current_place is not None else None
+    )
+    return _evidence(
+        "at_routine_anchor",
+        params={"anchor_type": anchor_type, "slot": slot},
+        entities={slot: entity_id},
+        observed=observed,
+        result=(
+            entity_id is not None and _at_routine_anchor(state, entity_id, anchor_type)
+        ),
+    )
+
+
+@_resolver("away_from_routine_anchor")
+def _away_from_routine_anchor(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot, anchor_type = match["slot"], match["anchor"]
+    entity_id = _entity(bindings, slot)
+    anchor, observed = _anchor_observation(state, entity_id, anchor_type)
+    current_place = observed["current_place_id"]
+    observed["current_place_zone"] = (
+        state.location_zones.get(current_place) if current_place is not None else None
+    )
+    return _evidence(
+        "away_from_routine_anchor",
+        params={"anchor_type": anchor_type, "slot": slot},
+        entities={slot: entity_id},
+        observed=observed,
+        result=(
+            entity_id is not None
+            and _anchor_active(anchor)
+            and not _at_routine_anchor(state, entity_id, anchor_type)
+        ),
+    )
+
+
+@_resolver("routine_anchor_has_destination")
+def _routine_anchor_has_destination(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot, anchor_type = match["slot"], match["anchor"]
+    entity_id = _entity(bindings, slot)
+    anchor, observed = _anchor_observation(state, entity_id, anchor_type)
+    observed["known_zone_ids"] = sorted(set(state.location_zones.values()))
+    return _evidence(
+        "routine_anchor_has_destination",
+        params={"anchor_type": anchor_type, "slot": slot},
+        entities={slot: entity_id},
+        observed=observed,
+        result=(
+            entity_id is not None
+            and _routine_anchor_destination_available(state, entity_id, anchor_type)
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trust and relationships
+# ---------------------------------------------------------------------------
+
+
+def _directed_trust(
+    state: WorldState, source: Optional[int], target: Optional[int]
+) -> int:
+    if source is None or target is None:
+        return 0
+    return state.trust.get((source, target), 0)
+
+
+@_resolver("trust_at_least")
+def _trust_at_least(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot_a, slot_b = match["a"], match["b"]
+    threshold = int(match["thresh"])
+    source = _entity(bindings, slot_a)
+    target = _entity(bindings, slot_b)
+    trust = _directed_trust(state, source, target)
+    return _evidence(
+        "trust_at_least",
+        params={"threshold": threshold, "from_slot": slot_a, "to_slot": slot_b},
+        entities={slot_a: source, slot_b: target},
+        observed={"trust": trust},
+        result=source is not None and target is not None and trust >= threshold,
+    )
+
+
+@_resolver("trust_below")
+def _trust_below(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot_a, slot_b = match["a"], match["b"]
+    threshold = int(match["thresh"])
+    source = _entity(bindings, slot_a)
+    target = _entity(bindings, slot_b)
+    trust = _directed_trust(state, source, target)
+    return _evidence(
+        "trust_below",
+        params={"threshold": threshold, "from_slot": slot_a, "to_slot": slot_b},
+        entities={slot_a: source, slot_b: target},
+        observed={"trust": trust},
+        result=source is not None and target is not None and trust < threshold,
+    )
+
+
+@_resolver("relationship_is_mutual_warm")
+def _relationship_is_mutual_warm(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot_a, slot_b = match["a"], match["b"]
+    source = _entity(bindings, slot_a)
+    target = _entity(bindings, slot_b)
+    forward = _directed_trust(state, source, target)
+    reverse = _directed_trust(state, target, source)
+    return _evidence(
+        "relationship_is_mutual_warm",
+        params={
+            "forward_min": 2,
+            "reverse_min": 1,
+            "slot_a": slot_a,
+            "slot_b": slot_b,
+        },
+        entities={slot_a: source, slot_b: target},
+        observed={"forward_trust": forward, "reverse_trust": reverse},
+        result=(
+            source is not None and target is not None and forward >= 2 and reverse >= 1
+        ),
+    )
+
+
+@_resolver("relationship_is_asymmetric")
+def _relationship_is_asymmetric(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot_a, slot_b = match["a"], match["b"]
+    threshold = int(match["thresh"])
+    source = _entity(bindings, slot_a)
+    target = _entity(bindings, slot_b)
+    forward = _directed_trust(state, source, target)
+    reverse = _directed_trust(state, target, source)
+    loaded = forward >= LOADED_TRUST_FORWARD_MIN and reverse <= LOADED_TRUST_REVERSE_MAX
+    return _evidence(
+        "relationship_is_asymmetric",
+        params={"gap_threshold": threshold, "slot_a": slot_a, "slot_b": slot_b},
+        entities={slot_a: source, slot_b: target},
+        observed={
+            "forward_trust": forward,
+            "reverse_trust": reverse,
+            "gap": abs(forward - reverse),
+            "loaded_one_sided": loaded,
+        },
+        result=(
+            source is not None
+            and target is not None
+            and _trust_values_are_asymmetric(forward, reverse, threshold)
+        ),
+    )
+
+
+@_resolver("direct_contact_is_dramatic")
+def _direct_contact_is_dramatic(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot_a, slot_b = match["a"], match["b"]
+    source = _entity(bindings, slot_a)
+    target = _entity(bindings, slot_b)
+    source_dramatic = sorted(DRAMATIC_CONTACT_TAGS & _current_tags(state, source))
+    target_dramatic = sorted(DRAMATIC_CONTACT_TAGS & _current_tags(state, target))
+    forward = _directed_trust(state, source, target)
+    reverse = _directed_trust(state, target, source)
+    triggers: list[str] = []
+    if source_dramatic or target_dramatic:
+        triggers.append("dramatic_tags")
+    if reverse <= -2:
+        triggers.append("reverse_trust_hostile")
+    if _trust_values_are_asymmetric(forward, reverse):
+        triggers.append("trust_asymmetry")
+    return _evidence(
+        "direct_contact_is_dramatic",
+        params={"from_slot": slot_a, "to_slot": slot_b},
+        entities={slot_a: source, slot_b: target},
+        observed={
+            "dramatic_tags": {slot_a: source_dramatic, slot_b: target_dramatic},
+            "forward_trust": forward,
+            "reverse_trust": reverse,
+        },
+        matched=triggers,
+        result=source is not None and target is not None and bool(triggers),
+    )
+
+
+@_resolver("has_relationship_of_type")
+def _has_relationship_of_type(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot_from, slot_to = match["from"], match["to"]
+    relationship_type = match["type"]
+    source = _entity(bindings, slot_from)
+    target = _entity(bindings, slot_to)
+    edge = (
+        state.relationship_types.get((source, target), frozenset())
+        if source is not None and target is not None
+        else frozenset()
+    )
+    return _evidence(
+        "has_relationship_of_type",
+        params={
+            "relationship_type": relationship_type,
+            "from_slot": slot_from,
+            "to_slot": slot_to,
+        },
+        entities={slot_from: source, slot_to: target},
+        observed={"edge_types": sorted(edge)},
+        matched=[relationship_type] if relationship_type in edge else [],
+        result=(
+            source is not None and target is not None and relationship_type in edge
+        ),
+    )
+
+
+@_resolver("has_symmetric_relationship_of_type")
+def _has_symmetric_relationship_of_type(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot_a, slot_b = match["a"], match["b"]
+    relationship_type = match["type"]
+    left = _entity(bindings, slot_a)
+    right = _entity(bindings, slot_b)
+    forward_edge = (
+        state.relationship_types.get((left, right), frozenset())
+        if left is not None and right is not None
+        else frozenset()
+    )
+    reverse_edge = (
+        state.relationship_types.get((right, left), frozenset())
+        if left is not None and right is not None
+        else frozenset()
+    )
+    matched = [
+        direction
+        for direction, edge in (("forward", forward_edge), ("reverse", reverse_edge))
+        if relationship_type in edge
+    ]
+    return _evidence(
+        "has_symmetric_relationship_of_type",
+        params={
+            "relationship_type": relationship_type,
+            "slot_a": slot_a,
+            "slot_b": slot_b,
+        },
+        entities={slot_a: left, slot_b: right},
+        observed={
+            "forward_edge_types": sorted(forward_edge),
+            "reverse_edge_types": sorted(reverse_edge),
+        },
+        matched=matched,
+        result=bool(matched),
+    )
+
+
+@_resolver("faction_member")
+def _faction_member(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    member_slot, faction_slot = match["member"], match["faction"]
+    member_id = _entity(bindings, member_slot)
+    faction_id = _entity(bindings, faction_slot)
+    memberships = (
+        state.faction_memberships.get(member_id, frozenset())
+        if member_id is not None
+        else frozenset()
+    )
+    return _evidence(
+        "faction_member",
+        params={"member_slot": member_slot, "faction_slot": faction_slot},
+        entities={member_slot: member_id, faction_slot: faction_id},
+        observed={"faction_ids": sorted(memberships)},
+        matched=[faction_id] if faction_id in memberships else [],
+        result=(
+            member_id is not None
+            and faction_id is not None
+            and faction_id in memberships
+        ),
+    )
+
+
+@_resolver("relative_orbit_distance")
+def _relative_orbit_distance(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    slot_a, slot_b = match["a"], match["b"]
+    max_distance = int(match["n"])
+    source = _entity(bindings, slot_a)
+    target = _entity(bindings, slot_b)
+    distance = (
+        state.orbit_distance.get((source, target))
+        if source is not None and target is not None
+        else None
+    )
+    return _evidence(
+        "relative_orbit_distance",
+        params={"max_distance": max_distance, "from_slot": slot_a, "to_slot": slot_b},
+        entities={slot_a: source, slot_b: target},
+        observed={"orbit_distance": distance},
+        result=distance is not None and distance <= max_distance,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Global scalars
+# ---------------------------------------------------------------------------
+
+
+@_resolver("time_of_day_in")
+def _time_of_day_in(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    candidates = match["values"].split(",")
+    matched = [state.time_of_day] if state.time_of_day in candidates else []
+    return _evidence(
+        "time_of_day_in",
+        params={"times": candidates},
+        entities={},
+        observed={"time_of_day": state.time_of_day},
+        matched=matched,
+        result=bool(matched),
+    )
+
+
+@_resolver("weather_is")
+def _weather_is(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    candidates = match["values"].split(",")
+    matched = [state.weather] if state.weather in candidates else []
+    return _evidence(
+        "weather_is",
+        params={"weather": candidates},
+        entities={},
+        observed={"weather": state.weather},
+        matched=matched,
+        result=bool(matched),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+
+def _event_payload(event: Any) -> dict[str, Any]:
+    return {
+        "event_type": event.event_type,
+        "tick": event.tick,
+        "actor_entity_id": event.actor_entity_id,
+        "target_entity_id": event.target_entity_id,
+    }
+
+
+@_resolver("recent_event")
+def _recent_event(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    event_type = match["event"]
+    within_ticks = int(match["n"])
+    actor_slot = match["actor"]
+    target_slot = match["target"]
+    fields_filter_active = match.group(0).rstrip(")").endswith(",fields")
+    actor_id = _entity(bindings, actor_slot) if actor_slot else None
+    target_id = _entity(bindings, target_slot) if target_slot else None
+    cutoff = state.current_tick - within_ticks
+    matched: list[dict[str, Any]] = []
+    slot_unbound = (actor_slot is not None and actor_id is None) or (
+        target_slot is not None and target_id is None
+    )
+    if not slot_unbound:
+        for event in state.recent_events:
+            if event.tick < cutoff:
+                continue
+            if event_type != "*" and event.event_type != event_type:
+                continue
+            if actor_id is not None and event.actor_entity_id != actor_id:
+                continue
+            if target_id is not None and event.target_entity_id != target_id:
+                continue
+            matched.append(_event_payload(event))
+    entities: dict[str, Optional[int]] = {}
+    if actor_slot:
+        entities[actor_slot] = actor_id
+    if target_slot:
+        entities[target_slot] = target_id
+    return _evidence(
+        "recent_event",
+        params={
+            "event_type": None if event_type == "*" else event_type,
+            "within_ticks": within_ticks,
+            "actor_slot": actor_slot,
+            "target_slot": target_slot,
+            "changed_fields_filter": fields_filter_active,
+        },
+        entities=entities,
+        observed={"current_tick": state.current_tick, "cutoff_tick": cutoff},
+        matched=matched,
+        # The changed_fields filter set lives only inside the closure; with
+        # the marker present the verdict is not recomputable from the name.
+        result=None if fields_filter_active else bool(matched),
+    )
+
+
+@_resolver("since_last_event_at_least")
+def _since_last_event_at_least(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    event_type = match["event"]
+    minimum_ticks = int(match["n"])
+    actor_slot = match["actor"]
+    target_slot = match["target"]
+    actor_id = _entity(bindings, actor_slot)
+    target_id = _entity(bindings, target_slot) if target_slot else None
+    latest_tick: Optional[int] = None
+    if actor_id is not None and not (target_slot is not None and target_id is None):
+        for event in state.recent_events:
+            if event.event_type != event_type:
+                continue
+            if event.actor_entity_id != actor_id:
+                continue
+            if target_id is not None and event.target_entity_id != target_id:
+                continue
+            if latest_tick is None or event.tick > latest_tick:
+                latest_tick = event.tick
+    elapsed = state.current_tick - latest_tick if latest_tick is not None else None
+    entities: dict[str, Optional[int]] = {actor_slot: actor_id}
+    if target_slot:
+        entities[target_slot] = target_id
+    if actor_id is None or (target_slot is not None and target_id is None):
+        result = False
+    else:
+        result = elapsed is None or elapsed >= minimum_ticks
+    return _evidence(
+        "since_last_event_at_least",
+        params={
+            "event_type": event_type,
+            "minimum_ticks": minimum_ticks,
+            "actor_slot": actor_slot,
+            "target_slot": target_slot,
+        },
+        entities=entities,
+        observed={
+            "current_tick": state.current_tick,
+            "latest_matching_tick": latest_tick,
+            "elapsed_ticks": elapsed,
+        },
+        result=result,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def resolve_evidence(
+    name: str, state: WorldState, bindings: Bindings
+) -> dict[str, Any]:
+    """Return the evidence payload for one leaf predicate name.
+
+    Raises :class:`EvidenceResolutionError` for names with no resolver —
+    coverage over every builtin leaf is enforced by tests, so an unknown
+    name means a new predicate factory landed without evidence support.
+    """
+
+    if name == "ALWAYS":
+        return _evidence("always", params={}, entities={}, observed={}, result=True)
+    if name == "NEVER":
+        return _evidence("never", params={}, entities={}, observed={}, result=False)
+
+    kind = name.split("(", 1)[0]
+    resolver = _RESOLVERS.get(kind)
+    if resolver is None:
+        raise EvidenceResolutionError(
+            f"No evidence resolver for predicate kind {kind!r} (leaf {name!r}); "
+            "add one to nexus/agents/orrery/evidence.py"
+        )
+    for pattern, _formatter in _PREDICATE_PARSERS:
+        match = pattern.fullmatch(name)
+        if match is not None:
+            return resolver(match, state, bindings)
+    raise EvidenceResolutionError(
+        f"Leaf {name!r} matched no catalog parser; the __name__ grammar and "
+        "catalog._PREDICATE_PARSERS have drifted"
+    )

--- a/nexus/agents/orrery/explain.py
+++ b/nexus/agents/orrery/explain.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass, field
 from typing import Any, Iterable, List, Mapping, Optional, Tuple
 
 from nexus.agents.orrery.catalog import _render_predicate_name
+from nexus.agents.orrery.evidence import resolve_evidence
 from nexus.agents.orrery.substrate import (
     Bindings,
     CompoundCondition,
@@ -54,6 +55,7 @@ class ConditionTrace:
     result: bool
     op: Optional[str] = None
     children: Tuple["ConditionTrace", ...] = ()
+    evidence: Optional[Mapping[str, Any]] = None
 
     @property
     def is_leaf(self) -> bool:
@@ -68,6 +70,10 @@ class ConditionTrace:
         if self.op is not None:
             node["op"] = self.op
             node["children"] = [child.to_dict() for child in self.children]
+        else:
+            node["evidence"] = (
+                dict(self.evidence) if self.evidence is not None else None
+            )
         return node
 
 
@@ -206,10 +212,22 @@ def trace_condition(
         )
 
     name = getattr(condition, "__name__", repr(condition))
+    result = bool(condition(state, bindings))
+    evidence = resolve_evidence(name, state, bindings)
+    # Evidence recomputes its own verdict from the parsed name; a mismatch
+    # means the factory closure and the evidence resolver have drifted.
+    # evidence["result"] is None only for name-unrecoverable filters
+    # (recent_event's changed_fields marker), where no cross-check is possible.
+    if evidence["result"] is not None and bool(evidence["result"]) != result:
+        raise AssertionError(
+            f"evidence/predicate divergence for {name!r}: predicate returned "
+            f"{result}, evidence recomputed {evidence['result']}"
+        )
     return ConditionTrace(
         raw=name,
         prose=_render_predicate_name(name),
-        result=bool(condition(state, bindings)),
+        result=result,
+        evidence=evidence,
     )
 
 

--- a/tests/test_orrery/test_evidence.py
+++ b/tests/test_orrery/test_evidence.py
@@ -1,0 +1,414 @@
+"""Coverage and parity tests for the leaf-predicate evidence resolver.
+
+Two layers of guarantee, no mocks:
+
+1. **Total factory coverage** — a synthetic rich state exercises every one of
+   the 53 predicate factories exactly as authored, asserting the evidence
+   resolver's recomputed verdict matches the real closure's return value and
+   that the sweep visits every registered resolver. A new factory landing in
+   substrate without an evidence resolver fails here (and fails the explain
+   path loudly at runtime).
+2. **Builtin template coverage** — every leaf in every builtin template's
+   gate and branch trees resolves against every demo preset, so the grammar
+   actually emitted by production templates is covered end to end.
+
+The per-leaf verdict cross-check also runs inside ``trace_condition`` on
+every explain, so the whole explain test suite doubles as a drift tripwire.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nexus.agents.orrery.demo import _all_preset_names, _resolve_preset
+from nexus.agents.orrery.evidence import (
+    _RESOLVERS,
+    EvidenceResolutionError,
+    resolve_evidence,
+)
+from nexus.agents.orrery.explain import explain_stack
+from nexus.agents.orrery.substrate import (
+    ALWAYS,
+    EventRecord,
+    RoutineAnchor,
+    Slot,
+    TravelState,
+    WorldState,
+    _condition_tree_leaves,
+    at_routine_anchor,
+    away_from_routine_anchor,
+    can_move_publicly,
+    co_located,
+    count_co_located,
+    direct_contact_is_dramatic,
+    faction_member,
+    fame_at_or_above,
+    fame_below,
+    has_any_current_tag,
+    has_any_intimacy_suppressor,
+    has_any_pair_tag,
+    has_any_status_at_or_above,
+    has_any_tag,
+    has_contact_of_kind,
+    has_ephemeral,
+    has_established_partner_co_located,
+    has_inbound_pair_tag,
+    has_location_class_destination,
+    has_minimal_context,
+    has_need_debt_at_or_above,
+    has_pair_tag,
+    has_pair_tag_to_current_location,
+    has_relationship_of_type,
+    has_routine_anchor,
+    has_severity_tag,
+    has_severity_tag_at_or_above,
+    has_symmetric_relationship_of_type,
+    has_tag,
+    has_travel_destination,
+    in_location,
+    in_location_class,
+    is_constrained,
+    is_hidden,
+    is_in_transit,
+    lacks_pair_tag,
+    lacks_tag,
+    recent_event,
+    relationship_is_asymmetric,
+    relationship_is_mutual_warm,
+    relative_orbit_distance,
+    resources_at_or_above,
+    resources_below,
+    routine_anchor_due,
+    routine_anchor_has_destination,
+    since_last_event_at_least,
+    time_of_day_in,
+    travel_progress_at_or_above,
+    travel_purpose_is,
+    travel_risk_is,
+    trust_at_least,
+    trust_below,
+    weather_is,
+)
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+from datetime import datetime
+
+ACTOR, TARGET, FACTION_ID = 1, 2, 9
+PLACE_ENTITY = 501
+
+RICH_STATE = WorldState(
+    tags={
+        ACTOR: frozenset({"off_grid", "known", "wealthy", "route_familiar"}),
+        TARGET: frozenset({"seeking_identity"}),
+        3: frozenset({"public_role"}),
+    },
+    ephemeral_tags={ACTOR: frozenset({"grieving", "wound_3_severe"})},
+    locations={ACTOR: 101, TARGET: 101, 3: 101, 4: 102},
+    activities={ACTOR: "keeping watch"},
+    trust={(ACTOR, TARGET): 2, (TARGET, ACTOR): 1},
+    relationship_types={(ACTOR, TARGET): frozenset({"romantic"})},
+    pair_tags={
+        (ACTOR, TARGET): frozenset({"contact:social"}),
+        (TARGET, ACTOR): frozenset({"hunting"}),
+        (ACTOR, PLACE_ENTITY): frozenset({"contact:lodging"}),
+        (ACTOR, FACTION_ID): frozenset({"status:senior"}),
+    },
+    faction_memberships={ACTOR: frozenset({FACTION_ID})},
+    location_class={102: "transit"},
+    location_classes={
+        101: frozenset({"commerce", "meeting"}),
+        102: frozenset({"transit"}),
+    },
+    location_entity_ids={101: PLACE_ENTITY},
+    location_zones={101: 7, 102: 8},
+    orbit_distance={(ACTOR, TARGET): 1},
+    need_debt_scores={(ACTOR, "sleep"): 12.5},
+    travel_states={
+        ACTOR: TravelState(
+            status="at_place",
+            destination_place_id=102,
+            progress_ratio=0.6,
+            route_purpose="socialize",
+            risk="low",
+        ),
+        4: TravelState(status="in_transit"),
+    },
+    routine_anchors={
+        (ACTOR, "work"): RoutineAnchor(
+            anchor_type="work",
+            place_id=102,
+            mobility_policy="fixed_place",
+            schedule={"weekdays": [0, 1, 2, 3, 4], "start": "09:00", "end": "17:00"},
+        ),
+    },
+    recent_events=(
+        EventRecord(event_type="threat_issued", tick=99, target_entity_id=ACTOR),
+        EventRecord(event_type="contact_made", tick=95, actor_entity_id=ACTOR),
+    ),
+    time_of_day="night",
+    world_time=datetime(2073, 5, 3, 11, 30),
+    weather="rain",
+    current_tick=100,
+)
+
+BINDINGS = {Slot.ACTOR: ACTOR, Slot.TARGET: TARGET, Slot.FACTION: FACTION_ID}
+
+# One authored predicate per factory — the sweep below asserts this table
+# covers every registered resolver, so a new factory cannot land silently.
+FACTORY_SWEEP = [
+    has_tag("off_grid"),
+    lacks_tag("captive"),
+    has_any_tag("off_grid", "public_role"),
+    has_any_current_tag("grieving", "nonexistent"),
+    has_ephemeral("grieving"),
+    is_constrained(),
+    is_hidden(),
+    has_any_intimacy_suppressor(),
+    has_severity_tag("wound"),
+    has_severity_tag_at_or_above("wound", 2),
+    fame_at_or_above("known"),
+    fame_below("renowned"),
+    resources_at_or_above("comfortable"),
+    resources_below("magnate"),
+    has_pair_tag("contact:social"),
+    lacks_pair_tag("hunting"),
+    has_any_pair_tag("hunting", "contact:social"),
+    has_pair_tag_to_current_location("contact:lodging"),
+    has_inbound_pair_tag("hunting"),
+    has_contact_of_kind("social"),
+    has_any_status_at_or_above("respected"),
+    has_minimal_context(),
+    can_move_publicly(),
+    has_need_debt_at_or_above("sleep", 8),
+    in_location_class("commerce"),
+    has_location_class_destination("transit"),
+    in_location(101),
+    co_located(),
+    count_co_located(2, with_tag="public_role", with_ephemeral="grieving"),
+    count_co_located(1),
+    has_established_partner_co_located(),
+    is_in_transit(),
+    has_travel_destination(),
+    travel_progress_at_or_above(0.5),
+    travel_purpose_is("socialize"),
+    travel_risk_is("low", "moderate"),
+    has_routine_anchor("work"),
+    routine_anchor_due("work"),
+    at_routine_anchor("work"),
+    away_from_routine_anchor("work"),
+    routine_anchor_has_destination("work"),
+    trust_at_least(2),
+    trust_below(5),
+    relationship_is_mutual_warm(),
+    relationship_is_asymmetric(),
+    direct_contact_is_dramatic(),
+    has_relationship_of_type("romantic"),
+    has_symmetric_relationship_of_type("romantic", Slot.TARGET, Slot.ACTOR),
+    faction_member(),
+    relative_orbit_distance(2),
+    time_of_day_in("night", "evening"),
+    weather_is("clear"),
+    recent_event("threat_issued", within_ticks=5, target_slot=Slot.ACTOR),
+    recent_event(within_ticks=3),
+    since_last_event_at_least("contact_made", 3),
+    since_last_event_at_least("contact_made", 3, target_slot=Slot.TARGET),
+]
+
+
+def test_factory_sweep_covers_every_registered_resolver() -> None:
+    """The sweep table and the resolver registry must stay in lockstep."""
+
+    swept_kinds = {predicate.__name__.split("(", 1)[0] for predicate in FACTORY_SWEEP}
+    assert swept_kinds == set(_RESOLVERS), (
+        "factory sweep and evidence resolver registry disagree; "
+        f"missing from sweep: {sorted(set(_RESOLVERS) - swept_kinds)}, "
+        f"unregistered kinds: {sorted(swept_kinds - set(_RESOLVERS))}"
+    )
+
+
+@pytest.mark.parametrize("predicate", FACTORY_SWEEP, ids=lambda p: p.__name__)
+def test_evidence_verdict_matches_predicate(predicate) -> None:
+    """Parse-and-recompute must agree with the real closure, value for value."""
+
+    evidence = resolve_evidence(predicate.__name__, RICH_STATE, BINDINGS)
+    assert evidence["result"] == predicate(RICH_STATE, BINDINGS)
+    assert evidence["kind"] == predicate.__name__.split("(", 1)[0]
+    # Payloads are for the dashboard: they must round-trip through JSON.
+    json.dumps(evidence)
+
+
+def test_unbound_slots_resolve_honestly() -> None:
+    """With no TARGET bound, evidence records the missing entity, not a lie."""
+
+    predicate = has_pair_tag("contact:social")
+    evidence = resolve_evidence(predicate.__name__, RICH_STATE, {Slot.ACTOR: ACTOR})
+    assert evidence["entities"]["target"] is None
+    assert evidence["result"] is False
+    assert evidence["result"] == predicate(RICH_STATE, {Slot.ACTOR: ACTOR})
+
+
+@pytest.mark.parametrize("preset_name", _all_preset_names())
+def test_every_builtin_leaf_resolves_on_preset(preset_name: str) -> None:
+    """Every gate and branch leaf of every builtin template has evidence."""
+
+    state, bindings = _resolve_preset(preset_name)
+    for template in BUILTIN_TEMPLATES:
+        conditions = [template.package_gate]
+        conditions.extend(branch.conditions for branch in template.branches)
+        for condition in conditions:
+            for leaf in _condition_tree_leaves(condition):
+                name = getattr(leaf, "__name__", repr(leaf))
+                evidence = resolve_evidence(name, state, bindings)
+                if evidence["result"] is not None:
+                    assert evidence["result"] == bool(leaf(state, bindings)), name
+
+
+def test_family_evidence_names_the_matching_member() -> None:
+    evidence = resolve_evidence(is_hidden().__name__, RICH_STATE, BINDINGS)
+    assert evidence["matched"] == ["off_grid"]
+    assert "hidden_tags" == evidence["params"]["family"]
+
+    suppressor = resolve_evidence(
+        has_any_intimacy_suppressor().__name__, RICH_STATE, BINDINGS
+    )
+    assert suppressor["matched"] == ["grieving"]
+
+
+def test_observed_values_surface_for_thresholds() -> None:
+    debt = resolve_evidence(
+        has_need_debt_at_or_above("sleep", 8).__name__, RICH_STATE, BINDINGS
+    )
+    assert debt["observed"]["debt_score"] == 12.5
+    assert debt["params"]["threshold"] == 8.0
+    assert debt["result"] is True
+
+    trust = resolve_evidence(trust_at_least(2).__name__, RICH_STATE, BINDINGS)
+    assert trust["observed"]["trust"] == 2
+
+    cooldown = resolve_evidence(
+        since_last_event_at_least("contact_made", 3).__name__,
+        RICH_STATE,
+        BINDINGS,
+    )
+    assert cooldown["observed"]["latest_matching_tick"] == 95
+    assert cooldown["observed"]["elapsed_ticks"] == 5
+    assert cooldown["result"] is True
+
+
+def test_inbound_pair_tag_evidence_names_the_subjects() -> None:
+    evidence = resolve_evidence(
+        has_inbound_pair_tag("hunting").__name__, RICH_STATE, BINDINGS
+    )
+    assert evidence["matched"] == [TARGET]
+
+
+def test_severity_evidence_parses_track_levels() -> None:
+    evidence = resolve_evidence(
+        has_severity_tag_at_or_above("wound", 2).__name__, RICH_STATE, BINDINGS
+    )
+    assert evidence["observed"]["severity_track"] == [
+        {"tag": "wound_3_severe", "level": 3}
+    ]
+    assert evidence["matched"] == ["wound_3_severe"]
+
+
+def test_tier_evidence_reports_default_when_untagged() -> None:
+    evidence = resolve_evidence(
+        fame_at_or_above("known").__name__,
+        RICH_STATE,
+        {Slot.ACTOR: TARGET},
+    )
+    assert evidence["observed"]["resolved_tier"] == "obscure"
+    assert evidence["observed"]["defaulted"] is True
+    assert evidence["result"] is False
+
+
+def test_always_never_and_unknown_names() -> None:
+    assert resolve_evidence("ALWAYS", RICH_STATE, BINDINGS)["result"] is True
+    assert resolve_evidence("NEVER", RICH_STATE, BINDINGS)["result"] is False
+    assert resolve_evidence(ALWAYS.__name__, RICH_STATE, BINDINGS)["result"] is True
+
+    with pytest.raises(EvidenceResolutionError, match="No evidence resolver"):
+        resolve_evidence("summon_dragon(@actor)", RICH_STATE, BINDINGS)
+
+
+def test_explain_stack_traces_carry_evidence() -> None:
+    """The inspector consumes evidence through the explain payload."""
+
+    state, bindings = _resolve_preset("hunted")
+    explanation = explain_stack(BUILTIN_TEMPLATES, state, bindings)
+    payload = json.loads(json.dumps(explanation.to_dict()))
+
+    def _leaves(node: dict):
+        if "children" in node:
+            for child in node["children"]:
+                yield from _leaves(child)
+        else:
+            yield node
+
+    leaf_count = 0
+    for template in payload["templates"]:
+        for leaf in _leaves(template["gate_trace"]):
+            assert leaf["evidence"] is not None
+            assert leaf["evidence"]["result"] == leaf["result"]
+            leaf_count += 1
+        assert (
+            "evidence" not in template["gate_trace"]
+            or template["gate_trace"].get("children") is None
+        )
+    assert leaf_count > 50, "expected a full stack of explained leaves"
+
+    winner = next(t for t in payload["templates"] if t["is_winner"])
+    hunting_leaves = [
+        leaf
+        for leaf in _leaves(winner["gate_trace"])
+        if leaf["evidence"]["kind"] == "has_inbound_pair_tag"
+    ]
+    assert hunting_leaves, "evade_pursuers gate reads the hunting pair tag"
+    assert hunting_leaves[0]["evidence"]["matched"] == [2]
+
+
+@pytest.mark.requires_postgres
+def test_slot_backed_explain_carries_evidence_end_to_end() -> None:
+    """Evidence must survive the full audit payload path on a real slot."""
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session
+
+    from nexus.agents.orrery.audit import explain_dry_run
+    from nexus.api.slot_utils import get_slot_db_url
+    from nexus.config import load_settings_as_dict
+
+    orrery = load_settings_as_dict()["orrery"]
+    engine = create_engine(get_slot_db_url(slot=2))
+    try:
+        with Session(engine) as session:
+            report = explain_dry_run(
+                session,
+                BUILTIN_TEMPLATES,
+                anchor_chunk_id=None,
+                window_chunks=int(orrery["binding"]["window_chunks"]),
+                sunhelm_settings=orrery.get("sunhelm"),
+            )
+    finally:
+        engine.dispose()
+
+    payload = json.loads(json.dumps(report.to_dict()))
+    assert payload["actors"], "save_02 is expected to bind off-screen actors"
+
+    def _leaves(node: dict):
+        if "children" in node:
+            for child in node["children"]:
+                yield from _leaves(child)
+        else:
+            yield node
+
+    checked = 0
+    for group in payload["actors"]:
+        for template in group["actor_stack"]["templates"]:
+            for leaf in _leaves(template["gate_trace"]):
+                assert leaf["evidence"] is not None
+                assert leaf["evidence"]["result"] == leaf["result"]
+                checked += 1
+    assert checked > 100, "expected slot-wide leaf evidence coverage"


### PR DESCRIPTION
## Summary

Step 4 of the audit-dashboard sequence in `docs/orrery_audit_dashboard_notes.md` — the evidence layer, via the spec's recommended parse-and-recompute path (no substrate changes). Every leaf `ConditionTrace` now carries the actual state values the predicate read, so the inspector can render `sleep debt 18.4 ≥ 12` right-aligned in mono and, on family predicates, name the specific member that matched ("which suppressor tag killed this package").

**Design**

- `nexus/agents/orrery/evidence.py`: 53 resolvers, one per predicate factory in `substrate.py`, keyed on the `__name__` grammar. The catalog's `_PREDICATE_PARSERS` regexes are reused verbatim — one grammar, defined once, zero regex duplication — and recomputation goes through substrate's own helpers (`_at_routine_anchor`, `_routine_schedule_due`, `_trust_values_are_asymmetric`, the tier-ladder semantics including the corrupt-exclusive-ladder refusal) so evidence reads exactly what production reads.
- Uniform payload per leaf: `kind` / `params` (config parsed from the name) / `entities` (slot → resolved id) / `observed` (state values) / `matched` (family members, inbound subjects, qualifying events...) / `result`.
- **Drift tripwire**: each resolver recomputes its own verdict, and `trace_condition` raises on any mismatch with the real closure's return — the same discipline `explain_template` already applies against `evaluate()`. Every explain anywhere in the test suite now doubles as a resolver-correctness check.
- The one name-unrecoverable input — `recent_event`'s `changed_fields` filter (the name carries only a `,fields` marker; no builtin template uses it) — yields `result: null` and skips the cross-check honestly rather than pretending to a verdict it cannot recompute.
- Unknown leaf names raise `EvidenceResolutionError` loudly: on an audit surface, a leaf whose reasoning cannot be shown is a coverage bug.

**Tests** (no mocks)

- Factory sweep: all 53 factories authored against a synthetic rich state, verdict parity asserted per resolver, plus a **registry-lockstep test** — the sweep table must exactly equal the resolver registry, so a new factory cannot land without evidence support.
- Every gate and branch leaf of every builtin template resolves across every demo preset.
- Observed-value assertions (need debt, trust, cooldown tick arithmetic), matched-member assertions (hidden-family tag, intimacy suppressor, inbound `hunting` subjects), tier-default behavior, unbound-slot honesty.
- Live save_02 sweep (`requires_postgres`): evidence survives the full `explain_dry_run` payload path, >100 leaves checked with payload/evidence result agreement.

Composes cleanly with #421: the what-if sandbox now explains both baseline and sandbox states with the evidence cross-check active on each (606 live tests pass on the rebased branch; the only failure is the known pre-existing `test_pair_tag_writer` failure that reproduces on origin/main).

Next in sequence: step 5 (coverage analyzer — batch over historical chunks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY