### PR TITLE
Orrery Bundle 4a: Habituation Dampening + Pair-Draft Fan-Out Quota

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -227,6 +227,24 @@ checkpoint_interval_chunks = 25
 max_rendered_proposals = 5
 max_rendered_pressures = 5
 
+[orrery.habituation]
+# Repetition dampening: each committed win inside window_ticks debits the
+# template's effective priority for that actor (capped), so a repeat winner
+# (surveil at 56% dominance) eventually yields to the packages it shadows.
+# Deterministic — counts come from committed orrery_resolutions rows.
+# Crisis-band packages never dampen.
+enabled = true
+window_ticks = 40
+penalty_per_win = 3.0
+max_penalty = 10.0
+exempt_bands = ["crisis_constraint"]
+
+[orrery.fanout]
+# Per-actor cap on two-party drafts per tick. Kept drafts prefer template
+# diversity, then magnitude; crisis-band drafts are never trimmed.
+max_pair_drafts_per_actor = 2
+exempt_bands = ["crisis_constraint"]
+
 [orrery.ecology]
 # Detection percent for emitted branch signals (signal_event_type) whose
 # event type has no explicit rate in [orrery.ecology.signal_detection].

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -640,6 +640,8 @@ class TurnCycleManager:
                 window_chunks=window_chunks,
                 sunhelm_settings=orrery_settings.get("sunhelm"),
                 selection_settings=orrery_settings.get("selection"),
+                habituation_settings=orrery_settings.get("habituation"),
+                fanout_settings=orrery_settings.get("fanout"),
             )
 
         turn_context.orrery_proposal = proposal

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -67,6 +67,7 @@ from nexus.agents.orrery.resolver import (
 )
 from nexus.agents.orrery.substrate import (
     coerce_branch_selection,
+    coerce_habituation,
     CONSTRAINED_TAGS,
     DRAMATIC_CONTACT_TAGS,
     DRIVE_BAND_ORDER,
@@ -471,6 +472,7 @@ def explain_dry_run(
     world_time_override: Optional[datetime] = None,
     overrides: Optional[WorldStateOverrides] = None,
     selection_settings: Optional[Any] = None,
+    habituation_settings: Optional[Any] = None,
 ) -> ExplainedTickReport:
     """Hydrate, bind, and explain Orrery packages without database writes.
 
@@ -487,12 +489,14 @@ def explain_dry_run(
 
     need_tuning = coerce_need_tuning(sunhelm_settings)
     selection = coerce_branch_selection(selection_settings)
+    habituation = coerce_habituation(habituation_settings)
     state = hydrate_world_state(
         session,
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
         need_tuning=need_tuning,
         world_time_override=world_time_override,
+        win_history_window=habituation.window_ticks if habituation.enabled else 0,
     )
 
     templates_list = list(templates)
@@ -558,19 +562,29 @@ def explain_dry_run(
         actor_stacks: dict[int, StackExplanation] = {}
         for bindings in actor_bindings:
             actor_stacks[bindings[Slot.ACTOR]] = explain_stack(
-                actor_only_templates, tick_state, bindings, selection
+                actor_only_templates, tick_state, bindings, selection, habituation
             )
         two_party_stacks: dict[int, List[StackExplanation]] = {}
         for pair_bindings in offscreen_pair_bindings:
             two_party_stacks.setdefault(pair_bindings[Slot.ACTOR], []).append(
                 explain_stack(
-                    actor_target_templates, tick_state, pair_bindings, selection
+                    actor_target_templates,
+                    tick_state,
+                    pair_bindings,
+                    selection,
+                    habituation,
                 )
             )
         pressure_stacks: dict[int, List[StackExplanation]] = {}
         for pair_bindings in present_pair_bindings:
             pressure_stacks.setdefault(pair_bindings[Slot.ACTOR], []).append(
-                explain_stack(pressure_templates, tick_state, pair_bindings, selection)
+                explain_stack(
+                    pressure_templates,
+                    tick_state,
+                    pair_bindings,
+                    selection,
+                    habituation,
+                )
             )
         need_pressure_specs = _present_need_pressure_specs(
             tick_state,

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -51,6 +51,8 @@ from nexus.agents.orrery.needs import (
 from nexus.agents.orrery.resolver import (
     _LOCATION_CLASS_CATEGORY_SQL,
     OrreryScenePressureDraft,
+    _apply_pair_fanout_quota,
+    _coerce_fanout,
     _entity_label,
     _load_entity_names,
     _load_need_debt_scores,
@@ -125,6 +127,7 @@ class ExplainedTickReport:
     location_names: Mapping[int, str]
     activities: Mapping[int, str]
     joint_beats: Tuple[OrreryJointBeat, ...] = ()
+    fanout_trimmed: Tuple[Mapping[str, Any], ...] = ()
     mode: str = "current"
     overrides: Optional[Mapping[str, Any]] = None
     need_pressures_diff: Optional[Mapping[str, Any]] = None
@@ -147,6 +150,7 @@ class ExplainedTickReport:
             "generated_at": self.generated_at,
             "actors": [self._group_payload(group) for group in self.actors],
             "joint_beats": [beat.to_dict() for beat in self.joint_beats],
+            "fanout_trimmed": [dict(item) for item in self.fanout_trimmed],
             "need_pressures": [draft.to_dict() for draft in self.need_pressures],
             "need_pressures_diff": (
                 dict(self.need_pressures_diff)
@@ -473,6 +477,7 @@ def explain_dry_run(
     overrides: Optional[WorldStateOverrides] = None,
     selection_settings: Optional[Any] = None,
     habituation_settings: Optional[Any] = None,
+    fanout_settings: Optional[Any] = None,
 ) -> ExplainedTickReport:
     """Hydrate, bind, and explain Orrery packages without database writes.
 
@@ -678,7 +683,28 @@ def explain_dry_run(
         for item in stack.templates
         if item.template_id == stack.winner_id
     ]
-    joint_beats = detect_joint_beats(joint_beat_inputs, entity_names)
+    # Production applies the fan-out quota to the draft list BEFORE joint
+    # beats; the audit path mirrors the trim for parity and reports what
+    # was dropped instead of silently hiding it.
+    fanout = _coerce_fanout(fanout_settings)
+    kept_inputs = _apply_pair_fanout_quota(
+        joint_beat_inputs,
+        templates_list,
+        max_pair_drafts_per_actor=fanout.max_pair_drafts_per_actor,
+        exempt_bands=fanout.exempt_bands,
+    )
+    kept_ids = {id(shim) for shim in kept_inputs}
+    fanout_trimmed = tuple(
+        {
+            "actor_entity_id": shim.bindings.get("actor"),
+            "target_entity_id": shim.bindings.get("target"),
+            "template_id": shim.template_id,
+            "magnitude": shim.magnitude,
+        }
+        for shim in joint_beat_inputs
+        if id(shim) not in kept_ids
+    )
+    joint_beats = detect_joint_beats(kept_inputs, entity_names)
 
     not_applicable_markers = tuple(
         {
@@ -743,6 +769,7 @@ def explain_dry_run(
         location_names=location_names,
         activities=dict(active_state.activities),
         joint_beats=joint_beats,
+        fanout_trimmed=fanout_trimmed,
         mode="what_if" if what_if else "current",
         overrides=overrides.to_dict() if what_if and overrides is not None else None,
         need_pressures_diff=need_pressures_diff,

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -297,6 +297,7 @@ def analyze_coverage(
     sunhelm_settings: Optional[Any] = None,
     epoch_min_world_times: int,
     selection_settings: Optional[Any] = None,
+    habituation_settings: Optional[Any] = None,
 ) -> dict[str, Any]:
     """Aggregate explained resolution coverage across historical anchors.
 
@@ -336,6 +337,7 @@ def analyze_coverage(
             window_chunks=window_chunks,
             sunhelm_settings=sunhelm_settings,
             selection_settings=selection_settings,
+            habituation_settings=habituation_settings,
         )
         anchors.append(_tally_report(report, tallies, gap_counts))
         entity_names.update(report.entity_names)

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -298,6 +298,7 @@ def analyze_coverage(
     epoch_min_world_times: int,
     selection_settings: Optional[Any] = None,
     habituation_settings: Optional[Any] = None,
+    fanout_settings: Optional[Any] = None,
 ) -> dict[str, Any]:
     """Aggregate explained resolution coverage across historical anchors.
 
@@ -338,6 +339,7 @@ def analyze_coverage(
             sunhelm_settings=sunhelm_settings,
             selection_settings=selection_settings,
             habituation_settings=habituation_settings,
+            fanout_settings=fanout_settings,
         )
         anchors.append(_tally_report(report, tallies, gap_counts))
         entity_names.update(report.entity_names)

--- a/nexus/agents/orrery/explain.py
+++ b/nexus/agents/orrery/explain.py
@@ -41,6 +41,8 @@ from nexus.agents.orrery.substrate import (
     binding_hash,
     evaluate,
     select_branch,
+    HabituationPolicy,
+    stack_order,
 )
 
 
@@ -332,15 +334,19 @@ def explain_stack(
     state: WorldState,
     bindings: Bindings,
     selection: Optional[BranchSelection] = None,
+    habituation: Optional[HabituationPolicy] = None,
 ) -> StackExplanation:
-    """Explain every template in priority order and flag the stack winner.
+    """Explain every template in effective-priority order; flag the winner.
 
-    Mirrors :func:`evaluate_stack` selection (highest priority firing template
-    wins) while retaining the full audit record for every template, so the
-    dashboard can render the winner alongside the shadowed packages.
+    Mirrors :func:`evaluate_stack` selection (highest effective priority
+    firing template wins) while retaining the full audit record for every
+    template, so the dashboard can render the winner alongside the shadowed
+    packages. Ordering routes through the shared :func:`stack_order`
+    authority — habituation dampening shows up here exactly as it does in
+    production.
     """
 
-    ordered = sorted(templates, key=lambda item: item.priority, reverse=True)
+    ordered = stack_order(templates, state, bindings, habituation)
     explanations = tuple(
         explain_template(template, state, bindings, selection) for template in ordered
     )

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -17,6 +17,7 @@ from nexus.agents.orrery.reciprocal import (
 from nexus.agents.orrery.substrate import (
     BranchSelection,
     coerce_branch_selection,
+    coerce_habituation,
     Bindings,
     EventRecord,
     INTIMACY_SUPPRESSOR_TAGS,
@@ -256,8 +257,14 @@ def hydrate_world_state(
     window_chunks: int,
     need_tuning: Optional[NeedTuning] = None,
     world_time_override: Optional[datetime] = None,
+    win_history_window: int = 0,
 ) -> WorldState:
-    """Hydrate the read-side Orrery state snapshot from database tables."""
+    """Hydrate the read-side Orrery state snapshot from database tables.
+
+    ``win_history_window`` > 0 additionally hydrates committed win counts
+    per (actor, template) over that many trailing ticks for habituation
+    dampening; 0 skips the query (habituation off).
+    """
 
     need_tuning = coerce_need_tuning(need_tuning)
 
@@ -433,6 +440,11 @@ def hydrate_world_state(
     )
     travel_states = _load_travel_states(session)
     routine_anchors = _load_routine_anchors(session)
+    win_history = _load_win_history(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        win_history_window=win_history_window,
+    )
 
     return WorldState(
         tags={entity_id: frozenset(values) for entity_id, values in tags.items()},
@@ -463,11 +475,43 @@ def hydrate_world_state(
         travel_states=travel_states,
         routine_anchors=routine_anchors,
         recent_events=recent_events,
+        win_history=win_history,
         time_of_day=time_of_day,
         world_time=world_time,
         weather=weather,
         current_tick=anchor_chunk_id or 0,
     )
+
+
+def _load_win_history(
+    session: Any,
+    *,
+    anchor_chunk_id: Optional[int],
+    win_history_window: int,
+) -> dict[tuple[int, str], int]:
+    """Committed wins per (actor, template) inside the habituation window."""
+
+    if win_history_window <= 0 or anchor_chunk_id is None:
+        return {}
+    cutoff = anchor_chunk_id - win_history_window
+    rows = session.execute(
+        text(
+            """
+            /* orrery:win_history */
+            SELECT actor_entity_id, template_id, COUNT(*) AS wins
+            FROM orrery_resolutions
+            WHERE tick_chunk_id > :cutoff
+              AND tick_chunk_id <= :anchor
+              AND actor_entity_id IS NOT NULL
+            GROUP BY actor_entity_id, template_id
+            """
+        ),
+        {"cutoff": cutoff, "anchor": anchor_chunk_id},
+    ).mappings()
+    return {
+        (int(row["actor_entity_id"]), str(row["template_id"])): int(row["wins"])
+        for row in rows
+    }
 
 
 def _load_routine_anchors(session: Any) -> dict[tuple[int, str], RoutineAnchor]:
@@ -801,6 +845,81 @@ _ACTOR_ONLY_SLOTS: Tuple[Slot, ...] = (Slot.ACTOR,)
 _ACTOR_TARGET_SLOTS: Tuple[Slot, ...] = (Slot.ACTOR, Slot.TARGET)
 
 
+@dataclass(frozen=True)
+class FanoutPolicy:
+    """Per-actor cap on two-party drafts ([orrery.fanout]).
+
+    One actor with several eligible targets can otherwise flood the tick
+    with near-duplicate pair drafts and crowd everything else out of the
+    storyteller prompt's first-N slice. Kept drafts prefer template
+    diversity (first draft of each template before any second of one),
+    then magnitude, then binding hash — a pure function of the draft set,
+    so replays trim identically. Crisis-band drafts are exempt: dropping
+    a protection or evasion beat is behavior loss, not noise reduction.
+    """
+
+    max_pair_drafts_per_actor: int = 0
+    exempt_bands: frozenset[str] = frozenset({"crisis_constraint"})
+
+
+def _coerce_fanout(raw: Any) -> FanoutPolicy:
+    if raw is None:
+        return FanoutPolicy()
+    if hasattr(raw, "max_pair_drafts_per_actor"):
+        return FanoutPolicy(
+            max_pair_drafts_per_actor=int(raw.max_pair_drafts_per_actor),
+            exempt_bands=frozenset(raw.exempt_bands),
+        )
+    if isinstance(raw, Mapping):
+        return FanoutPolicy(
+            max_pair_drafts_per_actor=int(raw.get("max_pair_drafts_per_actor", 0)),
+            exempt_bands=frozenset(raw.get("exempt_bands", ("crisis_constraint",))),
+        )
+    raise ValueError(f"Unsupported fanout settings: {type(raw)!r}")
+
+
+def _apply_pair_fanout_quota(
+    drafts: list[OrreryResolutionDraft],
+    templates_list: list[Template],
+    *,
+    max_pair_drafts_per_actor: int,
+    exempt_bands: frozenset[str],
+) -> list[OrreryResolutionDraft]:
+    if max_pair_drafts_per_actor <= 0:
+        return drafts
+    band_by_template = {t.id: t.drive_band.value for t in templates_list}
+
+    def is_pair(draft: OrreryResolutionDraft) -> bool:
+        return "target" in draft.bindings
+
+    kept: list[OrreryResolutionDraft] = []
+    per_actor: dict[Any, list[OrreryResolutionDraft]] = {}
+    for draft in drafts:
+        if (
+            not is_pair(draft)
+            or band_by_template.get(draft.template_id) in exempt_bands
+        ):
+            kept.append(draft)
+            continue
+        per_actor.setdefault(draft.bindings.get("actor"), []).append(draft)
+
+    for actor, pair_drafts in per_actor.items():
+        seen_templates: set[str] = set()
+        first_of_template: list[OrreryResolutionDraft] = []
+        repeats: list[OrreryResolutionDraft] = []
+        for draft in sorted(pair_drafts, key=lambda d: (-d.magnitude, d.binding_hash)):
+            if draft.template_id in seen_templates:
+                repeats.append(draft)
+            else:
+                seen_templates.add(draft.template_id)
+                first_of_template.append(draft)
+        kept.extend((first_of_template + repeats)[:max_pair_drafts_per_actor])
+
+    # Preserve the original draft ordering for everything that survived.
+    surviving = {id(d) for d in kept}
+    return [draft for draft in drafts if id(draft) in surviving]
+
+
 def resolve_dry_run(
     session: Any,
     templates: Iterable[Template],
@@ -810,17 +929,22 @@ def resolve_dry_run(
     sunhelm_settings: Optional[Any] = None,
     world_time_override: Optional[datetime] = None,
     selection_settings: Optional[Any] = None,
+    habituation_settings: Optional[Any] = None,
+    fanout_settings: Optional[Any] = None,
 ) -> OrreryTickProposal:
     """Hydrate, bind, and evaluate Orrery packages without database writes."""
 
     need_tuning = coerce_need_tuning(sunhelm_settings)
     selection = coerce_branch_selection(selection_settings)
+    habituation = coerce_habituation(habituation_settings)
+    fanout = _coerce_fanout(fanout_settings)
     state = hydrate_world_state(
         session,
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
         need_tuning=need_tuning,
         world_time_override=world_time_override,
+        win_history_window=habituation.window_ticks if habituation.enabled else 0,
     )
 
     templates_list = list(templates)
@@ -853,7 +977,9 @@ def resolve_dry_run(
         window_chunks=window_chunks,
     )
     for bindings in actor_bindings:
-        resolution = evaluate_stack(actor_only_templates, state, bindings, selection)
+        resolution = evaluate_stack(
+            actor_only_templates, state, bindings, selection, habituation
+        )
         if resolution is not None and resolution.passes:
             drafts.append(_draft_from_resolution(resolution))
 
@@ -869,7 +995,7 @@ def resolve_dry_run(
         )
         for bindings in actor_target_bindings:
             resolution = evaluate_stack(
-                actor_target_templates, state, bindings, selection
+                actor_target_templates, state, bindings, selection, habituation
             )
             if resolution is not None and resolution.passes:
                 drafts.append(_draft_from_resolution(resolution))
@@ -890,10 +1016,17 @@ def resolve_dry_run(
             )
             for bindings in present_target_bindings:
                 resolution = evaluate_stack(
-                    pressure_templates, state, bindings, selection
+                    pressure_templates, state, bindings, selection, habituation
                 )
                 if resolution is not None and resolution.passes:
                     scene_pressure_results.append(resolution)
+
+    drafts = _apply_pair_fanout_quota(
+        drafts,
+        templates_list,
+        max_pair_drafts_per_actor=fanout.max_pair_drafts_per_actor,
+        exempt_bands=fanout.exempt_bands,
+    )
 
     # Resolve binding entity names so Skald's adjudication payload says WHO
     # each off-screen proposal is about; bare entity ids invite misattribution

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -245,6 +245,10 @@ class WorldState:
 
     tags: Mapping[int, frozenset[str]] = field(default_factory=dict)
     ephemeral_tags: Mapping[int, frozenset[str]] = field(default_factory=dict)
+    # Committed wins per (actor_entity_id, template_id) inside the
+    # habituation window — hydrated from orrery_resolutions, so replay
+    # reconstructs identical dampening. Empty when habituation is off.
+    win_history: Mapping[Tuple[int, str], int] = field(default_factory=dict)
     locations: Mapping[int, int] = field(default_factory=dict)
     activities: Mapping[int, str] = field(default_factory=dict)
     trust: Mapping[Tuple[int, int], int] = field(default_factory=dict)
@@ -1974,15 +1978,97 @@ def evaluate(
     )
 
 
+@dataclass(frozen=True)
+class HabituationPolicy:
+    """Repetition dampening for stack ordering ([orrery.habituation]).
+
+    A template's effective priority drops by ``penalty_per_win`` for each
+    committed win by the same actor inside the trailing window (capped at
+    ``max_penalty``), so a package that keeps winning eventually yields the
+    stack to the shadowed packages beneath it. Bands in ``exempt_bands``
+    (crisis by default) never dampen — an actively hunted actor must not
+    tire of evading. Deterministic: win counts come from committed
+    orrery_resolutions rows hydrated into WorldState.
+    """
+
+    enabled: bool = False
+    penalty_per_win: float = 0.0
+    max_penalty: float = 0.0
+    window_ticks: int = 0
+    exempt_bands: frozenset[str] = frozenset({"crisis_constraint"})
+
+    def effective_priority(
+        self, template: Template, state: WorldState, bindings: Bindings
+    ) -> float:
+        base = float(template.priority)
+        if not self.enabled or template.drive_band.value in self.exempt_bands:
+            return base
+        actor = bindings.get(Slot.ACTOR)
+        if not isinstance(actor, int):
+            return base
+        wins = state.win_history.get((actor, template.id), 0)
+        if not wins:
+            return base
+        return base - min(self.penalty_per_win * wins, self.max_penalty)
+
+
+def coerce_habituation(raw: Any) -> HabituationPolicy:
+    """[orrery.habituation] settings payload -> HabituationPolicy."""
+
+    if raw is None:
+        return HabituationPolicy()
+    if hasattr(raw, "penalty_per_win"):
+        return HabituationPolicy(
+            enabled=bool(raw.enabled),
+            penalty_per_win=float(raw.penalty_per_win),
+            max_penalty=float(raw.max_penalty),
+            window_ticks=int(raw.window_ticks),
+            exempt_bands=frozenset(raw.exempt_bands),
+        )
+    if isinstance(raw, Mapping):
+        return HabituationPolicy(
+            enabled=bool(raw.get("enabled", False)),
+            penalty_per_win=float(raw.get("penalty_per_win", 0.0)),
+            max_penalty=float(raw.get("max_penalty", 0.0)),
+            window_ticks=int(raw.get("window_ticks", 0)),
+            exempt_bands=frozenset(raw.get("exempt_bands", ("crisis_constraint",))),
+        )
+    raise ValueError(f"Unsupported habituation settings: {type(raw)!r}")
+
+
+def stack_order(
+    templates: Iterable[Template],
+    state: WorldState,
+    bindings: Bindings,
+    habituation: Optional[HabituationPolicy] = None,
+) -> list[Template]:
+    """The single stack-ordering authority.
+
+    Both :func:`evaluate_stack` and the explain layer's ``explain_stack``
+    MUST route through this function — a second ordering implementation
+    would let the audit dashboard's winner silently diverge from
+    production. Sort is stable: equal effective priorities keep authored
+    registry order.
+    """
+
+    policy = habituation or HabituationPolicy()
+    return sorted(
+        templates,
+        key=lambda item: policy.effective_priority(item, state, bindings),
+        reverse=True,
+    )
+
+
 def evaluate_stack(
     templates: Iterable[Template],
     state: WorldState,
     bindings: Bindings,
     selection: Optional[BranchSelection] = None,
+    habituation: Optional[HabituationPolicy] = None,
 ) -> Optional[Resolution]:
-    """Evaluate templates in priority order and return the first firing branch."""
+    """Evaluate templates in effective-priority order; first firing branch wins."""
 
-    for template in sorted(templates, key=lambda item: item.priority, reverse=True):
+    for template in stack_order(templates, state, bindings, habituation):
         result = evaluate(template, state, bindings, selection)
         if result.passes:
             return result

--- a/nexus/api/orrery_dev_endpoints.py
+++ b/nexus/api/orrery_dev_endpoints.py
@@ -311,6 +311,7 @@ async def post_resolve(request: OrreryResolveRequest) -> dict[str, Any]:
                 overrides=overrides,
                 selection_settings=orrery.get("selection"),
                 habituation_settings=orrery.get("habituation"),
+                fanout_settings=orrery.get("fanout"),
             )
         except OverrideValidationError as exc:
             # Override validation (unknown vocab, no-op toggles) is caller
@@ -396,6 +397,7 @@ async def post_coverage(request: OrreryCoverageRequest) -> dict[str, Any]:
             epoch_min_world_times=epoch_min,
             selection_settings=orrery.get("selection"),
             habituation_settings=orrery.get("habituation"),
+            fanout_settings=orrery.get("fanout"),
         )
 
 

--- a/nexus/api/orrery_dev_endpoints.py
+++ b/nexus/api/orrery_dev_endpoints.py
@@ -310,6 +310,7 @@ async def post_resolve(request: OrreryResolveRequest) -> dict[str, Any]:
                 sunhelm_settings=orrery.get("sunhelm"),
                 overrides=overrides,
                 selection_settings=orrery.get("selection"),
+                habituation_settings=orrery.get("habituation"),
             )
         except OverrideValidationError as exc:
             # Override validation (unknown vocab, no-op toggles) is caller
@@ -394,6 +395,7 @@ async def post_coverage(request: OrreryCoverageRequest) -> dict[str, Any]:
             sunhelm_settings=orrery.get("sunhelm"),
             epoch_min_world_times=epoch_min,
             selection_settings=orrery.get("selection"),
+            habituation_settings=orrery.get("habituation"),
         )
 
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1102,6 +1102,70 @@ class OrreryPromptSettings(BaseModel):
     )
 
 
+class OrreryHabituationSettings(BaseModel):
+    """Repetition dampening for stack selection ([orrery.habituation])."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Dampen a template's effective priority by penalty_per_win for "
+            "each committed win by the same actor inside window_ticks, so a "
+            "repeat winner eventually yields the stack to the packages it "
+            "shadows. Deterministic: counts come from orrery_resolutions."
+        ),
+    )
+    window_ticks: int = Field(
+        default=40,
+        ge=1,
+        description="Trailing tick window for counting committed wins.",
+    )
+    penalty_per_win: float = Field(
+        default=3.0,
+        ge=0.0,
+        description="Effective-priority debit per committed win.",
+    )
+    max_penalty: float = Field(
+        default=10.0,
+        ge=0.0,
+        description=(
+            "Cap on the total debit; keep small enough that dampening "
+            "reorders within neighboring priorities without collapsing "
+            "high-stakes packages into the mundane band."
+        ),
+    )
+    exempt_bands: list[str] = Field(
+        default_factory=lambda: ["crisis_constraint"],
+        description=(
+            "Drive bands never dampened — an actively hunted actor must "
+            "not tire of evading."
+        ),
+    )
+
+
+class OrreryFanoutSettings(BaseModel):
+    """Per-actor cap on two-party drafts ([orrery.fanout])."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_pair_drafts_per_actor: int = Field(
+        default=2,
+        ge=0,
+        description=(
+            "Maximum two-party drafts one actor contributes per tick "
+            "(0 disables trimming). Kept drafts prefer template diversity, "
+            "then magnitude; crisis-band drafts are exempt. Bounds the "
+            "near-duplicate flood that crowds the storyteller prompt's "
+            "first-N slice."
+        ),
+    )
+    exempt_bands: list[str] = Field(
+        default_factory=lambda: ["crisis_constraint"],
+        description="Drive bands whose pair drafts are never trimmed.",
+    )
+
+
 class OrreryEcologySettings(BaseModel):
     """Event-ecology tuning: cross-package chains and their throttles."""
 
@@ -1157,6 +1221,10 @@ class OrrerySettings(BaseModel):
     )
     prompt: OrreryPromptSettings = Field(default_factory=OrreryPromptSettings)
     ecology: OrreryEcologySettings = Field(default_factory=OrreryEcologySettings)
+    habituation: OrreryHabituationSettings = Field(
+        default_factory=OrreryHabituationSettings
+    )
+    fanout: OrreryFanoutSettings = Field(default_factory=OrreryFanoutSettings)
 
 
 # =============================================================================

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -68,6 +68,7 @@ class FakeSession:
         need_debt_rows=None,
         travel_state_rows=None,
         routine_anchor_rows=None,
+        win_history_rows=None,
         world_time=None,
         weather="",
         max_chunk_id=100,
@@ -98,6 +99,7 @@ class FakeSession:
         self.need_debt_rows = need_debt_rows or []
         self.travel_state_rows = travel_state_rows or []
         self.routine_anchor_rows = routine_anchor_rows or []
+        self.win_history_rows = win_history_rows or []
         self.world_time = world_time or datetime(2073, 10, 31, 12, tzinfo=timezone.utc)
         self.weather = weather
         self.max_chunk_id = max_chunk_id
@@ -174,6 +176,8 @@ class FakeSession:
             assert "JOIN entities e" in sql
             assert "e.is_active = true" in sql
             return FakeResult(self.travel_state_rows)
+        if "/* orrery:win_history */" in sql:
+            return FakeResult(self.win_history_rows)
         if "/* orrery:routine_anchors */" in sql:
             assert "JOIN entities e" in sql
             assert "e.is_active = true" in sql
@@ -719,9 +723,7 @@ def test_mundane_band_physical_packages_refuse_non_corporeal_minds() -> None:
 
     physical = {"train", "run_errands", "stroll", "upkeep"}
     assert not [
-        draft
-        for draft in proposal.resolutions
-        if draft.template_id in physical
+        draft for draft in proposal.resolutions if draft.template_id in physical
     ]
 
 
@@ -2225,3 +2227,153 @@ def test_resolution_drafts_carry_binding_names_for_skald() -> None:
     assert data["binding_names"] == {"actor": "Brother Edran Vell"}
     rehydrated = OrreryResolutionDraft.from_dict(data)
     assert rehydrated.binding_names == {"actor": "Brother Edran Vell"}
+
+
+def test_habituation_dampens_repeat_winner_and_respects_exemptions() -> None:
+    """Committed wins reorder the stack; crisis packages never dampen."""
+
+    from nexus.agents.orrery.substrate import (
+        HabituationPolicy,
+        WorldState,
+        evaluate_stack,
+        stack_order,
+    )
+
+    high = Template(
+        id="surveil",  # real ids keep prose/catalog lookups valid
+        priority=48,
+        drive_band=DriveBand.PROJECT_IDENTITY,
+        blurb="synthetic",
+        required_slots=(Slot.ACTOR,),
+        package_gate=ALWAYS,
+        branches=(Branch("watch", ALWAYS, "{actor} watches."),),
+    )
+    low = Template(
+        id="reach_out",
+        priority=40,
+        drive_band=DriveBand.AFFILIATION,
+        blurb="synthetic",
+        required_slots=(Slot.ACTOR,),
+        package_gate=ALWAYS,
+        branches=(Branch("reach", ALWAYS, "{actor} reaches out."),),
+    )
+    crisis = Template(
+        id="evade_pursuers",
+        priority=48,
+        drive_band=DriveBand.CRISIS_CONSTRAINT,
+        blurb="synthetic",
+        required_slots=(Slot.ACTOR,),
+        package_gate=ALWAYS,
+        branches=(Branch("evade", ALWAYS, "{actor} evades."),),
+    )
+    policy = HabituationPolicy(
+        enabled=True, penalty_per_win=3.0, max_penalty=10.0, window_ticks=40
+    )
+    bindings = {Slot.ACTOR: 1}
+
+    fresh = WorldState()
+    assert evaluate_stack((low, high), fresh, bindings, None, policy).template_id == (
+        "surveil"
+    )
+
+    # Three committed wins drop surveil's effective priority to 39 < 40.
+    worn = WorldState(win_history={(1, "surveil"): 3})
+    assert evaluate_stack((low, high), worn, bindings, None, policy).template_id == (
+        "reach_out"
+    )
+    # The cap bounds the debit: ten wins is still only -10.
+    capped = WorldState(win_history={(1, "surveil"): 10})
+    ordered = stack_order((low, high), capped, bindings, policy)
+    assert [t.id for t in ordered] == ["reach_out", "surveil"]
+
+    # Crisis-band packages never dampen, whatever their history.
+    crisis_worn = WorldState(win_history={(1, "evade_pursuers"): 10})
+    ordered = stack_order((low, crisis), crisis_worn, bindings, policy)
+    assert [t.id for t in ordered] == ["evade_pursuers", "reach_out"]
+
+    # Disabled policy is inert.
+    assert evaluate_stack((low, high), worn, bindings, None, None).template_id == (
+        "surveil"
+    )
+
+
+def test_explain_stack_orders_like_evaluate_under_habituation() -> None:
+    """The audit layer's winner must match production under dampening."""
+
+    from nexus.agents.orrery.explain import explain_stack
+    from nexus.agents.orrery.substrate import (
+        HabituationPolicy,
+        WorldState,
+        evaluate_stack,
+    )
+    from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+
+    policy = HabituationPolicy(
+        enabled=True, penalty_per_win=3.0, max_penalty=10.0, window_ticks=40
+    )
+    state = WorldState(
+        tags={1: frozenset({"seeking_identity"})},
+        locations={1: 10},
+        activities={1: "idle"},
+        time_of_day="evening",
+        current_tick=100,
+        win_history={(1, "uncover_past"): 5},
+    )
+    bindings = {Slot.ACTOR: 1}
+    solo = [t for t in BUILTIN_TEMPLATES if t.required_slots == (Slot.ACTOR,)]
+
+    truth = evaluate_stack(solo, state, bindings, None, policy)
+    explained = explain_stack(solo, state, bindings, None, policy)
+    assert truth is not None
+    assert explained.winner_id == truth.template_id
+
+
+def test_pair_fanout_quota_prefers_template_diversity() -> None:
+    """The quota keeps the first draft of each template before any repeat."""
+
+    from nexus.agents.orrery.resolver import _apply_pair_fanout_quota
+    from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+
+    def pair_draft(template_id: str, target: int, magnitude: float):
+        return OrreryResolutionDraft(
+            template_id=template_id,
+            priority=48,
+            binding_hash=f"hash-{template_id}-{target}",
+            bindings={"actor": 1, "target": target},
+            branch_label="x",
+            narrative_stub="{actor} acts on {target}.",
+            magnitude=magnitude,
+        )
+
+    solo = OrreryResolutionDraft(
+        template_id="stroll",
+        priority=12,
+        binding_hash="hash-solo",
+        bindings={"actor": 1},
+        branch_label="x",
+        narrative_stub="{actor} strolls.",
+        magnitude=0.1,
+    )
+    crisis = pair_draft("evade_pursuers", 9, 0.2)
+    drafts = [
+        solo,
+        pair_draft("surveil", 2, 0.5),
+        pair_draft("surveil", 3, 0.9),
+        pair_draft("surveil", 4, 0.7),
+        pair_draft("reach_out", 5, 0.2),
+        crisis,
+    ]
+    trimmed = _apply_pair_fanout_quota(
+        drafts,
+        list(BUILTIN_TEMPLATES),
+        max_pair_drafts_per_actor=2,
+        exempt_bands=frozenset({"crisis_constraint"}),
+    )
+    kept = [(d.template_id, d.bindings.get("target")) for d in trimmed]
+    # Solo drafts and crisis-band pair drafts are untouched; of the four
+    # non-crisis pair drafts, diversity wins: best surveil + the reach_out.
+    assert ("stroll", None) in kept
+    assert ("evade_pursuers", 9) in kept
+    assert ("surveil", 3) in kept
+    assert ("reach_out", 5) in kept
+    assert len(kept) == 4


### PR DESCRIPTION
## Summary
Selection-side anti-monoculture: the two mechanisms designed against surveil's measured 56% dominance and the mundane band's cross-actor lockstep (flagged as a known limitation in #433).

- **Habituation** (`[orrery.habituation]`, shipped on): committed wins inside a 40-tick window debit that template's effective priority for that actor (3.0/win, cap 10). Deterministic — counts come from `orrery_resolutions`, committed and checkpointed state, so replays dampen identically. Crisis band exempt. The ordering moved into a **single-authority `stack_order()`** used by both `evaluate_stack` and `explain_stack`, so the audit dashboard's winner stays in lockstep with production by construction.
- **Fan-out quota** (`[orrery.fanout]`): per-actor cap of 2 two-party drafts per tick, keeping template diversity first, then magnitude, then binding hash. Solo and crisis-band drafts never trim. This ends one actor's five near-duplicate `reach_out` drafts crowding the prompt's first-5 slice.

Tick-floor need accrual is split to Bundle 4b (schema migration + needs.py; separate for reviewability).

## Verification
- New tests: dampening reorder + cap + crisis exemption + disabled-inert; explain/evaluate winner parity under dampening; quota diversity-first trim (solo/crisis untouched). 578 orrery tests pass (one environmental config failure from the local dashboard flag flip).
- Live window check on save_02: committed wins exist in-window (`work`×3 for two actors, `mourn_loss`×2 for both grievers), so dampening engages on the next real ticks — the grievers' repeated mourning now yields to eat/drink/errands interleaving.
- Threading audited: turn cycle (production), dev endpoints (resolve + explain), coverage, audit explain path all pass `[orrery.habituation]`; `win_history` hydrates only when enabled (zero-cost off).

## Known Follow-Up
The dashboard inspector still displays authored priority; the dampened effective value will be surfaced with the Bundle 1b audit work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY