### PR TITLE
Orrery Audit Dashboard UI: /dev/orrery (design-package port)

### DIFF
--- a/nexus/api/orrery_dev_endpoints.py
+++ b/nexus/api/orrery_dev_endpoints.py
@@ -410,3 +410,71 @@ async def get_adjudication_history(
 
     with _slot_session(slot) as session:
         return adjudication_history(session, template_id=template_id)
+
+
+@router.get("/vocab")
+async def get_vocab(slot: Optional[int] = None) -> dict[str, Any]:
+    """Slot-scoped vocabularies for the what-if drawer's pickers.
+
+    Read-only: active tag and pair-tag vocab (with layer), event types, and
+    places. Entity choices come from the resolve payload's entity names.
+    """
+
+    with _slot_session(slot) as session:
+        tags = [
+            dict(row)
+            for row in session.execute(
+                text(
+                    """
+                    SELECT tag, category, is_ephemeral
+                    FROM tags
+                    WHERE NOT deprecated AND synonym_for IS NULL
+                    ORDER BY category, tag
+                    """
+                )
+            ).mappings()
+        ]
+        pair_tags = [
+            dict(row)
+            for row in session.execute(
+                text(
+                    """
+                    SELECT tag, subject_kinds, object_kinds
+                    FROM pair_tags
+                    WHERE NOT deprecated
+                    ORDER BY tag
+                    """
+                )
+            ).mappings()
+        ]
+        event_types = [
+            dict(row)
+            for row in session.execute(
+                text(
+                    """
+                    SELECT type, category
+                    FROM event_types
+                    WHERE NOT deprecated
+                    ORDER BY type
+                    """
+                )
+            ).mappings()
+        ]
+        places = [
+            dict(row)
+            for row in session.execute(
+                text(
+                    """
+                    SELECT id, name
+                    FROM places
+                    ORDER BY name
+                    """
+                )
+            ).mappings()
+        ]
+    return {
+        "tags": tags,
+        "pair_tags": pair_tags,
+        "event_types": event_types,
+        "places": places,
+    }

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -635,6 +635,7 @@ def test_dashboard_flag_gates_router_registration(tmp_path: Path) -> None:
         "/api/dev/orrery/context/entities",
         "/api/dev/orrery/coverage",
         "/api/dev/orrery/history/adjudications",
+        "/api/dev/orrery/vocab",
     }
 
 
@@ -843,3 +844,21 @@ def test_joint_beats_parity_with_production(
     assert endpoint_beats == production_beats
     for beat in payload["joint_beats"]:
         assert beat["kind"] in {"reciprocal", "crossed"}
+
+
+@pytest.mark.requires_postgres
+def test_vocab_endpoint_serves_picker_vocabularies(client: TestClient) -> None:
+    """The what-if drawer's pickers read slot-scoped vocab from one call."""
+
+    response = client.get("/api/dev/orrery/vocab?slot=2")
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload) == {"tags", "pair_tags", "event_types", "places"}
+    assert payload["tags"], "tag vocabulary must be non-empty"
+    tag_row = payload["tags"][0]
+    assert set(tag_row) == {"tag", "category", "is_ephemeral"}
+    assert {"hunting"} <= {row["tag"] for row in payload["pair_tags"]}
+    assert {"threat_issued", "compliance_alert"} <= {
+        row["type"] for row in payload["event_types"]
+    }
+    assert all(row["name"] for row in payload["places"])

--- a/ui/.design-sync/import/orrery/EntityAudit.dc.html
+++ b/ui/.design-sync/import/orrery/EntityAudit.dc.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/fonts/fonts.css">
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/_ds_bundle.css">
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/styles.css">
+  <script src="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/_ds_bundle.js"></script>
+</helmet>
+<div style="display:flex;flex-direction:column;gap:9px;width:290px;font-family:var(--font-sans)">
+  <div style="display:flex;gap:10px;align-items:center">
+    <x-import component-from-global-scope="image-slot" from="./image-slot.js" id="{{ ent.portraitId }}" shape="circle" placeholder="+" style="width:46px;height:46px;flex:none;font-size:8px" hint-size="46px,46px"></x-import>
+    <div style="display:flex;flex-direction:column;gap:1px;min-width:0">
+      <span style="font-size:14.5px;font-weight:650;color:hsl(var(--foreground))">{{ ent.name }}</span>
+      <span style="font-size:11px;color:hsl(var(--muted-foreground))">{{ ent.place }}</span>
+      <span class="font-mono" style="font-size:8.5px;letter-spacing:0.1em;color:hsl(var(--muted-foreground) / 0.8)">{{ ent.classes }}</span>
+      <span class="font-mono" style="font-size:8.5px;letter-spacing:0.06em;color:hsl(var(--chart-5) / 0.9)">{{ ent.fameRes }}</span>
+    </div>
+  </div>
+  <div style="display:flex;flex-direction:column;gap:3px">
+    <sc-for list="{{ ent.needs }}" as="nr" hint-placeholder-count="5">
+      <div style="display:flex;align-items:center;gap:7px">
+        <span class="font-mono" style="font-size:8.5px;letter-spacing:0.08em;width:56px;flex:none;color:hsl(var(--muted-foreground))">{{ nr.nd }}</span>
+        <div style="flex:1;height:3px;border-radius:2px;background:hsl(var(--muted) / 0.3);overflow:hidden"><div style="width:{{ nr.pct }};height:100%;background:{{ nr.color }}"></div></div>
+        <span class="font-mono" style="font-size:9px;width:52px;text-align:right;color:{{ nr.color }}">{{ nr.val }}</span>
+        <span class="font-mono" style="font-size:7.5px;width:52px;color:hsl(var(--muted-foreground) / 0.7)">{{ nr.note }}</span>
+      </div>
+    </sc-for>
+  </div>
+  <div style="display:flex;flex-direction:column;gap:4px">
+    <span class="font-mono" style="font-size:8px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Durable</span>
+    <div style="display:flex;flex-wrap:wrap;gap:4px">
+      <sc-for list="{{ ent.durable }}" as="tg" hint-placeholder-count="3">
+        <span onMouseEnter="{{ tg.onEnter }}" onMouseLeave="{{ tg.onLeave }}" title="{{ tg.famTitle }} · {{ tg.dotTitle }}" class="font-mono" style="display:inline-flex;align-items:center;gap:4px;font-size:9px;letter-spacing:0.04em;border:1px solid hsl(var(--border));border-radius:99px;padding:1px 7px;color:hsl(var(--foreground) / 0.85);cursor:default" style-hover="border-color:hsl(var(--accent))">
+          <span style="color:hsl(var(--chart-5));font-size:8px">{{ tg.fam }}</span>{{ tg.name }}<span style="color:hsl(var(--muted-foreground));font-size:8px">{{ tg.dot }}</span>
+        </span>
+      </sc-for>
+    </div>
+    <sc-if value="{{ ent.hasEphemeral }}" hint-placeholder-val="{{ true }}">
+      <span class="font-mono" style="font-size:8px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground));margin-top:2px">Ephemeral</span>
+      <div style="display:flex;flex-wrap:wrap;gap:4px">
+        <sc-for list="{{ ent.ephemeral }}" as="tg" hint-placeholder-count="3">
+          <span onMouseEnter="{{ tg.onEnter }}" onMouseLeave="{{ tg.onLeave }}" title="{{ tg.famTitle }} · {{ tg.dotTitle }}" class="font-mono" style="display:inline-flex;align-items:center;gap:4px;font-size:9px;letter-spacing:0.04em;border:1px dashed hsl(var(--chart-2) / 0.6);border-radius:99px;padding:1px 7px;color:hsl(var(--chart-2));cursor:default" style-hover="border-color:hsl(var(--accent))">
+            <span style="color:hsl(var(--chart-5));font-size:8px">{{ tg.fam }}</span>{{ tg.name }}<span style="opacity:0.7;font-size:8px">{{ tg.dot }}</span>
+          </span>
+        </sc-for>
+      </div>
+    </sc-if>
+  </div>
+  <sc-if value="{{ ent.hasRels }}" hint-placeholder-val="{{ true }}">
+    <div style="display:flex;flex-direction:column;gap:3px">
+      <div style="display:flex;align-items:baseline;gap:6px">
+        <span class="font-mono" style="font-size:8px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Relationships</span>
+        <span class="font-mono" style="font-size:7.5px;letter-spacing:0.1em;color:hsl(var(--muted-foreground) / 0.55);font-style:italic">unversioned</span>
+      </div>
+      <sc-for list="{{ ent.rels }}" as="rl" hint-placeholder-count="2">
+        <div style="display:flex;align-items:baseline;gap:7px;font-size:11px">
+          <span class="font-mono" style="font-size:8.5px;color:hsl(var(--chart-4));flex:none;min-width:70px">{{ rl.types }}</span>
+          <span style="flex:1">{{ rl.other }}</span>
+          <span class="font-mono" style="font-size:9.5px;color:hsl(var(--muted-foreground))">trust {{ rl.trust }}</span>
+        </div>
+      </sc-for>
+    </div>
+  </sc-if>
+  <sc-if value="{{ ent.hasEvents }}" hint-placeholder-val="{{ true }}">
+    <div style="display:flex;flex-direction:column;gap:3px;border-top:1px solid hsl(var(--border));padding-top:6px">
+      <span class="font-mono" style="font-size:8px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Recent events</span>
+      <sc-for list="{{ ent.events }}" as="ev" hint-placeholder-count="3">
+        <div style="display:flex;gap:9px;align-items:baseline">
+          <span class="font-mono" style="font-size:9px;color:hsl(var(--muted-foreground))">{{ ev.t }}</span>
+          <span class="font-mono" style="font-size:9.5px;letter-spacing:0.04em;color:hsl(var(--foreground) / 0.85)">{{ ev.type }}</span>
+        </div>
+      </sc-for>
+    </div>
+  </sc-if>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;: {&quot;width&quot;: 320, &quot;height&quot;: 380}, &quot;ent&quot;: {&quot;editor&quot;: null, &quot;tsType&quot;: &quot;EntityAuditVM&quot;}}"></script>
+</body>
+</html>

--- a/ui/.design-sync/import/orrery/GateBrackets.dc.html
+++ b/ui/.design-sync/import/orrery/GateBrackets.dc.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/fonts/fonts.css">
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/_ds_bundle.css">
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/styles.css">
+  <script src="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/_ds_bundle.js"></script>
+</helmet>
+<div style="display:flex;flex-direction:column">
+  <sc-for list="{{ rows }}" as="r" hint-placeholder-count="10">
+    <div style="display:flex;align-items:stretch;min-height:{{ r.minH }}px">
+      <sc-for list="{{ r.rails }}" as="rl" hint-placeholder-count="2">
+        <span style="width:16px;flex:none;position:relative;display:flex;justify-content:center">
+          <span style="width:2px;background:{{ rl.color }};position:absolute;top:{{ rl.top }};bottom:{{ rl.bottom }}"></span>
+          <sc-if value="{{ rl.barred }}" hint-placeholder-val="{{ false }}">
+            <span style="position:absolute;top:45%;width:10px;height:2px;background:{{ rl.color }};transform:rotate(-30deg)"></span>
+          </sc-if>
+        </span>
+      </sc-for>
+      <sc-if value="{{ r.isOp }}" hint-placeholder-val="{{ false }}">
+        <span class="font-mono" style="{{ r.opStyle }}">{{ r.op }}</span>
+      </sc-if>
+      <sc-if value="{{ r.isLeaf }}" hint-placeholder-val="{{ true }}">
+        <span style="display:flex;align-items:baseline;gap:7px;padding:2.5px 4px;flex:1;min-width:0">
+          <span style="width:13px;flex:none;text-align:center;font-size:10px;color:{{ r.glyphColor }}">{{ r.glyph }}</span>
+          <span style="{{ r.proseStyle }}">{{ r.prose }}</span>
+          <span class="font-mono" style="font-size:9px;color:{{ r.evColor }};flex:none">{{ r.evidence }}</span>
+        </span>
+      </sc-if>
+    </div>
+  </sc-for>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;: {&quot;width&quot;: 540, &quot;height&quot;: 320}, &quot;node&quot;: {&quot;editor&quot;: null, &quot;tsType&quot;: &quot;EvaluatedGateNode&quot;}}">
+class Component extends DCLogic {
+  renderVals() {
+    const node = this.props.node;
+    const rows = [];
+    if (!node) return { rows };
+    const railColor = (n) => (n.pass ? 'hsl(var(--chart-5) / 0.75)' : 'hsl(var(--destructive) / 0.85)');
+    const walk = (n, rails) => {
+      if (!n) return;
+      if (n.kind === 'leaf') {
+        rows.push({
+          minH: 20, rails: rails.map((r, i) => ({ ...r, top: '0', bottom: '0' })),
+          isOp: false, isLeaf: true,
+          glyph: n.pass ? '✓' : '✗',
+          glyphColor: n.pass ? 'hsl(var(--chart-5))' : 'hsl(var(--destructive))',
+          prose: n.prose,
+          proseStyle: `flex:1;font-size:11.5px;min-width:0;${n.pass ? 'color:hsl(var(--foreground) / 0.85);' : 'color:hsl(var(--foreground));font-weight:650;'}`,
+          evidence: n.evidence,
+          evColor: n.pass ? 'hsl(var(--muted-foreground))' : 'hsl(var(--destructive))',
+        });
+        return;
+      }
+      const color = railColor(n);
+      const barred = n.op === 'NOT';
+      rows.push({
+        minH: 18, rails: rails.map((r) => ({ ...r, top: '0', bottom: '0' })),
+        isOp: true, isLeaf: false,
+        op: n.op + (barred ? ' ⊘' : ''),
+        opStyle: `font-size:8.5px;letter-spacing:0.2em;padding:3px 4px 1px;color:${color};text-transform:uppercase`,
+      });
+      const childRails = [...rails, { color, barred, top: '0', bottom: '0' }];
+      for (const k of n.children || []) walk(k, childRails);
+    };
+    walk(node, []);
+    // trim rail ends: first/last row of each depth — cosmetic; keep simple full bars
+    return { rows };
+  }
+}
+</script>
+</body>
+</html>

--- a/ui/.design-sync/import/orrery/Orrery Audit Dashboard.dc.html
+++ b/ui/.design-sync/import/orrery/Orrery Audit Dashboard.dc.html
@@ -1,0 +1,1238 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/fonts/fonts.css">
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/_ds_bundle.css">
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/styles.css">
+  <script src="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/_ds_bundle.js"></script>
+  <style>
+    html, body { margin: 0; padding: 0; height: 100%; background: hsl(220 40% 6%); overflow: hidden; overscroll-behavior: none; }
+    body { overflow-x: auto; }
+    ::selection { background: hsl(320 55% 48% / 0.35); }
+    @keyframes orr-pulse { 0%, 100% { opacity: 0.35; } 50% { opacity: 1; } }
+    [data-radix-popper-content-wrapper], [data-radix-portal] { zoom: var(--orr-z, 1); }
+  </style>
+</helmet>
+<x-import component-from-global-scope="NexusIris.DesignThemeRoot" hint-size="100%,100%">
+<div style="margin:calc(-1.5rem * var(--orr-zi, 1));height:calc(100vh * var(--orr-zi, 1));zoom:var(--orr-z, 1);min-width:1080px;display:flex;flex-direction:column;overflow:hidden;position:relative" class="bg-background text-foreground font-sans">
+
+  <!-- ═══════════════ TICK BAR ═══════════════ -->
+  <div data-screen-label="Tick bar" style="height:46px;flex:none;display:flex;align-items:center;gap:14px;padding:0 14px;border-bottom:1px solid hsl(var(--border))" class="bg-sidebar">
+    <div style="display:flex;align-items:baseline;gap:8px;flex:none">
+      <span class="font-display" style="font-size:17px;letter-spacing:0.06em;color:hsl(var(--primary))">ORRERY</span>
+      <span class="font-mono" style="font-size:9px;letter-spacing:0.22em;color:hsl(var(--muted-foreground));text-transform:uppercase">Audit</span>
+    </div>
+    <div style="width:1px;height:20px;background:hsl(var(--border));flex:none"></div>
+    <x-import component-from-global-scope="NexusIris.Select" value="{{ slot }}" on-value-change="{{ onSlot }}" hint-size="120px,28px">
+      <x-import component-from-global-scope="NexusIris.SelectTrigger" style="{{ slotTriggerStyle }}" dc-props="{{ slotTriggerProps }}" hint-size="120px,28px">
+        <x-import component-from-global-scope="NexusIris.SelectValue" hint-size="60px,16px"></x-import>
+      </x-import>
+      <x-import component-from-global-scope="NexusIris.SelectContent" hint-size="120px,100px">
+        <x-import component-from-global-scope="NexusIris.SelectItem" value="save_01" hint-size="110px,28px">save_01</x-import>
+        <x-import component-from-global-scope="NexusIris.SelectItem" value="save_02" hint-size="110px,28px">save_02</x-import>
+        <x-import component-from-global-scope="NexusIris.SelectItem" value="save_05" hint-size="110px,28px">save_05</x-import>
+      </x-import>
+    </x-import>
+    <div style="display:flex;align-items:center;gap:6px;flex:none">
+      <button onClick="{{ onStepBack }}" title="Previous chunk" style="width:24px;height:24px;border:1px solid hsl(var(--border));border-radius:4px;background:transparent;color:hsl(var(--muted-foreground));cursor:pointer;font-size:12px;line-height:1" style-hover="border-color:hsl(var(--primary));color:hsl(var(--foreground))">−</button>
+      <span class="font-mono" style="font-size:12px;letter-spacing:0.08em;min-width:88px;text-align:center">chunk {{ chunkStr }}</span>
+      <button onClick="{{ onStepFwd }}" title="Next chunk" style="width:24px;height:24px;border:1px solid hsl(var(--border));border-radius:4px;background:transparent;color:hsl(var(--muted-foreground));cursor:pointer;font-size:12px;line-height:1" style-hover="border-color:hsl(var(--primary));color:hsl(var(--foreground))">+</button>
+    </div>
+    <span class="font-mono" style="font-size:10.5px;letter-spacing:0.08em;color:hsl(var(--muted-foreground));flex:none">{{ worldTimeStr }}</span>
+    <div style="flex:1"></div>
+    <sc-if value="{{ resolving }}" hint-placeholder-val="{{ false }}">
+      <span class="font-mono" style="font-size:9.5px;letter-spacing:0.18em;color:hsl(var(--accent));animation:orr-pulse 0.9s infinite;text-transform:uppercase">resolving</span>
+    </sc-if>
+    <div style="display:flex;align-items:center;gap:2px;border:1px solid hsl(var(--border));border-radius:6px;padding:2px;flex:none" data-screen-label="Mode chips">
+      <button onClick="{{ onModeCurrent }}" class="font-mono" style="{{ modeChipCurrentStyle }}">Current</button>
+      <button onClick="{{ onModeWhatif }}" class="font-mono" style="{{ modeChipWhatifStyle }}">What-if</button>
+      <x-import component-from-global-scope="NexusIris.Popover" open="{{ asofOpen }}" on-open-change="{{ onAsofOpenChange }}" hint-size="70px,26px">
+        <x-import component-from-global-scope="NexusIris.PopoverTrigger" on-click="{{ onModeAsof }}" class="font-mono" style="{{ modeChipAsofStyle }}" hint-size="60px,24px">As-of</x-import>
+        <x-import component-from-global-scope="NexusIris.PopoverContent" align="end" hint-size="290px,220px">
+          <div style="display:flex;flex-direction:column;gap:7px;min-width:250px">
+            <div class="font-mono" style="font-size:9.5px;letter-spacing:0.18em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Per-axis honesty at chunk {{ chunkStr }}</div>
+            <sc-for list="{{ asofAxes }}" as="ax" hint-placeholder-count="7">
+              <div style="display:flex;align-items:baseline;gap:8px;font-size:12px">
+                <span style="width:14px;flex:none;text-align:center;color:{{ ax.color }}">{{ ax.glyph }}</span>
+                <span style="flex:1">{{ ax.axis }}</span>
+                <span class="font-mono" style="font-size:9.5px;color:hsl(var(--muted-foreground))">{{ ax.label }}</span>
+              </div>
+            </sc-for>
+            <div style="font-size:11px;color:hsl(var(--muted-foreground));border-top:1px solid hsl(var(--border));padding-top:6px;font-style:italic">Never a binary honest/chimera switch — provenance is per-row.</div>
+          </div>
+        </x-import>
+      </x-import>
+    </div>
+    <button onClick="{{ onReresolve }}" title="Re-resolve tick" style="width:28px;height:28px;border:1px solid hsl(var(--border));border-radius:6px;background:transparent;color:hsl(var(--primary));cursor:pointer;font-size:15px;flex:none" style-hover="border-color:hsl(var(--primary));background:hsl(var(--primary) / 0.12)">⟳</button>
+  </div>
+
+  <!-- override chips (pinned under tick bar) -->
+  <sc-if value="{{ hasOverrides }}" hint-placeholder-val="{{ false }}">
+    <div style="flex:none;display:flex;align-items:center;gap:8px;padding:6px 14px;border-bottom:1px dashed hsl(var(--accent) / 0.5);background:hsl(var(--accent) / 0.07)">
+      <span class="font-mono" style="font-size:9px;letter-spacing:0.2em;color:hsl(var(--accent));text-transform:uppercase;flex:none">Sandbox overrides</span>
+      <div style="display:flex;flex-wrap:wrap;gap:6px">
+        <sc-for list="{{ overrideChips }}" as="oc" hint-placeholder-count="1">
+          <span style="display:inline-flex;align-items:center;gap:6px;border:1px solid hsl(var(--accent) / 0.6);border-radius:99px;padding:2px 4px 2px 10px;font-size:11px;color:hsl(var(--accent-foreground));background:hsl(var(--accent) / 0.85)">
+            {{ oc.label }}
+            <button onClick="{{ oc.onRemove }}" style="border:none;background:hsl(var(--background) / 0.25);color:inherit;border-radius:99px;width:16px;height:16px;font-size:10px;cursor:pointer;line-height:1">✕</button>
+          </span>
+        </sc-for>
+      </div>
+    </div>
+  </sc-if>
+
+  <!-- ═══════════════ THREE REGIONS ═══════════════ -->
+  <div style="flex:1;min-height:0">
+    <div data-orr-flexwrap="1" style="height:100%;display:flex">
+
+      <!-- ─────────── LEFT RAIL ─────────── -->
+      <div style="width:17%;min-width:200px;height:100%">
+        <div data-screen-label="Band rail" class="bg-sidebar" style="height:100%;display:flex;flex-direction:column;border-right:1px solid hsl(var(--sidebar-border));overflow-y:auto">
+          <div class="font-mono" style="font-size:9px;letter-spacing:0.22em;text-transform:uppercase;color:hsl(var(--muted-foreground));padding:12px 14px 6px">Drive bands</div>
+          <sc-for list="{{ railBands }}" as="rb" hint-placeholder-count="5">
+            <div style="display:flex;align-items:center;gap:9px;padding:7px 14px">
+              <span style="width:8px;height:8px;border-radius:99px;background:{{ rb.color }};flex:none;box-shadow:0 0 6px {{ rb.glow }}"></span>
+              <span class="font-mono" style="font-size:10.5px;letter-spacing:0.1em;flex:1;color:hsl(var(--sidebar-foreground))">{{ rb.name }}</span>
+              <span class="font-mono" style="font-size:10px;min-width:20px;text-align:center;border:1px solid {{ rb.badgeBorder }};color:{{ rb.badgeText }};border-radius:99px;padding:1px 6px">{{ rb.count }}</span>
+            </div>
+          </sc-for>
+          <div style="margin:10px 14px;border-top:1px solid hsl(var(--sidebar-border))"></div>
+          <div class="font-mono" style="font-size:9px;letter-spacing:0.22em;text-transform:uppercase;color:hsl(var(--muted-foreground));padding:0 14px 8px">Lenses</div>
+          <div style="display:flex;flex-direction:column;gap:9px;padding:0 14px 12px">
+            <div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+              <span class="font-mono" style="font-size:10px;letter-spacing:0.08em">Two-party lane</span>
+              <x-import component-from-global-scope="NexusIris.Switch" checked="{{ fTwoParty }}" on-checked-change="{{ onFTwoParty }}" hint-size="36px,20px"></x-import>
+            </div>
+            <div style="display:flex;flex-direction:column;gap:4px">
+              <span class="font-mono" style="font-size:10px;letter-spacing:0.08em">Tag family</span>
+              <x-import component-from-global-scope="NexusIris.Popover" open="{{ famOpen }}" on-open-change="{{ onFamOpenChange }}" hint-size="100%,30px">
+                <x-import component-from-global-scope="NexusIris.PopoverTrigger" class="font-mono" style="width:100%;height:28px" dc-props="{{ famTriggerProps }}" hint-size="100%,28px">{{ famLabel }}</x-import>
+                <x-import component-from-global-scope="NexusIris.PopoverContent" align="start" hint-size="260px,240px">
+                  <x-import component-from-global-scope="NexusIris.Command" hint-size="240px,220px" style="background:transparent">
+                    <x-import component-from-global-scope="NexusIris.CommandInput" placeholder="Filter families…" hint-size="100%,32px"></x-import>
+                    <x-import component-from-global-scope="NexusIris.CommandList" hint-size="100%,180px">
+                      <x-import component-from-global-scope="NexusIris.CommandEmpty" hint-size="100%,30px">No family found.</x-import>
+                      <sc-for list="{{ familyItems }}" as="fi" hint-placeholder-count="5">
+                        <x-import component-from-global-scope="NexusIris.CommandItem" value="{{ fi.id }}" on-select="{{ fi.onPick }}" hint-size="100%,30px">
+                          <span class="font-mono" style="font-size:10px;letter-spacing:0.06em">{{ fi.name }}</span>
+                          <span style="font-size:10px;color:hsl(var(--muted-foreground));margin-left:auto">{{ fi.n }}</span>
+                        </x-import>
+                      </sc-for>
+                    </x-import>
+                  </x-import>
+                </x-import>
+              </x-import>
+            </div>
+            <div style="display:flex;flex-direction:column;gap:4px">
+              <span class="font-mono" style="font-size:10px;letter-spacing:0.08em">Event family</span>
+              <x-import component-from-global-scope="NexusIris.Select" value="{{ fEvent }}" on-value-change="{{ onFEvent }}" hint-size="100%,30px">
+                <x-import component-from-global-scope="NexusIris.SelectTrigger" style="height:28px;width:100%" dc-props="{{ smallTriggerProps }}" hint-size="100%,28px">
+                  <x-import component-from-global-scope="NexusIris.SelectValue" hint-size="60px,14px"></x-import>
+                </x-import>
+                <x-import component-from-global-scope="NexusIris.SelectContent" hint-size="200px,160px">
+                  <x-import component-from-global-scope="NexusIris.SelectItem" value="none" hint-size="100%,28px">— none —</x-import>
+                  <x-import component-from-global-scope="NexusIris.SelectItem" value="threat_issued" hint-size="100%,28px">threat_issued</x-import>
+                  <x-import component-from-global-scope="NexusIris.SelectItem" value="compliance_alert" hint-size="100%,28px">compliance_alert</x-import>
+                  <x-import component-from-global-scope="NexusIris.SelectItem" value="faction_realignment" hint-size="100%,28px">faction_realignment</x-import>
+                  <x-import component-from-global-scope="NexusIris.SelectItem" value="encoded_message" hint-size="100%,28px">encoded_message</x-import>
+                </x-import>
+              </x-import>
+            </div>
+            <div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+              <span class="font-mono" style="font-size:10px;letter-spacing:0.08em">Show gate-failed</span>
+              <x-import component-from-global-scope="NexusIris.Switch" checked="{{ fFailed }}" on-checked-change="{{ onFFailed }}" hint-size="36px,20px"></x-import>
+            </div>
+            <div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+              <span class="font-mono" style="font-size:10px;letter-spacing:0.08em">Show not-applicable</span>
+              <x-import component-from-global-scope="NexusIris.Switch" checked="{{ fNA }}" on-checked-change="{{ onFNA }}" hint-size="36px,20px"></x-import>
+            </div>
+          </div>
+          <div style="flex:1"></div>
+          <div class="font-mono" style="padding:10px 14px;font-size:9px;letter-spacing:0.14em;color:hsl(var(--muted-foreground));border-top:1px solid hsl(var(--sidebar-border))">{{ footerLine }}</div>
+        </div>
+      </div>
+
+      <!-- ─────────── CENTER: STREAM / GRAPH ─────────── -->
+      <div style="flex:1;min-width:0;height:100%">
+        <div style="height:100%;display:flex;flex-direction:column;min-width:0">
+          <div style="flex:none;display:flex;align-items:center;gap:4px;padding:8px 14px 0">
+            <button onClick="{{ onTabStream }}" class="font-mono" style="{{ tabStreamStyle }}">Actor stream</button>
+            <button onClick="{{ onTabGraph }}" class="font-mono" style="{{ tabGraphStyle }}">Interaction graph</button>
+            <div style="flex:1"></div>
+            <span class="font-mono" style="font-size:9.5px;letter-spacing:0.1em;color:hsl(var(--muted-foreground))">{{ streamSummary }}</span>
+          </div>
+
+          <sc-if value="{{ showEmptySlot }}" hint-placeholder-val="{{ false }}">
+            <div style="flex:1;display:flex;align-items:center;justify-content:center">
+              <div style="max-width:380px;text-align:center;display:flex;flex-direction:column;gap:10px;padding:24px;border:1px dashed hsl(var(--border));border-radius:8px">
+                <span class="font-mono" style="font-size:10px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground))">No Orrery data</span>
+                <span style="font-size:13px;color:hsl(var(--muted-foreground));font-style:italic">save_01 is the golden master — the retrograde pipeline never ran here. Switch to save_02 (dense backfill) or save_05 (live runtime).</span>
+              </div>
+            </div>
+          </sc-if>
+
+          <sc-if value="{{ showStream }}" hint-placeholder-val="{{ true }}">
+            <div id="orr-stream" data-screen-label="Actor stream" style="flex:1;min-height:0;overflow-y:auto;padding:10px 14px 24px;display:flex;flex-direction:column;gap:10px">
+              <sc-for list="{{ groups }}" as="g" hint-placeholder-count="6">
+                <div id="{{ g.domId }}" style="border:1px solid {{ g.borderColor }};border-radius:8px;background:hsl(var(--card) / 0.45)">
+                  <!-- group header -->
+                  <div onClick="{{ g.onToggle }}" style="display:flex;align-items:center;gap:10px;padding:8px 12px;cursor:pointer" style-hover="background:hsl(var(--muted) / 0.25)">
+                    <span style="font-size:9px;color:hsl(var(--muted-foreground));width:10px;flex:none">{{ g.chev }}</span>
+                    <span class="font-mono" style="width:30px;height:30px;border-radius:99px;border:1.5px solid {{ g.ringColor }};display:flex;align-items:center;justify-content:center;font-size:10px;color:hsl(var(--foreground) / 0.85);flex:none;background:hsl(var(--card))">{{ g.initials }}</span>
+                    <span data-orr-hover-anchor="header" style="font-size:14px;font-weight:600;color:hsl(var(--foreground));text-decoration:underline dotted hsl(var(--primary) / 0.5);text-underline-offset:3px;cursor:default" onMouseEnter="{{ g.onHoverIn }}" onMouseLeave="{{ onHoverOut }}">{{ g.name }}</span>
+                    <span class="font-mono" style="font-size:9.5px;letter-spacing:0.08em;color:hsl(var(--muted-foreground));border:1px solid hsl(var(--border));border-radius:99px;padding:1px 8px;flex:none">{{ g.placeName }}</span>
+                    <sc-if value="{{ g.diff }}" hint-placeholder-val="{{ false }}">
+                      <span title="Outcome changed vs pre-override tick" style="width:7px;height:7px;border-radius:99px;background:hsl(var(--accent));box-shadow:0 0 7px hsl(var(--accent));flex:none"></span>
+                    </sc-if>
+                    <div style="flex:1"></div>
+                    <sc-if value="{{ g.gap }}" hint-placeholder-val="{{ false }}">
+                      <span class="font-mono" style="font-size:9px;letter-spacing:0.14em;text-transform:uppercase;color:hsl(var(--destructive));border:1px solid hsl(var(--destructive) / 0.6);border-radius:99px;padding:2px 8px">coverage gap</span>
+                    </sc-if>
+                    <div style="display:flex;gap:4px;flex:none">
+                      <sc-for list="{{ g.bandDots }}" as="bd" hint-placeholder-count="2">
+                        <span title="{{ bd.title }}" style="width:7px;height:7px;border-radius:2px;background:{{ bd.color }}"></span>
+                      </sc-for>
+                    </div>
+                    <span class="font-mono" style="font-size:9.5px;color:hsl(var(--muted-foreground));flex:none">{{ g.activityLine }}</span>
+                  </div>
+                  <!-- group body -->
+                  <sc-if value="{{ g.open }}" hint-placeholder-val="{{ true }}">
+                    <div style="padding:2px 12px 12px 32px;display:flex;flex-direction:column;gap:8px">
+                      <sc-if value="{{ g.gap }}" hint-placeholder-val="{{ false }}">
+                        <div style="border:1px dashed hsl(var(--destructive) / 0.5);border-radius:6px;padding:9px 12px;font-size:12px;font-style:italic;color:hsl(var(--muted-foreground))">No package fires for this actor this tick — every gate refuses. {{ g.gapHint }}</div>
+                      </sc-if>
+                      <sc-for list="{{ g.cards }}" as="card" hint-placeholder-count="2">
+                        <dc-import name="ResolutionCard" card="{{ card }}" hint-size="100%,110px"></dc-import>
+                      </sc-for>
+                      <sc-if value="{{ g.hasPressures }}" hint-placeholder-val="{{ false }}">
+                        <div style="display:flex;flex-wrap:wrap;gap:6px;align-items:center">
+                          <sc-for list="{{ g.pressures }}" as="pr" hint-placeholder-count="1">
+                            <button onClick="{{ pr.onSelect }}" style="{{ pr.style }}" class="font-mono" title="{{ pr.title }}">⇢ {{ pr.label }}</button>
+                          </sc-for>
+                        </div>
+                      </sc-if>
+                      <sc-if value="{{ g.hasGhosts }}" hint-placeholder-val="{{ false }}">
+                        <div style="display:flex;flex-direction:column;gap:2px;margin-top:2px">
+                          <sc-for list="{{ g.ghosts }}" as="gh" hint-placeholder-count="3">
+                            <div onClick="{{ gh.onSelect }}" style="{{ gh.style }}" style-hover="background:hsl(var(--muted) / 0.2)">
+                              <span style="width:14px;flex:none;text-align:center;font-size:9px">{{ gh.glyph }}</span>
+                              <span class="font-mono" style="font-size:9.5px;letter-spacing:0.08em;flex:none;min-width:150px">{{ gh.name }}</span>
+                              <span style="flex:1;font-size:11px;font-style:italic;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ gh.reason }}</span>
+                              <span class="font-mono" style="font-size:9.5px;flex:none">{{ gh.evidence }}</span>
+                            </div>
+                          </sc-for>
+                        </div>
+                      </sc-if>
+                    </div>
+                  </sc-if>
+                </div>
+              </sc-for>
+              <!-- on-screen scene row -->
+              <div style="border:1px dashed hsl(var(--border));border-radius:8px;padding:9px 12px;display:flex;align-items:center;gap:10px">
+                <span class="font-mono" style="font-size:9px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground));flex:none">On-screen</span>
+                <sc-for list="{{ onscreenChips }}" as="oc" hint-placeholder-count="3">
+                  <span data-orr-hover-anchor="onscreen" style="font-size:12.5px;font-weight:600;color:hsl(var(--foreground));text-decoration:underline dotted hsl(var(--primary) / 0.5);text-underline-offset:3px;cursor:default" onMouseEnter="{{ oc.onHoverIn }}" onMouseLeave="{{ onHoverOut }}">{{ oc.name }}</span>
+                </sc-for>
+                <span style="flex:1"></span>
+                <sc-for list="{{ needPressureChips }}" as="np" hint-placeholder-count="1">
+                  <span class="font-mono" title="{{ np.title }}" style="font-size:10px;letter-spacing:0.05em;border:1px dashed hsl(var(--chart-2) / 0.7);color:hsl(var(--chart-2));border-radius:99px;padding:2px 9px">⇢ {{ np.label }}</span>
+                </sc-for>
+              </div>
+            </div>
+          </sc-if>
+
+          <sc-if value="{{ showGraph }}" hint-placeholder-val="{{ false }}">
+            <div data-screen-label="Interaction graph" style="flex:1;min-height:0;overflow:auto;padding:6px 14px 20px">
+              <div style="display:flex;gap:16px;align-items:center;flex-wrap:wrap;padding:2px 4px 10px;max-width:1400px;margin:0 auto">
+                <span style="display:inline-flex;align-items:center;gap:6px;font-size:10.5px;color:hsl(var(--muted-foreground))"><span style="width:18px;height:0;border-top:2px solid hsl(var(--chart-4));display:inline-block"></span>fired package · band color</span>
+                <span style="display:inline-flex;align-items:center;gap:6px;font-size:10.5px;color:hsl(var(--muted-foreground))"><span style="width:18px;height:0;border-top:2px dashed hsl(var(--accent));display:inline-block"></span>scene pressure → on-screen</span>
+                <span style="display:inline-flex;align-items:center;gap:6px;font-size:10.5px;color:hsl(var(--muted-foreground))"><span style="width:8px;height:8px;border:1.4px solid hsl(var(--chart-4));transform:rotate(45deg);display:inline-block"></span>reciprocal joint beat</span>
+                <span class="font-mono" style="margin-left:auto;font-size:9px;letter-spacing:0.1em;color:hsl(var(--muted-foreground))">hover a node for its audit · click an edge to trace it</span>
+              </div>
+              <svg viewBox="0 0 920 540" style="width:100%;max-width:1400px;height:auto;display:block;margin:0 auto">
+                <defs>
+                  <marker id="arr1" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L8,4 L0,8 z" fill="hsl(var(--chart-1))"></path></marker>
+                  <marker id="arr4" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L8,4 L0,8 z" fill="hsl(var(--chart-4))"></path></marker>
+                  <marker id="arr5" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L8,4 L0,8 z" fill="hsl(var(--chart-5))"></path></marker>
+                  <marker id="arrA" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L8,4 L0,8 z" fill="hsl(var(--accent))"></path></marker>
+                </defs>
+                <text x="70" y="30" class="font-mono" style="font-size:10px;letter-spacing:0.2em;text-transform:uppercase" fill="hsl(var(--muted-foreground))">Off-screen actors</text>
+                <text x="700" y="30" class="font-mono" style="font-size:10px;letter-spacing:0.2em;text-transform:uppercase" fill="hsl(var(--muted-foreground))">On-screen</text>
+                <line x1="640" y1="40" x2="640" y2="440" stroke="hsl(var(--border))" stroke-dasharray="2 5"></line>
+                <sc-for list="{{ graphEdges }}" as="ge" hint-placeholder-count="8">
+                  <g style="cursor:pointer" onClick="{{ ge.onSelect }}" onMouseEnter="{{ ge.onEnter }}" onMouseLeave="{{ ge.onLeave }}">
+                    <path d="{{ ge.d }}" fill="none" stroke="transparent" stroke-width="16" pointer-events="stroke"></path>
+                    <path d="{{ ge.d }}" fill="none" stroke="{{ ge.color }}" stroke-width="{{ ge.w }}" stroke-dasharray="{{ ge.dash }}" marker-end="{{ ge.marker }}" opacity="{{ ge.op }}" pointer-events="none"></path>
+                    <sc-if value="{{ ge.joint }}" hint-placeholder-val="{{ false }}">
+                      <g>
+                        <rect x="{{ ge.jx }}" y="{{ ge.jy }}" width="9" height="9" transform="{{ ge.jrot }}" fill="hsl(var(--background))" stroke="{{ ge.color }}" stroke-width="1.4"></rect>
+                        <text x="{{ ge.lx }}" y="{{ ge.jly }}" class="font-mono" style="font-size:8px;letter-spacing:0.1em" fill="hsl(var(--muted-foreground))" text-anchor="middle">joint beat</text>
+                      </g>
+                    </sc-if>
+                  </g>
+                </sc-for>
+                <sc-for list="{{ graphNodes }}" as="gn" hint-placeholder-count="9">
+                  <g style="cursor:pointer" onClick="{{ gn.onClick }}" onMouseEnter="{{ gn.onEnter }}" onMouseLeave="{{ onHoverOut }}">
+                    <circle cx="{{ gn.x }}" cy="{{ gn.y }}" r="19" fill="hsl(var(--card))" stroke="{{ gn.stroke }}" stroke-width="{{ gn.strokeW }}" stroke-dasharray="{{ gn.dash }}"></circle>
+                  </g>
+                </sc-for>
+                <sc-if value="{{ potentialActive }}" hint-placeholder-val="{{ false }}">
+                  <g>
+                    <rect x="60" y="452" width="9" height="9" transform="rotate(45 64.5 456.5)" fill="none" stroke="hsl(var(--muted-foreground))" stroke-width="1.2"></rect>
+                    <text x="80" y="476" class="font-mono" style="font-size:8px;letter-spacing:0.08em" fill="hsl(var(--muted-foreground))">consumed by gates · emitted by no branch — potential, never realized</text>
+                    <sc-for list="{{ potentialConsumers }}" as="pc" hint-placeholder-count="3">
+                      <g>
+                        <path d="{{ pc.d }}" fill="none" stroke="hsl(var(--muted-foreground))" stroke-width="1" stroke-dasharray="1.5 4" opacity="0.65"></path>
+                      </g>
+                    </sc-for>
+                  </g>
+                </sc-if>
+                {{ graphLabelsEl }}
+              </svg>
+            </div>
+          </sc-if>
+
+          <!-- ─────────── HEALTH STRIP (bottom drawer) ─────────── -->
+          <div data-screen-label="Health strip" style="flex:none;border-top:1px solid hsl(var(--border))" class="bg-sidebar">
+            <div onClick="{{ onToggleHealth }}" style="display:flex;align-items:center;gap:10px;padding:7px 14px;cursor:pointer" style-hover="background:hsl(var(--muted) / 0.2)">
+              <span style="font-size:9px;color:hsl(var(--muted-foreground))">{{ healthChev }}</span>
+              <span class="font-mono" style="font-size:9.5px;letter-spacing:0.22em;text-transform:uppercase;color:hsl(var(--muted-foreground))">System health</span>
+              <span class="font-mono" style="font-size:9.5px;border:1px solid hsl(var(--destructive) / 0.55);color:hsl(var(--destructive));border-radius:99px;padding:0 7px">{{ healthWarnCount }}</span>
+              <div style="flex:1"></div>
+              <span class="font-mono" style="font-size:9px;letter-spacing:0.1em;color:hsl(var(--muted-foreground))">window {{ windowLabel }}</span>
+            </div>
+            <sc-if value="{{ healthOpen }}" hint-placeholder-val="{{ false }}">
+              <div style="display:grid;grid-template-columns:repeat(auto-fit, minmax(240px, 1fr));gap:10px;padding:0 14px 12px">
+                <div style="border:1px solid hsl(var(--border));border-radius:6px;padding:10px 12px;display:flex;flex-direction:column;gap:6px">
+                  <span class="font-mono" style="font-size:8.5px;letter-spacing:0.18em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Winners by band — this tick</span>
+                  <sc-for list="{{ healthBands }}" as="hb" hint-placeholder-count="5">
+                    <div style="display:flex;align-items:center;gap:8px">
+                      <span class="font-mono" style="font-size:9px;letter-spacing:0.06em;width:86px;flex:none;color:hsl(var(--muted-foreground))">{{ hb.name }}</span>
+                      <div style="flex:1;height:6px;border-radius:3px;background:hsl(var(--muted) / 0.3);overflow:hidden"><div style="width:{{ hb.pct }};height:100%;background:{{ hb.color }}"></div></div>
+                      <span class="font-mono" style="font-size:10px;width:14px;text-align:right">{{ hb.count }}</span>
+                    </div>
+                  </sc-for>
+                </div>
+                <div style="border:1px solid hsl(var(--border));border-radius:6px;padding:10px 12px;display:flex;flex-direction:column;gap:6px">
+                  <span class="font-mono" style="font-size:8.5px;letter-spacing:0.18em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Coverage gaps — this tick</span>
+                  <sc-if value="{{ hasGaps }}" hint-placeholder-val="{{ true }}">
+                    <sc-for list="{{ healthGaps }}" as="hg" hint-placeholder-count="1">
+                      <button onClick="{{ hg.onJump }}" style="display:flex;align-items:center;gap:8px;background:transparent;border:none;cursor:pointer;padding:2px 0;color:hsl(var(--accent));font-size:12.5px;text-align:left" style-hover="text-decoration:underline">
+                        <span style="width:6px;height:6px;border-radius:99px;background:hsl(var(--destructive))"></span>{{ hg.name }}
+                        <span class="font-mono" style="font-size:9px;color:hsl(var(--muted-foreground))">{{ hg.why }}</span>
+                      </button>
+                    </sc-for>
+                  </sc-if>
+                  <sc-if value="{{ noGaps }}" hint-placeholder-val="{{ false }}">
+                    <span style="font-size:12px;font-style:italic;color:hsl(var(--muted-foreground))">Every candidate actor fired at least one package.</span>
+                  </sc-if>
+                </div>
+                <div style="border:1px solid hsl(var(--border));border-radius:6px;padding:10px 12px;display:flex;flex-direction:column;gap:5px">
+                  <span class="font-mono" style="font-size:8.5px;letter-spacing:0.18em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Never / always win — window</span>
+                  <sc-for list="{{ healthDominant }}" as="hd" hint-placeholder-count="3">
+                    <div style="display:flex;align-items:center;gap:8px">
+                      <span class="font-mono" style="font-size:9px;width:96px;flex:none;letter-spacing:0.04em">{{ hd.id }}</span>
+                      <div style="flex:1;height:6px;border-radius:3px;background:hsl(var(--muted) / 0.3);overflow:hidden"><div style="width:{{ hd.pct }};height:100%;background:hsl(var(--chart-1) / 0.8)"></div></div>
+                      <span class="font-mono" style="font-size:9.5px;width:32px;text-align:right">{{ hd.share }}</span>
+                    </div>
+                  </sc-for>
+                  <div style="font-size:10.5px;color:hsl(var(--muted-foreground));display:flex;flex-wrap:wrap;gap:4px;margin-top:2px">
+                    <span class="font-mono" style="font-size:8.5px;letter-spacing:0.14em;text-transform:uppercase">never:</span>
+                    <sc-for list="{{ healthNever }}" as="hn" hint-placeholder-count="4">
+                      <span class="font-mono" style="font-size:9px;border:1px solid hsl(var(--border));border-radius:99px;padding:0 6px">{{ hn.id }}</span>
+                    </sc-for>
+                  </div>
+                </div>
+                <div style="border:1px solid hsl(var(--border));border-radius:6px;padding:10px 12px;display:flex;flex-direction:column;gap:5px;overflow-y:auto;max-height:170px">
+                  <span class="font-mono" style="font-size:8.5px;letter-spacing:0.18em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Dead gate arms · data quality</span>
+                  <sc-for list="{{ healthDeadArms }}" as="da" hint-placeholder-count="4">
+                    <div style="display:flex;align-items:baseline;gap:6px;font-size:10.5px">
+                      <span class="font-mono" style="font-size:9px;color:hsl(var(--chart-5));flex:none">{{ da.event }}</span>
+                      <span style="color:hsl(var(--muted-foreground));overflow:hidden;text-overflow:ellipsis;white-space:nowrap">→ {{ da.consumers }} · never emitted</span>
+                    </div>
+                  </sc-for>
+                  <div style="border-top:1px solid hsl(var(--border));margin:3px 0"></div>
+                  <sc-for list="{{ healthDq }}" as="dq" hint-placeholder-count="4">
+                    <div style="display:flex;align-items:baseline;gap:7px;font-size:10.5px">
+                      <span style="width:6px;height:6px;border-radius:99px;background:{{ dq.color }};flex:none;position:relative;top:-1px"></span>
+                      <span style="color:hsl(var(--muted-foreground))">{{ dq.text }}</span>
+                    </div>
+                  </sc-for>
+                </div>
+              </div>
+            </sc-if>
+          </div>
+        </div>
+      </div>
+
+      <!-- ─────────── RIGHT: INSPECTOR ─────────── -->
+      <div style="width:30%;min-width:300px;height:100%">
+        <div data-screen-label="Inspector" style="height:100%;overflow-y:auto;border-left:1px solid hsl(var(--border));background:hsl(var(--card) / 0.3)">
+          <sc-if value="{{ noSelection }}" hint-placeholder-val="{{ true }}">
+            <div style="height:100%;display:flex;align-items:center;justify-content:center;padding:30px">
+              <div style="text-align:center;display:flex;flex-direction:column;gap:8px;max-width:240px">
+                <span style="font-size:22px;color:hsl(var(--muted-foreground) / 0.5)">◈</span>
+                <span class="font-mono" style="font-size:9.5px;letter-spacing:0.22em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Inspector</span>
+                <span style="font-size:12px;font-style:italic;color:hsl(var(--muted-foreground))">Select any card, ghost row, or pressure chip to open its full gate trace and branch ladder.</span>
+              </div>
+            </div>
+          </sc-if>
+          <sc-if value="{{ hasSelection }}" hint-placeholder-val="{{ false }}">
+            <div style="display:flex;flex-direction:column">
+              <div style="padding:14px 16px 12px;border-bottom:1px solid hsl(var(--border));border-left:3px solid {{ insp.bandColor }}">
+                <div style="display:flex;align-items:center;gap:8px">
+                  <span class="font-mono" style="font-size:13px;letter-spacing:0.12em">{{ insp.name }}</span>
+                  <span class="font-mono" style="font-size:9.5px;color:hsl(var(--muted-foreground))">pri {{ insp.priority }}</span>
+                  <sc-if value="{{ insp.tie }}" hint-placeholder-val="{{ false }}">
+                    <span title="{{ insp.tieTitle }}" class="font-mono" style="font-size:9px;letter-spacing:0.08em;border:1px solid hsl(var(--chart-5) / 0.7);color:hsl(var(--chart-5));border-radius:99px;padding:1px 7px;cursor:help">tie · tuple order</span>
+                  </sc-if>
+                  <div style="flex:1"></div>
+                  <span class="font-mono" style="{{ insp.statusStyle }}">{{ insp.statusLabel }}</span>
+                </div>
+                <div style="margin-top:6px;font-size:12px;color:hsl(var(--muted-foreground))">{{ insp.bindingLine }}</div>
+                <div style="margin-top:4px;font-size:12px;font-style:italic;color:hsl(var(--muted-foreground) / 0.85)">{{ insp.blurb }}</div>
+                <sc-if value="{{ insp.bandNote }}" hint-placeholder-val="{{ false }}">
+                  <div style="margin-top:5px;font-size:10.5px;color:hsl(var(--chart-5) / 0.9);font-style:italic">band rationale: {{ insp.bandNote }}</div>
+                </sc-if>
+              </div>
+
+              <sc-if value="{{ insp.isNA }}" hint-placeholder-val="{{ false }}">
+                <div style="padding:16px;display:flex;flex-direction:column;gap:8px">
+                  <span class="font-mono" style="font-size:9.5px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Not applicable</span>
+                  <span style="font-size:12.5px;font-style:italic;color:hsl(var(--muted-foreground))">No TARGET is bound in this actor's stacks — this two-party template was never composed, so nothing was evaluated. Not applicable is not a refusal: no gate ran, no predicate failed.</span>
+                </div>
+              </sc-if>
+
+              <sc-if value="{{ insp.hasTrace }}" hint-placeholder-val="{{ true }}">
+                <div style="padding:12px 16px;display:flex;flex-direction:column;gap:3px">
+                  <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
+                    <span class="font-mono" style="font-size:9.5px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Gate</span>
+                    <span class="font-mono" style="{{ insp.gateBadgeStyle }}">{{ insp.gateBadge }}</span>
+                  </div>
+                  <sc-for list="{{ insp.gateRows }}" as="gr" hint-placeholder-count="8">
+                    <div style="{{ gr.style }}">
+                      <span style="width:15px;flex:none;text-align:center;font-size:{{ gr.glyphSize }};color:{{ gr.glyphColor }}">{{ gr.glyph }}</span>
+                      <span style="{{ gr.proseStyle }}">{{ gr.prose }}</span>
+                      <span class="font-mono" style="font-size:9.5px;color:{{ gr.evColor }};flex:none;text-align:right">{{ gr.evidence }}</span>
+                    </div>
+                  </sc-for>
+                </div>
+
+                <div style="padding:4px 16px 12px;display:flex;flex-direction:column;gap:4px">
+                  <span class="font-mono" style="font-size:9.5px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground));margin-bottom:2px">Branch ladder — authored order</span>
+                  <sc-for list="{{ insp.branches }}" as="br" hint-placeholder-count="4">
+                    <div style="{{ br.style }}">
+                      <div style="display:flex;align-items:baseline;gap:8px">
+                        <span class="font-mono" style="font-size:9px;color:hsl(var(--muted-foreground));flex:none">{{ br.idx }}</span>
+                        <span style="font-size:12px;{{ br.labelStyle }};flex:1">{{ br.label }}</span>
+                        <span class="font-mono" style="font-size:10px;color:{{ br.magColor }};flex:none">{{ br.mag }}</span>
+                      </div>
+                      <sc-if value="{{ br.note }}" hint-placeholder-val="{{ false }}">
+                        <div style="margin:3px 0 0 17px;font-size:10.5px;color:hsl(var(--muted-foreground));display:flex;gap:6px;align-items:baseline">
+                          <span style="flex:none">{{ br.noteGlyph }}</span><span style="font-style:italic">{{ br.note }}</span>
+                        </div>
+                      </sc-if>
+                    </div>
+                  </sc-for>
+                </div>
+
+                <sc-if value="{{ insp.fired }}" hint-placeholder-val="{{ true }}">
+                  <div style="padding:4px 16px 20px;display:flex;flex-direction:column;gap:8px;border-top:1px solid hsl(var(--border))">
+                    <div style="display:flex;align-items:center;gap:8px;margin-top:10px">
+                      <span class="font-mono" style="font-size:9.5px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Resolution</span>
+                      <sc-if value="{{ insp.event }}" hint-placeholder-val="{{ true }}">
+                        <span class="font-mono" style="font-size:9.5px;border:1px solid {{ insp.bandColor }};color:{{ insp.bandColor }};border-radius:99px;padding:1px 8px">{{ insp.event }}</span>
+                      </sc-if>
+                      <div style="flex:1"></div>
+                      <span class="font-mono" style="font-size:10px;color:hsl(var(--muted-foreground))">mag {{ insp.mag }}</span>
+                    </div>
+                    <sc-if value="{{ insp.isPressure }}" hint-placeholder-val="{{ false }}">
+                      <div style="border:1px dashed hsl(var(--accent) / 0.5);border-radius:6px;padding:8px 10px;display:flex;flex-direction:column;gap:4px">
+                        <span class="font-mono" style="font-size:8.5px;letter-spacing:0.18em;text-transform:uppercase;color:hsl(var(--accent))">Scene pressure — prompt-only, no state mutation</span>
+                        <span style="font-size:11.5px;font-style:italic;color:hsl(var(--muted-foreground))">{{ insp.pressureStub }}</span>
+                      </div>
+                    </sc-if>
+                    <div style="display:flex;flex-direction:column;gap:3px">
+                      <sc-for list="{{ insp.deltaRows }}" as="dr" hint-placeholder-count="2">
+                        <div style="display:flex;gap:10px;font-size:10.5px;align-items:baseline">
+                          <span class="font-mono" style="font-size:9px;color:hsl(var(--muted-foreground));flex:none;min-width:150px;text-align:right">{{ dr.k }}</span>
+                          <span class="font-mono" style="font-size:10px;color:hsl(var(--chart-5))">{{ dr.v }}</span>
+                        </div>
+                      </sc-for>
+                    </div>
+                    <div class="font-mono" style="font-size:8.5px;color:hsl(var(--muted-foreground) / 0.6);letter-spacing:0.04em">{{ insp.bindingHash }}</div>
+                  </div>
+                </sc-if>
+              </sc-if>
+            </div>
+          </sc-if>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- what-if dashed sandbox frame -->
+  <sc-if value="{{ sandboxFrame }}" hint-placeholder-val="{{ false }}">
+    <div style="position:absolute;inset:0;pointer-events:none;border:2px dashed hsl(var(--accent) / 0.8);z-index:50">
+      <span class="font-mono" style="position:absolute;bottom:6px;right:12px;font-size:9px;letter-spacing:0.24em;text-transform:uppercase;color:hsl(var(--accent));background:hsl(var(--background) / 0.85);padding:2px 8px">Sandbox — not canon</span>
+    </div>
+  </sc-if>
+
+  <!-- floating hover-audit -->
+  <sc-if value="{{ hoverPanelOpen }}" hint-placeholder-val="{{ false }}">
+    <div style="{{ hoverPanelStyle }}" onMouseEnter="{{ onHoverPanelEnter }}" onMouseLeave="{{ onHoverOut }}" data-screen-label="Hover audit">
+      <dc-import name="EntityAudit" ent="{{ hoverPanelEnt }}" hint-size="300px,360px"></dc-import>
+    </div>
+  </sc-if>
+
+  <!-- ═══════════════ WHAT-IF DRAWER ═══════════════ -->
+  <div data-screen-label="What-if drawer" style="{{ drawerStyle }}">
+      <div style="display:flex;flex-direction:column;gap:16px">
+        <button onClick="{{ onCloseDrawer }}" title="Close" style="position:absolute;top:10px;right:12px;width:24px;height:24px;border:1px solid hsl(var(--border));border-radius:5px;background:transparent;color:hsl(var(--muted-foreground));cursor:pointer;font-size:11px;line-height:1" style-hover="border-color:hsl(var(--accent));color:hsl(var(--accent))">✕</button>
+        <div style="display:flex;flex-direction:column;gap:2px">
+          <span class="font-mono" style="font-size:11px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--accent))">What-if sandbox</span>
+          <span style="font-size:11.5px;font-style:italic;color:hsl(var(--muted-foreground))">Overrides copy the frozen WorldState and re-resolve live. Nothing canonical is written.</span>
+        </div>
+
+        <div style="display:flex;flex-direction:column;gap:6px">
+          <span class="font-mono" style="font-size:9px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Entity</span>
+          <x-import component-from-global-scope="NexusIris.Select" value="{{ wfEntity }}" on-value-change="{{ onWfEntity }}" hint-size="100%,32px">
+            <x-import component-from-global-scope="NexusIris.SelectTrigger" hint-size="100%,32px"><x-import component-from-global-scope="NexusIris.SelectValue" hint-size="60px,16px"></x-import></x-import>
+            <x-import component-from-global-scope="NexusIris.SelectContent" hint-size="200px,220px">
+              <sc-for list="{{ wfEntityItems }}" as="we" hint-placeholder-count="6">
+                <x-import component-from-global-scope="NexusIris.SelectItem" value="{{ we.id }}" hint-size="100%,28px">{{ we.name }}</x-import>
+              </sc-for>
+            </x-import>
+          </x-import>
+        </div>
+
+        <div style="display:flex;flex-direction:column;gap:6px">
+          <span class="font-mono" style="font-size:9px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Toggle tag</span>
+          <x-import component-from-global-scope="NexusIris.Command" style="border:1px solid hsl(var(--border));border-radius:6px;background:transparent" hint-size="100%,190px">
+            <x-import component-from-global-scope="NexusIris.CommandInput" placeholder="Search tag vocabulary…" hint-size="100%,32px"></x-import>
+            <x-import component-from-global-scope="NexusIris.CommandList" style="max-height:150px" hint-size="100%,150px">
+              <x-import component-from-global-scope="NexusIris.CommandEmpty" hint-size="100%,30px">No tag found.</x-import>
+              <sc-for list="{{ wfTagItems }}" as="wt" hint-placeholder-count="6">
+                <x-import component-from-global-scope="NexusIris.CommandItem" value="{{ wt.value }}" on-select="{{ wt.onPick }}" hint-size="100%,28px">
+                  <span style="width:13px;flex:none;color:{{ wt.stateColor }};font-size:10px">{{ wt.stateGlyph }}</span>
+                  <span class="font-mono" style="font-size:10.5px;letter-spacing:0.04em">{{ wt.label }}</span>
+                  <span class="font-mono" style="font-size:8.5px;color:hsl(var(--muted-foreground));margin-left:auto">{{ wt.kind }}</span>
+                </x-import>
+              </sc-for>
+            </x-import>
+          </x-import>
+        </div>
+
+        <div style="display:flex;flex-direction:column;gap:8px">
+          <span class="font-mono" style="font-size:9px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Set need — {{ wfNeedLabel }}</span>
+          <x-import component-from-global-scope="NexusIris.Select" value="{{ wfNeed }}" on-value-change="{{ onWfNeed }}" hint-size="100%,32px">
+            <x-import component-from-global-scope="NexusIris.SelectTrigger" hint-size="100%,30px"><x-import component-from-global-scope="NexusIris.SelectValue" hint-size="60px,16px"></x-import></x-import>
+            <x-import component-from-global-scope="NexusIris.SelectContent" hint-size="180px,190px">
+              <x-import component-from-global-scope="NexusIris.SelectItem" value="sleep" hint-size="100%,28px">sleep</x-import>
+              <x-import component-from-global-scope="NexusIris.SelectItem" value="hunger" hint-size="100%,28px">hunger</x-import>
+              <x-import component-from-global-scope="NexusIris.SelectItem" value="thirst" hint-size="100%,28px">thirst</x-import>
+              <x-import component-from-global-scope="NexusIris.SelectItem" value="socialize" hint-size="100%,28px">socialize</x-import>
+              <x-import component-from-global-scope="NexusIris.SelectItem" value="intimacy" hint-size="100%,28px">intimacy</x-import>
+            </x-import>
+          </x-import>
+          <div style="display:flex;align-items:center;gap:10px">
+            <x-import component-from-global-scope="NexusIris.Slider" value="{{ wfNeedValArr }}" min="{{ zero }}" max="{{ wfNeedMax }}" step="{{ one }}" on-value-change="{{ onWfNeedVal }}" style="flex:1" hint-size="100%,20px"></x-import>
+            <span class="font-mono" style="font-size:11px;min-width:34px;text-align:right">{{ wfNeedVal }}</span>
+            <button onClick="{{ onApplyNeed }}" class="font-mono" style="{{ wfApplyStyle }}">set</button>
+          </div>
+        </div>
+
+        <div style="display:flex;flex-direction:column;gap:6px">
+          <span class="font-mono" style="font-size:9px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Move actor</span>
+          <div style="display:flex;gap:8px;align-items:center">
+            <x-import component-from-global-scope="NexusIris.Select" value="{{ wfPlace }}" on-value-change="{{ onWfPlace }}" style="flex:1" hint-size="100%,32px">
+              <x-import component-from-global-scope="NexusIris.SelectTrigger" hint-size="100%,30px"><x-import component-from-global-scope="NexusIris.SelectValue" hint-size="60px,16px"></x-import></x-import>
+              <x-import component-from-global-scope="NexusIris.SelectContent" hint-size="240px,200px">
+                <sc-for list="{{ wfPlaceItems }}" as="wp" hint-placeholder-count="5">
+                  <x-import component-from-global-scope="NexusIris.SelectItem" value="{{ wp.id }}" hint-size="100%,28px">{{ wp.name }}</x-import>
+                </sc-for>
+              </x-import>
+            </x-import>
+            <button onClick="{{ onApplyMove }}" class="font-mono" style="{{ wfApplyStyle }}">move</button>
+          </div>
+        </div>
+
+        <div style="display:flex;flex-direction:column;gap:6px">
+          <span class="font-mono" style="font-size:9px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Inject recent event → {{ wfEntityName }}</span>
+          <div style="display:flex;gap:8px;align-items:center">
+            <x-import component-from-global-scope="NexusIris.Select" value="{{ wfEvent }}" on-value-change="{{ onWfEvent }}" style="flex:1" hint-size="100%,32px">
+              <x-import component-from-global-scope="NexusIris.SelectTrigger" hint-size="100%,30px"><x-import component-from-global-scope="NexusIris.SelectValue" hint-size="60px,16px"></x-import></x-import>
+              <x-import component-from-global-scope="NexusIris.SelectContent" hint-size="220px,180px">
+                <x-import component-from-global-scope="NexusIris.SelectItem" value="threat_issued" hint-size="100%,28px">threat_issued</x-import>
+                <x-import component-from-global-scope="NexusIris.SelectItem" value="compliance_alert" hint-size="100%,28px">compliance_alert</x-import>
+                <x-import component-from-global-scope="NexusIris.SelectItem" value="encoded_message" hint-size="100%,28px">encoded_message</x-import>
+                <x-import component-from-global-scope="NexusIris.SelectItem" value="faction_realignment" hint-size="100%,28px">faction_realignment</x-import>
+              </x-import>
+            </x-import>
+            <button onClick="{{ onApplyEvent }}" class="font-mono" style="{{ wfApplyStyle }}">inject</button>
+          </div>
+        </div>
+
+        <div style="border-top:1px solid hsl(var(--border));padding-top:10px;display:flex;flex-direction:column;gap:6px">
+          <span class="font-mono" style="font-size:9px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--muted-foreground))">Try the seeded questions</span>
+          <sc-for list="{{ wfPresets }}" as="wpr" hint-placeholder-count="3">
+            <button onClick="{{ wpr.onRun }}" style="text-align:left;border:1px dashed hsl(var(--accent) / 0.45);background:transparent;border-radius:6px;padding:7px 10px;font-size:11.5px;color:hsl(var(--foreground));cursor:pointer;font-style:italic" style-hover="background:hsl(var(--accent) / 0.1)">{{ wpr.label }}</button>
+          </sc-for>
+        </div>
+      </div>
+  </div>
+</div>
+</x-import>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;: {&quot;width&quot;: 1440, &quot;height&quot;: 900}, &quot;density&quot;: {&quot;editor&quot;: &quot;enum&quot;, &quot;options&quot;: [&quot;comfortable&quot;, &quot;compact&quot;], &quot;default&quot;: &quot;comfortable&quot;, &quot;tsType&quot;: &quot;'comfortable' | 'compact'&quot;, &quot;section&quot;: &quot;Layout&quot;}, &quot;magnitudeStyle&quot;: {&quot;editor&quot;: &quot;enum&quot;, &quot;options&quot;: [&quot;dial&quot;, &quot;numeric&quot;], &quot;default&quot;: &quot;dial&quot;, &quot;tsType&quot;: &quot;'dial' | 'numeric'&quot;, &quot;section&quot;: &quot;Cards&quot;}, &quot;healthOpenByDefault&quot;: {&quot;editor&quot;: &quot;boolean&quot;, &quot;default&quot;: false, &quot;tsType&quot;: &quot;boolean&quot;, &quot;section&quot;: &quot;Layout&quot;}}">
+class Component extends DCLogic {
+  state = {
+    ready: false,
+    slot: 'save_02', anchor: 108, mode: 'current',
+    overrides: [], resolving: false,
+    selected: null, hoverTag: null, hoverEdge: null,
+    groupOpen: {}, shadowOpen: {},
+    fTwoParty: false, fFamily: null, fEvent: 'none', fFailed: false, fNA: false,
+    famOpen: false, asofOpen: false,
+    centerTab: 'stream', healthOpen: false, whatifOpen: false,
+    wfEntity: 'talon', wfNeed: 'sleep', wfNeedVal: 24, wfPlace: 'glow', wfEvent: 'encoded_message',
+  };
+
+  componentDidMount() {
+    document.body.classList.add('dark');
+    this._orrZoom = () => {
+      const vw = window.innerWidth || 1440;
+      const z = Math.min(1.5, Math.max(1, vw / 1680));
+      document.documentElement.style.setProperty('--orr-z', String(z));
+      document.documentElement.style.setProperty('--orr-zi', String(1 / z));
+    };
+    this._orrZoom();
+    window.addEventListener('resize', this._orrZoom);
+    import('./orrery-engine.js').then((eng) => {
+      this.eng = eng;
+      const errs = eng.selfTest();
+      if (errs.length) console.warn('[orrery selfTest]', errs);
+      this.setState({ ready: true, healthOpen: !!(this.props.healthOpenByDefault ?? false) });
+    }).catch((e) => { console.error('engine load failed', e); });
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this._orrZoom);
+    clearTimeout(this._ht);
+    clearTimeout(this._rt);
+  }
+
+  // ---- resolve caching ----
+  _resolve(overrides, anchor) {
+    const key = anchor + '|' + JSON.stringify(overrides);
+    this._cache = this._cache || {};
+    if (!this._cache[key]) {
+      const s = this.eng.applyOverrides(this.eng.baseWorldState(), overrides, anchor);
+      this._cache[key] = { state: s, r: this.eng.resolveTick(s) };
+    }
+    return this._cache[key];
+  }
+
+  _flash() {
+    this.setState({ resolving: true });
+    clearTimeout(this._rt);
+    this._rt = setTimeout(() => this.setState({ resolving: false }), 420);
+  }
+
+  _addOverride(ov) {
+    const overrides = [...this.state.overrides, ov];
+    this.setState({ overrides, mode: 'whatif' });
+    this._flash();
+  }
+
+  _sig(w) { return w ? w.id + '/' + (w.resolution ? w.resolution.branchLabel : '') : '∅'; }
+
+  renderVals() {
+    const st = this.state;
+    const P = this.props;
+    const density = P.density ?? 'comfortable';
+    const magStyle = P.magnitudeStyle ?? 'dial';
+    const pad = density === 'compact' ? 7 : 10;
+
+    // ---------- static chrome vals (paint before engine loads) ----------
+    const chip = (active, color) => `border:none;border-radius:4px;padding:3px 10px;font-size:9.5px;letter-spacing:0.16em;text-transform:uppercase;cursor:pointer;background:${active ? `hsl(var(--${color}) / 0.18)` : 'transparent'};color:${active ? `hsl(var(--${color}))` : 'hsl(var(--muted-foreground))'}`;
+    const tab = (active) => `border:none;border-bottom:2px solid ${active ? 'hsl(var(--primary))' : 'transparent'};background:transparent;padding:4px 12px 6px;font-size:10px;letter-spacing:0.16em;text-transform:uppercase;cursor:pointer;color:${active ? 'hsl(var(--foreground))' : 'hsl(var(--muted-foreground))'}`;
+
+    const base = {
+      hoverDelay: 150, zero: 0, one: 1,
+      sizeRail: 17, sizeRailMin: 13, sizeCenter: 53, sizeCenterMin: 36, sizeInspector: 30, sizeInspectorMin: 22,
+      slot: st.slot, onSlot: (v) => { this.setState({ slot: v, selected: null }); this._flash(); },
+      slotTriggerStyle: 'height:28px;width:118px',
+      slotTriggerProps: { style: { height: 28, width: 118, fontSize: 11 } },
+      smallTriggerProps: { style: { height: 28, width: '100%', fontSize: '10.5px', fontFamily: 'var(--font-mono)' } },
+      famTriggerProps: { style: { width: '100%', height: 28, border: '1px solid hsl(var(--input))', borderRadius: 6, background: 'transparent', color: 'hsl(var(--foreground))', fontSize: 10, letterSpacing: '0.06em', cursor: 'pointer', textAlign: 'left', padding: '0 10px' } },
+      chunkStr: String(st.anchor).padStart(4, '0'),
+      onStepBack: () => { this.setState({ anchor: Math.max(100, st.anchor - 1), selected: null }); this._flash(); },
+      onStepFwd: () => { this.setState({ anchor: Math.min(120, st.anchor + 1), selected: null }); this._flash(); },
+      resolving: st.resolving,
+      onReresolve: () => { this._cache = {}; this._flash(); this.forceUpdate(); },
+      modeChipCurrentStyle: chip(st.mode === 'current', 'primary'),
+      modeChipWhatifStyle: chip(st.mode === 'whatif', 'accent'),
+      modeChipAsofStyle: chip(st.mode === 'asof', 'chart-5'),
+      onModeCurrent: () => this.setState({ mode: 'current', whatifOpen: false }),
+      onModeWhatif: () => this.setState({ mode: 'whatif', whatifOpen: true }),
+      onModeAsof: () => this.setState({ mode: 'asof', asofOpen: true }),
+      asofOpen: st.asofOpen, onAsofOpenChange: (v) => this.setState({ asofOpen: v }),
+      asofAxes: [
+        { axis: 'Recent events · world time · roster', glyph: '✓', color: 'hsl(var(--chart-5))', label: 'honest' },
+        { axis: 'Single-entity tags', glyph: '≈', color: 'hsl(var(--chart-2))', label: 'approximate' },
+        { axis: 'Pair tags', glyph: '≈', color: 'hsl(var(--chart-2))', label: 'approx · no clear log' },
+        { axis: 'Relationships / trust', glyph: '∅', color: 'hsl(var(--muted-foreground))', label: 'frozen · unversioned' },
+        { axis: 'Position / activity', glyph: '∅', color: 'hsl(var(--muted-foreground))', label: 'frozen · uninstrumented' },
+        { axis: 'Need debt', glyph: '✓', color: 'hsl(var(--chart-5))', label: 'replayable' },
+        { axis: 'Travel · anchors · factions · weather', glyph: '∅', color: 'hsl(var(--muted-foreground))', label: 'frozen' },
+      ],
+      onTabStream: () => this.setState({ centerTab: 'stream' }),
+      onTabGraph: () => this.setState({ centerTab: 'graph' }),
+      tabStreamStyle: tab(st.centerTab === 'stream'),
+      tabGraphStyle: tab(st.centerTab === 'graph'),
+      fTwoParty: st.fTwoParty, onFTwoParty: (v) => this.setState({ fTwoParty: v }),
+      fFailed: st.fFailed, onFFailed: (v) => this.setState({ fFailed: v }),
+      fNA: st.fNA, onFNA: (v) => this.setState({ fNA: v }),
+      fEvent: st.fEvent, onFEvent: (v) => this.setState({ fEvent: v }),
+      famOpen: st.famOpen, onFamOpenChange: (v) => this.setState({ famOpen: v }),
+      famLabel: st.fFamily || '— none —',
+      onToggleHealth: () => this.setState({ healthOpen: !st.healthOpen }),
+      healthOpen: st.healthOpen, healthChev: st.healthOpen ? '▾' : '▴',
+      drawerStyle: `position:fixed;top:0;right:0;bottom:0;width:390px;z-index:60;background:hsl(var(--background));border-left:1px solid hsl(var(--accent) / 0.55);box-shadow:-14px 0 44px hsl(220 40% 2% / 0.65);transform:translateX(${st.whatifOpen ? '0' : '103%'});transition:transform 0.28s cubic-bezier(0.32,0.72,0,1);overflow-y:auto;padding:16px 18px 30px`,
+      onCloseDrawer: () => this.setState({ whatifOpen: false }),
+      onTagHover: (t) => this.setState({ hoverTag: t }),
+      onHoverOut: () => { clearTimeout(this._ht); this._ht = setTimeout(() => this.setState({ hoverEnt: null }), 200); },
+      hoverPanelOpen: !!st.hoverEnt, hoverPanelStyle: `position:fixed;left:${st.hoverX || 0}px;top:${st.hoverY || 0}px;z-index:80;background:hsl(var(--popover));border:1px solid hsl(var(--popover-border));border-radius:8px;padding:14px;box-shadow:0 8px 28px hsl(220 40% 2% / 0.7)`,
+      hoverPanelEnt: null,
+      onHoverPanelEnter: () => clearTimeout(this._ht),
+      windowLabel: '79 → 108',
+      noSelection: !st.selected, hasSelection: !!st.selected,
+      sandboxFrame: st.mode === 'whatif' && st.overrides.length > 0,
+      hasOverrides: st.overrides.length > 0,
+      showEmptySlot: st.slot === 'save_01',
+      showStream: st.slot !== 'save_01' && st.centerTab === 'stream',
+      showGraph: st.slot !== 'save_01' && st.centerTab === 'graph',
+      footerLine: st.slot === 'save_02' ? 'slot 2 · retrograde backfill · 24 templates + 5 pseudo' : st.slot === 'save_05' ? 'slot 5 · live runtime · NULL world-time pathology' : 'slot 1 · golden master',
+      groups: [], onscreenChips: [], needPressureChips: [], railBands: [], overrideChips: [],
+      graphNodes: [], graphEdges: [], potentialActive: false, potentialEvent: '', potentialConsumers: [], graphLabelsEl: null,
+      healthBands: [], healthGaps: [], hasGaps: false, noGaps: false, healthDominant: [], healthNever: [], healthDeadArms: [], healthDq: [],
+      healthWarnCount: '—', streamSummary: '', worldTimeStr: '…', insp: null,
+      wfEntity: st.wfEntity, wfNeed: st.wfNeed, wfNeedVal: st.wfNeedVal, wfNeedValArr: [st.wfNeedVal],
+      wfPlace: st.wfPlace, wfEvent: st.wfEvent, wfEntityItems: [], wfTagItems: [], wfPlaceItems: [], wfPresets: [],
+      wfEntityName: st.wfEntity, wfNeedLabel: st.wfNeed, wfNeedMax: 340,
+      onWfEntity: (v) => this.setState({ wfEntity: v }),
+      onWfNeed: (v) => this.setState({ wfNeed: v }),
+      onWfNeedVal: (arr) => this.setState({ wfNeedVal: arr[0] }),
+      onWfPlace: (v) => this.setState({ wfPlace: v }),
+      onWfEvent: (v) => this.setState({ wfEvent: v }),
+      onApplyNeed: () => this._addOverride({ kind: 'need', entity: st.wfEntity, need: st.wfNeed, value: st.wfNeedVal, label: `${st.wfEntity}: ${st.wfNeed} = ${st.wfNeedVal}` }),
+      onApplyMove: () => this._addOverride({ kind: 'move', entity: st.wfEntity, place: st.wfPlace, label: `move ${st.wfEntity} → ${st.wfPlace}` }),
+      onApplyEvent: () => this._addOverride({ kind: 'event', type: st.wfEvent, target: st.wfEntity, ago: 1, label: `inject ${st.wfEvent} → ${st.wfEntity}` }),
+      wfApplyStyle: 'height:28px;border:1px solid hsl(var(--accent) / 0.6);border-radius:6px;background:hsl(var(--accent) / 0.12);color:hsl(var(--accent));font-size:9px;letter-spacing:0.14em;text-transform:uppercase;padding:0 12px;cursor:pointer',
+      familyItems: [],
+    };
+    if (!this.eng || !st.ready) return base;
+
+    // ---------- engine-backed vals ----------
+    const eng = this.eng;
+    const BAND_CHART = { crisis: 1, embodied: 2, routine: 3, affil: 4, project: 5 };
+    const bandColor = (b) => `hsl(var(--chart-${BAND_CHART[b]}))`;
+    const cur = this._resolve(st.overrides, st.anchor);
+    const baseCur = st.overrides.length ? this._resolve([], st.anchor) : cur;
+    const R = cur.r, S = cur.state;
+    const wt = eng.worldTimeFor(S);
+    base.worldTimeStr = `${wt.iso} · ${R.tod} · ${R.weather}`;
+
+    const slotFilter = (gid) => st.slot === 'save_05' ? ['victor', 'celia', 'talon'].includes(gid) : true;
+    const groups = R.groups.filter((g) => slotFilter(g.actor));
+    const baseGroups = Object.fromEntries(baseCur.r.groups.map((g) => [g.actor, g]));
+
+    // ---------- hover payloads ----------
+    const hoverIn = (id) => (e) => {
+      clearTimeout(this._ht);
+      const z = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--orr-z')) || 1;
+      const r = e.currentTarget.getBoundingClientRect();
+      const x = Math.min(r.left, (window.innerWidth || 1440) - 340 * z) / z;
+      const y = Math.min(r.bottom + 6, (window.innerHeight || 900) - 440 * z) / z;
+      this._ht = setTimeout(() => this.setState({ hoverEnt: id, hoverX: x, hoverY: y }), 180);
+    };
+    const hoverFor = (id) => {
+      const e = S.entities[id];
+      const pl = eng.PLACES[e.place];
+      const needRows = eng.NEEDS.map((nd) => {
+        const imm = eng.NEED_IMMUNITY[nd].find((t) => [...e.tags, ...e.ephemerals].includes(t));
+        const th = eng.NEED_THRESHOLDS[nd];
+        const v = e.needs[nd];
+        let sev = null; for (const nm of ['critical', 'severe', 'moderate', 'mild']) if (v >= th[nm]) { sev = nm; break; }
+        const color = imm ? 'hsl(var(--muted-foreground) / 0.4)' : sev === 'critical' || sev === 'severe' ? 'hsl(var(--destructive))' : sev === 'moderate' ? 'hsl(var(--chart-2))' : sev === 'mild' ? 'hsl(var(--chart-3))' : 'hsl(var(--muted-foreground) / 0.6)';
+        return { nd, val: imm ? 'immune' : String(v), note: imm ? `(${imm})` : sev || '', pct: imm ? '0%' : Math.min(100, Math.round((v / th.critical) * 100)) + '%', color };
+      });
+      const mkTag = (t, isEph) => {
+        const fams = eng.familiesOf(t);
+        const prov = eng.provenanceFor(id, t);
+        return { name: t, fam: fams.length ? '◈' : '', famTitle: fams.join(', ') || 'no family', dot: prov.dot === 'solid' ? '●' : prov.dot === 'ring' ? '◍' : '○', dotTitle: `${prov.src} · ${prov.note}`, isEph,
+          onEnter: () => this.setState({ hoverTag: t }), onLeave: () => this.setState({ hoverTag: null }) };
+      };
+      const rels = S.relationships.filter((r) => r.a === id || r.b === id).map((r) => {
+        const other = r.a === id ? r.b : r.a;
+        const types = r.a === id ? r.typesAB : r.typesBA;
+        const trust = r.a === id ? r.trustAB : r.trustBA;
+        return { other: S.entities[other].name, types: types.join(', '), trust: (trust >= 0 ? '+' : '') + trust };
+      });
+      const evs = S.events.filter((ev) => ev.actor === id || ev.target === id || (ev.pair && ev.pair.includes(id))).sort((a, b) => b.tick - a.tick).slice(0, 3)
+        .map((ev) => ({ t: 't' + String(ev.tick).padStart(4, '0'), type: ev.type }));
+      return {
+        name: e.name, portraitId: 'portrait-' + id, place: pl.name, classes: pl.classes.join(' · '),
+        fameRes: `fame ${e.fame} · resources ${e.resources}${e.onScreen ? ' · on-screen' : ''}`,
+        needs: needRows,
+        durable: e.tags.map((t) => mkTag(t, false)),
+        ephemeral: e.ephemerals.map((t) => mkTag(t, true)),
+        hasEphemeral: e.ephemerals.length > 0,
+        rels, hasRels: rels.length > 0, events: evs, hasEvents: evs.length > 0,
+      };
+    };
+
+    // ---------- selection helpers ----------
+    const isSel = (sel) => st.selected && st.selected.key === sel;
+    const famMembers = st.fFamily ? eng.FAMILIES[st.fFamily] : null;
+    const rowReadsFamily = (row) => {
+      if (!famMembers) return false;
+      let hit = false;
+      const walk = (n) => { if (!n || hit) return; if (n.kind === 'leaf') { if ((n.reads || []).some((t) => famMembers.includes(t))) hit = true; } else (n.children || []).forEach(walk); };
+      walk(row.gate);
+      return hit;
+    };
+    const rowConsumesEvent = (row, evType) => {
+      let hit = false;
+      const walk = (n) => { if (!n || hit) return; if (n.kind === 'leaf') { if ((n.p === 'evRecent' || n.p === 'cooldown') && row && JSON.stringify(n).includes(evType)) hit = true; } else (n.children || []).forEach(walk); };
+      walk(row.gate);
+      return hit;
+    };
+
+    // ---------- cards ----------
+    const magChip = (mag, color) => magStyle === 'dial'
+      ? { dial: true, deg: Math.round(mag * 360), color, text: mag.toFixed(2) }
+      : { dial: false, color, text: mag.toFixed(2) };
+
+    const mkCard = (g, row, kind, target, diffSig) => {
+      const key = [kind, g.actor, target || '', row.id].join(':');
+      const col = bandColor(row.band);
+      const dim = row.status === 'shadowed';
+      const famHit = famMembers ? rowReadsFamily(row) : false;
+      const evHit = st.fEvent !== 'none' ? rowConsumesEvent(row, st.fEvent) : false;
+      return {
+        key, kind, tplName: row.id, priority: 'pri ' + row.priority,
+        bandColor: col, dim,
+        tie: !!row.tie, tieTitle: row.tie ? `priority tied with ${row.tie.join(', ')} — authored tuple order decided` : '',
+        isPair: kind === 'pair', targetName: target ? S.entities[target].name : null,
+        targetHover: target ? hoverFor(target) : null,
+        branchLabel: row.resolution ? row.resolution.branchLabel : '',
+        event: row.resolution ? row.resolution.eventType : null,
+        mag: row.resolution ? magChip(row.resolution.magnitude, col) : null,
+        selected: isSel(key), diff: diffSig || false,
+        highlight: famHit || evHit,
+        dimByLens: (famMembers && !famHit) || (st.fEvent !== 'none' && !evHit),
+        pad, density,
+        onSelect: () => this.setState({ selected: { key, actor: g.actor, target: target || null, tpl: row.id, kind } }),
+      };
+    };
+
+    // ---------- groups ----------
+    base.groups = groups.map((g) => {
+      const e = S.entities[g.actor];
+      const bg = baseGroups[g.actor];
+      const open = st.groupOpen[g.actor] !== false;
+      const soloRows = g.solo.rows;
+      const winner = g.solo.winner;
+      const soloDiff = st.overrides.length > 0 && bg && this._sig(winner) !== this._sig(bg.solo.winner);
+
+      const cards = [];
+      if (winner && !st.fTwoParty) {
+        const c = mkCard(g, winner, 'solo', null, soloDiff);
+        const shadowed = soloRows.filter((r) => r.status === 'shadowed');
+        c.shadowCount = shadowed.length;
+        c.hasShadow = shadowed.length > 0;
+        c.shadowOpen = !!st.shadowOpen['solo:' + g.actor];
+        c.onToggleShadow = () => this.setState({ shadowOpen: { ...st.shadowOpen, ['solo:' + g.actor]: !st.shadowOpen['solo:' + g.actor] } });
+        c.shadowed = shadowed.map((r) => mkCard(g, r, 'solo', null, false));
+        cards.push(c);
+      }
+      for (const p of g.pairs) {
+        if (!p.winner) continue;
+        const bp = bg && bg.pairs.find((x) => x.target === p.target);
+        const pDiff = st.overrides.length > 0 && this._sig(p.winner) !== this._sig(bp && bp.winner);
+        const c = mkCard(g, p.winner, 'pair', p.target, pDiff);
+        const shadowed = p.rows.filter((r) => r.status === 'shadowed');
+        c.shadowCount = shadowed.length; c.hasShadow = shadowed.length > 0;
+        const sk = 'pair:' + g.actor + ':' + p.target;
+        c.shadowOpen = !!st.shadowOpen[sk];
+        c.onToggleShadow = () => this.setState({ shadowOpen: { ...st.shadowOpen, [sk]: !st.shadowOpen[sk] } });
+        c.shadowed = shadowed.map((r) => mkCard(g, r, 'pair', p.target, false));
+        cards.push(c);
+      }
+
+      // pressures
+      const pressures = g.pressures.map((p) => {
+        const key = ['pressure', g.actor, p.target, p.winner.id].join(':');
+        const bp = bg && bg.pressures.find((x) => x.target === p.target);
+        const pDiff = st.overrides.length > 0 && this._sig(p.winner) !== this._sig(bp && bp.winner);
+        return {
+          key, label: `${p.winner.id} → ${S.entities[p.target].name} · ${p.winner.resolution.magnitude.toFixed(2)}`,
+          title: p.winner.resolution.pressureStub,
+          style: `border:1px solid ${isSel(key) ? 'hsl(var(--accent))' : 'hsl(var(--accent) / 0.55)'};background:${isSel(key) ? 'hsl(var(--accent) / 0.16)' : pDiff ? 'hsl(var(--accent) / 0.1)' : 'transparent'};color:hsl(var(--accent));border-radius:99px;padding:3px 11px;font-size:10px;letter-spacing:0.05em;cursor:pointer`,
+          onSelect: () => this.setState({ selected: { key, actor: g.actor, target: p.target, tpl: p.winner.id, kind: 'pressure' } }),
+        };
+      });
+
+      // ghosts
+      const ghosts = [];
+      const ghostStyle = (na) => `display:flex;align-items:center;gap:8px;padding:2px 8px;border-radius:4px;cursor:pointer;color:hsl(var(--muted-foreground) / ${na ? '0.5' : '0.62'});${na ? 'border-left:2px dotted hsl(var(--muted-foreground) / 0.4);' : ''}`;
+      if (st.fFailed && !st.fTwoParty) {
+        for (const r of soloRows.filter((x) => x.status === 'gate_failed')) {
+          const key = ['solo', g.actor, '', r.id].join(':');
+          ghosts.push({ key, name: r.id, glyph: '✗', status: 'gate_failed',
+            reason: r.failLeaf ? (r.failLeaf.negated ? 'blocked: ' : 'failed: ') + r.failLeaf.prose : 'gate refused',
+            evidence: r.failLeaf ? r.failLeaf.evidence : '', style: ghostStyle(false), selected: isSel(key),
+            onSelect: () => this.setState({ selected: { key, actor: g.actor, target: null, tpl: r.id, kind: 'solo' } }) });
+        }
+        for (const p of g.pairs) {
+          for (const r of p.rows.filter((x) => x.status === 'gate_failed')) {
+            const key = ['pair', g.actor, p.target, r.id].join(':');
+            ghosts.push({ key, name: r.id + ' → ' + S.entities[p.target].name, glyph: '✗', status: 'gate_failed',
+              reason: r.failLeaf ? (r.failLeaf.negated ? 'blocked: ' : 'failed: ') + r.failLeaf.prose : 'gate refused',
+              evidence: r.failLeaf ? r.failLeaf.evidence : '', style: ghostStyle(false), selected: isSel(key),
+              onSelect: () => this.setState({ selected: { key, actor: g.actor, target: p.target, tpl: r.id, kind: 'pair' } }) });
+          }
+        }
+      }
+      if (st.fNA) {
+        for (const r of g.notApplicable) {
+          const key = ['na', g.actor, '', r.id].join(':');
+          ghosts.push({ key, name: r.id, glyph: '⊘', status: 'not_applicable',
+            reason: 'not applicable — no TARGET bound in this stack', evidence: 'slots: ACTOR, TARGET',
+            style: ghostStyle(true), selected: isSel(key),
+            onSelect: () => this.setState({ selected: { key, actor: g.actor, target: null, tpl: r.id, kind: 'na' } }) });
+        }
+      }
+
+      const bandDots = cards.filter((c) => !c.dim).map((c) => ({ color: c.bandColor, title: c.tplName }));
+      const groupDiff = soloDiff || cards.some((c) => c.diff) || pressures.some((p, i) => false);
+      return {
+        id: g.actor, domId: 'group-' + g.actor, name: e.name,
+        initials: e.name.split(/\s+/).map((w) => w[0]).join('').slice(0, 2).toUpperCase(),
+        ringColor: g.gap ? 'hsl(var(--destructive) / 0.7)' : winner ? bandColor(winner.band) : 'hsl(var(--border))',
+        placeName: eng.PLACES[e.place].name.split(' — ')[0],
+        hover: hoverFor(g.actor),
+        open, chev: open ? '▾' : '▸',
+        onHoverIn: hoverIn(g.actor),
+        onToggle: () => this.setState({ groupOpen: { ...st.groupOpen, [g.actor]: !open } }),
+        gap: g.gap, gapHint: st.fFailed ? '' : 'Toggle “show gate-failed” to see every refusal.',
+        diff: st.overrides.length > 0 && (soloDiff || cards.some((c) => c.diff)),
+        borderColor: g.gap ? 'hsl(var(--destructive) / 0.45)' : isSel(st.selected && st.selected.actor) === g.actor ? 'hsl(var(--primary) / 0.5)' : 'hsl(var(--border))',
+        cards: st.fTwoParty ? cards.filter((c) => c.isPair) : cards,
+        pressures, hasPressures: pressures.length > 0,
+        ghosts, hasGhosts: ghosts.length > 0,
+        bandDots,
+        activityLine: winner && winner.resolution ? winner.resolution.delta['character.current_activity'] || '' : g.gap ? '—' : '',
+      };
+    });
+
+    base.onscreenChips = Object.values(S.entities).filter((e) => e.onScreen).map((e) => ({ name: e.name, onHoverIn: hoverIn(e.id) }));
+    base.hoverPanelEnt = st.hoverEnt ? hoverFor(st.hoverEnt) : null;
+    base.needPressureChips = R.needPressures.map((np) => ({
+      label: `${np.id} → ${S.entities[np.target].name} · ${np.severity} · ${np.magnitude.toFixed(2)}`,
+      title: `pseudo-template · priority ${np.priority} · ${np.need} debt ${np.debt} (${np.severity}, L${np.level}) — outside the catalog; included explicitly`,
+    }));
+
+    // ---------- rail ----------
+    const winnersByBand = { crisis: 0, embodied: 0, routine: 0, affil: 0, project: 0 };
+    for (const g of groups) {
+      if (g.solo.winner) winnersByBand[g.solo.winner.band]++;
+      for (const p of g.pairs) if (p.winner) winnersByBand[p.winner.band]++;
+      for (const p of g.pressures) winnersByBand[p.winner.band]++;
+    }
+    for (const np of R.needPressures) winnersByBand.embodied++;
+    base.railBands = eng.BANDS.map((b) => ({
+      name: b.name, color: bandColor(b.id), glow: `hsl(var(--chart-${b.chart}) / 0.5)`,
+      count: winnersByBand[b.id],
+      badgeBorder: winnersByBand[b.id] ? bandColor(b.id) : 'hsl(var(--border))',
+      badgeText: winnersByBand[b.id] ? bandColor(b.id) : 'hsl(var(--muted-foreground))',
+    }));
+    base.familyItems = Object.keys(eng.FAMILIES).map((f) => ({
+      id: f, name: f, n: eng.FAMILIES[f].length,
+      onPick: () => this.setState({ fFamily: st.fFamily === f ? null : f, famOpen: false }),
+    })).concat([{ id: 'none', name: '— clear —', n: '', onPick: () => this.setState({ fFamily: null, famOpen: false }) }]);
+
+    const totalWinners = Object.values(winnersByBand).reduce((a, b) => a + b, 0);
+    base.streamSummary = `${groups.length} actors · ${totalWinners} winners · ${R.needPressures.length + groups.reduce((a, g) => a + g.pressures.length, 0)} pressures`;
+
+    // ---------- override chips ----------
+    base.overrideChips = st.overrides.map((ov, i) => ({
+      label: ov.label,
+      onRemove: () => { const overrides = st.overrides.filter((_, j) => j !== i); this.setState({ overrides, mode: overrides.length ? 'whatif' : st.mode }); this._flash(); },
+    }));
+
+    // ---------- inspector ----------
+    if (st.selected) {
+      const sel = st.selected;
+      const g = R.groups.find((x) => x.actor === sel.actor);
+      let row = null;
+      if (sel.kind === 'na') row = { id: sel.tpl, band: eng.TEMPLATE_BY_ID[sel.tpl].band, priority: eng.TEMPLATE_BY_ID[sel.tpl].priority, status: 'not_applicable' };
+      else if (sel.kind === 'solo') row = g && g.solo.rows.find((r) => r.id === sel.tpl);
+      else if (sel.kind === 'pair') { const p = g && g.pairs.find((x) => x.target === sel.target); row = p && p.rows.find((r) => r.id === sel.tpl); }
+      else if (sel.kind === 'pressure') { const p = g && g.pressures.find((x) => x.target === sel.target); row = p && p.rows.find((r) => r.id === sel.tpl); }
+      if (!row) { base.noSelection = true; base.hasSelection = false; }
+      else {
+        const tpl = eng.TEMPLATE_BY_ID[row.id];
+        const col = bandColor(row.band);
+        const statusMap = {
+          winner: ['winner', `border:1px solid ${col};color:${col}`],
+          shadowed: ['shadowed — fired, outranked', 'border:1px solid hsl(var(--muted-foreground) / 0.5);color:hsl(var(--muted-foreground))'],
+          gate_failed: ['gate-failed — evaluated, refused', 'border:1px solid hsl(var(--destructive) / 0.6);color:hsl(var(--destructive))'],
+          not_applicable: ['not applicable — no target bound', 'border:1px solid hsl(var(--muted-foreground) / 0.4);color:hsl(var(--muted-foreground) / 0.7)'],
+        };
+        const stat = statusMap[row.status] || statusMap.winner;
+        const isNA = row.status === 'not_applicable';
+
+        // flatten gate tree
+        const gateRows = [];
+        const hover = st.hoverTag;
+        const walk = (n, depth, onFail) => {
+          if (!n) return;
+          if (n.kind === 'leaf') {
+            const hl = hover && (n.reads || []).includes(hover);
+            const failHere = onFail && !n.pass;
+            gateRows.push({
+              style: `display:flex;align-items:baseline;gap:7px;padding:2px 4px 2px ${4 + depth * 15}px;border-radius:4px;${hl ? 'background:hsl(var(--accent) / 0.14);outline:1px dotted hsl(var(--accent) / 0.7);' : ''}`,
+              glyph: n.pass ? '✓' : '✗', glyphSize: '10px',
+              glyphColor: n.pass ? 'hsl(var(--chart-5))' : 'hsl(var(--destructive))',
+              prose: n.prose,
+              proseStyle: `flex:1;font-size:12px;${failHere ? 'font-weight:700;color:hsl(var(--foreground));' : n.pass ? 'color:hsl(var(--foreground) / 0.85);' : 'color:hsl(var(--muted-foreground));'}`,
+              evidence: n.evidence, evColor: failHere ? 'hsl(var(--destructive))' : 'hsl(var(--muted-foreground))',
+            });
+          } else {
+            gateRows.push({
+              style: `display:flex;align-items:baseline;gap:7px;padding:3px 4px 1px ${4 + depth * 15}px`,
+              glyph: n.pass ? '✓' : '✗', glyphSize: '9px',
+              glyphColor: n.pass ? 'hsl(var(--chart-5) / 0.7)' : 'hsl(var(--destructive) / 0.8)',
+              prose: n.op, proseStyle: `flex:1;font-size:9.5px;letter-spacing:0.2em;${!n.pass && onFail ? 'font-weight:700;color:hsl(var(--foreground) / 0.9);' : 'color:hsl(var(--muted-foreground) / 0.75);'}`,
+              evidence: '', evColor: 'transparent',
+            });
+            const kids = n.children || [];
+            for (const k of kids) {
+              const kidOnFail = onFail && !n.pass && (n.op === 'NOT' ? true : !k.pass || (n.op === 'OR'));
+              walk(k, depth + 1, n.op === 'NOT' ? onFail && !n.pass : kidOnFail);
+            }
+          }
+        };
+        if (row.gate) walk(row.gate, 0, !row.gatePassed);
+
+        const branches = (row.branches || []).map((b, i) => {
+          let noteGlyph = '', note = '', labelStyle = '', magColor = 'hsl(var(--muted-foreground))';
+          let style = 'padding:5px 8px;border-radius:5px;border-left:2px solid transparent';
+          if (b.selected) { style = `padding:5px 8px;border-radius:5px;border-left:2px solid ${col};background:hsl(var(--muted) / 0.22)`; labelStyle = 'font-weight:650'; magColor = col; noteGlyph = '◆'; note = 'selected — first passing branch in authored order'; }
+          else if (b.considered && b.passed === false) { noteGlyph = '✗'; note = b.failLeaf ? `${b.failLeaf.prose} — ${b.failLeaf.evidence}` : 'condition failed'; labelStyle = 'color:hsl(var(--muted-foreground))'; }
+          else if (!b.considered) { style += ';opacity:0.42'; note = row.gatePassed ? 'unevaluated — a branch above already fired' : 'unevaluated — gate refused'; noteGlyph = '·'; labelStyle = 'color:hsl(var(--muted-foreground))'; }
+          return { idx: 'B' + (i + 1), label: b.label, mag: b.mag.toFixed(2), style, labelStyle, magColor, note, noteGlyph };
+        });
+
+        const res = row.resolution;
+        base.insp = {
+          name: row.id, priority: row.priority, bandColor: col,
+          tie: !!row.tie, tieTitle: row.tie ? `priority ${row.priority} tied with ${row.tie.join(', ')} — BUILTIN_TEMPLATES tuple order decided` : '',
+          statusLabel: stat[0], statusStyle: `font-size:8.5px;letter-spacing:0.14em;text-transform:uppercase;border-radius:99px;padding:2px 9px;${stat[1]}`,
+          bindingLine: `ACTOR ${S.entities[sel.actor].name}${sel.target ? '  ·  TARGET ' + S.entities[sel.target].name : ''}${sel.kind === 'pressure' ? '  ·  present-target pass' : ''}`,
+          blurb: tpl.blurb, bandNote: tpl.bandNote || false,
+          isNA, hasTrace: !isNA,
+          gateRows, branches,
+          gateBadge: row.gatePassed ? 'pass' : 'refused',
+          gateBadgeStyle: `font-size:8.5px;letter-spacing:0.16em;text-transform:uppercase;border-radius:99px;padding:1px 8px;border:1px solid ${row.gatePassed ? 'hsl(var(--chart-5) / 0.6)' : 'hsl(var(--destructive) / 0.6)'};color:${row.gatePassed ? 'hsl(var(--chart-5))' : 'hsl(var(--destructive))'}`,
+          fired: !!res, mag: res ? res.magnitude.toFixed(2) : '—',
+          event: res ? res.eventType : null,
+          isPressure: sel.kind === 'pressure' && res && res.pressureStub,
+          pressureStub: res ? res.pressureStub : '',
+          deltaRows: res ? Object.entries(res.delta).map(([k, v]) => ({ k, v: Array.isArray(v) ? v.join(', ') : v })) : [],
+          bindingHash: res ? res.bindingHash : '',
+        };
+      }
+    }
+
+    // ---------- graph ----------
+    const offIds = groups.map((g) => g.actor);
+    const onIds = Object.values(S.entities).filter((e) => e.onScreen).map((e) => e.id);
+    const pos = {};
+    offIds.forEach((id, i) => {
+      const t = i / Math.max(1, offIds.length - 1);
+      pos[id] = { x: 180 + Math.sin(t * Math.PI) * 130, y: 70 + t * 360 };
+    });
+    onIds.forEach((id, i) => { pos[id] = { x: 760, y: 120 + i * 110 }; });
+    const winnerBandOf = (gid) => { const g = groups.find((x) => x.actor === gid); return g && g.solo.winner ? g.solo.winner.band : null; };
+    const jumpToStream = (actor) => {
+      this.setState({ centerTab: 'stream', groupOpen: { ...st.groupOpen, [actor]: true } });
+      setTimeout(() => {
+        const elC = document.getElementById('orr-stream');
+        const elG = document.getElementById('group-' + actor);
+        if (elC && elG) elC.scrollTop = elG.offsetTop - elC.offsetTop - 8;
+      }, 60);
+    };
+    base.graphNodes = [...offIds, ...onIds].map((id) => {
+      const e = S.entities[id]; const p = pos[id];
+      const g = groups.find((x) => x.actor === id);
+      const band = winnerBandOf(id);
+      const w = g && g.solo.winner;
+      return { x: p.x, y: p.y, ty: p.y + 3.5, ly: p.y + 34, sy: p.y + 46,
+        initials: e.name.split(/\s+/).map((x) => x[0]).join('').slice(0, 2).toUpperCase(),
+        name: e.name, gap: !!(g && g.gap),
+        stroke: g && g.gap ? 'hsl(var(--destructive))' : band ? bandColor(band) : e.onScreen ? 'hsl(var(--primary) / 0.7)' : 'hsl(var(--border))',
+        strokeW: st.selected && st.selected.actor === id ? 2.8 : 1.6,
+        dash: g && g.gap ? '3 3' : '1 0',
+        labelColor: 'hsl(var(--foreground) / 0.9)',
+        sub: g ? (g.gap ? 'coverage gap' : w ? w.id.toLowerCase() : 'pairs only') : eng.PLACES[e.place].name.split(' — ')[0].toLowerCase(),
+        subColor: g && g.gap ? 'hsl(var(--destructive))' : w ? bandColor(w.band) : 'hsl(var(--muted-foreground))',
+        onEnter: hoverIn(id),
+        onClick: g ? (w ? () => this.setState({ selected: { key: ['solo', id, '', w.id].join(':'), actor: id, target: null, tpl: w.id, kind: 'solo' } }) : () => jumpToStream(id)) : () => {} };
+    });
+    const recip = eng.reciprocalPairs(R);
+    const isRecip = (a, b) => recip.some((r) => (r.a === a && r.b === b) || (r.a === b && r.b === a));
+    const edges = [];
+    const mkPath = (a, b, bend, shrink = 22) => {
+      const pa = pos[a], pb = pos[b];
+      const dx = pb.x - pa.x, dy = pb.y - pa.y, len = Math.hypot(dx, dy);
+      const ux = dx / len, uy = dy / len;
+      const sx = pa.x + ux * shrink, sy = pa.y + uy * shrink;
+      const ex = pb.x - ux * shrink, ey = pb.y - uy * shrink;
+      const mx = (sx + ex) / 2 - uy * bend, my = (sy + ey) / 2 + ux * bend;
+      return { d: `M ${sx.toFixed(1)} ${sy.toFixed(1)} Q ${mx.toFixed(1)} ${my.toFixed(1)} ${ex.toFixed(1)} ${ey.toFixed(1)}`, lx: mx, ly: my - 6, jx: mx - 4.5, jy: my - 4.5 };
+    };
+    const markerFor = (band) => band === 'crisis' ? 'url(#arr1)' : band === 'affil' ? 'url(#arr4)' : 'url(#arr5)';
+    for (const g of groups) {
+      for (const p of g.pairs) {
+        if (!p.winner || !pos[p.target]) continue;
+        const joint = isRecip(g.actor, p.target);
+        const key = ['pair', g.actor, p.target, p.winner.id].join(':');
+        const path = mkPath(g.actor, p.target, joint ? 16 : 12);
+        edges.push({ ...path, key, selected: isSel(key), color: bandColor(p.winner.band), w: 1.6, dash: '1 0', op: 0.95,
+          marker: markerFor(p.winner.band), label: p.winner.id.toLowerCase(),
+          title: `${p.winner.id} · ${S.entities[g.actor].name} → ${S.entities[p.target].name} · “${p.winner.resolution.branchLabel}” · mag ${p.winner.resolution.magnitude.toFixed(2)}`,
+          onSelect: () => this.setState({ selected: { key, actor: g.actor, target: p.target, tpl: p.winner.id, kind: 'pair' } }),
+          onEnter: () => this.setState({ hoverEdge: key }), onLeave: () => this.setState({ hoverEdge: null }),
+          joint: joint && g.actor < p.target, jrot: `rotate(45 ${path.jx + 4.5} ${path.jy + 4.5})`, jly: path.ly + 26 });
+      }
+      for (const p of g.pressures) {
+        if (!pos[p.target]) continue;
+        const key = ['pressure', g.actor, p.target, p.winner.id].join(':');
+        const path = mkPath(g.actor, p.target, 24);
+        edges.push({ ...path, key, selected: isSel(key), color: 'hsl(var(--accent))', w: 1.3, dash: '5 4', op: 0.8,
+          marker: 'url(#arrA)', label: p.winner.id.toLowerCase() + ' ⇢',
+          title: `${p.winner.id} pressure · ${S.entities[g.actor].name} ⇢ ${S.entities[p.target].name} · prompt-only, no state mutation · mag ${p.winner.resolution.magnitude.toFixed(2)}`,
+          onSelect: () => this.setState({ selected: { key, actor: g.actor, target: p.target, tpl: p.winner.id, kind: 'pressure' } }),
+          onEnter: () => this.setState({ hoverEdge: key }), onLeave: () => this.setState({ hoverEdge: null }),
+          joint: false, jrot: '', jly: 0 });
+      }
+    }
+    const selEdgeActive = edges.some((e) => e.selected);
+    base.graphEdges = edges.map((e) => ({ ...e,
+      w: e.selected ? 3 : st.hoverEdge === e.key ? 2.5 : e.w,
+      op: e.selected ? 1 : selEdgeActive ? 0.3 : st.hoverEdge && st.hoverEdge !== e.key ? 0.5 : e.op }));
+    if (st.fEvent !== 'none') {
+      base.potentialActive = true;
+      base.potentialEvent = st.fEvent;
+      const arm = eng.DEAD_GATE_ARMS.find((d) => d.event === st.fEvent);
+      base.potentialConsumers = (arm ? arm.consumers : []).map((c, i) => ({
+        name: c, x: 250 + i * 160, y: 508,
+        d: `M 74 456 Q ${150 + i * 140} 495 ${245 + i * 160} 503`,
+      }));
+    }
+    // SVG text via createElement — template text holes don't render inside <svg>
+    {
+      const RE = React.createElement;
+      const t = [];
+      for (const e of base.graphEdges) {
+        t.push(RE('text', { key: 'el:' + e.key, x: e.lx, y: e.ly, textAnchor: 'middle', className: 'font-mono', style: { fontSize: '8.5px', letterSpacing: '0.08em' }, fill: e.color, opacity: e.op }, e.label));
+        t.push(RE('title', { key: 'tt:' + e.key }, e.title));
+      }
+      base.graphNodes.forEach((n, i) => {
+        t.push(RE('text', { key: 'ni' + i, x: n.x, y: n.ty, textAnchor: 'middle', className: 'font-mono', style: { fontSize: '10.5px' }, fill: 'hsl(var(--foreground))' }, n.initials));
+        t.push(RE('text', { key: 'nn' + i, x: n.x, y: n.ly, textAnchor: 'middle', style: { fontSize: '11px', fontWeight: 600 }, fill: n.labelColor }, n.name));
+        t.push(RE('text', { key: 'ns' + i, x: n.x, y: n.sy, textAnchor: 'middle', className: 'font-mono', style: { fontSize: '7.5px', letterSpacing: '0.12em', textTransform: 'uppercase' }, fill: n.subColor }, n.sub));
+      });
+      if (base.potentialActive) {
+        t.push(RE('text', { key: 'pe', x: 80, y: 461, className: 'font-mono', style: { fontSize: '9.5px', letterSpacing: '0.1em' }, fill: 'hsl(var(--foreground))' }, base.potentialEvent));
+        base.potentialConsumers.forEach((pc, i) => t.push(RE('text', { key: 'pc' + i, x: pc.x, y: pc.y, className: 'font-mono', style: { fontSize: '8.5px', letterSpacing: '0.08em' }, fill: 'hsl(var(--muted-foreground))' }, pc.name)));
+      }
+      base.graphLabelsEl = RE('g', { pointerEvents: 'none' }, t);
+    }
+
+    // ---------- health ----------
+    base.healthBands = eng.BANDS.map((b) => ({
+      name: b.name.replace(' / Constraint', '').replace(' Maintenance', '').replace('Anchored ', '').replace(' / Identity', ''),
+      color: bandColor(b.id), count: winnersByBand[b.id],
+      pct: totalWinners ? Math.round((winnersByBand[b.id] / totalWinners) * 100) + '%' : '0%',
+    }));
+    const gaps = groups.filter((g) => g.gap);
+    base.hasGaps = gaps.length > 0; base.noGaps = gaps.length === 0;
+    base.healthGaps = gaps.map((g) => ({
+      name: S.entities[g.actor].name,
+      why: 'every gate refused',
+      onJump: () => {
+        this.setState({ centerTab: 'stream', groupOpen: { ...st.groupOpen, [g.actor]: true } });
+        setTimeout(() => {
+          const elC = document.getElementById('orr-stream');
+          const elG = document.getElementById('group-' + g.actor);
+          if (elC && elG) elC.scrollTop = elG.offsetTop - elC.offsetTop - 8;
+        }, 60);
+      },
+    }));
+    base.healthDominant = eng.WINDOW_STATS.dominant.map((d) => ({ id: d.id, share: Math.round(d.share * 100) + '%', pct: Math.round(d.share * 100) + '%' }));
+    base.healthNever = eng.WINDOW_STATS.neverWin.map((id) => ({ id }));
+    base.healthDeadArms = eng.DEAD_GATE_ARMS.map((d) => ({ event: d.event, consumers: d.consumers.join(', ') }));
+    const dqBase = eng.WINDOW_STATS.dataQuality.filter((d) => st.slot === 'save_05' ? true : d.kind !== 'null_world_time');
+    base.healthDq = dqBase.map((d) => ({ text: d.text, color: d.sev === 'error' ? 'hsl(var(--destructive))' : d.sev === 'warn' ? 'hsl(var(--chart-2))' : 'hsl(var(--muted-foreground))' }));
+    base.healthWarnCount = String(dqBase.length + eng.DEAD_GATE_ARMS.length + gaps.length);
+
+    // ---------- what-if drawer data ----------
+    base.wfEntityItems = Object.values(S.entities).map((e) => ({ id: e.id, name: e.name + (e.onScreen ? ' (on-screen)' : '') }));
+    base.wfEntityName = S.entities[st.wfEntity] ? S.entities[st.wfEntity].name : st.wfEntity;
+    base.wfNeedLabel = st.wfNeed + ' · ' + (S.entities[st.wfEntity] ? S.entities[st.wfEntity].needs[st.wfNeed] : '—') + ' now';
+    base.wfNeedMax = st.wfNeed === 'intimacy' ? 340 : st.wfNeed === 'socialize' ? 340 : 80;
+    const ent = S.entities[st.wfEntity];
+    const vocab = [
+      ...new Set([
+        'off_grid', 'seeking_identity', 'ghostprint_active', 'public_role', 'undercover', 'fugitive', 'paranoid', 'informant_handler', 'signal_operator', 'broker', 'hacker', 'combat_trained', 'medical_skill', 'first_aid_trained', 'magical_healing', 'devout', 'work_obligation', 'safehouse_operator', 'route_familiar', 'vendetta_holder', 'violent_history', 'travel_ready',
+      ]),
+    ].map((t) => ({ t, eph: false })).concat([
+      'grudge_active', 'grieving', 'wounded', 'cns_stimulated', 'debt_pulse_active', 'captive', 'unconscious', 'dying',
+    ].map((t) => ({ t, eph: true })));
+    base.wfTagItems = [
+      { value: 'pair:hunting', label: 'hunting — Victor Sato → Talon (pair)', kind: 'pair',
+        stateGlyph: S.pairTags.some((p) => p.tag === 'hunting' && p.to === 'talon') ? '●' : '○',
+        stateColor: 'hsl(var(--destructive))',
+        onPick: () => this._addOverride({ kind: 'pairTag', from: 'victor', to: 'talon', tag: 'hunting', on: !S.pairTags.some((p) => p.tag === 'hunting' && p.to === 'talon'), label: (S.pairTags.some((p) => p.tag === 'hunting' && p.to === 'talon') ? 'clear' : 'set') + ' hunting → Talon' }) },
+      ...vocab.map(({ t, eph }) => {
+        const on = ent ? (eph ? ent.ephemerals.includes(t) : ent.tags.includes(t)) : false;
+        return { value: t, label: t, kind: eph ? 'ephemeral' : 'durable',
+          stateGlyph: on ? '●' : '○', stateColor: on ? 'hsl(var(--chart-5))' : 'hsl(var(--muted-foreground) / 0.5)',
+          onPick: () => this._addOverride({ kind: 'tag', entity: st.wfEntity, tag: t, eph, on: !on, label: `${on ? '−' : '+'} ${t} @ ${st.wfEntity}` }) };
+      }),
+    ];
+    base.wfPlaceItems = Object.values(eng.PLACES).map((p) => ({ id: p.id, name: p.name }));
+    base.wfPresets = [
+      { label: '“What if Talon weren’t hunted?” — clear the hunting pair tag', onRun: () => this._addOverride({ kind: 'pairTag', from: 'victor', to: 'talon', tag: 'hunting', on: false, label: 'clear hunting → Talon' }) },
+      { label: '“What wakes HONOR_DEBT?” — inject encoded_message at Asmodeus', onRun: () => this._addOverride({ kind: 'event', type: 'encoded_message', target: 'asmodeus', ago: 1, label: 'inject encoded_message → Asmodeus' }) },
+      { label: '“Does Lansky ever socialize?” — push his socialize debt to 30', onRun: () => this._addOverride({ kind: 'need', entity: 'lansky', need: 'socialize', value: 30, label: 'lansky: socialize = 30' }) },
+    ];
+
+    return base;
+  }
+}
+</script>
+</body>
+</html>

--- a/ui/.design-sync/import/orrery/Orrery Explorations.dc.html
+++ b/ui/.design-sync/import/orrery/Orrery Explorations.dc.html
@@ -1,0 +1,541 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <meta name="design_doc_mode" content="canvas">
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/fonts/fonts.css">
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/_ds_bundle.css">
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/styles.css">
+  <script src="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/_ds_bundle.js"></script>
+  <style>
+    html, body { margin: 0; padding: 0; background: hsl(220 40% 6%); }
+    ::selection { background: hsl(320 55% 48% / 0.35); }
+  </style>
+</helmet>
+<x-import component-from-global-scope="NexusIris.DesignThemeRoot" hint-size="100%,100%">
+<section style="margin:-1.5rem;padding:40px clamp(20px, 3vw, 44px) 80px;display:flex;flex-direction:column;gap:26px;min-width:0" class="bg-background text-foreground font-sans">
+
+  <div style="display:flex;align-items:baseline;gap:14px;flex-wrap:wrap">
+    <span class="font-mono" style="font-size:10px;letter-spacing:0.24em;text-transform:uppercase;color:hsl(var(--primary));border:1px solid hsl(var(--primary) / 0.5);border-radius:99px;padding:3px 12px">Turn 1</span>
+    <span class="font-display" style="font-size:26px;letter-spacing:0.04em">Anatomy explorations</span>
+    <span style="font-size:12.5px;color:hsl(var(--muted-foreground));font-style:italic">all data live from the seeded chunk-0108 resolver — same engine as the dashboard</span>
+  </div>
+
+  <!-- ══════ ROW 1 · RESOLUTION CARD ══════ -->
+  <div style="display:flex;flex-direction:column;gap:14px">
+    <div style="display:flex;align-items:baseline;gap:10px;border-bottom:1px solid hsl(var(--border));padding-bottom:6px">
+      <span class="font-mono" style="font-size:11px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--foreground))">Resolution card</span>
+      <span style="font-size:12px;color:hsl(var(--muted-foreground))">one fired package · Victor Sato → Celia · CULTIVATE_INFORMANT</span>
+    </div>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit, minmax(470px, 1fr));gap:22px;align-items:start">
+
+      <div id="1a" data-screen-label="1a — Dossier card" style="min-width:0;position:relative;display:flex;flex-direction:column;gap:8px">
+        <div style="display:flex;align-items:center;gap:8px">
+          <a href="#1a" style="text-decoration:none"><span class="font-mono" style="font-size:10px;letter-spacing:0.1em;background:hsl(var(--primary) / 0.15);color:hsl(var(--primary));border:1px solid hsl(var(--primary) / 0.5);border-radius:5px;padding:2px 8px">1a</span></a>
+          <span style="font-size:12.5px;font-weight:600">Dossier card</span>
+          <span class="font-mono" style="font-size:9px;color:hsl(var(--muted-foreground));letter-spacing:0.1em">— as built</span>
+        </div>
+        <dc-import name="ResolutionCard" card="{{ cardA }}" hint-size="560px,150px"></dc-import>
+        <sc-if value="{{ annotations }}" hint-placeholder-val="{{ true }}">
+          <span style="font-size:11.5px;color:hsl(var(--muted-foreground));font-style:italic;line-height:1.5">Band spine + conic magnitude dial. The authored branch label carries the row's meaning; full deltas stay in the inspector. The shape used in the faithful build.</span>
+        </sc-if>
+      </div>
+
+      <div id="1b" data-screen-label="1b — Ledger row" style="min-width:0;position:relative;display:flex;flex-direction:column;gap:8px">
+        <div style="display:flex;align-items:center;gap:8px">
+          <a href="#1b" style="text-decoration:none"><span class="font-mono" style="font-size:10px;letter-spacing:0.1em;background:hsl(var(--primary) / 0.15);color:hsl(var(--primary));border:1px solid hsl(var(--primary) / 0.5);border-radius:5px;padding:2px 8px">1b</span></a>
+          <span style="font-size:12.5px;font-weight:600">Ledger row</span>
+        </div>
+        <div style="border:1px solid hsl(var(--card-border));border-radius:6px;background:hsl(var(--card));overflow:hidden">
+          <div style="display:flex;align-items:center;gap:10px;padding:8px 12px">
+            <span style="width:3px;align-self:stretch;background:{{ lg.bandColor }};border-radius:2px;flex:none"></span>
+            <span class="font-mono" style="font-size:10.5px;letter-spacing:0.1em;flex:none">{{ lg.tpl }}</span>
+            <span style="font-size:11px;color:hsl(var(--muted-foreground));flex:none">→ {{ lg.target }}</span>
+            <span class="font-mono" style="font-size:8.5px;color:hsl(var(--muted-foreground));flex:none">pri {{ lg.pri }}</span>
+            <span style="flex:1;font-size:11px;color:hsl(var(--foreground) / 0.8);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ lg.branch }}</span>
+            <div style="width:64px;height:5px;border-radius:3px;background:hsl(var(--muted) / 0.3);overflow:hidden;flex:none"><div style="width:{{ lg.magPct }};height:100%;background:{{ lg.bandColor }}"></div></div>
+            <span class="font-mono" style="font-size:10px;color:{{ lg.bandColor }};flex:none;width:30px;text-align:right">{{ lg.mag }}</span>
+          </div>
+          <div style="display:flex;gap:6px;padding:0 12px 9px 25px;flex-wrap:wrap;align-items:center">
+            <span class="font-mono" style="font-size:8.5px;letter-spacing:0.06em;border:1px solid {{ lg.bandColor }};color:{{ lg.bandColor }};border-radius:99px;padding:1px 7px">{{ lg.event }}</span>
+            <sc-for list="{{ lg.deltas }}" as="d" hint-placeholder-count="2">
+              <span class="font-mono" style="font-size:8.5px;letter-spacing:0.04em;background:hsl(var(--muted) / 0.3);color:hsl(var(--muted-foreground));border-radius:4px;padding:1px 7px">{{ d.k }} · {{ d.v }}</span>
+            </sc-for>
+          </div>
+        </div>
+        <sc-if value="{{ annotations }}" hint-placeholder-val="{{ true }}">
+          <span style="font-size:11.5px;color:hsl(var(--muted-foreground));font-style:italic;line-height:1.5">Scan-first: one line per resolution, delta chips inline. Best when auditing dozens of rows per tick.</span>
+        </sc-if>
+      </div>
+
+      <div id="1c" data-screen-label="1c — Effect-first card" style="min-width:0;position:relative;display:flex;flex-direction:column;gap:8px">
+        <div style="display:flex;align-items:center;gap:8px">
+          <a href="#1c" style="text-decoration:none"><span class="font-mono" style="font-size:10px;letter-spacing:0.1em;background:hsl(var(--primary) / 0.15);color:hsl(var(--primary));border:1px solid hsl(var(--primary) / 0.5);border-radius:5px;padding:2px 8px">1c</span></a>
+          <span style="font-size:12.5px;font-weight:600">Effect-first</span>
+        </div>
+        <div style="border:1px solid hsl(var(--card-border));border-radius:6px;background:linear-gradient(135deg, {{ nf.washFrom }}, hsl(var(--card)) 55%);padding:14px 16px;display:flex;flex-direction:column;gap:9px">
+          <div style="display:flex;align-items:baseline;gap:8px">
+            <span class="font-mono" style="font-size:9px;letter-spacing:0.16em;text-transform:uppercase;color:{{ nf.bandColor }}">{{ nf.tpl }} → {{ nf.target }}</span>
+            <span style="flex:1"></span>
+            <span class="font-mono" style="font-size:8.5px;color:hsl(var(--muted-foreground))">{{ nf.branch }}</span>
+          </div>
+          <div style="display:flex;flex-direction:column;gap:7px">
+            <div style="display:flex;align-items:baseline;gap:8px">
+              <span class="font-mono" style="font-size:9px;letter-spacing:0.14em;text-transform:uppercase;color:hsl(var(--muted-foreground));flex:none">activity →</span>
+              <span class="font-mono" style="font-size:14px;color:hsl(var(--foreground))">“{{ nf.activity }}”</span>
+            </div>
+            <div style="display:flex;flex-wrap:wrap;gap:6px">
+              <sc-for list="{{ nf.chips }}" as="dch" hint-placeholder-count="2">
+                <span class="font-mono" style="font-size:9px;letter-spacing:0.04em;border:1px solid hsl(var(--muted-foreground) / 0.35);color:hsl(var(--foreground) / 0.82);background:hsl(var(--muted) / 0.25);border-radius:4px;padding:2px 8px">{{ dch.label }}</span>
+              </sc-for>
+            </div>
+          </div>
+          <div style="display:flex;gap:14px;border-top:1px solid hsl(var(--border) / 0.6);padding-top:8px;align-items:baseline">
+            <span class="font-mono" style="font-size:9px;color:hsl(var(--muted-foreground))">pri {{ nf.pri }}</span>
+            <span class="font-mono" style="font-size:9px;color:{{ nf.bandColor }}">mag {{ nf.mag }}</span>
+            <span class="font-mono" style="font-size:9px;color:hsl(var(--muted-foreground))">{{ nf.event }}</span>
+            <span style="flex:1"></span>
+          </div>
+        </div>
+        <sc-if value="{{ annotations }}" hint-placeholder-val="{{ true }}">
+          <span style="font-size:11.5px;color:hsl(var(--muted-foreground));font-style:italic;line-height:1.5">Audit-native: the state delta is the hero — the activity written, tags touched, event emitted. Narrative incorporation is Skald's discretion, so no prose surfaces here at all.</span>
+        </sc-if>
+      </div>
+    </div>
+  </div>
+
+  <!-- ══════ ROW 2 · GATE TREE ══════ -->
+  <div style="display:flex;flex-direction:column;gap:14px">
+    <div style="display:flex;align-items:baseline;gap:10px;border-bottom:1px solid hsl(var(--border));padding-bottom:6px">
+      <span class="font-mono" style="font-size:11px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--foreground))">Gate trace</span>
+      <span style="font-size:12px;color:hsl(var(--muted-foreground))">{{ gateSubjectLine }}</span>
+    </div>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit, minmax(470px, 1fr));gap:22px;align-items:start">
+
+      <div id="1d" data-screen-label="1d — Indented checklist" style="min-width:0;position:relative;display:flex;flex-direction:column;gap:8px">
+        <div style="display:flex;align-items:center;gap:8px">
+          <a href="#1d" style="text-decoration:none"><span class="font-mono" style="font-size:10px;letter-spacing:0.1em;background:hsl(var(--primary) / 0.15);color:hsl(var(--primary));border:1px solid hsl(var(--primary) / 0.5);border-radius:5px;padding:2px 8px">1d</span></a>
+          <span style="font-size:12.5px;font-weight:600">Indented checklist</span>
+          <span class="font-mono" style="font-size:9px;color:hsl(var(--muted-foreground));letter-spacing:0.1em">— as built</span>
+        </div>
+        <div style="border:1px solid hsl(var(--card-border));border-radius:6px;background:hsl(var(--card));padding:12px 14px;display:flex;flex-direction:column;gap:2px">
+          <sc-for list="{{ gateRows }}" as="gr" hint-placeholder-count="8">
+            <div style="{{ gr.style }}">
+              <span style="width:15px;flex:none;text-align:center;font-size:{{ gr.glyphSize }};color:{{ gr.glyphColor }}">{{ gr.glyph }}</span>
+              <span style="{{ gr.proseStyle }}">{{ gr.prose }}</span>
+              <span class="font-mono" style="font-size:9.5px;color:{{ gr.evColor }};flex:none;text-align:right">{{ gr.evidence }}</span>
+            </div>
+          </sc-for>
+        </div>
+        <sc-if value="{{ annotations }}" hint-placeholder-val="{{ true }}">
+          <span style="font-size:11.5px;color:hsl(var(--muted-foreground));font-style:italic;line-height:1.5">Depth = nesting, ✓/✗ per node, evidence in the right margin, failure path bolded. Reads top-to-bottom like the authored condition.</span>
+        </sc-if>
+      </div>
+
+      <div id="1e" data-screen-label="1e — Bracket circuit" style="min-width:0;position:relative;display:flex;flex-direction:column;gap:8px">
+        <div style="display:flex;align-items:center;gap:8px">
+          <a href="#1e" style="text-decoration:none"><span class="font-mono" style="font-size:10px;letter-spacing:0.1em;background:hsl(var(--primary) / 0.15);color:hsl(var(--primary));border:1px solid hsl(var(--primary) / 0.5);border-radius:5px;padding:2px 8px">1e</span></a>
+          <span style="font-size:12.5px;font-weight:600">Bracket circuit</span>
+        </div>
+        <div style="border:1px solid hsl(var(--card-border));border-radius:6px;background:hsl(var(--card));padding:12px 14px">
+          <dc-import name="GateBrackets" node="{{ gateTreeRaw }}" hint-size="100%,300px"></dc-import>
+        </div>
+        <sc-if value="{{ annotations }}" hint-placeholder-val="{{ true }}">
+          <span style="font-size:11.5px;color:hsl(var(--muted-foreground));font-style:italic;line-height:1.5">Operators become physical rails — a colored bracket wraps everything it governs, so AND/OR scope is spatial instead of typographic. Negation renders as a barred rail.</span>
+        </sc-if>
+      </div>
+
+      <div id="1f" data-screen-label="1f — Fail-path spotlight" style="min-width:0;position:relative;display:flex;flex-direction:column;gap:8px">
+        <div style="display:flex;align-items:center;gap:8px">
+          <a href="#1f" style="text-decoration:none"><span class="font-mono" style="font-size:10px;letter-spacing:0.1em;background:hsl(var(--primary) / 0.15);color:hsl(var(--primary));border:1px solid hsl(var(--primary) / 0.5);border-radius:5px;padding:2px 8px">1f</span></a>
+          <span style="font-size:12.5px;font-weight:600">Fail-path spotlight</span>
+        </div>
+        <div style="border:1px solid hsl(var(--card-border));border-radius:6px;background:hsl(var(--card));padding:14px 16px;display:flex;flex-direction:column;gap:12px">
+          <sc-if value="{{ spot.failed }}" hint-placeholder-val="{{ true }}">
+            <div style="display:flex;flex-direction:column;gap:8px">
+              <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+                <sc-for list="{{ spot.crumbs }}" as="cb" hint-placeholder-count="3">
+                  <span class="font-mono" style="{{ cb.style }}">{{ cb.label }}</span>
+                  <sc-if value="{{ cb.arrow }}" hint-placeholder-val="{{ true }}">
+                    <span style="color:hsl(var(--muted-foreground));font-size:10px">→</span>
+                  </sc-if>
+                </sc-for>
+              </div>
+              <div style="border-left:3px solid hsl(var(--destructive));background:hsl(var(--destructive) / 0.08);border-radius:0 6px 6px 0;padding:10px 12px;display:flex;flex-direction:column;gap:4px">
+                <span style="font-size:13px;font-weight:650">{{ spot.failProse }}</span>
+                <span class="font-mono" style="font-size:10px;color:hsl(var(--destructive))">{{ spot.failEvidence }}</span>
+                <span style="font-size:11px;color:hsl(var(--muted-foreground));font-style:italic">{{ spot.failNote }}</span>
+              </div>
+            </div>
+          </sc-if>
+          <sc-if value="{{ spot.passed }}" hint-placeholder-val="{{ false }}">
+            <div style="border-left:3px solid hsl(var(--chart-5));background:hsl(var(--chart-5) / 0.07);border-radius:0 6px 6px 0;padding:10px 12px">
+              <span style="font-size:13px;font-weight:650;color:hsl(var(--chart-5))">Gate passes</span>
+              <span style="font-size:11.5px;color:hsl(var(--muted-foreground));font-style:italic;display:block;margin-top:3px">No refusal to explain — every clause below resolved true.</span>
+            </div>
+          </sc-if>
+          <div style="display:flex;flex-wrap:wrap;gap:6px">
+            <sc-for list="{{ spot.passedChips }}" as="pc" hint-placeholder-count="4">
+              <span class="font-mono" style="font-size:9px;letter-spacing:0.04em;border:1px solid hsl(var(--chart-5) / 0.45);color:hsl(var(--chart-5) / 0.9);border-radius:99px;padding:2px 9px">✓ {{ pc.label }}</span>
+            </sc-for>
+          </div>
+        </div>
+        <sc-if value="{{ annotations }}" hint-placeholder-val="{{ true }}">
+          <span style="font-size:11.5px;color:hsl(var(--muted-foreground));font-style:italic;line-height:1.5">Answers “why didn't it fire?” in one glance: breadcrumb to the decisive leaf, full evidence on it, everything that passed compressed to chips. Zero reading of green rows.</span>
+        </sc-if>
+      </div>
+    </div>
+  </div>
+
+  <!-- ══════ ROW 3 · INTERACTION GRAPH ══════ -->
+  <div style="display:flex;flex-direction:column;gap:14px">
+    <div style="display:flex;align-items:baseline;gap:10px;border-bottom:1px solid hsl(var(--border));padding-bottom:6px">
+      <span class="font-mono" style="font-size:11px;letter-spacing:0.2em;text-transform:uppercase;color:hsl(var(--foreground))">Interaction graph</span>
+      <span style="font-size:12px;color:hsl(var(--muted-foreground))">who acts on whom this tick · solid = fired package · dashed = scene pressure · ⧫ = reciprocal joint beat</span>
+    </div>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit, minmax(470px, 1fr));gap:22px;align-items:start">
+
+      <div id="1g" data-screen-label="1g — Column flow" style="min-width:0;position:relative;display:flex;flex-direction:column;gap:8px">
+        <div style="display:flex;align-items:center;gap:8px">
+          <a href="#1g" style="text-decoration:none"><span class="font-mono" style="font-size:10px;letter-spacing:0.1em;background:hsl(var(--primary) / 0.15);color:hsl(var(--primary));border:1px solid hsl(var(--primary) / 0.5);border-radius:5px;padding:2px 8px">1g</span></a>
+          <span style="font-size:12.5px;font-weight:600">Column flow</span>
+          <span class="font-mono" style="font-size:9px;color:hsl(var(--muted-foreground));letter-spacing:0.1em">— as built</span>
+        </div>
+        <div style="border:1px solid hsl(var(--card-border));border-radius:6px;background:hsl(var(--card))">
+          <svg viewBox="0 0 560 430" style="width:100%;display:block">
+            <text x="40" y="26" class="font-mono" style="font-size:9px;letter-spacing:0.18em;text-transform:uppercase" fill="hsl(var(--muted-foreground))">off-screen</text>
+            <text x="440" y="26" class="font-mono" style="font-size:9px;letter-spacing:0.18em;text-transform:uppercase" fill="hsl(var(--muted-foreground))">on-screen</text>
+            <line x1="392" y1="34" x2="392" y2="400" stroke="hsl(var(--border))" stroke-dasharray="2 5"></line>
+            <sc-for list="{{ colEdges }}" as="e" hint-placeholder-count="8">
+              <g>
+                <path d="{{ e.d }}" fill="none" stroke="{{ e.color }}" stroke-width="{{ e.w }}" stroke-dasharray="{{ e.dash }}" opacity="{{ e.op }}"></path>
+                <sc-if value="{{ e.joint }}" hint-placeholder-val="{{ false }}">
+                  <rect x="{{ e.jx }}" y="{{ e.jy }}" width="8" height="8" transform="{{ e.jrot }}" fill="hsl(var(--card))" stroke="{{ e.color }}" stroke-width="1.3"></rect>
+                </sc-if>
+              </g>
+            </sc-for>
+            <sc-for list="{{ colNodes }}" as="n" hint-placeholder-count="9">
+              <g>
+                <circle cx="{{ n.x }}" cy="{{ n.y }}" r="15" fill="hsl(var(--card))" stroke="{{ n.stroke }}" stroke-width="1.5" stroke-dasharray="{{ n.dash }}"></circle>
+              </g>
+            </sc-for>
+            {{ colLabelsEl }}
+          </svg>
+        </div>
+        <sc-if value="{{ annotations }}" hint-placeholder-val="{{ true }}">
+          <span style="font-size:11.5px;color:hsl(var(--muted-foreground));font-style:italic;line-height:1.5">Preserves the brief's core boundary — the dashed membrane between simulation and scene. Pressures visibly cross it; packages stay left of it.</span>
+        </sc-if>
+      </div>
+
+      <div id="1h" data-screen-label="1h — Arc chord" style="min-width:0;position:relative;display:flex;flex-direction:column;gap:8px">
+        <div style="display:flex;align-items:center;gap:8px">
+          <a href="#1h" style="text-decoration:none"><span class="font-mono" style="font-size:10px;letter-spacing:0.1em;background:hsl(var(--primary) / 0.15);color:hsl(var(--primary));border:1px solid hsl(var(--primary) / 0.5);border-radius:5px;padding:2px 8px">1h</span></a>
+          <span style="font-size:12.5px;font-weight:600">Arc chord</span>
+        </div>
+        <div style="border:1px solid hsl(var(--card-border));border-radius:6px;background:hsl(var(--card))">
+          <svg viewBox="0 0 620 400" style="width:100%;display:block">
+            <text x="24" y="30" class="font-mono" style="font-size:8.5px;letter-spacing:0.14em;text-transform:uppercase" fill="hsl(var(--muted-foreground))">packages ↑</text>
+            <text x="24" y="382" class="font-mono" style="font-size:8.5px;letter-spacing:0.14em;text-transform:uppercase" fill="hsl(var(--muted-foreground))">pressures ↓</text>
+            <line x1="30" y1="230" x2="590" y2="230" stroke="hsl(var(--border))"></line>
+            <sc-for list="{{ arcEdges }}" as="e" hint-placeholder-count="8">
+              <g>
+                <path d="{{ e.d }}" fill="none" stroke="{{ e.color }}" stroke-width="{{ e.w }}" stroke-dasharray="{{ e.dash }}" opacity="{{ e.op }}"></path>
+                <sc-if value="{{ e.joint }}" hint-placeholder-val="{{ false }}">
+                  <rect x="{{ e.jx }}" y="{{ e.jy }}" width="8" height="8" transform="{{ e.jrot }}" fill="hsl(var(--card))" stroke="{{ e.color }}" stroke-width="1.3"></rect>
+                </sc-if>
+              </g>
+            </sc-for>
+            <sc-for list="{{ arcNodes }}" as="n" hint-placeholder-count="9">
+              <g>
+                <circle cx="{{ n.x }}" cy="230" r="13" fill="hsl(var(--card))" stroke="{{ n.stroke }}" stroke-width="1.5" stroke-dasharray="{{ n.dash }}"></circle>
+              </g>
+            </sc-for>
+            {{ arcLabelsEl }}
+          </svg>
+        </div>
+        <sc-if value="{{ annotations }}" hint-placeholder-val="{{ true }}">
+          <span style="font-size:11.5px;color:hsl(var(--muted-foreground));font-style:italic;line-height:1.5">One baseline, no columns: package arcs arch above, pressures hang below, so “how busy is this tick” becomes silhouette. Scales past nine actors better than columns.</span>
+        </sc-if>
+      </div>
+
+      <div id="1i" data-screen-label="1i — Adjacency matrix" style="min-width:0;position:relative;display:flex;flex-direction:column;gap:8px">
+        <div style="display:flex;align-items:center;gap:8px">
+          <a href="#1i" style="text-decoration:none"><span class="font-mono" style="font-size:10px;letter-spacing:0.1em;background:hsl(var(--primary) / 0.15);color:hsl(var(--primary));border:1px solid hsl(var(--primary) / 0.5);border-radius:5px;padding:2px 8px">1i</span></a>
+          <span style="font-size:12.5px;font-weight:600">Adjacency matrix</span>
+        </div>
+        <div style="border:1px solid hsl(var(--card-border));border-radius:6px;background:hsl(var(--card));padding:16px 18px;display:flex;flex-direction:column;gap:10px">
+          <div style="display:grid;grid-template-columns:110px repeat({{ mx.cols }}, minmax(46px, 1fr));gap:3px;align-items:center">
+            <span></span>
+            <sc-for list="{{ mx.colHeads }}" as="ch" hint-placeholder-count="5">
+              <span class="font-mono" style="font-size:8px;letter-spacing:0.04em;color:{{ ch.color }};text-align:center;text-transform:uppercase">{{ ch.name }}</span>
+            </sc-for>
+            <sc-for list="{{ mx.cells }}" as="c" hint-placeholder-count="20">
+              <sc-if value="{{ c.isHead }}" hint-placeholder-val="{{ false }}">
+                <span class="font-mono" style="font-size:9px;letter-spacing:0.04em;color:hsl(var(--foreground) / 0.85);text-align:right;padding-right:6px">{{ c.name }}</span>
+              </sc-if>
+              <sc-if value="{{ c.isCell }}" hint-placeholder-val="{{ true }}">
+                <div title="{{ c.title }}" style="{{ c.style }}">
+                  <sc-if value="{{ c.recip }}" hint-placeholder-val="{{ false }}"><span style="font-size:9px;line-height:1">⧫</span></sc-if>
+                  <sc-if value="{{ c.hasMag }}" hint-placeholder-val="{{ false }}"><span class="font-mono" style="font-size:7.5px;line-height:1">{{ c.mag }}</span></sc-if>
+                </div>
+              </sc-if>
+            </sc-for>
+          </div>
+          <div style="display:flex;gap:12px;align-items:center;border-top:1px solid hsl(var(--border) / 0.6);padding-top:8px">
+            <span style="display:inline-flex;align-items:center;gap:5px;font-size:10px;color:hsl(var(--muted-foreground))"><span style="width:10px;height:10px;border-radius:2px;background:hsl(var(--chart-1) / 0.75)"></span>fired</span>
+            <span style="display:inline-flex;align-items:center;gap:5px;font-size:10px;color:hsl(var(--muted-foreground))"><span style="width:10px;height:10px;border-radius:2px;border:1.5px dashed hsl(var(--accent))"></span>pressure</span>
+            <span style="display:inline-flex;align-items:center;gap:5px;font-size:10px;color:hsl(var(--muted-foreground))">⧫ reciprocal</span>
+            <span class="font-mono" style="font-size:8.5px;color:hsl(var(--muted-foreground));margin-left:auto">opacity ∝ magnitude</span>
+          </div>
+        </div>
+        <sc-if value="{{ annotations }}" hint-placeholder-val="{{ true }}">
+          <span style="font-size:11.5px;color:hsl(var(--muted-foreground));font-style:italic;line-height:1.5">No layout ambiguity, ever: rows act, columns receive. Empty row = coverage gap; empty column = nobody touches that actor. The lint view of the tick.</span>
+        </sc-if>
+      </div>
+    </div>
+  </div>
+</section>
+</x-import>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;: {&quot;width&quot;: 1920, &quot;height&quot;: 1400}, &quot;annotations&quot;: {&quot;editor&quot;: &quot;boolean&quot;, &quot;default&quot;: true, &quot;tsType&quot;: &quot;boolean&quot;, &quot;section&quot;: &quot;Presentation&quot;}, &quot;gateSubject&quot;: {&quot;editor&quot;: &quot;enum&quot;, &quot;options&quot;: [&quot;INTIMACY (blocked)&quot;, &quot;EVADE_PURSUERS (passing)&quot;], &quot;default&quot;: &quot;INTIMACY (blocked)&quot;, &quot;tsType&quot;: &quot;string&quot;, &quot;section&quot;: &quot;Gate variants&quot;}, &quot;graphPressures&quot;: {&quot;editor&quot;: &quot;boolean&quot;, &quot;default&quot;: true, &quot;tsType&quot;: &quot;boolean&quot;, &quot;section&quot;: &quot;Graph variants&quot;}}">
+class Component extends DCLogic {
+  state = { ready: false };
+  componentDidMount() {
+    document.body.classList.add('dark');
+    import('./orrery-engine.js').then((eng) => { this.eng = eng; this.setState({ ready: true }); })
+      .catch((e) => console.error('engine load failed', e));
+  }
+
+  renderVals() {
+    const P = this.props;
+    const annotations = P.annotations ?? true;
+    const showPressures = P.graphPressures ?? true;
+    const subject = P.gateSubject ?? 'INTIMACY (blocked)';
+    const base = {
+      annotations,
+      gateSubjectLine: '…',
+      cardA: null,
+      lg: { bandColor: 'transparent', tpl: '', target: '', pri: '', branch: '', magPct: '0%', mag: '', event: '', deltas: [] },
+      nf: { bandColor: 'transparent', washFrom: 'transparent', tpl: '', target: '', branch: '', activity: '', chips: [], pri: '', mag: '', event: '' },
+      gateRows: [], gateTreeRaw: null,
+      spot: { failed: false, passed: false, crumbs: [], passedChips: [], failProse: '', failEvidence: '', failNote: '' },
+      colEdges: [], colNodes: [], arcEdges: [], arcNodes: [], colLabelsEl: null, arcLabelsEl: null,
+      mx: { cols: 0, colHeads: [], cells: [] },
+    };
+    if (!this.eng || !this.state.ready) return base;
+    const eng = this.eng;
+    const BAND_CHART = { crisis: 1, embodied: 2, routine: 3, affil: 4, project: 5 };
+    const bandColor = (b) => `hsl(var(--chart-${BAND_CHART[b]}))`;
+    const S = eng.applyOverrides(eng.baseWorldState(), [], 108);
+    const R = eng.resolveTick(S);
+    const groups = Object.fromEntries(R.groups.map((g) => [g.actor, g]));
+
+    // ---------- card VMs (victor → celia CULTIVATE_INFORMANT) ----------
+    const vc = groups.victor.pairs.find((p) => p.target === 'celia');
+    const w = vc.winner;
+    const col = bandColor(w.band);
+    base.cardA = {
+      key: '1a', kind: 'pair', tplName: w.id, priority: 'pri ' + w.priority, bandColor: col, dim: false,
+      tie: false, tieTitle: '', isPair: true, targetName: 'Celia',
+      branchLabel: w.resolution.branchLabel, event: w.resolution.eventType,
+      mag: { dial: true, deg: Math.round(w.resolution.magnitude * 360), color: col, text: w.resolution.magnitude.toFixed(2) },
+      selected: false, diff: false, highlight: false, dimByLens: false, pad: 10, density: 'comfortable',
+      onSelect: () => {}, hasShadow: false, shadowCount: 0, shadowOpen: false, onToggleShadow: () => {}, shadowed: [],
+    };
+    const deltas = Object.entries(w.resolution.delta).map(([k, v]) => ({ k: k.replace('character.', ''), v: Array.isArray(v) ? v.join(', ') : v }));
+    base.lg = { bandColor: col, tpl: w.id, target: 'Celia', pri: w.priority, branch: w.resolution.branchLabel,
+      magPct: Math.round(w.resolution.magnitude * 100) + '%', mag: w.resolution.magnitude.toFixed(2),
+      event: w.resolution.eventType, deltas };
+    const fxChips = [];
+    for (const [k, v] of Object.entries(w.resolution.delta)) {
+      if (k === 'character.current_activity') continue;
+      for (const val of (Array.isArray(v) ? v : [v])) {
+        fxChips.push({ label: k === 'entity_tags.add' ? '+ ' + val : k === 'entity_tags.clear' ? '− ' + val : k === 'pair_tags.clear' ? '⊘ ' + val : k + ' · ' + val });
+      }
+    }
+    base.nf = { bandColor: col, washFrom: `hsl(var(--chart-${BAND_CHART[w.band]}) / 0.14)`, tpl: w.id, target: 'Celia',
+      branch: w.resolution.branchLabel, activity: w.resolution.delta['character.current_activity'] || '', pri: w.priority,
+      mag: w.resolution.magnitude.toFixed(2), event: w.resolution.eventType, chips: fxChips };
+
+    // ---------- gate VMs ----------
+    const useEvade = subject.startsWith('EVADE');
+    const gRow = useEvade
+      ? groups.talon.solo.rows.find((r) => r.id === 'EVADE_PURSUERS')
+      : groups.asmodeus.solo.rows.find((r) => r.id === 'INTIMACY');
+    base.gateSubjectLine = useEvade
+      ? 'Talon · EVADE_PURSUERS · gate passes — hunted, unconstrained, has a route'
+      : 'Asmodeus · INTIMACY · gate refused — intimacy debt is real, but a suppressor is present';
+    base.gateTreeRaw = gRow.gate;
+
+    const gateRows = [];
+    const walk = (n, depth, onFail) => {
+      if (!n) return;
+      if (n.kind === 'leaf') {
+        const failHere = onFail && !n.pass;
+        gateRows.push({
+          style: `display:flex;align-items:baseline;gap:7px;padding:2px 4px 2px ${4 + depth * 15}px;border-radius:4px`,
+          glyph: n.pass ? '✓' : '✗', glyphSize: '10px',
+          glyphColor: n.pass ? 'hsl(var(--chart-5))' : 'hsl(var(--destructive))',
+          prose: n.prose,
+          proseStyle: `flex:1;font-size:12px;${failHere ? 'font-weight:700;color:hsl(var(--foreground));' : n.pass ? 'color:hsl(var(--foreground) / 0.85);' : 'color:hsl(var(--muted-foreground));'}`,
+          evidence: n.evidence, evColor: failHere ? 'hsl(var(--destructive))' : 'hsl(var(--muted-foreground))',
+        });
+      } else {
+        gateRows.push({
+          style: `display:flex;align-items:baseline;gap:7px;padding:3px 4px 1px ${4 + depth * 15}px`,
+          glyph: n.pass ? '✓' : '✗', glyphSize: '9px',
+          glyphColor: n.pass ? 'hsl(var(--chart-5) / 0.7)' : 'hsl(var(--destructive) / 0.8)',
+          prose: n.op, proseStyle: `flex:1;font-size:9.5px;letter-spacing:0.2em;${!n.pass && onFail ? 'font-weight:700;color:hsl(var(--foreground) / 0.9);' : 'color:hsl(var(--muted-foreground) / 0.75);'}`,
+          evidence: '', evColor: 'transparent',
+        });
+        for (const k of n.children || []) walk(k, depth + 1, onFail && !n.pass);
+      }
+    };
+    walk(gRow.gate, 0, !gRow.gatePassed);
+    base.gateRows = gateRows;
+
+    // fail-path spotlight
+    const crumbStyle = (hot) => `font-size:9px;letter-spacing:0.16em;border:1px solid ${hot ? 'hsl(var(--destructive))' : 'hsl(var(--border))'};color:${hot ? 'hsl(var(--destructive))' : 'hsl(var(--muted-foreground))'};border-radius:99px;padding:2px 9px;text-transform:uppercase`;
+    const leafSummary = (n) => {
+      if (n.kind === 'leaf') return n.prose;
+      const c = countLeaves(n);
+      return n.op + ' · ' + c + ' conditions';
+    };
+    const countLeaves = (n) => n.kind === 'leaf' ? 1 : (n.children || []).reduce((a, k) => a + countLeaves(k), 0);
+    if (!gRow.gatePassed) {
+      const fl = eng.firstFailingLeaf(gRow.gate);
+      const crumbs = [];
+      let node = gRow.gate;
+      while (node && node.kind !== 'leaf') {
+        crumbs.push({ label: node.op, style: crumbStyle(false), arrow: true });
+        if (node.op === 'NOT') { node = node.children[0]; continue; }
+        const next = (node.children || []).find((k) => (node.op === 'AND' ? !k.pass : !k.pass));
+        node = next || (node.children || [])[0];
+      }
+      crumbs.push({ label: 'decisive leaf', style: crumbStyle(true), arrow: false });
+      base.spot = {
+        failed: true, passed: false, crumbs,
+        failProse: fl ? (fl.negated ? 'blocked: ' + fl.prose : fl.prose) : 'gate refused',
+        failEvidence: fl ? fl.evidence : '',
+        failNote: fl && fl.negated ? 'This leaf PASSED inside a NOT — its presence is what refuses the gate.' : 'First failing leaf on the refusal path, in authored order.',
+        passedChips: (gRow.gate.children || []).filter((c) => c.pass).map((c) => ({ label: leafSummary(c).slice(0, 46) })),
+      };
+    } else {
+      base.spot = {
+        failed: false, passed: true, crumbs: [],
+        failProse: '', failEvidence: '', failNote: '',
+        passedChips: (gRow.gate.children || []).map((c) => ({ label: leafSummary(c).slice(0, 46) })),
+      };
+    }
+
+    // ---------- graph data (shared) ----------
+    const offIds = R.groups.map((g) => g.actor);
+    const onIds = Object.values(S.entities).filter((e) => e.onScreen).map((e) => e.id);
+    const recip = eng.reciprocalPairs(R);
+    const isRecip = (a, b) => recip.some((r) => (r.a === a && r.b === b) || (r.a === b && r.b === a));
+    const edges = [];
+    for (const g of R.groups) {
+      for (const p of g.pairs) if (p.winner) edges.push({ from: g.actor, to: p.target, kind: 'pkg', band: p.winner.band, label: p.winner.id.toLowerCase(), mag: p.winner.resolution.magnitude, joint: isRecip(g.actor, p.target) });
+      if (showPressures) for (const p of g.pressures) edges.push({ from: g.actor, to: p.target, kind: 'press', band: p.winner.band, label: p.winner.id.toLowerCase(), mag: p.winner.resolution.magnitude, joint: false });
+    }
+    const winnerBandOf = (id) => { const g = groups[id]; return g && g.solo.winner ? g.solo.winner.band : null; };
+    const strokeOf = (id) => { const g = groups[id]; const b = winnerBandOf(id); return g && g.gap ? 'hsl(var(--destructive))' : b ? bandColor(b) : S.entities[id].onScreen ? 'hsl(var(--primary) / 0.7)' : 'hsl(var(--border))'; };
+    const dashOf = (id) => (groups[id] && groups[id].gap ? '3 3' : '1 0');
+    const initialsOf = (id) => S.entities[id].name.split(/\s+/).map((x) => x[0]).join('').slice(0, 2).toUpperCase();
+
+    // 1g column flow
+    const pos = {};
+    offIds.forEach((id, i) => { const t = i / Math.max(1, offIds.length - 1); pos[id] = { x: 120 + Math.sin(t * Math.PI) * 80, y: 62 + t * 320 }; });
+    onIds.forEach((id, i) => { pos[id] = { x: 480, y: 90 + i * 105 }; });
+    base.colNodes = [...offIds, ...onIds].map((id) => ({
+      x: pos[id].x, y: pos[id].y, ty: pos[id].y + 3,
+      lx: S.entities[id].onScreen ? pos[id].x + 22 : pos[id].x - 22,
+      lly: pos[id].y + 4, anchor: S.entities[id].onScreen ? 'start' : 'end',
+      initials: initialsOf(id), name: S.entities[id].name.split(' ')[0],
+      stroke: strokeOf(id), dash: dashOf(id),
+    }));
+    const mkCurve = (a, b, bend, shrink) => {
+      const pa = pos[a], pb = pos[b];
+      const dx = pb.x - pa.x, dy = pb.y - pa.y, len = Math.hypot(dx, dy) || 1;
+      const ux = dx / len, uy = dy / len;
+      const sx = pa.x + ux * shrink, sy = pa.y + uy * shrink, ex = pb.x - ux * shrink, ey = pb.y - uy * shrink;
+      const mx = (sx + ex) / 2 - uy * bend, my = (sy + ey) / 2 + ux * bend;
+      return { d: `M ${sx.toFixed(1)} ${sy.toFixed(1)} Q ${mx.toFixed(1)} ${my.toFixed(1)} ${ex.toFixed(1)} ${ey.toFixed(1)}`, lx: mx, ly: my - 5, jx: mx - 4, jy: my - 4 };
+    };
+    base.colEdges = edges.map((e) => {
+      const c = e.kind === 'press' ? 'hsl(var(--accent))' : bandColor(e.band);
+      const path = mkCurve(e.from, e.to, e.joint ? 14 : 10, 19);
+      return { ...path, color: c, w: e.kind === 'press' ? 1.2 : 1.5, dash: e.kind === 'press' ? '5 4' : '1 0',
+        op: e.kind === 'press' ? 0.75 : 0.95, label: e.label, joint: e.joint && e.from < e.to,
+        jrot: `rotate(45 ${path.jx + 4} ${path.jy + 4})` };
+    });
+
+    // 1h arc chord
+    const order = ['victor', 'celia', 'lansky', 'asmodeus', 'juno', 'talon', 'alex', 'pete', 'alina'];
+    const ax = {}; order.forEach((id, i) => { ax[id] = 52 + i * 64; });
+    base.arcNodes = order.map((id, i) => ({
+      x: ax[id], initials: initialsOf(id), short: S.entities[id].name.split(' ')[0].toLowerCase(),
+      ny: i % 2 === 0 ? 258 : 208, stroke: strokeOf(id), dash: dashOf(id),
+    }));
+    base.arcEdges = edges.map((e) => {
+      const x1 = ax[e.from], x2 = ax[e.to];
+      const up = e.kind === 'pkg';
+      const h = Math.min(170, Math.abs(x2 - x1) * 0.42 + 26);
+      const my = up ? 230 - h : 230 + h;
+      const mx = (x1 + x2) / 2;
+      return {
+        d: `M ${x1} ${up ? 217 : 243} Q ${mx} ${my} ${x2} ${up ? 217 : 243}`,
+        color: e.kind === 'press' ? 'hsl(var(--accent))' : bandColor(e.band),
+        w: e.kind === 'press' ? 1.2 : 1.5, dash: e.kind === 'press' ? '5 4' : '1 0', op: e.kind === 'press' ? 0.7 : 0.9,
+        joint: e.joint && e.from < e.to, jx: mx - 4, jy: (up ? 230 - h : 230 + h) - 4 + (up ? h * 0.24 : -h * 0.24),
+        jrot: `rotate(45 ${mx} ${(up ? 230 - h : 230 + h) + (up ? h * 0.24 : -h * 0.24)})`,
+      };
+    });
+
+    // SVG text via createElement — template text holes don't render inside <svg>
+    const RE = React.createElement;
+    base.colLabelsEl = RE('g', { pointerEvents: 'none' }, [
+      ...base.colEdges.map((e, i) => RE('text', { key: 'e' + i, x: e.lx, y: e.ly, textAnchor: 'middle', className: 'font-mono', style: { fontSize: '7.5px', letterSpacing: '0.06em' }, fill: e.color }, e.label)),
+      ...base.colNodes.flatMap((n, i) => [
+        RE('text', { key: 'i' + i, x: n.x, y: n.ty, textAnchor: 'middle', className: 'font-mono', style: { fontSize: '9px' }, fill: 'hsl(var(--foreground))' }, n.initials),
+        RE('text', { key: 'n' + i, x: n.lx, y: n.lly, textAnchor: n.anchor, style: { fontSize: '10px', fontWeight: 600 }, fill: 'hsl(var(--foreground) / 0.9)' }, n.name),
+      ]),
+    ]);
+    base.arcLabelsEl = RE('g', { pointerEvents: 'none' }, base.arcNodes.flatMap((n, i) => [
+      RE('text', { key: 'i' + i, x: n.x, y: 234, textAnchor: 'middle', className: 'font-mono', style: { fontSize: '8.5px' }, fill: 'hsl(var(--foreground))' }, n.initials),
+      RE('text', { key: 's' + i, x: n.x, y: n.ny, textAnchor: 'middle', className: 'font-mono', style: { fontSize: '8px', letterSpacing: '0.04em' }, fill: 'hsl(var(--muted-foreground))' }, n.short),
+    ]));
+
+    // 1i adjacency matrix
+    const froms = [...new Set(edges.map((e) => e.from))];
+    const tos = [...new Set(edges.map((e) => e.to))];
+    base.mx.cols = tos.length;
+    base.mx.colHeads = tos.map((id) => ({ name: S.entities[id].name.split(' ')[0], color: S.entities[id].onScreen ? 'hsl(var(--primary))' : 'hsl(var(--muted-foreground))' }));
+    const cells = [];
+    for (const f of froms) {
+      cells.push({ isHead: true, isCell: false, name: S.entities[f].name.split(' ')[0] });
+      for (const t of tos) {
+        const hit = edges.find((e) => e.from === f && e.to === t);
+        if (!hit) { cells.push({ isHead: false, isCell: true, title: '—', style: 'width:100%;min-width:46px;height:34px;border-radius:4px;background:hsl(var(--muted) / 0.12)', recip: false, hasMag: false, mag: '' }); continue; }
+        const c = hit.kind === 'press' ? 'hsl(var(--accent))' : `hsl(var(--chart-${BAND_CHART[hit.band]})`;
+        const alpha = (0.25 + hit.mag * 0.75).toFixed(2);
+        const style = hit.kind === 'press'
+          ? `width:100%;min-width:46px;height:34px;border-radius:4px;border:1.5px dashed hsl(var(--accent));display:flex;flex-direction:column;align-items:center;justify-content:center;gap:1px;color:hsl(var(--accent))`
+          : `width:100%;min-width:46px;height:34px;border-radius:4px;background:${c} / ${alpha});display:flex;flex-direction:column;align-items:center;justify-content:center;gap:1px;color:hsl(var(--foreground))`;
+        cells.push({ isHead: false, isCell: true, title: `${hit.label} · mag ${hit.mag.toFixed(2)}${hit.joint ? ' · reciprocal' : ''}`,
+          style, recip: hit.joint, hasMag: true, mag: hit.mag.toFixed(2) });
+      }
+    }
+    base.mx.cells = cells;
+    return base;
+  }
+}
+</script>
+</body>
+</html>

--- a/ui/.design-sync/import/orrery/ResolutionCard.dc.html
+++ b/ui/.design-sync/import/orrery/ResolutionCard.dc.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/fonts/fonts.css">
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/_ds_bundle.css">
+  <link rel="stylesheet" href="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/styles.css">
+  <script src="_ds/nexus-iris-9c704bc6-6c31-4387-82bf-2473a97893c8/_ds_bundle.js"></script>
+</helmet>
+<div style="display:flex;flex-direction:column;gap:4px;opacity:{{ wrapOpacity }}">
+  <div onClick="{{ card.onSelect }}" style="{{ cardStyle }}" style-hover="border-color:hsl(var(--primary) / 0.55)">
+    <sc-if value="{{ card.diff }}" hint-placeholder-val="{{ false }}">
+      <span title="Outcome changed vs pre-override tick" style="position:absolute;top:8px;right:8px;width:7px;height:7px;border-radius:99px;background:hsl(var(--accent));box-shadow:0 0 7px hsl(var(--accent))"></span>
+    </sc-if>
+    <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+      <span class="font-mono" style="font-size:11px;letter-spacing:0.12em;color:hsl(var(--foreground))">{{ card.tplName }}</span>
+      <sc-if value="{{ card.isPair }}" hint-placeholder-val="{{ false }}">
+        <span style="font-size:11.5px;color:hsl(var(--muted-foreground))">→ <span style="font-weight:600;color:hsl(var(--foreground) / 0.9)">{{ card.targetName }}</span></span>
+      </sc-if>
+      <span class="font-mono" style="font-size:9px;color:hsl(var(--muted-foreground));letter-spacing:0.08em">{{ card.priority }}</span>
+      <sc-if value="{{ card.tie }}" hint-placeholder-val="{{ false }}">
+        <span title="{{ card.tieTitle }}" class="font-mono" style="font-size:8.5px;letter-spacing:0.08em;border:1px solid hsl(var(--chart-5) / 0.7);color:hsl(var(--chart-5));border-radius:99px;padding:0 6px;cursor:help">tie</span>
+      </sc-if>
+      <span style="flex:1"></span>
+      <sc-if value="{{ card.event }}" hint-placeholder-val="{{ true }}">
+        <span class="font-mono" style="font-size:9px;letter-spacing:0.06em;border:1px solid {{ card.bandColor }};color:{{ card.bandColor }};border-radius:99px;padding:1px 8px;opacity:0.9">{{ card.event }}</span>
+      </sc-if>
+      <sc-if value="{{ isDial }}" hint-placeholder-val="{{ true }}">
+        <div style="display:flex;align-items:center;gap:6px;flex:none">
+          <div style="width:22px;height:22px;border-radius:99px;background:conic-gradient({{ card.mag.color }} {{ card.mag.deg }}deg, hsl(var(--muted) / 0.3) 0);display:flex;align-items:center;justify-content:center">
+            <div style="width:14px;height:14px;border-radius:99px;background:hsl(var(--card))"></div>
+          </div>
+          <span class="font-mono" style="font-size:10.5px;color:{{ card.mag.color }}">{{ card.mag.text }}</span>
+        </div>
+      </sc-if>
+      <sc-if value="{{ isNumeric }}" hint-placeholder-val="{{ false }}">
+        <span class="font-mono" style="flex:none;font-size:10.5px;border:1px solid {{ card.mag.color }};color:{{ card.mag.color }};border-radius:4px;padding:2px 7px">{{ card.mag.text }}</span>
+      </sc-if>
+    </div>
+    <div style="font-size:11.5px;color:hsl(var(--muted-foreground));margin-top:4px">{{ card.branchLabel }}</div>
+  </div>
+  <sc-if value="{{ card.hasShadow }}" hint-placeholder-val="{{ false }}">
+    <div style="margin-left:12px;display:flex;flex-direction:column;gap:4px">
+      <button onClick="{{ card.onToggleShadow }}" style="display:flex;align-items:center;gap:7px;background:transparent;border:none;cursor:pointer;padding:1px 0;width:fit-content" style-hover="opacity:0.8">
+        <span style="font-size:8px;color:hsl(var(--muted-foreground))">{{ shadowChev }}</span>
+        <span class="font-mono" style="font-size:8.5px;letter-spacing:0.18em;text-transform:uppercase;color:hsl(var(--muted-foreground))">shadowed</span>
+        <span class="font-mono" style="font-size:9px;border:1px solid hsl(var(--border));color:hsl(var(--muted-foreground));border-radius:99px;padding:0 6px">{{ card.shadowCount }}</span>
+      </button>
+      <sc-if value="{{ card.shadowOpen }}" hint-placeholder-val="{{ false }}">
+        <div style="display:flex;flex-direction:column;gap:4px">
+          <sc-for list="{{ card.shadowed }}" as="sh" hint-placeholder-count="2">
+            <div onClick="{{ sh.onSelect }}" style="{{ shShadowBase }}border-left:3px solid {{ sh.bandColor }};outline:{{ sh.outline }}" style-hover="opacity:0.9">
+              <div style="display:flex;align-items:baseline;gap:8px">
+                <span class="font-mono" style="font-size:10px;letter-spacing:0.1em">{{ sh.tplName }}</span>
+                <span class="font-mono" style="font-size:8.5px;color:hsl(var(--muted-foreground))">{{ sh.priority }}</span>
+                <sc-if value="{{ sh.tie }}" hint-placeholder-val="{{ false }}">
+                  <span title="{{ sh.tieTitle }}" class="font-mono" style="font-size:8px;border:1px solid hsl(var(--chart-5) / 0.7);color:hsl(var(--chart-5));border-radius:99px;padding:0 5px;cursor:help">tie</span>
+                </sc-if>
+                <span style="font-size:10.5px;color:hsl(var(--muted-foreground));overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1">{{ sh.branchLabel }}</span>
+                <span class="font-mono" style="font-size:9.5px;color:{{ sh.bandColor }};flex:none">{{ sh.mag.text }}</span>
+              </div>
+            </div>
+          </sc-for>
+        </div>
+      </sc-if>
+    </div>
+  </sc-if>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;: {&quot;width&quot;: 560, &quot;height&quot;: 150}, &quot;card&quot;: {&quot;editor&quot;: null, &quot;tsType&quot;: &quot;ResolutionCardVM&quot;}}">
+class Component extends DCLogic {
+  renderVals() {
+    const card = this.props.card || {};
+    const sel = card.selected;
+    return {
+      card,
+      wrapOpacity: card.dimByLens ? 0.35 : 1,
+      cardStyle: `position:relative;border:1px solid ${sel ? 'hsl(var(--primary))' : 'hsl(var(--card-border))'};border-left:3px solid ${card.bandColor};border-radius:6px;background:hsl(var(--card));padding:${(card.pad || 10)}px 12px;cursor:pointer;${card.highlight ? 'box-shadow:0 0 0 1px hsl(var(--chart-5) / 0.55);' : sel ? 'box-shadow:0 0 0 1px hsl(var(--primary) / 0.6);' : ''}`,
+      isDial: !!(card.mag && card.mag.dial),
+      isNumeric: !!(card.mag && !card.mag.dial),
+      shadowChev: card.shadowOpen ? '▾' : '▸',
+      shShadowBase: 'position:relative;border:1px solid hsl(var(--card-border) / 0.6);border-radius:5px;background:hsl(var(--card) / 0.55);padding:6px 10px;cursor:pointer;opacity:0.62;',
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/ui/.design-sync/import/orrery/image-slot.js
+++ b/ui/.design-sync/import/orrery/image-slot.js
@@ -1,0 +1,643 @@
+// @ds-adherence-ignore -- omelette starter scaffold (raw elements/hex/px by design)
+/* BEGIN USAGE */
+/**
+ * <image-slot> — user-fillable image placeholder.
+ *
+ * Drop this into a deck, mockup, or page wherever you want the user to
+ * supply an image. You control the slot's shape and size; the user fills it
+ * by dragging an image file onto it (or clicking to browse). The dropped
+ * image persists across reloads via a .image-slots.state.json sidecar —
+ * same read-via-fetch / write-via-window.omelette pattern as
+ * design_canvas.jsx, so the filled slot shows on share links, downloaded
+ * zips, and PPTX export. Outside the omelette runtime the slot is read-only.
+ *
+ * The host bridge only allows sidecar writes at the project root, so the
+ * HTML that uses this component is assumed to live at the project root too
+ * (same constraint as design_canvas.jsx).
+ *
+ * Attributes:
+ *   id           Persistence key. REQUIRED for the drop to survive reload —
+ *                every slot on the page needs a distinct id.
+ *   shape        'rect' | 'rounded' | 'circle' | 'pill'   (default 'rounded')
+ *                'circle' applies 50% border-radius; on a non-square slot
+ *                that's an ellipse — set equal width and height for a true
+ *                circle.
+ *   radius       Corner radius in px for 'rounded'.       (default 12)
+ *   mask         Any CSS clip-path value. Overrides `shape` — use this for
+ *                hexagons, blobs, arbitrary polygons.
+ *   fit          object-fit: cover | contain | fill.       (default 'cover')
+ *                With cover (the default) double-clicking the filled slot
+ *                enters a reframe mode: the whole image spills past the mask
+ *                (translucent outside, opaque inside), drag to reposition,
+ *                corner-drag to scale. The crop persists alongside the image
+ *                in the sidecar. contain/fill stay static.
+ *   position     object-position for fit=contain|fill.     (default '50% 50%')
+ *   placeholder  Empty-state caption.                      (default 'Drop an image')
+ *   src          Optional initial/fallback image URL. A user drop overrides
+ *                it; clearing the drop reveals src again.
+ *
+ * Size and layout come from ordinary CSS on the element — width/height
+ * inline or from a parent grid — so it composes with any layout.
+ *
+ * Usage:
+ *   <image-slot id="hero"   style="width:800px;height:450px" shape="rounded" radius="20"
+ *               placeholder="Drop a hero image"></image-slot>
+ *   <image-slot id="avatar" style="width:120px;height:120px" shape="circle"></image-slot>
+ *   <image-slot id="kite"   style="width:300px;height:300px"
+ *               mask="polygon(50% 0, 100% 50%, 50% 100%, 0 50%)"></image-slot>
+ */
+/* END USAGE */
+
+(() => {
+  const STATE_FILE = '.image-slots.state.json';
+  // 2× a ~600px slot in a 1920-wide deck — retina-sharp without making the
+  // sidecar enormous. A 1200px WebP at q=0.85 is ~150-300KB.
+  const MAX_DIM = 1200;
+  // Raster formats only. SVG is excluded (can carry script; createImageBitmap
+  // on SVG blobs is inconsistent). GIF is excluded because the canvas
+  // re-encode keeps only the first frame, so an animated GIF would silently
+  // go still — better to reject than surprise.
+  const ACCEPT = ['image/png', 'image/jpeg', 'image/webp', 'image/avif'];
+
+  // ── Shared sidecar store ────────────────────────────────────────────────
+  // One fetch + immediate write-on-change for every <image-slot> on the
+  // page. Reads via fetch() so viewing works anywhere the HTML and sidecar
+  // are served together; writes go through window.omelette.writeFile, which
+  // the host allowlists to *.state.json basenames only.
+  const subs = new Set();
+  let slots = {};
+  // ids explicitly cleared before the sidecar fetch resolved — otherwise
+  // the merge below can't tell "never set" from "just deleted" and would
+  // resurrect the sidecar's stale value.
+  const tombstones = new Set();
+  let loaded = false;
+  let loadP = null;
+
+  function load() {
+    if (loadP) return loadP;
+    loadP = fetch(STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        // Merge: sidecar loses to any in-memory change that raced ahead of
+        // the fetch (drop or clear) so neither is clobbered by hydration.
+        if (j && typeof j === 'object') {
+          const merged = Object.assign({}, j, slots);
+          // A framing-only write that raced ahead of hydration must not
+          // drop a user image that's only on disk — inherit u from the
+          // sidecar for any in-memory entry that lacks one.
+          for (const k in slots) {
+            if (merged[k] && !merged[k].u && j[k]) {
+              merged[k].u = typeof j[k] === 'string' ? j[k] : j[k].u;
+            }
+          }
+          for (const id of tombstones) delete merged[id];
+          slots = merged;
+        }
+        tombstones.clear();
+      })
+      .catch(() => {})
+      .then(() => { loaded = true; subs.forEach((fn) => fn()); });
+    return loadP;
+  }
+
+  // Serialize writes so two near-simultaneous drops on different slots
+  // can't reorder at the backend and leave the sidecar with only the
+  // first. A save requested mid-flight just marks dirty and re-fires on
+  // completion with the then-current slots.
+  let saving = false;
+  let saveDirty = false;
+  function save() {
+    if (saving) { saveDirty = true; return; }
+    const w = window.omelette && window.omelette.writeFile;
+    if (!w) return;
+    saving = true;
+    Promise.resolve(w(STATE_FILE, JSON.stringify(slots)))
+      .catch(() => {})
+      .then(() => { saving = false; if (saveDirty) { saveDirty = false; save(); } });
+  }
+
+  const S_MAX = 5;
+  const clampS = (s) => Math.max(1, Math.min(S_MAX, s));
+
+  // Normalize a stored slot value. Pre-reframe sidecars stored a bare
+  // data-URL string; newer ones store {u, s, x, y}. Either shape is valid.
+  function getSlot(id) {
+    const v = slots[id];
+    if (!v) return null;
+    return typeof v === 'string' ? { u: v, s: 1, x: 0, y: 0 } : v;
+  }
+
+  function setSlot(id, val) {
+    if (!id) return;
+    if (val) { slots[id] = val; tombstones.delete(id); }
+    else { delete slots[id]; if (!loaded) tombstones.add(id); }
+    subs.forEach((fn) => fn());
+    // A drop is rare + high-value — write immediately so nav-away can't lose
+    // it. Gate on the initial read so we don't overwrite a sidecar we haven't
+    // merged yet; the merge in load() keeps this change once the read lands.
+    if (loaded) save(); else load().then(save);
+  }
+
+  // ── Image downscale ─────────────────────────────────────────────────────
+  // Encode through a canvas so the sidecar carries resized bytes, not the
+  // raw upload. Longest side is capped at 2× the slot's rendered width
+  // (retina) and at MAX_DIM. WebP keeps alpha and is ~10× smaller than PNG
+  // for photos, so there's no need for per-image format picking.
+  async function toDataUrl(file, targetW) {
+    const bitmap = await createImageBitmap(file);
+    try {
+      const cap = Math.min(MAX_DIM, Math.max(1, Math.round(targetW * 2)) || MAX_DIM);
+      const scale = Math.min(1, cap / Math.max(bitmap.width, bitmap.height));
+      const w = Math.max(1, Math.round(bitmap.width * scale));
+      const h = Math.max(1, Math.round(bitmap.height * scale));
+      const canvas = document.createElement('canvas');
+      canvas.width = w; canvas.height = h;
+      canvas.getContext('2d').drawImage(bitmap, 0, 0, w, h);
+      return canvas.toDataURL('image/webp', 0.85);
+    } finally {
+      bitmap.close && bitmap.close();
+    }
+  }
+
+  // ── Custom element ──────────────────────────────────────────────────────
+  const stylesheet =
+    ':host{display:inline-block;position:relative;vertical-align:top;' +
+    '  font:13px/1.3 system-ui,-apple-system,sans-serif;color:rgba(0,0,0,.55);width:240px;height:160px}' +
+    '.frame{position:absolute;inset:0;overflow:hidden;background:rgba(0,0,0,.04)}' +
+    // .frame img (clipped) and .spill (unclipped ghost + handles) share the
+    // same left/top/width/height in frame-%, computed by _applyView(), so the
+    // inside-mask crop and the outside-mask spill stay pixel-aligned.
+    '.frame img{position:absolute;max-width:none;transform:translate(-50%,-50%);' +
+    '  -webkit-user-drag:none;user-select:none;touch-action:none}' +
+    // Reframe mode (double-click): the full image spills past the mask. The
+    // spill layer is sized to the IMAGE bounds so its corners are where the
+    // resize handles belong. The ghost <img> inside is translucent; the real
+    // clipped <img> underneath shows the opaque in-mask crop.
+    '.spill{position:absolute;transform:translate(-50%,-50%);display:none;z-index:1;' +
+    '  cursor:grab;touch-action:none}' +
+    ':host([data-panning]) .spill{cursor:grabbing}' +
+    '.spill .ghost{position:absolute;inset:0;width:100%;height:100%;opacity:.35;' +
+    '  pointer-events:none;-webkit-user-drag:none;user-select:none;' +
+    '  box-shadow:0 0 0 1px rgba(0,0,0,.2),0 12px 32px rgba(0,0,0,.2)}' +
+    '.spill .handle{position:absolute;width:12px;height:12px;border-radius:50%;' +
+    '  background:#fff;box-shadow:0 0 0 1.5px #c96442,0 1px 3px rgba(0,0,0,.3);' +
+    '  transform:translate(-50%,-50%)}' +
+    '.spill .handle[data-c=nw]{left:0;top:0;cursor:nwse-resize}' +
+    '.spill .handle[data-c=ne]{left:100%;top:0;cursor:nesw-resize}' +
+    '.spill .handle[data-c=sw]{left:0;top:100%;cursor:nesw-resize}' +
+    '.spill .handle[data-c=se]{left:100%;top:100%;cursor:nwse-resize}' +
+    ':host([data-reframe]){z-index:10}' +
+    ':host([data-reframe]) .spill{display:block}' +
+    ':host([data-reframe]) .frame{box-shadow:0 0 0 2px #c96442}' +
+    '.empty{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;' +
+    '  justify-content:center;gap:6px;text-align:center;padding:12px;box-sizing:border-box;' +
+    '  cursor:pointer;user-select:none}' +
+    '.empty svg{opacity:.45}' +
+    '.empty .cap{max-width:90%;font-weight:500;letter-spacing:.01em}' +
+    '.empty .sub{font-size:11px}' +
+    '.empty .sub u{text-underline-offset:2px;text-decoration-color:rgba(0,0,0,.25)}' +
+    '.empty:hover .sub u{color:rgba(0,0,0,.75);text-decoration-color:currentColor}' +
+    ':host([data-over]) .frame{outline:2px solid #c96442;outline-offset:-2px;' +
+    '  background:rgba(201,100,66,.10)}' +
+    '.ring{position:absolute;inset:0;pointer-events:none;border:1.5px dashed rgba(0,0,0,.25);' +
+    '  transition:border-color .12s}' +
+    ':host([data-over]) .ring{border-color:#c96442}' +
+    ':host([data-filled]) .ring{display:none}' +
+    // Controls sit BELOW the mask (top:100%), absolutely positioned so the
+    // author-declared slot height is unaffected. The gap is padding, not a
+    // top offset, so the hover target stays contiguous with the frame.
+    '.ctl{position:absolute;top:100%;left:50%;transform:translateX(-50%);padding-top:8px;' +
+    '  display:flex;gap:6px;opacity:0;pointer-events:none;transition:opacity .12s;z-index:2;' +
+    '  white-space:nowrap}' +
+    ':host([data-filled][data-editable]:hover) .ctl,:host([data-reframe]) .ctl' +
+    '  {opacity:1;pointer-events:auto}' +
+    '.ctl button{appearance:none;border:0;border-radius:6px;padding:5px 10px;cursor:pointer;' +
+    '  background:rgba(0,0,0,.65);color:#fff;font:11px/1 system-ui,-apple-system,sans-serif;' +
+    '  backdrop-filter:blur(6px)}' +
+    '.ctl button:hover{background:rgba(0,0,0,.8)}' +
+    '.err{position:absolute;left:8px;bottom:8px;right:8px;color:#b3261e;font-size:11px;' +
+    '  background:rgba(255,255,255,.85);padding:4px 6px;border-radius:5px;pointer-events:none}';
+
+  const icon =
+    '<svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+    'stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">' +
+    '<rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/>' +
+    '<path d="m21 15-5-5L5 21"/></svg>';
+
+  class ImageSlot extends HTMLElement {
+    static get observedAttributes() {
+      return ['shape', 'radius', 'mask', 'fit', 'position', 'placeholder', 'src', 'id'];
+    }
+
+    constructor() {
+      super();
+      const root = this.attachShadow({ mode: 'open' });
+      // .spill and .ctl sit OUTSIDE .frame so overflow:hidden + border-radius
+      // on the frame (circle, pill, rounded) can't clip them.
+      root.innerHTML =
+        '<style>' + stylesheet + '</style>' +
+        '<div class="frame" part="frame">' +
+        '  <img part="image" alt="" draggable="false" style="display:none">' +
+        '  <div class="empty" part="empty">' + icon +
+        '    <div class="cap"></div>' +
+        '    <div class="sub">or <u>browse files</u></div></div>' +
+        '  <div class="ring" part="ring"></div>' +
+        '</div>' +
+        '<div class="spill">' +
+        '  <img class="ghost" alt="" draggable="false">' +
+        '  <div class="handle" data-c="nw"></div><div class="handle" data-c="ne"></div>' +
+        '  <div class="handle" data-c="sw"></div><div class="handle" data-c="se"></div>' +
+        '</div>' +
+        '<div class="ctl"><button data-act="replace" title="Replace image">Replace</button>' +
+        '  <button data-act="clear" title="Remove image">Remove</button></div>' +
+        '<input type="file" accept="' + ACCEPT.join(',') + '" hidden>';
+      this._frame = root.querySelector('.frame');
+      this._ring = root.querySelector('.ring');
+      this._img = root.querySelector('.frame img');
+      this._empty = root.querySelector('.empty');
+      this._cap = root.querySelector('.cap');
+      this._sub = root.querySelector('.sub');
+      this._spill = root.querySelector('.spill');
+      this._ghost = root.querySelector('.ghost');
+      this._err = null;
+      this._input = root.querySelector('input');
+      this._depth = 0;
+      this._gen = 0;
+      this._view = { s: 1, x: 0, y: 0 };
+      this._subFn = () => this._render();
+      // Shadow-DOM listeners live with the shadow DOM — bound once here so
+      // disconnect/reconnect (e.g. React remount) doesn't stack handlers.
+      this._empty.addEventListener('click', () => this._input.click());
+      root.addEventListener('click', (e) => {
+        const act = e.target && e.target.getAttribute && e.target.getAttribute('data-act');
+        if (act === 'replace') { this._exitReframe(true); this._input.click(); }
+        if (act === 'clear') {
+          this._exitReframe(false);
+          this._gen++;
+          this._local = null;
+          if (this.id) setSlot(this.id, null); else this._render();
+        }
+      });
+      this._input.addEventListener('change', () => {
+        const f = this._input.files && this._input.files[0];
+        if (f) this._ingest(f);
+        this._input.value = '';
+      });
+      // naturalWidth/Height aren't known until load — re-apply so the cover
+      // baseline is computed from real dimensions, not the 100%×100% fallback.
+      this._img.addEventListener('load', () => this._applyView());
+      // Gated on editable + fit=cover so share links and contain/fill slots
+      // stay static.
+      this.addEventListener('dblclick', (e) => {
+        if (!this.hasAttribute('data-editable') || !this._reframes()) return;
+        e.preventDefault();
+        if (this.hasAttribute('data-reframe')) this._exitReframe(true);
+        else this._enterReframe();
+      });
+      // Pan + resize both originate on the spill layer. A handle pointerdown
+      // drives an aspect-locked resize anchored at the opposite corner; any
+      // other pointerdown on the spill pans. Offsets are frame-% so a
+      // reframed slot survives responsive resize / PPTX export.
+      this._spill.addEventListener('pointerdown', (e) => {
+        if (e.button !== 0 || !this.hasAttribute('data-reframe')) return;
+        e.preventDefault();
+        e.stopPropagation();
+        this._spill.setPointerCapture(e.pointerId);
+        const rect = this.getBoundingClientRect();
+        const fw = rect.width || 1, fh = rect.height || 1;
+        const corner = e.target.getAttribute && e.target.getAttribute('data-c');
+        let move;
+        if (corner) {
+          // Resize about the OPPOSITE corner. Viewport-px throughout (rect
+          // fw/fh, not clientWidth) so the math survives a transform:scale()
+          // ancestor — deck_stage renders slides scaled-to-fit.
+          const iw = this._img.naturalWidth || 1, ih = this._img.naturalHeight || 1;
+          const base = Math.max(fw / iw, fh / ih);
+          const sx = corner.includes('e') ? 1 : -1;
+          const sy = corner.includes('s') ? 1 : -1;
+          const s0 = this._view.s;
+          const w0 = iw * base * s0, h0 = ih * base * s0;
+          const cx0 = (50 + this._view.x) / 100 * fw;
+          const cy0 = (50 + this._view.y) / 100 * fh;
+          const ox = cx0 - sx * w0 / 2, oy = cy0 - sy * h0 / 2;
+          const diag0 = Math.hypot(w0, h0);
+          const ux = sx * w0 / diag0, uy = sy * h0 / diag0;
+          move = (ev) => {
+            const proj = (ev.clientX - rect.left - ox) * ux +
+                         (ev.clientY - rect.top - oy) * uy;
+            const s = clampS(s0 * proj / diag0);
+            const d = diag0 * s / s0;
+            this._view.s = s;
+            this._view.x = (ox + ux * d / 2) / fw * 100 - 50;
+            this._view.y = (oy + uy * d / 2) / fh * 100 - 50;
+            this._clampView();
+            this._applyView();
+          };
+        } else {
+          this.setAttribute('data-panning', '');
+          const start = { px: e.clientX, py: e.clientY, x: this._view.x, y: this._view.y };
+          move = (ev) => {
+            this._view.x = start.x + (ev.clientX - start.px) / fw * 100;
+            this._view.y = start.y + (ev.clientY - start.py) / fh * 100;
+            this._clampView();
+            this._applyView();
+          };
+        }
+        const up = () => {
+          try { this._spill.releasePointerCapture(e.pointerId); } catch {}
+          this._spill.removeEventListener('pointermove', move);
+          this._spill.removeEventListener('pointerup', up);
+          this._spill.removeEventListener('pointercancel', up);
+          this.removeAttribute('data-panning');
+          this._dragUp = null;
+        };
+        // Stashed so _exitReframe (Escape / outside-click mid-drag) can
+        // tear the capture + listeners down synchronously.
+        this._dragUp = up;
+        this._spill.addEventListener('pointermove', move);
+        this._spill.addEventListener('pointerup', up);
+        this._spill.addEventListener('pointercancel', up);
+      });
+      // Wheel zoom stays available inside reframe mode as a trackpad nicety —
+      // zooms toward the cursor (offset' = cursor·(1-k) + offset·k).
+      this.addEventListener('wheel', (e) => {
+        if (!this.hasAttribute('data-reframe')) return;
+        e.preventDefault();
+        const r = this.getBoundingClientRect();
+        const cx = (e.clientX - r.left) / r.width * 100 - 50;
+        const cy = (e.clientY - r.top) / r.height * 100 - 50;
+        const prev = this._view.s;
+        const next = clampS(prev * Math.pow(1.0015, -e.deltaY));
+        if (next === prev) return;
+        const k = next / prev;
+        this._view.s = next;
+        this._view.x = cx * (1 - k) + this._view.x * k;
+        this._view.y = cy * (1 - k) + this._view.y * k;
+        this._clampView();
+        this._applyView();
+      }, { passive: false });
+    }
+
+    connectedCallback() {
+      // Warn once per page — an id-less slot works for the session but
+      // cannot persist, and two id-less slots would share nothing.
+      if (!this.id && !ImageSlot._warned) {
+        ImageSlot._warned = true;
+        console.warn('<image-slot> without an id will not persist its dropped image.');
+      }
+      this.addEventListener('dragenter', this);
+      this.addEventListener('dragover', this);
+      this.addEventListener('dragleave', this);
+      this.addEventListener('drop', this);
+      subs.add(this._subFn);
+      // width%/height% in _applyView encode the frame aspect at call time —
+      // a host resize (responsive grid, pane divider) would stretch the
+      // image until the next _render. Re-render on size change: _render()
+      // re-seeds _view from stored before clamp/apply, so a shrink→grow
+      // cycle round-trips instead of ratcheting x/y toward the narrower
+      // frame's clamp range.
+      this._ro = new ResizeObserver(() => this._render());
+      this._ro.observe(this);
+      load();
+      this._render();
+    }
+
+    disconnectedCallback() {
+      subs.delete(this._subFn);
+      this.removeEventListener('dragenter', this);
+      this.removeEventListener('dragover', this);
+      this.removeEventListener('dragleave', this);
+      this.removeEventListener('drop', this);
+      if (this._ro) { this._ro.disconnect(); this._ro = null; }
+      this._exitReframe(false);
+    }
+
+    _enterReframe() {
+      if (this.hasAttribute('data-reframe')) return;
+      this.setAttribute('data-reframe', '');
+      this._applyView();
+      // Close on click outside (the spill handler stopPropagation()s so
+      // in-image drags don't reach this) and on Escape. Listeners are held
+      // on the instance so _exitReframe / disconnectedCallback can detach
+      // exactly what was attached.
+      this._outside = (e) => {
+        if (e.composedPath && e.composedPath().includes(this)) return;
+        this._exitReframe(true);
+      };
+      this._esc = (e) => { if (e.key === 'Escape') this._exitReframe(true); };
+      document.addEventListener('pointerdown', this._outside, true);
+      document.addEventListener('keydown', this._esc, true);
+    }
+
+    _exitReframe(commit) {
+      if (!this.hasAttribute('data-reframe')) return;
+      if (this._dragUp) this._dragUp();
+      this.removeAttribute('data-reframe');
+      this.removeAttribute('data-panning');
+      if (this._outside) document.removeEventListener('pointerdown', this._outside, true);
+      if (this._esc) document.removeEventListener('keydown', this._esc, true);
+      this._outside = this._esc = null;
+      if (commit) this._commitView();
+    }
+
+    attributeChangedCallback() { if (this.shadowRoot) this._render(); }
+
+    // handleEvent — one listener object for all four drag events keeps the
+    // add/remove symmetric and the depth counter correct.
+    handleEvent(e) {
+      if (e.type === 'dragenter' || e.type === 'dragover') {
+        // Without preventDefault the browser never fires 'drop'.
+        e.preventDefault();
+        e.stopPropagation();
+        if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+        if (e.type === 'dragenter') this._depth++;
+        this.setAttribute('data-over', '');
+      } else if (e.type === 'dragleave') {
+        // dragenter/leave fire for every descendant crossing — count depth
+        // so hovering the icon inside the empty state doesn't flicker.
+        if (--this._depth <= 0) { this._depth = 0; this.removeAttribute('data-over'); }
+      } else if (e.type === 'drop') {
+        e.preventDefault();
+        e.stopPropagation();
+        this._depth = 0;
+        this.removeAttribute('data-over');
+        const f = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
+        if (f) this._ingest(f);
+      }
+    }
+
+    async _ingest(file) {
+      this._setError(null);
+      if (!file || ACCEPT.indexOf(file.type) < 0) {
+        this._setError('Drop a PNG, JPEG, WebP, or AVIF image.');
+        return;
+      }
+      // toDataUrl can take hundreds of ms on a large photo. A Clear or a
+      // newer drop during that window would be clobbered when this await
+      // resumes — bump + capture a generation so stale encodes bail.
+      const gen = ++this._gen;
+      try {
+        const w = this.clientWidth || this.offsetWidth || MAX_DIM;
+        const url = await toDataUrl(file, w);
+        if (gen !== this._gen) return;
+        // Only exit reframe once the new image is in hand — a rejected type
+        // or decode failure leaves the in-progress crop untouched.
+        this._exitReframe(false);
+        const val = { u: url, s: 1, x: 0, y: 0 };
+        setSlot(this.id || '', val);
+        // Keep a session-local copy for id-less slots so the drop still
+        // shows, even though it cannot persist.
+        if (!this.id) { this._local = val; this._render(); }
+      } catch (err) {
+        if (gen !== this._gen) return;
+        this._setError('Could not read that image.');
+        console.warn('<image-slot> ingest failed:', err);
+      }
+    }
+
+    _setError(msg) {
+      if (this._err) { this._err.remove(); this._err = null; }
+      if (!msg) return;
+      const d = document.createElement('div');
+      d.className = 'err'; d.textContent = msg;
+      this.shadowRoot.appendChild(d);
+      this._err = d;
+      setTimeout(() => { if (this._err === d) { d.remove(); this._err = null; } }, 3000);
+    }
+
+    // Reframing (pan/resize) is only meaningful for fit=cover — contain/fill
+    // keep the old object-fit path and double-click is a no-op.
+    _reframes() {
+      return this.hasAttribute('data-filled') &&
+        (this.getAttribute('fit') || 'cover') === 'cover';
+    }
+
+    // Cover-baseline geometry, shared by clamp/apply/resize. Null until the
+    // img has loaded (naturalWidth is 0 before that) or when the slot has no
+    // layout box — ResizeObserver fires with a 0×0 rect under display:none,
+    // and clamping against a degenerate 1×1 frame would silently pull the
+    // stored pan toward zero.
+    _geom() {
+      const iw = this._img.naturalWidth, ih = this._img.naturalHeight;
+      const fw = this.clientWidth, fh = this.clientHeight;
+      if (!iw || !ih || !fw || !fh) return null;
+      return { iw, ih, fw, fh, base: Math.max(fw / iw, fh / ih) };
+    }
+
+    _clampView() {
+      // Pan range on each axis is half the overflow past the frame edge.
+      const g = this._geom();
+      if (!g) return;
+      const mx = Math.max(0, (g.iw * g.base * this._view.s / g.fw - 1) * 50);
+      const my = Math.max(0, (g.ih * g.base * this._view.s / g.fh - 1) * 50);
+      this._view.x = Math.max(-mx, Math.min(mx, this._view.x));
+      this._view.y = Math.max(-my, Math.min(my, this._view.y));
+    }
+
+    _applyView() {
+      const g = this._geom();
+      const fit = this.getAttribute('fit') || 'cover';
+      if (fit !== 'cover' || !g) {
+        // Non-cover, or dimensions not known yet (before img load).
+        this._img.style.width = '100%';
+        this._img.style.height = '100%';
+        this._img.style.left = '50%';
+        this._img.style.top = '50%';
+        this._img.style.objectFit = fit;
+        this._img.style.objectPosition = this.getAttribute('position') || '50% 50%';
+        return;
+      }
+      // Cover baseline: img fills the frame on its tighter axis at s=1, so
+      // pan works immediately on the overflowing axis without zooming first.
+      // Width/height and left/top are all frame-% — depends only on the
+      // frame aspect ratio, so a responsive resize keeps the same crop. The
+      // spill layer mirrors the same box so its corners = image corners.
+      const k = g.base * this._view.s;
+      const w = (g.iw * k / g.fw * 100) + '%';
+      const h = (g.ih * k / g.fh * 100) + '%';
+      const l = (50 + this._view.x) + '%';
+      const t = (50 + this._view.y) + '%';
+      this._img.style.width = w; this._img.style.height = h;
+      this._img.style.left = l; this._img.style.top = t;
+      this._img.style.objectFit = '';
+      this._spill.style.width = w; this._spill.style.height = h;
+      this._spill.style.left = l; this._spill.style.top = t;
+    }
+
+    _commitView() {
+      const v = { s: this._view.s, x: this._view.x, y: this._view.y };
+      if (this._userUrl) v.u = this._userUrl;
+      // Framing-only (no u) persists too so an author-src slot remembers its
+      // crop; clearing the sidecar still falls through to src=.
+      if (this.id) setSlot(this.id, v);
+      else { this._local = v; }
+    }
+
+    _render() {
+      // Shape / mask. Presets use border-radius so the dashed ring can
+      // follow the rounded outline; clip-path is only applied for an
+      // explicit `mask` (the ring is hidden there since a rectangle
+      // dashed border chopped by an arbitrary polygon looks broken).
+      const mask = this.getAttribute('mask');
+      const shape = (this.getAttribute('shape') || 'rounded').toLowerCase();
+      let radius = '';
+      if (shape === 'circle') radius = '50%';
+      else if (shape === 'pill') radius = '9999px';
+      else if (shape === 'rounded') {
+        const n = parseFloat(this.getAttribute('radius'));
+        radius = (Number.isFinite(n) ? n : 12) + 'px';
+      }
+      this._frame.style.borderRadius = mask ? '' : radius;
+      this._frame.style.clipPath = mask || '';
+      this._ring.style.borderRadius = mask ? '' : radius;
+      this._ring.style.display = mask ? 'none' : '';
+
+      // Controls and reframe entry gate on this so share links stay read-only.
+      const editable = !!(window.omelette && window.omelette.writeFile);
+      this.toggleAttribute('data-editable', editable);
+      this._sub.style.display = editable ? '' : 'none';
+
+      // Content. The sidecar is also writable by the agent's write_file
+      // tool, so its value isn't guaranteed canvas-originated — only accept
+      // data:image/ URLs from it. The `src` attribute is author-controlled
+      // (Claude wrote it into the HTML) so it passes through unchanged.
+      let stored = this.id ? getSlot(this.id) : this._local;
+      if (stored && stored.u && !/^data:image\//i.test(stored.u)) stored = null;
+      const srcAttr = this.getAttribute('src') || '';
+      this._userUrl = (stored && stored.u) || null;
+      const url = this._userUrl || srcAttr;
+      // Don't clobber an in-flight reframe with a store-triggered re-render.
+      if (!this.hasAttribute('data-reframe')) {
+        this._view = {
+          s: stored && Number.isFinite(stored.s) ? clampS(stored.s) : 1,
+          x: stored && Number.isFinite(stored.x) ? stored.x : 0,
+          y: stored && Number.isFinite(stored.y) ? stored.y : 0,
+        };
+      }
+      this._cap.textContent = this.getAttribute('placeholder') || 'Drop an image';
+      // Toggle via style.display — the [hidden] attribute alone loses to
+      // the display:flex / display:block rules in the stylesheet above.
+      if (url) {
+        if (this._img.getAttribute('src') !== url) {
+          this._img.src = url;
+          this._ghost.src = url;
+        }
+        this._img.style.display = 'block';
+        this._empty.style.display = 'none';
+        this.setAttribute('data-filled', '');
+        this._clampView();
+        this._applyView();
+      } else {
+        this._img.style.display = 'none';
+        this._img.removeAttribute('src');
+        this._ghost.removeAttribute('src');
+        this._empty.style.display = 'flex';
+        this.removeAttribute('data-filled');
+      }
+    }
+  }
+
+  if (!customElements.get('image-slot')) {
+    customElements.define('image-slot', ImageSlot);
+  }
+})();

--- a/ui/.design-sync/import/orrery/orrery-engine.js
+++ b/ui/.design-sync/import/orrery/orrery-engine.js
@@ -1,0 +1,1479 @@
+/*
+ * orrery-engine.js — seeded, deterministic mini-implementation of the Orrery
+ * off-screen resolver + explain layer, for the audit-dashboard prototype.
+ *
+ * Ground truth: docs/orrery_packages.md @ aaa854ee (all 25 BUILTIN_TEMPLATES:
+ * priorities, gates, branches, magnitudes, narrative stubs verbatim) and
+ * nexus/agents/orrery/needs.py (5 needs, severity thresholds, pressure tuning).
+ * Family tag sets are approximations of substrate.py frozensets (marked ~).
+ *
+ * Everything is pure: resolveTick(state) -> explained payload. No RNG.
+ */
+
+// ---------------------------------------------------------------- vocab ----
+
+export const BANDS = [
+  { id: 'crisis',   name: 'Crisis / Constraint',     chart: 1 },
+  { id: 'embodied', name: 'Embodied Maintenance',    chart: 2 },
+  { id: 'routine',  name: 'Anchored Routine',        chart: 3 },
+  { id: 'affil',    name: 'Affiliation',             chart: 4 },
+  { id: 'project',  name: 'Project / Identity',      chart: 5 },
+];
+
+export const FAME = ['unknown', 'local', 'known', 'renowned', 'legendary'];
+export const RESOURCES = ['destitute', 'poor', 'struggling', 'comfortable', 'wealthy', 'magnate'];
+
+export const NEEDS = ['sleep', 'hunger', 'thirst', 'socialize', 'intimacy'];
+export const NEED_THRESHOLDS = {
+  sleep:     { mild: 16, moderate: 30, severe: 48,  critical: 72 },
+  hunger:    { mild: 8,  moderate: 16, severe: 30,  critical: 48 },
+  thirst:    { mild: 4,  moderate: 8,  severe: 16,  critical: 24 },
+  socialize: { mild: 24, moderate: 72, severe: 168, critical: 336 },
+  intimacy:  { mild: 72, moderate: 168, severe: 336, critical: 720 },
+};
+export const NEED_PRESSURE_PRIORITY = { sleep: 25, thirst: 24, hunger: 22, socialize: 18, intimacy: 16 };
+export const NEED_IMMUNITY = {
+  sleep:  ['bodyform:android', 'bodyform:construct', 'digital_mind', 'inorganic', 'virtual'],
+  hunger: ['bodyform:android', 'bodyform:construct', 'digital_mind', 'inorganic', 'virtual'],
+  thirst: ['bodyform:android', 'bodyform:construct', 'digital_mind', 'inorganic', 'virtual'],
+  socialize: [],
+  intimacy: ['digital_mind', 'libido_absent', 'virtual'],
+};
+
+// ~approximations of substrate.py curated frozensets
+export const FAMILIES = {
+  INTIMACY_SUPPRESSOR_TAGS: ['grudge_active', 'distressed', 'cns_stimulated', 'at_vigil'],
+  HIDDEN_TAGS: ['off_grid', 'undercover', 'cover_identity', 'fugitive'],
+  CONSTRAINED_TAGS: ['captive', 'unconscious', 'dying'],
+  PUBLIC_MOBILITY_BLOCKERS: ['off_grid', 'fugitive', 'wanted', 'captive', 'unconscious'],
+  DRAMATIC_CONTACT_TAGS: ['off_grid', 'undercover', 'cover_identity', 'fugitive', 'wanted'],
+};
+export function familiesOf(tag) {
+  return Object.keys(FAMILIES).filter((f) => FAMILIES[f].includes(tag));
+}
+
+export const PLACES = {
+  rootline:    { id: 'rootline',    name: 'The Rootline — Sublevel Nine',   classes: ['subterranean', 'transit'] },
+  glow:        { id: 'glow',        name: 'The Glow — Market Concourse',    classes: ['commerce', 'meeting', 'place_open', 'urban_dense'] },
+  stacks:      { id: 'stacks',      name: 'The Stacks — Fabrication Row',   classes: ['craft', 'place_restricted', 'production'] },
+  remembrance: { id: 'remembrance', name: 'The Remembrance Yard',           classes: ['sacred', 'tomb'] },
+  ashgrid:     { id: 'ashgrid',     name: 'Ash-Grid Safehouse',             classes: ['haven', 'dwelling'] },
+};
+
+// ------------------------------------------------------- condition DSL ----
+
+const A = (...children) => ({ op: 'AND', children });
+const O = (...children) => ({ op: 'OR', children });
+const N = (child) => ({ op: 'NOT', children: [child] });
+const L = (p, args = {}, prose = '') => ({ p, ...args, prose });
+
+// Leaf builders (prose matches catalog rendering)
+const hydrated   = (w = 'actor') => L('hydrated', { w }, `${w} has enough hydrated context`);
+const tag        = (w, t) => L('tag', { w, t }, `${w} has \`${t}\` tag`);
+const eph        = (w, t) => L('eph', { w, t }, `${w} has \`${t}\` ephemeral`);
+const anyTag     = (w, list, label) => L('anyTag', { w, list }, label || `${w} has any of [${list.map((x) => '`' + x + '`').join(', ')}]`);
+const anyCur     = (w, list) => L('anyCur', { w, list }, `${w} has any current tag of [${list.map((x) => '`' + x + '`').join(', ')}]`);
+const inPair     = (w, t) => L('inPair', { w, t }, `${w} has inbound \`${t}\` pair tag`);
+const outPair    = (w, t) => L('outPair', { w, t }, `${w} has outbound \`${t}\` pair tag`);
+const residesHere = () => L('residesHere', {}, 'actor has `resides_at` pair tag to current location');
+const relShared  = (t) => L('relShared', { t }, `actor and target share \`${t}\` relationship (either direction)`);
+const relDir     = (t) => L('relDir', { t }, `actor has \`${t}\` relationship to target`);
+const trustLt    = (v) => L('trustLt', { v }, `trust actor→target < ${v}`);
+const trustGte   = (v) => L('trustGte', { v }, `trust actor→target ≥ ${v}`);
+const mutualWarm = () => L('mutualWarm', {}, 'actor and target have mutual warm trust');
+const trustLoaded = () => L('trustLoaded', {}, 'directional trust actor↔target differs by 3+ or is loaded');
+const dramatic   = () => L('dramatic', {}, 'direct contact actor→target is dramatic');
+const need       = (nd, v) => L('need', { nd, v }, `actor has \`${nd}\` debt ≥ ${v}`);
+const evRecent   = (t, targeting, within) => L('evRecent', { t, targeting, within },
+  targeting === 'any' ? `recent \`${t}\` event in last ${within} ticks` : `recent \`${t}\` event targeting ${targeting} in last ${within} ticks`);
+const cooldown   = (t, scope, ticks) => L('cooldown', { t, scope, ticks },
+  `≥ ${ticks} ticks since last \`${t}\` event for ${scope === 'pair' ? '(actor, target) pair' : 'actor'}`);
+const tod        = (list) => L('tod', { list }, `time of day is one of [${list.join(', ')}]`);
+const weather    = (list) => L('weather', { list }, `weather is one of [${list.join(', ')}]`);
+const place      = (w, c) => L('place', { w, c }, `${w} is in \`${c}\` place class`);
+const colo       = () => L('colo', {}, 'actor and target are co-located');
+const othersColo = (n, w = 'actor') => L('othersColo', { n, w }, `${n}+ other entities co-located with ${w}`);
+const othersGrieving = () => L('othersGrieving', {}, '1+ other entities with `grieving` ephemeral co-located with actor');
+const fameGte    = (r) => L('fameGte', { r }, `actor's own fame is \`${r}\` or wider`);
+const fameLt     = (r) => L('fameLt', { r }, `actor's own fame is narrower than \`${r}\``);
+const resGte     = (r) => L('resGte', { r }, `actor's own resources are \`${r}\` or better`);
+const resLt     = (r) => L('resLt', { r }, `actor's own resources are below \`${r}\``);
+const constrained = () => L('constrained', {}, 'actor is constrained or immobilized');
+const hiddenOff  = () => L('hiddenOff', {}, 'actor is hidden or off-grid');
+const pubFlow    = (w = 'actor') => L('pubFlow', { w }, `${w} can plausibly move through public flow`);
+const intimSupp  = () => L('intimSupp', {}, 'actor has an intimacy suppressor');
+const inTransit  = () => L('inTransit', {}, 'actor is in transit');
+const hasDest    = () => L('hasDest', {}, 'actor has a planned travel destination');
+const travProg   = (v) => L('travProg', { v }, `actor travel progress ≥ ${v}`);
+const travPurpose = (v) => L('travPurpose', { v }, `actor is traveling for \`${v}\` purpose`);
+const travRisk   = (list) => L('travRisk', { list }, `actor travel risk is one of [${list.join(', ')}]`);
+const anchorHas  = (k) => L('anchorHas', { k }, `actor has \`${k}\` routine anchor`);
+const anchorDue  = (k) => L('anchorDue', { k }, `actor's \`${k}\` routine is due now (weekdays 0=Monday; empty schedule always due)`);
+const anchorAway = (k) => L('anchorAway', { k }, `actor is away from \`${k}\` anchor`);
+const anchorAt   = (k) => L('anchorAt', { k }, `actor is at \`${k}\` anchor`);
+const anchorResolves = (k) => L('anchorResolves', { k }, `actor's \`${k}\` routine can resolve a destination`);
+const partnerColo = () => L('partnerColo', {}, 'actor has an established partner co-located');
+const factionSenior = () => L('factionSenior', {}, 'actor holds `status:senior`+ toward any faction');
+const resolveDest = (classes) => L('resolveDest', { classes }, `actor can resolve a destination with place class \`${classes.join(',')}\``);
+const ALWAYS = null;
+
+// --------------------------------------------------------- the catalog ----
+// Order = BUILTIN_TEMPLATES authored tuple order (priority desc; ties broken
+// by this order — CULTIVATE_INFORMANT before KEEP_VIGIL, MOURN_LOSS before SLEEP).
+
+const CRAFT_TAGS = ['combat_trained', 'soldier', 'warrior', 'fighter', 'arcane_caster', 'engineer', 'mechanic', 'tinkerer', 'hacker', 'artificer', 'musician', 'dancer', 'performer', 'artist', 'writer', 'artisan', 'athlete', 'martial_artist', 'ranger', 'scout', 'monk', 'keeps_shop', 'merchant', 'innkeeper', 'trader', 'domestic_role', 'cares_for_household', 'matriarch', 'patriarch', 'scholar', 'researcher', 'academic', 'loremaster'];
+
+export const TEMPLATES = [
+  {
+    id: 'EVADE_PURSUERS', tid: 'evade_pursuers', band: 'crisis', priority: 100, slots: ['ACTOR'], ptp: false,
+    blurb: 'When the city is closing in.',
+    gate: A(
+      O(inPair('actor', 'hunting'), evRecent('compliance_alert', 'actor', 5)),
+      N(constrained()),
+      O(A(place('actor', 'subterranean'), place('actor', 'transit')), outPair('actor', 'contact:lodging'), pubFlow()),
+    ),
+    branches: [
+      { label: 'Go to ground in flooded tunnels', mag: 0.72, when: A(A(place('actor', 'subterranean'), place('actor', 'transit')), weather(['rain'])),
+        does: 'activity → "hiding from active pursuit"; adds `off_grid` to actor', event: 'evade_pursuit',
+        delta: { 'character.current_activity': 'hiding from active pursuit', 'entity_tags.add': ['off_grid'] },
+        stub: '{actor} slips off a Rootline platform into a flooded service corridor and kills every transmitter on their person.' },
+      { label: 'Buy a discreet extraction', mag: 0.64, when: A(fameGte('renowned'), resGte('wealthy')),
+        does: 'activity → "buying a discreet extraction"', event: 'evade_pursuit',
+        delta: { 'character.current_activity': 'buying a discreet extraction' },
+        stub: '{actor} knows their face does half the pursuers\u2019 work for them, so they pay for the kind of exit that never touches public flow: a closed vehicle, a bought route, a driver whose business is not remembering.' },
+      { label: 'Reach a safe house through contacts', mag: 0.58, when: outPair('actor', 'contact:lodging'),
+        does: 'activity → "relocating through safe contacts"', event: 'evade_pursuit',
+        delta: { 'character.current_activity': 'relocating through safe contacts' },
+        stub: '{actor} pings a broker through a low-bandwidth dead-drop and takes a four-hop route to a safe house.' },
+      { label: 'Keep moving, blend into public flow', mag: 0.42, when: A(pubFlow(), fameLt('renowned')),
+        does: 'activity → "blending into public flow"', event: 'evade_pursuit',
+        delta: { 'character.current_activity': 'blending into public flow' },
+        stub: '{actor} joins the densest pedestrian current nearby, never stopping long enough to make a clean pattern.' },
+      { label: 'Break line of sight without a clean route', mag: 0.28, when: ALWAYS,
+        does: 'activity → "breaking pursuit pattern"', event: 'evade_pursuit',
+        delta: { 'character.current_activity': 'breaking pursuit pattern' },
+        stub: '{actor} cannot rely on a clean public path, so they buy seconds instead: doors, stairwells, service gaps, and any angle that keeps the pursuit from becoming certain.' },
+    ],
+  },
+  {
+    id: 'PROTECT_KIN', tid: 'protect_kin', band: 'crisis', priority: 95, slots: ['ACTOR', 'TARGET'], ptp: true,
+    blurb: 'A bond pulls the actor toward someone in active danger.',
+    gate: A(
+      O(relShared('family'), relShared('romantic'), relShared('chosen_kin'), relShared('comrade')),
+      O(inPair('target', 'hunting'), eph('target', 'wounded'), evRecent('threat_issued', 'target', 4)),
+      N(inPair('actor', 'hunting')),
+    ),
+    branches: [
+      { label: 'Physically intervene at the target\u2019s location', mag: 0.78, when: A(colo(), inPair('target', 'hunting')),
+        does: 'activity → "shielding kin from active threat"; adds `recently_protective` to actor; clears inbound `hunting` pair tags from target', event: 'protective_intervention',
+        delta: { 'character.current_activity': 'shielding kin from active threat', 'entity_tags.add': ['recently_protective'], 'pair_tags.clear': ['hunting → target'] },
+        stub: '{actor} reaches {target} as the noose tightens — pulling them off the line of sight, into a service corridor whose layout {actor} has memorized for exactly this kind of moment.',
+        pressure: '{actor} may be close enough to intervene around {target}\u2019s current danger. Treat this as potential off-screen support or complication for the scene, not as an automatic rescue.' },
+      { label: 'Travel toward the target\u2019s last known location', mag: 0.52, when: A(outPair('actor', 'contact:social'), N(colo())),
+        does: 'activity → "moving to reach kin in danger"', event: 'protective_intervention',
+        delta: { 'character.current_activity': 'moving to reach kin in danger' },
+        stub: '{actor} drops what they were doing and starts moving — calling in favors at every transit checkpoint to shave minutes off the route to {target}, knowing the minutes might matter.',
+        pressure: '{actor} is moving toward {target}\u2019s current location because they believe the danger is real. You may foreshadow, delay, or ignore their arrival based on the active scene.' },
+      { label: 'Signal kin networks to converge on the target', mag: 0.41, when: relShared('comrade'),
+        does: 'activity → "coordinating kin response"', event: 'protective_intervention',
+        delta: { 'character.current_activity': 'coordinating kin response' },
+        stub: '{actor} pushes a coded distress beacon through the kin network — the kind of signal that pulls three or four people toward {target} from different directions without coordination.',
+        pressure: '{actor} has signaled a kin network around {target}. This can become outside help, cross-traffic, noise, or a looming option if it fits the live scene.' },
+      { label: 'Maintain vigil and wait for resolution', mag: 0.22, when: ALWAYS,
+        does: 'activity → "waiting on news of kin"; adds `distressed` to actor', event: 'protective_intervention',
+        delta: { 'character.current_activity': 'waiting on news of kin', 'entity_tags.add': ['distressed'] },
+        stub: '{actor} can\u2019t reach {target} in time, can\u2019t call who they would need to call — and stays close to a comm, monitoring channels, waiting for the news that will determine what comes next.',
+        pressure: '{actor} is monitoring {target}\u2019s danger from off-screen. This is emotional and logistical pressure, not a command to change what {target} does in the scene.' },
+    ],
+  },
+  {
+    id: 'EXTRACT_VENGEANCE', tid: 'extract_vengeance', band: 'project', priority: 90, slots: ['ACTOR', 'TARGET'], ptp: true,
+    bandNote: 'Active vengeance is a high-pressure identity project; left alone, it should interrupt ordinary life.',
+    blurb: 'A grudge ripens until the moment is right to settle it.',
+    gate: A(
+      eph('actor', 'grudge_active'),
+      O(relShared('enemy'), relShared('rival'), trustLt(-2)),
+      cooldown('retaliation_attempted', 'actor', 8),
+      cooldown('retaliation_executed', 'actor', 8),
+      N(inPair('actor', 'hunting')),
+    ),
+    branches: [
+      { label: 'Strike directly when opportunity opens', mag: 0.85, when: A(colo(), N(othersColo(2, 'target')), anyTag('actor', ['vendetta_holder', 'violent_history'])),
+        does: 'activity → "executing retaliation"; adds `recently_violent` to actor; removes `grudge_active`', event: 'retaliation_executed',
+        delta: { 'character.current_activity': 'executing retaliation', 'entity_tags.add': ['recently_violent'], 'entity_tags.clear': ['grudge_active'] },
+        stub: '{actor} moves on {target} in the moment the corridor clears — no warning, no negotiation, the years of waiting compressed into the time it takes to close a few meters of distance.',
+        pressure: '{actor}\u2019s grudge is close enough to {target}\u2019s current scene to become immediate pressure. Treat it as a possible threat, interruption, warning sign, or delayed consequence rather than an automatic attack.' },
+      { label: 'Surface a reputation attack in the right channels', mag: 0.58, when: A(outPair('actor', 'contact:social'), O(place('actor', 'urban_dense'), place('actor', 'commerce'), place('actor', 'meeting'))),
+        does: 'activity → "running a reputation attack"; adds `reputation_compromised` to target', event: 'retaliation_attempted',
+        delta: { 'character.current_activity': 'running a reputation attack', 'entity_tags.add': ['reputation_compromised → target'] },
+        stub: '{actor} feeds a curated dossier on {target} into three brokers in the Glow, taking pains to make the leak look like an accident of incautious clients rather than deliberate sabotage.',
+        pressure: '{actor} is trying to compromise {target}\u2019s reputation through off-screen channels. If useful, let the current scene show a rumor, message, social consequence, or pressure wave instead of a direct state change.' },
+      { label: 'Watch and document, waiting for a better window', mag: 0.34, when: ALWAYS,
+        does: 'activity → "surveilling a grudge target"', event: 'retaliation_attempted',
+        delta: { 'character.current_activity': 'surveilling a grudge target' },
+        stub: '{actor} continues to observe {target}\u2019s patterns from cover — shift changes, contacts, the geometry of their movements — letting the grudge stay sharp without spending it prematurely.',
+        pressure: '{actor} is watching {target}\u2019s current patterns from cover. This can surface as unease, surveillance traces, or a later setup, but {target}\u2019s on-screen choices remain yours.' },
+    ],
+  },
+  {
+    id: 'TEND_WOUNDED', tid: 'tend_wounded', band: 'crisis', priority: 88, slots: ['ACTOR', 'TARGET'], ptp: true,
+    blurb: 'A wounded body pulls the actor toward the small work of mending.',
+    gate: A(
+      eph('target', 'wounded'),
+      colo(),
+      N(inPair('actor', 'hunting')),
+      N(inPair('target', 'hunting')),
+      cooldown('tended_wound', 'pair', 2),
+      cooldown('wound_healed', 'pair', 2),
+    ),
+    branches: [
+      { label: 'Channel restorative power through hands and voice', mag: 0.74, when: tag('actor', 'magical_healing'),
+        does: 'activity → "channeling restorative power"; removes `wounded` from target', event: 'wound_healed',
+        delta: { 'character.current_activity': 'channeling restorative power', 'entity_tags.clear': ['wounded → target'], 'entity_tags.add': ['recently_drained'] },
+        stub: '{actor} kneels beside {target} and places hands where the damage lives. Something passes between them — a quiet exchange of warmth and pain — and the body begins to remember how to be whole.',
+        pressure: '{actor} may be close enough to attempt restorative work on {target}\u2019s wound in the active scene. Treat as offered help the scene can accept, defer, or complicate, not as automatic healing.' },
+      { label: 'Work the wound with trained hands', mag: 0.58, when: anyTag('actor', ['surgical_training', 'medical_skill']),
+        does: 'activity → "providing skilled medical care"; removes `wounded` from target; adds `recently_tended` to target', event: 'tended_wound',
+        delta: { 'character.current_activity': 'providing skilled medical care', 'entity_tags.clear': ['wounded → target'], 'entity_tags.add': ['recently_tended → target'] },
+        stub: '{actor} cleans the wound by feel, finds what needs to be found, and does the work the body cannot do for itself. {target} watches the ceiling and counts something silently.',
+        pressure: '{actor} is moving to provide skilled medical care to {target}. The scene may show this as a quiet competent interruption, a wait for stabilization, or a beat of trust between them.' },
+      { label: 'Apply what first-aid the moment allows', mag: 0.42, when: tag('actor', 'first_aid_trained'),
+        does: 'activity → "applying field first aid"; adds `recently_tended` to target', event: 'tended_wound',
+        delta: { 'character.current_activity': 'applying field first aid', 'entity_tags.add': ['recently_tended → target'] },
+        stub: '{actor} works from memory — pressure here, elevation there, the things that buy time when time is the thing you need. It won\u2019t be enough on its own, but it\u2019s enough for now.',
+        pressure: '{actor} has practical first-aid training and is at {target}\u2019s side. Treat as a stabilizing presence the scene can use without granting full recovery.' },
+      { label: 'Stay with the wound and do what can be done', mag: 0.24, when: ALWAYS,
+        does: 'activity → "keeping watch over the wounded"', event: 'tended_wound',
+        delta: { 'character.current_activity': 'keeping watch over the wounded' },
+        stub: '{actor} has no real skill for this. They press a cloth where there is bleeding and speak softly so {target} has a voice to follow back from wherever the body has gone.',
+        pressure: '{actor} is present at {target}\u2019s side without medical ability. Use this as accompaniment and witness — not as intervention.' },
+    ],
+  },
+  {
+    id: 'HIDE', tid: 'hide', band: 'crisis', priority: 84, slots: ['ACTOR'], ptp: false,
+    blurb: 'Steady-state concealment for people who are already living out of sight.',
+    gate: A(
+      hydrated(),
+      hiddenOff(),
+      N(inPair('actor', 'hunting')),
+      N(constrained()),
+      cooldown('hideout_maintained', 'actor', 6),
+      cooldown('signal_exposure_reduced', 'actor', 6),
+      cooldown('counter_surveillance_sweep', 'actor', 6),
+    ),
+    branches: [
+      { label: 'Erase the identity and vanish completely', mag: 0.62, when: A(fameGte('legendary'), resGte('magnate')),
+        does: 'activity → "erasing their identity"', event: 'hideout_maintained',
+        delta: { 'character.current_activity': 'erasing their identity' },
+        stub: '{actor} is too widely known to be hidden by walls or habits, so they spend what almost no one can spend: the records, the debts, the face in the right databases — an identity dismantled piece by piece until there is nothing left to recognize.' },
+      { label: 'Relocate to safer ground', mag: 0.52, when: A(fameGte('renowned'), resGte('wealthy')),
+        does: 'activity → "relocating to safer ground"', event: 'hideout_maintained',
+        delta: { 'character.current_activity': 'relocating to safer ground' },
+        stub: '{actor} accepts that a recognizable face cannot outlast the neighborhood that recognizes it, and pays for the quiet logistics of being somewhere else entirely before anyone thinks to look.' },
+      { label: 'Change the face they show the street', mag: 0.44, when: A(fameGte('known'), resGte('comfortable')),
+        does: 'activity → "altering their appearance"', event: 'hideout_maintained',
+        delta: { 'character.current_activity': 'altering their appearance' },
+        stub: '{actor} is recognizable enough that habit alone will not protect them, so they spend on the cosmetic arithmetic of not being noticed: hair, clothes, gait, the small paid alterations that make a familiar face unfamiliar.' },
+      { label: 'Harden or sanitize a safehouse', mag: 0.4, when: A(place('actor', 'haven'), O(outPair('actor', 'contact:lodging'), anyCur('actor', ['fixer', 'route_familiar', 'safehouse_operator', 'survivalist']))),
+        does: 'activity → "hardening a safehouse"', event: 'hideout_maintained',
+        delta: { 'character.current_activity': 'hardening a safehouse' },
+        stub: '{actor} spends the turn making the safe place safer: cleaning traces, changing habits, checking exits, and removing the small comforts that become evidence.' },
+      { label: 'Go dark and reduce signal exposure', mag: 0.36, when: O(outPair('actor', 'contact:social'), anyCur('actor', ['ghostprint_active', 'hacker', 'off_grid', 'paranoid', 'signal_operator'])),
+        does: 'activity → "reducing signal exposure"', event: 'signal_exposure_reduced',
+        delta: { 'character.current_activity': 'reducing signal exposure' },
+        stub: '{actor} trims their signal down to almost nothing — no unnecessary pings, no sentimental check-ins, no pattern that would let a watcher say yes, there.' },
+      { label: 'Run a counter-surveillance sweep', mag: 0.34, when: O(anyCur('actor', ['combat_trained', 'hacker', 'informant_handler', 'paranoid', 'scout', 'surveillance_capable']), evRecent('compliance_alert', 'actor', 8)),
+        does: 'activity → "running counter-surveillance"', event: 'counter_surveillance_sweep',
+        delta: { 'character.current_activity': 'running counter-surveillance' },
+        stub: '{actor} checks whether anyone has learned the shape of their absence: doubled-back routes, watcher positions, unusual queries, and the tiny repetitions that turn hiding into a map.' },
+      { label: 'Shift a mobile route without surfacing', mag: 0.3, when: A(O(inTransit(), hasDest()), anyCur('actor', ['fugitive', 'route_familiar', 'travel_ready', 'wanted'])),
+        does: 'activity → "shifting concealed route"', event: 'hideout_maintained',
+        delta: { 'character.current_activity': 'shifting concealed route' },
+        stub: '{actor} changes the route without making the change look like a change, letting timing and terrain do what panic would ruin.' },
+      { label: 'Preserve the silence another day', mag: 0.22, when: ALWAYS,
+        does: 'activity → "preserving concealment"', event: 'hideout_maintained',
+        delta: { 'character.current_activity': 'preserving concealment' },
+        stub: '{actor} does the unglamorous work of staying missing: small routines, smaller footprints, and the discipline not to reach toward the people who would make the silence easier to bear.' },
+    ],
+  },
+  {
+    id: 'HONOR_DEBT', tid: 'honor_debt', band: 'project', priority: 80, slots: ['ACTOR'], ptp: false,
+    bandNote: 'Honor/debt pressure is a story obligation that may preempt ordinary maintenance when the relevant ledger is hot.',
+    blurb: 'A binding obligation surfaces from the blank years.',
+    gate: O(eph('actor', 'debt_pulse_active'), evRecent('encoded_message', 'actor', 3)),
+    branches: [
+      { label: 'Activate the Ghostprint Key at a sympathetic node', mag: 0.66, when: A(tag('actor', 'ghostprint_active'), A(place('actor', 'subterranean'), place('actor', 'transit'))),
+        does: 'activity → "signaling through a sympathetic node"', event: 'honor_debt',
+        delta: { 'character.current_activity': 'signaling through a sympathetic node' },
+        stub: '{actor} finds a half-decommissioned authentication terminal and pulses the Key against it.' },
+      { label: 'Fulfill obligation through a dead-drop', mag: 0.5, when: outPair('actor', 'contact:social'),
+        does: 'activity → "servicing an old debt"', event: 'honor_debt',
+        delta: { 'character.current_activity': 'servicing an old debt' },
+        stub: '{actor} tucks an encoded microdrive behind a loose ceramic tile and leaves a mark for the recipient.' },
+      { label: 'Leave a public sign', mag: 0.38, when: ALWAYS,
+        does: 'activity → "leaving a coded public sign"', event: 'honor_debt',
+        delta: { 'character.current_activity': 'leaving a coded public sign' },
+        stub: '{actor} pays a street artist in physical cash to place a specific glyph where only the intended recipient will read it.' },
+    ],
+  },
+  {
+    id: 'WARN_ALLY', tid: 'warn_ally', band: 'crisis', priority: 75, slots: ['ACTOR', 'TARGET'], ptp: true,
+    blurb: 'A threat surfaces; word reaches the people who need to know.',
+    gate: A(
+      O(relShared('family'), relShared('romantic'), relShared('chosen_kin'), relShared('comrade'), relShared('ally')),
+      O(evRecent('threat_issued', 'target', 3), evRecent('compliance_alert', 'target', 3), inPair('target', 'hunting')),
+      N(inPair('actor', 'hunting')),
+    ),
+    branches: [
+      { label: 'Reach the ally face-to-face before the word gets out', mag: 0.66, when: A(colo(), N(dramatic())),
+        does: 'activity → "delivering urgent warning in person"; adds `forewarned` to target', event: 'warning_delivered',
+        delta: { 'character.current_activity': 'delivering urgent warning in person', 'entity_tags.add': ['forewarned → target'] },
+        stub: '{actor} catches {target} before they have time to compose themselves and tells them quickly, in a voice stripped to the load-bearing words, what is coming and what they should do about it.',
+        pressure: '{actor} is moving to deliver an urgent warning to {target}. The scene may show this as interruption, intrusion, or a beat the storyteller folds into the current moment.' },
+      { label: 'Send word through whatever channel will reach them quickest', mag: 0.52, when: N(dramatic()),
+        does: 'activity → "sending urgent warning"; adds `forewarned` to target', event: 'warning_delivered',
+        delta: { 'character.current_activity': 'sending urgent warning', 'entity_tags.add': ['forewarned → target'] },
+        stub: '{actor} sends the warning through whatever channel will reach {target} fastest — a call, a runner, a sealed message, a coded signal — and hopes the gap between sending and receiving is short enough to matter.',
+        pressure: '{actor} has sent {target} an urgent warning by remote means. The scene may show this as an incoming message, a vague disturbance, a half-heard signal, or it may not land in time.' },
+      { label: 'Leak the warning without breaking cover', mag: 0.4, when: ALWAYS,
+        does: 'activity → "leaking urgent warning"; adds `forewarned` to target', event: 'warning_delivered',
+        delta: { 'character.current_activity': 'leaking urgent warning', 'entity_tags.add': ['forewarned → target'] },
+        stub: '{actor} still sends the warning, but strips their own hand from it: a proxy, a coded leak, an anonymous ping, something that can reach {target} without making contact itself the story.',
+        pressure: '{actor} has sent {target} an indirect warning. It may appear as a leak, proxy message, coded signal, or not land in time; Orrery is not deciding how {target} responds.' },
+    ],
+  },
+  {
+    id: 'PURSUE_GHOST_LEAD', tid: 'pursue_ghost_lead', band: 'project', priority: 60, slots: ['ACTOR'], ptp: false,
+    bandNote: 'Ghost-lead pursuit is a long-arc motive with explicit clue pressure, so it can outrank routine maintenance.',
+    blurb: 'The fragments of a buried identity tug at the actor.',
+    gate: A(tag('actor', 'seeking_identity'), tod(['evening', 'night']), N(inPair('actor', 'hunting'))),
+    branches: [
+      { label: 'Recon a hideout their body remembers', mag: 0.64, when: A(place('actor', 'subterranean'), place('actor', 'transit')),
+        does: 'activity → "reconning remembered terrain"', event: 'pursue_identity_lead',
+        delta: { 'character.current_activity': 'reconning remembered terrain' },
+        stub: '{actor} picks through maintenance corridors to a place their body recognizes before memory can explain why.' },
+      { label: 'Probe the data fog with the Key', mag: 0.57, when: tag('actor', 'ghostprint_active'),
+        does: 'activity → "probing identity records"', event: 'pursue_identity_lead',
+        delta: { 'character.current_activity': 'probing identity records' },
+        stub: '{actor} brushes against a mid-tier operator, ducks into a kiosk, and lets the Key scrape fragments from the ledger noise.' },
+      { label: 'Query the broker network', mag: 0.44, when: ALWAYS,
+        does: 'activity → "querying the broker network"', event: 'pursue_identity_lead',
+        delta: { 'character.current_activity': 'querying the broker network' },
+        stub: '{actor} visits a broker who owes them a favor and leaves with one new question and one dangerous name.' },
+    ],
+  },
+  {
+    id: 'CHECK_ON_DEPENDENT', tid: 'check_on_dependent', band: 'affil', priority: 55, slots: ['ACTOR', 'TARGET'], ptp: true,
+    bandNote: 'Dependent care is affiliation with responsibility attached, so it can preempt ordinary maintenance.',
+    blurb: 'A duty of care surfaces between the actor and someone in their charge.',
+    gate: A(
+      N(tag('actor', 'informant_handler')),
+      O(relDir('handler'), relDir('mentor'), relDir('patron'), relDir('guardian')),
+      cooldown('contact_made', 'pair', 12),
+      cooldown('welfare_check', 'pair', 12),
+      N(inPair('actor', 'hunting')),
+      N(eph('actor', 'grudge_active')),
+    ),
+    branches: [
+      { label: 'Drop by in person when the moment allows', mag: 0.44, when: A(colo(), cooldown('welfare_check', 'pair', 6)),
+        does: 'activity → "checking on a dependent in person"', event: 'welfare_check',
+        delta: { 'character.current_activity': 'checking on a dependent in person' },
+        stub: '{actor} stops by — ostensibly for something else, the way these visits often are — and uses the small window to read {target}\u2019s state: how they look, what they say without saying, what they decline to mention.',
+        pressure: '{actor} is making a casual welfare check on {target}. Treat as a low-key social presence the scene can absorb or use as a beat of relationship texture.' },
+      { label: 'Reach out through customary channels', mag: 0.22, when: ALWAYS,
+        does: 'activity → "checking in on a dependent"', event: 'contact_made',
+        delta: { 'character.current_activity': 'checking in on a dependent' },
+        stub: '{actor} sends the kind of message they always send — brief, light in tone, asking nothing real but leaving the door open for {target} to say something real if they want to — and watches for what comes back.',
+        pressure: '{actor} has sent {target} a routine welfare-check message. The scene may use this as an unread notification, an answered exchange, or texture for {target}\u2019s decisions.' },
+    ],
+  },
+  {
+    id: 'CULTIVATE_INFORMANT', tid: 'cultivate_informant', band: 'project', priority: 50, slots: ['ACTOR', 'TARGET'], ptp: true,
+    bandNote: 'Informant cultivation is relationship-shaped, but it serves an active project rather than ordinary affiliation.',
+    blurb: 'Patient intelligence work with a specific asset.',
+    gate: A(
+      tag('actor', 'informant_handler'),
+      O(relDir('handler'), L('relDirRev', { t: 'asset' }, 'target has `asset` relationship to actor')),
+      cooldown('informant_contact', 'pair', 4),
+      cooldown('intel_acquired', 'pair', 4),
+      tod(['evening', 'night']),
+      N(inPair('actor', 'hunting')),
+      N(eph('actor', 'grudge_active')),
+    ),
+    branches: [
+      { label: 'Press for material intel when trust is sufficient', mag: 0.62, when: A(colo(), trustGte(2), cooldown('intel_acquired', 'pair', 6)),
+        does: 'activity → "acquiring material intelligence"; adds `intelligence_asset_active` to actor', event: 'intel_acquired',
+        delta: { 'character.current_activity': 'acquiring material intelligence', 'entity_tags.add': ['intelligence_asset_active'] },
+        stub: '{actor} meets {target} in a place that looks ordinary to anyone watching and asks the question they\u2019ve been working toward for weeks. {target} doesn\u2019t answer immediately. Then they do.',
+        pressure: '{actor} may be trying to extract material intel from {target} while {target} is in the current scene. Use it only if it creates a believable opening, signal, or complication.' },
+      { label: 'Routine contact to maintain the relationship', mag: 0.28, when: A(colo(), trustGte(0)),
+        does: 'activity → "maintaining informant contact"', event: 'informant_contact',
+        delta: { 'character.current_activity': 'maintaining informant contact' },
+        stub: '{actor} sees {target} in passing — a transactional exchange with nothing to it, except that the exchange itself is the point. The relationship needs maintenance whether or not there is anything to report.',
+        pressure: '{actor} is maintaining contact with {target} through a subtle off-screen channel. It can surface as a message, glance, coded exchange, or be deferred.' },
+      { label: 'Place a small overture from a distance', mag: 0.18, when: ALWAYS,
+        does: 'activity → "courting an informant remotely"', event: 'informant_contact',
+        delta: { 'character.current_activity': 'courting an informant remotely' },
+        stub: '{actor} routes a small gift or unexpected courtesy to {target} through indirect channels — the kind of gesture that lands without obligation but accumulates over time into something the asset will eventually want to repay.',
+        pressure: '{actor} has placed a small indirect overture for {target}. Treat it as optional atmosphere or a hook the Storyteller can choose to pick up.' },
+    ],
+  },
+  {
+    id: 'KEEP_VIGIL', tid: 'keep_vigil', band: 'affil', priority: 50, slots: ['ACTOR', 'TARGET'], ptp: true,
+    bandNote: 'Vigil is affiliation under acute pressure, so it can outrank ordinary maintenance while a target is wounded or dying.',
+    blurb: 'The actor remains present through a slow, uncertain hour.',
+    gate: A(
+      colo(),
+      O(eph('target', 'wounded'), eph('target', 'dying'), eph('target', 'unconscious'), eph('target', 'captive')),
+      O(relDir('family'), relDir('romantic'), relDir('chosen_kin'), relDir('comrade'), relDir('ward'), relDir('guardian'), relDir('captor')),
+      cooldown('vigil_held', 'actor', 2),
+      N(inPair('actor', 'hunting')),
+    ),
+    branches: [
+      { label: 'Maintain prayerful or meditative presence', mag: 0.46, when: anyTag('actor', ['devout', 'contemplative', 'ritual_practitioner']),
+        does: 'activity → "holding meditative vigil"; adds `at_vigil` to actor', event: 'vigil_held',
+        delta: { 'character.current_activity': 'holding meditative vigil', 'entity_tags.add': ['at_vigil'] },
+        stub: '{actor} sits beside {target} with hands quiet, breathing matched to whatever rhythm {target}\u2019s body is still finding.',
+        pressure: '{actor} is keeping a contemplative vigil over {target}. Use this as an emotional anchor in the scene, not an active intervention.' },
+      { label: 'Speak softly through the long hours', mag: 0.38, when: eph('target', 'unconscious'),
+        does: 'activity → "speaking through the long hours"; adds `at_vigil` to actor', event: 'vigil_held',
+        delta: { 'character.current_activity': 'speaking through the long hours', 'entity_tags.add': ['at_vigil'] },
+        stub: '{actor} tells {target} small things — what the light is doing outside, what the others said today — in the belief that whatever can be reached should be reached.',
+        pressure: '{actor} is speaking to an unresponsive {target} through a long stretch. Treat as audible presence the scene can thread through quieter moments.' },
+      { label: 'Stand watch with attention but without intervention', mag: 0.32, when: ALWAYS,
+        does: 'activity → "standing vigil"; adds `at_vigil` to actor', event: 'vigil_held',
+        delta: { 'character.current_activity': 'standing vigil', 'entity_tags.add': ['at_vigil'] },
+        stub: '{actor} stays. Not doing anything — that\u2019s the point of being here. {target} is alone with whatever is happening to them, and {actor} is the witness who makes that aloneness less complete.',
+        pressure: '{actor} is keeping silent vigil over {target}. Use this as ambient presence — a witness who shapes the scene by being there, not by acting.' },
+    ],
+  },
+  {
+    id: 'SURVEIL', tid: 'surveil', band: 'project', priority: 48, slots: ['ACTOR', 'TARGET'], ptp: true,
+    bandNote: 'Surveillance usually serves live threat or investigation arcs, so it can sit above routine and social maintenance.',
+    blurb: 'Watching from afar without turning observation into contact.',
+    gate: A(
+      hydrated(),
+      N(constrained()),
+      N(inPair('actor', 'hunting')),
+      N(eph('actor', 'grudge_active')),
+      O(hiddenOff(), outPair('actor', 'contact:social'), anyCur('actor', ['broker', 'hacker', 'informant_handler', 'intelligence_asset_active', 'paranoid', 'researcher', 'signal_operator', 'surveillance_capable']), relDir('captor'), relDir('guardian'), relDir('handler'), trustLt(-2), evRecent('threat_issued', 'target', 8)),
+      cooldown('surveillance_performed', 'pair', 6),
+      cooldown('intel_reviewed', 'pair', 6),
+    ),
+    branches: [
+      { label: 'Intercept signal traffic', mag: 0.48, when: anyCur('actor', ['ghostprint_active', 'hacker', 'researcher', 'signal_operator', 'surveillance_capable']),
+        does: 'activity → "intercepting target signals"', event: 'surveillance_performed',
+        delta: { 'character.current_activity': 'intercepting target signals' },
+        stub: '{actor} watches the signal field around {target}: not the person directly, not yet, but the traffic and absences that make a life legible to someone patient enough.',
+        pressure: '{actor} may be reading signal traffic around {target}\u2019s current scene. Use it as optional pressure or atmosphere, not as a canonical breach unless the scene earns it.' },
+      { label: 'Keep tabs from a distance', mag: 0.44, when: O(hiddenOff(), trustLt(-2)),
+        does: 'activity → "keeping tabs from a distance"', event: 'surveillance_performed',
+        delta: { 'character.current_activity': 'keeping tabs from a distance' },
+        stub: '{actor} keeps tabs on {target} without touching the line between them: a pattern noticed, a channel checked, a small confirmation that does not become contact.',
+        pressure: '{actor} is keeping tabs on {target} from off-screen. Treat this as possible pressure, unease, traces, or delayed setup; do not turn it into automatic contact or control of {target}\u2019s choices.' },
+      { label: 'Collect a proxy watcher report', mag: 0.38, when: O(outPair('actor', 'contact:social'), anyCur('actor', ['broker', 'fixer', 'informant_handler'])),
+        does: 'activity → "collecting a proxy watcher report"', event: 'surveillance_performed',
+        delta: { 'character.current_activity': 'collecting a proxy watcher report' },
+        stub: '{actor} does not go near {target}. They let someone else look, then read the report for what the watcher understood and what they were too ordinary to notice.',
+        pressure: '{actor} has someone off-screen watching for signs around {target}. This can surface as a watcher, rumor, false alarm, or nothing at all.' },
+      { label: 'Review accumulated intel', mag: 0.34, when: anyCur('actor', ['academic', 'intelligence_asset_active', 'paranoid', 'researcher']),
+        does: 'activity → "reviewing accumulated intel"', event: 'intel_reviewed',
+        delta: { 'character.current_activity': 'reviewing accumulated intel' },
+        stub: '{actor} stops gathering and starts reading: old logs, half-useful reports, fragments whose meaning only appears after the same question has been asked too many times.',
+        pressure: '{actor} is reviewing accumulated intel related to {target}. If useful, let the scene feel watched or anticipated; the review itself does not force new facts into canon.' },
+      { label: 'Follow the public pattern', mag: 0.3, when: pubFlow('target'),
+        does: 'activity → "following target public pattern"', event: 'surveillance_performed',
+        delta: { 'character.current_activity': 'following target public pattern' },
+        stub: '{actor} follows the public shape of {target}\u2019s life: where they appear, what routes repeat, which absences look chosen and which look imposed.',
+        pressure: '{actor} may have mapped the public pattern around {target}. Use this only as Storyteller-controlled scene pressure or a future setup.' },
+      { label: 'Keep the target in view without contact', mag: 0.24, when: ALWAYS,
+        does: 'activity → "surveilling without contact"', event: 'surveillance_performed',
+        delta: { 'character.current_activity': 'surveilling without contact' },
+        stub: '{actor} keeps {target} in view at the lowest useful resolution, choosing continued uncertainty over the kind of move that would make the watching visible.',
+        pressure: '{actor} is watching around {target} but has not made contact. The Storyteller may adapt, delay, ignore, or incorporate that pressure without letting Orrery decide what {target} does.' },
+    ],
+  },
+  {
+    id: 'REACH_OUT_TO_KIN', tid: 'reach_out_to_kin', band: 'affil', priority: 40, slots: ['ACTOR', 'TARGET'], ptp: true,
+    bandNote: 'Kin maintenance is allowed to beat everyday self-maintenance when the relationship has gone quiet long enough.',
+    blurb: 'A small thread of contact between people who hold each other.',
+    gate: A(
+      O(relShared('family'), relShared('romantic'), relShared('chosen_kin'), relShared('comrade')),
+      O(mutualWarm(), trustLoaded(), dramatic()),
+      cooldown('contact_made', 'pair', 8),
+      cooldown('kin_visit', 'pair', 8),
+      cooldown('contact_deferred', 'pair', 8),
+      N(inPair('actor', 'hunting')),
+      N(eph('actor', 'grudge_active')),
+    ),
+    branches: [
+      { label: 'Find the moment for a real face-to-face conversation', mag: 0.36, when: A(colo(), mutualWarm(), N(dramatic()), cooldown('kin_visit', 'pair', 5)),
+        does: 'activity → "spending real time with kin"', event: 'kin_visit',
+        delta: { 'character.current_activity': 'spending real time with kin' },
+        stub: '{actor} makes the small effort that finding-time-for-someone requires — clearing a half hour, choosing a place, showing up — and {target} arrives, and for a while they are the kind of present together that distance erodes.',
+        pressure: '{actor} is meeting {target} in person for a real conversation. Use this as a relationship beat the scene can fold in or hold for later, not as a guaranteed off-screen event.' },
+      { label: 'Send a message that says less than it means', mag: 0.16, when: A(mutualWarm(), N(dramatic())),
+        does: 'activity → "keeping kin contact warm"', event: 'contact_made',
+        delta: { 'character.current_activity': 'keeping kin contact warm' },
+        stub: '{actor} sends {target} the small message that means more than the words it contains — a check-in, a shared joke, a question that doesn\u2019t really need answering — and the thread between them stays warm for another while.',
+        pressure: '{actor} has sent {target} a small affectionate message. Treat as ambient relationship-warmth — possibly an incoming notification, possibly not surfaced at all.' },
+      { label: 'Draft the message and leave it unsent', mag: 0.18, when: O(trustLoaded(), dramatic()),
+        does: 'activity → "drafting unsent kin contact"', event: 'contact_deferred',
+        delta: { 'character.current_activity': 'drafting unsent kin contact' },
+        stub: '{actor} writes the message anyway, or composes the call in their head, and then does not send it. The wanting is real; so is the cost of turning it into contact.',
+        pressure: '{actor} is holding back a loaded attempt to reach {target}. Use this as optional emotional pressure or a future story beat; Orrery has not made contact happen.' },
+      { label: 'Let the silence stand for now', mag: 0.08, when: ALWAYS,
+        does: 'activity → "deferring kin contact"', event: 'contact_deferred',
+        delta: { 'character.current_activity': 'deferring kin contact' },
+        stub: '{actor} lets the thread remain unpulled. Whatever exists between them and {target}, it is not made warmer by forcing the wrong kind of contact today.',
+        pressure: '{actor} is choosing not to contact {target} for now. Treat this as optional subtext, not as a visible scene event.' },
+    ],
+  },
+  {
+    id: 'CONSULT_RIVAL', tid: 'consult_rival', band: 'project', priority: 35, slots: ['ACTOR', 'TARGET'], ptp: true,
+    bandNote: 'Rival consultation is a deliberate project move, not casual social contact, and can outrank routine obligations.',
+    blurb: 'Two people who do not trust each other are forced into contact anyway.',
+    gate: A(
+      O(relDir('rival'), trustLt(0)),
+      O(evRecent('compliance_alert', 'any', 10), evRecent('threat_issued', 'any', 10), evRecent('faction_realignment', 'any', 15)),
+      cooldown('contact_made', 'pair', 20),
+      cooldown('rival_consulted', 'pair', 20),
+      N(eph('actor', 'grudge_active')),
+      N(inPair('actor', 'hunting')),
+    ),
+    branches: [
+      { label: 'Meet face-to-face on neutral ground', mag: 0.62, when: A(colo(), O(place('actor', 'meeting'), place('actor', 'commerce'), place('actor', 'place_open'))),
+        does: 'activity → "meeting a rival under truce"; adds `under_truce` to both', event: 'rival_consulted',
+        delta: { 'character.current_activity': 'meeting a rival under truce', 'entity_tags.add': ['under_truce', 'under_truce → target'] },
+        stub: '{actor} and {target} arrange to be in the same place at the same time without quite arranging it — both of them drinking something they don\u2019t particularly want, both of them speaking carefully — because whatever is happening is bigger than what they have between them, and they both know it.',
+        pressure: '{actor} is in a tense face-to-face meeting with {target}, a known rival. Treat as charged co-presence — the scene can show this as observed truce, ambient discomfort, or delayed consequence.' },
+      { label: 'Send a carefully-worded message through indirect channels', mag: 0.48, when: outPair('actor', 'contact:social'),
+        does: 'activity → "reaching out to a rival via intermediary"', event: 'rival_consulted',
+        delta: { 'character.current_activity': 'reaching out to a rival via intermediary' },
+        stub: '{actor} sends {target} a message routed through an intermediary they both trust slightly more than they trust each other — worded with enough care that the relay can be denied later, but with enough substance that {target} cannot reasonably ignore it.',
+        pressure: '{actor} has sent {target} a carefully-routed message via intermediary. Treat as off-screen pressure — the scene may show {target} reacting to it, or it may resurface later.' },
+      { label: 'Leave a sign the rival will recognize and a door they can open', mag: 0.34, when: ALWAYS,
+        does: 'activity → "leaving a tentative overture for a rival"', event: 'contact_made',
+        delta: { 'character.current_activity': 'leaving a tentative overture for a rival' },
+        stub: '{actor} doesn\u2019t quite reach out — but they place a sign where {target} will see it, the kind of signal that says *I am willing to talk if you are*, without committing to anything.',
+        pressure: '{actor} has placed a discreet overture for {target} to find. Treat as a passive hook the scene can pick up if useful, or leave dormant.' },
+    ],
+  },
+  {
+    id: 'ROUTINE_COMMUTE', tid: 'routine_commute', band: 'routine', priority: 26, slots: ['ACTOR'], ptp: false,
+    bandNote: 'Commute resolves where a routine-bound actor should be before nearby maintenance packages pick a place-shaped branch.',
+    blurb: 'Ordinary home/work movement from explicit routine anchors.',
+    gate: A(
+      hydrated(),
+      N(constrained()),
+      N(inTransit()),
+      N(inPair('actor', 'hunting')),
+      N(eph('actor', 'wounded')),
+      N(eph('actor', 'grieving')),
+      O(A(anchorHas('work'), anchorDue('work'), anchorAway('work')), A(anchorHas('home'), anchorDue('home'), anchorAway('home'))),
+    ),
+    branches: [
+      { label: 'Commute to the scheduled workplace', mag: 0.16, when: A(anchorHas('work'), anchorDue('work'), anchorAway('work'), anchorResolves('work')),
+        does: 'activity → "commuting to work"; starts planned travel', event: 'travel_departed',
+        delta: { 'character.current_activity': 'commuting to work', 'travel.start': 'work anchor' },
+        stub: '{actor} follows the ordinary route toward work: not a quest, not a crisis, just the daily movement that keeps a normal life legible.' },
+      { label: 'Commute home after the day\u2019s obligations', mag: 0.14, when: A(anchorHas('home'), anchorDue('home'), anchorAway('home'), anchorResolves('home')),
+        does: 'activity → "commuting home"; starts planned travel', event: 'travel_departed',
+        delta: { 'character.current_activity': 'commuting home', 'travel.start': 'home anchor' },
+        stub: '{actor} turns toward home with the unremarkable certainty of someone whose day has a next place.' },
+      { label: 'Recheck routine before moving', mag: 0.04, when: ALWAYS,
+        does: 'activity → "checking routine timing"', event: 'travel_prepared',
+        delta: { 'character.current_activity': 'checking routine timing' },
+        stub: '{actor} pauses at the edge of routine and checks the ordinary facts before moving: where they are, where the day says they should be, and whether the next leg is real.' },
+    ],
+  },
+  {
+    id: 'MOURN_LOSS', tid: 'mourn_loss', band: 'affil', priority: 25, slots: ['ACTOR'], ptp: false,
+    bandNote: 'Fresh grief suppresses ordinary social, intimacy, and routine loops; it should beat low-grade bodily maintenance.',
+    blurb: 'A loss settles into the body across many quiet days.',
+    gate: A(eph('actor', 'grieving'), cooldown('mourning_act', 'actor', 3), N(inPair('actor', 'hunting'))),
+    branches: [
+      { label: 'Visit the place of remembrance', mag: 0.42, when: O(place('actor', 'tomb'), place('actor', 'sacred')),
+        does: 'activity → "tending the dead"', event: 'mourning_act',
+        delta: { 'character.current_activity': 'tending the dead' },
+        stub: '{actor} returns to the place where the dead are kept — stone, name, photograph, marker, whatever this world has made for the purpose — and stands long enough to be still and remember, before going back to the work of being alive.' },
+      { label: 'Sit with others who carry the same loss', mag: 0.38, when: othersGrieving(),
+        does: 'activity → "gathering with co-mourners"', event: 'mourning_act',
+        delta: { 'character.current_activity': 'gathering with co-mourners' },
+        stub: '{actor} finds the others who knew the dead and sits with them — wordlessly, mostly.' },
+      { label: 'Pour the loss into the day\u2019s work', mag: 0.28, when: anyTag('actor', ['musician', 'writer', 'artisan', 'scholar', 'arcane_caster', 'soldier', 'keeps_shop', 'domestic_role']),
+        does: 'activity → "working through grief"', event: 'mourning_act',
+        delta: { 'character.current_activity': 'working through grief' },
+        stub: '{actor} returns to their work — the thing the loss hasn\u2019t taken — and does it with the dead person sitting somewhere just behind them, watching the work with the particular silence the dead have.' },
+      { label: 'Carry the weight in private', mag: 0.14, when: ALWAYS,
+        does: 'activity → "carrying private grief"', event: 'mourning_act',
+        delta: { 'character.current_activity': 'carrying private grief' },
+        stub: '{actor} goes through the day\u2019s motions with the loss settled inside them like a second heartbeat — not louder than the day, just underneath it.' },
+    ],
+  },
+  {
+    id: 'SLEEP', tid: 'sleep', band: 'embodied', priority: 25, slots: ['ACTOR'], ptp: false,
+    blurb: 'The body asks for the thing without which it cannot continue.',
+    gate: A(
+      O(A(tod(['night']), need('sleep', 8)), need('sleep', 16)),
+      N(eph('actor', 'cns_stimulated')),
+      N(inPair('actor', 'hunting')),
+    ),
+    branches: [
+      { label: 'Collapse into deferred sleep', mag: 0.74, when: need('sleep', 48),
+        does: 'activity → "collapsing into deferred sleep"; fulfills `sleep`, quality `collapse_rough`, discharge 4', event: 'slept',
+        delta: { 'character.current_activity': 'collapsing into deferred sleep', 'need.fulfill': 'sleep · collapse_rough · discharge 4' },
+        stub: '{actor} stops negotiating with exhaustion. Whatever place they have reached becomes the place where the body claims its overdue sleep.' },
+      { label: 'Sleep at home', mag: 0.22, when: A(place('actor', 'dwelling'), residesHere()),
+        does: 'activity → "sleeping at home"; fulfills `sleep`, quality `good`, discharge 10', event: 'slept',
+        delta: { 'character.current_activity': 'sleeping at home', 'need.fulfill': 'sleep · good · discharge 10' },
+        stub: '{actor} reaches familiar shelter and lets sleep take them where the room already knows their shape.' },
+      { label: 'Sleep in safe lodgings', mag: 0.28, when: O(O(place('actor', 'dwelling'), place('actor', 'haven')), outPair('actor', 'contact:lodging')),
+        does: 'activity → "sleeping in safe lodgings"; fulfills `sleep`, quality `adequate`, discharge 7', event: 'slept',
+        delta: { 'character.current_activity': 'sleeping in safe lodgings', 'need.fulfill': 'sleep · adequate · discharge 7' },
+        stub: '{actor} finds a place secure enough to become temporary shelter and lets the unfamiliar room do enough of the work.' },
+      { label: 'Sleep rough in cover or transit', mag: 0.36, when: ALWAYS,
+        does: 'activity → "sleeping rough"; fulfills `sleep`, quality `rough`, discharge 3', event: 'slept',
+        delta: { 'character.current_activity': 'sleeping rough', 'need.fulfill': 'sleep · rough · discharge 3' },
+        stub: '{actor} sleeps in fragments, taking what rest the place allows and waking with some part of the debt still unpaid.' },
+    ],
+  },
+  {
+    id: 'DRINK', tid: 'drink', band: 'embodied', priority: 24, slots: ['ACTOR'], ptp: false,
+    blurb: 'The body asks for water; what it accepts shapes the small hour.',
+    gate: A(
+      need('thirst', 2),
+      O(need('thirst', 16), N(A(need('hunger', 4), tod(['morning', 'afternoon', 'evening']), O(A(place('actor', 'dwelling'), residesHere()), O(place('actor', 'commerce'), place('actor', 'entertainment'), place('actor', 'meeting'), place('actor', 'production')))))),
+      N(inPair('actor', 'hunting')),
+    ),
+    branches: [
+      { label: 'Drink desperately, whatever is available', mag: 0.56, when: need('thirst', 16),
+        does: 'activity → "drinking to relieve severe thirst"; fulfills `thirst`, quality `desperate`', event: 'drank',
+        delta: { 'character.current_activity': 'drinking to relieve severe thirst', 'need.fulfill': 'thirst · desperate' },
+        stub: '{actor} drinks with the single-mindedness that severe thirst produces, past concern for source or dignity.' },
+      { label: 'Drink in a public room', mag: 0.22, when: O(place('actor', 'commerce'), place('actor', 'entertainment'), place('actor', 'meeting')),
+        does: 'activity → "drinking in company"; fulfills `thirst`, quality `social`', event: 'drank',
+        delta: { 'character.current_activity': 'drinking in company', 'need.fulfill': 'thirst · social' },
+        stub: '{actor} drinks what the room serves and lets the small ritual of holding a cup make the hour easier.' },
+      { label: 'Drink from a public or wild source', mag: 0.14, when: O(place('actor', 'water_source'), place('actor', 'wilderness')),
+        does: 'activity → "drinking from an available source"; fulfills `thirst`, quality `available_source`', event: 'drank',
+        delta: { 'character.current_activity': 'drinking from an available source', 'need.fulfill': 'thirst · available_source' },
+        stub: '{actor} drinks from whatever the place provides, and the relief of water makes the rest of the day briefly simpler.' },
+      { label: 'Drink routinely from what is at hand', mag: 0.1, when: ALWAYS,
+        does: 'activity → "drinking routinely"; fulfills `thirst`, quality `routine`', event: 'drank',
+        delta: { 'character.current_activity': 'drinking routinely', 'need.fulfill': 'thirst · routine' },
+        stub: '{actor} drinks because the body has been quietly asking, then returns to the shape of the hour.' },
+    ],
+  },
+  {
+    id: 'EAT', tid: 'eat', band: 'embodied', priority: 22, slots: ['ACTOR'], ptp: false,
+    blurb: 'The body asks for fuel; what it gets matters more than the cookbook suggests.',
+    gate: A(
+      need('hunger', 4),
+      O(tod(['morning', 'afternoon', 'evening']), need('hunger', 8)),
+      N(inPair('actor', 'hunting')),
+    ),
+    branches: [
+      { label: 'Eat ravenously, whatever is available', mag: 0.62, when: need('hunger', 16),
+        does: 'activity → "eating to relieve severe hunger"; fulfills `hunger`, quality `desperate`', event: 'ate',
+        delta: { 'character.current_activity': 'eating to relieve severe hunger', 'need.fulfill': 'hunger · desperate' },
+        stub: '{actor} eats with the inattention of real hunger, relief overtaking any concern about what the food ought to be.' },
+      { label: 'Eat at home with household', mag: 0.22, when: A(A(place('actor', 'dwelling'), residesHere()), anyTag('actor', ['married', 'parent', 'extended_household'])),
+        does: 'activity → "sharing a household meal"; fulfills `hunger`, quality `household_meal`', event: 'ate',
+        delta: { 'character.current_activity': 'sharing a household meal', 'need.fulfill': 'hunger · household_meal' },
+        stub: '{actor} sits down to the meal that home means and lets being-with stand in for being-alone for a while.' },
+      { label: 'Eat at home alone', mag: 0.2, when: A(place('actor', 'dwelling'), residesHere()),
+        does: 'activity → "eating at home"; fulfills `hunger`, quality `home_meal`', event: 'ate',
+        delta: { 'character.current_activity': 'eating at home', 'need.fulfill': 'hunger · home_meal' },
+        stub: '{actor} makes the kind of meal home makes possible: unremarkable, private, and enough to let the evening continue on ordinary terms.' },
+      { label: 'Eat in a public dining place', mag: 0.26, when: O(place('actor', 'commerce'), place('actor', 'entertainment'), place('actor', 'meeting'), place('actor', 'production')),
+        does: 'activity → "eating in a public place"; fulfills `hunger`, quality `public_meal`', event: 'ate',
+        delta: { 'character.current_activity': 'eating in a public place', 'need.fulfill': 'hunger · public_meal' },
+        stub: '{actor} eats something the place can provide and watches the room continue its public life around them.' },
+      { label: 'Forage or hunt from the country', mag: 0.38, when: A(place('actor', 'wilderness'), anyTag('actor', ['forager', 'hunter', 'survivalist', 'ranger', 'scout'])),
+        does: 'activity → "foraging for a meal"; fulfills `hunger`, quality `wild_meal`', event: 'ate',
+        delta: { 'character.current_activity': 'foraging for a meal', 'need.fulfill': 'hunger · wild_meal' },
+        stub: '{actor} works the country for what the season has put within reach and makes a meal out of survival knowledge.' },
+      { label: 'Eat from rations or what was packed', mag: 0.18, when: tag('actor', 'travel_provisioned'),
+        does: 'activity → "eating travel rations"; fulfills `hunger`, quality `rations_meal`', event: 'ate',
+        delta: { 'character.current_activity': 'eating travel rations', 'need.fulfill': 'hunger · rations_meal' },
+        stub: '{actor} eats what was packed for exactly this kind of hour: practical, portable, and enough.' },
+      { label: 'Find something and eat it', mag: 0.14, when: ALWAYS,
+        does: 'activity → "eating opportunistically"; fulfills `hunger`, quality `opportunistic_meal`', event: 'ate',
+        delta: { 'character.current_activity': 'eating opportunistically', 'need.fulfill': 'hunger · opportunistic_meal' },
+        stub: '{actor} eats what is nearest and workable, attentive mostly to the fact that the body can stop asking for now.' },
+    ],
+  },
+  {
+    id: 'TRAVEL', tid: 'travel', band: 'routine', priority: 21, slots: ['ACTOR'], ptp: false,
+    blurb: 'A character moves between meaningful places without pretending the road is a room.',
+    gate: A(O(inTransit(), hasDest()), N(eph('actor', 'wounded')), N(eph('actor', 'grieving'))),
+    branches: [
+      { label: 'Arrive where people can be encountered', mag: 0.36, when: A(inTransit(), travProg(0.95), travPurpose('socialize')),
+        does: 'activity → "arriving where people gather"; arrives at travel destination', event: 'travel_arrived',
+        delta: { 'character.current_activity': 'arriving where people gather', 'travel.arrive': 'destination' },
+        stub: '{actor} reaches the place they picked because other people would be there. The route ends, and the social possibility becomes immediate rather than theoretical.' },
+      { label: 'Arrive at the planned destination', mag: 0.34, when: A(inTransit(), travProg(0.95)),
+        does: 'activity → "arriving at destination"; arrives at travel destination', event: 'travel_arrived',
+        delta: { 'character.current_activity': 'arriving at destination', 'travel.arrive': 'destination' },
+        stub: '{actor} reaches the destination at last. The route drops away behind them into the ordinary unreliability of maps, and the place ahead becomes immediate.' },
+      { label: 'Lose time to bad conditions or route friction', mag: 0.24, when: A(inTransit(), O(travRisk(['high', 'extreme']), weather(['rain', 'snow', 'fog']))),
+        does: 'activity → "delayed in transit"; records travel delay', event: 'travel_delayed',
+        delta: { 'character.current_activity': 'delayed in transit', 'travel.delay': 'recorded' },
+        stub: '{actor} loses time to the route itself — weather, traffic, closed access, or the thousand small refusals a city can make when someone is trying to cross it.' },
+      { label: 'Make steady progress along the route', mag: 0.18, when: inTransit(),
+        does: 'activity → "traveling toward destination"; advances travel by 0.35', event: 'travel_progressed',
+        delta: { 'character.current_activity': 'traveling toward destination', 'travel.advance': '0.35' },
+        stub: '{actor} keeps moving: transfers, crossings, service corridors, streets whose names matter less than the fact that each one puts the destination a little closer.' },
+      { label: 'Charter private transport', mag: 0.3, when: A(hasDest(), N(inTransit()), resGte('wealthy')),
+        does: 'activity → "departing by chartered transport"; starts planned travel', event: 'travel_departed',
+        delta: { 'character.current_activity': 'departing by chartered transport', 'travel.start': 'planned' },
+        stub: '{actor} does not queue, transfer, or wait. Money turns the journey into a closed door and a window: a private vehicle, a paid schedule, a route that exists because they asked for it.' },
+      { label: 'Slip out along covert routes', mag: 0.32, when: A(hasDest(), N(inTransit()), fameGte('renowned'), O(tag('actor', 'travel_ready'), tag('actor', 'travel_provisioned'), tag('actor', 'route_familiar'))),
+        does: 'activity → "departing along covert routes"; starts planned travel', event: 'travel_departed',
+        delta: { 'character.current_activity': 'departing along covert routes', 'travel.start': 'planned' },
+        stub: '{actor} cannot ride public flow without being a sighting, so the route runs through the city\u2019s blind spots: service levels, freight corridors, the hours and angles where a recognizable face passes unwitnessed.' },
+      { label: 'Depart toward the planned destination', mag: 0.28, when: A(hasDest(), N(inTransit()), O(tag('actor', 'travel_ready'), tag('actor', 'travel_provisioned'), tag('actor', 'route_familiar'), place('actor', 'transit'))),
+        does: 'activity → "departing toward destination"; starts planned travel', event: 'travel_departed',
+        delta: { 'character.current_activity': 'departing toward destination', 'travel.start': 'planned' },
+        stub: '{actor} starts the journey with enough of a route in mind to make the first leg real. The exact path can change; the destination no longer can.' },
+      { label: 'Prepare the journey rather than starting badly', mag: 0.12, when: ALWAYS,
+        does: 'activity → "preparing route and supplies"; adds `travel_ready` to actor', event: 'travel_prepared',
+        delta: { 'character.current_activity': 'preparing route and supplies', 'entity_tags.add': ['travel_ready'] },
+        stub: '{actor} does not start badly. They check timing, supplies, weather, access, and the parts of the route that might betray them before they have earned the right to improvise.' },
+    ],
+  },
+  {
+    id: 'SOCIALIZE', tid: 'socialize', band: 'affil', priority: 18, slots: ['ACTOR'], ptp: false,
+    bandNote: 'Accumulated social debt is allowed to interrupt generic work/routine before it becomes a crisis.',
+    blurb: 'The need for the company of others, on whatever terms a character can have it.',
+    gate: A(
+      need('socialize', 24),
+      cooldown('socialized', 'actor', 4),
+      cooldown('socialized_alone', 'actor', 4),
+      cooldown('social_travel_departed', 'actor', 4),
+      N(inPair('actor', 'hunting')),
+      N(eph('actor', 'grieving')),
+      N(eph('actor', 'wounded')),
+    ),
+    branches: [
+      { label: 'Host chosen company on their own ground', mag: 0.24, when: A(fameGte('renowned'), outPair('actor', 'contact:social')),
+        does: 'activity → "hosting chosen company privately"; fulfills `socialize`, quality `private_company`', event: 'socialized',
+        delta: { 'character.current_activity': 'hosting chosen company privately', 'need.fulfill': 'socialize · private_company' },
+        stub: '{actor} does not go looking for company in rooms that would turn to watch them enter. They summon it instead: a few chosen people, a door that closes, an evening where nobody performs recognition.' },
+      { label: 'Seek company after extended isolation', mag: 0.54, when: A(need('socialize', 168), N(othersColo(1)), N(O(place('actor', 'commerce'), place('actor', 'entertainment'), place('actor', 'meeting'), place('actor', 'place_open'))), pubFlow(), fameLt('renowned'), resolveDest(['commerce', 'entertainment', 'meeting', 'place_open'])),
+        does: 'activity → "seeking company after isolation"; starts social travel', event: 'social_travel_departed',
+        delta: { 'character.current_activity': 'seeking company after isolation', 'travel.start': 'social destination' },
+        stub: '{actor} feels the particular pressure that comes from going too long without other people in their life, and moves toward somewhere there will be voices, even if those voices are not for them.' },
+      { label: 'Engage with company already present', mag: 0.22, when: othersColo(1),
+        does: 'activity → "engaging with present company"; fulfills `socialize`, quality `present_company`', event: 'socialized',
+        delta: { 'character.current_activity': 'engaging with present company', 'need.fulfill': 'socialize · present_company' },
+        stub: '{actor} spends real attention on the people around them — not transactional attention, the other kind — for long enough that the social need is briefly met without anyone naming it as such.' },
+      { label: 'Seek a trusted voice rather than a crowd', mag: 0.22, when: A(anyTag('actor', ['solitary', 'reserved']), outPair('actor', 'contact:social')),
+        does: 'activity → "talking with a trusted contact"; fulfills `socialize`, quality `trusted_contact`, discharge 72', event: 'socialized',
+        delta: { 'character.current_activity': 'talking with a trusted contact', 'need.fulfill': 'socialize · trusted_contact · 72' },
+        stub: '{actor} weighs the noise of a public room against the particular relief of one familiar voice, and chooses the voice — a long, unhurried exchange with someone who does not need anything explained.' },
+      { label: 'Set out toward public company', mag: 0.26, when: A(N(othersColo(1)), N(O(place('actor', 'commerce'), place('actor', 'entertainment'), place('actor', 'meeting'), place('actor', 'place_open'))), pubFlow(), fameLt('renowned'), resolveDest(['commerce', 'entertainment', 'meeting', 'place_open'])),
+        does: 'activity → "seeking public company"; starts social travel', event: 'social_travel_departed',
+        delta: { 'character.current_activity': 'seeking public company', 'travel.start': 'social destination' },
+        stub: '{actor} chooses movement over more empty time and sets out toward a place where other people can be encountered without requiring the story to pre-name them.' },
+      { label: 'Go where people are', mag: 0.2, when: A(O(place('actor', 'commerce'), place('actor', 'entertainment'), place('actor', 'meeting'), place('actor', 'place_open')), fameLt('renowned')),
+        does: 'activity → "passing time in a populated place"; fulfills `socialize`, quality `public_company`', event: 'socialized',
+        delta: { 'character.current_activity': 'passing time in a populated place', 'need.fulfill': 'socialize · public_company' },
+        stub: '{actor} goes to one of the places built around the fact that people gather there, and stays long enough to become part of the room\u2019s ordinary texture.' },
+      { label: 'Reach out to a contact for no urgent reason', mag: 0.24, when: outPair('actor', 'contact:social'),
+        does: 'activity → "reconnecting with a contact"; fulfills `socialize`, quality `remote_contact`, discharge 72', event: 'socialized',
+        delta: { 'character.current_activity': 'reconnecting with a contact', 'need.fulfill': 'socialize · remote_contact · 72' },
+        stub: '{actor} thinks of someone they have not spoken with in too long and reaches out for no urgent reason, which is its own kind of reason.' },
+      { label: 'Practice parasocial company', mag: 0.16, when: ALWAYS,
+        does: 'activity → "spending time with a stranger\u2019s voice"; fulfills `socialize`, quality `parasocial`, discharge 12', event: 'socialized_alone',
+        delta: { 'character.current_activity': 'spending time with a stranger\u2019s voice', 'need.fulfill': 'socialize · parasocial · 12' },
+        stub: '{actor} spends an hour with the voice of a stranger — a book, a serial, a recording — which is not the same as company but is enough like company to take the worst edge off.' },
+    ],
+  },
+  {
+    id: 'INTIMACY', tid: 'intimacy', band: 'affil', priority: 16, slots: ['ACTOR'], ptp: false,
+    bandNote: 'Intimacy pressure should beat generic work when gates and suppressors allow it, but remain below basic embodied maintenance.',
+    blurb: 'The body asks for the kind of connection that is not conversation.',
+    gate: A(
+      need('intimacy', 72),
+      N(intimSupp()),
+      cooldown('intimacy_fulfilled', 'actor', 8),
+      cooldown('intimacy_pursued', 'actor', 8),
+      cooldown('intimacy_partial', 'actor', 8),
+      cooldown('intimacy_deferred', 'actor', 8),
+      N(inPair('actor', 'hunting')),
+      N(eph('actor', 'wounded')),
+      N(eph('actor', 'grieving')),
+    ),
+    branches: [
+      { label: 'Spend private time with an established partner', mag: 0.32, when: A(A(place('actor', 'dwelling'), residesHere()), partnerColo()),
+        does: 'activity → "spending private time with partner"; fulfills `intimacy`, quality `established_partner`', event: 'intimacy_fulfilled',
+        delta: { 'character.current_activity': 'spending private time with partner', 'need.fulfill': 'intimacy · established_partner' },
+        stub: '{actor} closes the door on the day and lets private time with an established partner answer a need the public world has no claim on.' },
+      { label: 'Visit a place where compatible company gathers', mag: 0.48, when: A(O(place('actor', 'entertainment'), place('actor', 'meeting')), need('intimacy', 168), N(tag('actor', 'partnered_exclusively'))),
+        does: 'activity → "seeking compatible company"; fulfills `intimacy`, quality `pursued_possibility`, discharge 24', event: 'intimacy_pursued',
+        delta: { 'character.current_activity': 'seeking compatible company', 'need.fulfill': 'intimacy · pursued_possibility · 24' },
+        stub: '{actor} goes to the kind of place where someone like them might meet someone they would want to meet, alert to the possibility without presuming the outcome.' },
+      { label: 'Engage contracted intimate company', mag: 0.28, when: A(O(place('actor', 'commerce'), place('actor', 'entertainment')), outPair('actor', 'contact:intimate'), N(tag('actor', 'partnered_exclusively')), N(anyTag('actor', ['vow_of_celibacy', 'religiously_abstinent', 'ethically_opposed_to_contracted_intimacy']))),
+        does: 'activity → "engaging contracted intimate company"; fulfills `intimacy`, quality `contracted_companion`', event: 'intimacy_fulfilled',
+        delta: { 'character.current_activity': 'engaging contracted intimate company', 'need.fulfill': 'intimacy · contracted_companion' },
+        stub: '{actor} arranges what can be arranged, in one of the places where the transaction is understood by everyone involved and made ordinary by that clarity.' },
+      { label: 'Attend to the need in private', mag: 0.06, when: A(O(place('actor', 'dwelling'), place('actor', 'place_restricted')), N(othersColo(1))),
+        does: 'activity → "private personal time"; fulfills `intimacy`, quality `private_solo`, discharge 48', event: 'intimacy_partial',
+        delta: { 'character.current_activity': 'private personal time', 'need.fulfill': 'intimacy · private_solo · 48' },
+        stub: '{actor} attends to the body\u2019s quieter demands in private — an unremarkable hour the rest of the world has no business knowing about.' },
+      { label: 'Let the want stay where it is', mag: 0.1, when: ALWAYS,
+        does: 'activity → "carrying an unaddressed want"', event: 'intimacy_deferred',
+        delta: { 'character.current_activity': 'carrying an unaddressed want' },
+        stub: '{actor} does not pursue what the body is asking for — the wrong company, the wrong hour, the wrong life — and the want stays where it has been for a while now.' },
+    ],
+  },
+  {
+    id: 'TEND_CRAFT', tid: 'tend_craft', band: 'project', priority: 15, slots: ['ACTOR'], ptp: false,
+    bandNote: 'Craft is the low-pressure identity/project floor and intentionally sits just above generic work.',
+    blurb: 'A small act of care for the work that defines them.',
+    gate: A(
+      anyTag('actor', CRAFT_TAGS, 'actor has any craft-identity tag'),
+      cooldown('craft_tended', 'actor', 4),
+      N(inPair('actor', 'hunting')),
+      N(eph('actor', 'wounded')),
+      N(eph('actor', 'grieving')),
+    ),
+    branches: [
+      { label: 'Put real money into the craft', mag: 0.18, when: resGte('wealthy'),
+        does: 'activity → "investing in the craft"; adds `recently_tended_craft`', event: 'craft_tended',
+        delta: { 'character.current_activity': 'investing in the craft', 'entity_tags.add': ['recently_tended_craft'] },
+        stub: '{actor} spends on the work the way only someone with money can: the proper materials instead of the workable ones, the commissioned part instead of the salvaged one, the bought afternoon of uninterrupted attention.' },
+      { label: 'Make the weapon ready for what comes next', mag: 0.18, when: anyTag('actor', ['combat_trained', 'soldier', 'warrior', 'fighter']),
+        does: 'activity → "making the weapon ready"; adds `recently_tended_craft`', event: 'craft_tended',
+        delta: { 'character.current_activity': 'making the weapon ready', 'entity_tags.add': ['recently_tended_craft'] },
+        stub: '{actor} takes the weapon apart with the slow patience of someone who has done this enough times to know the geometry of each piece by feel, and puts it back together the same way, attentive to small things only they will notice.' },
+      { label: 'Lay hands on the arcane work-in-progress', mag: 0.18, when: tag('actor', 'arcane_caster'),
+        does: 'activity → "tending arcane work"; adds `recently_tended_craft`', event: 'craft_tended',
+        delta: { 'character.current_activity': 'tending arcane work', 'entity_tags.add': ['recently_tended_craft'] },
+        stub: '{actor} spends an unhurried hour with whatever is currently between their hands and the world\u2019s underlying grammar.' },
+      { label: 'Maintain and improve the tools of the trade', mag: 0.18, when: anyTag('actor', ['engineer', 'mechanic', 'tinkerer', 'hacker', 'artificer']),
+        does: 'activity → "maintaining equipment"; adds `recently_tended_craft`', event: 'craft_tended',
+        delta: { 'character.current_activity': 'maintaining equipment', 'entity_tags.add': ['recently_tended_craft'] },
+        stub: '{actor} attends to the equipment — the part that\u2019s been annoying them for weeks, the upgrade they keep meaning to install, the calibration that\u2019s been just slightly off — and emerges with the tools a small degree better than they were.' },
+      { label: 'Run through the work that keeps the work possible', mag: 0.18, when: anyTag('actor', ['musician', 'dancer', 'performer', 'artist', 'writer', 'artisan']),
+        does: 'activity → "practicing the unseen work"; adds `recently_tended_craft`', event: 'craft_tended',
+        delta: { 'character.current_activity': 'practicing the unseen work', 'entity_tags.add': ['recently_tended_craft'] },
+        stub: '{actor} works through the practice that no one will ever see — the scales, the exercises, the small motions that the public version of the art rests on.' },
+      { label: 'Move the body through its daily reckoning', mag: 0.18, when: anyTag('actor', ['athlete', 'martial_artist', 'ranger', 'scout', 'monk']),
+        does: 'activity → "conditioning the body"; adds `recently_tended_craft`', event: 'craft_tended',
+        delta: { 'character.current_activity': 'conditioning the body', 'entity_tags.add': ['recently_tended_craft'] },
+        stub: '{actor} puts the body through its daily reckoning — the run, the forms, the small punishments that keep the body ready for whatever the next demand will be.' },
+      { label: 'Tend the small shop\u2019s quiet machinery', mag: 0.18, when: anyTag('actor', ['keeps_shop', 'merchant', 'innkeeper', 'trader']),
+        does: 'activity → "tending the shop\u2019s rhythms"; adds `recently_tended_craft`', event: 'craft_tended',
+        delta: { 'character.current_activity': 'tending the shop\u2019s rhythms', 'entity_tags.add': ['recently_tended_craft'] },
+        stub: '{actor} does the things a place of business needs in order to keep being a place of business.' },
+      { label: 'Keep the household running', mag: 0.18, when: anyTag('actor', ['domestic_role', 'cares_for_household', 'matriarch', 'patriarch']),
+        does: 'activity → "tending the household"; adds `recently_tended_craft`', event: 'craft_tended',
+        delta: { 'character.current_activity': 'tending the household', 'entity_tags.add': ['recently_tended_craft'] },
+        stub: '{actor} does the work that holds a household together — the meals, the cleaning, the small attentions no one particularly thanks anyone for but whose absence would be felt immediately.' },
+      { label: 'Return to the unfinished study', mag: 0.18, when: anyTag('actor', ['scholar', 'researcher', 'academic', 'loremaster']),
+        does: 'activity → "advancing the long study"; adds `recently_tended_craft`', event: 'craft_tended',
+        delta: { 'character.current_activity': 'advancing the long study', 'entity_tags.add': ['recently_tended_craft'] },
+        stub: '{actor} returns to the long work that is always almost but never finished, and gives the work another quiet evening of the only thing it really needs.' },
+      { label: 'Take a small action of care for the work that is theirs', mag: 0.12, when: ALWAYS,
+        does: 'activity → "tending the work that is theirs"; adds `recently_tended_craft`', event: 'craft_tended',
+        delta: { 'character.current_activity': 'tending the work that is theirs', 'entity_tags.add': ['recently_tended_craft'] },
+        stub: '{actor} does a small thing for the work that defines them — they would not call it that, probably, but that is what it is — and the day is briefly better for it.' },
+    ],
+  },
+  {
+    id: 'WORK', tid: 'work', band: 'routine', priority: 14, slots: ['ACTOR'], ptp: false,
+    blurb: 'The recurring work that keeps a life, household, or organization functioning.',
+    gate: A(
+      O(A(anchorHas('work'), anchorDue('work'), anchorAt('work')), tag('actor', 'work_obligation'), anyTag('actor', ['domestic_role', 'cares_for_household', 'field_worker'])),
+      N(inTransit()),
+      cooldown('work_performed', 'actor', 4),
+      cooldown('household_work_performed', 'actor', 4),
+      N(inPair('actor', 'hunting')),
+      N(eph('actor', 'wounded')),
+      N(eph('actor', 'grieving')),
+    ),
+    branches: [
+      { label: 'Take whatever paying work the day offers', mag: 0.2, when: resLt('poor'),
+        does: 'activity → "scraping together day labor"', event: 'work_performed',
+        delta: { 'character.current_activity': 'scraping together day labor' },
+        stub: '{actor} cannot afford the luxury of work that matches who they are. They take what the day pays for — hauling, queueing, standing in for someone luckier — and count the result in meals, not meaning.' },
+      { label: 'Direct the work rather than perform it', mag: 0.16, when: resGte('wealthy'),
+        does: 'activity → "directing the work of others"', event: 'work_performed',
+        delta: { 'character.current_activity': 'directing the work of others' },
+        stub: '{actor} does not stand a shift; they decide what the shifts are for.' },
+      { label: 'Work a public-facing shift', mag: 0.18, when: O(O(place('actor', 'administration'), place('actor', 'craft'), place('actor', 'military'), place('actor', 'place_medical'), place('actor', 'production')), place('actor', 'commerce'), anyTag('actor', ['keeps_shop', 'merchant', 'innkeeper', 'trader'])),
+        does: 'activity → "working a public-facing shift"', event: 'work_performed',
+        delta: { 'character.current_activity': 'working a public-facing shift' },
+        stub: '{actor} gives the day to work that other people can see: the counter, the ledger, the bargaining, the small maintenance of trust that keeps trade from becoming chaos.' },
+      { label: 'Handle field or maintenance work', mag: 0.2, when: O(O(place('actor', 'craft'), place('actor', 'military'), place('actor', 'production')), tag('actor', 'field_worker')),
+        does: 'activity → "handling field maintenance work"', event: 'work_performed',
+        delta: { 'character.current_activity': 'handling field maintenance work' },
+        stub: '{actor} spends the hour in practical labor: repairs, inspection, hauling, checking systems whose importance only becomes visible when they fail.' },
+      { label: 'Keep administrative obligations moving', mag: 0.16, when: O(place('actor', 'administration'), anyTag('actor', ['researcher', 'academic', 'soldier']), factionSenior()),
+        does: 'activity → "handling administrative work"', event: 'work_performed',
+        delta: { 'character.current_activity': 'handling administrative work' },
+        stub: '{actor} moves necessary work through the quiet machinery: forms, messages, rosters, notes, approvals, the kind of paper trail that decides what can happen tomorrow.' },
+      { label: 'Do the labor that holds a household together', mag: 0.18, when: anyTag('actor', ['domestic_role', 'cares_for_household']),
+        does: 'activity → "doing household work"', event: 'household_work_performed',
+        delta: { 'character.current_activity': 'doing household work' },
+        stub: '{actor} does household work with the competence of someone who knows that ordinary life is not self-maintaining.' },
+      { label: 'Keep the obligation from slipping', mag: 0.1, when: ALWAYS,
+        does: 'activity → "keeping obligations current"', event: 'work_performed',
+        delta: { 'character.current_activity': 'keeping obligations current' },
+        stub: '{actor} takes care of the work that would otherwise start to fray — not enough to become a story by itself, but enough that the world does not have to break here today.' },
+    ],
+  },
+  {
+    id: 'MAINTAIN_COVER', tid: 'maintain_cover', band: 'crisis', priority: 0, slots: ['ACTOR'], ptp: false,
+    bandNote: 'priority-order exempt: intentionally a floor package that should not force routine needs or story obligations to justify outranking it.',
+    blurb: 'Specific public-cover maintenance, not a universal fallback.',
+    gate: A(
+      hydrated(),
+      N(constrained()),
+      N(hiddenOff()),
+      N(inTransit()),
+      anyCur('actor', ['broker', 'cover_identity', 'fixer', 'operative', 'public_role', 'undercover']),
+      O(place('actor', 'urban_dense'), place('actor', 'place_open'), place('actor', 'transit'), place('actor', 'commerce'), place('actor', 'meeting')),
+      cooldown('maintain_cover', 'actor', 6),
+    ),
+    branches: [
+      { label: 'Be seen exactly where they are expected', mag: 0.14, when: fameGte('renowned'),
+        does: 'activity → "performing the expected public pattern"', event: 'maintain_cover',
+        delta: { 'character.current_activity': 'performing the expected public pattern' },
+        stub: '{actor} cannot be nobody, so they are conspicuously, boringly themselves: the usual table, the usual hours, the usual complaints — a public pattern so consistent that nobody thinks to ask what it covers.' },
+      { label: 'Run a low-level courier job', mag: 0.16, when: A(O(place('actor', 'urban_dense'), place('actor', 'place_open'), place('actor', 'transit'), place('actor', 'commerce'), place('actor', 'meeting')), pubFlow(), fameLt('renowned')),
+        does: 'activity → "running low-level cover work"', event: 'maintain_cover',
+        delta: { 'character.current_activity': 'running low-level cover work' },
+        stub: '{actor} picks up a benign data packet, walks it across the district, and earns just enough to register as ordinary.' },
+      { label: 'Maintain a specific cover identity', mag: 0.14, when: anyCur('actor', ['cover_identity', 'public_role', 'undercover']),
+        does: 'activity → "maintaining cover identity"', event: 'maintain_cover',
+        delta: { 'character.current_activity': 'maintaining cover identity' },
+        stub: '{actor} services the identity that keeps questions from forming: one believable errand, one ordinary exchange, one small proof that the mask has a life of its own.' },
+      { label: 'Keep a public role legible', mag: 0.12, when: anyCur('actor', ['broker', 'fixer', 'operative']),
+        does: 'activity → "keeping public role legible"', event: 'maintain_cover',
+        delta: { 'character.current_activity': 'keeping public role legible' },
+        stub: '{actor} keeps their visible role legible to the people who expect to see it — enough routine, enough responsiveness, enough plausible friction to look like a life.' },
+      { label: 'Drift through public space', mag: 0.1, when: A(pubFlow(), fameLt('renowned')),
+        does: 'activity → "maintaining public cover"', event: 'maintain_cover',
+        delta: { 'character.current_activity': 'maintaining public cover' },
+        stub: '{actor} moves through public space at the pace of someone with somewhere to be, generating forgettable civilian noise.' },
+      { label: 'Keep the ledger plausible from a fixed post', mag: 0.08, when: ALWAYS,
+        does: 'activity → "maintaining fixed cover"', event: 'maintain_cover',
+        delta: { 'character.current_activity': 'maintaining fixed cover' },
+        stub: '{actor} makes no dramatic move. They answer what must be answered, neglect what can be neglected, and keep their visible life plausible without pretending to be free of it.' },
+    ],
+  },
+];
+
+export const TEMPLATE_BY_ID = Object.fromEntries(TEMPLATES.map((t) => [t.id, t]));
+export const ACTOR_ONLY = TEMPLATES.filter((t) => t.slots.length === 1);
+export const TWO_PARTY = TEMPLATES.filter((t) => t.slots.length === 2);
+
+// Event types consumed by gates but emitted by no branch — the dead-arm lint.
+export const DEAD_GATE_ARMS = [
+  { event: 'threat_issued',      consumers: ['WARN_ALLY', 'PROTECT_KIN', 'CONSULT_RIVAL', 'SURVEIL'] },
+  { event: 'compliance_alert',   consumers: ['EVADE_PURSUERS', 'WARN_ALLY', 'CONSULT_RIVAL', 'HIDE (branch)'] },
+  { event: 'faction_realignment', consumers: ['CONSULT_RIVAL'] },
+  { event: 'encoded_message',    consumers: ['HONOR_DEBT'] },
+];
+
+// ------------------------------------------------------------ seed tick ----
+
+export function baseWorldState() {
+  return {
+    slot: 'save_02',
+    anchor: 108,
+    windowChunks: 30,
+    baseAnchor: 108,
+    baseWorldTime: Date.UTC(2073, 9, 14, 21, 40) / 1000, // 2073-10-14 21:40
+    weatherByTick: (t) => (t >= 104 && t <= 112 ? 'rain' : 'clear'),
+    entities: {
+      victor: { id: 'victor', name: 'Victor Sato', onScreen: false, place: 'glow', fame: 'local', resources: 'comfortable',
+        tags: ['informant_handler', 'signal_operator', 'undercover', 'work_obligation'], ephemerals: ['intelligence_asset_active'],
+        needs: { sleep: 6, hunger: 5, thirst: 1.5, socialize: 30, intimacy: 20 }, resolveDest: true },
+      lansky: { id: 'lansky', name: 'Lansky', onScreen: false, place: 'glow', fame: 'known', resources: 'comfortable',
+        tags: ['broker', 'reserved'], ephemerals: [],
+        needs: { sleep: 5, hunger: 3.5, thirst: 1, socialize: 20, intimacy: 40 }, resolveDest: true },
+      asmodeus: { id: 'asmodeus', name: 'Asmodeus', onScreen: false, place: 'ashgrid', fame: 'local', resources: 'comfortable',
+        tags: ['vendetta_holder', 'violent_history', 'hacker', 'safehouse_operator', 'off_grid'], ephemerals: ['grudge_active', 'cns_stimulated', 'reputation_compromised'],
+        needs: { sleep: 14, hunger: 3, thirst: 1.2, socialize: 12, intimacy: 80 }, resolveDest: true },
+      celia: { id: 'celia', name: 'Celia', onScreen: false, place: 'glow', fame: 'local', resources: 'struggling',
+        tags: ['fugitive', 'paranoid'], ephemerals: ['intelligence_asset_active', 'wounded'],
+        needs: { sleep: 49.5, hunger: 3.1, thirst: 1.8, socialize: 26, intimacy: 15 }, resolveDest: true },
+      juno: { id: 'juno', name: 'Juno', onScreen: false, place: 'remembrance', fame: 'local', resources: 'poor',
+        tags: ['combat_trained'], ephemerals: ['grieving', 'recently_violent', 'grudge_active'],
+        needs: { sleep: 26, hunger: 6, thirst: 2.5, socialize: 18, intimacy: 30 }, resolveDest: true },
+      talon: { id: 'talon', name: 'Talon', onScreen: false, place: 'rootline', fame: 'local', resources: 'struggling',
+        tags: ['route_familiar', 'combat_trained'], ephemerals: ['wounded', 'grudge_active', 'recently_violent'],
+        needs: { sleep: 18, hunger: 17, thirst: 3.8, socialize: 40, intimacy: 25 }, resolveDest: true },
+      alex: { id: 'alex', name: 'Alex', onScreen: true, place: 'glow', fame: 'known', resources: 'comfortable',
+        tags: ['seeking_identity', 'ghostprint_active'], ephemerals: [],
+        needs: { sleep: 7, hunger: 4.5, thirst: 2.1, socialize: 5, intimacy: 12 }, resolveDest: true },
+      pete: { id: 'pete', name: 'Pete', onScreen: true, place: 'glow', fame: 'local', resources: 'struggling',
+        tags: ['hacker'], ephemerals: [],
+        needs: { sleep: 9, hunger: 6, thirst: 9, socialize: 4, intimacy: 20 }, resolveDest: true },
+      alina: { id: 'alina', name: 'Alina', onScreen: true, place: 'glow', fame: 'local', resources: 'comfortable',
+        tags: ['bodyform:android', 'signal_operator'], ephemerals: [],
+        needs: { sleep: 0, hunger: 0, thirst: 0, socialize: 14, intimacy: 0 }, resolveDest: true },
+    },
+    pairTags: [
+      { from: 'victor', to: 'talon', tag: 'hunting' },
+      { from: 'talon', to: 'asmodeus', tag: 'contact:lodging' },
+      { from: 'juno', to: 'asmodeus', tag: 'contact:social' },
+    ],
+    relationships: [
+      { a: 'victor', b: 'celia', typesAB: ['handler', 'rival'], typesBA: ['asset', 'rival'], trustAB: 2, trustBA: -1 },
+      { a: 'victor', b: 'talon', typesAB: ['enemy'], typesBA: ['enemy'], trustAB: -3, trustBA: -4 },
+      { a: 'asmodeus', b: 'talon', typesAB: ['comrade'], typesBA: ['comrade'], trustAB: 2, trustBA: 3 },
+      { a: 'juno', b: 'talon', typesAB: ['comrade'], typesBA: ['comrade'], trustAB: 3, trustBA: 3 },
+      { a: 'asmodeus', b: 'alex', typesAB: ['enemy'], typesBA: ['enemy'], trustAB: -4, trustBA: -2 },
+      { a: 'victor', b: 'alex', typesAB: ['rival'], typesBA: ['rival'], trustAB: -2, trustBA: -1 },
+      { a: 'celia', b: 'alex', typesAB: ['rival'], typesBA: ['rival'], trustAB: -1, trustBA: 0 },
+      { a: 'lansky', b: 'alex', typesAB: ['ally'], typesBA: ['ally'], trustAB: 0, trustBA: 0 },
+    ],
+    events: [
+      { type: 'threat_issued', tick: 107, target: 'talon' },
+      { type: 'compliance_alert', tick: 106, target: 'celia' },
+      { type: 'surveillance_performed', tick: 103, pair: ['celia', 'victor'] },
+      { type: 'tended_wound', tick: 107, pair: ['victor', 'celia'] },
+      { type: 'intel_reviewed', tick: 104, pair: ['lansky', 'alex'] },
+      { type: 'maintain_cover', tick: 105, actor: 'lansky' },
+      { type: 'encoded_message', tick: 92, target: 'asmodeus' },
+      { type: 'evade_pursuit', tick: 96, actor: 'talon' },
+      { type: 'mourning_act', tick: 101, actor: 'juno' },
+    ],
+    overrides: [],
+  };
+}
+
+// Tag provenance for the hover-audit (per-row, not global).
+// solid = exact (source chunk + world time), ring = approximate (retrograde
+// backfill epoch), hollow = unknowable (skald_inline, NULL world time).
+export const PROVENANCE = {
+  'talon:wounded': { dot: 'hollow', src: 'skald_inline', note: 'NULL world time' },
+  'asmodeus:cns_stimulated': { dot: 'hollow', src: 'skald_inline', note: 'NULL world time' },
+  'asmodeus:grudge_active': { dot: 'solid', src: 'resolver', note: 'chunk 0089' },
+  'juno:grieving': { dot: 'solid', src: 'resolver', note: 'chunk 0094' },
+  'juno:grudge_active': { dot: 'solid', src: 'resolver', note: 'chunk 0095' },
+  'talon:grudge_active': { dot: 'solid', src: 'resolver', note: 'chunk 0095' },
+  'celia:wounded': { dot: 'solid', src: 'resolver', note: 'chunk 0102' },
+  'victor:intelligence_asset_active': { dot: 'solid', src: 'resolver', note: 'chunk 0099' },
+  'celia:intelligence_asset_active': { dot: 'solid', src: 'resolver', note: 'chunk 0099' },
+};
+export function provenanceFor(entityId, tagName) {
+  return PROVENANCE[entityId + ':' + tagName] || { dot: 'ring', src: 'retrograde', note: 'backfill epoch' };
+}
+
+// ------------------------------------------------------------- clock ----
+
+export function worldTimeFor(state) {
+  const dTicks = state.anchor - state.baseAnchor;
+  const secs = state.baseWorldTime + dTicks * 45 * 60;
+  const d = new Date(secs * 1000);
+  const p = (n) => String(n).padStart(2, '0');
+  return {
+    iso: `2073-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())} ${p(d.getUTCHours())}:${p(d.getUTCMinutes())}`,
+    hours: d.getUTCHours() + d.getUTCMinutes() / 60,
+  };
+}
+export function timeOfDayFor(state) {
+  const h = worldTimeFor(state).hours;
+  if (h >= 5 && h < 12) return 'morning';
+  if (h >= 12 && h < 17) return 'afternoon';
+  if (h >= 17 && h < 21) return 'evening';
+  return 'night';
+}
+
+// ------------------------------------------------------ override layer ----
+
+export function applyOverrides(base, overrides, anchor) {
+  const s = JSON.parse(JSON.stringify({ ...base, weatherByTick: undefined }));
+  s.weatherByTick = base.weatherByTick;
+  s.anchor = anchor != null ? anchor : base.anchor;
+  s.overrides = overrides || [];
+  // need accrual with anchor drift (rate 1.0/hr, 0.75h per tick, clamped ≥0)
+  const drift = (s.anchor - base.baseAnchor) * 0.75;
+  for (const e of Object.values(s.entities)) {
+    for (const n of NEEDS) e.needs[n] = Math.max(0, +(e.needs[n] + drift).toFixed(1));
+  }
+  for (const ov of s.overrides) {
+    if (ov.kind === 'tag') {
+      const e = s.entities[ov.entity];
+      const list = ov.eph ? e.ephemerals : e.tags;
+      const i = list.indexOf(ov.tag);
+      if (ov.on && i < 0) list.push(ov.tag);
+      if (!ov.on && i >= 0) list.splice(i, 1);
+    } else if (ov.kind === 'pairTag') {
+      const i = s.pairTags.findIndex((p) => p.from === ov.from && p.to === ov.to && p.tag === ov.tag);
+      if (ov.on && i < 0) s.pairTags.push({ from: ov.from, to: ov.to, tag: ov.tag });
+      if (!ov.on && i >= 0) s.pairTags.splice(i, 1);
+    } else if (ov.kind === 'need') {
+      s.entities[ov.entity].needs[ov.need] = ov.value;
+    } else if (ov.kind === 'move') {
+      s.entities[ov.entity].place = ov.place;
+    } else if (ov.kind === 'event') {
+      s.events.push({ type: ov.type, tick: s.anchor - (ov.ago ?? 1), target: ov.target });
+    }
+  }
+  return s;
+}
+
+// --------------------------------------------------------- evaluation ----
+
+function ctx(state) {
+  return { state, tod: timeOfDayFor(state), weather: state.weatherByTick(state.anchor), tick: state.anchor };
+}
+
+function evalLeaf(leaf, c, b) {
+  const S = c.state;
+  const who = (w) => (w === 'target' ? b.TARGET : b.ACTOR);
+  const ent = (w) => S.entities[who(w)];
+  const trust = (x, y) => {
+    for (const r of S.relationships) {
+      if (r.a === x && r.b === y) return r.trustAB;
+      if (r.a === y && r.b === x) return r.trustBA;
+    }
+    return 0;
+  };
+  const relTypes = (x, y) => { // directional: types x holds toward y
+    for (const r of S.relationships) {
+      if (r.a === x && r.b === y) return r.typesAB;
+      if (r.a === y && r.b === x) return r.typesBA;
+    }
+    return [];
+  };
+  const relUnion = (x, y) => [...new Set([...relTypes(x, y), ...relTypes(y, x)])];
+  const hasIn = (id, t) => S.pairTags.some((p) => p.to === id && p.tag === t);
+  const hasOut = (id, t) => S.pairTags.some((p) => p.from === id && p.tag === t);
+  const cur = (e) => [...e.tags, ...e.ephemerals];
+  const placeOf = (e) => PLACES[e.place];
+  const fmt = (v) => (typeof v === 'number' ? +v.toFixed(1) : v);
+  let pass = false, ev = '', reads = [];
+
+  switch (leaf.p) {
+    case 'hydrated': pass = true; ev = `window ${S.windowChunks} chunks`; break;
+    case 'tag': { const e = ent(leaf.w); pass = e.tags.includes(leaf.t); ev = pass ? 'present' : 'absent'; reads = [leaf.t]; break; }
+    case 'eph': { const e = ent(leaf.w); pass = e.ephemerals.includes(leaf.t); ev = pass ? 'present' : 'absent'; reads = [leaf.t]; break; }
+    case 'anyTag': { const e = ent(leaf.w); const hit = leaf.list.find((t) => e.tags.includes(t)); pass = !!hit; ev = hit ? `matched: ${hit}` : 'no member present'; reads = leaf.list; break; }
+    case 'anyCur': { const e = ent(leaf.w); const hit = leaf.list.find((t) => cur(e).includes(t)); pass = !!hit; ev = hit ? `matched: ${hit}` : 'no member present'; reads = leaf.list; break; }
+    case 'inPair': { const id = who(leaf.w); const srcs = S.pairTags.filter((p) => p.to === id && p.tag === leaf.t); pass = srcs.length > 0; ev = pass ? `from ${srcs.map((p) => S.entities[p.from].name).join(', ')}` : 'none inbound'; reads = [leaf.t]; break; }
+    case 'outPair': { const id = who(leaf.w); const dsts = S.pairTags.filter((p) => p.from === id && p.tag === leaf.t); pass = dsts.length > 0; ev = pass ? `to ${dsts.map((p) => S.entities[p.to].name).join(', ')}` : 'none outbound'; reads = [leaf.t]; break; }
+    case 'residesHere': { pass = S.pairTags.some((p) => p.from === b.ACTOR && p.tag === 'resides_at' && p.to === ent('actor').place); ev = pass ? 'resides here' : 'not their residence'; reads = ['resides_at']; break; }
+    case 'relShared': { const ts = relUnion(b.ACTOR, b.TARGET); pass = ts.includes(leaf.t); ev = ts.length ? `edge: {${ts.join(', ')}}` : 'no edge'; break; }
+    case 'relDir': { const ts = relTypes(b.ACTOR, b.TARGET); pass = ts.includes(leaf.t); ev = ts.length ? `actor→target: {${ts.join(', ')}}` : 'no directed edge'; break; }
+    case 'relDirRev': { const ts = relTypes(b.TARGET, b.ACTOR); pass = ts.includes(leaf.t); ev = ts.length ? `target→actor: {${ts.join(', ')}}` : 'no directed edge'; break; }
+    case 'trustLt': { const v = trust(b.ACTOR, b.TARGET); pass = v < leaf.v; ev = `trust ${v} ${pass ? '<' : '≥'} ${leaf.v}`; break; }
+    case 'trustGte': { const v = trust(b.ACTOR, b.TARGET); pass = v >= leaf.v; ev = `trust ${v} ${pass ? '≥' : '<'} ${leaf.v}`; break; }
+    case 'mutualWarm': { const a2 = trust(b.ACTOR, b.TARGET), b2 = trust(b.TARGET, b.ACTOR); pass = a2 >= 2 && b2 >= 2; ev = `trust ${a2} / ${b2}`; break; }
+    case 'trustLoaded': { const a2 = trust(b.ACTOR, b.TARGET), b2 = trust(b.TARGET, b.ACTOR); pass = Math.abs(a2 - b2) >= 3 || a2 <= -2 || b2 <= -2; ev = `trust ${a2} / ${b2}`; break; }
+    case 'dramatic': {
+      const aH = FAMILIES.DRAMATIC_CONTACT_TAGS.find((t) => cur(ent('actor')).includes(t));
+      const tH = b.TARGET ? FAMILIES.DRAMATIC_CONTACT_TAGS.find((t) => cur(ent('target')).includes(t)) : null;
+      const hunted = b.TARGET && hasIn(b.TARGET, 'hunting');
+      pass = !!(aH || tH || hunted);
+      ev = aH ? `actor ${aH} ∈ DRAMATIC_CONTACT` : tH ? `target ${tH} ∈ DRAMATIC_CONTACT` : hunted ? 'target has inbound hunting' : 'contact is ordinary';
+      reads = FAMILIES.DRAMATIC_CONTACT_TAGS.concat(['hunting']); break;
+    }
+    case 'need': { const e = ent('actor'); const imm = NEED_IMMUNITY[leaf.nd].find((t) => cur(e).includes(t)); if (imm) { pass = false; ev = `immune (${imm})`; } else { const v = e.needs[leaf.nd]; pass = v >= leaf.v; ev = `${leaf.nd} debt ${fmt(v)} ${pass ? '≥' : '<'} ${leaf.v}`; } break; }
+    case 'evRecent': {
+      const hit = S.events.filter((e) => e.type === leaf.t && (c.tick - e.tick) <= leaf.within && (c.tick - e.tick) >= 0)
+        .filter((e) => leaf.targeting === 'any' ? true : e.target === who(leaf.targeting));
+      pass = hit.length > 0;
+      const near = S.events.filter((e) => e.type === leaf.t && (leaf.targeting === 'any' || e.target === who(leaf.targeting))).sort((x, y) => y.tick - x.tick)[0];
+      ev = pass ? `t${hit[0].tick} → ${c.tick - hit[0].tick} ≤ ${leaf.within}` : near ? `last t${near.tick} → ${c.tick - near.tick} > ${leaf.within}` : 'none in window';
+      break;
+    }
+    case 'cooldown': {
+      const match = S.events.filter((e) => e.type === leaf.t && (
+        leaf.scope === 'pair' ? (e.pair && e.pair[0] === b.ACTOR && e.pair[1] === b.TARGET) : (e.actor === b.ACTOR)
+      )).sort((x, y) => y.tick - x.tick)[0];
+      if (!match) { pass = true; ev = 'none in window'; }
+      else { const dt = c.tick - match.tick; pass = dt >= leaf.ticks; ev = `last t${match.tick} → ${dt} ${pass ? '≥' : '<'} ${leaf.ticks}`; }
+      break;
+    }
+    case 'tod': pass = leaf.list.includes(c.tod); ev = c.tod; break;
+    case 'weather': pass = leaf.list.includes(c.weather); ev = c.weather; break;
+    case 'place': { const p = placeOf(ent(leaf.w)); pass = p.classes.includes(leaf.c); ev = `${p.name.split(' — ')[0]} {${p.classes.join(', ')}}`; break; }
+    case 'colo': { pass = ent('actor').place === ent('target').place; ev = pass ? `both at ${placeOf(ent('actor')).name.split(' — ')[0]}` : `${placeOf(ent('actor')).name.split(' — ')[0]} vs ${placeOf(ent('target')).name.split(' — ')[0]}`; break; }
+    case 'othersColo': { const id = who(leaf.w); const p = S.entities[id].place; const n = Object.values(S.entities).filter((e) => e.id !== id && e.place === p).length; pass = n >= leaf.n; ev = `${n} co-located`; break; }
+    case 'othersGrieving': { const p = ent('actor').place; const n = Object.values(S.entities).filter((e) => e.id !== b.ACTOR && e.place === p && e.ephemerals.includes('grieving')).length; pass = n >= 1; ev = `${n} grieving co-located`; reads = ['grieving']; break; }
+    case 'fameGte': { const e = ent('actor'); pass = FAME.indexOf(e.fame) >= FAME.indexOf(leaf.r); ev = `fame: ${e.fame}`; break; }
+    case 'fameLt': { const e = ent('actor'); pass = FAME.indexOf(e.fame) < FAME.indexOf(leaf.r); ev = `fame: ${e.fame}`; break; }
+    case 'resGte': { const e = ent('actor'); pass = RESOURCES.indexOf(e.resources) >= RESOURCES.indexOf(leaf.r); ev = `resources: ${e.resources}`; break; }
+    case 'resLt': { const e = ent('actor'); pass = RESOURCES.indexOf(e.resources) < RESOURCES.indexOf(leaf.r); ev = `resources: ${e.resources}`; break; }
+    case 'constrained': { const hit = FAMILIES.CONSTRAINED_TAGS.find((t) => cur(ent('actor')).includes(t)); pass = !!hit; ev = hit ? `matched: ${hit} ∈ CONSTRAINED` : 'unconstrained'; reads = FAMILIES.CONSTRAINED_TAGS; break; }
+    case 'hiddenOff': { const hit = FAMILIES.HIDDEN_TAGS.find((t) => cur(ent('actor')).includes(t)); pass = !!hit; ev = hit ? `matched: ${hit} ∈ HIDDEN` : 'not hidden'; reads = FAMILIES.HIDDEN_TAGS; break; }
+    case 'pubFlow': { const e = ent(leaf.w); const hit = FAMILIES.PUBLIC_MOBILITY_BLOCKERS.find((t) => cur(e).includes(t)); pass = !hit; ev = hit ? `blocked: ${hit} ∈ MOBILITY_BLOCKERS` : 'unblocked'; reads = FAMILIES.PUBLIC_MOBILITY_BLOCKERS; break; }
+    case 'intimSupp': { const hit = FAMILIES.INTIMACY_SUPPRESSOR_TAGS.find((t) => cur(ent('actor')).includes(t)); pass = !!hit; ev = hit ? `matched: ${hit} ∈ INTIMACY_SUPPRESSOR` : 'no suppressor'; reads = FAMILIES.INTIMACY_SUPPRESSOR_TAGS; break; }
+    case 'inTransit': { pass = !!(ent('actor').travel && ent('actor').travel.inTransit); ev = pass ? 'in transit' : 'not in transit'; break; }
+    case 'hasDest': { pass = !!(ent('actor').travel && ent('actor').travel.dest); ev = pass ? `dest: ${ent('actor').travel.dest}` : 'no destination'; break; }
+    case 'travProg': { const t = ent('actor').travel; const v = t ? t.progress || 0 : 0; pass = v >= leaf.v; ev = `progress ${v}`; break; }
+    case 'travPurpose': { const t = ent('actor').travel; pass = !!t && t.purpose === leaf.v; ev = t ? `purpose: ${t.purpose || '—'}` : 'not traveling'; break; }
+    case 'travRisk': { const t = ent('actor').travel; pass = !!t && leaf.list.includes(t.risk); ev = t ? `risk: ${t.risk || '—'}` : 'not traveling'; break; }
+    case 'anchorHas': case 'anchorDue': case 'anchorAway': case 'anchorAt': case 'anchorResolves': {
+      const anch = (ent('actor').routine || {})[leaf.k];
+      if (leaf.p === 'anchorHas') { pass = !!anch; ev = anch ? 'anchor set' : 'no anchor (slot 2 backfill)'; }
+      else if (!anch) { pass = false; ev = 'no anchor'; }
+      else { pass = true; ev = 'anchor ok'; }
+      break;
+    }
+    case 'partnerColo': { const p = ent('actor').place; const partner = S.relationships.find((r) => ((r.a === b.ACTOR && S.entities[r.b].place === p) || (r.b === b.ACTOR && S.entities[r.a].place === p)) && [...(r.typesAB || []), ...(r.typesBA || [])].includes('romantic')); pass = !!partner; ev = pass ? 'partner present' : 'no established partner co-located'; break; }
+    case 'factionSenior': { pass = !!ent('actor').factionSenior; ev = pass ? 'status:senior+' : 'no senior standing'; break; }
+    case 'resolveDest': { pass = !!ent('actor').resolveDest; ev = pass ? 'route graph resolves' : 'no destination resolvable'; break; }
+    default: pass = false; ev = 'unknown predicate';
+  }
+  return { kind: 'leaf', p: leaf.p, prose: leaf.prose, pass, evidence: ev, reads };
+}
+
+export function evalNode(node, c, b) {
+  if (!node) return null;
+  if (!node.op) return evalLeaf(node, c, b);
+  const children = node.children.map((ch) => evalNode(ch, c, b));
+  let pass;
+  if (node.op === 'AND') pass = children.every((x) => x.pass);
+  else if (node.op === 'OR') pass = children.some((x) => x.pass);
+  else pass = !children[0].pass;
+  return { kind: 'op', op: node.op, pass, children };
+}
+
+function firstFailingLeaf(trace) {
+  // walk the trace, return the shallowest failing leaf on the failure path
+  if (!trace) return null;
+  if (trace.kind === 'leaf') return trace.pass ? null : trace;
+  if (trace.op === 'NOT') {
+    if (trace.pass) return null;
+    // NOT failed because child passed — report the child leaf that passed
+    const passing = firstPassingLeaf(trace.children[0]);
+    return passing ? { ...passing, negated: true } : null;
+  }
+  if (trace.pass) return null;
+  if (trace.op === 'AND') { for (const ch of trace.children) { const f = firstFailingLeaf(ch); if (f) return f; } }
+  if (trace.op === 'OR') { for (const ch of trace.children) { const f = firstFailingLeaf(ch); if (f) return f; } }
+  return null;
+}
+function firstPassingLeaf(trace) {
+  if (!trace) return null;
+  if (trace.kind === 'leaf') return trace.pass ? trace : null;
+  if (trace.op === 'NOT') return trace.pass ? firstFailingLeaf(trace.children[0]) : null;
+  for (const ch of trace.children) { const f = firstPassingLeaf(ch); if (f) return f; }
+  return null;
+}
+export { firstFailingLeaf, firstPassingLeaf };
+
+function subst(text, c, b) {
+  if (!text) return text;
+  return text
+    .replaceAll('{actor}', c.state.entities[b.ACTOR].name)
+    .replaceAll('{target}', b.TARGET ? c.state.entities[b.TARGET].name : '{target}');
+}
+
+export function explainTemplate(tpl, c, b) {
+  const gate = evalNode(tpl.gate, c, b);
+  const out = {
+    id: tpl.id, tid: tpl.tid, name: tpl.id, band: tpl.band, priority: tpl.priority,
+    slots: tpl.slots, ptp: tpl.ptp, blurb: tpl.blurb, bandNote: tpl.bandNote || null,
+    bindings: { ACTOR: b.ACTOR, TARGET: b.TARGET || null },
+    gate, gatePassed: gate.pass, fired: false, branches: [], resolution: null,
+    failLeaf: gate.pass ? null : firstFailingLeaf(gate),
+  };
+  let selected = -1;
+  out.branches = tpl.branches.map((br, i) => {
+    if (!gate.pass || selected >= 0) {
+      return { i, label: br.label, mag: br.mag, considered: false, passed: null, trace: null, selected: false, failLeaf: null };
+    }
+    const trace = br.when ? evalNode(br.when, c, b) : { kind: 'leaf', p: 'always', prose: '(always)', pass: true, evidence: 'terminal fallback', reads: [] };
+    const passed = trace.pass;
+    if (passed) selected = i;
+    return { i, label: br.label, mag: br.mag, considered: true, passed, trace, selected: passed, failLeaf: passed ? null : firstFailingLeaf(trace) };
+  });
+  if (gate.pass && selected >= 0) {
+    const br = tpl.branches[selected];
+    out.fired = true;
+    out.resolution = {
+      branchLabel: br.label, magnitude: br.mag, eventType: br.event,
+      stub: subst(br.stub, c, b), does: br.does, delta: br.delta,
+      pressureStub: br.pressure ? subst(br.pressure, c, b) : null,
+      bindingHash: 'sha256:' + [tpl.tid, b.ACTOR, b.TARGET || ''].join(':'),
+    };
+  }
+  return out;
+}
+
+export function explainStack(templates, c, b) {
+  // priority desc, authored tuple order for ties (array order IS authored order)
+  const rows = templates.map((t) => explainTemplate(t, c, b));
+  let winner = null;
+  for (const r of rows) {
+    if (r.fired && !winner) { r.status = 'winner'; winner = r; }
+    else if (r.fired) r.status = 'shadowed';
+    else r.status = 'gate_failed';
+  }
+  // priority ties among fired templates
+  for (const r of rows) {
+    if (!r.fired) continue;
+    const peers = rows.filter((x) => x.fired && x !== r && x.priority === r.priority);
+    r.tie = peers.length ? peers.map((p) => p.id) : null;
+  }
+  return { rows, winner };
+}
+
+// -------------------------------------------------------- the resolver ----
+
+export function resolveTick(state) {
+  const c = ctx(state);
+  const offscreen = Object.values(state.entities).filter((e) => !e.onScreen);
+  const onscreen = Object.values(state.entities).filter((e) => e.onScreen);
+  const edgesOf = (id) => state.relationships.filter((r) => r.a === id || r.b === id)
+    .map((r) => (r.a === id ? r.b : r.a));
+
+  const groups = offscreen.map((actor) => {
+    const b = { ACTOR: actor.id };
+    const solo = explainStack(ACTOR_ONLY, c, b);
+    const partners = edgesOf(actor.id);
+    const offPartners = partners.filter((p) => !state.entities[p].onScreen);
+    const onPartners = partners.filter((p) => state.entities[p].onScreen);
+
+    const pairs = offPartners.map((tid) => {
+      const pb = { ACTOR: actor.id, TARGET: tid };
+      const stack = explainStack(TWO_PARTY, c, pb);
+      return { target: tid, ...stack };
+    });
+
+    // two-party templates with no off-screen target bound at all → not applicable
+    const notApplicable = offPartners.length === 0
+      ? TWO_PARTY.map((t) => ({ id: t.id, tid: t.tid, band: t.band, priority: t.priority, status: 'not_applicable', slots: t.slots }))
+      : [];
+
+    const pressures = [];
+    for (const tid of onPartners) {
+      const pb = { ACTOR: actor.id, TARGET: tid };
+      const stack = explainStack(TWO_PARTY, c, pb);
+      if (stack.winner) pressures.push({ target: tid, ...stack });
+    }
+
+    const fires = [solo.winner, ...pairs.map((p) => p.winner)].filter(Boolean);
+    return { actor: actor.id, solo, pairs, pressures, notApplicable, gap: fires.length === 0 && pressures.length === 0 };
+  });
+
+  // present-target need pressures (pseudo-templates, outside the catalog)
+  const needPressures = [];
+  for (const e of onscreen) {
+    for (const nd of NEEDS) {
+      if (NEED_IMMUNITY[nd].some((t) => [...e.tags, ...e.ephemerals].includes(t))) continue;
+      const v = e.needs[nd];
+      const th = NEED_THRESHOLDS[nd];
+      let level = 0, name = null;
+      for (const [lv, nm] of [[4, 'critical'], [3, 'severe'], [2, 'moderate'], [1, 'mild']]) {
+        if (v >= th[nm]) { level = lv; name = nm; break; }
+      }
+      if (level >= 2) {
+        needPressures.push({
+          pseudo: true, id: `${nd}_need_pressure`, band: 'embodied',
+          priority: NEED_PRESSURE_PRIORITY[nd], target: e.id, need: nd, debt: +v.toFixed(1),
+          severity: name, level, magnitude: Math.min(0.85, 0.35 + level * 0.10),
+        });
+      }
+    }
+  }
+
+  return { groups, needPressures, tod: c.tod, weather: c.weather, tick: c.tick };
+}
+
+// Reciprocal detection: pure post-pass over winners, keyed on reversed (actor, target)
+export function reciprocalPairs(resolved) {
+  const winners = [];
+  for (const g of resolved.groups) for (const p of g.pairs) if (p.winner) winners.push({ from: g.actor, to: p.target, tpl: p.winner.id });
+  const out = [];
+  for (const w of winners) {
+    const rev = winners.find((x) => x.from === w.to && x.to === w.from);
+    if (rev && w.from < w.to) out.push({ a: w.from, b: w.to, tplA: w.tpl, tplB: rev.tpl });
+  }
+  return out;
+}
+
+// ------------------------------------------------- window batch stats ----
+// Invented-but-plausible coverage analysis over the loaded window (79→108),
+// shaped like the real save_02 pathologies.
+
+export const WINDOW_STATS = {
+  window: '79 → 108',
+  ticks: 30,
+  neverWin: ['MAINTAIN_COVER', 'CONSULT_RIVAL', 'ROUTINE_COMMUTE', 'INTIMACY', 'HONOR_DEBT'],
+  dominant: [
+    { id: 'HIDE', share: 0.61 },
+    { id: 'TEND_CRAFT', share: 0.12 },
+    { id: 'WORK', share: 0.09 },
+    { id: 'SURVEIL', share: 0.07 },
+  ],
+  dataQuality: [
+    { kind: 'null_world_time', text: '22 / 35 resolver bestowals carry NULL applied_at_world_time', sev: 'warn' },
+    { kind: 'wall_clock_epoch', text: 'retrograde epoch: world-times 2073-06 → 2073-10 written at one wall-clock instant', sev: 'warn' },
+    { kind: 'clearance_log', text: '398 / 403 cleared tag rows have no clearance-log entry', sev: 'warn' },
+    { kind: 'pair_clears', text: 'pair-tag clears are unlogged on every path', sev: 'error' },
+    { kind: 'routine_anchors', text: 'no routine anchors seeded in slot 2 — ROUTINE_COMMUTE / WORK anchor arms unreachable', sev: 'info' },
+  ],
+};
+
+// ------------------------------------------------------------ self test ----
+
+export function selfTest() {
+  const s = applyOverrides(baseWorldState(), [], 108);
+  const r = resolveTick(s);
+  const g = Object.fromEntries(r.groups.map((x) => [x.actor, x]));
+  const errs = [];
+  const expectWinner = (grp, tpl, branch) => {
+    const w = grp.solo.winner;
+    if (!w) { errs.push(`${grp.actor}: expected solo winner ${tpl}, got none`); return; }
+    if (w.id !== tpl) errs.push(`${grp.actor}: expected solo ${tpl}, got ${w.id}`);
+    else if (branch && w.resolution.branchLabel !== branch) errs.push(`${grp.actor}: ${tpl} branch "${w.resolution.branchLabel}" ≠ "${branch}"`);
+  };
+  expectWinner(g.victor, 'HIDE', 'Go dark and reduce signal exposure');
+  expectWinner(g.asmodeus, 'HIDE', 'Harden or sanitize a safehouse');
+  expectWinner(g.celia, 'HIDE', 'Go dark and reduce signal exposure');
+  expectWinner(g.juno, 'MOURN_LOSS', 'Visit the place of remembrance');
+  expectWinner(g.talon, 'EVADE_PURSUERS', 'Go to ground in flooded tunnels');
+  if (g.lansky.solo.winner) errs.push('lansky: expected coverage gap, got ' + g.lansky.solo.winner.id);
+  if (!g.lansky.gap) errs.push('lansky: gap flag not set');
+  const vc = g.victor.pairs.find((p) => p.target === 'celia');
+  if (!vc || !vc.winner || vc.winner.id !== 'CULTIVATE_INFORMANT') errs.push('victor→celia: expected CULTIVATE_INFORMANT, got ' + (vc && vc.winner ? vc.winner.id : 'none'));
+  if (vc && vc.winner && vc.winner.resolution.branchLabel !== 'Press for material intel when trust is sufficient') errs.push('victor→celia branch: ' + (vc.winner.resolution || {}).branchLabel);
+  const vcSurveil = vc && vc.rows.find((x) => x.id === 'SURVEIL');
+  if (!vcSurveil || vcSurveil.status !== 'shadowed') errs.push('victor→celia SURVEIL should be shadowed (50 vs 48), is ' + (vcSurveil && vcSurveil.status));
+  const vcTend = vc && vc.rows.find((x) => x.id === 'TEND_WOUNDED');
+  if (!vcTend || vcTend.status !== 'gate_failed') errs.push('victor→celia TEND_WOUNDED should gate-fail on cooldown, is ' + (vcTend && vcTend.status));
+  const vt = g.victor.pairs.find((p) => p.target === 'talon');
+  if (!vt || !vt.winner || vt.winner.id !== 'SURVEIL') errs.push('victor→talon: expected SURVEIL, got ' + (vt && vt.winner ? vt.winner.id : 'none'));
+  const cv = g.celia.pairs.find((p) => p.target === 'victor');
+  if (!cv || !cv.winner || cv.winner.id !== 'CONSULT_RIVAL') errs.push('celia→victor: expected CONSULT_RIVAL, got ' + (cv && cv.winner ? cv.winner.id : 'none'));
+  const at = g.asmodeus.pairs.find((p) => p.target === 'talon');
+  if (!at || !at.winner || at.winner.id !== 'PROTECT_KIN') errs.push('asmodeus→talon: expected PROTECT_KIN, got ' + (at && at.winner ? at.winner.id : 'none'));
+  const jt = g.juno.pairs.find((p) => p.target === 'talon');
+  if (!jt || !jt.winner || jt.winner.id !== 'PROTECT_KIN') errs.push('juno→talon: expected PROTECT_KIN, got ' + (jt && jt.winner ? jt.winner.id : 'none'));
+  if (jt && jt.winner && jt.winner.resolution.branchLabel !== 'Travel toward the target\u2019s last known location') errs.push('juno→talon branch: ' + jt.winner.resolution.branchLabel);
+  const jw = jt && jt.rows.find((x) => x.id === 'WARN_ALLY');
+  if (!jw || jw.status !== 'shadowed') errs.push('juno→talon WARN_ALLY should be shadowed, is ' + (jw && jw.status));
+  const mournTie = g.juno.solo.rows.find((x) => x.id === 'MOURN_LOSS');
+  if (!mournTie || !mournTie.tie || !mournTie.tie.includes('SLEEP')) errs.push('juno MOURN_LOSS should tie with SLEEP');
+  const celiaSleep = g.celia.solo.rows.find((x) => x.id === 'SLEEP');
+  if (!celiaSleep || celiaSleep.status !== 'shadowed' || celiaSleep.resolution.magnitude !== 0.74) errs.push('celia SLEEP should be shadowed at mag 0.74');
+  const asmSocial = g.asmodeus.solo.rows.find((x) => x.id === 'INTIMACY');
+  if (!asmSocial || asmSocial.status !== 'gate_failed') errs.push('asmodeus INTIMACY should gate-fail (suppressor)');
+  const press = {};
+  for (const grp of r.groups) for (const p of grp.pressures) press[grp.actor + '→' + p.target] = p.winner.id + '/' + p.winner.resolution.magnitude;
+  if (press['asmodeus→alex'] !== 'EXTRACT_VENGEANCE/0.34') errs.push('asmodeus→alex pressure: ' + press['asmodeus→alex']);
+  if (press['victor→alex'] !== 'SURVEIL/0.48') errs.push('victor→alex pressure: ' + press['victor→alex']);
+  if (press['celia→alex'] !== 'SURVEIL/0.44') errs.push('celia→alex pressure: ' + press['celia→alex']);
+  if (press['lansky→alex']) errs.push('lansky→alex should emit no pressure (cooldown)');
+  if (!r.needPressures.find((p) => p.target === 'pete' && p.need === 'thirst' && p.magnitude === 0.55)) errs.push('pete thirst need-pressure missing');
+  const recip = reciprocalPairs(r);
+  if (!recip.find((x) => (x.a === 'celia' && x.b === 'victor') || (x.a === 'victor' && x.b === 'celia'))) errs.push('victor↔celia reciprocal pair missing');
+  // what-if: clearing the hunting pair tag flips Talon to SLEEP (safe lodgings)
+  const s2 = applyOverrides(baseWorldState(), [{ kind: 'pairTag', from: 'victor', to: 'talon', tag: 'hunting', on: false }], 108);
+  const r2 = resolveTick(s2);
+  const t2 = r2.groups.find((x) => x.actor === 'talon');
+  if (!t2.solo.winner || t2.solo.winner.id !== 'SLEEP') errs.push('what-if: talon expected SLEEP, got ' + (t2.solo.winner ? t2.solo.winner.id : 'none'));
+  return errs;
+}

--- a/ui/.design-sync/import/orrery/support.js
+++ b/ui/.design-sync/import/orrery/support.js
@@ -1,0 +1,1658 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+      const raw = t ? parseDcText(t) : null;
+      if (raw?.template) runtime.updateHtml(rootName, raw.template);
+    }).catch(() => {
+    });
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || el.getAttribute("src") || el.getAttribute("import") || "";
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const kids = hasContent ? walkChildren(el, host) : [];
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...kids.map((b, j) => b(vals, ctx, j)));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = BABEL_URL;
+        s.integrity = BABEL_SRI;
+        s.crossOrigin = "anonymous";
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => fetch(url)).then((r) => {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        return r.text();
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          doc.documentElement.dataset.theme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const sel = pseudo === "before" || pseudo === "after" ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(sel + "{" + css + "}", el.sheet.cssRules.length);
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      fetch(url).then((res) => {
+        if (!res.ok) {
+          console.error(
+            "[dc-runtime] sibling fetch for <" + name + "/> failed:",
+            url,
+            "returned",
+            res.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res.text();
+      }).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            "[dc-runtime] sibling fetch for <" + name + "/>:",
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          "[dc-runtime] sibling fetch for <" + name + "/> threw:",
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/index.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      s.integrity = integrity;
+      s.crossOrigin = "anonymous";
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    return Promise.all([
+      loadScript(REACT_URL, REACT_SRI),
+      loadScript(REACT_DOM_URL, REACT_DOM_SRI)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const api = {
+      __dcUpdate: (name, kind, content, streaming) => {
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`<sc-comp>`,
+       *  `sc-camel-*` attrs); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();

--- a/ui/client/src/App.tsx
+++ b/ui/client/src/App.tsx
@@ -19,6 +19,12 @@ const DevMarkdownPreview = import.meta.env.DEV
   ? lazy(() => import("@/pages/DevMarkdownPreview"))
   : null;
 
+// Dev-only Orrery audit dashboard: lazy + DEV-guarded so the module never
+// reaches the production bundle.
+const DevOrreryPage = import.meta.env.DEV
+  ? lazy(() => import("@/pages/dev-orrery"))
+  : null;
+
 function Router() {
   return (
     <Switch>
@@ -29,6 +35,13 @@ function Router() {
         <Route path="/dev/markdown">
           <Suspense fallback={null}>
             <DevMarkdownPreview />
+          </Suspense>
+        </Route>
+      )}
+      {DevOrreryPage && (
+        <Route path="/dev/orrery">
+          <Suspense fallback={null}>
+            <DevOrreryPage />
           </Suspense>
         </Route>
       )}

--- a/ui/client/src/pages/dev-orrery/EntityAudit.tsx
+++ b/ui/client/src/pages/dev-orrery/EntityAudit.tsx
@@ -1,0 +1,334 @@
+// Hover-audit card for a single entity: portrait/initials header, need
+// meters, durable/ephemeral tag chips (family glyph + provenance dot,
+// hover handlers feed the gate-highlight lens), relationships with the
+// "unversioned" watermark, and recent events. Pure presentational —
+// the VM is computed upstream by vm.buildEntityAudit.
+
+import { useState } from "react";
+import type { CSSProperties } from "react";
+import type { EntityAuditTagVM, EntityAuditVM } from "./types";
+
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((w) => w[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+const SECTION_LABEL: CSSProperties = {
+  fontSize: 8,
+  letterSpacing: "0.2em",
+  textTransform: "uppercase",
+  color: "hsl(var(--muted-foreground))",
+};
+
+function TagChip({
+  tag,
+  variant,
+}: {
+  tag: EntityAuditTagVM;
+  variant: "durable" | "ephemeral";
+}) {
+  const [hover, setHover] = useState(false);
+  const base: CSSProperties =
+    variant === "durable"
+      ? {
+          border: "1px solid hsl(var(--border))",
+          color: "hsl(var(--foreground) / 0.85)",
+        }
+      : {
+          border: "1px dashed hsl(var(--chart-2) / 0.6)",
+          color: "hsl(var(--chart-2))",
+        };
+  return (
+    <span
+      onMouseEnter={() => {
+        setHover(true);
+        tag.onEnter?.();
+      }}
+      onMouseLeave={() => {
+        setHover(false);
+        tag.onLeave?.();
+      }}
+      title={`${tag.famTitle} · ${tag.dotTitle}`}
+      className="font-mono"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        fontSize: 9,
+        letterSpacing: "0.04em",
+        borderRadius: 99,
+        padding: "1px 7px",
+        cursor: "default",
+        ...base,
+        ...(hover ? { borderColor: "hsl(var(--accent))" } : {}),
+      }}
+    >
+      <span style={{ color: "hsl(var(--chart-5))", fontSize: 8 }}>{tag.fam}</span>
+      {tag.name}
+      <span
+        style={
+          variant === "durable"
+            ? { color: "hsl(var(--muted-foreground))", fontSize: 8 }
+            : { opacity: 0.7, fontSize: 8 }
+        }
+      >
+        {tag.dot}
+      </span>
+    </span>
+  );
+}
+
+export default function EntityAudit({ ent }: { ent: EntityAuditVM }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 9,
+        width: 290,
+        fontFamily: "var(--font-sans)",
+      }}
+    >
+      <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
+        {/* Portrait placeholder: the app has no portrait pipeline on this
+            page yet, so the prototype's image-slot is an initials circle. */}
+        <div
+          className="font-mono"
+          style={{
+            width: 46,
+            height: 46,
+            flex: "none",
+            borderRadius: "50%",
+            border: "1px solid hsl(var(--border))",
+            background: "hsl(var(--muted) / 0.3)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 13,
+            letterSpacing: "0.06em",
+            color: "hsl(var(--muted-foreground))",
+          }}
+        >
+          {initialsOf(ent.name)}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 1,
+            minWidth: 0,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 14.5,
+              fontWeight: 650,
+              color: "hsl(var(--foreground))",
+            }}
+          >
+            {ent.name}
+          </span>
+          <span style={{ fontSize: 11, color: "hsl(var(--muted-foreground))" }}>
+            {ent.place}
+          </span>
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 8.5,
+              letterSpacing: "0.1em",
+              color: "hsl(var(--muted-foreground) / 0.8)",
+            }}
+          >
+            {ent.classes}
+          </span>
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 8.5,
+              letterSpacing: "0.06em",
+              color: "hsl(var(--chart-5) / 0.9)",
+            }}
+          >
+            {ent.fameRes}
+          </span>
+        </div>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        {ent.needs.map((nr) => (
+          <div
+            key={nr.nd}
+            style={{ display: "flex", alignItems: "center", gap: 7 }}
+          >
+            <span
+              className="font-mono"
+              style={{
+                fontSize: 8.5,
+                letterSpacing: "0.08em",
+                width: 56,
+                flex: "none",
+                color: "hsl(var(--muted-foreground))",
+              }}
+            >
+              {nr.nd}
+            </span>
+            <div
+              style={{
+                flex: 1,
+                height: 3,
+                borderRadius: 2,
+                background: "hsl(var(--muted) / 0.3)",
+                overflow: "hidden",
+              }}
+            >
+              <div
+                style={{ width: nr.pct, height: "100%", background: nr.color }}
+              />
+            </div>
+            <span
+              className="font-mono"
+              style={{
+                fontSize: 9,
+                width: 52,
+                textAlign: "right",
+                color: nr.color,
+              }}
+            >
+              {nr.val}
+            </span>
+            <span
+              className="font-mono"
+              style={{
+                fontSize: 7.5,
+                width: 52,
+                color: "hsl(var(--muted-foreground) / 0.7)",
+              }}
+            >
+              {nr.note}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <span className="font-mono" style={SECTION_LABEL}>
+          Durable
+        </span>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+          {ent.durable.map((tg, i) => (
+            <TagChip key={`${tg.name}:${i}`} tag={tg} variant="durable" />
+          ))}
+        </div>
+        {ent.hasEphemeral && (
+          <>
+            <span
+              className="font-mono"
+              style={{ ...SECTION_LABEL, marginTop: 2 }}
+            >
+              Ephemeral
+            </span>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+              {ent.ephemeral.map((tg, i) => (
+                <TagChip key={`${tg.name}:${i}`} tag={tg} variant="ephemeral" />
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+
+      {ent.hasRels && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
+            <span className="font-mono" style={SECTION_LABEL}>
+              Relationships
+            </span>
+            <span
+              className="font-mono"
+              style={{
+                fontSize: 7.5,
+                letterSpacing: "0.1em",
+                color: "hsl(var(--muted-foreground) / 0.55)",
+                fontStyle: "italic",
+              }}
+            >
+              unversioned
+            </span>
+          </div>
+          {ent.rels.map((rl, i) => (
+            <div
+              key={`${rl.other}:${i}`}
+              style={{
+                display: "flex",
+                alignItems: "baseline",
+                gap: 7,
+                fontSize: 11,
+              }}
+            >
+              <span
+                className="font-mono"
+                style={{
+                  fontSize: 8.5,
+                  color: "hsl(var(--chart-4))",
+                  flex: "none",
+                  minWidth: 70,
+                }}
+              >
+                {rl.types}
+              </span>
+              <span style={{ flex: 1 }}>{rl.other}</span>
+              <span
+                className="font-mono"
+                style={{ fontSize: 9.5, color: "hsl(var(--muted-foreground))" }}
+              >
+                trust {rl.trust}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {ent.hasEvents && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 3,
+            borderTop: "1px solid hsl(var(--border))",
+            paddingTop: 6,
+          }}
+        >
+          <span className="font-mono" style={SECTION_LABEL}>
+            Recent events
+          </span>
+          {ent.events.map((ev, i) => (
+            <div
+              key={`${ev.t}:${ev.type}:${i}`}
+              style={{ display: "flex", gap: 9, alignItems: "baseline" }}
+            >
+              <span
+                className="font-mono"
+                style={{ fontSize: 9, color: "hsl(var(--muted-foreground))" }}
+              >
+                {ev.t}
+              </span>
+              <span
+                className="font-mono"
+                style={{
+                  fontSize: 9.5,
+                  letterSpacing: "0.04em",
+                  color: "hsl(var(--foreground) / 0.85)",
+                }}
+              >
+                {ev.type}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/client/src/pages/dev-orrery/GateBrackets.tsx
+++ b/ui/client/src/pages/dev-orrery/GateBrackets.tsx
@@ -1,0 +1,192 @@
+/**
+ * GateBrackets — vertical rail rendering of an evaluated gate tree.
+ *
+ * Port of the GateBrackets.dc.html prototype: each op node emits a small
+ * uppercase mono label row and opens a colored rail (green-ish chart-5 when
+ * the subtree passed, destructive when it failed) that runs down the left of
+ * all its descendants; NOT rails additionally carry a rotated bar glyph.
+ * Leaf rows show a ✓/✗ glyph, the predicate prose, and the right-aligned
+ * mono evidence string.
+ */
+import type { CSSProperties } from "react";
+import type { EvaluatedGateNode } from "./types";
+
+interface Rail {
+  color: string;
+  barred: boolean;
+  top: string;
+  bottom: string;
+}
+
+interface OpRow {
+  minH: number;
+  rails: Rail[];
+  isOp: true;
+  isLeaf: false;
+  op: string;
+  opStyle: CSSProperties;
+}
+
+interface LeafRow {
+  minH: number;
+  rails: Rail[];
+  isOp: false;
+  isLeaf: true;
+  glyph: string;
+  glyphColor: string;
+  prose: string;
+  proseStyle: CSSProperties;
+  evidence: string;
+  evColor: string;
+}
+
+type Row = OpRow | LeafRow;
+
+function railColor(n: EvaluatedGateNode): string {
+  return n.pass ? "hsl(var(--chart-5) / 0.75)" : "hsl(var(--destructive) / 0.85)";
+}
+
+function buildRows(node: EvaluatedGateNode | null): Row[] {
+  const rows: Row[] = [];
+  if (!node) return rows;
+  const walk = (n: EvaluatedGateNode | undefined, rails: Rail[]): void => {
+    if (!n) return;
+    if (n.kind === "leaf") {
+      rows.push({
+        minH: 20,
+        rails: rails.map((r) => ({ ...r, top: "0", bottom: "0" })),
+        isOp: false,
+        isLeaf: true,
+        glyph: n.pass ? "✓" : "✗",
+        glyphColor: n.pass ? "hsl(var(--chart-5))" : "hsl(var(--destructive))",
+        prose: n.prose,
+        proseStyle: {
+          flex: 1,
+          fontSize: 11.5,
+          minWidth: 0,
+          ...(n.pass
+            ? { color: "hsl(var(--foreground) / 0.85)" }
+            : { color: "hsl(var(--foreground))", fontWeight: 650 }),
+        },
+        evidence: n.evidence,
+        evColor: n.pass
+          ? "hsl(var(--muted-foreground))"
+          : "hsl(var(--destructive))",
+      });
+      return;
+    }
+    const color = railColor(n);
+    const barred = n.op === "NOT";
+    rows.push({
+      minH: 18,
+      rails: rails.map((r) => ({ ...r, top: "0", bottom: "0" })),
+      isOp: true,
+      isLeaf: false,
+      op: (n.op ?? "") + (barred ? " ⊘" : ""),
+      opStyle: {
+        fontSize: 8.5,
+        letterSpacing: "0.2em",
+        padding: "3px 4px 1px",
+        color,
+        textTransform: "uppercase",
+      },
+    });
+    const childRails: Rail[] = [
+      ...rails,
+      { color, barred, top: "0", bottom: "0" },
+    ];
+    for (const k of n.children ?? []) walk(k, childRails);
+  };
+  walk(node, []);
+  // trim rail ends: first/last row of each depth — cosmetic; keep simple full bars
+  return rows;
+}
+
+export default function GateBrackets({
+  node,
+}: {
+  node: EvaluatedGateNode | null;
+}) {
+  const rows = buildRows(node);
+  return (
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      {rows.map((r, i) => (
+        <div
+          key={i}
+          style={{ display: "flex", alignItems: "stretch", minHeight: r.minH }}
+        >
+          {r.rails.map((rl, j) => (
+            <span
+              key={j}
+              style={{
+                width: 16,
+                flex: "none",
+                position: "relative",
+                display: "flex",
+                justifyContent: "center",
+              }}
+            >
+              <span
+                style={{
+                  width: 2,
+                  background: rl.color,
+                  position: "absolute",
+                  top: rl.top,
+                  bottom: rl.bottom,
+                }}
+              />
+              {rl.barred && (
+                <span
+                  style={{
+                    position: "absolute",
+                    top: "45%",
+                    width: 10,
+                    height: 2,
+                    background: rl.color,
+                    transform: "rotate(-30deg)",
+                  }}
+                />
+              )}
+            </span>
+          ))}
+          {r.isOp && (
+            <span className="font-mono" style={r.opStyle}>
+              {r.op}
+            </span>
+          )}
+          {r.isLeaf && (
+            <span
+              style={{
+                display: "flex",
+                alignItems: "baseline",
+                gap: 7,
+                padding: "2.5px 4px",
+                flex: 1,
+                minWidth: 0,
+              }}
+            >
+              <span
+                style={{
+                  width: 13,
+                  flex: "none",
+                  textAlign: "center",
+                  fontSize: 10,
+                  color: r.glyphColor,
+                }}
+              >
+                {r.glyph}
+              </span>
+              <span style={r.proseStyle}>{r.prose}</span>
+              <span
+                className="font-mono"
+                style={{ fontSize: 9, color: r.evColor, flex: "none" }}
+              >
+                {r.evidence}
+              </span>
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/ui/client/src/pages/dev-orrery/HealthStrip.tsx
+++ b/ui/client/src/pages/dev-orrery/HealthStrip.tsx
@@ -1,0 +1,342 @@
+// Health strip — collapsible bottom drawer with four tile groups: winners by
+// band, coverage gaps, never/always-win window stats, and dead gate arms +
+// data quality. Port of the "Health strip" screen from the design prototype
+// (Orrery Audit Dashboard.dc.html); all aggregation happens in the parent,
+// this component just renders the view models it is handed.
+
+import type { CSSProperties } from "react";
+
+export interface HealthStripProps {
+  open: boolean;
+  onToggle: () => void;
+  bands: { name: string; color: string; count: number; pct: string }[];
+  gaps: { name: string; onJump: () => void }[];
+  dominant: { id: string; share: string }[];
+  neverWin: { id: string }[];
+  deadArms: { event: string; consumers: string }[];
+  dataQuality: { text: string; color: string }[];
+  warnCount: string;
+}
+
+const tileStyle: CSSProperties = {
+  border: "1px solid hsl(var(--border))",
+  borderRadius: 6,
+  padding: "10px 12px",
+  display: "flex",
+  flexDirection: "column",
+};
+
+const tileHeadingStyle: CSSProperties = {
+  fontSize: 8.5,
+  letterSpacing: "0.18em",
+  textTransform: "uppercase",
+  color: "hsl(var(--muted-foreground))",
+};
+
+const barTrackStyle: CSSProperties = {
+  flex: 1,
+  height: 6,
+  borderRadius: 3,
+  background: "hsl(var(--muted) / 0.3)",
+  overflow: "hidden",
+};
+
+export default function HealthStrip(props: HealthStripProps) {
+  const {
+    open,
+    onToggle,
+    bands,
+    gaps,
+    dominant,
+    neverWin,
+    deadArms,
+    dataQuality,
+    warnCount,
+  } = props;
+
+  return (
+    <div
+      className="bg-sidebar"
+      style={{ flex: "none", borderTop: "1px solid hsl(var(--border))" }}
+    >
+      <div
+        onClick={onToggle}
+        className="hover:bg-muted/20"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          padding: "7px 14px",
+          cursor: "pointer",
+        }}
+      >
+        <span style={{ fontSize: 9, color: "hsl(var(--muted-foreground))" }}>
+          {open ? "▾" : "▴"}
+        </span>
+        <span
+          className="font-mono"
+          style={{
+            fontSize: 9.5,
+            letterSpacing: "0.22em",
+            textTransform: "uppercase",
+            color: "hsl(var(--muted-foreground))",
+          }}
+        >
+          System health
+        </span>
+        <span
+          className="font-mono"
+          style={{
+            fontSize: 9.5,
+            border: "1px solid hsl(var(--destructive) / 0.55)",
+            color: "hsl(var(--destructive))",
+            borderRadius: 99,
+            padding: "0 7px",
+          }}
+        >
+          {warnCount}
+        </span>
+        <div style={{ flex: 1 }} />
+      </div>
+      {open && (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+            gap: 10,
+            padding: "0 14px 12px",
+          }}
+        >
+          <div style={{ ...tileStyle, gap: 6 }}>
+            <span className="font-mono" style={tileHeadingStyle}>
+              Winners by band — this tick
+            </span>
+            {bands.map((hb) => (
+              <div
+                key={hb.name}
+                style={{ display: "flex", alignItems: "center", gap: 8 }}
+              >
+                <span
+                  className="font-mono"
+                  style={{
+                    fontSize: 9,
+                    letterSpacing: "0.06em",
+                    width: 86,
+                    flex: "none",
+                    color: "hsl(var(--muted-foreground))",
+                  }}
+                >
+                  {hb.name}
+                </span>
+                <div style={barTrackStyle}>
+                  <div
+                    style={{ width: hb.pct, height: "100%", background: hb.color }}
+                  />
+                </div>
+                <span
+                  className="font-mono"
+                  style={{ fontSize: 10, width: 14, textAlign: "right" }}
+                >
+                  {hb.count}
+                </span>
+              </div>
+            ))}
+          </div>
+          <div style={{ ...tileStyle, gap: 6 }}>
+            <span className="font-mono" style={tileHeadingStyle}>
+              Coverage gaps — this tick
+            </span>
+            {gaps.length > 0 ? (
+              gaps.map((hg) => (
+                <button
+                  key={hg.name}
+                  onClick={hg.onJump}
+                  className="hover:underline"
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    background: "transparent",
+                    border: "none",
+                    cursor: "pointer",
+                    padding: "2px 0",
+                    color: "hsl(var(--accent))",
+                    fontSize: 12.5,
+                    textAlign: "left",
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: 99,
+                      background: "hsl(var(--destructive))",
+                    }}
+                  />
+                  {hg.name}
+                  <span
+                    className="font-mono"
+                    style={{ fontSize: 9, color: "hsl(var(--muted-foreground))" }}
+                  >
+                    every gate refused
+                  </span>
+                </button>
+              ))
+            ) : (
+              <span
+                style={{
+                  fontSize: 12,
+                  fontStyle: "italic",
+                  color: "hsl(var(--muted-foreground))",
+                }}
+              >
+                Every candidate actor fired at least one package.
+              </span>
+            )}
+          </div>
+          <div style={{ ...tileStyle, gap: 5 }}>
+            <span className="font-mono" style={tileHeadingStyle}>
+              Never / always win — window
+            </span>
+            {dominant.map((hd) => (
+              <div
+                key={hd.id}
+                style={{ display: "flex", alignItems: "center", gap: 8 }}
+              >
+                <span
+                  className="font-mono"
+                  style={{
+                    fontSize: 9,
+                    width: 96,
+                    flex: "none",
+                    letterSpacing: "0.04em",
+                  }}
+                >
+                  {hd.id}
+                </span>
+                <div style={barTrackStyle}>
+                  <div
+                    style={{
+                      width: hd.share,
+                      height: "100%",
+                      background: "hsl(var(--chart-1) / 0.8)",
+                    }}
+                  />
+                </div>
+                <span
+                  className="font-mono"
+                  style={{ fontSize: 9.5, width: 32, textAlign: "right" }}
+                >
+                  {hd.share}
+                </span>
+              </div>
+            ))}
+            <div
+              style={{
+                fontSize: 10.5,
+                color: "hsl(var(--muted-foreground))",
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 4,
+                marginTop: 2,
+              }}
+            >
+              <span
+                className="font-mono"
+                style={{
+                  fontSize: 8.5,
+                  letterSpacing: "0.14em",
+                  textTransform: "uppercase",
+                }}
+              >
+                never:
+              </span>
+              {neverWin.map((hn) => (
+                <span
+                  key={hn.id}
+                  className="font-mono"
+                  style={{
+                    fontSize: 9,
+                    border: "1px solid hsl(var(--border))",
+                    borderRadius: 99,
+                    padding: "0 6px",
+                  }}
+                >
+                  {hn.id}
+                </span>
+              ))}
+            </div>
+          </div>
+          <div
+            style={{ ...tileStyle, gap: 5, overflowY: "auto", maxHeight: 170 }}
+          >
+            <span className="font-mono" style={tileHeadingStyle}>
+              Dead gate arms · data quality
+            </span>
+            {deadArms.map((da) => (
+              <div
+                key={da.event}
+                style={{
+                  display: "flex",
+                  alignItems: "baseline",
+                  gap: 6,
+                  fontSize: 10.5,
+                }}
+              >
+                <span
+                  className="font-mono"
+                  style={{
+                    fontSize: 9,
+                    color: "hsl(var(--chart-5))",
+                    flex: "none",
+                  }}
+                >
+                  {da.event}
+                </span>
+                <span
+                  style={{
+                    color: "hsl(var(--muted-foreground))",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  → {da.consumers} · never emitted
+                </span>
+              </div>
+            ))}
+            <div
+              style={{ borderTop: "1px solid hsl(var(--border))", margin: "3px 0" }}
+            />
+            {dataQuality.map((dq, i) => (
+              <div
+                key={i}
+                style={{
+                  display: "flex",
+                  alignItems: "baseline",
+                  gap: 7,
+                  fontSize: 10.5,
+                }}
+              >
+                <span
+                  style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: 99,
+                    background: dq.color,
+                    flex: "none",
+                    position: "relative",
+                    top: -1,
+                  }}
+                />
+                <span style={{ color: "hsl(var(--muted-foreground))" }}>
+                  {dq.text}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/client/src/pages/dev-orrery/HoverAudit.tsx
+++ b/ui/client/src/pages/dev-orrery/HoverAudit.tsx
@@ -1,0 +1,43 @@
+// Floating hover-audit popover: the fixed-position shell (hoverPanelStyle in
+// the prototype's logic block) around EntityAudit. The parent owns the hover
+// intent timers; onEnter/onLeave let the panel keep itself alive while the
+// pointer is inside it.
+
+import EntityAudit from "./EntityAudit";
+import type { EntityAuditVM } from "./types";
+
+export default function HoverAudit({
+  ent,
+  x,
+  y,
+  onEnter,
+  onLeave,
+}: {
+  ent: EntityAuditVM | null;
+  x: number;
+  y: number;
+  onEnter: () => void;
+  onLeave: () => void;
+}) {
+  if (!ent) return null;
+  return (
+    <div
+      data-screen-label="Hover audit"
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+      style={{
+        position: "fixed",
+        left: x,
+        top: y,
+        zIndex: 80,
+        background: "hsl(var(--popover))",
+        border: "1px solid hsl(var(--popover-border))",
+        borderRadius: 8,
+        padding: 14,
+        boxShadow: "0 8px 28px hsl(220 40% 2% / 0.7)",
+      }}
+    >
+      <EntityAudit ent={ent} />
+    </div>
+  );
+}

--- a/ui/client/src/pages/dev-orrery/InteractionGraph.tsx
+++ b/ui/client/src/pages/dev-orrery/InteractionGraph.tsx
@@ -1,0 +1,692 @@
+// Interaction graph — SVG view of this tick's resolution: off-screen actors
+// on a sine arc (left), on-screen entities in a right column, directed curved
+// edges for two-party winners (band color), dashed accent edges for scene
+// pressures, joint beats marked with the doubled-edge diamond, and dotted
+// "potential event" arcs at the bottom when an event lens is active.
+//
+// Port of the "Interaction graph" screen from the design prototype (Orrery
+// Audit Dashboard.dc.html, logic block ~lines 1068-1172). Differences from
+// the prototype, driven by the live payload shape:
+//   - onIds derivation: the payload has no explicit on-screen entity list, so
+//     on-screen nodes are the union of scene_pressure_stacks target bindings
+//     (present-target passes only bind on-screen entities by construction).
+//   - on-screen node sublabel: the mock showed the entity's place name; the
+//     live payload carries no place for non-actor entities, so it reads
+//     "on-screen" instead.
+//   - a no-solo-winner off-screen node click is a no-op here (the prototype
+//     jumped to the actor's stream group — a parent-level concern that isn't
+//     expressible through onSelect).
+//   - SVG <text> renders normally in real JSX; the prototype's
+//     React.createElement workaround for template holes inside <svg> is
+//     unnecessary, and edge <title> tooltips live inside their edge group.
+
+import * as React from "react";
+import type {
+  ActorGroupPayload,
+  ResolvePayload,
+  SelectionRef,
+  StackPayload,
+  TemplatePayload,
+} from "./types";
+import { bandColor } from "./vm";
+
+export interface InteractionGraphProps {
+  payload: ResolvePayload;
+  selectedKey: string | null;
+  onSelect: (sel: SelectionRef) => void;
+  onHoverEntity: (id: number, e: React.MouseEvent) => void;
+  eventLens: string | null;
+  deadArmConsumers: string[];
+}
+
+interface NodeVM {
+  id: number;
+  x: number;
+  y: number;
+  initials: string;
+  name: string;
+  stroke: string;
+  strokeW: number;
+  dash: string;
+  sub: string;
+  subColor: string;
+  onClick: () => void;
+}
+
+interface PathBits {
+  d: string;
+  lx: number;
+  ly: number;
+  jx: number;
+  jy: number;
+}
+
+interface EdgeVM extends PathBits {
+  key: string;
+  color: string;
+  baseW: number;
+  dash: string;
+  baseOp: number;
+  marker: string;
+  label: string;
+  title: string;
+  joint: boolean;
+  jrot: string;
+  jly: number;
+  sel: SelectionRef;
+}
+
+const initialsOf = (name: string): string =>
+  name
+    .split(/\s+/)
+    .map((w) => w[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+const winnerOf = (stack: StackPayload): TemplatePayload | null =>
+  stack.templates.find((t) => t.is_winner) ?? null;
+
+const groupHasFired = (g: ActorGroupPayload): boolean =>
+  g.actor_stack.templates.some((t) => t.fired) ||
+  g.two_party_stacks.some((s) => s.templates.some((t) => t.fired));
+
+const markerFor = (band: string): string =>
+  band === "crisis_constraint"
+    ? "url(#arr1)"
+    : band === "affiliation"
+      ? "url(#arr4)"
+      : "url(#arr5)";
+
+const monoText = (
+  fontSize: number,
+  letterSpacing: string,
+): React.CSSProperties => ({ fontSize, letterSpacing });
+
+export default function InteractionGraph(props: InteractionGraphProps) {
+  const {
+    payload,
+    selectedKey,
+    onSelect,
+    onHoverEntity,
+    eventLens,
+    deadArmConsumers,
+  } = props;
+  const [hoverEdge, setHoverEdge] = React.useState<string | null>(null);
+
+  // Selection keys are "kind:actor:target:tpl" (see vm.ts buildCard).
+  const selectedActor = selectedKey ? Number(selectedKey.split(":")[1]) : null;
+
+  // ---------- layout ----------
+  const offIds = payload.actors.map((g) => g.actor_entity_id);
+  // On-screen entities: union of present-target (scene pressure) bindings.
+  const onIds: number[] = [];
+  const onNames = new Map<number, string>();
+  for (const g of payload.actors) {
+    for (const stack of g.scene_pressure_stacks) {
+      const target = stack.bindings.target ?? null;
+      if (target == null || offIds.includes(target) || onNames.has(target))
+        continue;
+      onIds.push(target);
+      onNames.set(
+        target,
+        stack.binding_names.target ??
+          payload.entity_names[String(target)] ??
+          String(target),
+      );
+    }
+  }
+
+  // The prototype's sine arc was tuned for ~8 actors; real slots run 19+.
+  // Fixed 72px vertical pitch keeps nodes legible and the svg grows (and
+  // scrolls) with the roster instead of compressing it.
+  const OFF_PITCH = 72;
+  const svgHeight = Math.max(540, 90 + offIds.length * OFF_PITCH);
+  const pos = new Map<number, { x: number; y: number }>();
+  offIds.forEach((id, i) => {
+    const t = i / Math.max(1, offIds.length - 1);
+    pos.set(id, { x: 180 + Math.sin(t * Math.PI) * 130, y: 70 + i * OFF_PITCH });
+  });
+  onIds.forEach((id, i) => {
+    pos.set(id, {
+      x: 760,
+      y: 120 + (i * (svgHeight - 200)) / Math.max(1, onIds.length - 1 || 1),
+    });
+  });
+
+  const nameOf = (id: number): string =>
+    payload.actors.find((g) => g.actor_entity_id === id)?.actor_name ??
+    onNames.get(id) ??
+    payload.entity_names[String(id)] ??
+    String(id);
+
+  // ---------- nodes ----------
+  const nodes: NodeVM[] = [];
+  for (const g of payload.actors) {
+    const p = pos.get(g.actor_entity_id);
+    if (!p) continue;
+    const soloWinner = winnerOf(g.actor_stack);
+    const gap = !groupHasFired(g);
+    nodes.push({
+      id: g.actor_entity_id,
+      x: p.x,
+      y: p.y,
+      initials: initialsOf(g.actor_name),
+      name: g.actor_name,
+      stroke: gap
+        ? "hsl(var(--destructive))"
+        : soloWinner
+          ? bandColor(soloWinner.drive_band)
+          : "hsl(var(--border))",
+      strokeW: selectedActor === g.actor_entity_id ? 2.8 : 1.6,
+      dash: gap ? "3 3" : "1 0",
+      sub: gap
+        ? "coverage gap"
+        : soloWinner
+          ? soloWinner.template_id.toLowerCase()
+          : "pairs only",
+      subColor: gap
+        ? "hsl(var(--destructive))"
+        : soloWinner
+          ? bandColor(soloWinner.drive_band)
+          : "hsl(var(--muted-foreground))",
+      onClick: soloWinner
+        ? () =>
+            onSelect({
+              key: [
+                "solo",
+                g.actor_entity_id,
+                "",
+                soloWinner.template_id,
+              ].join(":"),
+              actor: g.actor_entity_id,
+              target: null,
+              tpl: soloWinner.template_id,
+              kind: "solo",
+            })
+        : () => {},
+    });
+  }
+  for (const id of onIds) {
+    const p = pos.get(id);
+    if (!p) continue;
+    const name = onNames.get(id) ?? String(id);
+    nodes.push({
+      id,
+      x: p.x,
+      y: p.y,
+      initials: initialsOf(name),
+      name,
+      stroke: "hsl(var(--primary) / 0.7)",
+      strokeW: selectedActor === id ? 2.8 : 1.6,
+      dash: "1 0",
+      sub: "on-screen",
+      subColor: "hsl(var(--muted-foreground))",
+      onClick: () => {},
+    });
+  }
+
+  // ---------- edges ----------
+  const isRecip = (a: number, b: number): boolean =>
+    payload.joint_beats.some(
+      (jb) =>
+        (jb.entity_a === a && jb.entity_b === b) ||
+        (jb.entity_a === b && jb.entity_b === a),
+    );
+  const mkPath = (a: number, b: number, bend: number, shrink = 22): PathBits => {
+    const pa = pos.get(a)!;
+    const pb = pos.get(b)!;
+    const dx = pb.x - pa.x;
+    const dy = pb.y - pa.y;
+    const len = Math.hypot(dx, dy) || 1;
+    const ux = dx / len;
+    const uy = dy / len;
+    const sx = pa.x + ux * shrink;
+    const sy = pa.y + uy * shrink;
+    const ex = pb.x - ux * shrink;
+    const ey = pb.y - uy * shrink;
+    const mx = (sx + ex) / 2 - uy * bend;
+    const my = (sy + ey) / 2 + ux * bend;
+    return {
+      d: `M ${sx.toFixed(1)} ${sy.toFixed(1)} Q ${mx.toFixed(1)} ${my.toFixed(1)} ${ex.toFixed(1)} ${ey.toFixed(1)}`,
+      lx: mx,
+      ly: my - 6,
+      jx: mx - 4.5,
+      jy: my - 4.5,
+    };
+  };
+
+  const edges: EdgeVM[] = [];
+  for (const g of payload.actors) {
+    for (const stack of g.two_party_stacks) {
+      const winner = winnerOf(stack);
+      const target = stack.bindings.target ?? null;
+      if (!winner || target == null || !pos.has(target)) continue;
+      const joint = isRecip(g.actor_entity_id, target);
+      const key = ["pair", g.actor_entity_id, target, winner.template_id].join(
+        ":",
+      );
+      const path = mkPath(g.actor_entity_id, target, joint ? 16 : 12);
+      edges.push({
+        ...path,
+        key,
+        color: bandColor(winner.drive_band),
+        baseW: 1.6,
+        dash: "1 0",
+        baseOp: 0.95,
+        marker: markerFor(winner.drive_band),
+        label: winner.template_id.toLowerCase(),
+        title: `${winner.template_id} · ${g.actor_name} → ${nameOf(target)} · “${winner.chosen_branch ?? ""}” · mag ${(winner.magnitude ?? 0).toFixed(2)}`,
+        joint: joint && g.actor_entity_id < target,
+        jrot: `rotate(45 ${path.jx + 4.5} ${path.jy + 4.5})`,
+        jly: path.ly + 26,
+        sel: {
+          key,
+          actor: g.actor_entity_id,
+          target,
+          tpl: winner.template_id,
+          kind: "pair",
+        },
+      });
+    }
+    for (const stack of g.scene_pressure_stacks) {
+      const winner = winnerOf(stack);
+      const target = stack.bindings.target ?? null;
+      if (!winner || target == null || !pos.has(target)) continue;
+      const key = [
+        "pressure",
+        g.actor_entity_id,
+        target,
+        winner.template_id,
+      ].join(":");
+      const path = mkPath(g.actor_entity_id, target, 24);
+      edges.push({
+        ...path,
+        key,
+        color: "hsl(var(--accent))",
+        baseW: 1.3,
+        dash: "5 4",
+        baseOp: 0.8,
+        marker: "url(#arrA)",
+        label: winner.template_id.toLowerCase() + " ⇢",
+        title: `${winner.template_id} pressure · ${g.actor_name} ⇢ ${nameOf(target)} · prompt-only, no state mutation · mag ${(winner.magnitude ?? 0).toFixed(2)}`,
+        joint: false,
+        jrot: "",
+        jly: 0,
+        sel: {
+          key,
+          actor: g.actor_entity_id,
+          target,
+          tpl: winner.template_id,
+          kind: "pressure",
+        },
+      });
+    }
+  }
+  const selEdgeActive = edges.some((e) => e.key === selectedKey);
+  const edgeW = (e: EdgeVM): number =>
+    e.key === selectedKey ? 3 : hoverEdge === e.key ? 2.5 : e.baseW;
+  const edgeOp = (e: EdgeVM): number =>
+    e.key === selectedKey
+      ? 1
+      : selEdgeActive
+        ? 0.3
+        : hoverEdge && hoverEdge !== e.key
+          ? 0.5
+          : e.baseOp;
+
+  // ---------- potential-event arcs ----------
+  const potentialActive = eventLens != null;
+  const potentialConsumers = potentialActive
+    ? deadArmConsumers.map((c, i) => ({
+        name: c,
+        x: 250 + i * 160,
+        y: 508,
+        d: `M 74 456 Q ${150 + i * 140} 495 ${245 + i * 160} 503`,
+      }))
+    : [];
+
+  return (
+    <div style={{ flex: 1, minHeight: 0, overflow: "auto", padding: "6px 14px 20px" }}>
+      <div
+        style={{
+          display: "flex",
+          gap: 16,
+          alignItems: "center",
+          flexWrap: "wrap",
+          padding: "2px 4px 10px",
+          maxWidth: 1400,
+          margin: "0 auto",
+        }}
+      >
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            fontSize: 10.5,
+            color: "hsl(var(--muted-foreground))",
+          }}
+        >
+          <span
+            style={{
+              width: 18,
+              height: 0,
+              borderTop: "2px solid hsl(var(--chart-4))",
+              display: "inline-block",
+            }}
+          />
+          fired package · band color
+        </span>
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            fontSize: 10.5,
+            color: "hsl(var(--muted-foreground))",
+          }}
+        >
+          <span
+            style={{
+              width: 18,
+              height: 0,
+              borderTop: "2px dashed hsl(var(--accent))",
+              display: "inline-block",
+            }}
+          />
+          scene pressure → on-screen
+        </span>
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            fontSize: 10.5,
+            color: "hsl(var(--muted-foreground))",
+          }}
+        >
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              border: "1.4px solid hsl(var(--chart-4))",
+              transform: "rotate(45deg)",
+              display: "inline-block",
+            }}
+          />
+          reciprocal joint beat
+        </span>
+        <span
+          className="font-mono"
+          style={{
+            marginLeft: "auto",
+            fontSize: 9,
+            letterSpacing: "0.1em",
+            color: "hsl(var(--muted-foreground))",
+          }}
+        >
+          hover a node for its audit · click an edge to trace it
+        </span>
+      </div>
+      <svg
+        viewBox={`0 0 920 ${svgHeight}`}
+        style={{
+          width: "100%",
+          maxWidth: 1400,
+          height: "auto",
+          display: "block",
+          margin: "0 auto",
+        }}
+      >
+        <defs>
+          <marker
+            id="arr1"
+            viewBox="0 0 8 8"
+            refX={7}
+            refY={4}
+            markerWidth={7}
+            markerHeight={7}
+            orient="auto-start-reverse"
+          >
+            <path d="M0,0 L8,4 L0,8 z" fill="hsl(var(--chart-1))" />
+          </marker>
+          <marker
+            id="arr4"
+            viewBox="0 0 8 8"
+            refX={7}
+            refY={4}
+            markerWidth={7}
+            markerHeight={7}
+            orient="auto-start-reverse"
+          >
+            <path d="M0,0 L8,4 L0,8 z" fill="hsl(var(--chart-4))" />
+          </marker>
+          <marker
+            id="arr5"
+            viewBox="0 0 8 8"
+            refX={7}
+            refY={4}
+            markerWidth={7}
+            markerHeight={7}
+            orient="auto-start-reverse"
+          >
+            <path d="M0,0 L8,4 L0,8 z" fill="hsl(var(--chart-5))" />
+          </marker>
+          <marker
+            id="arrA"
+            viewBox="0 0 8 8"
+            refX={7}
+            refY={4}
+            markerWidth={7}
+            markerHeight={7}
+            orient="auto-start-reverse"
+          >
+            <path d="M0,0 L8,4 L0,8 z" fill="hsl(var(--accent))" />
+          </marker>
+        </defs>
+        <text
+          x={70}
+          y={30}
+          className="font-mono"
+          style={{ fontSize: 10, letterSpacing: "0.2em", textTransform: "uppercase" }}
+          fill="hsl(var(--muted-foreground))"
+        >
+          Off-screen actors
+        </text>
+        <text
+          x={700}
+          y={30}
+          className="font-mono"
+          style={{ fontSize: 10, letterSpacing: "0.2em", textTransform: "uppercase" }}
+          fill="hsl(var(--muted-foreground))"
+        >
+          On-screen
+        </text>
+        <line
+          x1={640}
+          y1={40}
+          x2={640}
+          y2={440}
+          stroke="hsl(var(--border))"
+          strokeDasharray="2 5"
+        />
+        {edges.map((e) => {
+          const w = edgeW(e);
+          const op = edgeOp(e);
+          return (
+            <g
+              key={e.key}
+              style={{ cursor: "pointer" }}
+              onClick={() => onSelect(e.sel)}
+              onMouseEnter={() => setHoverEdge(e.key)}
+              onMouseLeave={() => setHoverEdge(null)}
+            >
+              <title>{e.title}</title>
+              <path
+                d={e.d}
+                fill="none"
+                stroke="transparent"
+                strokeWidth={16}
+                pointerEvents="stroke"
+              />
+              <path
+                d={e.d}
+                fill="none"
+                stroke={e.color}
+                strokeWidth={w}
+                strokeDasharray={e.dash}
+                markerEnd={e.marker}
+                opacity={op}
+                pointerEvents="none"
+              />
+              {e.joint && (
+                <g pointerEvents="none">
+                  <rect
+                    x={e.jx}
+                    y={e.jy}
+                    width={9}
+                    height={9}
+                    transform={e.jrot}
+                    fill="hsl(var(--background))"
+                    stroke={e.color}
+                    strokeWidth={1.4}
+                  />
+                  <text
+                    x={e.lx}
+                    y={e.jly}
+                    className="font-mono"
+                    style={monoText(8, "0.1em")}
+                    fill="hsl(var(--muted-foreground))"
+                    textAnchor="middle"
+                  >
+                    joint beat
+                  </text>
+                </g>
+              )}
+              <text
+                x={e.lx}
+                y={e.ly}
+                textAnchor="middle"
+                className="font-mono"
+                style={monoText(8.5, "0.08em")}
+                fill={e.color}
+                opacity={op}
+                pointerEvents="none"
+              >
+                {e.label}
+              </text>
+            </g>
+          );
+        })}
+        {nodes.map((n) => (
+          <g
+            key={n.id}
+            style={{ cursor: "pointer" }}
+            onClick={n.onClick}
+            onMouseEnter={(e) => onHoverEntity(n.id, e)}
+          >
+            <circle
+              cx={n.x}
+              cy={n.y}
+              r={19}
+              fill="hsl(var(--card))"
+              stroke={n.stroke}
+              strokeWidth={n.strokeW}
+              strokeDasharray={n.dash}
+            />
+            <text
+              x={n.x}
+              y={n.y + 3.5}
+              textAnchor="middle"
+              className="font-mono"
+              style={{ fontSize: 10.5 }}
+              fill="hsl(var(--foreground))"
+              pointerEvents="none"
+            >
+              {n.initials}
+            </text>
+            <text
+              x={n.x}
+              y={n.y + 34}
+              textAnchor="middle"
+              style={{ fontSize: 11, fontWeight: 600 }}
+              fill="hsl(var(--foreground) / 0.9)"
+              pointerEvents="none"
+            >
+              {n.name}
+            </text>
+            <text
+              x={n.x}
+              y={n.y + 46}
+              textAnchor="middle"
+              className="font-mono"
+              style={{
+                fontSize: 7.5,
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+              }}
+              fill={n.subColor}
+              pointerEvents="none"
+            >
+              {n.sub}
+            </text>
+          </g>
+        ))}
+        {potentialActive && (
+          <g>
+            <rect
+              x={60}
+              y={452}
+              width={9}
+              height={9}
+              transform="rotate(45 64.5 456.5)"
+              fill="none"
+              stroke="hsl(var(--muted-foreground))"
+              strokeWidth={1.2}
+            />
+            <text
+              x={80}
+              y={461}
+              className="font-mono"
+              style={monoText(9.5, "0.1em")}
+              fill="hsl(var(--foreground))"
+            >
+              {eventLens}
+            </text>
+            <text
+              x={80}
+              y={476}
+              className="font-mono"
+              style={monoText(8, "0.08em")}
+              fill="hsl(var(--muted-foreground))"
+            >
+              consumed by gates · emitted by no branch — potential, never realized
+            </text>
+            {potentialConsumers.map((pc) => (
+              <g key={pc.name}>
+                <path
+                  d={pc.d}
+                  fill="none"
+                  stroke="hsl(var(--muted-foreground))"
+                  strokeWidth={1}
+                  strokeDasharray="1.5 4"
+                  opacity={0.65}
+                />
+                <text
+                  x={pc.x}
+                  y={pc.y}
+                  className="font-mono"
+                  style={monoText(8.5, "0.08em")}
+                  fill="hsl(var(--muted-foreground))"
+                >
+                  {pc.name}
+                </text>
+              </g>
+            ))}
+          </g>
+        )}
+      </svg>
+    </div>
+  );
+}

--- a/ui/client/src/pages/dev-orrery/ResolutionCard.tsx
+++ b/ui/client/src/pages/dev-orrery/ResolutionCard.tsx
@@ -1,0 +1,349 @@
+// ResolutionCard — winner card for a resolution stack, with an optional
+// collapsible "shadowed" list of fired-but-outranked templates.
+//
+// Translated from ui/.design-sync/import/orrery/ResolutionCard.dc.html.
+// The DCLogic block's wrapOpacity / cardStyle / isDial / isNumeric /
+// shadowChev / shShadowBase computations are ported into the component body.
+// Shadowed entries render inline via ShadowEntry (they are plain rows without
+// their own shadow sections — no recursion into ResolutionCard).
+
+import { useState } from "react";
+import type { CSSProperties } from "react";
+
+import type { ResolutionCardVM } from "./types";
+
+export interface ResolutionCardProps {
+  card: ResolutionCardVM;
+  magnitudeStyle: "dial" | "numeric";
+}
+
+/** Shadowed sub-row: the sh.* template block from the prototype. */
+function ShadowEntry({ sh }: { sh: ResolutionCardVM }) {
+  const [hovered, setHovered] = useState(false);
+  // shShadowBase from DCLogic, plus per-row band border + selection outline.
+  // The prototype's `sh.outline` is not part of ResolutionCardVM; it is
+  // derived here from `sh.selected` (the only selection signal the VM carries).
+  const style: CSSProperties = {
+    position: "relative",
+    border: "1px solid hsl(var(--card-border) / 0.6)",
+    borderRadius: 5,
+    background: "hsl(var(--card) / 0.55)",
+    padding: "6px 10px",
+    cursor: "pointer",
+    opacity: hovered ? 0.9 : 0.62,
+    borderLeft: `3px solid ${sh.bandColor}`,
+    outline: sh.selected ? "1px solid hsl(var(--primary) / 0.6)" : "none",
+  };
+  return (
+    <div
+      onClick={sh.onSelect}
+      style={style}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+        <span className="font-mono" style={{ fontSize: 10, letterSpacing: "0.1em" }}>
+          {sh.tplName}
+        </span>
+        <span
+          className="font-mono"
+          style={{ fontSize: 8.5, color: "hsl(var(--muted-foreground))" }}
+        >
+          {sh.priority}
+        </span>
+        {sh.tie && (
+          <span
+            title={sh.tieTitle}
+            className="font-mono"
+            style={{
+              fontSize: 8,
+              border: "1px solid hsl(var(--chart-5) / 0.7)",
+              color: "hsl(var(--chart-5))",
+              borderRadius: 99,
+              padding: "0 5px",
+              cursor: "help",
+            }}
+          >
+            tie
+          </span>
+        )}
+        <span
+          style={{
+            fontSize: 10.5,
+            color: "hsl(var(--muted-foreground))",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            flex: 1,
+          }}
+        >
+          {sh.branchLabel}
+        </span>
+        <span
+          className="font-mono"
+          style={{ fontSize: 9.5, color: sh.bandColor, flex: "none" }}
+        >
+          {sh.mag?.text ?? ""}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default function ResolutionCard({ card, magnitudeStyle }: ResolutionCardProps) {
+  const [hovered, setHovered] = useState(false);
+
+  // --- DCLogic port ---------------------------------------------------------
+  const sel = card.selected;
+  const wrapOpacity = card.dimByLens ? 0.35 : 1;
+  const mag = card.mag;
+  // The dial/numeric decision lives on the MagChip itself (vm.ts bakes
+  // `magnitudeStyle` into `mag.dial` when building the chip); the prop is
+  // accepted per the page's prop contract but the chip flag is authoritative.
+  void magnitudeStyle;
+  const isDial = !!(mag && mag.dial);
+  const isNumeric = !!(mag && !mag.dial);
+  const shadowChev = card.shadowOpen ? "▾" : "▸";
+
+  const cardStyle: CSSProperties = {
+    position: "relative",
+    border: `1px solid ${sel ? "hsl(var(--primary))" : "hsl(var(--card-border))"}`,
+    borderLeft: `3px solid ${card.bandColor}`,
+    borderRadius: 6,
+    background: "hsl(var(--card))",
+    padding: `${card.pad || 10}px 12px`,
+    cursor: "pointer",
+    ...(card.highlight
+      ? { boxShadow: "0 0 0 1px hsl(var(--chart-5) / 0.55)" }
+      : sel
+        ? { boxShadow: "0 0 0 1px hsl(var(--primary) / 0.6)" }
+        : {}),
+    // style-hover="border-color:hsl(var(--primary) / 0.55)" — the hover
+    // declaration lands after the base border declarations, as in the DSL.
+    ...(hovered ? { borderColor: "hsl(var(--primary) / 0.55)" } : {}),
+  };
+  // ---------------------------------------------------------------------------
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+        opacity: wrapOpacity,
+      }}
+    >
+      <div
+        onClick={card.onSelect}
+        style={cardStyle}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        {card.diff && (
+          <span
+            title="Outcome changed vs pre-override tick"
+            style={{
+              position: "absolute",
+              top: 8,
+              right: 8,
+              width: 7,
+              height: 7,
+              borderRadius: 99,
+              background: "hsl(var(--accent))",
+              boxShadow: "0 0 7px hsl(var(--accent))",
+            }}
+          />
+        )}
+        <div
+          style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}
+        >
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 11,
+              letterSpacing: "0.12em",
+              color: "hsl(var(--foreground))",
+            }}
+          >
+            {card.tplName}
+          </span>
+          {card.isPair && (
+            <span style={{ fontSize: 11.5, color: "hsl(var(--muted-foreground))" }}>
+              {"→ "}
+              <span
+                style={{ fontWeight: 600, color: "hsl(var(--foreground) / 0.9)" }}
+              >
+                {card.targetName}
+              </span>
+            </span>
+          )}
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 9,
+              color: "hsl(var(--muted-foreground))",
+              letterSpacing: "0.08em",
+            }}
+          >
+            {card.priority}
+          </span>
+          {card.tie && (
+            <span
+              title={card.tieTitle}
+              className="font-mono"
+              style={{
+                fontSize: 8.5,
+                letterSpacing: "0.08em",
+                border: "1px solid hsl(var(--chart-5) / 0.7)",
+                color: "hsl(var(--chart-5))",
+                borderRadius: 99,
+                padding: "0 6px",
+                cursor: "help",
+              }}
+            >
+              tie
+            </span>
+          )}
+          <span style={{ flex: 1 }} />
+          {card.event && (
+            <span
+              className="font-mono"
+              style={{
+                fontSize: 9,
+                letterSpacing: "0.06em",
+                border: `1px solid ${card.bandColor}`,
+                color: card.bandColor,
+                borderRadius: 99,
+                padding: "1px 8px",
+                opacity: 0.9,
+              }}
+            >
+              {card.event}
+            </span>
+          )}
+          {isDial && mag && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                flex: "none",
+              }}
+            >
+              <div
+                style={{
+                  width: 22,
+                  height: 22,
+                  borderRadius: 99,
+                  background: `conic-gradient(${mag.color} ${mag.deg ?? 0}deg, hsl(var(--muted) / 0.3) 0)`,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <div
+                  style={{
+                    width: 14,
+                    height: 14,
+                    borderRadius: 99,
+                    background: "hsl(var(--card))",
+                  }}
+                />
+              </div>
+              <span
+                className="font-mono"
+                style={{ fontSize: 10.5, color: mag.color }}
+              >
+                {mag.text}
+              </span>
+            </div>
+          )}
+          {isNumeric && mag && (
+            <span
+              className="font-mono"
+              style={{
+                flex: "none",
+                fontSize: 10.5,
+                border: `1px solid ${mag.color}`,
+                color: mag.color,
+                borderRadius: 4,
+                padding: "2px 7px",
+              }}
+            >
+              {mag.text}
+            </span>
+          )}
+        </div>
+        <div
+          style={{
+            fontSize: 11.5,
+            color: "hsl(var(--muted-foreground))",
+            marginTop: 4,
+          }}
+        >
+          {card.branchLabel}
+        </div>
+      </div>
+      {card.hasShadow && (
+        <div
+          style={{
+            marginLeft: 12,
+            display: "flex",
+            flexDirection: "column",
+            gap: 4,
+          }}
+        >
+          <button
+            type="button"
+            onClick={card.onToggleShadow}
+            className="hover:opacity-80"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 7,
+              background: "transparent",
+              border: "none",
+              cursor: "pointer",
+              padding: "1px 0",
+              width: "fit-content",
+            }}
+          >
+            <span style={{ fontSize: 8, color: "hsl(var(--muted-foreground))" }}>
+              {shadowChev}
+            </span>
+            <span
+              className="font-mono"
+              style={{
+                fontSize: 8.5,
+                letterSpacing: "0.18em",
+                textTransform: "uppercase",
+                color: "hsl(var(--muted-foreground))",
+              }}
+            >
+              shadowed
+            </span>
+            <span
+              className="font-mono"
+              style={{
+                fontSize: 9,
+                border: "1px solid hsl(var(--border))",
+                color: "hsl(var(--muted-foreground))",
+                borderRadius: 99,
+                padding: "0 6px",
+              }}
+            >
+              {card.shadowCount}
+            </span>
+          </button>
+          {card.shadowOpen && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+              {card.shadowed.map((sh) => (
+                <ShadowEntry key={sh.key} sh={sh} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/client/src/pages/dev-orrery/WhatIfDrawer.tsx
+++ b/ui/client/src/pages/dev-orrery/WhatIfDrawer.tsx
@@ -1,0 +1,404 @@
+// What-if sandbox drawer: composes override patches in the live API shape
+// (OrreryOverridesModel) and hands them up as OverrideChipEntry rows. Port of
+// the prototype's "What-if drawer" region (Orrery Audit Dashboard.dc.html)
+// with the mock engine's entities/places/events replaced by live props and
+// /vocab data. The prototype's seeded presets and hardcoded pair-tag entry
+// referenced mock entities and were dropped; pair-tag overrides are not
+// exposed in v1.
+
+import { useState } from "react";
+import type { CSSProperties } from "react";
+
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Slider } from "@/components/ui/slider";
+
+import type { ContextEntity, OverrideChipEntry, VocabPayload } from "./types";
+
+export interface WhatIfDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  entities: { id: number; name: string }[];
+  vocab: VocabPayload | null;
+  needs: string[];
+  onApply: (chip: OverrideChipEntry) => void;
+  entityContext: (id: number) => ContextEntity | undefined;
+}
+
+const sectionLabelStyle: CSSProperties = {
+  fontSize: 9,
+  letterSpacing: "0.2em",
+  textTransform: "uppercase",
+  color: "hsl(var(--muted-foreground))",
+};
+
+const applyButtonStyle: CSSProperties = {
+  height: 28,
+  border: "1px solid hsl(var(--accent) / 0.6)",
+  borderRadius: 6,
+  background: "hsl(var(--accent) / 0.12)",
+  color: "hsl(var(--accent))",
+  fontSize: 9,
+  letterSpacing: "0.14em",
+  textTransform: "uppercase",
+  padding: "0 12px",
+  cursor: "pointer",
+};
+
+function needMaxFor(need: string): number {
+  return need === "intimacy" || need === "socialize" ? 340 : 80;
+}
+
+export default function WhatIfDrawer(props: WhatIfDrawerProps) {
+  const { open, onClose, entities, vocab, needs, onApply, entityContext } =
+    props;
+
+  const [entitySel, setEntitySel] = useState<string>("");
+  const [need, setNeed] = useState<string>(needs[0] ?? "sleep");
+  const [needVal, setNeedVal] = useState<number>(24);
+  const [placeSel, setPlaceSel] = useState<string>("");
+  const [eventSel, setEventSel] = useState<string>("");
+  const [closeHover, setCloseHover] = useState(false);
+
+  const entityId =
+    entitySel !== "" ? Number(entitySel) : (entities[0]?.id ?? null);
+  const entityName =
+    entities.find((e) => e.id === entityId)?.name ??
+    (entityId != null ? String(entityId) : "—");
+  const ctx = entityId != null ? entityContext(entityId) : undefined;
+
+  const needMax = needMaxFor(need);
+  const needValClamped = Math.min(needVal, needMax);
+  const needNowRow = ctx?.needs.find((n) => n.need_type === need);
+  const needLabel = `${need} · ${
+    needNowRow ? needNowRow.debt_score.toFixed(1) : "—"
+  } now`;
+
+  const placeId =
+    placeSel !== "" ? Number(placeSel) : (vocab?.places[0]?.id ?? null);
+  const eventType = eventSel !== "" ? eventSel : (vocab?.event_types[0]?.type ?? "");
+
+  const onTags = new Set(
+    ctx
+      ? [...ctx.tags.durable, ...ctx.tags.ephemeral].map((row) => row.tag)
+      : [],
+  );
+
+  const applyTag = (tag: string, ephemeral: boolean, currentlyOn: boolean) => {
+    if (entityId == null) return;
+    onApply({
+      label: `${currentlyOn ? "−" : "+"} ${tag} @ ${entityName}`,
+      patch: {
+        tags: [
+          {
+            entity_id: entityId,
+            tag,
+            op: currentlyOn ? "remove" : "add",
+            ephemeral,
+          },
+        ],
+      },
+    });
+  };
+
+  const applyNeed = () => {
+    if (entityId == null) return;
+    onApply({
+      label: `${entityName}: ${need} = ${needValClamped}`,
+      patch: {
+        needs: [
+          { entity_id: entityId, need_type: need, debt_score: needValClamped },
+        ],
+      },
+    });
+  };
+
+  const applyMove = () => {
+    if (entityId == null || placeId == null) return;
+    const placeName =
+      vocab?.places.find((p) => p.id === placeId)?.name ?? String(placeId);
+    onApply({
+      label: `move ${entityName} → ${placeName}`,
+      patch: { locations: [{ entity_id: entityId, place_id: placeId }] },
+    });
+  };
+
+  const applyEvent = () => {
+    if (entityId == null || !eventType) return;
+    onApply({
+      label: `inject ${eventType} → ${entityName}`,
+      patch: {
+        events: [
+          { event_type: eventType, target_entity_id: entityId, ticks_ago: 1 },
+        ],
+      },
+    });
+  };
+
+  return (
+    <div
+      data-screen-label="What-if drawer"
+      style={{
+        position: "fixed",
+        top: 0,
+        right: 0,
+        bottom: 0,
+        width: 390,
+        zIndex: 40, // below shadcn portals (z-50) so Select/Command dropdowns paint above
+        background: "hsl(var(--background))",
+        borderLeft: "1px solid hsl(var(--accent) / 0.55)",
+        boxShadow: "-14px 0 44px hsl(220 40% 2% / 0.65)",
+        transform: open ? "translateX(0)" : "translateX(103%)",
+        transition: "transform 0.28s cubic-bezier(0.32,0.72,0,1)",
+        overflowY: "auto",
+        padding: "16px 18px 30px",
+      }}
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <button
+          onClick={onClose}
+          title="Close"
+          onMouseEnter={() => setCloseHover(true)}
+          onMouseLeave={() => setCloseHover(false)}
+          style={{
+            position: "absolute",
+            top: 10,
+            right: 12,
+            width: 24,
+            height: 24,
+            border: `1px solid ${
+              closeHover ? "hsl(var(--accent))" : "hsl(var(--border))"
+            }`,
+            borderRadius: 5,
+            background: "transparent",
+            color: closeHover
+              ? "hsl(var(--accent))"
+              : "hsl(var(--muted-foreground))",
+            cursor: "pointer",
+            fontSize: 11,
+            lineHeight: 1,
+          }}
+        >
+          ✕
+        </button>
+        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 11,
+              letterSpacing: "0.2em",
+              textTransform: "uppercase",
+              color: "hsl(var(--accent))",
+            }}
+          >
+            What-if sandbox
+          </span>
+          <span
+            style={{
+              fontSize: 11.5,
+              fontStyle: "italic",
+              color: "hsl(var(--muted-foreground))",
+            }}
+          >
+            Overrides copy the frozen WorldState and re-resolve live. Nothing
+            canonical is written.
+          </span>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span className="font-mono" style={sectionLabelStyle}>
+            Entity
+          </span>
+          <Select
+            value={entityId != null ? String(entityId) : ""}
+            onValueChange={setEntitySel}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {entities.map((e) => (
+                <SelectItem key={e.id} value={String(e.id)}>
+                  {e.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span className="font-mono" style={sectionLabelStyle}>
+            Toggle tag
+          </span>
+          <Command
+            style={{
+              border: "1px solid hsl(var(--border))",
+              borderRadius: 6,
+              background: "transparent",
+            }}
+          >
+            <CommandInput placeholder="Search tag vocabulary…" />
+            <CommandList style={{ maxHeight: 150 }}>
+              <CommandEmpty>No tag found.</CommandEmpty>
+              {(vocab?.tags ?? []).map((t) => {
+                const on = onTags.has(t.tag);
+                return (
+                  <CommandItem
+                    key={t.tag}
+                    value={t.tag}
+                    onSelect={() => applyTag(t.tag, t.is_ephemeral, on)}
+                  >
+                    <span
+                      style={{
+                        width: 13,
+                        flex: "none",
+                        color: on
+                          ? "hsl(var(--chart-5))"
+                          : "hsl(var(--muted-foreground) / 0.5)",
+                        fontSize: 10,
+                      }}
+                    >
+                      {on ? "●" : "○"}
+                    </span>
+                    <span
+                      className="font-mono"
+                      style={{ fontSize: 10.5, letterSpacing: "0.04em" }}
+                    >
+                      {t.tag}
+                    </span>
+                    <span
+                      className="font-mono"
+                      style={{
+                        fontSize: 8.5,
+                        color: "hsl(var(--muted-foreground))",
+                        marginLeft: "auto",
+                      }}
+                    >
+                      {t.is_ephemeral ? "ephemeral" : "durable"}
+                    </span>
+                  </CommandItem>
+                );
+              })}
+            </CommandList>
+          </Command>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <span className="font-mono" style={sectionLabelStyle}>
+            Set need — {needLabel}
+          </span>
+          <Select
+            value={need}
+            onValueChange={(v) => {
+              setNeed(v);
+              setNeedVal((cur) => Math.min(cur, needMaxFor(v)));
+            }}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {needs.map((nd) => (
+                <SelectItem key={nd} value={nd}>
+                  {nd}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <Slider
+              value={[needValClamped]}
+              min={0}
+              max={needMax}
+              step={1}
+              onValueChange={(arr) => setNeedVal(arr[0] ?? 0)}
+              style={{ flex: 1 }}
+            />
+            <span
+              className="font-mono"
+              style={{ fontSize: 11, minWidth: 34, textAlign: "right" }}
+            >
+              {needValClamped}
+            </span>
+            <button
+              onClick={applyNeed}
+              className="font-mono"
+              style={applyButtonStyle}
+            >
+              set
+            </button>
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span className="font-mono" style={sectionLabelStyle}>
+            Move actor
+          </span>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <Select
+              value={placeId != null ? String(placeId) : ""}
+              onValueChange={setPlaceSel}
+            >
+              <SelectTrigger style={{ flex: 1 }}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {(vocab?.places ?? []).map((p) => (
+                  <SelectItem key={p.id} value={String(p.id)}>
+                    {p.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <button
+              onClick={applyMove}
+              className="font-mono"
+              style={applyButtonStyle}
+            >
+              move
+            </button>
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span className="font-mono" style={sectionLabelStyle}>
+            Inject recent event → {entityName}
+          </span>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <Select value={eventType} onValueChange={setEventSel}>
+              <SelectTrigger style={{ flex: 1 }}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {(vocab?.event_types ?? []).map((ev) => (
+                  <SelectItem key={ev.type} value={ev.type}>
+                    {ev.type}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <button
+              onClick={applyEvent}
+              className="font-mono"
+              style={applyButtonStyle}
+            >
+              inject
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/client/src/pages/dev-orrery/api.ts
+++ b/ui/client/src/pages/dev-orrery/api.ts
@@ -1,0 +1,98 @@
+// Typed fetchers for the dev-only Orrery audit endpoints. The gateway
+// registers /api/dev/orrery/* only when [orrery.dashboard] enabled is true
+// in nexus.toml; a 404 here means the server-side flag is off, which the
+// page surfaces as an explicit setup notice (see index.tsx).
+
+import type {
+  CatalogPayload,
+  ContextPayload,
+  CoveragePayload,
+  OverridesRequest,
+  ResolvePayload,
+  VocabPayload,
+} from "./types";
+
+const BASE = "/api/dev/orrery";
+
+export class OrreryApiError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+  ) {
+    super(message);
+  }
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+  if (!res.ok) {
+    let detail = res.statusText;
+    try {
+      const body = await res.json();
+      if (body?.detail) detail = String(body.detail);
+    } catch {
+      /* non-JSON error body: keep statusText */
+    }
+    throw new OrreryApiError(detail, res.status);
+  }
+  return res.json() as Promise<T>;
+}
+
+export function fetchResolve(params: {
+  slot: number;
+  anchorChunkId?: number | null;
+  overrides?: Partial<OverridesRequest> | null;
+}): Promise<ResolvePayload> {
+  return request<ResolvePayload>("/resolve", {
+    method: "POST",
+    body: JSON.stringify({
+      slot: params.slot,
+      anchor_chunk_id: params.anchorChunkId ?? null,
+      overrides: params.overrides ?? null,
+    }),
+  });
+}
+
+export function fetchCatalog(): Promise<CatalogPayload> {
+  return request<CatalogPayload>("/catalog");
+}
+
+export function fetchEntityContext(params: {
+  slot: number;
+  entityIds: number[];
+  anchorChunkId?: number | null;
+}): Promise<ContextPayload> {
+  return request<ContextPayload>("/context/entities", {
+    method: "POST",
+    body: JSON.stringify({
+      slot: params.slot,
+      entity_ids: params.entityIds,
+      anchor_chunk_id: params.anchorChunkId ?? null,
+      recent_events_limit: 3,
+    }),
+  });
+}
+
+export function fetchCoverage(params: {
+  slot: number;
+  count?: number;
+  stride?: number;
+  endChunkId?: number | null;
+}): Promise<CoveragePayload> {
+  return request<CoveragePayload>("/coverage", {
+    method: "POST",
+    body: JSON.stringify({
+      slot: params.slot,
+      count: params.count ?? 10,
+      stride: params.stride ?? 1,
+      end_chunk_id: params.endChunkId ?? null,
+    }),
+  });
+}
+
+export function fetchVocab(slot: number): Promise<VocabPayload> {
+  return request<VocabPayload>(`/vocab?slot=${slot}`);
+}

--- a/ui/client/src/pages/dev-orrery/index.tsx
+++ b/ui/client/src/pages/dev-orrery/index.tsx
@@ -1056,7 +1056,14 @@ export default function DevOrreryPage() {
   );
 
   // ---- queries ---------------------------------------------------------------
-  const overridesReq = useMemo(() => mergeOverrides(overrides), [overrides]);
+  // Overrides reach the resolver only in what-if mode: "Current" must always
+  // show canon, while staged chips persist in the drawer for the next sandbox
+  // run. Without the mode gate, flipping back to Current would keep serving
+  // what-if results under a canonical-looking frame.
+  const overridesReq = useMemo(
+    () => (mode === "whatif" ? mergeOverrides(overrides) : null),
+    [mode, overrides],
+  );
   const overridesJson = overridesReq ? JSON.stringify(overridesReq) : "";
 
   const resolveQ = useQuery<ResolvePayload, Error>({
@@ -1119,7 +1126,7 @@ export default function DevOrreryPage() {
   );
 
   const hoverCtxQ = useQuery<ContextPayload, Error>({
-    queryKey: ["orrery", "context", slot, hoverEnt],
+    queryKey: ["orrery", "context", slot, anchor, hoverEnt],
     queryFn: () =>
       fetchEntityContext({
         slot,
@@ -1150,7 +1157,7 @@ export default function DevOrreryPage() {
   }, [payload]);
   const drawerIdsKey = drawerEntities.map((e) => e.id).join(",");
   const drawerCtxQ = useQuery<ContextPayload, Error>({
-    queryKey: ["orrery", "context", slot, "drawer", drawerIdsKey],
+    queryKey: ["orrery", "context", slot, anchor, "drawer", drawerIdsKey],
     queryFn: () =>
       fetchEntityContext({
         slot,

--- a/ui/client/src/pages/dev-orrery/index.tsx
+++ b/ui/client/src/pages/dev-orrery/index.tsx
@@ -1,0 +1,2481 @@
+// DevOrreryPage — the Orrery audit dashboard, assembled from the design
+// prototype (ui/.design-sync/import/orrery/Orrery Audit Dashboard.dc.html)
+// with the mock engine replaced by the live /api/dev/orrery endpoints via
+// ./api.ts (fetchers), ./vm.ts (payload -> view-model adapters) and
+// @tanstack/react-query.
+//
+// Deviations from the prototype, and why:
+//   - slot picker offers all five save slots (the mock hardcoded 3);
+//     footer line is "slot N · <actor_count> actors" (no per-slot lore).
+//   - the empty-slot notice is generalized ("No off-screen actors resolve
+//     on this slot.") instead of the mock's save_01 copy.
+//   - "As-of" only opens the informational per-axis honesty popover; it
+//     never changes resolve behavior (the live API has no as-of mode).
+//   - windowLabel renders in the tick bar (HealthStrip has no slot for it).
+//   - switching slots clears overrides/selection (entity ids are per-slot;
+//     stale overrides would be nonsense against another database).
+//   - density/magnitudeStyle are constants (comfortable, dial) — no editor.
+//   - the root drops the prototype's negative margin (that countered the
+//     design-preview frame padding, which the app shell doesn't have).
+//   - card target-name hover audits are not wired: ResolutionCardVM carries
+//     no hover callback (group headers, on-screen chips and graph nodes
+//     cover the hover-audit surface).
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  CSSProperties,
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+} from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+
+import {
+  OrreryApiError,
+  fetchCatalog,
+  fetchCoverage,
+  fetchEntityContext,
+  fetchResolve,
+  fetchVocab,
+} from "./api";
+import {
+  BAND_LABELS,
+  BAND_ORDER,
+  NEEDS,
+  bandColor,
+  buildEntityAudit,
+  buildGroups,
+  buildInspector,
+  priorityTies,
+  winnersByBand,
+} from "./vm";
+import type { GroupBuildCtx } from "./vm";
+import type {
+  ActorGroupVM,
+  CatalogPayload,
+  ContextEntity,
+  ContextPayload,
+  CoveragePayload,
+  GhostRowVM,
+  InspectorGateRowVM,
+  InspectorVM,
+  OverrideChipEntry,
+  OverridesRequest,
+  PressureChipVM,
+  ResolvePayload,
+  SelectionRef,
+  VocabPayload,
+} from "./types";
+import HealthStrip from "./HealthStrip";
+import type { HealthStripProps } from "./HealthStrip";
+import HoverAudit from "./HoverAudit";
+import InteractionGraph from "./InteractionGraph";
+import ResolutionCard from "./ResolutionCard";
+import WhatIfDrawer from "./WhatIfDrawer";
+
+// ---------------------------------------------------------------------------
+// Constants (the prototype's density/magnitudeStyle editor props, frozen)
+// ---------------------------------------------------------------------------
+
+const MAGNITUDE_STYLE: "dial" | "numeric" = "dial";
+const PAD = 10; // density: comfortable
+
+const PAGE_CSS = `
+@keyframes orr-pulse { 0%, 100% { opacity: 0.35; } 50% { opacity: 1; } }
+`;
+
+// Exact axes list from the prototype's logic block (asofAxes).
+const ASOF_AXES: { axis: string; glyph: string; color: string; label: string }[] = [
+  {
+    axis: "Recent events · world time · roster",
+    glyph: "✓",
+    color: "hsl(var(--chart-5))",
+    label: "honest",
+  },
+  {
+    axis: "Single-entity tags",
+    glyph: "≈",
+    color: "hsl(var(--chart-2))",
+    label: "approximate",
+  },
+  {
+    axis: "Pair tags",
+    glyph: "≈",
+    color: "hsl(var(--chart-2))",
+    label: "approx · no clear log",
+  },
+  {
+    axis: "Relationships / trust",
+    glyph: "∅",
+    color: "hsl(var(--muted-foreground))",
+    label: "frozen · unversioned",
+  },
+  {
+    axis: "Position / activity",
+    glyph: "∅",
+    color: "hsl(var(--muted-foreground))",
+    label: "frozen · uninstrumented",
+  },
+  {
+    axis: "Need debt",
+    glyph: "✓",
+    color: "hsl(var(--chart-5))",
+    label: "replayable",
+  },
+  {
+    axis: "Travel · anchors · factions · weather",
+    glyph: "∅",
+    color: "hsl(var(--muted-foreground))",
+    label: "frozen",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Style helpers (ports of the prototype's chip()/tab()/status maps)
+// ---------------------------------------------------------------------------
+
+const chipStyle = (active: boolean, color: string): CSSProperties => ({
+  border: "none",
+  borderRadius: 4,
+  padding: "3px 10px",
+  fontSize: 9.5,
+  letterSpacing: "0.16em",
+  textTransform: "uppercase",
+  cursor: "pointer",
+  background: active ? `hsl(var(--${color}) / 0.18)` : "transparent",
+  color: active ? `hsl(var(--${color}))` : "hsl(var(--muted-foreground))",
+});
+
+const tabStyle = (active: boolean): CSSProperties => ({
+  border: "none",
+  borderBottom: `2px solid ${active ? "hsl(var(--primary))" : "transparent"}`,
+  background: "transparent",
+  padding: "4px 12px 6px",
+  fontSize: 10,
+  letterSpacing: "0.16em",
+  textTransform: "uppercase",
+  cursor: "pointer",
+  color: active ? "hsl(var(--foreground))" : "hsl(var(--muted-foreground))",
+});
+
+const railLabelStyle: CSSProperties = {
+  fontSize: 9,
+  letterSpacing: "0.22em",
+  textTransform: "uppercase",
+  color: "hsl(var(--muted-foreground))",
+};
+
+const statusChipStyle = (
+  tone: InspectorVM["statusTone"],
+  band: string,
+): CSSProperties => {
+  const base: CSSProperties = {
+    fontSize: 8.5,
+    letterSpacing: "0.14em",
+    textTransform: "uppercase",
+    borderRadius: 99,
+    padding: "2px 9px",
+  };
+  switch (tone) {
+    case "winner":
+      return { ...base, border: `1px solid ${band}`, color: band };
+    case "shadowed":
+      return {
+        ...base,
+        border: "1px solid hsl(var(--muted-foreground) / 0.5)",
+        color: "hsl(var(--muted-foreground))",
+      };
+    case "failed":
+      return {
+        ...base,
+        border: "1px solid hsl(var(--destructive) / 0.6)",
+        color: "hsl(var(--destructive))",
+      };
+    case "na":
+      return {
+        ...base,
+        border: "1px solid hsl(var(--muted-foreground) / 0.4)",
+        color: "hsl(var(--muted-foreground) / 0.7)",
+      };
+  }
+};
+
+const pressureChipStyle = (selected: boolean, diff: boolean): CSSProperties => ({
+  border: `1px solid ${selected ? "hsl(var(--accent))" : "hsl(var(--accent) / 0.55)"}`,
+  background: selected
+    ? "hsl(var(--accent) / 0.16)"
+    : diff
+      ? "hsl(var(--accent) / 0.1)"
+      : "transparent",
+  color: "hsl(var(--accent))",
+  borderRadius: 99,
+  padding: "3px 11px",
+  fontSize: 10,
+  letterSpacing: "0.05em",
+  cursor: "pointer",
+});
+
+// ---------------------------------------------------------------------------
+// Small hover-styled building blocks (style-hover="" in the DSL)
+// ---------------------------------------------------------------------------
+
+function HoverBtn({
+  style,
+  hoverStyle,
+  onClick,
+  title,
+  className,
+  children,
+}: {
+  style: CSSProperties;
+  hoverStyle: CSSProperties;
+  onClick: () => void;
+  title?: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <button
+      type="button"
+      title={title}
+      className={className}
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{ ...style, ...(hovered ? hoverStyle : {}) }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function GhostRow({ gh }: { gh: GhostRowVM }) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <div
+      onClick={gh.onSelect}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "2px 8px",
+        borderRadius: 4,
+        cursor: "pointer",
+        color: `hsl(var(--muted-foreground) / ${gh.na ? "0.5" : "0.62"})`,
+        ...(gh.na
+          ? { borderLeft: "2px dotted hsl(var(--muted-foreground) / 0.4)" }
+          : {}),
+        ...(hovered ? { background: "hsl(var(--muted) / 0.2)" } : {}),
+      }}
+    >
+      <span style={{ width: 14, flex: "none", textAlign: "center", fontSize: 9 }}>
+        {gh.glyph}
+      </span>
+      <span
+        className="font-mono"
+        style={{
+          fontSize: 9.5,
+          letterSpacing: "0.08em",
+          flex: "none",
+          minWidth: 150,
+        }}
+      >
+        {gh.name}
+      </span>
+      <span
+        style={{
+          flex: 1,
+          fontSize: 11,
+          fontStyle: "italic",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {gh.reason}
+      </span>
+      <span className="font-mono" style={{ fontSize: 9.5, flex: "none" }}>
+        {gh.evidence}
+      </span>
+    </div>
+  );
+}
+
+function PressureChip({ pr }: { pr: PressureChipVM }) {
+  return (
+    <button
+      type="button"
+      onClick={pr.onSelect}
+      title={pr.title}
+      className="font-mono"
+      style={pressureChipStyle(pr.selected, pr.diff)}
+    >
+      ⇢ {pr.label}
+    </button>
+  );
+}
+
+function StreamGroup({
+  g,
+  selectedActor,
+  showFailedHint,
+  onHoverName,
+  onHoverOut,
+}: {
+  g: ActorGroupVM;
+  selectedActor: number | null;
+  showFailedHint: boolean;
+  onHoverName: (id: number) => (e: ReactMouseEvent) => void;
+  onHoverOut: () => void;
+}) {
+  const [headHover, setHeadHover] = useState(false);
+  const borderColor = g.gap
+    ? "hsl(var(--destructive) / 0.45)"
+    : selectedActor === g.id
+      ? "hsl(var(--primary) / 0.5)"
+      : "hsl(var(--border))";
+  return (
+    <div
+      id={g.domId}
+      style={{
+        border: `1px solid ${borderColor}`,
+        borderRadius: 8,
+        background: "hsl(var(--card) / 0.45)",
+      }}
+    >
+      <div
+        onClick={g.onToggle}
+        onMouseEnter={() => setHeadHover(true)}
+        onMouseLeave={() => setHeadHover(false)}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          padding: "8px 12px",
+          cursor: "pointer",
+          ...(headHover ? { background: "hsl(var(--muted) / 0.25)" } : {}),
+        }}
+      >
+        <span
+          style={{
+            fontSize: 9,
+            color: "hsl(var(--muted-foreground))",
+            width: 10,
+            flex: "none",
+          }}
+        >
+          {g.open ? "▾" : "▸"}
+        </span>
+        <span
+          className="font-mono"
+          style={{
+            width: 30,
+            height: 30,
+            borderRadius: 99,
+            border: `1.5px solid ${g.ringColor}`,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 10,
+            color: "hsl(var(--foreground) / 0.85)",
+            flex: "none",
+            background: "hsl(var(--card))",
+          }}
+        >
+          {g.initials}
+        </span>
+        <span
+          onMouseEnter={onHoverName(g.id)}
+          onMouseLeave={onHoverOut}
+          style={{
+            fontSize: 14,
+            fontWeight: 600,
+            color: "hsl(var(--foreground))",
+            textDecoration: "underline dotted hsl(var(--primary) / 0.5)",
+            textUnderlineOffset: 3,
+            cursor: "default",
+          }}
+        >
+          {g.name}
+        </span>
+        <span
+          className="font-mono"
+          style={{
+            fontSize: 9.5,
+            letterSpacing: "0.08em",
+            color: "hsl(var(--muted-foreground))",
+            border: "1px solid hsl(var(--border))",
+            borderRadius: 99,
+            padding: "1px 8px",
+            flex: "none",
+          }}
+        >
+          {g.placeName}
+        </span>
+        {g.diff && (
+          <span
+            title="Outcome changed vs pre-override tick"
+            style={{
+              width: 7,
+              height: 7,
+              borderRadius: 99,
+              background: "hsl(var(--accent))",
+              boxShadow: "0 0 7px hsl(var(--accent))",
+              flex: "none",
+            }}
+          />
+        )}
+        <div style={{ flex: 1 }} />
+        {g.gap && (
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 9,
+              letterSpacing: "0.14em",
+              textTransform: "uppercase",
+              color: "hsl(var(--destructive))",
+              border: "1px solid hsl(var(--destructive) / 0.6)",
+              borderRadius: 99,
+              padding: "2px 8px",
+            }}
+          >
+            coverage gap
+          </span>
+        )}
+        <div style={{ display: "flex", gap: 4, flex: "none" }}>
+          {g.bandDots.map((bd, i) => (
+            <span
+              key={`${bd.title}:${i}`}
+              title={bd.title}
+              style={{
+                width: 7,
+                height: 7,
+                borderRadius: 2,
+                background: bd.color,
+              }}
+            />
+          ))}
+        </div>
+        <span
+          className="font-mono"
+          style={{
+            fontSize: 9.5,
+            color: "hsl(var(--muted-foreground))",
+            flex: "none",
+          }}
+        >
+          {g.activityLine}
+        </span>
+      </div>
+      {g.open && (
+        <div
+          style={{
+            padding: "2px 12px 12px 32px",
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+          }}
+        >
+          {g.gap && (
+            <div
+              style={{
+                border: "1px dashed hsl(var(--destructive) / 0.5)",
+                borderRadius: 6,
+                padding: "9px 12px",
+                fontSize: 12,
+                fontStyle: "italic",
+                color: "hsl(var(--muted-foreground))",
+              }}
+            >
+              No package fires for this actor this tick — every gate refuses.{" "}
+              {showFailedHint
+                ? "Toggle “show gate-failed” to see every refusal."
+                : ""}
+            </div>
+          )}
+          {g.cards.map((card) => (
+            <ResolutionCard
+              key={card.key}
+              card={card}
+              magnitudeStyle={MAGNITUDE_STYLE}
+            />
+          ))}
+          {g.pressures.length > 0 && (
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 6,
+                alignItems: "center",
+              }}
+            >
+              {g.pressures.map((pr) => (
+                <PressureChip key={pr.key} pr={pr} />
+              ))}
+            </div>
+          )}
+          {g.ghosts.length > 0 && (
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 2,
+                marginTop: 2,
+              }}
+            >
+              {g.ghosts.map((gh) => (
+                <GhostRow key={gh.key} gh={gh} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inspector rendering (the template's right column, fed by InspectorVM)
+// ---------------------------------------------------------------------------
+
+function gateRowProseStyle(gr: InspectorGateRowVM): CSSProperties {
+  if (gr.isOp) {
+    return {
+      flex: 1,
+      fontSize: 9.5,
+      letterSpacing: "0.2em",
+      ...(gr.emphasized
+        ? { fontWeight: 700, color: "hsl(var(--foreground) / 0.9)" }
+        : { color: "hsl(var(--muted-foreground) / 0.75)" }),
+    };
+  }
+  return {
+    flex: 1,
+    fontSize: 12,
+    ...(gr.emphasized
+      ? { fontWeight: 700, color: "hsl(var(--foreground))" }
+      : gr.muted
+        ? { color: "hsl(var(--muted-foreground))" }
+        : { color: "hsl(var(--foreground) / 0.85)" }),
+  };
+}
+
+function InspectorPane({ insp }: { insp: InspectorVM }) {
+  const sectionLabel: CSSProperties = {
+    fontSize: 9.5,
+    letterSpacing: "0.2em",
+    textTransform: "uppercase",
+    color: "hsl(var(--muted-foreground))",
+  };
+  const eventChip: CSSProperties = {
+    fontSize: 9.5,
+    border: `1px solid ${insp.bandColor}`,
+    color: insp.bandColor,
+    borderRadius: 99,
+    padding: "1px 8px",
+  };
+  return (
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      <div
+        style={{
+          padding: "14px 16px 12px",
+          borderBottom: "1px solid hsl(var(--border))",
+          borderLeft: `3px solid ${insp.bandColor}`,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span
+            className="font-mono"
+            style={{ fontSize: 13, letterSpacing: "0.12em" }}
+          >
+            {insp.name}
+          </span>
+          <span
+            className="font-mono"
+            style={{ fontSize: 9.5, color: "hsl(var(--muted-foreground))" }}
+          >
+            pri {insp.priority}
+          </span>
+          {insp.tie && (
+            <span
+              title={insp.tieTitle}
+              className="font-mono"
+              style={{
+                fontSize: 9,
+                letterSpacing: "0.08em",
+                border: "1px solid hsl(var(--chart-5) / 0.7)",
+                color: "hsl(var(--chart-5))",
+                borderRadius: 99,
+                padding: "1px 7px",
+                cursor: "help",
+              }}
+            >
+              tie · tuple order
+            </span>
+          )}
+          <div style={{ flex: 1 }} />
+          <span
+            className="font-mono"
+            style={statusChipStyle(insp.statusTone, insp.bandColor)}
+          >
+            {insp.statusLabel}
+          </span>
+        </div>
+        <div
+          style={{
+            marginTop: 6,
+            fontSize: 12,
+            color: "hsl(var(--muted-foreground))",
+          }}
+        >
+          {insp.bindingLine}
+        </div>
+        <div
+          style={{
+            marginTop: 4,
+            fontSize: 12,
+            fontStyle: "italic",
+            color: "hsl(var(--muted-foreground) / 0.85)",
+          }}
+        >
+          {insp.blurb}
+        </div>
+      </div>
+
+      {insp.isNA && (
+        <div
+          style={{
+            padding: 16,
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+          }}
+        >
+          <span className="font-mono" style={sectionLabel}>
+            Not applicable
+          </span>
+          <span
+            style={{
+              fontSize: 12.5,
+              fontStyle: "italic",
+              color: "hsl(var(--muted-foreground))",
+            }}
+          >
+            No TARGET is bound in this actor's stacks — this two-party template
+            was never composed, so nothing was evaluated. Not applicable is not
+            a refusal: no gate ran, no predicate failed.
+          </span>
+        </div>
+      )}
+
+      {!insp.isNA && (
+        <>
+          <div
+            style={{
+              padding: "12px 16px",
+              display: "flex",
+              flexDirection: "column",
+              gap: 3,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                marginBottom: 4,
+              }}
+            >
+              <span className="font-mono" style={sectionLabel}>
+                Gate
+              </span>
+              <span
+                className="font-mono"
+                style={{
+                  fontSize: 8.5,
+                  letterSpacing: "0.16em",
+                  textTransform: "uppercase",
+                  borderRadius: 99,
+                  padding: "1px 8px",
+                  border: `1px solid ${
+                    insp.gatePassed
+                      ? "hsl(var(--chart-5) / 0.6)"
+                      : "hsl(var(--destructive) / 0.6)"
+                  }`,
+                  color: insp.gatePassed
+                    ? "hsl(var(--chart-5))"
+                    : "hsl(var(--destructive))",
+                }}
+              >
+                {insp.gatePassed ? "pass" : "refused"}
+              </span>
+            </div>
+            {insp.gateRows.map((gr, i) => (
+              <div
+                key={i}
+                style={{
+                  display: "flex",
+                  alignItems: "baseline",
+                  gap: 7,
+                  padding: gr.isOp
+                    ? `3px 4px 1px ${4 + gr.depth * 15}px`
+                    : `2px 4px 2px ${4 + gr.depth * 15}px`,
+                  borderRadius: 4,
+                  ...(gr.highlighted
+                    ? {
+                        background: "hsl(var(--accent) / 0.14)",
+                        outline: "1px dotted hsl(var(--accent) / 0.7)",
+                      }
+                    : {}),
+                }}
+              >
+                <span
+                  style={{
+                    width: 15,
+                    flex: "none",
+                    textAlign: "center",
+                    fontSize: gr.isOp ? 9 : 10,
+                    color: gr.glyphColor,
+                  }}
+                >
+                  {gr.glyph}
+                </span>
+                <span style={gateRowProseStyle(gr)}>{gr.prose}</span>
+                <span
+                  className="font-mono"
+                  style={{
+                    fontSize: 9.5,
+                    color: gr.evidenceHot
+                      ? "hsl(var(--destructive))"
+                      : "hsl(var(--muted-foreground))",
+                    flex: "none",
+                    textAlign: "right",
+                  }}
+                >
+                  {gr.evidence}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          <div
+            style={{
+              padding: "4px 16px 12px",
+              display: "flex",
+              flexDirection: "column",
+              gap: 4,
+            }}
+          >
+            <span
+              className="font-mono"
+              style={{ ...sectionLabel, marginBottom: 2 }}
+            >
+              Branch ladder — authored order
+            </span>
+            {insp.branches.map((br) => (
+              <div
+                key={br.idx}
+                style={{
+                  padding: "5px 8px",
+                  borderRadius: 5,
+                  borderLeft: `2px solid ${br.selected ? insp.bandColor : "transparent"}`,
+                  ...(br.selected
+                    ? { background: "hsl(var(--muted) / 0.22)" }
+                    : {}),
+                  ...(br.unevaluated ? { opacity: 0.42 } : {}),
+                }}
+              >
+                <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+                  <span
+                    className="font-mono"
+                    style={{
+                      fontSize: 9,
+                      color: "hsl(var(--muted-foreground))",
+                      flex: "none",
+                    }}
+                  >
+                    {br.idx}
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 12,
+                      flex: 1,
+                      ...(br.selected
+                        ? { fontWeight: 650 }
+                        : { color: "hsl(var(--muted-foreground))" }),
+                    }}
+                  >
+                    {br.label}
+                  </span>
+                  <span
+                    className="font-mono"
+                    style={{ fontSize: 10, color: br.magColor, flex: "none" }}
+                  >
+                    {br.mag}
+                  </span>
+                </div>
+                {br.note && (
+                  <div
+                    style={{
+                      margin: "3px 0 0 17px",
+                      fontSize: 10.5,
+                      color: "hsl(var(--muted-foreground))",
+                      display: "flex",
+                      gap: 6,
+                      alignItems: "baseline",
+                    }}
+                  >
+                    <span style={{ flex: "none" }}>{br.noteGlyph}</span>
+                    <span style={{ fontStyle: "italic" }}>{br.note}</span>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {insp.fired && (
+            <div
+              style={{
+                padding: "4px 16px 20px",
+                display: "flex",
+                flexDirection: "column",
+                gap: 8,
+                borderTop: "1px solid hsl(var(--border))",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  marginTop: 10,
+                }}
+              >
+                <span className="font-mono" style={sectionLabel}>
+                  Resolution
+                </span>
+                {insp.event && (
+                  <span className="font-mono" style={eventChip}>
+                    {insp.event}
+                  </span>
+                )}
+                {insp.signalEvent && (
+                  <span
+                    className="font-mono"
+                    title="signal event — emitted alongside the primary event"
+                    style={eventChip}
+                  >
+                    signal · {insp.signalEvent}
+                  </span>
+                )}
+                <div style={{ flex: 1 }} />
+                <span
+                  className="font-mono"
+                  style={{ fontSize: 10, color: "hsl(var(--muted-foreground))" }}
+                >
+                  mag {insp.mag}
+                </span>
+              </div>
+              {insp.isPressure && (
+                <div
+                  style={{
+                    border: "1px dashed hsl(var(--accent) / 0.5)",
+                    borderRadius: 6,
+                    padding: "8px 10px",
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 4,
+                  }}
+                >
+                  <span
+                    className="font-mono"
+                    style={{
+                      fontSize: 8.5,
+                      letterSpacing: "0.18em",
+                      textTransform: "uppercase",
+                      color: "hsl(var(--accent))",
+                    }}
+                  >
+                    Scene pressure — prompt-only, no state mutation
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 11.5,
+                      fontStyle: "italic",
+                      color: "hsl(var(--muted-foreground))",
+                    }}
+                  >
+                    {insp.pressureStub}
+                  </span>
+                </div>
+              )}
+              <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+                {insp.deltaRows.map((dr) => (
+                  <div
+                    key={dr.k}
+                    style={{
+                      display: "flex",
+                      gap: 10,
+                      fontSize: 10.5,
+                      alignItems: "baseline",
+                    }}
+                  >
+                    <span
+                      className="font-mono"
+                      style={{
+                        fontSize: 9,
+                        color: "hsl(var(--muted-foreground))",
+                        flex: "none",
+                        minWidth: 150,
+                        textAlign: "right",
+                      }}
+                    >
+                      {dr.k}
+                    </span>
+                    <span
+                      className="font-mono"
+                      style={{ fontSize: 10, color: "hsl(var(--chart-5))" }}
+                    >
+                      {dr.v}
+                    </span>
+                  </div>
+                ))}
+              </div>
+              <div
+                className="font-mono"
+                style={{
+                  fontSize: 8.5,
+                  color: "hsl(var(--muted-foreground) / 0.6)",
+                  letterSpacing: "0.04em",
+                }}
+              >
+                {insp.bindingHash}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Overrides merging
+// ---------------------------------------------------------------------------
+
+function mergeOverrides(chips: OverrideChipEntry[]): OverridesRequest | null {
+  if (chips.length === 0) return null;
+  const req: OverridesRequest = {
+    tags: [],
+    pair_tags: [],
+    needs: [],
+    locations: [],
+    events: [],
+  };
+  for (const chip of chips) {
+    req.tags.push(...(chip.patch.tags ?? []));
+    req.pair_tags.push(...(chip.patch.pair_tags ?? []));
+    req.needs.push(...(chip.patch.needs ?? []));
+    req.locations.push(...(chip.patch.locations ?? []));
+    req.events.push(...(chip.patch.events ?? []));
+  }
+  return req;
+}
+
+const shortBandLabel = (band: string): string =>
+  (BAND_LABELS[band] ?? band)
+    .replace(" / Constraint", "")
+    .replace(" Maintenance", "")
+    .replace("Anchored ", "")
+    .replace(" / Identity", "");
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function DevOrreryPage() {
+  // ---- state ---------------------------------------------------------------
+  const [slot, setSlot] = useState(2);
+  const [anchor, setAnchor] = useState<number | null>(null); // null = head
+  const [head, setHead] = useState<number | null>(null);
+  const [mode, setMode] = useState<"current" | "whatif">("current");
+  const [asofOpen, setAsofOpen] = useState(false);
+  const [overrides, setOverrides] = useState<OverrideChipEntry[]>([]);
+  const [selection, setSelection] = useState<SelectionRef | null>(null);
+  const [hoverTag, setHoverTag] = useState<string | null>(null);
+  const [fTwoParty, setFTwoParty] = useState(false);
+  const [fFamily, setFFamily] = useState<string | null>(null);
+  const [famOpen, setFamOpen] = useState(false);
+  const [fEvent, setFEvent] = useState("none");
+  const [fFailed, setFFailed] = useState(false);
+  const [fNA, setFNA] = useState(false);
+  const [groupOpen, setGroupOpen] = useState<Record<number, boolean>>({});
+  const [shadowOpen, setShadowOpen] = useState<Record<string, boolean>>({});
+  const [centerTab, setCenterTab] = useState<"stream" | "graph">("stream");
+  const [healthOpen, setHealthOpen] = useState(false);
+  const [whatifOpen, setWhatifOpen] = useState(false);
+  const [hoverEnt, setHoverEnt] = useState<number | null>(null);
+  const [hoverPos, setHoverPos] = useState({ x: 0, y: 0 });
+  const hoverTimer = useRef<number | null>(null);
+  const closeTimer = useRef<number | null>(null);
+
+  // The prototype's --orr-z CSS zoom rig is deliberately NOT ported: CSS
+  // `zoom` corrupts getBoundingClientRect coordinates, which Radix/floating-ui
+  // portals (Select, Popover, Command) use for positioning — dropdowns land
+  // off-viewport on wide monitors. The flex layout scales fine without it.
+
+  useEffect(
+    () => () => {
+      if (hoverTimer.current != null) window.clearTimeout(hoverTimer.current);
+      if (closeTimer.current != null) window.clearTimeout(closeTimer.current);
+    },
+    [],
+  );
+
+  // ---- queries ---------------------------------------------------------------
+  const overridesReq = useMemo(() => mergeOverrides(overrides), [overrides]);
+  const overridesJson = overridesReq ? JSON.stringify(overridesReq) : "";
+
+  const resolveQ = useQuery<ResolvePayload, Error>({
+    queryKey: ["orrery", "resolve", slot, anchor, overridesJson],
+    queryFn: () =>
+      fetchResolve({ slot, anchorChunkId: anchor, overrides: overridesReq }),
+    placeholderData: (prev) => prev,
+  });
+  const catalogQ = useQuery<CatalogPayload, Error>({
+    queryKey: ["orrery", "catalog"],
+    queryFn: fetchCatalog,
+  });
+  const coverageQ = useQuery<CoveragePayload, Error>({
+    queryKey: ["orrery", "coverage", slot],
+    queryFn: () => fetchCoverage({ slot }),
+  });
+  const vocabQ = useQuery<VocabPayload, Error>({
+    queryKey: ["orrery", "vocab", slot],
+    queryFn: () => fetchVocab(slot),
+  });
+
+  const payload = resolveQ.data;
+  const catalog = catalogQ.data;
+  const coverage = coverageQ.data;
+
+  // Head anchor: the first at-head resolve fixes the stepper's upper bound.
+  useEffect(() => {
+    if (
+      anchor === null &&
+      payload &&
+      !resolveQ.isPlaceholderData &&
+      payload.anchor_chunk_id != null
+    ) {
+      setHead(payload.anchor_chunk_id);
+    }
+  }, [anchor, payload, resolveQ.isPlaceholderData]);
+
+  // ---- hover intent (180ms in, 200ms out — prototype's hoverIn/onHoverOut) --
+  const hoverIntent = useCallback((id: number, e: ReactMouseEvent) => {
+    if (hoverTimer.current != null) window.clearTimeout(hoverTimer.current);
+    if (closeTimer.current != null) window.clearTimeout(closeTimer.current);
+    const r = e.currentTarget.getBoundingClientRect();
+    const x = Math.min(r.left, (window.innerWidth || 1440) - 340);
+    const y = Math.min(r.bottom + 6, (window.innerHeight || 900) - 440);
+    hoverTimer.current = window.setTimeout(() => {
+      setHoverEnt(id);
+      setHoverPos({ x, y });
+    }, 180);
+  }, []);
+  const hoverOut = useCallback(() => {
+    if (hoverTimer.current != null) window.clearTimeout(hoverTimer.current);
+    closeTimer.current = window.setTimeout(() => setHoverEnt(null), 200);
+  }, []);
+  const hoverPanelEnter = useCallback(() => {
+    if (closeTimer.current != null) window.clearTimeout(closeTimer.current);
+  }, []);
+  const hoverNameHandler = useCallback(
+    (id: number) => (e: ReactMouseEvent) => hoverIntent(id, e),
+    [hoverIntent],
+  );
+
+  const hoverCtxQ = useQuery<ContextPayload, Error>({
+    queryKey: ["orrery", "context", slot, hoverEnt],
+    queryFn: () =>
+      fetchEntityContext({
+        slot,
+        entityIds: [hoverEnt as number],
+        anchorChunkId: anchor,
+      }),
+    enabled: hoverEnt != null,
+  });
+
+  // Drawer bulk context: every entity the payload names, fetched on open.
+  const drawerEntities = useMemo(() => {
+    // Actors plus the characters their stacks bind — not every named
+    // entity (payload.entity_names also carries places and factions).
+    if (!payload) return [] as { id: number; name: string }[];
+    const m = new Map<number, string>();
+    const nameOf = (id: number) =>
+      payload.entity_names[String(id)] ?? `entity ${id}`;
+    for (const g of payload.actors) {
+      m.set(g.actor_entity_id, g.actor_name);
+      for (const stack of [...g.two_party_stacks, ...g.scene_pressure_stacks]) {
+        const target = stack.bindings.target;
+        if (target != null && !m.has(target)) m.set(target, nameOf(target));
+      }
+    }
+    return Array.from(m, ([id, name]) => ({ id, name })).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+  }, [payload]);
+  const drawerIdsKey = drawerEntities.map((e) => e.id).join(",");
+  const drawerCtxQ = useQuery<ContextPayload, Error>({
+    queryKey: ["orrery", "context", slot, "drawer", drawerIdsKey],
+    queryFn: () =>
+      fetchEntityContext({
+        slot,
+        entityIds: drawerEntities.map((e) => e.id),
+        anchorChunkId: anchor,
+      }),
+    enabled: whatifOpen && drawerEntities.length > 0,
+  });
+  const entityContext = useCallback(
+    (id: number): ContextEntity | undefined =>
+      drawerCtxQ.data?.entities.find((e) => e.entity_id === id) ??
+      hoverCtxQ.data?.entities.find((e) => e.entity_id === id),
+    [drawerCtxQ.data, hoverCtxQ.data],
+  );
+
+  // ---- catalog-derived lookups ------------------------------------------------
+  const blurbMap = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const band of catalog?.drive_bands ?? [])
+      for (const t of band.templates) m.set(t.template_id, t.blurb);
+    return m;
+  }, [catalog]);
+  const blurbFor = useCallback(
+    (tpl: string) => blurbMap.get(tpl) ?? "",
+    [blurbMap],
+  );
+  const branchMap = useMemo(() => {
+    const m = new Map<string, { label: string; magnitude: number }[]>();
+    for (const band of catalog?.drive_bands ?? [])
+      for (const t of band.templates)
+        m.set(
+          t.template_id,
+          t.branches.map((b) => ({ label: b.label, magnitude: b.magnitude })),
+        );
+    return m;
+  }, [catalog]);
+  const branchesFor = useCallback(
+    (tpl: string) => branchMap.get(tpl) ?? [],
+    [branchMap],
+  );
+  const ties = useMemo(
+    () => priorityTies(catalog?.priority_ties ?? []),
+    [catalog],
+  );
+  const familyEntries = useMemo(
+    () => Object.entries(catalog?.tag_families ?? {}),
+    [catalog],
+  );
+  const eventOptions = useMemo(
+    () =>
+      Object.entries(catalog?.event_map ?? {})
+        .filter(
+          ([, v]) => v.consumed_by_gate.length + v.consumed_by_branch.length > 0,
+        )
+        .map(([k]) => k)
+        .sort(),
+    [catalog],
+  );
+
+  const familyMembers = fFamily
+    ? (catalog?.tag_families[fFamily]?.members ?? null)
+    : null;
+  const eventLens = fEvent === "none" ? null : fEvent;
+
+  // ---- groups -------------------------------------------------------------------
+  const groups: ActorGroupVM[] = useMemo(() => {
+    if (!payload) return [];
+    const ctx: GroupBuildCtx = {
+      selectedKey: selection?.key ?? null,
+      familyMembers,
+      eventLens,
+      magnitudeStyle: MAGNITUDE_STYLE,
+      pad: PAD,
+      ties,
+      shadowOpen,
+      select: (sel) => setSelection(sel),
+      toggleShadow: (key) =>
+        setShadowOpen((prev) => ({ ...prev, [key]: !prev[key] })),
+      showTwoPartyOnly: fTwoParty,
+      showFailed: fFailed,
+      showNA: fNA,
+      groupOpen,
+      toggleGroup: (id) =>
+        setGroupOpen((prev) => ({ ...prev, [id]: prev[id] === false })),
+    };
+    return buildGroups(payload, ctx);
+  }, [
+    payload,
+    selection,
+    familyMembers,
+    eventLens,
+    ties,
+    shadowOpen,
+    fTwoParty,
+    fFailed,
+    fNA,
+    groupOpen,
+  ]);
+
+  // ---- inspector -------------------------------------------------------------
+  const inspector = useMemo(
+    () =>
+      payload && selection
+        ? buildInspector(payload, selection, {
+            hoverTag,
+            blurbFor,
+            branchesFor,
+            ties,
+          })
+        : null,
+    [payload, selection, hoverTag, blurbFor, branchesFor, ties],
+  );
+
+  // ---- rail / summary ----------------------------------------------------------
+  const bandCounts = useMemo(
+    () => (payload ? winnersByBand(payload) : null),
+    [payload],
+  );
+  const totalWinners = bandCounts
+    ? Object.values(bandCounts).reduce((a, b) => a + b, 0)
+    : 0;
+  const scenePressureCount = groups.reduce((a, g) => a + g.pressures.length, 0);
+  const streamSummary = payload
+    ? `${payload.actors.length} actors · ${totalWinners} winners · ${
+        payload.need_pressures.length + scenePressureCount
+      } pressures`
+    : "";
+  const displayAnchor =
+    anchor ??
+    head ??
+    (payload && !resolveQ.isPlaceholderData ? payload.anchor_chunk_id : null);
+  const chunkStr =
+    displayAnchor != null ? String(displayAnchor).padStart(4, "0") : "····";
+  const worldTimeStr = payload
+    ? `${payload.world_time ?? "—"} · ${payload.time_of_day} · ${payload.weather}`
+    : "…";
+  const windowLabel =
+    payload && payload.anchor_chunk_id != null
+      ? `${payload.anchor_chunk_id - payload.window_chunks + 1} → ${payload.anchor_chunk_id}`
+      : "—";
+  const footerLine = payload
+    ? `slot ${slot} · ${payload.actor_count} actors`
+    : `slot ${slot}`;
+
+  // ---- on-screen chips + need-pressure chips ---------------------------------
+  const onscreenChips = useMemo(() => {
+    if (!payload) return [] as { id: number; name: string }[];
+    const offIds = new Set(payload.actors.map((g) => g.actor_entity_id));
+    const m = new Map<number, string>();
+    for (const g of payload.actors) {
+      for (const stack of g.scene_pressure_stacks) {
+        const target = stack.bindings.target ?? null;
+        if (target == null || offIds.has(target) || m.has(target)) continue;
+        m.set(
+          target,
+          stack.binding_names.target ??
+            payload.entity_names[String(target)] ??
+            String(target),
+        );
+      }
+    }
+    return Array.from(m, ([id, name]) => ({ id, name }));
+  }, [payload]);
+
+  const needPressureChips = useMemo(() => {
+    if (!payload) return [] as { key: string; label: string; title: string }[];
+    return payload.need_pressures.map((np) => {
+      const target =
+        np.bindings["actor"] ?? Object.values(np.bindings)[0] ?? null;
+      const name =
+        target != null
+          ? (payload.entity_names[String(target)] ?? String(target))
+          : "—";
+      return {
+        key: `${np.template_id}:${np.binding_hash}`,
+        label: `${np.template_id} → ${name} · ${np.magnitude.toFixed(2)}`,
+        title: `pseudo-template · priority ${np.priority} · ${np.pressure_stub} — outside the catalog; included explicitly`,
+      };
+    });
+  }, [payload]);
+
+  // ---- health strip ---------------------------------------------------------------
+  const jumpToGroup = useCallback((actorId: number) => {
+    setCenterTab("stream");
+    setGroupOpen((prev) => ({ ...prev, [actorId]: true }));
+    window.setTimeout(() => {
+      const elC = document.getElementById("orr-stream");
+      const elG = document.getElementById(`group-${actorId}`);
+      if (elC && elG) elC.scrollTop = elG.offsetTop - elC.offsetTop - 8;
+    }, 60);
+  }, []);
+
+  const health: HealthStripProps = useMemo(() => {
+    const bands = BAND_ORDER.map((b) => ({
+      name: shortBandLabel(b),
+      color: bandColor(b),
+      count: bandCounts?.[b] ?? 0,
+      pct: totalWinners
+        ? `${Math.round(((bandCounts?.[b] ?? 0) / totalWinners) * 100)}%`
+        : "0%",
+    }));
+    const gaps = groups
+      .filter((g) => g.gap)
+      .map((g) => ({ name: g.name, onJump: () => jumpToGroup(g.id) }));
+    const wonEntries = Object.entries(coverage?.templates ?? {})
+      .map(([id, t]) => ({ id, won: t.won }))
+      .filter((t) => t.won > 0)
+      .sort((a, b) => b.won - a.won);
+    const totalWon = wonEntries.reduce((a, t) => a + t.won, 0);
+    const dominant = wonEntries.slice(0, 3).map((t) => ({
+      id: t.id,
+      share: totalWon ? `${Math.round((t.won / totalWon) * 100)}%` : "0%",
+    }));
+    const neverWin = (coverage?.never_fired ?? []).map((id) => ({ id }));
+    const deadArms = Object.entries(coverage?.dead_gate_arms ?? {}).map(
+      ([event, v]) => ({
+        event,
+        consumers: [...v.consumed_by_gate, ...v.consumed_by_branch].join(", "),
+      }),
+    );
+    const dataQuality: { text: string; color: string }[] = [];
+    for (const row of coverage?.data_quality.null_world_time_bestowals ?? []) {
+      dataQuality.push({
+        text: `${row.bestowal_table} (${row.source_kind}): ${row.null_world_time_rows}/${row.active_rows} active rows have NULL world-time`,
+        color: "hsl(var(--destructive))",
+      });
+    }
+    for (const row of coverage?.data_quality.wall_clock_epochs ?? []) {
+      dataQuality.push({
+        text: `${row.bestowal_table}: ${row.rows} rows share wall-clock ${row.wall_clock_instant} across ${row.distinct_world_times} world-times`,
+        color: "hsl(var(--chart-2))",
+      });
+    }
+    return {
+      open: healthOpen,
+      onToggle: () => setHealthOpen((v) => !v),
+      bands,
+      gaps,
+      dominant,
+      neverWin,
+      deadArms,
+      dataQuality,
+      warnCount: coverage
+        ? String(dataQuality.length + deadArms.length + gaps.length)
+        : "—",
+    };
+  }, [bandCounts, totalWinners, groups, coverage, healthOpen, jumpToGroup]);
+
+  const deadArmConsumers = useMemo(() => {
+    if (!eventLens || !coverage) return [] as string[];
+    const arm = coverage.dead_gate_arms[eventLens];
+    return arm ? [...arm.consumed_by_gate, ...arm.consumed_by_branch] : [];
+  }, [eventLens, coverage]);
+
+  // ---- hover audit VM ----------------------------------------------------------
+  const hoverVM = useMemo(() => {
+    if (hoverEnt == null || !payload) return null;
+    const ent = hoverCtxQ.data?.entities.find((e) => e.entity_id === hoverEnt);
+    if (!ent) return null;
+    const offScreen = payload.actors.some(
+      (g) => g.actor_entity_id === hoverEnt,
+    );
+    return buildEntityAudit(ent, !offScreen, {
+      onTagEnter: (tag) => setHoverTag(tag),
+      onTagLeave: () => setHoverTag(null),
+    });
+  }, [hoverEnt, payload, hoverCtxQ.data]);
+
+  // ---- handlers -----------------------------------------------------------------
+  const onSlotChange = (v: string) => {
+    setSlot(Number(v));
+    setAnchor(null);
+    setHead(null);
+    setSelection(null);
+    setOverrides([]);
+    setGroupOpen({});
+    setShadowOpen({});
+    setHoverEnt(null);
+    setMode("current");
+  };
+  const stepTo = (next: number) => {
+    if (head == null) return;
+    const clamped = Math.max(1, Math.min(head, next));
+    setAnchor(clamped === head ? null : clamped);
+    setSelection(null);
+  };
+  const onStepBack = () => {
+    const cur = anchor ?? head;
+    if (cur != null) stepTo(cur - 1);
+  };
+  const onStepFwd = () => {
+    const cur = anchor ?? head;
+    if (cur != null) stepTo(cur + 1);
+  };
+  const applyOverride = (chip: OverrideChipEntry) => {
+    setOverrides((prev) => [...prev, chip]);
+    setMode("whatif");
+  };
+  const removeOverride = (idx: number) => {
+    setOverrides((prev) => prev.filter((_, j) => j !== idx));
+  };
+
+  // ---- error states (loud, not graceful) ---------------------------------------
+  const fatal =
+    resolveQ.error ??
+    catalogQ.error ??
+    coverageQ.error ??
+    vocabQ.error ??
+    drawerCtxQ.error ??
+    hoverCtxQ.error ??
+    null;
+
+  const rootStyle: CSSProperties = {
+    height: "100vh",
+    minWidth: 1080,
+    display: "flex",
+    flexDirection: "column",
+    overflow: "hidden",
+    position: "relative",
+  };
+
+  if (fatal) {
+    const is404 = fatal instanceof OrreryApiError && fatal.status === 404;
+    return (
+      <div
+        className="dark bg-background text-foreground font-sans"
+        style={rootStyle}
+      >
+        <style>{PAGE_CSS}</style>
+        <div
+          style={{
+            flex: 1,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: 40,
+          }}
+        >
+          <div
+            style={{
+              maxWidth: 520,
+              textAlign: "center",
+              display: "flex",
+              flexDirection: "column",
+              gap: 12,
+            }}
+          >
+            {is404 ? (
+              <>
+                <span
+                  className="font-mono"
+                  style={{
+                    fontSize: 10,
+                    letterSpacing: "0.22em",
+                    textTransform: "uppercase",
+                    color: "hsl(var(--destructive))",
+                  }}
+                >
+                  Dashboard router is off
+                </span>
+                <span
+                  style={{ fontSize: 13.5, color: "hsl(var(--foreground))" }}
+                >
+                  Flip{" "}
+                  <code className="font-mono">
+                    [orrery.dashboard] enabled = true
+                  </code>{" "}
+                  in nexus.toml and restart the gateway.
+                </span>
+              </>
+            ) : (
+              <span
+                className="font-mono"
+                style={{ fontSize: 13, color: "hsl(var(--destructive))" }}
+              >
+                {fatal.message}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const showEmptySlot = !!payload && payload.actors.length === 0;
+  const showStream = !!payload && !showEmptySlot && centerTab === "stream";
+  const showGraph = !!payload && !showEmptySlot && centerTab === "graph";
+  const sandboxFrame = mode === "whatif" && overrides.length > 0;
+
+  const stepBtnStyle: CSSProperties = {
+    width: 24,
+    height: 24,
+    border: "1px solid hsl(var(--border))",
+    borderRadius: 4,
+    background: "transparent",
+    color: "hsl(var(--muted-foreground))",
+    cursor: "pointer",
+    fontSize: 12,
+    lineHeight: 1,
+  };
+  const stepBtnHover: CSSProperties = {
+    borderColor: "hsl(var(--primary))",
+    color: "hsl(var(--foreground))",
+  };
+
+  return (
+    <div
+      className="dark bg-background text-foreground font-sans"
+      style={rootStyle}
+    >
+      <style>{PAGE_CSS}</style>
+
+      {/* ═══════════════ TICK BAR ═══════════════ */}
+      <div
+        className="bg-sidebar"
+        style={{
+          height: 46,
+          flex: "none",
+          display: "flex",
+          alignItems: "center",
+          gap: 14,
+          padding: "0 14px",
+          borderBottom: "1px solid hsl(var(--border))",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: 8,
+            flex: "none",
+          }}
+        >
+          <span
+            className="font-display"
+            style={{
+              fontSize: 17,
+              letterSpacing: "0.06em",
+              color: "hsl(var(--primary))",
+            }}
+          >
+            ORRERY
+          </span>
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 9,
+              letterSpacing: "0.22em",
+              color: "hsl(var(--muted-foreground))",
+              textTransform: "uppercase",
+            }}
+          >
+            Audit
+          </span>
+        </div>
+        <div
+          style={{
+            width: 1,
+            height: 20,
+            background: "hsl(var(--border))",
+            flex: "none",
+          }}
+        />
+        <Select value={String(slot)} onValueChange={onSlotChange}>
+          <SelectTrigger style={{ height: 28, width: 118, fontSize: 11 }}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {[1, 2, 3, 4, 5].map((n) => (
+              <SelectItem key={n} value={String(n)}>
+                save_{String(n).padStart(2, "0")}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <div
+          style={{ display: "flex", alignItems: "center", gap: 6, flex: "none" }}
+        >
+          <HoverBtn
+            title="Previous chunk"
+            onClick={onStepBack}
+            style={stepBtnStyle}
+            hoverStyle={stepBtnHover}
+          >
+            −
+          </HoverBtn>
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 12,
+              letterSpacing: "0.08em",
+              minWidth: 88,
+              textAlign: "center",
+            }}
+          >
+            chunk {chunkStr}
+          </span>
+          <HoverBtn
+            title="Next chunk"
+            onClick={onStepFwd}
+            style={stepBtnStyle}
+            hoverStyle={stepBtnHover}
+          >
+            +
+          </HoverBtn>
+        </div>
+        <span
+          className="font-mono"
+          style={{
+            fontSize: 10.5,
+            letterSpacing: "0.08em",
+            color: "hsl(var(--muted-foreground))",
+            flex: "none",
+          }}
+        >
+          {worldTimeStr}
+        </span>
+        <span
+          className="font-mono"
+          style={{
+            fontSize: 9,
+            letterSpacing: "0.1em",
+            color: "hsl(var(--muted-foreground))",
+            flex: "none",
+          }}
+        >
+          window {windowLabel}
+        </span>
+        <div style={{ flex: 1 }} />
+        {resolveQ.isFetching && (
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 9.5,
+              letterSpacing: "0.18em",
+              color: "hsl(var(--accent))",
+              animation: "orr-pulse 0.9s infinite",
+              textTransform: "uppercase",
+            }}
+          >
+            resolving
+          </span>
+        )}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 2,
+            border: "1px solid hsl(var(--border))",
+            borderRadius: 6,
+            padding: 2,
+            flex: "none",
+          }}
+        >
+          <button
+            type="button"
+            className="font-mono"
+            style={chipStyle(mode === "current", "primary")}
+            onClick={() => {
+              setMode("current");
+              setWhatifOpen(false);
+            }}
+          >
+            Current
+          </button>
+          <button
+            type="button"
+            className="font-mono"
+            style={chipStyle(mode === "whatif", "accent")}
+            onClick={() => {
+              setMode("whatif");
+              setWhatifOpen(true);
+            }}
+          >
+            What-if
+          </button>
+          <Popover open={asofOpen} onOpenChange={setAsofOpen}>
+            <PopoverTrigger
+              className="font-mono"
+              style={chipStyle(asofOpen, "chart-5")}
+            >
+              As-of
+            </PopoverTrigger>
+            <PopoverContent align="end">
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 7,
+                  minWidth: 250,
+                }}
+              >
+                <div
+                  className="font-mono"
+                  style={{
+                    fontSize: 9.5,
+                    letterSpacing: "0.18em",
+                    textTransform: "uppercase",
+                    color: "hsl(var(--muted-foreground))",
+                  }}
+                >
+                  Per-axis honesty at chunk {chunkStr}
+                </div>
+                {ASOF_AXES.map((ax) => (
+                  <div
+                    key={ax.axis}
+                    style={{
+                      display: "flex",
+                      alignItems: "baseline",
+                      gap: 8,
+                      fontSize: 12,
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 14,
+                        flex: "none",
+                        textAlign: "center",
+                        color: ax.color,
+                      }}
+                    >
+                      {ax.glyph}
+                    </span>
+                    <span style={{ flex: 1 }}>{ax.axis}</span>
+                    <span
+                      className="font-mono"
+                      style={{
+                        fontSize: 9.5,
+                        color: "hsl(var(--muted-foreground))",
+                      }}
+                    >
+                      {ax.label}
+                    </span>
+                  </div>
+                ))}
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: "hsl(var(--muted-foreground))",
+                    borderTop: "1px solid hsl(var(--border))",
+                    paddingTop: 6,
+                    fontStyle: "italic",
+                  }}
+                >
+                  Never a binary honest/chimera switch — provenance is per-row.
+                </div>
+              </div>
+            </PopoverContent>
+          </Popover>
+        </div>
+        <HoverBtn
+          title="Re-resolve tick"
+          onClick={() => {
+            void resolveQ.refetch();
+          }}
+          style={{
+            width: 28,
+            height: 28,
+            border: "1px solid hsl(var(--border))",
+            borderRadius: 6,
+            background: "transparent",
+            color: "hsl(var(--primary))",
+            cursor: "pointer",
+            fontSize: 15,
+            flex: "none",
+          }}
+          hoverStyle={{
+            borderColor: "hsl(var(--primary))",
+            background: "hsl(var(--primary) / 0.12)",
+          }}
+        >
+          ⟳
+        </HoverBtn>
+      </div>
+
+      {/* override chips (pinned under tick bar) */}
+      {overrides.length > 0 && (
+        <div
+          style={{
+            flex: "none",
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "6px 14px",
+            borderBottom: "1px dashed hsl(var(--accent) / 0.5)",
+            background: "hsl(var(--accent) / 0.07)",
+          }}
+        >
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 9,
+              letterSpacing: "0.2em",
+              color: "hsl(var(--accent))",
+              textTransform: "uppercase",
+              flex: "none",
+            }}
+          >
+            Sandbox overrides
+          </span>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+            {overrides.map((oc, i) => (
+              <span
+                key={`${oc.label}:${i}`}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 6,
+                  border: "1px solid hsl(var(--accent) / 0.6)",
+                  borderRadius: 99,
+                  padding: "2px 4px 2px 10px",
+                  fontSize: 11,
+                  color: "hsl(var(--accent-foreground))",
+                  background: "hsl(var(--accent) / 0.85)",
+                }}
+              >
+                {oc.label}
+                <button
+                  type="button"
+                  onClick={() => removeOverride(i)}
+                  style={{
+                    border: "none",
+                    background: "hsl(var(--background) / 0.25)",
+                    color: "inherit",
+                    borderRadius: 99,
+                    width: 16,
+                    height: 16,
+                    fontSize: 10,
+                    cursor: "pointer",
+                    lineHeight: 1,
+                  }}
+                >
+                  ✕
+                </button>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ═══════════════ THREE REGIONS ═══════════════ */}
+      <div style={{ flex: 1, minHeight: 0 }}>
+        <div style={{ height: "100%", display: "flex" }}>
+          {/* ─────────── LEFT RAIL ─────────── */}
+          <div style={{ width: "17%", minWidth: 200, height: "100%" }}>
+            <div
+              className="bg-sidebar"
+              style={{
+                height: "100%",
+                display: "flex",
+                flexDirection: "column",
+                borderRight: "1px solid hsl(var(--sidebar-border))",
+                overflowY: "auto",
+              }}
+            >
+              <div
+                className="font-mono"
+                style={{ ...railLabelStyle, padding: "12px 14px 6px" }}
+              >
+                Drive bands
+              </div>
+              {BAND_ORDER.map((b) => {
+                const count = bandCounts?.[b] ?? 0;
+                const col = bandColor(b);
+                return (
+                  <div
+                    key={b}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 9,
+                      padding: "7px 14px",
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: 99,
+                        background: col,
+                        flex: "none",
+                        boxShadow: `0 0 6px ${col.replace("))", ") / 0.5)")}`,
+                      }}
+                    />
+                    <span
+                      className="font-mono"
+                      style={{
+                        fontSize: 10.5,
+                        letterSpacing: "0.1em",
+                        flex: 1,
+                        color: "hsl(var(--sidebar-foreground))",
+                      }}
+                    >
+                      {BAND_LABELS[b]}
+                    </span>
+                    <span
+                      className="font-mono"
+                      style={{
+                        fontSize: 10,
+                        minWidth: 20,
+                        textAlign: "center",
+                        border: `1px solid ${count ? col : "hsl(var(--border))"}`,
+                        color: count ? col : "hsl(var(--muted-foreground))",
+                        borderRadius: 99,
+                        padding: "1px 6px",
+                      }}
+                    >
+                      {count}
+                    </span>
+                  </div>
+                );
+              })}
+              <div
+                style={{
+                  margin: "10px 14px",
+                  borderTop: "1px solid hsl(var(--sidebar-border))",
+                }}
+              />
+              <div
+                className="font-mono"
+                style={{ ...railLabelStyle, padding: "0 14px 8px" }}
+              >
+                Lenses
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 9,
+                  padding: "0 14px 12px",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 8,
+                  }}
+                >
+                  <span
+                    className="font-mono"
+                    style={{ fontSize: 10, letterSpacing: "0.08em" }}
+                  >
+                    Two-party lane
+                  </span>
+                  <Switch checked={fTwoParty} onCheckedChange={setFTwoParty} />
+                </div>
+                <div
+                  style={{ display: "flex", flexDirection: "column", gap: 4 }}
+                >
+                  <span
+                    className="font-mono"
+                    style={{ fontSize: 10, letterSpacing: "0.08em" }}
+                  >
+                    Tag family
+                  </span>
+                  <Popover open={famOpen} onOpenChange={setFamOpen}>
+                    <PopoverTrigger
+                      className="font-mono"
+                      style={{
+                        width: "100%",
+                        height: 28,
+                        border: "1px solid hsl(var(--input))",
+                        borderRadius: 6,
+                        background: "transparent",
+                        color: "hsl(var(--foreground))",
+                        fontSize: 10,
+                        letterSpacing: "0.06em",
+                        cursor: "pointer",
+                        textAlign: "left",
+                        padding: "0 10px",
+                      }}
+                    >
+                      {fFamily ?? "— none —"}
+                    </PopoverTrigger>
+                    <PopoverContent align="start">
+                      <Command style={{ background: "transparent" }}>
+                        <CommandInput placeholder="Filter families…" />
+                        <CommandList>
+                          <CommandEmpty>No family found.</CommandEmpty>
+                          {familyEntries.map(([name, fam]) => (
+                            <CommandItem
+                              key={name}
+                              value={name}
+                              onSelect={() => {
+                                setFFamily(fFamily === name ? null : name);
+                                setFamOpen(false);
+                              }}
+                            >
+                              <span
+                                className="font-mono"
+                                style={{
+                                  fontSize: 10,
+                                  letterSpacing: "0.06em",
+                                }}
+                              >
+                                {name}
+                              </span>
+                              <span
+                                style={{
+                                  fontSize: 10,
+                                  color: "hsl(var(--muted-foreground))",
+                                  marginLeft: "auto",
+                                }}
+                              >
+                                {fam.members.length}
+                              </span>
+                            </CommandItem>
+                          ))}
+                          <CommandItem
+                            value="— clear —"
+                            onSelect={() => {
+                              setFFamily(null);
+                              setFamOpen(false);
+                            }}
+                          >
+                            <span
+                              className="font-mono"
+                              style={{ fontSize: 10, letterSpacing: "0.06em" }}
+                            >
+                              — clear —
+                            </span>
+                          </CommandItem>
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+                <div
+                  style={{ display: "flex", flexDirection: "column", gap: 4 }}
+                >
+                  <span
+                    className="font-mono"
+                    style={{ fontSize: 10, letterSpacing: "0.08em" }}
+                  >
+                    Event family
+                  </span>
+                  <Select value={fEvent} onValueChange={setFEvent}>
+                    <SelectTrigger
+                      style={{
+                        height: 28,
+                        width: "100%",
+                        fontSize: 10.5,
+                        fontFamily: "var(--font-mono)",
+                      }}
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">— none —</SelectItem>
+                      {eventOptions.map((ev) => (
+                        <SelectItem key={ev} value={ev}>
+                          {ev}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 8,
+                  }}
+                >
+                  <span
+                    className="font-mono"
+                    style={{ fontSize: 10, letterSpacing: "0.08em" }}
+                  >
+                    Show gate-failed
+                  </span>
+                  <Switch checked={fFailed} onCheckedChange={setFFailed} />
+                </div>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 8,
+                  }}
+                >
+                  <span
+                    className="font-mono"
+                    style={{ fontSize: 10, letterSpacing: "0.08em" }}
+                  >
+                    Show not-applicable
+                  </span>
+                  <Switch checked={fNA} onCheckedChange={setFNA} />
+                </div>
+              </div>
+              <div style={{ flex: 1 }} />
+              <div
+                className="font-mono"
+                style={{
+                  padding: "10px 14px",
+                  fontSize: 9,
+                  letterSpacing: "0.14em",
+                  color: "hsl(var(--muted-foreground))",
+                  borderTop: "1px solid hsl(var(--sidebar-border))",
+                }}
+              >
+                {footerLine}
+              </div>
+            </div>
+          </div>
+
+          {/* ─────────── CENTER: STREAM / GRAPH ─────────── */}
+          <div style={{ flex: 1, minWidth: 0, height: "100%" }}>
+            <div
+              style={{
+                height: "100%",
+                display: "flex",
+                flexDirection: "column",
+                minWidth: 0,
+              }}
+            >
+              <div
+                style={{
+                  flex: "none",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 4,
+                  padding: "8px 14px 0",
+                }}
+              >
+                <button
+                  type="button"
+                  className="font-mono"
+                  style={tabStyle(centerTab === "stream")}
+                  onClick={() => setCenterTab("stream")}
+                >
+                  Actor stream
+                </button>
+                <button
+                  type="button"
+                  className="font-mono"
+                  style={tabStyle(centerTab === "graph")}
+                  onClick={() => setCenterTab("graph")}
+                >
+                  Interaction graph
+                </button>
+                <div style={{ flex: 1 }} />
+                <span
+                  className="font-mono"
+                  style={{
+                    fontSize: 9.5,
+                    letterSpacing: "0.1em",
+                    color: "hsl(var(--muted-foreground))",
+                  }}
+                >
+                  {streamSummary}
+                </span>
+              </div>
+
+              {showEmptySlot && (
+                <div
+                  style={{
+                    flex: 1,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <div
+                    style={{
+                      maxWidth: 380,
+                      textAlign: "center",
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 10,
+                      padding: 24,
+                      border: "1px dashed hsl(var(--border))",
+                      borderRadius: 8,
+                    }}
+                  >
+                    <span
+                      className="font-mono"
+                      style={{
+                        fontSize: 10,
+                        letterSpacing: "0.2em",
+                        textTransform: "uppercase",
+                        color: "hsl(var(--muted-foreground))",
+                      }}
+                    >
+                      No Orrery data
+                    </span>
+                    <span
+                      style={{
+                        fontSize: 13,
+                        color: "hsl(var(--muted-foreground))",
+                        fontStyle: "italic",
+                      }}
+                    >
+                      No off-screen actors resolve on this slot.
+                    </span>
+                  </div>
+                </div>
+              )}
+
+              {!payload && (
+                <div style={{ flex: 1, minHeight: 0 }} />
+              )}
+
+              {showStream && (
+                <div
+                  id="orr-stream"
+                  style={{
+                    flex: 1,
+                    minHeight: 0,
+                    overflowY: "auto",
+                    padding: "10px 14px 24px",
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 10,
+                  }}
+                >
+                  {groups.map((g) => (
+                    <StreamGroup
+                      key={g.id}
+                      g={g}
+                      selectedActor={selection?.actor ?? null}
+                      showFailedHint={!fFailed}
+                      onHoverName={hoverNameHandler}
+                      onHoverOut={hoverOut}
+                    />
+                  ))}
+                  {/* on-screen scene row */}
+                  <div
+                    style={{
+                      border: "1px dashed hsl(var(--border))",
+                      borderRadius: 8,
+                      padding: "9px 12px",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 10,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <span
+                      className="font-mono"
+                      style={{
+                        fontSize: 9,
+                        letterSpacing: "0.2em",
+                        textTransform: "uppercase",
+                        color: "hsl(var(--muted-foreground))",
+                        flex: "none",
+                      }}
+                    >
+                      On-screen
+                    </span>
+                    {onscreenChips.map((oc) => (
+                      <span
+                        key={oc.id}
+                        onMouseEnter={hoverNameHandler(oc.id)}
+                        onMouseLeave={hoverOut}
+                        style={{
+                          fontSize: 12.5,
+                          fontWeight: 600,
+                          color: "hsl(var(--foreground))",
+                          textDecoration:
+                            "underline dotted hsl(var(--primary) / 0.5)",
+                          textUnderlineOffset: 3,
+                          cursor: "default",
+                        }}
+                      >
+                        {oc.name}
+                      </span>
+                    ))}
+                    <span style={{ flex: 1 }} />
+                    {needPressureChips.map((np) => (
+                      <span
+                        key={np.key}
+                        className="font-mono"
+                        title={np.title}
+                        style={{
+                          fontSize: 10,
+                          letterSpacing: "0.05em",
+                          border: "1px dashed hsl(var(--chart-2) / 0.7)",
+                          color: "hsl(var(--chart-2))",
+                          borderRadius: 99,
+                          padding: "2px 9px",
+                        }}
+                      >
+                        ⇢ {np.label}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {showGraph && payload && (
+                <InteractionGraph
+                  payload={payload}
+                  selectedKey={selection?.key ?? null}
+                  onSelect={(sel) => setSelection(sel)}
+                  onHoverEntity={hoverIntent}
+                  eventLens={eventLens}
+                  deadArmConsumers={deadArmConsumers}
+                />
+              )}
+
+              {/* ─────────── HEALTH STRIP ─────────── */}
+              <HealthStrip {...health} />
+            </div>
+          </div>
+
+          {/* ─────────── RIGHT: INSPECTOR ─────────── */}
+          <div style={{ width: "30%", minWidth: 300, height: "100%" }}>
+            <div
+              style={{
+                height: "100%",
+                overflowY: "auto",
+                borderLeft: "1px solid hsl(var(--border))",
+                background: "hsl(var(--card) / 0.3)",
+              }}
+            >
+              {inspector ? (
+                <InspectorPane insp={inspector} />
+              ) : (
+                <div
+                  style={{
+                    height: "100%",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    padding: 30,
+                  }}
+                >
+                  <div
+                    style={{
+                      textAlign: "center",
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 8,
+                      maxWidth: 240,
+                    }}
+                  >
+                    <span
+                      style={{
+                        fontSize: 22,
+                        color: "hsl(var(--muted-foreground) / 0.5)",
+                      }}
+                    >
+                      ◈
+                    </span>
+                    <span
+                      className="font-mono"
+                      style={{
+                        fontSize: 9.5,
+                        letterSpacing: "0.22em",
+                        textTransform: "uppercase",
+                        color: "hsl(var(--muted-foreground))",
+                      }}
+                    >
+                      Inspector
+                    </span>
+                    <span
+                      style={{
+                        fontSize: 12,
+                        fontStyle: "italic",
+                        color: "hsl(var(--muted-foreground))",
+                      }}
+                    >
+                      Select any card, ghost row, or pressure chip to open its
+                      full gate trace and branch ladder.
+                    </span>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* what-if dashed sandbox frame */}
+      {sandboxFrame && (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            pointerEvents: "none",
+            border: "2px dashed hsl(var(--accent) / 0.8)",
+            zIndex: 50,
+          }}
+        >
+          <span
+            className="font-mono"
+            style={{
+              position: "absolute",
+              bottom: 6,
+              right: 12,
+              fontSize: 9,
+              letterSpacing: "0.24em",
+              textTransform: "uppercase",
+              color: "hsl(var(--accent))",
+              background: "hsl(var(--background) / 0.85)",
+              padding: "2px 8px",
+            }}
+          >
+            Sandbox — not canon
+          </span>
+        </div>
+      )}
+
+      {/* floating hover-audit */}
+      <HoverAudit
+        ent={hoverVM}
+        x={hoverPos.x}
+        y={hoverPos.y}
+        onEnter={hoverPanelEnter}
+        onLeave={hoverOut}
+      />
+
+      {/* ═══════════════ WHAT-IF DRAWER ═══════════════ */}
+      <WhatIfDrawer
+        open={whatifOpen}
+        onClose={() => setWhatifOpen(false)}
+        entities={drawerEntities}
+        vocab={vocabQ.data ?? null}
+        needs={NEEDS}
+        onApply={applyOverride}
+        entityContext={entityContext}
+      />
+    </div>
+  );
+}

--- a/ui/client/src/pages/dev-orrery/types.ts
+++ b/ui/client/src/pages/dev-orrery/types.ts
@@ -1,0 +1,514 @@
+// Payload types for /api/dev/orrery/* (mirrors nexus/agents/orrery/audit.py
+// and orrery_dev_endpoints.py) plus the view-model shapes the design
+// prototype's components render. The adapter between them lives in vm.ts.
+
+// ---------------------------------------------------------------------------
+// API payloads
+// ---------------------------------------------------------------------------
+
+export interface TraceEvidence {
+  kind: string;
+  params: Record<string, unknown>;
+  entities: Record<string, number | null>;
+  observed: Record<string, unknown>;
+  matched: unknown[] | null;
+  result: boolean | null;
+}
+
+export interface TraceNode {
+  raw: string;
+  prose: string;
+  result: boolean;
+  op?: "AND" | "OR" | "NOT";
+  children?: TraceNode[];
+  evidence?: TraceEvidence | null;
+}
+
+export interface BranchTracePayload {
+  label: string;
+  magnitude: number;
+  considered: boolean;
+  result: boolean;
+  selected: boolean;
+  trace: TraceNode | null;
+}
+
+export interface TemplatePayload {
+  template_id: string;
+  priority: number;
+  drive_band: string;
+  blurb: string;
+  required_slots: string[];
+  present_target_policy: string;
+  gate_passed: boolean;
+  gate_trace: TraceNode;
+  fired: boolean;
+  chosen_branch: string | null;
+  branches: BranchTracePayload[];
+  magnitude: number | null;
+  event_type: string | null;
+  signal_event_type: string | null;
+  narrative_stub: string | null;
+  narrative_stub_rendered: string | null;
+  scene_pressure_prompt_rendered: string | null;
+  binding_hash: string;
+  state_delta: Record<string, unknown>;
+  changed_fields: string[];
+  is_winner: boolean;
+  is_shadowed: boolean;
+}
+
+export interface StackDiff {
+  changed: boolean;
+  baseline_winner_id: string | null;
+  baseline_chosen_branch: string | null;
+  baseline_magnitude: number | null;
+  changed_template_ids: string[];
+}
+
+export interface StackPayload {
+  bindings: Record<string, number>;
+  binding_names: Record<string, string>;
+  winner_id: string | null;
+  shadowed_ids: string[];
+  templates: TemplatePayload[];
+  diff: StackDiff | null;
+}
+
+export interface NotApplicableMarker {
+  template_id: string;
+  priority: number;
+  drive_band: string;
+  reason: string;
+}
+
+export interface ActorGroupPayload {
+  actor_entity_id: number;
+  actor_name: string;
+  location: { place_id: number; name: string | null } | null;
+  activity: string | null;
+  actor_stack: StackPayload;
+  two_party_stacks: StackPayload[];
+  scene_pressure_stacks: StackPayload[];
+  not_applicable: NotApplicableMarker[];
+}
+
+export interface NeedPressurePayload {
+  template_id: string;
+  priority: number;
+  binding_hash: string;
+  bindings: Record<string, number>;
+  branch_label: string;
+  pressure_stub: string;
+  prompt_text: string;
+  magnitude: number;
+}
+
+export interface JointBeatPayload {
+  kind: "reciprocal" | "crossed";
+  entity_a: number;
+  entity_b: number;
+  forward_proposal_id: string;
+  reverse_proposal_id: string;
+  forward_template_id: string;
+  reverse_template_id: string;
+  forward_stub: string;
+  reverse_stub: string;
+  magnitude: number;
+  entity_names: Record<string, string>;
+}
+
+export interface ResolvePayload {
+  anchor_chunk_id: number | null;
+  window_chunks: number;
+  world_time: string | null;
+  time_of_day: string;
+  weather: string;
+  actor_count: number;
+  mode: "current" | "what_if";
+  overrides: Record<string, unknown> | null;
+  generated_at: string;
+  actors: ActorGroupPayload[];
+  joint_beats: JointBeatPayload[];
+  need_pressures: NeedPressurePayload[];
+  need_pressures_diff: {
+    added: NeedPressurePayload[];
+    removed: NeedPressurePayload[];
+    changed: { current: NeedPressurePayload; baseline: NeedPressurePayload }[];
+  } | null;
+  entity_names: Record<string, string>;
+}
+
+// --- what-if override request shapes (mirror OrreryOverridesModel) ---------
+
+export interface TagOverride {
+  entity_id: number;
+  tag: string;
+  op: "add" | "remove";
+  ephemeral: boolean;
+}
+export interface PairTagOverride {
+  subject_entity_id: number;
+  object_entity_id: number;
+  tag: string;
+  op: "add" | "remove";
+}
+export interface NeedOverride {
+  entity_id: number;
+  need_type: string;
+  debt_score: number;
+}
+export interface LocationOverride {
+  entity_id: number;
+  place_id: number;
+}
+export interface EventOverride {
+  event_type: string;
+  actor_entity_id?: number | null;
+  target_entity_id?: number | null;
+  ticks_ago?: number;
+}
+export interface OverridesRequest {
+  tags: TagOverride[];
+  pair_tags: PairTagOverride[];
+  needs: NeedOverride[];
+  locations: LocationOverride[];
+  events: EventOverride[];
+}
+/** One override plus the chip label shown under the tick bar. */
+export interface OverrideChipEntry {
+  label: string;
+  patch: Partial<OverridesRequest>;
+}
+
+// --- catalog ----------------------------------------------------------------
+
+export interface CatalogTemplate {
+  template_id: string;
+  priority: number;
+  tuple_index: number;
+  drive_band: string;
+  blurb: string;
+  required_slots: string[];
+  arity: "actor_only" | "two_party";
+  present_target_policy: string;
+  priority_override_rationale: string | null;
+  branches: {
+    label: string;
+    magnitude: number;
+    event_type: string | null;
+    signal_event_type: string | null;
+  }[];
+  consumed_event_types: { gate: string[]; branch: string[] };
+  emitted_event_types: string[];
+}
+
+export interface CatalogPayload {
+  drive_bands: { band: string; urgency_rank: number; templates: CatalogTemplate[] }[];
+  pseudo_templates: { template_id: string; need_type: string; priority: number }[];
+  tag_families: Record<string, { kind: string; members: string[] }>;
+  event_map: Record<
+    string,
+    {
+      consumed_by_gate: string[];
+      consumed_by_branch: string[];
+      emitted_by: string[];
+      exogenous_only: boolean;
+    }
+  >;
+  priority_ties: { arity: string; priority: number; template_ids: string[] }[];
+  promotion: { priority_threshold: number; magnitude_threshold: number } | null;
+}
+
+// --- entity context (hover audit) -------------------------------------------
+
+export interface ContextTagRow {
+  tag: string;
+  category: string;
+  is_ephemeral: boolean;
+  source_kind: string;
+  applied_at_world_time: string | null;
+  source_chunk_id: number | null;
+  provenance: "exact" | "approximate" | "unknowable";
+  families: string[];
+}
+
+export interface ContextEntity {
+  entity_id: number;
+  name: string;
+  kind: string | null;
+  place: {
+    place_id: number;
+    name: string | null;
+    place_type: string | null;
+    classes: string[];
+  } | null;
+  activity: string | null;
+  needs: {
+    need_type: string;
+    debt_score: number;
+    severity_level: number | null;
+    severity_name: string | null;
+  }[];
+  tags: { durable: ContextTagRow[]; ephemeral: ContextTagRow[] };
+  pair_tags: {
+    tag: string;
+    direction: "outbound" | "inbound";
+    other_entity_id: number;
+    other_name?: string;
+    provenance: string;
+  }[];
+  relationships: {
+    relationship_type: string;
+    valence_magnitude: number | null;
+    direction: "outbound" | "inbound";
+    other_entity_id: number;
+    other_name?: string;
+    versioned: boolean;
+  }[];
+  recent_events: {
+    event_type: string;
+    tick_chunk_id: number;
+    actor_name: string | null;
+    target_name: string | null;
+  }[];
+}
+
+export interface ContextPayload {
+  anchor_chunk_id: number | null;
+  world_time: string | null;
+  entities: ContextEntity[];
+}
+
+// --- coverage ----------------------------------------------------------------
+
+export interface CoveragePayload {
+  anchor_chunk_ids: number[];
+  anchors: {
+    anchor_chunk_id: number;
+    winners_by_band: Record<string, number>;
+    gap_actor_ids: number[];
+    need_pressure_count: number;
+  }[];
+  templates: Record<
+    string,
+    {
+      drive_band: string;
+      evaluated: number;
+      fired: number;
+      won: number;
+      pressure_fired: number;
+      pressure_won: number;
+    }
+  >;
+  never_fired: string[];
+  fired_never_won: string[];
+  always_won_when_fired: string[];
+  gap_actors: {
+    entity_id: number;
+    name: string | null;
+    seen_anchors: number;
+    gapped_anchors: number;
+  }[];
+  dead_gate_arms: Record<
+    string,
+    { consumed_by_gate: string[]; consumed_by_branch: string[] }
+  >;
+  data_quality: {
+    null_world_time_bestowals: {
+      bestowal_table: string;
+      source_kind: string;
+      null_world_time_rows: number;
+      active_rows: number;
+    }[];
+    wall_clock_epochs: {
+      bestowal_table: string;
+      wall_clock_instant: string;
+      rows: number;
+      distinct_world_times: number;
+    }[];
+  };
+  hydration_honesty: Record<string, string[]>;
+}
+
+// --- vocab -------------------------------------------------------------------
+
+export interface VocabPayload {
+  tags: { tag: string; category: string; is_ephemeral: boolean }[];
+  pair_tags: { tag: string; subject_kinds: string[]; object_kinds: string[] }[];
+  event_types: { type: string; category: string | null }[];
+  places: { id: number; name: string }[];
+}
+
+// ---------------------------------------------------------------------------
+// View models (the shapes the design components render)
+// ---------------------------------------------------------------------------
+
+/** GateBrackets / inspector tree node. */
+export interface EvaluatedGateNode {
+  kind: "leaf" | "op";
+  op?: "AND" | "OR" | "NOT";
+  pass: boolean;
+  prose: string;
+  evidence: string;
+  reads: string[];
+  children?: EvaluatedGateNode[];
+}
+
+export interface MagChip {
+  dial: boolean;
+  deg?: number;
+  color: string;
+  text: string;
+}
+
+export interface ResolutionCardVM {
+  key: string;
+  kind: "solo" | "pair";
+  tplName: string;
+  priority: string;
+  bandColor: string;
+  dim: boolean;
+  tie: boolean;
+  tieTitle: string;
+  isPair: boolean;
+  targetName: string | null;
+  targetEntityId: number | null;
+  branchLabel: string;
+  event: string | null;
+  mag: MagChip | null;
+  selected: boolean;
+  diff: boolean;
+  highlight: boolean;
+  dimByLens: boolean;
+  pad: number;
+  shadowCount: number;
+  hasShadow: boolean;
+  shadowOpen: boolean;
+  shadowed: ResolutionCardVM[];
+  onSelect: () => void;
+  onToggleShadow?: () => void;
+}
+
+export interface EntityAuditVM {
+  name: string;
+  place: string;
+  classes: string;
+  fameRes: string;
+  needs: { nd: string; val: string; note: string; pct: string; color: string }[];
+  durable: EntityAuditTagVM[];
+  ephemeral: EntityAuditTagVM[];
+  hasEphemeral: boolean;
+  rels: { types: string; other: string; trust: string }[];
+  hasRels: boolean;
+  events: { t: string; type: string }[];
+  hasEvents: boolean;
+}
+
+export interface EntityAuditTagVM {
+  name: string;
+  fam: string;
+  famTitle: string;
+  dot: string;
+  dotTitle: string;
+  onEnter?: () => void;
+  onLeave?: () => void;
+}
+
+export type RowStatus = "winner" | "shadowed" | "gate_failed" | "not_applicable";
+
+export interface GhostRowVM {
+  key: string;
+  name: string;
+  glyph: string;
+  status: RowStatus;
+  reason: string;
+  evidence: string;
+  na: boolean;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+export interface PressureChipVM {
+  key: string;
+  label: string;
+  title: string;
+  selected: boolean;
+  diff: boolean;
+  onSelect: () => void;
+}
+
+export interface ActorGroupVM {
+  id: number;
+  domId: string;
+  name: string;
+  initials: string;
+  ringColor: string;
+  placeName: string;
+  open: boolean;
+  gap: boolean;
+  diff: boolean;
+  cards: ResolutionCardVM[];
+  pressures: PressureChipVM[];
+  ghosts: GhostRowVM[];
+  bandDots: { color: string; title: string }[];
+  activityLine: string;
+  onToggle: () => void;
+}
+
+export interface SelectionRef {
+  key: string;
+  actor: number;
+  target: number | null;
+  tpl: string;
+  kind: "solo" | "pair" | "pressure" | "na";
+}
+
+export interface InspectorGateRowVM {
+  depth: number;
+  isOp: boolean;
+  glyph: string;
+  glyphColor: string;
+  prose: string;
+  emphasized: boolean;
+  muted: boolean;
+  evidence: string;
+  evidenceHot: boolean;
+  highlighted: boolean;
+}
+
+export interface InspectorBranchVM {
+  idx: string;
+  label: string;
+  mag: string;
+  selected: boolean;
+  unevaluated: boolean;
+  failed: boolean;
+  note: string;
+  noteGlyph: string;
+  magColor: string;
+}
+
+export interface InspectorVM {
+  name: string;
+  priority: number;
+  bandColor: string;
+  tie: boolean;
+  tieTitle: string;
+  statusLabel: string;
+  statusTone: "winner" | "shadowed" | "failed" | "na";
+  bindingLine: string;
+  blurb: string;
+  isNA: boolean;
+  gatePassed: boolean;
+  gateRows: InspectorGateRowVM[];
+  branches: InspectorBranchVM[];
+  fired: boolean;
+  mag: string;
+  event: string | null;
+  signalEvent: string | null;
+  isPressure: boolean;
+  pressureStub: string;
+  deltaRows: { k: string; v: string }[];
+  bindingHash: string;
+}

--- a/ui/client/src/pages/dev-orrery/vm.ts
+++ b/ui/client/src/pages/dev-orrery/vm.ts
@@ -1,0 +1,865 @@
+// Adapter: live /api/dev/orrery payloads -> the view models the design
+// prototype's components render. This is the port of the prototype's
+// DCLogic (Orrery Audit Dashboard.dc.html) with the mock engine's shapes
+// replaced by the real API contract:
+//   - what-if diffs come from the server (`stack.diff`), not a second resolve
+//   - joint beats come from `payload.joint_beats`, not reciprocalPairs()
+//   - evidence is the structured dict from the evidence layer, formatted
+//     into the compact mono string the inspector right-column shows
+//   - band ids are the live drive_band values, not the mock's short ids
+
+import type {
+  ActorGroupPayload,
+  ActorGroupVM,
+  ContextEntity,
+  EntityAuditVM,
+  EvaluatedGateNode,
+  GhostRowVM,
+  InspectorVM,
+  MagChip,
+  PressureChipVM,
+  ResolutionCardVM,
+  ResolvePayload,
+  RowStatus,
+  SelectionRef,
+  StackPayload,
+  TemplatePayload,
+  TraceEvidence,
+  TraceNode,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Bands: live drive_band value -> chart token (five bands, five tokens)
+// ---------------------------------------------------------------------------
+
+export const BAND_CHART: Record<string, number> = {
+  crisis_constraint: 1,
+  embodied_maintenance: 2,
+  anchored_routine: 3,
+  affiliation: 4,
+  project_identity: 5,
+};
+
+export const BAND_LABELS: Record<string, string> = {
+  crisis_constraint: "Crisis / Constraint",
+  embodied_maintenance: "Embodied Maintenance",
+  anchored_routine: "Anchored Routine",
+  affiliation: "Affiliation",
+  project_identity: "Project / Identity",
+};
+
+export const BAND_ORDER = [
+  "crisis_constraint",
+  "embodied_maintenance",
+  "anchored_routine",
+  "affiliation",
+  "project_identity",
+];
+
+export const NEEDS = ["sleep", "thirst", "hunger", "socialize", "intimacy"];
+
+export function bandColor(band: string): string {
+  return `hsl(var(--chart-${BAND_CHART[band] ?? 5}))`;
+}
+
+// ---------------------------------------------------------------------------
+// Evidence: structured dict -> compact mono string
+// ---------------------------------------------------------------------------
+
+const fmtNum = (v: unknown): string =>
+  typeof v === "number" ? (Number.isInteger(v) ? String(v) : v.toFixed(1)) : String(v);
+
+/** Render the evidence layer's structured payload as the short observed-value
+ * string the inspector's right column and the gate brackets show. */
+export function evidenceText(ev: TraceEvidence | null | undefined): string {
+  if (!ev) return "";
+  const o = ev.observed ?? {};
+  const matched = (ev.matched ?? []) as unknown[];
+  switch (ev.kind) {
+    case "always":
+      return "always";
+    case "never":
+      return "never";
+    case "has_need_debt_at_or_above":
+      return `${fmtNum(o.debt_score)} ${ev.result ? "≥" : "<"} ${fmtNum(
+        (ev.params as Record<string, unknown>).threshold,
+      )}`;
+    case "trust_at_least":
+    case "trust_below":
+      return `trust ${fmtNum(o.trust)}`;
+    case "relationship_is_mutual_warm":
+    case "relationship_is_asymmetric":
+      return `${fmtNum(o.forward_trust)} / ${fmtNum(o.reverse_trust)}`;
+    case "direct_contact_is_dramatic":
+      return matched.length ? String(matched.join(", ")) : "no trigger";
+    case "time_of_day_in":
+      return String(o.time_of_day ?? "");
+    case "weather_is":
+      return String(o.weather ?? "");
+    case "since_last_event_at_least": {
+      const elapsed = o.elapsed_ticks;
+      return elapsed == null ? "never fired" : `${fmtNum(elapsed)} ticks ago`;
+    }
+    case "recent_event":
+      return matched.length
+        ? `${matched.length} in window`
+        : "none in window";
+    case "in_location_class":
+    case "in_location":
+      return o.place_id == null ? "no place" : `place ${fmtNum(o.place_id)}`;
+    case "has_location_class_destination":
+      return `${fmtNum(o.destination_count)} candidates`;
+    case "count_co_located":
+      return `${fmtNum(o.count)} present`;
+    case "co_located": {
+      const places = (o.places ?? {}) as Record<string, unknown>;
+      return Object.values(places).map(fmtNum).join(" · ");
+    }
+    case "fame_at_or_above":
+    case "fame_below":
+    case "resources_at_or_above":
+    case "resources_below":
+      return `${String(o.resolved_tier)}${o.defaulted ? " (default)" : ""}`;
+    case "has_any_status_at_or_above":
+      return matched.length
+        ? String((matched[0] as Record<string, unknown>).tag)
+        : "no standing";
+    case "travel_progress_at_or_above":
+      return o.progress_ratio == null ? "not traveling" : fmtNum(o.progress_ratio);
+    case "is_in_transit":
+      return String(o.travel_status ?? "no travel state");
+    default: {
+      // Family/tag/pair predicates and anything else: matched members are
+      // the story; otherwise summarize the first observed value.
+      if (matched.length) {
+        return matched
+          .slice(0, 3)
+          .map((m) =>
+            typeof m === "object" && m !== null
+              ? String(Object.values(m as Record<string, unknown>)[0])
+              : String(m),
+          )
+          .join(", ");
+      }
+      const first = Object.entries(o)[0];
+      if (!first) return ev.result === false ? "no match" : "";
+      const [, v] = first;
+      if (Array.isArray(v)) {
+        if (!v.length) return "none";
+        const shown = v.slice(0, 3).map(fmtNum).join(", ");
+        return v.length > 3 ? `${shown} +${v.length - 3}` : shown;
+      }
+      return v == null ? "—" : fmtNum(v);
+    }
+  }
+}
+
+/** Tags a leaf's evidence references (for tag-hover highlighting). */
+export function evidenceReads(ev: TraceEvidence | null | undefined): string[] {
+  if (!ev) return [];
+  const reads = new Set<string>();
+  const p = ev.params as Record<string, unknown>;
+  for (const key of ["tag", "tags", "family_members"]) {
+    const v = p[key];
+    if (typeof v === "string") reads.add(v);
+    if (Array.isArray(v)) for (const t of v) reads.add(String(t));
+  }
+  for (const m of ev.matched ?? []) if (typeof m === "string") reads.add(m);
+  return Array.from(reads);
+}
+
+// ---------------------------------------------------------------------------
+// Gate trees
+// ---------------------------------------------------------------------------
+
+/** Live TraceNode -> the EvaluatedGateNode shape GateBrackets renders. */
+export function toGateNode(node: TraceNode): EvaluatedGateNode {
+  if (node.op) {
+    return {
+      kind: "op",
+      op: node.op,
+      pass: node.result,
+      prose: node.op,
+      evidence: "",
+      reads: [],
+      children: (node.children ?? []).map(toGateNode),
+    };
+  }
+  return {
+    kind: "leaf",
+    pass: node.result,
+    prose: node.prose,
+    evidence: evidenceText(node.evidence),
+    reads: evidenceReads(node.evidence),
+  };
+}
+
+export interface FailLeaf {
+  prose: string;
+  evidence: string;
+  negated: boolean;
+}
+
+/** First failing leaf on the gate's failure path (ghost-row reason line).
+ * Under NOT, a *passing* leaf is the blocker. */
+export function firstFailingLeaf(node: TraceNode, negated = false): FailLeaf | null {
+  if (!node.op) {
+    const failsHere = negated ? node.result : !node.result;
+    return failsHere
+      ? { prose: node.prose, evidence: evidenceText(node.evidence), negated }
+      : null;
+  }
+  const kids = node.children ?? [];
+  if (node.op === "NOT") return kids[0] ? firstFailingLeaf(kids[0], !negated) : null;
+  const gateFails = negated ? node.result : !node.result;
+  if (!gateFails) return null;
+  for (const child of kids) {
+    const hit = firstFailingLeaf(child, negated);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/** Whether any leaf of the gate reads a member of `members` (family lens). */
+export function gateReadsAny(node: TraceNode, members: string[]): boolean {
+  if (!node.op) return evidenceReads(node.evidence).some((t) => members.includes(t));
+  return (node.children ?? []).some((c) => gateReadsAny(c, members));
+}
+
+/** Whether the gate consumes the given event type (event lens). */
+export function gateConsumesEvent(node: TraceNode, eventType: string): boolean {
+  if (!node.op)
+    return (
+      (node.raw.startsWith("recent_event(") ||
+        node.raw.startsWith("since_last_event_at_least(")) &&
+      node.raw.includes(eventType)
+    );
+  return (node.children ?? []).some((c) => gateConsumesEvent(c, eventType));
+}
+
+// ---------------------------------------------------------------------------
+// Rows and cards
+// ---------------------------------------------------------------------------
+
+export function rowStatus(t: TemplatePayload): RowStatus {
+  if (t.is_winner) return "winner";
+  if (t.is_shadowed) return "shadowed";
+  return "gate_failed";
+}
+
+export function magChip(
+  mag: number,
+  color: string,
+  style: "dial" | "numeric",
+): MagChip {
+  return style === "dial"
+    ? { dial: true, deg: Math.round(mag * 360), color, text: mag.toFixed(2) }
+    : { dial: false, color, text: mag.toFixed(2) };
+}
+
+export interface CardBuildCtx {
+  selectedKey: string | null;
+  familyMembers: string[] | null;
+  eventLens: string | null;
+  magnitudeStyle: "dial" | "numeric";
+  pad: number;
+  ties: Map<string, string[]>;
+  shadowOpen: Record<string, boolean>;
+  select: (sel: SelectionRef) => void;
+  toggleShadow: (key: string) => void;
+}
+
+function buildCard(
+  group: ActorGroupPayload,
+  stack: StackPayload,
+  t: TemplatePayload,
+  kind: "solo" | "pair",
+  ctx: CardBuildCtx,
+): ResolutionCardVM {
+  const target = kind === "pair" ? (stack.bindings.target ?? null) : null;
+  const key = [kind, group.actor_entity_id, target ?? "", t.template_id].join(":");
+  const col = bandColor(t.drive_band);
+  const famHit = ctx.familyMembers
+    ? gateReadsAny(t.gate_trace, ctx.familyMembers)
+    : false;
+  const evHit = ctx.eventLens ? gateConsumesEvent(t.gate_trace, ctx.eventLens) : false;
+  const tie = ctx.ties.get(t.template_id) ?? null;
+  const diff =
+    !!stack.diff &&
+    (stack.diff.changed_template_ids.includes(t.template_id) ||
+      (t.is_winner && stack.diff.changed));
+  return {
+    key,
+    kind,
+    tplName: t.template_id,
+    priority: `pri ${t.priority}`,
+    bandColor: col,
+    dim: t.is_shadowed,
+    tie: !!tie,
+    tieTitle: tie
+      ? `priority tied with ${tie.join(", ")} — authored tuple order decided`
+      : "",
+    isPair: kind === "pair",
+    targetName: target != null ? (stack.binding_names.target ?? String(target)) : null,
+    targetEntityId: target,
+    branchLabel: t.chosen_branch ?? "",
+    event: t.event_type,
+    mag:
+      t.magnitude != null ? magChip(t.magnitude, col, ctx.magnitudeStyle) : null,
+    selected: ctx.selectedKey === key,
+    diff,
+    highlight: famHit || evHit,
+    dimByLens:
+      (!!ctx.familyMembers && !famHit) || (!!ctx.eventLens && !evHit),
+    pad: ctx.pad,
+    shadowCount: 0,
+    hasShadow: false,
+    shadowOpen: false,
+    shadowed: [],
+    onSelect: () =>
+      ctx.select({
+        key,
+        actor: group.actor_entity_id,
+        target,
+        tpl: t.template_id,
+        kind,
+      }),
+  };
+}
+
+function attachShadow(
+  card: ResolutionCardVM,
+  group: ActorGroupPayload,
+  stack: StackPayload,
+  kind: "solo" | "pair",
+  shadowKey: string,
+  ctx: CardBuildCtx,
+): void {
+  const shadowed = stack.templates.filter((t) => t.is_shadowed);
+  card.shadowCount = shadowed.length;
+  card.hasShadow = shadowed.length > 0;
+  card.shadowOpen = !!ctx.shadowOpen[shadowKey];
+  card.shadowed = shadowed.map((t) => buildCard(group, stack, t, kind, ctx));
+  card.onToggleShadow = () => ctx.toggleShadow(shadowKey);
+}
+
+// ---------------------------------------------------------------------------
+// Groups
+// ---------------------------------------------------------------------------
+
+export interface GroupBuildCtx extends CardBuildCtx {
+  showTwoPartyOnly: boolean;
+  showFailed: boolean;
+  showNA: boolean;
+  groupOpen: Record<number, boolean>;
+  toggleGroup: (id: number) => void;
+}
+
+export function buildGroups(
+  payload: ResolvePayload,
+  ctx: GroupBuildCtx,
+): ActorGroupVM[] {
+  return payload.actors.map((g) => {
+    const open = ctx.groupOpen[g.actor_entity_id] !== false;
+    const soloWinner = g.actor_stack.templates.find((t) => t.is_winner) ?? null;
+    const cards: ResolutionCardVM[] = [];
+
+    if (soloWinner && !ctx.showTwoPartyOnly) {
+      const c = buildCard(g, g.actor_stack, soloWinner, "solo", ctx);
+      attachShadow(c, g, g.actor_stack, "solo", `solo:${g.actor_entity_id}`, ctx);
+      cards.push(c);
+    }
+    for (const stack of g.two_party_stacks) {
+      const winner = stack.templates.find((t) => t.is_winner);
+      if (!winner) continue;
+      const c = buildCard(g, stack, winner, "pair", ctx);
+      attachShadow(
+        c,
+        g,
+        stack,
+        "pair",
+        `pair:${g.actor_entity_id}:${stack.bindings.target}`,
+        ctx,
+      );
+      cards.push(c);
+    }
+
+    const pressures: PressureChipVM[] = g.scene_pressure_stacks.flatMap((stack) => {
+      const winner = stack.templates.find((t) => t.is_winner);
+      if (!winner) return [];
+      const target = stack.bindings.target;
+      const key = ["pressure", g.actor_entity_id, target, winner.template_id].join(":");
+      return [
+        {
+          key,
+          label: `${winner.template_id} → ${
+            stack.binding_names.target ?? target
+          } · ${(winner.magnitude ?? 0).toFixed(2)}`,
+          title: winner.scene_pressure_prompt_rendered ?? "",
+          selected: ctx.selectedKey === key,
+          diff: !!stack.diff?.changed,
+          onSelect: () =>
+            ctx.select({
+              key,
+              actor: g.actor_entity_id,
+              target,
+              tpl: winner.template_id,
+              kind: "pressure",
+            }),
+        },
+      ];
+    });
+
+    const ghosts: GhostRowVM[] = [];
+    if (ctx.showFailed) {
+      const pushFailures = (
+        stack: StackPayload,
+        kind: "solo" | "pair",
+        target: number | null,
+        suffix: string,
+      ) => {
+        for (const t of stack.templates) {
+          if (t.fired || t.gate_passed) continue;
+          const key = [kind, g.actor_entity_id, target ?? "", t.template_id].join(":");
+          const fail = firstFailingLeaf(t.gate_trace);
+          ghosts.push({
+            key,
+            name: t.template_id + suffix,
+            glyph: "✗",
+            status: "gate_failed",
+            reason: fail
+              ? `${fail.negated ? "blocked: " : "failed: "}${fail.prose}`
+              : "gate refused",
+            evidence: fail?.evidence ?? "",
+            na: false,
+            selected: ctx.selectedKey === key,
+            onSelect: () =>
+              ctx.select({
+                key,
+                actor: g.actor_entity_id,
+                target,
+                tpl: t.template_id,
+                kind,
+              }),
+          });
+        }
+      };
+      if (!ctx.showTwoPartyOnly) pushFailures(g.actor_stack, "solo", null, "");
+      for (const stack of g.two_party_stacks) {
+        const target = stack.bindings.target;
+        pushFailures(
+          stack,
+          "pair",
+          target,
+          ` → ${stack.binding_names.target ?? target}`,
+        );
+      }
+    }
+    if (ctx.showNA) {
+      for (const marker of g.not_applicable) {
+        const key = ["na", g.actor_entity_id, "", marker.template_id].join(":");
+        ghosts.push({
+          key,
+          name: marker.template_id,
+          glyph: "⊘",
+          status: "not_applicable",
+          reason: "not applicable — no TARGET bound in this stack",
+          evidence: "slots: ACTOR, TARGET",
+          na: true,
+          selected: ctx.selectedKey === key,
+          onSelect: () =>
+            ctx.select({
+              key,
+              actor: g.actor_entity_id,
+              target: null,
+              tpl: marker.template_id,
+              kind: "na",
+            }),
+        });
+      }
+    }
+
+    const gap =
+      !g.actor_stack.templates.some((t) => t.fired) &&
+      !g.two_party_stacks.some((s) => s.templates.some((t) => t.fired));
+    const visibleCards = ctx.showTwoPartyOnly ? cards.filter((c) => c.isPair) : cards;
+    const diff =
+      cards.some((c) => c.diff) || pressures.some((p) => p.diff);
+
+    return {
+      id: g.actor_entity_id,
+      domId: `group-${g.actor_entity_id}`,
+      name: g.actor_name,
+      initials: g.actor_name
+        .split(/\s+/)
+        .map((w) => w[0])
+        .join("")
+        .slice(0, 2)
+        .toUpperCase(),
+      ringColor: gap
+        ? "hsl(var(--destructive) / 0.7)"
+        : soloWinner
+          ? bandColor(soloWinner.drive_band)
+          : "hsl(var(--border))",
+      placeName: g.location?.name ?? "—",
+      open,
+      gap,
+      diff,
+      cards: visibleCards,
+      pressures,
+      ghosts,
+      bandDots: visibleCards
+        .filter((c) => !c.dim)
+        .map((c) => ({ color: c.bandColor, title: c.tplName })),
+      activityLine:
+        (soloWinner?.state_delta?.["character.current_activity"] as string) ??
+        (gap ? "—" : ""),
+      onToggle: () => ctx.toggleGroup(g.actor_entity_id),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Inspector
+// ---------------------------------------------------------------------------
+
+export function findSelectedTemplate(
+  payload: ResolvePayload,
+  sel: SelectionRef,
+): { template: TemplatePayload | null; stack: StackPayload | null } {
+  const g = payload.actors.find((a) => a.actor_entity_id === sel.actor);
+  if (!g) return { template: null, stack: null };
+  const inStack = (stack: StackPayload) =>
+    stack.templates.find((t) => t.template_id === sel.tpl) ?? null;
+  if (sel.kind === "solo" || sel.kind === "na") {
+    const t = inStack(g.actor_stack);
+    if (t) return { template: t, stack: g.actor_stack };
+    return { template: null, stack: null };
+  }
+  const stacks =
+    sel.kind === "pair" ? g.two_party_stacks : g.scene_pressure_stacks;
+  const stack = stacks.find((s) => s.bindings.target === sel.target) ?? null;
+  return { template: stack ? inStack(stack) : null, stack };
+}
+
+export function buildInspector(
+  payload: ResolvePayload,
+  sel: SelectionRef,
+  opts: {
+    hoverTag: string | null;
+    naMarker?: { priority: number; drive_band: string } | null;
+    blurbFor: (tpl: string) => string;
+    branchesFor: (tpl: string) => { label: string; magnitude: number }[];
+    ties: Map<string, string[]>;
+  },
+): InspectorVM | null {
+  // Not-applicable rows have no evaluated stack entry; synthesize the header.
+  if (sel.kind === "na") {
+    const g = payload.actors.find((a) => a.actor_entity_id === sel.actor);
+    const marker = g?.not_applicable.find((m) => m.template_id === sel.tpl);
+    if (!marker) return null;
+    return {
+      name: marker.template_id,
+      priority: marker.priority,
+      bandColor: bandColor(marker.drive_band),
+      tie: false,
+      tieTitle: "",
+      statusLabel: "not applicable — no target bound",
+      statusTone: "na",
+      bindingLine: `ACTOR ${g?.actor_name ?? sel.actor}`,
+      blurb: opts.blurbFor(marker.template_id),
+      isNA: true,
+      gatePassed: false,
+      gateRows: [],
+      branches: [],
+      fired: false,
+      mag: "—",
+      event: null,
+      signalEvent: null,
+      isPressure: false,
+      pressureStub: "",
+      deltaRows: [],
+      bindingHash: "",
+    };
+  }
+
+  const { template: t, stack } = findSelectedTemplate(payload, sel);
+  if (!t || !stack) return null;
+  const col = bandColor(t.drive_band);
+  const status: RowStatus = rowStatus(t);
+  const statusLabel =
+    status === "winner"
+      ? "winner"
+      : status === "shadowed"
+        ? "shadowed — fired, outranked"
+        : "gate-failed — evaluated, refused";
+  const tie = opts.ties.get(t.template_id) ?? null;
+
+  const gateRows: InspectorVM["gateRows"] = [];
+  const walk = (n: TraceNode, depth: number, onFail: boolean) => {
+    if (!n.op) {
+      const reads = evidenceReads(n.evidence);
+      const failHere = onFail && !n.result;
+      gateRows.push({
+        depth,
+        isOp: false,
+        glyph: n.result ? "✓" : "✗",
+        glyphColor: n.result ? "hsl(var(--chart-5))" : "hsl(var(--destructive))",
+        prose: n.prose,
+        emphasized: failHere,
+        muted: !n.result && !failHere,
+        evidence: evidenceText(n.evidence),
+        evidenceHot: failHere,
+        highlighted: !!opts.hoverTag && reads.includes(opts.hoverTag),
+      });
+      return;
+    }
+    gateRows.push({
+      depth,
+      isOp: true,
+      glyph: n.result ? "✓" : "✗",
+      glyphColor: n.result
+        ? "hsl(var(--chart-5) / 0.7)"
+        : "hsl(var(--destructive) / 0.8)",
+      prose: n.op ?? "",
+      emphasized: !n.result && onFail,
+      muted: n.result,
+      evidence: "",
+      evidenceHot: false,
+      highlighted: false,
+    });
+    for (const k of n.children ?? []) {
+      const kidOnFail =
+        n.op === "NOT"
+          ? onFail && !n.result
+          : onFail && !n.result && (!k.result || n.op === "OR");
+      walk(k, depth + 1, kidOnFail);
+    }
+  };
+  walk(t.gate_trace, 0, !t.gate_passed);
+
+  // The explain payload traces branches only when the gate passed; for
+  // refused gates, show the authored ladder from the catalog, all
+  // unevaluated — matching the prototype's always-visible ladder.
+  const branchSource: { label: string; magnitude: number; considered: boolean; result: boolean; selected: boolean; trace: TraceNode | null }[] =
+    t.branches.length > 0
+      ? t.branches
+      : opts.branchesFor(t.template_id).map((b) => ({
+          label: b.label,
+          magnitude: b.magnitude,
+          considered: false,
+          result: false,
+          selected: false,
+          trace: null,
+        }));
+  const branches: InspectorVM["branches"] = branchSource.map((b, i) => {
+    if (b.selected)
+      return {
+        idx: `B${i + 1}`,
+        label: b.label,
+        mag: b.magnitude.toFixed(2),
+        selected: true,
+        unevaluated: false,
+        failed: false,
+        note: "selected",
+        noteGlyph: "◆",
+        magColor: col,
+      };
+    if (b.considered && !b.result) {
+      const fail = b.trace ? firstFailingLeaf(b.trace) : null;
+      return {
+        idx: `B${i + 1}`,
+        label: b.label,
+        mag: b.magnitude.toFixed(2),
+        selected: false,
+        unevaluated: false,
+        failed: true,
+        note: fail ? `${fail.prose} — ${fail.evidence}` : "condition failed",
+        noteGlyph: "✗",
+        magColor: "hsl(var(--muted-foreground))",
+      };
+    }
+    if (b.considered && b.result && !b.selected)
+      return {
+        idx: `B${i + 1}`,
+        label: b.label,
+        mag: b.magnitude.toFixed(2),
+        selected: false,
+        unevaluated: false,
+        failed: false,
+        note: "passed — not sampled this tick",
+        noteGlyph: "○",
+        magColor: "hsl(var(--muted-foreground))",
+      };
+    return {
+      idx: `B${i + 1}`,
+      label: b.label,
+      mag: b.magnitude.toFixed(2),
+      selected: false,
+      unevaluated: true,
+      failed: false,
+      note: t.gate_passed
+        ? "unevaluated — a branch above already fired"
+        : "unevaluated — gate refused",
+      noteGlyph: "·",
+      magColor: "hsl(var(--muted-foreground))",
+    };
+  });
+
+  const targetName =
+    sel.target != null ? (stack.binding_names.target ?? String(sel.target)) : null;
+  return {
+    name: t.template_id,
+    priority: t.priority,
+    bandColor: col,
+    tie: !!tie,
+    tieTitle: tie
+      ? `priority ${t.priority} tied with ${tie.join(", ")} — BUILTIN_TEMPLATES tuple order decided`
+      : "",
+    statusLabel,
+    statusTone:
+      status === "winner" ? "winner" : status === "shadowed" ? "shadowed" : "failed",
+    bindingLine: `ACTOR ${stack.binding_names.actor ?? sel.actor}${
+      targetName ? `  ·  TARGET ${targetName}` : ""
+    }${sel.kind === "pressure" ? "  ·  present-target pass" : ""}`,
+    blurb: opts.blurbFor(t.template_id),
+    isNA: false,
+    gatePassed: t.gate_passed,
+    gateRows,
+    branches,
+    fired: t.fired,
+    mag: t.magnitude != null ? t.magnitude.toFixed(2) : "—",
+    event: t.event_type,
+    signalEvent: t.signal_event_type,
+    isPressure: sel.kind === "pressure",
+    pressureStub: t.scene_pressure_prompt_rendered ?? "",
+    deltaRows: Object.entries(t.state_delta ?? {}).map(([k, v]) => ({
+      k,
+      v: Array.isArray(v) ? v.join(", ") : String(v),
+    })),
+    bindingHash: t.binding_hash,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hover audit (entity context -> EntityAuditVM)
+// ---------------------------------------------------------------------------
+
+const NEED_ORDER = ["sleep", "thirst", "hunger", "socialize", "intimacy"];
+
+export function buildEntityAudit(
+  ent: ContextEntity,
+  onScreen: boolean,
+  hover: {
+    onTagEnter: (tag: string) => void;
+    onTagLeave: () => void;
+  },
+): EntityAuditVM {
+  const needByType = new Map(ent.needs.map((n) => [n.need_type, n]));
+  const needs = NEED_ORDER.map((nd) => {
+    const row = needByType.get(nd);
+    if (!row)
+      return {
+        nd,
+        val: "immune",
+        note: "",
+        pct: "0%",
+        color: "hsl(var(--muted-foreground) / 0.4)",
+      };
+    const sev = row.severity_name;
+    const color =
+      sev === "critical" || sev === "severe"
+        ? "hsl(var(--destructive))"
+        : sev === "moderate"
+          ? "hsl(var(--chart-2))"
+          : sev === "mild"
+            ? "hsl(var(--chart-3))"
+            : "hsl(var(--muted-foreground) / 0.6)";
+    const pct = Math.min(100, Math.round(((row.severity_level ?? 0) / 4) * 100));
+    return {
+      nd,
+      val: row.debt_score.toFixed(1),
+      note: sev ?? "",
+      pct: `${sev ? Math.max(pct, 8) : Math.min(99, Math.round(row.debt_score))}%`,
+      color,
+    };
+  });
+
+  const provenanceDot = (p: string) =>
+    p === "exact" ? "●" : p === "approximate" ? "◍" : "○";
+  const provenanceTitle = (row: { source_kind: string; provenance: string }) =>
+    `${row.source_kind} · ${row.provenance}`;
+  const mkTag = (row: ContextEntity["tags"]["durable"][number]) => ({
+    name: row.tag,
+    fam: row.families.length ? "◈" : "",
+    famTitle: row.families.join(", ") || "no family",
+    dot: provenanceDot(row.provenance),
+    dotTitle: provenanceTitle(row),
+    onEnter: () => hover.onTagEnter(row.tag),
+    onLeave: () => hover.onTagLeave(),
+  });
+
+  const rels = ent.relationships.map((r) => ({
+    types: r.relationship_type,
+    other: r.other_name ?? String(r.other_entity_id),
+    trust:
+      r.valence_magnitude == null
+        ? "—"
+        : `${r.valence_magnitude >= 0 ? "+" : ""}${r.valence_magnitude}`,
+  }));
+  const events = ent.recent_events.map((ev) => ({
+    t: `t${String(ev.tick_chunk_id).padStart(4, "0")}`,
+    type: ev.event_type,
+  }));
+
+  return {
+    name: ent.name,
+    place: ent.place?.name ?? "—",
+    classes: ent.place?.classes.join(" · ") ?? "",
+    fameRes: onScreen ? "on-screen" : "off-screen",
+    needs,
+    durable: ent.tags.durable.map(mkTag),
+    ephemeral: ent.tags.ephemeral.map(mkTag),
+    hasEphemeral: ent.tags.ephemeral.length > 0,
+    rels,
+    hasRels: rels.length > 0,
+    events,
+    hasEvents: events.length > 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Rail / summary helpers
+// ---------------------------------------------------------------------------
+
+export function winnersByBand(payload: ResolvePayload): Record<string, number> {
+  const counts: Record<string, number> = Object.fromEntries(
+    BAND_ORDER.map((b) => [b, 0]),
+  );
+  for (const g of payload.actors) {
+    const bump = (stack: StackPayload) => {
+      const w = stack.templates.find((t) => t.is_winner);
+      if (w) counts[w.drive_band] = (counts[w.drive_band] ?? 0) + 1;
+    };
+    bump(g.actor_stack);
+    g.two_party_stacks.forEach(bump);
+    g.scene_pressure_stacks.forEach(bump);
+  }
+  counts.embodied_maintenance += payload.need_pressures.length;
+  return counts;
+}
+
+export function priorityTies(
+  ties: { template_ids: string[] }[],
+): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const tie of ties) {
+    for (const id of tie.template_ids) {
+      map.set(
+        id,
+        tie.template_ids.filter((other) => other !== id),
+      );
+    }
+  }
+  return map;
+}

--- a/ui/client/src/pages/dev-orrery/vm.ts
+++ b/ui/client/src/pages/dev-orrery/vm.ts
@@ -596,10 +596,19 @@ export function buildInspector(
   const tie = opts.ties.get(t.template_id) ?? null;
 
   const gateRows: InspectorVM["gateRows"] = [];
-  const walk = (n: TraceNode, depth: number, onFail: boolean) => {
+  const walk = (
+    n: TraceNode,
+    depth: number,
+    onFail: boolean,
+    negated: boolean,
+  ) => {
+    // Effective failure is polarity-aware, mirroring firstFailingLeaf: under
+    // an odd number of enclosing NOTs, a *true* node is what blocks the gate.
+    // Glyphs stay raw (the leaf's own truth); only emphasis/muting flips.
+    const effFails = negated ? n.result : !n.result;
     if (!n.op) {
       const reads = evidenceReads(n.evidence);
-      const failHere = onFail && !n.result;
+      const failHere = onFail && effFails;
       gateRows.push({
         depth,
         isOp: false,
@@ -607,7 +616,7 @@ export function buildInspector(
         glyphColor: n.result ? "hsl(var(--chart-5))" : "hsl(var(--destructive))",
         prose: n.prose,
         emphasized: failHere,
-        muted: !n.result && !failHere,
+        muted: effFails && !failHere,
         evidence: evidenceText(n.evidence),
         evidenceHot: failHere,
         highlighted: !!opts.hoverTag && reads.includes(opts.hoverTag),
@@ -622,21 +631,25 @@ export function buildInspector(
         ? "hsl(var(--chart-5) / 0.7)"
         : "hsl(var(--destructive) / 0.8)",
       prose: n.op ?? "",
-      emphasized: !n.result && onFail,
-      muted: n.result,
+      emphasized: onFail && effFails,
+      muted: !effFails,
       evidence: "",
       evidenceHot: false,
       highlighted: false,
     });
+    // Under negation AND/OR swap culprit rules (De Morgan): a blocking
+    // effective-AND implicates only its effectively-failing children; a
+    // blocking effective-OR implicates all of them.
+    const effOr = negated ? n.op === "AND" : n.op === "OR";
     for (const k of n.children ?? []) {
+      const kidNegated = n.op === "NOT" ? !negated : negated;
+      const kidEffFails = kidNegated ? k.result : !k.result;
       const kidOnFail =
-        n.op === "NOT"
-          ? onFail && !n.result
-          : onFail && !n.result && (!k.result || n.op === "OR");
-      walk(k, depth + 1, kidOnFail);
+        onFail && effFails && (n.op === "NOT" || kidEffFails || effOr);
+      walk(k, depth + 1, kidOnFail, kidNegated);
     }
   };
-  walk(t.gate_trace, 0, !t.gate_passed);
+  walk(t.gate_trace, 0, !t.gate_passed, false);
 
   // The explain payload traces branches only when the gate passed; for
   // refused gates, show the authored ladder from the catalog, all


### PR DESCRIPTION
Step 2 of the audit-dashboard plan (#415 adjacent; spec: docs/orrery_audit_dashboard_notes.md): the Claude Design five-page package, ported into a real DEV-only React page wired to the live `/api/dev/orrery/*` backend (#420–#425, #427–#429).

## What's in the page

`/dev/orrery` (lazy, `import.meta.env.DEV`-guarded, verified tree-shaken from production bundles): tick bar with slot picker + anchor stepper + world-clock, drive-band rail with live winner counts, actor stream (winner cards, shadowed stacks, pressure chips, gate-failed ghosts with first-failing-leaf evidence, not-applicable rows), inspector (full gate trace with structured evidence, tie badges, branch ladder, state-delta table), what-if sandbox drawer (need/tag/move/event overrides against real vocab), interaction graph (pressure + pair edges, joint beats), system-health strip (band mix, coverage gaps, dominance/never-win, dead gate arms, NULL-world-time data quality), and hover dossiers (needs, tags with three-tier provenance dots, unversioned relationships, recent events).

## Adapter notes (vm.ts)

The prototype's mock engine diverged from the live contract in enumerable ways; the adapter is the port's load-bearing piece:
- structured evidence dicts → compact observed-value strings (per-predicate formatting)
- NOT-aware fail-path walker for ghost reasons and inspector emphasis
- catalog-backed branch-ladder fallback (explain only traces branches when the gate passes)
- server-side what-if diffs (`stack.diff`) replace the prototype's client-side double-resolve
- live `joint_beats` replace the mock's reciprocal-pair recomputation

## Deliberate deviations from the prototype

- **No `--orr-z` zoom rig**: CSS `zoom` corrupts `getBoundingClientRect`, so every Radix/floating-ui portal (Select, Popover, Command) landed off-viewport on wide monitors. Found live; removed with a comment explaining why it must not return.
- Interaction graph uses fixed 72px vertical pitch + growing viewBox — the sine arc was tuned for ~8 actors, real slots run 19+.
- What-if drawer entity picker lists actors + bound targets only; hardcoded mock presets dropped.
- Drawer z-index sits below the shadcn portal layer (z-40 < z-50) so dropdowns paint above it.

## Backend

New `GET /api/dev/orrery/vocab` (slot-scoped tags / pair tags / event types / places) feeding the drawer's pickers — the prototype hardcoded a 30-tag list; the real vocabulary is 455 tags. Live-DB test added; route-set gate updated.

## Verification (live, save_02 head, chunk 1461, 19 actors)

- Gate-failed ghosts explain themselves: `sleep — failed: time of day is one of [night] — AFTERNOON`, `drink — 0.1 < 2`, `consult_rival — recent compliance_alert — NONE IN WINDOW`
- What-if `Pete: sleep = 24` → SLEEP fires ("Sleep in safe lodgings", mag 0.28), Embodied 0→1, diff markers + sandbox chip + NOT CANON watermark; removing the chip restores baseline
- Health strip matches the CLI coverage audit: SURVEIL 56% dominance, 18 never-win templates, `faction_realignment` dead arm, NULL-world-time counts
- Hover dossier: Victor Sato's live needs/relationships (trust ±5 Emilia)/events
- `tsc`, `vite build` (page absent from prod bundle), backend tests 22/22, mypy clean

Design sources (five `.dc.html` + the seeded mock engine) archived under `ui/.design-sync/import/orrery/` so design intent survives independently of the claude.ai project.

Ships with `[orrery.dashboard] enabled = false`, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY