### PR TITLE
Byte-Resume for Cancelled Downloads; Decimal-GB Progress Totals

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -71,6 +71,8 @@ models = [
 # from [global.model.api_models.local], not duplicated here.
 [local_models]
 models_dir = "~/.lmstudio/models/lmstudio-community"
+# Classic-HTTP downloads byte-resume after cancel; Xet chunk transfer does not.
+download_disable_xet = true
 catalog = [
     { family = "hermes-4-70b", label = "Hermes 4 70B Q4_K_M", hf_repo = "lmstudio-community/Hermes-4-70B-GGUF", subdir = "Hermes-4-70B-GGUF", filename = "Hermes-4-70B-Q4_K_M.gguf", quant = "Q4_K_M", size_gb = 42.5, min_ram_gb = 48 },
     { family = "hermes-4-70b", label = "Hermes 4 70B Q6_K", hf_repo = "lmstudio-community/Hermes-4-70B-GGUF", subdir = "Hermes-4-70B-GGUF", filename = "Hermes-4-70B-Q6_K-00001-of-00002.gguf", quant = "Q6_K", size_gb = 57.9, min_ram_gb = 64 },

--- a/nexus/api/local_inference.py
+++ b/nexus/api/local_inference.py
@@ -534,6 +534,13 @@ def start_download(
             str(resolved_dir),
             *[argument for filename in files for argument in ("--file", filename)],
         ]
+        worker_env = dict(os.environ)
+        if get_local_models_settings().download_disable_xet:
+            # Xet's chunk-based transfer discards byte partials on restart
+            # (verified live: a 7.2GB .incomplete restarted from zero). The
+            # classic HTTP path resumes via open("ab") + Range, which is what
+            # a cancelled multi-GB pull needs.
+            worker_env["HF_HUB_DISABLE_XET"] = "1"
         try:
             with (state_dir / DOWNLOAD_LOG_FILENAME).open("ab") as log_handle:
                 process = subprocess.Popen(
@@ -543,6 +550,7 @@ def start_download(
                     stderr=subprocess.STDOUT,
                     close_fds=True,
                     start_new_session=True,
+                    env=worker_env,
                 )
         except OSError as exc:
             raise LocalInferenceError(

--- a/nexus/api/local_models_endpoints.py
+++ b/nexus/api/local_models_endpoints.py
@@ -227,7 +227,10 @@ def download(request: DownloadRequest) -> dict[str, Any]:
         )
     files = _catalog_files(entry.filename)
     targets = [local_dir / filename for filename in files]
-    total_bytes = round(entry.size_gb * 1024**3)
+    # Catalog size_gb values are decimal gigabytes (matching HF's listed
+    # sizes); multiplying by 1024**3 overstated totals ~7% and capped a
+    # completed download's reported progress at ~0.93 (verified live).
+    total_bytes = round(entry.size_gb * 1000**3)
     if (
         all(target.is_file() for target in targets)
         and inspect_gguf(str(targets[0])).valid

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -291,6 +291,15 @@ class LocalModelsSettings(BaseModel):
         description="Root directory scanned recursively for GGUF model files",
     )
     catalog: List[LocalModelCatalogEntry] = Field(default_factory=list)
+    download_disable_xet: bool = Field(
+        default=True,
+        description=(
+            "Spawn download workers with HF_HUB_DISABLE_XET=1 so multi-GB "
+            "GGUF pulls use the classic HTTP path with genuine byte-append "
+            "resume after a cancel; Xet's chunk transfer does not preserve "
+            "byte partials across restarts"
+        ),
+    )
 
     @field_validator("models_dir")
     @classmethod

--- a/poetry.lock
+++ b/poetry.lock
@@ -810,6 +810,45 @@ files = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.1"
+description = "Fast transfer of large files with the Hugging Face Hub."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""
+files = [
+    {file = "hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577"},
+    {file = "hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43"},
+    {file = "hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947"},
+    {file = "hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8"},
+    {file = "hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283"},
+    {file = "hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342"},
+    {file = "hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff"},
+    {file = "hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d"},
+    {file = "hf_xet-1.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3474760d10e3bb6f92ff3f024fcb00c0b3e4001e9b035c7483e49a5dd17aa70f"},
+    {file = "hf_xet-1.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6762d89b9e3267dfd502b29b2a327b4525f33b17e7b509a78d94e2151a30ce30"},
+    {file = "hf_xet-1.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf67e6ed10260cef62e852789dc91ebb03f382d5bdc4b1dbeb64763ea275e7d6"},
+    {file = "hf_xet-1.5.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b6cd08ca095058780b50b8ce4d6cbf6787bcf27841705d58a9d32246e3e47a"},
+    {file = "hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1af0de8ca6f190d4294a28b88023db64a1e2d1d719cab044baf75bec569e7a9"},
+    {file = "hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4f561cbbb92f80960772059864b7fb07eae879adde1b2e781ec6f86f6ac26c59"},
+    {file = "hf_xet-1.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e7dbb40617410f432182d918e37c12303fe6700fd6aa6c5964e30a535a4461d6"},
+    {file = "hf_xet-1.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6071d5ccb4d8d2cbd5fea5cc798da4f0ba3f44e25369591c4e89a4987050e61d"},
+    {file = "hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e"},
+    {file = "hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e"},
+    {file = "hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350"},
+    {file = "hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4"},
+    {file = "hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6"},
+    {file = "hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf"},
+    {file = "hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5"},
+    {file = "hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e"},
+    {file = "hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6"},
+]
+
+[package.extras]
+tests = ["pytest"]
+
+[[package]]
 name = "httpcore"
 version = "1.0.7"
 description = "A minimal low-level HTTP client."
@@ -858,19 +897,20 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "huggingface-hub"
-version = "0.30.2"
+version = "0.36.2"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
 optional = false
 python-versions = ">=3.8.0"
 groups = ["main"]
 files = [
-    {file = "huggingface_hub-0.30.2-py3-none-any.whl", hash = "sha256:68ff05969927058cfa41df4f2155d4bb48f5f54f719dd0390103eefa9b191e28"},
-    {file = "huggingface_hub-0.30.2.tar.gz", hash = "sha256:9a7897c5b6fd9dad3168a794a8998d6378210f5b9688d0dfc180b1a228dc2466"},
+    {file = "huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270"},
+    {file = "huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a"},
 ]
 
 [package.dependencies]
 filelock = "*"
 fsspec = ">=2023.5.0"
+hf-xet = {version = ">=1.1.3,<2.0.0", markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""}
 packaging = ">=20.9"
 pyyaml = ">=5.1"
 requests = "*"
@@ -878,17 +918,19 @@ tqdm = ">=4.42.1"
 typing-extensions = ">=3.7.4.3"
 
 [package.extras]
-all = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "fastapi", "gradio (>=4.0.0)", "jedi", "libcst (==1.4.0)", "mypy (==1.5.1)", "numpy", "pytest (>=8.1.1,<8.2.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "ruff (>=0.9.0)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
+all = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "authlib (>=1.3.2)", "fastapi", "fastapi", "gradio (>=4.0.0)", "httpx", "itsdangerous", "jedi", "libcst (>=1.4.0)", "mypy (==1.15.0) ; python_version >= \"3.9\"", "mypy (>=1.14.1,<1.15.0) ; python_version == \"3.8\"", "numpy", "pytest (>=8.1.1,<8.2.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures (<16.0)", "pytest-vcr", "pytest-xdist", "ruff (>=0.9.0)", "soundfile", "ty", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
 cli = ["InquirerPy (==0.3.4)"]
-dev = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "fastapi", "gradio (>=4.0.0)", "jedi", "libcst (==1.4.0)", "mypy (==1.5.1)", "numpy", "pytest (>=8.1.1,<8.2.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "ruff (>=0.9.0)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
+dev = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "authlib (>=1.3.2)", "fastapi", "fastapi", "gradio (>=4.0.0)", "httpx", "itsdangerous", "jedi", "libcst (>=1.4.0)", "mypy (==1.15.0) ; python_version >= \"3.9\"", "mypy (>=1.14.1,<1.15.0) ; python_version == \"3.8\"", "numpy", "pytest (>=8.1.1,<8.2.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures (<16.0)", "pytest-vcr", "pytest-xdist", "ruff (>=0.9.0)", "soundfile", "ty", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
 fastai = ["fastai (>=2.4)", "fastcore (>=1.3.27)", "toml"]
-hf-transfer = ["hf-transfer (>=0.1.4)"]
-hf-xet = ["hf-xet (>=0.1.4)"]
+hf-transfer = ["hf_transfer (>=0.1.4)"]
+hf-xet = ["hf-xet (>=1.1.2,<2.0.0)"]
 inference = ["aiohttp"]
-quality = ["libcst (==1.4.0)", "mypy (==1.5.1)", "ruff (>=0.9.0)"]
+mcp = ["aiohttp", "mcp (>=1.8.0)", "typer"]
+oauth = ["authlib (>=1.3.2)", "fastapi", "httpx", "itsdangerous"]
+quality = ["libcst (>=1.4.0)", "mypy (==1.15.0) ; python_version >= \"3.9\"", "mypy (>=1.14.1,<1.15.0) ; python_version == \"3.8\"", "ruff (>=0.9.0)", "ty"]
 tensorflow = ["graphviz", "pydot", "tensorflow"]
 tensorflow-testing = ["keras (<3.0)", "tensorflow"]
-testing = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "fastapi", "gradio (>=4.0.0)", "jedi", "numpy", "pytest (>=8.1.1,<8.2.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "soundfile", "urllib3 (<2.0)"]
+testing = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "authlib (>=1.3.2)", "fastapi", "fastapi", "gradio (>=4.0.0)", "httpx", "itsdangerous", "jedi", "numpy", "pytest (>=8.1.1,<8.2.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures (<16.0)", "pytest-vcr", "pytest-xdist", "soundfile", "urllib3 (<2.0)"]
 torch = ["safetensors[torch]", "torch"]
 typing = ["types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)"]
 
@@ -3515,4 +3557,4 @@ dev = ["black", "flake8", "mypy", "pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "3bded0935140db731bcc096d0d6600753efbd3ba2bdbb76eeb3929b87d164157"
+content-hash = "ac716278dd658b10932be9918d74223580414207646711e3762a0a358cd73428"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "sentencepiece (>=0.2.0,<0.3.0)",
     "python-multipart (>=0.0.32,<0.0.33)",
     "gguf>=0.19.0,<1.0.0",
-    "huggingface-hub (>=0.30.0,<1.0.0)"
+    "huggingface-hub (>=0.32.0,<1.0.0)"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_api/test_local_inference.py
+++ b/tests/test_api/test_local_inference.py
@@ -406,6 +406,39 @@ def test_start_download_ignores_stale_record_with_recycled_pid(
     assert record["pid"] == 999
 
 
+def test_start_download_env_controls_xet(tmp_path, monkeypatch) -> None:
+    """The worker env carries HF_HUB_DISABLE_XET=1 exactly when configured."""
+    from types import SimpleNamespace as NS
+
+    settings = _settings_with_state_dir(tmp_path)
+    captured = {}
+
+    def fake_popen(command, **kwargs):
+        captured.update(kwargs)
+        return NS(pid=4242)
+
+    monkeypatch.setattr(local_inference, "load_settings", lambda: settings)
+    monkeypatch.setattr(local_inference.subprocess, "Popen", fake_popen)
+
+    for disable, expected in ((True, "1"), (False, None)):
+        captured.clear()
+        monkeypatch.setattr(
+            local_inference,
+            "get_local_models_settings",
+            lambda disable=disable: NS(download_disable_xet=disable),
+        )
+        local_inference.start_download(
+            family="test",
+            quant="Q4_K_M",
+            repo_id="example/test",
+            local_dir=str(tmp_path / "models"),
+            files=["test.gguf"],
+            total_bytes=100,
+        )
+        assert captured["env"].get("HF_HUB_DISABLE_XET") == expected
+        (tmp_path / local_inference.DOWNLOAD_FILENAME).unlink()
+
+
 def _write_download_state(
     tmp_path: Path, *, files: list[str], total_bytes: int = 100
 ) -> None:

--- a/tests/test_api/test_local_models_endpoints.py
+++ b/tests/test_api/test_local_models_endpoints.py
@@ -329,7 +329,7 @@ def test_download_endpoint_starts_curated_entry(
         "family": "test",
         "quant": "Q4_K_M",
         "downloaded_bytes": 0,
-        "total_bytes": 1024**3,
+        "total_bytes": 1000**3,
         "progress": 0.0,
         "files": ["test.gguf"],
         "local_dir": str(tmp_path / "Test-GGUF"),
@@ -359,7 +359,7 @@ def test_download_endpoint_starts_curated_entry(
             "repo_id": "example/test",
             "local_dir": str(tmp_path / "Test-GGUF"),
             "files": ["test.gguf"],
-            "total_bytes": 1024**3,
+            "total_bytes": 1000**3,
         }
     ]
 


### PR DESCRIPTION
Two findings from live Hermes-scale verification of the #465 Phase 2 backend (a real 29.7 GB download/cancel/restart cycle through the endpoints), plus the dependency bump the fix turned out to require.

## Findings and Fixes

1. **Cancelled downloads didn't resume.** A cancelled 29.7 GB pull left a 7.2 GB partial, but restarting re-downloaded from zero — `hf_xet` (a stray pip install, no dependents) routes transfers through Xet chunk semantics that discard byte partials. Fix: workers now spawn with `HF_HUB_DISABLE_XET=1`, config-driven via `[local_models] download_disable_xet` (default `true`), forcing the classic HTTP path with `open("ab")` + Range resume.
2. **The first version of that fix was falsified live**: hub 0.30.2 has no `HF_HUB_DISABLE_XET` constant — the env var was a no-op (kill-at-2.6GB probe still restarted from zero). Bumped `huggingface-hub` to `>=0.32,<1.0` (resolves 0.36.2, within every transitive constraint). Re-ran the probe: the same ETag-named `.incomplete` grew **2.02 GB → 2.44 GB** across a kill/restart — genuine byte-append resume.
3. **Completed downloads reported `progress: 0.93`.** Catalog `size_gb` values are decimal GB (HF's listings) but the endpoint multiplied by 1024³, overstating totals ~7%. Now uses 1000³.

## Live Verification (Hermes-Scale, Real HF)

- 29.7 GB Q6_K: download started, real-time progress ticks (~66 MB/s), **cancel in 61 ms** (worker group terminated, state → idle, partial preserved), completion → `state: done`, file lands and `inspect_gguf` validates.
- Delete: active model → **409** (file intact); out-of-root → generic 404 in 3.5 ms; inactive 28 GB model → deleted in 3 s.
- Byte-resume probe: kill at 2.02 GB → restart → partial appends (2.44 GB at t+8s), never resets.

## Gates

Full suite **1147 passed** (hub 0.36.2 — no ripples in transformers/sentence-transformers); black, flake8, mypy clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)