### PR TITLE
Design-Sync: Exclude dev-orrery, Stub API-Keys Endpoint for Re-Sync

### DIFF
--- a/ui/.design-sync/NOTES.md
+++ b/ui/.design-sync/NOTES.md
@@ -77,6 +77,13 @@ around it:
 - `build.mjs`'s font-url rewrite (`/fonts/` → `../../../client/public/fonts/`) is
   path-depth-specific to `.cache/lib-dist/`.
 - Playwright/Chromium installed under `.ds-sync/node_modules` + `~/.cache/ms-playwright`.
+- **`pages/dev-orrery/` is excluded from the bundle** (`gen-entry.mjs` `find` filter).
+  It's the internal `/dev/orrery` audit dashboard (#430, a separate "design-package
+  port"), not IRIS's customer design system — its viz deps must not bloat the synced
+  bundle. If a genuinely new IRIS component appears (e.g. `Intertitle`, #456), it rides
+  the bundle uncarded until deliberately added to `config.json`'s `componentSrcMap` with
+  an authored preview. Never blind-merge `.cache/componentSrcMap.json`: discovery drifts
+  (it renamed the `Form` card's primary export to `FormItem`).
 
 ## Component-type recipes (folded from wave-2 authoring)
 

--- a/ui/.design-sync/ds-provider.tsx
+++ b/ui/.design-sync/ds-provider.tsx
@@ -2,8 +2,9 @@
 // Mounts the app's real providers so components that call useTheme/useFonts/
 // useSettings render instead of throwing, and applies the Veil (.dark) theme +
 // fonts. The fetch stub below mocks /api/settings (theme echoes each preview's
-// localStorage) and the character endpoints; retries are off so the render settles
-// immediately. Exported through the Vite lib entry → window.NexusIris.DesignThemeRoot.
+// localStorage), /api/secrets/status (API-key rows), and the character endpoints;
+// retries are off so the render settles immediately. Exported through the Vite lib
+// entry → window.NexusIris.DesignThemeRoot.
 import React from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/lib/queryClient";
@@ -31,6 +32,16 @@ if (typeof window !== "undefined" && !(window as any).__dsFetchStubbed) {
     { id: 1, name: "Mira Vané", summary: "A cartographer of the drowned districts, charting streets the tide reclaimed.", appearance: "Lean and weather-worn, ink-stained fingers, a coat patched with old chart-cloth.", personality: "Methodical, stubborn, quietly funny when the lanterns are low.", emotionalState: "Wary but resolved.", currentActivity: "Tracing a route toward the Spire.", currentLocationName: "The Drowned Plaza", portraitPath: null },
     { id: 2, name: "Cassius Brenn", summary: "A dock-warden who runs more than he guards.", appearance: "Broad, scarred, a brass warden's pin he no longer has the right to wear.", personality: "Affable, calculating, loyal to whoever paid last.", emotionalState: "Restless.", currentActivity: "Counting debts in the lantern-light.", currentLocationName: "Harbor Steps", portraitPath: null },
     { id: 3, name: "The Archivist", summary: "Keeper of the Spire's flooded records; speaks in retrieved fragments.", appearance: "Robed, ageless, eyes like wet glass.", personality: "Patient, oblique, unnervingly precise.", emotionalState: "Serene.", currentActivity: "Cataloguing what the water took.", currentLocationName: "The Spire Vaults", portraitPath: null },
+  ];
+  // API-key status rows (GET /api/secrets/status → SecretStatus[]). Masked
+  // status only — no plaintext. A mixed present/absent set renders the KeysSection
+  // card populated (present rows show a filled dot + ••••last4 placeholder); an
+  // absent row shows the empty dot. Without this the query 404s and KeysSection's
+  // `if (error) throw error` blanks the whole SettingsPane.
+  const SECRETS = [
+    { provider: "anthropic", account: "nexus-api", present: true, last4: "8f2a" },
+    { provider: "openai", account: "nexus-api", present: true, last4: "b41c" },
+    { provider: "openrouter", account: "nexus-api", present: false, last4: null },
   ];
   // Full settings payload; theme echoes the preview's own localStorage so the
   // Theme/Font providers don't override a deco/splash card's intended theme.
@@ -65,6 +76,7 @@ if (typeof window !== "undefined" && !(window as any).__dsFetchStubbed) {
     const method = (init?.method ?? "GET").toUpperCase();
     const url = typeof input === "string" ? input : input?.url ?? "";
     if (method === "GET") {
+      if (url.includes("/api/secrets/status")) return Promise.resolve(json(SECRETS));
       if (url.includes("/api/settings")) {
         const theme = window.localStorage.getItem("nexus-theme") || "veil";
         return Promise.resolve(json(SETTINGS(theme)));

--- a/ui/.design-sync/gen-entry.mjs
+++ b/ui/.design-sync/gen-entry.mjs
@@ -33,6 +33,10 @@ const files = execSync(
   .split("\n")
   .filter(Boolean)
   .filter((p) => !/\.(test|spec|stories)\./.test(p))
+  // pages/dev-orrery/ is the internal /dev/orrery audit dashboard (a separate
+  // "design-package port", NOT part of the IRIS customer design system). Keep
+  // its heavy viz deps out of the synced bundle. See .design-sync/NOTES.md.
+  .filter((p) => !/\/pages\/dev-orrery\//.test(p))
   .sort();
 
 const project = new Project({


### PR DESCRIPTION
## Summary

Two durable `design-sync` input fixes surfaced while re-syncing the **NEXUS Iris** design system to Claude Design (the SettingsPane #459 + NarrativePane #456 delta). Both are needed by every future re-sync — without them the next run either re-bloats the bundle or fails the SettingsPane render check.

- **`gen-entry.mjs`** — exclude `pages/dev-orrery/` from the synced bundle. The `/dev/orrery` audit dashboard (#430, a separate "design-package port") is internal dev tooling, not IRIS's customer-facing design system; its viz deps were bloating `_ds_bundle.js` by ~177 KB.
- **`ds-provider.tsx`** — mock `GET /api/secrets/status` (`SecretStatus[]`) in the headless preview fetch stub. #459's API-Keys card calls it, and `KeysSection`'s `if (error) throw error` blanked the entire SettingsPane preview (render check reported `root empty`) until the stub fed it realistic masked-key rows.
- **`NOTES.md`** — record the dev-orrery exclusion and the `componentSrcMap` discipline (never blind-merge discovery — it drifts `Form` → `FormItem` and would pull in the new `dev-orrery` pages).

## Verification

- Re-sync driver: `ok: true`, all stages green, `render check: 95/95 previews render cleanly` (SettingsPane went `root empty` → 129 KB populated with all 8 sections including API Keys).
- Canary spot-check (NewStoryPage, Card, DecoSunburst, CharacterPhase) confirmed carried grades hold.
- Uploaded to the pinned project (atomic path): the changed shared bundle + styling + refreshed anchor; live anchor `bundleSha12` verified at `07900f73c628`.

Sync inputs only — no runtime/app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)