### PR TITLE
TEST-Mode Wizard Restored: Mock Server Learns the Responses-API Dialect

### DIFF
--- a/nexus/api/mock_openai.py
+++ b/nexus/api/mock_openai.py
@@ -130,6 +130,161 @@ def query_bootstrap_narrative() -> Dict[str, Any]:
             return cur.fetchone() or {}
 
 
+def build_setting_arguments(cache: Dict[str, Any]) -> Dict[str, Any]:
+    """Build ``SettingCard`` tool arguments from a wizard cache row."""
+
+    return {
+        "tone": cache.get("setting_tone"),
+        "genre": cache.get("setting_genre"),
+        "themes": _parse_pg_array(cache.get("setting_themes")),
+        "tech_level": cache.get("setting_tech_level"),
+        "world_name": cache.get("setting_world_name"),
+        "time_period": cache.get("setting_time_period"),
+        "magic_exists": cache.get("setting_magic_exists", False),
+        "magic_description": cache.get("setting_magic_description"),
+        "cultural_notes": cache.get("setting_cultural_notes"),
+        "language_notes": cache.get("setting_language_notes"),
+        "major_conflict": cache.get("setting_major_conflict"),
+        "geographic_scope": cache.get("setting_geographic_scope"),
+        "secondary_genres": _parse_pg_array(cache.get("setting_secondary_genres")),
+        "political_structure": cache.get("setting_political_structure"),
+        "diegetic_artifact": cache.get("setting_diegetic_artifact"),
+    }
+
+
+def _selected_trait_rows(traits: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return the three complete selected standard-trait rows or fail loudly."""
+
+    selected = [
+        trait
+        for trait in traits
+        if trait.get("is_selected")
+        and isinstance(trait.get("id"), int)
+        and trait["id"] <= 10
+    ]
+    if len(selected) != 3:
+        raise ValueError(
+            "Mock traits must contain exactly 3 selected rows with id <= 10; "
+            f"found {len(selected)}"
+        )
+
+    for trait in selected:
+        name = trait.get("name")
+        rationale = trait.get("rationale")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("Each selected mock trait must have a non-empty name")
+        if not isinstance(rationale, str) or not rationale.strip():
+            raise ValueError(
+                f"Selected mock trait {name!r} must have a non-empty rationale"
+            )
+    return selected
+
+
+def build_character_concept_arguments(
+    cache: Dict[str, Any], traits: List[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Build ``CharacterConceptSubmission`` arguments from mock rows."""
+
+    selected = _selected_trait_rows(traits)
+    return {
+        "name": cache.get("character_name"),
+        "archetype": cache.get("character_archetype"),
+        "background": cache.get("character_background"),
+        "appearance": cache.get("character_appearance"),
+        "suggested_traits": [
+            {"name": trait["name"], "rationale": trait["rationale"]}
+            for trait in selected
+        ],
+    }
+
+
+def build_trait_selection_arguments(
+    traits: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build ``TraitSelection`` arguments from mock trait rows."""
+
+    selected = _selected_trait_rows(traits)
+    names = [trait["name"] for trait in selected]
+    return {
+        "selected_traits": names,
+        "trait_rationales": {trait["name"]: trait["rationale"] for trait in selected},
+        "suggested_by_llm": names,
+    }
+
+
+def build_wildcard_trait_arguments(
+    traits: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build ``WildcardTrait`` arguments from the id-11 mock trait row."""
+
+    wildcard = next((trait for trait in traits if trait.get("id") == 11), None)
+    if wildcard is None:
+        raise ValueError("Mock traits are missing the required wildcard row with id 11")
+
+    name = wildcard.get("name")
+    rationale = wildcard.get("rationale")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("Mock wildcard trait id 11 must have a non-empty name")
+    if not isinstance(rationale, str) or len(rationale.strip()) < 20:
+        raise ValueError(
+            "Mock wildcard trait id 11 rationale must be at least 20 characters"
+        )
+    return {
+        "wildcard_name": name,
+        "wildcard_description": rationale,
+    }
+
+
+def build_story_seed_arguments(cache: Dict[str, Any]) -> Dict[str, Any]:
+    """Build ``StorySeedSubmission`` arguments from a wizard cache row."""
+
+    location = cache.get("initial_location") or {}
+    base_timestamp = cache.get("base_timestamp")
+    if not base_timestamp:
+        raise ValueError(
+            "Mock wizard cache is missing the persisted diegetic base_timestamp"
+        )
+    if not isinstance(base_timestamp, datetime) or base_timestamp.tzinfo is None:
+        raise ValueError(
+            "Mock wizard cache base_timestamp must be a timezone-aware "
+            "PostgreSQL datetime"
+        )
+    base_timestamp = base_timestamp.astimezone(timezone.utc)
+    base_timestamp_dict = {
+        "year": base_timestamp.year,
+        "month": base_timestamp.month,
+        "day": base_timestamp.day,
+        "hour": base_timestamp.hour,
+        "minute": base_timestamp.minute,
+    }
+
+    location_name = location.get("name", "unknown location")
+    location_summary = location.get("summary", "")
+    zone_name = cache.get("zone_name", "")
+    layer_name = cache.get("layer_name", "")
+    location_sketch = (
+        f"A place called {location_name} in the {zone_name} region of {layer_name}. "
+        f"{location_summary}"
+    )
+
+    return {
+        "seed": {
+            "seed_type": cache.get("seed_type"),
+            "title": cache.get("seed_title"),
+            "situation": cache.get("seed_situation"),
+            "hook": cache.get("seed_hook"),
+            "immediate_goal": cache.get("seed_immediate_goal"),
+            "stakes": cache.get("seed_stakes"),
+            "tension_source": cache.get("seed_tension_source"),
+            "base_timestamp": base_timestamp_dict,
+            "weather": cache.get("seed_weather"),
+            "key_npcs": _parse_pg_array(cache.get("seed_key_npcs")),
+            "secrets": cache.get("seed_secrets"),
+        },
+        "location_sketch": location_sketch,
+    }
+
+
 def get_cached_phase_response(
     phase: str, subphase: Optional[str] = None
 ) -> Dict[str, Any]:
@@ -144,164 +299,61 @@ def get_cached_phase_response(
         return {
             "phase_complete": True,
             "artifact_type": "submit_world_document",
-            "data": {
-                "tone": cache.get("setting_tone"),
-                "genre": cache.get("setting_genre"),
-                "themes": _parse_pg_array(cache.get("setting_themes")),
-                "tech_level": cache.get("setting_tech_level"),
-                "world_name": cache.get("setting_world_name"),
-                "time_period": cache.get("setting_time_period"),
-                "magic_exists": cache.get("setting_magic_exists", False),
-                "magic_description": cache.get("setting_magic_description"),
-                "cultural_notes": cache.get("setting_cultural_notes"),
-                "language_notes": cache.get("setting_language_notes"),
-                "major_conflict": cache.get("setting_major_conflict"),
-                "geographic_scope": cache.get("setting_geographic_scope"),
-                "secondary_genres": _parse_pg_array(
-                    cache.get("setting_secondary_genres")
-                ),
-                "political_structure": cache.get("setting_political_structure"),
-                "diegetic_artifact": cache.get("setting_diegetic_artifact"),
-            },
+            "data": build_setting_arguments(cache),
             "message": "[TEST MODE] World setting loaded from mock database.",
         }
 
     elif phase == "character":
-        # Query traits from assets.traits table
         traits = query_traits()
-        selected_traits = [
-            t for t in traits if t.get("is_selected") and t.get("id") <= 10
-        ]
-        wildcard = next((t for t in traits if t.get("id") == 11), None)
-
-        # Build trait names and rationales from selected traits
-        selected_names = [t.get("name") for t in selected_traits]
-        trait_rationales = {
-            t.get("name"): t.get("rationale")
-            for t in selected_traits
-            if t.get("rationale")
-        }
-
         if subphase == "concept":
-            # For concept submission, suggest 3 traits if none are selected yet
-            if not selected_names:
-                # Default suggestions based on typical character archetypes
-                suggested_names = ["status", "reputation", "obligations"]
-                suggested_rationales = {
-                    "status": "Given the character's background, their status in the world creates tension.",
-                    "reputation": "The character's reputation precedes them, opening some doors while slamming others.",
-                    "obligations": "Obligations pull the character into situations against their better judgment.",
-                }
-            else:
-                suggested_names = selected_names
-                suggested_rationales = trait_rationales
-
             return {
                 "phase_complete": False,
                 "artifact_type": "submit_character_concept",
-                "data": {
-                    "name": cache.get("character_name"),
-                    "archetype": cache.get("character_archetype"),
-                    "background": cache.get("character_background"),
-                    "appearance": cache.get("character_appearance"),
-                    "suggested_traits": suggested_names,
-                    "trait_rationales": suggested_rationales,
-                },
+                "data": build_character_concept_arguments(cache, traits),
                 "message": "[TEST MODE] Character concept loaded from mock database.",
             }
         elif subphase == "traits":
             return {
                 "phase_complete": False,
                 "artifact_type": "submit_trait_selection",
-                "data": {
-                    "selected_traits": selected_names,
-                    "trait_rationales": trait_rationales,
-                },
+                "data": build_trait_selection_arguments(traits),
                 "message": "[TEST MODE] Traits loaded from mock database.",
             }
         elif subphase == "wildcard":
             return {
                 "phase_complete": True,
                 "artifact_type": "submit_wildcard_trait",
+                "data": build_wildcard_trait_arguments(traits),
+                "message": "[TEST MODE] Wildcard loaded from mock database.",
+            }
+        elif subphase == "sheet":
+            concept = build_character_concept_arguments(cache, traits)
+            selection = build_trait_selection_arguments(traits)
+            wildcard = build_wildcard_trait_arguments(traits)
+            return {
+                "phase_complete": True,
+                "artifact_type": "submit_character_sheet",
                 "data": {
                     "character_state": {
                         "concept": {
-                            "name": cache.get("character_name"),
-                            "archetype": cache.get("character_archetype"),
-                            "background": cache.get("character_background"),
-                            "appearance": cache.get("character_appearance"),
+                            key: concept[key]
+                            for key in ("name", "archetype", "background", "appearance")
                         },
                         "trait_selection": {
-                            "selected_traits": selected_names,
+                            "selected_traits": selection["selected_traits"],
                         },
-                        "wildcard": {
-                            "wildcard_name": (
-                                wildcard.get("name") if wildcard else "wildcard"
-                            ),
-                            "wildcard_description": (
-                                wildcard.get("rationale") if wildcard else None
-                            ),
-                        },
+                        "wildcard": wildcard,
                     },
                 },
-                "message": "[TEST MODE] Wildcard loaded from mock database.",
+                "message": "[TEST MODE] Character sheet loaded from mock database.",
             }
 
     elif phase == "seed":
-        location = cache.get("initial_location") or {}
-        base_timestamp = cache.get("base_timestamp")
-        if not base_timestamp:
-            raise ValueError(
-                "Mock wizard cache is missing the persisted diegetic base_timestamp"
-            )
-        if not isinstance(base_timestamp, datetime) or base_timestamp.tzinfo is None:
-            raise ValueError(
-                "Mock wizard cache base_timestamp must be a timezone-aware "
-                "PostgreSQL datetime"
-            )
-        base_timestamp = base_timestamp.astimezone(timezone.utc)
-        base_timestamp_dict = {
-            "year": base_timestamp.year,
-            "month": base_timestamp.month,
-            "day": base_timestamp.day,
-            "hour": base_timestamp.hour,
-            "minute": base_timestamp.minute,
-        }
-        # Two-phase seed generation: Return StorySeedSubmission format
-        # Phase 1: seed + location_sketch (creative content)
-        # Phase 2: set designer generates layer/zone/location (handled in wizard_chat.py)
-
-        # Generate location_sketch from existing location data for backward compatibility
-        location_name = location.get("name", "unknown location")
-        location_summary = location.get("summary", "")
-        zone_name = cache.get("zone_name", "")
-        layer_name = cache.get("layer_name", "")
-
-        location_sketch = (
-            f"A place called {location_name} in the {zone_name} region of {layer_name}. "
-            f"{location_summary}"
-        )
-
         return {
             "phase_complete": False,  # Not complete until set designer runs
             "requires_set_design": True,
             "artifact_type": "submit_starting_scenario",
-            "data": {
-                "seed": {
-                    "seed_type": cache.get("seed_type"),
-                    "title": cache.get("seed_title"),
-                    "situation": cache.get("seed_situation"),
-                    "hook": cache.get("seed_hook"),
-                    "immediate_goal": cache.get("seed_immediate_goal"),
-                    "stakes": cache.get("seed_stakes"),
-                    "tension_source": cache.get("seed_tension_source"),
-                    "base_timestamp": base_timestamp_dict,
-                    "weather": cache.get("seed_weather"),
-                    "key_npcs": _parse_pg_array(cache.get("seed_key_npcs")),
-                    "secrets": cache.get("seed_secrets"),
-                },
-                "location_sketch": location_sketch,
-            },
+            "data": build_story_seed_arguments(cache),
             # Include pre-computed location data for TEST mode bypass
             # wizard_chat.py can use this instead of calling set designer
             "_mock_location_data": {
@@ -314,7 +366,7 @@ def get_cached_phase_response(
                     "name": cache.get("zone_name"),
                     "summary": cache.get("zone_summary"),
                 },
-                "location": location,
+                "location": cache.get("initial_location") or {},
             },
             "message": "[TEST MODE] Seed loaded from mock database.",
         }
@@ -450,35 +502,119 @@ def build_artifact_response(artifact_type: str, data: Dict[str, Any]) -> Dict[st
 
 def build_archetype_intro() -> Dict[str, Any]:
     """Build character phase introduction with archetype choices."""
-    message = "[TEST MODE] Welcome to character creation. Based on the world of Neon Palimpsest, which archetypal path speaks to you?"
-    choices = [
-        "The Amnesiac Courier - Someone who wakes with no memory but dangerous skills, hunted by forces they don't remember crossing.",
-        "The Double Agent - A figure walking the line between corporate authority and underground resistance, trusted by neither.",
-        "The Memory Architect - A technician who can edit, erase, or fabricate identities, now running from their own creations.",
-    ]
-    return build_respond_with_choices(message, choices)
+    intro = build_archetype_intro_data()
+    return build_respond_with_choices(intro["message"], intro["choices"])
+
+
+def build_archetype_intro_data() -> Dict[str, Any]:
+    """Build a ``WizardResponse``-shaped character introduction."""
+
+    return {
+        "message": (
+            "[TEST MODE] Welcome to character creation. Based on the world of "
+            "Neon Palimpsest, which archetypal path speaks to you?"
+        ),
+        "choices": [
+            "The Amnesiac Courier - Someone who wakes with no memory but dangerous "
+            "skills, hunted by forces they don't remember crossing.",
+            "The Double Agent - A figure walking the line between corporate authority "
+            "and underground resistance, trusted by neither.",
+            "The Memory Architect - A technician who can edit, erase, or fabricate "
+            "identities, now running from their own creations.",
+        ],
+    }
 
 
 def build_wildcard_intro() -> Dict[str, Any]:
     """Build wildcard selection introduction."""
-    message = "[TEST MODE] Your character's core is taking shape. Now add a wildcard element that sets them apart. Which resonates with your vision?"
-    choices = [
-        "Ghostprint Key - A pre-Council identity root hidden under their skin that can briefly assume anyone's credentials, but draws dangerous attention with each use.",
-        "Neural Echo - Fragmented memories of their erased past that surface unpredictably, sometimes revealing crucial information, sometimes triggering buried protocols.",
-        "Dead Man's Archive - A cached data-store of secrets they gathered before their memory was wiped, accessible only through specific emotional triggers.",
-    ]
-    return build_respond_with_choices(message, choices)
+    intro = build_wildcard_intro_data()
+    return build_respond_with_choices(intro["message"], intro["choices"])
+
+
+def build_wildcard_intro_data() -> Dict[str, Any]:
+    """Build a ``WizardResponse``-shaped wildcard introduction."""
+
+    return {
+        "message": (
+            "[TEST MODE] Your character's core is taking shape. Now add a wildcard "
+            "element that sets them apart. Which resonates with your vision?"
+        ),
+        "choices": [
+            "Ghostprint Key - A pre-Council identity root hidden under their skin that "
+            "can briefly assume anyone's credentials, but draws dangerous attention "
+            "with each use.",
+            "Neural Echo - Fragmented memories of their erased past that surface "
+            "unpredictably, sometimes revealing crucial information, sometimes "
+            "triggering buried protocols.",
+            "Dead Man's Archive - A cached data-store of secrets they gathered before "
+            "their memory was wiped, accessible only through specific emotional "
+            "triggers.",
+        ],
+    }
 
 
 def build_seed_intro() -> Dict[str, Any]:
     """Build seed phase introduction with scenario choices."""
-    message = "[TEST MODE] Your character is ready. Now let's craft the opening scene. Which draws you in?"
-    choices = [
-        "The Job You Already Took - Kade wakes on a rattling tram, a courier's satchel handcuffed to their wrist and no memory of accepting the job. The city's ledgers insist the delivery is already in breach.",
-        "The Message That Found You - A ghost-frequency ping activates in Kade's burned neural mesh—coordinates and a single word: 'Remember.' Someone from their erased past wants to make contact.",
-        "The Face You Used to Wear - Kade spots their own face on a wanted feed, but the name and crimes belong to someone they don't remember being. The bounty is high enough to turn every stranger into a threat.",
-    ]
-    return build_respond_with_choices(message, choices)
+    intro = build_seed_intro_data()
+    return build_respond_with_choices(intro["message"], intro["choices"])
+
+
+def build_seed_intro_data() -> Dict[str, Any]:
+    """Build a ``WizardResponse``-shaped seed introduction."""
+
+    return {
+        "message": (
+            "[TEST MODE] Your character is ready. Now let's craft the opening scene. "
+            "Which draws you in?"
+        ),
+        "choices": [
+            "The Job You Already Took - Kade wakes on a rattling tram, a courier's "
+            "satchel handcuffed to their wrist and no memory of accepting the job. "
+            "The city's ledgers insist the delivery is already in breach.",
+            "The Message That Found You - A ghost-frequency ping activates in Kade's "
+            "burned neural mesh—coordinates and a single word: 'Remember.' Someone "
+            "from their erased past wants to make contact.",
+            "The Face You Used to Wear - Kade spots their own face on a wanted feed, "
+            "but the name and crimes belong to someone they don't remember being. "
+            "The bounty is high enough to turn every stranger into a threat.",
+        ],
+    }
+
+
+def build_wizard_intro_data(
+    phase: str, subphase: Optional[str] = None
+) -> Dict[str, Any]:
+    """Build a valid wizard introduction for any wizard phase."""
+
+    if phase == "character" and subphase == "concept":
+        return build_archetype_intro_data()
+    if phase == "character" and subphase == "wildcard":
+        return build_wildcard_intro_data()
+    if phase == "seed":
+        return build_seed_intro_data()
+    if phase == "character" and subphase == "traits":
+        return {
+            "message": (
+                "[TEST MODE] Choose the three traits that should carry the most "
+                "narrative weight for this character."
+            ),
+            "choices": [
+                "Use the suggested three traits.",
+                "Review the trait menu before deciding.",
+                "Choose a different combination.",
+            ],
+        }
+    return {
+        "message": (
+            "[TEST MODE] Let's establish the world that will shape this story. "
+            "Choose how you would like to begin."
+        ),
+        "choices": [
+            "Use the prepared test setting.",
+            "Review the world's central conflict.",
+            "Explore the setting's tone and themes.",
+        ],
+    }
 
 
 @app.get("/health")
@@ -556,20 +692,15 @@ async def chat_completions(request: ChatCompletionRequest):
             else:
                 # Any input (choice selection, accept_fate, or freeform) → advance
                 cached = get_cached_phase_response("character", "wildcard")
-                wildcard_data = (
-                    cached.get("data", {})
-                    .get("character_state", {})
-                    .get("wildcard", {})
-                )
                 message = build_artifact_response(
-                    "submit_wildcard_trait", wildcard_data
+                    "submit_wildcard_trait", cached.get("data", {})
                 )
                 logger.info("[MOCK] Returning wildcard trait artifact")
 
         # Subphase: Character Sheet (all subphases complete)
         elif subphase == "sheet":
             # Return the final character sheet
-            cached = get_cached_phase_response("character", "wildcard")
+            cached = get_cached_phase_response("character", "sheet")
             message = build_artifact_response(
                 "submit_character_sheet", cached.get("data", {})
             )
@@ -713,6 +844,45 @@ def _collect_text(value: Any) -> str:
     return ""
 
 
+RESPONSES_WIZARD_TOOLS: Dict[str, tuple[str, Optional[str]]] = {
+    "submit_world_document": ("setting", None),
+    "submit_character_concept": ("character", "concept"),
+    "submit_trait_selection": ("character", "traits"),
+    "submit_wildcard_trait": ("character", "wildcard"),
+    "submit_starting_scenario": ("seed", None),
+}
+
+
+def detect_responses_wizard_tool(
+    tools: Optional[List[Dict[str, Any]]],
+) -> Optional[tuple[str, str, Optional[str]]]:
+    """Find a Responses-format wizard tool and its phase mapping."""
+
+    tool_names = {
+        tool.get("name")
+        for tool in tools or []
+        if isinstance(tool, dict) and isinstance(tool.get("name"), str)
+    }
+    for tool_name, (phase, subphase) in RESPONSES_WIZARD_TOOLS.items():
+        if tool_name in tool_names:
+            return tool_name, phase, subphase
+    return None
+
+
+def get_latest_responses_user_message(input_data: Any) -> str:
+    """Extract the last user-authored text from Responses API input."""
+
+    if isinstance(input_data, str):
+        return input_data
+    if isinstance(input_data, list):
+        for item in reversed(input_data):
+            if isinstance(item, dict) and item.get("role") == "user":
+                return _collect_text(item.get("content"))
+    if isinstance(input_data, dict) and input_data.get("role") == "user":
+        return _collect_text(input_data.get("content"))
+    return ""
+
+
 def _extract_orrery_proposal_ids(prompt: str) -> List[str]:
     """Extract proposal IDs from LogonUtility's prompt-facing Orrery list.
 
@@ -819,7 +989,10 @@ def _mock_storyteller_response(prompt: str) -> Dict[str, Any]:
 
 
 def _responses_payload(
-    output_data: Dict[str, Any], *, final_result_tool: bool = False
+    output_data: Dict[str, Any],
+    *,
+    final_result_tool: bool = False,
+    tool_name: str = "final_result",
 ) -> Dict[str, Any]:
     """Format structured JSON as an OpenAI Responses-compatible payload."""
 
@@ -830,7 +1003,7 @@ def _responses_payload(
                 "type": "function_call",
                 "id": f"fc-mock-{uuid.uuid4().hex[:8]}",
                 "call_id": f"call-mock-{uuid.uuid4().hex[:8]}",
-                "name": "final_result",
+                "name": tool_name,
                 "arguments": output_json,
                 "status": "completed",
             }
@@ -905,6 +1078,28 @@ async def responses_create(request: ResponsesRequest):
     the OpenAI responses API with structured output.
     """
     logger.info(f"[MOCK] Responses request for model: {request.model}")
+
+    wizard_tool = detect_responses_wizard_tool(request.tools)
+    if wizard_tool is not None:
+        tool_name, phase, subphase = wizard_tool
+        last_user_message = get_latest_responses_user_message(request.input)
+        logger.info(
+            "[MOCK] Responses wizard request: tool=%s phase=%s subphase=%s",
+            tool_name,
+            phase,
+            subphase,
+        )
+        if is_phase_transition(last_user_message):
+            logger.info("[MOCK] Returning Responses wizard phase introduction")
+            return _responses_payload(build_wizard_intro_data(phase, subphase))
+
+        cached = get_cached_phase_response(phase, subphase)
+        logger.info("[MOCK] Returning Responses wizard artifact: %s", tool_name)
+        return _responses_payload(
+            cached.get("data", {}),
+            final_result_tool=True,
+            tool_name=tool_name,
+        )
 
     input_text = _collect_text(request.input)
     proposal_ids = _extract_orrery_proposal_ids(input_text)

--- a/nexus/api/wizard_agent.py
+++ b/nexus/api/wizard_agent.py
@@ -600,7 +600,9 @@ _setting_agent = Agent(
     model_settings=_wizard_model_settings,
     retries=_wizard_retries,
 )
-_setting_agent.tool(retries=_wizard_retries)(_submit_world_impl)
+_setting_agent.tool(name="submit_world_document", retries=_wizard_retries)(
+    _submit_world_impl
+)
 
 # Config 2: Setting phase, accept_fate (forces submit_world_document)
 _setting_accept_agent = Agent(
@@ -610,7 +612,9 @@ _setting_accept_agent = Agent(
     model_settings=_wizard_model_settings,
     retries=_wizard_retries,
 )
-_setting_accept_agent.tool(retries=_wizard_retries)(_submit_world_impl)
+_setting_accept_agent.tool(name="submit_world_document", retries=_wizard_retries)(
+    _submit_world_impl
+)
 _setting_accept_agent.output_validator(
     _make_accept_fate_validator("submit_world_document")
 )
@@ -627,7 +631,9 @@ _concept_agent = Agent(
     model_settings=_wizard_model_settings,
     retries=_wizard_retries,
 )
-_concept_agent.tool(retries=_wizard_retries)(_submit_concept_impl)
+_concept_agent.tool(name="submit_character_concept", retries=_wizard_retries)(
+    _submit_concept_impl
+)
 
 # Config 4: Character/concept, accept_fate (forces submit_character_concept)
 _concept_accept_agent = Agent(
@@ -637,7 +643,9 @@ _concept_accept_agent = Agent(
     model_settings=_wizard_model_settings,
     retries=_wizard_retries,
 )
-_concept_accept_agent.tool(retries=_wizard_retries)(_submit_concept_impl)
+_concept_accept_agent.tool(name="submit_character_concept", retries=_wizard_retries)(
+    _submit_concept_impl
+)
 _concept_accept_agent.output_validator(
     _make_accept_fate_validator("submit_character_concept")
 )
@@ -655,7 +663,9 @@ _traits_agent = Agent(
     model_settings=_wizard_model_settings,
     retries=_wizard_retries,
 )
-_traits_agent.tool(retries=_wizard_retries)(_submit_traits_impl)
+_traits_agent.tool(name="submit_trait_selection", retries=_wizard_retries)(
+    _submit_traits_impl
+)
 
 # -----------------------------------------------------------------------------
 # Character Phase - Wildcard Subphase Agents
@@ -669,7 +679,9 @@ _wildcard_agent = Agent(
     model_settings=_wizard_model_settings,
     retries=_wizard_retries,
 )
-_wildcard_agent.tool(retries=_wizard_retries)(_submit_wildcard_impl)
+_wildcard_agent.tool(name="submit_wildcard_trait", retries=_wizard_retries)(
+    _submit_wildcard_impl
+)
 
 # Config 8: Character/wildcard, accept_fate (forces submit_wildcard_trait)
 _wildcard_accept_agent = Agent(
@@ -679,7 +691,9 @@ _wildcard_accept_agent = Agent(
     model_settings=_wizard_model_settings,
     retries=_wizard_retries,
 )
-_wildcard_accept_agent.tool(retries=_wizard_retries)(_submit_wildcard_impl)
+_wildcard_accept_agent.tool(name="submit_wildcard_trait", retries=_wizard_retries)(
+    _submit_wildcard_impl
+)
 _wildcard_accept_agent.output_validator(
     _make_accept_fate_validator("submit_wildcard_trait")
 )
@@ -696,7 +710,9 @@ _seed_agent = Agent(
     model_settings=_wizard_model_settings,
     retries=_wizard_retries,
 )
-_seed_agent.tool(retries=_wizard_retries)(_submit_scenario_impl)
+_seed_agent.tool(name="submit_starting_scenario", retries=_wizard_retries)(
+    _submit_scenario_impl
+)
 
 # Config 10: Seed phase, accept_fate (forces submit_starting_scenario)
 _seed_accept_agent = Agent(
@@ -706,7 +722,9 @@ _seed_accept_agent = Agent(
     model_settings=_wizard_model_settings,
     retries=_wizard_retries,
 )
-_seed_accept_agent.tool(retries=_wizard_retries)(_submit_scenario_impl)
+_seed_accept_agent.tool(name="submit_starting_scenario", retries=_wizard_retries)(
+    _submit_scenario_impl
+)
 _seed_accept_agent.output_validator(
     _make_accept_fate_validator("submit_starting_scenario")
 )

--- a/nexus/api/wizard_chat.py
+++ b/nexus/api/wizard_chat.py
@@ -593,8 +593,9 @@ async def new_story_chat_endpoint(request: ChatRequest):
     except HTTPException:
         raise
     except Exception as e:
-        logger.error("Error in chat endpoint: %s", e)
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.exception("Error in chat endpoint: %s", e)
+        detail = f"{e} (cause: {e.__cause__})" if e.__cause__ is not None else str(e)
+        raise HTTPException(status_code=500, detail=detail)
 
 
 @router.post("/chat/stream")

--- a/tests/test_api/test_mock_wizard_responses.py
+++ b/tests/test_api/test_mock_wizard_responses.py
@@ -201,48 +201,79 @@ def mock_rows(monkeypatch) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
     return cache_row, trait_rows
 
 
-def test_responses_wizard_artifact_returns_submission_function_call(mock_rows) -> None:
+@pytest.mark.parametrize(
+    ("tool_name", "schema"),
+    [
+        ("submit_world_document", SettingCard),
+        ("submit_character_concept", CharacterConceptSubmission),
+        ("submit_trait_selection", TraitSelection),
+        ("submit_wildcard_trait", WildcardTrait),
+        ("submit_starting_scenario", StorySeedSubmission),
+    ],
+)
+def test_responses_wizard_artifact_returns_submission_function_call(
+    mock_rows, tool_name: str, schema: type
+) -> None:
     """A normal wizard turn invokes the phase's flattened submission tool."""
 
     response = TestClient(mock_openai.app).post(
         "/v1/responses",
         json={
             "model": "TEST",
-            "tools": [_responses_tool("submit_world_document", SettingCard)],
-            "input": [
-                {
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": "Accept fate."}],
-                }
-            ],
+            "tools": [_responses_tool(tool_name, schema)],
+            "input": [{"role": "user", "content": "Accept fate."}],
         },
     )
 
     assert response.status_code == 200
     tool_call = response.json()["output"][0]
     assert tool_call["type"] == "function_call"
-    assert tool_call["name"] == "submit_world_document"
-    SettingCard.model_validate(json.loads(tool_call["arguments"]))
+    assert tool_call["name"] == tool_name
+    schema.model_validate(json.loads(tool_call["arguments"]))
 
 
-def test_responses_wizard_transition_returns_native_intro(mock_rows) -> None:
+@pytest.mark.parametrize(
+    ("tool_name", "schema", "transition_message", "expected_copy"),
+    [
+        (
+            "submit_character_concept",
+            CharacterConceptSubmission,
+            "[SYSTEM] Phase setting complete. Proceeding to character.",
+            "character creation",
+        ),
+        (
+            "submit_wildcard_trait",
+            WildcardTrait,
+            "[SYSTEM] Phase traits complete. Proceeding to wildcard.",
+            "wildcard",
+        ),
+        (
+            "submit_starting_scenario",
+            StorySeedSubmission,
+            "[SYSTEM] Phase character complete. Proceeding to seed.",
+            "opening scene",
+        ),
+    ],
+)
+def test_responses_wizard_transition_returns_phase_specific_intro(
+    mock_rows,
+    tool_name: str,
+    schema: type,
+    transition_message: str,
+    expected_copy: str,
+) -> None:
     """A phase-transition turn returns WizardResponse JSON as output text."""
 
     response = TestClient(mock_openai.app).post(
         "/v1/responses",
         json={
             "model": "TEST",
-            "tools": [
-                _responses_tool("submit_character_concept", CharacterConceptSubmission)
-            ],
+            "tools": [_responses_tool(tool_name, schema)],
             "input": [
                 {"role": "assistant", "content": "Prior wizard message."},
                 {
                     "role": "user",
-                    "content": (
-                        "[SYSTEM] Phase setting complete. Proceeding to character. "
-                        "Please introduce the next phase."
-                    ),
+                    "content": transition_message,
                 },
             ],
         },
@@ -251,7 +282,8 @@ def test_responses_wizard_transition_returns_native_intro(mock_rows) -> None:
     assert response.status_code == 200
     payload = response.json()
     assert payload["output"][0]["type"] == "message"
-    WizardResponse.model_validate_json(payload["output_text"])
+    wizard_response = WizardResponse.model_validate_json(payload["output_text"])
+    assert expected_copy in wizard_response.message.lower()
 
 
 def test_responses_non_wizard_extended_storyteller_route_is_unchanged(

--- a/tests/test_api/test_mock_wizard_responses.py
+++ b/tests/test_api/test_mock_wizard_responses.py
@@ -1,0 +1,325 @@
+"""Schema and routing coverage for TEST-mode Responses API wizard calls."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+from fastapi.testclient import TestClient
+
+from nexus.api import mock_openai
+from nexus.api.new_story_schemas import (
+    CharacterConceptSubmission,
+    SettingCard,
+    StorySeedSubmission,
+    TraitSelection,
+    WildcardTrait,
+    WizardResponse,
+)
+from nexus.api.wizard_agent import WizardContext, get_wizard_agent
+
+FIXTURE_PATH = Path(__file__).parents[1] / "fixtures" / "test_cache_wizard.json"
+
+
+def _pg_array(values: List[str]) -> str:
+    """Render a list in the row shape returned by the mock RealDictCursor."""
+
+    return "{" + ",".join(values) + "}"
+
+
+def _fixture_rows() -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """Derive mock database rows from the persisted wizard fixture."""
+
+    raw = json.loads(FIXTURE_PATH.read_text())
+    setting = json.loads(raw["setting_draft"])
+    character = json.loads(raw["character_draft"])
+    seed = json.loads(raw["selected_seed"])
+    location = json.loads(raw["initial_location"])
+    layer = json.loads(raw["layer_draft"])
+    zone = json.loads(raw["zone_draft"])
+    concept = character["concept"]
+    selection = character["trait_selection"]
+
+    cache_row = {
+        **{f"setting_{key}": value for key, value in setting.items()},
+        "setting_themes": _pg_array(setting["themes"]),
+        "setting_secondary_genres": _pg_array(setting["secondary_genres"]),
+        "character_name": concept["name"],
+        "character_archetype": concept["archetype"],
+        "character_background": concept["background"],
+        "character_appearance": concept["appearance"],
+        "seed_type": seed["seed_type"],
+        "seed_title": seed["title"],
+        "seed_situation": seed["situation"],
+        "seed_hook": seed["hook"],
+        "seed_immediate_goal": seed["immediate_goal"],
+        "seed_stakes": seed["stakes"],
+        "seed_tension_source": seed["tension_source"],
+        "seed_weather": seed["weather"],
+        "seed_key_npcs": _pg_array(seed["key_npcs"]),
+        "seed_secrets": seed["secrets"],
+        "base_timestamp": datetime.fromisoformat(raw["base_timestamp"]),
+        "initial_location": location,
+        "layer_name": layer["name"],
+        "layer_type": layer["type"],
+        "layer_description": layer["description"],
+        "zone_name": zone["name"],
+        "zone_summary": zone["summary"],
+    }
+    selected_traits = [
+        {
+            "id": index,
+            "name": name,
+            "description": f"Mock description for {name}",
+            "is_selected": True,
+            "rationale": selection["trait_rationales"][name],
+        }
+        for index, name in enumerate(selection["selected_traits"], start=1)
+    ]
+    wildcard = character["wildcard"]
+    trait_rows = selected_traits + [
+        {
+            "id": 11,
+            "name": wildcard["wildcard_name"],
+            "description": "Unique wildcard trait",
+            "is_selected": False,
+            "rationale": wildcard["wildcard_description"],
+        }
+    ]
+    return cache_row, trait_rows
+
+
+def _responses_tool(name: str, schema: type) -> Dict[str, Any]:
+    """Build a pydantic-ai Responses-format function tool."""
+
+    return {
+        "type": "function",
+        "name": name,
+        "parameters": schema.model_json_schema(),
+        "strict": True,
+    }
+
+
+def test_canned_artifact_arguments_validate_against_current_schemas() -> None:
+    """Every row-to-arguments builder must track its live Pydantic schema."""
+
+    cache_row, trait_rows = _fixture_rows()
+
+    SettingCard.model_validate(mock_openai.build_setting_arguments(cache_row))
+    CharacterConceptSubmission.model_validate(
+        mock_openai.build_character_concept_arguments(cache_row, trait_rows)
+    )
+    TraitSelection.model_validate(
+        mock_openai.build_trait_selection_arguments(trait_rows)
+    )
+    WildcardTrait.model_validate(mock_openai.build_wildcard_trait_arguments(trait_rows))
+    StorySeedSubmission.model_validate(
+        mock_openai.build_story_seed_arguments(cache_row)
+    )
+
+
+@pytest.mark.parametrize(
+    ("phase", "subphase"),
+    [
+        ("setting", None),
+        ("character", "concept"),
+        ("character", "traits"),
+        ("character", "wildcard"),
+        ("seed", None),
+    ],
+)
+def test_canned_intro_payloads_validate_as_wizard_response(
+    phase: str, subphase: str | None
+) -> None:
+    """Every wizard phase introduction obeys the native output contract."""
+
+    WizardResponse.model_validate(mock_openai.build_wizard_intro_data(phase, subphase))
+
+
+@pytest.mark.parametrize(
+    ("phase", "context_data", "accept_fate", "expected_name"),
+    [
+        ("setting", None, False, "submit_world_document"),
+        ("setting", None, True, "submit_world_document"),
+        ("character", {"character_state": {}}, False, "submit_character_concept"),
+        ("character", {"character_state": {}}, True, "submit_character_concept"),
+        (
+            "character",
+            {"character_state": {"concept": {}}},
+            False,
+            "submit_trait_selection",
+        ),
+        (
+            "character",
+            {"character_state": {"concept": {}, "trait_selection": {}}},
+            False,
+            "submit_wildcard_trait",
+        ),
+        (
+            "character",
+            {"character_state": {"concept": {}, "trait_selection": {}}},
+            True,
+            "submit_wildcard_trait",
+        ),
+        ("seed", None, False, "submit_starting_scenario"),
+        ("seed", None, True, "submit_starting_scenario"),
+    ],
+)
+def test_wizard_factory_tool_names_match_mock_routing(
+    phase: str,
+    context_data: Dict[str, Any] | None,
+    accept_fate: bool,
+    expected_name: str,
+) -> None:
+    """Keep factory tool names aligned with prompts and mock routing."""
+
+    context = WizardContext(
+        slot=1,
+        cache=None,
+        phase=phase,
+        thread_id="tool-name-tripwire",
+        model="TEST",
+        context_data=context_data,
+        accept_fate=accept_fate,
+    )
+    agent = get_wizard_agent(context)
+
+    # Deliberate drift tripwire against pydantic-ai's registered function tools.
+    registered_names = set(agent._function_toolset.tools)
+    assert registered_names == {expected_name}
+    assert registered_names <= mock_openai.RESPONSES_WIZARD_TOOLS.keys()
+
+
+@pytest.fixture
+def mock_rows(monkeypatch) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """Replace the mock server's thin DB wrappers with fixture-derived rows."""
+
+    cache_row, trait_rows = _fixture_rows()
+    monkeypatch.setattr(mock_openai, "query_wizard_cache", lambda: cache_row)
+    monkeypatch.setattr(mock_openai, "query_traits", lambda: trait_rows)
+    return cache_row, trait_rows
+
+
+def test_responses_wizard_artifact_returns_submission_function_call(mock_rows) -> None:
+    """A normal wizard turn invokes the phase's flattened submission tool."""
+
+    response = TestClient(mock_openai.app).post(
+        "/v1/responses",
+        json={
+            "model": "TEST",
+            "tools": [_responses_tool("submit_world_document", SettingCard)],
+            "input": [
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Accept fate."}],
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    tool_call = response.json()["output"][0]
+    assert tool_call["type"] == "function_call"
+    assert tool_call["name"] == "submit_world_document"
+    SettingCard.model_validate(json.loads(tool_call["arguments"]))
+
+
+def test_responses_wizard_transition_returns_native_intro(mock_rows) -> None:
+    """A phase-transition turn returns WizardResponse JSON as output text."""
+
+    response = TestClient(mock_openai.app).post(
+        "/v1/responses",
+        json={
+            "model": "TEST",
+            "tools": [
+                _responses_tool("submit_character_concept", CharacterConceptSubmission)
+            ],
+            "input": [
+                {"role": "assistant", "content": "Prior wizard message."},
+                {
+                    "role": "user",
+                    "content": (
+                        "[SYSTEM] Phase setting complete. Proceeding to character. "
+                        "Please introduce the next phase."
+                    ),
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["output"][0]["type"] == "message"
+    WizardResponse.model_validate_json(payload["output_text"])
+
+
+def test_responses_non_wizard_extended_storyteller_route_is_unchanged(
+    mock_rows,
+) -> None:
+    """Wizard precedence must not disturb state-update storyteller routing."""
+
+    response = TestClient(mock_openai.app).post(
+        "/v1/responses",
+        json={
+            "model": "TEST",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "final_result",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"state_updates": {"type": "object"}},
+                    },
+                    "strict": True,
+                }
+            ],
+            "input": [{"role": "user", "content": "Continue the story."}],
+        },
+    )
+
+    assert response.status_code == 200
+    tool_call = response.json()["output"][0]
+    assert tool_call["type"] == "function_call"
+    assert tool_call["name"] == "final_result"
+    assert "state_updates" in json.loads(tool_call["arguments"])
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [
+        lambda cache, traits: mock_openai.build_character_concept_arguments(
+            cache, traits
+        ),
+        lambda _cache, traits: mock_openai.build_trait_selection_arguments(traits),
+    ],
+)
+def test_selected_trait_builders_reject_wrong_count(builder) -> None:
+    """Selected-trait schema drift fails before an invalid tool call is emitted."""
+
+    cache_row, trait_rows = _fixture_rows()
+    incomplete_rows = [row for row in trait_rows if row.get("id") != 3]
+
+    with pytest.raises(ValueError, match="exactly 3 selected rows"):
+        builder(cache_row, incomplete_rows)
+
+
+@pytest.mark.parametrize("rationale", [None, "too short"])
+def test_wildcard_builder_rejects_missing_or_short_rationale(rationale) -> None:
+    """The wildcard builder enforces the schema's minimum description length."""
+
+    _, trait_rows = _fixture_rows()
+    wildcard = next(row for row in trait_rows if row["id"] == 11)
+    wildcard["rationale"] = rationale
+
+    with pytest.raises(ValueError, match="at least 20 characters"):
+        mock_openai.build_wildcard_trait_arguments(trait_rows)
+
+
+def test_wildcard_builder_rejects_missing_row() -> None:
+    """The wildcard builder requires the canonical id-11 row."""
+
+    _, trait_rows = _fixture_rows()
+
+    with pytest.raises(ValueError, match="missing.*id 11"):
+        mock_openai.build_wildcard_trait_arguments(trait_rows[:-1])


### PR DESCRIPTION
Closes #450.

## The Rot

PR #410 moved the wizard onto pydantic-ai's `OpenAIResponsesModel` with `NativeOutput(WizardResponse, strict=True)` — native grammar-level structured output over `POST /v1/responses`. The mock server's wizard-phase intelligence, however, only existed on the legacy `/v1/chat/completions` handler. Every TEST-mode wizard request fell through to the bootstrap branch of `/v1/responses` and received `{narrative, choices}`, which can never validate against `WizardResponse` (`{message, choices}`, `extra="forbid"`) — hence "Exceeded maximum retries (2) for output validation" at every phase, with the underlying pydantic detail swallowed by a `logger.error("%s", e)`.

## The Fix

- **Wizard branch on `/v1/responses`** (`mock_openai.py`): detects the five `submit_*` tools by top-level Responses-format `name`; phase-transition turns return WizardResponse JSON via native `output_text`, all other turns return a `function_call` whose arguments are the bare single-model-flattened fields — so the **real** tool handlers execute against mock-generated data, preserving TEST mode's maximal-realism seam. Non-wizard routing (extended storyteller / bootstrap / orrery) is byte-for-byte unchanged.
- **Explicit canonical tool names** (`wizard_agent.py`): pydantic-ai derives wire names from function names, so all models — including production — saw `_submit_world_impl` while the system prompt and accept-fate validators said `submit_world_document`. Found by capturing the live wire request after the first E2E attempt still failed; fixed at the registration site with `name=` kwargs, aligning prompt, wire, and mock routing.
- **Canned payloads modernized to current schemas**: `CharacterConceptSubmission.suggested_traits` as `[{name, rationale}]` objects, bare `WildcardTrait`, `StorySeedSubmission` — built by transport-neutral pure functions shared with the legacy chat-completions handler. The silent status/reputation/obligations trait fallback is deleted; missing or invalid mock rows now raise loud `ValueError`s.
- **Loud validation errors** (`wizard_chat.py`): generic handler now uses `logger.exception` and includes the chained cause in the HTTP 500 detail. This is what turned attempt #1's opaque summary into the exact two-line pydantic error that identified the real payload on the wire.
- **Drift tests** (`tests/test_api/test_mock_wizard_responses.py`): every canned artifact and intro validates against its live Pydantic schema; TestClient coverage of artifact/intro/non-wizard routing; error-path tests; and a tripwire asserting each wizard agent's actually-registered tool names equal the mock's routing table — so the next dialect drift fails at commit time instead of rotting silently.

## Verification

- Full suite: **1063 passed, 175 skipped** (from the worktree root with the shared venv).
- Live E2E per the issue's repro: gateway + mock server, fresh slot 5, `nexus continue --slot 5 --model TEST --accept-fate` through **every** phase — setting → concept → traits (deterministic) → wildcard → seed → transition (Retrograde correctly skipped for the mock model) → bootstrap chunk 1 → a narrative turn generating chunk 2 via the extended storyteller schema. The exact commands that failed in #450 now run end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7zXr7MsZHMkKrE2y5Sze5