### PR TITLE
Gate Model Loading Behind APPLY/EJECT; Fix the Swap Port-Release Race

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -913,6 +913,7 @@ timeout_seconds = 2.0            # per HTTP health probe
 startup_deadline_seconds = 30.0  # nexus up waits this long per service
 poll_interval_seconds = 0.25
 stop_grace_seconds = 10.0        # terminate -> kill escalation on nexus down
+port_release_timeout_seconds = 5.0 # swap waits this long for the old llama-server's socket
 
 [runtime.logs]
 tail_lines = 100          # default for `nexus logs`

--- a/nexus/api/local_inference.py
+++ b/nexus/api/local_inference.py
@@ -407,6 +407,12 @@ def _deactivate_locked(settings: Settings) -> dict[str, Any]:
         except ProcessLookupError:
             pass
     _state_path(settings).unlink(missing_ok=True)
+    # Teardown is not finished until the listener is gone: the record is
+    # already unlinked, so a follow-up activate (EJECT then APPLY) would
+    # otherwise fast-probe the port, meet this server's lingering socket,
+    # and reject with a spurious foreign-occupancy 409.
+    host, port, _ = _endpoint(settings)
+    _await_port_release(settings, host, port)
     return {"stopped": True, "pid": pid}
 
 
@@ -427,22 +433,15 @@ def activate(gguf_path: str) -> dict[str, Any]:
         settings = load_settings()
         host, port, alias = _endpoint(settings)
         current = _read_active(settings)
-        just_stopped_own = False
         if current is not None and current.get("failed") is not True:
             if Path(current["gguf_path"]) == candidate:
                 return current
+            # Waits out the dying server's socket before returning, so the
+            # probe below only ever sees genuinely foreign occupancy.
             _deactivate_locked(settings)
-            just_stopped_own = True
         elif current is not None:
             _state_path(settings).unlink(missing_ok=True)
-        # Foreign occupancy fails fast; our own just-stopped server gets the
-        # release window before its lingering socket counts as foreign.
-        port_busy = (
-            not _await_port_release(settings, host, port)
-            if just_stopped_own
-            else _port_open(settings, host, port)
-        )
-        if port_busy:
+        if _port_open(settings, host, port):
             raise LocalInferenceError(
                 f"Port {port} is already in use by a process this manager does "
                 "not own; stop the static llama_server service or the other "

--- a/nexus/api/local_inference.py
+++ b/nexus/api/local_inference.py
@@ -239,6 +239,28 @@ def _port_open(settings: Settings, host: str, port: int) -> bool:
         return sock.connect_ex((host, port)) == 0
 
 
+def _await_port_release(settings: Settings, host: str, port: int) -> bool:
+    """Poll until the managed port stops accepting connections.
+
+    A just-killed llama-server can hold its listener for a beat after
+    SIGKILL (kernel socket teardown), and one dying mid-mmap of a large
+    model routinely rides out the whole SIGTERM grace first. Probing the
+    port instantly after teardown misreads our own dying server as a
+    foreign occupant and rejects the swap with a spurious 409. Returns
+    True once the port frees within the release window, False if it is
+    still held at the deadline (a genuinely foreign process).
+    """
+    if settings.runtime is None:
+        raise LocalInferenceError("[runtime] is required for port probe settings")
+    health = settings.runtime.health
+    deadline = time.monotonic() + health.port_release_timeout_seconds
+    while _port_open(settings, host, port):
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(health.poll_interval_seconds)
+    return True
+
+
 def _process_is_ours(settings: Settings, pid: int, gguf_path: str) -> bool:
     """Verify a live PID still names our binary and exact recorded model path."""
     if settings.runtime is None:
@@ -405,13 +427,22 @@ def activate(gguf_path: str) -> dict[str, Any]:
         settings = load_settings()
         host, port, alias = _endpoint(settings)
         current = _read_active(settings)
+        just_stopped_own = False
         if current is not None and current.get("failed") is not True:
             if Path(current["gguf_path"]) == candidate:
                 return current
             _deactivate_locked(settings)
+            just_stopped_own = True
         elif current is not None:
             _state_path(settings).unlink(missing_ok=True)
-        if _port_open(settings, host, port):
+        # Foreign occupancy fails fast; our own just-stopped server gets the
+        # release window before its lingering socket counts as foreign.
+        port_busy = (
+            not _await_port_release(settings, host, port)
+            if just_stopped_own
+            else _port_open(settings, host, port)
+        )
+        if port_busy:
             raise LocalInferenceError(
                 f"Port {port} is already in use by a process this manager does "
                 "not own; stop the static llama_server service or the other "

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -380,6 +380,14 @@ class RuntimeHealthSettings(BaseModel):
         gt=0,
         description="SIGTERM-to-SIGKILL escalation window on nexus down",
     )
+    port_release_timeout_seconds: float = Field(
+        default=5.0,
+        gt=0,
+        description=(
+            "How long a model swap waits for the just-stopped llama-server "
+            "to release its port before treating the occupant as foreign"
+        ),
+    )
 
 
 class RuntimeLogsSettings(BaseModel):

--- a/tests/test_api/test_local_inference.py
+++ b/tests/test_api/test_local_inference.py
@@ -632,15 +632,58 @@ def test_download_worker_fetches_files_in_order(tmp_path: Path, monkeypatch) -> 
     ]
 
 
-def test_swap_waits_for_own_port_release(tmp_path: Path, monkeypatch) -> None:
-    """A swap tolerates the dying server's lingering socket instead of 409ing."""
+def test_deactivate_waits_for_port_release(tmp_path: Path, monkeypatch) -> None:
+    """Teardown returns only after the dying server's socket frees.
+
+    The record is unlinked before the wait, so without it an immediate
+    follow-up activate (EJECT then APPLY) would fast-probe the port and
+    misread the lingering socket as foreign occupancy.
+    """
+    settings = _settings_with_state_dir(tmp_path)
+    state_path = tmp_path / local_inference.STATE_FILENAME
+    state_path.write_text("{}")
+    probes = {"count": 0}
+
+    def flaky_port_open(settings, host, port):
+        # Held for the first two probes (socket teardown lag), then free.
+        probes["count"] += 1
+        return probes["count"] <= 2
+
+    monkeypatch.setattr(
+        local_inference,
+        "_read_active",
+        lambda value: {
+            "pid": 43210,
+            "gguf_path": "/served/model.gguf",
+            "ready": True,
+            "failed": False,
+        },
+    )
+    monkeypatch.setattr(local_inference, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        local_inference, "_process_is_ours", lambda settings, pid, path: True
+    )
+    monkeypatch.setattr(local_inference, "_signal_process_group", lambda pid, sig: None)
+    monkeypatch.setattr(local_inference, "_port_open", flaky_port_open)
+    monkeypatch.setattr(local_inference.time, "sleep", lambda seconds: None)
+
+    result = local_inference._deactivate_locked(settings)
+
+    assert result == {"stopped": True, "pid": 43210}
+    assert not state_path.exists()
+    assert probes["count"] >= 3
+
+
+def test_swap_proceeds_once_teardown_frees_the_port(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A swap spawns after real teardown (with its port wait) completes."""
     settings = _settings_with_state_dir(tmp_path)
     gguf_path = tmp_path / "next.gguf"
     gguf_path.write_bytes(b"GGUF")
     probes = {"count": 0}
 
     def flaky_port_open(settings, host, port):
-        # Held for the first two probes (teardown lag), then released.
         probes["count"] += 1
         return probes["count"] <= 2
 
@@ -660,12 +703,11 @@ def test_swap_waits_for_own_port_release(tmp_path: Path, monkeypatch) -> None:
             "failed": False,
         },
     )
-    deactivations = []
+    monkeypatch.setattr(local_inference, "_pid_alive", lambda pid: False)
     monkeypatch.setattr(
-        local_inference,
-        "_deactivate_locked",
-        lambda value: deactivations.append(value) or {},
+        local_inference, "_process_is_ours", lambda settings, pid, path: True
     )
+    monkeypatch.setattr(local_inference, "_signal_process_group", lambda pid, sig: None)
     monkeypatch.setattr(local_inference, "_port_open", flaky_port_open)
     monkeypatch.setattr(local_inference.time, "sleep", lambda seconds: None)
     monkeypatch.setattr(local_inference.shutil, "which", lambda value: value)
@@ -677,15 +719,14 @@ def test_swap_waits_for_own_port_release(tmp_path: Path, monkeypatch) -> None:
 
     result = local_inference.activate(str(gguf_path))
 
-    assert deactivations, "swap should tear down the previous server"
+    # Two held probes inside teardown's release wait, one free probe there,
+    # then activate's own fast probe sees it free and spawns.
     assert result["pid"] == 54321
     assert probes["count"] >= 3
 
 
-def test_swap_rejects_port_still_held_past_release_window(
-    tmp_path: Path, monkeypatch
-) -> None:
-    """A port held beyond the release window is treated as foreign."""
+def test_swap_rejects_port_held_by_foreign_process(tmp_path: Path, monkeypatch) -> None:
+    """A port still held past the release window is treated as foreign."""
     settings = _settings_with_state_dir(tmp_path)
     assert settings.runtime is not None
     settings.runtime.health.port_release_timeout_seconds = 0.01
@@ -708,7 +749,11 @@ def test_swap_rejects_port_still_held_past_release_window(
             "failed": False,
         },
     )
-    monkeypatch.setattr(local_inference, "_deactivate_locked", lambda value: {})
+    monkeypatch.setattr(local_inference, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        local_inference, "_process_is_ours", lambda settings, pid, path: True
+    )
+    monkeypatch.setattr(local_inference, "_signal_process_group", lambda pid, sig: None)
     monkeypatch.setattr(
         local_inference, "_port_open", lambda settings, host, port: True
     )

--- a/tests/test_api/test_local_inference.py
+++ b/tests/test_api/test_local_inference.py
@@ -630,3 +630,89 @@ def test_download_worker_fetches_files_in_order(tmp_path: Path, monkeypatch) -> 
             "local_dir": str(tmp_path),
         },
     ]
+
+
+def test_swap_waits_for_own_port_release(tmp_path: Path, monkeypatch) -> None:
+    """A swap tolerates the dying server's lingering socket instead of 409ing."""
+    settings = _settings_with_state_dir(tmp_path)
+    gguf_path = tmp_path / "next.gguf"
+    gguf_path.write_bytes(b"GGUF")
+    probes = {"count": 0}
+
+    def flaky_port_open(settings, host, port):
+        # Held for the first two probes (teardown lag), then released.
+        probes["count"] += 1
+        return probes["count"] <= 2
+
+    monkeypatch.setattr(local_inference, "load_settings", lambda: settings)
+    monkeypatch.setattr(
+        local_inference,
+        "inspect_gguf",
+        lambda path: GgufInfo(architecture="test", quantization="Q6_K", valid=True),
+    )
+    monkeypatch.setattr(
+        local_inference,
+        "_read_active",
+        lambda value: {
+            "pid": 43210,
+            "gguf_path": "/previous/model.gguf",
+            "ready": True,
+            "failed": False,
+        },
+    )
+    deactivations = []
+    monkeypatch.setattr(
+        local_inference,
+        "_deactivate_locked",
+        lambda value: deactivations.append(value) or {},
+    )
+    monkeypatch.setattr(local_inference, "_port_open", flaky_port_open)
+    monkeypatch.setattr(local_inference.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(local_inference.shutil, "which", lambda value: value)
+    monkeypatch.setattr(
+        local_inference.subprocess,
+        "Popen",
+        lambda command, **kwargs: SimpleNamespace(pid=54321),
+    )
+
+    result = local_inference.activate(str(gguf_path))
+
+    assert deactivations, "swap should tear down the previous server"
+    assert result["pid"] == 54321
+    assert probes["count"] >= 3
+
+
+def test_swap_rejects_port_still_held_past_release_window(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A port held beyond the release window is treated as foreign."""
+    settings = _settings_with_state_dir(tmp_path)
+    assert settings.runtime is not None
+    settings.runtime.health.port_release_timeout_seconds = 0.01
+    gguf_path = tmp_path / "next.gguf"
+    gguf_path.write_bytes(b"GGUF")
+
+    monkeypatch.setattr(local_inference, "load_settings", lambda: settings)
+    monkeypatch.setattr(
+        local_inference,
+        "inspect_gguf",
+        lambda path: GgufInfo(architecture="test", quantization="Q6_K", valid=True),
+    )
+    monkeypatch.setattr(
+        local_inference,
+        "_read_active",
+        lambda value: {
+            "pid": 43210,
+            "gguf_path": "/previous/model.gguf",
+            "ready": True,
+            "failed": False,
+        },
+    )
+    monkeypatch.setattr(local_inference, "_deactivate_locked", lambda value: {})
+    monkeypatch.setattr(
+        local_inference, "_port_open", lambda settings, host, port: True
+    )
+    monkeypatch.setattr(local_inference.time, "sleep", lambda seconds: None)
+
+    with pytest.raises(local_inference.LocalInferenceError, match="already in use"):
+        local_inference.activate(str(gguf_path))

--- a/ui/client/src/components/nexus/LocalModelRows.test.tsx
+++ b/ui/client/src/components/nexus/LocalModelRows.test.tsx
@@ -195,29 +195,43 @@ describe("LocalModelRows", () => {
     expect(apiRequestMock).not.toHaveBeenCalled();
   });
 
-  it("activates and selects local when a ready non-serving quant is clicked", () => {
+  it("stages a ready quant on click without any network write", () => {
     const onPickLocal = vi.fn();
-    renderRows({
-      status: {
-        ...STATUS,
-        installed: [
-          ...STATUS.installed,
-          {
-            path: `${MODELS_DIR}/Hermes-4.3-36B-GGUF/h36-q6.gguf`,
-            filename: "h36-q6.gguf",
-            arch: "seed_oss",
-            quant: "Q6_K",
-            size_bytes: 29_700_000_000,
-            verified: true,
-            active: false,
-          },
-        ],
-      },
-      onPickLocal,
-    });
+    renderRows({ status: WITH_Q6_INSTALLED, onPickLocal });
+
+    fireEvent.click(screen.getByTestId("lm-toggle-hermes-4.3-36b"));
+    const row = screen.getByTestId("lm-quant-hermes-4.3-36b-Q6_K");
+    fireEvent.click(row);
+
+    expect(row).toHaveClass("staged");
+    expect(screen.getByTestId("lm-staged-caption")).toHaveTextContent(
+      "hermes 4.3 36b q6_k · 29.7 gb",
+    );
+    expect(apiRequestMock).not.toHaveBeenCalled();
+    expect(onPickLocal).not.toHaveBeenCalled();
+  });
+
+  it("unstages on a second click and hides APPLY", () => {
+    renderRows({ status: WITH_Q6_INSTALLED });
+
+    fireEvent.click(screen.getByTestId("lm-toggle-hermes-4.3-36b"));
+    const row = screen.getByTestId("lm-quant-hermes-4.3-36b-Q6_K");
+    fireEvent.click(row);
+    expect(screen.getByTestId("lm-apply")).toBeInTheDocument();
+    fireEvent.click(row);
+
+    expect(row).not.toHaveClass("staged");
+    expect(screen.queryByTestId("lm-apply")).not.toBeInTheDocument();
+    expect(apiRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("APPLY loads the staged quant and selects local as storyteller", () => {
+    const onPickLocal = vi.fn();
+    renderRows({ status: WITH_Q6_INSTALLED, onPickLocal });
 
     fireEvent.click(screen.getByTestId("lm-toggle-hermes-4.3-36b"));
     fireEvent.click(screen.getByTestId("lm-quant-hermes-4.3-36b-Q6_K"));
+    fireEvent.click(screen.getByTestId("lm-apply"));
 
     expect(apiRequestMock).toHaveBeenCalledWith(
       "POST",
@@ -225,6 +239,35 @@ describe("LocalModelRows", () => {
       { path: `${MODELS_DIR}/Hermes-4.3-36B-GGUF/h36-q6.gguf` },
     );
     expect(onPickLocal).toHaveBeenCalledTimes(1);
+  });
+
+  it("EJECT unloads the serving model", () => {
+    renderRows();
+
+    fireEvent.click(screen.getByTestId("lm-eject"));
+
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      "POST",
+      "/api/local-models/deactivate",
+    );
+  });
+
+  it("family click with nothing serving only toggles the quant list", () => {
+    const onPickLocal = vi.fn();
+    renderRows({
+      status: { ...WITH_Q6_INSTALLED, active: null },
+      onPickLocal,
+    });
+
+    fireEvent.click(screen.getByTestId("model-local-hermes-4.3-36b"));
+
+    // The accordion opened (quant rows now in the document), but nothing
+    // loaded and the storyteller selection did not move.
+    expect(
+      screen.getByTestId("lm-quant-hermes-4.3-36b-Q6_K"),
+    ).toBeInTheDocument();
+    expect(apiRequestMock).not.toHaveBeenCalled();
+    expect(onPickLocal).not.toHaveBeenCalled();
   });
 
   it("starts a download when an absent quant is clicked", () => {

--- a/ui/client/src/components/nexus/LocalModelRows.tsx
+++ b/ui/client/src/components/nexus/LocalModelRows.tsx
@@ -4,10 +4,17 @@
  * "Local LLM Manager - Final").
  *
  * Each catalog family renders as a model-row with a chevron-expanded
- * quant list. Quant states: absent (download), downloading (percent +
- * cancel + thin progress bar), ready (activate on click, two-stage armed
- * delete), exceeds-RAM (dimmed, tooltip). Activating a quant also selects
- * the local provider as the storyteller model, mirroring the prototype.
+ * quant list. Quant states: absent (download on click), downloading
+ * (percent + cancel + thin progress bar), ready (STAGE on click,
+ * two-stage armed delete), exceeds-RAM (dimmed, tooltip).
+ *
+ * Loading is gated behind an explicit APPLY (owner decision after
+ * hands-on use): clicking a ready quant only stages it — these are
+ * 20-75 GB models whose swaps take tens of seconds to minutes, so
+ * nothing that heavy may ride on a single row click. APPLY activates
+ * the staged quant and selects local as the storyteller; EJECT unloads
+ * the serving model. Downloads stay direct: they never disturb the
+ * serving model and carry their own cancel.
  *
  * Server truth arrives by polling; cadence comes from `[ui.local_models]`
  * in nexus.toml. Activation is fire-and-forget on the backend, so the
@@ -98,6 +105,8 @@ export function LocalModelRows({
 
   const [open, setOpen] = useState<Record<string, boolean>>({});
   const [armed, setArmed] = useState<string | null>(null);
+  // Client-local staged quant path; APPLY is the only thing that loads it.
+  const [staged, setStaged] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   // In-flight action guard: server-derived guards (downloading, isLoading)
   // only flip after the POST's invalidation refetch lands, leaving a
@@ -216,27 +225,23 @@ export function LocalModelRows({
       onPickLocal();
       return;
     }
-    if (pending) return;
-    setActionError(null);
-    const best = quants
-      .filter((q) => q.ready && !q.exceeds)
-      .sort((a, b) => b.entry.size_gb - a.entry.size_gb)[0];
-    if (best) {
-      run(() => actions.activate(best.path));
-      onPickLocal();
-      return;
-    }
-    // Nothing runnable: open the quant list so the download menu is the
-    // affordance the click lands on.
-    setOpen((state) => ({ ...state, [quants[0].entry.family]: true }));
+    // Nothing serving here: the click opens the quant list. Loading only
+    // ever happens through APPLY on an explicitly staged quant.
+    setOpen((state) => ({
+      ...state,
+      [quants[0].entry.family]: !state[quants[0].entry.family],
+    }));
   };
 
   const clickQuant = (q: QuantView) => {
     if (pending || q.exceeds || q.isDownloading || q.isLoading) return;
     setActionError(null);
-    if (q.ready) {
-      if (!q.isActive) run(() => actions.activate(q.path));
+    if (q.isActive) {
       onPickLocal();
+      return;
+    }
+    if (q.ready) {
+      setStaged((current) => (current === q.path ? null : q.path));
       return;
     }
     if (!downloading) {
@@ -257,6 +262,36 @@ export function LocalModelRows({
       : downloadError
         ? { title: "DOWNLOAD FAILED", text: downloadError }
         : null;
+
+  // A staged path is honored only while it still names a loadable,
+  // non-serving quant in current server truth (a delete or an external
+  // swap invalidates it silently).
+  const stagedGroup = staged
+    ? families.find(([, group]) =>
+        group.quants.some(
+          (q) => q.path === staged && q.ready && !q.exceeds && !q.isActive,
+        ),
+      )
+    : undefined;
+  const stagedQuant = stagedGroup?.[1].quants.find((q) => q.path === staged);
+  const stagedLabel = stagedQuant
+    ? `${stagedGroup![1].label.toLowerCase()} ${stagedQuant.entry.quant.toLowerCase()} · ${stagedQuant.entry.size_gb.toFixed(1)} gb`
+    : null;
+  const serving = Boolean(status.active && !status.active.failed);
+
+  const applyStaged = () => {
+    if (!stagedQuant || pending) return;
+    setActionError(null);
+    setStaged(null);
+    run(() => actions.activate(stagedQuant.path));
+    onPickLocal();
+  };
+
+  const eject = () => {
+    if (pending) return;
+    setActionError(null);
+    run(() => actions.deactivate());
+  };
 
   return (
     <TooltipProvider>
@@ -324,6 +359,7 @@ export function LocalModelRows({
                           "lm-quant",
                           q.ready ? "ready" : "",
                           q.isActive ? "active" : "",
+                          stagedQuant?.path === q.path ? "staged" : "",
                           q.isDownloading ? "dl" : "",
                           q.exceeds ? "exceeds" : "",
                           blocked ? "blocked" : "",
@@ -352,6 +388,8 @@ export function LocalModelRows({
                             <span
                               className={`lm-dot ${q.isLoading ? "loading" : ""}`}
                             />
+                          ) : stagedQuant?.path === q.path ? (
+                            <span className="lm-stage-mark" />
                           ) : !q.installed && !q.exceeds ? (
                             <ArrowDownToLine size={12} className="lm-get" />
                           ) : null}
@@ -442,6 +480,39 @@ export function LocalModelRows({
           </Collapsible>
         );
       })}
+      {(stagedQuant || serving) && (
+        <li className="lm-group lm-actions" data-testid="lm-actions">
+          {stagedLabel && (
+            <span
+              className="caption dim lm-staged-caption"
+              data-testid="lm-staged-caption"
+            >
+              {stagedLabel}
+            </span>
+          )}
+          <span className="lm-spacer" />
+          {serving && (
+            <button
+              className="btn-soft"
+              onClick={eject}
+              aria-label="Unload the serving local model"
+              data-testid="lm-eject"
+            >
+              EJECT
+            </button>
+          )}
+          {stagedQuant && (
+            <button
+              className="btn-primary"
+              onClick={applyStaged}
+              aria-label={`Load ${stagedLabel ?? "staged quant"}`}
+              data-testid="lm-apply"
+            >
+              APPLY
+            </button>
+          )}
+        </li>
+      )}
       {alert && (
         <li className="lm-group">
           <div className="alert danger lm-alert" data-testid="lm-alert">

--- a/ui/client/src/components/nexus/nexus-layout.css
+++ b/ui/client/src/components/nexus/nexus-layout.css
@@ -1591,10 +1591,12 @@
   display: grid; grid-template-columns: 12px 62px 1fr auto;
   gap: 9px; align-items: center;
   min-height: 30px; padding: 4px 10px;
+  border: 1px solid transparent;
   border-radius: var(--radius-sm);
   cursor: pointer;
 }
 .lm-quant.ready { background: var(--bg-elev-3); }
+.lm-quant.staged { border-color: var(--brass); border-style: dashed; }
 .lm-quant.dl { cursor: default; }
 .lm-quant.exceeds { opacity: .35; cursor: not-allowed; }
 .lm-quant.blocked { opacity: .5; cursor: default; }
@@ -1632,6 +1634,15 @@
   box-shadow: var(--glow-soft);
   transition: width .18s linear;
 }
+.lm-stage-mark {
+  width: 5px; height: 5px; border-radius: 50%;
+  border: 1px solid var(--brass-bright);
+}
+.lm-actions {
+  display: flex; align-items: center; gap: 10px;
+  padding: 4px 10px 8px;
+}
+.lm-staged-caption { letter-spacing: .1em; }
 .lm-alert { margin-top: 4px; }
 /* Portaled outside .nexus-shell; brand tokens resolve via html.dark. */
 .lm-tip.lm-tip {


### PR DESCRIPTION
Owner feedback after first hands-on use of the #465 model manager (PR #482): family clicks auto-loaded the family's **largest** installed quant (one click = a 75 GB, minutes-long load), swapping away from a mid-load server felt like lag, and rapid switching surfaced spurious `409: Port 1234 is already in use by a process this manager does not own` — making quant selection feel dead.

## Manager Fix (the actual bug)

`activate()` killed its own server and probed the port **instantly**. A llama-server dying mid-mmap rides out the whole SIGTERM grace and its listener lingers a beat past SIGKILL, so the probe misread the manager's own dying server as a foreign occupant. The gateway log showed the signature: `200, 409, 200, 200, 409` under rapid switching.

The swap path now waits through `[runtime.health].port_release_timeout_seconds` (new tunable, default 5.0) for the port to free before treating the occupant as foreign; genuinely foreign occupancy still fails fast. Both directions regression-tested, and **live-verified with the previously-failing pattern**: APPLY during a mid-load swap now lands `200/200` (was `200/409`), target model serving, UI converging on the busy poll.

## UI Redesign (owner decision: explicit APPLY)

- Clicking a ready quant **stages** it — dashed brass border, hollow marker, staged caption. No network.
- **APPLY** activates the staged quant and selects local as the storyteller. **EJECT** unloads the serving model — and doubles as the escape hatch from a regretted mid-load swap. Both render only when applicable.
- Family clicks only expand the quant list; the auto-load heuristic is gone entirely.
- Downloads stay direct (they never disturb the serving model and carry their own cancel); two-stage armed delete unchanged.
- Staged state is honored only while server truth still shows the quant loadable (a delete or external swap silently invalidates it).

Live-verified end to end in the browser: stage/unstage toggling, APPLY → loading pulse → ready, the mid-load APPLY swap, EJECT → topbar meter vanishes, clean rest state. 210 UI tests, 20 manager tests, `tsc`/`black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fDr2FWHMuebgKWuhgsTvh