### PR TITLE
Orrery Bundle 4b: Tick-Floor Need Accrual

### DIFF
--- a/migrations/070_need_state_chunk_stamp.sql
+++ b/migrations/070_need_state_chunk_stamp.sql
@@ -1,0 +1,23 @@
+-- 070_need_state_chunk_stamp.sql
+--
+-- Tick-floor need accrual (Bundle 4b): need debt currently accrues only
+-- with elapsed WORLD time, but the narrative advances ~5 minutes per
+-- chunk, so hour-denominated thresholds take hundreds of chunks to
+-- re-arm (socialize mild = 24h ≈ 288 chunks) — a measured starvation
+-- regime (548 need-debt refusals in the blocker histogram).
+--
+-- last_evaluated_chunk_id records WHICH tick last evaluated the row, so
+-- the resolver can floor accrual in story time:
+--   effective_hours = max(elapsed_world_hours,
+--                         chunks_elapsed * min_accrual_hours_per_chunk)
+-- Rows never stamped (NULL) get no floor — the floor engages as ticks
+-- naturally restamp the cast.
+
+ALTER TABLE character_need_states
+    ADD COLUMN IF NOT EXISTS last_evaluated_chunk_id BIGINT;
+
+COMMENT ON COLUMN character_need_states.last_evaluated_chunk_id IS
+    'Tick chunk that last evaluated/stamped this need row. Enables the '
+    'story-time accrual floor ([orrery.sunhelm] min_accrual_hours_per_chunk): '
+    'each elapsed chunk counts as at least that many world-hours of accrual. '
+    'NULL = never stamped since migration 070; floor inert for the row.';

--- a/nexus.toml
+++ b/nexus.toml
@@ -310,6 +310,15 @@ perceptual_summary_max_chars = 240
 accrual_rates = { sleep = 1.0, hunger = 1.0, thirst = 1.0, socialize = 1.0, intimacy = 1.0 }
 priorities = { sleep = 25, thirst = 24, hunger = 22, socialize = 18, intimacy = 16 }
 
