### PR TITLE
Orrery Bundle 2: The Mundane Band + Routine-Anchor Backfill

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1727,6 +1727,64 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 ---
 
+## TRAIN — priority 16
+
+> Keeping the body and the trained skill from dulling.
+
+**Drive band:** anchored routine
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor has enough hydrated context
+  - actor has any of [`combat_trained`, `soldier`, `warrior`, `fighter`, `martial_artist`, `athlete`, `monk`, `scout`, `ranger`, `hunter`, `dancer`, `hacker`, `arcane_caster`, `medical_skill`, `surgical_training`, `first_aid_trained`, `musician`, `performer`, `surveillance_capable`]
+  - time of day is one of [morning, midday, afternoon, evening]
+  - ≥ 8 ticks since last `training_performed` event for actor
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:** actor has any of [`virtual`, `digital_mind`, `bodyform:non_corporeal`]
+  - **NOT:** actor is in transit
+  - **NOT:** actor has inbound `hunting` pair tag
+  - **NOT:** actor has `wounded` ephemeral
+
+### Branch 1 — Drill the fighting forms  *(mag 0.22)*
+
+**When:** actor has any of [`combat_trained`, `soldier`, `warrior`, `fighter`, `martial_artist`, `monk`]
+
+**Does:** activity → "drilling fighting forms"
+**Event:** `training_performed`
+
+> {actor} runs the forms until the body stops asking why — footwork, repetition, the unglamorous maintenance that keeps a fighter's skill from becoming a fighter's memory.
+
+### Branch 2 — Condition the body  *(mag 0.18)*
+
+**When:** actor has any of [`athlete`, `dancer`, `scout`, `ranger`, `hunter`]
+
+**Does:** activity → "conditioning the body"
+**Event:** `training_performed`
+
+> {actor} puts the body through its paces — distance, climbing, stretch and strain — paying the quiet daily tax that keeps it answering when called.
+
+### Branch 3 — Sharpen the finer skill  *(mag 0.18)*
+
+**When:** actor has any of [`hacker`, `arcane_caster`, `medical_skill`, `surgical_training`, `first_aid_trained`, `musician`, `performer`, `surveillance_capable`]
+
+**Does:** activity → "sharpening a trained skill"
+**Event:** `training_performed`
+
+> {actor} practices the exacting part of what they do — scales, sutures, sigils, whatever their craft calls its fundamentals — because the difference between good and trusted is repetition nobody sees.
+
+### Branch 4 — Keep the edge from dulling  *(mag 0.12)*
+
+**When:** *(always)*
+
+**Does:** activity → "maintaining their training"
+**Event:** `training_performed`
+
+> {actor} gives an hour to basic upkeep of their discipline — nothing ambitious, just enough that tomorrow's version of them inherits a tool that still works.
+
+---
+
 ## INTIMACY — priority 16
 
 > The body asks for the kind of connection that is not conversation.
@@ -2040,6 +2098,250 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 ---
 
+## RUN_ERRANDS — priority 13
+
+> The small acquisitions and obligations that keep a life stocked.
+
+**Drive band:** anchored routine
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor has enough hydrated context
+  - time of day is one of [morning, midday, afternoon]
+  - ≥ 9 ticks since last `errands_run` event for actor
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:** actor has any of [`virtual`, `digital_mind`, `bodyform:non_corporeal`]
+  - **NOT:** actor is in transit
+  - **NOT:** actor is hidden or off-grid
+  - **NOT:** actor has inbound `hunting` pair tag
+  - **NOT:** actor has `wounded` ephemeral
+
+### Branch 1 — Make the market run  *(mag 0.18)*
+
+**When:** actor is in `commerce` place class
+
+**Does:** activity → "making a market run"
+**Event:** `errands_run`
+
+> {actor} works through the stalls and counters with a mental list — provisions, replacements, the one thing that ran out at the worst moment — trading small money for the continued smooth running of a life.
+
+### Branch 2 — Scrounge for what the day needs  *(mag 0.16)*
+
+**When:** actor's own resources are below `poor`
+
+**Does:** activity → "scrounging necessities"
+**Event:** `errands_run`
+
+> {actor} does the poor person's version of errands: finding, borrowing, bartering, stretching — acquiring by ingenuity what others acquire by purse.
+
+### Branch 3 — Provision the household  *(mag 0.16)*
+
+**When:** actor has any of [`domestic_role`, `cares_for_household`, `matriarch`, `patriarch`]
+
+**Does:** activity → "provisioning the household"
+**Event:** `errands_run`
+
+> {actor} runs the rounds a household quietly depends on — food in, worn things out, the standing orders renewed — the invisible supply chain of ordinary life.
+
+### Branch 4 — Knock out the small obligations  *(mag 0.1)*
+
+**When:** *(always)*
+
+**Does:** activity → "running small errands"
+**Event:** `errands_run`
+
+> {actor} spends the hour on the small errands that accumulate at the edges of any life — a thing to return, a message to leave, a small debt of logistics repaid.
+
+---
+
+## STROLL — priority 12
+
+> Taking air: an unhurried walk with no destination that matters.
+
+**Drive band:** anchored routine
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor has enough hydrated context
+  - ≥ 5 ticks since last `stroll_taken` event for actor
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:** actor has any of [`virtual`, `digital_mind`, `bodyform:non_corporeal`]
+  - **NOT:** actor is in transit
+  - **NOT:** actor is hidden or off-grid
+  - **NOT:** actor has inbound `hunting` pair tag
+  - **NOT:** actor has `wounded` ephemeral
+
+### Branch 1 — Walk under open sky  *(mag 0.16)*
+
+**When:**
+
+- **AND:**
+  - weather is one of [clear, warm]
+  - **NOT:** actor is in `subterranean` place class
+
+**Does:** activity → "walking under open sky"
+**Event:** `stroll_taken`
+
+> {actor} walks for the sake of walking, under weather good enough to notice — the pace of someone whose next hour has, for once, no owner.
+
+### Branch 2 — Walk the familiar streets  *(mag 0.14)*
+
+**When:**
+
+- **OR:**
+  - actor is in `urban_dense` place class
+  - actor is in `place_open` place class
+  - actor is in `transit` place class
+  - actor is in `commerce` place class
+  - actor is in `meeting` place class
+
+**Does:** activity → "walking the neighborhood"
+**Event:** `stroll_taken`
+
+> {actor} takes the long way through streets they know by wear rather than by name, registering the small changes — a new face at a stall, a repaired door — that a neighborhood shows only to its regulars.
+
+### Branch 3 — Take the night air  *(mag 0.12)*
+
+**When:** time of day is one of [evening, night]
+
+**Does:** activity → "taking the night air"
+**Event:** `stroll_taken`
+
+> {actor} steps out into the dark hours, when the world runs quieter and thoughts get room to finish themselves.
+
+### Branch 4 — Pace the near ground  *(mag 0.08)*
+
+**When:** *(always)*
+
+**Does:** activity → "pacing the near ground"
+**Event:** `stroll_taken`
+
+> {actor} moves through whatever ground is nearest — corridors, courtyard, the length of a deck or a lane — walking off the restlessness that sitting still breeds.
+
+---
+
+## UPKEEP — priority 11
+
+> Tending one's own space, kit, and tools before they fail.
+
+**Drive band:** anchored routine
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor has enough hydrated context
+  - ≥ 7 ticks since last `upkeep_done` event for actor
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:** actor has any of [`virtual`, `digital_mind`, `bodyform:non_corporeal`]
+  - **NOT:** actor is in transit
+  - **NOT:** actor has inbound `hunting` pair tag
+
+### Branch 1 — Maintain the working tools  *(mag 0.16)*
+
+**When:** actor has any of [`engineer`, `mechanic`, `tinkerer`, `artificer`, `artisan`, `keeps_shop`, `merchant`, `hacker`, `musician`]
+
+**Does:** activity → "maintaining their tools"
+**Event:** `upkeep_done`
+
+> {actor} goes over the tools of their trade — cleaning, adjusting, replacing the part that was about to become a story — because the work is only ever as good as the kit.
+
+### Branch 2 — Mend and ready the kit  *(mag 0.15)*
+
+**When:** actor has any of [`soldier`, `scout`, `ranger`, `hunter`, `combat_trained`, `travel_ready`]
+
+**Does:** activity → "readying their kit"
+**Event:** `upkeep_done`
+
+> {actor} strips, checks, and rights their gear with the economy of habit — edges, straps, seals, charges — so that when it matters, nothing surprises them.
+
+### Branch 3 — Set the home in order  *(mag 0.14)*
+
+**When:** actor is at `home` anchor
+
+**Does:** activity → "setting their home in order"
+**Event:** `upkeep_done`
+
+> {actor} puts their own place back in order — the small repairs and resets that make a room somewhere to return to instead of somewhere to pass through.
+
+### Branch 4 — Tidy what is theirs  *(mag 0.08)*
+
+**When:** *(always)*
+
+**Does:** activity → "tidying their own space"
+**Event:** `upkeep_done`
+
+> {actor} tends whatever corner of the world is currently theirs — folding, sorting, wiping down, the small housekeeping that keeps a life from silting up.
+
+---
+
+## RECREATE — priority 9
+
+> Unproductive time taken on purpose: play, spectacle, small pleasure.
+
+**Drive band:** anchored routine
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor has enough hydrated context
+  - time of day is one of [afternoon, evening, night]
+  - ≥ 6 ticks since last `recreation_taken` event for actor
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:** actor is in transit
+  - **NOT:** actor has inbound `hunting` pair tag
+  - **NOT:** actor has `grieving` ephemeral
+
+### Branch 1 — Find games and company  *(mag 0.15)*
+
+**When:**
+
+- **AND:**
+  - **OR:**
+    - actor is in `meeting` place class
+    - actor is in `commerce` place class
+    - actor is in `place_open` place class
+  - **NOT:** actor is hidden or off-grid
+
+**Does:** activity → "at games in company"
+**Event:** `recreation_taken`
+
+> {actor} joins whatever the room is playing at — dice, cards, darts, argument — for stakes small enough to laugh about and company good enough to stay for.
+
+### Branch 2 — Lose an hour to the loved thing  *(mag 0.14)*
+
+**When:** actor has any of [`musician`, `artist`, `writer`, `scholar`, `dancer`, `performer`, `loremaster`]
+
+**Does:** activity → "lost in a loved pastime"
+**Event:** `recreation_taken`
+
+> {actor} returns to the thing they love with no audience and no deadline — playing, sketching, reading — the version of their craft that belongs to no one else.
+
+### Branch 3 — Watch the world go by  *(mag 0.1)*
+
+**When:** time of day is one of [evening, night]
+
+**Does:** activity → "watching the world go by"
+**Event:** `recreation_taken`
+
+> {actor} claims a seat with a view of other people's evenings and lets the spectacle of ordinary life be the entertainment.
+
+### Branch 4 — Take a small private pleasure  *(mag 0.08)*
+
+**When:** *(always)*
+
+**Does:** activity → "taking a small pleasure"
+**Event:** `recreation_taken`
+
+> {actor} gives themselves a modest hour — a familiar comfort, an idle game, a stretch of doing nothing in particular — and does not apologize for it.
+
+---
+
 ## MAINTAIN_COVER — priority 0
 
 > Specific public-cover maintenance, not a universal fallback.
@@ -2178,11 +2480,13 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `artisan`
 - `artist`
 - `athlete`
+- `bodyform:non_corporeal`
 - `cares_for_household`
 - `combat_trained`
 - `contemplative`
 - `dancer`
 - `devout`
+- `digital_mind`
 - `domestic_role`
 - `engineer`
 - `ethically_opposed_to_contracted_intimacy`
@@ -2224,6 +2528,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `soldier`
 - `solitary`
 - `surgical_training`
+- `surveillance_capable`
 - `survivalist`
 - `tinkerer`
 - `trader`
@@ -2231,6 +2536,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `travel_ready`
 - `vendetta_holder`
 - `violent_history`
+- `virtual`
 - `vow_of_celibacy`
 - `warrior`
 - `work_obligation`
@@ -2305,6 +2611,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `craft_tended`
 - `drank`
 - `encoded_message`
+- `errands_run`
 - `evade_pursuit`
 - `faction_realignment`
 - `hideout_maintained`
@@ -2323,6 +2630,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `mourning_completed`
 - `protective_intervention`
 - `pursue_identity_lead`
+- `recreation_taken`
 - `retaliation_attempted`
 - `retaliation_executed`
 - `rival_consulted`
@@ -2331,14 +2639,17 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `social_travel_departed`
 - `socialized`
 - `socialized_alone`
+- `stroll_taken`
 - `surveillance_performed`
 - `tended_wound`
 - `threat_issued`
+- `training_performed`
 - `travel_arrived`
 - `travel_delayed`
 - `travel_departed`
 - `travel_prepared`
 - `travel_progressed`
+- `upkeep_done`
 - `vigil_held`
 - `warning_delivered`
 - `welfare_check`

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1727,64 +1727,6 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 ---
 
-## TRAIN — priority 16
-
-> Keeping the body and the trained skill from dulling.
-
-**Drive band:** anchored routine
-**Slots:** ACTOR
-
-**Gate:**
-
-- **AND:**
-  - actor has enough hydrated context
-  - actor has any of [`combat_trained`, `soldier`, `warrior`, `fighter`, `martial_artist`, `athlete`, `monk`, `scout`, `ranger`, `hunter`, `dancer`, `hacker`, `arcane_caster`, `medical_skill`, `surgical_training`, `first_aid_trained`, `musician`, `performer`, `surveillance_capable`]
-  - time of day is one of [morning, midday, afternoon, evening]
-  - ≥ 8 ticks since last `training_performed` event for actor
-  - **NOT:** actor is constrained or immobilized
-  - **NOT:** actor has any of [`virtual`, `digital_mind`, `bodyform:non_corporeal`]
-  - **NOT:** actor is in transit
-  - **NOT:** actor has inbound `hunting` pair tag
-  - **NOT:** actor has `wounded` ephemeral
-
-### Branch 1 — Drill the fighting forms  *(mag 0.22)*
-
-**When:** actor has any of [`combat_trained`, `soldier`, `warrior`, `fighter`, `martial_artist`, `monk`]
-
-**Does:** activity → "drilling fighting forms"
-**Event:** `training_performed`
-
-> {actor} runs the forms until the body stops asking why — footwork, repetition, the unglamorous maintenance that keeps a fighter's skill from becoming a fighter's memory.
-
-### Branch 2 — Condition the body  *(mag 0.18)*
-
-**When:** actor has any of [`athlete`, `dancer`, `scout`, `ranger`, `hunter`]
-
-**Does:** activity → "conditioning the body"
-**Event:** `training_performed`
-
-> {actor} puts the body through its paces — distance, climbing, stretch and strain — paying the quiet daily tax that keeps it answering when called.
-
-### Branch 3 — Sharpen the finer skill  *(mag 0.18)*
-
-**When:** actor has any of [`hacker`, `arcane_caster`, `medical_skill`, `surgical_training`, `first_aid_trained`, `musician`, `performer`, `surveillance_capable`]
-
-**Does:** activity → "sharpening a trained skill"
-**Event:** `training_performed`
-
-> {actor} practices the exacting part of what they do — scales, sutures, sigils, whatever their craft calls its fundamentals — because the difference between good and trusted is repetition nobody sees.
-
-### Branch 4 — Keep the edge from dulling  *(mag 0.12)*
-
-**When:** *(always)*
-
-**Does:** activity → "maintaining their training"
-**Event:** `training_performed`
-
-> {actor} gives an hour to basic upkeep of their discipline — nothing ambitious, just enough that tomorrow's version of them inherits a tool that still works.
-
----
-
 ## INTIMACY — priority 16
 
 > The body asks for the kind of connection that is not conversation.
@@ -2276,6 +2218,64 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 **Event:** `upkeep_done`
 
 > {actor} tends whatever corner of the world is currently theirs — folding, sorting, wiping down, the small housekeeping that keeps a life from silting up.
+
+---
+
+## TRAIN — priority 10
+
+> Keeping the body and the trained skill from dulling.
+
+**Drive band:** anchored routine
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor has enough hydrated context
+  - actor has any of [`combat_trained`, `soldier`, `warrior`, `fighter`, `martial_artist`, `athlete`, `monk`, `scout`, `ranger`, `hunter`, `dancer`, `hacker`, `arcane_caster`, `medical_skill`, `surgical_training`, `first_aid_trained`, `musician`, `performer`, `surveillance_capable`]
+  - time of day is one of [morning, midday, afternoon, evening]
+  - ≥ 8 ticks since last `training_performed` event for actor
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:** actor has any of [`virtual`, `digital_mind`, `bodyform:non_corporeal`]
+  - **NOT:** actor is in transit
+  - **NOT:** actor has inbound `hunting` pair tag
+  - **NOT:** actor has `wounded` ephemeral
+
+### Branch 1 — Drill the fighting forms  *(mag 0.22)*
+
+**When:** actor has any of [`combat_trained`, `soldier`, `warrior`, `fighter`, `martial_artist`, `monk`]
+
+**Does:** activity → "drilling fighting forms"
+**Event:** `training_performed`
+
+> {actor} runs the forms until the body stops asking why — footwork, repetition, the unglamorous maintenance that keeps a fighter's skill from becoming a fighter's memory.
+
+### Branch 2 — Condition the body  *(mag 0.18)*
+
+**When:** actor has any of [`athlete`, `dancer`, `scout`, `ranger`, `hunter`]
+
+**Does:** activity → "conditioning the body"
+**Event:** `training_performed`
+
+> {actor} puts the body through its paces — distance, climbing, stretch and strain — paying the quiet daily tax that keeps it answering when called.
+
+### Branch 3 — Sharpen the finer skill  *(mag 0.18)*
+
+**When:** actor has any of [`hacker`, `arcane_caster`, `medical_skill`, `surgical_training`, `first_aid_trained`, `musician`, `performer`, `surveillance_capable`]
+
+**Does:** activity → "sharpening a trained skill"
+**Event:** `training_performed`
+
+> {actor} practices the exacting part of what they do — scales, sutures, sigils, whatever their craft calls its fundamentals — because the difference between good and trusted is repetition nobody sees.
+
+### Branch 4 — Keep the edge from dulling  *(mag 0.12)*
+
+**When:** *(always)*
+
+**Does:** activity → "maintaining their training"
+**Event:** `training_performed`
+
+> {actor} gives an hour to basic upkeep of their discipline — nothing ambitious, just enough that tomorrow's version of them inherits a tool that still works.
 
 ---
 

--- a/migrations/068_mundane_band_event_vocab.sql
+++ b/migrations/068_mundane_band_event_vocab.sql
@@ -1,0 +1,42 @@
+-- 068_mundane_band_event_vocab.sql
+--
+-- Event vocabulary for the mundane band (TRAIN, RUN_ERRANDS, STROLL,
+-- UPKEEP, RECREATE): genre-neutral low-priority packages covering what
+-- people do in the absence of more pressing concerns. Each package's
+-- branches emit a single event type consumed by its own since_last
+-- cooldown; the cooldowns are deliberately staggered (5-9 ticks) so
+-- unpressured actors cycle through varied mundane verbs.
+
+INSERT INTO event_types (type, category, severity, description)
+VALUES
+    (
+        'training_performed',
+        'embodied',
+        'minor',
+        'The actor spent time maintaining a trained discipline — drilling forms, conditioning the body, or practicing a skilled craft''s fundamentals. Consumed by TRAIN''s own cooldown.'
+    ),
+    (
+        'errands_run',
+        'routine',
+        'minor',
+        'The actor handled small acquisitions and obligations: market runs, household provisioning, minor logistics. Consumed by RUN_ERRANDS''s own cooldown.'
+    ),
+    (
+        'stroll_taken',
+        'embodied',
+        'minor',
+        'The actor took an unhurried walk with no consequential destination. Consumed by STROLL''s own cooldown.'
+    ),
+    (
+        'upkeep_done',
+        'routine',
+        'minor',
+        'The actor tended their own space, kit, or tools. Distinct from work_performed/household_work_performed, which are role obligations. Consumed by UPKEEP''s own cooldown.'
+    ),
+    (
+        'recreation_taken',
+        'routine',
+        'minor',
+        'The actor took deliberate unproductive time: games, spectacle, private pastimes. Consumed by RECREATE''s own cooldown.'
+    )
+ON CONFLICT (type) DO NOTHING;

--- a/nexus/agents/orrery/demo.py
+++ b/nexus/agents/orrery/demo.py
@@ -26,6 +26,26 @@ REMEMBRANCE_PLACE_ID = 104
 NEUTRAL_PLACE_ID = 105
 
 
+def _mundane_cooldown_events(actor_id: int, tick: int) -> tuple:
+    """Recent mundane-band events for presets that pin another package.
+
+    The mundane band (train/errands/stroll/upkeep/recreate) is a universal
+    ambient floor; presets exercising a specific quieter package suppress it
+    through the band's own cooldowns rather than by mutating gates.
+    """
+
+    return tuple(
+        EventRecord(event_type=event_type, tick=tick - 1, actor_entity_id=actor_id)
+        for event_type in (
+            "training_performed",
+            "errands_run",
+            "stroll_taken",
+            "upkeep_done",
+            "recreation_taken",
+        )
+    )
+
+
 def build_presets() -> Dict[str, WorldState]:
     """Return deterministic demo states that mirror the original JSX simulator."""
 
@@ -104,6 +124,7 @@ def build_presets() -> Dict[str, WorldState]:
             location_classes=semantic_location_classes,
             time_of_day="midday",
             weather="clear",
+            recent_events=_mundane_cooldown_events(ACTOR_ID, 100),
             current_tick=100,
         ),
         "hiding": WorldState(
@@ -113,6 +134,7 @@ def build_presets() -> Dict[str, WorldState]:
             location_classes=semantic_location_classes,
             time_of_day="night",
             weather="clear",
+            recent_events=_mundane_cooldown_events(ACTOR_ID, 100),
             current_tick=100,
         ),
         # Round-2 solo presets
@@ -132,6 +154,7 @@ def build_presets() -> Dict[str, WorldState]:
             location_classes=semantic_location_classes,
             time_of_day="evening",
             weather="clear",
+            recent_events=_mundane_cooldown_events(ACTOR_ID, 100),
             current_tick=100,
         ),
     }

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -3671,8 +3671,10 @@ INTIMACY = Template(
 #
 # Anti-monoculture comes from cooldown staggering: every package carries a
 # different since_last cooldown (5-9 ticks), so an unpressured actor cycles
-# through varied mundane verbs — stroll, errands, upkeep, recreation,
-# training — rather than repeating one. Magnitudes stay below the
+# through varied mundane verbs — errands (13), stroll (12), upkeep (11),
+# training (10), recreation (9) — rather than repeating one. The whole
+# ladder sits strictly below WORK (14) and every need package: mundane
+# texture never outranks an actionable pressure. Magnitudes stay below the
 # [orrery.promote] floor: this band is ambient texture and event-ecology
 # fuel, not storyteller-prompt pressure.
 # ----------------------------------------------------------------------------
@@ -3680,7 +3682,7 @@ INTIMACY = Template(
 
 TRAIN = Template(
     id="train",
-    priority=16,
+    priority=10,
     drive_band=DriveBand.ANCHORED_ROUTINE,
     blurb="Keeping the body and the trained skill from dulling.",
     required_slots=(Slot.ACTOR,),

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -88,6 +88,11 @@ WORKPLACE_PLACE = _place_any(
     "administration", "craft", "military", "place_medical", "production"
 )
 WORKSITE_PLACE = _place_any("craft", "military", "production")
+
+# Non-corporeal minds have no body to walk, train, provision, or tidy with.
+# Mirrors NEED_IMMUNITY_TAGS in needs.py: embodied-inorganic forms (androids,
+# constructs) keep full access to the physical mundane packages.
+NON_CORPOREAL_TAGS = ("virtual", "digital_mind", "bodyform:non_corporeal")
 ADMINISTRATION_PLACE = _place_any("administration")
 PUBLIC_MEETING_PLACE = _place_any("meeting", "commerce", "place_open")
 DWELLING_PLACE = _place_any("dwelling")
@@ -3654,6 +3659,505 @@ INTIMACY = Template(
 )
 
 
+# ----------------------------------------------------------------------------
+# Section — The mundane band
+#
+# Genre-neutral things people do in the absence of more pressing concerns.
+# Deliberately universal: unlike TEND_CRAFT's tag-restricted entry, these
+# gates admit any hydrated actor (TRAIN excepted — training is identity-
+# conditional), because the measured famine was actors with NO reachable
+# package, not actors with too many. Displacing MAINTAIN_COVER (priority 0)
+# for ordinary life is the intent.
+#
+# Anti-monoculture comes from cooldown staggering: every package carries a
+# different since_last cooldown (5-9 ticks), so an unpressured actor cycles
+# through varied mundane verbs — stroll, errands, upkeep, recreation,
+# training — rather than repeating one. Magnitudes stay below the
+# [orrery.promote] floor: this band is ambient texture and event-ecology
+# fuel, not storyteller-prompt pressure.
+# ----------------------------------------------------------------------------
+
+
+TRAIN = Template(
+    id="train",
+    priority=16,
+    drive_band=DriveBand.ANCHORED_ROUTINE,
+    blurb="Keeping the body and the trained skill from dulling.",
+    required_slots=(Slot.ACTOR,),
+    # Identity-conditional like TEND_CRAFT: training is upkeep of a
+    # discipline the actor actually has. The wide tag OR is the entry;
+    # branches pick which discipline gets the hour.
+    package_gate=AND(
+        has_minimal_context(),
+        has_any_tag(
+            # body
+            "combat_trained",
+            "soldier",
+            "warrior",
+            "fighter",
+            "martial_artist",
+            "athlete",
+            "monk",
+            "scout",
+            "ranger",
+            "hunter",
+            "dancer",
+            # skill
+            "hacker",
+            "arcane_caster",
+            "medical_skill",
+            "surgical_training",
+            "first_aid_trained",
+            "musician",
+            "performer",
+            "surveillance_capable",
+        ),
+        time_of_day_in("morning", "midday", "afternoon", "evening"),
+        since_last_event_at_least("training_performed", minimum_ticks=8),
+        NOT(is_constrained()),
+        NOT(has_any_tag(*NON_CORPOREAL_TAGS)),
+        NOT(is_in_transit()),
+        NOT(has_inbound_pair_tag("hunting")),
+        NOT(has_ephemeral("wounded")),
+    ),
+    branches=(
+        Branch(
+            label="Drill the fighting forms",
+            conditions=has_any_tag(
+                "combat_trained",
+                "soldier",
+                "warrior",
+                "fighter",
+                "martial_artist",
+                "monk",
+            ),
+            narrative_stub=(
+                "{actor} runs the forms until the body stops asking why — "
+                "footwork, repetition, the unglamorous maintenance that "
+                "keeps a fighter's skill from becoming a fighter's memory."
+            ),
+            state_delta={
+                "character.current_activity": "drilling fighting forms",
+            },
+            event_type="training_performed",
+            changed_fields=("character.current_activity",),
+            magnitude=0.22,
+        ),
+        Branch(
+            label="Condition the body",
+            conditions=has_any_tag("athlete", "dancer", "scout", "ranger", "hunter"),
+            narrative_stub=(
+                "{actor} puts the body through its paces — distance, "
+                "climbing, stretch and strain — paying the quiet daily tax "
+                "that keeps it answering when called."
+            ),
+            state_delta={
+                "character.current_activity": "conditioning the body",
+            },
+            event_type="training_performed",
+            changed_fields=("character.current_activity",),
+            magnitude=0.18,
+        ),
+        Branch(
+            label="Sharpen the finer skill",
+            conditions=has_any_tag(
+                "hacker",
+                "arcane_caster",
+                "medical_skill",
+                "surgical_training",
+                "first_aid_trained",
+                "musician",
+                "performer",
+                "surveillance_capable",
+            ),
+            narrative_stub=(
+                "{actor} practices the exacting part of what they do — "
+                "scales, sutures, sigils, whatever their craft calls its "
+                "fundamentals — because the difference between good and "
+                "trusted is repetition nobody sees."
+            ),
+            state_delta={
+                "character.current_activity": "sharpening a trained skill",
+            },
+            event_type="training_performed",
+            changed_fields=("character.current_activity",),
+            magnitude=0.18,
+        ),
+        Branch(
+            label="Keep the edge from dulling",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} gives an hour to basic upkeep of their discipline "
+                "— nothing ambitious, just enough that tomorrow's version "
+                "of them inherits a tool that still works."
+            ),
+            state_delta={
+                "character.current_activity": "maintaining their training",
+            },
+            event_type="training_performed",
+            changed_fields=("character.current_activity",),
+            magnitude=0.12,
+        ),
+    ),
+)
+
+
+RUN_ERRANDS = Template(
+    id="run_errands",
+    priority=13,
+    drive_band=DriveBand.ANCHORED_ROUTINE,
+    blurb="The small acquisitions and obligations that keep a life stocked.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        has_minimal_context(),
+        time_of_day_in("morning", "midday", "afternoon"),
+        since_last_event_at_least("errands_run", minimum_ticks=9),
+        NOT(is_constrained()),
+        NOT(has_any_tag(*NON_CORPOREAL_TAGS)),
+        NOT(is_in_transit()),
+        NOT(is_hidden()),
+        NOT(has_inbound_pair_tag("hunting")),
+        NOT(has_ephemeral("wounded")),
+    ),
+    branches=(
+        Branch(
+            label="Make the market run",
+            conditions=in_location_class("commerce"),
+            narrative_stub=(
+                "{actor} works through the stalls and counters with a "
+                "mental list — provisions, replacements, the one thing "
+                "that ran out at the worst moment — trading small money "
+                "for the continued smooth running of a life."
+            ),
+            state_delta={
+                "character.current_activity": "making a market run",
+            },
+            event_type="errands_run",
+            changed_fields=("character.current_activity",),
+            magnitude=0.18,
+        ),
+        Branch(
+            label="Scrounge for what the day needs",
+            conditions=resources_below("poor"),
+            narrative_stub=(
+                "{actor} does the poor person's version of errands: "
+                "finding, borrowing, bartering, stretching — acquiring by "
+                "ingenuity what others acquire by purse."
+            ),
+            state_delta={
+                "character.current_activity": "scrounging necessities",
+            },
+            event_type="errands_run",
+            changed_fields=("character.current_activity",),
+            magnitude=0.16,
+        ),
+        Branch(
+            label="Provision the household",
+            conditions=has_any_tag(
+                "domestic_role", "cares_for_household", "matriarch", "patriarch"
+            ),
+            narrative_stub=(
+                "{actor} runs the rounds a household quietly depends on — "
+                "food in, worn things out, the standing orders renewed — "
+                "the invisible supply chain of ordinary life."
+            ),
+            state_delta={
+                "character.current_activity": "provisioning the household",
+            },
+            event_type="errands_run",
+            changed_fields=("character.current_activity",),
+            magnitude=0.16,
+        ),
+        Branch(
+            label="Knock out the small obligations",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} spends the hour on the small errands that "
+                "accumulate at the edges of any life — a thing to return, "
+                "a message to leave, a small debt of logistics repaid."
+            ),
+            state_delta={
+                "character.current_activity": "running small errands",
+            },
+            event_type="errands_run",
+            changed_fields=("character.current_activity",),
+            magnitude=0.10,
+        ),
+    ),
+)
+
+
+STROLL = Template(
+    id="stroll",
+    priority=12,
+    drive_band=DriveBand.ANCHORED_ROUTINE,
+    blurb="Taking air: an unhurried walk with no destination that matters.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        has_minimal_context(),
+        since_last_event_at_least("stroll_taken", minimum_ticks=5),
+        NOT(is_constrained()),
+        NOT(has_any_tag(*NON_CORPOREAL_TAGS)),
+        NOT(is_in_transit()),
+        NOT(is_hidden()),
+        NOT(has_inbound_pair_tag("hunting")),
+        NOT(has_ephemeral("wounded")),
+    ),
+    branches=(
+        Branch(
+            label="Walk under open sky",
+            conditions=AND(
+                weather_is("clear", "warm"),
+                NOT(in_location_class("subterranean")),
+            ),
+            narrative_stub=(
+                "{actor} walks for the sake of walking, under weather good "
+                "enough to notice — the pace of someone whose next hour "
+                "has, for once, no owner."
+            ),
+            state_delta={
+                "character.current_activity": "walking under open sky",
+            },
+            event_type="stroll_taken",
+            changed_fields=("character.current_activity",),
+            magnitude=0.16,
+        ),
+        Branch(
+            label="Walk the familiar streets",
+            conditions=URBAN_PUBLIC_FLOW_PLACE,
+            narrative_stub=(
+                "{actor} takes the long way through streets they know by "
+                "wear rather than by name, registering the small changes — "
+                "a new face at a stall, a repaired door — that a "
+                "neighborhood shows only to its regulars."
+            ),
+            state_delta={
+                "character.current_activity": "walking the neighborhood",
+            },
+            event_type="stroll_taken",
+            changed_fields=("character.current_activity",),
+            magnitude=0.14,
+        ),
+        Branch(
+            label="Take the night air",
+            conditions=time_of_day_in("evening", "night"),
+            narrative_stub=(
+                "{actor} steps out into the dark hours, when the world "
+                "runs quieter and thoughts get room to finish themselves."
+            ),
+            state_delta={
+                "character.current_activity": "taking the night air",
+            },
+            event_type="stroll_taken",
+            changed_fields=("character.current_activity",),
+            magnitude=0.12,
+        ),
+        Branch(
+            label="Pace the near ground",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} moves through whatever ground is nearest — "
+                "corridors, courtyard, the length of a deck or a lane — "
+                "walking off the restlessness that sitting still breeds."
+            ),
+            state_delta={
+                "character.current_activity": "pacing the near ground",
+            },
+            event_type="stroll_taken",
+            changed_fields=("character.current_activity",),
+            magnitude=0.08,
+        ),
+    ),
+)
+
+
+UPKEEP = Template(
+    id="upkeep",
+    priority=11,
+    drive_band=DriveBand.ANCHORED_ROUTINE,
+    blurb="Tending one's own space, kit, and tools before they fail.",
+    required_slots=(Slot.ACTOR,),
+    # Distinct from WORK's household branch: that is labor performed as a
+    # role obligation (domestic_role and kin); this is any actor tending
+    # what is theirs — quarters, gear, tools.
+    package_gate=AND(
+        has_minimal_context(),
+        since_last_event_at_least("upkeep_done", minimum_ticks=7),
+        NOT(is_constrained()),
+        NOT(has_any_tag(*NON_CORPOREAL_TAGS)),
+        NOT(is_in_transit()),
+        NOT(has_inbound_pair_tag("hunting")),
+    ),
+    branches=(
+        Branch(
+            label="Maintain the working tools",
+            conditions=has_any_tag(
+                "engineer",
+                "mechanic",
+                "tinkerer",
+                "artificer",
+                "artisan",
+                "keeps_shop",
+                "merchant",
+                "hacker",
+                "musician",
+            ),
+            narrative_stub=(
+                "{actor} goes over the tools of their trade — cleaning, "
+                "adjusting, replacing the part that was about to become a "
+                "story — because the work is only ever as good as the kit."
+            ),
+            state_delta={
+                "character.current_activity": "maintaining their tools",
+            },
+            event_type="upkeep_done",
+            changed_fields=("character.current_activity",),
+            magnitude=0.16,
+        ),
+        Branch(
+            label="Mend and ready the kit",
+            conditions=has_any_tag(
+                "soldier",
+                "scout",
+                "ranger",
+                "hunter",
+                "combat_trained",
+                "travel_ready",
+            ),
+            narrative_stub=(
+                "{actor} strips, checks, and rights their gear with the "
+                "economy of habit — edges, straps, seals, charges — so "
+                "that when it matters, nothing surprises them."
+            ),
+            state_delta={
+                "character.current_activity": "readying their kit",
+            },
+            event_type="upkeep_done",
+            changed_fields=("character.current_activity",),
+            magnitude=0.15,
+        ),
+        Branch(
+            label="Set the home in order",
+            conditions=at_routine_anchor("home"),
+            narrative_stub=(
+                "{actor} puts their own place back in order — the small "
+                "repairs and resets that make a room somewhere to return "
+                "to instead of somewhere to pass through."
+            ),
+            state_delta={
+                "character.current_activity": "setting their home in order",
+            },
+            event_type="upkeep_done",
+            changed_fields=("character.current_activity",),
+            magnitude=0.14,
+        ),
+        Branch(
+            label="Tidy what is theirs",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} tends whatever corner of the world is currently "
+                "theirs — folding, sorting, wiping down, the small "
+                "housekeeping that keeps a life from silting up."
+            ),
+            state_delta={
+                "character.current_activity": "tidying their own space",
+            },
+            event_type="upkeep_done",
+            changed_fields=("character.current_activity",),
+            magnitude=0.08,
+        ),
+    ),
+)
+
+
+RECREATE = Template(
+    id="recreate",
+    priority=9,
+    drive_band=DriveBand.ANCHORED_ROUTINE,
+    blurb="Unproductive time taken on purpose: play, spectacle, small pleasure.",
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        has_minimal_context(),
+        time_of_day_in("afternoon", "evening", "night"),
+        since_last_event_at_least("recreation_taken", minimum_ticks=6),
+        NOT(is_constrained()),
+        NOT(is_in_transit()),
+        NOT(has_inbound_pair_tag("hunting")),
+        NOT(has_ephemeral("grieving")),
+    ),
+    branches=(
+        Branch(
+            label="Find games and company",
+            conditions=AND(PUBLIC_MEETING_PLACE, NOT(is_hidden())),
+            narrative_stub=(
+                "{actor} joins whatever the room is playing at — dice, "
+                "cards, darts, argument — for stakes small enough to laugh "
+                "about and company good enough to stay for."
+            ),
+            state_delta={
+                "character.current_activity": "at games in company",
+            },
+            event_type="recreation_taken",
+            changed_fields=("character.current_activity",),
+            magnitude=0.15,
+        ),
+        Branch(
+            label="Lose an hour to the loved thing",
+            conditions=has_any_tag(
+                "musician",
+                "artist",
+                "writer",
+                "scholar",
+                "dancer",
+                "performer",
+                "loremaster",
+            ),
+            narrative_stub=(
+                "{actor} returns to the thing they love with no audience "
+                "and no deadline — playing, sketching, reading — the "
+                "version of their craft that belongs to no one else."
+            ),
+            state_delta={
+                "character.current_activity": "lost in a loved pastime",
+            },
+            event_type="recreation_taken",
+            changed_fields=("character.current_activity",),
+            magnitude=0.14,
+        ),
+        Branch(
+            label="Watch the world go by",
+            conditions=time_of_day_in("evening", "night"),
+            narrative_stub=(
+                "{actor} claims a seat with a view of other people's "
+                "evenings and lets the spectacle of ordinary life be the "
+                "entertainment."
+            ),
+            state_delta={
+                "character.current_activity": "watching the world go by",
+            },
+            event_type="recreation_taken",
+            changed_fields=("character.current_activity",),
+            magnitude=0.10,
+        ),
+        Branch(
+            label="Take a small private pleasure",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} gives themselves a modest hour — a familiar "
+                "comfort, an idle game, a stretch of doing nothing in "
+                "particular — and does not apologize for it."
+            ),
+            state_delta={
+                "character.current_activity": "taking a small pleasure",
+            },
+            event_type="recreation_taken",
+            changed_fields=("character.current_activity",),
+            magnitude=0.08,
+        ),
+    ),
+)
+
+
 BUILTIN_TEMPLATES = (
     EVADE_PURSUERS,
     PROTECT_KIN,
@@ -3674,11 +4178,16 @@ BUILTIN_TEMPLATES = (
     TRAVEL,
     WORK,
     TEND_CRAFT,
+    TRAIN,
     SLEEP,
     DRINK,
     EAT,
     SOCIALIZE,
     INTIMACY,
+    RUN_ERRANDS,
+    STROLL,
+    UPKEEP,
+    RECREATE,
     MAINTAIN_COVER,
 )
 

--- a/scripts/backfill_routine_anchors.py
+++ b/scripts/backfill_routine_anchors.py
@@ -18,13 +18,16 @@ Work anchors are NOT derived: profession evidence is currently too
 sparse to guess workplaces deterministically; the report lists them so
 the retrofit pass can fill them with human review.
 
-Default is a dry-run that writes a review CSV. Re-run with ``--apply``
-after review to insert rows (source='compiler_backfill').
+Default is a dry-run that writes a review CSV. ``--apply`` takes the
+REVIEWED CSV back as its input and inserts exactly the rows it still
+contains (source='compiler_backfill') — delete or edit rows during
+review and the deletions/edits are honored; the database is never
+re-derived behind the reviewer's back.
 
 Usage:
-    python scripts/backfill_routine_anchors.py --slot 2
     python scripts/backfill_routine_anchors.py --slot 2 --out review.csv
-    python scripts/backfill_routine_anchors.py --slot 2 --apply
+    # ... review/edit review.csv ...
+    python scripts/backfill_routine_anchors.py --slot 2 --apply review.csv
 """
 
 from __future__ import annotations
@@ -163,6 +166,40 @@ def write_csv(proposals: list[AnchorProposal], out) -> None:
         )
 
 
+def read_reviewed_csv(path: str) -> list[AnchorProposal]:
+    """Load reviewed proposals; the CSV is the authority after review."""
+
+    proposals: list[AnchorProposal] = []
+    with open(path, newline="") as handle:
+        reader = csv.DictReader(handle)
+        required = {
+            "character_entity_id",
+            "anchor_type",
+            "mobility_policy",
+            "place_id",
+            "zone_id",
+        }
+        missing = required - set(reader.fieldnames or [])
+        if missing:
+            raise ValueError(
+                f"{path}: reviewed CSV is missing columns {sorted(missing)}"
+            )
+        for row in reader:
+            proposals.append(
+                AnchorProposal(
+                    character_entity_id=int(row["character_entity_id"]),
+                    character_name=row.get("character_name", ""),
+                    anchor_type=row["anchor_type"],
+                    mobility_policy=row["mobility_policy"],
+                    place_id=int(row["place_id"]) if row["place_id"] else None,
+                    zone_id=int(row["zone_id"]) if row["zone_id"] else None,
+                    evidence=row.get("evidence", ""),
+                    confidence=row.get("confidence", ""),
+                )
+            )
+    return proposals
+
+
 def apply_proposals(conn, proposals: list[AnchorProposal]) -> int:
     applied = 0
     for p in proposals:
@@ -204,39 +241,44 @@ def main() -> None:
     )
     parser.add_argument(
         "--apply",
-        action="store_true",
-        help="Write derivable anchors to the database (after CSV review)",
+        type=str,
+        default=None,
+        metavar="REVIEWED_CSV",
+        help="Insert exactly the rows in this reviewed CSV (the review is "
+        "the authority; the database is not re-derived)",
     )
     args = parser.parse_args()
 
     engine = create_engine(get_slot_db_url(slot=args.slot))
     with engine.begin() as conn:
+        if args.apply:
+            reviewed = read_reviewed_csv(args.apply)
+            applied = apply_proposals(conn, reviewed)
+            skipped = len(reviewed) - applied
+            print(
+                f"slot {args.slot}: applied {applied} anchors from "
+                f"{args.apply}; skipped {skipped} unprovisioned rows"
+            )
+            return
+
         proposals = collect_proposals(conn)
         derivable = [p for p in proposals if p.mobility_policy != UNPROVISIONED]
         missing = [p for p in proposals if p.mobility_policy == UNPROVISIONED]
 
-        if args.apply:
-            applied = apply_proposals(conn, proposals)
-            print(
-                f"slot {args.slot}: applied {applied} home anchors; "
-                f"{len(missing)} characters remain unprovisioned "
-                "(no derivable evidence — retrofit pass required)"
-            )
-        else:
-            out = open(args.out, "w", newline="") if args.out else sys.stdout
-            try:
-                write_csv(proposals, out)
-            finally:
-                if args.out:
-                    out.close()
-            print(
-                f"\nslot {args.slot}: {len(derivable)} derivable "
-                f"({sum(1 for p in derivable if p.confidence == 'high')} high, "
-                f"{sum(1 for p in derivable if p.confidence == 'medium')} medium), "
-                f"{len(missing)} unprovisioned. Dry run — re-run with --apply "
-                "after review.",
-                file=sys.stderr,
-            )
+        out = open(args.out, "w", newline="") if args.out else sys.stdout
+        try:
+            write_csv(proposals, out)
+        finally:
+            if args.out:
+                out.close()
+        print(
+            f"\nslot {args.slot}: {len(derivable)} derivable "
+            f"({sum(1 for p in derivable if p.confidence == 'high')} high, "
+            f"{sum(1 for p in derivable if p.confidence == 'medium')} medium), "
+            f"{len(missing)} unprovisioned. Dry run — review the CSV, then "
+            "re-run with --apply <reviewed.csv>.",
+            file=sys.stderr,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/backfill_routine_anchors.py
+++ b/scripts/backfill_routine_anchors.py
@@ -1,0 +1,243 @@
+"""Backfill routine anchors for characters that have none.
+
+The anchored_routine drive band (ROUTINE_COMMUTE, WORK, and the mundane
+band) can only serve characters with `character_routine_anchors` rows;
+an unprovisioned character refuses every anchor-gated package. This
+script proposes home anchors for the unprovisioned cast.
+
+Derivation ladder (home anchor, best evidence wins):
+
+1. active ``resides_at`` pair tag -> that place, ``fixed_place``
+   (high confidence — the fiction has committed to a residence)
+2. ``characters.current_location`` -> that place's zone,
+   ``zone_resolved`` (medium confidence — coarse on purpose: a wrong
+   concrete home contradicts canon, a zone rarely does)
+3. no evidence -> reported as unprovisioned for the slot-retrofit pass
+
+Work anchors are NOT derived: profession evidence is currently too
+sparse to guess workplaces deterministically; the report lists them so
+the retrofit pass can fill them with human review.
+
+Default is a dry-run that writes a review CSV. Re-run with ``--apply``
+after review to insert rows (source='compiler_backfill').
+
+Usage:
+    python scripts/backfill_routine_anchors.py --slot 2
+    python scripts/backfill_routine_anchors.py --slot 2 --out review.csv
+    python scripts/backfill_routine_anchors.py --slot 2 --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+from sqlalchemy import create_engine, text
+
+from nexus.api.slot_utils import get_slot_db_url
+
+
+@dataclass(frozen=True)
+class AnchorProposal:
+    character_entity_id: int
+    character_name: str
+    anchor_type: str
+    mobility_policy: str
+    place_id: Optional[int]
+    zone_id: Optional[int]
+    evidence: str
+    confidence: str
+
+
+UNPROVISIONED = "unprovisioned"
+
+
+def collect_proposals(conn) -> list[AnchorProposal]:
+    rows = conn.execute(
+        text(
+            """
+            SELECT
+                c.entity_id,
+                c.name,
+                resides.place_id AS resides_place_id,
+                cur.id AS current_place_id,
+                NULLIF(cur.zone, 0) AS current_zone_id
+            FROM characters c
+            LEFT JOIN character_routine_anchors cra
+                ON cra.character_entity_id = c.entity_id
+               AND cra.anchor_type = 'home'
+            LEFT JOIN LATERAL (
+                SELECT p.id AS place_id
+                FROM entity_pair_tags ept
+                JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+                JOIN places p ON p.entity_id = ept.object_entity_id
+                WHERE ept.subject_entity_id = c.entity_id
+                  AND pt.tag = 'resides_at'
+                  AND ept.cleared_at IS NULL
+                ORDER BY ept.applied_at DESC
+                LIMIT 1
+            ) resides ON TRUE
+            LEFT JOIN places cur ON cur.id = c.current_location
+            WHERE cra.id IS NULL
+            ORDER BY c.entity_id
+            """
+        )
+    ).mappings()
+
+    proposals: list[AnchorProposal] = []
+    for row in rows:
+        if row["resides_place_id"] is not None:
+            proposals.append(
+                AnchorProposal(
+                    character_entity_id=row["entity_id"],
+                    character_name=row["name"],
+                    anchor_type="home",
+                    mobility_policy="fixed_place",
+                    place_id=row["resides_place_id"],
+                    zone_id=None,
+                    evidence=f"resides_at -> place {row['resides_place_id']}",
+                    confidence="high",
+                )
+            )
+        elif row["current_zone_id"] is not None:
+            proposals.append(
+                AnchorProposal(
+                    character_entity_id=row["entity_id"],
+                    character_name=row["name"],
+                    anchor_type="home",
+                    mobility_policy="zone_resolved",
+                    place_id=None,
+                    zone_id=row["current_zone_id"],
+                    evidence=(
+                        f"current_location place {row['current_place_id']} "
+                        f"-> zone {row['current_zone_id']}"
+                    ),
+                    confidence="medium",
+                )
+            )
+        else:
+            proposals.append(
+                AnchorProposal(
+                    character_entity_id=row["entity_id"],
+                    character_name=row["name"],
+                    anchor_type="home",
+                    mobility_policy=UNPROVISIONED,
+                    place_id=None,
+                    zone_id=None,
+                    evidence="no resides_at tag; current location has no zone",
+                    confidence="none",
+                )
+            )
+    return proposals
+
+
+def write_csv(proposals: list[AnchorProposal], out) -> None:
+    writer = csv.writer(out)
+    writer.writerow(
+        [
+            "character_entity_id",
+            "character_name",
+            "anchor_type",
+            "mobility_policy",
+            "place_id",
+            "zone_id",
+            "evidence",
+            "confidence",
+        ]
+    )
+    for p in proposals:
+        writer.writerow(
+            [
+                p.character_entity_id,
+                p.character_name,
+                p.anchor_type,
+                p.mobility_policy,
+                p.place_id if p.place_id is not None else "",
+                p.zone_id if p.zone_id is not None else "",
+                p.evidence,
+                p.confidence,
+            ]
+        )
+
+
+def apply_proposals(conn, proposals: list[AnchorProposal]) -> int:
+    applied = 0
+    for p in proposals:
+        if p.mobility_policy == UNPROVISIONED:
+            continue
+        conn.execute(
+            text(
+                """
+                INSERT INTO character_routine_anchors (
+                    character_entity_id, anchor_type, place_id, zone_id,
+                    mobility_policy, schedule, source
+                ) VALUES (
+                    :entity_id, :anchor_type, :place_id, :zone_id,
+                    :mobility_policy, '{}'::jsonb, 'compiler_backfill'
+                )
+                ON CONFLICT (character_entity_id, anchor_type) DO NOTHING
+                """
+            ),
+            {
+                "entity_id": p.character_entity_id,
+                "anchor_type": p.anchor_type,
+                "place_id": p.place_id,
+                "zone_id": p.zone_id,
+                "mobility_policy": p.mobility_policy,
+            },
+        )
+        applied += 1
+    return applied
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--slot", type=int, required=True, help="Save slot (1-5)")
+    parser.add_argument(
+        "--out",
+        type=str,
+        default=None,
+        help="Review CSV path (default: stdout)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write derivable anchors to the database (after CSV review)",
+    )
+    args = parser.parse_args()
+
+    engine = create_engine(get_slot_db_url(slot=args.slot))
+    with engine.begin() as conn:
+        proposals = collect_proposals(conn)
+        derivable = [p for p in proposals if p.mobility_policy != UNPROVISIONED]
+        missing = [p for p in proposals if p.mobility_policy == UNPROVISIONED]
+
+        if args.apply:
+            applied = apply_proposals(conn, proposals)
+            print(
+                f"slot {args.slot}: applied {applied} home anchors; "
+                f"{len(missing)} characters remain unprovisioned "
+                "(no derivable evidence — retrofit pass required)"
+            )
+        else:
+            out = open(args.out, "w", newline="") if args.out else sys.stdout
+            try:
+                write_csv(proposals, out)
+            finally:
+                if args.out:
+                    out.close()
+            print(
+                f"\nslot {args.slot}: {len(derivable)} derivable "
+                f"({sum(1 for p in derivable if p.confidence == 'high')} high, "
+                f"{sum(1 for p in derivable if p.confidence == 'medium')} medium), "
+                f"{len(missing)} unprovisioned. Dry run — re-run with --apply "
+                "after review.",
+                file=sys.stderr,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backfill_routine_anchors.py
+++ b/scripts/backfill_routine_anchors.py
@@ -57,6 +57,11 @@ class AnchorProposal:
 
 UNPROVISIONED = "unprovisioned"
 
+# Zone 0 is the "vehicles" zone: a character currently aboard a conveyance
+# has no home-zone evidence there (though it may mean they are nomadic —
+# a retrofit-review question, not a backfill guess).
+VEHICLES_ZONE_ID = 0
+
 
 def collect_proposals(conn) -> list[AnchorProposal]:
     rows = conn.execute(
@@ -67,7 +72,7 @@ def collect_proposals(conn) -> list[AnchorProposal]:
                 c.name,
                 resides.place_id AS resides_place_id,
                 cur.id AS current_place_id,
-                NULLIF(cur.zone, 0) AS current_zone_id
+                cur.zone AS current_zone_id
             FROM characters c
             LEFT JOIN character_routine_anchors cra
                 ON cra.character_entity_id = c.entity_id
@@ -103,6 +108,23 @@ def collect_proposals(conn) -> list[AnchorProposal]:
                     zone_id=None,
                     evidence=f"resides_at -> place {row['resides_place_id']}",
                     confidence="high",
+                )
+            )
+        elif row["current_zone_id"] == VEHICLES_ZONE_ID:
+            proposals.append(
+                AnchorProposal(
+                    character_entity_id=row["entity_id"],
+                    character_name=row["name"],
+                    anchor_type="home",
+                    mobility_policy=UNPROVISIONED,
+                    place_id=None,
+                    zone_id=None,
+                    evidence=(
+                        f"current location place {row['current_place_id']} is "
+                        "in the vehicles zone — aboard a conveyance, not home "
+                        "evidence (possibly nomadic; review)"
+                    ),
+                    confidence="none",
                 )
             )
         elif row["current_zone_id"] is not None:

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -207,11 +207,39 @@ class FakeLore:
         self.memnon = FakeMemnon(session)
 
 
+MUNDANE_BAND_IDS = frozenset({"train", "run_errands", "stroll", "upkeep", "recreate"})
+
+
+def _mundane_cooldown_event_rows(entity_id: int, anchor_chunk_id: int) -> list:
+    """Recent mundane-band events: tests that pin another package's behavior
+    suppress the universal ambient floor through its own cooldowns."""
+
+    return [
+        {
+            "event_type": event_type,
+            "tick_chunk_id": anchor_chunk_id - 1,
+            "actor_entity_id": entity_id,
+            "target_entity_id": None,
+            "location_id": None,
+            "changed_fields": [],
+            "world_layer": "primary",
+            "payload": {},
+        }
+        for event_type in (
+            "training_performed",
+            "errands_run",
+            "stroll_taken",
+            "upkeep_done",
+            "recreation_taken",
+        )
+    ]
+
+
 def test_resolve_dry_run_allows_null_resolution() -> None:
     """Dry-run resolution can skip under-specified actors without fallback noise."""
 
     proposal = resolve_dry_run(
-        FakeSession(),
+        FakeSession(event_rows=_mundane_cooldown_event_rows(1, 100)),
         BUILTIN_TEMPLATES,
         anchor_chunk_id=100,
         window_chunks=30,
@@ -221,6 +249,20 @@ def test_resolve_dry_run_allows_null_resolution() -> None:
     assert proposal.actor_count == 1
     assert proposal.resolution_count == 0
     assert proposal.pressure_count == 0
+
+
+def test_resolve_dry_run_idle_actor_gets_mundane_floor() -> None:
+    """A located, idle actor with no other pressure fires the mundane band."""
+
+    proposal = resolve_dry_run(
+        FakeSession(),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert proposal.resolution_count == 1
+    assert proposal.resolutions[0].template_id in MUNDANE_BAND_IDS
 
 
 def test_resolve_dry_run_excludes_anchor_present_characters() -> None:
@@ -365,6 +407,7 @@ def test_maintain_cover_requires_positive_cover_context() -> None:
                 {"id": 10, "location_class": "fixed_location", "is_primary": True},
                 {"id": 10, "location_class": "place_open", "is_primary": False},
             ],
+            event_rows=_mundane_cooldown_event_rows(1, 100),
         ),
         BUILTIN_TEMPLATES,
         anchor_chunk_id=100,
@@ -651,6 +694,7 @@ def test_resolve_dry_run_filters_inapplicable_need_rows(
                     ),
                 }
             ],
+            event_rows=_mundane_cooldown_event_rows(1, 100),
         ),
         BUILTIN_TEMPLATES,
         anchor_chunk_id=100,
@@ -659,6 +703,26 @@ def test_resolve_dry_run_filters_inapplicable_need_rows(
 
     assert proposal.resolution_count == 0
     assert proposal.pressure_count == 0
+
+
+def test_mundane_band_physical_packages_refuse_non_corporeal_minds() -> None:
+    """A virtual mind does not stroll, train, run errands, or tidy quarters."""
+
+    proposal = resolve_dry_run(
+        FakeSession(
+            tag_rows=[{"entity_id": 1, "tag": "virtual", "is_ephemeral": False}],
+        ),
+        BUILTIN_TEMPLATES,
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    physical = {"train", "run_errands", "stroll", "upkeep"}
+    assert not [
+        draft
+        for draft in proposal.resolutions
+        if draft.template_id in physical
+    ]
 
 
 def test_resolve_dry_run_keeps_socialize_for_virtual_characters() -> None:
@@ -779,6 +843,7 @@ def test_resolve_dry_run_fires_intimacy_need_template_without_pairing() -> None:
                     ),
                 }
             ],
+            event_rows=_mundane_cooldown_event_rows(1, 100),
         ),
         BUILTIN_TEMPLATES,
         anchor_chunk_id=100,
@@ -927,6 +992,7 @@ def test_intimacy_partner_branch_requires_partner_relationship() -> None:
                     ),
                 }
             ],
+            event_rows=_mundane_cooldown_event_rows(1, 100),
         ),
         BUILTIN_TEMPLATES,
         anchor_chunk_id=100,
@@ -966,6 +1032,7 @@ def test_intimacy_suppressor_blocks_intimacy_template() -> None:
                     ),
                 }
             ],
+            event_rows=_mundane_cooldown_event_rows(1, 100),
         ),
         BUILTIN_TEMPLATES,
         anchor_chunk_id=100,
@@ -1352,6 +1419,7 @@ def test_work_does_not_fire_from_workplace_place_class_alone() -> None:
                     "is_primary": True,
                 },
             ],
+            event_rows=_mundane_cooldown_event_rows(1, 100),
         ),
         BUILTIN_TEMPLATES,
         anchor_chunk_id=100,
@@ -1520,7 +1588,8 @@ def test_work_template_uses_one_global_work_cooldown() -> None:
                     "world_layer": "primary",
                     "payload": {},
                 }
-            ],
+            ]
+            + _mundane_cooldown_event_rows(1, 100),
         ),
         BUILTIN_TEMPLATES,
         anchor_chunk_id=100,
@@ -1619,7 +1688,8 @@ async def test_resolve_orrery_attaches_proposal_when_enabled() -> None:
 
     assert context.orrery_proposal is not None
     assert context.orrery_proposal.anchor_chunk_id == 100
-    assert context.phase_states["orrery_resolve"]["resolution_count"] == 0
+    # The default idle located actor receives the mundane-band floor.
+    assert context.phase_states["orrery_resolve"]["resolution_count"] == 1
     assert context.context_payload == {}
 
 


### PR DESCRIPTION
## Summary
Second dynamism bundle — the user's core idea: a low-priority, setting-neutral band of things NPCs do absent external pressure, paired with "somewhere to be" (routine anchors).

**Five new packages** (all `anchored_routine`, magnitudes below the promote floor — ambient texture + event-ecology fuel):

| Package | Pri | Gate character |
|---|---|---|
| `train` | 16 | identity-conditional (wide body/skill tag OR) |
| `run_errands` | 13 | universal, daytime |
| `stroll` | 12 | universal |
| `upkeep` | 11 | universal (own space/kit; distinct from WORK's household-as-role branch) |
| `recreate` | 9 | universal, afternoon–night, not while grieving |

Bodyform discipline mirrors `NEED_IMMUNITY_TAGS`: non-corporeal minds refuse the four physical packages (a virtual entity does not stroll); androids/constructs keep full access. Constrained actors refuse everywhere. Staggered cooldowns (5/6/7/8/9 ticks) + migration 068's five event types make an unpressured actor cycle through varied verbs.

**Routine-anchor backfill** (`scripts/backfill_routine_anchors.py`): review-CSV-gated home-anchor proposals — `resides_at` → fixed_place (high), else current location's zone → zone_resolved (medium). Slot 2 dry run: 20 medium, 21 unprovisioned (procedural retrograde cast — needs the retrofit pass). **Not applied**; the CSV is a user-review deliverable.

## Live Verification (slot 2 head, 19 actors)
- Silent actors: **15 → 0**. Every actor has exactly one solo winner; previously-trapped actors (Sullivan, Raven, Dr. Cross…) now fire.
- Winner census: run_errands 19, reach_out 13 (Bundle 1's widened gate reaching real friends/companions), surveil 2, check_on_dependent 1.
- 573 orrery tests pass (one environmental failure: local uncommitted `[orrery.dashboard]` flag). Demo presets and package-pinning tests suppress the ambient floor via the band's own cooldown events — gates untouched.

## Known Limitation (deliberate)
First-fire cross-actor lockstep: cooldowns start in sync, so unpressured actors currently march through the same verb sequence together. Bundle 4 (habituation from committed win history + fan-out quota) is the designed fix; noting it here so reviewers don't re-derive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY