### PR TITLE
Multi-entity dynamism: joint beats + live event chains (migration 066)

### DIFF
--- a/migrations/066_signal_event_vocab.sql
+++ b/migrations/066_signal_event_vocab.sql
@@ -1,0 +1,24 @@
+-- 066_signal_event_vocab.sql
+--
+-- Register the two gate-consumed event types that no writer could legally
+-- emit (world_events FKs event_types.type): compliance_alert and
+-- encoded_message. With these seeded, branch signal emissions (spec idea 7:
+-- lighting up the dormant trigger events) can turn the dead gate arms into
+-- live package-to-package chains. threat_issued and faction_realignment
+-- already exist in the vocabulary.
+
+INSERT INTO event_types (type, category, severity, description)
+VALUES
+    (
+        'compliance_alert',
+        'intelligence',
+        'moderate',
+        'The subject has reason to believe surveillance or enforcement attention is closing in on them. Consumed by evasion/warning gates; emitted as a signal by detectable surveillance branches.'
+    ),
+    (
+        'encoded_message',
+        'interpersonal',
+        'minor',
+        'A covert communication reached the target through indirect channels. Consumed by obligation gates; emitted as a signal by distanced informant overtures.'
+    )
+ON CONFLICT (type) DO NOTHING;

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -692,6 +692,32 @@ class LogonUtility:
                 if prompt_text:
                     sections.append(f"- {label}: {prompt_text}")
 
+        joint_beats = context.get("orrery_joint_beats") or []
+        if joint_beats:
+            sections.append("\n=== ORRERY JOINT BEATS ===")
+            sections.append(
+                "These proposal pairs have the same two characters acting "
+                "toward each other in this tick. Treat each pair as one "
+                "scene if you wish: 'reciprocal' means both chose the same "
+                "behavior (a meeting of intent); 'crossed' means their "
+                "behaviors differ (tension you may spring). Adjudicate the "
+                "underlying proposals by proposal_id as usual."
+            )
+            for beat in joint_beats[:max_rendered_proposals]:
+                if not isinstance(beat, dict):
+                    continue
+                names = beat.get("entity_names") or {}
+                pair = " & ".join(str(name) for name in names.values()) or (
+                    f"{beat.get('entity_a')} & {beat.get('entity_b')}"
+                )
+                sections.append(
+                    f"- [{beat.get('kind')}] {pair}: "
+                    f"{beat.get('forward_template_id')} <-> "
+                    f"{beat.get('reverse_template_id')} "
+                    f"({beat.get('forward_proposal_id')} / "
+                    f"{beat.get('reverse_proposal_id')})"
+                )
+
         bleed_menu = context.get("orrery_bleed_menu") or []
         if bleed_menu:
             sections.append("\n=== ORRERY AMBIENT PERIPHERALS ===")

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -737,6 +737,11 @@ class TurnCycleManager:
                 for pressure in turn_context.orrery_proposal.scene_pressures
             ]
 
+        if proposal and getattr(proposal, "joint_beats", ()):
+            turn_context.context_payload["orrery_joint_beats"] = [
+                beat.to_dict() for beat in proposal.joint_beats
+            ]
+
         if turn_context.bleed_menu:
             turn_context.context_payload["orrery_bleed_menu"] = [
                 candidate.to_prompt_dict() for candidate in turn_context.bleed_menu

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -823,11 +823,14 @@ def build_catalog(
             branch_consumed |= _consumed_event_types(branch.conditions)
             if branch.event_type:
                 emitted.add(branch.event_type)
+            if branch.signal_event_type:
+                emitted.add(branch.signal_event_type)
             branch_payloads.append(
                 {
                     "label": branch.label,
                     "magnitude": branch.magnitude,
                     "event_type": branch.event_type,
+                    "signal_event_type": branch.signal_event_type,
                     "has_scene_pressure_stub": branch.scene_pressure_stub is not None,
                 }
             )

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -37,6 +37,7 @@ from typing import Any, Iterable, List, Mapping, Optional, Sequence, Tuple
 from sqlalchemy import text
 
 from nexus.agents.orrery.explain import StackExplanation, explain_stack
+from nexus.agents.orrery.reciprocal import OrreryJointBeat, detect_joint_beats
 from nexus.agents.orrery.overrides import (
     OverrideValidationError,
     WorldStateOverrides,
@@ -122,6 +123,7 @@ class ExplainedTickReport:
     locations: Mapping[int, Any]
     location_names: Mapping[int, str]
     activities: Mapping[int, str]
+    joint_beats: Tuple[OrreryJointBeat, ...] = ()
     mode: str = "current"
     overrides: Optional[Mapping[str, Any]] = None
     need_pressures_diff: Optional[Mapping[str, Any]] = None
@@ -143,6 +145,7 @@ class ExplainedTickReport:
             "overrides": dict(self.overrides) if self.overrides is not None else None,
             "generated_at": self.generated_at,
             "actors": [self._group_payload(group) for group in self.actors],
+            "joint_beats": [beat.to_dict() for beat in self.joint_beats],
             "need_pressures": [draft.to_dict() for draft in self.need_pressures],
             "need_pressures_diff": (
                 dict(self.need_pressures_diff)
@@ -637,6 +640,32 @@ def explain_dry_run(
     if what_if:
         need_pressures_diff = _need_pressure_diff(_pressures(baseline), need_pressures)
 
+    class _WinnerShim:
+        __slots__ = (
+            "template_id",
+            "binding_hash",
+            "bindings",
+            "magnitude",
+            "narrative_stub",
+        )
+
+        def __init__(self, stack: StackExplanation, item: Any) -> None:
+            self.template_id = item.template_id
+            self.binding_hash = item.binding_hash
+            self.bindings = dict(stack.bindings)
+            self.magnitude = item.magnitude
+            self.narrative_stub = item.narrative_stub
+
+    joint_beat_inputs = [
+        _WinnerShim(stack, item)
+        for stacks in active.two_party_stacks.values()
+        for stack in stacks
+        if stack.winner_id is not None
+        for item in stack.templates
+        if item.template_id == stack.winner_id
+    ]
+    joint_beats = detect_joint_beats(joint_beat_inputs, entity_names)
+
     not_applicable_markers = tuple(
         {
             "template_id": template.id,
@@ -699,6 +728,7 @@ def explain_dry_run(
         locations=dict(active_state.locations),
         location_names=location_names,
         activities=dict(active_state.activities),
+        joint_beats=joint_beats,
         mode="what_if" if what_if else "current",
         overrides=overrides.to_dict() if what_if and overrides is not None else None,
         need_pressures_diff=need_pressures_diff,

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -2839,6 +2839,8 @@ def _emit_world_event_sync(
         return None
 
     _ensure_event_type_sync(cur, draft.event_type)
+    if draft.signal_event_type:
+        _ensure_event_type_sync(cur, draft.signal_event_type)
     location_id = _actor_location_sync(cur, actor_entity_id)
     payload = {
         "proposal_id": draft.proposal_id,
@@ -2889,6 +2891,30 @@ def _emit_world_event_sync(
             """,
             (event_id, target_entity_id),
         )
+    if draft.signal_event_type:
+        # The act's signal: a second, additive emission with the same
+        # bindings so other packages' gates can hear it (spec idea 7).
+        cur.execute(
+            """
+            INSERT INTO world_events (
+                event_type, tick_chunk_id, actor_entity_id, target_entity_id,
+                location_id, world_layer, source, changed_fields, magnitude,
+                resolution_id, payload
+            ) VALUES (%s, %s, %s, %s, %s, %s, 'resolver', %s, %s, %s, %s::jsonb)
+            """,
+            (
+                draft.signal_event_type,
+                tick_chunk_id,
+                actor_entity_id,
+                target_entity_id,
+                location_id,
+                world_layer,
+                [],
+                draft.magnitude,
+                resolution_id,
+                json.dumps({**payload, "signal_of": draft.event_type}),
+            ),
+        )
     return event_id
 
 
@@ -2906,6 +2932,8 @@ async def _emit_world_event_async(
         return None
 
     await _ensure_event_type_async(conn, draft.event_type)
+    if draft.signal_event_type:
+        await _ensure_event_type_async(conn, draft.signal_event_type)
     location_id = await _actor_location_async(conn, actor_entity_id)
     payload = {
         "proposal_id": draft.proposal_id,
@@ -2957,6 +2985,27 @@ async def _emit_world_event_async(
             """,
             event_id,
             target_entity_id,
+        )
+    if draft.signal_event_type:
+        # Same additive signal emission as the sync twin.
+        await conn.execute(
+            """
+            INSERT INTO world_events (
+                event_type, tick_chunk_id, actor_entity_id, target_entity_id,
+                location_id, world_layer, source, changed_fields, magnitude,
+                resolution_id, payload
+            ) VALUES ($1, $2, $3, $4, $5, $6, 'resolver', $7, $8, $9, $10::jsonb)
+            """,
+            draft.signal_event_type,
+            tick_chunk_id,
+            actor_entity_id,
+            target_entity_id,
+            location_id,
+            world_layer,
+            [],
+            draft.magnitude,
+            resolution_id,
+            json.dumps({**payload, "signal_of": draft.event_type}),
         )
     return event_id
 

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -2994,7 +2994,10 @@ async def _emit_world_event_async(
                 event_type, tick_chunk_id, actor_entity_id, target_entity_id,
                 location_id, world_layer, source, changed_fields, magnitude,
                 resolution_id, payload
-            ) VALUES ($1, $2, $3, $4, $5, $6, 'resolver', $7, $8, $9, $10::jsonb)
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6::world_layer_type, 'resolver',
+                $7::text[], $8, $9, $10::jsonb
+            )
             """,
             draft.signal_event_type,
             tick_chunk_id,

--- a/nexus/agents/orrery/explain.py
+++ b/nexus/agents/orrery/explain.py
@@ -123,6 +123,7 @@ class TemplateExplanation:
     branches: Tuple[BranchTrace, ...]
     magnitude: float
     event_type: Optional[str]
+    signal_event_type: Optional[str]
     narrative_stub: Optional[str]
     binding_hash: str
     state_delta: Mapping[str, Any] = field(default_factory=dict)
@@ -147,6 +148,7 @@ class TemplateExplanation:
             "branches": [branch.to_dict() for branch in self.branches],
             "magnitude": self.magnitude if self.fired else None,
             "event_type": self.event_type if self.fired else None,
+            "signal_event_type": self.signal_event_type if self.fired else None,
             "narrative_stub": self.narrative_stub,
             "binding_hash": self.binding_hash,
             "state_delta": dict(self.state_delta),
@@ -316,6 +318,7 @@ def explain_template(
         branches=tuple(branch_traces),
         magnitude=truth.magnitude,
         event_type=truth.event_type,
+        signal_event_type=truth.signal_event_type,
         narrative_stub=truth.narrative_stub,
         binding_hash=truth.binding_hash,
         state_delta=dict(truth.state_delta),

--- a/nexus/agents/orrery/reciprocal.py
+++ b/nexus/agents/orrery/reciprocal.py
@@ -1,0 +1,157 @@
+"""Reciprocal/conflict post-pass over a tick's two-party resolutions.
+
+The spec's "richest untapped vein" (docs/orrery_audit_dashboard_notes.md,
+idea 6): ``compose_actor_target_bindings`` emits both orderings of every
+relationship edge, so A→B and B→A drafts already coexist in one
+``OrreryTickProposal``. This module is the pure post-pass that notices —
+no resolver changes, no writes.
+
+When both directions of a pair fire in the same tick, the pair composes
+into a **joint beat**:
+
+- ``reciprocal`` — both directions fired the *same* template (mutual reach,
+  mutual surveillance): the two halves are one scene.
+- ``crossed`` — the directions fired *different* templates (one cultivates
+  while the other hunts): tension the storyteller can spring.
+
+Joint beats are advisory prose for the storyteller and the audit dashboard;
+the two underlying drafts remain the committable, adjudicable units — a
+beat never replaces its parents in the commit path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
+
+
+@dataclass(frozen=True, slots=True)
+class OrreryJointBeat:
+    """One composed two-way beat between a pair of entities in one tick."""
+
+    kind: str  # 'reciprocal' | 'crossed'
+    entity_a: int
+    entity_b: int
+    forward_proposal_id: str
+    reverse_proposal_id: str
+    forward_template_id: str
+    reverse_template_id: str
+    forward_stub: str
+    reverse_stub: str
+    magnitude: float
+    entity_names: Mapping[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "entity_a": self.entity_a,
+            "entity_b": self.entity_b,
+            "forward_proposal_id": self.forward_proposal_id,
+            "reverse_proposal_id": self.reverse_proposal_id,
+            "forward_template_id": self.forward_template_id,
+            "reverse_template_id": self.reverse_template_id,
+            "forward_stub": self.forward_stub,
+            "reverse_stub": self.reverse_stub,
+            "magnitude": self.magnitude,
+            "entity_names": dict(self.entity_names),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "OrreryJointBeat":
+        return cls(
+            kind=str(data["kind"]),
+            entity_a=int(data["entity_a"]),
+            entity_b=int(data["entity_b"]),
+            forward_proposal_id=str(data["forward_proposal_id"]),
+            reverse_proposal_id=str(data["reverse_proposal_id"]),
+            forward_template_id=str(data["forward_template_id"]),
+            reverse_template_id=str(data["reverse_template_id"]),
+            forward_stub=str(data["forward_stub"]),
+            reverse_stub=str(data["reverse_stub"]),
+            magnitude=float(data["magnitude"]),
+            entity_names=dict(data.get("entity_names") or {}),
+        )
+
+
+def _pair_key(item: Any) -> Optional[Tuple[int, int]]:
+    bindings = getattr(item, "bindings", None) or {}
+    actor = bindings.get("actor")
+    target = bindings.get("target")
+    if isinstance(actor, int) and isinstance(target, int):
+        return actor, target
+    return None
+
+
+def detect_joint_beats(
+    resolutions: Iterable[Any],
+    entity_names: Optional[Mapping[Any, str]] = None,
+) -> Tuple[OrreryJointBeat, ...]:
+    """Compose joint beats from a tick's two-party resolution drafts.
+
+    Accepts anything draft-shaped (``bindings`` with int actor/target,
+    ``template_id``, ``binding_hash``, ``branch stub`` fields, ``magnitude``)
+    so both the production proposal and the audit layer's stack winners can
+    feed it. Deterministic: pairs are keyed on the unordered entity pair,
+    with the forward direction being the lower entity id's draft.
+    """
+
+    by_direction: dict[Tuple[int, int], Any] = {}
+    for item in resolutions:
+        key = _pair_key(item)
+        if key is not None:
+            # Winner-take-all means at most one two-party draft per ordered
+            # pair; keep the first defensively if that invariant ever bends.
+            by_direction.setdefault(key, item)
+
+    names = entity_names or {}
+    beats: list[OrreryJointBeat] = []
+    for (actor, target), forward in sorted(by_direction.items()):
+        if actor > target:
+            continue  # handled from the lower-id side
+        reverse = by_direction.get((target, actor))
+        if reverse is None:
+            continue
+        forward_template = str(forward.template_id)
+        reverse_template = str(reverse.template_id)
+        beats.append(
+            OrreryJointBeat(
+                kind=(
+                    "reciprocal" if forward_template == reverse_template else "crossed"
+                ),
+                entity_a=actor,
+                entity_b=target,
+                forward_proposal_id=(f"{forward_template}:{forward.binding_hash}"),
+                reverse_proposal_id=(f"{reverse_template}:{reverse.binding_hash}"),
+                forward_template_id=forward_template,
+                reverse_template_id=reverse_template,
+                forward_stub=str(getattr(forward, "narrative_stub", "") or ""),
+                reverse_stub=str(getattr(reverse, "narrative_stub", "") or ""),
+                magnitude=max(
+                    float(getattr(forward, "magnitude", 0.0) or 0.0),
+                    float(getattr(reverse, "magnitude", 0.0) or 0.0),
+                ),
+                entity_names={
+                    str(actor): str(names.get(actor, f"entity {actor}")),
+                    str(target): str(names.get(target, f"entity {target}")),
+                },
+            )
+        )
+    return tuple(beats)
+
+
+def coerce_joint_beats(value: Any) -> Tuple[OrreryJointBeat, ...]:
+    """Hydrate joint beats from serialized proposal data (tolerant of
+    pre-beat payloads: missing/None means no beats)."""
+
+    if not value:
+        return ()
+    if isinstance(value, Sequence):
+        return tuple(
+            (
+                item
+                if isinstance(item, OrreryJointBeat)
+                else OrreryJointBeat.from_dict(item)
+            )
+            for item in value
+        )
+    raise ValueError(f"Unsupported joint-beat payload: {type(value)!r}")

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -9,6 +9,11 @@ from typing import Any, Iterable, Mapping, Optional, Tuple
 
 from sqlalchemy import text
 
+from nexus.agents.orrery.reciprocal import (
+    OrreryJointBeat,
+    coerce_joint_beats,
+    detect_joint_beats,
+)
 from nexus.agents.orrery.substrate import (
     BranchSelection,
     coerce_branch_selection,
@@ -180,6 +185,7 @@ class OrreryTickProposal:
     actor_count: int
     resolutions: Tuple[OrreryResolutionDraft, ...]
     scene_pressures: Tuple[OrreryScenePressureDraft, ...] = ()
+    joint_beats: Tuple[OrreryJointBeat, ...] = ()
     generated_at: str = field(
         default_factory=lambda: datetime.now(timezone.utc).isoformat()
     )
@@ -207,6 +213,7 @@ class OrreryTickProposal:
             "scene_pressures": [
                 pressure.to_dict() for pressure in self.scene_pressures
             ],
+            "joint_beats": [beat.to_dict() for beat in self.joint_beats],
         }
 
     @classmethod
@@ -225,6 +232,7 @@ class OrreryTickProposal:
                 OrreryScenePressureDraft.from_dict(item)
                 for item in data.get("scene_pressures", ())
             ),
+            joint_beats=coerce_joint_beats(data.get("joint_beats")),
         )
 
 
@@ -944,6 +952,7 @@ def resolve_dry_run(
         actor_count=len(unique_actors),
         resolutions=tuple(drafts),
         scene_pressures=scene_pressures,
+        joint_beats=detect_joint_beats(drafts, draft_entity_names),
     )
 
 

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -70,6 +70,7 @@ class OrreryResolutionDraft:
     narrative_stub: str
     state_delta: Mapping[str, Any] = field(default_factory=dict)
     event_type: Optional[str] = None
+    signal_event_type: Optional[str] = None
     changed_fields: Tuple[str, ...] = ()
     magnitude: float = 0.0
     # Slot name -> entity display name. Skald adjudicates these proposals;
@@ -97,6 +98,7 @@ class OrreryResolutionDraft:
             "narrative_stub": self.narrative_stub,
             "state_delta": dict(self.state_delta),
             "event_type": self.event_type,
+            "signal_event_type": self.signal_event_type,
             "changed_fields": list(self.changed_fields),
             "magnitude": self.magnitude,
         }
@@ -127,6 +129,7 @@ class OrreryResolutionDraft:
             narrative_stub=str(data["narrative_stub"]),
             state_delta=dict(data.get("state_delta") or {}),
             event_type=data.get("event_type"),
+            signal_event_type=data.get("signal_event_type"),
             changed_fields=tuple(data.get("changed_fields") or ()),
             magnitude=float(data.get("magnitude") or 0.0),
             binding_names=dict(data.get("binding_names") or {}),
@@ -1134,6 +1137,7 @@ def _draft_from_resolution(resolution: Resolution) -> OrreryResolutionDraft:
         narrative_stub=resolution.narrative_stub,
         state_delta=resolution.state_delta,
         event_type=resolution.event_type,
+        signal_event_type=resolution.signal_event_type,
         changed_fields=resolution.changed_fields,
         magnitude=resolution.magnitude,
     )

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -1667,6 +1667,11 @@ class Branch:
     changed_fields: Tuple[str, ...] = ()
     magnitude: float = 0.0
     scene_pressure_stub: Optional[str] = None
+    # A second, additive world-event emission: the signal an act gives off
+    # (threat_issued, compliance_alert, ...) alongside the deed's own
+    # event_type. Signals feed other packages' gates without disturbing the
+    # emitting package's cooldowns.
+    signal_event_type: Optional[str] = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -1719,6 +1724,7 @@ class Resolution:
     changed_fields: Tuple[str, ...] = ()
     magnitude: float = 0.0
     scene_pressure_stub: Optional[str] = None
+    signal_event_type: Optional[str] = None
 
 
 def binding_hash(bindings: Bindings) -> str:
@@ -1885,6 +1891,7 @@ def evaluate(
             changed_fields=branch.changed_fields,
             magnitude=branch.magnitude,
             scene_pressure_stub=branch.scene_pressure_stub,
+            signal_event_type=branch.signal_event_type,
         )
 
     return Resolution(

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -718,6 +718,7 @@ EXTRACT_VENGEANCE = Template(
                 "entity_tags_target.remove": ["grudge_active"],
             },
             event_type="retaliation_executed",
+            signal_event_type="threat_issued",
             changed_fields=(
                 "character.current_activity",
                 "entity_tags",
@@ -747,6 +748,7 @@ EXTRACT_VENGEANCE = Template(
                 "entity_tags_target.add": ["reputation_compromised"],
             },
             event_type="retaliation_attempted",
+            signal_event_type="threat_issued",
             changed_fields=("character.current_activity", "entity_tags"),
             magnitude=0.58,
             scene_pressure_stub=(
@@ -964,6 +966,7 @@ SURVEIL = Template(
                 "character.current_activity": "intercepting target signals",
             },
             event_type="surveillance_performed",
+            signal_event_type="compliance_alert",
             changed_fields=("character.current_activity",),
             magnitude=0.48,
             scene_pressure_stub=(
@@ -1057,6 +1060,7 @@ SURVEIL = Template(
                 "character.current_activity": "following target public pattern",
             },
             event_type="surveillance_performed",
+            signal_event_type="compliance_alert",
             changed_fields=("character.current_activity",),
             magnitude=0.30,
             scene_pressure_stub=(
@@ -1194,6 +1198,7 @@ CULTIVATE_INFORMANT = Template(
                 "character.current_activity": "courting an informant remotely",
             },
             event_type="informant_contact",
+            signal_event_type="encoded_message",
             changed_fields=("character.current_activity",),
             magnitude=0.18,
             scene_pressure_stub=(

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -819,3 +819,32 @@ def test_adjudication_history_endpoint_over_http(client: TestClient) -> None:
     assert filtered.status_code == 200
     filtered_payload = filtered.json()
     assert set(filtered_payload["templates"]) <= {"surveil"}
+
+
+@pytest.mark.requires_postgres
+@pytest.mark.parametrize("slot", AUDIT_SLOTS)
+def test_joint_beats_parity_with_production(
+    client: TestClient,
+    production_proposals: dict[int, tuple[Optional[int], OrreryTickProposal]],
+    slot: int,
+) -> None:
+    """The audit payload's joint beats must match the production post-pass."""
+
+    anchor_chunk_id, proposal = production_proposals[slot]
+    response = client.post(
+        "/api/dev/orrery/resolve",
+        json={"slot": slot, "anchor_chunk_id": anchor_chunk_id},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    endpoint_beats = {
+        (beat["forward_proposal_id"], beat["reverse_proposal_id"])
+        for beat in payload["joint_beats"]
+    }
+    production_beats = {
+        (beat.forward_proposal_id, beat.reverse_proposal_id)
+        for beat in proposal.joint_beats
+    }
+    assert endpoint_beats == production_beats
+    for beat in payload["joint_beats"]:
+        assert beat["kind"] in {"reciprocal", "crossed"}

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -695,13 +695,8 @@ def test_coverage_report_is_internally_consistent(
     for gap in payload["gap_actors"]:
         assert 0 < gap["gapped_anchors"] <= gap["seen_anchors"]
 
-    # The static lint re-derives exactly the four dead gate arms.
-    assert set(payload["dead_gate_arms"]) == {
-        "threat_issued",
-        "compliance_alert",
-        "faction_realignment",
-        "encoded_message",
-    }
+    # Post-signal-emissions, only faction_realignment lacks an emitter.
+    assert set(payload["dead_gate_arms"]) == {"faction_realignment"}
     assert set(payload["hydration_honesty"]) == {
         "rewound_to_anchor",
         "current_projection",

--- a/tests/test_orrery/test_audit.py
+++ b/tests/test_orrery/test_audit.py
@@ -77,7 +77,8 @@ def test_catalog_surfaces_priority_ties_in_tuple_order() -> None:
 
 
 def test_catalog_flags_exogenous_only_event_types() -> None:
-    """The four gate-consumed, never-emitted event types are dead gate arms."""
+    """Only faction_realignment remains a dead gate arm: the other three
+    former dead arms gained real signal emitters (live event chains)."""
 
     catalog = _catalog()
     exogenous = {
@@ -86,12 +87,15 @@ def test_catalog_flags_exogenous_only_event_types() -> None:
         if entry["exogenous_only"]
     }
 
-    assert {
-        "threat_issued",
-        "compliance_alert",
-        "faction_realignment",
-        "encoded_message",
-    } <= exogenous
+    assert "faction_realignment" in exogenous
+    assert (
+        not {
+            "threat_issued",
+            "compliance_alert",
+            "encoded_message",
+        }
+        & exogenous
+    )
     for event_type in exogenous:
         assert not catalog["event_map"][event_type]["emitted_by"]
 

--- a/tests/test_orrery/test_reciprocal.py
+++ b/tests/test_orrery/test_reciprocal.py
@@ -1,0 +1,153 @@
+"""Tests for the reciprocal/conflict joint-beat post-pass.
+
+Pure synthetic drafts pin the composition semantics; the live test asserts
+the endpoint payload and production proposal agree on the same slots. Joint
+beats are advisory (prompt + audit surface): the underlying drafts remain
+the committable units, so no commit-path behavior changes here.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nexus.agents.orrery.reciprocal import (
+    OrreryJointBeat,
+    coerce_joint_beats,
+    detect_joint_beats,
+)
+from nexus.agents.orrery.resolver import OrreryResolutionDraft, OrreryTickProposal
+
+
+def _draft(
+    template_id: str, actor: int, target: int | None, magnitude: float = 0.2
+) -> OrreryResolutionDraft:
+    bindings: dict[str, int] = {"actor": actor}
+    if target is not None:
+        bindings["target"] = target
+    return OrreryResolutionDraft(
+        template_id=template_id,
+        priority=50,
+        binding_hash=f"hash-{template_id}-{actor}-{target}",
+        bindings=bindings,
+        branch_label="test branch",
+        narrative_stub=f"{{actor}} acts toward {{target}} via {template_id}.",
+        magnitude=magnitude,
+    )
+
+
+NAMES = {1: "Alex", 2: "Emilia", 3: "Pete"}
+
+
+def test_reciprocal_pair_composes_one_beat() -> None:
+    beats = detect_joint_beats(
+        [
+            _draft("reach_out_to_kin", 1, 2, magnitude=0.3),
+            _draft("reach_out_to_kin", 2, 1, magnitude=0.5),
+            _draft("sleep", 3, None),
+        ],
+        NAMES,
+    )
+    assert len(beats) == 1
+    (beat,) = beats
+    assert beat.kind == "reciprocal"
+    assert (beat.entity_a, beat.entity_b) == (1, 2)
+    assert beat.magnitude == 0.5
+    assert beat.entity_names == {"1": "Alex", "2": "Emilia"}
+    assert beat.forward_proposal_id.startswith("reach_out_to_kin:")
+    assert beat.forward_proposal_id != beat.reverse_proposal_id
+
+
+def test_crossed_pair_flags_divergent_intents() -> None:
+    beats = detect_joint_beats(
+        [
+            _draft("cultivate_informant", 1, 2),
+            _draft("extract_vengeance", 2, 1),
+        ],
+        NAMES,
+    )
+    (beat,) = beats
+    assert beat.kind == "crossed"
+    assert beat.forward_template_id == "cultivate_informant"
+    assert beat.reverse_template_id == "extract_vengeance"
+
+
+def test_one_sided_drafts_produce_no_beat() -> None:
+    """(1,2) stays one-sided and yields nothing; (1,3)/(3,1) composes."""
+
+    beats = detect_joint_beats(
+        [
+            _draft("surveil", 1, 2),
+            _draft("surveil", 1, 3),
+            _draft("keep_vigil", 3, 1),
+        ],
+        NAMES,
+    )
+    assert len(beats) == 1
+    assert (beats[0].entity_a, beats[0].entity_b) == (1, 3)
+    assert beats[0].kind == "crossed"
+
+    assert detect_joint_beats([_draft("surveil", 1, 2)], NAMES) == ()
+
+
+def test_beats_are_deterministic_and_lower_id_forward() -> None:
+    drafts = [
+        _draft("keep_vigil", 9, 4),
+        _draft("keep_vigil", 4, 9),
+        _draft("surveil", 2, 1),
+        _draft("surveil", 1, 2),
+    ]
+    beats = detect_joint_beats(drafts, NAMES)
+    assert [(b.entity_a, b.entity_b) for b in beats] == [(1, 2), (4, 9)]
+    assert beats == detect_joint_beats(list(reversed(drafts)), NAMES)
+
+
+def test_proposal_serialization_round_trips_joint_beats() -> None:
+    proposal = OrreryTickProposal(
+        anchor_chunk_id=100,
+        actor_count=2,
+        resolutions=(
+            _draft("reach_out_to_kin", 1, 2),
+            _draft("reach_out_to_kin", 2, 1),
+        ),
+        joint_beats=detect_joint_beats(
+            [
+                _draft("reach_out_to_kin", 1, 2),
+                _draft("reach_out_to_kin", 2, 1),
+            ],
+            NAMES,
+        ),
+    )
+    payload = json.loads(json.dumps(proposal.to_dict()))
+    assert len(payload["joint_beats"]) == 1
+    hydrated = OrreryTickProposal.from_dict(payload)
+    assert hydrated.joint_beats == proposal.joint_beats
+
+    # Pre-beat incubator payloads hydrate cleanly (advisory field).
+    del payload["joint_beats"]
+    assert OrreryTickProposal.from_dict(payload).joint_beats == ()
+
+
+def test_coerce_joint_beats_rejects_garbage() -> None:
+    assert coerce_joint_beats(None) == ()
+    assert coerce_joint_beats([]) == ()
+    round_tripped = coerce_joint_beats(
+        [
+            OrreryJointBeat(
+                kind="reciprocal",
+                entity_a=1,
+                entity_b=2,
+                forward_proposal_id="a:1",
+                reverse_proposal_id="b:2",
+                forward_template_id="a",
+                reverse_template_id="a",
+                forward_stub="x",
+                reverse_stub="y",
+                magnitude=0.1,
+            )
+        ]
+    )
+    assert round_tripped[0].kind == "reciprocal"
+    with pytest.raises(ValueError, match="Unsupported joint-beat payload"):
+        coerce_joint_beats(42)

--- a/tests/test_orrery/test_signal_events.py
+++ b/tests/test_orrery/test_signal_events.py
@@ -1,0 +1,204 @@
+"""Tests for branch signal emissions — the live package-to-package chains.
+
+Before this feature, threat_issued / compliance_alert / encoded_message were
+gate-consumed but never emitted: package chaining was aspirational. A branch
+signal is a second, additive world-event emission (the deed keeps its own
+event_type and cooldowns; the signal is what the act gives off). The live
+test drives the real commit path and then proves the chain input: the
+consuming gate's predicate sees the signal on real slot state.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import psycopg2
+import pytest
+
+from nexus.agents.orrery.events import commit_orrery_tick_sync
+from nexus.agents.orrery.resolver import (
+    OrreryResolutionDraft,
+    OrreryTickProposal,
+)
+from nexus.agents.orrery.substrate import (
+    ALWAYS,
+    Branch,
+    DriveBand,
+    Slot,
+    Template,
+    WorldState,
+    evaluate,
+    recent_event,
+)
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+
+WRITE_SLOT = 2
+
+SIGNALLED = Template(
+    id="extract_vengeance",  # real id keeps prose/catalog lookups valid
+    priority=60,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    blurb="Synthetic signal-bearing template.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    package_gate=ALWAYS,
+    branches=(
+        Branch(
+            label="show the hand",
+            conditions=ALWAYS,
+            narrative_stub="{actor} lets {target} feel the pressure.",
+            event_type="retaliation_attempted",
+            signal_event_type="threat_issued",
+            magnitude=0.5,
+        ),
+    ),
+)
+
+
+def test_resolution_carries_the_branch_signal() -> None:
+    resolution = evaluate(
+        SIGNALLED, WorldState(current_tick=10), {Slot.ACTOR: 1, Slot.TARGET: 2}
+    )
+    assert resolution.passes
+    assert resolution.event_type == "retaliation_attempted"
+    assert resolution.signal_event_type == "threat_issued"
+
+
+def test_builtin_signal_wiring() -> None:
+    by_id = {template.id: template for template in BUILTIN_TEMPLATES}
+    signals = {
+        template_id: {
+            branch.label: branch.signal_event_type
+            for branch in by_id[template_id].branches
+            if branch.signal_event_type
+        }
+        for template_id in ("extract_vengeance", "surveil", "cultivate_informant")
+    }
+    assert set(signals["extract_vengeance"].values()) == {"threat_issued"}
+    assert set(signals["surveil"].values()) == {"compliance_alert"}
+    assert set(signals["cultivate_informant"].values()) == {"encoded_message"}
+    # The deed events are untouched: cooldown consumers keep their food.
+    assert all(
+        branch.event_type != branch.signal_event_type
+        for template in BUILTIN_TEMPLATES
+        for branch in template.branches
+        if branch.signal_event_type
+    )
+
+
+def test_draft_serialization_round_trips_signal() -> None:
+    draft = OrreryResolutionDraft(
+        template_id="extract_vengeance",
+        priority=60,
+        binding_hash="h",
+        bindings={"actor": 1, "target": 2},
+        branch_label="show the hand",
+        narrative_stub="x",
+        event_type="retaliation_attempted",
+        signal_event_type="threat_issued",
+        magnitude=0.5,
+    )
+    hydrated = OrreryResolutionDraft.from_dict(draft.to_dict())
+    assert hydrated.signal_event_type == "threat_issued"
+
+
+@pytest.mark.requires_postgres
+def test_committed_signal_feeds_consumer_gates_live() -> None:
+    """The full chain, on real state: commit emits deed + signal rows, and
+    the hunted target's gate predicate hears the threat next resolve."""
+
+    conn = psycopg2.connect(
+        host=os.environ.get("PGHOST", "localhost"),
+        database=f"save_{WRITE_SLOT:02d}",
+        user=os.environ.get("PGUSER", "pythagor"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT max(id) FROM narrative_chunks")
+            anchor_chunk_id = cur.fetchone()[0]
+            cur.execute(
+                """
+                SELECT entity_id FROM characters
+                WHERE entity_id IS NOT NULL ORDER BY entity_id LIMIT 2
+                """
+            )
+            (avenger,), (target,) = cur.fetchall()
+
+        draft = OrreryResolutionDraft(
+            template_id="extract_vengeance",
+            priority=60,
+            binding_hash=f"signal-{uuid.uuid4().hex}",
+            bindings={"actor": avenger, "target": target},
+            branch_label="show the hand",
+            narrative_stub="{actor} lets {target} feel the pressure.",
+            event_type="retaliation_attempted",
+            signal_event_type="threat_issued",
+            magnitude=0.5,
+        )
+        result = commit_orrery_tick_sync(
+            conn,
+            OrreryTickProposal(
+                anchor_chunk_id=anchor_chunk_id,
+                actor_count=1,
+                resolutions=(draft,),
+            ),
+            tick_chunk_id=anchor_chunk_id,
+            slot=WRITE_SLOT,
+        )
+        assert result.resolution_count == 1
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT event_type, payload->>'signal_of'
+                FROM world_events
+                WHERE tick_chunk_id = %s AND target_entity_id = %s
+                  AND event_type IN ('retaliation_attempted', 'threat_issued')
+                ORDER BY id
+                """,
+                (anchor_chunk_id, target),
+            )
+            rows = cur.fetchall()
+        kinds = {row[0]: row[1] for row in rows}
+        assert set(kinds) == {"retaliation_attempted", "threat_issued"}
+        assert kinds["threat_issued"] == "retaliation_attempted"
+
+        # The chain input: the committed signal is queryable exactly as
+        # hydration's recent-events window will read it next resolve.
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT count(*) FROM world_events
+                WHERE event_type = 'threat_issued'
+                  AND target_entity_id = %s
+                  AND tick_chunk_id >= %s - 5
+                """,
+                (target, anchor_chunk_id),
+            )
+            heard = cur.fetchone()[0]
+        assert heard >= 1
+
+        # Predicate semantics on state mirroring the committed rows: the
+        # target hears the threat as next tick's actor; the avenger does not.
+        from nexus.agents.orrery.substrate import EventRecord
+
+        threatened_gate = recent_event(
+            "threat_issued", within_ticks=5, target_slot=Slot.ACTOR
+        )
+        state = WorldState(
+            recent_events=(
+                EventRecord(
+                    event_type="threat_issued",
+                    tick=anchor_chunk_id,
+                    actor_entity_id=avenger,
+                    target_entity_id=target,
+                ),
+            ),
+            current_tick=anchor_chunk_id,
+        )
+        assert threatened_gate(state, {Slot.ACTOR: target}) is True
+        assert threatened_gate(state, {Slot.ACTOR: avenger}) is False
+    finally:
+        conn.rollback()
+        conn.close()

--- a/tests/test_orrery/test_signal_events.py
+++ b/tests/test_orrery/test_signal_events.py
@@ -202,3 +202,74 @@ def test_committed_signal_feeds_consumer_gates_live() -> None:
     finally:
         conn.rollback()
         conn.close()
+
+
+@pytest.mark.requires_postgres
+def test_async_commit_emits_signal_rows_live() -> None:
+    """The asyncpg twin needs explicit ::world_layer_type / ::text[] casts
+    (review finding on #429) — and had no live coverage anywhere before
+    this test. Real commit_orrery_tick_async, rolled-back transaction."""
+
+    import asyncio
+
+    import asyncpg
+
+    async def _run() -> None:
+        conn = await asyncpg.connect(
+            host=os.environ.get("PGHOST", "localhost"),
+            database=f"save_{WRITE_SLOT:02d}",
+            user=os.environ.get("PGUSER", "pythagor"),
+        )
+        tx = conn.transaction()
+        await tx.start()
+        try:
+            anchor = await conn.fetchval("SELECT max(id) FROM narrative_chunks")
+            rows = await conn.fetch(
+                """
+                SELECT entity_id FROM characters
+                WHERE entity_id IS NOT NULL ORDER BY entity_id LIMIT 2
+                """
+            )
+            avenger, target = rows[0][0], rows[1][0]
+            draft = OrreryResolutionDraft(
+                template_id="extract_vengeance",
+                priority=60,
+                binding_hash=f"async-signal-{uuid.uuid4().hex}",
+                bindings={"actor": avenger, "target": target},
+                branch_label="show the hand",
+                narrative_stub="{actor} lets {target} feel the pressure.",
+                event_type="retaliation_attempted",
+                signal_event_type="threat_issued",
+                magnitude=0.5,
+            )
+            from nexus.agents.orrery.events import commit_orrery_tick_async
+
+            result = await commit_orrery_tick_async(
+                conn,
+                OrreryTickProposal(
+                    anchor_chunk_id=anchor, actor_count=1, resolutions=(draft,)
+                ),
+                tick_chunk_id=anchor,
+                slot=WRITE_SLOT,
+            )
+            assert result.resolution_count == 1
+            kinds = {
+                row[0]
+                for row in await conn.fetch(
+                    """
+                    SELECT event_type FROM world_events
+                    WHERE tick_chunk_id = $1 AND target_entity_id = $2
+                      AND event_type IN (
+                        'retaliation_attempted', 'threat_issued'
+                      )
+                    """,
+                    anchor,
+                    target,
+                )
+            }
+            assert kinds == {"retaliation_attempted", "threat_issued"}
+        finally:
+            await tx.rollback()
+            await conn.close()
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary

Dynamism rounds 2 and 3 — the multi-entity half of the emergence mandate. Two stacked commits:

### Joint beats (reciprocal/conflict post-pass — spec idea 6)

`compose_actor_target_bindings` already emits both orderings of every relationship edge, so A→B and B→A drafts coexist in one proposal. A pure post-pass now composes them: **`reciprocal`** (same template both directions — mutual reach, mutual surveillance: one scene) or **`crossed`** (different templates — one cultivates while the other hunts: tension to spring). Beats are advisory: rendered to the storyteller as a new `ORRERY JOINT BEATS` prompt section (cap shares `[orrery.prompt]`), carried on the proposal (serialization tolerant of pre-beat incubator payloads), and mirrored in the audit payload with an endpoint↔production parity test. The commit path is untouched — the two underlying proposals remain the adjudicable units.

### Live event chains (branch signals — spec idea 7, migration 066)

The four dead gate arms existed because nothing could legally emit them. Branches gain an optional **`signal_event_type`** — a second, *additive* world-event emission: the deed keeps its own `event_type` and every cooldown that consumes it; the signal is what the act gives off.

- `extract_vengeance`'s visible branches signal `threat_issued` → the target's `warn_ally`/`protect_kin`/`consult_rival`/`surveil` gates open next ticks.
- `surveil`'s detectable branches signal `compliance_alert` → the hunted feel the net (`evade_pursuers`/`warn_ally`).
- `cultivate_informant`'s distanced overture signals `encoded_message` → `honor_debt` hears it.
- `faction_realignment` stays dormant (no natural emitter) and is now the **only** exogenous-only arm — the catalog lint, dead-arm assertions, and coverage payload updated accordingly.

Migration 066 seeds `compliance_alert` + `encoded_message` into `event_types` (gate-consumed but never registered; `world_events` FKs the vocabulary). Applied to template + all slots.

## Tests

Pure: composition semantics (reciprocal/crossed, one-sided pairs yield nothing, deterministic ordering, serialization round trips including pre-beat payloads), resolution/draft signal passthrough, builtin wiring pinned with deed ≠ signal everywhere. Live (rollback transactions on save_02): a signalling draft commits **both** world-event rows (deed + signal with a `signal_of` payload marker), and the consumer-gate semantics are proven — the target hears `threat_issued` as next tick's actor while the avenger does not. Endpoint joint-beat parity on both audit slots. 717 live / 985 offline pass (only the known pre-existing `test_pair_tag_writer` failure).

Together with #427 (stochastic branches): variation within a character's day, pairs acting on each other, and one character's choice changing another's next choice. Closing follow-up: the before/after variety audit via the coverage analyzer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY