### PR TITLE
Add the Replay Consumer: Point-in-Time State Reconstruction and the Checkpoint Verify Oracle

### DIFF
--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -24,8 +24,11 @@ produces. Sections and their replay sources:
   Exact only while ``[orrery.sunhelm]`` tuning matches its value at the
   original commit; the tuning is not versioned. The un-ledgered
   need-applicability trigger (migration 057: entity_tags changes insert/
-  delete need rows and clear severity tags) is mirrored after tag replay,
-  since its final effect is a pure function of the final tag set.
+  delete need rows and clear severity tags) is mirrored after tag replay:
+  row presence follows the final tag set, and rows whose applicability
+  toggled off-and-back inside the window are reset to the trigger's
+  fresh-insert shape (detected chronologically from chunk-keyed
+  immunity-tag events).
 - ``character_travel_states`` — forward for explicit payloads;
   ``travel.start`` resolves destinations and routes from live state at
   commit time, so windows containing travel deltas are approximate.
@@ -55,6 +58,7 @@ from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Optional
 
 from nexus.agents.orrery.needs import (
+    NEED_IMMUNITY_TAGS,
     NEED_TYPES,
     effective_debt_score,
     load_need_tuning,
@@ -264,11 +268,13 @@ def _coerce_need_payload(raw: Any) -> dict[str, Any]:
 
 
 def _coerce_travel_payload(raw: Any) -> dict[str, Any]:
-    if raw is True:
+    # Mirror events._coerce_travel_payload: None and True both mean "use
+    # defaults" — a JSON null travel value is a live production write path.
+    if raw is None or raw is True:
         return {}
     if isinstance(raw, dict):
         return dict(raw)
-    raise ValueError(f"travel payload must be a mapping or true, got {raw!r}")
+    raise ValueError(f"travel payload must be a mapping, null, or true, got {raw!r}")
 
 
 class _Replayer:
@@ -367,6 +373,8 @@ class _Replayer:
             characters,
             tag_workings["entity_tags"],
             needs,
+            base_chunk,
+            base_state,
             result,
         )
         for section, working in tag_workings.items():
@@ -905,6 +913,8 @@ class _Replayer:
         characters: dict[int, dict[str, Any]],
         entity_tags_working: dict[int, dict[str, Any]],
         needs: dict[tuple[int, str], dict[str, Any]],
+        base_chunk: int,
+        base_state: dict[str, Any],
         result: ReplayResult,
     ) -> None:
         """Mirror ``orrery_sync_character_need_states`` (migration 057).
@@ -912,10 +922,14 @@ class _Replayer:
         Production triggers on entity_tags changes (and character INSERTs)
         ensure need rows for every applicable need type, DELETE rows for
         needs the entity's tags make inapplicable, and clear that need's
-        severity tags — all un-ledgered. The final table state is a pure
-        function of the final active tag set, so the mirror runs once, after
-        tag replay, over the entities whose tags changed in the window (the
-        population the trigger fired for).
+        severity tags — all un-ledgered. Row PRESENCE at the target is a
+        pure function of the final active tag set; row CONTENTS are not —
+        an applicability toggle (immunity tag applied then cleared inside
+        one window) makes production delete and re-insert a FRESH row, so
+        toggled rows are reset to the fresh-insert shape here with their
+        wall-clock-dependent columns flagged unreproducible. Toggles are
+        detected by walking the window's chunk-keyed immunity-tag events
+        chronologically.
         """
 
         if not affected_entities:
@@ -937,9 +951,13 @@ class _Replayer:
                 (list(tag_ids),),
             )
             tag_names = dict(self.cur.fetchall())
+        went_inapplicable = self._needs_that_toggled_inapplicable(
+            affected_entities & character_entities, base_chunk, base_state
+        )
 
         synthesized = 0
         deleted = 0
+        reset = 0
         severity_cleared = 0
         for entity_id in sorted(affected_entities & character_entities):
             active_tags = {
@@ -952,6 +970,7 @@ class _Replayer:
             }
             for need in NEED_TYPES:
                 key = (entity_id, need)
+                row_key = f"{entity_id}:{need}"
                 if need in applicable and key not in needs:
                     needs[key] = {
                         "character_entity_id": entity_id,
@@ -966,12 +985,40 @@ class _Replayer:
                     # The trigger stamps MAX(chunk_metadata.world_time) at
                     # firing time — not reconstructable after the fact.
                     result.unreproducible.add(
-                        (
-                            "character_need_states",
-                            f"{entity_id}:{need}",
-                            "last_evaluated_at",
-                        )
+                        ("character_need_states", row_key, "last_evaluated_at")
                     )
+                elif need in applicable and key in needs and key in went_inapplicable:
+                    # Applicability toggled off then back on inside the
+                    # window: production deleted the row and re-inserted a
+                    # FRESH one; the checkpoint-inherited contents are stale.
+                    fulfilled_after = (
+                        needs[key].get("last_evaluated_chunk_id") or 0
+                    ) > base_chunk
+                    needs[key] = {
+                        "character_entity_id": entity_id,
+                        "need_type": need,
+                        "debt_score": 0.0,
+                        "last_evaluated_at": None,
+                        "last_evaluated_chunk_id": None,
+                        "last_fulfilled_at": None,
+                        "metadata": {"synced_by": "need_applicability"},
+                    }
+                    reset += 1
+                    columns = ["last_evaluated_at"]
+                    if fulfilled_after:
+                        # A need.fulfill also landed in the window; whether
+                        # it hit the pre-toggle or post-toggle row is not
+                        # reconstructable from the ledger's chunk grain.
+                        columns += [
+                            "debt_score",
+                            "last_evaluated_chunk_id",
+                            "last_fulfilled_at",
+                            "metadata",
+                        ]
+                    for column in columns:
+                        result.unreproducible.add(
+                            ("character_need_states", row_key, column)
+                        )
                 elif need not in applicable and key in needs:
                     del needs[key]
                     deleted += 1
@@ -986,14 +1033,96 @@ class _Replayer:
                     ]:
                         del entity_tags_working[row_id]
                         severity_cleared += 1
-        if synthesized or deleted or severity_cleared:
+        if synthesized or deleted or reset or severity_cleared:
             result.add_note(
                 "character_need_states",
                 "need-applicability trigger mirrored: "
                 f"{synthesized} row(s) synthesized, {deleted} deleted, "
+                f"{reset} reset after an applicability toggle, "
                 f"{severity_cleared} un-logged severity tag clear(s) applied",
                 approximate=False,
             )
+
+    def _needs_that_toggled_inapplicable(
+        self,
+        entities: set[int],
+        base_chunk: int,
+        base_state: dict[str, Any],
+    ) -> set[tuple[int, str]]:
+        """(entity, need) pairs whose applicability went FALSE at some point
+        in the window, per a chronological walk of chunk-keyed immunity-tag
+        bestowals and clearances. An immunity tag both bestowed and cleared
+        in the SAME chunk counts as a toggle (the trigger fires per
+        statement; intra-chunk order is not reconstructable)."""
+
+        if not entities:
+            return set()
+        all_immunity = frozenset().union(*NEED_IMMUNITY_TAGS.values())
+        self.cur.execute(
+            "SELECT id, tag FROM tags WHERE tag = ANY(%s)",
+            (list(all_immunity),),
+        )
+        immunity_by_id: dict[int, str] = dict(self.cur.fetchall())
+        if not immunity_by_id:
+            return set()
+
+        current: dict[int, set[str]] = {entity: set() for entity in entities}
+        for row in base_state["entity_tags"]:
+            name = immunity_by_id.get(row["tag_id"])
+            if name is not None and row["entity_id"] in current:
+                current[row["entity_id"]].add(name)
+
+        events: dict[tuple[int, int], tuple[set[str], set[str]]] = {}
+
+        def _event(entity: int, chunk: int) -> tuple[set[str], set[str]]:
+            return events.setdefault((entity, chunk), (set(), set()))
+
+        self.cur.execute(
+            """
+            SELECT entity_id, tag_id, source_chunk_id FROM entity_tags
+            WHERE entity_id = ANY(%s) AND tag_id = ANY(%s)
+              AND source_chunk_id > %s AND source_chunk_id <= %s
+            """,
+            (
+                list(entities),
+                list(immunity_by_id),
+                base_chunk,
+                self.target_chunk_id,
+            ),
+        )
+        for entity_id, tag_id, chunk in self.cur.fetchall():
+            _event(entity_id, chunk)[0].add(immunity_by_id[tag_id])
+        self.cur.execute(
+            """
+            SELECT et.entity_id, et.tag_id, l.source_chunk_id
+            FROM tag_clearance_log l
+            JOIN entity_tags et ON et.id = l.entity_tag_id
+            WHERE et.entity_id = ANY(%s) AND et.tag_id = ANY(%s)
+              AND l.source_chunk_id > %s AND l.source_chunk_id <= %s
+            """,
+            (
+                list(entities),
+                list(immunity_by_id),
+                base_chunk,
+                self.target_chunk_id,
+            ),
+        )
+        for entity_id, tag_id, chunk in self.cur.fetchall():
+            _event(entity_id, chunk)[1].add(immunity_by_id[tag_id])
+
+        toggled: set[tuple[int, str]] = set()
+        for (entity_id, _chunk), (added, cleared) in sorted(
+            events.items(), key=lambda item: (item[0][0], item[0][1])
+        ):
+            transient = added & cleared
+            state = current[entity_id]
+            state |= added
+            state -= cleared
+            for need in NEED_TYPES:
+                immunity = NEED_IMMUNITY_TAGS[need]
+                if immunity & state or immunity & transient:
+                    toggled.add((entity_id, need))
+        return toggled
 
     # -- relationship unwind ---------------------------------------------------
 

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -620,14 +620,17 @@ class _Replayer:
         metadata["last_fulfillment"] = payload
         row["metadata"] = metadata
         if world_time is None:
-            # Production fell back to wall-clock now() at commit time —
-            # unreproducible; leave prior values and flag the columns.
-            for column in ("last_evaluated_at", "last_fulfilled_at"):
+            # Production fell back to wall-clock now() at commit time and
+            # accrued debt against it — the timestamps AND the debt math are
+            # unreproducible; leave prior timestamp values and flag all three
+            # columns.
+            for column in ("last_evaluated_at", "last_fulfilled_at", "debt_score"):
                 result.unreproducible.add(("character_need_states", row_key, column))
             result.add_note(
                 "character_need_states",
                 f"chunk {chunk_id} has NULL world_time; production stamped "
-                f"wall-clock now() on {row_key} — timestamps unreproducible",
+                f"wall-clock now() on {row_key} — timestamps and accrued "
+                "debt unreproducible",
                 approximate=True,
             )
         else:
@@ -654,6 +657,16 @@ class _Replayer:
     ) -> None:
         payload = _coerce_travel_payload(raw_payload)
         row = travel.get(actor_entity_id)
+        if world_time is None:
+            # Production stamped wall-clock now() on this tick's travel
+            # world-time columns; replay writes NULLs it cannot back.
+            time_columns = ["updated_at_world_time"]
+            if delta_key == "travel.start":
+                time_columns.append("started_at_world_time")
+            for column in time_columns:
+                result.unreproducible.add(
+                    ("character_travel_states", str(actor_entity_id), column)
+                )
         if delta_key == "travel.start":
             destination = payload.get("destination_place_id")
             origin = payload.get("origin_place_id") or (
@@ -723,11 +736,25 @@ class _Replayer:
                 "destination_place_id"
             )
             if destination is None:
+                # Production DID move the character (destination came from
+                # live travel state at commit time); replay cannot know
+                # where. Flag every column the arrival wrote so verify skips
+                # instead of reporting false drift.
+                character = characters_by_entity.get(actor_entity_id)
+                if character is not None:
+                    result.unreproducible.add(
+                        ("characters", str(character["id"]), "current_location")
+                    )
+                for column in ("anchor_place_id", "route_metadata"):
+                    result.unreproducible.add(
+                        ("character_travel_states", str(actor_entity_id), column)
+                    )
                 result.add_note(
                     "characters",
                     f"travel.arrive at chunk {chunk_id} for actor "
                     f"{actor_entity_id} has no reconstructable destination; "
-                    "current_location not updated",
+                    "current_location and arrival columns flagged "
+                    "unreproducible",
                     approximate=True,
                 )
             else:

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -1,0 +1,1236 @@
+"""Replay consumer for the reconstruction-sufficiency layer (issue #426).
+
+Reconstructs the mutable world-state surface at an arbitrary chunk N from
+the artifacts the write side (migrations 064/065, ``reconstruction.py``)
+produces. Sections and their replay sources:
+
+- ``characters`` / ``places`` scalars — forward from the base checkpoint:
+  ``state_delta_log`` rows (Skald, applied first within a chunk), then
+  ``orrery_resolutions.state_delta`` keys ``character.current_activity``
+  and ``travel.arrive`` (whose location write is *not* Skald-ledgered).
+- ``entity_tags`` / ``entity_pair_tags`` — forward from the checkpoint via
+  the provenance tables alone: bestowals keyed by ``source_chunk_id``,
+  clearances by ``tag_clearance_log.source_chunk_id``. The tag keys inside
+  ``orrery_resolutions.state_delta`` are deliberately ignored: the same
+  commit already wrote them to the provenance tables (double-entry), and
+  ``need.fulfill``'s derived severity tags exist *only* in provenance.
+- the three relationship tables — backward from the *current* rows,
+  unwinding ``relationship_versions`` pre-images (``id DESC``), then
+  dropping rows whose ``created_at`` postdates chunk N (INSERTs never fire
+  the versioning triggers; wall-clock correlation is the only insert-time
+  evidence).
+- ``character_need_states`` — forward, re-executing ``need.fulfill``
+  through the same ``effective_debt_score`` authority production used.
+  Exact only while ``[orrery.sunhelm]`` tuning matches its value at the
+  original commit; the tuning is not versioned. The un-ledgered
+  need-applicability trigger (migration 057: entity_tags changes insert/
+  delete need rows and clear severity tags) is mirrored after tag replay,
+  since its final effect is a pure function of the final tag set.
+- ``character_travel_states`` — forward for explicit payloads;
+  ``travel.start`` resolves destinations and routes from live state at
+  commit time, so windows containing travel deltas are approximate.
+- ``character_routine_anchors`` — checkpoint pass-through (no runtime
+  writer; offline seed scripts mutate it invisibly between checkpoints).
+
+Known undetectable gaps: (1) reapplication policies ``replace`` and
+``extend_expiry`` overwrite a live tag row's ``source_chunk_id`` in place
+with no history row — a tag bestowed inside the window and re-applied
+after N reads as bestowed later and drops out of the reconstruction;
+(2) a manual checkpoint taken long after its chunk committed snapshots
+capture-time state, but replay correlates wall-clock evidence against the
+chunk's created_at — offline edits in that gap blur the boundary.
+
+``verify_checkpoints_sync`` turns every stored checkpoint pair into a
+regression oracle: reconstruct forward from checkpoint A to checkpoint B's
+chunk and diff against B's stored document. Any writer that ships
+un-ledgered shows up as drift here.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Any, Optional
+
+from nexus.agents.orrery.needs import (
+    NEED_TYPES,
+    effective_debt_score,
+    load_need_tuning,
+    need_applies_to_tags,
+    severity_tags_for_need,
+)
+from nexus.agents.orrery.reconstruction import CHECKPOINT_SECTIONS
+
+# Composite natural keys, verbatim column order (faction_relationships
+# enforces faction1_id < faction2_id; character_relationships only c1 <> c2
+# — never re-canonicalize when re-inserting delete pre-images).
+RELATIONSHIP_KEY_COLUMNS: dict[str, tuple[str, ...]] = {
+    "character_relationships": ("character1_id", "character2_id"),
+    "faction_character_relationships": ("faction_id", "character_id"),
+    "faction_relationships": ("faction1_id", "faction2_id"),
+}
+
+# Wall-clock columns the DB stamps with now() at write time; excluded from
+# verify comparison because replay cannot reproduce them by design.
+VOLATILE_COLUMNS: dict[str, frozenset[str]] = {
+    "character_need_states": frozenset({"created_at", "updated_at"}),
+    "character_travel_states": frozenset({"created_at", "updated_at"}),
+}
+
+SKALD_SCALAR_FIELDS = frozenset(
+    {
+        "characters.emotional_state",
+        "characters.current_activity",
+        "characters.current_location",
+        "places.current_status",
+    }
+)
+
+# Delta keys whose effects live entirely in the tag provenance tables;
+# replaying them here would double-count.
+TAG_DELTA_KEYS = frozenset(
+    {
+        "entity_tags.add",
+        "entity_tags.remove",
+        "entity_tags_target.add",
+        "entity_tags_target.remove",
+        "entity_pair_tags.add_outbound",
+        "entity_pair_tags.clear_outbound",
+        "entity_pair_tags_target.clear_inbound",
+    }
+)
+
+REPLAYED_DELTA_KEYS = frozenset(
+    {
+        "character.current_activity",
+        "need.fulfill",
+        "travel.start",
+        "travel.advance",
+        "travel.delay",
+        "travel.arrive",
+    }
+)
+
+# Mirrors the applier default at events.py _apply_travel_advance_sync.
+TRAVEL_ADVANCE_DEFAULT_DELTA = 0.35
+
+
+def _pg_round(value: float, places: int) -> float:
+    """Round the way Postgres numeric(_, places) storage does — half away
+    from zero, not Python's banker's rounding."""
+
+    quantum = Decimal(1).scaleb(-places)
+    return float(Decimal(str(value)).quantize(quantum, rounding=ROUND_HALF_UP))
+
+
+@dataclass
+class ReplayResult:
+    """A reconstructed state document plus its honesty report."""
+
+    target_chunk_id: int
+    base_checkpoint_id: int
+    base_checkpoint_chunk_id: int
+    state: dict[str, list[dict[str, Any]]]
+    notes: dict[str, list[str]] = field(default_factory=dict)
+    approximate_sections: set[str] = field(default_factory=set)
+    # (section, row_key, column) triples replay could not reproduce
+    # (e.g. timestamps from a NULL-world-time tick); verify skips these.
+    unreproducible: set[tuple[str, str, str]] = field(default_factory=set)
+    # (section, row_key) pairs whose PRESENCE at the target is undecidable:
+    # Step 8.6 of the commit (maturation stubs + tag hints) runs after the
+    # Step 8.55 checkpoint inside one transaction, and now() is constant
+    # across it, so wall-clock bounds cannot split "before capture" from
+    # "after capture" at the target chunk. Verify skips presence mismatches
+    # on these rows instead of reporting phantom drift.
+    uncertain_rows: set[tuple[str, str]] = field(default_factory=set)
+
+    def add_note(self, section: str, note: str, *, approximate: bool) -> None:
+        self.notes.setdefault(section, []).append(note)
+        if approximate:
+            self.approximate_sections.add(section)
+
+
+@dataclass
+class Drift:
+    section: str
+    row_key: str
+    column: Optional[str]
+    kind: str  # 'missing_row' | 'extra_row' | 'value'
+    expected: Any
+    actual: Any
+
+
+@dataclass
+class CheckpointPairVerdict:
+    base_checkpoint_id: int
+    base_chunk_id: int
+    target_checkpoint_id: int
+    target_chunk_id: int
+    drifts: list[Drift]
+    skipped_unreproducible: int
+    notes: dict[str, list[str]]
+
+
+def _as_document(value: Any) -> dict[str, Any]:
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+def _row_value(row: Any, index: int) -> Any:
+    return row[index]
+
+
+def _fetch_chunk_created_at(cur: Any, chunk_id: int) -> datetime:
+    cur.execute("SELECT created_at FROM narrative_chunks WHERE id = %s", (chunk_id,))
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"Chunk {chunk_id} does not exist")
+    created_at = _row_value(row, 0)
+    if created_at is None:
+        raise ValueError(
+            f"Chunk {chunk_id} has NULL created_at; wall-clock correlation "
+            "for relationship inserts is impossible"
+        )
+    return created_at
+
+
+def _fetch_world_time(cur: Any, chunk_id: int) -> Optional[datetime]:
+    cur.execute(
+        "SELECT world_time FROM chunk_metadata WHERE chunk_id = %s", (chunk_id,)
+    )
+    row = cur.fetchone()
+    return _row_value(row, 0) if row is not None else None
+
+
+def _isoformat(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def _canonical_datetime(value: datetime) -> str:
+    # Same instant, different offsets ("+00:00" vs "-04:00") must compare
+    # equal; aware datetimes normalize to UTC before serializing.
+    if value.tzinfo is not None:
+        value = value.astimezone(timezone.utc)
+    return value.isoformat()
+
+
+def canonicalize(value: Any) -> Any:
+    """Normalize a leaf value for cross-representation equality.
+
+    Checkpoint documents come from ``to_jsonb`` (timestamps as ISO strings,
+    numerics as JSON numbers); replayed rows carry Python datetimes and
+    floats. Both sides funnel through here before comparison.
+    """
+
+    if isinstance(value, datetime):
+        return _canonical_datetime(value)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return _canonical_datetime(datetime.fromisoformat(value))
+        except ValueError:
+            pass
+        try:
+            return float(value)
+        except ValueError:
+            return value
+    return value
+
+
+def _coerce_need_payload(raw: Any) -> dict[str, Any]:
+    """Mirror events._coerce_need_fulfillment for byte-identical metadata."""
+
+    if isinstance(raw, str):
+        payload: dict[str, Any] = {"type": raw}
+    elif isinstance(raw, dict):
+        payload = dict(raw)
+    else:
+        raise ValueError(f"need.fulfill must be a string or mapping, got {raw!r}")
+    need_type = payload.get("type") or payload.get("need")
+    if need_type is None:
+        raise ValueError("need.fulfill payload lacks a 'type'/'need' field")
+    payload["type"] = str(need_type).lower()
+    discharge = payload.get("discharge_debt", payload.get("discharge", 9999.0))
+    payload["discharge_debt"] = float(discharge)
+    return payload
+
+
+def _coerce_travel_payload(raw: Any) -> dict[str, Any]:
+    if raw is True:
+        return {}
+    if isinstance(raw, dict):
+        return dict(raw)
+    raise ValueError(f"travel payload must be a mapping or true, got {raw!r}")
+
+
+class _Replayer:
+    """Single-use forward/backward replay over one (checkpoint, N] window."""
+
+    def __init__(self, cur: Any, target_chunk_id: int) -> None:
+        self.cur = cur
+        self.target_chunk_id = target_chunk_id
+        self.target_created_at = _fetch_chunk_created_at(cur, target_chunk_id)
+        self.need_tuning = load_need_tuning()
+
+    # -- base checkpoint ---------------------------------------------------
+
+    def load_base_checkpoint(
+        self, base_checkpoint_id: Optional[int]
+    ) -> tuple[int, int, datetime, dict[str, Any]]:
+        if base_checkpoint_id is not None:
+            self.cur.execute(
+                """
+                SELECT id, chunk_id, created_at, state FROM state_checkpoints
+                WHERE id = %s
+                """,
+                (base_checkpoint_id,),
+            )
+        else:
+            self.cur.execute(
+                """
+                SELECT id, chunk_id, created_at, state FROM state_checkpoints
+                WHERE chunk_id IS NOT NULL AND chunk_id <= %s
+                ORDER BY chunk_id DESC, id DESC
+                LIMIT 1
+                """,
+                (self.target_chunk_id,),
+            )
+        row = self.cur.fetchone()
+        if row is None:
+            raise ValueError(
+                f"No checkpoint at or before chunk {self.target_chunk_id}; "
+                "that chunk predates the instrumentation era (migration 065) "
+                "and is not reconstructable"
+            )
+        checkpoint_id = _row_value(row, 0)
+        chunk_id = _row_value(row, 1)
+        created_at = _row_value(row, 2)
+        state = _as_document(_row_value(row, 3))
+        if chunk_id is None or chunk_id > self.target_chunk_id:
+            raise ValueError(
+                f"Checkpoint {checkpoint_id} (chunk {chunk_id}) is not a valid "
+                f"base for reconstruction at chunk {self.target_chunk_id}"
+            )
+        missing = set(CHECKPOINT_SECTIONS) - set(state)
+        if missing:
+            raise ValueError(
+                f"Checkpoint {checkpoint_id} lacks sections {sorted(missing)}"
+            )
+        return checkpoint_id, chunk_id, created_at, state
+
+    # -- forward scalar replay ----------------------------------------------
+
+    def replay(self, base_checkpoint_id: Optional[int] = None) -> ReplayResult:
+        checkpoint_id, base_chunk, base_created_at, base_state = (
+            self.load_base_checkpoint(base_checkpoint_id)
+        )
+        result = ReplayResult(
+            target_chunk_id=self.target_chunk_id,
+            base_checkpoint_id=checkpoint_id,
+            base_checkpoint_chunk_id=base_chunk,
+            state={},
+        )
+
+        characters = {row["id"]: dict(row) for row in base_state["characters"]}
+        places = {row["id"]: dict(row) for row in base_state["places"]}
+        needs = {
+            (row["character_entity_id"], row["need_type"]): dict(row)
+            for row in base_state["character_need_states"]
+        }
+        travel = {
+            row["character_entity_id"]: dict(row)
+            for row in base_state["character_travel_states"]
+        }
+
+        born_entities = self._seed_window_births(characters, places, result)
+
+        if base_chunk < self.target_chunk_id:
+            for chunk_id in self._window_chunks(base_chunk):
+                self._apply_skald_rows(chunk_id, characters, places, result)
+                self._apply_orrery_resolutions(
+                    chunk_id, characters, needs, travel, result
+                )
+
+        tag_workings, tag_touched_entities = self._replay_tags(
+            base_chunk, base_created_at, base_state, result
+        )
+        self._sync_need_applicability(
+            born_entities | tag_touched_entities,
+            characters,
+            tag_workings["entity_tags"],
+            needs,
+            result,
+        )
+        for section, working in tag_workings.items():
+            result.state[section] = sorted(working.values(), key=lambda r: r["id"])
+
+        result.state["characters"] = sorted(characters.values(), key=lambda r: r["id"])
+        result.state["places"] = sorted(places.values(), key=lambda r: r["id"])
+        result.state["character_need_states"] = [
+            needs[key] for key in sorted(needs, key=lambda k: (k[0], k[1]))
+        ]
+        result.state["character_travel_states"] = [
+            travel[key] for key in sorted(travel)
+        ]
+        result.state["character_routine_anchors"] = sorted(
+            (dict(row) for row in base_state["character_routine_anchors"]),
+            key=lambda r: r["id"],
+        )
+        result.add_note(
+            "character_routine_anchors",
+            "checkpoint pass-through; the table has no runtime writer, but "
+            "offline seed/backfill scripts are invisible between checkpoints",
+            approximate=False,
+        )
+
+        for table in RELATIONSHIP_KEY_COLUMNS:
+            self._unwind_relationships(table, result)
+        return result
+
+    def _window_chunks(self, base_chunk: int) -> list[int]:
+        self.cur.execute(
+            """
+            SELECT DISTINCT chunk_id FROM (
+                SELECT source_chunk_id AS chunk_id FROM state_delta_log
+                WHERE source_chunk_id > %(base)s AND source_chunk_id <= %(n)s
+                UNION
+                SELECT tick_chunk_id FROM orrery_resolutions
+                WHERE tick_chunk_id > %(base)s AND tick_chunk_id <= %(n)s
+            ) w ORDER BY chunk_id
+            """,
+            {"base": base_chunk, "n": self.target_chunk_id},
+        )
+        return [_row_value(row, 0) for row in self.cur.fetchall()]
+
+    def _seed_window_births(
+        self,
+        characters: dict[int, dict[str, Any]],
+        places: dict[int, dict[str, Any]],
+        result: ReplayResult,
+    ) -> set[int]:
+        """Entities INSERTed between checkpoint and N are un-ledgered.
+
+        Their existence is seeded (wall-clock bounded) but their initial
+        scalar values are NOT copied from the current rows — the current
+        values may include writes from after N, which would both mask
+        un-ledgered drift and fabricate phantom drift in verify. Scalars
+        start ``None`` and are marked unreproducible; a ledgered write in
+        the window clears the mark for the column it sets. Rows whose
+        created_at equals the target chunk's are presence-uncertain (the
+        Step 8.6 stub-creation ambiguity). Returns born character entity
+        ids for the need-applicability sync.
+        """
+
+        born_entities: set[int] = set()
+        for section, sql, columns in (
+            (
+                "characters",
+                "SELECT id, entity_id, created_at FROM characters "
+                "WHERE created_at <= %s",
+                ("current_location", "current_activity", "emotional_state"),
+            ),
+            (
+                "places",
+                "SELECT id, entity_id, created_at FROM places "
+                "WHERE created_at <= %s",
+                ("current_status",),
+            ),
+        ):
+            working = characters if section == "characters" else places
+            self.cur.execute(sql, (self.target_created_at,))
+            births = 0
+            for row_id, entity_id, created_at in self.cur.fetchall():
+                if row_id in working:
+                    continue
+                working[row_id] = {
+                    "id": row_id,
+                    "entity_id": entity_id,
+                    **{column: None for column in columns},
+                }
+                births += 1
+                for column in columns:
+                    result.unreproducible.add((section, str(row_id), column))
+                if created_at == self.target_created_at:
+                    result.uncertain_rows.add((section, str(row_id)))
+                if section == "characters" and entity_id is not None:
+                    born_entities.add(entity_id)
+            if births:
+                result.add_note(
+                    section,
+                    f"{births} row(s) born in the window; initial scalars are "
+                    "un-ledgered INSERTs — seeded as unknown, filled only by "
+                    "ledgered writes",
+                    approximate=True,
+                )
+        return born_entities
+
+    def _apply_skald_rows(
+        self,
+        chunk_id: int,
+        characters: dict[int, dict[str, Any]],
+        places: dict[int, dict[str, Any]],
+        result: ReplayResult,
+    ) -> None:
+        self.cur.execute(
+            """
+            SELECT field, entity_id, new_value FROM state_delta_log
+            WHERE source_chunk_id = %s ORDER BY id
+            """,
+            (chunk_id,),
+        )
+        by_entity_char = {row["entity_id"]: row for row in characters.values()}
+        by_entity_place = {row["entity_id"]: row for row in places.values()}
+        for db_field, entity_id, new_value in self.cur.fetchall():
+            if db_field not in SKALD_SCALAR_FIELDS:
+                raise ValueError(
+                    f"state_delta_log chunk {chunk_id} carries unknown field "
+                    f"{db_field!r}; the replayer must be taught about it"
+                )
+            table, column = db_field.split(".", 1)
+            rows = by_entity_char if table == "characters" else by_entity_place
+            row = rows.get(entity_id)
+            if row is None:
+                raise ValueError(
+                    f"state_delta_log chunk {chunk_id} targets entity "
+                    f"{entity_id} with no {table} row in the working state"
+                )
+            row[column] = new_value
+            # A ledgered write makes the column reproducible even for a
+            # window-born row seeded as unknown.
+            result.unreproducible.discard((table, str(row["id"]), column))
+
+    def _apply_orrery_resolutions(
+        self,
+        chunk_id: int,
+        characters: dict[int, dict[str, Any]],
+        needs: dict[tuple[int, str], dict[str, Any]],
+        travel: dict[int, dict[str, Any]],
+        result: ReplayResult,
+    ) -> None:
+        self.cur.execute(
+            """
+            SELECT id, actor_entity_id, state_delta FROM orrery_resolutions
+            WHERE tick_chunk_id = %s ORDER BY id
+            """,
+            (chunk_id,),
+        )
+        resolutions = [
+            (row[0], row[1], _as_document(row[2])) for row in self.cur.fetchall()
+        ]
+        if not resolutions:
+            return
+        world_time = _fetch_world_time(self.cur, chunk_id)
+        by_entity = {row["entity_id"]: row for row in characters.values()}
+        for resolution_id, actor_entity_id, delta in resolutions:
+            unknown = set(delta) - REPLAYED_DELTA_KEYS - TAG_DELTA_KEYS
+            if unknown:
+                raise ValueError(
+                    f"orrery_resolutions row {resolution_id} carries delta "
+                    f"keys {sorted(unknown)} the replayer must be taught about"
+                )
+            # Per-resolution key order mirrors the applier's if-chain.
+            if "character.current_activity" in delta:
+                row = by_entity.get(actor_entity_id)
+                if row is None:
+                    raise ValueError(
+                        f"resolution {resolution_id} actor {actor_entity_id} "
+                        "has no character row in the working state"
+                    )
+                row["current_activity"] = delta["character.current_activity"]
+                result.unreproducible.discard(
+                    ("characters", str(row["id"]), "current_activity")
+                )
+            if "need.fulfill" in delta:
+                self._replay_need_fulfill(
+                    chunk_id,
+                    actor_entity_id,
+                    delta["need.fulfill"],
+                    world_time,
+                    needs,
+                    result,
+                )
+            for travel_key in (
+                "travel.start",
+                "travel.advance",
+                "travel.delay",
+                "travel.arrive",
+            ):
+                if travel_key in delta:
+                    self._replay_travel(
+                        travel_key,
+                        chunk_id,
+                        actor_entity_id,
+                        delta[travel_key],
+                        world_time,
+                        travel,
+                        by_entity,
+                        result,
+                    )
+
+    def _replay_need_fulfill(
+        self,
+        chunk_id: int,
+        actor_entity_id: int,
+        raw_payload: Any,
+        world_time: Optional[datetime],
+        needs: dict[tuple[int, str], dict[str, Any]],
+        result: ReplayResult,
+    ) -> None:
+        payload = _coerce_need_payload(raw_payload)
+        need_type = payload["type"]
+        key = (actor_entity_id, need_type)
+        row_key = f"{actor_entity_id}:{need_type}"
+        if key not in needs:
+            needs[key] = {
+                "character_entity_id": actor_entity_id,
+                "need_type": need_type,
+                "debt_score": 0.0,
+                "last_evaluated_at": _isoformat(world_time),
+                "last_evaluated_chunk_id": None,
+                "last_fulfilled_at": None,
+                "metadata": {},
+            }
+        row = needs[key]
+        last_evaluated = row.get("last_evaluated_at")
+        if isinstance(last_evaluated, str):
+            last_evaluated = datetime.fromisoformat(last_evaluated)
+        current_debt = effective_debt_score(
+            need_type,
+            float(row.get("debt_score") or 0.0),
+            last_evaluated_at=last_evaluated,
+            current_world_time=world_time,
+            tuning=self.need_tuning,
+            last_evaluated_chunk_id=row.get("last_evaluated_chunk_id"),
+            current_chunk_id=chunk_id,
+        )
+        # numeric(8,2) storage rounds; mirror it.
+        row["debt_score"] = _pg_round(
+            max(0.0, current_debt - payload["discharge_debt"]), 2
+        )
+        row["last_evaluated_chunk_id"] = chunk_id
+        metadata = dict(row.get("metadata") or {})
+        metadata["last_fulfillment"] = payload
+        row["metadata"] = metadata
+        if world_time is None:
+            # Production fell back to wall-clock now() at commit time —
+            # unreproducible; leave prior values and flag the columns.
+            for column in ("last_evaluated_at", "last_fulfilled_at"):
+                result.unreproducible.add(("character_need_states", row_key, column))
+            result.add_note(
+                "character_need_states",
+                f"chunk {chunk_id} has NULL world_time; production stamped "
+                f"wall-clock now() on {row_key} — timestamps unreproducible",
+                approximate=True,
+            )
+        else:
+            row["last_evaluated_at"] = _isoformat(world_time)
+            row["last_fulfilled_at"] = _isoformat(world_time)
+        result.add_note(
+            "character_need_states",
+            "need.fulfill replayed through effective_debt_score with the "
+            "*current* [orrery.sunhelm] tuning; exact only while tuning "
+            "matches its value at original commit",
+            approximate=False,
+        )
+
+    def _replay_travel(
+        self,
+        delta_key: str,
+        chunk_id: int,
+        actor_entity_id: int,
+        raw_payload: Any,
+        world_time: Optional[datetime],
+        travel: dict[int, dict[str, Any]],
+        characters_by_entity: dict[int, dict[str, Any]],
+        result: ReplayResult,
+    ) -> None:
+        payload = _coerce_travel_payload(raw_payload)
+        row = travel.get(actor_entity_id)
+        if delta_key == "travel.start":
+            destination = payload.get("destination_place_id")
+            origin = payload.get("origin_place_id") or (
+                characters_by_entity.get(actor_entity_id, {}).get("current_location")
+            )
+            base = dict(row) if row else {"character_entity_id": actor_entity_id}
+            base.update(
+                {
+                    "status": "in_transit",
+                    # Production anchors an in-transit row at its origin.
+                    "anchor_place_id": origin,
+                    "origin_place_id": origin,
+                    "destination_place_id": destination,
+                    "progress_ratio": float(payload.get("initial_progress", 0.0)),
+                    "updated_at_world_time": _isoformat(world_time),
+                    "started_at_world_time": _isoformat(world_time),
+                }
+            )
+            travel[actor_entity_id] = base
+            note = (
+                f"travel.start at chunk {chunk_id}: destination, route, and "
+                "route-adjusted mode/risk are resolved from live state at "
+                "commit time; replayed row is approximate"
+            )
+            if destination is None:
+                note += " (destination not explicit in payload — unknown)"
+            result.add_note("character_travel_states", note, approximate=True)
+            # Route selection derives these from live graph/place state (and
+            # may override the payload's mode/risk); not reconstructable.
+            unreproducible_columns = [
+                "route_method",
+                "travel_mode",
+                "risk",
+                "estimated_distance_m",
+                "estimated_duration_minutes",
+                "eta_world_time",
+                "route_metadata",
+            ]
+            if destination is None:
+                unreproducible_columns.append("destination_place_id")
+            for column in unreproducible_columns:
+                result.unreproducible.add(
+                    ("character_travel_states", str(actor_entity_id), column)
+                )
+            return
+        if row is None:
+            raise ValueError(
+                f"{delta_key} at chunk {chunk_id} for actor {actor_entity_id} "
+                "with no travel row in the working state"
+            )
+        if delta_key == "travel.advance":
+            delta = float(payload.get("progress_delta", TRAVEL_ADVANCE_DEFAULT_DELTA))
+            row["progress_ratio"] = _pg_round(
+                min(1.0, max(0.0, float(row.get("progress_ratio") or 0.0) + delta)),
+                4,
+            )
+            row["updated_at_world_time"] = _isoformat(world_time)
+        elif delta_key == "travel.delay":
+            if payload.get("risk"):
+                row["risk"] = payload["risk"]
+            metadata = dict(row.get("route_metadata") or {})
+            metadata["last_delay"] = payload
+            row["route_metadata"] = metadata
+            row["updated_at_world_time"] = _isoformat(world_time)
+        elif delta_key == "travel.arrive":
+            destination = payload.get("destination_place_id") or row.get(
+                "destination_place_id"
+            )
+            if destination is None:
+                result.add_note(
+                    "characters",
+                    f"travel.arrive at chunk {chunk_id} for actor "
+                    f"{actor_entity_id} has no reconstructable destination; "
+                    "current_location not updated",
+                    approximate=True,
+                )
+            else:
+                character = characters_by_entity.get(actor_entity_id)
+                if character is None:
+                    raise ValueError(
+                        f"travel.arrive actor {actor_entity_id} has no "
+                        "character row in the working state"
+                    )
+                character["current_location"] = destination
+                result.unreproducible.discard(
+                    ("characters", str(character["id"]), "current_location")
+                )
+            metadata = dict(row.get("route_metadata") or {})
+            metadata["last_arrived_place_id"] = destination
+            row.update(
+                {
+                    "status": "at_place",
+                    "anchor_place_id": destination,
+                    "origin_place_id": None,
+                    "destination_place_id": None,
+                    "progress_ratio": 0.0,
+                    "estimated_distance_m": None,
+                    "estimated_duration_minutes": None,
+                    "started_at_world_time": None,
+                    "updated_at_world_time": _isoformat(world_time),
+                    "eta_world_time": None,
+                    "route_metadata": metadata,
+                }
+            )
+
+    # -- tag provenance replay -----------------------------------------------
+
+    def _replay_tags(
+        self,
+        base_chunk: int,
+        base_created_at: datetime,
+        base_state: dict[str, Any],
+        result: ReplayResult,
+    ) -> tuple[dict[str, dict[int, dict[str, Any]]], set[int]]:
+        """Forward-replay both tag sections from provenance.
+
+        Returns the working row sets (finalized by the caller after the
+        need-applicability sync) and the set of character entity ids whose
+        entity_tags changed in the window — the population the
+        need-applicability trigger fired for.
+        """
+
+        workings: dict[str, dict[int, dict[str, Any]]] = {}
+        touched_entities: set[int] = set()
+        for section, log_column in (
+            ("entity_tags", "entity_tag_id"),
+            ("entity_pair_tags", "entity_pair_tag_id"),
+        ):
+            working = {row["id"]: dict(row) for row in base_state[section]}
+            self.cur.execute(
+                f"""
+                SELECT to_jsonb(t) FROM {section} t
+                WHERE t.source_chunk_id > %s AND t.source_chunk_id <= %s
+                """,
+                (base_chunk, self.target_chunk_id),
+            )
+            for (row_json,) in self.cur.fetchall():
+                row = _as_document(row_json)
+                # Active-at-N normalization: a row cleared after N was live
+                # at N; the checkpoint shape stores active rows with NULL
+                # cleared_at.
+                row["cleared_at"] = None
+                working[row["id"]] = row
+                if section == "entity_tags":
+                    touched_entities.add(row["entity_id"])
+            self.cur.execute(
+                f"""
+                SELECT {log_column} FROM tag_clearance_log
+                WHERE {log_column} IS NOT NULL
+                  AND source_chunk_id > %s AND source_chunk_id <= %s
+                """,
+                (base_chunk, self.target_chunk_id),
+            )
+            for (tag_row_id,) in self.cur.fetchall():
+                removed = working.pop(tag_row_id, None)
+                if removed is not None and section == "entity_tags":
+                    touched_entities.add(removed["entity_id"])
+
+            # Best-effort inclusion of un-keyed bestowals inside the window
+            # (mid-commit new-entity bestowals, Step 8.6 tag hints, offline
+            # tools) via wall-clock bounds; excluding them is guaranteed
+            # wrong, including them is approximate. The lower bound is
+            # inclusive because Step 8.6 of the BASE chunk's commit bestows
+            # after the base checkpoint was captured, at the identical
+            # transaction timestamp; rows the base checkpoint already holds
+            # dedupe by id. Rows at the upper bound are presence-uncertain
+            # (same ambiguity at the target chunk).
+            self.cur.execute(
+                f"""
+                SELECT to_jsonb(t) FROM {section} t
+                WHERE t.source_chunk_id IS NULL
+                  AND t.applied_at >= %s AND t.applied_at <= %s
+                """,
+                (base_created_at, self.target_created_at),
+            )
+            unkeyed = 0
+            for (row_json,) in self.cur.fetchall():
+                row = _as_document(row_json)
+                if row["id"] not in working:
+                    row["cleared_at"] = None
+                    working[row["id"]] = row
+                    unkeyed += 1
+                    if section == "entity_tags":
+                        touched_entities.add(row["entity_id"])
+                    applied_at = canonicalize(row.get("applied_at"))
+                    if applied_at == canonicalize(self.target_created_at):
+                        result.uncertain_rows.add((section, str(row["id"])))
+            if unkeyed:
+                result.add_note(
+                    section,
+                    f"{unkeyed} bestowal(s) in the window carry NULL "
+                    "source_chunk_id (new-entity mid-commit, Step 8.6 tag "
+                    "hints, or offline tools); included by wall-clock "
+                    "correlation",
+                    approximate=True,
+                )
+            # Clears with NULL attribution cannot be positioned at all.
+            self.cur.execute(
+                f"""
+                SELECT count(*) FROM tag_clearance_log
+                WHERE {log_column} IS NOT NULL AND source_chunk_id IS NULL
+                  AND cleared_at > %s AND cleared_at <= %s
+                """,
+                (base_created_at, self.target_created_at),
+            )
+            null_clears = _row_value(self.cur.fetchone(), 0)
+            if null_clears:
+                result.add_note(
+                    section,
+                    f"{null_clears} clearance(s) in the wall-clock window "
+                    "carry NULL source_chunk_id and were NOT applied",
+                    approximate=True,
+                )
+            workings[section] = working
+        return workings, touched_entities
+
+    # -- need-applicability trigger mirror ------------------------------------
+
+    def _sync_need_applicability(
+        self,
+        affected_entities: set[int],
+        characters: dict[int, dict[str, Any]],
+        entity_tags_working: dict[int, dict[str, Any]],
+        needs: dict[tuple[int, str], dict[str, Any]],
+        result: ReplayResult,
+    ) -> None:
+        """Mirror ``orrery_sync_character_need_states`` (migration 057).
+
+        Production triggers on entity_tags changes (and character INSERTs)
+        ensure need rows for every applicable need type, DELETE rows for
+        needs the entity's tags make inapplicable, and clear that need's
+        severity tags — all un-ledgered. The final table state is a pure
+        function of the final active tag set, so the mirror runs once, after
+        tag replay, over the entities whose tags changed in the window (the
+        population the trigger fired for).
+        """
+
+        if not affected_entities:
+            return
+        character_entities = {
+            row["entity_id"]
+            for row in characters.values()
+            if row.get("entity_id") is not None
+        }
+        tag_ids = {
+            row["tag_id"]
+            for row in entity_tags_working.values()
+            if row["entity_id"] in affected_entities
+        }
+        tag_names: dict[int, str] = {}
+        if tag_ids:
+            self.cur.execute(
+                "SELECT id, tag FROM tags WHERE id = ANY(%s)",
+                (list(tag_ids),),
+            )
+            tag_names = dict(self.cur.fetchall())
+
+        synthesized = 0
+        deleted = 0
+        severity_cleared = 0
+        for entity_id in sorted(affected_entities & character_entities):
+            active_tags = {
+                tag_names[row["tag_id"]]
+                for row in entity_tags_working.values()
+                if row["entity_id"] == entity_id and row["tag_id"] in tag_names
+            }
+            applicable = {
+                need for need in NEED_TYPES if need_applies_to_tags(need, active_tags)
+            }
+            for need in NEED_TYPES:
+                key = (entity_id, need)
+                if need in applicable and key not in needs:
+                    needs[key] = {
+                        "character_entity_id": entity_id,
+                        "need_type": need,
+                        "debt_score": 0.0,
+                        "last_evaluated_at": None,
+                        "last_evaluated_chunk_id": None,
+                        "last_fulfilled_at": None,
+                        "metadata": {"synced_by": "need_applicability"},
+                    }
+                    synthesized += 1
+                    # The trigger stamps MAX(chunk_metadata.world_time) at
+                    # firing time — not reconstructable after the fact.
+                    result.unreproducible.add(
+                        (
+                            "character_need_states",
+                            f"{entity_id}:{need}",
+                            "last_evaluated_at",
+                        )
+                    )
+                elif need not in applicable and key in needs:
+                    del needs[key]
+                    deleted += 1
+                    # The trigger also clears this need's severity tags with
+                    # NO tag_clearance_log row — mirror the clear here.
+                    severity = set(severity_tags_for_need(need))
+                    for row_id in [
+                        rid
+                        for rid, row in entity_tags_working.items()
+                        if row["entity_id"] == entity_id
+                        and tag_names.get(row["tag_id"]) in severity
+                    ]:
+                        del entity_tags_working[row_id]
+                        severity_cleared += 1
+        if synthesized or deleted or severity_cleared:
+            result.add_note(
+                "character_need_states",
+                "need-applicability trigger mirrored: "
+                f"{synthesized} row(s) synthesized, {deleted} deleted, "
+                f"{severity_cleared} un-logged severity tag clear(s) applied",
+                approximate=False,
+            )
+
+    # -- relationship unwind ---------------------------------------------------
+
+    def _unwind_relationships(self, table: str, result: ReplayResult) -> None:
+        key_columns = RELATIONSHIP_KEY_COLUMNS[table]
+        self.cur.execute(f"SELECT to_jsonb(t) FROM {table} t")
+        working: dict[tuple[Any, ...], dict[str, Any]] = {}
+        for (row_json,) in self.cur.fetchall():
+            row = _as_document(row_json)
+            working[tuple(row[c] for c in key_columns)] = row
+
+        self.cur.execute(
+            """
+            SELECT operation, old_row, source_chunk_id, created_at
+            FROM relationship_versions
+            WHERE relationship_table = %s
+              AND (
+                source_chunk_id > %s
+                OR (source_chunk_id IS NULL AND created_at > %s)
+              )
+            ORDER BY id DESC
+            """,
+            (table, self.target_chunk_id, self.target_created_at),
+        )
+        null_attributed = 0
+        for (
+            operation,
+            old_row_json,
+            source_chunk_id,
+            _created_at,
+        ) in self.cur.fetchall():
+            old_row = _as_document(old_row_json)
+            if source_chunk_id is None:
+                null_attributed += 1
+            # For both 'update' and 'delete' the pre-image IS the row state
+            # before the mutation; assignment restores it (delete pre-images
+            # re-insert).
+            working[tuple(old_row[c] for c in key_columns)] = old_row
+        if null_attributed:
+            result.add_note(
+                table,
+                f"{null_attributed} unattributed version row(s) unwound by "
+                "wall-clock correlation (NULL source_chunk_id)",
+                approximate=True,
+            )
+
+        # Rows INSERTed after N never fired the trigger; the only insertion
+        # evidence is created_at (also preserved inside pre-images, so this
+        # filter must run AFTER the unwind).
+        survivors = []
+        dropped = 0
+        for row in working.values():
+            created = row.get("created_at")
+            created_dt = (
+                datetime.fromisoformat(created) if isinstance(created, str) else created
+            )
+            if created_dt is not None and created_dt > self.target_created_at:
+                dropped += 1
+                continue
+            survivors.append(row)
+        if dropped:
+            result.add_note(
+                table,
+                f"{dropped} row(s) dropped as post-chunk INSERTs by "
+                "wall-clock correlation (inserts never fire the versioning "
+                "trigger)",
+                approximate=True,
+            )
+        result.state[table] = sorted(
+            survivors,
+            key=lambda r: tuple(str(r[c]) for c in key_columns),
+        )
+
+
+def reconstruct_state_at_sync(
+    cur: Any,
+    chunk_id: int,
+    *,
+    base_checkpoint_id: Optional[int] = None,
+) -> ReplayResult:
+    """Reconstruct the full mutable state surface as of ``chunk_id``.
+
+    ``base_checkpoint_id`` pins the starting checkpoint (used by verify to
+    force replay across a window that ends at a stored checkpoint); by
+    default the latest checkpoint at or before ``chunk_id`` is used.
+    """
+
+    return _Replayer(cur, chunk_id).replay(base_checkpoint_id)
+
+
+def _values_equal(expected: Any, actual: Any) -> bool:
+    """Pairwise-aware equality across jsonb/Python representations.
+
+    When BOTH sides are strings the numeric coercion is skipped — free-text
+    scalar drift like ``"12"`` vs ``"12.0"`` must count as drift; only
+    genuinely mixed representations (jsonb number vs Python float, ISO
+    string vs datetime) are normalized.
+    """
+
+    if isinstance(expected, str) and isinstance(actual, str):
+        try:
+            return _canonical_datetime(
+                datetime.fromisoformat(expected)
+            ) == _canonical_datetime(datetime.fromisoformat(actual))
+        except ValueError:
+            return expected == actual
+    exp_value = canonicalize(expected)
+    act_value = canonicalize(actual)
+    if isinstance(exp_value, float) and isinstance(act_value, float):
+        return abs(exp_value - act_value) < 1e-9
+    return exp_value == act_value
+
+
+def _diff_section(
+    section: str,
+    expected_rows: list[dict[str, Any]],
+    actual_rows: list[dict[str, Any]],
+    key_fn: Any,
+    unreproducible: set[tuple[str, str, str]],
+    uncertain_rows: set[tuple[str, str]],
+) -> tuple[list[Drift], int]:
+    volatile = VOLATILE_COLUMNS.get(section, frozenset())
+    expected = {key_fn(row): row for row in expected_rows}
+    actual = {key_fn(row): row for row in actual_rows}
+    drifts: list[Drift] = []
+    skipped = 0
+    for key in sorted(set(expected) | set(actual), key=str):
+        if key not in actual or key not in expected:
+            if (section, str(key)) in uncertain_rows:
+                skipped += 1
+                continue
+            if key not in actual:
+                drifts.append(
+                    Drift(section, str(key), None, "missing_row", expected[key], None)
+                )
+            else:
+                drifts.append(
+                    Drift(section, str(key), None, "extra_row", None, actual[key])
+                )
+            continue
+        exp_row, act_row = expected[key], actual[key]
+        for column in sorted(set(exp_row) | set(act_row)):
+            if column in volatile:
+                continue
+            if (section, str(key), column) in unreproducible:
+                skipped += 1
+                continue
+            if _values_equal(exp_row.get(column), act_row.get(column)):
+                continue
+            drifts.append(
+                Drift(
+                    section,
+                    str(key),
+                    column,
+                    "value",
+                    exp_row.get(column),
+                    act_row.get(column),
+                )
+            )
+    return drifts, skipped
+
+
+def _section_key_fn(section: str) -> Any:
+    if section in RELATIONSHIP_KEY_COLUMNS:
+        columns = RELATIONSHIP_KEY_COLUMNS[section]
+        return lambda row: tuple(row[c] for c in columns)
+    if section == "character_need_states":
+        return lambda row: f"{row['character_entity_id']}:{row['need_type']}"
+    if section == "character_travel_states":
+        return lambda row: row["character_entity_id"]
+    return lambda row: row["id"]
+
+
+def _load_checkpoint_state(cur: Any, checkpoint_id: int) -> dict[str, Any]:
+    cur.execute("SELECT state FROM state_checkpoints WHERE id = %s", (checkpoint_id,))
+    return _as_document(_row_value(cur.fetchone(), 0))
+
+
+def verify_checkpoints_sync(cur: Any) -> list[CheckpointPairVerdict]:
+    """Replay every consecutive checkpoint pair and diff against the stored
+    target document. Zero drift means the ledgers were sufficient across
+    that window; any drift names the writer that shipped un-ledgered.
+
+    Two checkpoints at the SAME chunk (e.g. interval + manual) are diffed
+    stored-vs-stored — anything written between the two captures surfaces
+    as drift there instead of being silently skipped.
+
+    Known blind spot: relationship sections replay backward from the
+    CURRENT tables, so when nothing touched a relationship after the target
+    checkpoint the diff compares live rows against a snapshot of the same
+    live rows. The unwind path itself is exercised by dedicated tests, not
+    by this oracle.
+    """
+
+    cur.execute(
+        """
+        SELECT id, chunk_id FROM state_checkpoints
+        WHERE chunk_id IS NOT NULL ORDER BY chunk_id, id
+        """
+    )
+    checkpoints = cur.fetchall()
+    verdicts: list[CheckpointPairVerdict] = []
+    for (base_id, base_chunk), (target_id, target_chunk) in zip(
+        checkpoints, checkpoints[1:]
+    ):
+        if base_chunk == target_chunk:
+            # Same-chunk captures must be identical documents; diff them
+            # directly, no replay involved.
+            base_stored = _load_checkpoint_state(cur, base_id)
+            target_stored = _load_checkpoint_state(cur, target_id)
+            drifts = []
+            for section in CHECKPOINT_SECTIONS:
+                section_drifts, _ = _diff_section(
+                    section,
+                    base_stored[section],
+                    target_stored[section],
+                    _section_key_fn(section),
+                    set(),
+                    set(),
+                )
+                drifts.extend(section_drifts)
+            verdicts.append(
+                CheckpointPairVerdict(
+                    base_checkpoint_id=base_id,
+                    base_chunk_id=base_chunk,
+                    target_checkpoint_id=target_id,
+                    target_chunk_id=target_chunk,
+                    drifts=drifts,
+                    skipped_unreproducible=0,
+                    notes={
+                        "_pair": [
+                            "same-chunk captures compared directly "
+                            "(stored vs stored)"
+                        ]
+                    },
+                )
+            )
+            continue
+        result = reconstruct_state_at_sync(
+            cur, target_chunk, base_checkpoint_id=base_id
+        )
+        stored = _load_checkpoint_state(cur, target_id)
+        drifts = []
+        skipped = 0
+        for section in CHECKPOINT_SECTIONS:
+            section_drifts, section_skipped = _diff_section(
+                section,
+                stored[section],
+                result.state[section],
+                _section_key_fn(section),
+                result.unreproducible,
+                result.uncertain_rows,
+            )
+            drifts.extend(section_drifts)
+            skipped += section_skipped
+        verdicts.append(
+            CheckpointPairVerdict(
+                base_checkpoint_id=base_id,
+                base_chunk_id=base_chunk,
+                target_checkpoint_id=target_id,
+                target_chunk_id=target_chunk,
+                drifts=drifts,
+                skipped_unreproducible=skipped,
+                notes=result.notes,
+            )
+        )
+    return verdicts

--- a/scripts/replay_state.py
+++ b/scripts/replay_state.py
@@ -1,0 +1,132 @@
+"""Reconstruct world state at an arbitrary chunk, or audit ledger sufficiency.
+
+The read half of the reconstruction contract (issue #426): world state at
+chunk N = latest checkpoint at or before N + the Orrery and Skald ledgers
+in chunk order, with relationships unwound from trigger pre-images.
+
+Usage:
+    python scripts/replay_state.py --slot 2 --chunk 1400
+    python scripts/replay_state.py --slot 2 --chunk 1400 --output state.json
+    python scripts/replay_state.py --slot 2 --verify
+
+``--verify`` replays every consecutive checkpoint pair and diffs the result
+against the stored target checkpoint; exits nonzero on drift. Zero drift
+proves the ledgers were sufficient across every checkpointed window.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from typing import Any
+
+import psycopg2
+
+from nexus.agents.orrery.replay import (
+    reconstruct_state_at_sync,
+    verify_checkpoints_sync,
+)
+from nexus.api.slot_utils import slot_dbname
+
+
+def _connect(slot: int) -> Any:
+    conn = psycopg2.connect(dbname=slot_dbname(slot), host="localhost")
+    conn.set_session(readonly=True)
+    return conn
+
+
+def _print_reconstruction(slot: int, chunk_id: int, output: str | None) -> None:
+    conn = _connect(slot)
+    try:
+        with conn.cursor() as cur:
+            result = reconstruct_state_at_sync(cur, chunk_id)
+    finally:
+        conn.close()
+
+    print(
+        f"slot {slot}: state at chunk {result.target_chunk_id} "
+        f"(base checkpoint {result.base_checkpoint_id} "
+        f"at chunk {result.base_checkpoint_chunk_id})"
+    )
+    for section, rows in result.state.items():
+        tier = "approximate" if section in result.approximate_sections else "exact"
+        print(f"  {section:<32} {len(rows):>5} rows  [{tier}]")
+        for note in result.notes.get(section, []):
+            print(f"    - {note}")
+    if output:
+        document = {
+            "target_chunk_id": result.target_chunk_id,
+            "base_checkpoint_id": result.base_checkpoint_id,
+            "base_checkpoint_chunk_id": result.base_checkpoint_chunk_id,
+            "approximate_sections": sorted(result.approximate_sections),
+            "notes": result.notes,
+            "state": result.state,
+        }
+        with open(output, "w") as handle:
+            json.dump(document, handle, indent=2, default=str)
+        print(f"wrote {output}")
+
+
+def _print_verification(slot: int) -> int:
+    conn = _connect(slot)
+    try:
+        with conn.cursor() as cur:
+            verdicts = verify_checkpoints_sync(cur)
+    finally:
+        conn.close()
+
+    if not verdicts:
+        print(
+            f"slot {slot}: fewer than two checkpoints at distinct chunks — "
+            "nothing to verify"
+        )
+        return 0
+    total_drift = 0
+    for verdict in verdicts:
+        status = "DRIFT" if verdict.drifts else "ok"
+        print(
+            f"slot {slot}: checkpoint {verdict.base_checkpoint_id} "
+            f"(chunk {verdict.base_chunk_id}) -> "
+            f"checkpoint {verdict.target_checkpoint_id} "
+            f"(chunk {verdict.target_chunk_id}): {status}"
+            + (
+                f", {verdict.skipped_unreproducible} unreproducible "
+                "column(s) skipped"
+                if verdict.skipped_unreproducible
+                else ""
+            )
+        )
+        for drift in verdict.drifts:
+            total_drift += 1
+            print(f"  {json.dumps(asdict(drift), default=str)}")
+    if total_drift:
+        print(
+            f"{total_drift} drift finding(s): a writer mutated checkpointed "
+            "state without a replayable ledger record"
+        )
+        return 1
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--slot", type=int, choices=range(1, 6), required=True)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--chunk", type=int, help="chunk id to reconstruct at")
+    group.add_argument(
+        "--verify",
+        action="store_true",
+        help="replay every checkpoint pair and diff against stored documents",
+    )
+    parser.add_argument("--output", help="write the full state document (JSON)")
+    args = parser.parse_args()
+
+    if args.verify:
+        sys.exit(_print_verification(args.slot))
+    _print_reconstruction(args.slot, args.chunk, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_orrery/test_replay.py
+++ b/tests/test_orrery/test_replay.py
@@ -722,6 +722,50 @@ def test_travel_replay_start_advance_arrive() -> None:
         conn.close()
 
 
+def test_unresolved_arrival_marks_location_unreproducible() -> None:
+    """travel.start via anchor/class (no explicit destination) followed by a
+    bare travel.arrive: production moved the character somewhere replay
+    cannot know — every column the arrival wrote must be flagged, not left
+    to read as false drift."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            char_id, char_entity, _, _ = _probe_character(cur)
+            base_id = capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
+            start_chunk = _fabricate_chunk(cur, _next_world_time(cur))
+            arrive_chunk = _fabricate_chunk(
+                cur, _next_world_time(cur) + timedelta(hours=1)
+            )
+            _insert_resolution(
+                cur,
+                start_chunk,
+                char_entity,
+                {"travel.start": {"destination_anchor": "home"}},
+            )
+            _insert_resolution(cur, arrive_chunk, char_entity, {"travel.arrive": True})
+
+            at_arrive = reconstruct_state_at_sync(
+                cur, arrive_chunk, base_checkpoint_id=base_id
+            )
+            assert (
+                "characters",
+                str(char_id),
+                "current_location",
+            ) in at_arrive.unreproducible
+            for column in ("anchor_place_id", "route_metadata", "destination_place_id"):
+                assert (
+                    "character_travel_states",
+                    str(char_entity),
+                    column,
+                ) in at_arrive.unreproducible
+            assert "characters" in at_arrive.approximate_sections
+    finally:
+        conn.rollback()
+        conn.close()
+
+
 def test_null_world_time_marks_need_timestamps_unreproducible() -> None:
     """A tick without world_time makes production stamp wall-clock now();
     replay must flag those columns instead of guessing — and verify must
@@ -755,17 +799,21 @@ def test_null_world_time_marks_need_timestamps_unreproducible() -> None:
                 cur, probe_chunk, base_checkpoint_id=base_id
             )
             row_key = f"{char_entity}:thirst"
-            assert (
-                "character_need_states",
-                row_key,
-                "last_evaluated_at",
-            ) in at_probe.unreproducible
+            for column in ("last_evaluated_at", "last_fulfilled_at", "debt_score"):
+                assert (
+                    "character_need_states",
+                    row_key,
+                    column,
+                ) in at_probe.unreproducible, (
+                    f"{column} depends on the wall-clock fallback and must be "
+                    "flagged"
+                )
 
             verdicts = verify_checkpoints_sync(cur)
             probe_pair = [v for v in verdicts if v.target_chunk_id == probe_chunk]
             assert len(probe_pair) == 1
             assert probe_pair[0].drifts == []
-            assert probe_pair[0].skipped_unreproducible >= 2
+            assert probe_pair[0].skipped_unreproducible >= 3
     finally:
         conn.rollback()
         conn.close()

--- a/tests/test_orrery/test_replay.py
+++ b/tests/test_orrery/test_replay.py
@@ -568,6 +568,84 @@ def test_need_applicability_trigger_is_mirrored() -> None:
         conn.close()
 
 
+def test_applicability_toggle_resets_need_row_to_fresh_shape() -> None:
+    """Immunity applied at one chunk and cleared at the next: the REAL
+    trigger deletes then re-inserts a FRESH need row. The mirror must reset
+    the checkpoint-inherited row rather than let stale contents survive."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            _, char_entity, _, _ = _probe_character(cur)
+            base_id = capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
+            bestow_chunk = _fabricate_chunk(cur, None)
+            clear_chunk = _fabricate_chunk(cur, None)
+
+            cur.execute("SELECT id FROM tags WHERE tag = 'inorganic'")
+            immunity_tag_id = cur.fetchone()[0]
+            cur.execute(
+                """
+                INSERT INTO entity_tags (
+                    entity_id, tag_id, source_kind, source_chunk_id
+                ) VALUES (%s, %s, 'template', %s) RETURNING id
+                """,
+                (char_entity, immunity_tag_id, bestow_chunk),
+            )
+            immunity_row_id = cur.fetchone()[0]
+            # Clear it one chunk later — the UPDATE fires the trigger, which
+            # re-inserts fresh rows for the newly-applicable needs.
+            cur.execute(
+                "UPDATE entity_tags SET cleared_at = now() WHERE id = %s",
+                (immunity_row_id,),
+            )
+            cur.execute(
+                """
+                INSERT INTO tag_clearance_log (
+                    entity_tag_id, mechanism, source_chunk_id
+                ) VALUES (%s, 'authored', %s)
+                """,
+                (immunity_row_id, clear_chunk),
+            )
+            cur.execute(
+                """
+                SELECT metadata FROM character_need_states
+                WHERE character_entity_id = %s AND need_type = 'hunger'
+                """,
+                (char_entity,),
+            )
+            live_metadata = cur.fetchone()[0]
+            assert (
+                live_metadata.get("synced_by") == "need_applicability"
+            ), "the DB trigger must have re-inserted a fresh row"
+            capture_state_checkpoint_sync(cur, chunk_id=clear_chunk, label="manual")
+
+            at_clear = reconstruct_state_at_sync(
+                cur, clear_chunk, base_checkpoint_id=base_id
+            )
+            row = _section_row(
+                at_clear.state["character_need_states"],
+                character_entity_id=char_entity,
+                need_type="hunger",
+            )
+            assert row is not None, "hunger must be applicable again at clear_chunk"
+            assert row["debt_score"] == 0.0
+            assert row["metadata"] == {"synced_by": "need_applicability"}
+            assert (
+                "character_need_states",
+                f"{char_entity}:hunger",
+                "last_evaluated_at",
+            ) in at_clear.unreproducible
+
+            verdicts = verify_checkpoints_sync(cur)
+            probe_pair = [v for v in verdicts if v.target_chunk_id == clear_chunk]
+            assert len(probe_pair) == 1
+            assert probe_pair[0].drifts == []
+    finally:
+        conn.rollback()
+        conn.close()
+
+
 def test_travel_replay_start_advance_arrive() -> None:
     """Travel deltas replay production-faithfully for explicit payloads:
     travel.start anchors at the origin, travel.arrive moves the character

--- a/tests/test_orrery/test_replay.py
+++ b/tests/test_orrery/test_replay.py
@@ -1,0 +1,963 @@
+"""Live tests for the replay consumer (nexus/agents/orrery/replay.py).
+
+Real writers, real triggers, real ledgers against save_02 inside
+always-rolled-back transactions — the #428 test pattern. Each test
+fabricates post-checkpoint history through the same code paths production
+uses, then proves the replayer inverts it:
+
+- scalar round trip: Skald writes then an Orrery activity write in one
+  chunk; replay honors within-chunk ordering (Skald first) and the
+  checkpoint-pair verify oracle reports zero drift.
+- tag window replay: bestowals and clearances land/lift at exactly the
+  chunks their provenance says.
+- relationship unwind: updates rewind to pre-images, deletes resurrect,
+  post-chunk INSERTs are dropped by wall-clock correlation.
+- need replay: the production fulfillment applier's debt math is
+  reproduced through the same effective_debt_score authority.
+- drift detection: an un-ledgered scalar write between checkpoints is
+  caught by verify — the oracle actually fires.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+import psycopg2
+import pytest
+
+from nexus.agents.logon.apex_schema import (
+    CharacterStateUpdate,
+    LocationStateUpdate,
+    StateUpdates,
+)
+from nexus.agents.orrery.events import _apply_need_fulfillment_sync
+from nexus.agents.orrery.needs import load_need_tuning
+from nexus.agents.orrery.reconstruction import (
+    capture_state_checkpoint_sync,
+    set_commit_chunk_attribution_sync,
+)
+from nexus.agents.orrery.replay import (
+    reconstruct_state_at_sync,
+    verify_checkpoints_sync,
+)
+from nexus.api.commit_handler_sync import apply_state_updates_sync
+
+pytestmark = pytest.mark.requires_postgres
+
+WRITE_SLOT = 2
+
+
+def _connect() -> Any:
+    return psycopg2.connect(
+        host=os.environ.get("PGHOST", "localhost"),
+        database=f"save_{WRITE_SLOT:02d}",
+        user=os.environ.get("PGUSER", "pythagor"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+def _head_chunk(cur: Any) -> int:
+    cur.execute("SELECT max(id) FROM narrative_chunks")
+    return cur.fetchone()[0]
+
+
+def _fabricate_chunk(
+    cur: Any,
+    world_time: Optional[datetime],
+    *,
+    created_offset_minutes: int = 0,
+) -> int:
+    # now() is transaction time — constant across one rolled-back test
+    # transaction — so tests that depend on wall-clock ordering (the
+    # relationship insert-drop filter) must stagger created_at explicitly,
+    # the way separate production transactions would naturally.
+    cur.execute(
+        """
+        INSERT INTO narrative_chunks (id, raw_text, created_at)
+        SELECT max(id) + 1, 'replay probe chunk',
+               now() + make_interval(mins => %s)
+        FROM narrative_chunks
+        RETURNING id
+        """,
+        (created_offset_minutes,),
+    )
+    chunk_id = cur.fetchone()[0]
+    if world_time is not None:
+        cur.execute(
+            "INSERT INTO chunk_metadata (chunk_id, world_time) VALUES (%s, %s)",
+            (chunk_id, world_time),
+        )
+    # No metadata row when world_time is None: trg_chunk_metadata_refresh_
+    # world_time backfills world_time on insert, so a NULL-world-time chunk
+    # is only fabricable by omitting the row entirely.
+    return chunk_id
+
+
+def _insert_resolution(
+    cur: Any, chunk_id: int, actor_entity_id: int, state_delta: dict[str, Any]
+) -> None:
+    cur.execute(
+        """
+        INSERT INTO orrery_resolutions (
+            tick_chunk_id, template_id, binding_hash, actor_entity_id,
+            priority, magnitude, state_delta
+        ) VALUES (%s, 'replay_probe', %s, %s, 50, 0.5, %s)
+        """,
+        (chunk_id, f"probe-{chunk_id}", actor_entity_id, json.dumps(state_delta)),
+    )
+
+
+def _probe_character(cur: Any) -> tuple[int, int, str, Optional[int]]:
+    cur.execute(
+        """
+        SELECT id, entity_id, current_activity, current_location
+        FROM characters WHERE entity_id IS NOT NULL ORDER BY id LIMIT 1
+        """
+    )
+    return cur.fetchone()
+
+
+def _section_row(rows: list[dict[str, Any]], **match: Any) -> Optional[dict]:
+    for row in rows:
+        if all(row.get(k) == v for k, v in match.items()):
+            return row
+    return None
+
+
+def _next_world_time(cur: Any) -> datetime:
+    """A world_time after every existing stamp, so need accrual is sane."""
+
+    cur.execute("SELECT max(world_time) FROM chunk_metadata")
+    latest = cur.fetchone()[0]
+    base = latest or datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return base + timedelta(hours=6)
+
+
+def test_scalar_replay_round_trip_and_within_chunk_ordering() -> None:
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            char_id, char_entity, original_activity, original_location = (
+                _probe_character(cur)
+            )
+            cur.execute("SELECT id FROM places ORDER BY id LIMIT 1")
+            place_id = cur.fetchone()[0]
+
+            base_id = capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
+            probe_chunk = _fabricate_chunk(cur, _next_world_time(cur))
+
+        # Skald writes first (Step 8), through the real writer + ledger.
+        apply_state_updates_sync(
+            conn,
+            StateUpdates(
+                characters=[
+                    CharacterStateUpdate(
+                        character_id=char_id,
+                        character_name="probe",
+                        current_activity="skald probe activity",
+                        current_location=place_id,
+                    )
+                ],
+                locations=[
+                    LocationStateUpdate(
+                        place_id=place_id,
+                        place_name="probe",
+                        current_conditions="replay probe conditions",
+                    )
+                ],
+            ),
+            source_chunk_id=probe_chunk,
+        )
+
+        with conn.cursor() as cur:
+            # Orrery activity write lands after Skald's in the same chunk
+            # (Step 8.5) — the replayed final value must be Orrery's.
+            cur.execute(
+                "UPDATE characters SET current_activity = %s WHERE entity_id = %s",
+                ("orrery probe activity", char_entity),
+            )
+            _insert_resolution(
+                cur,
+                probe_chunk,
+                char_entity,
+                {"character.current_activity": "orrery probe activity"},
+            )
+            capture_state_checkpoint_sync(cur, chunk_id=probe_chunk, label="manual")
+
+            at_head = reconstruct_state_at_sync(cur, head, base_checkpoint_id=base_id)
+            row = _section_row(at_head.state["characters"], id=char_id)
+            assert row["current_activity"] == original_activity
+            assert row["current_location"] == original_location
+
+            # Force forward replay across the window (default base selection
+            # would pick the checkpoint AT probe_chunk — pure passthrough).
+            at_probe = reconstruct_state_at_sync(
+                cur, probe_chunk, base_checkpoint_id=base_id
+            )
+            row = _section_row(at_probe.state["characters"], id=char_id)
+            assert row["current_activity"] == "orrery probe activity"
+            assert row["current_location"] == place_id
+            place_row = _section_row(at_probe.state["places"], id=place_id)
+            assert place_row["current_status"] == "replay probe conditions"
+
+            verdicts = verify_checkpoints_sync(cur)
+            probe_pair = [v for v in verdicts if v.target_chunk_id == probe_chunk]
+            assert len(probe_pair) == 1
+            assert probe_pair[0].drifts == []
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_tag_bestowal_and_clearance_replay_at_exact_chunks() -> None:
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            _, char_entity, _, _ = _probe_character(cur)
+            cur.execute(
+                """
+                SELECT t.id FROM tags t
+                WHERE NOT t.deprecated AND t.synonym_for IS NULL
+                  AND NOT EXISTS (
+                    SELECT 1 FROM entity_tags et
+                    WHERE et.entity_id = %s AND et.tag_id = t.id
+                      AND et.cleared_at IS NULL
+                  )
+                ORDER BY t.id LIMIT 1
+                """,
+                (char_entity,),
+            )
+            new_tag_id = cur.fetchone()[0]
+            cur.execute(
+                "SELECT id FROM entity_tags WHERE cleared_at IS NULL "
+                "ORDER BY id LIMIT 1"
+            )
+            victim_row_id = cur.fetchone()[0]
+
+            capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
+            bestow_chunk = _fabricate_chunk(cur, None)
+            clear_chunk = _fabricate_chunk(cur, None)
+
+            cur.execute(
+                """
+                INSERT INTO entity_tags (
+                    entity_id, tag_id, source_kind, source_chunk_id
+                ) VALUES (%s, %s, 'template', %s) RETURNING id
+                """,
+                (char_entity, new_tag_id, bestow_chunk),
+            )
+            bestowed_row_id = cur.fetchone()[0]
+            cur.execute(
+                "UPDATE entity_tags SET cleared_at = now() WHERE id = %s",
+                (victim_row_id,),
+            )
+            cur.execute(
+                """
+                INSERT INTO tag_clearance_log (
+                    entity_tag_id, mechanism, source_chunk_id
+                ) VALUES (%s, 'authored', %s)
+                """,
+                (victim_row_id, clear_chunk),
+            )
+            capture_state_checkpoint_sync(cur, chunk_id=clear_chunk, label="manual")
+
+            def active_ids(chunk: int) -> set[int]:
+                result = reconstruct_state_at_sync(cur, chunk)
+                return {row["id"] for row in result.state["entity_tags"]}
+
+            at_head = active_ids(head)
+            assert bestowed_row_id not in at_head
+            assert victim_row_id in at_head
+
+            at_bestow = active_ids(bestow_chunk)
+            assert bestowed_row_id in at_bestow
+            assert victim_row_id in at_bestow
+
+            at_clear = active_ids(clear_chunk)
+            assert bestowed_row_id in at_clear
+            assert victim_row_id not in at_clear
+
+            verdicts = verify_checkpoints_sync(cur)
+            probe_pair = [v for v in verdicts if v.target_chunk_id == clear_chunk]
+            assert len(probe_pair) == 1
+            assert probe_pair[0].drifts == []
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_relationship_unwind_restores_updates_deletes_and_drops_inserts() -> None:
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            # Reconstruct at a fabricated pre-chunk, not the historical head:
+            # anchoring at head would unwind any unattributed version rows
+            # accumulated on slot 2 since May, making the assertions hostage
+            # to unrelated history.
+            head = _fabricate_chunk(cur, None)
+            cur.execute(
+                """
+                SELECT character1_id, character2_id, dynamic
+                FROM character_relationships ORDER BY character1_id LIMIT 2
+                """
+            )
+            (u1, u2, original_dynamic), (d1, d2, _) = cur.fetchall()
+
+            probe_chunk = _fabricate_chunk(cur, None)
+            set_commit_chunk_attribution_sync(cur, probe_chunk)
+            cur.execute(
+                """
+                UPDATE character_relationships SET dynamic = 'replay probe dynamic'
+                WHERE character1_id = %s AND character2_id = %s
+                """,
+                (u1, u2),
+            )
+            cur.execute(
+                """
+                DELETE FROM character_relationships
+                WHERE character1_id = %s AND character2_id = %s
+                """,
+                (d1, d2),
+            )
+
+            at_head = reconstruct_state_at_sync(cur, head)
+            rows = at_head.state["character_relationships"]
+            updated = _section_row(rows, character1_id=u1, character2_id=u2)
+            assert updated["dynamic"] == original_dynamic
+            assert _section_row(
+                rows, character1_id=d1, character2_id=d2
+            ), "delete pre-image must resurrect at the earlier chunk"
+
+            at_probe = reconstruct_state_at_sync(cur, probe_chunk)
+            rows = at_probe.state["character_relationships"]
+            updated = _section_row(rows, character1_id=u1, character2_id=u2)
+            assert updated["dynamic"] == "replay probe dynamic"
+            assert _section_row(rows, character1_id=d1, character2_id=d2) is None
+
+            # A row INSERTed after probe_chunk never fires the trigger; the
+            # wall-clock filter must drop it at probe_chunk and keep it at a
+            # later chunk.
+            cur.execute(
+                """
+                SELECT a.id, b.id FROM characters a
+                JOIN characters b ON b.id > a.id
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM character_relationships r
+                    WHERE r.character1_id = a.id AND r.character2_id = b.id
+                )
+                ORDER BY a.id, b.id LIMIT 1
+                """
+            )
+            n1, n2 = cur.fetchone()
+            cur.execute(
+                """
+                INSERT INTO character_relationships (
+                    character1_id, character2_id, relationship_type,
+                    emotional_valence, dynamic, recent_events, history,
+                    created_at
+                ) VALUES (%s, %s, 'ally', 'neutral', 'probe', 'probe',
+                          'probe', now() + interval '1 minute')
+                """,
+                (n1, n2),
+            )
+            later_chunk = _fabricate_chunk(cur, None, created_offset_minutes=2)
+
+            at_probe = reconstruct_state_at_sync(cur, probe_chunk)
+            assert (
+                _section_row(
+                    at_probe.state["character_relationships"],
+                    character1_id=n1,
+                    character2_id=n2,
+                )
+                is None
+            ), "post-chunk INSERT must be dropped by wall-clock correlation"
+            at_later = reconstruct_state_at_sync(cur, later_chunk)
+            assert _section_row(
+                at_later.state["character_relationships"],
+                character1_id=n1,
+                character2_id=n2,
+            )
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_need_fulfillment_replay_matches_production_applier() -> None:
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            _, char_entity, _, _ = _probe_character(cur)
+            capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
+            probe_chunk = _fabricate_chunk(cur, _next_world_time(cur))
+
+            payload = {"type": "hunger", "quality": "probe_meal", "discharge_debt": 3.5}
+            _apply_need_fulfillment_sync(
+                cur,
+                actor_entity_id=char_entity,
+                fulfillment=dict(payload),
+                template_id="replay_probe",
+                source_chunk_id=probe_chunk,
+                need_tuning=load_need_tuning(),
+            )
+            _insert_resolution(cur, probe_chunk, char_entity, {"need.fulfill": payload})
+            capture_state_checkpoint_sync(cur, chunk_id=probe_chunk, label="manual")
+
+            cur.execute(
+                """
+                SELECT debt_score, last_evaluated_chunk_id
+                FROM character_need_states
+                WHERE character_entity_id = %s AND need_type = 'hunger'
+                """,
+                (char_entity,),
+            )
+            live_debt, live_chunk_stamp = cur.fetchone()
+            assert live_chunk_stamp == probe_chunk
+
+            at_probe = reconstruct_state_at_sync(cur, probe_chunk)
+            row = _section_row(
+                at_probe.state["character_need_states"],
+                character_entity_id=char_entity,
+                need_type="hunger",
+            )
+            assert row["last_evaluated_chunk_id"] == probe_chunk
+            assert abs(row["debt_score"] - float(live_debt)) < 0.005
+            assert row["metadata"]["last_fulfillment"]["quality"] == "probe_meal"
+
+            verdicts = verify_checkpoints_sync(cur)
+            probe_pair = [v for v in verdicts if v.target_chunk_id == probe_chunk]
+            assert len(probe_pair) == 1
+            assert probe_pair[0].drifts == []
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_verify_catches_unledgered_scalar_drift() -> None:
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            char_id, _, _, _ = _probe_character(cur)
+            capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
+            probe_chunk = _fabricate_chunk(cur, None)
+
+            # The forbidden move: mutate checkpointed state with no ledger
+            # record of any kind.
+            cur.execute(
+                "UPDATE characters SET emotional_state = %s WHERE id = %s",
+                ("unledgered drift probe", char_id),
+            )
+            capture_state_checkpoint_sync(cur, chunk_id=probe_chunk, label="manual")
+
+            verdicts = verify_checkpoints_sync(cur)
+            probe_pair = [v for v in verdicts if v.target_chunk_id == probe_chunk]
+            assert len(probe_pair) == 1
+            drifts = probe_pair[0].drifts
+            assert any(
+                d.section == "characters"
+                and d.column == "emotional_state"
+                and d.kind == "value"
+                and d.expected == "unledgered drift probe"
+                for d in drifts
+            ), f"verify must catch the un-ledgered write; got {drifts}"
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_reconstruction_refuses_pre_instrumentation_chunks() -> None:
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT min(chunk_id) FROM state_checkpoints "
+                "WHERE chunk_id IS NOT NULL"
+            )
+            earliest = cur.fetchone()[0]
+            assert earliest is not None, "save_02 must carry a genesis checkpoint"
+            cur.execute(
+                "SELECT max(id) FROM narrative_chunks WHERE id < %s", (earliest,)
+            )
+            ancient = cur.fetchone()[0]
+            with pytest.raises(ValueError, match="instrumentation era"):
+                reconstruct_state_at_sync(cur, ancient)
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_need_applicability_trigger_is_mirrored() -> None:
+    """Bestowing a need-immunity tag fires the REAL migration-057 trigger
+    (deleting the character's need rows, un-logged); the replayer's mirror
+    must reproduce that from the final tag set, or verify cries wolf on
+    honest data."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            _, char_entity, _, _ = _probe_character(cur)
+            cur.execute(
+                "SELECT count(*) FROM character_need_states "
+                "WHERE character_entity_id = %s",
+                (char_entity,),
+            )
+            assert cur.fetchone()[0] > 0, "probe character must carry need rows"
+
+            base_id = capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
+            probe_chunk = _fabricate_chunk(cur, None)
+            cur.execute("SELECT id FROM tags WHERE tag = 'inorganic'")
+            immunity_tag_id = cur.fetchone()[0]
+            cur.execute(
+                """
+                INSERT INTO entity_tags (
+                    entity_id, tag_id, source_kind, source_chunk_id
+                ) VALUES (%s, %s, 'template', %s)
+                """,
+                (char_entity, immunity_tag_id, probe_chunk),
+            )
+            # 'inorganic' exempts sleep/hunger/thirst; socialize and intimacy
+            # legitimately survive (NEED_IMMUNITY_TAGS).
+            cur.execute(
+                "SELECT need_type::text FROM character_need_states "
+                "WHERE character_entity_id = %s ORDER BY need_type",
+                (char_entity,),
+            )
+            live_need_types = {row[0] for row in cur.fetchall()}
+            assert not live_need_types & {
+                "sleep",
+                "hunger",
+                "thirst",
+            }, "the DB trigger must have deleted the immune needs"
+            capture_state_checkpoint_sync(cur, chunk_id=probe_chunk, label="manual")
+
+            at_probe = reconstruct_state_at_sync(
+                cur, probe_chunk, base_checkpoint_id=base_id
+            )
+            replayed_need_types = {
+                row["need_type"]
+                for row in at_probe.state["character_need_states"]
+                if row["character_entity_id"] == char_entity
+            }
+            assert (
+                replayed_need_types == live_need_types
+            ), "mirror must reproduce exactly the trigger's surviving rows"
+            at_head = reconstruct_state_at_sync(cur, head, base_checkpoint_id=base_id)
+            assert {
+                row["need_type"]
+                for row in at_head.state["character_need_states"]
+                if row["character_entity_id"] == char_entity
+            } & {
+                "sleep",
+                "hunger",
+                "thirst",
+            }, "immune needs must survive at the pre-bestowal chunk"
+
+            verdicts = verify_checkpoints_sync(cur)
+            probe_pair = [v for v in verdicts if v.target_chunk_id == probe_chunk]
+            assert len(probe_pair) == 1
+            assert probe_pair[0].drifts == []
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_travel_replay_start_advance_arrive() -> None:
+    """Travel deltas replay production-faithfully for explicit payloads:
+    travel.start anchors at the origin, travel.arrive moves the character
+    (an Orrery location write with NO state_delta_log row) and resets the
+    row; route-derived columns are flagged unreproducible so verify skips
+    rather than lies."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            _, char_entity, _, _ = _probe_character(cur)
+            cur.execute("SELECT id FROM places ORDER BY id LIMIT 2")
+            (origin,), (destination,) = cur.fetchall()
+
+            base_id = capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
+            start_chunk = _fabricate_chunk(cur, _next_world_time(cur))
+            arrive_chunk = _fabricate_chunk(
+                cur, _next_world_time(cur) + timedelta(hours=1)
+            )
+
+            # trg_chunk_metadata_refresh_world_time recomputes world_time on
+            # insert; the production-shape writes below must use what the DB
+            # actually stored, exactly as the real appliers do.
+            def stored_world_time(chunk: int) -> datetime:
+                cur.execute(
+                    "SELECT world_time FROM chunk_metadata WHERE chunk_id = %s",
+                    (chunk,),
+                )
+                return cur.fetchone()[0]
+
+            world_time_1 = stored_world_time(start_chunk)
+            world_time_2 = stored_world_time(arrive_chunk)
+
+            start_payload = {
+                "origin_place_id": origin,
+                "destination_place_id": destination,
+                "initial_progress": 0.25,
+            }
+            # Production-shape writes (the full-row upsert travel.start
+            # performs, with route columns the replayer must NOT claim).
+            cur.execute(
+                """
+                INSERT INTO character_travel_states (
+                    character_entity_id, status, anchor_place_id,
+                    origin_place_id, destination_place_id, route_method,
+                    travel_mode, risk, progress_ratio, estimated_distance_m,
+                    estimated_duration_minutes, started_at_world_time,
+                    updated_at_world_time, eta_world_time, route_metadata
+                ) VALUES (
+                    %s, 'in_transit', %s, %s, %s, 'estimated', 'mixed', 'low',
+                    0.25, 1234.5, 42, %s, %s, %s, '{"probe": true}'::jsonb
+                )
+                ON CONFLICT (character_entity_id) DO UPDATE SET
+                    status = EXCLUDED.status,
+                    anchor_place_id = EXCLUDED.anchor_place_id,
+                    origin_place_id = EXCLUDED.origin_place_id,
+                    destination_place_id = EXCLUDED.destination_place_id,
+                    route_method = EXCLUDED.route_method,
+                    travel_mode = EXCLUDED.travel_mode,
+                    risk = EXCLUDED.risk,
+                    progress_ratio = EXCLUDED.progress_ratio,
+                    estimated_distance_m = EXCLUDED.estimated_distance_m,
+                    estimated_duration_minutes = EXCLUDED.estimated_duration_minutes,
+                    started_at_world_time = EXCLUDED.started_at_world_time,
+                    updated_at_world_time = EXCLUDED.updated_at_world_time,
+                    eta_world_time = EXCLUDED.eta_world_time,
+                    route_metadata = EXCLUDED.route_metadata,
+                    updated_at = now()
+                """,
+                (
+                    char_entity,
+                    origin,
+                    origin,
+                    destination,
+                    world_time_1,
+                    world_time_1,
+                    world_time_1,
+                ),
+            )
+            _insert_resolution(
+                cur, start_chunk, char_entity, {"travel.start": start_payload}
+            )
+
+            # Arrive: production writes characters.current_location and
+            # resets the travel row.
+            cur.execute(
+                "UPDATE characters SET current_location = %s WHERE entity_id = %s",
+                (destination, char_entity),
+            )
+            cur.execute(
+                """
+                UPDATE character_travel_states
+                SET status = 'at_place', anchor_place_id = %s,
+                    origin_place_id = NULL, destination_place_id = NULL,
+                    progress_ratio = 0, estimated_distance_m = NULL,
+                    estimated_duration_minutes = NULL,
+                    started_at_world_time = NULL,
+                    updated_at_world_time = %s, eta_world_time = NULL,
+                    route_metadata = route_metadata
+                        || jsonb_build_object('last_arrived_place_id', %s::bigint),
+                    updated_at = now()
+                WHERE character_entity_id = %s
+                """,
+                (destination, world_time_2, destination, char_entity),
+            )
+            _insert_resolution(cur, arrive_chunk, char_entity, {"travel.arrive": True})
+            capture_state_checkpoint_sync(cur, chunk_id=arrive_chunk, label="manual")
+
+            at_start = reconstruct_state_at_sync(
+                cur, start_chunk, base_checkpoint_id=base_id
+            )
+            travel_row = _section_row(
+                at_start.state["character_travel_states"],
+                character_entity_id=char_entity,
+            )
+            assert travel_row["status"] == "in_transit"
+            assert (
+                travel_row["anchor_place_id"] == origin
+            ), "production anchors an in-transit row at its origin"
+            assert travel_row["origin_place_id"] == origin
+            assert travel_row["destination_place_id"] == destination
+            assert travel_row["progress_ratio"] == 0.25
+
+            at_arrive = reconstruct_state_at_sync(
+                cur, arrive_chunk, base_checkpoint_id=base_id
+            )
+            char_row = _section_row(
+                at_arrive.state["characters"], entity_id=char_entity
+            )
+            assert char_row["current_location"] == destination, (
+                "travel.arrive's location write has no state_delta_log row; "
+                "replay must apply it from the Orrery ledger"
+            )
+            travel_row = _section_row(
+                at_arrive.state["character_travel_states"],
+                character_entity_id=char_entity,
+            )
+            assert travel_row["status"] == "at_place"
+            assert travel_row["anchor_place_id"] == destination
+            assert travel_row["destination_place_id"] is None
+
+            verdicts = verify_checkpoints_sync(cur)
+            probe_pair = [v for v in verdicts if v.target_chunk_id == arrive_chunk]
+            assert len(probe_pair) == 1
+            assert probe_pair[0].drifts == []
+            assert (
+                probe_pair[0].skipped_unreproducible > 0
+            ), "route-derived columns must be skipped as unreproducible"
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_null_world_time_marks_need_timestamps_unreproducible() -> None:
+    """A tick without world_time makes production stamp wall-clock now();
+    replay must flag those columns instead of guessing — and verify must
+    skip them, not drift."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            _, char_entity, _, _ = _probe_character(cur)
+            base_id = capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
+            probe_chunk = _fabricate_chunk(cur, None)  # world_time NULL
+
+            _apply_need_fulfillment_sync(
+                cur,
+                actor_entity_id=char_entity,
+                fulfillment={"type": "thirst", "discharge_debt": 1.0},
+                template_id="replay_probe",
+                source_chunk_id=probe_chunk,
+                need_tuning=load_need_tuning(),
+            )
+            _insert_resolution(
+                cur,
+                probe_chunk,
+                char_entity,
+                {"need.fulfill": {"type": "thirst", "discharge_debt": 1.0}},
+            )
+            capture_state_checkpoint_sync(cur, chunk_id=probe_chunk, label="manual")
+
+            at_probe = reconstruct_state_at_sync(
+                cur, probe_chunk, base_checkpoint_id=base_id
+            )
+            row_key = f"{char_entity}:thirst"
+            assert (
+                "character_need_states",
+                row_key,
+                "last_evaluated_at",
+            ) in at_probe.unreproducible
+
+            verdicts = verify_checkpoints_sync(cur)
+            probe_pair = [v for v in verdicts if v.target_chunk_id == probe_chunk]
+            assert len(probe_pair) == 1
+            assert probe_pair[0].drifts == []
+            assert probe_pair[0].skipped_unreproducible >= 2
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_verify_catches_unlogged_tag_clear() -> None:
+    """The oracle must be sensitive beyond character scalars: a tag cleared
+    without a tag_clearance_log row is exactly the class of un-ledgered
+    write verify exists to catch."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
+            probe_chunk = _fabricate_chunk(cur, None)
+
+            # A non-severity tag cleared with no log row (severity tags are
+            # legitimately cleared un-logged by the applicability trigger and
+            # mirrored; anything else is drift).
+            cur.execute(
+                """
+                UPDATE entity_tags et SET cleared_at = now()
+                FROM tags t
+                WHERE et.tag_id = t.id AND et.cleared_at IS NULL
+                  AND t.tag NOT LIKE 'sleep_deprived%%'
+                  AND t.tag NOT LIKE 'hungry%%'
+                  AND t.tag NOT LIKE 'thirsty%%'
+                  AND t.tag NOT LIKE 'under_socialized%%'
+                  AND t.tag NOT LIKE 'intimacy_starved%%'
+                  AND et.id = (
+                    SELECT et2.id FROM entity_tags et2
+                    JOIN tags t2 ON t2.id = et2.tag_id
+                    WHERE et2.cleared_at IS NULL
+                      AND t2.tag NOT LIKE 'sleep_deprived%%'
+                      AND t2.tag NOT LIKE 'hungry%%'
+                      AND t2.tag NOT LIKE 'thirsty%%'
+                      AND t2.tag NOT LIKE 'under_socialized%%'
+                      AND t2.tag NOT LIKE 'intimacy_starved%%'
+                    ORDER BY et2.id LIMIT 1
+                  )
+                RETURNING et.id
+                """
+            )
+            cleared_row_id = cur.fetchone()[0]
+            capture_state_checkpoint_sync(cur, chunk_id=probe_chunk, label="manual")
+
+            verdicts = verify_checkpoints_sync(cur)
+            probe_pair = [v for v in verdicts if v.target_chunk_id == probe_chunk]
+            assert len(probe_pair) == 1
+            assert any(
+                d.section == "entity_tags"
+                and d.kind == "extra_row"
+                and d.row_key == str(cleared_row_id)
+                for d in probe_pair[0].drifts
+            ), "verify must catch the un-logged clear as extra_row drift"
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_relationship_multi_version_unwind_order() -> None:
+    """Two attributed updates across two chunks must unwind newest-first
+    (relationship_versions.id DESC): the middle chunk sees the middle value."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            pre_chunk = _fabricate_chunk(cur, None)
+            mid_chunk = _fabricate_chunk(cur, None)
+            late_chunk = _fabricate_chunk(cur, None)
+            cur.execute(
+                """
+                SELECT character1_id, character2_id, dynamic
+                FROM character_relationships ORDER BY character1_id LIMIT 1
+                """
+            )
+            c1, c2, original = cur.fetchone()
+
+            set_commit_chunk_attribution_sync(cur, mid_chunk)
+            cur.execute(
+                """
+                UPDATE character_relationships SET dynamic = 'mid value'
+                WHERE character1_id = %s AND character2_id = %s
+                """,
+                (c1, c2),
+            )
+            set_commit_chunk_attribution_sync(cur, late_chunk)
+            cur.execute(
+                """
+                UPDATE character_relationships SET dynamic = 'late value'
+                WHERE character1_id = %s AND character2_id = %s
+                """,
+                (c1, c2),
+            )
+
+            def dynamic_at(chunk: int) -> str:
+                result = reconstruct_state_at_sync(cur, chunk)
+                return _section_row(
+                    result.state["character_relationships"],
+                    character1_id=c1,
+                    character2_id=c2,
+                )["dynamic"]
+
+            assert dynamic_at(pre_chunk) == original
+            assert dynamic_at(mid_chunk) == "mid value"
+            assert dynamic_at(late_chunk) == "late value"
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_pair_tag_bestowal_and_clearance_replay() -> None:
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            cur.execute(
+                """
+                SELECT pt.id FROM pair_tags pt WHERE NOT pt.deprecated
+                ORDER BY pt.id LIMIT 1
+                """
+            )
+            pair_tag_id = cur.fetchone()[0]
+            cur.execute(
+                """
+                SELECT a.entity_id, b.entity_id FROM characters a
+                JOIN characters b ON b.entity_id > a.entity_id
+                WHERE a.entity_id IS NOT NULL AND b.entity_id IS NOT NULL
+                  AND NOT EXISTS (
+                    SELECT 1 FROM entity_pair_tags ept
+                    WHERE ept.subject_entity_id = a.entity_id
+                      AND ept.object_entity_id = b.entity_id
+                      AND ept.pair_tag_id = %s AND ept.cleared_at IS NULL
+                  )
+                ORDER BY a.entity_id, b.entity_id LIMIT 1
+                """,
+                (pair_tag_id,),
+            )
+            subject, obj = cur.fetchone()
+
+            capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
+            bestow_chunk = _fabricate_chunk(cur, None)
+            clear_chunk = _fabricate_chunk(cur, None)
+            cur.execute(
+                """
+                INSERT INTO entity_pair_tags (
+                    subject_entity_id, object_entity_id, pair_tag_id,
+                    source_kind, source_chunk_id
+                ) VALUES (%s, %s, %s, 'template', %s) RETURNING id
+                """,
+                (subject, obj, pair_tag_id, bestow_chunk),
+            )
+            pair_row_id = cur.fetchone()[0]
+            cur.execute(
+                "UPDATE entity_pair_tags SET cleared_at = now() WHERE id = %s",
+                (pair_row_id,),
+            )
+            cur.execute(
+                """
+                INSERT INTO tag_clearance_log (
+                    entity_pair_tag_id, mechanism, source_chunk_id
+                ) VALUES (%s, 'authored', %s)
+                """,
+                (pair_row_id, clear_chunk),
+            )
+            capture_state_checkpoint_sync(cur, chunk_id=clear_chunk, label="manual")
+
+            def pair_ids(chunk: int) -> set[int]:
+                result = reconstruct_state_at_sync(cur, chunk)
+                return {row["id"] for row in result.state["entity_pair_tags"]}
+
+            assert pair_row_id not in pair_ids(head)
+            assert pair_row_id in pair_ids(bestow_chunk)
+            assert pair_row_id not in pair_ids(clear_chunk)
+
+            verdicts = verify_checkpoints_sync(cur)
+            probe_pair = [v for v in verdicts if v.target_chunk_id == clear_chunk]
+            assert len(probe_pair) == 1
+            assert probe_pair[0].drifts == []
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_pg_round_matches_postgres_numeric_storage() -> None:
+    """Postgres numeric rounds half away from zero; Python round() is
+    banker's. 2.675 must store as 2.68."""
+
+    from nexus.agents.orrery.replay import _pg_round
+
+    assert _pg_round(2.675, 2) == 2.68
+    assert _pg_round(0.5, 0) == 1.0
+    assert _pg_round(0.35125, 4) == 0.3513
+    assert round(2.675, 2) != 2.68, "if this fails, Python changed rounding"


### PR DESCRIPTION
## Summary

The read half of the reconstruction contract from #426. PR #428 shipped the write side in July (Skald delta ledger, JSONB checkpoints, trigger-enforced relationship versioning) — but nothing ever consumed those artifacts. This PR makes the write side prove itself by being read:

- **`nexus/agents/orrery/replay.py`** — `reconstruct_state_at_sync(cur, N)` rebuilds the full mutable state surface (all ten `CHECKPOINT_SECTIONS`) at any post-instrumentation chunk. The replay partition follows a five-agent code survey of the actual writers:
  - **Scalars** forward from the base checkpoint: `state_delta_log` (Skald, first within a chunk), then `orrery_resolutions.state_delta` in `id` order — including `travel.arrive`'s location write, which is *not* Skald-ledgered.
  - **Tags/pair tags** purely from the migration-064 provenance tables (bestowal `source_chunk_id`, `tag_clearance_log`); the delta tag keys are deliberately ignored (double-entry), and `need.fulfill`'s derived severity tags exist *only* in provenance.
  - **Relationships** backward from the current tables via `relationship_versions` pre-images (`id DESC`), with a post-unwind wall-clock drop of rows INSERTed after N (inserts never fire the triggers).
  - **Needs** re-execute through the same `effective_debt_score` authority production used (config-sensitive, flagged), and the un-ledgered migration-057 **need-applicability trigger** (entity_tags changes insert/delete need rows and clear severity tags with no log rows) is mirrored from the final tag set.
  - Every result carries a **fidelity report**: per-section notes, exact/approximate tiers, unreproducible columns, and presence-uncertain rows (the Step 8.6-after-8.55 same-transaction-timestamp ambiguity).

- **`verify_checkpoints_sync`** — the payoff: replays every consecutive checkpoint pair and diffs against the stored target document (same-chunk pairs diff stored-vs-stored). Since the commit path auto-checkpoints every 25 chunks, every slot accumulates a standing regression oracle — **any future writer that ships un-ledgered surfaces as drift**, named by section, row, and column.

- **`scripts/replay_state.py`** — CLI: `--slot N --chunk M` prints/exports the reconstruction with its fidelity report; `--slot N --verify` runs the oracle, exiting nonzero on drift. Read-only session.

## Tests

13 live tests on save_02 in always-rolled-back transactions (the #428 pattern), fabricating history through the **real** writers and **real** DB triggers: Skald→Orrery within-chunk ordering, tag/pair-tag bestow/clear windows at exact chunks, multi-version relationship unwind ordering, delete resurrection, post-chunk INSERT drops, the applicability trigger firing live against its replay mirror, NULL-world-time unreproducibility bookkeeping, Postgres half-away-from-zero vs banker's rounding, and both drift detections (un-ledgered scalar write, un-logged tag clear). All 13 pass; the CLI is live-verified against save_02.

Notable environment discoveries encoded in the tests: `now()` is transaction-constant (wall-clock ordering must be staggered explicitly), and `trg_chunk_metadata_refresh_world_time` backfills/overrides `world_time` on insert.

## Review Provenance

Adversarially reviewed pre-commit by a 38-agent find/refute workflow: 34 raw findings → 21 confirmed → all fixed (need-applicability trigger mirror, Step 8.6 boundary semantics, `travel.start` anchor + route-derived columns, window-birth seeding honesty, pairwise canonicalization) or documented as inherent limits (backward-unwind blind spot when current == target, tag reapplication `source_chunk_id` overwrite).

Closes #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY