### PR TITLE
Orrery Bundle 3: Ecology — Hunting Writer, ACT_ON_INTEL, Signal Detection Filter

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -207,9 +207,10 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 - **AND:**
   - actor has `hunting` pair tag to target
+  - **NOT:** actor and target are co-located
   - ≥ 18 ticks since last `hunt_declared` event for (actor, target) pair
 
-**Does:** activity → "letting a hunt go cold"; clears inbound `hunting` pair tags from target
+**Does:** activity → "letting a hunt go cold"; `entity_pair_tags.clear_outbound` = `['hunting']`
 **Event:** `hunt_called_off`
 
 > {actor} stops feeding the hunt for {target} — the watchers wander off, the standing questions expire — not forgiveness, just the quiet arithmetic of effort against a target who will not surface.

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -210,7 +210,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **NOT:** actor and target are co-located
   - ≥ 18 ticks since last `hunt_declared` event for (actor, target) pair
 
-**Does:** activity → "letting a hunt go cold"; `entity_pair_tags.clear_outbound` = `['hunting']`
+**Does:** activity → "letting a hunt go cold"; clears own outbound `hunting` pair tag to target
 **Event:** `hunt_called_off`
 
 > {actor} stops feeding the hunt for {target} — the watchers wander off, the standing questions expire — not forgiveness, just the quiet arithmetic of effort against a target who will not surface.
@@ -266,7 +266,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - actor has any of [`vendetta_holder`, `violent_history`]
   - **NOT:** actor has `hunting` pair tag to target
 
-**Does:** activity → "hunting a grudge target"; `entity_pair_tags.add_outbound` = `['hunting']`
+**Does:** activity → "hunting a grudge target"; adds outbound `hunting` pair tag to target
 **Event:** `hunt_declared`
 
 > {actor} stops waiting for {target} to wander into reach and starts hunting in earnest — questions placed with the right people, routes watched, a price quietly attached to a location. The grudge acquires infrastructure.

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -197,9 +197,28 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
     - trust actor→target < -2
   - ≥ 8 ticks since last `retaliation_attempted` event for actor
   - ≥ 8 ticks since last `retaliation_executed` event for actor
+  - ≥ 8 ticks since last `hunt_declared` event for actor
+  - ≥ 8 ticks since last `hunt_called_off` event for actor
   - **NOT:** actor has inbound `hunting` pair tag
 
-### Branch 1 — Strike directly when opportunity opens  *(mag 0.85)*
+### Branch 1 — Let the hunt go cold  *(mag 0.3)* · **preemptive**
+
+**When:**
+
+- **AND:**
+  - actor has `hunting` pair tag to target
+  - ≥ 18 ticks since last `hunt_declared` event for (actor, target) pair
+
+**Does:** activity → "letting a hunt go cold"; clears inbound `hunting` pair tags from target
+**Event:** `hunt_called_off`
+
+> {actor} stops feeding the hunt for {target} — the watchers wander off, the standing questions expire — not forgiveness, just the quiet arithmetic of effort against a target who will not surface.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} has quietly stopped hunting {target}. If the scene touches it, show the pressure lifting — a tail that is no longer there — rather than an announcement.
+
+### Branch 2 — Strike directly when opportunity opens  *(mag 0.85)*
 
 **When:**
 
@@ -217,7 +236,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor}'s grudge is close enough to {target}'s current scene to become immediate pressure. Treat it as a possible threat, interruption, warning sign, or delayed consequence rather than an automatic attack.
 
-### Branch 2 — Surface a reputation attack in the right channels  *(mag 0.58)*
+### Branch 3 — Surface a reputation attack in the right channels  *(mag 0.58)*
 
 **When:**
 
@@ -237,7 +256,25 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} is trying to compromise {target}'s reputation through off-screen channels. If useful, let the current scene show a rumor, message, social consequence, or pressure wave instead of a direct state change.
 
-### Branch 3 — Watch and document, waiting for a better window  *(mag 0.34)*
+### Branch 4 — Declare the hunt  *(mag 0.66)*
+
+**When:**
+
+- **AND:**
+  - **NOT:** actor and target are co-located
+  - actor has any of [`vendetta_holder`, `violent_history`]
+  - **NOT:** actor has `hunting` pair tag to target
+
+**Does:** activity → "hunting a grudge target"; `entity_pair_tags.add_outbound` = `['hunting']`
+**Event:** `hunt_declared`
+
+> {actor} stops waiting for {target} to wander into reach and starts hunting in earnest — questions placed with the right people, routes watched, a price quietly attached to a location. The grudge acquires infrastructure.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} has begun actively hunting {target}. The scene may surface this as watchers, questions asked about {target}, or a warning reaching them — the hunt exists off-screen either way.
+
+### Branch 5 — Watch and document, waiting for a better window  *(mag 0.34)*
 
 **When:** *(always)*
 
@@ -664,6 +701,70 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 **Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
 
 > {actor} has sent {target} a routine welfare-check message. The scene may use this as an unread notification, an answered exchange, or texture for {target}'s decisions.
+
+---
+
+## ACT_ON_INTEL — priority 52
+
+> Watching turns into acting: accumulated intel gets spent.
+
+**Drive band:** project identity — Spending accumulated surveillance is a deliberate project move that outranks continuing to watch (SURVEIL, 48): intel hoarded forever is the dominance pathology this package exists to break.
+**Slots:** ACTOR, TARGET
+**Present-target policy:** may target an on-screen entity — but only as a prompt-only scene-pressure draft routed through storyteller LLM review (no direct state mutation, no canonical event)
+
+**Gate:**
+
+- **AND:**
+  - ≥ 3 `surveillance_performed` events within 25 ticks for (actor, target) pair
+  - ≥ 12 ticks since last `intel_acted_on` event for (actor, target) pair
+  - **NOT:** actor has inbound `hunting` pair tag
+  - **NOT:** actor is constrained or immobilized
+
+### Branch 1 — Sell the dossier  *(mag 0.62)*
+
+**When:**
+
+- **OR:**
+  - actor has outbound `contact:social` pair tag
+  - **OR:**
+    - actor is in `urban_dense` place class
+    - actor is in `commerce` place class
+    - actor is in `meeting` place class
+
+**Does:** activity → "selling gathered intelligence"
+**Event:** `intel_acted_on`
+
+> {actor} packages what watching {target} has taught them — patterns, contacts, weaknesses — and trades it to someone who pays in favors or coin. The knowledge stops being private the moment it changes hands.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} has sold intelligence about {target}. The scene may surface this as {target} noticing new attention, a contact warning them, or consequences arriving from a third party.
+
+### Branch 2 — Confront the subject with what they know  *(mag 0.58)*
+
+**When:** actor and target are co-located
+
+**Does:** activity → "confronting a surveilled subject"
+**Event:** `intel_acted_on`
+
+> {actor} stops pretending not to watch and puts what they know in front of {target} — names, times, patterns — to see what the knowledge is worth when spent face to face.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is confronting {target} with gathered intelligence. Treat as charged pressure the scene can play as threat, negotiation, or revelation.
+
+### Branch 3 — File it and keep the watch alive  *(mag 0.3)*
+
+**When:** *(always)*
+
+**Does:** activity → "consolidating intelligence"
+**Event:** `intel_acted_on`
+
+> {actor} consolidates what watching {target} has produced — cross-checking, indexing, pruning dead leads — turning scattered observation into something that could be used on short notice.
+
+**Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
+
+> {actor} is quietly consolidating what they know about {target}. Background pressure only; nothing reaches {target} this tick.
 
 ---
 
@@ -2617,8 +2718,11 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `hideout_maintained`
 - `honor_debt`
 - `household_work_performed`
+- `hunt_called_off`
+- `hunt_declared`
 - `informant_contact`
 - `intel_acquired`
+- `intel_acted_on`
 - `intel_reviewed`
 - `intimacy_deferred`
 - `intimacy_fulfilled`

--- a/migrations/069_ecology_event_vocab.sql
+++ b/migrations/069_ecology_event_vocab.sql
@@ -1,0 +1,27 @@
+-- 069_ecology_event_vocab.sql
+--
+-- Event vocabulary for the ecology bundle: the hunting lifecycle
+-- (EXTRACT_VENGEANCE's declare/off-ramp branches are the first writer of
+-- the `hunting` pair tag) and ACT_ON_INTEL's accumulate-then-spend cycle.
+
+INSERT INTO event_types (type, category, severity, description)
+VALUES
+    (
+        'hunt_declared',
+        'threat',
+        'moderate',
+        'The actor escalated a grudge into an active hunt for the target, applying the outbound hunting pair tag. Consumed by EXTRACT_VENGEANCE''s own pacing cooldowns; the tag itself arms EVADE_PURSUERS/HIDE/WARN_ALLY/PROTECT_KIN.'
+    ),
+    (
+        'hunt_called_off',
+        'threat',
+        'minor',
+        'A hunt went cold: the hunter released the outbound hunting pair tag after a long unproductive stretch. The prey''s suppressed social and routine packages reopen.'
+    ),
+    (
+        'intel_acted_on',
+        'intelligence',
+        'moderate',
+        'Accumulated surveillance was spent: sold onward, used in confrontation, or consolidated. Consumed by ACT_ON_INTEL''s per-target cooldown.'
+    )
+ON CONFLICT (type) DO NOTHING;

--- a/nexus.toml
+++ b/nexus.toml
@@ -227,6 +227,21 @@ checkpoint_interval_chunks = 25
 max_rendered_proposals = 5
 max_rendered_pressures = 5
 
+[orrery.ecology]
+# Detection percent for emitted branch signals (signal_event_type) whose
+# event type has no explicit rate in [orrery.ecology.signal_detection].
+# The roll is a deterministic hash of (template, actor, target, tick,
+# event type): same state -> same outcome on replay.
+signal_detection_default = 100
+
+[orrery.ecology.signal_detection]
+# Most surveillance goes unnoticed by its subject; overt acts are hard to
+# miss. Undetected signals are recorded in the primary event's payload for
+# the audit layer but feed no gates.
+compliance_alert = 35
+threat_issued = 80
+encoded_message = 95
+
 [orrery.dashboard]
 # Registers the read-only /api/dev/orrery/* audit router on the gateway.
 # Server-side gate (import.meta.env.DEV only hides the client bundle): the

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -508,6 +508,14 @@ def _render_state_delta(delta: Mapping[str, Any]) -> str:
             tags = ", ".join(f"`{t}`" for t in value)
             parts.append(f"clears inbound {tags} pair tags from target")
             continue
+        if key == "entity_pair_tags.add_outbound":
+            tags = ", ".join(f"`{t}`" for t in value)
+            parts.append(f"adds outbound {tags} pair tag to target")
+            continue
+        if key == "entity_pair_tags.clear_outbound":
+            tags = ", ".join(f"`{t}`" for t in value)
+            parts.append(f"clears own outbound {tags} pair tag to target")
+            continue
         if key == "need.fulfill":
             if isinstance(value, Mapping):
                 need = value.get("type") or value.get("need")
@@ -758,7 +766,11 @@ def _collect_vocabulary(
             if branch.event_type:
                 events.add(branch.event_type)
             for key, value in branch.state_delta.items():
-                if key == "entity_pair_tags_target.clear_inbound":
+                if key in (
+                    "entity_pair_tags_target.clear_inbound",
+                    "entity_pair_tags.add_outbound",
+                    "entity_pair_tags.clear_outbound",
+                ):
                     if isinstance(value, list):
                         for tag in value:
                             pair_tags.add(str(tag))

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -7,7 +7,8 @@ only place that materializes those proposals into canonical Orrery tables.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
+from hashlib import sha256
 from datetime import timedelta
 import json
 from typing import Any, Mapping, Optional
@@ -42,6 +43,7 @@ SUPPORTED_STATE_DELTA_KEYS = frozenset(
         "entity_tags.remove",
         "entity_tags_target.add",
         "entity_tags_target.remove",
+        "entity_pair_tags.add_outbound",
         "entity_pair_tags_target.clear_inbound",
         "need.fulfill",
         "travel.start",
@@ -58,8 +60,65 @@ REPLACEMENT_STATE_DELTA_ALIASES = {
     "entity_tags_remove": "entity_tags.remove",
     "entity_tags_target_add": "entity_tags_target.add",
     "entity_tags_target_remove": "entity_tags_target.remove",
+    "entity_pair_tags_add_outbound": "entity_pair_tags.add_outbound",
     "entity_pair_tags_target_clear_inbound": ("entity_pair_tags_target.clear_inbound"),
 }
+
+
+@dataclass(frozen=True)
+class SignalDetection:
+    """Deterministic detection policy for branch signal emissions.
+
+    A branch's signal_event_type only lands as a world_events row (and so
+    only feeds other packages' gates) when a hash roll over (template,
+    actor, target, tick, event type) clears the configured percent. The
+    default policy detects everything — filtering is opt-in via
+    [orrery.ecology] in nexus.toml.
+    """
+
+    default_pct: int = 100
+    rates: Mapping[str, int] = field(default_factory=dict)
+
+    def outcome(
+        self,
+        *,
+        template_id: str,
+        actor_entity_id: Optional[int],
+        target_entity_id: Optional[int],
+        tick_chunk_id: int,
+        event_type: str,
+    ) -> dict[str, Any]:
+        threshold = int(self.rates.get(event_type, self.default_pct))
+        material = (
+            f"{template_id}:{actor_entity_id}:{target_entity_id}"
+            f":{tick_chunk_id}:{event_type}"
+        )
+        roll = int(sha256(material.encode("utf-8")).hexdigest(), 16) % 100
+        return {
+            "event_type": event_type,
+            "roll": roll,
+            "threshold": threshold,
+            "detected": roll < threshold,
+        }
+
+
+def coerce_signal_detection(raw: Any) -> SignalDetection:
+    """[orrery.ecology] settings payload -> SignalDetection policy."""
+
+    if raw is None:
+        return SignalDetection()
+    if hasattr(raw, "signal_detection_default"):
+        return SignalDetection(
+            default_pct=int(raw.signal_detection_default),
+            rates=dict(raw.signal_detection),
+        )
+    if isinstance(raw, Mapping):
+        return SignalDetection(
+            default_pct=int(raw.get("signal_detection_default", 100)),
+            rates=dict(raw.get("signal_detection") or {}),
+        )
+    raise ValueError(f"Unsupported orrery ecology settings: {type(raw)!r}")
+
 
 TRAVEL_MODE_DETOUR_FACTOR = {
     "walking": 1.35,
@@ -264,9 +323,11 @@ def commit_orrery_tick_sync(
     adjudications: Any = None,
     storyteller_state_updates: Any = None,
     prompt_settings: Optional[Any] = None,
+    ecology_settings: Optional[Any] = None,
 ) -> CommitOrreryTickResult:
     """Materialize a preview proposal inside the accepted-chunk transaction."""
 
+    signal_detection = coerce_signal_detection(ecology_settings)
     coerced = coerce_proposal(proposal)
     has_resolutions = coerced is not None and bool(coerced.resolutions)
     if has_resolutions:
@@ -433,6 +494,7 @@ def commit_orrery_tick_sync(
                 actor_entity_id=actor_entity_id,
                 target_entity_id=target_entity_id,
                 world_layer=world_layer,
+                signal_detection=signal_detection,
             )
             if event_id is not None:
                 event_count += 1
@@ -472,9 +534,11 @@ async def commit_orrery_tick_async(
     adjudications: Any = None,
     storyteller_state_updates: Any = None,
     prompt_settings: Optional[Any] = None,
+    ecology_settings: Optional[Any] = None,
 ) -> CommitOrreryTickResult:
     """Async parity wrapper for tests and non-production commit callers."""
 
+    signal_detection = coerce_signal_detection(ecology_settings)
     coerced = coerce_proposal(proposal)
     has_resolutions = coerced is not None and bool(coerced.resolutions)
     if has_resolutions:
@@ -640,6 +704,7 @@ async def commit_orrery_tick_async(
             actor_entity_id=actor_entity_id,
             target_entity_id=target_entity_id,
             world_layer=world_layer,
+            signal_detection=signal_detection,
         )
         if event_id is not None:
             event_count += 1
@@ -1415,6 +1480,25 @@ def _apply_state_delta_sync(
                 template_id=draft.template_id,
                 source_chunk_id=source_chunk_id,
             )
+    outbound_pair_tag_adds = (
+        draft.state_delta.get("entity_pair_tags.add_outbound", ()) or ()
+    )
+    if outbound_pair_tag_adds:
+        if target_entity_id is None:
+            raise ValueError(
+                f"Orrery draft {draft.template_id} adds an outbound pair tag "
+                "but has no target binding"
+            )
+        for tag in outbound_pair_tag_adds:
+            if _add_outbound_pair_tag_sync(
+                cur,
+                subject_entity_id=actor_entity_id,
+                object_entity_id=target_entity_id,
+                tag=str(tag),
+                template_id=draft.template_id,
+                source_chunk_id=source_chunk_id,
+            ):
+                tag_mutations += 1
     if "need.fulfill" in draft.state_delta:
         tag_mutations += _apply_need_fulfillment_sync(
             cur,
@@ -1539,6 +1623,25 @@ async def _apply_state_delta_async(
                 template_id=draft.template_id,
                 source_chunk_id=source_chunk_id,
             )
+    outbound_pair_tag_adds = (
+        draft.state_delta.get("entity_pair_tags.add_outbound", ()) or ()
+    )
+    if outbound_pair_tag_adds:
+        if target_entity_id is None:
+            raise ValueError(
+                f"Orrery draft {draft.template_id} adds an outbound pair tag "
+                "but has no target binding"
+            )
+        for tag in outbound_pair_tag_adds:
+            if await _add_outbound_pair_tag_async(
+                conn,
+                subject_entity_id=actor_entity_id,
+                object_entity_id=target_entity_id,
+                tag=str(tag),
+                template_id=draft.template_id,
+                source_chunk_id=source_chunk_id,
+            ):
+                tag_mutations += 1
     if "need.fulfill" in draft.state_delta:
         tag_mutations += await _apply_need_fulfillment_async(
             conn,
@@ -2739,6 +2842,53 @@ def _clear_inbound_pair_tags_sync(
     return len(cleared_ids)
 
 
+def _registered_pair_tag_id_sync(cur: Any, tag: str) -> int:
+    cur.execute("SELECT id FROM pair_tags WHERE tag = %s", (tag,))
+    row = cur.fetchone()
+    if not row:
+        raise ValueError(f"Orrery pair tag {tag!r} is not registered")
+    return _row_get(row, "id", 0)
+
+
+def _add_outbound_pair_tag_sync(
+    cur: Any,
+    *,
+    subject_entity_id: int,
+    object_entity_id: int,
+    tag: str,
+    template_id: str,
+    source_chunk_id: int,
+) -> bool:
+    """Create a directed pair tag (actor -> target) from a branch outcome.
+
+    The write mirrors _add_entity_tag_sync: template provenance, world-time
+    stamp, and ON CONFLICT DO NOTHING against the unique current-row index
+    so re-fires while the edge is live are no-ops.
+    """
+
+    pair_tag_id = _registered_pair_tag_id_sync(cur, tag)
+    cur.execute(
+        """
+        INSERT INTO entity_pair_tags (
+            subject_entity_id, object_entity_id, pair_tag_id,
+            source_kind, applied_at_world_time, template_id, source_chunk_id
+        )
+        VALUES (%s, %s, %s, 'template', %s, %s, %s)
+        ON CONFLICT DO NOTHING
+        RETURNING id
+        """,
+        (
+            subject_entity_id,
+            object_entity_id,
+            pair_tag_id,
+            _chunk_world_time_sync(cur, source_chunk_id),
+            template_id,
+            source_chunk_id,
+        ),
+    )
+    return cur.fetchone() is not None
+
+
 async def _remove_entity_tag_async(
     conn: Any,
     entity_id: int,
@@ -2825,6 +2975,46 @@ async def _clear_inbound_pair_tags_async(
     return len(cleared_ids)
 
 
+async def _registered_pair_tag_id_async(conn: Any, tag: str) -> int:
+    row = await conn.fetchrow("SELECT id FROM pair_tags WHERE tag = $1", tag)
+    if not row:
+        raise ValueError(f"Orrery pair tag {tag!r} is not registered")
+    return _row_get(row, "id", 0)
+
+
+async def _add_outbound_pair_tag_async(
+    conn: Any,
+    *,
+    subject_entity_id: int,
+    object_entity_id: int,
+    tag: str,
+    template_id: str,
+    source_chunk_id: int,
+) -> bool:
+    """Async twin of _add_outbound_pair_tag_sync."""
+
+    pair_tag_id = await _registered_pair_tag_id_async(conn, tag)
+    world_time = await _chunk_world_time_async(conn, source_chunk_id)
+    row = await conn.fetchrow(
+        """
+        INSERT INTO entity_pair_tags (
+            subject_entity_id, object_entity_id, pair_tag_id,
+            source_kind, applied_at_world_time, template_id, source_chunk_id
+        )
+        VALUES ($1, $2, $3, 'template', $4, $5, $6)
+        ON CONFLICT DO NOTHING
+        RETURNING id
+        """,
+        subject_entity_id,
+        object_entity_id,
+        pair_tag_id,
+        world_time,
+        template_id,
+        source_chunk_id,
+    )
+    return row is not None
+
+
 def _emit_world_event_sync(
     cur: Any,
     draft: OrreryResolutionDraft,
@@ -2834,13 +3024,22 @@ def _emit_world_event_sync(
     actor_entity_id: Optional[int],
     target_entity_id: Optional[int],
     world_layer: Optional[str],
+    signal_detection: SignalDetection,
 ) -> Optional[int]:
     if not draft.event_type:
         return None
 
     _ensure_event_type_sync(cur, draft.event_type)
+    detection_outcome: Optional[dict[str, Any]] = None
     if draft.signal_event_type:
         _ensure_event_type_sync(cur, draft.signal_event_type)
+        detection_outcome = signal_detection.outcome(
+            template_id=draft.template_id,
+            actor_entity_id=actor_entity_id,
+            target_entity_id=target_entity_id,
+            tick_chunk_id=tick_chunk_id,
+            event_type=draft.signal_event_type,
+        )
     location_id = _actor_location_sync(cur, actor_entity_id)
     payload = {
         "proposal_id": draft.proposal_id,
@@ -2850,6 +3049,10 @@ def _emit_world_event_sync(
         "branch_label": draft.branch_label,
         "narrative_stub": draft.narrative_stub,
     }
+    if detection_outcome is not None:
+        # Recorded on the primary event either way so the audit layer can
+        # show "signal went out, undetected" without a phantom event row.
+        payload["signal_detection"] = detection_outcome
     cur.execute(
         """
         INSERT INTO world_events (
@@ -2891,7 +3094,7 @@ def _emit_world_event_sync(
             """,
             (event_id, target_entity_id),
         )
-    if draft.signal_event_type:
+    if draft.signal_event_type and detection_outcome and detection_outcome["detected"]:
         # The act's signal: a second, additive emission with the same
         # bindings so other packages' gates can hear it (spec idea 7).
         cur.execute(
@@ -2927,13 +3130,22 @@ async def _emit_world_event_async(
     actor_entity_id: Optional[int],
     target_entity_id: Optional[int],
     world_layer: Optional[str],
+    signal_detection: SignalDetection,
 ) -> Optional[int]:
     if not draft.event_type:
         return None
 
     await _ensure_event_type_async(conn, draft.event_type)
+    detection_outcome: Optional[dict[str, Any]] = None
     if draft.signal_event_type:
         await _ensure_event_type_async(conn, draft.signal_event_type)
+        detection_outcome = signal_detection.outcome(
+            template_id=draft.template_id,
+            actor_entity_id=actor_entity_id,
+            target_entity_id=target_entity_id,
+            tick_chunk_id=tick_chunk_id,
+            event_type=draft.signal_event_type,
+        )
     location_id = await _actor_location_async(conn, actor_entity_id)
     payload = {
         "proposal_id": draft.proposal_id,
@@ -2943,6 +3155,8 @@ async def _emit_world_event_async(
         "branch_label": draft.branch_label,
         "narrative_stub": draft.narrative_stub,
     }
+    if detection_outcome is not None:
+        payload["signal_detection"] = detection_outcome
     event_id = await conn.fetchval(
         """
         INSERT INTO world_events (
@@ -2986,7 +3200,7 @@ async def _emit_world_event_async(
             event_id,
             target_entity_id,
         )
-    if draft.signal_event_type:
+    if draft.signal_event_type and detection_outcome and detection_outcome["detected"]:
         # Same additive signal emission as the sync twin.
         await conn.execute(
             """

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -44,6 +44,7 @@ SUPPORTED_STATE_DELTA_KEYS = frozenset(
         "entity_tags_target.add",
         "entity_tags_target.remove",
         "entity_pair_tags.add_outbound",
+        "entity_pair_tags.clear_outbound",
         "entity_pair_tags_target.clear_inbound",
         "need.fulfill",
         "travel.start",
@@ -61,6 +62,7 @@ REPLACEMENT_STATE_DELTA_ALIASES = {
     "entity_tags_target_add": "entity_tags_target.add",
     "entity_tags_target_remove": "entity_tags_target.remove",
     "entity_pair_tags_add_outbound": "entity_pair_tags.add_outbound",
+    "entity_pair_tags_clear_outbound": "entity_pair_tags.clear_outbound",
     "entity_pair_tags_target_clear_inbound": ("entity_pair_tags_target.clear_inbound"),
 }
 
@@ -1499,6 +1501,24 @@ def _apply_state_delta_sync(
                 source_chunk_id=source_chunk_id,
             ):
                 tag_mutations += 1
+    outbound_pair_tag_clears = (
+        draft.state_delta.get("entity_pair_tags.clear_outbound", ()) or ()
+    )
+    if outbound_pair_tag_clears:
+        if target_entity_id is None:
+            raise ValueError(
+                f"Orrery draft {draft.template_id} clears an outbound pair "
+                "tag but has no target binding"
+            )
+        for tag in outbound_pair_tag_clears:
+            tag_mutations += _clear_outbound_pair_tag_sync(
+                cur,
+                subject_entity_id=actor_entity_id,
+                object_entity_id=target_entity_id,
+                tag=str(tag),
+                template_id=draft.template_id,
+                source_chunk_id=source_chunk_id,
+            )
     if "need.fulfill" in draft.state_delta:
         tag_mutations += _apply_need_fulfillment_sync(
             cur,
@@ -1642,6 +1662,24 @@ async def _apply_state_delta_async(
                 source_chunk_id=source_chunk_id,
             ):
                 tag_mutations += 1
+    outbound_pair_tag_clears = (
+        draft.state_delta.get("entity_pair_tags.clear_outbound", ()) or ()
+    )
+    if outbound_pair_tag_clears:
+        if target_entity_id is None:
+            raise ValueError(
+                f"Orrery draft {draft.template_id} clears an outbound pair "
+                "tag but has no target binding"
+            )
+        for tag in outbound_pair_tag_clears:
+            tag_mutations += await _clear_outbound_pair_tag_async(
+                conn,
+                subject_entity_id=actor_entity_id,
+                object_entity_id=target_entity_id,
+                tag=str(tag),
+                template_id=draft.template_id,
+                source_chunk_id=source_chunk_id,
+            )
     if "need.fulfill" in draft.state_delta:
         tag_mutations += await _apply_need_fulfillment_async(
             conn,
@@ -2889,6 +2927,62 @@ def _add_outbound_pair_tag_sync(
     return cur.fetchone() is not None
 
 
+def _clear_outbound_pair_tag_sync(
+    cur: Any,
+    *,
+    subject_entity_id: int,
+    object_entity_id: int,
+    tag: str,
+    template_id: str,
+    source_chunk_id: int,
+) -> int:
+    """Clear one directed edge (actor -> target) only.
+
+    The target-wide variant (_clear_inbound_pair_tags_sync) releases every
+    subject's edge at once — right for a protective intervention, wrong for
+    one hunter abandoning their own hunt while another's is still live.
+    """
+
+    cur.execute(
+        """
+        UPDATE entity_pair_tags ept
+        SET cleared_at = now()
+        FROM pair_tags pt
+        WHERE ept.pair_tag_id = pt.id
+          AND ept.subject_entity_id = %s
+          AND ept.object_entity_id = %s
+          AND pt.tag = %s
+          AND ept.cleared_at IS NULL
+        RETURNING ept.id
+        """,
+        (subject_entity_id, object_entity_id, tag),
+    )
+    cleared_ids = [_row_get(row, "id", 0) for row in cur.fetchall()]
+    world_time = _chunk_world_time_sync(cur, source_chunk_id)
+    for pair_tag_row_id in cleared_ids:
+        cur.execute(
+            """
+            INSERT INTO tag_clearance_log (
+                entity_pair_tag_id, mechanism, cleared_at_world_time,
+                justification, source_chunk_id
+            ) VALUES (%s, 'authored', %s, %s::jsonb, %s)
+            """,
+            (
+                pair_tag_row_id,
+                world_time,
+                json.dumps(
+                    {
+                        "template_id": template_id,
+                        "state_delta": "entity_pair_tags.clear_outbound",
+                        "tag": tag,
+                    }
+                ),
+                source_chunk_id,
+            ),
+        )
+    return len(cleared_ids)
+
+
 async def _remove_entity_tag_async(
     conn: Any,
     entity_id: int,
@@ -3013,6 +3107,57 @@ async def _add_outbound_pair_tag_async(
         source_chunk_id,
     )
     return row is not None
+
+
+async def _clear_outbound_pair_tag_async(
+    conn: Any,
+    *,
+    subject_entity_id: int,
+    object_entity_id: int,
+    tag: str,
+    template_id: str,
+    source_chunk_id: int,
+) -> int:
+    """Async twin of _clear_outbound_pair_tag_sync."""
+
+    rows = await conn.fetch(
+        """
+        UPDATE entity_pair_tags ept
+        SET cleared_at = now()
+        FROM pair_tags pt
+        WHERE ept.pair_tag_id = pt.id
+          AND ept.subject_entity_id = $1
+          AND ept.object_entity_id = $2
+          AND pt.tag = $3
+          AND ept.cleared_at IS NULL
+        RETURNING ept.id
+        """,
+        subject_entity_id,
+        object_entity_id,
+        tag,
+    )
+    cleared_ids = [_row_get(row, "id", 0) for row in rows]
+    world_time = await _chunk_world_time_async(conn, source_chunk_id)
+    for pair_tag_row_id in cleared_ids:
+        await conn.execute(
+            """
+            INSERT INTO tag_clearance_log (
+                entity_pair_tag_id, mechanism, cleared_at_world_time,
+                justification, source_chunk_id
+            ) VALUES ($1, 'authored', $2, $3::jsonb, $4)
+            """,
+            pair_tag_row_id,
+            world_time,
+            json.dumps(
+                {
+                    "template_id": template_id,
+                    "state_delta": "entity_pair_tags.clear_outbound",
+                    "tag": tag,
+                }
+            ),
+            source_chunk_id,
+        )
+    return len(cleared_ids)
 
 
 def _emit_world_event_sync(

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -2881,7 +2881,7 @@ def _clear_inbound_pair_tags_sync(
 
 
 def _registered_pair_tag_id_sync(cur: Any, tag: str) -> int:
-    cur.execute("SELECT id FROM pair_tags WHERE tag = %s", (tag,))
+    cur.execute("SELECT id FROM pair_tags WHERE tag = %s AND NOT deprecated", (tag,))
     row = cur.fetchone()
     if not row:
         raise ValueError(f"Orrery pair tag {tag!r} is not registered")
@@ -3070,7 +3070,9 @@ async def _clear_inbound_pair_tags_async(
 
 
 async def _registered_pair_tag_id_async(conn: Any, tag: str) -> int:
-    row = await conn.fetchrow("SELECT id FROM pair_tags WHERE tag = $1", tag)
+    row = await conn.fetchrow(
+        "SELECT id FROM pair_tags WHERE tag = $1 AND NOT deprecated", tag
+    )
     if not row:
         raise ValueError(f"Orrery pair tag {tag!r} is not registered")
     return _row_get(row, "id", 0)

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -730,8 +730,13 @@ EXTRACT_VENGEANCE = Template(
         # an off-ramp, hunting is an absorbing state from the prey's side.
         Branch(
             label="Let the hunt go cold",
+            # NOT co_located: a hunter who finally has access strikes (the
+            # branch below), they do not shrug at the finish line. The
+            # clear is subject-scoped: abandoning one's own hunt must not
+            # release another hunter's live edge into the same target.
             conditions=AND(
                 has_pair_tag("hunting"),
+                NOT(co_located(Slot.ACTOR, Slot.TARGET)),
                 since_last_event_at_least(
                     "hunt_declared", minimum_ticks=18, target_slot=Slot.TARGET
                 ),
@@ -744,7 +749,7 @@ EXTRACT_VENGEANCE = Template(
             ),
             state_delta={
                 "character.current_activity": "letting a hunt go cold",
-                "entity_pair_tags_target.clear_inbound": ["hunting"],
+                "entity_pair_tags.clear_outbound": ["hunting"],
             },
             event_type="hunt_called_off",
             changed_fields=("character.current_activity", "entity_pair_tags"),

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -30,6 +30,7 @@ from nexus.agents.orrery.substrate import (
     has_location_class_destination,
     has_minimal_context,
     has_need_debt_at_or_above,
+    has_pair_tag,
     has_pair_tag_to_current_location,
     has_relationship_of_type,
     has_symmetric_relationship_of_type,
@@ -718,9 +719,43 @@ EXTRACT_VENGEANCE = Template(
         ),
         since_last_event_at_least("retaliation_attempted", minimum_ticks=8),
         since_last_event_at_least("retaliation_executed", minimum_ticks=8),
+        since_last_event_at_least("hunt_declared", minimum_ticks=8),
+        since_last_event_at_least("hunt_called_off", minimum_ticks=8),
         NOT(has_inbound_pair_tag("hunting")),
     ),
     branches=(
+        # Lifecycle terminal: a hunt that has produced nothing for a long
+        # stretch goes cold, and the outbound `hunting` edge is released so
+        # the quarry's suppressed social/routine bands can reopen. Without
+        # an off-ramp, hunting is an absorbing state from the prey's side.
+        Branch(
+            label="Let the hunt go cold",
+            conditions=AND(
+                has_pair_tag("hunting"),
+                since_last_event_at_least(
+                    "hunt_declared", minimum_ticks=18, target_slot=Slot.TARGET
+                ),
+            ),
+            narrative_stub=(
+                "{actor} stops feeding the hunt for {target} — the watchers "
+                "wander off, the standing questions expire — not forgiveness, "
+                "just the quiet arithmetic of effort against a target who "
+                "will not surface."
+            ),
+            state_delta={
+                "character.current_activity": "letting a hunt go cold",
+                "entity_pair_tags_target.clear_inbound": ["hunting"],
+            },
+            event_type="hunt_called_off",
+            changed_fields=("character.current_activity", "entity_pair_tags"),
+            magnitude=0.30,
+            preemptive=True,
+            scene_pressure_stub=(
+                "{actor} has quietly stopped hunting {target}. If the scene "
+                "touches it, show the pressure lifting — a tail that is no "
+                "longer there — rather than an announcement."
+            ),
+        ),
         Branch(
             label="Strike directly when opportunity opens",
             conditions=AND(
@@ -778,6 +813,43 @@ EXTRACT_VENGEANCE = Template(
                 "off-screen channels. If useful, let the current scene show a "
                 "rumor, message, social consequence, or pressure wave instead "
                 "of a direct state change."
+            ),
+        ),
+        # The only writer of the `hunting` pair tag: vengeance without
+        # access escalates into an open hunt, which arms the entire
+        # predator/prey machinery (EVADE_PURSUERS, HIDE, WARN_ALLY,
+        # PROTECT_KIN all consume the inbound edge). The off-ramp branch
+        # above and PROTECT_KIN's protective clear are the release valves.
+        Branch(
+            label="Declare the hunt",
+            conditions=AND(
+                NOT(co_located(Slot.ACTOR, Slot.TARGET)),
+                has_any_tag("vendetta_holder", "violent_history"),
+                NOT(has_pair_tag("hunting")),
+            ),
+            narrative_stub=(
+                "{actor} stops waiting for {target} to wander into reach and "
+                "starts hunting in earnest — questions placed with the right "
+                "people, routes watched, a price quietly attached to a "
+                "location. The grudge acquires infrastructure."
+            ),
+            state_delta={
+                "character.current_activity": "hunting a grudge target",
+                "entity_pair_tags.add_outbound": ["hunting"],
+            },
+            event_type="hunt_declared",
+            signal_event_type="threat_issued",
+            changed_fields=(
+                "character.current_activity",
+                "entity_pair_tags",
+                "world_events",
+            ),
+            magnitude=0.66,
+            scene_pressure_stub=(
+                "{actor} has begun actively hunting {target}. The scene may "
+                "surface this as watchers, questions asked about {target}, "
+                "or a warning reaching them — the hunt exists off-screen "
+                "either way."
             ),
         ),
         Branch(
@@ -1109,6 +1181,104 @@ SURVEIL = Template(
                 "{actor} is watching around {target} but has not made contact. "
                 "The Storyteller may adapt, delay, ignore, or incorporate that "
                 "pressure without letting Orrery decide what {target} does."
+            ),
+        ),
+    ),
+    present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
+)
+
+
+ACT_ON_INTEL = Template(
+    id="act_on_intel",
+    priority=52,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "Spending accumulated surveillance is a deliberate project move that "
+        "outranks continuing to watch (SURVEIL, 48): intel hoarded forever "
+        "is the dominance pathology this package exists to break."
+    ),
+    blurb="Watching turns into acting: accumulated intel gets spent.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    # Entry demands a real stockpile: three surveillance passes on this
+    # specific target inside the hydration window. The long per-target
+    # cooldown makes acting rare relative to watching — watch, watch,
+    # watch, act.
+    package_gate=AND(
+        count_recent_events_at_least(
+            "surveillance_performed",
+            within_ticks=25,
+            min_count=3,
+            target_slot=Slot.TARGET,
+        ),
+        since_last_event_at_least(
+            "intel_acted_on", minimum_ticks=12, target_slot=Slot.TARGET
+        ),
+        NOT(has_inbound_pair_tag("hunting")),
+        NOT(is_constrained()),
+    ),
+    branches=(
+        Branch(
+            label="Sell the dossier",
+            conditions=OR(has_contact_of_kind("social"), URBAN_BROKERAGE_PLACE),
+            narrative_stub=(
+                "{actor} packages what watching {target} has taught them — "
+                "patterns, contacts, weaknesses — and trades it to someone "
+                "who pays in favors or coin. The knowledge stops being "
+                "private the moment it changes hands."
+            ),
+            state_delta={
+                "character.current_activity": "selling gathered intelligence",
+            },
+            event_type="intel_acted_on",
+            signal_event_type="compliance_alert",
+            changed_fields=("character.current_activity", "world_events"),
+            magnitude=0.62,
+            scene_pressure_stub=(
+                "{actor} has sold intelligence about {target}. The scene may "
+                "surface this as {target} noticing new attention, a contact "
+                "warning them, or consequences arriving from a third party."
+            ),
+        ),
+        Branch(
+            label="Confront the subject with what they know",
+            conditions=co_located(Slot.ACTOR, Slot.TARGET),
+            narrative_stub=(
+                "{actor} stops pretending not to watch and puts what they "
+                "know in front of {target} — names, times, patterns — to "
+                "see what the knowledge is worth when spent face to face."
+            ),
+            state_delta={
+                "character.current_activity": "confronting a surveilled subject",
+            },
+            event_type="intel_acted_on",
+            signal_event_type="threat_issued",
+            changed_fields=("character.current_activity", "world_events"),
+            magnitude=0.58,
+            scene_pressure_stub=(
+                "{actor} is confronting {target} with gathered intelligence. "
+                "Treat as charged pressure the scene can play as threat, "
+                "negotiation, or revelation."
+            ),
+        ),
+        Branch(
+            label="File it and keep the watch alive",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} consolidates what watching {target} has produced — "
+                "cross-checking, indexing, pruning dead leads — turning "
+                "scattered observation into something that could be used "
+                "on short notice."
+            ),
+            state_delta={
+                "character.current_activity": "consolidating intelligence",
+            },
+            event_type="intel_acted_on",
+            changed_fields=("character.current_activity",),
+            magnitude=0.30,
+            scene_pressure_stub=(
+                "{actor} is quietly consolidating what they know about "
+                "{target}. Background pressure only; nothing reaches "
+                "{target} this tick."
             ),
         ),
     ),
@@ -4169,6 +4339,7 @@ BUILTIN_TEMPLATES = (
     HONOR_DEBT,
     WARN_ALLY,
     SURVEIL,
+    ACT_ON_INTEL,
     UNCOVER_PAST,
     CHECK_ON_DEPENDENT,
     CULTIVATE_INFORMANT,

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -549,6 +549,7 @@ async def commit_incubator_to_database(
                 adjudications=incubator.get("orrery_adjudications"),
                 storyteller_state_updates=incubator.get("entity_updates"),
                 prompt_settings=_orrery_prompt_settings(),
+                ecology_settings=_orrery_ecology_settings(),
             )
             if (
                 orrery_result.resolution_count
@@ -607,6 +608,14 @@ async def commit_incubator_to_database(
 
     logger.info("Successfully committed chunk %s from session %s", chunk_id, session_id)
     return chunk_id
+
+
+def _orrery_ecology_settings() -> Any:
+    """[orrery.ecology] signal-detection policy for branch signal emissions."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("ecology")
 
 
 def _orrery_prompt_settings() -> Any:

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -545,6 +545,7 @@ def commit_incubator_to_database_sync(
                 adjudications=incubator.get("orrery_adjudications"),
                 storyteller_state_updates=incubator.get("entity_updates"),
                 prompt_settings=_orrery_prompt_settings(),
+                ecology_settings=_orrery_ecology_settings(),
             )
             if (
                 orrery_result.resolution_count
@@ -788,6 +789,14 @@ def _apply_state_tags(
     )
     if any(counters.values()):
         logger.info(f"Tag bestowal {kind}/{subtype_id}: {counters}")
+
+
+def _orrery_ecology_settings() -> Any:
+    """[orrery.ecology] signal-detection policy for branch signal emissions."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("ecology")
 
 
 def _orrery_prompt_settings() -> Any:

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1102,6 +1102,35 @@ class OrreryPromptSettings(BaseModel):
     )
 
 
+class OrreryEcologySettings(BaseModel):
+    """Event-ecology tuning: cross-package chains and their throttles."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    signal_detection_default: int = Field(
+        default=100,
+        ge=0,
+        le=100,
+        description=(
+            "Percent chance an emitted branch signal (signal_event_type) is "
+            "actually detected and lands as a world_events row, for event "
+            "types without an explicit rate below. 100 = always detected. "
+            "The roll is a deterministic hash of (template, actor, target, "
+            "tick, event type), so replays reconstruct identical outcomes."
+        ),
+    )
+    signal_detection: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Per-event-type detection percents overriding the default — "
+            "e.g. compliance_alert = 35 means most surveillance goes "
+            "unnoticed by its subject. Undetected signals are recorded in "
+            "the primary event's payload for the audit layer, but feed no "
+            "gates."
+        ),
+    )
+
+
 class OrrerySettings(BaseModel):
     """Orrery off-screen behavior settings.
 
@@ -1127,6 +1156,7 @@ class OrrerySettings(BaseModel):
         default_factory=OrreryReconstructionSettings
     )
     prompt: OrreryPromptSettings = Field(default_factory=OrreryPromptSettings)
+    ecology: OrreryEcologySettings = Field(default_factory=OrreryEcologySettings)
 
 
 # =============================================================================

--- a/tests/test_orrery/test_ecology_live.py
+++ b/tests/test_orrery/test_ecology_live.py
@@ -1,0 +1,250 @@
+"""Ecology-bundle machinery: signal detection policy + outbound pair tags.
+
+The detection policy is a pure function and is tested directly. The
+pair-tag ADD op and the detection gate ride the real commit writer
+against live ``save_02`` rows (skipped unless ``NEXUS_RUN_POSTGRES=1``),
+mirroring test_live_cycle's synthetic-draft-plus-cleanup harness — no
+LLM involvement, so the test costs nothing but a transaction.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+import psycopg2
+import pytest
+from psycopg2.extras import RealDictCursor
+
+from nexus.agents.orrery.events import (
+    SignalDetection,
+    coerce_signal_detection,
+    commit_orrery_tick_sync,
+)
+from nexus.agents.orrery.resolver import OrreryResolutionDraft, OrreryTickProposal
+
+LIVE_SLOT = 2
+
+
+# ---------------------------------------------------------------------------
+# SignalDetection policy (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_signal_detection_roll_is_deterministic_and_threshold_bounded() -> None:
+    policy = SignalDetection(default_pct=100, rates={"compliance_alert": 35})
+
+    kwargs = dict(
+        template_id="surveil",
+        actor_entity_id=7,
+        target_entity_id=9,
+        tick_chunk_id=1200,
+        event_type="compliance_alert",
+    )
+    first = policy.outcome(**kwargs)
+    second = policy.outcome(**kwargs)
+    assert first == second, "same state must roll the same outcome"
+    assert first["threshold"] == 35
+    assert 0 <= first["roll"] < 100
+
+    # Different tick -> independent roll (the chain is per-emission).
+    moved = policy.outcome(**{**kwargs, "tick_chunk_id": 1201})
+    assert moved["roll"] != first["roll"] or moved == first
+
+    always = SignalDetection(default_pct=100).outcome(**kwargs)
+    assert always["detected"] is True and always["threshold"] == 100
+    never = SignalDetection(default_pct=0).outcome(**kwargs)
+    assert never["detected"] is False and never["threshold"] == 0
+
+
+def test_coerce_signal_detection_shapes() -> None:
+    assert coerce_signal_detection(None) == SignalDetection()
+
+    mapping = coerce_signal_detection(
+        {
+            "signal_detection_default": 80,
+            "signal_detection": {"threat_issued": 100},
+        }
+    )
+    assert mapping.default_pct == 80
+    assert mapping.rates == {"threat_issued": 100}
+
+    with pytest.raises(ValueError):
+        coerce_signal_detection(42)
+
+
+# ---------------------------------------------------------------------------
+# Live commit path (real save_02 rows, cleaned up)
+# ---------------------------------------------------------------------------
+
+pytestmark_live = pytest.mark.requires_postgres
+
+
+def _connect() -> Any:
+    return psycopg2.connect(
+        host=os.environ.get("PGHOST", "localhost"),
+        database=f"save_{LIVE_SLOT:02d}",
+        user=os.environ.get("PGUSER", "pythagor"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+def _hunt_draft(actor_entity_id: int, target_entity_id: int) -> OrreryResolutionDraft:
+    return OrreryResolutionDraft(
+        template_id="extract_vengeance",
+        priority=90,
+        binding_hash=f"ecology-live-{uuid.uuid4().hex}",
+        bindings={"actor": actor_entity_id, "target": target_entity_id},
+        branch_label="Declare the hunt",
+        narrative_stub="{actor} starts hunting {target} in earnest.",
+        state_delta={
+            "character.current_activity": "hunting a grudge target",
+            "entity_pair_tags.add_outbound": ["hunting"],
+        },
+        event_type="hunt_declared",
+        signal_event_type="threat_issued",
+        changed_fields=("character.current_activity", "entity_pair_tags"),
+        magnitude=0.66,
+    )
+
+
+@pytest.mark.requires_postgres
+def test_outbound_pair_tag_and_detection_gate_live() -> None:
+    """Committing the hunt draft writes the edge; detection gates the signal."""
+
+    conn: Any = None
+    resolution_ids: list[int] = []
+    pair_tag_ids: list[int] = []
+    try:
+        conn = _connect()
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT c.entity_id
+                    FROM characters c
+                    ORDER BY c.entity_id
+                    LIMIT 2
+                    """
+                )
+                rows = cur.fetchall()
+                assert len(rows) == 2
+                actor_id, target_id = (int(r["entity_id"]) for r in rows)
+                cur.execute("SELECT max(id) AS max_id FROM narrative_chunks")
+                anchor = int(cur.fetchone()["max_id"])
+
+        def commit_hunt(detect_pct: int) -> int:
+            proposal = OrreryTickProposal(
+                anchor_chunk_id=anchor,
+                actor_count=1,
+                resolutions=(_hunt_draft(actor_id, target_id),),
+            )
+            with conn:
+                result = commit_orrery_tick_sync(
+                    conn,
+                    proposal,
+                    tick_chunk_id=anchor,
+                    slot=LIVE_SLOT,
+                    ecology_settings={
+                        "signal_detection_default": 100,
+                        "signal_detection": {"threat_issued": detect_pct},
+                    },
+                )
+            assert result.resolution_count == 1
+            with conn:
+                with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                    cur.execute(
+                        """
+                        SELECT id FROM orrery_resolutions
+                        WHERE tick_chunk_id = %s
+                        ORDER BY id DESC LIMIT 1
+                        """,
+                        (anchor,),
+                    )
+                    resolution_id = int(cur.fetchone()["id"])
+            resolution_ids.append(resolution_id)
+            return resolution_id
+
+        # Phase 1: guaranteed-undetected signal. The hunting edge lands;
+        # the threat_issued row does not; the primary event records why.
+        rid = commit_hunt(detect_pct=0)
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT ept.id
+                    FROM entity_pair_tags ept
+                    JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+                    WHERE ept.subject_entity_id = %s
+                      AND ept.object_entity_id = %s
+                      AND pt.tag = 'hunting'
+                      AND ept.cleared_at IS NULL
+                      AND ept.template_id = 'extract_vengeance'
+                    """,
+                    (actor_id, target_id),
+                )
+                edge_rows = cur.fetchall()
+                assert len(edge_rows) == 1, "hunting edge must be written once"
+                pair_tag_ids.extend(int(r["id"]) for r in edge_rows)
+
+                cur.execute(
+                    """
+                    SELECT event_type, payload
+                    FROM world_events
+                    WHERE resolution_id = %s
+                    ORDER BY id
+                    """,
+                    (rid,),
+                )
+                events = cur.fetchall()
+                assert [e["event_type"] for e in events] == ["hunt_declared"]
+                detection = events[0]["payload"]["signal_detection"]
+                assert detection["detected"] is False
+                assert detection["threshold"] == 0
+
+        # Phase 2: guaranteed-detected signal. The edge INSERT is a no-op
+        # (live row exists) but the threat_issued signal lands.
+        rid2 = commit_hunt(detect_pct=100)
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT event_type, payload
+                    FROM world_events
+                    WHERE resolution_id = %s
+                    ORDER BY id
+                    """,
+                    (rid2,),
+                )
+                events = cur.fetchall()
+                assert [e["event_type"] for e in events] == [
+                    "hunt_declared",
+                    "threat_issued",
+                ]
+                assert events[0]["payload"]["signal_detection"]["detected"] is True
+                assert events[1]["payload"]["signal_of"] == "hunt_declared"
+    finally:
+        if conn is not None:
+            with conn:
+                with conn.cursor() as cur:
+                    if resolution_ids:
+                        cur.execute(
+                            "DELETE FROM world_events WHERE resolution_id = ANY(%s)",
+                            (resolution_ids,),
+                        )
+                        cur.execute(
+                            "DELETE FROM orrery_resolutions WHERE id = ANY(%s)",
+                            (resolution_ids,),
+                        )
+                    if pair_tag_ids:
+                        cur.execute(
+                            "DELETE FROM tag_clearance_log "
+                            "WHERE entity_pair_tag_id = ANY(%s)",
+                            (pair_tag_ids,),
+                        )
+                        cur.execute(
+                            "DELETE FROM entity_pair_tags WHERE id = ANY(%s)",
+                            (pair_tag_ids,),
+                        )
+            conn.close()

--- a/tests/test_orrery/test_ecology_live.py
+++ b/tests/test_orrery/test_ecology_live.py
@@ -224,6 +224,87 @@ def test_outbound_pair_tag_and_detection_gate_live() -> None:
                 ]
                 assert events[0]["payload"]["signal_detection"]["detected"] is True
                 assert events[1]["payload"]["signal_of"] == "hunt_declared"
+
+        # Phase 3: the off-ramp's subject-scoped clear releases only the
+        # actor's own edge — a rival hunter's edge into the same target
+        # survives.
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT c.entity_id FROM characters c
+                    WHERE c.entity_id NOT IN (%s, %s)
+                    ORDER BY c.entity_id LIMIT 1
+                    """,
+                    (actor_id, target_id),
+                )
+                rival_id = int(cur.fetchone()["entity_id"])
+                cur.execute(
+                    """
+                    INSERT INTO entity_pair_tags (
+                        subject_entity_id, object_entity_id, pair_tag_id,
+                        source_kind, template_id
+                    )
+                    SELECT %s, %s, pt.id, 'template', 'extract_vengeance'
+                    FROM pair_tags pt WHERE pt.tag = 'hunting'
+                    RETURNING id
+                    """,
+                    (rival_id, target_id),
+                )
+                rival_edge_id = int(cur.fetchone()["id"])
+                pair_tag_ids.append(rival_edge_id)
+
+        cold_draft = OrreryResolutionDraft(
+            template_id="extract_vengeance",
+            priority=90,
+            binding_hash=f"ecology-live-{uuid.uuid4().hex}",
+            bindings={"actor": actor_id, "target": target_id},
+            branch_label="Let the hunt go cold",
+            narrative_stub="{actor} lets the hunt for {target} go cold.",
+            state_delta={
+                "character.current_activity": "letting a hunt go cold",
+                "entity_pair_tags.clear_outbound": ["hunting"],
+            },
+            event_type="hunt_called_off",
+            changed_fields=("character.current_activity", "entity_pair_tags"),
+            magnitude=0.30,
+        )
+        with conn:
+            result = commit_orrery_tick_sync(
+                conn,
+                OrreryTickProposal(
+                    anchor_chunk_id=anchor,
+                    actor_count=1,
+                    resolutions=(cold_draft,),
+                ),
+                tick_chunk_id=anchor,
+                slot=LIVE_SLOT,
+            )
+        assert result.resolution_count == 1
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT id FROM orrery_resolutions
+                    WHERE tick_chunk_id = %s ORDER BY id DESC LIMIT 1
+                    """,
+                    (anchor,),
+                )
+                resolution_ids.append(int(cur.fetchone()["id"]))
+                cur.execute(
+                    """
+                    SELECT ept.subject_entity_id, ept.cleared_at IS NULL AS live
+                    FROM entity_pair_tags ept
+                    JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+                    WHERE ept.object_entity_id = %s AND pt.tag = 'hunting'
+                      AND ept.id = ANY(%s)
+                    ORDER BY ept.subject_entity_id
+                    """,
+                    (target_id, pair_tag_ids),
+                )
+                edges = {r["subject_entity_id"]: r["live"] for r in cur.fetchall()}
+                assert edges[actor_id] is False, "actor's own hunt must clear"
+                assert edges[rival_id] is True, "rival's hunt must survive"
     finally:
         if conn is not None:
             with conn:


### PR DESCRIPTION
## Summary
Third dynamism bundle: the event food-web gets its missing writers and its overdue throttle. (Process note: this content briefly landed on main as e655a13e by mistake and was reverted in 09a88e72; this PR re-lands it through review. The diff is identical to the reverted commit.)

- **`entity_pair_tags.add_outbound`** — a new branch-effect op (sync + async writers, template provenance, no-op on live duplicate). Predation was structurally unwritable before this: 26 gate references to `hunting`, zero possible writers.
- **EXTRACT_VENGEANCE** gains two branches: *Declare the hunt* (vengeance without co-location escalates — the first and only writer of the `hunting` edge, arming EVADE_PURSUERS/HIDE/WARN_ALLY/PROTECT_KIN) and a preemptive *Let the hunt go cold* off-ramp (releases the edge after 18 unproductive ticks; PROTECT_KIN's protective clear remains the dramatic release valve). Hunting can never absorb the prey permanently.
- **ACT_ON_INTEL** (project_identity 52 > SURVEIL 48): ≥3 surveillance passes on a target within the window arm an accumulate-then-spend move — sell the dossier (`compliance_alert` signal), confront (`threat_issued`), or consolidate. This makes the dominant watching-verb a chain igniter with narrative shape.
- **Signal detection filter** (`[orrery.ecology]`): 066's signal emissions were unconditional — every surveil would alert its prey once chains went live. Signals now land only when a deterministic hash roll (template, actor, target, tick, event type) clears the configured percent (compliance_alert 35 / threat_issued 80 / encoded_message 95); the outcome is recorded on the primary event's payload either way ("surveilled, undetected" is auditable). Threaded through both commit handlers.
- **Deferred by design**: grudge counter-seeding waits for Bundle 5 — planting `grudge_active` on victims with no vengeance path would recreate the absorbing-state pathology Bundle 1 cured for grief.

## Verification
- Live commit-path test on save_02 (new `test_ecology_live.py`, `requires_postgres`): hunt draft writes exactly one provenance-stamped hunting edge; `detect_pct=0` suppresses the signal row and records `detected: false`; `detect_pct=100` lands `threat_issued` with `signal_of` lineage. Cleanup verified.
- 578 orrery tests pass. Migration 069 applied to all slots.
- Pre-existing unrelated live failure noted: retrograde data (June 18) broke `test_pair_tag_writer`'s clean-slate fixture on save_05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY