### PR TITLE
Orrery Bundle 1: Grief Decomposer, Vengeance Slot Fix, Self-Evident Renames

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1173,7 +1173,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - ≥ 8 ticks since last `mourning_completed` event for actor
   - **NOT:** actor has inbound `hunting` pair tag
 
-### Branch 1 — Lay the grief down  *(mag 0.34)*
+### Branch 1 — Lay the grief down  *(mag 0.34)* · **preemptive**
 
 **When:** ≥ 4 `mourning_act` events within 30 ticks for actor
 

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -208,7 +208,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **NOT:** 2+ other entities co-located with target
   - actor has any of [`vendetta_holder`, `violent_history`]
 
-**Does:** activity → "executing retaliation"; adds `recently_violent` to actor; removes `grudge_active` from target
+**Does:** activity → "executing retaliation"; adds `recently_violent` to actor
 **Event:** `retaliation_executed`
 
 > {actor} moves on {target} in the moment the corridor clears — no warning, no negotiation, the years of waiting compressed into the time it takes to close a few meters of distance.
@@ -566,11 +566,11 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 ---
 
-## PURSUE_GHOST_LEAD — priority 60
+## UNCOVER_PAST — priority 60
 
-> The fragments of a buried identity tug at the actor.
+> Fragments of the actor's own buried past demand investigation.
 
-**Drive band:** project identity — Ghost-lead pursuit is a long-arc motive with explicit clue pressure, so it can outrank routine maintenance.
+**Drive band:** project identity — Digging into one's own buried past is a long-arc motive with explicit clue pressure, so it can outrank routine maintenance.
 **Slots:** ACTOR
 
 **Gate:**
@@ -580,7 +580,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - time of day is one of [evening, night]
   - **NOT:** actor has inbound `hunting` pair tag
 
-### Branch 1 — Recon a hideout their body remembers  *(mag 0.64)*
+### Branch 1 — Revisit a place their body remembers  *(mag 0.64)*
 
 **When:**
 
@@ -588,28 +588,28 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - actor is in `subterranean` place class
   - actor is in `transit` place class
 
-**Does:** activity → "reconning remembered terrain"
+**Does:** activity → "revisiting remembered ground"
 **Event:** `pursue_identity_lead`
 
-> {actor} picks through maintenance corridors to a place their body recognizes before memory can explain why.
+> {actor} works their way back to a place their body recognizes before memory can explain why — a doorway, a stairwell, a smell — and stands in it, waiting for the past to blink first.
 
-### Branch 2 — Probe the data fog with the Key  *(mag 0.57)*
+### Branch 2 — Search the records for their own name  *(mag 0.57)*
 
-**When:** actor has `ghostprint_active` tag
+**When:** actor has any of [`scholar`, `researcher`, `academic`, `loremaster`, `hacker`, `investigator`]
 
-**Does:** activity → "probing identity records"
+**Does:** activity → "searching records for their past"
 **Event:** `pursue_identity_lead`
 
-> {actor} brushes against a mid-tier operator, ducks into a kiosk, and lets the Key scrape fragments from the ledger noise.
+> {actor} takes their questions to the records — whatever form this world keeps them in — and hunts for the entry that proves the person they used to be existed.
 
-### Branch 3 — Query the broker network  *(mag 0.44)*
+### Branch 3 — Ask someone who trades in answers  *(mag 0.44)*
 
 **When:** *(always)*
 
-**Does:** activity → "querying the broker network"
+**Does:** activity → "buying answers about their past"
 **Event:** `pursue_identity_lead`
 
-> {actor} visits a broker who owes them a favor and leaves with one new question and one dangerous name.
+> {actor} finds someone who deals in other people's histories and leaves the exchange with one new question and one dangerous name.
 
 ---
 
@@ -922,11 +922,11 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 ---
 
-## REACH_OUT_TO_KIN — priority 40
+## REACH_OUT — priority 40
 
 > A small thread of contact between people who hold each other.
 
-**Drive band:** affiliation — Kin maintenance is allowed to beat everyday self-maintenance when the relationship has gone quiet long enough.
+**Drive band:** affiliation — Relationship maintenance is allowed to beat everyday self-maintenance when the bond has gone quiet long enough.
 **Slots:** ACTOR, TARGET
 **Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
 
@@ -938,6 +938,8 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
     - actor and target share `romantic` relationship (either direction)
     - actor and target share `chosen_kin` relationship (either direction)
     - actor and target share `comrade` relationship (either direction)
+    - actor and target share `friend` relationship (either direction)
+    - actor and target share `companion` relationship (either direction)
   - **OR:**
     - actor and target have mutual warm trust
     - directional trust actor↔target differs by 3+ or is loaded
@@ -958,7 +960,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **NOT:** direct contact actor→target is dramatic
   - ≥ 5 ticks since last `kin_visit` event for (actor, target) pair
 
-**Does:** activity → "spending real time with kin"
+**Does:** activity → "spending real time with someone held dear"
 **Event:** `kin_visit`
 
 > {actor} makes the small effort that finding-time-for-someone requires — clearing a half hour, choosing a place, showing up — and {target} arrives, and for a while they are the kind of present together that distance erodes.
@@ -975,7 +977,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - actor and target have mutual warm trust
   - **NOT:** direct contact actor→target is dramatic
 
-**Does:** activity → "keeping kin contact warm"
+**Does:** activity → "keeping a close bond warm"
 **Event:** `contact_made`
 
 > {actor} sends {target} the small message that means more than the words it contains — a check-in, a shared joke, a question that doesn't really need answering — and the thread between them stays warm for another while.
@@ -992,7 +994,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - directional trust actor↔target differs by 3+ or is loaded
   - direct contact actor→target is dramatic
 
-**Does:** activity → "drafting unsent kin contact"
+**Does:** activity → "drafting unsent contact"
 **Event:** `contact_deferred`
 
 > {actor} writes the message anyway, or composes the call in their head, and then does not send it. The wanting is real; so is the cost of turning it into contact.
@@ -1005,7 +1007,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 **When:** *(always)*
 
-**Does:** activity → "deferring kin contact"
+**Does:** activity → "deferring contact"
 **Event:** `contact_deferred`
 
 > {actor} lets the thread remain unpulled. Whatever exists between them and {target}, it is not made warmer by forcing the wrong kind of contact today.
@@ -1029,6 +1031,8 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 - **AND:**
   - **OR:**
     - actor has `rival` relationship to target
+    - actor and target share `enemy` relationship (either direction)
+    - actor has `complex` relationship to target
     - trust actor→target < 0
   - **OR:**
     - recent `compliance_alert` event in last 10 ticks
@@ -1166,9 +1170,19 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 - **AND:**
   - actor has `grieving` ephemeral
   - ≥ 3 ticks since last `mourning_act` event for actor
+  - ≥ 8 ticks since last `mourning_completed` event for actor
   - **NOT:** actor has inbound `hunting` pair tag
 
-### Branch 1 — Visit the place of remembrance  *(mag 0.42)*
+### Branch 1 — Lay the grief down  *(mag 0.34)*
+
+**When:** ≥ 4 `mourning_act` events within 30 ticks for actor
+
+**Does:** activity → "laying a long grief down"
+**Event:** `mourning_completed`
+
+> {actor} reaches for the grief out of habit and finds it has changed shape — still there, but carried now rather than carrying them. Whatever small act marks an ending in this world, {actor} performs it, and lets the day be an ordinary day.
+
+### Branch 2 — Visit the place of remembrance  *(mag 0.42)*
 
 **When:**
 
@@ -1181,7 +1195,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} returns to the place where the dead are kept — stone, name, photograph, marker, whatever this world has made for the purpose — and stands long enough to be still and remember, before going back to the work of being alive.
 
-### Branch 2 — Sit with others who carry the same loss  *(mag 0.38)*
+### Branch 3 — Sit with others who carry the same loss  *(mag 0.38)*
 
 **When:** 1+ other entities with `grieving` ephemeral co-located with actor
 
@@ -1190,7 +1204,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} finds the others who knew the dead and sits with them — wordlessly, mostly. The presence of someone else who is also not over it makes the grief feel less like evidence of personal failure.
 
-### Branch 3 — Pour the loss into the day's work  *(mag 0.28)*
+### Branch 4 — Pour the loss into the day's work  *(mag 0.28)*
 
 **When:** actor has any of [`musician`, `writer`, `artisan`, `scholar`, `arcane_caster`, `soldier`, `keeps_shop`, `domestic_role`]
 
@@ -1199,7 +1213,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} returns to their work — the thing the loss hasn't taken — and does it with the dead person sitting somewhere just behind them, watching the work with the particular silence the dead have.
 
-### Branch 4 — Carry the weight in private  *(mag 0.14)*
+### Branch 5 — Carry the weight in private  *(mag 0.14)*
 
 **When:** *(always)*
 
@@ -2154,6 +2168,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/057_orrery_need_bodyform_applicability.py`
 - `migrations/059_orrery_social_travel_event.py`
 - `migrations/063_orrery_adjudication_history.sql`
+- `migrations/067_rename_orrery_templates.sql`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 
@@ -2181,6 +2196,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `hunter`
 - `informant_handler`
 - `innkeeper`
+- `investigator`
 - `keeps_shop`
 - `loremaster`
 - `magical_healing`
@@ -2304,6 +2320,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `kin_visit`
 - `maintain_cover`
 - `mourning_act`
+- `mourning_completed`
 - `protective_intervention`
 - `pursue_identity_lead`
 - `retaliation_attempted`
@@ -2356,9 +2373,12 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `asset`
 - `captor`
 - `chosen_kin`
+- `companion`
+- `complex`
 - `comrade`
 - `enemy`
 - `family`
+- `friend`
 - `guardian`
 - `handler`
 - `mentor`

--- a/migrations/067_rename_orrery_templates.sql
+++ b/migrations/067_rename_orrery_templates.sql
@@ -1,0 +1,39 @@
+-- 067_rename_orrery_templates.sql
+--
+-- Rename two orrery template ids so package names are self-evident:
+--
+--   reach_out_to_kin  -> reach_out     (gate widened beyond kin to friend/
+--                                       companion ties; the old name would
+--                                       misdescribe what fires)
+--   pursue_ghost_lead -> uncover_past  (genre-neutral rewrite of the
+--                                       buried-identity project arc)
+--
+-- template_id is denormalized onto six base tables (entity_tags_current is
+-- a view over entity_tags and needs no update). Historical rows are
+-- rewritten so provenance joins against the current catalog stay whole.
+
+UPDATE entity_tags SET template_id = 'reach_out'
+    WHERE template_id = 'reach_out_to_kin';
+UPDATE entity_pair_tags SET template_id = 'reach_out'
+    WHERE template_id = 'reach_out_to_kin';
+UPDATE orrery_resolutions SET template_id = 'reach_out'
+    WHERE template_id = 'reach_out_to_kin';
+UPDATE orrery_adjudication_log SET template_id = 'reach_out'
+    WHERE template_id = 'reach_out_to_kin';
+UPDATE orrery_scene_pressures SET template_id = 'reach_out'
+    WHERE template_id = 'reach_out_to_kin';
+UPDATE orrery_prompt_exposures SET template_id = 'reach_out'
+    WHERE template_id = 'reach_out_to_kin';
+
+UPDATE entity_tags SET template_id = 'uncover_past'
+    WHERE template_id = 'pursue_ghost_lead';
+UPDATE entity_pair_tags SET template_id = 'uncover_past'
+    WHERE template_id = 'pursue_ghost_lead';
+UPDATE orrery_resolutions SET template_id = 'uncover_past'
+    WHERE template_id = 'pursue_ghost_lead';
+UPDATE orrery_adjudication_log SET template_id = 'uncover_past'
+    WHERE template_id = 'pursue_ghost_lead';
+UPDATE orrery_scene_pressures SET template_id = 'uncover_past'
+    WHERE template_id = 'pursue_ghost_lead';
+UPDATE orrery_prompt_exposures SET template_id = 'uncover_past'
+    WHERE template_id = 'pursue_ghost_lead';

--- a/migrations/067_rename_orrery_templates.sql
+++ b/migrations/067_rename_orrery_templates.sql
@@ -11,6 +11,11 @@
 -- template_id is denormalized onto six base tables (entity_tags_current is
 -- a view over entity_tags and needs no update). Historical rows are
 -- rewritten so provenance joins against the current catalog stay whole.
+--
+-- proposal_id ('<template_id>:<binding_hash>') is likewise rewritten on
+-- orrery_adjudication_log and orrery_prompt_exposures: adjudication
+-- history reconstructs committed resolution ids from the CURRENT template
+-- id, so a stale prefix would orphan old timelines from renamed packages.
 
 UPDATE entity_tags SET template_id = 'reach_out'
     WHERE template_id = 'reach_out_to_kin';
@@ -37,3 +42,16 @@ UPDATE orrery_scene_pressures SET template_id = 'uncover_past'
     WHERE template_id = 'pursue_ghost_lead';
 UPDATE orrery_prompt_exposures SET template_id = 'uncover_past'
     WHERE template_id = 'pursue_ghost_lead';
+
+UPDATE orrery_adjudication_log
+    SET proposal_id = regexp_replace(proposal_id, '^reach_out_to_kin:', 'reach_out:')
+    WHERE proposal_id LIKE 'reach_out_to_kin:%';
+UPDATE orrery_prompt_exposures
+    SET proposal_id = regexp_replace(proposal_id, '^reach_out_to_kin:', 'reach_out:')
+    WHERE proposal_id LIKE 'reach_out_to_kin:%';
+UPDATE orrery_adjudication_log
+    SET proposal_id = regexp_replace(proposal_id, '^pursue_ghost_lead:', 'uncover_past:')
+    WHERE proposal_id LIKE 'pursue_ghost_lead:%';
+UPDATE orrery_prompt_exposures
+    SET proposal_id = regexp_replace(proposal_id, '^pursue_ghost_lead:', 'uncover_past:')
+    WHERE proposal_id LIKE 'pursue_ghost_lead:%';

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -571,7 +571,11 @@ def _render_narrative_stub(stub: str) -> List[str]:
 
 
 def _render_branch(idx: int, branch: Branch) -> List[str]:
-    lines = [f"### Branch {idx} — {branch.label}  *(mag {branch.magnitude})*", ""]
+    marker = " · **preemptive**" if branch.preemptive else ""
+    lines = [
+        f"### Branch {idx} — {branch.label}  *(mag {branch.magnitude})*{marker}",
+        "",
+    ]
     if isinstance(branch.conditions, CompoundCondition):
         lines.extend(["**When:**", ""])
         lines.extend(_render_condition_lines(branch.conditions))

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -411,6 +411,27 @@ _register(
 )
 
 
+def _render_count_recent_events(m: re.Match) -> str:
+    event = m.group("event")
+    count = m.group("count")
+    n = m.group("n")
+    actor = m.group("actor")
+    target = m.group("target")
+    if target:
+        scope = f"({_slot(actor)}, {_slot(target)}) pair"
+    else:
+        scope = _slot(actor)
+    return f"≥ {count} `{event}` events within {n} ticks for {scope}"
+
+
+_register(
+    r"count_recent_events_at_least\("
+    r"(?P<event>[^,()]+),>=(?P<count>\d+),<=(?P<n>\d+)@(?P<actor>\w+)"
+    r"(?:,target=(?P<target>\w+))?\)",
+    _render_count_recent_events,
+)
+
+
 def _render_predicate_name(name: str) -> str:
     """Convert a substrate ``__name__`` into prose-friendly text."""
 

--- a/nexus/agents/orrery/evidence.py
+++ b/nexus/agents/orrery/evidence.py
@@ -1473,6 +1473,54 @@ def _since_last_event_at_least(
     )
 
 
+@_resolver("count_recent_events_at_least")
+def _count_recent_events_at_least(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict:
+    event_type = match["event"]
+    min_count = int(match["count"])
+    within_ticks = int(match["n"])
+    actor_slot = match["actor"]
+    target_slot = match["target"]
+    actor_id = _entity(bindings, actor_slot)
+    target_id = _entity(bindings, target_slot) if target_slot else None
+    slot_unbound = actor_id is None or (target_slot is not None and target_id is None)
+    cutoff = state.current_tick - within_ticks
+    matched: list[dict[str, Any]] = []
+    if not slot_unbound:
+        for event in state.recent_events:
+            if event.tick < cutoff:
+                continue
+            if event.event_type != event_type:
+                continue
+            if event.actor_entity_id != actor_id:
+                continue
+            if target_id is not None and event.target_entity_id != target_id:
+                continue
+            matched.append(_event_payload(event))
+    entities: dict[str, Optional[int]] = {actor_slot: actor_id}
+    if target_slot:
+        entities[target_slot] = target_id
+    return _evidence(
+        "count_recent_events_at_least",
+        params={
+            "event_type": event_type,
+            "min_count": min_count,
+            "within_ticks": within_ticks,
+            "actor_slot": actor_slot,
+            "target_slot": target_slot,
+        },
+        entities=entities,
+        observed={
+            "current_tick": state.current_tick,
+            "cutoff_tick": cutoff,
+            "matched_count": len(matched),
+        },
+        matched=matched,
+        result=False if slot_unbound else len(matched) >= min_count,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -1721,6 +1721,12 @@ class Branch:
     # event_type. Signals feed other packages' gates without disturbing the
     # emitting package's cooldowns.
     signal_event_type: Optional[str] = None
+    # Lifecycle-terminal branches (a state transition like grief completing)
+    # must fire the tick they become eligible in EVERY selection mode;
+    # stochastic sampling is for flavor variety among peer branches, not
+    # state machines. Preemptive branches are checked first, in authored
+    # order, before any mode-specific selection runs.
+    preemptive: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -1867,33 +1873,49 @@ def select_branch(
     each other and raise on divergence, so a second selection implementation
     is a correctness bug by construction.
 
-    ``authored_order`` (and a missing ``selection``) preserves the legacy
-    short-circuit exactly; ``stochastic`` evaluates all branches (the traces
-    become exhaustive) and softmax-samples the passing set by magnitude.
-    At ``temperature == 0`` stochastic degenerates to argmax by magnitude
-    (authored order breaking ties).
+    Preemptive branches are checked first in authored order under every
+    mode — a passing lifecycle-terminal branch wins outright and the
+    remaining branches are not evaluated. Otherwise ``authored_order``
+    (and a missing ``selection``) preserves the legacy short-circuit
+    exactly; ``stochastic`` evaluates all non-preemptive branches (those
+    traces become exhaustive) and softmax-samples the passing set by
+    magnitude. At ``temperature == 0`` stochastic degenerates to argmax
+    by magnitude (authored order breaking ties).
     """
 
-    if selection is None or selection.mode == "authored_order":
-        considered = []
-        for branch in template.branches:
-            considered.append(True)
-            if branch.conditions(state, bindings):
-                considered.extend(False for _ in template.branches[len(considered) :])
-                return branch, tuple(considered)
-        return None, tuple(considered)
+    considered_flags = [False] * len(template.branches)
 
-    passing = [
-        branch for branch in template.branches if branch.conditions(state, bindings)
-    ]
-    considered_all = tuple(True for _ in template.branches)
+    for index, branch in enumerate(template.branches):
+        if not branch.preemptive:
+            continue
+        considered_flags[index] = True
+        if branch.conditions(state, bindings):
+            return branch, tuple(considered_flags)
+
+    if selection is None or selection.mode == "authored_order":
+        for index, branch in enumerate(template.branches):
+            if branch.preemptive:
+                continue
+            considered_flags[index] = True
+            if branch.conditions(state, bindings):
+                return branch, tuple(considered_flags)
+        return None, tuple(considered_flags)
+
+    passing = []
+    for index, branch in enumerate(template.branches):
+        if branch.preemptive:
+            continue
+        considered_flags[index] = True
+        if branch.conditions(state, bindings):
+            passing.append(branch)
+    considered = tuple(considered_flags)
     if not passing:
-        return None, considered_all
+        return None, considered
     if len(passing) == 1:
-        return passing[0], considered_all
+        return passing[0], considered
 
     if selection.temperature == 0:
-        return max(passing, key=lambda branch: branch.magnitude), considered_all
+        return max(passing, key=lambda branch: branch.magnitude), considered
 
     # Softmax over magnitude, shifted for numerical stability.
     peak = max(branch.magnitude for branch in passing)
@@ -1902,7 +1924,7 @@ def select_branch(
         for branch in passing
     ]
     rng = _selection_rng(digest, state.current_tick, template.id, selection.seed_salt)
-    return rng.choices(passing, weights=weights, k=1)[0], considered_all
+    return rng.choices(passing, weights=weights, k=1)[0], considered
 
 
 def evaluate(

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -1590,6 +1590,55 @@ def since_last_event_at_least(
     )
 
 
+def count_recent_events_at_least(
+    event_type: str,
+    *,
+    within_ticks: int,
+    min_count: int,
+    actor_slot: Slot = Slot.ACTOR,
+    target_slot: Optional[Slot] = None,
+) -> Condition:
+    """Return whether at least ``min_count`` matching events landed in the window.
+
+    Counting is bounded by the recent-event hydration window
+    (``[orrery.binding] window_chunks``), so ``within_ticks`` larger than
+    that window only ever sees hydrated history. Use for
+    accumulate-then-act thresholds (grief completing after enough
+    mourning acts, acting on piled-up surveillance) rather than simple
+    cooldowns, which belong to :func:`since_last_event_at_least`.
+    """
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        actor_id = _slot_entity(bindings, actor_slot)
+        if actor_id is None:
+            return False
+        target_id = _slot_entity(bindings, target_slot) if target_slot else None
+        if target_slot is not None and target_id is None:
+            return False
+        cutoff = state.current_tick - within_ticks
+        count = 0
+        for event in state.recent_events:
+            if event.tick < cutoff:
+                continue
+            if event.event_type != event_type:
+                continue
+            if event.actor_entity_id != actor_id:
+                continue
+            if target_id is not None and event.target_entity_id != target_id:
+                continue
+            count += 1
+            if count >= min_count:
+                return True
+        return False
+
+    suffix = f",target={target_slot.value}" if target_slot else ""
+    return _named(
+        _condition,
+        f"count_recent_events_at_least({event_type},>={min_count},<={within_ticks}"
+        f"@{actor_slot.value}{suffix})",
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class CompoundCondition:
     """Self-describing AND / OR / NOT composition.

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -1404,13 +1404,14 @@ MOURN_LOSS = Template(
         NOT(has_inbound_pair_tag("hunting")),
     ),
     branches=(
-        # Terminal branch first (authored-order selection short-circuits):
-        # enough mourning acts inside the hydration window means the grief
-        # has been worked, and the completion event lets the tag-clearance
-        # machinery digest `grieving` (clear_on -> mourning_completed).
-        # Without this branch nothing ever emits mourning_completed and
-        # grief is an absorbing state that suppresses the actor's entire
-        # routine/social band indefinitely.
+        # Lifecycle terminal: enough mourning acts inside the hydration
+        # window means the grief has been worked, and the completion event
+        # lets the tag-clearance machinery digest `grieving`
+        # (clear_on -> mourning_completed). Without this branch nothing
+        # ever emits mourning_completed and grief is an absorbing state
+        # that suppresses the actor's entire routine/social band
+        # indefinitely. Preemptive so stochastic branch sampling cannot
+        # keep re-selecting a flavor branch past the threshold.
         Branch(
             label="Lay the grief down",
             conditions=count_recent_events_at_least(
@@ -1429,6 +1430,7 @@ MOURN_LOSS = Template(
             event_type="mourning_completed",
             changed_fields=("character.current_activity",),
             magnitude=0.34,
+            preemptive=True,
         ),
         Branch(
             label="Visit the place of remembrance",

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -1260,10 +1260,11 @@ CULTIVATE_INFORMANT = Template(
 #
 #   * `grieving` / `dying` / `unconscious` ephemerals are seeded with
 #     event-based clearance pointing at `mourning_completed` / `death_recorded`
-#     / `regained_consciousness`. These events are authored externally
-#     (CommitOrreryTick or future world-state systems); MOURN_LOSS and
-#     KEEP_VIGIL never emit them. The framework will need to honor the
-#     clearance predicates when those events eventually fire.
+#     / `regained_consciousness`. MOURN_LOSS emits `mourning_completed`
+#     itself via its preemptive "Lay the grief down" branch — grief is a
+#     resolver-owned lifecycle. `death_recorded` and `regained_consciousness`
+#     remain externally authored (CommitOrreryTick or future world-state
+#     systems); KEEP_VIGIL never emits them.
 # ----------------------------------------------------------------------------
 
 

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -35,6 +35,7 @@ from nexus.agents.orrery.substrate import (
     has_symmetric_relationship_of_type,
     has_tag,
     has_travel_destination,
+    count_recent_events_at_least,
     has_routine_anchor,
     in_location_class,
     is_constrained,
@@ -458,15 +459,15 @@ HONOR_DEBT = Template(
 )
 
 
-PURSUE_GHOST_LEAD = Template(
-    id="pursue_ghost_lead",
+UNCOVER_PAST = Template(
+    id="uncover_past",
     priority=60,
     drive_band=DriveBand.PROJECT_IDENTITY,
     priority_override_rationale=(
-        "Ghost-lead pursuit is a long-arc motive with explicit clue pressure, "
-        "so it can outrank routine maintenance."
+        "Digging into one's own buried past is a long-arc motive with "
+        "explicit clue pressure, so it can outrank routine maintenance."
     ),
-    blurb="The fragments of a buried identity tug at the actor.",
+    blurb="Fragments of the actor's own buried past demand investigation.",
     required_slots=(Slot.ACTOR,),
     package_gate=AND(
         has_tag("seeking_identity"),
@@ -475,37 +476,52 @@ PURSUE_GHOST_LEAD = Template(
     ),
     branches=(
         Branch(
-            label="Recon a hideout their body remembers",
+            label="Revisit a place their body remembers",
             conditions=ROOTS_TRANSIT_PLACE,
             narrative_stub=(
-                "{actor} picks through maintenance corridors to a place their "
-                "body recognizes before memory can explain why."
+                "{actor} works their way back to a place their body "
+                "recognizes before memory can explain why — a doorway, a "
+                "stairwell, a smell — and stands in it, waiting for the "
+                "past to blink first."
             ),
-            state_delta={"character.current_activity": "reconning remembered terrain"},
+            state_delta={"character.current_activity": "revisiting remembered ground"},
             event_type="pursue_identity_lead",
             changed_fields=("character.current_activity",),
             magnitude=0.64,
         ),
         Branch(
-            label="Probe the data fog with the Key",
-            conditions=has_tag("ghostprint_active"),
-            narrative_stub=(
-                "{actor} brushes against a mid-tier operator, ducks into a "
-                "kiosk, and lets the Key scrape fragments from the ledger noise."
+            label="Search the records for their own name",
+            conditions=has_any_tag(
+                "scholar",
+                "researcher",
+                "academic",
+                "loremaster",
+                "hacker",
+                "investigator",
             ),
-            state_delta={"character.current_activity": "probing identity records"},
+            narrative_stub=(
+                "{actor} takes their questions to the records — whatever "
+                "form this world keeps them in — and hunts for the entry "
+                "that proves the person they used to be existed."
+            ),
+            state_delta={
+                "character.current_activity": "searching records for their past"
+            },
             event_type="pursue_identity_lead",
             changed_fields=("character.current_activity",),
             magnitude=0.57,
         ),
         Branch(
-            label="Query the broker network",
+            label="Ask someone who trades in answers",
             conditions=ALWAYS,
             narrative_stub=(
-                "{actor} visits a broker who owes them a favor and leaves with "
-                "one new question and one dangerous name."
+                "{actor} finds someone who deals in other people's "
+                "histories and leaves the exchange with one new question "
+                "and one dangerous name."
             ),
-            state_delta={"character.current_activity": "querying the broker network"},
+            state_delta={
+                "character.current_activity": "buying answers about their past"
+            },
             event_type="pursue_identity_lead",
             changed_fields=("character.current_activity",),
             magnitude=0.44,
@@ -712,10 +728,11 @@ EXTRACT_VENGEANCE = Template(
                 "no warning, no negotiation, the years of waiting compressed "
                 "into the time it takes to close a few meters of distance."
             ),
+            # The ACTOR's grudge_active (the tag this gate reads) is
+            # digested by tag clearance: clear_on -> retaliation_executed.
             state_delta={
                 "character.current_activity": "executing retaliation",
                 "entity_tags.add": ["recently_violent"],
-                "entity_tags_target.remove": ["grudge_active"],
             },
             event_type="retaliation_executed",
             signal_event_type="threat_issued",
@@ -1377,12 +1394,42 @@ MOURN_LOSS = Template(
     ),
     blurb="A loss settles into the body across many quiet days.",
     required_slots=(Slot.ACTOR,),
+    # The mourning_completed cooldown paces back-to-back griefs: completion
+    # clears `grieving`, so a fresh loss landing immediately afterward
+    # should not be laid down again within the same handful of ticks.
     package_gate=AND(
         has_ephemeral("grieving"),
         since_last_event_at_least("mourning_act", minimum_ticks=3),
+        since_last_event_at_least("mourning_completed", minimum_ticks=8),
         NOT(has_inbound_pair_tag("hunting")),
     ),
     branches=(
+        # Terminal branch first (authored-order selection short-circuits):
+        # enough mourning acts inside the hydration window means the grief
+        # has been worked, and the completion event lets the tag-clearance
+        # machinery digest `grieving` (clear_on -> mourning_completed).
+        # Without this branch nothing ever emits mourning_completed and
+        # grief is an absorbing state that suppresses the actor's entire
+        # routine/social band indefinitely.
+        Branch(
+            label="Lay the grief down",
+            conditions=count_recent_events_at_least(
+                "mourning_act", within_ticks=30, min_count=4
+            ),
+            narrative_stub=(
+                "{actor} reaches for the grief out of habit and finds it "
+                "has changed shape — still there, but carried now rather "
+                "than carrying them. Whatever small act marks an ending in "
+                "this world, {actor} performs it, and lets the day be an "
+                "ordinary day."
+            ),
+            state_delta={
+                "character.current_activity": "laying a long grief down",
+            },
+            event_type="mourning_completed",
+            changed_fields=("character.current_activity",),
+            magnitude=0.34,
+        ),
         Branch(
             label="Visit the place of remembrance",
             conditions=REMEMBRANCE_PLACE,
@@ -2500,25 +2547,31 @@ CHECK_ON_DEPENDENT = Template(
 )
 
 
-REACH_OUT_TO_KIN = Template(
-    id="reach_out_to_kin",
+REACH_OUT = Template(
+    id="reach_out",
     priority=40,
     drive_band=DriveBand.AFFILIATION,
     priority_override_rationale=(
-        "Kin maintenance is allowed to beat everyday self-maintenance when "
-        "the relationship has gone quiet long enough."
+        "Relationship maintenance is allowed to beat everyday "
+        "self-maintenance when the bond has gone quiet long enough."
     ),
     blurb="A small thread of contact between people who hold each other.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
     # Cooldown: gate must check BOTH events any branch can emit
     # (kin_visit from the face-to-face branch, contact_made from the
     # remote branch). See CHECK_ON_DEPENDENT for the same pattern.
+    #
+    # The bond OR spans kin AND chosen social ties (friend, companion);
+    # the warmth/asymmetry OR below is what keeps casual edges from
+    # firing hollow contact beats.
     package_gate=AND(
         OR(
             has_symmetric_relationship_of_type("family"),
             has_symmetric_relationship_of_type("romantic"),
             has_symmetric_relationship_of_type("chosen_kin"),
             has_symmetric_relationship_of_type("comrade"),
+            has_symmetric_relationship_of_type("friend"),
+            has_symmetric_relationship_of_type("companion"),
         ),
         OR(
             relationship_is_mutual_warm(),
@@ -2555,7 +2608,9 @@ REACH_OUT_TO_KIN = Template(
                 "are the kind of present together that distance erodes."
             ),
             state_delta={
-                "character.current_activity": "spending real time with kin",
+                "character.current_activity": (
+                    "spending real time with someone held dear"
+                ),
             },
             event_type="kin_visit",
             changed_fields=("character.current_activity",),
@@ -2580,7 +2635,7 @@ REACH_OUT_TO_KIN = Template(
                 "and the thread between them stays warm for another while."
             ),
             state_delta={
-                "character.current_activity": "keeping kin contact warm",
+                "character.current_activity": "keeping a close bond warm",
             },
             event_type="contact_made",
             changed_fields=("character.current_activity",),
@@ -2600,7 +2655,7 @@ REACH_OUT_TO_KIN = Template(
                 "so is the cost of turning it into contact."
             ),
             state_delta={
-                "character.current_activity": "drafting unsent kin contact",
+                "character.current_activity": "drafting unsent contact",
             },
             event_type="contact_deferred",
             changed_fields=("character.current_activity",),
@@ -2620,7 +2675,7 @@ REACH_OUT_TO_KIN = Template(
                 "the wrong kind of contact today."
             ),
             state_delta={
-                "character.current_activity": "deferring kin contact",
+                "character.current_activity": "deferring contact",
             },
             event_type="contact_deferred",
             changed_fields=("character.current_activity",),
@@ -2654,9 +2709,14 @@ CONSULT_RIVAL = Template(
     # (rival_consulted from the meaningful branches, contact_made from the
     # ALWAYS fallback). Without the rival_consulted cooldown the high-
     # magnitude branches could refire next tick — caught by Codex on PR #223.
+    # The fraught-tie OR deliberately spans rivalry, open enmity, and
+    # `complex` history — the blurb's contract is "people who do not
+    # trust each other," not the narrow rival label.
     package_gate=AND(
         OR(
             has_relationship_of_type("rival"),
+            has_symmetric_relationship_of_type("enemy"),
+            has_relationship_of_type("complex"),
             trust_below(0),
         ),
         OR(
@@ -3600,11 +3660,11 @@ BUILTIN_TEMPLATES = (
     HONOR_DEBT,
     WARN_ALLY,
     SURVEIL,
-    PURSUE_GHOST_LEAD,
+    UNCOVER_PAST,
     CHECK_ON_DEPENDENT,
     CULTIVATE_INFORMANT,
     KEEP_VIGIL,
-    REACH_OUT_TO_KIN,
+    REACH_OUT,
     CONSULT_RIVAL,
     MOURN_LOSS,
     ROUTINE_COMMUTE,

--- a/tests/test_orrery/test_branch_selection.py
+++ b/tests/test_orrery/test_branch_selection.py
@@ -172,6 +172,57 @@ def test_explain_stack_parity_on_presets_under_stochastic_policy() -> None:
         assert winner.chosen_branch == truth.branch_label
 
 
+def test_preemptive_branch_wins_under_every_selection_mode() -> None:
+    """Lifecycle-terminal branches bypass sampling the tick they turn eligible.
+
+    MOURN_LOSS's completion branch is the motivating case: under stochastic
+    selection a flavor branch must not be sampled past the threshold, or the
+    grieving tag's clearance event may never be emitted.
+    """
+
+    lifecycle = Template(
+        id="mourn_loss",  # real id so catalog/prose lookups stay valid
+        priority=10,
+        drive_band=DriveBand.AFFILIATION,
+        blurb="Synthetic lifecycle surface for preemption tests.",
+        required_slots=(Slot.ACTOR,),
+        package_gate=ALWAYS,
+        branches=(
+            Branch(
+                label="flavor",
+                conditions=ALWAYS,
+                narrative_stub="{actor} mourns.",
+                magnitude=0.9,
+            ),
+            Branch(
+                label="complete",
+                conditions=ALWAYS,
+                narrative_stub="{actor} lays the grief down.",
+                magnitude=0.2,
+                preemptive=True,
+            ),
+        ),
+    )
+
+    for tick in range(40):
+        branch, considered = select_branch(
+            lifecycle,
+            _state(tick),
+            BINDINGS,
+            digest="digest",
+            selection=STOCHASTIC,
+        )
+        assert branch is not None and branch.label == "complete"
+        # The preemptive win short-circuits: the flavor branch is never
+        # evaluated, and considered flags must say so.
+        assert considered == (False, True)
+
+    authored, _ = select_branch(
+        lifecycle, _state(1), BINDINGS, digest="digest", selection=None
+    )
+    assert authored is not None and authored.label == "complete"
+
+
 def test_select_branch_reports_considered_flags() -> None:
     state = _state(7)
     _, legacy_flags = select_branch(VARIED, state, BINDINGS, digest="d", selection=None)

--- a/tests/test_orrery/test_evidence.py
+++ b/tests/test_orrery/test_evidence.py
@@ -42,6 +42,7 @@ from nexus.agents.orrery.substrate import (
     can_move_publicly,
     co_located,
     count_co_located,
+    count_recent_events_at_least,
     direct_contact_is_dramatic,
     faction_member,
     fame_at_or_above,
@@ -213,6 +214,13 @@ FACTORY_SWEEP = [
     recent_event(within_ticks=3),
     since_last_event_at_least("contact_made", 3),
     since_last_event_at_least("contact_made", 3, target_slot=Slot.TARGET),
+    count_recent_events_at_least("mourning_act", within_ticks=30, min_count=4),
+    count_recent_events_at_least(
+        "surveillance_performed",
+        within_ticks=12,
+        min_count=3,
+        target_slot=Slot.TARGET,
+    ),
 ]
 
 

--- a/tests/test_orrery/test_reciprocal.py
+++ b/tests/test_orrery/test_reciprocal.py
@@ -43,8 +43,8 @@ NAMES = {1: "Alex", 2: "Emilia", 3: "Pete"}
 def test_reciprocal_pair_composes_one_beat() -> None:
     beats = detect_joint_beats(
         [
-            _draft("reach_out_to_kin", 1, 2, magnitude=0.3),
-            _draft("reach_out_to_kin", 2, 1, magnitude=0.5),
+            _draft("reach_out", 1, 2, magnitude=0.3),
+            _draft("reach_out", 2, 1, magnitude=0.5),
             _draft("sleep", 3, None),
         ],
         NAMES,
@@ -55,7 +55,7 @@ def test_reciprocal_pair_composes_one_beat() -> None:
     assert (beat.entity_a, beat.entity_b) == (1, 2)
     assert beat.magnitude == 0.5
     assert beat.entity_names == {"1": "Alex", "2": "Emilia"}
-    assert beat.forward_proposal_id.startswith("reach_out_to_kin:")
+    assert beat.forward_proposal_id.startswith("reach_out:")
     assert beat.forward_proposal_id != beat.reverse_proposal_id
 
 
@@ -108,13 +108,13 @@ def test_proposal_serialization_round_trips_joint_beats() -> None:
         anchor_chunk_id=100,
         actor_count=2,
         resolutions=(
-            _draft("reach_out_to_kin", 1, 2),
-            _draft("reach_out_to_kin", 2, 1),
+            _draft("reach_out", 1, 2),
+            _draft("reach_out", 2, 1),
         ),
         joint_beats=detect_joint_beats(
             [
-                _draft("reach_out_to_kin", 1, 2),
-                _draft("reach_out_to_kin", 2, 1),
+                _draft("reach_out", 1, 2),
+                _draft("reach_out", 2, 1),
             ],
             NAMES,
         ),

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -333,8 +333,8 @@ def test_resolve_dry_run_excludes_anchor_present_characters() -> None:
                 ],
                 world_time=datetime(2073, 10, 31, 18, tzinfo=timezone.utc),
             ),
-            "pursue_ghost_lead",
-            "Recon a hideout their body remembers",
+            "uncover_past",
+            "Revisit a place their body remembers",
         ),
     ],
 )
@@ -585,11 +585,7 @@ def test_asymmetric_kin_defers_contact_instead_of_affectionate_message() -> None
         window_chunks=30,
     )
 
-    kin = [
-        draft
-        for draft in proposal.resolutions
-        if draft.template_id == "reach_out_to_kin"
-    ]
+    kin = [draft for draft in proposal.resolutions if draft.template_id == "reach_out"]
     assert len(kin) == 1
     assert kin[0].branch_label == "Draft the message and leave it unsent"
     assert kin[0].event_type == "contact_deferred"

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -24,6 +24,7 @@ from nexus.agents.orrery.substrate import (
     can_move_publicly,
     co_located,
     count_co_located,
+    count_recent_events_at_least,
     contact_pair_tag_for_kind,
     direct_contact_is_dramatic,
     evaluate_stack,
@@ -153,7 +154,7 @@ def test_storyteller_pressure_templates_require_pressure_stubs() -> None:
     ("preset", "template_id", "branch_label"),
     [
         ("hunted", "evade_pursuers", "Go to ground in flooded tunnels"),
-        ("fragment", "pursue_ghost_lead", "Recon a hideout their body remembers"),
+        ("fragment", "uncover_past", "Revisit a place their body remembers"),
         ("debt", "honor_debt", "Fulfill obligation through a dead-drop"),
         ("quiet", "maintain_cover", "Run a low-level courier job"),
         ("hiding", "hide", "Go dark and reduce signal exposure"),
@@ -210,7 +211,7 @@ def test_storyteller_pressure_templates_require_pressure_stubs() -> None:
         ),
         (
             "kin_visit",
-            "reach_out_to_kin",
+            "reach_out",
             "Find the moment for a real face-to-face conversation",
         ),
         (
@@ -870,6 +871,83 @@ def test_binding_hash_handles_runtime_non_slot_keys() -> None:
     assert binding_hash({Slot.ACTOR: 1, "custom": 2}) == binding_hash(
         {"custom": 2, Slot.ACTOR: 1}
     )
+
+
+def test_count_recent_events_at_least_thresholds_and_scope() -> None:
+    """The counting predicate honors min_count, window, actor role, and target scope."""
+
+    from nexus.agents.orrery.substrate import EventRecord
+
+    def act(tick: int, target: int = 2) -> EventRecord:
+        return EventRecord(
+            event_type="mourning_act",
+            tick=tick,
+            actor_entity_id=1,
+            target_entity_id=target,
+        )
+
+    state = WorldState(
+        recent_events=(act(4), act(7), act(10, target=3), act(13)),
+        current_tick=15,
+    )
+
+    assert count_recent_events_at_least("mourning_act", within_ticks=15, min_count=4)(
+        state, {Slot.ACTOR: 1}
+    )
+    assert not count_recent_events_at_least(
+        "mourning_act", within_ticks=15, min_count=5
+    )(state, {Slot.ACTOR: 1})
+    # Window cutoff drops the tick-4 event.
+    assert not count_recent_events_at_least(
+        "mourning_act", within_ticks=10, min_count=4
+    )(state, {Slot.ACTOR: 1})
+    # Actor role is strict: entity 2 was only ever a target.
+    assert not count_recent_events_at_least(
+        "mourning_act", within_ticks=15, min_count=1
+    )(state, {Slot.ACTOR: 2})
+    # Target scoping counts only the pair's events.
+    assert count_recent_events_at_least(
+        "mourning_act", within_ticks=15, min_count=3, target_slot=Slot.TARGET
+    )(state, {Slot.ACTOR: 1, Slot.TARGET: 2})
+    assert not count_recent_events_at_least(
+        "mourning_act", within_ticks=15, min_count=4, target_slot=Slot.TARGET
+    )(state, {Slot.ACTOR: 1, Slot.TARGET: 2})
+
+
+def test_mourn_loss_completes_after_sustained_mourning() -> None:
+    """Enough mourning acts trigger the terminal branch that clears grief.
+
+    The terminal branch emits mourning_completed — the event the `grieving`
+    tag's clear_on rule digests. Without it grief is an absorbing state.
+    """
+
+    from nexus.agents.orrery.substrate import EventRecord, evaluate
+    from nexus.agents.orrery.templates import MOURN_LOSS
+
+    def acts(*ticks: int) -> tuple[EventRecord, ...]:
+        return tuple(
+            EventRecord(event_type="mourning_act", tick=t, actor_entity_id=1)
+            for t in ticks
+        )
+
+    fresh_grief = WorldState(
+        ephemeral_tags={1: frozenset({"grieving"})},
+        recent_events=acts(20),
+        current_tick=25,
+    )
+    ongoing = evaluate(MOURN_LOSS, fresh_grief, {Slot.ACTOR: 1})
+    assert ongoing.passes is True
+    assert ongoing.event_type == "mourning_act"
+
+    worked_grief = WorldState(
+        ephemeral_tags={1: frozenset({"grieving"})},
+        recent_events=acts(8, 12, 16, 20),
+        current_tick=25,
+    )
+    completed = evaluate(MOURN_LOSS, worked_grief, {Slot.ACTOR: 1})
+    assert completed.passes is True
+    assert completed.branch_label == "Lay the grief down"
+    assert completed.event_type == "mourning_completed"
 
 
 def test_evaluate_stack_returns_none_when_no_template_passes() -> None:


### PR DESCRIPTION
## Summary
First of the staged dynamism bundles (diagnosis: the Orrery is starved, not broken — full five-lens audit in session notes; user approved "try them all, in staged bundles").

- **Grief decomposer fixed.** The `grieving` tag's `clear_on` rule has waited on `mourning_completed` since migration 050, but no branch ever emitted it — grief was an absorbing state that suppressed six lower-band packages (commute, work, socialize, intimacy, craft, travel) indefinitely. MOURN_LOSS now opens with a terminal "Lay the grief down" branch gated on a new `count_recent_events_at_least` predicate (≥4 mourning acts within 30 ticks): worked grief completes; fresh grief keeps mourning. New predicate ships with catalog prose renderer + evidence resolver (the evidence layer's loud-error coverage caught both).
- **EXTRACT_VENGEANCE slot bug.** The strike branch removed `grudge_active` from the TARGET while the gate reads it on the ACTOR (whose copy is digested by `clear_on → retaliation_executed`). Wrong-slot no-op dropped.
- **`reach_out_to_kin` → `reach_out`.** Gate honestly widened to `friend`/`companion` ties (23 live rows in save_02 become gate-visible); the warmth/asymmetry OR still filters casual edges. Renamed because the old name would misdescribe what fires — per the new naming doctrine: refactor, don't alias.
- **`pursue_ghost_lead` → `uncover_past`.** Genre-neutral rewrite; slot-2 story artifacts (Ghostprint Key, "data fog") removed from stubs and branch conditions.
- **CONSULT_RIVAL** fraught-tie OR gains `enemy` (4 rows) and `complex` (8 rows), matching its blurb's "people who do not trust each other" contract.
- **Migration 067** rewrites stored `template_id` provenance across all six base tables for both renames (applied to template + all slots).

## Verification (live, slot 2)
- 570 orrery tests pass, including new predicate unit tests and a MOURN_LOSS lifecycle test. (One local failure, `test_orrery_settings_resolve_model_reference`, is environmental: uncommitted local `[orrery.dashboard] enabled=true` flip; passes against committed nexus.toml.)
- Live resolve at head: `reach_out`/`uncover_past` are the served ids; the new `mourning_completed` cooldown arm renders in gate traces with correct prose.
- The two live grievers (Odette Baptiste, Tante Sol) show the intended arc: both currently on mourning_act cooldown, with 3 and 1 acts banked toward the 4-act completion threshold.

Coverage lints (gate-satisfiability, producer/consumer matrix, inert-outcome ratio) split to a follow-on PR to keep this reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY