### PR TITLE
Forward-fix tag provenance (migration 064): chunk-keyed bestowals + logged clears

### DIFF
--- a/migrations/064_tag_provenance_forward_fix.sql
+++ b/migrations/064_tag_provenance_forward_fix.sql
@@ -1,0 +1,70 @@
+-- 064_tag_provenance_forward_fix.sql
+--
+-- Forward-fix migrations for tag provenance (step 7 of
+-- docs/orrery_audit_dashboard_notes.md, "Reconstruction Sufficiency").
+-- Going forward, bestowals carry the chunk that caused them and clearances
+-- are logged on every path — the prerequisites for honest as-of rewind of
+-- tags and pair tags. Pre-064 rows keep NULLs: per-row provenance stays
+-- "approximate" (world time only) or "unknowable" (neither), and the
+-- hover-audit renders the epoch per row.
+
+-- 1. Bestowal chunk keys. The resolver's apply path and the Skald commit
+--    path both hold the committing chunk id; these columns give them a
+--    place to put it. "Exact" as-of provenance is defined as
+--    source_chunk_id IS NOT NULL.
+ALTER TABLE entity_tags
+ADD COLUMN IF NOT EXISTS source_chunk_id bigint REFERENCES narrative_chunks(id);
+
+COMMENT ON COLUMN entity_tags.source_chunk_id IS
+    'Chunk whose commit bestowed this tag. NULL on rows written before migration 064 and on pre-chunk bestowals (wizard seeding, entity-reference resolution); non-NULL is the "exact" as-of provenance tier.';
+
+ALTER TABLE entity_pair_tags
+ADD COLUMN IF NOT EXISTS source_chunk_id bigint REFERENCES narrative_chunks(id);
+
+COMMENT ON COLUMN entity_pair_tags.source_chunk_id IS
+    'Chunk whose commit bestowed this pair tag. NULL on pre-064 rows; non-NULL is the "exact" as-of provenance tier.';
+
+-- 2. Pair-tag clearance logging. tag_clearance_log.entity_tag_id was NOT
+--    NULL and single-entity only, so pair-tag clears were structurally
+--    unloggable. The log becomes polymorphic: exactly one of
+--    entity_tag_id / entity_pair_tag_id per row.
+ALTER TABLE tag_clearance_log
+ALTER COLUMN entity_tag_id DROP NOT NULL;
+
+ALTER TABLE tag_clearance_log
+ADD COLUMN IF NOT EXISTS entity_pair_tag_id bigint REFERENCES entity_pair_tags(id);
+
+ALTER TABLE tag_clearance_log
+DROP CONSTRAINT IF EXISTS tag_clearance_log_exactly_one_subject;
+ALTER TABLE tag_clearance_log
+ADD CONSTRAINT tag_clearance_log_exactly_one_subject
+CHECK (num_nonnulls(entity_tag_id, entity_pair_tag_id) = 1);
+
+COMMENT ON COLUMN tag_clearance_log.entity_pair_tag_id IS
+    'Cleared entity_pair_tags row, for pair-tag clearances (loggable since migration 064). Exactly one of entity_tag_id / entity_pair_tag_id is set per row.';
+
+CREATE INDEX IF NOT EXISTS ix_tag_clearance_log_entity_pair_tag_id
+    ON tag_clearance_log (entity_pair_tag_id);
+
+-- 3. Surface the new provenance in the audit hover's read path.
+--    entity_tags_current is a column-projection view; the new column must
+--    be projected explicitly.
+CREATE OR REPLACE VIEW entity_tags_current AS
+SELECT et.id AS entity_tag_id,
+       et.entity_id,
+       e.kind AS entity_kind,
+       t.tag,
+       t.category,
+       t.is_ephemeral,
+       t.clearance_kind,
+       et.applied_at,
+       et.applied_at_world_time,
+       et.source_kind,
+       et.template_id,
+       et.source_chunk_id
+FROM entity_tags et
+JOIN entities e ON e.id = et.entity_id
+JOIN tags t ON t.id = et.tag_id
+WHERE t.deprecated = false
+  AND et.cleared_at IS NULL
+  AND t.synonym_for IS NULL;

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -907,10 +907,15 @@ def build_catalog(
 # ---------------------------------------------------------------------------
 
 
-def _tag_provenance(applied_at_world_time: Optional[datetime]) -> str:
-    # "exact" is reserved for rows carrying a source_chunk_id bestowal key,
-    # which does not exist pre-migration (see the reconstruction-sufficiency
-    # notes in docs/orrery_audit_dashboard_notes.md).
+def _tag_provenance(
+    applied_at_world_time: Optional[datetime],
+    source_chunk_id: Optional[int] = None,
+) -> str:
+    # Three tiers per the reconstruction-sufficiency notes: "exact" rows
+    # carry the migration-064 chunk bestowal key; "approximate" rows have
+    # only an in-world timestamp; the rest are "unknowable".
+    if source_chunk_id is not None:
+        return "exact"
     return "approximate" if applied_at_world_time is not None else "unknowable"
 
 
@@ -964,7 +969,7 @@ def entity_context(
             /* orrery_audit:entity_tags */
             SELECT entity_id, tag, category, is_ephemeral, source_kind::text
                    AS source_kind, template_id, applied_at,
-                   applied_at_world_time
+                   applied_at_world_time, source_chunk_id
             FROM entity_tags_current
             WHERE entity_id = ANY(:ids)
             ORDER BY entity_id, tag
@@ -982,7 +987,10 @@ def entity_context(
                 "template_id": row["template_id"],
                 "applied_at": _iso(row["applied_at"]),
                 "applied_at_world_time": _iso(row["applied_at_world_time"]),
-                "provenance": _tag_provenance(row["applied_at_world_time"]),
+                "source_chunk_id": row["source_chunk_id"],
+                "provenance": _tag_provenance(
+                    row["applied_at_world_time"], row["source_chunk_id"]
+                ),
                 "families": [
                     name
                     for name, members in _TAG_FAMILY_TAG_SETS.items()
@@ -1007,7 +1015,8 @@ def entity_context(
                    ept.source_kind::text AS source_kind,
                    ept.template_id,
                    ept.applied_at,
-                   ept.applied_at_world_time
+                   ept.applied_at_world_time,
+                   ept.source_chunk_id
             FROM entity_pair_tags ept
             JOIN pair_tags pt ON pt.id = ept.pair_tag_id
             WHERE ept.cleared_at IS NULL
@@ -1028,7 +1037,10 @@ def entity_context(
             "template_id": row["template_id"],
             "applied_at": _iso(row["applied_at"]),
             "applied_at_world_time": _iso(row["applied_at_world_time"]),
-            "provenance": _tag_provenance(row["applied_at_world_time"]),
+            "source_chunk_id": row["source_chunk_id"],
+            "provenance": _tag_provenance(
+                row["applied_at_world_time"], row["source_chunk_id"]
+            ),
         }
         if subject_id in kinds:
             pair_tags_by_entity.setdefault(subject_id, []).append(

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -1363,7 +1363,13 @@ def _apply_state_delta_sync(
             )
 
     for tag in draft.state_delta.get("entity_tags.add", ()) or ():
-        if _add_entity_tag_sync(cur, actor_entity_id, str(tag), draft.template_id):
+        if _add_entity_tag_sync(
+            cur,
+            actor_entity_id,
+            str(tag),
+            draft.template_id,
+            source_chunk_id=source_chunk_id,
+        ):
             tag_mutations += 1
     for tag in draft.state_delta.get("entity_tags.remove", ()) or ():
         tag_mutations += _remove_entity_tag_sync(
@@ -1384,7 +1390,13 @@ def _apply_state_delta_sync(
         if target_entity_id is None:
             raise ValueError(f"Orrery draft {draft.template_id} has no target binding")
         for tag in target_tag_adds:
-            if _add_entity_tag_sync(cur, target_entity_id, str(tag), draft.template_id):
+            if _add_entity_tag_sync(
+                cur,
+                target_entity_id,
+                str(tag),
+                draft.template_id,
+                source_chunk_id=source_chunk_id,
+            ):
                 tag_mutations += 1
         for tag in target_tag_removes:
             tag_mutations += _remove_entity_tag_sync(
@@ -1400,6 +1412,8 @@ def _apply_state_delta_sync(
                 cur,
                 object_entity_id=target_entity_id,
                 tag=str(tag),
+                template_id=draft.template_id,
+                source_chunk_id=source_chunk_id,
             )
     if "need.fulfill" in draft.state_delta:
         tag_mutations += _apply_need_fulfillment_sync(
@@ -1474,7 +1488,11 @@ async def _apply_state_delta_async(
 
     for tag in draft.state_delta.get("entity_tags.add", ()) or ():
         if await _add_entity_tag_async(
-            conn, actor_entity_id, str(tag), draft.template_id
+            conn,
+            actor_entity_id,
+            str(tag),
+            draft.template_id,
+            source_chunk_id=source_chunk_id,
         ):
             tag_mutations += 1
     for tag in draft.state_delta.get("entity_tags.remove", ()) or ():
@@ -1497,7 +1515,11 @@ async def _apply_state_delta_async(
             raise ValueError(f"Orrery draft {draft.template_id} has no target binding")
         for tag in target_tag_adds:
             if await _add_entity_tag_async(
-                conn, target_entity_id, str(tag), draft.template_id
+                conn,
+                target_entity_id,
+                str(tag),
+                draft.template_id,
+                source_chunk_id=source_chunk_id,
             ):
                 tag_mutations += 1
         for tag in target_tag_removes:
@@ -1514,6 +1536,8 @@ async def _apply_state_delta_async(
                 conn,
                 object_entity_id=target_entity_id,
                 tag=str(tag),
+                template_id=draft.template_id,
+                source_chunk_id=source_chunk_id,
             )
     if "need.fulfill" in draft.state_delta:
         tag_mutations += await _apply_need_fulfillment_async(
@@ -2219,6 +2243,28 @@ async def _apply_travel_arrive_async(
         )
 
 
+def _chunk_world_time_sync(cur: Any, source_chunk_id: int) -> Any:
+    """The chunk's in-world time, or None — NEVER a wall-clock fallback.
+
+    Provenance columns (applied_at_world_time, cleared_at_world_time) must
+    stay NULL rather than lie with wall time when chunk_metadata is missing.
+    """
+
+    cur.execute(
+        "SELECT world_time FROM chunk_metadata WHERE chunk_id = %s",
+        (source_chunk_id,),
+    )
+    row = cur.fetchone()
+    return _row_get(row, "world_time", 0) if row else None
+
+
+async def _chunk_world_time_async(conn: Any, source_chunk_id: int) -> Any:
+    return await conn.fetchval(
+        "SELECT world_time FROM chunk_metadata WHERE chunk_id = $1",
+        source_chunk_id,
+    )
+
+
 def _tick_world_time_sync(cur: Any, source_chunk_id: int) -> Any:
     cur.execute(
         "SELECT world_time FROM chunk_metadata WHERE chunk_id = %s",
@@ -2414,7 +2460,13 @@ def _sync_need_severity_tags_sync(
     if (
         desired
         and desired not in current_tags
-        and _add_entity_tag_sync(cur, actor_entity_id, desired, template_id)
+        and _add_entity_tag_sync(
+            cur,
+            actor_entity_id,
+            desired,
+            template_id,
+            source_chunk_id=source_chunk_id,
+        )
     ):
         mutations += 1
     return mutations
@@ -2451,7 +2503,13 @@ async def _sync_need_severity_tags_async(
     if (
         desired
         and desired not in current_tags
-        and await _add_entity_tag_async(conn, actor_entity_id, desired, template_id)
+        and await _add_entity_tag_async(
+            conn,
+            actor_entity_id,
+            desired,
+            template_id,
+            source_chunk_id=source_chunk_id,
+        )
     ):
         mutations += 1
     return mutations
@@ -2505,17 +2563,28 @@ def _add_entity_tag_sync(
     entity_id: int,
     tag: str,
     template_id: str,
+    *,
+    source_chunk_id: int,
 ) -> bool:
     tag_id = _registered_tag_id_sync(cur, tag)
 
     cur.execute(
         """
-        INSERT INTO entity_tags (entity_id, tag_id, template_id, source_kind)
-        VALUES (%s, %s, %s, 'template')
+        INSERT INTO entity_tags (
+            entity_id, tag_id, template_id, source_kind,
+            applied_at_world_time, source_chunk_id
+        )
+        VALUES (%s, %s, %s, 'template', %s, %s)
         ON CONFLICT DO NOTHING
         RETURNING id
         """,
-        (entity_id, tag_id, template_id),
+        (
+            entity_id,
+            tag_id,
+            template_id,
+            _chunk_world_time_sync(cur, source_chunk_id),
+            source_chunk_id,
+        ),
     )
     return cur.fetchone() is not None
 
@@ -2542,19 +2611,26 @@ async def _add_entity_tag_async(
     entity_id: int,
     tag: str,
     template_id: str,
+    *,
+    source_chunk_id: int,
 ) -> bool:
     tag_id = await _registered_tag_id_async(conn, tag)
 
     inserted_id = await conn.fetchval(
         """
-        INSERT INTO entity_tags (entity_id, tag_id, template_id, source_kind)
-        VALUES ($1, $2, $3, 'template')
+        INSERT INTO entity_tags (
+            entity_id, tag_id, template_id, source_kind,
+            applied_at_world_time, source_chunk_id
+        )
+        VALUES ($1, $2, $3, 'template', $4, $5)
         ON CONFLICT DO NOTHING
         RETURNING id
         """,
         entity_id,
         tag_id,
         template_id,
+        await _chunk_world_time_async(conn, source_chunk_id),
+        source_chunk_id,
     )
     return inserted_id is not None
 
@@ -2621,6 +2697,8 @@ def _clear_inbound_pair_tags_sync(
     *,
     object_entity_id: int,
     tag: str,
+    template_id: str,
+    source_chunk_id: int,
 ) -> int:
     cur.execute(
         """
@@ -2631,13 +2709,34 @@ def _clear_inbound_pair_tags_sync(
           AND ept.object_entity_id = %s
           AND pt.tag = %s
           AND ept.cleared_at IS NULL
+        RETURNING ept.id
         """,
         (object_entity_id, tag),
     )
-    rowcount = getattr(cur, "rowcount", 0)
-    if rowcount is None or rowcount < 0:
-        return 0
-    return int(rowcount)
+    cleared_ids = [_row_get(row, "id", 0) for row in cur.fetchall()]
+    world_time = _chunk_world_time_sync(cur, source_chunk_id)
+    for pair_tag_row_id in cleared_ids:
+        cur.execute(
+            """
+            INSERT INTO tag_clearance_log (
+                entity_pair_tag_id, mechanism, cleared_at_world_time,
+                justification, source_chunk_id
+            ) VALUES (%s, 'authored', %s, %s::jsonb, %s)
+            """,
+            (
+                pair_tag_row_id,
+                world_time,
+                json.dumps(
+                    {
+                        "template_id": template_id,
+                        "state_delta": "entity_pair_tags_target.clear_inbound",
+                        "tag": tag,
+                    }
+                ),
+                source_chunk_id,
+            ),
+        )
+    return len(cleared_ids)
 
 
 async def _remove_entity_tag_async(
@@ -2685,8 +2784,10 @@ async def _clear_inbound_pair_tags_async(
     *,
     object_entity_id: int,
     tag: str,
+    template_id: str,
+    source_chunk_id: int,
 ) -> int:
-    status = await conn.execute(
+    rows = await conn.fetch(
         """
         UPDATE entity_pair_tags ept
         SET cleared_at = now()
@@ -2695,11 +2796,33 @@ async def _clear_inbound_pair_tags_async(
           AND ept.object_entity_id = $1
           AND pt.tag = $2
           AND ept.cleared_at IS NULL
+        RETURNING ept.id
         """,
         object_entity_id,
         tag,
     )
-    return _affected_count(status)
+    cleared_ids = [_row_get(row, "id", 0) for row in rows]
+    world_time = await _chunk_world_time_async(conn, source_chunk_id)
+    for pair_tag_row_id in cleared_ids:
+        await conn.execute(
+            """
+            INSERT INTO tag_clearance_log (
+                entity_pair_tag_id, mechanism, cleared_at_world_time,
+                justification, source_chunk_id
+            ) VALUES ($1, 'authored', $2, $3::jsonb, $4)
+            """,
+            pair_tag_row_id,
+            world_time,
+            json.dumps(
+                {
+                    "template_id": template_id,
+                    "state_delta": "entity_pair_tags_target.clear_inbound",
+                    "tag": tag,
+                }
+            ),
+            source_chunk_id,
+        )
+    return len(cleared_ids)
 
 
 def _emit_world_event_sync(

--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -92,10 +92,14 @@ def apply_tag_bestowal(
             f"No Orrery tag categories registered for entity_kind={entity_kind!r}"
         )
 
-    if world_time is None and source_chunk_id is not None:
-        world_time = _chunk_world_time(cur, source_chunk_id)
     if world_time is None:
-        world_time = _load_world_time(cur)
+        if source_chunk_id is not None:
+            # Chunk-keyed rows take the bestowing chunk's clock or stay NULL —
+            # never the global-max fallback, which would stamp an "exact" row
+            # with a wrong world time when chunk metadata is missing.
+            world_time = _chunk_world_time(cur, source_chunk_id)
+        else:
+            world_time = _load_world_time(cur)
 
     tags_to_apply: list[_TagApplication] = []
     for tag_name in bestowal.applied_tags:
@@ -234,10 +238,12 @@ async def apply_tag_bestowal_async(
             f"No Orrery tag categories registered for entity_kind={entity_kind!r}"
         )
 
-    if world_time is None and source_chunk_id is not None:
-        world_time = await _chunk_world_time_async(conn, source_chunk_id)
     if world_time is None:
-        world_time = await _load_world_time_async(conn)
+        if source_chunk_id is not None:
+            # Same rule as the sync twin: chunk clock or NULL, never global max.
+            world_time = await _chunk_world_time_async(conn, source_chunk_id)
+        else:
+            world_time = await _load_world_time_async(conn)
 
     tags_to_apply: list[_TagApplication] = []
     for tag_name in bestowal.applied_tags:
@@ -344,10 +350,14 @@ def apply_exclusive_tag_bestowal(
     tag_id = _row_value(tag_row, "id", 0)
     reapplication_policy = _row_value(tag_row, "reapplication_policy", 3)
 
-    if world_time is None and source_chunk_id is not None:
-        world_time = _chunk_world_time(cur, source_chunk_id)
     if world_time is None:
-        world_time = _load_world_time(cur)
+        if source_chunk_id is not None:
+            # Chunk-keyed rows take the bestowing chunk's clock or stay NULL —
+            # never the global-max fallback, which would stamp an "exact" row
+            # with a wrong world time when chunk metadata is missing.
+            world_time = _chunk_world_time(cur, source_chunk_id)
+        else:
+            world_time = _load_world_time(cur)
 
     _clear_entity_tag_siblings(
         cur,
@@ -1042,10 +1052,14 @@ def apply_pair_tag_bestowal(
         object_kinds=object_kinds,
     )
 
-    if world_time is None and source_chunk_id is not None:
-        world_time = _chunk_world_time(cur, source_chunk_id)
     if world_time is None:
-        world_time = _load_world_time(cur)
+        if source_chunk_id is not None:
+            # Chunk-keyed rows take the bestowing chunk's clock or stay NULL —
+            # never the global-max fallback, which would stamp an "exact" row
+            # with a wrong world time when chunk metadata is missing.
+            world_time = _chunk_world_time(cur, source_chunk_id)
+        else:
+            world_time = _load_world_time(cur)
 
     return _insert_pair_tag_row(
         cur,
@@ -1161,10 +1175,14 @@ def apply_status_pair_tag_bestowal(
         subject_kinds=_row_value(row, "subject_kinds", 1),
         object_kinds=_row_value(row, "object_kinds", 2),
     )
-    if world_time is None and source_chunk_id is not None:
-        world_time = _chunk_world_time(cur, source_chunk_id)
     if world_time is None:
-        world_time = _load_world_time(cur)
+        if source_chunk_id is not None:
+            # Chunk-keyed rows take the bestowing chunk's clock or stay NULL —
+            # never the global-max fallback, which would stamp an "exact" row
+            # with a wrong world time when chunk metadata is missing.
+            world_time = _chunk_world_time(cur, source_chunk_id)
+        else:
+            world_time = _load_world_time(cur)
 
     _clear_pair_tags_by_name(
         cur,

--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -20,6 +20,7 @@ scheduled-expiry column used by duration-bearing tags.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Literal, Optional, TypeAlias
@@ -51,6 +52,7 @@ def apply_tag_bestowal(
     source_kind: str = "skald_inline",
     world_time: Optional[datetime] = None,
     duration_override: Optional[timedelta] = None,
+    source_chunk_id: Optional[int] = None,
 ) -> dict[str, int]:
     """Apply a closed-vocabulary tag bestowal to the database.
 
@@ -90,6 +92,8 @@ def apply_tag_bestowal(
             f"No Orrery tag categories registered for entity_kind={entity_kind!r}"
         )
 
+    if world_time is None and source_chunk_id is not None:
+        world_time = _chunk_world_time(cur, source_chunk_id)
     if world_time is None:
         world_time = _load_world_time(cur)
 
@@ -132,13 +136,21 @@ def apply_tag_bestowal(
             world_time=world_time,
             duration_override=duration_override,
             reapplication_policy=tag_application.reapplication_policy,
+            source_chunk_id=source_chunk_id,
         )
         if applied:
             counters["applied"] += 1
 
     # 2. clear tags that no longer apply (update contexts only)
     for tag_id in tags_to_clear:
-        if _clear_entity_tag(cur, entity_id=entity_id, tag_id=tag_id):
+        if _clear_entity_tag(
+            cur,
+            entity_id=entity_id,
+            tag_id=tag_id,
+            world_time=world_time,
+            source_chunk_id=source_chunk_id,
+            reason="bestowal.tags_to_clear",
+        ):
             counters["cleared"] += 1
 
     return counters
@@ -197,6 +209,7 @@ async def apply_tag_bestowal_async(
     source_kind: str = "skald_inline",
     world_time: Optional[datetime] = None,
     duration_override: Optional[timedelta] = None,
+    source_chunk_id: Optional[int] = None,
 ) -> dict[str, int]:
     """Asyncpg equivalent of apply_tag_bestowal for async commit paths."""
 
@@ -221,6 +234,8 @@ async def apply_tag_bestowal_async(
             f"No Orrery tag categories registered for entity_kind={entity_kind!r}"
         )
 
+    if world_time is None and source_chunk_id is not None:
+        world_time = await _chunk_world_time_async(conn, source_chunk_id)
     if world_time is None:
         world_time = await _load_world_time_async(conn)
 
@@ -262,12 +277,20 @@ async def apply_tag_bestowal_async(
             world_time=world_time,
             duration_override=duration_override,
             reapplication_policy=tag_application.reapplication_policy,
+            source_chunk_id=source_chunk_id,
         )
         if applied:
             counters["applied"] += 1
 
     for tag_id in tags_to_clear:
-        if await _clear_entity_tag_async(conn, entity_id=entity_id, tag_id=tag_id):
+        if await _clear_entity_tag_async(
+            conn,
+            entity_id=entity_id,
+            tag_id=tag_id,
+            world_time=world_time,
+            source_chunk_id=source_chunk_id,
+            reason="bestowal.tags_to_clear",
+        ):
             counters["cleared"] += 1
 
     return counters
@@ -281,6 +304,7 @@ def apply_exclusive_tag_bestowal(
     tag: str,
     source_kind: str = "skald_inline",
     world_time: Optional[datetime] = None,
+    source_chunk_id: Optional[int] = None,
     duration_override: Optional[timedelta] = None,
 ) -> bool:
     """Replace the active tag within a single-entity exclusive category.
@@ -320,6 +344,8 @@ def apply_exclusive_tag_bestowal(
     tag_id = _row_value(tag_row, "id", 0)
     reapplication_policy = _row_value(tag_row, "reapplication_policy", 3)
 
+    if world_time is None and source_chunk_id is not None:
+        world_time = _chunk_world_time(cur, source_chunk_id)
     if world_time is None:
         world_time = _load_world_time(cur)
 
@@ -327,6 +353,8 @@ def apply_exclusive_tag_bestowal(
         cur,
         entity_id=entity_id,
         category=category,
+        world_time=world_time,
+        source_chunk_id=source_chunk_id,
         keep_tag_id=tag_id,
     )
     return _insert_entity_tag(
@@ -335,6 +363,7 @@ def apply_exclusive_tag_bestowal(
         tag_id=tag_id,
         source_kind=source_kind,
         world_time=world_time,
+        source_chunk_id=source_chunk_id,
         duration_override=duration_override,
         reapplication_policy=reapplication_policy,
     )
@@ -452,6 +481,100 @@ async def _load_world_time_async(conn: Any) -> Optional[datetime]:
     return _row_value(row, "world_time", 0)
 
 
+def _log_entity_tag_clearance(
+    cur: Any,
+    *,
+    entity_tag_id: int,
+    world_time: Optional[datetime],
+    source_chunk_id: Optional[int],
+    reason: str,
+) -> None:
+    """Record one single-entity tag clearance (mechanism 'authored').
+
+    Before migration 064 every tag_writer clear was silent; as-of
+    reconstruction needs the log row even when world_time/chunk id are
+    unknown (they stay NULL — honest, not fabricated).
+    """
+
+    cur.execute(
+        """
+        INSERT INTO tag_clearance_log (
+            entity_tag_id, mechanism, cleared_at_world_time,
+            justification, source_chunk_id
+        ) VALUES (%s, 'authored', %s, %s::jsonb, %s)
+        """,
+        (entity_tag_id, world_time, json.dumps({"reason": reason}), source_chunk_id),
+    )
+
+
+async def _log_entity_tag_clearance_async(
+    conn: Any,
+    *,
+    entity_tag_id: int,
+    world_time: Optional[datetime],
+    source_chunk_id: Optional[int],
+    reason: str,
+) -> None:
+    await conn.execute(
+        """
+        INSERT INTO tag_clearance_log (
+            entity_tag_id, mechanism, cleared_at_world_time,
+            justification, source_chunk_id
+        ) VALUES ($1, 'authored', $2, $3::jsonb, $4)
+        """,
+        entity_tag_id,
+        world_time,
+        json.dumps({"reason": reason}),
+        source_chunk_id,
+    )
+
+
+def _log_pair_tag_clearance(
+    cur: Any,
+    *,
+    entity_pair_tag_id: int,
+    world_time: Optional[datetime],
+    source_chunk_id: Optional[int],
+    reason: str,
+) -> None:
+    """Record one pair-tag clearance (loggable since migration 064)."""
+
+    cur.execute(
+        """
+        INSERT INTO tag_clearance_log (
+            entity_pair_tag_id, mechanism, cleared_at_world_time,
+            justification, source_chunk_id
+        ) VALUES (%s, 'authored', %s, %s::jsonb, %s)
+        """,
+        (
+            entity_pair_tag_id,
+            world_time,
+            json.dumps({"reason": reason}),
+            source_chunk_id,
+        ),
+    )
+
+
+def _chunk_world_time(cur: Any, source_chunk_id: int) -> Optional[datetime]:
+    """The bestowing chunk's in-world time, or None (never wall clock)."""
+
+    cur.execute(
+        "SELECT world_time FROM chunk_metadata WHERE chunk_id = %s",
+        (source_chunk_id,),
+    )
+    row = cur.fetchone()
+    return _row_value(row, "world_time", 0) if row else None
+
+
+async def _chunk_world_time_async(
+    conn: Any, source_chunk_id: int
+) -> Optional[datetime]:
+    return await conn.fetchval(
+        "SELECT world_time FROM chunk_metadata WHERE chunk_id = $1",
+        source_chunk_id,
+    )
+
+
 def _insert_entity_tag(
     cur: Any,
     *,
@@ -461,6 +584,7 @@ def _insert_entity_tag(
     world_time: Optional[datetime],
     duration_override: Optional[timedelta],
     reapplication_policy: Optional[ReapplicationPolicy],
+    source_chunk_id: Optional[int] = None,
 ) -> bool:
     reapplication_policy = reapplication_policy or "new_row"
     if reapplication_policy not in _REAPPLICATION_POLICIES:
@@ -482,18 +606,26 @@ def _insert_entity_tag(
             """
             INSERT INTO entity_tags (
                 entity_id, tag_id, applied_at_world_time,
-                expires_at_world_time, source_kind
+                expires_at_world_time, source_kind, source_chunk_id
             )
-            VALUES (%s, %s, %s, %s, %s::entity_tag_source_kind)
+            VALUES (%s, %s, %s, %s, %s::entity_tag_source_kind, %s)
             ON CONFLICT (entity_id, tag_id)
               WHERE cleared_at IS NULL
               DO UPDATE SET
                 applied_at = now(),
                 applied_at_world_time = EXCLUDED.applied_at_world_time,
                 expires_at_world_time = EXCLUDED.expires_at_world_time,
-                source_kind = EXCLUDED.source_kind
+                source_kind = EXCLUDED.source_kind,
+                source_chunk_id = EXCLUDED.source_chunk_id
             """,
-            (entity_id, tag_id, world_time, expires_at_world_time, source_kind),
+            (
+                entity_id,
+                tag_id,
+                world_time,
+                expires_at_world_time,
+                source_kind,
+                source_chunk_id,
+            ),
         )
         return bool(cur.rowcount)
 
@@ -502,9 +634,9 @@ def _insert_entity_tag(
             """
             INSERT INTO entity_tags (
                 entity_id, tag_id, applied_at_world_time,
-                expires_at_world_time, source_kind
+                expires_at_world_time, source_kind, source_chunk_id
             )
-            VALUES (%s, %s, %s, %s, %s::entity_tag_source_kind)
+            VALUES (%s, %s, %s, %s, %s::entity_tag_source_kind, %s)
             ON CONFLICT (entity_id, tag_id)
               WHERE cleared_at IS NULL
               DO UPDATE SET
@@ -517,7 +649,8 @@ def _insert_entity_tag(
                     ),
                     EXCLUDED.applied_at_world_time
                 ) + %s,
-                source_kind = EXCLUDED.source_kind
+                source_kind = EXCLUDED.source_kind,
+                source_chunk_id = EXCLUDED.source_chunk_id
             """,
             (
                 entity_id,
@@ -525,6 +658,7 @@ def _insert_entity_tag(
                 world_time,
                 expires_at_world_time,
                 source_kind,
+                source_chunk_id,
                 duration_override,
             ),
         )
@@ -536,14 +670,21 @@ def _insert_entity_tag(
         """
         INSERT INTO entity_tags (
             entity_id, tag_id, applied_at_world_time,
-            expires_at_world_time, source_kind
+            expires_at_world_time, source_kind, source_chunk_id
         )
-        VALUES (%s, %s, %s, %s, %s::entity_tag_source_kind)
+        VALUES (%s, %s, %s, %s, %s::entity_tag_source_kind, %s)
         ON CONFLICT (entity_id, tag_id)
           WHERE cleared_at IS NULL
           DO NOTHING
         """,
-        (entity_id, tag_id, world_time, expires_at_world_time, source_kind),
+        (
+            entity_id,
+            tag_id,
+            world_time,
+            expires_at_world_time,
+            source_kind,
+            source_chunk_id,
+        ),
     )
     return bool(cur.rowcount)
 
@@ -557,6 +698,7 @@ async def _insert_entity_tag_async(
     world_time: Optional[datetime],
     duration_override: Optional[timedelta],
     reapplication_policy: Optional[ReapplicationPolicy],
+    source_chunk_id: Optional[int] = None,
 ) -> bool:
     reapplication_policy = reapplication_policy or "new_row"
     if reapplication_policy not in _REAPPLICATION_POLICIES:
@@ -578,22 +720,24 @@ async def _insert_entity_tag_async(
             """
             INSERT INTO entity_tags (
                 entity_id, tag_id, applied_at_world_time,
-                expires_at_world_time, source_kind
+                expires_at_world_time, source_kind, source_chunk_id
             )
-            VALUES ($1, $2, $3, $4, $5::entity_tag_source_kind)
+            VALUES ($1, $2, $3, $4, $5::entity_tag_source_kind, $6)
             ON CONFLICT (entity_id, tag_id)
               WHERE cleared_at IS NULL
               DO UPDATE SET
                 applied_at = now(),
                 applied_at_world_time = EXCLUDED.applied_at_world_time,
                 expires_at_world_time = EXCLUDED.expires_at_world_time,
-                source_kind = EXCLUDED.source_kind
+                source_kind = EXCLUDED.source_kind,
+                source_chunk_id = EXCLUDED.source_chunk_id
             """,
             entity_id,
             tag_id,
             world_time,
             expires_at_world_time,
             source_kind,
+            source_chunk_id,
         )
         return _asyncpg_status_changed(result)
 
@@ -602,9 +746,9 @@ async def _insert_entity_tag_async(
             """
             INSERT INTO entity_tags (
                 entity_id, tag_id, applied_at_world_time,
-                expires_at_world_time, source_kind
+                expires_at_world_time, source_kind, source_chunk_id
             )
-            VALUES ($1, $2, $3, $4, $5::entity_tag_source_kind)
+            VALUES ($1, $2, $3, $4, $5::entity_tag_source_kind, $6)
             ON CONFLICT (entity_id, tag_id)
               WHERE cleared_at IS NULL
               DO UPDATE SET
@@ -616,14 +760,16 @@ async def _insert_entity_tag_async(
                         EXCLUDED.applied_at_world_time
                     ),
                     EXCLUDED.applied_at_world_time
-                ) + $6,
-                source_kind = EXCLUDED.source_kind
+                ) + $7,
+                source_kind = EXCLUDED.source_kind,
+                source_chunk_id = EXCLUDED.source_chunk_id
             """,
             entity_id,
             tag_id,
             world_time,
             expires_at_world_time,
             source_kind,
+            source_chunk_id,
             duration_override,
         )
         return _asyncpg_status_changed(result)
@@ -632,9 +778,9 @@ async def _insert_entity_tag_async(
         """
         INSERT INTO entity_tags (
             entity_id, tag_id, applied_at_world_time,
-            expires_at_world_time, source_kind
+            expires_at_world_time, source_kind, source_chunk_id
         )
-        VALUES ($1, $2, $3, $4, $5::entity_tag_source_kind)
+        VALUES ($1, $2, $3, $4, $5::entity_tag_source_kind, $6)
         ON CONFLICT (entity_id, tag_id)
           WHERE cleared_at IS NULL
           DO NOTHING
@@ -644,6 +790,7 @@ async def _insert_entity_tag_async(
         world_time,
         expires_at_world_time,
         source_kind,
+        source_chunk_id,
     )
     return _asyncpg_status_changed(result)
 
@@ -666,6 +813,8 @@ def _clear_entity_tag_siblings(
     entity_id: int,
     category: str,
     keep_tag_id: int,
+    world_time: Optional[datetime] = None,
+    source_chunk_id: Optional[int] = None,
 ) -> int:
     cur.execute(
         """
@@ -677,13 +826,30 @@ def _clear_entity_tag_siblings(
           AND t.category = %s
           AND t.id <> %s
           AND et.cleared_at IS NULL
+        RETURNING et.id
         """,
         (entity_id, category, keep_tag_id),
     )
-    return int(cur.rowcount)
+    cleared_ids = [_row_value(row, "id", 0) for row in cur.fetchall()]
+    for entity_tag_id in cleared_ids:
+        _log_entity_tag_clearance(
+            cur,
+            entity_tag_id=entity_tag_id,
+            world_time=world_time,
+            source_chunk_id=source_chunk_id,
+            reason="exclusive_ladder_replace",
+        )
+    return len(cleared_ids)
 
 
-def clear_entity_tag(cur: Any, *, entity_id: int, tag: str) -> bool:
+def clear_entity_tag(
+    cur: Any,
+    *,
+    entity_id: int,
+    tag: str,
+    world_time: Optional[datetime] = None,
+    source_chunk_id: Optional[int] = None,
+) -> bool:
     """Mark an active single-entity tag as cleared (UPDATE cleared_at = now()).
 
     Returns ``True`` if a row was cleared, ``False`` if no active row existed for
@@ -711,35 +877,80 @@ def clear_entity_tag(cur: Any, *, entity_id: int, tag: str) -> bool:
           AND NOT t.deprecated
           AND t.synonym_for IS NULL
           AND et.cleared_at IS NULL
+        RETURNING et.id
         """,
         (entity_id, canonical_name),
     )
-    return bool(cur.rowcount)
+    cleared_ids = [_row_value(row, "id", 0) for row in cur.fetchall()]
+    for entity_tag_id in cleared_ids:
+        _log_entity_tag_clearance(
+            cur,
+            entity_tag_id=entity_tag_id,
+            world_time=world_time,
+            source_chunk_id=source_chunk_id,
+            reason="clear_entity_tag",
+        )
+    return bool(cleared_ids)
 
 
-def _clear_entity_tag(cur: Any, *, entity_id: int, tag_id: int) -> bool:
+def _clear_entity_tag(
+    cur: Any,
+    *,
+    entity_id: int,
+    tag_id: int,
+    world_time: Optional[datetime] = None,
+    source_chunk_id: Optional[int] = None,
+    reason: str = "tag_writer.clear",
+) -> bool:
     cur.execute(
         """
         UPDATE entity_tags
         SET cleared_at = now()
         WHERE entity_id = %s AND tag_id = %s AND cleared_at IS NULL
+        RETURNING id
         """,
         (entity_id, tag_id),
     )
-    return bool(cur.rowcount)
+    cleared_ids = [_row_value(row, "id", 0) for row in cur.fetchall()]
+    for entity_tag_id in cleared_ids:
+        _log_entity_tag_clearance(
+            cur,
+            entity_tag_id=entity_tag_id,
+            world_time=world_time,
+            source_chunk_id=source_chunk_id,
+            reason=reason,
+        )
+    return bool(cleared_ids)
 
 
-async def _clear_entity_tag_async(conn: Any, *, entity_id: int, tag_id: int) -> bool:
-    result = await conn.execute(
+async def _clear_entity_tag_async(
+    conn: Any,
+    *,
+    entity_id: int,
+    tag_id: int,
+    world_time: Optional[datetime] = None,
+    source_chunk_id: Optional[int] = None,
+    reason: str = "tag_writer.clear",
+) -> bool:
+    rows = await conn.fetch(
         """
         UPDATE entity_tags
         SET cleared_at = now()
         WHERE entity_id = $1 AND tag_id = $2 AND cleared_at IS NULL
+        RETURNING id
         """,
         entity_id,
         tag_id,
     )
-    return _asyncpg_status_changed(result)
+    for row in rows:
+        await _log_entity_tag_clearance_async(
+            conn,
+            entity_tag_id=_row_value(row, "id", 0),
+            world_time=world_time,
+            source_chunk_id=source_chunk_id,
+            reason=reason,
+        )
+    return bool(rows)
 
 
 def _asyncpg_status_changed(status: str) -> bool:
@@ -782,6 +993,7 @@ def apply_pair_tag_bestowal(
     tag: str,
     source_kind: str = "skald_inline",
     world_time: Optional[datetime] = None,
+    source_chunk_id: Optional[int] = None,
 ) -> bool:
     """Apply a directed multi-entity tag (relation) from subject to object.
 
@@ -830,6 +1042,8 @@ def apply_pair_tag_bestowal(
         object_kinds=object_kinds,
     )
 
+    if world_time is None and source_chunk_id is not None:
+        world_time = _chunk_world_time(cur, source_chunk_id)
     if world_time is None:
         world_time = _load_world_time(cur)
 
@@ -840,6 +1054,7 @@ def apply_pair_tag_bestowal(
         pair_tag_id=pair_tag_id,
         source_kind=source_kind,
         world_time=world_time,
+        source_chunk_id=source_chunk_id,
     )
 
 
@@ -886,19 +1101,27 @@ def _insert_pair_tag_row(
     pair_tag_id: int,
     source_kind: str,
     world_time: Optional[datetime],
+    source_chunk_id: Optional[int] = None,
 ) -> bool:
     cur.execute(
         """
         INSERT INTO entity_pair_tags (
             subject_entity_id, object_entity_id, pair_tag_id,
-            applied_at_world_time, source_kind
+            applied_at_world_time, source_kind, source_chunk_id
         )
-        VALUES (%s, %s, %s, %s, %s::entity_tag_source_kind)
+        VALUES (%s, %s, %s, %s, %s::entity_tag_source_kind, %s)
         ON CONFLICT (subject_entity_id, object_entity_id, pair_tag_id)
           WHERE cleared_at IS NULL
           DO NOTHING
         """,
-        (subject_entity_id, object_entity_id, pair_tag_id, world_time, source_kind),
+        (
+            subject_entity_id,
+            object_entity_id,
+            pair_tag_id,
+            world_time,
+            source_kind,
+            source_chunk_id,
+        ),
     )
     return bool(cur.rowcount)
 
@@ -912,6 +1135,7 @@ def apply_status_pair_tag_bestowal(
     level: str,
     source_kind: str = "skald_inline",
     world_time: Optional[datetime] = None,
+    source_chunk_id: Optional[int] = None,
 ) -> bool:
     """Replace the active ``status:*`` level for one subject→faction edge.
 
@@ -937,6 +1161,8 @@ def apply_status_pair_tag_bestowal(
         subject_kinds=_row_value(row, "subject_kinds", 1),
         object_kinds=_row_value(row, "object_kinds", 2),
     )
+    if world_time is None and source_chunk_id is not None:
+        world_time = _chunk_world_time(cur, source_chunk_id)
     if world_time is None:
         world_time = _load_world_time(cur)
 
@@ -945,6 +1171,9 @@ def apply_status_pair_tag_bestowal(
         subject_entity_id=subject_entity_id,
         object_entity_id=scope_faction_entity_id,
         tags=STATUS_TAGS - {tag},
+        world_time=world_time,
+        source_chunk_id=source_chunk_id,
+        reason="status_ladder_replace",
     )
     return _insert_pair_tag_row(
         cur,
@@ -953,6 +1182,7 @@ def apply_status_pair_tag_bestowal(
         pair_tag_id=pair_tag_id,
         source_kind=source_kind,
         world_time=world_time,
+        source_chunk_id=source_chunk_id,
     )
 
 
@@ -962,6 +1192,8 @@ def clear_pair_tag(
     subject_entity_id: int,
     object_entity_id: int,
     tag: str,
+    world_time: Optional[datetime] = None,
+    source_chunk_id: Optional[int] = None,
 ) -> bool:
     """Mark an active multi-entity tag as cleared (UPDATE cleared_at = now()).
 
@@ -991,10 +1223,20 @@ def clear_pair_tag(
           AND ept.subject_entity_id = %s
           AND ept.object_entity_id = %s
           AND ept.cleared_at IS NULL
+        RETURNING ept.id
         """,
         (tag, subject_entity_id, object_entity_id),
     )
-    return bool(cur.rowcount)
+    cleared_ids = [_row_value(row, "id", 0) for row in cur.fetchall()]
+    for pair_tag_row_id in cleared_ids:
+        _log_pair_tag_clearance(
+            cur,
+            entity_pair_tag_id=pair_tag_row_id,
+            world_time=world_time,
+            source_chunk_id=source_chunk_id,
+            reason="clear_pair_tag",
+        )
+    return bool(cleared_ids)
 
 
 def _clear_pair_tags_by_name(
@@ -1003,6 +1245,9 @@ def _clear_pair_tags_by_name(
     subject_entity_id: int,
     object_entity_id: int,
     tags: set[str],
+    world_time: Optional[datetime] = None,
+    source_chunk_id: Optional[int] = None,
+    reason: str = "clear_pair_tags_by_name",
 ) -> int:
     if not tags:
         return 0
@@ -1016,7 +1261,17 @@ def _clear_pair_tags_by_name(
           AND ept.object_entity_id = %s
           AND pt.tag = ANY(%s)
           AND ept.cleared_at IS NULL
+        RETURNING ept.id
         """,
         (subject_entity_id, object_entity_id, sorted(tags)),
     )
-    return int(cur.rowcount)
+    cleared_ids = [_row_value(row, "id", 0) for row in cur.fetchall()]
+    for pair_tag_row_id in cleared_ids:
+        _log_pair_tag_clearance(
+            cur,
+            entity_pair_tag_id=pair_tag_row_id,
+            world_time=world_time,
+            source_chunk_id=source_chunk_id,
+            reason=reason,
+        )
+    return len(cleared_ids)

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -233,7 +233,9 @@ async def insert_faction_references(
 
 
 async def apply_state_updates(
-    conn: asyncpg.Connection, state_updates: StateUpdates
+    conn: asyncpg.Connection,
+    state_updates: StateUpdates,
+    source_chunk_id: Optional[int] = None,
 ) -> None:
     """
     Apply entity state updates from the LLM response.
@@ -284,6 +286,7 @@ async def apply_state_updates(
                     subtype_table="characters",
                     subtype_id=char_update.character_id,
                     bestowal=bestowal,
+                    source_chunk_id=source_chunk_id,
                 )
 
     # Update place states. The schema field is current_conditions
@@ -310,6 +313,7 @@ async def apply_state_updates(
                 subtype_table="places",
                 subtype_id=place_update.place_id,
                 bestowal=bestowal,
+                source_chunk_id=source_chunk_id,
             )
 
     for faction_update in state_updates.factions:
@@ -321,6 +325,7 @@ async def apply_state_updates(
                 subtype_table="factions",
                 subtype_id=faction_update.faction_id,
                 bestowal=bestowal,
+                source_chunk_id=source_chunk_id,
             )
 
 
@@ -331,6 +336,7 @@ async def apply_state_tags_async(
     subtype_table: str,
     subtype_id: int,
     bestowal,
+    source_chunk_id: Optional[int] = None,
 ) -> None:
     """Look up the entity_id for a subtype row and apply Skald-bestowed tags."""
 
@@ -348,6 +354,7 @@ async def apply_state_tags_async(
         entity_kind=kind,
         bestowal=bestowal,
         source_kind="skald_inline",
+        source_chunk_id=source_chunk_id,
     )
     if any(counters.values()):
         logger.info(f"Tag bestowal {kind}/{subtype_id}: {counters}")
@@ -485,7 +492,7 @@ async def commit_incubator_to_database(
             # Step 8: Update entity states (if provided)
             if incubator.get("entity_updates"):
                 state_updates = StateUpdates(**incubator["entity_updates"])
-                await apply_state_updates(conn, state_updates)
+                await apply_state_updates(conn, state_updates, source_chunk_id=chunk_id)
 
             # Step 8.5: Commit Orrery proposal inside the accepted-chunk transaction
             orrery_result = await commit_orrery_tick_async(

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -525,7 +525,7 @@ def commit_incubator_to_database_sync(
             # Step 8: Update entity states (if provided)
             if incubator.get("entity_updates"):
                 state_updates = StateUpdates(**incubator["entity_updates"])
-                apply_state_updates_sync(conn, state_updates)
+                apply_state_updates_sync(conn, state_updates, source_chunk_id=chunk_id)
 
             # Step 8.5: Commit Orrery proposal inside the accepted-chunk transaction
             orrery_result = commit_orrery_tick_sync(
@@ -615,7 +615,9 @@ def commit_incubator_to_database_sync(
     return chunk_id
 
 
-def apply_state_updates_sync(conn, state_updates: StateUpdates):
+def apply_state_updates_sync(
+    conn, state_updates: StateUpdates, source_chunk_id: Optional[int] = None
+):
     """Apply entity state updates synchronously"""
     with conn.cursor() as cur:
         # Update character states
@@ -652,6 +654,7 @@ def apply_state_updates_sync(conn, state_updates: StateUpdates):
                         subtype_table="characters",
                         subtype_id=char_update.character_id,
                         bestowal=bestowal,
+                        source_chunk_id=source_chunk_id,
                     )
 
         # Update place states. The schema field is current_conditions
@@ -673,6 +676,7 @@ def apply_state_updates_sync(conn, state_updates: StateUpdates):
                     subtype_table="places",
                     subtype_id=place_update.place_id,
                     bestowal=bestowal,
+                    source_chunk_id=source_chunk_id,
                 )
 
         # Update faction states
@@ -685,10 +689,19 @@ def apply_state_updates_sync(conn, state_updates: StateUpdates):
                     subtype_table="factions",
                     subtype_id=faction_update.faction_id,
                     bestowal=bestowal,
+                    source_chunk_id=source_chunk_id,
                 )
 
 
-def _apply_state_tags(cur, *, kind, subtype_table, subtype_id, bestowal) -> None:
+def _apply_state_tags(
+    cur,
+    *,
+    kind,
+    subtype_table,
+    subtype_id,
+    bestowal,
+    source_chunk_id: Optional[int] = None,
+) -> None:
     """Look up the entity_id for a subtype row and apply Skald-bestowed tags."""
     cur.execute(
         f"SELECT entity_id FROM {subtype_table} WHERE id = %s",
@@ -705,6 +718,7 @@ def _apply_state_tags(cur, *, kind, subtype_table, subtype_id, bestowal) -> None
         entity_kind=kind,
         bestowal=bestowal,
         source_kind="skald_inline",
+        source_chunk_id=source_chunk_id,
     )
     if any(counters.values()):
         logger.info(f"Tag bestowal {kind}/{subtype_id}: {counters}")

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -265,10 +265,19 @@ def test_entity_context_hover_payload(client: TestClient) -> None:
         assert entity["kind"] == "character"
         for bucket in ("durable", "ephemeral"):
             for tag_row in entity["tags"][bucket]:
-                assert tag_row["provenance"] in {"approximate", "unknowable"}
-                assert (tag_row["provenance"] == "approximate") == (
-                    tag_row["applied_at_world_time"] is not None
-                )
+                # Three-tier provenance since migration 064: exact rows carry
+                # the chunk bestowal key, approximate rows only a world time.
+                assert tag_row["provenance"] in {
+                    "exact",
+                    "approximate",
+                    "unknowable",
+                }
+                if tag_row["source_chunk_id"] is not None:
+                    assert tag_row["provenance"] == "exact"
+                else:
+                    assert (tag_row["provenance"] == "approximate") == (
+                        tag_row["applied_at_world_time"] is not None
+                    )
                 assert isinstance(tag_row["families"], list)
         for relationship in entity["relationships"]:
             assert relationship["versioned"] is False

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -72,6 +72,7 @@ class RecordingCursor:
         self.location_class_destinations = list(location_class_destinations or [])
         self.place_zones = dict(place_zones or {})
         self.executed = []
+        self.clearance_log_rows = []
         self.rowcount = 1
         self._fetchone = None
         self._fetchall = []
@@ -115,8 +116,11 @@ class RecordingCursor:
             tag = params[0]
             if tag in self.known_tags:
                 self._fetchone = {"id": self.known_tags[tag]}
+        elif "INSERT INTO tag_clearance_log" in normalized:
+            self.clearance_log_rows.append(params)
+            self.rowcount = 1
         elif "INSERT INTO entity_tags" in normalized:
-            entity_id, tag_id, _template_id = params
+            entity_id, tag_id, _template_id, _world_time, _source_chunk_id = params
             tags_by_id = {value: key for key, value in self.known_tags.items()}
             tag = tags_by_id[tag_id]
             if (entity_id, tag) not in self.current_tags:
@@ -329,6 +333,11 @@ class RecordingCursor:
         elif "UPDATE characters SET current_location" in normalized:
             self.rowcount = 1
         elif "UPDATE entity_pair_tags ept SET cleared_at = now()" in normalized:
+            # RETURNING ept.id — one fake row id per "cleared" row.
+            self._fetchall = [
+                {"id": 900 + offset}
+                for offset in range(self.inbound_pair_tag_clear_count)
+            ]
             self.rowcount = self.inbound_pair_tag_clear_count
         elif "INSERT INTO world_events" in normalized:
             self._fetchone = {"id": 20}
@@ -2300,7 +2309,8 @@ def test_commit_orrery_tick_applies_need_fulfillment_delta() -> None:
     assert cursor.need_state[(1, "sleep")]["debt_score"] == 18
     assert "UPDATE character_need_states" in statements
     assert any(
-        "INSERT INTO entity_tags" in sql and params == (1, 101, "sleep")
+        "INSERT INTO entity_tags" in sql
+        and params == (1, 101, "sleep", world_time, 100)
         for sql, params in cursor.executed
     )
 

--- a/tests/test_orrery/test_pair_tag_predicates.py
+++ b/tests/test_orrery/test_pair_tag_predicates.py
@@ -130,8 +130,21 @@ def test_entities(
     finally:
         with slot_connection:
             with slot_connection.cursor() as cur:
-                # ON DELETE CASCADE on entity_pair_tags handles any pair tags;
-                # no manual pair-tag cleanup needed.
+                # tag_clearance_log references entity_pair_tags without
+                # ON DELETE CASCADE (migration 064), so purge log rows for
+                # the test entities' pair rows first; the entities DELETE
+                # then cascades to entity_pair_tags as before.
+                cur.execute(
+                    """
+                    DELETE FROM tag_clearance_log
+                    WHERE entity_pair_tag_id IN (
+                        SELECT id FROM entity_pair_tags
+                        WHERE subject_entity_id = ANY(%s)
+                           OR object_entity_id = ANY(%s)
+                    )
+                    """,
+                    (created_ids, created_ids),
+                )
                 cur.execute(
                     "DELETE FROM entities WHERE id = ANY(%s)",
                     (created_ids,),

--- a/tests/test_orrery/test_pair_tag_substrate.py
+++ b/tests/test_orrery/test_pair_tag_substrate.py
@@ -108,6 +108,21 @@ def test_entities(
     finally:
         with slot_connection:
             with slot_connection.cursor() as cur:
+                # tag_clearance_log references entity_pair_tags without
+                # ON DELETE CASCADE (migration 064), so purge log rows for
+                # the test entities' pair rows first; the entities DELETE
+                # then cascades to entity_pair_tags as before.
+                cur.execute(
+                    """
+                    DELETE FROM tag_clearance_log
+                    WHERE entity_pair_tag_id IN (
+                        SELECT id FROM entity_pair_tags
+                        WHERE subject_entity_id = ANY(%s)
+                           OR object_entity_id = ANY(%s)
+                    )
+                    """,
+                    (created_ids, created_ids),
+                )
                 cur.execute("DELETE FROM entities WHERE id = ANY(%s)", (created_ids,))
 
 

--- a/tests/test_orrery/test_pair_tag_writer.py
+++ b/tests/test_orrery/test_pair_tag_writer.py
@@ -125,6 +125,21 @@ def test_entities(
                 ids_in_scope = [char_a, char_b]
                 if faction is not None:
                     ids_in_scope.append(faction)
+                # tag_clearance_log references entity_pair_tags without
+                # ON DELETE CASCADE (migration 064); purge log rows for the
+                # test-created pair rows first or their DELETE FK-fails.
+                cur.execute(
+                    """
+                    DELETE FROM tag_clearance_log
+                    WHERE entity_pair_tag_id IN (
+                        SELECT id FROM entity_pair_tags
+                        WHERE subject_entity_id = ANY(%s)
+                          AND object_entity_id = ANY(%s)
+                          AND NOT (id = ANY(%s))
+                    )
+                    """,
+                    (ids_in_scope, ids_in_scope, list(entities.preexisting_ids)),
+                )
                 cur.execute(
                     """
                     DELETE FROM entity_pair_tags

--- a/tests/test_orrery/test_status_family.py
+++ b/tests/test_orrery/test_status_family.py
@@ -47,12 +47,34 @@ class _PairCursor:
         self.rowcount = 0
         self._next_row: Any = None
         self._next_rows: list[Any] = []
+        self._next_pair_row_id = 1
+        for row in self.entity_pair_tags:
+            row.setdefault("id", self._next_pair_row_id)
+            self._next_pair_row_id += 1
+        self.clearance_log_rows: list[dict[str, Any]] = []
 
     def execute(self, sql: str, params: Optional[tuple] = None) -> None:
         params = params or ()
         sql_upper = sql.strip().upper()
         if sql_upper.startswith("SELECT MAX(WORLD_TIME)"):
             self._next_row = _FakeRow({"world_time": _WORLD_TIME}, ["world_time"])
+            self.rowcount = 1
+            return
+        if sql_upper.startswith("SELECT WORLD_TIME FROM CHUNK_METADATA"):
+            self._next_row = None
+            self.rowcount = 0
+            return
+        if sql_upper.startswith("INSERT INTO TAG_CLEARANCE_LOG"):
+            entity_pair_tag_id, world_time, justification, source_chunk_id = params
+            self.clearance_log_rows.append(
+                {
+                    "entity_pair_tag_id": entity_pair_tag_id,
+                    "mechanism": "authored",
+                    "cleared_at_world_time": world_time,
+                    "justification": justification,
+                    "source_chunk_id": source_chunk_id,
+                }
+            )
             self.rowcount = 1
             return
         if sql_upper.startswith("SELECT ID, SUBJECT_KINDS, OBJECT_KINDS"):
@@ -75,7 +97,7 @@ class _PairCursor:
         if sql_upper.startswith("UPDATE ENTITY_PAIR_TAGS EPT"):
             subject_id, object_id, tags = params
             tag_names = set(tags)
-            cleared = 0
+            cleared_ids: list[int] = []
             id_to_tag = {row["id"]: tag for tag, row in self.pair_tags.items()}
             for row in self.entity_pair_tags:
                 if (
@@ -85,11 +107,22 @@ class _PairCursor:
                     and id_to_tag.get(row["pair_tag_id"]) in tag_names
                 ):
                     row["cleared_at"] = "now"
-                    cleared += 1
-            self.rowcount = cleared
+                    cleared_ids.append(row["id"])
+            # UPDATE ... RETURNING ept.id
+            self._next_rows = [
+                _FakeRow({"id": row_id}, ["id"]) for row_id in cleared_ids
+            ]
+            self.rowcount = len(cleared_ids)
             return
         if sql_upper.startswith("INSERT INTO ENTITY_PAIR_TAGS"):
-            subject_id, object_id, pair_tag_id, world_time, source_kind = params
+            (
+                subject_id,
+                object_id,
+                pair_tag_id,
+                world_time,
+                source_kind,
+                source_chunk_id,
+            ) = params
             for row in self.entity_pair_tags:
                 if (
                     row["subject_entity_id"] == subject_id
@@ -101,14 +134,17 @@ class _PairCursor:
                     return
             self.entity_pair_tags.append(
                 {
+                    "id": self._next_pair_row_id,
                     "subject_entity_id": subject_id,
                     "object_entity_id": object_id,
                     "pair_tag_id": pair_tag_id,
                     "applied_at_world_time": world_time,
                     "source_kind": source_kind,
+                    "source_chunk_id": source_chunk_id,
                     "cleared_at": None,
                 }
             )
+            self._next_pair_row_id += 1
             self.rowcount = 1
             return
         if sql_upper.startswith("SELECT EPT.OBJECT_ENTITY_ID"):
@@ -275,6 +311,12 @@ def test_status_bestowal_replaces_status_family_within_one_scope_edge() -> None:
         and row["cleared_at"] is None
     ]
     assert len(active_rows_for_scope) == 1
+    # Ladder replacement logs each displaced sibling in tag_clearance_log.
+    assert len(cur.clearance_log_rows) == 2
+    assert all(
+        log["mechanism"] == "authored" and log["entity_pair_tag_id"] is not None
+        for log in cur.clearance_log_rows
+    )
 
 
 def test_status_bestowal_self_scope_error_uses_scope_parameter_name() -> None:

--- a/tests/test_orrery/test_tag_provenance.py
+++ b/tests/test_orrery/test_tag_provenance.py
@@ -295,3 +295,48 @@ def test_entity_context_reports_exact_provenance_tier() -> None:
             session.rollback()
     finally:
         engine.dispose()
+
+
+def test_chunk_keyed_bestowal_without_metadata_leaves_world_time_null() -> None:
+    """A chunk-keyed row must never borrow the global-max clock (review
+    finding on #425): chunk clock or NULL, so the "exact" tier cannot carry
+    a fabricated world time."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            _, actor_id, _ = _anchor_and_actors(cur)
+            cur.execute(
+                """
+                INSERT INTO narrative_chunks (raw_text)
+                VALUES ('provenance probe: chunk without metadata')
+                RETURNING id
+                """
+            )
+            bare_chunk_id = cur.fetchone()[0]
+
+            counters = apply_tag_bestowal(
+                cur,
+                entity_id=actor_id,
+                entity_kind="character",
+                bestowal=OrreryTagBestowal(applied_tags=["off_grid"]),
+                source_chunk_id=bare_chunk_id,
+            )
+            assert counters["applied"] == 1
+            cur.execute(
+                """
+                SELECT et.source_chunk_id, et.applied_at_world_time
+                FROM entity_tags et
+                JOIN tags t ON t.id = et.tag_id
+                WHERE et.entity_id = %s AND t.tag = 'off_grid'
+                  AND et.cleared_at IS NULL
+                ORDER BY et.id DESC LIMIT 1
+                """,
+                (actor_id,),
+            )
+            source_chunk_id, world_time = cur.fetchone()
+            assert source_chunk_id == bare_chunk_id
+            assert world_time is None
+    finally:
+        conn.rollback()
+        conn.close()

--- a/tests/test_orrery/test_tag_provenance.py
+++ b/tests/test_orrery/test_tag_provenance.py
@@ -1,0 +1,297 @@
+"""Live tests for migration 064's forward-fix tag provenance.
+
+Real writers against save_02 inside always-rolled-back transactions — real
+SQL, real constraints, zero persistent writes. Pins the forward-fix
+guarantees from docs/orrery_audit_dashboard_notes.md step 7:
+
+1. Resolver bestowals stamp ``source_chunk_id`` and the bestowing chunk's
+   in-world time (previously both were the NULL leak the notes cite).
+2. tag_writer bestowals stamp the chunk key when the caller supplies it, and
+   every tag_writer clear now writes a ``tag_clearance_log`` row.
+3. Pair-tag clears — structurally unloggable before 064 — log with
+   ``entity_pair_tag_id``.
+4. The hover-audit's per-row provenance gains the "exact" tier, visible
+   end-to-end through ``entity_context``.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+import psycopg2
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from nexus.agents.orrery.audit import entity_context
+from nexus.agents.orrery.events import commit_orrery_tick_sync
+from nexus.agents.orrery.resolver import (
+    OrreryResolutionDraft,
+    OrreryTickProposal,
+)
+from nexus.agents.orrery.tag_writer import (
+    apply_pair_tag_bestowal,
+    apply_tag_bestowal,
+    clear_pair_tag,
+)
+from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
+from nexus.api.slot_utils import get_slot_db_url
+
+pytestmark = pytest.mark.requires_postgres
+
+WRITE_SLOT = 2
+
+
+def _connect() -> Any:
+    return psycopg2.connect(
+        host=os.environ.get("PGHOST", "localhost"),
+        database=f"save_{WRITE_SLOT:02d}",
+        user=os.environ.get("PGUSER", "pythagor"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+def _anchor_and_actors(cur: Any) -> tuple[int, int, int]:
+    cur.execute("SELECT max(id) FROM narrative_chunks")
+    anchor_chunk_id = cur.fetchone()[0]
+    cur.execute(
+        """
+        SELECT c.entity_id FROM characters c
+        WHERE c.entity_id IS NOT NULL
+        ORDER BY c.entity_id
+        LIMIT 2
+        """
+    )
+    rows = cur.fetchall()
+    assert len(rows) == 2, "save_02 is expected to hold at least two characters"
+    return anchor_chunk_id, rows[0][0], rows[1][0]
+
+
+def test_resolver_commit_stamps_bestowal_provenance() -> None:
+    """entity_tags.add through the tick commit carries chunk + world time."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            anchor_chunk_id, actor_id, target_id = _anchor_and_actors(cur)
+            cur.execute(
+                "SELECT world_time FROM chunk_metadata WHERE chunk_id = %s",
+                (anchor_chunk_id,),
+            )
+            row = cur.fetchone()
+            chunk_world_time = row[0] if row else None
+            # Give the target an inbound `hunting` pair tag so the draft's
+            # clear_inbound delta has something real to clear and log.
+            assert apply_pair_tag_bestowal(
+                cur,
+                subject_entity_id=actor_id,
+                object_entity_id=target_id,
+                subject_kind="character",
+                object_kind="character",
+                tag="hunting",
+                source_chunk_id=anchor_chunk_id,
+            )
+            cur.execute(
+                """
+                SELECT source_chunk_id FROM entity_pair_tags
+                WHERE subject_entity_id = %s AND object_entity_id = %s
+                  AND cleared_at IS NULL
+                ORDER BY id DESC LIMIT 1
+                """,
+                (actor_id, target_id),
+            )
+            assert cur.fetchone()[0] == anchor_chunk_id
+
+        draft = OrreryResolutionDraft(
+            template_id="evade_pursuers",
+            priority=100,
+            binding_hash=f"prov-{uuid.uuid4().hex}",
+            bindings={"actor": actor_id, "target": target_id},
+            branch_label="Provenance probe",
+            narrative_stub="{actor} slips the cordon.",
+            magnitude=0.5,
+            state_delta={
+                "entity_tags.add": ["off_grid"],
+                "entity_pair_tags_target.clear_inbound": ["hunting"],
+            },
+        )
+        result = commit_orrery_tick_sync(
+            conn,
+            OrreryTickProposal(
+                anchor_chunk_id=anchor_chunk_id,
+                actor_count=1,
+                resolutions=(draft,),
+            ),
+            tick_chunk_id=anchor_chunk_id,
+            slot=WRITE_SLOT,
+        )
+        assert result.resolution_count == 1
+        assert result.tag_mutation_count >= 2
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT et.source_chunk_id, et.applied_at_world_time
+                FROM entity_tags et
+                JOIN tags t ON t.id = et.tag_id
+                WHERE et.entity_id = %s AND t.tag = 'off_grid'
+                  AND et.cleared_at IS NULL
+                  AND et.source_kind = 'template'
+                ORDER BY et.id DESC LIMIT 1
+                """,
+                (actor_id,),
+            )
+            source_chunk_id, applied_world_time = cur.fetchone()
+            assert source_chunk_id == anchor_chunk_id
+            assert applied_world_time == chunk_world_time
+
+            # The pair-tag clear must be logged with the pair row's id.
+            cur.execute(
+                """
+                SELECT tcl.entity_pair_tag_id, tcl.source_chunk_id,
+                       tcl.mechanism::text, ept.cleared_at
+                FROM tag_clearance_log tcl
+                JOIN entity_pair_tags ept ON ept.id = tcl.entity_pair_tag_id
+                JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+                WHERE ept.subject_entity_id = %s
+                  AND ept.object_entity_id = %s
+                  AND pt.tag = 'hunting'
+                ORDER BY tcl.id DESC LIMIT 1
+                """,
+                (actor_id, target_id),
+            )
+            log_row = cur.fetchone()
+            assert log_row is not None, "pair-tag clearance must be logged"
+            assert log_row[1] == anchor_chunk_id
+            assert log_row[2] == "authored"
+            assert log_row[3] is not None
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_tag_writer_clears_are_logged_and_bestowals_stamped() -> None:
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            anchor_chunk_id, actor_id, target_id = _anchor_and_actors(cur)
+
+            counters = apply_tag_bestowal(
+                cur,
+                entity_id=actor_id,
+                entity_kind="character",
+                bestowal=OrreryTagBestowal(applied_tags=["off_grid"]),
+                source_chunk_id=anchor_chunk_id,
+            )
+            cur.execute(
+                """
+                SELECT et.source_chunk_id, et.applied_at_world_time
+                FROM entity_tags et
+                JOIN tags t ON t.id = et.tag_id
+                WHERE et.entity_id = %s AND t.tag = 'off_grid'
+                  AND et.cleared_at IS NULL
+                ORDER BY et.id DESC LIMIT 1
+                """,
+                (actor_id,),
+            )
+            source_chunk_id, world_time = cur.fetchone()
+            if counters["applied"]:
+                assert source_chunk_id == anchor_chunk_id
+                assert world_time is not None
+
+            cleared = apply_tag_bestowal(
+                cur,
+                entity_id=actor_id,
+                entity_kind="character",
+                bestowal=OrreryTagBestowal(tags_to_clear=["off_grid"]),
+                source_chunk_id=anchor_chunk_id,
+            )
+            assert cleared["cleared"] >= 1
+            cur.execute(
+                """
+                SELECT tcl.mechanism::text, tcl.source_chunk_id,
+                       tcl.justification->>'reason'
+                FROM tag_clearance_log tcl
+                JOIN entity_tags et ON et.id = tcl.entity_tag_id
+                JOIN tags t ON t.id = et.tag_id
+                WHERE et.entity_id = %s AND t.tag = 'off_grid'
+                ORDER BY tcl.id DESC LIMIT 1
+                """,
+                (actor_id,),
+            )
+            mechanism, log_chunk, reason = cur.fetchone()
+            assert mechanism == "authored"
+            assert log_chunk == anchor_chunk_id
+            assert reason == "bestowal.tags_to_clear"
+
+            # Direct pair-tag clear path logs too.
+            assert apply_pair_tag_bestowal(
+                cur,
+                subject_entity_id=actor_id,
+                object_entity_id=target_id,
+                subject_kind="character",
+                object_kind="character",
+                tag="hunting",
+                source_chunk_id=anchor_chunk_id,
+            )
+            assert clear_pair_tag(
+                cur,
+                subject_entity_id=actor_id,
+                object_entity_id=target_id,
+                tag="hunting",
+                source_chunk_id=anchor_chunk_id,
+            )
+            cur.execute(
+                """
+                SELECT count(*)
+                FROM tag_clearance_log tcl
+                JOIN entity_pair_tags ept ON ept.id = tcl.entity_pair_tag_id
+                WHERE ept.subject_entity_id = %s AND ept.object_entity_id = %s
+                  AND tcl.justification->>'reason' = 'clear_pair_tag'
+                """,
+                (actor_id, target_id),
+            )
+            assert cur.fetchone()[0] >= 1
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_entity_context_reports_exact_provenance_tier() -> None:
+    """A 064-era bestowal shows as provenance "exact" in the hover payload."""
+
+    engine = create_engine(get_slot_db_url(slot=WRITE_SLOT))
+    try:
+        with Session(engine) as session:
+            raw = session.connection().connection.cursor()
+            anchor_chunk_id, actor_id, _ = _anchor_and_actors(raw)
+            apply_tag_bestowal(
+                raw,
+                entity_id=actor_id,
+                entity_kind="character",
+                bestowal=OrreryTagBestowal(applied_tags=["off_grid"]),
+                source_chunk_id=anchor_chunk_id,
+            )
+            payload = entity_context(
+                session,
+                [actor_id],
+                anchor_chunk_id=anchor_chunk_id,
+            )
+            (entity,) = payload["entities"]
+            rows = entity["tags"]["durable"] + entity["tags"]["ephemeral"]
+            exact_rows = [row for row in rows if row["provenance"] == "exact"]
+            assert exact_rows, "the fresh bestowal must surface as exact"
+            for row in exact_rows:
+                assert row["source_chunk_id"] is not None
+            for row in rows:
+                if row["source_chunk_id"] is not None:
+                    assert row["provenance"] == "exact"
+                elif row["applied_at_world_time"] is not None:
+                    assert row["provenance"] == "approximate"
+                else:
+                    assert row["provenance"] == "unknowable"
+            session.rollback()
+    finally:
+        engine.dispose()

--- a/tests/test_orrery/test_tag_writer.py
+++ b/tests/test_orrery/test_tag_writer.py
@@ -68,14 +68,20 @@ class FakeCursor:
         self.entity_tags = list(entity_tags or [])
         self.category_registry = category_registry or _default_category_registry()
         self.world_time = world_time
+        self.chunk_world_times: dict[int, datetime] = {}
         self.rowcount = 0
         self._next_row: Any = None
         self._next_rows: list[Any] = []
         self._next_id = 1000
+        self._next_entity_tag_id = 1
+        for row in self.entity_tags:
+            row.setdefault("id", self._next_entity_tag_id)
+            self._next_entity_tag_id += 1
         self.inserted_tag_rows: list[dict[str, Any]] = []
         self.inserted_entity_tag_rows: list[dict[str, Any]] = []
         self.inserted_category_rows: list[dict[str, Any]] = []
         self.cleared_keys: list[tuple[int, int]] = []
+        self.clearance_log_rows: list[dict[str, Any]] = []
 
     def execute(self, sql: str, params: Optional[tuple] = None) -> None:
         params = params or ()
@@ -83,6 +89,34 @@ class FakeCursor:
         sql_upper = sql_trimmed.upper()
         if sql_upper.startswith("SELECT MAX(WORLD_TIME)"):
             self._next_row = _FakeRow({"world_time": self.world_time}, ["world_time"])
+            self.rowcount = 1
+            return
+        if sql_upper.startswith("SELECT WORLD_TIME FROM CHUNK_METADATA"):
+            (chunk_id,) = params
+            world_time = self.chunk_world_times.get(chunk_id)
+            self._next_row = (
+                _FakeRow({"world_time": world_time}, ["world_time"])
+                if world_time is not None
+                else None
+            )
+            self.rowcount = 1 if world_time is not None else 0
+            return
+        if sql_upper.startswith("INSERT INTO TAG_CLEARANCE_LOG"):
+            cleared_id, world_time, justification, source_chunk_id = params
+            key = (
+                "entity_pair_tag_id"
+                if "ENTITY_PAIR_TAG_ID" in sql_upper
+                else "entity_tag_id"
+            )
+            self.clearance_log_rows.append(
+                {
+                    key: cleared_id,
+                    "mechanism": "authored",
+                    "cleared_at_world_time": world_time,
+                    "justification": justification,
+                    "source_chunk_id": source_chunk_id,
+                }
+            )
             self.rowcount = 1
             return
         if (
@@ -166,15 +200,15 @@ class FakeCursor:
             self.rowcount = 1
             return
         if sql_upper.startswith("INSERT INTO ENTITY_TAGS"):
-            if len(params) == 4:
-                entity_id, tag_id, world_time, source_kind = params
-                expires_at_world_time = None
-                duration_override = None
-            else:
-                entity_id, tag_id, world_time, expires_at_world_time, source_kind = (
-                    params[:5]
-                )
-                duration_override = params[5] if len(params) > 5 else None
+            (
+                entity_id,
+                tag_id,
+                world_time,
+                expires_at_world_time,
+                source_kind,
+                source_chunk_id,
+            ) = params[:6]
+            duration_override = params[6] if len(params) > 6 else None
             for row in self.entity_tags:
                 if (
                     row["entity_id"] == entity_id
@@ -189,24 +223,29 @@ class FakeCursor:
                         row["applied_at_world_time"] = world_time
                         row["expires_at_world_time"] = base + duration_override
                         row["source_kind"] = source_kind
+                        row["source_chunk_id"] = source_chunk_id
                         self.rowcount = 1
                         return
                     if "DO UPDATE SET" in sql_upper:
                         row["applied_at_world_time"] = world_time
                         row["expires_at_world_time"] = expires_at_world_time
                         row["source_kind"] = source_kind
+                        row["source_chunk_id"] = source_chunk_id
                         self.rowcount = 1
                         return
                     self.rowcount = 0
                     return
             new_row = {
+                "id": self._next_entity_tag_id,
                 "entity_id": entity_id,
                 "tag_id": tag_id,
                 "applied_at_world_time": world_time,
                 "expires_at_world_time": expires_at_world_time,
                 "source_kind": source_kind,
+                "source_chunk_id": source_chunk_id,
                 "cleared_at": None,
             }
+            self._next_entity_tag_id += 1
             self.entity_tags.append(new_row)
             self.inserted_entity_tag_rows.append(new_row)
             self.rowcount = 1
@@ -214,7 +253,7 @@ class FakeCursor:
         if sql_upper.startswith("UPDATE ENTITY_TAGS ET") and "T.TAG =" in sql_upper:
             entity_id, tag = params
             tag_row = self.tags.get(tag)
-            cleared = 0
+            cleared_ids: list[int] = []
             if (
                 tag_row is not None
                 and not tag_row.get("deprecated")
@@ -228,13 +267,13 @@ class FakeCursor:
                         and row["cleared_at"] is None
                     ):
                         row["cleared_at"] = "now"
-                        cleared += 1
+                        cleared_ids.append(row["id"])
                         self.cleared_keys.append((entity_id, tag_id))
-            self.rowcount = cleared
+            self._queue_returning_ids(cleared_ids)
             return
         if sql_upper.startswith("UPDATE ENTITY_TAGS ET"):
             entity_id, category, keep_tag_id = params
-            cleared = 0
+            cleared_ids = []
             tag_id_to_category = {
                 row["id"]: row["category"] for row in self.tags.values()
             }
@@ -246,13 +285,13 @@ class FakeCursor:
                     and tag_id_to_category.get(row["tag_id"]) == category
                 ):
                     row["cleared_at"] = "now"
-                    cleared += 1
+                    cleared_ids.append(row["id"])
                     self.cleared_keys.append((entity_id, row["tag_id"]))
-            self.rowcount = cleared
+            self._queue_returning_ids(cleared_ids)
             return
         if sql_upper.startswith("UPDATE ENTITY_TAGS"):
             entity_id, tag_id = params
-            cleared = 0
+            cleared_ids = []
             for row in self.entity_tags:
                 if (
                     row["entity_id"] == entity_id
@@ -260,11 +299,16 @@ class FakeCursor:
                     and row["cleared_at"] is None
                 ):
                     row["cleared_at"] = "now"
-                    cleared += 1
+                    cleared_ids.append(row["id"])
                     self.cleared_keys.append((entity_id, tag_id))
-            self.rowcount = cleared
+            self._queue_returning_ids(cleared_ids)
             return
         raise AssertionError(f"FakeCursor: unhandled SQL: {sql_trimmed[:80]!r}")
+
+    def _queue_returning_ids(self, cleared_ids: list[int]) -> None:
+        """Model ``UPDATE ... RETURNING id``: queue one id-row per cleared row."""
+        self._next_rows = [_FakeRow({"id": row_id}, ["id"]) for row_id in cleared_ids]
+        self.rowcount = len(cleared_ids)
 
     def fetchone(self):
         row = self._next_row
@@ -533,6 +577,9 @@ def test_clears_existing_tag():
     )
     assert counters["cleared"] == 1
     assert cur.cleared_keys == [(11, tag_id)]
+    assert len(cur.clearance_log_rows) == 1
+    assert cur.clearance_log_rows[0]["entity_tag_id"] == cur.entity_tags[0]["id"]
+    assert cur.clearance_log_rows[0]["mechanism"] == "authored"
 
 
 def test_clear_entity_tag_marks_known_active_tag_cleared():
@@ -555,6 +602,8 @@ def test_clear_entity_tag_marks_known_active_tag_cleared():
     assert cleared is True
     assert cur.entity_tags[0]["cleared_at"] == "now"
     assert cur.cleared_keys == [(11, tag_id)]
+    assert len(cur.clearance_log_rows) == 1
+    assert cur.clearance_log_rows[0]["entity_tag_id"] == cur.entity_tags[0]["id"]
 
 
 def test_clear_entity_tag_is_idempotent():
@@ -574,6 +623,8 @@ def test_clear_entity_tag_is_idempotent():
 
     assert clear_entity_tag(cur, entity_id=11, tag="scrying_target") is True
     assert clear_entity_tag(cur, entity_id=11, tag="scrying_target") is False
+    # Only the first (effective) clear writes a clearance-log row.
+    assert len(cur.clearance_log_rows) == 1
 
 
 def test_clear_entity_tag_returns_false_when_no_active_row():

--- a/tests/test_trait_compiler.py
+++ b/tests/test_trait_compiler.py
@@ -368,7 +368,14 @@ class TraitCompilerCursor:
             return
 
         if normalized.startswith("INSERT INTO ENTITY_PAIR_TAGS"):
-            subject_id, object_id, pair_tag_id, _world_time, source_kind = params
+            (
+                subject_id,
+                object_id,
+                pair_tag_id,
+                _world_time,
+                source_kind,
+                _source_chunk_id,
+            ) = params
             active = [
                 row
                 for row in self.entity_pair_tags


### PR DESCRIPTION
## Summary

Step 7's forward-fix migrations from `docs/orrery_audit_dashboard_notes.md` ("Reconstruction Sufficiency") — going forward, every tag bestowal carries the chunk that caused it and every clearance is logged, on every path. These are the prerequisites for honest as-of rewind of tags/pair tags (the fast-follow the spec gates on this landing).

### Migration `064_tag_provenance_forward_fix.sql` (applied to template + all slots)

- `source_chunk_id` on `entity_tags` **and** `entity_pair_tags` — defining the **"exact"** provenance tier the hover-audit reserved since v1. Pre-064 rows stay NULL honestly.
- `tag_clearance_log` becomes polymorphic (nullable `entity_tag_id` + new `entity_pair_tag_id`, CHECK exactly-one): recon confirmed the old NOT NULL single-entity FK made pair-tag clears *structurally unloggable*.
- `entity_tags_current` re-created to project the new column (it's a column-projection view; recon's paraphrase of the view definition would have broken `CREATE OR REPLACE` on a column alias — validated against `pg_get_viewdef` first).

### Writers

- **Resolver bestowals** stamp `source_chunk_id` + the bestowing chunk's world time — closing the resolver-template NULL leak the notes cite ("the apply path already holds it" — confirmed; it just never forwarded it). New strict `_chunk_world_time_*` helpers return NULL rather than the wall-clock fallback the existing helper uses: provenance must not lie.
- **Every tag_writer clear path now logs** (`bestowal.tags_to_clear`, public clears, exclusive-ladder sibling clears, status-ladder replacement, pair-tag clears) with mechanism `authored`, world time, chunk id, and a jsonb reason. Resolver inbound pair-tag clears log with `entity_pair_tag_id`.
- **Skald commit handlers** thread the committing chunk through `apply_state_updates` → `apply_tag_bestowal` — closing the `skald_inline` NULL-world-time leak (19 of save_05's 30 NULL bestowals). Bestowals now prefer the committing chunk's clock over the legacy global-max default.
- `entity_context` provenance goes three-tier: `exact` / `approximate` / `unknowable`, with `source_chunk_id` in every row.

### Tests (no mocks for the new behavior)

Live rollback-transaction tests against save_02 drive the real resolver commit and tag_writer: bestowal stamping (chunk id + world time match `chunk_metadata`), clearance logging on single/pair/inbound paths, and the end-to-end `exact` tier read back through `entity_context` inside the same uncommitted transaction. Seven legacy fake-cursor fixture files updated to model the new SQL (RETURNING clears, 6-param inserts, clearance-log writes) with new-contract assertions **added** — idempotent clears log exactly once, status replacement logs both displaced siblings — and none weakened.

Full suite: 967 passed offline; live orrery+api suites 695 passed with only the known pre-existing `test_pair_tag_writer` failure (reproduces on origin/main).

Remaining step-7 slices (separate PRs): 7b Skald-side chunk-keyed delta logging on the on-screen commit path, 7c genesis snapshot + checkpoints, 7d relationship versioning — 7c/7d design will be drafted for review rather than landed unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY