### PR TITLE
Genre-Banded Maturation Weird: entropy(cold_start) > entropy(maturation)

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -414,6 +414,11 @@ generate_candidates = 4
 select_target = 2
 deferred_secret_cap = 1
 weird_level = "medium"
+# entropy(cold_start) > entropy(maturation): runtime backstory rolls within
+# the lower fraction of the story's genre weird band, measured from its
+# floor. Cold-start wizard history keeps the full band; a mid-story entity's
+# backstory retrofits around its on-screen introduction. 1.0 = full band.
+weird_band_fraction = 0.6
 # Frontier model for the R4/R6 maturation calls.
 model_ref = "@openai.default"
 # Maturation responses are larger than ordinary wizard chat turns.

--- a/nexus/agents/orrery/retrograde_maturation.py
+++ b/nexus/agents/orrery/retrograde_maturation.py
@@ -525,6 +525,7 @@ def _mature_one(
                 )
                 return manifest
             context = _load_job_context(cur, row=row, cfg=cfg)
+            story_setting = _load_story_setting(cur)
 
     from nexus.agents.orrery.retrograde_vocabulary import (
         enumerate_seed_eligible_vocabulary,
@@ -537,6 +538,7 @@ def _mature_one(
         context=context,
         cfg=cfg,
         dbname=dbname,
+        setting=story_setting,
     )
 
     from nexus.agents.orrery.retrograde_seed_candidates import run_seed_stage
@@ -737,12 +739,15 @@ def build_runtime_maturation_packet(
     context: Mapping[str, Any],
     cfg: OrreryRetrogradeMaturationSettings,
     dbname: str,
+    setting: Mapping[str, Any],
 ) -> dict[str, Any]:
     """Build a scoped single-entity packet for the runtime maturation pass.
 
     Reuses the wizard-time request builder and prompt renderer so the R4/R5
-    validator sees an identical contract; only the scaffolds, budget, and an
-    explicit maturation directive differ.
+    validator sees an identical contract; only the scaffolds, budget, weird
+    band, and an explicit maturation directive differ. ``setting`` is the
+    persisted ``global_variables.setting`` payload whose genre selects the
+    weird band.
     """
 
     from nexus.agents.orrery.retrograde_packet import build_seed_generation_request
@@ -788,25 +793,16 @@ def build_runtime_maturation_packet(
         },
     }
 
-    # Runtime maturation has no wizard genre context to resolve a banded
-    # roll, so the calibration float comes from [orrery.retrograde.weird.dev]
-    # explicitly; genre-banded runtime resolution is a follow-up (#442).
     from nexus.config import load_settings
 
     _settings = load_settings()
     if _settings.orrery is None:
         raise ValueError("settings.orrery is required for maturation weirdness")
-    _raw_default = float(_settings.orrery.retrograde.weird.dev.default)
-    weird = {
-        "source": "maturation_default",
-        "level": cfg.weird_level,
-        # raw_min == raw_max == raw: the raw-override invariant
-        # resolve_weird_profile establishes, so weird_roll metadata stays
-        # internally consistent.
-        "raw": _raw_default,
-        "raw_min": _raw_default,
-        "raw_max": _raw_default,
-    }
+    weird = _resolve_maturation_weird(
+        settings=_settings,
+        setting=setting,
+        cfg=cfg,
+    )
     request = build_seed_generation_request(
         candidate_scaffolds=scaffolds,
         vocabulary=vocabulary,
@@ -926,6 +922,60 @@ def load_maturation_status_sync(cur: Any) -> dict[str, int]:
 # ============================================================================
 # Internal Helpers
 # ============================================================================
+
+
+def _resolve_maturation_weird(
+    *,
+    settings: Any,
+    setting: Mapping[str, Any],
+    cfg: OrreryRetrogradeMaturationSettings,
+) -> dict[str, Any]:
+    """Resolve the genre weird band, contracted for runtime maturation.
+
+    entropy(cold_start) > entropy(maturation): the wizard rolls the full
+    genre band because cold-start history *becomes* the baseline, while a
+    mid-story entity's backstory retrofits around its on-screen
+    introduction. ``weird_band_fraction`` keeps the band floor and lowers
+    the ceiling; the R3 graph builder then rolls within the contracted
+    band from its own seeded RNG.
+    """
+
+    from nexus.agents.orrery.retrograde_packet import resolve_weird_profile
+
+    profile = resolve_weird_profile(
+        settings=settings,
+        setting=setting,
+        weird_level=cfg.weird_level,
+    )
+    raw_min = float(profile["raw_min"])
+    width = float(profile["raw_max"]) - raw_min
+    raw_max = raw_min + width * float(cfg.weird_band_fraction)
+    return {
+        **profile,
+        "source": "maturation_band",
+        "band_fraction": float(cfg.weird_band_fraction),
+        "raw_max": raw_max,
+        "raw_midpoint": (raw_min + raw_max) / 2.0,
+    }
+
+
+def _load_story_setting(cur: Any) -> dict[str, Any]:
+    """Load the persisted wizard setting payload for weird-band resolution."""
+
+    cur.execute(
+        """
+        /* orrery:maturation:story_setting */
+        SELECT setting FROM global_variables
+        """
+    )
+    row = cur.fetchone()
+    setting = _row_value(row, "setting", 0) if row is not None else None
+    if not isinstance(setting, Mapping) or not setting:
+        raise ValueError(
+            "global_variables.setting is missing or empty; runtime maturation "
+            "needs the wizard setting payload to resolve its genre weird band"
+        )
+    return dict(setting)
 
 
 def _load_job_context(

--- a/nexus/agents/orrery/retrograde_maturation.py
+++ b/nexus/agents/orrery/retrograde_maturation.py
@@ -965,7 +965,7 @@ def _load_story_setting(cur: Any) -> dict[str, Any]:
     cur.execute(
         """
         /* orrery:maturation:story_setting */
-        SELECT setting FROM global_variables
+        SELECT setting FROM global_variables WHERE id = true
         """
     )
     row = cur.fetchone()

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1043,6 +1043,18 @@ class OrreryRetrogradeMaturationSettings(BaseModel):
         default="medium",
         description="Coarse weirdness level for runtime maturation seeds.",
     )
+    weird_band_fraction: float = Field(
+        default=0.6,
+        gt=0.0,
+        le=1.0,
+        description=(
+            "Fraction of the genre weird band (measured from its floor) "
+            "available to runtime maturation rolls. Cold-start wizard "
+            "history rolls the full band; mid-story backstory retrofits "
+            "around an entity's on-screen introduction, so its entropy "
+            "ceiling stays lower. 1.0 reproduces the full cold-start band."
+        ),
+    )
     model_ref: Optional[str] = Field(
         default=None,
         description=(

--- a/tests/test_orrery/test_retrograde_graph.py
+++ b/tests/test_orrery/test_retrograde_graph.py
@@ -193,7 +193,8 @@ def test_runtime_maturation_packet_sizes_graph_from_its_own_budget() -> None:
     )
     from nexus.config import load_settings
 
-    cfg = load_settings().orrery.retrograde.maturation
+    settings = load_settings()
+    cfg = settings.orrery.retrograde.maturation
     packet = build_runtime_maturation_packet(
         vocabulary=VOCABULARY,
         row={
@@ -210,11 +211,22 @@ def test_runtime_maturation_packet_sizes_graph_from_its_own_budget() -> None:
         },
         cfg=cfg,
         dbname="save_05",
+        setting={"genre": "fantasy"},
     )
     request = packet["seed_generation_request"]
     assert request["budget"]["generate_candidates"] == cfg.generate_candidates
     edges = request["candidate_graph"]["dangling_edges"]
     expected_max = max(2, ceil(cfg.generate_candidates * 1.5))
     assert len(edges) <= expected_max
+
+    # entropy(cold_start) > entropy(maturation): the roll happens inside
+    # the genre band contracted by weird_band_fraction from its floor.
+    band = getattr(
+        settings.orrery.retrograde.weird.bands_by_genre["fantasy"],
+        cfg.weird_level,
+    )
     roll = request["candidate_graph"]["weird_roll"]
-    assert roll["raw_min"] == roll["raw_max"] == roll["raw"]
+    expected_max_raw = band.min + (band.max - band.min) * cfg.weird_band_fraction
+    assert roll["raw_min"] == pytest.approx(band.min)
+    assert roll["raw_max"] == pytest.approx(expected_max_raw)
+    assert roll["raw_min"] <= roll["raw"] <= roll["raw_max"]

--- a/tests/test_orrery/test_retrograde_maturation.py
+++ b/tests/test_orrery/test_retrograde_maturation.py
@@ -23,6 +23,8 @@ from nexus.agents.logon.apex_schema import (
 from nexus.agents.orrery.retrograde_maturation import (
     MaturationEnqueueResult,
     RetrogradeMaturationVocabularyError,
+    _load_story_setting,
+    _resolve_maturation_weird,
     _slot_label,
     enqueue_declared_entity_maturations,
     namespace_expansion_event_refs,
@@ -363,6 +365,61 @@ def test_namespace_leaves_unknown_source_refs_for_validation() -> None:
     }
     rewritten = namespace_expansion_event_refs(payload, prefix="maturation_job_7")
     assert rewritten["entity_tag_plan"][0]["source_event_ref"] == "EV9"
+
+
+# ============================================================================
+# Genre-Banded Maturation Weird (#442)
+# ============================================================================
+
+
+def test_resolve_maturation_weird_contracts_the_genre_band() -> None:
+    """entropy(cold_start) > entropy(maturation): same floor, lower ceiling."""
+
+    from nexus.agents.orrery.retrograde_packet import resolve_weird_profile
+    from nexus.config import load_settings
+
+    settings = load_settings()
+    cfg = settings.orrery.retrograde.maturation
+    setting = {"genre": "fantasy", "secondary_genres": ["mystery"]}
+
+    cold = resolve_weird_profile(
+        settings=settings,
+        setting=setting,
+        weird_level=cfg.weird_level,
+    )
+    maturation = _resolve_maturation_weird(
+        settings=settings,
+        setting=setting,
+        cfg=cfg,
+    )
+
+    assert maturation["source"] == "maturation_band"
+    assert maturation["genre"] == cold["genre"]
+    assert maturation["raw_min"] == cold["raw_min"]
+    expected_max = cold["raw_min"] + (cold["raw_max"] - cold["raw_min"]) * float(
+        cfg.weird_band_fraction
+    )
+    assert maturation["raw_max"] == pytest.approx(expected_max)
+    # The configured default must actually contract; 1.0 would silently
+    # erase the cold-start/maturation entropy distinction.
+    assert cfg.weird_band_fraction < 1.0
+    assert maturation["raw_max"] < cold["raw_max"]
+    # No raw override: the R3 graph builder rolls within the band.
+    assert "raw" not in maturation
+
+
+def test_load_story_setting_raises_on_missing_payload() -> None:
+    """A slot without a persisted wizard setting fails loudly, not silently."""
+
+    class _EmptySettingCursor:
+        def execute(self, sql: str, params: Any = None) -> None:
+            assert "global_variables" in sql
+
+        def fetchone(self) -> Any:
+            return {"setting": None}
+
+    with pytest.raises(ValueError, match="global_variables.setting"):
+        _load_story_setting(_EmptySettingCursor())
 
 
 # ============================================================================


### PR DESCRIPTION
## Why

Runtime maturation pinned its weird roll to the flat `[orrery.retrograde.weird.dev].default` — a dev calibration constant, not story state. Discussed and approved on #442: cold-start wizard history rolls the full genre band because whatever it invents *becomes* the baseline; a mid-story entity's backstory retrofits around its on-screen introduction and the story's established tone, so its entropy ceiling should sit lower.

## What

- The maturation worker loads the persisted wizard setting (`global_variables.setting` — genre + secondary_genres) inside the same cursor pass as job context, and fails loudly if a slot has no setting payload.
- `_resolve_maturation_weird` resolves the genre band through the exact `resolve_weird_profile` path the wizard uses, then contracts it **from the floor**: `raw_max = raw_min + width × weird_band_fraction`. No raw override — the R3 graph builder rolls within the contracted band from its seeded RNG, so the roll is deterministic per job and the weird_roll metadata is honest about its band.
- New knob `[orrery.retrograde.maturation].weird_band_fraction` (default 0.6, `(0, 1]`; 1.0 reproduces the full cold-start band), validated in `OrreryRetrogradeMaturationSettings`.

## Tests

- `test_resolve_maturation_weird_contracts_the_genre_band`: same floor and genre as the wizard profile, ceiling contracted by exactly the configured fraction, no `raw` key, and a guard that the configured default actually contracts (1.0 would silently erase the distinction).
- `test_load_story_setting_raises_on_missing_payload`: loud failure, no silent fallback.
- The maturation packet graph test now asserts the roll lands inside the contracted fantasy band computed from live settings instead of the old `raw_min == raw_max == raw` pin.

Orrery suite: 609 passed; only the known local dashboard-flag config failure.

Closes the genre-banded weird item of #442. Remaining there: mundane-event filtering from the R3 edge pools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY