### PR TITLE
Add Orrery adjudication history (migration 063 + enriched logging + endpoint)

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -2153,6 +2153,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/056_orrery_routine_anchors.py`
 - `migrations/057_orrery_need_bodyform_applicability.py`
 - `migrations/059_orrery_social_travel_event.py`
+- `migrations/063_orrery_adjudication_history.sql`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 

--- a/migrations/063_orrery_adjudication_history.sql
+++ b/migrations/063_orrery_adjudication_history.sql
@@ -1,0 +1,76 @@
+-- 063_orrery_adjudication_history.sql
+--
+-- Adjudication-history enrichment for the Orrery audit dashboard (step 6 of
+-- docs/orrery_audit_dashboard_notes.md). Closes the recorded-history holes:
+-- the log's subject is recoverable after the incubator row is deleted
+-- (actor_entity_id + bindings), scene pressures persist past commit, and the
+-- set of proposals actually rendered to the storyteller is recorded so
+-- "ratified by omission" and "never shown" stop being indistinguishable.
+-- Pre-migration rows keep NULLs; consumers treat NULL as the pre-063 epoch.
+
+ALTER TABLE orrery_adjudication_log
+ADD COLUMN IF NOT EXISTS actor_entity_id bigint REFERENCES entities(id),
+ADD COLUMN IF NOT EXISTS bindings jsonb;
+
+COMMENT ON COLUMN orrery_adjudication_log.actor_entity_id IS
+    'Acting entity of the adjudicated draft, stamped at insert while the draft is in hand; NULL on rows written before migration 063 (the incubator proposal that carried it is deleted at commit).';
+COMMENT ON COLUMN orrery_adjudication_log.bindings IS
+    'Serialized slot bindings of the adjudicated draft (e.g. {"actor": 5, "target": 7}); NULL on pre-063 rows. binding_hash remains the opaque dedup key.';
+
+CREATE INDEX IF NOT EXISTS ix_orrery_adjudication_log_actor_entity_id
+    ON orrery_adjudication_log (actor_entity_id);
+
+CREATE TABLE IF NOT EXISTS orrery_scene_pressures (
+    id               bigserial PRIMARY KEY,
+    tick_chunk_id    bigint NOT NULL REFERENCES narrative_chunks(id),
+    template_id      text NOT NULL,
+    binding_hash     text NOT NULL,
+    actor_entity_id  bigint REFERENCES entities(id),
+    target_entity_id bigint REFERENCES entities(id),
+    priority         int NOT NULL,
+    magnitude        numeric(4,3),
+    branch_label     text,
+    pressure_stub    text,
+    prompt_text      text,
+    bindings         jsonb,
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (tick_chunk_id, template_id, binding_hash)
+);
+
+COMMENT ON TABLE orrery_scene_pressures IS
+    'Storyteller-mediated scene pressures persisted at chunk commit. Before migration 063 pressures were prompt-only and vanished with the incubator row, so "which packages pressured on-screen entities" was answerable live but never historically.';
+COMMENT ON COLUMN orrery_scene_pressures.template_id IS
+    'Behavior package (or {need}_need_pressure pseudo-template) that produced the pressure.';
+COMMENT ON COLUMN orrery_scene_pressures.binding_hash IS
+    'sha256 of the sorted bindings; with template_id forms the stable per-tick pressure identity.';
+COMMENT ON COLUMN orrery_scene_pressures.actor_entity_id IS
+    'Off-screen (or need-pressured present) actor exerting the pressure.';
+COMMENT ON COLUMN orrery_scene_pressures.target_entity_id IS
+    'On-screen target of a two-party pressure; NULL for need pseudo-pressures.';
+COMMENT ON COLUMN orrery_scene_pressures.prompt_text IS
+    'Rendered pressure line as offered to the storyteller.';
+
+CREATE INDEX IF NOT EXISTS ix_orrery_scene_pressures_tick_chunk_id
+    ON orrery_scene_pressures (tick_chunk_id);
+CREATE INDEX IF NOT EXISTS ix_orrery_scene_pressures_actor_entity_id
+    ON orrery_scene_pressures (actor_entity_id);
+
+CREATE TABLE IF NOT EXISTS orrery_prompt_exposures (
+    id            bigserial PRIMARY KEY,
+    tick_chunk_id bigint NOT NULL REFERENCES narrative_chunks(id),
+    kind          text NOT NULL CHECK (kind IN ('resolution', 'scene_pressure')),
+    proposal_id   text NOT NULL,
+    template_id   text NOT NULL,
+    binding_hash  text NOT NULL,
+    position      int NOT NULL,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (tick_chunk_id, kind, template_id, binding_hash)
+);
+
+COMMENT ON TABLE orrery_prompt_exposures IS
+    'Which Orrery proposals and scene pressures were rendered to the storyteller for a tick (the render cap is [orrery.prompt] in nexus.toml). Distinguishes "Skald saw and ratified by omission" from "never shown beyond the render cap". Rows exist only for ticks committed after migration 063.';
+COMMENT ON COLUMN orrery_prompt_exposures.position IS
+    'Zero-based render order within the kind, matching proposal order.';
+
+CREATE INDEX IF NOT EXISTS ix_orrery_prompt_exposures_tick_chunk_id
+    ON orrery_prompt_exposures (tick_chunk_id);

--- a/nexus.toml
+++ b/nexus.toml
@@ -206,6 +206,13 @@ enabled = true
 [orrery.binding]
 window_chunks = 30
 
+[orrery.prompt]
+# Render caps for Orrery material in the storyteller prompt. The commit-time
+# prompt-exposure log records the same first-N slice, so these are also the
+# boundary between "ratified by omission" and "never shown".
+max_rendered_proposals = 5
+max_rendered_pressures = 5
+
 [orrery.dashboard]
 # Registers the read-only /api/dev/orrery/* audit router on the gateway.
 # Server-side gate (import.meta.env.DEV only hides the client bundle): the

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -633,6 +633,25 @@ class LogonUtility:
                     f"[Score: {passage.get('score', 0):.2f}] {passage.get('text', '')}"
                 )
 
+        # Render caps shared with the commit-time prompt-exposure log
+        # (orrery_prompt_exposures): both sides must slice identically or the
+        # recorded "shown set" lies. Model defaults keep a single source when
+        # the orrery section is absent.
+        from nexus.config.settings_models import OrreryPromptSettings
+
+        _prompt_defaults = OrreryPromptSettings()
+        _prompt_cfg = (self.settings.get("orrery") or {}).get("prompt") or {}
+        max_rendered_proposals = int(
+            _prompt_cfg.get(
+                "max_rendered_proposals", _prompt_defaults.max_rendered_proposals
+            )
+        )
+        max_rendered_pressures = int(
+            _prompt_cfg.get(
+                "max_rendered_pressures", _prompt_defaults.max_rendered_pressures
+            )
+        )
+
         imminent_activity = context.get("orrery_imminent_activity") or []
         if imminent_activity:
             sections.append("\n=== ORRERY IMMINENT ACTIVITY ===")
@@ -645,7 +664,7 @@ class LogonUtility:
                 "only emits a world_event if you provide replacement_event_type. "
                 "Refer only to proposal_id; do not rely on prose parsing."
             )
-            for proposal in imminent_activity[:5]:
+            for proposal in imminent_activity[:max_rendered_proposals]:
                 if not isinstance(proposal, dict):
                     continue
                 proposal_id = proposal.get("proposal_id")
@@ -663,7 +682,7 @@ class LogonUtility:
                 "adapt, delay, ignore, or incorporate them. Do not let Orrery "
                 "decide what present characters do."
             )
-            for pressure in scene_pressures[:5]:
+            for pressure in scene_pressures[:max_rendered_pressures]:
                 if not isinstance(pressure, dict):
                     continue
                 label = pressure.get("branch_label") or pressure.get("template_id")

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -95,6 +95,31 @@ class CommitOrreryTickResult:
     deferred_count: int = 0
     voided_count: int = 0
     replaced_count: int = 0
+    scene_pressure_count: int = 0
+    prompt_exposure_count: int = 0
+
+
+def _coerce_prompt_limits(prompt_settings: Any) -> tuple[int, int]:
+    """Resolve the storyteller render caps for prompt-exposure logging.
+
+    Accepts the [orrery.prompt] mapping (or the Pydantic model); ``None``
+    resolves to the model defaults. Must agree with the render slice in
+    nexus/agents/lore/logon_utility.py or the recorded shown set lies.
+    """
+
+    from nexus.config.settings_models import OrreryPromptSettings
+
+    if prompt_settings is None:
+        prompt_settings = OrreryPromptSettings()
+    if isinstance(prompt_settings, OrreryPromptSettings):
+        return (
+            prompt_settings.max_rendered_proposals,
+            prompt_settings.max_rendered_pressures,
+        )
+    return (
+        int(prompt_settings["max_rendered_proposals"]),
+        int(prompt_settings["max_rendered_pressures"]),
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -238,6 +263,7 @@ def commit_orrery_tick_sync(
     sunhelm_settings: Optional[Any] = None,
     adjudications: Any = None,
     storyteller_state_updates: Any = None,
+    prompt_settings: Optional[Any] = None,
 ) -> CommitOrreryTickResult:
     """Materialize a preview proposal inside the accepted-chunk transaction."""
 
@@ -256,8 +282,28 @@ def commit_orrery_tick_sync(
             cur,
             source_chunk_id=tick_chunk_id,
         )
+        # Pressures and exposures persist even on resolution-free ticks —
+        # a tick can carry scene pressure with zero off-screen resolutions.
+        scene_pressure_count = 0
+        prompt_exposure_count = 0
+        if coerced is not None:
+            max_proposals, max_pressures = _coerce_prompt_limits(prompt_settings)
+            scene_pressure_count = _insert_scene_pressures_sync(
+                cur, coerced, tick_chunk_id=tick_chunk_id
+            )
+            prompt_exposure_count = _insert_prompt_exposures_sync(
+                cur,
+                coerced,
+                tick_chunk_id=tick_chunk_id,
+                max_proposals=max_proposals,
+                max_pressures=max_pressures,
+            )
         if not has_resolutions:
-            return CommitOrreryTickResult(cleared_tag_count=expired_tag_count)
+            return CommitOrreryTickResult(
+                cleared_tag_count=expired_tag_count,
+                scene_pressure_count=scene_pressure_count,
+                prompt_exposure_count=prompt_exposure_count,
+            )
 
         assert coerced is not None
         entity_ids = _entity_ids_from_proposal(coerced)
@@ -333,6 +379,23 @@ def commit_orrery_tick_sync(
             )
             if resolution_id is None:
                 skipped_existing_count += 1
+                # A replace-with-delta ruling must reach the history log even
+                # when the resolution row already exists (idempotent
+                # re-commit): resolve the existing id instead of silently
+                # dropping the ruling.
+                if adjudicated.adjudication is not None:
+                    if adjudicated.adjudication.action == "replace":
+                        replaced_count += 1
+                    _insert_adjudication_log_sync(
+                        cur,
+                        draft,
+                        adjudicated.adjudication,
+                        tick_chunk_id=tick_chunk_id,
+                        adjudication_source=adjudicated.adjudication_source,
+                        applied_resolution_id=_existing_resolution_id_sync(
+                            cur, draft, tick_chunk_id=tick_chunk_id
+                        ),
+                    )
                 continue
 
             if adjudicated.adjudication is not None:
@@ -387,6 +450,8 @@ def commit_orrery_tick_sync(
         deferred_count=deferred_count,
         voided_count=voided_count,
         replaced_count=replaced_count,
+        scene_pressure_count=scene_pressure_count,
+        prompt_exposure_count=prompt_exposure_count,
     )
 
 
@@ -400,6 +465,7 @@ async def commit_orrery_tick_async(
     sunhelm_settings: Optional[Any] = None,
     adjudications: Any = None,
     storyteller_state_updates: Any = None,
+    prompt_settings: Optional[Any] = None,
 ) -> CommitOrreryTickResult:
     """Async parity wrapper for tests and non-production commit callers."""
 
@@ -417,8 +483,28 @@ async def commit_orrery_tick_async(
         conn,
         source_chunk_id=tick_chunk_id,
     )
+    # Pressures and exposures persist even on resolution-free ticks — a tick
+    # can carry scene pressure with zero off-screen resolutions.
+    scene_pressure_count = 0
+    prompt_exposure_count = 0
+    if coerced is not None:
+        max_proposals, max_pressures = _coerce_prompt_limits(prompt_settings)
+        scene_pressure_count = await _insert_scene_pressures_async(
+            conn, coerced, tick_chunk_id=tick_chunk_id
+        )
+        prompt_exposure_count = await _insert_prompt_exposures_async(
+            conn,
+            coerced,
+            tick_chunk_id=tick_chunk_id,
+            max_proposals=max_proposals,
+            max_pressures=max_pressures,
+        )
     if not has_resolutions:
-        return CommitOrreryTickResult(cleared_tag_count=expired_tag_count)
+        return CommitOrreryTickResult(
+            cleared_tag_count=expired_tag_count,
+            scene_pressure_count=scene_pressure_count,
+            prompt_exposure_count=prompt_exposure_count,
+        )
 
     assert coerced is not None
     entity_ids = _entity_ids_from_proposal(coerced)
@@ -496,6 +582,21 @@ async def commit_orrery_tick_async(
         )
         if resolution_id is None:
             skipped_existing_count += 1
+            # Same idempotent-re-commit guarantee as the sync twin: the
+            # replace ruling reaches the log with the existing resolution id.
+            if adjudicated.adjudication is not None:
+                if adjudicated.adjudication.action == "replace":
+                    replaced_count += 1
+                await _insert_adjudication_log_async(
+                    conn,
+                    draft,
+                    adjudicated.adjudication,
+                    tick_chunk_id=tick_chunk_id,
+                    adjudication_source=adjudicated.adjudication_source,
+                    applied_resolution_id=await _existing_resolution_id_async(
+                        conn, draft, tick_chunk_id=tick_chunk_id
+                    ),
+                )
             continue
 
         if adjudicated.adjudication is not None:
@@ -550,6 +651,8 @@ async def commit_orrery_tick_async(
         deferred_count=deferred_count,
         voided_count=voided_count,
         replaced_count=replaced_count,
+        scene_pressure_count=scene_pressure_count,
+        prompt_exposure_count=prompt_exposure_count,
     )
 
 
@@ -856,8 +959,10 @@ def _insert_adjudication_log_sync(
         INSERT INTO orrery_adjudication_log (
             tick_chunk_id, proposal_id, template_id, binding_hash, action,
             adjudication_source, skald_note, original_state_delta,
-            replacement_state_delta, replacement_event_type, applied_resolution_id
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s)
+            replacement_state_delta, replacement_event_type,
+            applied_resolution_id, actor_entity_id, bindings
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s,
+                  %s, %s::jsonb)
         """,
         (
             tick_chunk_id,
@@ -875,6 +980,8 @@ def _insert_adjudication_log_sync(
             ),
             adjudication.replacement_event_type,
             applied_resolution_id,
+            _scalar_entity_binding(draft.bindings, "actor"),
+            json.dumps(dict(draft.bindings)),
         ),
     )
 
@@ -897,8 +1004,10 @@ async def _insert_adjudication_log_async(
         INSERT INTO orrery_adjudication_log (
             tick_chunk_id, proposal_id, template_id, binding_hash, action,
             adjudication_source, skald_note, original_state_delta,
-            replacement_state_delta, replacement_event_type, applied_resolution_id
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9::jsonb, $10, $11)
+            replacement_state_delta, replacement_event_type,
+            applied_resolution_id, actor_entity_id, bindings
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9::jsonb, $10, $11,
+                  $12, $13::jsonb)
         """,
         tick_chunk_id,
         adjudication.proposal_id,
@@ -915,7 +1024,198 @@ async def _insert_adjudication_log_async(
         ),
         adjudication.replacement_event_type,
         applied_resolution_id,
+        _scalar_entity_binding(draft.bindings, "actor"),
+        json.dumps(dict(draft.bindings)),
     )
+
+
+def _existing_resolution_id_sync(
+    cur: Any,
+    draft: OrreryResolutionDraft,
+    *,
+    tick_chunk_id: int,
+) -> Optional[int]:
+    cur.execute(
+        """
+        SELECT id FROM orrery_resolutions
+        WHERE tick_chunk_id = %s AND template_id = %s AND binding_hash = %s
+        """,
+        (tick_chunk_id, draft.template_id, draft.binding_hash),
+    )
+    row = cur.fetchone()
+    if not row:
+        return None
+    return _row_get(row, "id", 0)
+
+
+async def _existing_resolution_id_async(
+    conn: Any,
+    draft: OrreryResolutionDraft,
+    *,
+    tick_chunk_id: int,
+) -> Optional[int]:
+    return await conn.fetchval(
+        """
+        SELECT id FROM orrery_resolutions
+        WHERE tick_chunk_id = $1 AND template_id = $2 AND binding_hash = $3
+        """,
+        tick_chunk_id,
+        draft.template_id,
+        draft.binding_hash,
+    )
+
+
+def _insert_scene_pressures_sync(cur: Any, proposal: Any, *, tick_chunk_id: int) -> int:
+    count = 0
+    for pressure in proposal.scene_pressures:
+        cur.execute(
+            """
+            INSERT INTO orrery_scene_pressures (
+                tick_chunk_id, template_id, binding_hash, actor_entity_id,
+                target_entity_id, priority, magnitude, branch_label,
+                pressure_stub, prompt_text, bindings
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb)
+            ON CONFLICT (tick_chunk_id, template_id, binding_hash) DO NOTHING
+            RETURNING id
+            """,
+            (
+                tick_chunk_id,
+                pressure.template_id,
+                pressure.binding_hash,
+                _scalar_entity_binding(pressure.bindings, "actor"),
+                _scalar_entity_binding(pressure.bindings, "target"),
+                pressure.priority,
+                pressure.magnitude,
+                pressure.branch_label,
+                pressure.pressure_stub,
+                pressure.prompt_text,
+                json.dumps(dict(pressure.bindings)),
+            ),
+        )
+        if cur.fetchone():
+            count += 1
+    return count
+
+
+async def _insert_scene_pressures_async(
+    conn: Any, proposal: Any, *, tick_chunk_id: int
+) -> int:
+    count = 0
+    for pressure in proposal.scene_pressures:
+        inserted = await conn.fetchval(
+            """
+            INSERT INTO orrery_scene_pressures (
+                tick_chunk_id, template_id, binding_hash, actor_entity_id,
+                target_entity_id, priority, magnitude, branch_label,
+                pressure_stub, prompt_text, bindings
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb)
+            ON CONFLICT (tick_chunk_id, template_id, binding_hash) DO NOTHING
+            RETURNING id
+            """,
+            tick_chunk_id,
+            pressure.template_id,
+            pressure.binding_hash,
+            _scalar_entity_binding(pressure.bindings, "actor"),
+            _scalar_entity_binding(pressure.bindings, "target"),
+            pressure.priority,
+            pressure.magnitude,
+            pressure.branch_label,
+            pressure.pressure_stub,
+            pressure.prompt_text,
+            json.dumps(dict(pressure.bindings)),
+        )
+        if inserted is not None:
+            count += 1
+    return count
+
+
+def _prompt_exposure_rows(
+    proposal: Any, *, max_proposals: int, max_pressures: int
+) -> list[tuple[str, str, str, int]]:
+    """(kind, template_id, binding_hash, position) for the rendered slice.
+
+    Mirrors the render slices in logon_utility's storyteller prompt: the
+    first N proposals and first N pressures in proposal order.
+    """
+
+    rows: list[tuple[str, str, str, int]] = []
+    for position, draft in enumerate(proposal.resolutions[:max_proposals]):
+        rows.append(("resolution", draft.template_id, draft.binding_hash, position))
+    for position, pressure in enumerate(proposal.scene_pressures[:max_pressures]):
+        rows.append(
+            ("scene_pressure", pressure.template_id, pressure.binding_hash, position)
+        )
+    return rows
+
+
+def _insert_prompt_exposures_sync(
+    cur: Any,
+    proposal: Any,
+    *,
+    tick_chunk_id: int,
+    max_proposals: int,
+    max_pressures: int,
+) -> int:
+    count = 0
+    for kind, template_id, binding_hash, position in _prompt_exposure_rows(
+        proposal, max_proposals=max_proposals, max_pressures=max_pressures
+    ):
+        cur.execute(
+            """
+            INSERT INTO orrery_prompt_exposures (
+                tick_chunk_id, kind, proposal_id, template_id, binding_hash,
+                position
+            ) VALUES (%s, %s, %s, %s, %s, %s)
+            ON CONFLICT (tick_chunk_id, kind, template_id, binding_hash)
+                DO NOTHING
+            RETURNING id
+            """,
+            (
+                tick_chunk_id,
+                kind,
+                f"{template_id}:{binding_hash}",
+                template_id,
+                binding_hash,
+                position,
+            ),
+        )
+        if cur.fetchone():
+            count += 1
+    return count
+
+
+async def _insert_prompt_exposures_async(
+    conn: Any,
+    proposal: Any,
+    *,
+    tick_chunk_id: int,
+    max_proposals: int,
+    max_pressures: int,
+) -> int:
+    count = 0
+    for kind, template_id, binding_hash, position in _prompt_exposure_rows(
+        proposal, max_proposals=max_proposals, max_pressures=max_pressures
+    ):
+        inserted = await conn.fetchval(
+            """
+            INSERT INTO orrery_prompt_exposures (
+                tick_chunk_id, kind, proposal_id, template_id, binding_hash,
+                position
+            ) VALUES ($1, $2, $3, $4, $5, $6)
+            ON CONFLICT (tick_chunk_id, kind, template_id, binding_hash)
+                DO NOTHING
+            RETURNING id
+            """,
+            tick_chunk_id,
+            kind,
+            f"{template_id}:{binding_hash}",
+            template_id,
+            binding_hash,
+            position,
+        )
+        if inserted is not None:
+            count += 1
+    return count
 
 
 def _insert_resolution_sync(

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -382,8 +382,14 @@ def commit_orrery_tick_sync(
                 # A replace-with-delta ruling must reach the history log even
                 # when the resolution row already exists (idempotent
                 # re-commit): resolve the existing id instead of silently
-                # dropping the ruling.
-                if adjudicated.adjudication is not None:
+                # dropping the ruling. The log has no unique key, so guard
+                # against duplicate rows on repeated re-commits.
+                if (
+                    adjudicated.adjudication is not None
+                    and not _replace_already_logged_sync(
+                        cur, draft, tick_chunk_id=tick_chunk_id
+                    )
+                ):
                     if adjudicated.adjudication.action == "replace":
                         replaced_count += 1
                     _insert_adjudication_log_sync(
@@ -583,8 +589,14 @@ async def commit_orrery_tick_async(
         if resolution_id is None:
             skipped_existing_count += 1
             # Same idempotent-re-commit guarantee as the sync twin: the
-            # replace ruling reaches the log with the existing resolution id.
-            if adjudicated.adjudication is not None:
+            # replace ruling reaches the log with the existing resolution id,
+            # guarded against duplicate rows on repeated re-commits.
+            if (
+                adjudicated.adjudication is not None
+                and not await _replace_already_logged_async(
+                    conn, draft, tick_chunk_id=tick_chunk_id
+                )
+            ):
                 if adjudicated.adjudication.action == "replace":
                     replaced_count += 1
                 await _insert_adjudication_log_async(
@@ -1026,6 +1038,43 @@ async def _insert_adjudication_log_async(
         applied_resolution_id,
         _scalar_entity_binding(draft.bindings, "actor"),
         json.dumps(dict(draft.bindings)),
+    )
+
+
+def _replace_already_logged_sync(
+    cur: Any,
+    draft: OrreryResolutionDraft,
+    *,
+    tick_chunk_id: int,
+) -> bool:
+    cur.execute(
+        """
+        SELECT 1 FROM orrery_adjudication_log
+        WHERE tick_chunk_id = %s AND proposal_id = %s AND action = 'replace'
+        LIMIT 1
+        """,
+        (tick_chunk_id, draft.proposal_id),
+    )
+    return cur.fetchone() is not None
+
+
+async def _replace_already_logged_async(
+    conn: Any,
+    draft: OrreryResolutionDraft,
+    *,
+    tick_chunk_id: int,
+) -> bool:
+    return (
+        await conn.fetchval(
+            """
+            SELECT 1 FROM orrery_adjudication_log
+            WHERE tick_chunk_id = $1 AND proposal_id = $2 AND action = 'replace'
+            LIMIT 1
+            """,
+            tick_chunk_id,
+            draft.proposal_id,
+        )
+        is not None
     )
 
 

--- a/nexus/agents/orrery/history.py
+++ b/nexus/agents/orrery/history.py
@@ -1,0 +1,315 @@
+"""Adjudication history for the Orrery audit dashboard.
+
+Aggregates the persisted decision ledger — how often Skald defers, replaces,
+or voids each package (always faceted by adjudication source: machine-inferred
+``structured_state_update`` replaces are not authored rulings), the lifecycle
+funnel from committed resolution through promotion to narration, and the
+single most diagnostic derived metric: **defer streaks** (how many consecutive
+rulings a proposal absorbed before ratification, replacement, void, or its
+streak is still open).
+
+Epoch honesty: rows written before migration 063 lack ``actor_entity_id`` /
+``bindings`` on the log, and prompt exposures / scene pressures exist only for
+ticks committed after 063. The payload's ``epoch`` block quantifies exactly
+how much of the ledger is enriched rather than implying full coverage.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, List, Optional
+
+from sqlalchemy import text
+
+from nexus.agents.orrery.resolver import _entity_label, _load_entity_names
+
+_ACTIONS = ("defer", "replace", "void")
+
+
+def _streaks_for_proposal(
+    proposal_id: str,
+    template_id: str,
+    actor_entity_id: Optional[int],
+    timeline: List[tuple[int, str]],
+) -> List[dict[str, Any]]:
+    """Walk one proposal's merged ruling/commit timeline into defer streaks.
+
+    ``timeline`` is (tick, event) ascending, where event is a log action or
+    the synthetic ``committed``. A streak is a run of consecutive ``defer``
+    entries; whatever ends it is the outcome, and a run nothing has ended yet
+    is ``open``.
+    """
+
+    streaks: List[dict[str, Any]] = []
+    run_start: Optional[int] = None
+    run_end: Optional[int] = None
+    run_length = 0
+    for tick, event in timeline:
+        if event == "defer":
+            if run_start is None:
+                run_start = tick
+            run_end = tick
+            run_length += 1
+            continue
+        if run_length:
+            streaks.append(
+                {
+                    "proposal_id": proposal_id,
+                    "template_id": template_id,
+                    "actor_entity_id": actor_entity_id,
+                    "length": run_length,
+                    "start_tick": run_start,
+                    "end_tick": run_end,
+                    "outcome": "ratified" if event == "committed" else event,
+                    "outcome_tick": tick,
+                }
+            )
+            run_start, run_end, run_length = None, None, 0
+    if run_length:
+        streaks.append(
+            {
+                "proposal_id": proposal_id,
+                "template_id": template_id,
+                "actor_entity_id": actor_entity_id,
+                "length": run_length,
+                "start_tick": run_start,
+                "end_tick": run_end,
+                "outcome": "open",
+                "outcome_tick": None,
+            }
+        )
+    return streaks
+
+
+def adjudication_history(
+    session: Any,
+    *,
+    template_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Return the adjudication-history payload for one slot.
+
+    Read-only. ``template_id`` narrows every block to one package.
+    """
+
+    template_clause = "WHERE template_id = :template_id" if template_id else ""
+    params: dict[str, Any] = {"template_id": template_id} if template_id else {}
+
+    log_rows = [
+        dict(row)
+        for row in session.execute(
+            text(
+                f"""
+                /* orrery_history:adjudication_log */
+                SELECT tick_chunk_id, proposal_id, template_id, binding_hash,
+                       action, adjudication_source, skald_note,
+                       applied_resolution_id, actor_entity_id, bindings
+                FROM orrery_adjudication_log
+                {template_clause}
+                ORDER BY proposal_id, tick_chunk_id, id
+                """
+            ),
+            params,
+        ).mappings()
+    ]
+
+    resolution_rows = [
+        dict(row)
+        for row in session.execute(
+            text(
+                f"""
+                /* orrery_history:resolutions */
+                SELECT tick_chunk_id, template_id, binding_hash,
+                       actor_entity_id, promotion_status::text
+                           AS promotion_status,
+                       narration_status::text AS narration_status
+                FROM orrery_resolutions
+                {template_clause}
+                ORDER BY template_id, binding_hash, tick_chunk_id
+                """
+            ),
+            params,
+        ).mappings()
+    ]
+
+    exposure_stats = session.execute(
+        text(
+            f"""
+            /* orrery_history:exposures */
+            SELECT kind,
+                   count(*) AS rows,
+                   min(tick_chunk_id) AS earliest_tick
+            FROM orrery_prompt_exposures
+            {template_clause}
+            GROUP BY kind
+            """
+        ),
+        params,
+    ).mappings()
+    exposures = {
+        row["kind"]: {"rows": row["rows"], "earliest_tick": row["earliest_tick"]}
+        for row in exposure_stats
+    }
+
+    pressure_stats = (
+        session.execute(
+            text(
+                f"""
+                /* orrery_history:scene_pressures */
+                SELECT count(*) AS rows, min(tick_chunk_id) AS earliest_tick
+                FROM orrery_scene_pressures
+                {template_clause}
+                """
+            ),
+            params,
+        )
+        .mappings()
+        .one()
+    )
+
+    # --- Per-template action and funnel aggregation -------------------------
+    templates: dict[str, dict[str, Any]] = {}
+
+    def _template_entry(entry_template_id: str) -> dict[str, Any]:
+        return templates.setdefault(
+            entry_template_id,
+            {
+                "actions": {action: {} for action in _ACTIONS},
+                "committed": 0,
+                "promoted": 0,
+                "promotion_skipped": 0,
+                "promotion_pending": 0,
+                "narrated": 0,
+                "replaced_with_delta_committed": 0,
+            },
+        )
+
+    for row in log_rows:
+        entry = _template_entry(row["template_id"])
+        sources = entry["actions"][row["action"]]
+        sources[row["adjudication_source"]] = (
+            sources.get(row["adjudication_source"], 0) + 1
+        )
+        if row["action"] == "replace" and row["applied_resolution_id"] is not None:
+            entry["replaced_with_delta_committed"] += 1
+
+    for row in resolution_rows:
+        entry = _template_entry(row["template_id"])
+        entry["committed"] += 1
+        if row["promotion_status"] == "promoted":
+            entry["promoted"] += 1
+        elif row["promotion_status"] == "skipped":
+            entry["promotion_skipped"] += 1
+        else:
+            entry["promotion_pending"] += 1
+        if row["narration_status"] == "succeeded":
+            entry["narrated"] += 1
+
+    for entry in templates.values():
+        # Ratification is by omission and leaves no log row; a committed
+        # resolution is a ratification unless a replace-with-delta produced it.
+        entry["ratified_committed"] = (
+            entry["committed"] - entry["replaced_with_delta_committed"]
+        )
+
+    # --- Defer streaks -------------------------------------------------------
+    commits_by_proposal: dict[str, List[tuple[int, str]]] = {}
+    actor_by_proposal: dict[str, Optional[int]] = {}
+    for row in resolution_rows:
+        proposal_id = f"{row['template_id']}:{row['binding_hash']}"
+        commits_by_proposal.setdefault(proposal_id, []).append(
+            (row["tick_chunk_id"], "committed")
+        )
+        if row["actor_entity_id"] is not None:
+            actor_by_proposal.setdefault(proposal_id, row["actor_entity_id"])
+
+    timelines: dict[str, List[tuple[int, str]]] = {}
+    template_by_proposal: dict[str, str] = {}
+    for row in log_rows:
+        proposal_id = row["proposal_id"]
+        template_by_proposal[proposal_id] = row["template_id"]
+        timelines.setdefault(proposal_id, []).append(
+            (row["tick_chunk_id"], row["action"])
+        )
+        if row["actor_entity_id"] is not None:
+            actor_by_proposal.setdefault(proposal_id, row["actor_entity_id"])
+
+    defer_streaks: List[dict[str, Any]] = []
+    for proposal_id, timeline in timelines.items():
+        merged = sorted(
+            timeline + commits_by_proposal.get(proposal_id, []),
+            key=lambda item: item[0],
+        )
+        defer_streaks.extend(
+            _streaks_for_proposal(
+                proposal_id,
+                template_by_proposal[proposal_id],
+                actor_by_proposal.get(proposal_id),
+                merged,
+            )
+        )
+    defer_streaks.sort(key=lambda item: (-item["length"], item["proposal_id"]))
+
+    # --- Names and epoch honesty --------------------------------------------
+    entity_ids = {
+        actor_id for actor_id in actor_by_proposal.values() if actor_id is not None
+    }
+    entity_names = _load_entity_names(session, entity_ids) if entity_ids else {}
+    for streak in defer_streaks:
+        streak["actor_name"] = (
+            _entity_label(streak["actor_entity_id"], entity_names)
+            if streak["actor_entity_id"] is not None
+            else None
+        )
+
+    enriched_log_rows = sum(1 for row in log_rows if row["actor_entity_id"] is not None)
+
+    totals_actions: dict[str, int] = {action: 0 for action in _ACTIONS}
+    totals_sources: dict[str, int] = {}
+    for row in log_rows:
+        totals_actions[row["action"]] += 1
+        totals_sources[row["adjudication_source"]] = (
+            totals_sources.get(row["adjudication_source"], 0) + 1
+        )
+
+    return {
+        "template_filter": template_id,
+        "totals": {
+            "log_rows": len(log_rows),
+            "actions": totals_actions,
+            "sources": totals_sources,
+            "committed_resolutions": len(resolution_rows),
+        },
+        "templates": templates,
+        "defer_streaks": defer_streaks,
+        "exposures": {
+            "resolution": exposures.get(
+                "resolution", {"rows": 0, "earliest_tick": None}
+            ),
+            "scene_pressure": exposures.get(
+                "scene_pressure", {"rows": 0, "earliest_tick": None}
+            ),
+        },
+        "scene_pressures": {
+            "rows": pressure_stats["rows"],
+            "earliest_tick": pressure_stats["earliest_tick"],
+        },
+        "entity_names": {
+            str(entity_id): name for entity_id, name in entity_names.items()
+        },
+        "epoch": {
+            # Pre-063 rows have no subject; consumers must not read absence
+            # of actor_entity_id as "no actor".
+            "log_rows_with_subject": enriched_log_rows,
+            "log_rows_total": len(log_rows),
+            "exposure_logging_since_tick": min(
+                (
+                    block["earliest_tick"]
+                    for block in exposures.values()
+                    if block["earliest_tick"] is not None
+                ),
+                default=None,
+            ),
+            "scene_pressure_logging_since_tick": pressure_stats["earliest_tick"],
+        },
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -496,6 +496,7 @@ async def commit_incubator_to_database(
                 world_layer=world_layer,
                 adjudications=incubator.get("orrery_adjudications"),
                 storyteller_state_updates=incubator.get("entity_updates"),
+                prompt_settings=_orrery_prompt_settings(),
             )
             if (
                 orrery_result.resolution_count
@@ -536,3 +537,12 @@ async def commit_incubator_to_database(
 
     logger.info("Successfully committed chunk %s from session %s", chunk_id, session_id)
     return chunk_id
+
+
+def _orrery_prompt_settings() -> Any:
+    """[orrery.prompt] render caps, so the prompt-exposure log matches what
+    logon_utility actually rendered for this tick."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("prompt")

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -503,11 +503,14 @@ async def commit_incubator_to_database(
                 or orrery_result.skipped_existing_count
                 or orrery_result.adjudication_count
                 or orrery_result.cleared_tag_count
+                or orrery_result.scene_pressure_count
+                or orrery_result.prompt_exposure_count
             ):
                 logger.info(
                     "Committed Orrery tick for chunk %s: %s resolutions, %s events, "
                     "%s tag mutations, %s cleared tags, %s existing skipped, "
-                    "%s adjudications (%s deferred, %s voided, %s replaced)",
+                    "%s adjudications (%s deferred, %s voided, %s replaced), "
+                    "%s scene pressures, %s prompt exposures",
                     chunk_id,
                     orrery_result.resolution_count,
                     orrery_result.event_count,
@@ -518,6 +521,8 @@ async def commit_incubator_to_database(
                     orrery_result.deferred_count,
                     orrery_result.voided_count,
                     orrery_result.replaced_count,
+                    orrery_result.scene_pressure_count,
+                    orrery_result.prompt_exposure_count,
                 )
 
             # Step 9: Clear incubator

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -536,6 +536,7 @@ def commit_incubator_to_database_sync(
                 world_layer=world_layer,
                 adjudications=incubator.get("orrery_adjudications"),
                 storyteller_state_updates=incubator.get("entity_updates"),
+                prompt_settings=_orrery_prompt_settings(),
             )
             if (
                 orrery_result.resolution_count
@@ -702,3 +703,12 @@ def _apply_state_tags(cur, *, kind, subtype_table, subtype_id, bestowal) -> None
     )
     if any(counters.values()):
         logger.info(f"Tag bestowal {kind}/{subtype_id}: {counters}")
+
+
+def _orrery_prompt_settings() -> Any:
+    """[orrery.prompt] render caps, so the prompt-exposure log matches what
+    logon_utility actually rendered for this tick."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("prompt")

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -543,11 +543,14 @@ def commit_incubator_to_database_sync(
                 or orrery_result.skipped_existing_count
                 or orrery_result.adjudication_count
                 or orrery_result.cleared_tag_count
+                or orrery_result.scene_pressure_count
+                or orrery_result.prompt_exposure_count
             ):
                 logger.info(
                     "Committed Orrery tick for chunk %s: %s resolutions, %s events, "
                     "%s tag mutations, %s cleared tags, %s existing skipped, "
-                    "%s adjudications (%s deferred, %s voided, %s replaced)",
+                    "%s adjudications (%s deferred, %s voided, %s replaced), "
+                    "%s scene pressures, %s prompt exposures",
                     chunk_id,
                     orrery_result.resolution_count,
                     orrery_result.event_count,
@@ -558,6 +561,8 @@ def commit_incubator_to_database_sync(
                     orrery_result.deferred_count,
                     orrery_result.voided_count,
                     orrery_result.replaced_count,
+                    orrery_result.scene_pressure_count,
+                    orrery_result.prompt_exposure_count,
                 )
 
             # Step 8.6: Process Skald new-entity declarations inside the

--- a/nexus/api/orrery_dev_endpoints.py
+++ b/nexus/api/orrery_dev_endpoints.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 
 from nexus.agents.orrery.audit import build_catalog, entity_context, explain_dry_run
 from nexus.agents.orrery.coverage import analyze_coverage, sample_anchor_ids
+from nexus.agents.orrery.history import adjudication_history
 from nexus.agents.orrery.overrides import (
     EventOverride,
     LocationOverride,
@@ -392,3 +393,18 @@ async def post_coverage(request: OrreryCoverageRequest) -> dict[str, Any]:
             sunhelm_settings=orrery.get("sunhelm"),
             epoch_min_world_times=epoch_min,
         )
+
+
+@router.get("/history/adjudications")
+async def get_adjudication_history(
+    slot: Optional[int] = None,
+    template_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Adjudication ledger: action rates, lifecycle funnel, defer streaks.
+
+    Read-only. Faceted by adjudication_source in the payload; epoch block
+    reports how much of the ledger predates the 063 enrichment.
+    """
+
+    with _slot_session(slot) as session:
+        return adjudication_history(session, template_id=template_id)

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1022,6 +1022,31 @@ class OrreryDashboardSettings(BaseModel):
     )
 
 
+class OrreryPromptSettings(BaseModel):
+    """Render caps for Orrery material in the storyteller prompt.
+
+    The commit-time prompt-exposure log (orrery_prompt_exposures) records the
+    same first-N slice these caps produce at render time — the two sites must
+    read the same values or the recorded "shown set" lies.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_rendered_proposals: int = Field(
+        default=5,
+        ge=1,
+        description=(
+            "How many current-tick Orrery proposals the storyteller prompt "
+            "renders (ratify-by-omission applies only to rendered rows)."
+        ),
+    )
+    max_rendered_pressures: int = Field(
+        default=5,
+        ge=1,
+        description=("How many scene pressures the storyteller prompt renders."),
+    )
+
+
 class OrrerySettings(BaseModel):
     """Orrery off-screen behavior settings.
 
@@ -1042,6 +1067,7 @@ class OrrerySettings(BaseModel):
     sunhelm: OrrerySunhelmSettings = Field(default_factory=OrrerySunhelmSettings)
     retrograde: OrreryRetrogradeSettings
     dashboard: OrreryDashboardSettings = Field(default_factory=OrreryDashboardSettings)
+    prompt: OrreryPromptSettings = Field(default_factory=OrreryPromptSettings)
 
 
 # =============================================================================

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -624,6 +624,7 @@ def test_dashboard_flag_gates_router_registration(tmp_path: Path) -> None:
         "/api/dev/orrery/resolve",
         "/api/dev/orrery/context/entities",
         "/api/dev/orrery/coverage",
+        "/api/dev/orrery/history/adjudications",
     }
 
 
@@ -788,3 +789,23 @@ def test_coverage_anchor_cap_and_sampling(client: TestClient) -> None:
     )
     assert response.status_code == 200
     assert response.json()["anchor_chunk_ids"] == expected
+
+
+@pytest.mark.requires_postgres
+def test_adjudication_history_endpoint_over_http(client: TestClient) -> None:
+    response = client.get("/api/dev/orrery/history/adjudications?slot=5")
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload["totals"]["actions"]) == {"defer", "replace", "void"}
+    assert (
+        payload["epoch"]["log_rows_total"] >= payload["epoch"]["log_rows_with_subject"]
+    )
+    for streak in payload["defer_streaks"]:
+        assert streak["outcome"] in {"ratified", "replace", "void", "open"}
+
+    filtered = client.get(
+        "/api/dev/orrery/history/adjudications?slot=5&template_id=surveil"
+    )
+    assert filtered.status_code == 200
+    filtered_payload = filtered.json()
+    assert set(filtered_payload["templates"]) <= {"surveil"}

--- a/tests/test_orrery/test_adjudication_history.py
+++ b/tests/test_orrery/test_adjudication_history.py
@@ -220,6 +220,35 @@ def test_commit_persists_enriched_history_then_rolls_back() -> None:
             # land, pointing at the resolution row that already existed.
             assert replace_row[1] == existing_resolution_id
             assert replace_row[2] == actor_entity_id
+
+        # --- Round 3: a third commit must not duplicate the replace row ----
+        result_three = commit_orrery_tick_sync(
+            conn,
+            proposal,
+            tick_chunk_id=anchor_chunk_id,
+            slot=WRITE_SLOT,
+            adjudications=[
+                {
+                    "proposal_id": ratified.proposal_id,
+                    "action": "replace",
+                    "replacement_state_delta": {
+                        "character.current_activity": "audit-history probe"
+                    },
+                },
+            ],
+        )
+        assert result_three.replaced_count == 0
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT count(*) FROM orrery_adjudication_log
+                WHERE binding_hash = %s AND action = 'replace'
+                """,
+                (ratify_hash,),
+            )
+            assert (
+                cur.fetchone()[0] == 1
+            ), "repeated re-commits must not inflate replace history"
     finally:
         conn.rollback()
         conn.close()

--- a/tests/test_orrery/test_adjudication_history.py
+++ b/tests/test_orrery/test_adjudication_history.py
@@ -1,0 +1,315 @@
+"""Live tests for adjudication-history persistence and the history payload.
+
+The commit-side tests drive the real ``commit_orrery_tick_sync`` writer
+against save_02 inside a transaction that is **always rolled back** — real
+SQL, real constraints, zero persistent writes (see CLAUDE.md testing
+philosophy). They pin the three 063 guarantees:
+
+1. Adjudication log rows carry the subject (``actor_entity_id`` +
+   ``bindings``) stamped while the draft is in hand.
+2. Scene pressures and the rendered-slice prompt exposures persist at
+   commit, including on re-commit (idempotent, ON CONFLICT).
+3. A replace ruling whose resolution insert conflicts still reaches the log
+   with the existing resolution id — the pre-063 silent skip is closed.
+
+The history-payload tests read the real ledgers on save_02/save_05.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from typing import Any
+
+import psycopg2
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+from nexus.agents.orrery.events import commit_orrery_tick_sync
+from nexus.agents.orrery.history import adjudication_history
+from nexus.agents.orrery.resolver import (
+    OrreryResolutionDraft,
+    OrreryScenePressureDraft,
+    OrreryTickProposal,
+)
+from nexus.api.slot_utils import get_slot_db_url
+
+pytestmark = pytest.mark.requires_postgres
+
+WRITE_SLOT = 2
+HISTORY_SLOTS = (2, 5)
+
+
+def _connect(slot: int) -> Any:
+    return psycopg2.connect(
+        host=os.environ.get("PGHOST", "localhost"),
+        database=f"save_{slot:02d}",
+        user=os.environ.get("PGUSER", "pythagor"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+def _fetch_one(cur: Any, sql: str, params: tuple = ()) -> tuple:
+    cur.execute(sql, params)
+    row = cur.fetchone()
+    assert row is not None, sql
+    return row
+
+
+def test_commit_persists_enriched_history_then_rolls_back() -> None:
+    conn = _connect(WRITE_SLOT)
+    try:
+        with conn.cursor() as cur:
+            anchor_chunk_id = _fetch_one(cur, "SELECT max(id) FROM narrative_chunks")[0]
+            actor_entity_id = _fetch_one(
+                cur,
+                """
+                SELECT c.entity_id FROM characters c
+                JOIN entities e ON e.id = c.entity_id
+                WHERE c.entity_id IS NOT NULL
+                ORDER BY c.entity_id
+                LIMIT 1
+                """,
+            )[0]
+
+        ratify_hash = f"audit-ratify-{uuid.uuid4().hex}"
+        defer_hash = f"audit-defer-{uuid.uuid4().hex}"
+        pressure_hash = f"audit-pressure-{uuid.uuid4().hex}"
+        ratified = OrreryResolutionDraft(
+            template_id="hide",
+            priority=40,
+            binding_hash=ratify_hash,
+            bindings={"actor": actor_entity_id},
+            branch_label="Audit-history probe (ratified)",
+            narrative_stub="{actor} keeps their head down.",
+            magnitude=0.4,
+        )
+        deferred = OrreryResolutionDraft(
+            template_id="sleep",
+            priority=25,
+            binding_hash=defer_hash,
+            bindings={"actor": actor_entity_id},
+            branch_label="Audit-history probe (deferred)",
+            narrative_stub="{actor} finally rests.",
+            magnitude=0.2,
+        )
+        pressure = OrreryScenePressureDraft(
+            template_id="sleep_need_pressure",
+            priority=25,
+            binding_hash=pressure_hash,
+            bindings={"actor": actor_entity_id},
+            branch_label="critical",
+            pressure_stub="{actor} is running on fumes.",
+            prompt_text="Someone is running on fumes.",
+            magnitude=0.3,
+        )
+        proposal = OrreryTickProposal(
+            anchor_chunk_id=anchor_chunk_id,
+            actor_count=1,
+            resolutions=(ratified, deferred),
+            scene_pressures=(pressure,),
+        )
+
+        # --- Round 1: ratify A, defer B; render caps 1/1 -------------------
+        result = commit_orrery_tick_sync(
+            conn,
+            proposal,
+            tick_chunk_id=anchor_chunk_id,
+            slot=WRITE_SLOT,
+            adjudications=[{"proposal_id": deferred.proposal_id, "action": "defer"}],
+            prompt_settings={
+                "max_rendered_proposals": 1,
+                "max_rendered_pressures": 1,
+            },
+        )
+        assert result.resolution_count == 1
+        assert result.deferred_count == 1
+        assert result.scene_pressure_count == 1
+        # One resolution exposure (cap 1 of 2 drafts) + one pressure exposure.
+        assert result.prompt_exposure_count == 2
+
+        with conn.cursor() as cur:
+            log_actor, log_bindings = _fetch_one(
+                cur,
+                """
+                SELECT actor_entity_id, bindings
+                FROM orrery_adjudication_log
+                WHERE binding_hash = %s
+                """,
+                (defer_hash,),
+            )
+            assert log_actor == actor_entity_id
+            assert log_bindings == {"actor": actor_entity_id}
+
+            pressure_row = _fetch_one(
+                cur,
+                """
+                SELECT actor_entity_id, prompt_text, magnitude
+                FROM orrery_scene_pressures
+                WHERE tick_chunk_id = %s AND binding_hash = %s
+                """,
+                (anchor_chunk_id, pressure_hash),
+            )
+            assert pressure_row[0] == actor_entity_id
+            assert pressure_row[1] == "Someone is running on fumes."
+
+            cur.execute(
+                """
+                SELECT kind, template_id, position
+                FROM orrery_prompt_exposures
+                WHERE tick_chunk_id = %s
+                  AND binding_hash IN (%s, %s, %s)
+                ORDER BY kind, position
+                """,
+                (anchor_chunk_id, ratify_hash, defer_hash, pressure_hash),
+            )
+            exposures = cur.fetchall()
+            # The deferred draft sat beyond the render cap: not recorded.
+            assert [(k, t, p) for k, t, p in exposures] == [
+                ("resolution", "hide", 0),
+                ("scene_pressure", "sleep_need_pressure", 0),
+            ]
+
+            existing_resolution_id = _fetch_one(
+                cur,
+                "SELECT id FROM orrery_resolutions WHERE binding_hash = %s",
+                (ratify_hash,),
+            )[0]
+
+        # --- Round 2: re-commit; replace-with-delta hits ON CONFLICT -------
+        result_two = commit_orrery_tick_sync(
+            conn,
+            proposal,
+            tick_chunk_id=anchor_chunk_id,
+            slot=WRITE_SLOT,
+            adjudications=[
+                {"proposal_id": deferred.proposal_id, "action": "defer"},
+                {
+                    "proposal_id": ratified.proposal_id,
+                    "action": "replace",
+                    "note": "audit probe: ruling must survive re-commit",
+                    "replacement_state_delta": {
+                        "character.current_activity": "audit-history probe"
+                    },
+                },
+            ],
+            prompt_settings={
+                "max_rendered_proposals": 1,
+                "max_rendered_pressures": 1,
+            },
+        )
+        assert result_two.skipped_existing_count == 1
+        assert result_two.replaced_count == 1
+        # Idempotent: no duplicate pressure/exposure rows on re-commit.
+        assert result_two.scene_pressure_count == 0
+        assert result_two.prompt_exposure_count == 0
+
+        with conn.cursor() as cur:
+            replace_row = _fetch_one(
+                cur,
+                """
+                SELECT action, applied_resolution_id, actor_entity_id
+                FROM orrery_adjudication_log
+                WHERE binding_hash = %s AND action = 'replace'
+                """,
+                (ratify_hash,),
+            )
+            # The pre-063 writer silently dropped this ruling; it must now
+            # land, pointing at the resolution row that already existed.
+            assert replace_row[1] == existing_resolution_id
+            assert replace_row[2] == actor_entity_id
+    finally:
+        conn.rollback()
+        conn.close()
+
+    # Nothing persisted: the probe hashes must not exist outside the txn.
+    check = _connect(WRITE_SLOT)
+    try:
+        with check.cursor() as cur:
+            cur.execute(
+                """
+                SELECT count(*) FROM orrery_adjudication_log
+                WHERE binding_hash IN (%s, %s)
+                """,
+                (ratify_hash, defer_hash),
+            )
+            assert cur.fetchone()[0] == 0
+    finally:
+        check.close()
+
+
+@pytest.mark.parametrize("slot", HISTORY_SLOTS)
+def test_adjudication_history_matches_sql_oracle(slot: int) -> None:
+    engine = create_engine(get_slot_db_url(slot=slot))
+    try:
+        with Session(engine) as session:
+            payload = adjudication_history(session)
+            oracle_actions = {
+                row["action"]: row["count"]
+                for row in session.execute(
+                    text(
+                        """
+                        SELECT action, count(*) AS count
+                        FROM orrery_adjudication_log GROUP BY action
+                        """
+                    )
+                ).mappings()
+            }
+            oracle_committed = session.execute(
+                text("SELECT count(*) FROM orrery_resolutions")
+            ).scalar()
+            oracle_promoted = session.execute(
+                text(
+                    """
+                    SELECT count(*) FROM orrery_resolutions
+                    WHERE promotion_status = 'promoted'
+                    """
+                )
+            ).scalar()
+    finally:
+        engine.dispose()
+
+    totals = payload["totals"]
+    for action in ("defer", "replace", "void"):
+        assert totals["actions"][action] == oracle_actions.get(action, 0)
+    assert totals["committed_resolutions"] == oracle_committed
+    assert (
+        sum(entry["promoted"] for entry in payload["templates"].values())
+        == oracle_promoted
+    )
+
+    # Streak arithmetic: every defer belongs to exactly one streak.
+    assert (
+        sum(streak["length"] for streak in payload["defer_streaks"])
+        == totals["actions"]["defer"]
+    )
+    for streak in payload["defer_streaks"]:
+        assert streak["outcome"] in {"ratified", "replace", "void", "open"}
+        assert streak["length"] >= 1
+        assert streak["start_tick"] <= streak["end_tick"]
+
+    # Funnel monotonicity per template.
+    for template_id, entry in payload["templates"].items():
+        assert entry["narrated"] <= entry["promoted"] <= entry["committed"], template_id
+        assert entry["ratified_committed"] >= 0
+
+    json.dumps(payload)
+
+
+def test_history_is_non_vacuous_on_audited_slots() -> None:
+    """Both slots must still carry adjudication data or the suite is hollow."""
+
+    total_rows = 0
+    for slot in HISTORY_SLOTS:
+        engine = create_engine(get_slot_db_url(slot=slot))
+        try:
+            with Session(engine) as session:
+                total_rows += adjudication_history(session)["totals"]["log_rows"]
+        finally:
+            engine.dispose()
+    assert total_rows > 0, (
+        "no audited slot has adjudication-log rows — the history assertions "
+        "are vacuous; repoint HISTORY_SLOTS at a slot with Skald rulings"
+    )

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -959,8 +959,10 @@ def test_commit_orrery_tick_does_not_cancel_travel_for_activity_only_update() ->
     )
 
 
-def test_commit_orrery_tick_does_not_count_duplicate_replacement() -> None:
-    """Replacement metrics describe applied or handled replacements, not duplicates."""
+def test_commit_orrery_tick_logs_duplicate_replacement() -> None:
+    """A replace ruling on an already-committed resolution still reaches the
+    history log (the pre-063 writer silently dropped it) and counts as a
+    handled replacement even though the resolution insert conflicts."""
 
     cursor = RecordingCursor(duplicate_resolution=True)
     result = commit_orrery_tick_sync(
@@ -981,7 +983,11 @@ def test_commit_orrery_tick_does_not_count_duplicate_replacement() -> None:
     )
 
     assert result.skipped_existing_count == 1
-    assert result.replaced_count == 0
+    assert result.replaced_count == 1
+    log_statements = [
+        sql for sql, _params in cursor.executed if "orrery_adjudication_log" in sql
+    ]
+    assert log_statements, "duplicate replace ruling must reach the history log"
 
 
 def test_commit_orrery_tick_skips_existing_resolution_without_double_writes() -> None:


### PR DESCRIPTION
## Summary

Step 6 of the audit-dashboard sequence in `docs/orrery_audit_dashboard_notes.md`: the adjudication-history layer. Recon against live schemas confirmed all five recorded-history holes the spec names; this PR closes four of them and ships the ledger endpoint (the fifth — ratifications leave no row — is by design reconstructed as committed-resolutions-minus-replacements).

### Migration `063_orrery_adjudication_history.sql` (applied locally to template + all slots)

- `orrery_adjudication_log` + `actor_entity_id`, `bindings` — a deferred proposal's subject was previously recoverable only from the incubator JSONB, which `DELETE FROM incubator` wipes at commit. Stamped at insert while the draft is in hand.
- **`orrery_scene_pressures`** — pressures were generated (`resolver.py`), rendered, and dropped; zero persistence. Now written at commit.
- **`orrery_prompt_exposures`** — the storyteller prompt renders only the first N proposals/pressures with ratify-by-omission semantics, and nothing recorded which were shown. Now the rendered slice is logged per tick.
- Pre-063 rows keep NULLs; the endpoint's `epoch` block quantifies enrichment coverage instead of implying it.

### Writer changes (`events.py`, sync + async twins kept in lockstep)

- Pressure/exposure inserts run **before** the `has_resolutions` early return — a tick can carry scene pressure with zero resolutions (save_02's head tick does exactly this).
- **ON CONFLICT silent-skip closed**: a replace-with-delta ruling whose resolution insert conflicts previously vanished from history entirely (recon confirmed the `continue` at the exact lines the spec predicted); it now lands with `applied_resolution_id` resolved from the existing row.
- All inserts idempotent for re-commit safety.

### Config

The hardcoded `[:5]` render slices in `logon_utility.py` become `[orrery.prompt] max_rendered_proposals` / `max_rendered_pressures` (per the no-hardcoded-tunables directive), and both commit handlers pass the same config into the exposure logger — one knob, two sites, no drift between what was rendered and what was recorded.

### Endpoint

`GET /api/dev/orrery/history/adjudications?slot=&template_id=` — action rates faceted by `adjudication_source` (machine-inferred `structured_state_update` never blends with authored rulings), the lifecycle funnel (committed → promoted/skipped → narrated, `ratified_committed` derived), **defer streaks** (the spec's "single most diagnostic derived metric": consecutive defers per `proposal_id` with outcome ratified/replace/void/open), exposure + pressure ledger stats, and the epoch block. Live smoke reproduces the recon oracle exactly (save_02: 15/1/3 defer/replace/void over 66 committed; save_05: 13/3/7 over 4 — including `surveil` deferred 3 consecutive ticks before a replace).

### Tests (no mocks)

- A **rollback-transaction commit test** drives the real `commit_orrery_tick_sync` against save_02 — real SQL, real constraints, always rolled back, with a post-rollback probe confirming zero persistence. Pins subject stamping, pressure persistence, exposure cap semantics (a draft beyond the cap is not recorded), the conflict-path log fix with the existing resolution id, and idempotent re-commit.
- History payloads verified against direct SQL oracles on save_02 + save_05; streak arithmetic (`sum(lengths) == total defers`) and funnel monotonicity (`narrated ≤ promoted ≤ committed`) enforced; joint non-vacuity guard.
- The recording-cursor test that asserted the old silent-skip behavior now pins the new contract.
- Full suite: 885 passed offline; live suites pass with only the known pre-existing `test_pair_tag_writer` failure (reproduces on origin/main). The four `events.py` mypy arg-type notes at the `_validate_*` calls also predate this change.

Next in sequence: step 7 (reconstructability: forward-fix migrations, Skald-side delta logging, genesis snapshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY