### PR TITLE
Local-Model Download & Delete Backend (#465 Phase 2)

### DIFF
--- a/nexus/api/local_download_worker.py
+++ b/nexus/api/local_download_worker.py
@@ -1,0 +1,33 @@
+"""Detached worker for downloading curated local-model GGUF files."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from huggingface_hub import hf_hub_download
+
+
+def main() -> int:
+    """Download each requested catalog file into its managed local directory."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-id", required=True)
+    parser.add_argument("--local-dir", required=True)
+    parser.add_argument("--file", action="append", required=True, dest="files")
+    arguments = parser.parse_args()
+
+    try:
+        for filename in arguments.files:
+            hf_hub_download(
+                repo_id=arguments.repo_id,
+                filename=filename,
+                local_dir=arguments.local_dir,
+            )
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nexus/api/local_inference.py
+++ b/nexus/api/local_inference.py
@@ -508,7 +508,16 @@ def start_download(
     with _download_lock:
         settings = load_settings()
         existing = _read_download_record(settings)
-        if existing is not None and _pid_alive(existing["pid"]):
+        if (
+            existing is not None
+            and _pid_alive(existing["pid"])
+            # PID-reuse guard (mirrors download_status/cancel_download): a
+            # stale record whose PID was recycled by an unrelated process must
+            # not block downloads until that stranger exits.
+            and _download_process_is_ours(
+                settings, existing["pid"], existing["repo_id"]
+            )
+        ):
             raise LocalInferenceError("A local-model download is already in progress")
 
         resolved_dir = Path(local_dir).expanduser().resolve()

--- a/nexus/api/local_inference.py
+++ b/nexus/api/local_inference.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import signal
 import socket
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -18,17 +20,24 @@ from urllib.parse import urlsplit
 
 import requests  # type: ignore[import-untyped]
 
-from nexus.config import load_settings
+from nexus.config import get_local_models_settings, load_settings
 from nexus.config.settings_models import Settings
 from nexus.util.gguf_inspect import inspect_gguf
 
 STATE_FILENAME = "local-model.pid.json"
 LOG_FILENAME = "local-model.log"
+DOWNLOAD_FILENAME = "local-model.download.json"
+DOWNLOAD_LOG_FILENAME = "local-model.download.log"
 REGISTERED_FILENAME = "local-models.registered.json"
 
 _lifecycle_lock = threading.RLock()
+_download_lock = threading.Lock()
 _registration_lock = threading.Lock()
 _MANAGED_OPTIONS = frozenset({"--model", "--alias", "--host", "--port"})
+_SPLIT_GGUF_PATTERN = re.compile(
+    r"^(?P<stem>.+)-(?P<part>\d{5})-of-(?P<total>\d{5})\.gguf$",
+    re.IGNORECASE,
+)
 
 
 class LocalInferenceError(RuntimeError):
@@ -50,6 +59,10 @@ def _state_dir(settings: Settings) -> Path:
 
 def _state_path(settings: Settings) -> Path:
     return _state_dir(settings) / STATE_FILENAME
+
+
+def _download_path(settings: Settings) -> Path:
+    return _state_dir(settings) / DOWNLOAD_FILENAME
 
 
 def _registered_path(settings: Settings) -> Path:
@@ -100,6 +113,52 @@ def _pid_alive(pid: int) -> bool:
     except PermissionError:
         return True
     return True
+
+
+def _allowed_roots() -> tuple[Path, Path]:
+    """Return the canonical roots allowed for local-model filesystem actions."""
+    return (
+        Path(get_local_models_settings().models_dir).resolve(),
+        Path.home().resolve(),
+    )
+
+
+def _is_within(path: Path, roots: tuple[Path, ...]) -> bool:
+    """Return whether a resolved path is within one of the allowed roots."""
+    return any(path == root or path.is_relative_to(root) for root in roots)
+
+
+def split_shard(path: Path) -> tuple[str, int, int] | None:
+    """Return split stem, part, and total for llama.cpp split filenames."""
+    match = _SPLIT_GGUF_PATTERN.match(path.name)
+    if match is None:
+        return None
+    return match.group("stem"), int(match.group("part")), int(match.group("total"))
+
+
+def shard_set(path: Path, roots: tuple[Path, ...]) -> list[Path]:
+    """Enumerate a GGUF's root-validated split siblings, or the file itself."""
+    resolved_path = path.resolve()
+    split = split_shard(resolved_path)
+    if split is None:
+        # Defense in depth: the split branch below already root-validates each
+        # sibling, so the non-split path must too — a caller that skips the
+        # endpoint's _verified_path guard must never delete outside the roots.
+        return [resolved_path] if _is_within(resolved_path, roots) else []
+    stem, _, total = split
+    siblings: list[Path] = []
+    for sibling in resolved_path.parent.glob(f"{stem}-*-of-{total:05d}.gguf"):
+        resolved = sibling.resolve()
+        sibling_split = split_shard(resolved)
+        if (
+            sibling_split is not None
+            and sibling_split[0] == stem
+            and sibling_split[2] == total
+            and _is_within(resolved, roots)
+            and resolved.is_file()
+        ):
+            siblings.append(resolved)
+    return sorted(siblings)
 
 
 def _endpoint(settings: Settings) -> tuple[str, int, str]:
@@ -196,6 +255,28 @@ def _process_is_ours(settings: Settings, pid: int, gguf_path: str) -> bool:
         return False
     command = result.stdout.strip()
     return result.returncode == 0 and "llama-server" in command and gguf_path in command
+
+
+def _download_process_is_ours(settings: Settings, pid: int, repo_id: str) -> bool:
+    """Verify a live PID still names the detached downloader and its repository."""
+    if settings.runtime is None:
+        raise LocalInferenceError("[runtime] is required for process probe settings")
+    try:
+        result = subprocess.run(
+            ["ps", "-ww", "-p", str(pid), "-o", "command="],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=settings.runtime.health.timeout_seconds,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    command = result.stdout.strip()
+    return (
+        result.returncode == 0
+        and "local_download_worker" in command
+        and repo_id in command
+    )
 
 
 def _read_active(settings: Settings) -> dict[str, Any] | None:
@@ -387,6 +468,250 @@ def activate(gguf_path: str) -> dict[str, Any]:
             "ready": False,
             "failed": False,
         }
+
+
+def _read_download_record(settings: Settings) -> dict[str, Any] | None:
+    """Read and validate the manager-owned detached download record."""
+    record = _read_json(_download_path(settings))
+    if record is None:
+        return None
+    try:
+        normalized = {
+            "pid": int(record["pid"]),
+            "family": str(record["family"]),
+            "quant": str(record["quant"]),
+            "repo_id": str(record["repo_id"]),
+            "local_dir": str(record["local_dir"]),
+            "files": [str(filename) for filename in record["files"]],
+            "total_bytes": int(record["total_bytes"]),
+            "started_at": str(record["started_at"]),
+        }
+    except (KeyError, TypeError, ValueError) as exc:
+        raise LocalInferenceError(
+            f"Malformed local-model download state: {exc}"
+        ) from exc
+    if not isinstance(record["files"], list) or not record["files"]:
+        raise LocalInferenceError("Malformed local-model download state: files")
+    return normalized
+
+
+def start_download(
+    *,
+    family: str,
+    quant: str,
+    repo_id: str,
+    local_dir: str,
+    files: list[str],
+    total_bytes: int,
+) -> dict[str, Any]:
+    """Start one detached curated-model download and persist its job record."""
+    with _download_lock:
+        settings = load_settings()
+        existing = _read_download_record(settings)
+        if existing is not None and _pid_alive(existing["pid"]):
+            raise LocalInferenceError("A local-model download is already in progress")
+
+        resolved_dir = Path(local_dir).expanduser().resolve()
+        resolved_dir.mkdir(parents=True, exist_ok=True)
+        state_dir = _state_dir(settings)
+        state_dir.mkdir(parents=True, exist_ok=True)
+        command = [
+            sys.executable,
+            "-m",
+            "nexus.api.local_download_worker",
+            "--repo-id",
+            repo_id,
+            "--local-dir",
+            str(resolved_dir),
+            *[argument for filename in files for argument in ("--file", filename)],
+        ]
+        try:
+            with (state_dir / DOWNLOAD_LOG_FILENAME).open("ab") as log_handle:
+                process = subprocess.Popen(
+                    command,
+                    stdin=subprocess.DEVNULL,
+                    stdout=log_handle,
+                    stderr=subprocess.STDOUT,
+                    close_fds=True,
+                    start_new_session=True,
+                )
+        except OSError as exc:
+            raise LocalInferenceError(
+                f"Failed to spawn local-model download worker: {exc}"
+            ) from exc
+
+        record = {
+            "pid": process.pid,
+            "family": family,
+            "quant": quant,
+            "repo_id": repo_id,
+            "local_dir": str(resolved_dir),
+            "files": files,
+            "total_bytes": total_bytes,
+            "started_at": datetime.now(timezone.utc).isoformat(),
+        }
+        try:
+            _write_json(_download_path(settings), record)
+        except LocalInferenceError:
+            try:
+                _signal_process_group(process.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            raise
+        return record
+
+
+def _downloaded_bytes(record: dict[str, Any]) -> int:
+    """Sum completed target files plus any in-flight download blob.
+
+    huggingface_hub stages each file as a HASH-named ``*.incomplete`` under
+    ``<local_dir>/.cache/huggingface/download`` and moves it to the final path
+    on completion — so a file is EITHER a final target OR an in-flight blob,
+    never both (verified: no ``*.incomplete`` lingers after a file completes).
+    We therefore count finals and cache-scoped incompletes separately, which is
+    correct by construction. Granularity is per-completed-file at minimum;
+    sub-file progress is best-effort and depends on how eagerly hf flushes the
+    staged blob to disk. (The prior per-filename glob never matched hf's
+    hash-named blob at all, so it only ever advanced per completed file.)
+    """
+    local_dir = Path(record["local_dir"])
+    downloaded = 0
+    for filename in record["files"]:
+        try:
+            downloaded += (local_dir / filename).stat().st_size
+        except FileNotFoundError:
+            pass
+    cache = local_dir / ".cache" / "huggingface" / "download"
+    if cache.exists():
+        for partial in cache.rglob("*.incomplete"):
+            try:
+                downloaded += partial.stat().st_size
+            except FileNotFoundError:
+                pass
+    return downloaded
+
+
+def _download_error(settings: Settings) -> str:
+    """Return the final non-empty worker log line, if the worker wrote one."""
+    try:
+        lines = (
+            (Path(_state_dir(settings)) / DOWNLOAD_LOG_FILENAME)
+            .read_text()
+            .splitlines()
+        )
+    except FileNotFoundError:
+        lines = []
+    return next(
+        (line.strip() for line in reversed(lines) if line.strip()),
+        "download did not complete",
+    )
+
+
+def download_status() -> dict[str, Any] | None:
+    """Rediscover and report the detached curated-model download."""
+    with _download_lock:
+        settings = load_settings()
+        record = _read_download_record(settings)
+        if record is None:
+            return None
+        pid_alive = _pid_alive(record["pid"]) and _download_process_is_ours(
+            settings, record["pid"], record["repo_id"]
+        )
+        local_dir = Path(record["local_dir"])
+        targets = [local_dir / filename for filename in record["files"]]
+        downloaded_bytes = _downloaded_bytes(record)
+        total_bytes = record["total_bytes"]
+        progress = (
+            min(1.0, max(0.0, downloaded_bytes / total_bytes))
+            if total_bytes > 0
+            else 0.0
+        )
+        payload: dict[str, Any] = {
+            "state": "downloading",
+            "family": record["family"],
+            "quant": record["quant"],
+            "downloaded_bytes": downloaded_bytes,
+            "total_bytes": total_bytes,
+            "progress": progress,
+            "files": record["files"],
+            "local_dir": record["local_dir"],
+        }
+        if pid_alive:
+            return payload
+        if (
+            all(target.is_file() for target in targets)
+            and inspect_gguf(str(targets[0])).valid
+        ):
+            payload["state"] = "done"
+            return payload
+        payload["state"] = "failed"
+        payload["error"] = _download_error(settings)
+        return payload
+
+
+def cancel_download() -> dict[str, Any]:
+    """Stop the detached download process group and clear its job record."""
+    with _download_lock:
+        settings = load_settings()
+        record = _read_download_record(settings)
+        if record is None or not _pid_alive(record["pid"]):
+            return {"cancelled": False, "reason": "no active download"}
+        pid = record["pid"]
+        if not _download_process_is_ours(settings, pid, record["repo_id"]):
+            _download_path(settings).unlink(missing_ok=True)
+            return {"cancelled": False, "reason": "no active download"}
+        try:
+            _signal_process_group(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        if settings.runtime is None:
+            raise LocalInferenceError("[runtime] is required for shutdown settings")
+        health = settings.runtime.health
+        deadline = time.monotonic() + health.stop_grace_seconds
+        while (
+            _pid_alive(pid)
+            and _download_process_is_ours(settings, pid, record["repo_id"])
+            and time.monotonic() < deadline
+        ):
+            time.sleep(health.poll_interval_seconds)
+        if _pid_alive(pid) and _download_process_is_ours(
+            settings, pid, record["repo_id"]
+        ):
+            try:
+                _signal_process_group(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        _download_path(settings).unlink(missing_ok=True)
+        return {"cancelled": True}
+
+
+def delete_model(path: str) -> dict[str, Any]:
+    """Delete a root-validated GGUF shard set unless one shard is active."""
+    with _lifecycle_lock:
+        candidate = Path(path).resolve()
+        shards = shard_set(candidate, _allowed_roots())
+        current = active()
+        if current is not None:
+            active_path = Path(current["gguf_path"]).resolve()
+            if active_path in shards:
+                raise LocalInferenceError("Cannot delete the active local model")
+
+        deleted: list[str] = []
+        for shard in shards:
+            try:
+                os.remove(shard)
+            except FileNotFoundError:
+                continue
+            deleted.append(str(shard))
+
+        requested = str(candidate)
+        with _registration_lock:
+            paths = registered_paths()
+            was_registered = requested in paths
+            if was_registered:
+                paths.remove(requested)
+                _write_json(_registered_path(load_settings()), paths)
+        return {"deleted": deleted, "was_registered": was_registered}
 
 
 def registered_paths() -> list[str]:

--- a/nexus/api/local_models_endpoints.py
+++ b/nexus/api/local_models_endpoints.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import asdict
 from pathlib import Path
-import re
 from threading import Lock
 from typing import Any
 
@@ -20,10 +19,6 @@ router = APIRouter(prefix="/api/local-models", tags=["local-models"])
 _inspection_cache: dict[tuple[str, int, int], GgufInfo] = {}
 _inspection_cache_lock = Lock()
 _GENERIC_GGUF_ERROR = "No accessible GGUF model at the requested path."
-_SPLIT_GGUF_PATTERN = re.compile(
-    r"^(?P<stem>.+)-(?P<part>\d{5})-of-(?P<total>\d{5})\.gguf$",
-    re.IGNORECASE,
-)
 
 
 class PathRequest(BaseModel):
@@ -32,6 +27,15 @@ class PathRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     path: str
+
+
+class DownloadRequest(BaseModel):
+    """A curated catalog family and quantization selection."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    family: str
+    quant: str
 
 
 def _cached_inspect(path: Path) -> GgufInfo:
@@ -76,10 +80,7 @@ def _verified_path(raw_path: str, status_code: int) -> tuple[Path, GgufInfo]:
 
 def _split_shard(path: Path) -> tuple[str, int, int] | None:
     """Return split stem, part, and total for llama.cpp split filenames."""
-    match = _SPLIT_GGUF_PATTERN.match(path.name)
-    if match is None:
-        return None
-    return match.group("stem"), int(match.group("part")), int(match.group("total"))
+    return local_inference.split_shard(path)
 
 
 def _is_activatable_shard(path: Path) -> bool:
@@ -90,23 +91,7 @@ def _is_activatable_shard(path: Path) -> bool:
 
 def _model_size(path: Path, roots: tuple[Path, ...]) -> int:
     """Return one file's size or the aggregate size of its split set."""
-    split = _split_shard(path)
-    if split is None:
-        return path.stat().st_size
-    stem, _, total = split
-    size = 0
-    for sibling in path.parent.glob(f"{stem}-*-of-{total:05d}.gguf"):
-        resolved = sibling.resolve()
-        sibling_split = _split_shard(resolved)
-        if (
-            sibling_split is not None
-            and sibling_split[0] == stem
-            and sibling_split[2] == total
-            and _is_within(resolved, roots)
-            and resolved.is_file()
-        ):
-            size += resolved.stat().st_size
-    return size
+    return sum(shard.stat().st_size for shard in local_inference.shard_set(path, roots))
 
 
 def _installed_models(active_path: str | None) -> list[dict[str, Any]]:
@@ -209,15 +194,100 @@ def deactivate() -> dict[str, Any]:
     return {"active": None, **result}
 
 
-def _allowed_roots() -> tuple[Path, Path]:
-    return (
-        Path(get_local_models_settings().models_dir).resolve(),
-        Path.home().resolve(),
+def _catalog_files(filename: str) -> list[str]:
+    """Expand a catalog filename to its complete ordered split set."""
+    split = _split_shard(Path(filename))
+    if split is None:
+        return [filename]
+    stem, _, total = split
+    return [f"{stem}-{part:05d}-of-{total:05d}.gguf" for part in range(1, total + 1)]
+
+
+@router.post("/download")
+def download(request: DownloadRequest) -> dict[str, Any]:
+    """Start downloading one curated catalog quantization."""
+    settings = get_local_models_settings()
+    entry = next(
+        (
+            item
+            for item in settings.catalog
+            if item.family == request.family and item.quant == request.quant
+        ),
+        None,
     )
+    if entry is None:
+        raise HTTPException(
+            status_code=404, detail="Local model catalog entry not found"
+        )
+
+    local_dir = (Path(settings.models_dir) / entry.subdir).resolve()
+    if not _is_within(local_dir, _allowed_roots()):
+        raise HTTPException(
+            status_code=400, detail="Catalog model directory is outside allowed roots"
+        )
+    files = _catalog_files(entry.filename)
+    targets = [local_dir / filename for filename in files]
+    total_bytes = round(entry.size_gb * 1024**3)
+    if (
+        all(target.is_file() for target in targets)
+        and inspect_gguf(str(targets[0])).valid
+    ):
+        return {
+            "status": "already_installed",
+            "family": entry.family,
+            "quant": entry.quant,
+            "files": files,
+            "local_dir": str(local_dir),
+            "total_bytes": total_bytes,
+        }
+    try:
+        local_inference.start_download(
+            family=entry.family,
+            quant=entry.quant,
+            repo_id=entry.hf_repo,
+            local_dir=str(local_dir),
+            files=files,
+            total_bytes=total_bytes,
+        )
+    except local_inference.LocalInferenceError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    current = local_inference.download_status()
+    if current is None:
+        raise local_inference.LocalInferenceError(
+            "Download worker state disappeared immediately after start"
+        )
+    return {"status": "started", **current}
+
+
+@router.get("/download")
+def download_status() -> dict[str, Any]:
+    """Return the current detached download state, or idle."""
+    return local_inference.download_status() or {"state": "idle"}
+
+
+@router.post("/download/cancel")
+def cancel_download() -> dict[str, Any]:
+    """Cancel the current detached local-model download."""
+    return local_inference.cancel_download()
+
+
+@router.post("/delete")
+def delete_model(request: PathRequest) -> dict[str, Any]:
+    """Delete one verified inactive GGUF model or its full shard set."""
+    candidate, _ = _verified_path(request.path, status_code=404)
+    try:
+        result = local_inference.delete_model(str(candidate))
+    except local_inference.LocalInferenceError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return {"status": "deleted", **result}
+
+
+def _allowed_roots() -> tuple[Path, Path]:
+    return local_inference._allowed_roots()
 
 
 def _is_within(path: Path, roots: tuple[Path, ...]) -> bool:
-    return any(path == root or path.is_relative_to(root) for root in roots)
+    return local_inference._is_within(path, roots)
 
 
 @router.get("/browse")

--- a/poetry.lock
+++ b/poetry.lock
@@ -3515,4 +3515,4 @@ dev = ["black", "flake8", "mypy", "pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "264f44e23a7e9bf38db1815197dd442d40ea87d1d3271e9ad4241f84dbd019bd"
+content-hash = "3bded0935140db731bcc096d0d6600753efbd3ba2bdbb76eeb3929b87d164157"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "protobuf (>=6.0.0,<7.0.0)",
     "sentencepiece (>=0.2.0,<0.3.0)",
     "python-multipart (>=0.0.32,<0.0.33)",
-    "gguf>=0.19.0,<1.0.0"
+    "gguf>=0.19.0,<1.0.0",
+    "huggingface-hub (>=0.30.0,<1.0.0)"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_api/test_local_inference.py
+++ b/tests/test_api/test_local_inference.py
@@ -335,6 +335,13 @@ def test_concurrent_download_spawns_only_one_process(
 
     monkeypatch.setattr(local_inference, "load_settings", lambda: settings)
     monkeypatch.setattr(local_inference, "_pid_alive", lambda pid: True)
+    # This test exercises the lock's check-then-spawn race, so the fake PID
+    # must read as ours — the recycled-PID case is covered separately below.
+    monkeypatch.setattr(
+        local_inference,
+        "_download_process_is_ours",
+        lambda settings, pid, repo_id: True,
+    )
     monkeypatch.setattr(local_inference.subprocess, "Popen", fake_popen)
 
     def run_download():
@@ -363,6 +370,40 @@ def test_concurrent_download_spawns_only_one_process(
     ]
     assert len(errors) == 1
     assert "already in progress" in str(errors[0])
+
+
+def test_start_download_ignores_stale_record_with_recycled_pid(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A live PID recycled by an unrelated process must not block downloads."""
+    settings = _settings_with_state_dir(tmp_path)
+    _write_download_state(tmp_path, files=["test.gguf"])
+    spawned = []
+
+    monkeypatch.setattr(local_inference, "load_settings", lambda: settings)
+    monkeypatch.setattr(local_inference, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        local_inference,
+        "_download_process_is_ours",
+        lambda settings, pid, repo_id: False,
+    )
+    monkeypatch.setattr(
+        local_inference.subprocess,
+        "Popen",
+        lambda command, **kwargs: spawned.append(command) or SimpleNamespace(pid=999),
+    )
+
+    record = local_inference.start_download(
+        family="test",
+        quant="Q4_K_M",
+        repo_id="example/test",
+        local_dir=str(tmp_path / "models"),
+        files=["test.gguf"],
+        total_bytes=100,
+    )
+
+    assert len(spawned) == 1
+    assert record["pid"] == 999
 
 
 def _write_download_state(

--- a/tests/test_api/test_local_inference.py
+++ b/tests/test_api/test_local_inference.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from nexus.api import local_inference
+from nexus.api import local_download_worker, local_inference
 from nexus.config import load_settings
 from nexus.util.gguf_inspect import GgufInfo
 
@@ -317,3 +317,242 @@ def test_concurrent_activate_spawns_only_one_process(
 
     assert spawn_count == 1
     assert [result["pid"] for result in results] == [43210, 43210]
+
+
+def test_concurrent_download_spawns_only_one_process(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The download lock closes the singleton check-then-spawn race."""
+    settings = _settings_with_state_dir(tmp_path)
+    barrier = threading.Barrier(2)
+    spawn_count = 0
+
+    def fake_popen(command, **kwargs):
+        nonlocal spawn_count
+        spawn_count += 1
+        time.sleep(0.05)
+        return SimpleNamespace(pid=43210)
+
+    monkeypatch.setattr(local_inference, "load_settings", lambda: settings)
+    monkeypatch.setattr(local_inference, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(local_inference.subprocess, "Popen", fake_popen)
+
+    def run_download():
+        barrier.wait()
+        try:
+            return local_inference.start_download(
+                family="test",
+                quant="Q4_K_M",
+                repo_id="example/test",
+                local_dir=str(tmp_path / "models"),
+                files=["test.gguf"],
+                total_bytes=100,
+            )
+        except local_inference.LocalInferenceError as exc:
+            return exc
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda _: run_download(), range(2)))
+
+    assert spawn_count == 1
+    assert len([result for result in results if isinstance(result, dict)]) == 1
+    errors = [
+        result
+        for result in results
+        if isinstance(result, local_inference.LocalInferenceError)
+    ]
+    assert len(errors) == 1
+    assert "already in progress" in str(errors[0])
+
+
+def _write_download_state(
+    tmp_path: Path, *, files: list[str], total_bytes: int = 100
+) -> None:
+    (tmp_path / local_inference.DOWNLOAD_FILENAME).write_text(
+        json.dumps(
+            {
+                "pid": 43210,
+                "family": "test",
+                "quant": "Q4_K_M",
+                "repo_id": "example/test",
+                "local_dir": str(tmp_path / "models"),
+                "files": files,
+                "total_bytes": total_bytes,
+                "started_at": "2026-01-01T00:00:00+00:00",
+            }
+        )
+    )
+
+
+def test_download_status_rediscovers_completed_download(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A dead worker with every valid target is reported as done."""
+    settings = _settings_with_state_dir(tmp_path)
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    (model_dir / "test.gguf").write_bytes(b"GGUF complete")
+    _write_download_state(tmp_path, files=["test.gguf"])
+    monkeypatch.setattr(local_inference, "load_settings", lambda: settings)
+    monkeypatch.setattr(local_inference, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        local_inference,
+        "inspect_gguf",
+        lambda path: GgufInfo(valid=True),
+    )
+
+    status = local_inference.download_status()
+
+    assert status is not None
+    assert status["state"] == "done"
+    assert status["downloaded_bytes"] == len(b"GGUF complete")
+
+
+def test_download_status_rediscovers_failed_download(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A dead worker with missing targets reports its final log error."""
+    settings = _settings_with_state_dir(tmp_path)
+    _write_download_state(tmp_path, files=["missing.gguf"])
+    (tmp_path / local_inference.DOWNLOAD_LOG_FILENAME).write_text(
+        "starting\n\nrepository file not found\n"
+    )
+    monkeypatch.setattr(local_inference, "load_settings", lambda: settings)
+    monkeypatch.setattr(local_inference, "_pid_alive", lambda pid: False)
+
+    status = local_inference.download_status()
+
+    assert status is not None
+    assert status["state"] == "failed"
+    assert status["downloaded_bytes"] == 0
+    assert status["error"] == "repository file not found"
+
+
+def test_download_status_reports_live_progress(tmp_path: Path, monkeypatch) -> None:
+    """A rediscovered owned worker includes completed and partial byte progress."""
+    settings = _settings_with_state_dir(tmp_path)
+    model_dir = tmp_path / "models"
+    partial_dir = model_dir / ".cache" / "huggingface" / "download"
+    partial_dir.mkdir(parents=True)
+    (model_dir / "first.gguf").write_bytes(b"1234")
+    (partial_dir / "second.gguf.hash.incomplete").write_bytes(b"12")
+    _write_download_state(tmp_path, files=["first.gguf", "second.gguf"], total_bytes=12)
+    monkeypatch.setattr(local_inference, "load_settings", lambda: settings)
+    monkeypatch.setattr(local_inference, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        local_inference,
+        "_download_process_is_ours",
+        lambda value, pid, repo_id: True,
+    )
+
+    status = local_inference.download_status()
+
+    assert status is not None
+    assert status["state"] == "downloading"
+    assert status["downloaded_bytes"] == 6
+    assert status["progress"] == 0.5
+
+
+def test_delete_model_rejects_active_shard(tmp_path: Path, monkeypatch) -> None:
+    """No shard set containing the serving model can be deleted."""
+    settings = _settings_with_state_dir(tmp_path)
+    first = tmp_path / "Hermes-Q6_K-00001-of-00002.gguf"
+    second = tmp_path / "Hermes-Q6_K-00002-of-00002.gguf"
+    first.write_bytes(b"GGUF first")
+    second.write_bytes(b"GGUF second")
+    monkeypatch.setattr(
+        local_inference,
+        "get_local_models_settings",
+        lambda: SimpleNamespace(models_dir=str(tmp_path)),
+    )
+    monkeypatch.setattr(local_inference, "load_settings", lambda: settings)
+    monkeypatch.setattr(
+        local_inference,
+        "active",
+        lambda: {"gguf_path": str(second), "ready": True, "pid": 123},
+    )
+
+    with pytest.raises(local_inference.LocalInferenceError, match="active"):
+        local_inference.delete_model(str(first))
+
+    assert first.exists()
+    assert second.exists()
+
+
+def test_delete_model_removes_all_shards(tmp_path: Path, monkeypatch) -> None:
+    """Deleting a split model removes every matching root-validated shard."""
+    settings = _settings_with_state_dir(tmp_path)
+    first = tmp_path / "Hermes-Q6_K-00001-of-00002.gguf"
+    second = tmp_path / "Hermes-Q6_K-00002-of-00002.gguf"
+    first.write_bytes(b"GGUF first")
+    second.write_bytes(b"GGUF second")
+    monkeypatch.setattr(
+        local_inference,
+        "get_local_models_settings",
+        lambda: SimpleNamespace(models_dir=str(tmp_path)),
+    )
+    monkeypatch.setattr(local_inference, "load_settings", lambda: settings)
+    monkeypatch.setattr(local_inference, "active", lambda: None)
+    monkeypatch.setattr(local_inference, "registered_paths", lambda: [])
+
+    result = local_inference.delete_model(str(first))
+
+    assert result == {
+        "deleted": [str(first), str(second)],
+        "was_registered": False,
+    }
+    assert not first.exists()
+    assert not second.exists()
+
+
+def test_shard_set_excludes_non_split_path_outside_roots(tmp_path: Path) -> None:
+    """A non-split path outside the allowed roots yields no deletable shards."""
+    root = tmp_path / "models"
+    root.mkdir()
+    inside = root / "model.gguf"
+    inside.write_bytes(b"GGUF inside")
+    outside = tmp_path / "elsewhere.gguf"
+    outside.write_bytes(b"GGUF outside")
+    roots = (root.resolve(),)
+
+    assert local_inference.shard_set(inside, roots) == [inside.resolve()]
+    assert local_inference.shard_set(outside, roots) == []
+
+
+def test_download_worker_fetches_files_in_order(tmp_path: Path, monkeypatch) -> None:
+    """The worker sends each requested shard through hf_hub_download in order."""
+    calls = []
+    monkeypatch.setattr(
+        local_download_worker.sys,
+        "argv",
+        [
+            "local_download_worker",
+            "--repo-id",
+            "example/test",
+            "--local-dir",
+            str(tmp_path),
+            "--file",
+            "first.gguf",
+            "--file",
+            "second.gguf",
+        ],
+    )
+    monkeypatch.setattr(
+        local_download_worker,
+        "hf_hub_download",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    assert local_download_worker.main() == 0
+    assert calls == [
+        {
+            "repo_id": "example/test",
+            "filename": "first.gguf",
+            "local_dir": str(tmp_path),
+        },
+        {
+            "repo_id": "example/test",
+            "filename": "second.gguf",
+            "local_dir": str(tmp_path),
+        },
+    ]

--- a/tests/test_api/test_local_models_endpoints.py
+++ b/tests/test_api/test_local_models_endpoints.py
@@ -39,6 +39,11 @@ def fake_settings(tmp_path: Path, monkeypatch) -> LocalModelsSettings:
     monkeypatch.setattr(
         local_models_endpoints, "get_local_models_settings", lambda: settings
     )
+    monkeypatch.setattr(
+        local_models_endpoints.local_inference,
+        "get_local_models_settings",
+        lambda: settings,
+    )
     return settings
 
 
@@ -293,3 +298,166 @@ def test_activate_rejects_non_first_split_shard(
     assert response.json()["detail"] == (
         "No accessible GGUF model at the requested path."
     )
+
+
+def test_download_endpoint_rejects_unknown_catalog_entry(
+    client: TestClient, fake_settings: LocalModelsSettings, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        local_models_endpoints.local_inference,
+        "start_download",
+        lambda **kwargs: pytest.fail("unknown catalog entry started a download"),
+    )
+
+    response = client.post(
+        "/api/local-models/download",
+        json={"family": "missing", "quant": "Q4_K_M"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_download_endpoint_starts_curated_entry(
+    client: TestClient,
+    fake_settings: LocalModelsSettings,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls = []
+    expected_status = {
+        "state": "downloading",
+        "family": "test",
+        "quant": "Q4_K_M",
+        "downloaded_bytes": 0,
+        "total_bytes": 1024**3,
+        "progress": 0.0,
+        "files": ["test.gguf"],
+        "local_dir": str(tmp_path / "Test-GGUF"),
+    }
+    monkeypatch.setattr(
+        local_models_endpoints.local_inference,
+        "start_download",
+        lambda **kwargs: calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        local_models_endpoints.local_inference,
+        "download_status",
+        lambda: expected_status,
+    )
+
+    response = client.post(
+        "/api/local-models/download",
+        json={"family": "test", "quant": "Q4_K_M"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "started", **expected_status}
+    assert calls == [
+        {
+            "family": "test",
+            "quant": "Q4_K_M",
+            "repo_id": "example/test",
+            "local_dir": str(tmp_path / "Test-GGUF"),
+            "files": ["test.gguf"],
+            "total_bytes": 1024**3,
+        }
+    ]
+
+
+def test_download_endpoint_returns_already_installed(
+    client: TestClient,
+    fake_settings: LocalModelsSettings,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    model_dir = tmp_path / "Test-GGUF"
+    model_dir.mkdir()
+    (model_dir / "test.gguf").write_bytes(b"GGUF complete")
+    monkeypatch.setattr(
+        local_models_endpoints,
+        "inspect_gguf",
+        lambda path: GgufInfo(valid=True),
+    )
+    monkeypatch.setattr(
+        local_models_endpoints.local_inference,
+        "start_download",
+        lambda **kwargs: pytest.fail("installed model spawned a download"),
+    )
+
+    response = client.post(
+        "/api/local-models/download",
+        json={"family": "test", "quant": "Q4_K_M"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "already_installed"
+    assert response.json()["files"] == ["test.gguf"]
+
+
+def test_delete_endpoint_rejects_active_model(
+    client: TestClient,
+    fake_settings: LocalModelsSettings,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    model = tmp_path / "active.gguf"
+    model.write_bytes(b"GGUF")
+    monkeypatch.setattr(
+        local_models_endpoints,
+        "inspect_gguf",
+        lambda path: GgufInfo(valid=True),
+    )
+    monkeypatch.setattr(
+        local_models_endpoints.local_inference,
+        "delete_model",
+        lambda path: (_ for _ in ()).throw(
+            local_models_endpoints.local_inference.LocalInferenceError(
+                "Cannot delete the active local model"
+            )
+        ),
+    )
+
+    response = client.post("/api/local-models/delete", json={"path": str(model)})
+
+    assert response.status_code == 409
+    assert model.exists()
+
+
+def test_delete_failures_have_one_non_oracular_response(
+    client: TestClient,
+    fake_settings: LocalModelsSettings,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    missing = tmp_path / "secret-name.gguf"
+    wrong_magic = tmp_path / "readable-secret-name.gguf"
+    wrong_magic.write_bytes(b"NOPE")
+    manager_calls = []
+    original_inspect = local_models_endpoints.inspect_gguf
+
+    def guarded_inspect(path: str):
+        assert Path(path).is_relative_to(tmp_path)
+        return original_inspect(path)
+
+    monkeypatch.setattr(local_models_endpoints, "inspect_gguf", guarded_inspect)
+    monkeypatch.setattr(
+        local_models_endpoints.local_inference,
+        "delete_model",
+        lambda path: manager_calls.append(path),
+    )
+    with tempfile.TemporaryDirectory(dir="/tmp") as directory:
+        outside = Path(directory) / "outside-secret-name.gguf"
+        outside.write_bytes(b"GGUF")
+        requested = [missing, wrong_magic, outside]
+        responses = [
+            client.post("/api/local-models/delete", json={"path": str(path)})
+            for path in requested
+        ]
+
+    assert {response.status_code for response in responses} == {404}
+    assert {response.json()["detail"] for response in responses} == {
+        "No accessible GGUF model at the requested path."
+    }
+    assert manager_calls == []
+    for path in requested:
+        assert all(str(path) not in response.text for response in responses)


### PR DESCRIPTION
Closes the Phase 2 backend of #465 — `huggingface_hub` download + delete for curated local GGUF quants, on top of the Phase 1a process manager (#466). Backend + endpoints only; the settings-pane UI is being designed separately in Claude Design.

## What's here
- **Detached download worker** (`local_download_worker.py`) — `hf_hub_download` per file, PID-tracked in `local-model.download.json`. Resumable, cancellable, survives gateway restarts (same durability model as llama-server).
- **Manager** (`local_inference.py`) — `start_download` (singleton-locked), `download_status` (progress computed on-read + PID rediscovery), `cancel_download` (`[runtime.health]` grace), `delete_model` (all shards; **refuses the active model → 409**). `shard_set`/`split_shard` extracted as shared helpers.
- **Endpoints** — `POST /download`, `GET /download`, `POST /download/cancel`, `POST /delete`. Delete reuses #466's `_verified_path` (root-before-work + non-oracular error); download resolves the curated catalog and derives split shards from `-NNNNN-of-NNNNN`.
- `huggingface-hub` promoted to an explicit dependency.

## Review + live verification applied over the Codex draft
Codex's tests mock `hf_hub_download`, so the following only surfaced under real HF / real disk:

1. **Reverted a wrong catalog change.** Codex stripped the `NousResearch_` prefix from the three 36B filenames claiming it "does not exist upstream" — but `list_repo_files("bartowski/NousResearch_Hermes-4.3-36B-GGUF")` shows the prefixed names **do** exist and the unprefixed ones **404**. The prefixed names also match the on-disk files, so `already_installed` detects them and skips a 21.8 GB duplicate pull. All 5 catalog entries now verify `installed=True` against disk.
2. **`shard_set` root-validates the non-split branch** too (defense in depth — the split branch already did), with a regression test.
3. **Rewrote `_downloaded_bytes`.** hf stages a *hash-named* `*.incomplete` under `.cache/huggingface/download` and moves it on completion, so the prior per-filename glob never matched (and could have double-counted). Now counts finals + cache-scoped incompletes — correct by construction. Confirmed the blob is **moved, not copied** (no disk-doubling for large pulls).

**Live-tested** (tiny `ggml-org/models` GGUFs — a few MB): single + split downloads land and `inspect_gguf`-validate; delete removes a real file; out-of-root deletion refused. Multi-GB Hermes pulls intentionally not run.

## Gates
34 unit tests pass; black, flake8, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)