### PR TITLE
Reader-Facing Intertitle: Scene Grounding in IRIS at Scene Boundaries

### DIFF
--- a/nexus/api/reader_endpoints.py
+++ b/nexus/api/reader_endpoints.py
@@ -20,6 +20,7 @@ table dropped most of the columns Drizzle still declared).
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
@@ -30,6 +31,12 @@ from nexus.api.slot_utils import require_slot_dbname
 logger = logging.getLogger("nexus.api.reader_endpoints")
 
 router = APIRouter(tags=["reader"])
+
+# Issue #448 double-display policy: this anchored marker matched all 1,425
+# legacy chunks in save_01/save_02 and zero clean chunks in save_01/save_02/save_05.
+_INLINE_SCENE_MARKUP_RE = re.compile(
+    r"^<!-- SCENE BREAK: S\d{2}E\d{2}_\d{3} " r"\((?:storyteller|episode) heading\) -->"
+)
 
 
 def resolve_dbname(slot: Optional[int]) -> str:
@@ -67,6 +74,7 @@ _CHUNK_SELECT = """
         cm.episode,
         cm.scene,
         cm.world_layer::text AS world_layer,
+        cm.world_time,
         cm.time_delta::text AS time_delta,
         cm.generation_date,
         cm.slug
@@ -86,6 +94,7 @@ def _chunk_payload(row: Dict[str, Any]) -> Dict[str, Any]:
         "choiceObject": row["choice_object"],
         "choiceText": row["choice_text"],
         "createdAt": row["created_at"],
+        "hasInlineSceneMarkup": bool(_INLINE_SCENE_MARKUP_RE.match(row["raw_text"])),
     }
     if row["chunk_id"] is not None:
         payload["metadata"] = {
@@ -95,6 +104,9 @@ def _chunk_payload(row: Dict[str, Any]) -> Dict[str, Any]:
             "episode": row["episode"],
             "scene": row["scene"],
             "worldLayer": row["world_layer"],
+            "worldTime": (
+                row["world_time"].isoformat() if row["world_time"] is not None else None
+            ),
             "timeDelta": row["time_delta"],
             "generationDate": row["generation_date"],
             "slug": row["slug"],

--- a/tests/test_api/test_reader_asset_endpoints.py
+++ b/tests/test_api/test_reader_asset_endpoints.py
@@ -70,6 +70,7 @@ class TestNarrativeReads:
             "choiceObject",
             "choiceText",
             "createdAt",
+            "hasInlineSceneMarkup",
             "metadata",
         }
         meta = chunk["metadata"]
@@ -81,6 +82,7 @@ class TestNarrativeReads:
             "episode",
             "scene",
             "worldLayer",
+            "worldTime",
             "timeDelta",
             "generationDate",
             "slug",

--- a/tests/test_api/test_reader_chunk_payload.py
+++ b/tests/test_api/test_reader_chunk_payload.py
@@ -1,0 +1,72 @@
+"""Focused wire-format tests for the reader chunk serializer."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+import pytest
+
+from nexus.api.reader_endpoints import _chunk_payload
+
+
+def _row(**overrides: Any) -> Dict[str, Any]:
+    """Build one complete chunk query row for serializer tests."""
+    row: Dict[str, Any] = {
+        "id": 448,
+        "raw_text": "Clean prose.",
+        "storyteller_text": "Clean prose.",
+        "choice_object": None,
+        "choice_text": None,
+        "created_at": datetime(2026, 7, 10, tzinfo=timezone.utc),
+        "chunk_id": 448,
+        "season": 5,
+        "episode": 6,
+        "scene": 13,
+        "world_layer": "primary",
+        "world_time": None,
+        "time_delta": "00:15:00",
+        "generation_date": datetime(2026, 7, 10),
+        "slug": "S05E06_013",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_chunk_payload_serializes_world_time() -> None:
+    """A populated world clock is emitted as an ISO 8601 string."""
+    world_time = datetime(2087, 11, 3, 22, 47, tzinfo=timezone.utc)
+
+    payload = _chunk_payload(_row(world_time=world_time))
+
+    assert payload["metadata"]["worldTime"] == "2087-11-03T22:47:00+00:00"
+
+
+def test_chunk_payload_preserves_null_world_time() -> None:
+    """An unknown world clock remains JSON-null-compatible None."""
+    payload = _chunk_payload(_row(world_time=None))
+
+    assert payload["metadata"]["worldTime"] is None
+
+
+@pytest.mark.parametrize(
+    ("raw_text", "expected"),
+    [
+        (
+            "<!-- SCENE BREAK: S03E14_014 (storyteller heading) -->\n# Scene",
+            True,
+        ),
+        ("Clean prose with no embedded scene marker.", False),
+        (
+            "Opening prose.\n<!-- SCENE BREAK: S03E14_014 " "(episode heading) -->",
+            False,
+        ),
+    ],
+)
+def test_chunk_payload_detects_only_anchored_legacy_scene_markup(
+    raw_text: str, expected: bool
+) -> None:
+    """Only an exact byte-zero legacy scene-break marker enables suppression."""
+    payload = _chunk_payload(_row(raw_text=raw_text))
+
+    assert payload["hasInlineSceneMarkup"] is expected

--- a/ui/client/src/components/nexus/Intertitle.test.tsx
+++ b/ui/client/src/components/nexus/Intertitle.test.tsx
@@ -1,0 +1,45 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+import { Intertitle } from "./Intertitle";
+
+function renderIntertitle(worldTime: string | null, worldLayer = "primary") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  queryClient.setQueryData(["/api/settings"], { ui: { theme: "veil" } });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <Intertitle
+          season={5}
+          episode={6}
+          scene={13}
+          worldLayer={worldLayer}
+          worldTime={worldTime}
+        />
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("Intertitle", () => {
+  it("renders scene grounding and a minute-precision world time", () => {
+    renderIntertitle("2087-11-03T22:47:00+00:00", "flashback");
+
+    expect(
+      screen.getByText("S05E06 · Scene 13 · flashback layer"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("3 Nov 2087 · 22:47")).toBeInTheDocument();
+  });
+
+  it("omits the second line when world time is unknown", () => {
+    renderIntertitle(null);
+
+    const intertitle = screen.getByTestId("intertitle");
+    expect(intertitle).toHaveTextContent("S05E06 · Scene 13");
+    expect(intertitle.querySelectorAll(".intertitle-copy > div")).toHaveLength(1);
+  });
+});

--- a/ui/client/src/components/nexus/Intertitle.tsx
+++ b/ui/client/src/components/nexus/Intertitle.tsx
@@ -1,0 +1,64 @@
+import { DecoDivider } from "@/components/deco";
+
+interface IntertitleProps {
+  season: number;
+  episode: number;
+  scene: number;
+  worldLayer: string | null;
+  worldTime: string | null;
+}
+
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+
+export function formatWorldTime(worldTime: string): string {
+  const match = worldTime.match(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/,
+  );
+  if (!match) {
+    throw new Error(`Invalid worldTime ISO timestamp: ${worldTime}`);
+  }
+  const [, year, month, day, hour, minute] = match;
+  const monthName = MONTHS[Number(month) - 1];
+  if (!monthName) {
+    throw new Error(`Invalid worldTime month: ${worldTime}`);
+  }
+  return `${Number(day)} ${monthName} ${year} · ${hour}:${minute}`;
+}
+
+/** Quiet scene grounding shown only at committed scene boundaries. */
+export function Intertitle({
+  season,
+  episode,
+  scene,
+  worldLayer,
+  worldTime,
+}: IntertitleProps) {
+  const layerSuffix =
+    worldLayer && worldLayer !== "primary" ? ` · ${worldLayer} layer` : "";
+  const slugLine = `S${String(season).padStart(2, "0")}E${String(
+    episode,
+  ).padStart(2, "0")} · Scene ${scene}${layerSuffix}`;
+
+  return (
+    <aside className="intertitle" data-testid="intertitle">
+      <DecoDivider variant="line" className="intertitle-divider" />
+      <div className="intertitle-copy">
+        <div>{slugLine}</div>
+        {worldTime && <div>{formatWorldTime(worldTime)}</div>}
+      </div>
+    </aside>
+  );
+}

--- a/ui/client/src/components/nexus/NarrativePane.test.tsx
+++ b/ui/client/src/components/nexus/NarrativePane.test.tsx
@@ -1,0 +1,156 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+import type { NarrativeEngine } from "@/hooks/useNarrativeEngine";
+import type { ChunkWithMetadata, SlotState } from "@/types/narrative";
+import { NarrativePane } from "./NarrativePane";
+
+const SLOT = 2;
+
+beforeAll(() => {
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+function makeChunk(
+  id: number,
+  scene: number,
+  hasInlineSceneMarkup = false,
+): ChunkWithMetadata {
+  return {
+    id,
+    rawText: `Chunk ${id}`,
+    storytellerText: `Chunk ${id}`,
+    choiceText: null,
+    choiceObject: null,
+    createdAt: new Date("2026-07-10T12:00:00Z"),
+    hasInlineSceneMarkup,
+    metadata: {
+      id,
+      chunkId: id,
+      season: 5,
+      episode: 6,
+      scene,
+      worldLayer: "primary",
+      worldTime: "2087-11-03T22:47:00+00:00",
+      timeDelta: null,
+      generationDate: new Date("2026-07-10T12:00:00Z"),
+      slug: `S05E06_${String(scene).padStart(3, "0")}`,
+    },
+  };
+}
+
+function makeEngine(slotState: SlotState): NarrativeEngine {
+  return {
+    slotState,
+    slotStateError: null,
+    isSlotStateLoading: false,
+    phase: null,
+    skaldStatus: "READY",
+    elapsedMs: 0,
+    generationError: null,
+    isGenerating: false,
+    completedGenerations: 0,
+    submitTurn: vi.fn(async () => undefined),
+  };
+}
+
+function renderPane(
+  chunks: ChunkWithMetadata[],
+  readingChunkId: number | null = null,
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  const latest = chunks[chunks.length - 1];
+  queryClient.setQueryData(["/api/settings"], { ui: { theme: "veil" } });
+  queryClient.setQueryData(["/api/narrative/latest-chunk", SLOT], latest);
+  queryClient.setQueryData(
+    ["/api/narrative/outline", SLOT],
+    chunks.map((chunk) => ({
+      id: chunk.id,
+      season: chunk.metadata!.season,
+      episode: chunk.metadata!.episode,
+      scene: chunk.metadata!.scene,
+      slug: chunk.metadata!.slug,
+    })),
+  );
+  queryClient.setQueryData(
+    ["/api/narrative/chunks", 5, 6, SLOT],
+    { chunks, total: chunks.length },
+  );
+  const headChunkId = readingChunkId ?? latest.id;
+  queryClient.setQueryData(["/api/narrative/chunks/context", headChunkId, SLOT], {
+    characters: [],
+    places: [],
+  });
+  if (readingChunkId !== null) {
+    queryClient.setQueryData(
+      ["/api/narrative/chunk", readingChunkId, SLOT],
+      chunks.find((chunk) => chunk.id === readingChunkId),
+    );
+  }
+  const slotState: SlotState = {
+    slot: SLOT,
+    is_empty: false,
+    is_wizard_mode: false,
+    phase: null,
+    subphase: null,
+    thread_id: null,
+    current_chunk_id: latest.id,
+    has_pending: readingChunkId === null,
+    storyteller_text: readingChunkId === null ? "Pending prose" : null,
+    choices: [],
+    session_id: null,
+    model: null,
+  };
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <NarrativePane
+          slot={SLOT}
+          engine={makeEngine(slotState)}
+          typewriterMsPerChar={0}
+          readingChunkId={readingChunkId}
+          onNavigate={vi.fn()}
+        />
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("NarrativePane intertitle boundaries", () => {
+  it("shows the first scene and scene changes, but not repeats or inline markup", () => {
+    renderPane([
+      makeChunk(101, 1),
+      makeChunk(102, 1),
+      makeChunk(103, 2),
+      makeChunk(104, 3, true),
+    ]);
+
+    const intertitles = screen.getAllByTestId("intertitle");
+    expect(intertitles).toHaveLength(2);
+    expect(intertitles[0]).toHaveTextContent("S05E06 · Scene 1");
+    expect(intertitles[1]).toHaveTextContent("S05E06 · Scene 2");
+    expect(screen.queryByText("S05E06 · Scene 3")).not.toBeInTheDocument();
+    expect(screen.getByTestId("chunk-pending")).toBeInTheDocument();
+  });
+
+  it("shows the first historical chunk when it has no inline scene markup", () => {
+    renderPane([makeChunk(201, 7)], 201);
+
+    expect(screen.getByTestId("intertitle")).toHaveTextContent(
+      "S05E06 · Scene 7",
+    );
+  });
+
+  it("suppresses the historical intertitle for legacy inline markup", () => {
+    renderPane([makeChunk(202, 8, true)], 202);
+
+    expect(screen.queryByTestId("intertitle")).not.toBeInTheDocument();
+  });
+});

--- a/ui/client/src/components/nexus/NarrativePane.tsx
+++ b/ui/client/src/components/nexus/NarrativePane.tsx
@@ -33,6 +33,7 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { DecoDivider } from "@/components/deco";
 import { Textarea } from "@/components/ui/textarea";
+import { Intertitle } from "./Intertitle";
 import { InlineMarkdown, ProseMarkdown } from "./ProseMarkdown";
 import { TypewriterText } from "./TypewriterText";
 import {
@@ -64,6 +65,32 @@ interface NarrativePaneProps {
   readingChunkId: number | null;
   /** Navigate the reading position (null returns to the live frontier). */
   onNavigate: (chunkId: number | null) => void;
+}
+
+interface SceneGrounding {
+  season: number;
+  episode: number;
+  scene: number;
+  worldLayer: string | null;
+  worldTime: string | null;
+}
+
+function sceneGrounding(chunk: ChunkWithMetadata): SceneGrounding | null {
+  const metadata = chunk.metadata;
+  if (
+    metadata?.season == null ||
+    metadata.episode == null ||
+    metadata.scene == null
+  ) {
+    return null;
+  }
+  return {
+    season: metadata.season,
+    episode: metadata.episode,
+    scene: metadata.scene,
+    worldLayer: metadata.worldLayer,
+    worldTime: metadata.worldTime,
+  };
 }
 
 /** "<" / ">" pagination pair (plus "»" back to the frontier while reading
@@ -207,9 +234,19 @@ export function NarrativePane({
   // a memo keeps render pure (no mutation during JSX evaluation).
   const { chunkRenders, pendingDivider } = useMemo(() => {
     let previousVoice: "st" | "you" | null = null;
-    const renders = chunks.map((chunk) => {
+    let previousSceneKey: string | null | undefined;
+    const renders = chunks.map((chunk, index) => {
       const parts: Array<{ voice: "st" | "you"; text: string; divider: boolean }> =
         [];
+      const grounding = sceneGrounding(chunk);
+      const sceneKey = grounding
+        ? `${grounding.season}:${grounding.episode}:${grounding.scene}`
+        : null;
+      const showIntertitle =
+        grounding !== null &&
+        !chunk.hasInlineSceneMarkup &&
+        (index === 0 || sceneKey !== previousSceneKey);
+      previousSceneKey = sceneKey;
       const storyteller = chunk.storytellerText ?? chunk.rawText;
       if (storyteller) {
         parts.push({
@@ -227,7 +264,12 @@ export function NarrativePane({
         });
         previousVoice = "you";
       }
-      return { id: chunk.id, isCurrent: chunk.id === currentChunkId, parts };
+      return {
+        id: chunk.id,
+        isCurrent: chunk.id === currentChunkId,
+        intertitle: showIntertitle ? grounding : null,
+        parts,
+      };
     });
     return {
       chunkRenders: renders,
@@ -255,6 +297,14 @@ export function NarrativePane({
     }
     return parts;
   }, [historicalChunk]);
+
+  const historicalGrounding = historicalChunk
+    ? sceneGrounding(historicalChunk)
+    : null;
+  const historicalIntertitle =
+    historicalGrounding && !historicalChunk?.hasInlineSceneMarkup
+      ? historicalGrounding
+      : null;
 
   const canSubmit = !isGenerating && !!slotState && !slotState.is_wizard_mode;
 
@@ -394,21 +444,26 @@ export function NarrativePane({
 
             <section className="chunk-stream">
               {historicalChunk && (
-                <div
-                  className="chunk-block archival"
-                  data-testid={`chunk-${historicalChunk.id}`}
-                >
-                  <div className="prose-block">
-                    {historicalParts.map((part, i) => (
-                      <Fragment key={i}>
-                        {part.divider && <hr className="voice-divider" />}
-                        <div className={`md-part ${part.voice}`}>
-                          <ProseMarkdown text={part.text} />
-                        </div>
-                      </Fragment>
-                    ))}
+                <>
+                  {historicalIntertitle && (
+                    <Intertitle {...historicalIntertitle} />
+                  )}
+                  <div
+                    className="chunk-block archival"
+                    data-testid={`chunk-${historicalChunk.id}`}
+                  >
+                    <div className="prose-block">
+                      {historicalParts.map((part, i) => (
+                        <Fragment key={i}>
+                          {part.divider && <hr className="voice-divider" />}
+                          <div className={`md-part ${part.voice}`}>
+                            <ProseMarkdown text={part.text} />
+                          </div>
+                        </Fragment>
+                      ))}
+                    </div>
                   </div>
-                </div>
+                </>
               )}
             </section>
 
@@ -443,22 +498,24 @@ export function NarrativePane({
 
           <section className="chunk-stream">
             {chunkRenders.map((chunk) => (
-              <div
-                key={chunk.id}
-                className={`chunk-block ${chunk.isCurrent ? "current" : ""}`}
-                data-testid={`chunk-${chunk.id}`}
-              >
-                <div className="prose-block">
-                  {chunk.parts.map((part) => (
-                    <Fragment key={part.voice}>
-                      {part.divider && <hr className="voice-divider" />}
-                      <div className={`md-part ${part.voice}`}>
-                        <ProseMarkdown text={part.text} />
-                      </div>
-                    </Fragment>
-                  ))}
+              <Fragment key={chunk.id}>
+                {chunk.intertitle && <Intertitle {...chunk.intertitle} />}
+                <div
+                  className={`chunk-block ${chunk.isCurrent ? "current" : ""}`}
+                  data-testid={`chunk-${chunk.id}`}
+                >
+                  <div className="prose-block">
+                    {chunk.parts.map((part) => (
+                      <Fragment key={part.voice}>
+                        {part.divider && <hr className="voice-divider" />}
+                        <div className={`md-part ${part.voice}`}>
+                          <ProseMarkdown text={part.text} />
+                        </div>
+                      </Fragment>
+                    ))}
+                  </div>
                 </div>
-              </div>
+              </Fragment>
             ))}
 
             {pendingText && (

--- a/ui/client/src/components/nexus/nexus-layout.css
+++ b/ui/client/src/components/nexus/nexus-layout.css
@@ -333,6 +333,21 @@
   flex-direction: column;
   gap: 8px;
 }
+.intertitle {
+  width: min(100%, 42ch);
+  margin: 20px auto 12px;
+  text-align: center;
+  font-family: var(--font-menu);
+  font-size: 11px;
+  line-height: 1.55;
+  letter-spacing: var(--track-wider);
+  color: var(--fg-muted);
+}
+.intertitle-divider {
+  padding: 0 0 8px;
+  opacity: .55;
+}
+.intertitle-copy { display: grid; gap: 1px; }
 .chunk-block {
   position: relative;
   border-left: 3px solid transparent;

--- a/ui/client/src/types/narrative.ts
+++ b/ui/client/src/types/narrative.ts
@@ -9,7 +9,8 @@ import type { NarrativeChunk, ChunkMetadata } from "@shared/schema";
 /** A committed chunk joined with its metadata row (gateway read routes). */
 export type ChunkWithMetadata = Omit<NarrativeChunk, "choiceObject"> & {
   choiceObject?: ChoiceObject | null;
-  metadata?: ChunkMetadata;
+  hasInlineSceneMarkup?: boolean;
+  metadata?: ChunkMetadata & { worldTime: string | null };
 };
 
 /**

--- a/ui/client/src/types/narrative.ts
+++ b/ui/client/src/types/narrative.ts
@@ -9,7 +9,7 @@ import type { NarrativeChunk, ChunkMetadata } from "@shared/schema";
 /** A committed chunk joined with its metadata row (gateway read routes). */
 export type ChunkWithMetadata = Omit<NarrativeChunk, "choiceObject"> & {
   choiceObject?: ChoiceObject | null;
-  hasInlineSceneMarkup?: boolean;
+  hasInlineSceneMarkup: boolean;
   metadata?: ChunkMetadata & { worldTime: string | null };
 };
 


### PR DESCRIPTION
Closes #448.

## What

The reader now gets the same scene grounding Skald sees — rendered as a quiet intertitle at committed scene boundaries: a theme divider over two muted, letter-spaced lines (`S05E06 · Scene 2` / `31 Oct 2073 · 09:44`).

## Design Decisions (and Why the Scope Shrank)

- **The API half is nearly free**: the reader serializer already emitted season/episode/scene per chunk. This adds `metadata.worldTime` (the trigger-materialized `chunk_metadata.world_time`, ISO 8601) and one policy flag.
- **Place is omitted in v1** — the runtime intertitle derives location from the protagonist's *live* position, which is only valid for the newest chunk; historical chunks have no per-chunk place data. Honest data over decorative data; revisit if per-chunk location tracking ever lands.
- **Trigger = scene-tuple change** between consecutive rendered chunks (plus the stream's first chunk). No "significant time jump" threshold tunable — time is displayed, not a trigger.
- **Legacy double-display is solved exactly, not heuristically**: `hasInlineSceneMarkup` is an anchored regex matching the `<!-- SCENE BREAK: ... -->` comment at byte 0 — corpus-verified against all 1,425 legacy chunks in save_01/save_02 (100% hit rate, zero false positives on clean chunks in any slot). Flagged chunks never get a metadata intertitle.
- **Visual language is the house system**: composes the existing `DecoDivider` (theme-aware) with vendored tokens (`--font-menu`, `--track-wider`, `--fg-muted`). Natural-case content — the small-caps look is the theme typeface itself, not a CSS transform. Per the shadcn-crawl convention: `Separator` was considered and passed over in favor of the already-present house divider; nothing new installed.

## Verification

- 1074 python tests, 183 UI tests (incl. new serializer, component, and boundary-policy coverage), `tsc` and production build green — run independently after review.
- **Live visual check** (worktree gateway + built PWA, slot 2): intertitle renders above fresh chunk 1427 with values matching its DB row (`S05E06 · Scene 2`, `31 Oct 2073 · 09:44`); correctly absent above legacy chunk 1425, which keeps only its baked-in inline headings.
- API smoke: `GET /api/narrative/chunks/1428?slot=2` → `worldTime: 2073-10-31T10:29:00-04:00`, `hasInlineSceneMarkup: false`; chunk 1400 → `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7zXr7MsZHMkKrE2y5Sze5