### PR TITLE
Add reconstructability layer (migration 065): delta log, checkpoints, relationship triggers

### DIFF
--- a/migrations/065_reconstructability.sql
+++ b/migrations/065_reconstructability.sql
@@ -1,0 +1,133 @@
+-- 065_reconstructability.sql
+--
+-- The "sufficient-from-now-on" reconstruction bar from
+-- docs/orrery_audit_dashboard_notes.md (step 7b-7d), per the decisions on
+-- issue #426: log every Skald-side scalar write (7b), JSONB state
+-- checkpoints auto-taken in the commit path plus a retro-fitted genesis
+-- (7c), and trigger-based relationship versioning that cannot be forgotten
+-- by a future runtime writer (7d).
+
+-- 7b. Skald-side chunk-keyed delta log. Orrery's half is already
+--     event-sourced in orrery_resolutions.state_delta; this is the peer
+--     ledger for the on-screen commit path, which previously moved
+--     characters and set activity with no record of any kind.
+CREATE TABLE IF NOT EXISTS state_delta_log (
+    id              bigserial PRIMARY KEY,
+    source_chunk_id bigint NOT NULL REFERENCES narrative_chunks(id),
+    writer          text NOT NULL
+        CHECK (writer IN ('skald_state_update', 'wizard_seed')),
+    entity_id       bigint REFERENCES entities(id),
+    field           text NOT NULL,
+    old_value       jsonb,
+    new_value       jsonb,
+    created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE state_delta_log IS
+    'Chunk-keyed ledger of every Skald-side scalar state write (policy: log everything, including writes that repeat the current value). Replay from a checkpoint = apply orrery_resolutions.state_delta plus these rows in chunk order. Rows exist only for chunks committed after migration 065.';
+COMMENT ON COLUMN state_delta_log.field IS
+    'Qualified column the write touched, e.g. characters.current_location.';
+COMMENT ON COLUMN state_delta_log.old_value IS
+    'Prior value when the writer captured it; NULL means not captured (the Skald logger records new_value only), not "was NULL".';
+
+CREATE INDEX IF NOT EXISTS ix_state_delta_log_source_chunk_id
+    ON state_delta_log (source_chunk_id);
+CREATE INDEX IF NOT EXISTS ix_state_delta_log_entity_id
+    ON state_delta_log (entity_id);
+
+-- 7c. JSONB state checkpoints: a full queryable snapshot of the mutable
+--     state surface, bounding replay cost and giving mature slots an
+--     explicit instrumentation-era boundary (exact after, approximate
+--     before). "genesis" checkpoints are retro-fitted at migration time for
+--     existing slots — the true wizard-era genesis is unrecoverable.
+CREATE TABLE IF NOT EXISTS state_checkpoints (
+    id            bigserial PRIMARY KEY,
+    chunk_id      bigint REFERENCES narrative_chunks(id),
+    label         text NOT NULL
+        CHECK (label IN ('genesis', 'interval', 'manual')),
+    state         jsonb NOT NULL,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (chunk_id, label)
+);
+
+COMMENT ON TABLE state_checkpoints IS
+    'Point-in-time JSONB snapshots of the mutable world-state surface (tags, pair tags, character scalars, relationships, needs, travel, routine anchors, faction memberships). Auto-taken every [orrery.reconstruction] checkpoint_interval_chunks accepted chunks; "genesis" marks the instrumentation-era boundary for slots older than migration 065.';
+COMMENT ON COLUMN state_checkpoints.chunk_id IS
+    'Head chunk at snapshot time; NULL only for empty slots checkpointed before any chunk exists.';
+
+CREATE INDEX IF NOT EXISTS ix_state_checkpoints_chunk_id
+    ON state_checkpoints (chunk_id);
+
+-- 7d. Relationship versioning, trigger-enforced (issue #426 decision):
+--     the three current-state relationship tables are mutable and
+--     unversioned; the first runtime writer would destroy history on
+--     contact. Row-level triggers write the OLD row before every UPDATE or
+--     DELETE, attributed to the committing chunk via the nexus.source_chunk_id
+--     session setting when the writer provides one.
+CREATE TABLE IF NOT EXISTS relationship_versions (
+    id                 bigserial PRIMARY KEY,
+    relationship_table text NOT NULL
+        CHECK (relationship_table IN (
+            'character_relationships',
+            'faction_character_relationships',
+            'faction_relationships'
+        )),
+    operation          text NOT NULL CHECK (operation IN ('update', 'delete')),
+    -- The three tables use composite natural keys and have no surrogate id;
+    -- old_row carries the full pre-image including the key columns.
+    old_row            jsonb NOT NULL,
+    source_chunk_id    bigint REFERENCES narrative_chunks(id),
+    created_at         timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE relationship_versions IS
+    'Append-only sidecar of superseded relationship rows, written by row-level triggers on the three current-state relationship tables. source_chunk_id comes from the nexus.source_chunk_id session setting (set by the commit transaction); NULL means the write happened outside an attributed commit.';
+
+CREATE INDEX IF NOT EXISTS ix_relationship_versions_table_created
+    ON relationship_versions (relationship_table, created_at);
+
+CREATE OR REPLACE FUNCTION fn_version_relationship_row()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    chunk_setting text := current_setting('nexus.source_chunk_id', true);
+BEGIN
+    INSERT INTO relationship_versions (
+        relationship_table, operation, old_row, source_chunk_id
+    ) VALUES (
+        TG_TABLE_NAME,
+        lower(TG_OP),
+        to_jsonb(OLD),
+        CASE
+            WHEN chunk_setting IS NULL OR chunk_setting = '' THEN NULL
+            ELSE chunk_setting::bigint
+        END
+    );
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION fn_version_relationship_row() IS
+    'Writes the pre-image of any relationship row mutation into relationship_versions. Trigger-enforced so a future runtime relationship writer cannot forget to version.';
+
+DROP TRIGGER IF EXISTS trg_version_character_relationships
+    ON character_relationships;
+CREATE TRIGGER trg_version_character_relationships
+    BEFORE UPDATE OR DELETE ON character_relationships
+    FOR EACH ROW EXECUTE FUNCTION fn_version_relationship_row();
+
+DROP TRIGGER IF EXISTS trg_version_faction_character_relationships
+    ON faction_character_relationships;
+CREATE TRIGGER trg_version_faction_character_relationships
+    BEFORE UPDATE OR DELETE ON faction_character_relationships
+    FOR EACH ROW EXECUTE FUNCTION fn_version_relationship_row();
+
+DROP TRIGGER IF EXISTS trg_version_faction_relationships
+    ON faction_relationships;
+CREATE TRIGGER trg_version_faction_relationships
+    BEFORE UPDATE OR DELETE ON faction_relationships
+    FOR EACH ROW EXECUTE FUNCTION fn_version_relationship_row();

--- a/migrations/065_reconstructability.sql
+++ b/migrations/065_reconstructability.sql
@@ -131,3 +131,28 @@ DROP TRIGGER IF EXISTS trg_version_faction_relationships
 CREATE TRIGGER trg_version_faction_relationships
     BEFORE UPDATE OR DELETE ON faction_relationships
     FOR EACH ROW EXECUTE FUNCTION fn_version_relationship_row();
+
+-- Retro-fitted genesis checkpoint: the migration itself establishes the
+-- instrumentation-era boundary so no environment depends on remembering to
+-- run scripts/checkpoint_state.py. Idempotent: skipped when any genesis
+-- checkpoint already exists. Sections must mirror
+-- nexus/agents/orrery/reconstruction.CHECKPOINT_SECTIONS (tested).
+INSERT INTO state_checkpoints (chunk_id, label, state)
+SELECT
+    (SELECT max(id) FROM narrative_chunks),
+    'genesis',
+    jsonb_build_object(
+        'entity_tags', (SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) FROM (SELECT * FROM entity_tags WHERE cleared_at IS NULL) t),
+        'entity_pair_tags', (SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) FROM (SELECT * FROM entity_pair_tags WHERE cleared_at IS NULL) t),
+        'characters', (SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) FROM (SELECT id, entity_id, current_location, current_activity, emotional_state FROM characters) t),
+        'places', (SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) FROM (SELECT id, entity_id, current_status FROM places) t),
+        'character_relationships', (SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) FROM character_relationships t),
+        'faction_character_relationships', (SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) FROM faction_character_relationships t),
+        'faction_relationships', (SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) FROM faction_relationships t),
+        'character_need_states', (SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) FROM character_need_states t),
+        'character_travel_states', (SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) FROM character_travel_states t),
+        'character_routine_anchors', (SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) FROM character_routine_anchors t)
+    )
+WHERE NOT EXISTS (
+    SELECT 1 FROM state_checkpoints WHERE label = 'genesis'
+);

--- a/nexus.toml
+++ b/nexus.toml
@@ -215,6 +215,11 @@ mode = "stochastic"
 temperature = 0.25
 seed_salt = ""
 
+[orrery.reconstruction]
+# JSONB state checkpoint every N accepted chunks (0 disables); genesis and
+# manual snapshots via scripts/checkpoint_state.py.
+checkpoint_interval_chunks = 25
+
 [orrery.prompt]
 # Render caps for Orrery material in the storyteller prompt. The commit-time
 # prompt-exposure log records the same first-N slice, so these are also the

--- a/nexus/agents/orrery/reconstruction.py
+++ b/nexus/agents/orrery/reconstruction.py
@@ -1,0 +1,208 @@
+"""State checkpoints and delta logging for reconstruction sufficiency.
+
+Implements the 7b/7c halves of the reconstruction bar
+(docs/orrery_audit_dashboard_notes.md; decisions on issue #426): JSONB
+checkpoints of the whole mutable state surface, auto-taken in the commit
+path every ``[orrery.reconstruction] checkpoint_interval_chunks`` accepted
+chunks, plus the Skald-side ``state_delta_log`` writer helpers.
+
+Replay contract: world state at chunk T = the latest checkpoint at or before
+T, plus ``orrery_resolutions.state_delta`` and ``state_delta_log`` rows in
+chunk order up to T. Relationship pre-images live in
+``relationship_versions`` (trigger-enforced, 7d).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+# Every mutable table the resolver's hydration or the Skald commit path can
+# read or write. A checkpoint is one JSONB document with one array per entry.
+# Order is presentation-only; each section is captured atomically inside the
+# caller's transaction.
+CHECKPOINT_SECTIONS: dict[str, str] = {
+    "entity_tags": (
+        "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
+        "FROM (SELECT * FROM entity_tags WHERE cleared_at IS NULL) t"
+    ),
+    "entity_pair_tags": (
+        "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
+        "FROM (SELECT * FROM entity_pair_tags WHERE cleared_at IS NULL) t"
+    ),
+    "characters": (
+        "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
+        "FROM (SELECT id, entity_id, current_location, current_activity, "
+        "emotional_state FROM characters) t"
+    ),
+    "places": (
+        "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
+        "FROM (SELECT id, entity_id, current_status FROM places) t"
+    ),
+    "character_relationships": (
+        "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
+        "FROM character_relationships t"
+    ),
+    "faction_character_relationships": (
+        "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
+        "FROM faction_character_relationships t"
+    ),
+    "faction_relationships": (
+        "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
+        "FROM faction_relationships t"
+    ),
+    "character_need_states": (
+        "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
+        "FROM character_need_states t"
+    ),
+    "character_travel_states": (
+        "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
+        "FROM character_travel_states t"
+    ),
+    "character_routine_anchors": (
+        "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
+        "FROM character_routine_anchors t"
+    ),
+}
+
+CHECKPOINT_LABELS = ("genesis", "interval", "manual")
+
+
+def _validate_label(label: str) -> None:
+    if label not in CHECKPOINT_LABELS:
+        raise ValueError(
+            f"Unknown checkpoint label {label!r}; expected one of "
+            f"{CHECKPOINT_LABELS}"
+        )
+
+
+def capture_state_checkpoint_sync(
+    cur: Any,
+    *,
+    chunk_id: Optional[int],
+    label: str,
+) -> Optional[int]:
+    """Snapshot the mutable state surface. Returns the checkpoint id, or
+    ``None`` when a checkpoint for ``(chunk_id, label)`` already exists
+    (idempotent re-commit)."""
+
+    _validate_label(label)
+    state: dict[str, Any] = {}
+    for section, sql in CHECKPOINT_SECTIONS.items():
+        cur.execute(sql)
+        row = cur.fetchone()
+        state[section] = row[0] if not hasattr(row, "keys") else list(row.values())[0]
+    cur.execute(
+        """
+        INSERT INTO state_checkpoints (chunk_id, label, state)
+        VALUES (%s, %s, %s::jsonb)
+        ON CONFLICT (chunk_id, label) DO NOTHING
+        RETURNING id
+        """,
+        (chunk_id, label, json.dumps(state)),
+    )
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
+async def capture_state_checkpoint_async(
+    conn: Any,
+    *,
+    chunk_id: Optional[int],
+    label: str,
+) -> Optional[int]:
+    _validate_label(label)
+    state: dict[str, Any] = {}
+    for section, sql in CHECKPOINT_SECTIONS.items():
+        value = await conn.fetchval(sql)
+        state[section] = json.loads(value) if isinstance(value, str) else value
+    return await conn.fetchval(
+        """
+        INSERT INTO state_checkpoints (chunk_id, label, state)
+        VALUES ($1, $2, $3::jsonb)
+        ON CONFLICT (chunk_id, label) DO NOTHING
+        RETURNING id
+        """,
+        chunk_id,
+        label,
+        json.dumps(state),
+    )
+
+
+def log_state_delta_sync(
+    cur: Any,
+    *,
+    source_chunk_id: int,
+    writer: str,
+    entity_id: Optional[int],
+    field: str,
+    new_value: Any,
+    old_value: Any = None,
+) -> None:
+    """Append one Skald-side scalar write to the chunk-keyed delta ledger.
+
+    Policy per issue #426: log everything, including writes that repeat the
+    current value — the ledger's completeness is what makes replay honest.
+    """
+
+    cur.execute(
+        """
+        INSERT INTO state_delta_log (
+            source_chunk_id, writer, entity_id, field, old_value, new_value
+        ) VALUES (%s, %s, %s, %s, %s::jsonb, %s::jsonb)
+        """,
+        (
+            source_chunk_id,
+            writer,
+            entity_id,
+            field,
+            json.dumps(old_value) if old_value is not None else None,
+            json.dumps(new_value),
+        ),
+    )
+
+
+async def log_state_delta_async(
+    conn: Any,
+    *,
+    source_chunk_id: int,
+    writer: str,
+    entity_id: Optional[int],
+    field: str,
+    new_value: Any,
+    old_value: Any = None,
+) -> None:
+    await conn.execute(
+        """
+        INSERT INTO state_delta_log (
+            source_chunk_id, writer, entity_id, field, old_value, new_value
+        ) VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb)
+        """,
+        source_chunk_id,
+        writer,
+        entity_id,
+        field,
+        json.dumps(old_value) if old_value is not None else None,
+        json.dumps(new_value),
+    )
+
+
+def set_commit_chunk_attribution_sync(cur: Any, chunk_id: int) -> None:
+    """Attribute this transaction's trigger-versioned writes to a chunk.
+
+    The relationship-versioning triggers (migration 065) read the
+    transaction-local ``nexus.source_chunk_id`` setting; rows written
+    outside an attributed commit get NULL.
+    """
+
+    cur.execute(
+        "SELECT set_config('nexus.source_chunk_id', %s, true)",
+        (str(chunk_id),),
+    )
+
+
+async def set_commit_chunk_attribution_async(conn: Any, chunk_id: int) -> None:
+    await conn.execute(
+        "SELECT set_config('nexus.source_chunk_id', $1, true)",
+        str(chunk_id),
+    )

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -19,6 +19,11 @@ from nexus.agents.logon.apex_schema import (
     StateUpdates,
 )
 from nexus.agents.orrery.events import commit_orrery_tick_async
+from nexus.agents.orrery.reconstruction import (
+    capture_state_checkpoint_async,
+    log_state_delta_async,
+    set_commit_chunk_attribution_async,
+)
 from nexus.agents.orrery.tag_writer import apply_tag_bestowal_async
 from nexus.api.db_converters import (
     chronology_to_db_values,
@@ -122,6 +127,9 @@ async def insert_narrative_chunk(
         choice_text,
     )
     logger.info(f"Created narrative chunk {chunk_id}")
+    # Attribute trigger-versioned writes in this transaction
+    # (relationship_versions) to the committing chunk.
+    await set_commit_chunk_attribution_async(conn, chunk_id)
     return chunk_id
 
 
@@ -251,20 +259,31 @@ async def apply_state_updates(
             params = []
             param_count = 1
 
+            written_fields = []
+
             if char_update.emotional_state:
                 updates.append(f"emotional_state = ${param_count}")
                 params.append(char_update.emotional_state)
                 param_count += 1
+                written_fields.append(
+                    ("characters.emotional_state", char_update.emotional_state)
+                )
 
             if char_update.current_activity:
                 updates.append(f"current_activity = ${param_count}")
                 params.append(char_update.current_activity)
                 param_count += 1
+                written_fields.append(
+                    ("characters.current_activity", char_update.current_activity)
+                )
 
             if char_update.current_location:
                 updates.append(f"current_location = ${param_count}")
                 params.append(char_update.current_location)
                 param_count += 1
+                written_fields.append(
+                    ("characters.current_location", char_update.current_location)
+                )
 
             if updates:
                 params.append(char_update.character_id)
@@ -277,6 +296,20 @@ async def apply_state_updates(
                     *params,
                 )
                 logger.info(f"Updated character {char_update.character_id}")
+                if source_chunk_id is not None:
+                    char_entity_id = await conn.fetchval(
+                        "SELECT entity_id FROM characters WHERE id = $1",
+                        char_update.character_id,
+                    )
+                    for field, value in written_fields:
+                        await log_state_delta_async(
+                            conn,
+                            source_chunk_id=source_chunk_id,
+                            writer="skald_state_update",
+                            entity_id=char_entity_id,
+                            field=field,
+                            new_value=value,
+                        )
 
             bestowal = getattr(char_update, "orrery_tags", None)
             if bestowal is not None:
@@ -304,6 +337,18 @@ async def apply_state_updates(
                 place_update.place_id,
             )
             logger.info(f"Updated place {place_update.place_id}")
+            if source_chunk_id is not None:
+                await log_state_delta_async(
+                    conn,
+                    source_chunk_id=source_chunk_id,
+                    writer="skald_state_update",
+                    entity_id=await conn.fetchval(
+                        "SELECT entity_id FROM places WHERE id = $1",
+                        place_update.place_id,
+                    ),
+                    field="places.current_status",
+                    new_value=place_update.current_conditions,
+                )
 
         bestowal = getattr(place_update, "orrery_tags", None)
         if place_update.place_id and bestowal is not None:
@@ -532,6 +577,19 @@ async def commit_incubator_to_database(
                     orrery_result.prompt_exposure_count,
                 )
 
+            # Step 8.55: interval state checkpoint (reconstruction bar 7c)
+            checkpoint_interval = _orrery_checkpoint_interval()
+            if checkpoint_interval and chunk_id % checkpoint_interval == 0:
+                checkpoint_id = await capture_state_checkpoint_async(
+                    conn, chunk_id=chunk_id, label="interval"
+                )
+                if checkpoint_id is not None:
+                    logger.info(
+                        "State checkpoint %s taken at chunk %s",
+                        checkpoint_id,
+                        chunk_id,
+                    )
+
             # Step 9: Clear incubator
             await clear_incubator(conn, session_id)
 
@@ -558,3 +616,13 @@ def _orrery_prompt_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("prompt")
+
+
+def _orrery_checkpoint_interval() -> int:
+    """[orrery.reconstruction] checkpoint cadence; 0 disables."""
+
+    from nexus.config import load_settings_as_dict
+
+    orrery = load_settings_as_dict().get("orrery") or {}
+    reconstruction = orrery.get("reconstruction") or {}
+    return int(reconstruction.get("checkpoint_interval_chunks", 0))

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -25,6 +25,11 @@ from nexus.agents.orrery.events import commit_orrery_tick_sync
 from nexus.agents.orrery.retrograde_maturation import (
     enqueue_declared_entity_maturations,
 )
+from nexus.agents.orrery.reconstruction import (
+    capture_state_checkpoint_sync,
+    log_state_delta_sync,
+    set_commit_chunk_attribution_sync,
+)
 from nexus.agents.orrery.tag_writer import _row_value, apply_tag_bestowal
 from nexus.api.db_converters import chronology_to_db_values
 from nexus.api.summary_triggers import (
@@ -445,6 +450,9 @@ def commit_incubator_to_database_sync(
                 if chunk_id is None:
                     raise ValueError("Failed to obtain chunk_id after insert")
                 logger.info("Created narrative chunk %s", chunk_id)
+                # Attribute trigger-versioned writes in this transaction
+                # (relationship_versions) to the committing chunk.
+                set_commit_chunk_attribution_sync(cur, chunk_id)
 
             # Step 6: Insert chunk metadata
             with conn.cursor() as cur:
@@ -565,6 +573,19 @@ def commit_incubator_to_database_sync(
                     orrery_result.prompt_exposure_count,
                 )
 
+            # Step 8.55: interval state checkpoint (reconstruction bar 7c)
+            checkpoint_interval = _orrery_checkpoint_interval()
+            if checkpoint_interval and chunk_id % checkpoint_interval == 0:
+                checkpoint_id = capture_state_checkpoint_sync(
+                    cur, chunk_id=chunk_id, label="interval"
+                )
+                if checkpoint_id is not None:
+                    logger.info(
+                        "State checkpoint %s taken at chunk %s",
+                        checkpoint_id,
+                        chunk_id,
+                    )
+
             # Step 8.6: Process Skald new-entity declarations inside the
             # commit transaction (Retrograde stub maturation outbox, spec
             # decisions 9/10/12): validate hints, create stubs, and enqueue
@@ -625,18 +646,28 @@ def apply_state_updates_sync(
             if char_update.character_id:
                 updates = []
                 params = []
+                written_fields = []
 
                 if char_update.emotional_state:
                     updates.append("emotional_state = %s")
                     params.append(char_update.emotional_state)
+                    written_fields.append(
+                        ("characters.emotional_state", char_update.emotional_state)
+                    )
 
                 if char_update.current_activity:
                     updates.append("current_activity = %s")
                     params.append(char_update.current_activity)
+                    written_fields.append(
+                        ("characters.current_activity", char_update.current_activity)
+                    )
 
                 if char_update.current_location:
                     updates.append("current_location = %s")
                     params.append(char_update.current_location)
+                    written_fields.append(
+                        ("characters.current_location", char_update.current_location)
+                    )
 
                 if updates:
                     params.append(char_update.character_id)
@@ -645,6 +676,24 @@ def apply_state_updates_sync(
                         params,
                     )
                     logger.info(f"Updated character {char_update.character_id}")
+                    if source_chunk_id is not None:
+                        cur.execute(
+                            "SELECT entity_id FROM characters WHERE id = %s",
+                            (char_update.character_id,),
+                        )
+                        row = cur.fetchone()
+                        char_entity_id = (
+                            _row_value(row, "entity_id", 0) if row else None
+                        )
+                        for field, value in written_fields:
+                            log_state_delta_sync(
+                                cur,
+                                source_chunk_id=source_chunk_id,
+                                writer="skald_state_update",
+                                entity_id=char_entity_id,
+                                field=field,
+                                new_value=value,
+                            )
 
                 bestowal = getattr(char_update, "orrery_tags", None)
                 if char_update.character_id and bestowal is not None:
@@ -667,6 +716,20 @@ def apply_state_updates_sync(
                     (place_update.current_conditions, place_update.place_id),
                 )
                 logger.info(f"Updated place {place_update.place_id}")
+                if source_chunk_id is not None:
+                    cur.execute(
+                        "SELECT entity_id FROM places WHERE id = %s",
+                        (place_update.place_id,),
+                    )
+                    row = cur.fetchone()
+                    log_state_delta_sync(
+                        cur,
+                        source_chunk_id=source_chunk_id,
+                        writer="skald_state_update",
+                        entity_id=_row_value(row, "entity_id", 0) if row else None,
+                        field="places.current_status",
+                        new_value=place_update.current_conditions,
+                    )
 
             bestowal = getattr(place_update, "orrery_tags", None)
             if place_update.place_id and bestowal is not None:
@@ -731,3 +794,13 @@ def _orrery_prompt_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("prompt")
+
+
+def _orrery_checkpoint_interval() -> int:
+    """[orrery.reconstruction] checkpoint cadence; 0 disables."""
+
+    from nexus.config import load_settings_as_dict
+
+    orrery = load_settings_as_dict().get("orrery") or {}
+    reconstruction = orrery.get("reconstruction") or {}
+    return int(reconstruction.get("checkpoint_interval_chunks", 0))

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -573,12 +573,15 @@ def commit_incubator_to_database_sync(
                     orrery_result.prompt_exposure_count,
                 )
 
-            # Step 8.55: interval state checkpoint (reconstruction bar 7c)
+            # Step 8.55: interval state checkpoint (reconstruction bar 7c).
+            # Fresh cursor: the earlier `with conn.cursor()` blocks have
+            # closed theirs by this point (review finding on #428).
             checkpoint_interval = _orrery_checkpoint_interval()
             if checkpoint_interval and chunk_id % checkpoint_interval == 0:
-                checkpoint_id = capture_state_checkpoint_sync(
-                    cur, chunk_id=chunk_id, label="interval"
-                )
+                with conn.cursor() as checkpoint_cur:
+                    checkpoint_id = capture_state_checkpoint_sync(
+                        checkpoint_cur, chunk_id=chunk_id, label="interval"
+                    )
                 if checkpoint_id is not None:
                     logger.info(
                         "State checkpoint %s taken at chunk %s",

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -680,6 +680,23 @@ class OrrerySelectionSettings(BaseModel):
     )
 
 
+class OrreryReconstructionSettings(BaseModel):
+    """Reconstruction-sufficiency knobs (issue #426)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    checkpoint_interval_chunks: int = Field(
+        default=25,
+        ge=0,
+        description=(
+            "Take a JSONB state checkpoint every N accepted chunks inside "
+            "the commit transaction; 0 disables auto-checkpointing "
+            "(scripts/checkpoint_state.py remains available for manual and "
+            "genesis snapshots)."
+        ),
+    )
+
+
 class OrrerySunhelmSettings(BaseModel):
     """Timestamp-plus-debt tuning for Orrery basic needs."""
 
@@ -1106,6 +1123,9 @@ class OrrerySettings(BaseModel):
     selection: OrrerySelectionSettings = Field(default_factory=OrrerySelectionSettings)
     retrograde: OrreryRetrogradeSettings
     dashboard: OrreryDashboardSettings = Field(default_factory=OrreryDashboardSettings)
+    reconstruction: OrreryReconstructionSettings = Field(
+        default_factory=OrreryReconstructionSettings
+    )
     prompt: OrreryPromptSettings = Field(default_factory=OrreryPromptSettings)
 
 

--- a/scripts/checkpoint_state.py
+++ b/scripts/checkpoint_state.py
@@ -1,0 +1,56 @@
+"""Take a state checkpoint for one save slot (or all slots).
+
+Usage:
+    python scripts/checkpoint_state.py --slot 2 --label manual
+    python scripts/checkpoint_state.py --all --label genesis
+
+Genesis checkpoints retro-fit the instrumentation-era boundary for slots
+older than migration 065: state is exact from this checkpoint forward,
+approximate before (docs/orrery_audit_dashboard_notes.md, issue #426).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import psycopg2
+
+from nexus.agents.orrery.reconstruction import capture_state_checkpoint_sync
+from nexus.api.slot_utils import slot_dbname
+
+
+def checkpoint_slot(slot: int, label: str) -> None:
+    conn = psycopg2.connect(dbname=slot_dbname(slot), host="localhost")
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT max(id) FROM narrative_chunks")
+            chunk_id = cur.fetchone()[0]
+            checkpoint_id = capture_state_checkpoint_sync(
+                cur, chunk_id=chunk_id, label=label
+            )
+        conn.commit()
+        if checkpoint_id is None:
+            print(f"slot {slot}: checkpoint ({chunk_id}, {label}) already exists")
+        else:
+            print(f"slot {slot}: checkpoint {checkpoint_id} at chunk {chunk_id}")
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--slot", type=int, choices=range(1, 6))
+    group.add_argument("--all", action="store_true")
+    parser.add_argument(
+        "--label", choices=("genesis", "interval", "manual"), default="manual"
+    )
+    args = parser.parse_args()
+
+    slots = range(1, 6) if args.all else [args.slot]
+    for slot in slots:
+        checkpoint_slot(slot, args.label)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_orrery/test_reconstruction.py
+++ b/tests/test_orrery/test_reconstruction.py
@@ -1,0 +1,235 @@
+"""Live tests for the reconstruction-sufficiency layer (migration 065).
+
+Real writers and real triggers against save_02 inside always-rolled-back
+transactions — zero persistent writes. Pins the issue #426 decisions:
+
+- 7b: every Skald-side scalar write lands in ``state_delta_log``, chunk-keyed.
+- 7c: checkpoints capture every section of the mutable state surface and are
+  idempotent per (chunk, label).
+- 7d: the relationship-versioning triggers write pre-images on UPDATE and
+  DELETE with chunk attribution from the transaction-local setting — and
+  NULL attribution when a writer forgets, never a silent skip.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import psycopg2
+import pytest
+
+from nexus.agents.logon.apex_schema import (
+    CharacterStateUpdate,
+    LocationStateUpdate,
+    StateUpdates,
+)
+from nexus.agents.orrery.reconstruction import (
+    CHECKPOINT_SECTIONS,
+    capture_state_checkpoint_sync,
+    set_commit_chunk_attribution_sync,
+)
+from nexus.api.commit_handler_sync import apply_state_updates_sync
+
+pytestmark = pytest.mark.requires_postgres
+
+WRITE_SLOT = 2
+
+
+def _connect() -> Any:
+    return psycopg2.connect(
+        host=os.environ.get("PGHOST", "localhost"),
+        database=f"save_{WRITE_SLOT:02d}",
+        user=os.environ.get("PGUSER", "pythagor"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+def test_checkpoint_captures_every_section_and_is_idempotent() -> None:
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT max(id) FROM narrative_chunks")
+            chunk_id = cur.fetchone()[0]
+            checkpoint_id = capture_state_checkpoint_sync(
+                cur, chunk_id=chunk_id, label="manual"
+            )
+            assert checkpoint_id is not None
+
+            cur.execute(
+                "SELECT state FROM state_checkpoints WHERE id = %s",
+                (checkpoint_id,),
+            )
+            state = cur.fetchone()[0]
+            if isinstance(state, str):
+                state = json.loads(state)
+            assert set(state) == set(CHECKPOINT_SECTIONS)
+
+            cur.execute("SELECT count(*) FROM entity_tags WHERE cleared_at IS NULL")
+            active_tags = cur.fetchone()[0]
+            assert len(state["entity_tags"]) == active_tags
+            assert active_tags > 0, "save_02 must carry active tags"
+            assert state["characters"], "character scalars must be captured"
+
+            # Idempotent per (chunk, label): re-commit of the same tick
+            # cannot duplicate the snapshot.
+            assert (
+                capture_state_checkpoint_sync(cur, chunk_id=chunk_id, label="manual")
+                is None
+            )
+        with conn.cursor() as cur:
+            with pytest.raises(ValueError, match="Unknown checkpoint label"):
+                capture_state_checkpoint_sync(cur, chunk_id=chunk_id, label="hourly")
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_skald_state_updates_are_ledgered() -> None:
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT max(id) FROM narrative_chunks")
+            chunk_id = cur.fetchone()[0]
+            cur.execute(
+                """
+                SELECT c.id, c.entity_id FROM characters c
+                WHERE c.entity_id IS NOT NULL ORDER BY c.id LIMIT 1
+                """
+            )
+            character_id, entity_id = cur.fetchone()
+            cur.execute("SELECT id, entity_id FROM places ORDER BY id LIMIT 1")
+            place_id, place_entity_id = cur.fetchone()
+
+        apply_state_updates_sync(
+            conn,
+            StateUpdates(
+                characters=[
+                    CharacterStateUpdate(
+                        character_id=character_id,
+                        character_name="probe",
+                        current_activity="ledger probe activity",
+                        current_location=place_id,
+                    )
+                ],
+                locations=[
+                    LocationStateUpdate(
+                        place_id=place_id,
+                        place_name="probe",
+                        current_conditions="ledger probe conditions",
+                    )
+                ],
+            ),
+            source_chunk_id=chunk_id,
+        )
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT field, entity_id, new_value
+                FROM state_delta_log
+                WHERE source_chunk_id = %s AND writer = 'skald_state_update'
+                ORDER BY id
+                """,
+                (chunk_id,),
+            )
+            rows = cur.fetchall()
+        by_field = {row[0]: row for row in rows}
+        assert set(by_field) == {
+            "characters.current_activity",
+            "characters.current_location",
+            "places.current_status",
+        }
+        assert by_field["characters.current_activity"][1] == entity_id
+        assert by_field["characters.current_activity"][2] == "ledger probe activity"
+        assert by_field["characters.current_location"][2] == place_id
+        assert by_field["places.current_status"][1] == place_entity_id
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_relationship_triggers_version_updates_and_deletes() -> None:
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT max(id) FROM narrative_chunks")
+            chunk_id = cur.fetchone()[0]
+            set_commit_chunk_attribution_sync(cur, chunk_id)
+
+            cur.execute(
+                """
+                UPDATE character_relationships
+                SET dynamic = dynamic || ' [version probe]'
+                WHERE (character1_id, character2_id) IN (
+                    SELECT character1_id, character2_id
+                    FROM character_relationships LIMIT 1
+                )
+                RETURNING character1_id, character2_id
+                """
+            )
+            c1, c2 = cur.fetchone()
+            cur.execute(
+                """
+                SELECT operation, source_chunk_id, old_row
+                FROM relationship_versions
+                WHERE relationship_table = 'character_relationships'
+                ORDER BY id DESC LIMIT 1
+                """
+            )
+            operation, source_chunk_id, old_row = cur.fetchone()
+            assert operation == "update"
+            assert source_chunk_id == chunk_id
+            assert int(old_row["character1_id"]) == c1
+            assert (
+                "[version probe]" not in old_row["dynamic"]
+            ), "trigger must capture the PRE-image"
+
+            cur.execute(
+                """
+                DELETE FROM character_relationships
+                WHERE character1_id = %s AND character2_id = %s
+                """,
+                (c1, c2),
+            )
+            cur.execute(
+                """
+                SELECT operation FROM relationship_versions
+                WHERE relationship_table = 'character_relationships'
+                ORDER BY id DESC LIMIT 1
+                """
+            )
+            assert cur.fetchone()[0] == "delete"
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_unattributed_relationship_write_versions_with_null_chunk() -> None:
+    """A writer that forgets attribution still gets versioned — with NULL
+    chunk, never a silent skip. The trigger cannot be forgotten."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE character_relationships
+                SET dynamic = dynamic || ' [unattributed]'
+                WHERE (character1_id, character2_id) IN (
+                    SELECT character1_id, character2_id
+                    FROM character_relationships LIMIT 1
+                )
+                """
+            )
+            cur.execute(
+                """
+                SELECT source_chunk_id FROM relationship_versions
+                ORDER BY id DESC LIMIT 1
+                """
+            )
+            assert cur.fetchone()[0] is None
+    finally:
+        conn.rollback()
+        conn.close()

--- a/tests/test_orrery/test_reconstruction.py
+++ b/tests/test_orrery/test_reconstruction.py
@@ -233,3 +233,21 @@ def test_unattributed_relationship_write_versions_with_null_chunk() -> None:
     finally:
         conn.rollback()
         conn.close()
+
+
+def test_migration_genesis_sections_mirror_checkpoint_sections() -> None:
+    """The 065 genesis backfill duplicates CHECKPOINT_SECTIONS in SQL; this
+    tripwire fails if either side gains a section the other lacks."""
+
+    from pathlib import Path
+
+    migration = Path("migrations/065_reconstructability.sql").read_text()
+    genesis = migration[migration.index("jsonb_build_object") :]
+    for section in CHECKPOINT_SECTIONS:
+        assert (
+            f"'{section}', (" in genesis
+        ), f"migration genesis backfill lacks section {section!r}"
+    import re
+
+    migration_sections = set(re.findall(r"'(\w+)', \(SELECT", genesis))
+    assert migration_sections == set(CHECKPOINT_SECTIONS)


### PR DESCRIPTION
## Summary

Steps 7b–7d of the reconstruction-sufficiency bar, implementing the maintainer decisions on #426: **log everything**, **JSONB checkpoints**, **auto-checkpoint in the commit path**, **retro-fitted genesis**, **trigger-based relationship versioning**.

### 7b — `state_delta_log` (the spec's "single biggest hole")

Every Skald-side scalar write — character `emotional_state`/`current_activity`/`current_location`, place `current_status` — now lands in a chunk-keyed ledger from both commit handlers, with entity-id resolution. The on-screen commit path previously moved characters with no record of any kind, invisible to any replay forever. Replay contract: latest checkpoint + `orrery_resolutions.state_delta` + `state_delta_log` in chunk order.

### 7c — `state_checkpoints`

One JSONB document per checkpoint covering the full mutable surface (active tags + pair tags, character/place scalars, all three relationship tables, need states, travel states, routine anchors). Auto-taken every `[orrery.reconstruction] checkpoint_interval_chunks` (default 25, 0 disables) inside the commit transaction, idempotent per (chunk, label). `scripts/checkpoint_state.py` handles manual/genesis snapshots — **genesis checkpoints are already taken on all five slots** (~170KB on the dense slot), marking the instrumentation-era boundary: exact after, approximate before.

### 7d — `relationship_versions` (trigger-enforced)

`BEFORE UPDATE OR DELETE` row triggers on the three current-state relationship tables write the full pre-image. Implementation note: those tables use **composite natural keys** (no surrogate id — caught before first trigger fire; the `old_row` jsonb is self-identifying). Attribution comes from the transaction-local `nexus.source_chunk_id` setting both commit handlers now set right after chunk creation; a writer that forgets attribution still gets versioned with NULL chunk — never a silent skip. The first future runtime relationship writer cannot destroy history on contact.

## Tests

Live save_02 in always-rolled-back transactions: checkpoint section coverage against `CHECKPOINT_SECTIONS` with SQL count parity + idempotency + label validation; the Skald ledger end-to-end through `apply_state_updates_sync` (three fields, entity ids resolved); trigger pre-image capture on UPDATE and DELETE with chunk attribution; NULL attribution for unattributed writes. 700 live / 967 offline pass (only the known pre-existing `test_pair_tag_writer` failure).

With this, the spec's step-7 sufficiency bar is met going forward: bestowals chunk-keyed (#425), clearances logged on every path (#425), Skald deltas ledgered, checkpoints bounding replay, relationships version-safe. Closes the implementation scope of #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY