### PR TITLE
Fix coverage-gap flag: scene-pressure fires count as coverage

### DIFF
--- a/ui/client/src/pages/dev-orrery/InteractionGraph.tsx
+++ b/ui/client/src/pages/dev-orrery/InteractionGraph.tsx
@@ -22,13 +22,12 @@
 
 import * as React from "react";
 import type {
-  ActorGroupPayload,
   ResolvePayload,
   SelectionRef,
   StackPayload,
   TemplatePayload,
 } from "./types";
-import { bandColor } from "./vm";
+import { actorHasFired, bandColor } from "./vm";
 
 export interface InteractionGraphProps {
   payload: ResolvePayload;
@@ -86,10 +85,6 @@ const initialsOf = (name: string): string =>
 
 const winnerOf = (stack: StackPayload): TemplatePayload | null =>
   stack.templates.find((t) => t.is_winner) ?? null;
-
-const groupHasFired = (g: ActorGroupPayload): boolean =>
-  g.actor_stack.templates.some((t) => t.fired) ||
-  g.two_party_stacks.some((s) => s.templates.some((t) => t.fired));
 
 const markerFor = (band: string): string =>
   band === "crisis_constraint"
@@ -166,7 +161,7 @@ export default function InteractionGraph(props: InteractionGraphProps) {
     const p = pos.get(g.actor_entity_id);
     if (!p) continue;
     const soloWinner = winnerOf(g.actor_stack);
-    const gap = !groupHasFired(g);
+    const gap = !actorHasFired(g);
     nodes.push({
       id: g.actor_entity_id,
       x: p.x,

--- a/ui/client/src/pages/dev-orrery/vm.ts
+++ b/ui/client/src/pages/dev-orrery/vm.ts
@@ -347,6 +347,19 @@ function attachShadow(
 // Groups
 // ---------------------------------------------------------------------------
 
+/**
+ * Whether anything fired for this actor across all three stack kinds. A
+ * pressure fire counts as coverage (prototype: `fires.length === 0 &&
+ * pressures.length === 0`) — actors whose only activity is scene pressure
+ * are not coverage gaps. Shared by the stream (gap notice, avatar ring)
+ * and InteractionGraph (dotted gap nodes) so the two can never disagree.
+ */
+export function actorHasFired(g: ActorGroupPayload): boolean {
+  return [g.actor_stack, ...g.two_party_stacks, ...g.scene_pressure_stacks].some(
+    (s) => s.templates.some((t) => t.fired),
+  );
+}
+
 export interface GroupBuildCtx extends CardBuildCtx {
   showTwoPartyOnly: boolean;
   showFailed: boolean;
@@ -479,13 +492,7 @@ export function buildGroups(
       }
     }
 
-    // A pressure fire counts as coverage (prototype: `fires.length === 0 &&
-    // pressures.length === 0`) — actors whose only activity is scene
-    // pressure are not coverage gaps.
-    const gap =
-      !g.actor_stack.templates.some((t) => t.fired) &&
-      !g.two_party_stacks.some((s) => s.templates.some((t) => t.fired)) &&
-      !g.scene_pressure_stacks.some((s) => s.templates.some((t) => t.fired));
+    const gap = !actorHasFired(g);
     const visibleCards = ctx.showTwoPartyOnly ? cards.filter((c) => c.isPair) : cards;
     const diff =
       cards.some((c) => c.diff) || pressures.some((p) => p.diff);

--- a/ui/client/src/pages/dev-orrery/vm.ts
+++ b/ui/client/src/pages/dev-orrery/vm.ts
@@ -479,9 +479,13 @@ export function buildGroups(
       }
     }
 
+    // A pressure fire counts as coverage (prototype: `fires.length === 0 &&
+    // pressures.length === 0`) — actors whose only activity is scene
+    // pressure are not coverage gaps.
     const gap =
       !g.actor_stack.templates.some((t) => t.fired) &&
-      !g.two_party_stacks.some((s) => s.templates.some((t) => t.fired));
+      !g.two_party_stacks.some((s) => s.templates.some((t) => t.fired)) &&
+      !g.scene_pressure_stacks.some((s) => s.templates.some((t) => t.fired));
     const visibleCards = ctx.showTwoPartyOnly ? cards.filter((c) => c.isPair) : cards;
     const diff =
       cards.some((c) => c.diff) || pressures.some((p) => p.diff);


### PR DESCRIPTION
## Summary
One-line logic fix in the /dev/orrery dashboard's per-actor coverage-gap flag (`vm.ts`, `buildGroups`).

The design prototype computed the gap as `fires.length === 0 && pressures.length === 0` (orrery-engine.js:1358). The TSX port checked only the solo stack and two-party stacks, dropping the scene-pressure clause — so an actor whose only activity this tick is a scene-pressure fire (e.g. `surveil`) showed the "No package fires for this actor this tick — every gate refuses" notice *directly above its own rendered fire chip*, and got the destructive-red avatar ring.

## Verification (live, slot 2 head)
Ran the real `buildGroups` over the live resolve payload via tsx: 4 of 19 actors (Victor Sato, Naomi Kurata, Asmodeus, Archivist Veil-24831f24) carry pressure-only fires and now read `gap=false`; the 15 actors with zero fires in any stack keep the notice, correctly. Assertion: gap flag agrees with `fired` across all three stack kinds for every actor. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY