### PR TITLE
Mundane-Event Filter: Bar Bookkeeping Categories from the R3 Backstory Dice

### DIFF
--- a/docs/orrery_retrograde_spec.md
+++ b/docs/orrery_retrograde_spec.md
@@ -88,7 +88,7 @@ Six stages, labeled **R1–R6** to disambiguate from the forward Orrery pipeline
 
 - **R2. Stub generator.** From wizard choices (setting, genre, starting characters, selected traits), emit entity stubs and a sparse relationship graph — the *intentional core*. This is deterministic-ish scaffolding, low entropy, fully implied by wizard input.
 
-- **R3. Graph builder.** Expand the sparse core into a candidate relationship/event graph with open attachment points (dangling edges where history could connect).
+- **R3. Graph builder.** Expand the sparse core into a candidate relationship/event graph with open attachment points (dangling edges where history could connect). The event edge pool excludes tick-loop bookkeeping categories (`[orrery.retrograde.graph].excluded_event_categories`, default `routine`/`physiological`/`orrery_resolution`) — those event types remain valid for R6 expansion validation but are never rolled as backstory dice.
 
 - **R4. Seed generation (high-entropy, high-friction).** Over-generate candidate seeds — events, grudges, debts, secrets, vanished parties — that are *directionally connected* to the graph but NOT implied by it. This is where surprise is injected. Generate more than will be kept. The current implementation renders a Skald prompt from the dry-run packet, makes the Skald call when invoked via `nexus retrograde-seed-candidates`, and requires JSON matching the seed-candidate response schema; no generated seed is persisted at this stage.
 

--- a/nexus.toml
+++ b/nexus.toml
@@ -393,6 +393,11 @@ max_sample_retries = 12
 edge_kind_weights = { relationship = 0.4, pair_tag = 0.3, event = 0.3 }
 anchor_role_weights = { protagonist = 3.0, starting_location = 2.0, default = 1.0 }
 event_open_endpoint_weights = { character = 0.6, faction = 0.25, place = 0.15 }
+# Tick-loop bookkeeping makes weak backstory dice — never roll "once did
+# upkeep with an unknown party" into a history menu. Event types in these
+# registry categories are barred from the event edge pool only; expansion
+# validation still accepts every registered type.
+excluded_event_categories = ["orrery_resolution", "physiological", "routine"]
 
 [orrery.retrograde.maturation]
 # Runtime stub maturation (spec decisions 9/10/12, M8). When Skald declares a

--- a/nexus/agents/orrery/retrograde_graph.py
+++ b/nexus/agents/orrery/retrograde_graph.py
@@ -128,7 +128,25 @@ def build_candidate_graph(
 
     relationship_types = list(vocabulary.get("relationship_types", ()))
     pair_tag_definitions = list(vocabulary.get("multi_entity_tag_definitions", ()))
-    event_types = list(vocabulary.get("event_types", ()))
+    # Mundane-event filter (issue #442): tick-loop bookkeeping categories
+    # (needs, upkeep, package resolution) make weak backstory dice, so they
+    # never enter the event edge pool. Only the dice are filtered — R6
+    # expansion validation still accepts every registered event type. Types
+    # without a registered category (template-only vocabulary) cannot match.
+    registered_event_types = list(vocabulary.get("event_types", ()))
+    event_type_categories = vocabulary.get("event_type_categories") or {}
+    excluded_categories = set(cfg.excluded_event_categories)
+    event_types = [
+        event_type
+        for event_type in registered_event_types
+        if event_type_categories.get(event_type) not in excluded_categories
+    ]
+    if registered_event_types and not event_types:
+        raise ValueError(
+            "excluded_event_categories removed every registered event type "
+            "from the R3 event pool; loosen [orrery.retrograde.graph]."
+            f"excluded_event_categories (currently {sorted(excluded_categories)})"
+        )
     if not (relationship_types or pair_tag_definitions or event_types):
         raise ValueError(
             "Retrograde graph requires seed-eligible vocabulary; all three "
@@ -251,6 +269,11 @@ def build_candidate_graph(
             "raw": weird_roll,
             "raw_min": raw_min,
             "raw_max": raw_max,
+        },
+        "event_pool": {
+            "registered": len(registered_event_types),
+            "eligible": len(event_types),
+            "excluded_categories": sorted(excluded_categories),
         },
         "nodes": nodes,
         "dangling_edges": list(edges),

--- a/nexus/agents/orrery/retrograde_vocabulary.py
+++ b/nexus/agents/orrery/retrograde_vocabulary.py
@@ -7,7 +7,11 @@ from typing import Iterable, Literal, TypedDict
 from nexus.agents.orrery.catalog import collect_template_vocabulary
 from nexus.agents.orrery.pair_tag_registry import PAIR_TAG_SEED
 from nexus.agents.orrery.substrate import EntityKind, Slot
-from nexus.agents.orrery.tag_library import read_event_types, read_tag_library
+from nexus.agents.orrery.tag_library import (
+    read_event_type_categories,
+    read_event_types,
+    read_tag_library,
+)
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 
 
@@ -76,6 +80,7 @@ class SeedEligibleVocabulary(TypedDict):
     multi_entity_tag_families: list[str]
     multi_entity_tag_definitions: list[PairTagPrimitive]
     event_types: list[str]
+    event_type_categories: dict[str, str]
     place_classes: list[str]
     relationship_types: list[str]
 
@@ -154,6 +159,13 @@ def enumerate_seed_eligible_vocabulary(
         if dbname is not None
         else _sorted_strings(template_vocab["event_types"])
     )
+    # Registry-backed, like the registered_* sections: complete on the slot
+    # path, empty for template-only introspection (templates reference event
+    # types by name and carry no category data). Only categorized types can
+    # match the R3 excluded_event_categories filter.
+    event_type_categories = (
+        read_event_type_categories(dbname) if dbname is not None else {}
+    )
     single_entity_tags = sorted(
         set(template_vocab["durable_tags"])
         | set(template_vocab["ephemeral_tags"])
@@ -188,6 +200,7 @@ def enumerate_seed_eligible_vocabulary(
         "multi_entity_tag_families": [item["tag"] for item in pair_tag_definitions],
         "multi_entity_tag_definitions": pair_tag_definitions,
         "event_types": event_types,
+        "event_type_categories": event_type_categories,
         "place_classes": _sorted_strings(template_vocab["place_classes"]),
         "relationship_types": _sorted_strings(template_vocab["relationship_types"]),
     }

--- a/nexus/agents/orrery/tag_library.py
+++ b/nexus/agents/orrery/tag_library.py
@@ -103,6 +103,25 @@ def read_event_types(dbname: Optional[str] = None) -> list[str]:
         conn.close()
 
 
+def read_event_type_categories(dbname: Optional[str] = None) -> dict[str, str]:
+    """Read the registry category of every active world event type."""
+
+    conn = _connect(dbname)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT type, category
+                FROM event_types
+                WHERE deprecated = FALSE
+                ORDER BY type
+                """
+            )
+            return {str(row["type"]): str(row["category"]) for row in cur.fetchall()}
+    finally:
+        conn.close()
+
+
 def read_pair_tag_library(dbname: Optional[str] = None) -> list[str]:
     """Read active Orrery pair-tag names from the target slot database."""
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -983,6 +983,15 @@ class OrreryRetrogradeGraphSettings(BaseModel):
         },
         description="Open-endpoint kind mix for event edges.",
     )
+    excluded_event_categories: List[str] = Field(
+        default_factory=lambda: ["orrery_resolution", "physiological", "routine"],
+        description=(
+            "Event-type registry categories barred from the R3 event edge "
+            "pool. Tick-loop bookkeeping (needs, upkeep, package resolution) "
+            "makes weak backstory dice; expansion validation still accepts "
+            "every registered type."
+        ),
+    )
 
 
 class OrreryRetrogradeMaturationSettings(BaseModel):

--- a/tests/test_orrery/test_retrograde_graph.py
+++ b/tests/test_orrery/test_retrograde_graph.py
@@ -45,7 +45,22 @@ VOCABULARY = {
             "is_ephemeral": False,
         },
     ],
-    "event_types": ["threat_issued", "contact_made", "mourning_act"],
+    "event_types": [
+        "threat_issued",
+        "contact_made",
+        "mourning_act",
+        "upkeep_done",
+        "slept",
+    ],
+    # Registry categories: bookkeeping categories (routine, physiological,
+    # orrery_resolution by default) are barred from the event edge pool.
+    "event_type_categories": {
+        "threat_issued": "interpersonal",
+        "contact_made": "interpersonal",
+        "mourning_act": "emotional",
+        "upkeep_done": "routine",
+        "slept": "physiological",
+    },
     # Keys the request builder touches beyond the edge pools.
     "entity_kinds": ["character", "place", "faction"],
     "slots": ["actor", "target"],
@@ -181,6 +196,83 @@ def test_graph_settings_are_configurable() -> None:
     )
     assert len(graph["dangling_edges"]) <= 12
     assert all(edge["kind"] == "event" for edge in graph["dangling_edges"])
+
+
+def test_mundane_event_categories_never_enter_the_event_pool() -> None:
+    """Bookkeeping events are excluded from the backstory dice (issue #442)."""
+
+    graph = build_candidate_graph(
+        candidate_scaffolds=SCAFFOLDS,
+        vocabulary=VOCABULARY,
+        weird=WEIRD,
+        generate_candidates=8,
+        rng_seed_material="test:mundane",
+        graph_settings={
+            "edge_kind_weights": {"event": 1.0},
+            "edges_per_candidate": 3.0,
+        },
+    )
+    rolled = {edge["edge_type"] for edge in graph["dangling_edges"]}
+    assert rolled <= {"threat_issued", "contact_made", "mourning_act"}
+    assert graph["event_pool"] == {
+        "registered": 5,
+        "eligible": 3,
+        "excluded_categories": ["orrery_resolution", "physiological", "routine"],
+    }
+
+
+def test_uncategorized_event_types_cannot_be_excluded() -> None:
+    """Template-only vocabulary carries no categories; the filter is a no-op."""
+
+    vocabulary = {**VOCABULARY, "event_type_categories": {}}
+    graph = build_candidate_graph(
+        candidate_scaffolds=SCAFFOLDS,
+        vocabulary=vocabulary,
+        weird=WEIRD,
+        generate_candidates=8,
+        rng_seed_material="test:uncategorized",
+        graph_settings={
+            "edge_kind_weights": {"event": 1.0},
+            "edges_per_candidate": 3.0,
+        },
+    )
+    rolled = {edge["edge_type"] for edge in graph["dangling_edges"]}
+    assert rolled == set(VOCABULARY["event_types"])
+    assert graph["event_pool"]["eligible"] == 5
+
+
+def test_exclusion_that_empties_the_event_pool_raises_loudly() -> None:
+    """Excluding every registered category is a misconfiguration, not a state."""
+
+    with pytest.raises(ValueError, match="excluded_event_categories"):
+        build_candidate_graph(
+            candidate_scaffolds=SCAFFOLDS,
+            vocabulary=VOCABULARY,
+            weird=WEIRD,
+            generate_candidates=4,
+            rng_seed_material="test:allmundane",
+            graph_settings={
+                "excluded_event_categories": [
+                    "interpersonal",
+                    "emotional",
+                    "physiological",
+                    "routine",
+                ],
+            },
+        )
+
+
+def test_excluded_event_categories_come_from_settings() -> None:
+    """nexus.toml owns the exclusion list, not module constants."""
+
+    from nexus.config import load_settings
+
+    cfg = load_settings().orrery.retrograde.graph
+    assert cfg.excluded_event_categories == [
+        "orrery_resolution",
+        "physiological",
+        "routine",
+    ]
 
 
 def test_runtime_maturation_packet_sizes_graph_from_its_own_budget() -> None:

--- a/tests/test_orrery/test_retrograde_vocabulary.py
+++ b/tests/test_orrery/test_retrograde_vocabulary.py
@@ -28,6 +28,9 @@ def test_seed_eligible_vocabulary_includes_template_primitives() -> None:
     assert "wilderness" in vocabulary["place_classes"]
     assert vocabulary["registered_single_entity_tags"] == []
     assert vocabulary["registered_tags_by_category"] == {}
+    # Registry-backed like the registered_* sections: templates reference
+    # event types by name only, so the template path carries no categories.
+    assert vocabulary["event_type_categories"] == {}
     assert "family" in vocabulary["relationship_types"]
     assert "handler" in vocabulary["relationship_types"]
 
@@ -49,6 +52,8 @@ def test_seed_eligible_vocabulary_can_include_live_tag_registry() -> None:
     )
     assert "grieving" in vocabulary["registered_tags_by_entity_kind"]["character"]
     assert "commerce" in vocabulary["registered_tags_by_entity_kind"]["place"]
+    assert vocabulary["event_type_categories"]["upkeep_done"] == "routine"
+    assert vocabulary["event_type_categories"]["slept"] == "physiological"
     policies = {
         item["category"]: item["policy"]
         for item in vocabulary["registered_category_seed_policies"]
@@ -127,6 +132,11 @@ def test_seed_eligible_vocabulary_classifies_registered_categories(
         "read_event_types",
         lambda _dbname: ["live_warning"],
     )
+    monkeypatch.setattr(
+        retrograde_vocabulary,
+        "read_event_type_categories",
+        lambda _dbname: {"live_warning": "interpersonal"},
+    )
 
     vocabulary = enumerate_seed_eligible_vocabulary(dbname="save_05")
     policies = {
@@ -147,6 +157,7 @@ def test_seed_eligible_vocabulary_classifies_registered_categories(
         "untested_signal"
     ]
     assert vocabulary["event_types"] == ["live_warning"]
+    assert vocabulary["event_type_categories"] == {"live_warning": "interpersonal"}
 
 
 def test_category_seed_policy_returns_complete_struct() -> None:


### PR DESCRIPTION
## Summary

Closes the last open item on #442. Tick-loop bookkeeping event types (`upkeep_done`, `recreation_taken`, `slept`, `maintain_cover`, …) were landing in the R3 candidate-graph event pool and rolling weak backstory edges — observed live in the Halvess maturation packet as "once did upkeep with an unknown party"-grade dice. Event types whose registry category is listed in `[orrery.retrograde.graph].excluded_event_categories` are now barred from the event edge pool before sampling.

## Design

- **Only the dice are filtered.** R4/R6 prompt building and expansion validation still accept every registered event type; the exclusion lives solely at the R3 sampling site in `retrograde_graph.py`.
- **Category data threads through the vocabulary.** `tag_library.read_event_type_categories()` reads `{type: category}` from the same `event_types` table (`category` is `NOT NULL`), and `SeedEligibleVocabulary` gains a registry-backed `event_type_categories` key — complete on the slot-database path, empty for template-only introspection, matching the existing `registered_*` convention. Uncategorized types therefore can never match an exclusion.
- **Loud misconfiguration failure.** An exclusion list that empties a non-empty event pool raises `ValueError` immediately instead of silently starving the sampler.
- **Observability.** The graph payload records a compact `event_pool` block (`registered` / `eligible` / `excluded_categories`) alongside `weird_roll` for replay and debugging.

## Default Exclusion List

`["orrery_resolution", "physiological", "routine"]` in nexus.toml.

The issue thread ratified `routine` + `orrery_resolution`; this PR **adds `physiological`** (`ate`, `drank`, `slept`) as a default because it is the same need-tick bookkeeping class — "once slept with an unknown party" would be an even worse roll than upkeep. It is one config-line to remove if unwanted.

## Verification

- Live save_05 smoke: 68 registered types → 57 eligible; the 11 excluded are exactly the members of the three bookkeeping categories; 56 distinct event types rolled across a 60-edge request with zero banned types.
- Live save_02 registry test (`NEXUS_RUN_POSTGRES=1`) covers the category mapping read.
- New unit tests: default exclusion keeps mundane types out of the pool (with `event_pool` metadata pinned), template-path no-op semantics, empty-pool misconfiguration raises, and the nexus.toml list resolves through `load_settings()`.
- Full suite: 1035 passed; the single local failure is the documented `[orrery.dashboard]` local-flag artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)