### PR TITLE
Migrate Local Inference to Headless llama-server; Retire LM Studio

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -148,8 +148,15 @@ every request builder routes to it.
 The supervisor treats these the same way: `[runtime.services.mock_openai]`
 spawns the mock server only while the TEST provider is registered
 (`enabled = "auto"`), and config load cross-validates that the service port
-and the registry `base_url` agree. A future local-LLM service follows the
-same pattern.
+and the registry `base_url` agree.
+
+`[runtime.services.llama_server]` defines the headless llama.cpp server for
+the `@local` provider. It is shipped with `enabled = "never"` because loading
+the configured Q6_K model consumes about 58 GB, so ordinary `nexus up` runs do
+not start it. For an on-demand session, run the configured `command` directly;
+it binds `127.0.0.1:1234`, exposes `/v1` and `/health`, and can be stopped with
+Ctrl+C. To make the supervisor own it, set `enabled = "always"` and run
+`nexus up`; use `nexus down llama_server` when it should be unloaded again.
 
 Per-model request-parameter capability also lives in the registry: an
 entry's `unsupported_params` lists parameters its API rejects (e.g.

--- a/nexus.toml
+++ b/nexus.toml
@@ -53,16 +53,17 @@ models = [
     { id = "TEST", label = "TEST", description = "Mock server with cached data (dev)" },
 ]
 
-# The first structured request after loading a model pays a one-time JSON-schema
-# grammar compile cost. Hermes 4 70B Extended measured about 17 min; cached after.
-[global.model.api_models.lmstudio]
+# Headless `llama-server` (llama.cpp) serves this local model. A GGUF quant is
+# required: MLX's Outlines grammar engine compiles the Extended schema
+# pathologically slowly. This timeout is generous for local grammar compilation
+# plus generation.
+[global.model.api_models.local]
 base_url = "http://127.0.0.1:1234/v1"
 structured_transport = "chat_completions"
-# Local 70B on a full Skald prompt can take many minutes; the SDK's 600s default is too tight.
 request_timeout_seconds = 1800
 roles = { default = "nousresearch/hermes-4-70b" }
 models = [
-    { id = "nousresearch/hermes-4-70b", label = "Hermes 4 70B (Local)", description = "Local LM Studio inference (MLX)" },
+    { id = "nousresearch/hermes-4-70b", label = "Hermes 4 70B (Local)", description = "Local llama-server inference (GGUF)" },
 ]
 
 # =============================================================================
@@ -905,6 +906,27 @@ host = "127.0.0.1"
 port = 5102  # must match [global.model.api_models.test] base_url (validated)
 health_path = "/health"
 enabled = "auto"  # spawn only while the TEST provider is registered above
+
+[runtime.services.llama_server]
+# Headless llama.cpp OpenAI server for the local `@local` provider. Serves the
+# Q6_K GGUF via llama.cpp's fast GBNF grammar (the MLX/Outlines path compiled
+# the Extended schema in ~17 min; llama.cpp does it in seconds). Retires the
+# LM Studio GUI. The model is ~58GB, so this is NOT auto-started — enabled =
+# "never" keeps it off `nexus up`. Start it on demand for local inference, or
+# set enabled = "always" to keep it resident (e.g. for the guest sandbox).
+command = [
+    "/opt/homebrew/bin/llama-server",
+    "--model", "/Users/pythagor/.lmstudio/models/lmstudio-community/Hermes-4-70B-GGUF/Hermes-4-70B-Q6_K-00001-of-00002.gguf",
+    # --alias makes /v1/models report the registry id instead of the GGUF path,
+    # so it matches [global.model.api_models.local].models[].id.
+    "--alias", "nousresearch/hermes-4-70b",
+    "--host", "{host}", "--port", "{port}",
+    "--ctx-size", "32768", "-ngl", "999", "--jinja",
+]
+host = "127.0.0.1"
+port = 1234  # must match [global.model.api_models.local] base_url
+health_path = "/health"
+enabled = "never"
 
 # Attach targets for profile = "external" (uncomment to use):
 # [runtime.external]

--- a/nexus.toml
+++ b/nexus.toml
@@ -53,10 +53,11 @@ models = [
     { id = "TEST", label = "TEST", description = "Mock server with cached data (dev)" },
 ]
 
-# Headless `llama-server` (llama.cpp) serves this local model. A GGUF quant is
-# required: MLX's Outlines grammar engine compiles the Extended schema
-# pathologically slowly. This timeout is generous for local grammar compilation
-# plus generation.
+# Headless `llama-server` (llama.cpp) serves this local model over a GGUF quant.
+# llama.cpp's GBNF grammar compiles the Extended schema in seconds (the MLX
+# path's Outlines engine took ~17 min, which is why GGUF is required). The
+# 1800s timeout is generation headroom for a large local model, not grammar
+# compile — a full 70B turn can run several minutes.
 [global.model.api_models.local]
 base_url = "http://127.0.0.1:1234/v1"
 structured_transport = "chat_completions"
@@ -924,7 +925,7 @@ command = [
     "--ctx-size", "32768", "-ngl", "999", "--jinja",
 ]
 host = "127.0.0.1"
-port = 1234  # must match [global.model.api_models.local] base_url
+port = 1234  # must match [global.model.api_models.local] base_url (validated)
 health_path = "/health"
 enabled = "never"
 

--- a/nexus/api/pydantic_ai_utils.py
+++ b/nexus/api/pydantic_ai_utils.py
@@ -69,7 +69,7 @@ def build_pydantic_ai_model(model: str) -> Model:
         raise ValueError(f"No base_url registry entry for model {model!r}")
     timeout = endpoint["request_timeout_seconds"]
     if timeout is not None:
-        # Slow local servers (LM Studio grammar compile) blow past the OpenAI
+        # Slow local servers (for example, grammar compilation) blow past the OpenAI
         # SDK's 600s default. Mirror the legacy provider call sites: hand the
         # pydantic-ai provider a client that carries the registry timeout.
         pyd_provider = PydanticOpenAIProvider(

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -2062,6 +2062,35 @@ class Settings(BaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def _validate_runtime_llama_server_port_consistency(self) -> "Settings":
+        """The llama_server service port and the local provider base_url must agree.
+
+        Same failure mode as the mock/test pairing: if the supervised
+        [runtime.services.llama_server] binds a different port than the local
+        provider's base_url targets, every @local call connection-refuses at
+        request time. Reject the drift at load instead. Skipped while the
+        service is disabled (enabled = "never"), since nothing binds then.
+        """
+        if self.runtime is None:
+            return self
+        llama = self.runtime.services.get("llama_server")
+        local_provider = self.global_.model.api_models.get("local")
+        if llama is None or llama.enabled == "never":
+            return self
+        if local_provider is None or not local_provider.base_url:
+            return self
+        from urllib.parse import urlparse
+
+        base_port = urlparse(local_provider.base_url).port
+        if base_port != llama.port:
+            raise ValueError(
+                f"[runtime.services.llama_server] port {llama.port} does not "
+                f"match the local provider base_url port {base_port} "
+                f"({local_provider.base_url}). Keep them in sync."
+            )
+        return self
+
     def model_entry(self, model_id: str) -> APIModelEntry:
         """Return the registry entry for a concrete model ID (raises if absent)."""
         for provider_models in self.global_.model.api_models.values():

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -125,7 +125,7 @@ class ProviderModels(BaseModel):
         default="responses",
         description=(
             "OpenAI-compatible surface used for structured output. Use "
-            "'chat_completions' for local servers such as LM Studio, Ollama, "
+            "'chat_completions' for local servers such as llama-server, Ollama, "
             "or vLLM whose /v1/responses endpoint is missing or silently "
             "ignores text.format."
         ),

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -16,6 +16,7 @@ from nexus.config.settings_models import (
     APIModelEntry,
     ModelConfig,
     ProviderModels,
+    RuntimeServiceSettings,
     Settings,
 )
 
@@ -252,9 +253,10 @@ def test_get_openai_compatible_endpoint_routing():
         "structured_transport": "responses",
         "request_timeout_seconds": None,
     }
-    lmstudio = settings.global_.model.api_models["lmstudio"]
-    assert get_openai_compatible_endpoint(lmstudio.roles["default"]) == {
-        "base_url": lmstudio.base_url,
+    local = settings.global_.model.api_models["local"]
+    assert resolve_model_ref("@local.default") == "nousresearch/hermes-4-70b"
+    assert get_openai_compatible_endpoint(local.roles["default"]) == {
+        "base_url": local.base_url,
         "api_key": "nexus-local-no-key",
         "structured_transport": "chat_completions",
         "request_timeout_seconds": 1800,
@@ -263,6 +265,17 @@ def test_get_openai_compatible_endpoint_routing():
     assert get_openai_compatible_endpoint("claude-opus-4-8") is None
     # Models absent from the registry are treated as native/legacy overrides.
     assert get_openai_compatible_endpoint("unregistered-model") is None
+
+
+def test_llama_server_runtime_service_parses():
+    """The local llama-server is a disabled-by-default managed service."""
+    service = load_settings("nexus.toml").runtime.services["llama_server"]
+
+    assert isinstance(service, RuntimeServiceSettings)
+    assert service.command[0] == "/opt/homebrew/bin/llama-server"
+    assert service.enabled == "never"
+    assert service.port == 1234
+    assert service.health_path == "/health"
 
 
 def test_native_structured_output_override_parses_and_resolves(tmp_path, monkeypatch):

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -88,6 +88,22 @@ def test_global_default_slot_model_unknown_role_rejected():
         Settings(**raw)
 
 
+def test_llama_server_port_drift_rejected_when_enabled():
+    """An enabled llama_server whose port differs from the local base_url fails."""
+    raw = _nexus_toml_dict()
+    raw["runtime"]["services"]["llama_server"]["enabled"] = "always"
+    raw["runtime"]["services"]["llama_server"]["port"] = 1299
+    with pytest.raises(ValidationError, match="does not.*match the local provider"):
+        Settings(**raw)
+
+
+def test_llama_server_port_drift_ignored_while_disabled():
+    """Port drift is tolerated while the service is disabled (nothing binds)."""
+    raw = _nexus_toml_dict()
+    raw["runtime"]["services"]["llama_server"]["port"] = 1299  # enabled stays "never"
+    Settings(**raw)
+
+
 def test_global_default_slot_model_role_ref_resolves_at_load():
     """A valid role ref in default_slot_model resolves to the concrete ID."""
     raw = _nexus_toml_dict()

--- a/tests/test_api/test_pydantic_ai_utils.py
+++ b/tests/test_api/test_pydantic_ai_utils.py
@@ -77,16 +77,16 @@ def test_build_anthropic_model_without_override_omits_profile(monkeypatch):
     assert set(captured) == {"model_name", "provider"}
 
 
-def test_build_pydantic_ai_model_uses_chat_model_for_lmstudio():
+def test_build_pydantic_ai_model_uses_chat_model_for_local():
     """Chat-transport endpoints use pydantic-ai's Chat Completions model."""
     model = pydantic_ai_utils.build_pydantic_ai_model(
-        resolve_model_ref("@lmstudio.default")
+        resolve_model_ref("@local.default")
     )
 
     assert isinstance(model, OpenAIChatModel)
 
 
-def test_build_pydantic_ai_model_applies_registry_timeout_for_lmstudio():
+def test_build_pydantic_ai_model_applies_registry_timeout_for_local():
     """The registry request_timeout_seconds reaches the pydantic-ai client.
 
     The wizard chat flow builds its model here; without this, picking the
@@ -94,11 +94,11 @@ def test_build_pydantic_ai_model_applies_registry_timeout_for_lmstudio():
     and time out on the ~17-min local grammar compile.
     """
     model = pydantic_ai_utils.build_pydantic_ai_model(
-        resolve_model_ref("@lmstudio.default")
+        resolve_model_ref("@local.default")
     )
 
     expected = pydantic_ai_utils.get_openai_compatible_endpoint(
-        resolve_model_ref("@lmstudio.default")
+        resolve_model_ref("@local.default")
     )["request_timeout_seconds"]
     assert expected is not None
     assert model.client.timeout == expected

--- a/tests/test_local_skald_live.py
+++ b/tests/test_local_skald_live.py
@@ -1,4 +1,4 @@
-"""Live structured-output verification against the registered LM Studio model."""
+"""Live structured-output verification against the registered local model."""
 
 from __future__ import annotations
 
@@ -12,14 +12,16 @@ from scripts.api_openai import OpenAIProvider
 pytestmark = pytest.mark.live_llm
 
 
-def _require_lmstudio_model(base_url: str, model: str) -> None:
-    """Skip clearly when LM Studio or the configured model is unavailable."""
+def _require_local_model(base_url: str, model: str) -> None:
+    """Skip clearly when llama-server or the configured model is unavailable."""
     models_url = f"{base_url.rstrip('/')}/models"
     try:
         response = requests.get(models_url, timeout=2)
         response.raise_for_status()
     except requests.RequestException as exc:
-        pytest.skip(f"LM Studio models endpoint is unreachable at {models_url}: {exc}")
+        pytest.skip(
+            f"llama-server models endpoint is unreachable at {models_url}: {exc}"
+        )
 
     listed_models = {
         entry.get("id")
@@ -27,15 +29,15 @@ def _require_lmstudio_model(base_url: str, model: str) -> None:
         if isinstance(entry, dict)
     }
     if model not in listed_models:
-        pytest.skip(f"LM Studio does not list the configured model {model!r}")
+        pytest.skip(f"llama-server does not list the configured model {model!r}")
 
 
-def test_lmstudio_bootstrap_structured_completion_live() -> None:
+def test_local_bootstrap_structured_completion_live() -> None:
     """Generate and validate the Bootstrap schema through Chat Completions."""
-    model = resolve_model_ref("@lmstudio.default")
+    model = resolve_model_ref("@local.default")
     endpoint = get_openai_compatible_endpoint(model)
     assert endpoint is not None
-    _require_lmstudio_model(endpoint["base_url"], model)
+    _require_local_model(endpoint["base_url"], model)
 
     provider = OpenAIProvider(
         model=model,

--- a/tests/test_lore/test_lore_retrieve_context.py
+++ b/tests/test_lore/test_lore_retrieve_context.py
@@ -52,7 +52,7 @@ class FakeMemnon:
 
 @pytest.mark.asyncio
 async def test_retrieve_context_uses_direct_memnon_queries_without_local_llm() -> None:
-    """The legacy retrieval helper should no longer initialize LM Studio."""
+    """The legacy retrieval helper should no longer initialize local inference."""
 
     lore = LORE.__new__(LORE)
     lore.memnon = FakeMemnon()

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -371,7 +371,7 @@ def test_openai_chat_transport_dispatches_without_responses_attempt() -> None:
     """Configured Chat transport bypasses Responses at method dispatch."""
     expected = (_bootstrap_response(), Mock())
     provider = build_native_structured_provider(
-        model=resolve_model_ref("@lmstudio.default"),
+        model=resolve_model_ref("@local.default"),
         max_tokens=600,
         system_prompt="System prompt",
         structured_output_retries=0,
@@ -403,7 +403,7 @@ async def test_openai_chat_transport_dispatches_async_without_responses_attempt(
     """Configured Chat transport also bypasses Responses on the async path."""
     expected = (_bootstrap_response(), Mock())
     provider = build_native_structured_provider(
-        model=resolve_model_ref("@lmstudio.default"),
+        model=resolve_model_ref("@local.default"),
         max_tokens=600,
         system_prompt="System prompt",
         structured_output_retries=0,


### PR DESCRIPTION
Retires LM Studio in favor of headless `llama-server` (llama.cpp's OpenAI-compatible server) as the local-inference backend.

## Why

LM Studio was a convenient experiment harness, but it's a GUI app requiring a manual model load. The piece that actually fixed the local structured-output latency (2.4s vs MLX/Outlines' 17-min grammar compile) is **llama.cpp** — LM Studio just wraps it. `llama-server` (already installed via brew) is the same engine, headless: scriptable, boot-able as a service, no GUI, and a lighter dependency for a distributable NEXUS. Proven a drop-in: it accepts NEXUS's exact `response_format` json_schema envelope with identical performance.

## What

- **Provider rename** `[global.model.api_models.lmstudio]` → `[global.model.api_models.local]` (the name no longer refers to LM Studio); base_url, model id, `structured_transport`, and `request_timeout_seconds` unchanged. All `@lmstudio.default` refs → `@local.default`.
- **Managed service** `[runtime.services.llama_server]`: supervisor-spawned headless llama-server on the Q6_K GGUF, `/health`-probed. `enabled = "never"` so the ~58GB model isn't force-loaded on every `nexus up`; flip to `"always"` for the always-on guest-sandbox case (documented in `docs/runtime.md`).
- **`--alias nousresearch/hermes-4-70b`** so `/v1/models` reports the registry id rather than the GGUF file path (llama-server tolerates the model id in requests regardless; the alias keeps discovery/health-checks consistent).

## Verification

- **Live**: `NEXUS_RUN_LIVE_LLM=1 pytest tests/test_local_skald_live.py` passes against the real headless llama-server — structured Extended output through the actual provider code, 17s.
- Full suite: 1106 passed. Supervisor confirmed it parses/manages the non-python `enabled="never"` service.

Follow-ups (separate): a UI model-management surface (pick + download/delete curated quants) and Hermes 4.3 36B viability for sub-128GB hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7zXr7MsZHMkKrE2y5Sze5