+[orrery.sunhelm.min_accrual_hours_per_chunk]
+# Story-time accrual floor: each elapsed chunk counts as at least this many
+# world-hours for the named need. The narrative advances ~5 in-world minutes
+# per chunk, so hour-denominated social thresholds starve without a floor
+# (socialize mild = 24h ~ 288 chunks). Sparse: unlisted needs accrue on
+# world time alone — flooring biological needs risks prose dissonance.
+socialize = 0.5
+intimacy = 0.25
+
 [orrery.sunhelm.severity_thresholds.sleep]
 mild = 16.0
 moderate = 30.0

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -1223,6 +1223,7 @@ def entity_context(
         tags_by_entity={
             entity_id: frozenset(values) for entity_id, values in tag_sets.items()
         },
+        anchor_chunk_id=anchor_chunk_id,
     )
     needs_by_entity: dict[int, list[dict[str, Any]]] = {}
     for (entity_id, need_type), score in sorted(need_scores.items()):

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -1774,6 +1774,7 @@ def _apply_need_fulfillment_sync(
         UPDATE character_need_states
         SET debt_score = %s,
             last_evaluated_at = %s,
+            last_evaluated_chunk_id = %s,
             last_fulfilled_at = %s,
             updated_at = now(),
             metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb
@@ -1783,6 +1784,7 @@ def _apply_need_fulfillment_sync(
         (
             new_debt,
             world_time,
+            source_chunk_id,
             world_time,
             json.dumps({"last_fulfillment": payload}),
             actor_entity_id,
@@ -1830,14 +1832,16 @@ async def _apply_need_fulfillment_async(
         UPDATE character_need_states
         SET debt_score = $1,
             last_evaluated_at = $2,
-            last_fulfilled_at = $3,
+            last_evaluated_chunk_id = $3,
+            last_fulfilled_at = $4,
             updated_at = now(),
-            metadata = COALESCE(metadata, '{}'::jsonb) || $4::jsonb
-        WHERE character_entity_id = $5
-          AND need_type = $6::character_need_type
+            metadata = COALESCE(metadata, '{}'::jsonb) || $5::jsonb
+        WHERE character_entity_id = $6
+          AND need_type = $7::character_need_type
         """,
         new_debt,
         world_time,
+        source_chunk_id,
         world_time,
         json.dumps({"last_fulfillment": payload}),
         actor_entity_id,

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -16,6 +16,7 @@ from typing import Any, Mapping, Optional
 from nexus.agents.orrery.needs import (
     NeedTuning,
     coerce_need_tuning,
+    effective_debt_score,
     need_applies_to_tags,
     normalize_need_type,
     severity_tag_for_debt,
@@ -1767,6 +1768,7 @@ def _apply_need_fulfillment_sync(
         need_type=need_type,
         world_time=world_time,
         need_tuning=need_tuning,
+        source_chunk_id=source_chunk_id,
     )
     new_debt = max(0.0, current_debt - float(payload["discharge_debt"]))
     cur.execute(
@@ -1825,6 +1827,7 @@ async def _apply_need_fulfillment_async(
         need_type=need_type,
         world_time=world_time,
         need_tuning=need_tuning,
+        source_chunk_id=source_chunk_id,
     )
     new_debt = max(0.0, current_debt - float(payload["discharge_debt"]))
     await conn.execute(
@@ -2439,6 +2442,7 @@ def _load_or_create_need_debt_sync(
     need_type: str,
     world_time: Any,
     need_tuning: NeedTuning,
+    source_chunk_id: Optional[int] = None,
 ) -> float:
     if not _need_applies_to_entity_sync(
         cur,
@@ -2462,7 +2466,7 @@ def _load_or_create_need_debt_sync(
     )
     cur.execute(
         """
-        SELECT debt_score, last_evaluated_at
+        SELECT debt_score, last_evaluated_at, last_evaluated_chunk_id
         FROM character_need_states
         WHERE character_entity_id = %s
           AND need_type = %s::character_need_type
@@ -2474,12 +2478,19 @@ def _load_or_create_need_debt_sync(
         raise ValueError(
             f"Orrery need state missing for actor {actor_entity_id} {need_type}"
         )
-    debt_score = float(_row_get(row, "debt_score", 0) or 0.0)
-    last_evaluated_at = _row_get(row, "last_evaluated_at", 1)
-    elapsed = (world_time - last_evaluated_at).total_seconds() / 3600.0
-    if elapsed <= 0:
-        return max(0.0, debt_score)
-    return max(0.0, debt_score + elapsed * need_tuning.accrual_rates[need_type])
+    # Route through the same accrual authority the resolver reads with —
+    # a fulfillment must discharge against floor-adjusted debt, or the
+    # story-time floor between stamps is silently discarded at the moment
+    # it matters most.
+    return effective_debt_score(
+        need_type,
+        float(_row_get(row, "debt_score", 0) or 0.0),
+        last_evaluated_at=_row_get(row, "last_evaluated_at", 1),
+        current_world_time=world_time,
+        tuning=need_tuning,
+        last_evaluated_chunk_id=_row_get(row, "last_evaluated_chunk_id", 2),
+        current_chunk_id=source_chunk_id,
+    )
 
 
 async def _load_or_create_need_debt_async(
@@ -2489,6 +2500,7 @@ async def _load_or_create_need_debt_async(
     need_type: str,
     world_time: Any,
     need_tuning: NeedTuning,
+    source_chunk_id: Optional[int] = None,
 ) -> float:
     if not await _need_applies_to_entity_async(
         conn,
@@ -2514,7 +2526,7 @@ async def _load_or_create_need_debt_async(
     )
     row = await conn.fetchrow(
         """
-        SELECT debt_score, last_evaluated_at
+        SELECT debt_score, last_evaluated_at, last_evaluated_chunk_id
         FROM character_need_states
         WHERE character_entity_id = $1
           AND need_type = $2::character_need_type
@@ -2526,12 +2538,15 @@ async def _load_or_create_need_debt_async(
         raise ValueError(
             f"Orrery need state missing for actor {actor_entity_id} {need_type}"
         )
-    debt_score = float(_row_get(row, "debt_score", 0) or 0.0)
-    last_evaluated_at = _row_get(row, "last_evaluated_at", 1)
-    elapsed = (world_time - last_evaluated_at).total_seconds() / 3600.0
-    if elapsed <= 0:
-        return max(0.0, debt_score)
-    return max(0.0, debt_score + elapsed * need_tuning.accrual_rates[need_type])
+    return effective_debt_score(
+        need_type,
+        float(_row_get(row, "debt_score", 0) or 0.0),
+        last_evaluated_at=_row_get(row, "last_evaluated_at", 1),
+        current_world_time=world_time,
+        tuning=need_tuning,
+        last_evaluated_chunk_id=_row_get(row, "last_evaluated_chunk_id", 2),
+        current_chunk_id=source_chunk_id,
+    )
 
 
 def _need_applies_to_entity_sync(

--- a/nexus/agents/orrery/needs.py
+++ b/nexus/agents/orrery/needs.py
@@ -68,6 +68,13 @@ NEED_IMMUNITY_TAGS: Mapping[str, frozenset[str]] = {
         }
     ),
 }
+DEFAULT_MIN_ACCRUAL_HOURS_PER_CHUNK: Mapping[str, float] = {
+    NeedType.SLEEP.value: 0.0,
+    NeedType.HUNGER.value: 0.0,
+    NeedType.THIRST.value: 0.0,
+    NeedType.SOCIALIZE.value: 0.0,
+    NeedType.INTIMACY.value: 0.0,
+}
 NEED_SEVERITY_LEVELS: tuple[tuple[int, str], ...] = (
     (4, "critical"),
     (3, "severe"),
@@ -161,6 +168,20 @@ class NeedTuning:
     severity_thresholds: Mapping[str, Mapping[str, float]]
     priorities: Mapping[str, int]
     pressure: NeedPressureTuning
+    # Story-time accrual floor: each elapsed chunk counts as at least this
+    # many world-hours per need. 0.0 = pure world-clock accrual. Meant for
+    # story-paced needs (socialize, intimacy) whose hour thresholds starve
+    # at ~5 in-world minutes per chunk; flooring biological needs risks
+    # prose dissonance (starving hours after a meal).
+    min_accrual_hours_per_chunk: Mapping[str, float] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.min_accrual_hours_per_chunk is None:
+            object.__setattr__(
+                self,
+                "min_accrual_hours_per_chunk",
+                dict(DEFAULT_MIN_ACCRUAL_HOURS_PER_CHUNK),
+            )
 
     @classmethod
     def default(cls) -> "NeedTuning":
@@ -174,6 +195,7 @@ class NeedTuning:
             },
             priorities=dict(DEFAULT_NEED_PRIORITIES),
             pressure=NeedPressureTuning(),
+            min_accrual_hours_per_chunk=dict(DEFAULT_MIN_ACCRUAL_HOURS_PER_CHUNK),
         )
 
     @classmethod
@@ -208,6 +230,11 @@ class NeedTuning:
             severity_thresholds=severity_thresholds,
             priorities=priorities,
             pressure=NeedPressureTuning.from_mapping(raw.get("pressure")),
+            min_accrual_hours_per_chunk=_coerce_need_mapping(
+                raw.get("min_accrual_hours_per_chunk"),
+                defaults=DEFAULT_MIN_ACCRUAL_HOURS_PER_CHUNK,
+                cast=float,
+            ),
         )
 
 
@@ -278,20 +305,42 @@ def effective_debt_score(
     last_evaluated_at: Optional[datetime],
     current_world_time: Optional[datetime],
     tuning: Optional[NeedTuning] = None,
+    last_evaluated_chunk_id: Optional[int] = None,
+    current_chunk_id: Optional[int] = None,
 ) -> float:
-    """Return debt after accruing elapsed world time without mutating state."""
+    """Return debt after accruing elapsed time without mutating state.
+
+    Accrual runs on world time, floored in story time: when both chunk ids
+    are known, each elapsed chunk counts as at least the need's
+    ``min_accrual_hours_per_chunk``. The floor rescues needs whose
+    hour-denominated thresholds starve at the narrative's ~minutes-per-
+    chunk pace; a 0.0 floor (the default) reproduces pure world-clock
+    accrual exactly.
+    """
 
     tuning = tuning or load_need_tuning()
     normalized = normalize_need_type(need_type)
-    if last_evaluated_at is None or current_world_time is None:
-        return max(0.0, float(debt_score))
 
-    elapsed_seconds = (current_world_time - last_evaluated_at).total_seconds()
-    if elapsed_seconds <= 0:
-        return max(0.0, float(debt_score))
+    elapsed_hours = 0.0
+    if last_evaluated_at is not None and current_world_time is not None:
+        elapsed_seconds = (current_world_time - last_evaluated_at).total_seconds()
+        if elapsed_seconds > 0:
+            elapsed_hours = elapsed_seconds / 3600.0
 
-    elapsed_hours = elapsed_seconds / 3600.0
-    accrued = elapsed_hours * tuning.accrual_rates[normalized]
+    floor_hours = 0.0
+    floor_per_chunk = tuning.min_accrual_hours_per_chunk[normalized]
+    if (
+        floor_per_chunk > 0
+        and last_evaluated_chunk_id is not None
+        and current_chunk_id is not None
+        and current_chunk_id > last_evaluated_chunk_id
+    ):
+        floor_hours = (current_chunk_id - last_evaluated_chunk_id) * floor_per_chunk
+
+    effective_hours = max(elapsed_hours, floor_hours)
+    if effective_hours <= 0:
+        return max(0.0, float(debt_score))
+    accrued = effective_hours * tuning.accrual_rates[normalized]
     return max(0.0, float(debt_score) + accrued)
 
 

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -437,6 +437,7 @@ def hydrate_world_state(
         tags_by_entity={
             entity_id: frozenset(values) for entity_id, values in tags.items()
         },
+        anchor_chunk_id=anchor_chunk_id,
     )
     travel_states = _load_travel_states(session)
     routine_anchors = _load_routine_anchors(session)
@@ -1182,6 +1183,7 @@ def _load_need_debt_scores(
     current_world_time: Optional[datetime],
     need_tuning: NeedTuning,
     tags_by_entity: Mapping[int, frozenset[str]],
+    anchor_chunk_id: Optional[int] = None,
 ) -> dict[tuple[int, str], float]:
     """Load effective need debt scores without mutating canonical state."""
 
@@ -1193,7 +1195,8 @@ def _load_need_debt_scores(
             SELECT character_entity_id,
                    need_type::text AS need_type,
                    debt_score,
-                   last_evaluated_at
+                   last_evaluated_at,
+                   last_evaluated_chunk_id
             FROM character_need_states cns
             JOIN entities e
               ON e.id = cns.character_entity_id
@@ -1214,6 +1217,8 @@ def _load_need_debt_scores(
             last_evaluated_at=row["last_evaluated_at"],
             current_world_time=current_world_time,
             tuning=need_tuning,
+            last_evaluated_chunk_id=row.get("last_evaluated_chunk_id"),
+            current_chunk_id=anchor_chunk_id,
         )
     return scores
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -710,6 +710,16 @@ class OrrerySunhelmSettings(BaseModel):
     pressure: OrreryNeedPressureSettings = Field(
         default_factory=OrreryNeedPressureSettings
     )
+    min_accrual_hours_per_chunk: Dict[str, float] = Field(
+        default_factory=dict,
+        description=(
+            "Story-time accrual floor: each elapsed chunk counts as at "
+            "least this many world-hours for the named need. Sparse — "
+            "needs not listed accrue on world time alone. Meant for "
+            "story-paced needs (socialize, intimacy); flooring biological "
+            "needs risks prose dissonance."
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_need_keys(self) -> "OrrerySunhelmSettings":

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -135,11 +135,15 @@ class RecordingCursor:
             entity_id, need_type, world_time = params
             self.need_state.setdefault(
                 (entity_id, need_type),
-                {"debt_score": 0, "last_evaluated_at": world_time},
+                {
+                    "debt_score": 0,
+                    "last_evaluated_at": world_time,
+                    "last_evaluated_chunk_id": None,
+                },
             )
         elif (
-            "SELECT debt_score, last_evaluated_at FROM character_need_states"
-            in normalized
+            "SELECT debt_score, last_evaluated_at, last_evaluated_chunk_id"
+            " FROM character_need_states" in normalized
         ):
             entity_id, need_type = params
             self._fetchone = self.need_state.get((entity_id, need_type))
@@ -156,6 +160,7 @@ class RecordingCursor:
             self.need_state[(entity_id, need_type)] = {
                 "debt_score": debt_score,
                 "last_evaluated_at": world_time,
+                "last_evaluated_chunk_id": _evaluated_chunk_id,
             }
         elif "SELECT etc.tag FROM entity_tags_current etc" in normalized:
             entity_id = params[0]
@@ -2295,6 +2300,7 @@ def test_commit_orrery_tick_applies_need_fulfillment_delta() -> None:
             (1, "sleep"): {
                 "debt_score": 20,
                 "last_evaluated_at": world_time - timedelta(hours=2),
+                "last_evaluated_chunk_id": None,
             }
         },
     )

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -144,9 +144,15 @@ class RecordingCursor:
             entity_id, need_type = params
             self._fetchone = self.need_state.get((entity_id, need_type))
         elif "UPDATE character_need_states" in normalized:
-            debt_score, world_time, _fulfilled_at, _metadata, entity_id, need_type = (
-                params
-            )
+            (
+                debt_score,
+                world_time,
+                _evaluated_chunk_id,
+                _fulfilled_at,
+                _metadata,
+                entity_id,
+                need_type,
+            ) = params
             self.need_state[(entity_id, need_type)] = {
                 "debt_score": debt_score,
                 "last_evaluated_at": world_time,

--- a/tests/test_orrery/test_needs_floor.py
+++ b/tests/test_orrery/test_needs_floor.py
@@ -106,8 +106,9 @@ def test_resolver_loader_threads_chunk_stamp() -> None:
     """The hydration path applies the floor from stored chunk stamps."""
 
     import sys
+    from pathlib import Path
 
-    sys.path.insert(0, "tests/test_orrery")
+    sys.path.insert(0, str(Path(__file__).parent))
     from test_resolver import FakeSession
 
     from nexus.agents.orrery.resolver import _load_need_debt_scores

--- a/tests/test_orrery/test_needs_floor.py
+++ b/tests/test_orrery/test_needs_floor.py
@@ -1,0 +1,134 @@
+"""Tick-floor need accrual: story time rescues world-clock starvation.
+
+The narrative advances ~5 in-world minutes per chunk, so hour-denominated
+need thresholds effectively never re-arm on the world clock alone. The
+floor makes each elapsed chunk count as at least
+``min_accrual_hours_per_chunk`` world-hours for the configured needs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from nexus.agents.orrery.needs import NeedTuning, effective_debt_score
+
+BASE = datetime(2073, 10, 31, 12, tzinfo=timezone.utc)
+
+FLOORED = NeedTuning.from_mapping({"min_accrual_hours_per_chunk": {"socialize": 0.5}})
+
+
+def test_floor_engages_when_story_outpaces_world_clock() -> None:
+    """Five in-world minutes across 10 chunks accrues 5 floor-hours."""
+
+    debt = effective_debt_score(
+        "socialize",
+        0.0,
+        last_evaluated_at=BASE,
+        current_world_time=BASE + timedelta(minutes=5),
+        tuning=FLOORED,
+        last_evaluated_chunk_id=100,
+        current_chunk_id=110,
+    )
+    world_only = effective_debt_score(
+        "socialize",
+        0.0,
+        last_evaluated_at=BASE,
+        current_world_time=BASE + timedelta(minutes=5),
+        tuning=FLOORED,
+    )
+    rate = FLOORED.accrual_rates["socialize"]
+    assert debt == 10 * 0.5 * rate
+    assert world_only < debt, "without chunk ids the floor is inert"
+
+
+def test_world_clock_wins_when_it_exceeds_the_floor() -> None:
+    """max() semantics: a long in-world gap is never reduced by the floor."""
+
+    debt = effective_debt_score(
+        "socialize",
+        0.0,
+        last_evaluated_at=BASE,
+        current_world_time=BASE + timedelta(hours=30),
+        tuning=FLOORED,
+        last_evaluated_chunk_id=100,
+        current_chunk_id=102,
+    )
+    rate = FLOORED.accrual_rates["socialize"]
+    assert debt == 30 * rate
+
+
+def test_unfloored_needs_and_null_stamps_reproduce_legacy_accrual() -> None:
+    """Defaults are exact no-ops: 0.0 floors, NULL stamps, unlisted needs."""
+
+    rate = FLOORED.accrual_rates["hunger"]
+    legacy = effective_debt_score(
+        "hunger",
+        1.0,
+        last_evaluated_at=BASE,
+        current_world_time=BASE + timedelta(hours=2),
+        tuning=FLOORED,
+        last_evaluated_chunk_id=100,
+        current_chunk_id=200,
+    )
+    assert legacy == 1.0 + 2 * rate
+
+    null_stamp = effective_debt_score(
+        "socialize",
+        1.0,
+        last_evaluated_at=BASE,
+        current_world_time=BASE + timedelta(minutes=5),
+        tuning=FLOORED,
+        last_evaluated_chunk_id=None,
+        current_chunk_id=200,
+    )
+    assert null_stamp == effective_debt_score(
+        "socialize",
+        1.0,
+        last_evaluated_at=BASE,
+        current_world_time=BASE + timedelta(minutes=5),
+        tuning=FLOORED,
+    )
+
+
+def test_default_tuning_floors_are_all_zero() -> None:
+    tuning = NeedTuning.default()
+    assert set(tuning.min_accrual_hours_per_chunk) == {
+        "sleep",
+        "hunger",
+        "thirst",
+        "socialize",
+        "intimacy",
+    }
+    assert all(v == 0.0 for v in tuning.min_accrual_hours_per_chunk.values())
+
+
+def test_resolver_loader_threads_chunk_stamp() -> None:
+    """The hydration path applies the floor from stored chunk stamps."""
+
+    import sys
+
+    sys.path.insert(0, "tests/test_orrery")
+    from test_resolver import FakeSession
+
+    from nexus.agents.orrery.resolver import _load_need_debt_scores
+
+    session = FakeSession(
+        need_debt_rows=[
+            {
+                "character_entity_id": 1,
+                "need_type": "socialize",
+                "debt_score": 0.0,
+                "last_evaluated_at": BASE,
+                "last_evaluated_chunk_id": 100,
+            }
+        ],
+    )
+    scores = _load_need_debt_scores(
+        session,
+        current_world_time=BASE + timedelta(minutes=5),
+        need_tuning=FLOORED,
+        tags_by_entity={},
+        anchor_chunk_id=120,
+    )
+    rate = FLOORED.accrual_rates["socialize"]
+    assert scores[(1, "socialize")] == 20 * 0.5 * rate


### PR DESCRIPTION
## Summary
Completes Bundle 4: need debt now accrues on world time **floored in story time**. The narrative advances ~5 in-world minutes per chunk, so hour-denominated thresholds effectively never re-armed (socialize mild = 24h ≈ 288 chunks) — 548 first-fail refusals in the blocker histogram.

- `effective_debt_score`: `effective_hours = max(elapsed_world_hours, chunks_elapsed × min_accrual_hours_per_chunk)`. Exact legacy behavior for 0.0 floors, NULL stamps, or unlisted needs.
- Migration 070: `character_need_states.last_evaluated_chunk_id` (with column comment); both fulfillment writers stamp it. No backfill — the floor engages as ticks restamp rows naturally.
- Shipped floors: `socialize 0.5`, `intimacy 0.25` hours/chunk (sparse config; biological needs deliberately unfloored to avoid prose dissonance — the severity tags are hour-labeled).

## Verification
Five new tests: floor engagement, max() semantics (a long world-clock gap is never reduced), legacy-exactness for unfloored/unstamped rows, default-tuning zeros, and hydration-path threading via the resolver loader. 583 orrery tests pass (one environmental config failure from the local dashboard flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY