### PR TITLE
Local Skald Transport: Chat-Completions Structured Output for Local Models

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -53,6 +53,16 @@ models = [
     { id = "TEST", label = "TEST", description = "Mock server with cached data (dev)" },
 ]
 
+# The first structured request after loading a model pays a one-time JSON-schema
+# grammar compile cost. Hermes 4 70B Extended measured about 17 min; cached after.
+[global.model.api_models.lmstudio]
+base_url = "http://127.0.0.1:1234/v1"
+structured_transport = "chat_completions"
+roles = { default = "nousresearch/hermes-4-70b" }
+models = [
+    { id = "nousresearch/hermes-4-70b", label = "Hermes 4 70B (Local)", description = "Local LM Studio inference (MLX)" },
+]
+
 # =============================================================================
 # Secrets (API Keys)
 # =============================================================================

--- a/nexus.toml
+++ b/nexus.toml
@@ -58,6 +58,8 @@ models = [
 [global.model.api_models.lmstudio]
 base_url = "http://127.0.0.1:1234/v1"
 structured_transport = "chat_completions"
+# Local 70B on a full Skald prompt can take many minutes; the SDK's 600s default is too tight.
+request_timeout_seconds = 1800
 roles = { default = "nousresearch/hermes-4-70b" }
 models = [
     { id = "nousresearch/hermes-4-70b", label = "Hermes 4 70B (Local)", description = "Local LM Studio inference (MLX)" },

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -274,6 +274,7 @@ class LogonUtility:
         structured_transport = (
             endpoint["structured_transport"] if endpoint else "responses"
         )
+        request_timeout = endpoint["request_timeout_seconds"] if endpoint else None
         if base_url:
             logger.info(f"Model {model}: routing to base_url {base_url}")
 
@@ -327,6 +328,7 @@ class LogonUtility:
                 base_url=base_url,
                 api_key=api_key,
                 structured_transport=structured_transport,
+                request_timeout=request_timeout,
                 structured_output_retries=structured_output_retries,
                 output_validator=output_validator,
             )

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -271,6 +271,9 @@ class LogonUtility:
         endpoint = get_openai_compatible_endpoint(model)
         base_url = endpoint["base_url"] if endpoint else None
         api_key = endpoint["api_key"] if endpoint else None
+        structured_transport = (
+            endpoint["structured_transport"] if endpoint else "responses"
+        )
         if base_url:
             logger.info(f"Model {model}: routing to base_url {base_url}")
 
@@ -323,6 +326,7 @@ class LogonUtility:
                 system_prompt=system_prompt,
                 base_url=base_url,
                 api_key=api_key,
+                structured_transport=structured_transport,
                 structured_output_retries=structured_output_retries,
                 output_validator=output_validator,
             )

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -677,6 +677,7 @@ def _narration_provider(settings: Mapping[str, Any]) -> Any:
             base_url=endpoint["base_url"],
             api_key=endpoint["api_key"],
             structured_transport=endpoint["structured_transport"],
+            request_timeout=endpoint["request_timeout_seconds"],
         )
     raise ValueError(f"Unsupported Orrery narration provider: {provider_name}")
 

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -676,6 +676,7 @@ def _narration_provider(settings: Mapping[str, Any]) -> Any:
             system_prompt=NARRATION_SYSTEM_PROMPT,
             base_url=endpoint["base_url"],
             api_key=endpoint["api_key"],
+            structured_transport=endpoint["structured_transport"],
         )
     raise ValueError(f"Unsupported Orrery narration provider: {provider_name}")
 

--- a/nexus/api/native_structured_output.py
+++ b/nexus/api/native_structured_output.py
@@ -187,6 +187,7 @@ def build_native_structured_provider(
             structured_transport=(
                 endpoint["structured_transport"] if endpoint else "responses"
             ),
+            request_timeout=(endpoint["request_timeout_seconds"] if endpoint else None),
             structured_output_retries=structured_output_retries,
             output_validator=output_validator,
         )

--- a/nexus/api/native_structured_output.py
+++ b/nexus/api/native_structured_output.py
@@ -184,6 +184,9 @@ def build_native_structured_provider(
             system_prompt=system_prompt,
             base_url=endpoint["base_url"] if endpoint else None,
             api_key=endpoint["api_key"] if endpoint else None,
+            structured_transport=(
+                endpoint["structured_transport"] if endpoint else "responses"
+            ),
             structured_output_retries=structured_output_retries,
             output_validator=output_validator,
         )

--- a/nexus/api/pydantic_ai_utils.py
+++ b/nexus/api/pydantic_ai_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import replace
 from typing import Any, Dict, List, Optional, Sequence
 
+from openai import AsyncOpenAI
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -66,9 +67,22 @@ def build_pydantic_ai_model(model: str) -> Model:
     endpoint = get_openai_compatible_endpoint(model)
     if endpoint is None:
         raise ValueError(f"No base_url registry entry for model {model!r}")
-    pyd_provider = PydanticOpenAIProvider(
-        api_key=endpoint["api_key"], base_url=endpoint["base_url"]
-    )
+    timeout = endpoint["request_timeout_seconds"]
+    if timeout is not None:
+        # Slow local servers (LM Studio grammar compile) blow past the OpenAI
+        # SDK's 600s default. Mirror the legacy provider call sites: hand the
+        # pydantic-ai provider a client that carries the registry timeout.
+        pyd_provider = PydanticOpenAIProvider(
+            openai_client=AsyncOpenAI(
+                api_key=endpoint["api_key"],
+                base_url=endpoint["base_url"],
+                timeout=timeout,
+            )
+        )
+    else:
+        pyd_provider = PydanticOpenAIProvider(
+            api_key=endpoint["api_key"], base_url=endpoint["base_url"]
+        )
     if endpoint["structured_transport"] == "chat_completions":
         return OpenAIChatModel(model_name=model, provider=pyd_provider)
     return OpenAIResponsesModel(model_name=model, provider=pyd_provider)

--- a/nexus/api/pydantic_ai_utils.py
+++ b/nexus/api/pydantic_ai_utils.py
@@ -15,7 +15,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models import Model
 from pydantic_ai.models.anthropic import AnthropicModel
-from pydantic_ai.models.openai import OpenAIResponsesModel
+from pydantic_ai.models.openai import OpenAIChatModel, OpenAIResponsesModel
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
 from pydantic_ai.providers.anthropic import (
     AnthropicProvider as PydanticAnthropicProvider,
@@ -69,6 +69,8 @@ def build_pydantic_ai_model(model: str) -> Model:
     pyd_provider = PydanticOpenAIProvider(
         api_key=endpoint["api_key"], base_url=endpoint["base_url"]
     )
+    if endpoint["structured_transport"] == "chat_completions":
+        return OpenAIChatModel(model_name=model, provider=pyd_provider)
     return OpenAIResponsesModel(model_name=model, provider=pyd_provider)
 
 

--- a/nexus/config/loader.py
+++ b/nexus/config/loader.py
@@ -236,12 +236,12 @@ def get_openai_compatible_endpoint(model_id: str) -> Optional[Dict[str, str]]:
         model_id: Concrete model ID from the api_models registry
 
     Returns:
-        ``{"base_url": ..., "api_key": ...}`` for base_url providers, or None
-        for native providers and for models absent from the registry (callers
-        that accept ad-hoc model overrides treat those as native-SDK models).
-        ``api_key`` is read from Keychain when the provider declares
-        ``api_key_secret``; otherwise a placeholder is returned because OpenAI
-        clients require a non-empty key.
+        ``{"base_url": ..., "api_key": ..., "structured_transport": ...}``
+        for base_url providers, or None for native providers and for models
+        absent from the registry (callers that accept ad-hoc model overrides
+        treat those as native-SDK models). ``api_key`` is read from Keychain
+        when the provider declares ``api_key_secret``; otherwise a placeholder
+        is returned because OpenAI clients require a non-empty key.
     """
     from nexus.config.settings_models import NATIVE_API_PROVIDERS
 
@@ -257,7 +257,11 @@ def get_openai_compatible_endpoint(model_id: str) -> Optional[Dict[str, str]]:
         api_key = get_secret(entry.api_key_secret)
     else:
         api_key = "nexus-local-no-key"
-    return {"base_url": entry.base_url, "api_key": api_key}
+    return {
+        "base_url": entry.base_url,
+        "api_key": api_key,
+        "structured_transport": entry.structured_transport,
+    }
 
 
 def resolve_model_ref(ref: str, path: Union[str, Path, None] = None) -> str:

--- a/nexus/config/loader.py
+++ b/nexus/config/loader.py
@@ -222,7 +222,7 @@ def get_native_structured_output_override(model_id: str) -> Optional[bool]:
     return None
 
 
-def get_openai_compatible_endpoint(model_id: str) -> Optional[Dict[str, str]]:
+def get_openai_compatible_endpoint(model_id: str) -> Optional[Dict[str, Any]]:
     """
     Resolve the OpenAI-compatible endpoint for a registry model, if any.
 
@@ -236,12 +236,13 @@ def get_openai_compatible_endpoint(model_id: str) -> Optional[Dict[str, str]]:
         model_id: Concrete model ID from the api_models registry
 
     Returns:
-        ``{"base_url": ..., "api_key": ..., "structured_transport": ...}``
-        for base_url providers, or None for native providers and for models
-        absent from the registry (callers that accept ad-hoc model overrides
-        treat those as native-SDK models). ``api_key`` is read from Keychain
-        when the provider declares ``api_key_secret``; otherwise a placeholder
-        is returned because OpenAI clients require a non-empty key.
+        ``{"base_url": ..., "api_key": ..., "structured_transport": ...,
+        "request_timeout_seconds": ...}`` for base_url providers, or None for
+        native providers and for models absent from the registry (callers that
+        accept ad-hoc model overrides treat those as native-SDK models).
+        ``api_key`` is read from Keychain when the provider declares
+        ``api_key_secret``; otherwise a placeholder is returned because OpenAI
+        clients require a non-empty key.
     """
     from nexus.config.settings_models import NATIVE_API_PROVIDERS
 
@@ -261,6 +262,7 @@ def get_openai_compatible_endpoint(model_id: str) -> Optional[Dict[str, str]]:
         "base_url": entry.base_url,
         "api_key": api_key,
         "structured_transport": entry.structured_transport,
+        "request_timeout_seconds": entry.request_timeout_seconds,
     }
 
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -130,6 +130,13 @@ class ProviderModels(BaseModel):
             "ignores text.format."
         ),
     )
+    request_timeout_seconds: Optional[float] = Field(
+        default=None,
+        description=(
+            "Override the OpenAI SDK's 600-second request timeout for slow "
+            "local servers. None defers to the SDK default."
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_structured_transport(self) -> "ProviderModels":

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -121,6 +121,25 @@ class ProviderModels(BaseModel):
             "key is sent because OpenAI clients require a non-empty key."
         ),
     )
+    structured_transport: Literal["responses", "chat_completions"] = Field(
+        default="responses",
+        description=(
+            "OpenAI-compatible surface used for structured output. Use "
+            "'chat_completions' for local servers such as LM Studio, Ollama, "
+            "or vLLM whose /v1/responses endpoint is missing or silently "
+            "ignores text.format."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_structured_transport(self) -> "ProviderModels":
+        """Chat Completions structured output requires a base_url provider."""
+        if self.structured_transport == "chat_completions" and not self.base_url:
+            raise ValueError(
+                "structured_transport='chat_completions' requires a base_url; "
+                "native SDK providers must use structured_transport='responses'"
+            )
+        return self
 
     @model_validator(mode="after")
     def _validate_roles_reference_known_models(self) -> "ProviderModels":

--- a/scripts/api_openai.py
+++ b/scripts/api_openai.py
@@ -292,6 +292,7 @@ class OpenAIProvider(LLMProvider):
         reasoning_effort: Optional[str] = None,
         base_url: Optional[str] = None,
         structured_transport: Literal["responses", "chat_completions"] = "responses",
+        request_timeout: Optional[float] = None,
         structured_output_retries: Optional[int] = None,
         output_validator: Optional[Any] = None,
     ):
@@ -311,6 +312,8 @@ class OpenAIProvider(LLMProvider):
             base_url: Optional base URL for API (e.g., for mock servers)
             structured_transport: OpenAI-compatible surface used for strict
                 structured output
+            request_timeout: Optional request timeout in seconds. None uses the
+                OpenAI SDK default.
             structured_output_retries: Validation retry budget for structured
                 output agents (apex.structured_output_retries in nexus.toml)
             output_validator: Optional async pydantic_ai output validator
@@ -319,6 +322,7 @@ class OpenAIProvider(LLMProvider):
         self.reasoning_effort = reasoning_effort
         self.max_output_tokens = max_output_tokens or max_tokens
         self.base_url = base_url
+        self.request_timeout = request_timeout
         if structured_transport not in {"responses", "chat_completions"}:
             raise ValueError(
                 "structured_transport must be 'responses' or 'chat_completions'"
@@ -374,10 +378,12 @@ class OpenAIProvider(LLMProvider):
         self.supports_temperature = not self.is_reasoning_model
 
         # Create client with optional base_url for mock servers
-        client_kwargs = {"api_key": self.api_key}
+        client_kwargs: Dict[str, Any] = {"api_key": self.api_key}
         if self.base_url:
             client_kwargs["base_url"] = self.base_url
             logger.info(f"Using custom base URL: {self.base_url}")
+        if self.request_timeout is not None:
+            client_kwargs["timeout"] = self.request_timeout
         self.client = openai.OpenAI(**client_kwargs)
 
         # Log the model type

--- a/scripts/api_openai.py
+++ b/scripts/api_openai.py
@@ -42,7 +42,18 @@ import json
 import time
 import signal
 import threading
-from typing import List, Dict, Any, Tuple, Optional, Union, Protocol, Type, TypeVar
+from typing import (
+    List,
+    Dict,
+    Any,
+    Tuple,
+    Optional,
+    Union,
+    Protocol,
+    Type,
+    TypeVar,
+    Literal,
+)
 from datetime import datetime, timedelta
 
 # Try to import keyboard module for abort functionality
@@ -280,6 +291,7 @@ class OpenAIProvider(LLMProvider):
         system_prompt: Optional[str] = None,
         reasoning_effort: Optional[str] = None,
         base_url: Optional[str] = None,
+        structured_transport: Literal["responses", "chat_completions"] = "responses",
         structured_output_retries: Optional[int] = None,
         output_validator: Optional[Any] = None,
     ):
@@ -297,6 +309,8 @@ class OpenAIProvider(LLMProvider):
                 - GPT-5: 'minimal', 'medium', 'high'
                 - o3: 'low', 'medium', 'high'
             base_url: Optional base URL for API (e.g., for mock servers)
+            structured_transport: OpenAI-compatible surface used for strict
+                structured output
             structured_output_retries: Validation retry budget for structured
                 output agents (apex.structured_output_retries in nexus.toml)
             output_validator: Optional async pydantic_ai output validator
@@ -305,6 +319,15 @@ class OpenAIProvider(LLMProvider):
         self.reasoning_effort = reasoning_effort
         self.max_output_tokens = max_output_tokens or max_tokens
         self.base_url = base_url
+        if structured_transport not in {"responses", "chat_completions"}:
+            raise ValueError(
+                "structured_transport must be 'responses' or 'chat_completions'"
+            )
+        if structured_transport == "chat_completions" and not base_url:
+            raise ValueError(
+                "structured_transport='chat_completions' requires a base_url"
+            )
+        self.structured_transport = structured_transport
         self.structured_output_retries = (
             structured_output_retries
             if structured_output_retries is not None
@@ -431,11 +454,8 @@ class OpenAIProvider(LLMProvider):
         text_format: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, LLMResponse]:
         """Get a structured completion without blocking an existing event loop."""
-        return await asyncio.to_thread(
-            self._get_structured_completion_native_sync,
-            prompt,
-            schema_model,
-            text_format=text_format,
+        return await self._get_structured_completion_native_async(
+            prompt, schema_model, text_format=text_format
         )
 
     def _raise_if_running_loop(self, method_name: str, async_method_name: str) -> None:
@@ -458,6 +478,11 @@ class OpenAIProvider(LLMProvider):
         text_format: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, LLMResponse]:
         """Run a native strict-schema Responses request with bounded repair."""
+
+        if self.structured_transport == "chat_completions":
+            return self._get_structured_completion_chat_completions_sync(
+                prompt, schema_model, text_format=text_format
+            )
 
         from pydantic_ai import ModelRetry
 
@@ -505,6 +530,26 @@ class OpenAIProvider(LLMProvider):
                 active_prompt = retry_prompt(prompt, str(exc))
 
         raise RuntimeError("Structured completion failed") from last_error
+
+    async def _get_structured_completion_native_async(
+        self,
+        prompt: str,
+        schema_model: Type,
+        *,
+        text_format: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Any, LLMResponse]:
+        """Dispatch structured output without blocking an existing event loop."""
+
+        if self.structured_transport == "chat_completions":
+            return await self._get_structured_completion_chat_completions_async(
+                prompt, schema_model, text_format=text_format
+            )
+        return await asyncio.to_thread(
+            self._get_structured_completion_native_sync,
+            prompt,
+            schema_model,
+            text_format=text_format,
+        )
 
     def _should_fallback_to_chat_completions(self, exc: BaseException) -> bool:
         """Return True when a local OpenAI-compatible server needs Chat format."""
@@ -569,6 +614,22 @@ class OpenAIProvider(LLMProvider):
                 active_prompt = retry_prompt(prompt, str(exc))
 
         raise RuntimeError("Structured chat completion failed") from last_error
+
+    async def _get_structured_completion_chat_completions_async(
+        self,
+        prompt: str,
+        schema_model: Type,
+        *,
+        text_format: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Any, LLMResponse]:
+        """Run Chat Completions structured output off the event-loop thread."""
+
+        return await asyncio.to_thread(
+            self._get_structured_completion_chat_completions_sync,
+            prompt,
+            schema_model,
+            text_format=text_format,
+        )
 
     def _build_native_structured_request_params(
         self,

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -151,6 +151,37 @@ def test_non_native_provider_requires_base_url():
         Settings(**raw)
 
 
+def test_structured_transport_defaults_to_responses():
+    """Providers keep the Responses structured-output surface by default."""
+    provider = ProviderModels()
+
+    assert provider.structured_transport == "responses"
+
+
+def test_chat_completions_structured_transport_requires_base_url():
+    """A native provider cannot opt into the local-server transport."""
+    raw = _nexus_toml_dict()
+    raw["global"]["model"]["api_models"]["anthropic"][
+        "structured_transport"
+    ] = "chat_completions"
+
+    with pytest.raises(
+        ValidationError,
+        match="structured_transport='chat_completions' requires a base_url",
+    ):
+        Settings(**raw)
+
+
+def test_chat_completions_structured_transport_accepts_base_url():
+    """An OpenAI-compatible base_url provider may use Chat Completions."""
+    provider = ProviderModels(
+        base_url="http://127.0.0.1:1234/v1",
+        structured_transport="chat_completions",
+    )
+
+    assert provider.structured_transport == "chat_completions"
+
+
 def test_native_provider_rejects_base_url():
     """Native SDK providers use their own endpoints; base_url is a config error."""
     raw = _nexus_toml_dict()
@@ -206,6 +237,7 @@ def test_get_openai_compatible_endpoint_routing():
     assert endpoint == {
         "base_url": settings.global_.model.api_models["test"].base_url,
         "api_key": "nexus-local-no-key",
+        "structured_transport": "responses",
     }
     assert get_openai_compatible_endpoint("gpt-5.5") is None
     assert get_openai_compatible_endpoint("claude-opus-4-8") is None
@@ -281,6 +313,7 @@ def test_default_load_honors_runtime_config_env(tmp_path, monkeypatch):
     assert get_openai_compatible_endpoint("TEMPTEST") == {
         "base_url": "http://127.0.0.1:5999/v1",
         "api_key": "nexus-local-no-key",
+        "structured_transport": "responses",
     }
     assert (
         load_settings("nexus.toml")

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -158,6 +158,18 @@ def test_structured_transport_defaults_to_responses():
     assert provider.structured_transport == "responses"
 
 
+def test_request_timeout_parses_and_defaults_to_none():
+    """Base URL providers may override the SDK request timeout."""
+    assert ProviderModels().request_timeout_seconds is None
+
+    provider = ProviderModels(
+        base_url="http://127.0.0.1:1234/v1",
+        request_timeout_seconds=1800,
+    )
+
+    assert provider.request_timeout_seconds == 1800
+
+
 def test_chat_completions_structured_transport_requires_base_url():
     """A native provider cannot opt into the local-server transport."""
     raw = _nexus_toml_dict()
@@ -238,6 +250,14 @@ def test_get_openai_compatible_endpoint_routing():
         "base_url": settings.global_.model.api_models["test"].base_url,
         "api_key": "nexus-local-no-key",
         "structured_transport": "responses",
+        "request_timeout_seconds": None,
+    }
+    lmstudio = settings.global_.model.api_models["lmstudio"]
+    assert get_openai_compatible_endpoint(lmstudio.roles["default"]) == {
+        "base_url": lmstudio.base_url,
+        "api_key": "nexus-local-no-key",
+        "structured_transport": "chat_completions",
+        "request_timeout_seconds": 1800,
     }
     assert get_openai_compatible_endpoint("gpt-5.5") is None
     assert get_openai_compatible_endpoint("claude-opus-4-8") is None
@@ -314,6 +334,7 @@ def test_default_load_honors_runtime_config_env(tmp_path, monkeypatch):
         "base_url": "http://127.0.0.1:5999/v1",
         "api_key": "nexus-local-no-key",
         "structured_transport": "responses",
+        "request_timeout_seconds": None,
     }
     assert (
         load_settings("nexus.toml")

--- a/tests/test_api/test_pydantic_ai_utils.py
+++ b/tests/test_api/test_pydantic_ai_utils.py
@@ -2,10 +2,12 @@
 
 import pytest
 from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.models.openai import OpenAIChatModel, OpenAIResponsesModel
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
 
 from nexus.api import pydantic_ai_utils
 from nexus.api.native_structured_output import AnthropicJsonSchemaTransformer
+from nexus.config import resolve_model_ref
 
 
 class _LegacyAnthropicProviderStub:
@@ -73,3 +75,21 @@ def test_build_anthropic_model_without_override_omits_profile(monkeypatch):
     pydantic_ai_utils.build_pydantic_ai_model("registry-anthropic-model")
 
     assert set(captured) == {"model_name", "provider"}
+
+
+def test_build_pydantic_ai_model_uses_chat_model_for_lmstudio():
+    """Chat-transport endpoints use pydantic-ai's Chat Completions model."""
+    model = pydantic_ai_utils.build_pydantic_ai_model(
+        resolve_model_ref("@lmstudio.default")
+    )
+
+    assert isinstance(model, OpenAIChatModel)
+
+
+def test_build_pydantic_ai_model_keeps_test_on_responses():
+    """The TEST mock retains the default pydantic-ai Responses model."""
+    model = pydantic_ai_utils.build_pydantic_ai_model(
+        resolve_model_ref("@test.default")
+    )
+
+    assert isinstance(model, OpenAIResponsesModel)

--- a/tests/test_api/test_pydantic_ai_utils.py
+++ b/tests/test_api/test_pydantic_ai_utils.py
@@ -86,6 +86,24 @@ def test_build_pydantic_ai_model_uses_chat_model_for_lmstudio():
     assert isinstance(model, OpenAIChatModel)
 
 
+def test_build_pydantic_ai_model_applies_registry_timeout_for_lmstudio():
+    """The registry request_timeout_seconds reaches the pydantic-ai client.
+
+    The wizard chat flow builds its model here; without this, picking the
+    local model for the wizard would inherit the OpenAI SDK's 600s default
+    and time out on the ~17-min local grammar compile.
+    """
+    model = pydantic_ai_utils.build_pydantic_ai_model(
+        resolve_model_ref("@lmstudio.default")
+    )
+
+    expected = pydantic_ai_utils.get_openai_compatible_endpoint(
+        resolve_model_ref("@lmstudio.default")
+    )["request_timeout_seconds"]
+    assert expected is not None
+    assert model.client.timeout == expected
+
+
 def test_build_pydantic_ai_model_keeps_test_on_responses():
     """The TEST mock retains the default pydantic-ai Responses model."""
     model = pydantic_ai_utils.build_pydantic_ai_model(

--- a/tests/test_local_skald_live.py
+++ b/tests/test_local_skald_live.py
@@ -1,0 +1,55 @@
+"""Live structured-output verification against the registered LM Studio model."""
+
+from __future__ import annotations
+
+import pytest
+import requests
+
+from nexus.agents.logon.apex_schema import StorytellerResponseBootstrap
+from nexus.config import get_openai_compatible_endpoint, resolve_model_ref
+from scripts.api_openai import OpenAIProvider
+
+pytestmark = pytest.mark.live_llm
+
+
+def _require_lmstudio_model(base_url: str, model: str) -> None:
+    """Skip clearly when LM Studio or the configured model is unavailable."""
+    models_url = f"{base_url.rstrip('/')}/models"
+    try:
+        response = requests.get(models_url, timeout=2)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        pytest.skip(f"LM Studio models endpoint is unreachable at {models_url}: {exc}")
+
+    listed_models = {
+        entry.get("id")
+        for entry in response.json().get("data", [])
+        if isinstance(entry, dict)
+    }
+    if model not in listed_models:
+        pytest.skip(f"LM Studio does not list the configured model {model!r}")
+
+
+def test_lmstudio_bootstrap_structured_completion_live() -> None:
+    """Generate and validate the Bootstrap schema through Chat Completions."""
+    model = resolve_model_ref("@lmstudio.default")
+    endpoint = get_openai_compatible_endpoint(model)
+    assert endpoint is not None
+    _require_lmstudio_model(endpoint["base_url"], model)
+
+    provider = OpenAIProvider(
+        model=model,
+        base_url=endpoint["base_url"],
+        api_key=endpoint["api_key"],
+        structured_transport=endpoint["structured_transport"],
+        max_output_tokens=600,
+        temperature=0.1,
+    )
+    parsed, _response = provider.get_structured_completion(
+        "Write a two-sentence opening about a traveler arriving at a quiet inn. "
+        "Offer exactly two concise, actionable player choices.",
+        StorytellerResponseBootstrap,
+    )
+
+    assert isinstance(parsed, StorytellerResponseBootstrap)
+    StorytellerResponseBootstrap.model_validate(parsed.model_dump())

--- a/tests/test_local_skald_live.py
+++ b/tests/test_local_skald_live.py
@@ -42,6 +42,7 @@ def test_lmstudio_bootstrap_structured_completion_live() -> None:
         base_url=endpoint["base_url"],
         api_key=endpoint["api_key"],
         structured_transport=endpoint["structured_transport"],
+        request_timeout=endpoint["request_timeout_seconds"],
         max_output_tokens=600,
         temperature=0.1,
     )

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
 
 from nexus.agents.logon.apex_schema import (
     StorytellerResponseBootstrap,
@@ -15,9 +18,11 @@ from nexus.api.native_structured_output import (
     anthropic_output_config,
     anthropic_output_format,
     anthropic_strict_tool,
+    build_native_structured_provider,
     openai_response_text_format,
     strict_json_schema,
 )
+from nexus.config import resolve_model_ref
 from scripts.api_anthropic import AnthropicProvider
 from scripts.api_openai import OpenAIProvider
 
@@ -326,6 +331,67 @@ def test_openai_base_url_falls_back_to_chat_response_format() -> None:
             "strict": True,
         },
     }
+
+
+def test_openai_chat_transport_dispatches_without_responses_attempt() -> None:
+    """Configured Chat transport bypasses Responses at method dispatch."""
+    expected = (_bootstrap_response(), Mock())
+    provider = build_native_structured_provider(
+        model=resolve_model_ref("@lmstudio.default"),
+        max_tokens=600,
+        system_prompt="System prompt",
+        structured_output_retries=0,
+    )
+    assert isinstance(provider, OpenAIProvider)
+    assert provider.structured_transport == "chat_completions"
+    provider._get_structured_completion_chat_completions_sync = Mock(
+        return_value=expected
+    )
+    provider.client.responses.parse = Mock(
+        side_effect=AssertionError("Responses must not be called")
+    )
+
+    result = provider._get_structured_completion_native_sync(
+        "Prompt", StorytellerResponseBootstrap
+    )
+
+    assert result == expected
+    provider._get_structured_completion_chat_completions_sync.assert_called_once_with(
+        "Prompt", StorytellerResponseBootstrap, text_format=None
+    )
+    provider.client.responses.parse.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_transport_dispatches_async_without_responses_attempt() -> (
+    None
+):
+    """Configured Chat transport also bypasses Responses on the async path."""
+    expected = (_bootstrap_response(), Mock())
+    provider = build_native_structured_provider(
+        model=resolve_model_ref("@lmstudio.default"),
+        max_tokens=600,
+        system_prompt="System prompt",
+        structured_output_retries=0,
+    )
+    assert isinstance(provider, OpenAIProvider)
+    assert provider.structured_transport == "chat_completions"
+    provider._get_structured_completion_chat_completions_async = AsyncMock(
+        return_value=expected
+    )
+    provider.client.responses.parse = Mock(
+        side_effect=AssertionError("Responses must not be called")
+    )
+
+    result = await provider._get_structured_completion_native_async(
+        "Prompt", StorytellerResponseBootstrap
+    )
+
+    assert result == expected
+    provider._get_structured_completion_chat_completions_async.assert_awaited_once_with(
+        "Prompt", StorytellerResponseBootstrap, text_format=None
+    )
+    provider.client.responses.parse.assert_not_called()
 
 
 def test_anthropic_provider_uses_native_output_format() -> None:

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -23,6 +23,7 @@ from nexus.api.native_structured_output import (
     strict_json_schema,
 )
 from nexus.config import resolve_model_ref
+from scripts import api_openai
 from scripts.api_anthropic import AnthropicProvider
 from scripts.api_openai import OpenAIProvider
 
@@ -193,6 +194,39 @@ def test_anthropic_strict_tool_helper_sets_strict_true() -> None:
     assert tool["name"] == "submit_structured_response"
     assert tool["strict"] is True
     assert tool["input_schema"]["additionalProperties"] is False
+
+
+@pytest.mark.parametrize(
+    ("request_timeout", "expected_timeout"),
+    [(1800.0, 1800.0), (None, None)],
+)
+def test_openai_provider_forwards_only_configured_request_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    request_timeout: float | None,
+    expected_timeout: float | None,
+) -> None:
+    """Client construction overrides timeout only when explicitly configured."""
+    captured: dict[str, object] = {}
+    fake_client = SimpleNamespace()
+
+    def fake_openai(**kwargs: object) -> SimpleNamespace:
+        captured.update(kwargs)
+        return fake_client
+
+    monkeypatch.setattr(api_openai.openai, "OpenAI", fake_openai)
+
+    provider = OpenAIProvider(
+        model="local-test-model",
+        api_key="test-key",
+        base_url="http://127.0.0.1:1234/v1",
+        request_timeout=request_timeout,
+    )
+
+    assert provider.client is fake_client
+    if expected_timeout is None:
+        assert "timeout" not in captured
+    else:
+        assert captured["timeout"] == expected_timeout
 
 
 def test_openai_provider_uses_responses_parse_text_format() -> None:


### PR DESCRIPTION
Advances #416 (does not close it — see #462 for the remaining Extended-schema perf work).

## What

Lets NEXUS run the storyteller against a **local OpenAI-compatible server** (LM Studio here) without adding a third structured-output schema. The existing OpenAI strict schema is reused verbatim over `/v1/chat/completions` + `response_format`.

- **`structured_transport` registry field** (`responses` | `chat_completions`), validated to require a `base_url`. Local servers whose `/v1/responses` is missing or silently ignores `text.format` use `chat_completions`.
- **Direct transport dispatch** in `OpenAIProvider` (both sync + async): a `chat_completions` provider goes straight to Chat Completions `response_format`, never attempting the Responses API first (the existing error-driven fallback can't help, because LM Studio returns 200-with-prose rather than an error).
- **pydantic-ai path** uses `OpenAIChatModel` for `chat_completions` endpoints so the wizard's `NativeOutput` is delivered as chat `response_format`.
- **Per-provider `request_timeout_seconds`** — local 70B on a full prompt exceeds the SDK's 600s default; LM Studio set to 1800.
- **`[global.model.api_models.lmstudio]`** registry entry for Hermes 4 70B.

## Why not a third schema

Verified: the adapter layer only ever emits the two existing formats (OpenAI strict dict, Anthropic stripped dict); local reuses the OpenAI one. `/v1/responses` on LM Studio is a **trap** — it 200s with a well-formed envelope but ignores `text.format` and returns prose, which is why the transport is configured explicitly rather than sniffed.

## Verification (real local inference, per repo doctrine)

- `tests/test_local_skald_live.py` (gated on `NEXUS_RUN_LIVE_LLM` + LM Studio reachable): a real Hermes turn produces structured output that validates against `StorytellerResponseBootstrap`. Passes in ~12s.
- Full suite: 1104 passed. Config/routing/model-class-selection all covered hermetically.

## Scope boundary (why this doesn't close #416)

The **Bootstrap** schema runs fast and is proven. The **Extended** schema (the full production turn) is a 42 KB recursive structure that LM Studio's grammar compiler takes ~17 min to compile — a schema-complexity cost, not a bug (measured: stripping the Orrery enums doesn't help, and breaks small `Literal` enums). That's a design fork (reduced local schema vs prompt-based vs accept-warmup) tracked in **#462**, to resolve alongside its only consumer, the #415 Phase 2 guest sandbox. The transport delivered here is the foundation both need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7zXr7MsZHMkKrE2y5Sze5