### PR TITLE
Add Orrery coverage analyzer over historical anchors

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -212,6 +212,11 @@ window_chunks = 30
 # gateway has no auth and binds 0.0.0.0, so this ships off — flip to true
 # locally while working on the audit dashboard (issue #415).
 enabled = false
+# Coverage analyzer bounds: max anchors per request (each anchor is a full
+# explained dry-run tick) and the backfill-epoch lint threshold (distinct
+# world times written within one wall-clock second).
+coverage_max_anchors = 50
+coverage_epoch_min_world_times = 10
 
 [orrery.route_graph]
 max_edges_per_query = 5000

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -68,6 +68,13 @@ class _TemplateTally:
     gate_passed: int = 0
     fired: int = 0
     won: int = 0
+    # Present-target pressure stacks tallied separately: their winners are
+    # prompt pressures, not resolutions, so they must not blur the
+    # resolution-side reconciliation — but a pressure firing is still a
+    # firing for never-fired and gap purposes.
+    pressure_evaluated: int = 0
+    pressure_fired: int = 0
+    pressure_won: int = 0
 
     def __post_init__(self) -> None:
         self.branch_chosen: dict[str, int] = {label: 0 for label in self.branch_labels}
@@ -91,24 +98,29 @@ def sample_anchor_ids(
     if stride < 1:
         raise ValueError(f"anchor sample stride must be >= 1, got {stride}")
     end_clause = "WHERE id <= :end_chunk_id" if end_chunk_id is not None else ""
-    params: dict[str, Any] = {"limit": count * stride}
+    params: dict[str, Any] = {"stride": stride, "limit": count}
     if end_chunk_id is not None:
         params["end_chunk_id"] = end_chunk_id
+    # Stride inside SQL so only `count` ids ever reach Python — a large
+    # stride must not scale the fetched row set (review finding on #423).
     rows = session.execute(
         text(
             f"""
             /* orrery_coverage:sample_anchors */
-            SELECT id FROM narrative_chunks
-            {end_clause}
+            SELECT id FROM (
+                SELECT id,
+                       row_number() OVER (ORDER BY id DESC) AS rn
+                FROM narrative_chunks
+                {end_clause}
+            ) ordered
+            WHERE mod(rn - 1, :stride) = 0
             ORDER BY id DESC
             LIMIT :limit
             """
         ),
         params,
     ).scalars()
-    descending = list(rows)
-    sampled = descending[::stride][:count]
-    return sorted(sampled)
+    return sorted(rows)
 
 
 def _resolution_stacks(
@@ -145,6 +157,15 @@ def _tally_report(
                     winners_by_band[item.drive_band] = (
                         winners_by_band.get(item.drive_band, 0) + 1
                     )
+        for stack in group.scene_pressure_stacks:
+            for item in stack.templates:
+                tally = tallies[item.template_id]
+                tally.pressure_evaluated += 1
+                if item.fired:
+                    fired_anywhere = True
+                    tally.pressure_fired += 1
+                if item.template_id == stack.winner_id:
+                    tally.pressure_won += 1
         actor_gaps = gap_counts.setdefault(
             group.actor_entity_id, {"seen_anchors": 0, "gapped_anchors": 0}
         )
@@ -325,6 +346,9 @@ def analyze_coverage(
             "gate_passed": tally.gate_passed,
             "fired": tally.fired,
             "won": tally.won,
+            "pressure_evaluated": tally.pressure_evaluated,
+            "pressure_fired": tally.pressure_fired,
+            "pressure_won": tally.pressure_won,
             "branch_chosen": dict(tally.branch_chosen),
             "branch_labels_never_chosen": [
                 label for label, chosen in tally.branch_chosen.items() if chosen == 0

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -1,0 +1,383 @@
+"""Batch coverage analysis for Orrery packages over historical anchors.
+
+The audit dashboard's health strip and the spec's coverage analyzer are the
+same tool (docs/orrery_audit_dashboard_notes.md): run the explained resolver
+across a window of historical chunks and aggregate what actually happens —
+actors no package ever fires for, packages that never (or always) win,
+branches never chosen, the statically dead gate arms, and slot data-quality
+findings (NULL bestowal world times, wall-clock backfill epochs).
+
+Honesty: hydration at a historical anchor rewinds only recent events, the
+clock, the actor roster, and the need-debt accrual tail; tags, pair tags,
+relationships, positions, travel, and routine anchors are **current
+projections**. Every payload carries :data:`HYDRATION_HONESTY` verbatim so
+the UI can render the per-axis label instead of implying a clean rewind.
+
+Never-chosen branches here mean "never selected across the analyzed window."
+That is weaker than "dead behind its gate" (which needs exhaustive branch
+traces — branch evaluation stops at the first passing branch) but is the
+correct first-order signal for authored-magnitude ladders.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from sqlalchemy import text
+
+from nexus.agents.orrery.audit import (
+    ActorGroupExplanation,
+    ExplainedTickReport,
+    build_catalog,
+    explain_dry_run,
+)
+from nexus.agents.orrery.explain import StackExplanation
+from nexus.agents.orrery.substrate import Template
+
+HYDRATION_HONESTY: Mapping[str, Tuple[str, ...]] = {
+    "rewound_to_anchor": (
+        "recent_events",
+        "world_time",
+        "time_of_day",
+        "actor_roster",
+        "need_debt_accrual",
+    ),
+    "current_projection": (
+        "tags",
+        "pair_tags",
+        "relationships",
+        "trust",
+        "positions",
+        "activities",
+        "travel_states",
+        "routine_anchors",
+        "faction_memberships",
+        "weather",
+    ),
+}
+
+
+@dataclass
+class _TemplateTally:
+    drive_band: str
+    arity: str
+    branch_labels: Tuple[str, ...]
+    evaluated: int = 0
+    gate_passed: int = 0
+    fired: int = 0
+    won: int = 0
+
+    def __post_init__(self) -> None:
+        self.branch_chosen: dict[str, int] = {label: 0 for label in self.branch_labels}
+
+
+def sample_anchor_ids(
+    session: Any,
+    *,
+    count: int,
+    stride: int,
+    end_chunk_id: Optional[int] = None,
+) -> List[int]:
+    """Return up to ``count`` real chunk ids walking backward from the end.
+
+    Chunk ids may have gaps, so sampling selects every ``stride``-th existing
+    chunk rather than assuming contiguous ids. Returned ascending.
+    """
+
+    if count < 1:
+        raise ValueError(f"anchor sample count must be >= 1, got {count}")
+    if stride < 1:
+        raise ValueError(f"anchor sample stride must be >= 1, got {stride}")
+    end_clause = "WHERE id <= :end_chunk_id" if end_chunk_id is not None else ""
+    params: dict[str, Any] = {"limit": count * stride}
+    if end_chunk_id is not None:
+        params["end_chunk_id"] = end_chunk_id
+    rows = session.execute(
+        text(
+            f"""
+            /* orrery_coverage:sample_anchors */
+            SELECT id FROM narrative_chunks
+            {end_clause}
+            ORDER BY id DESC
+            LIMIT :limit
+            """
+        ),
+        params,
+    ).scalars()
+    descending = list(rows)
+    sampled = descending[::stride][:count]
+    return sorted(sampled)
+
+
+def _resolution_stacks(
+    group: ActorGroupExplanation,
+) -> Iterable[StackExplanation]:
+    """The stacks whose winners become resolutions (pressure stacks excluded)."""
+
+    yield group.actor_stack
+    yield from group.two_party_stacks
+
+
+def _tally_report(
+    report: ExplainedTickReport,
+    tallies: dict[str, _TemplateTally],
+    gap_counts: dict[int, dict[str, int]],
+) -> dict[str, Any]:
+    winners_by_band: dict[str, int] = {}
+    gap_actor_ids: list[int] = []
+    for group in report.actors:
+        fired_anywhere = False
+        for stack in _resolution_stacks(group):
+            for item in stack.templates:
+                tally = tallies[item.template_id]
+                tally.evaluated += 1
+                if item.gate_passed:
+                    tally.gate_passed += 1
+                if item.fired:
+                    fired_anywhere = True
+                    tally.fired += 1
+                    if item.chosen_branch is not None:
+                        tally.branch_chosen[item.chosen_branch] += 1
+                if item.template_id == stack.winner_id:
+                    tally.won += 1
+                    winners_by_band[item.drive_band] = (
+                        winners_by_band.get(item.drive_band, 0) + 1
+                    )
+        actor_gaps = gap_counts.setdefault(
+            group.actor_entity_id, {"seen_anchors": 0, "gapped_anchors": 0}
+        )
+        actor_gaps["seen_anchors"] += 1
+        if not fired_anywhere:
+            actor_gaps["gapped_anchors"] += 1
+            gap_actor_ids.append(group.actor_entity_id)
+
+    return {
+        "anchor_chunk_id": report.anchor_chunk_id,
+        "world_time": (
+            report.world_time.isoformat() if report.world_time is not None else None
+        ),
+        "time_of_day": report.time_of_day,
+        "actor_count": report.actor_count,
+        "winners_by_band": winners_by_band,
+        "gap_actor_ids": gap_actor_ids,
+        "need_pressure_count": len(report.need_pressures),
+    }
+
+
+def _data_quality_findings(
+    session: Any, *, epoch_min_world_times: int
+) -> dict[str, Any]:
+    """Slot data-quality findings for the health strip.
+
+    NULL bestowal world times make per-row as-of provenance "unknowable";
+    a wall-clock instant carrying many distinct world times is the signature
+    of a retrograde backfill epoch (months of world time written at once) —
+    the standing reason wall clocks must never be used as chunk proxies.
+    """
+
+    null_bestowals = [
+        dict(row)
+        for row in session.execute(
+            text(
+                """
+                /* orrery_coverage:null_world_time_bestowals */
+                SELECT 'entity_tags' AS bestowal_table,
+                       source_kind::text AS source_kind,
+                       count(*) FILTER (WHERE applied_at_world_time IS NULL)
+                           AS null_world_time_rows,
+                       count(*) AS active_rows
+                FROM entity_tags
+                WHERE cleared_at IS NULL
+                GROUP BY source_kind
+                UNION ALL
+                SELECT 'entity_pair_tags',
+                       source_kind::text,
+                       count(*) FILTER (WHERE applied_at_world_time IS NULL),
+                       count(*)
+                FROM entity_pair_tags
+                WHERE cleared_at IS NULL
+                GROUP BY source_kind
+                ORDER BY bestowal_table, source_kind
+                """
+            )
+        ).mappings()
+    ]
+
+    epochs = [
+        {
+            "bestowal_table": row["bestowal_table"],
+            "wall_clock_instant": row["wall_clock_instant"].isoformat(),
+            "rows": row["rows"],
+            "distinct_world_times": row["distinct_world_times"],
+            "world_time_span": (
+                [
+                    row["min_world_time"].isoformat(),
+                    row["max_world_time"].isoformat(),
+                ]
+                if row["min_world_time"] is not None
+                else None
+            ),
+        }
+        for row in session.execute(
+            text(
+                """
+                /* orrery_coverage:wall_clock_epochs */
+                SELECT bestowal_table,
+                       wall_clock_instant,
+                       rows,
+                       distinct_world_times,
+                       min_world_time,
+                       max_world_time
+                FROM (
+                    SELECT 'entity_tags' AS bestowal_table,
+                           date_trunc('second', applied_at) AS wall_clock_instant,
+                           count(*) AS rows,
+                           count(DISTINCT applied_at_world_time)
+                               AS distinct_world_times,
+                           min(applied_at_world_time) AS min_world_time,
+                           max(applied_at_world_time) AS max_world_time
+                    FROM entity_tags
+                    WHERE applied_at_world_time IS NOT NULL
+                    GROUP BY 2
+                    UNION ALL
+                    SELECT 'entity_pair_tags',
+                           date_trunc('second', applied_at),
+                           count(*),
+                           count(DISTINCT applied_at_world_time),
+                           min(applied_at_world_time),
+                           max(applied_at_world_time)
+                    FROM entity_pair_tags
+                    WHERE applied_at_world_time IS NOT NULL
+                    GROUP BY 2
+                ) grouped
+                WHERE distinct_world_times >= :epoch_min
+                ORDER BY rows DESC
+                """
+            ),
+            {"epoch_min": epoch_min_world_times},
+        ).mappings()
+    ]
+
+    return {
+        "null_world_time_bestowals": null_bestowals,
+        "wall_clock_epochs": epochs,
+        "epoch_min_world_times": epoch_min_world_times,
+    }
+
+
+def analyze_coverage(
+    session: Any,
+    templates: Sequence[Template],
+    *,
+    anchor_chunk_ids: Sequence[int],
+    window_chunks: int,
+    sunhelm_settings: Optional[Any] = None,
+    epoch_min_world_times: int,
+) -> dict[str, Any]:
+    """Aggregate explained resolution coverage across historical anchors.
+
+    Runs :func:`explain_dry_run` once per anchor (production-parity by
+    construction) and aggregates winner/fired/gate statistics per template,
+    branch-selection counts, per-actor gap counts, per-anchor band tallies,
+    the static dead-gate-arm lint, and slot data-quality findings.
+    """
+
+    if not anchor_chunk_ids:
+        raise ValueError("analyze_coverage requires at least one anchor chunk id")
+
+    templates_tuple = tuple(templates)
+    catalog = build_catalog(templates_tuple)
+    arity_by_id = {
+        payload["template_id"]: payload["arity"]
+        for band in catalog["drive_bands"]
+        for payload in band["templates"]
+    }
+    tallies = {
+        template.id: _TemplateTally(
+            drive_band=template.drive_band.value,
+            arity=arity_by_id[template.id],
+            branch_labels=tuple(branch.label for branch in template.branches),
+        )
+        for template in templates_tuple
+    }
+
+    gap_counts: dict[int, dict[str, int]] = {}
+    entity_names: dict[int, str] = {}
+    anchors: list[dict[str, Any]] = []
+    for anchor_chunk_id in anchor_chunk_ids:
+        report = explain_dry_run(
+            session,
+            templates_tuple,
+            anchor_chunk_id=anchor_chunk_id,
+            window_chunks=window_chunks,
+            sunhelm_settings=sunhelm_settings,
+        )
+        anchors.append(_tally_report(report, tallies, gap_counts))
+        entity_names.update(report.entity_names)
+
+    template_payloads = {
+        template_id: {
+            "drive_band": tally.drive_band,
+            "arity": tally.arity,
+            "evaluated": tally.evaluated,
+            "gate_passed": tally.gate_passed,
+            "fired": tally.fired,
+            "won": tally.won,
+            "branch_chosen": dict(tally.branch_chosen),
+            "branch_labels_never_chosen": [
+                label for label, chosen in tally.branch_chosen.items() if chosen == 0
+            ],
+        }
+        for template_id, tally in tallies.items()
+    }
+
+    gap_actors = [
+        {
+            "entity_id": entity_id,
+            "name": entity_names.get(entity_id),
+            "seen_anchors": counts["seen_anchors"],
+            "gapped_anchors": counts["gapped_anchors"],
+        }
+        for entity_id, counts in sorted(gap_counts.items())
+        if counts["gapped_anchors"] > 0
+    ]
+
+    dead_gate_arms = {
+        event_type: {
+            "consumed_by_gate": entry["consumed_by_gate"],
+            "consumed_by_branch": entry["consumed_by_branch"],
+        }
+        for event_type, entry in sorted(catalog["event_map"].items())
+        if entry["exogenous_only"]
+    }
+
+    return {
+        "anchor_chunk_ids": list(anchor_chunk_ids),
+        "window_chunks": window_chunks,
+        "anchors": anchors,
+        "templates": template_payloads,
+        "never_fired": sorted(
+            template_id for template_id, tally in tallies.items() if tally.fired == 0
+        ),
+        "fired_never_won": sorted(
+            template_id
+            for template_id, tally in tallies.items()
+            if tally.fired > 0 and tally.won == 0
+        ),
+        "always_won_when_fired": sorted(
+            template_id
+            for template_id, tally in tallies.items()
+            if tally.fired > 0 and tally.won == tally.fired
+        ),
+        "gap_actors": gap_actors,
+        "dead_gate_arms": dead_gate_arms,
+        "data_quality": _data_quality_findings(
+            session, epoch_min_world_times=epoch_min_world_times
+        ),
+        "hydration_honesty": {
+            axis: list(fields) for axis, fields in HYDRATION_HONESTY.items()
+        },
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/nexus/api/orrery_dev_endpoints.py
+++ b/nexus/api/orrery_dev_endpoints.py
@@ -22,6 +22,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
 from nexus.agents.orrery.audit import build_catalog, entity_context, explain_dry_run
+from nexus.agents.orrery.coverage import analyze_coverage, sample_anchor_ids
 from nexus.agents.orrery.overrides import (
     EventOverride,
     LocationOverride,
@@ -188,6 +189,30 @@ class OrreryResolveRequest(BaseModel):
     )
 
 
+class OrreryCoverageRequest(BaseModel):
+    """Parameters for a batch coverage analysis over historical anchors."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    slot: Optional[int] = Field(default=None)
+    anchor_chunk_ids: Optional[List[int]] = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Explicit anchors to analyze. When omitted, `count`/`stride`/"
+            "`end_chunk_id` sample real chunk ids walking backward from the "
+            "slot head."
+        ),
+    )
+    count: int = Field(default=10, ge=1)
+    stride: int = Field(default=1, ge=1)
+    end_chunk_id: Optional[int] = Field(default=None)
+    window_chunks: Optional[int] = Field(
+        default=None,
+        description="Binding window; defaults to [orrery.binding] window_chunks.",
+    )
+
+
 class OrreryEntityContextRequest(BaseModel):
     """Parameters for the entity hover/context payload."""
 
@@ -310,4 +335,60 @@ async def post_entity_context(
             anchor_chunk_id=anchor_chunk_id,
             recent_events_limit=request.recent_events_limit,
             sunhelm_settings=orrery.get("sunhelm"),
+        )
+
+
+@router.post("/coverage")
+async def post_coverage(request: OrreryCoverageRequest) -> dict[str, Any]:
+    """Batch coverage analysis over historical anchors. Read-only.
+
+    Each anchor is a full explained dry-run tick, so the anchor count is
+    bounded by [orrery.dashboard] coverage_max_anchors.
+    """
+
+    orrery = _orrery_settings()
+    dashboard = orrery.get("dashboard", {})
+    max_anchors = int(dashboard["coverage_max_anchors"])
+    epoch_min = int(dashboard["coverage_epoch_min_world_times"])
+    window_chunks = (
+        request.window_chunks
+        if request.window_chunks is not None
+        else int(orrery["binding"]["window_chunks"])
+    )
+    requested = (
+        len(request.anchor_chunk_ids)
+        if request.anchor_chunk_ids is not None
+        else request.count
+    )
+    if requested > max_anchors:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Coverage request asks for {requested} anchors; "
+                f"[orrery.dashboard] coverage_max_anchors is {max_anchors}"
+            ),
+        )
+    with _slot_session(request.slot) as session:
+        anchor_chunk_ids = (
+            list(request.anchor_chunk_ids)
+            if request.anchor_chunk_ids is not None
+            else sample_anchor_ids(
+                session,
+                count=request.count,
+                stride=request.stride,
+                end_chunk_id=request.end_chunk_id,
+            )
+        )
+        if not anchor_chunk_ids:
+            raise HTTPException(
+                status_code=400,
+                detail="No anchors to analyze: the slot has no narrative chunks",
+            )
+        return analyze_coverage(
+            session,
+            BUILTIN_TEMPLATES,
+            anchor_chunk_ids=anchor_chunk_ids,
+            window_chunks=window_chunks,
+            sunhelm_settings=orrery.get("sunhelm"),
+            epoch_min_world_times=epoch_min,
         )

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1002,6 +1002,24 @@ class OrreryDashboardSettings(BaseModel):
             "explicitly for local development."
         ),
     )
+    coverage_max_anchors: int = Field(
+        default=50,
+        ge=1,
+        description=(
+            "Upper bound on anchors a single POST /api/dev/orrery/coverage "
+            "request may analyze; each anchor is a full explained dry-run "
+            "tick, so this bounds request latency and payload size."
+        ),
+    )
+    coverage_epoch_min_world_times: int = Field(
+        default=10,
+        ge=2,
+        description=(
+            "Data-quality lint threshold: a single wall-clock second whose "
+            "bestowals carry at least this many distinct world times is "
+            "flagged as a retrograde backfill epoch."
+        ),
+    )
 
 
 class OrrerySettings(BaseModel):

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -659,6 +659,8 @@ def test_coverage_report_is_internally_consistent(
         authored_labels = [b.label for b in templates_by_id[template_id].branches]
         assert sorted(stats["branch_chosen"]) == sorted(authored_labels)
         assert sum(stats["branch_chosen"].values()) == stats["fired"]
+        assert stats["pressure_won"] <= stats["pressure_fired"], template_id
+        assert stats["pressure_fired"] <= stats["pressure_evaluated"], template_id
         total_won += stats["won"]
 
     # Winner counts per anchor band tally must reconcile with template wins.
@@ -672,7 +674,9 @@ def test_coverage_report_is_internally_consistent(
     # Derived lists partition consistently.
     assert not set(payload["never_fired"]) & set(payload["fired_never_won"])
     for template_id in payload["never_fired"]:
+        # never_fired means no resolution-stack AND no pressure-stack firing.
         assert payload["templates"][template_id]["fired"] == 0
+        assert payload["templates"][template_id]["pressure_fired"] == 0
     for template_id in payload["fired_never_won"]:
         stats = payload["templates"][template_id]
         assert stats["fired"] > 0 and stats["won"] == 0

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -623,4 +623,164 @@ def test_dashboard_flag_gates_router_registration(tmp_path: Path) -> None:
         "/api/dev/orrery/catalog",
         "/api/dev/orrery/resolve",
         "/api/dev/orrery/context/entities",
+        "/api/dev/orrery/coverage",
     }
+
+
+# ---------------------------------------------------------------------------
+# Coverage analyzer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_postgres
+@pytest.mark.parametrize("slot", AUDIT_SLOTS)
+def test_coverage_report_is_internally_consistent(
+    client: TestClient, slot: int
+) -> None:
+    response = client.post(
+        "/api/dev/orrery/coverage", json={"slot": slot, "count": 3, "stride": 5}
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+
+    assert payload["anchor_chunk_ids"] == sorted(payload["anchor_chunk_ids"])
+    assert 1 <= len(payload["anchor_chunk_ids"]) <= 3
+    assert [a["anchor_chunk_id"] for a in payload["anchors"]] == payload[
+        "anchor_chunk_ids"
+    ]
+
+    templates_by_id = {t.id: t for t in BUILTIN_TEMPLATES}
+    assert set(payload["templates"]) == set(templates_by_id)
+    total_won = 0
+    for template_id, stats in payload["templates"].items():
+        assert (
+            stats["won"] <= stats["fired"] <= stats["gate_passed"] <= stats["evaluated"]
+        ), template_id
+        authored_labels = [b.label for b in templates_by_id[template_id].branches]
+        assert sorted(stats["branch_chosen"]) == sorted(authored_labels)
+        assert sum(stats["branch_chosen"].values()) == stats["fired"]
+        total_won += stats["won"]
+
+    # Winner counts per anchor band tally must reconcile with template wins.
+    band_total = sum(
+        count
+        for anchor in payload["anchors"]
+        for count in anchor["winners_by_band"].values()
+    )
+    assert band_total == total_won
+
+    # Derived lists partition consistently.
+    assert not set(payload["never_fired"]) & set(payload["fired_never_won"])
+    for template_id in payload["never_fired"]:
+        assert payload["templates"][template_id]["fired"] == 0
+    for template_id in payload["fired_never_won"]:
+        stats = payload["templates"][template_id]
+        assert stats["fired"] > 0 and stats["won"] == 0
+
+    for gap in payload["gap_actors"]:
+        assert 0 < gap["gapped_anchors"] <= gap["seen_anchors"]
+
+    # The static lint re-derives exactly the four dead gate arms.
+    assert set(payload["dead_gate_arms"]) == {
+        "threat_issued",
+        "compliance_alert",
+        "faction_realignment",
+        "encoded_message",
+    }
+    assert set(payload["hydration_honesty"]) == {
+        "rewound_to_anchor",
+        "current_projection",
+    }
+
+
+@pytest.mark.requires_postgres
+def test_coverage_head_anchor_reconciles_with_production(
+    client: TestClient,
+    production_proposals: dict[int, tuple[Optional[int], OrreryTickProposal]],
+) -> None:
+    """Per-anchor band tallies must equal the production resolution count."""
+
+    for slot in AUDIT_SLOTS:
+        anchor_chunk_id, proposal = production_proposals[slot]
+        if anchor_chunk_id is None:
+            continue
+        response = client.post(
+            "/api/dev/orrery/coverage",
+            json={"slot": slot, "anchor_chunk_ids": [anchor_chunk_id]},
+        )
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        (anchor,) = payload["anchors"]
+        assert anchor["anchor_chunk_id"] == anchor_chunk_id
+        assert sum(anchor["winners_by_band"].values()) == len(proposal.resolutions)
+
+
+@pytest.mark.requires_postgres
+def test_coverage_data_quality_matches_sql_oracle(client: TestClient) -> None:
+    """save_05 exhibits the NULL-world-time bestowal pathology; the health
+    strip must report exactly what SQL reports."""
+
+    response = client.post("/api/dev/orrery/coverage", json={"slot": 5, "count": 1})
+    assert response.status_code == 200, response.text
+    findings = response.json()["data_quality"]["null_world_time_bestowals"]
+
+    engine = create_engine(get_slot_db_url(slot=5))
+    try:
+        with Session(engine) as session:
+            oracle_nulls, oracle_active = session.execute(
+                text(
+                    """
+                    SELECT count(*) FILTER (WHERE applied_at_world_time IS NULL),
+                           count(*)
+                    FROM entity_tags WHERE cleared_at IS NULL
+                    """
+                )
+            ).one()
+    finally:
+        engine.dispose()
+
+    tag_rows = [f for f in findings if f["bestowal_table"] == "entity_tags"]
+    assert sum(f["null_world_time_rows"] for f in tag_rows) == oracle_nulls
+    assert sum(f["active_rows"] for f in tag_rows) == oracle_active
+    assert oracle_nulls > 0, (
+        "save_05 no longer exhibits the NULL-world-time pathology — the "
+        "data-quality assertion is vacuous; repoint at a slot that does"
+    )
+
+
+@pytest.mark.requires_postgres
+def test_coverage_anchor_cap_and_sampling(client: TestClient) -> None:
+    from nexus.config import load_settings_as_dict
+
+    max_anchors = load_settings_as_dict()["orrery"]["dashboard"]["coverage_max_anchors"]
+
+    over = client.post(
+        "/api/dev/orrery/coverage", json={"slot": 2, "count": max_anchors + 1}
+    )
+    assert over.status_code == 400
+    assert "coverage_max_anchors" in over.json()["detail"]
+
+    over_explicit = client.post(
+        "/api/dev/orrery/coverage",
+        json={"slot": 2, "anchor_chunk_ids": list(range(1, max_anchors + 2))},
+    )
+    assert over_explicit.status_code == 400
+
+    # Stride sampling walks real chunk ids backward from the head.
+    engine = create_engine(get_slot_db_url(slot=2))
+    try:
+        with Session(engine) as session:
+            ids_desc = list(
+                session.execute(
+                    text("SELECT id FROM narrative_chunks ORDER BY id DESC LIMIT 9")
+                ).scalars()
+            )
+    finally:
+        engine.dispose()
+    expected = sorted(ids_desc[::3][:3])
+
+    response = client.post(
+        "/api/dev/orrery/coverage", json={"slot": 2, "count": 3, "stride": 3}
+    )
+    assert response.status_code == 200
+    assert response.json()["anchor_chunk_ids"] == expected

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -50,6 +50,8 @@ def test_orrery_settings_resolve_model_reference() -> None:
     }
     assert settings.orrery.sunhelm.pressure.min_severity_level == 2
     assert settings.orrery.dashboard.enabled is False
+    assert settings.orrery.dashboard.coverage_max_anchors == 50
+    assert settings.orrery.dashboard.coverage_epoch_min_world_times == 10
     weird = settings.orrery.retrograde.weird
     assert weird.default_level == "medium"
     assert weird.dev.cli_flag == "--weird"


### PR DESCRIPTION
## Summary

Step 5 of the audit-dashboard sequence in `docs/orrery_audit_dashboard_notes.md` — the coverage analyzer. The spec's framing: the dashboard's batch-over-chunks mode *is* the analyzer; auditing and coverage testing are the same tool.

`POST /api/dev/orrery/coverage` runs the explained resolver (`explain_dry_run`, production parity by construction) across a set of historical anchors — explicit ids or `count`/`stride`/`end_chunk_id` sampling over real chunk ids — and aggregates:

- **Per-template stats**: evaluated / gate_passed / fired / won, plus per-branch selection counts and never-chosen branch labels (documented as "never selected across the window," deliberately weaker than dead-behind-gate, which needs exhaustive branch traces).
- **Derived lists**: `never_fired`, `fired_never_won`, `always_won_when_fired`.
- **Gap actors**: actors with zero firing packages, with gapped/seen anchor counts and names.
- **Per-anchor tallies**: winners by drive band (the health-strip tile), need-pressure counts, world time.
- **Dead gate arms**: the static emit/consume lint re-derived from the catalog (`threat_issued`, `compliance_alert`, `faction_realignment`, `encoded_message`).
- **Data quality**: NULL bestowal world times by table × source_kind, and wall-clock backfill epochs (one wall-clock second carrying ≥ N distinct world times — the retrograde-backfill signature behind the "never use wall clocks as chunk proxies" rule).

**Honesty labeling**: historical hydration rewinds only events/clock/roster/need-accrual; tags, pair tags, relationships, and positions are current projections. Every payload carries the per-axis `hydration_honesty` map so the UI never implies a clean rewind.

**Config** (both in `nexus.toml` under `[orrery.dashboard]`, per the no-hardcoded-tunables directive): `coverage_max_anchors = 50` bounds request cost (each anchor is a full explained tick; over-cap → 400), `coverage_epoch_min_world_times = 10` tunes the epoch lint.

## Tests

Live against save_02 and save_05, no mocks: internal-consistency invariants (`won ≤ fired ≤ gate_passed ≤ evaluated`; branch-selection counts reconcile with fired counts; per-anchor band tallies reconcile with total template wins), head-anchor reconciliation against production `resolve_dry_run` resolution counts, data-quality findings matched against a direct SQL oracle with a save_05 non-vacuity guard (the NULL-world-time pathology must exist or the test demands repointing), anchor-cap 400s for both request shapes, and stride-sampling parity against SQL. Full suite: 885 passed offline; live suites pass with only the known pre-existing `test_pair_tag_writer` failure that reproduces on origin/main.

Disjoint from #422 (evidence layer); composes with #420/#421.

Next in sequence: step 6 (adjudication history: log-enrichment migration + `GET history/adjudications`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY