### PR TITLE
Add seeded stochastic branch selection ([orrery.selection])

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -206,6 +206,15 @@ enabled = true
 [orrery.binding]
 window_chunks = 30
 
+[orrery.selection]
+# Branch selection inside a fired package: "stochastic" softmax-samples all
+# passing branches by magnitude (PRNG seeded on per-resolution persisted
+# values -> reproducible; committed state_delta log stays the replay
+# authority); "authored_order" is the legacy deterministic rule.
+mode = "stochastic"
+temperature = 0.25
+seed_salt = ""
+
 [orrery.prompt]
 # Render caps for Orrery material in the storyteller prompt. The commit-time
 # prompt-exposure log records the same first-N slice, so these are also the

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -639,6 +639,7 @@ class TurnCycleManager:
                 anchor_chunk_id=anchor_chunk_id,
                 window_chunks=window_chunks,
                 sunhelm_settings=orrery_settings.get("sunhelm"),
+                selection_settings=orrery_settings.get("selection"),
             )
 
         turn_context.orrery_proposal = proposal

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -65,6 +65,7 @@ from nexus.agents.orrery.resolver import (
     hydrate_world_state,
 )
 from nexus.agents.orrery.substrate import (
+    coerce_branch_selection,
     CONSTRAINED_TAGS,
     DRAMATIC_CONTACT_TAGS,
     DRIVE_BAND_ORDER,
@@ -466,6 +467,7 @@ def explain_dry_run(
     sunhelm_settings: Optional[Any] = None,
     world_time_override: Optional[datetime] = None,
     overrides: Optional[WorldStateOverrides] = None,
+    selection_settings: Optional[Any] = None,
 ) -> ExplainedTickReport:
     """Hydrate, bind, and explain Orrery packages without database writes.
 
@@ -481,6 +483,7 @@ def explain_dry_run(
     """
 
     need_tuning = coerce_need_tuning(sunhelm_settings)
+    selection = coerce_branch_selection(selection_settings)
     state = hydrate_world_state(
         session,
         anchor_chunk_id=anchor_chunk_id,
@@ -552,17 +555,19 @@ def explain_dry_run(
         actor_stacks: dict[int, StackExplanation] = {}
         for bindings in actor_bindings:
             actor_stacks[bindings[Slot.ACTOR]] = explain_stack(
-                actor_only_templates, tick_state, bindings
+                actor_only_templates, tick_state, bindings, selection
             )
         two_party_stacks: dict[int, List[StackExplanation]] = {}
         for pair_bindings in offscreen_pair_bindings:
             two_party_stacks.setdefault(pair_bindings[Slot.ACTOR], []).append(
-                explain_stack(actor_target_templates, tick_state, pair_bindings)
+                explain_stack(
+                    actor_target_templates, tick_state, pair_bindings, selection
+                )
             )
         pressure_stacks: dict[int, List[StackExplanation]] = {}
         for pair_bindings in present_pair_bindings:
             pressure_stacks.setdefault(pair_bindings[Slot.ACTOR], []).append(
-                explain_stack(pressure_templates, tick_state, pair_bindings)
+                explain_stack(pressure_templates, tick_state, pair_bindings, selection)
             )
         need_pressure_specs = _present_need_pressure_specs(
             tick_state,

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -296,6 +296,7 @@ def analyze_coverage(
     window_chunks: int,
     sunhelm_settings: Optional[Any] = None,
     epoch_min_world_times: int,
+    selection_settings: Optional[Any] = None,
 ) -> dict[str, Any]:
     """Aggregate explained resolution coverage across historical anchors.
 
@@ -334,6 +335,7 @@ def analyze_coverage(
             anchor_chunk_id=anchor_chunk_id,
             window_chunks=window_chunks,
             sunhelm_settings=sunhelm_settings,
+            selection_settings=selection_settings,
         )
         anchors.append(_tally_report(report, tallies, gap_counts))
         entity_names.update(report.entity_names)

--- a/nexus/agents/orrery/explain.py
+++ b/nexus/agents/orrery/explain.py
@@ -31,6 +31,7 @@ from nexus.agents.orrery.catalog import _render_predicate_name
 from nexus.agents.orrery.evidence import resolve_evidence
 from nexus.agents.orrery.substrate import (
     Bindings,
+    BranchSelection,
     CompoundCondition,
     Condition,
     Resolution,
@@ -38,6 +39,7 @@ from nexus.agents.orrery.substrate import (
     Template,
     WorldState,
     evaluate,
+    select_branch,
 )
 
 
@@ -232,9 +234,19 @@ def trace_condition(
 
 
 def explain_template(
-    template: Template, state: WorldState, bindings: Bindings
+    template: Template,
+    state: WorldState,
+    bindings: Bindings,
+    selection: Optional[BranchSelection] = None,
 ) -> TemplateExplanation:
-    """Produce a full audit record for one template against one binding set."""
+    """Produce a full audit record for one template against one binding set.
+
+    Branch selection routes through the same :func:`select_branch` authority
+    the production resolver uses, so stochastic sampling stays in lockstep
+    (the seed is derived from persisted values, making both sides
+    deterministic for a given state). In stochastic mode every branch is
+    considered, so the traces become exhaustive.
+    """
 
     gate_trace = trace_condition(template.package_gate, state, bindings)
     gate_passed = bool(template.package_gate(state, bindings))
@@ -242,9 +254,18 @@ def explain_template(
     branch_traces: List[BranchTrace] = []
     chosen_branch: Optional[str] = None
     if gate_passed:
-        decided = False
-        for branch in template.branches:
-            if decided:
+        from nexus.agents.orrery.substrate import binding_hash as _binding_hash
+
+        chosen, considered_flags = select_branch(
+            template,
+            state,
+            bindings,
+            digest=_binding_hash(bindings),
+            selection=selection,
+        )
+        chosen_branch = chosen.label if chosen is not None else None
+        for branch, considered in zip(template.branches, considered_flags):
+            if not considered:
                 branch_traces.append(
                     BranchTrace(
                         label=branch.label,
@@ -264,17 +285,14 @@ def explain_template(
                     magnitude=branch.magnitude,
                     considered=True,
                     result=passes,
-                    selected=passes,
+                    selected=chosen is not None and branch.label == chosen.label,
                     trace=branch_trace,
                 )
             )
-            if passes:
-                chosen_branch = branch.label
-                decided = True
 
     # Source-of-truth cross-check against the production resolver. Any mismatch
     # means a predicate is non-deterministic or side-effecting; surface it.
-    truth: Resolution = evaluate(template, state, bindings)
+    truth: Resolution = evaluate(template, state, bindings, selection)
     if (
         truth.passes != (chosen_branch is not None)
         or truth.branch_label != chosen_branch
@@ -308,7 +326,10 @@ def explain_template(
 
 
 def explain_stack(
-    templates: Iterable[Template], state: WorldState, bindings: Bindings
+    templates: Iterable[Template],
+    state: WorldState,
+    bindings: Bindings,
+    selection: Optional[BranchSelection] = None,
 ) -> StackExplanation:
     """Explain every template in priority order and flag the stack winner.
 
@@ -319,7 +340,7 @@ def explain_stack(
 
     ordered = sorted(templates, key=lambda item: item.priority, reverse=True)
     explanations = tuple(
-        explain_template(template, state, bindings) for template in ordered
+        explain_template(template, state, bindings, selection) for template in ordered
     )
     winner_id = next((item.template_id for item in explanations if item.fired), None)
     serialized_bindings = {

--- a/nexus/agents/orrery/explain.py
+++ b/nexus/agents/orrery/explain.py
@@ -38,6 +38,7 @@ from nexus.agents.orrery.substrate import (
     Slot,
     Template,
     WorldState,
+    binding_hash,
     evaluate,
     select_branch,
 )
@@ -254,13 +255,11 @@ def explain_template(
     branch_traces: List[BranchTrace] = []
     chosen_branch: Optional[str] = None
     if gate_passed:
-        from nexus.agents.orrery.substrate import binding_hash as _binding_hash
-
         chosen, considered_flags = select_branch(
             template,
             state,
             bindings,
-            digest=_binding_hash(bindings),
+            digest=binding_hash(bindings),
             selection=selection,
         )
         chosen_branch = chosen.label if chosen is not None else None

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -10,6 +10,8 @@ from typing import Any, Iterable, Mapping, Optional, Tuple
 from sqlalchemy import text
 
 from nexus.agents.orrery.substrate import (
+    BranchSelection,
+    coerce_branch_selection,
     Bindings,
     EventRecord,
     INTIMACY_SUPPRESSOR_TAGS,
@@ -796,10 +798,12 @@ def resolve_dry_run(
     window_chunks: int,
     sunhelm_settings: Optional[Any] = None,
     world_time_override: Optional[datetime] = None,
+    selection_settings: Optional[Any] = None,
 ) -> OrreryTickProposal:
     """Hydrate, bind, and evaluate Orrery packages without database writes."""
 
     need_tuning = coerce_need_tuning(sunhelm_settings)
+    selection = coerce_branch_selection(selection_settings)
     state = hydrate_world_state(
         session,
         anchor_chunk_id=anchor_chunk_id,
@@ -838,7 +842,7 @@ def resolve_dry_run(
         window_chunks=window_chunks,
     )
     for bindings in actor_bindings:
-        resolution = evaluate_stack(actor_only_templates, state, bindings)
+        resolution = evaluate_stack(actor_only_templates, state, bindings, selection)
         if resolution is not None and resolution.passes:
             drafts.append(_draft_from_resolution(resolution))
 
@@ -853,7 +857,9 @@ def resolve_dry_run(
             target_presence="offscreen",
         )
         for bindings in actor_target_bindings:
-            resolution = evaluate_stack(actor_target_templates, state, bindings)
+            resolution = evaluate_stack(
+                actor_target_templates, state, bindings, selection
+            )
             if resolution is not None and resolution.passes:
                 drafts.append(_draft_from_resolution(resolution))
 
@@ -872,7 +878,9 @@ def resolve_dry_run(
                 target_presence="present",
             )
             for bindings in present_target_bindings:
-                resolution = evaluate_stack(pressure_templates, state, bindings)
+                resolution = evaluate_stack(
+                    pressure_templates, state, bindings, selection
+                )
                 if resolution is not None and resolution.passes:
                     scene_pressure_results.append(resolution)
 

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from enum import Enum
 from hashlib import sha256
 import json
+import math
+import random
 from typing import Any, Callable, Dict, Iterable, Literal, Mapping, Optional, Tuple
 
 from nexus.agents.orrery.needs import normalize_need_type
@@ -1734,7 +1736,126 @@ def binding_hash(bindings: Bindings) -> str:
     return sha256(encoded.encode("utf-8")).hexdigest()
 
 
-def evaluate(template: Template, state: WorldState, bindings: Bindings) -> Resolution:
+@dataclass(frozen=True, slots=True)
+class BranchSelection:
+    """Branch-selection policy, threaded from [orrery.selection] in nexus.toml.
+
+    ``authored_order`` is the legacy deterministic rule: first passing branch
+    in authored order wins (magnitude ladders are convention, not engine).
+    ``stochastic`` evaluates every branch and samples the passing set with a
+    magnitude-softmax at ``temperature``; the PRNG is keyed on values
+    persisted with every resolution (binding hash, tick, template id, plus
+    ``seed_salt``), so the same state always picks the same branch —
+    reproducible dynamism, and reconstruction stays owned by the committed
+    state_delta log, never a re-run of the sampler.
+    """
+
+    mode: str = "authored_order"
+    temperature: float = 0.0
+    seed_salt: str = ""
+
+    def __post_init__(self) -> None:
+        if self.mode not in ("authored_order", "stochastic"):
+            raise ValueError(
+                f"Unknown branch-selection mode {self.mode!r}; expected "
+                "'authored_order' or 'stochastic'"
+            )
+        if self.temperature < 0:
+            raise ValueError(
+                f"Branch-selection temperature must be >= 0, got {self.temperature}"
+            )
+
+
+def coerce_branch_selection(value: Any) -> Optional[BranchSelection]:
+    """Coerce [orrery.selection] config (mapping / model / None) to policy.
+
+    ``None`` means "no policy supplied" and preserves legacy authored-order
+    selection — callers that want configured behavior must pass the settings.
+    """
+
+    if value is None or isinstance(value, BranchSelection):
+        return value
+    if isinstance(value, Mapping):
+        return BranchSelection(
+            mode=str(value["mode"]),
+            temperature=float(value["temperature"]),
+            seed_salt=str(value.get("seed_salt", "")),
+        )
+    return BranchSelection(
+        mode=str(value.mode),
+        temperature=float(value.temperature),
+        seed_salt=str(getattr(value, "seed_salt", "")),
+    )
+
+
+def _selection_rng(
+    digest: str, tick: int, template_id: str, seed_salt: str
+) -> random.Random:
+    seed_material = f"{digest}:{tick}:{template_id}:{seed_salt}"
+    return random.Random(int(sha256(seed_material.encode("utf-8")).hexdigest(), 16))
+
+
+def select_branch(
+    template: Template,
+    state: WorldState,
+    bindings: Bindings,
+    *,
+    digest: str,
+    selection: Optional["BranchSelection"] = None,
+) -> Tuple[Optional[Branch], Tuple[bool, ...]]:
+    """The single branch-selection authority for one gated template.
+
+    Returns ``(chosen_branch_or_None, considered_flags)`` where
+    ``considered_flags[i]`` says whether ``branches[i]``'s conditions were
+    evaluated. Both :func:`evaluate` and the explain layer's
+    ``explain_template`` MUST route through this function — they cross-check
+    each other and raise on divergence, so a second selection implementation
+    is a correctness bug by construction.
+
+    ``authored_order`` (and a missing ``selection``) preserves the legacy
+    short-circuit exactly; ``stochastic`` evaluates all branches (the traces
+    become exhaustive) and softmax-samples the passing set by magnitude.
+    At ``temperature == 0`` stochastic degenerates to argmax by magnitude
+    (authored order breaking ties).
+    """
+
+    if selection is None or selection.mode == "authored_order":
+        considered = []
+        for branch in template.branches:
+            considered.append(True)
+            if branch.conditions(state, bindings):
+                considered.extend(False for _ in template.branches[len(considered) :])
+                return branch, tuple(considered)
+        return None, tuple(considered)
+
+    passing = [
+        branch for branch in template.branches if branch.conditions(state, bindings)
+    ]
+    considered_all = tuple(True for _ in template.branches)
+    if not passing:
+        return None, considered_all
+    if len(passing) == 1:
+        return passing[0], considered_all
+
+    if selection.temperature == 0:
+        return max(passing, key=lambda branch: branch.magnitude), considered_all
+
+    # Softmax over magnitude, shifted for numerical stability.
+    peak = max(branch.magnitude for branch in passing)
+    weights = [
+        math.exp((branch.magnitude - peak) / selection.temperature)
+        for branch in passing
+    ]
+    rng = _selection_rng(digest, state.current_tick, template.id, selection.seed_salt)
+    return rng.choices(passing, weights=weights, k=1)[0], considered_all
+
+
+def evaluate(
+    template: Template,
+    state: WorldState,
+    bindings: Bindings,
+    selection: Optional[BranchSelection] = None,
+) -> Resolution:
     """Evaluate one template and binding set against world state."""
 
     digest = binding_hash(bindings)
@@ -1747,22 +1868,24 @@ def evaluate(template: Template, state: WorldState, bindings: Bindings) -> Resol
             passes=False,
         )
 
-    for branch in template.branches:
-        if branch.conditions(state, bindings):
-            return Resolution(
-                template_id=template.id,
-                priority=template.priority,
-                binding_hash=digest,
-                bindings=bindings,
-                passes=True,
-                branch_label=branch.label,
-                narrative_stub=branch.narrative_stub,
-                state_delta=branch.state_delta,
-                event_type=branch.event_type,
-                changed_fields=branch.changed_fields,
-                magnitude=branch.magnitude,
-                scene_pressure_stub=branch.scene_pressure_stub,
-            )
+    branch, _considered = select_branch(
+        template, state, bindings, digest=digest, selection=selection
+    )
+    if branch is not None:
+        return Resolution(
+            template_id=template.id,
+            priority=template.priority,
+            binding_hash=digest,
+            bindings=bindings,
+            passes=True,
+            branch_label=branch.label,
+            narrative_stub=branch.narrative_stub,
+            state_delta=branch.state_delta,
+            event_type=branch.event_type,
+            changed_fields=branch.changed_fields,
+            magnitude=branch.magnitude,
+            scene_pressure_stub=branch.scene_pressure_stub,
+        )
 
     return Resolution(
         template_id=template.id,
@@ -1774,12 +1897,15 @@ def evaluate(template: Template, state: WorldState, bindings: Bindings) -> Resol
 
 
 def evaluate_stack(
-    templates: Iterable[Template], state: WorldState, bindings: Bindings
+    templates: Iterable[Template],
+    state: WorldState,
+    bindings: Bindings,
+    selection: Optional[BranchSelection] = None,
 ) -> Optional[Resolution]:
     """Evaluate templates in priority order and return the first firing branch."""
 
     for template in sorted(templates, key=lambda item: item.priority, reverse=True):
-        result = evaluate(template, state, bindings)
+        result = evaluate(template, state, bindings, selection)
         if result.passes:
             return result
     return None

--- a/nexus/api/orrery_dev_endpoints.py
+++ b/nexus/api/orrery_dev_endpoints.py
@@ -309,6 +309,7 @@ async def post_resolve(request: OrreryResolveRequest) -> dict[str, Any]:
                 window_chunks=window_chunks,
                 sunhelm_settings=orrery.get("sunhelm"),
                 overrides=overrides,
+                selection_settings=orrery.get("selection"),
             )
         except OverrideValidationError as exc:
             # Override validation (unknown vocab, no-op toggles) is caller
@@ -392,6 +393,7 @@ async def post_coverage(request: OrreryCoverageRequest) -> dict[str, Any]:
             window_chunks=window_chunks,
             sunhelm_settings=orrery.get("sunhelm"),
             epoch_min_world_times=epoch_min,
+            selection_settings=orrery.get("selection"),
         )
 
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -642,6 +642,44 @@ class OrreryNeedPressureSettings(BaseModel):
     magnitude_cap: float = Field(default=0.85, ge=0.0, le=1.0)
 
 
+class OrrerySelectionSettings(BaseModel):
+    """Branch-selection policy for Orrery behavior packages.
+
+    ``stochastic`` samples all passing branches with a magnitude-softmax at
+    ``temperature`` (seeded on persisted per-resolution values, so the same
+    state always resolves the same way — reproducible dynamism, and replay
+    of the committed state_delta log remains the reconstruction authority).
+    ``authored_order`` is the legacy deterministic first-passing rule.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["authored_order", "stochastic"] = Field(
+        default="stochastic",
+        description=(
+            "Branch-selection rule: legacy authored-order short-circuit, or "
+            "seeded magnitude-softmax sampling over all passing branches."
+        ),
+    )
+    temperature: float = Field(
+        default=0.25,
+        ge=0.0,
+        description=(
+            "Softmax temperature for stochastic mode. 0 degenerates to "
+            "argmax-by-magnitude; higher values flatten toward uniform. "
+            "Builtin magnitudes differ by ~0.1-0.3, so 0.25 keeps salient "
+            "branches favored ~3:1 without silencing fallbacks."
+        ),
+    )
+    seed_salt: str = Field(
+        default="",
+        description=(
+            "Extra PRNG seed material. Change to reroll every stochastic "
+            "choice without touching state; keep stable for reproducibility."
+        ),
+    )
+
+
 class OrrerySunhelmSettings(BaseModel):
     """Timestamp-plus-debt tuning for Orrery basic needs."""
 
@@ -1065,6 +1103,7 @@ class OrrerySettings(BaseModel):
     bleed: OrreryBleedSettings = Field(default_factory=OrreryBleedSettings)
     promote: OrreryPromoteSettings = Field(default_factory=OrreryPromoteSettings)
     sunhelm: OrrerySunhelmSettings = Field(default_factory=OrrerySunhelmSettings)
+    selection: OrrerySelectionSettings = Field(default_factory=OrrerySelectionSettings)
     retrograde: OrreryRetrogradeSettings
     dashboard: OrreryDashboardSettings = Field(default_factory=OrreryDashboardSettings)
     prompt: OrreryPromptSettings = Field(default_factory=OrreryPromptSettings)

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -68,6 +68,7 @@ def _production_proposal(slot: int) -> tuple[Optional[int], OrreryTickProposal]:
                 anchor_chunk_id=anchor_chunk_id,
                 window_chunks=int(orrery["binding"]["window_chunks"]),
                 sunhelm_settings=orrery.get("sunhelm"),
+                selection_settings=orrery.get("selection"),
             )
     finally:
         engine.dispose()

--- a/tests/test_orrery/test_branch_selection.py
+++ b/tests/test_orrery/test_branch_selection.py
@@ -1,0 +1,197 @@
+"""Tests for seeded stochastic branch selection (BranchSelection).
+
+Real engine, no mocks: synthetic templates with always-passing branches give
+a controlled multi-branch surface, and the demo presets pin legacy parity.
+The properties that matter:
+
+1. Legacy default (no policy / authored_order) is byte-identical to the old
+   first-passing rule, short-circuit and all.
+2. Stochastic selection is deterministic per (bindings, tick, template,
+   salt) — reproducible dynamism, never a dice roll at replay time.
+3. Across ticks the same state genuinely varies (the whole point), with
+   frequencies ordered by magnitude.
+4. explain_template stays in lockstep with evaluate under the same policy —
+   the cross-check they share runs the same seeded selection.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+from nexus.agents.orrery.demo import _all_preset_names, _resolve_preset
+from nexus.agents.orrery.explain import explain_stack, explain_template
+from nexus.agents.orrery.substrate import (
+    ALWAYS,
+    Branch,
+    BranchSelection,
+    DriveBand,
+    Slot,
+    Template,
+    WorldState,
+    coerce_branch_selection,
+    evaluate,
+    evaluate_stack,
+    select_branch,
+)
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+
+BINDINGS = {Slot.ACTOR: 1}
+
+VARIED = Template(
+    id="tend_craft",  # real id so catalog/prose lookups stay valid
+    priority=10,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    blurb="Synthetic multi-branch surface for selection tests.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=ALWAYS,
+    branches=(
+        Branch(
+            label="deep work",
+            conditions=ALWAYS,
+            narrative_stub="{actor} loses hours to the bench.",
+            magnitude=0.6,
+        ),
+        Branch(
+            label="light touch",
+            conditions=ALWAYS,
+            narrative_stub="{actor} tidies the workspace.",
+            magnitude=0.3,
+        ),
+        Branch(
+            label="idle glance",
+            conditions=ALWAYS,
+            narrative_stub="{actor} glances at the unfinished work.",
+            magnitude=0.1,
+        ),
+    ),
+)
+
+STOCHASTIC = BranchSelection(mode="stochastic", temperature=0.25)
+
+
+def _state(tick: int) -> WorldState:
+    return WorldState(current_tick=tick)
+
+
+def test_default_selection_matches_legacy_first_passing() -> None:
+    """No policy (and authored_order) keeps the old rule and short-circuit."""
+
+    for preset_name in _all_preset_names():
+        state, bindings = _resolve_preset(preset_name)
+        legacy = evaluate_stack(BUILTIN_TEMPLATES, state, bindings)
+        explicit = evaluate_stack(
+            BUILTIN_TEMPLATES,
+            state,
+            bindings,
+            BranchSelection(mode="authored_order"),
+        )
+        if legacy is None:
+            assert explicit is None
+            continue
+        assert explicit is not None
+        assert explicit.template_id == legacy.template_id
+        assert explicit.branch_label == legacy.branch_label
+
+    # Authored order picks the FIRST passing branch even when a later branch
+    # has higher magnitude — the convention stochastic mode exists to relax.
+    resolution = evaluate(VARIED, _state(100), BINDINGS)
+    assert resolution.branch_label == "deep work"
+
+
+def test_stochastic_selection_is_deterministic_per_seed() -> None:
+    state = _state(4242)
+    first = evaluate(VARIED, state, BINDINGS, STOCHASTIC)
+    for _ in range(5):
+        again = evaluate(VARIED, state, BINDINGS, STOCHASTIC)
+        assert again.branch_label == first.branch_label
+
+
+def test_stochastic_selection_varies_across_ticks_by_magnitude() -> None:
+    """The same state at different ticks picks different branches, with
+    frequency ordered by magnitude — variety without noise dominance."""
+
+    counts: Counter[str] = Counter()
+    for tick in range(400):
+        resolution = evaluate(VARIED, _state(tick), BINDINGS, STOCHASTIC)
+        assert resolution.passes
+        assert resolution.branch_label is not None
+        counts[resolution.branch_label] += 1
+
+    assert len(counts) >= 2, "stochastic selection never varied"
+    assert counts["deep work"] > counts["light touch"] > counts["idle glance"]
+
+
+def test_temperature_zero_is_argmax_by_magnitude() -> None:
+    argmax = BranchSelection(mode="stochastic", temperature=0.0)
+    for tick in range(20):
+        resolution = evaluate(VARIED, _state(tick), BINDINGS, argmax)
+        assert resolution.branch_label == "deep work"
+
+
+def test_seed_salt_rerolls_choices() -> None:
+    salted = BranchSelection(mode="stochastic", temperature=0.25, seed_salt="alt")
+    differing = sum(
+        1
+        for tick in range(200)
+        if evaluate(VARIED, _state(tick), BINDINGS, STOCHASTIC).branch_label
+        != evaluate(VARIED, _state(tick), BINDINGS, salted).branch_label
+    )
+    assert differing > 0, "seed_salt must be able to reroll selections"
+
+
+def test_explain_matches_evaluate_under_stochastic_policy() -> None:
+    """The shared select_branch authority keeps the cross-check green."""
+
+    for tick in range(50):
+        state = _state(tick)
+        explanation = explain_template(VARIED, state, BINDINGS, STOCHASTIC)
+        truth = evaluate(VARIED, state, BINDINGS, STOCHASTIC)
+        assert explanation.chosen_branch == truth.branch_label
+        # Stochastic mode evaluates every branch: traces are exhaustive.
+        assert all(branch.considered for branch in explanation.branches)
+        selected = [b for b in explanation.branches if b.selected]
+        assert len(selected) == 1
+
+
+def test_explain_stack_parity_on_presets_under_stochastic_policy() -> None:
+    for preset_name in _all_preset_names():
+        state, bindings = _resolve_preset(preset_name)
+        truth = evaluate_stack(BUILTIN_TEMPLATES, state, bindings, STOCHASTIC)
+        explanation = explain_stack(BUILTIN_TEMPLATES, state, bindings, STOCHASTIC)
+        if truth is None:
+            assert explanation.winner_id is None
+            continue
+        assert explanation.winner_id == truth.template_id
+        winner = next(
+            item
+            for item in explanation.templates
+            if item.template_id == truth.template_id
+        )
+        assert winner.chosen_branch == truth.branch_label
+
+
+def test_select_branch_reports_considered_flags() -> None:
+    state = _state(7)
+    _, legacy_flags = select_branch(VARIED, state, BINDINGS, digest="d", selection=None)
+    # Legacy short-circuits after the first passing branch.
+    assert legacy_flags == (True, False, False)
+    _, stochastic_flags = select_branch(
+        VARIED, state, BINDINGS, digest="d", selection=STOCHASTIC
+    )
+    assert stochastic_flags == (True, True, True)
+
+
+def test_coerce_branch_selection_shapes_and_errors() -> None:
+    assert coerce_branch_selection(None) is None
+    policy = coerce_branch_selection(
+        {"mode": "stochastic", "temperature": 0.5, "seed_salt": "x"}
+    )
+    assert policy == BranchSelection("stochastic", 0.5, "x")
+    assert coerce_branch_selection(policy) is policy
+
+    with pytest.raises(ValueError, match="Unknown branch-selection mode"):
+        BranchSelection(mode="chaotic")
+    with pytest.raises(ValueError, match="temperature must be >= 0"):
+        BranchSelection(mode="stochastic", temperature=-1)


### PR DESCRIPTION
## Summary

Dynamism round 1 — the spec's "same state ⇒ same beat" fix. A character with three passing ways to spend a tick no longer performs the first-authored one forever.

**The one-authority rule (spec's hard constraint):** `substrate.select_branch()` is the single selection function, used by both `evaluate()` and `explain_template()`. Since those two cross-check each other and raise on divergence, a second selection implementation is a correctness bug by construction.

**Reproducible dynamism:** stochastic mode softmax-samples all passing branches by magnitude; the PRNG is seeded on `sha256(binding_hash : tick : template_id : seed_salt)` — every ingredient persisted with each resolution — so the same state always resolves identically. The committed `state_delta` log remains the sole replay authority; the sampler is never re-run for reconstruction.

**Compatibility:** `authored_order` (and an absent policy) preserves the legacy first-passing rule byte-for-byte, short-circuit included — pinned by a preset-sweep parity test. Stochastic mode evaluates every branch, making explain traces exhaustive (the dead-branch question becomes answerable for free, as the spec predicted).

**Config:** `[orrery.selection]` in nexus.toml — `mode = "stochastic"`, `temperature = 0.25`, `seed_salt = ""`. Default is live per the dynamism mandate; builtin magnitudes differ by ~0.1–0.3, so 0.25 keeps salient branches favored ~3:1 without silencing fallbacks. Threaded through the turn cycle, `resolve_dry_run`, `explain_dry_run`, the coverage analyzer, and the dev endpoints (the parity oracle uses the same policy).

## Measured effect (live save_02, same 30 anchors)

| | authored_order | stochastic@0.25 |
|---|---|---|
| distinct (template, branch) beats | 13 | **20** |
| templates using >1 branch | 3 | **5** |

`reach_out_to_kin` goes from 2 branches to 4 — "Let the silence stand for now" and "Send a message that says less than it means" now actually happen off-screen. `surveil` from 4 to 6. `eat`/`work` start varying at all.

## Tests

Legacy byte-parity across all demo presets; per-seed determinism; tick-to-tick variety with magnitude-ordered frequencies over 400 ticks; temperature-zero argmax; `seed_salt` rerolls; explain/evaluate lockstep under the stochastic policy; exhaustive-trace `considered` flags; coercion validation. Full suite 976 passed; live endpoint parity green with the stochastic policy active on both sides.

Disjoint from #425 (tag provenance). Next dynamism rounds: reciprocal/conflict post-pass, then emitting the dormant trigger events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY