### PR TITLE
Bound Live Postgres Waits in Default Pytest Runs

### DIFF
--- a/nexus/api/mock_openai.py
+++ b/nexus/api/mock_openai.py
@@ -21,10 +21,12 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 import psycopg2
-from psycopg2.extras import RealDictCursor
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from psycopg2.extras import RealDictCursor
 from pydantic import BaseModel
+
+from nexus.config import load_settings
 
 logger = logging.getLogger("nexus.api.mock_openai")
 
@@ -58,12 +60,17 @@ app.add_middleware(
 )
 
 
-def get_mock_connection():
+def get_mock_connection() -> psycopg2.extensions.connection:
     """Get connection to mock database."""
+    settings = load_settings()
+    if settings.api is None:
+        raise ValueError("nexus.toml is missing the [api] section")
+
     return psycopg2.connect(
         host="localhost",
         database=MOCK_DB,
         user="pythagor",
+        connect_timeout=settings.api.database.connect_timeout_seconds,
         cursor_factory=RealDictCursor,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from typing import Iterable
 
+import psycopg2
 import pytest
 
 
@@ -17,6 +18,21 @@ def _apply_marker_skip(items: Iterable[pytest.Item], marker: str, reason: str) -
     for item in items:
         if marker in item.keywords:
             item.add_marker(skip_marker)
+
+
+@pytest.fixture(autouse=True)
+def _forbid_unopted_postgres_connections(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail immediately if a default-path test attempts a live DB connection."""
+    if _flag_enabled("NEXUS_RUN_POSTGRES"):
+        return
+
+    def fail_connect(*args: object, **kwargs: object) -> None:
+        raise AssertionError(
+            "Unit test attempted psycopg2.connect; mark it requires_postgres "
+            "and run with NEXUS_RUN_POSTGRES=1."
+        )
+
+    monkeypatch.setattr(psycopg2, "connect", fail_connect)
 
 
 def pytest_collection_modifyitems(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,9 +27,13 @@ def _forbid_unopted_postgres_connections(monkeypatch: pytest.MonkeyPatch) -> Non
         return
 
     def fail_connect(*args: object, **kwargs: object) -> None:
-        raise AssertionError(
+        # pytest.fail raises a BaseException-derived outcome, so application
+        # code that wraps optional DB reads in `except Exception` cannot
+        # swallow the tripwire and quietly proceed.
+        pytest.fail(
             "Unit test attempted psycopg2.connect; mark it requires_postgres "
-            "and run with NEXUS_RUN_POSTGRES=1."
+            "and run with NEXUS_RUN_POSTGRES=1.",
+            pytrace=False,
         )
 
     monkeypatch.setattr(psycopg2, "connect", fail_connect)

--- a/tests/test_lore/conftest.py
+++ b/tests/test_lore/conftest.py
@@ -12,6 +12,8 @@ from typing import Dict, Any, Generator
 from unittest.mock import MagicMock
 import sys
 
+TEST_DB_CONNECT_TIMEOUT_SECONDS = 2
+
 # Configure logging for tests
 logging.basicConfig(
     level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -86,6 +88,7 @@ def db_connection(settings) -> Generator[psycopg2.extensions.connection, None, N
         user=db_config.get("user", "pythagor"),
         host=db_config.get("host", "localhost"),
         port=db_config.get("port", 5432),
+        connect_timeout=TEST_DB_CONNECT_TIMEOUT_SECONDS,
     )
 
     try:

--- a/tests/test_lore/test_chunk_operations.py
+++ b/tests/test_lore/test_chunk_operations.py
@@ -38,6 +38,7 @@ class TestTokenCalculation:
         """Test empty string token count."""
         assert calculate_chunk_tokens("") == 0
     
+    @pytest.mark.requires_postgres
     def test_calculate_chunk_tokens_narrative(self, sample_chunks):
         """Test token counting on real narrative text."""
         # Use a dialogue scene

--- a/tests/test_mock_openai.py
+++ b/tests/test_mock_openai.py
@@ -197,6 +197,7 @@ async def test_mock_responses_routes_turn_schema_as_native_text_format() -> None
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_postgres
 async def test_mock_responses_routes_bootstrap_schema_as_final_result_tool() -> None:
     """Bootstrap structured output must also call the required output tool."""
 
@@ -216,6 +217,7 @@ async def test_mock_responses_routes_bootstrap_schema_as_final_result_tool() -> 
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_postgres
 async def test_mock_responses_routes_bootstrap_schema_as_native_text_format() -> None:
     """Bootstrap native structured output should return message JSON."""
 


### PR DESCRIPTION
## Summary

Implements the frozen spec in #473 (codex-first: Codex implemented, Claude reviewed and verified). The default pytest run could stall ~3 minutes when local Postgres auth was unavailable — three tests outside the `requires_postgres` gate each rode the driver's ~60s default connect wait.

- The three offenders (`test_calculate_chunk_tokens_narrative`, both bootstrap schema-routing tests) are reclassified `requires_postgres` — the spec's sanctioned alternative to mocking the DB boundary, keeping them as real integration tests under `NEXUS_RUN_POSTGRES=1`.
- **Tripwire**: an autouse fixture replaces `psycopg2.connect` with an immediate, instructive `AssertionError` whenever `NEXUS_RUN_POSTGRES` is unset — any future unmarked test that reaches for a live connection fails in milliseconds instead of hanging. Disabled entirely for opt-in runs.
- The mock server's DB connections are bounded by the existing validated `[api.database].connect_timeout_seconds`; the narrative fixture connection gets a 2s test constant.

## Verification (run by Claude in the worktree)

- Default suite: `1153 passed, 196 skipped in 12.79s` (was `194.23s` in the audit).
- Opt-in: `NEXUS_RUN_POSTGRES=1` on the affected files: `34 passed`.
- flake8 clean on changed files (two pre-existing nits on HEAD confirmed unrelated).

Closes #473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY