### PR TITLE
Orrery Band-Window Softmax: Seeded Near-Tie Package Selection

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -260,6 +260,15 @@ mode = "stochastic"
 temperature = 0.25
 seed_salt = ""
 
+[orrery.package_selection]
+# Stack winner selection after habituation: crisis (and any other exempt band)
+# keeps strict priority. Otherwise, gate-passing packages within window_points
+# of the maximum enter a seeded softmax on the 0-100 priority scale.
+mode = "stochastic"
+window_points = 6.0
+temperature = 2.0
+exempt_bands = ["crisis_constraint"]
+
 [orrery.reconstruction]
 # JSONB state checkpoint every N accepted chunks (0 disables); genesis and
 # manual snapshots via scripts/checkpoint_state.py.

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -642,6 +642,7 @@ class TurnCycleManager:
                 sunhelm_settings=orrery_settings.get("sunhelm"),
                 selection_settings=orrery_settings.get("selection"),
                 habituation_settings=orrery_settings.get("habituation"),
+                package_selection_settings=orrery_settings.get("package_selection"),
                 fanout_settings=orrery_settings.get("fanout"),
             )
 

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -70,6 +70,7 @@ from nexus.agents.orrery.resolver import (
 from nexus.agents.orrery.substrate import (
     coerce_branch_selection,
     coerce_habituation,
+    coerce_package_selection,
     CONSTRAINED_TAGS,
     DRAMATIC_CONTACT_TAGS,
     DRIVE_BAND_ORDER,
@@ -477,6 +478,7 @@ def explain_dry_run(
     overrides: Optional[WorldStateOverrides] = None,
     selection_settings: Optional[Any] = None,
     habituation_settings: Optional[Any] = None,
+    package_selection_settings: Optional[Any] = None,
     fanout_settings: Optional[Any] = None,
 ) -> ExplainedTickReport:
     """Hydrate, bind, and explain Orrery packages without database writes.
@@ -495,6 +497,7 @@ def explain_dry_run(
     need_tuning = coerce_need_tuning(sunhelm_settings)
     selection = coerce_branch_selection(selection_settings)
     habituation = coerce_habituation(habituation_settings)
+    package_selection = coerce_package_selection(package_selection_settings)
     state = hydrate_world_state(
         session,
         anchor_chunk_id=anchor_chunk_id,
@@ -567,7 +570,12 @@ def explain_dry_run(
         actor_stacks: dict[int, StackExplanation] = {}
         for bindings in actor_bindings:
             actor_stacks[bindings[Slot.ACTOR]] = explain_stack(
-                actor_only_templates, tick_state, bindings, selection, habituation
+                actor_only_templates,
+                tick_state,
+                bindings,
+                selection,
+                habituation,
+                package_selection,
             )
         two_party_stacks: dict[int, List[StackExplanation]] = {}
         for pair_bindings in offscreen_pair_bindings:
@@ -578,6 +586,7 @@ def explain_dry_run(
                     pair_bindings,
                     selection,
                     habituation,
+                    package_selection,
                 )
             )
         pressure_stacks: dict[int, List[StackExplanation]] = {}
@@ -589,6 +598,7 @@ def explain_dry_run(
                     pair_bindings,
                     selection,
                     habituation,
+                    package_selection,
                 )
             )
         need_pressure_specs = _present_need_pressure_specs(

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -298,6 +298,7 @@ def analyze_coverage(
     epoch_min_world_times: int,
     selection_settings: Optional[Any] = None,
     habituation_settings: Optional[Any] = None,
+    package_selection_settings: Optional[Any] = None,
     fanout_settings: Optional[Any] = None,
 ) -> dict[str, Any]:
     """Aggregate explained resolution coverage across historical anchors.
@@ -339,6 +340,7 @@ def analyze_coverage(
             sunhelm_settings=sunhelm_settings,
             selection_settings=selection_settings,
             habituation_settings=habituation_settings,
+            package_selection_settings=package_selection_settings,
             fanout_settings=fanout_settings,
         )
         anchors.append(_tally_report(report, tallies, gap_counts))

--- a/nexus/agents/orrery/explain.py
+++ b/nexus/agents/orrery/explain.py
@@ -34,6 +34,8 @@ from nexus.agents.orrery.substrate import (
     BranchSelection,
     CompoundCondition,
     Condition,
+    HabituationPolicy,
+    PackageSelection,
     Resolution,
     Slot,
     Template,
@@ -41,7 +43,7 @@ from nexus.agents.orrery.substrate import (
     binding_hash,
     evaluate,
     select_branch,
-    HabituationPolicy,
+    select_package,
     stack_order,
 )
 
@@ -166,6 +168,9 @@ class StackExplanation:
     bindings: Mapping[str, Any]
     winner_id: Optional[str]
     templates: Tuple[TemplateExplanation, ...]
+    selection_window_ids: Tuple[str, ...] = ()
+    chosen_by_softmax: bool = False
+    selection_reason: str = "no_passing_candidate"
 
     @property
     def shadowed_ids(self) -> Tuple[str, ...]:
@@ -188,6 +193,9 @@ class StackExplanation:
         return {
             "bindings": dict(self.bindings),
             "winner_id": self.winner_id,
+            "selection_window_ids": list(self.selection_window_ids),
+            "chosen_by_softmax": self.chosen_by_softmax,
+            "selection_reason": self.selection_reason,
             "shadowed_ids": list(self.shadowed_ids),
             "templates": templates,
         }
@@ -335,22 +343,31 @@ def explain_stack(
     bindings: Bindings,
     selection: Optional[BranchSelection] = None,
     habituation: Optional[HabituationPolicy] = None,
+    package_selection: Optional[PackageSelection] = None,
 ) -> StackExplanation:
     """Explain every template in effective-priority order; flag the winner.
 
-    Mirrors :func:`evaluate_stack` selection (highest effective priority
-    firing template wins) while retaining the full audit record for every
-    template, so the dashboard can render the winner alongside the shadowed
-    packages. Ordering routes through the shared :func:`stack_order`
-    authority — habituation dampening shows up here exactly as it does in
-    production.
+    Mirrors :func:`evaluate_stack` through the shared :func:`select_package`
+    authority while retaining the full audit record for every template, so
+    the dashboard can render the winner, near-tie window, and shadowed
+    packages. Ordering routes through :func:`stack_order`, so habituation
+    dampening shows up here exactly as it does in production.
     """
 
-    ordered = stack_order(templates, state, bindings, habituation)
+    templates_tuple = tuple(templates)
+    outcome = select_package(
+        templates_tuple,
+        state,
+        bindings,
+        selection,
+        habituation,
+        package_selection,
+    )
+    ordered = stack_order(templates_tuple, state, bindings, habituation)
     explanations = tuple(
         explain_template(template, state, bindings, selection) for template in ordered
     )
-    winner_id = next((item.template_id for item in explanations if item.fired), None)
+    winner_id = outcome.winner.template_id if outcome.winner is not None else None
     serialized_bindings = {
         slot.value if isinstance(slot, Slot) else str(slot): value
         for slot, value in bindings.items()
@@ -359,4 +376,7 @@ def explain_stack(
         bindings=serialized_bindings,
         winner_id=winner_id,
         templates=explanations,
+        selection_window_ids=outcome.window_template_ids,
+        chosen_by_softmax=outcome.chosen_by_softmax,
+        selection_reason=outcome.reason,
     )

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -15,9 +15,10 @@ from nexus.agents.orrery.reciprocal import (
     detect_joint_beats,
 )
 from nexus.agents.orrery.substrate import (
-    BranchSelection,
+    PackageSelection,
     coerce_branch_selection,
     coerce_habituation,
+    coerce_package_selection,
     Bindings,
     EventRecord,
     INTIMACY_SUPPRESSOR_TAGS,
@@ -931,6 +932,7 @@ def resolve_dry_run(
     world_time_override: Optional[datetime] = None,
     selection_settings: Optional[Any] = None,
     habituation_settings: Optional[Any] = None,
+    package_selection_settings: Optional[Any] = None,
     fanout_settings: Optional[Any] = None,
 ) -> OrreryTickProposal:
     """Hydrate, bind, and evaluate Orrery packages without database writes."""
@@ -938,6 +940,9 @@ def resolve_dry_run(
     need_tuning = coerce_need_tuning(sunhelm_settings)
     selection = coerce_branch_selection(selection_settings)
     habituation = coerce_habituation(habituation_settings)
+    package_selection: Optional[PackageSelection] = coerce_package_selection(
+        package_selection_settings
+    )
     fanout = _coerce_fanout(fanout_settings)
     state = hydrate_world_state(
         session,
@@ -979,7 +984,12 @@ def resolve_dry_run(
     )
     for bindings in actor_bindings:
         resolution = evaluate_stack(
-            actor_only_templates, state, bindings, selection, habituation
+            actor_only_templates,
+            state,
+            bindings,
+            selection,
+            habituation,
+            package_selection,
         )
         if resolution is not None and resolution.passes:
             drafts.append(_draft_from_resolution(resolution))
@@ -996,7 +1006,12 @@ def resolve_dry_run(
         )
         for bindings in actor_target_bindings:
             resolution = evaluate_stack(
-                actor_target_templates, state, bindings, selection, habituation
+                actor_target_templates,
+                state,
+                bindings,
+                selection,
+                habituation,
+                package_selection,
             )
             if resolution is not None and resolution.passes:
                 drafts.append(_draft_from_resolution(resolution))
@@ -1017,7 +1032,12 @@ def resolve_dry_run(
             )
             for bindings in present_target_bindings:
                 resolution = evaluate_stack(
-                    pressure_templates, state, bindings, selection, habituation
+                    pressure_templates,
+                    state,
+                    bindings,
+                    selection,
+                    habituation,
+                    package_selection,
                 )
                 if resolution is not None and resolution.passes:
                     scene_pressure_results.append(resolution)

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -2036,6 +2036,80 @@ def coerce_habituation(raw: Any) -> HabituationPolicy:
     raise ValueError(f"Unsupported habituation settings: {type(raw)!r}")
 
 
+@dataclass(frozen=True, slots=True)
+class PackageSelection:
+    """Stack-winner policy from [orrery.package_selection].
+
+    ``argmax`` preserves the legacy first-firing template in effective-priority
+    order. ``stochastic`` softmax-samples only the gate-passing templates whose
+    effective priorities sit within ``window_points`` of the maximum. Any
+    passing template in ``exempt_bands`` disables sampling for the whole stack,
+    preserving strict priority for crisis and other configured safety bands.
+    """
+
+    mode: str
+    window_points: float
+    temperature: float
+    exempt_bands: frozenset[str]
+
+    def __post_init__(self) -> None:
+        if self.mode not in ("argmax", "stochastic"):
+            raise ValueError(
+                f"Unknown package-selection mode {self.mode!r}; expected "
+                "'argmax' or 'stochastic'"
+            )
+        if self.window_points < 0:
+            raise ValueError(
+                "Package-selection window_points must be >= 0, got "
+                f"{self.window_points}"
+            )
+        if self.temperature <= 0:
+            raise ValueError(
+                "Package-selection temperature must be > 0, got " f"{self.temperature}"
+            )
+
+
+def coerce_package_selection(raw: Any) -> Optional[PackageSelection]:
+    """Coerce [orrery.package_selection] config to its runtime policy.
+
+    ``None`` preserves the legacy strict-argmax stack behavior for callers
+    that have not supplied configuration.
+    """
+
+    if raw is None or isinstance(raw, PackageSelection):
+        return raw
+    if isinstance(raw, Mapping):
+        return PackageSelection(
+            mode=str(raw["mode"]),
+            window_points=float(raw["window_points"]),
+            temperature=float(raw["temperature"]),
+            exempt_bands=frozenset(raw["exempt_bands"]),
+        )
+    return PackageSelection(
+        mode=str(raw.mode),
+        window_points=float(raw.window_points),
+        temperature=float(raw.temperature),
+        exempt_bands=frozenset(raw.exempt_bands),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PackageSelectionOutcome:
+    """Auditable result from the shared stack-winner authority."""
+
+    winner: Optional[Resolution]
+    window_template_ids: Tuple[str, ...] = ()
+    chosen_by_softmax: bool = False
+    reason: str = "no_passing_candidate"
+
+
+def _package_selection_rng(digest: str, tick: int) -> random.Random:
+    """PRNG keyed on binding identity, persisted tick, and a distinct salt."""
+
+    seed_material = f"{digest}:{tick}:package_selection"
+    return random.Random(int(sha256(seed_material.encode("utf-8")).hexdigest(), 16))
+
+
 def stack_order(
     templates: Iterable[Template],
     state: WorldState,
@@ -2059,20 +2133,104 @@ def stack_order(
     )
 
 
+def select_package(
+    templates: Iterable[Template],
+    state: WorldState,
+    bindings: Bindings,
+    branch_selection: Optional[BranchSelection] = None,
+    habituation: Optional[HabituationPolicy] = None,
+    package_selection: Optional[PackageSelection] = None,
+) -> PackageSelectionOutcome:
+    """Choose one firing package through the production/explain authority.
+
+    Effective priority is computed after habituation for every firing
+    candidate. Missing policy and explicit ``argmax`` retain the former
+    first-firing behavior. In stochastic mode, configured exempt bands
+    preempt randomization; otherwise only candidates in the near-tie window
+    enter a seeded softmax. The seed uses binding identity and the persisted
+    tick plus a package-specific salt, so the same evaluation is replay-
+    identical without sharing branch-selection calibration.
+    """
+
+    habituation_policy = habituation or HabituationPolicy()
+    ordered = stack_order(templates, state, bindings, habituation_policy)
+    passing = [
+        (
+            template,
+            evaluate(template, state, bindings, branch_selection),
+            habituation_policy.effective_priority(template, state, bindings),
+        )
+        for template in ordered
+    ]
+    passing = [candidate for candidate in passing if candidate[1].passes]
+    if not passing:
+        return PackageSelectionOutcome(winner=None)
+
+    argmax = passing[0]
+    if package_selection is None or package_selection.mode == "argmax":
+        return PackageSelectionOutcome(
+            winner=argmax[1],
+            window_template_ids=(argmax[0].id,),
+            reason="argmax",
+        )
+
+    if any(
+        template.drive_band.value in package_selection.exempt_bands
+        for template, _resolution, _priority in passing
+    ):
+        return PackageSelectionOutcome(
+            winner=argmax[1],
+            window_template_ids=(argmax[0].id,),
+            reason="exempt_band_argmax",
+        )
+
+    peak = argmax[2]
+    window = [
+        candidate
+        for candidate in passing
+        if peak - candidate[2] <= package_selection.window_points
+    ]
+    window_ids = tuple(template.id for template, _resolution, _priority in window)
+    if len(window) == 1:
+        return PackageSelectionOutcome(
+            winner=argmax[1],
+            window_template_ids=window_ids,
+            reason="single_candidate_window",
+        )
+
+    weights = [
+        math.exp((effective_priority - peak) / package_selection.temperature)
+        for _template, _resolution, effective_priority in window
+    ]
+    digest = binding_hash(bindings)
+    rng = _package_selection_rng(digest, state.current_tick)
+    chosen = rng.choices(window, weights=weights, k=1)[0]
+    return PackageSelectionOutcome(
+        winner=chosen[1],
+        window_template_ids=window_ids,
+        chosen_by_softmax=True,
+        reason="window_softmax",
+    )
+
+
 def evaluate_stack(
     templates: Iterable[Template],
     state: WorldState,
     bindings: Bindings,
     selection: Optional[BranchSelection] = None,
     habituation: Optional[HabituationPolicy] = None,
+    package_selection: Optional[PackageSelection] = None,
 ) -> Optional[Resolution]:
-    """Evaluate templates in effective-priority order; first firing branch wins."""
+    """Evaluate a stack through the shared package-selection authority."""
 
-    for template in stack_order(templates, state, bindings, habituation):
-        result = evaluate(template, state, bindings, selection)
-        if result.passes:
-            return result
-    return None
+    return select_package(
+        templates,
+        state,
+        bindings,
+        selection,
+        habituation,
+        package_selection,
+    ).winner
 
 
 def validate_always_fallbacks(templates: Iterable[Template]) -> None:

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -2143,40 +2143,55 @@ def select_package(
 ) -> PackageSelectionOutcome:
     """Choose one firing package through the production/explain authority.
 
-    Effective priority is computed after habituation for every firing
-    candidate. Missing policy and explicit ``argmax`` retain the former
-    first-firing behavior. In stochastic mode, configured exempt bands
-    preempt randomization; otherwise only candidates in the near-tie window
-    enter a seeded softmax. The seed uses binding identity and the persisted
-    tick plus a package-specific salt, so the same evaluation is replay-
-    identical without sharing branch-selection calibration.
+    Evaluation is lazy in effective-priority order: with no policy or
+    explicit ``argmax``, the first firing template returns immediately —
+    exactly the legacy ``evaluate_stack`` short-circuit; shadowed templates
+    are never evaluated. Stochastic mode keeps evaluating only down to the
+    near-tie window's floor (``peak - window_points``); candidates below
+    the floor cannot win under either regime, so their gates and branch
+    RNG never run. An exempt-band candidate firing at or above the floor
+    preempts randomization for the whole stack. The softmax seed uses
+    binding identity and the persisted tick plus a package-specific salt,
+    so the same evaluation is replay-identical without sharing
+    branch-selection calibration.
     """
 
     habituation_policy = habituation or HabituationPolicy()
     ordered = stack_order(templates, state, bindings, habituation_policy)
-    passing = [
-        (
-            template,
-            evaluate(template, state, bindings, branch_selection),
-            habituation_policy.effective_priority(template, state, bindings),
+    stochastic = (
+        package_selection is not None and package_selection.mode == "stochastic"
+    )
+
+    window: list[tuple[Template, Resolution, float]] = []
+    peak: Optional[float] = None
+    for template in ordered:
+        effective_priority = habituation_policy.effective_priority(
+            template, state, bindings
         )
-        for template in ordered
-    ]
-    passing = [candidate for candidate in passing if candidate[1].passes]
-    if not passing:
+        if peak is not None and (
+            effective_priority < peak - package_selection.window_points
+        ):
+            break  # ordered descending: nothing below the floor can win
+        resolution = evaluate(template, state, bindings, branch_selection)
+        if not resolution.passes:
+            continue
+        if not stochastic:
+            return PackageSelectionOutcome(
+                winner=resolution,
+                window_template_ids=(template.id,),
+                reason="argmax",
+            )
+        if peak is None:
+            peak = effective_priority
+        window.append((template, resolution, effective_priority))
+
+    if not window:
         return PackageSelectionOutcome(winner=None)
 
-    argmax = passing[0]
-    if package_selection is None or package_selection.mode == "argmax":
-        return PackageSelectionOutcome(
-            winner=argmax[1],
-            window_template_ids=(argmax[0].id,),
-            reason="argmax",
-        )
-
+    argmax = window[0]
     if any(
         template.drive_band.value in package_selection.exempt_bands
-        for template, _resolution, _priority in passing
+        for template, _resolution, _priority in window
     ):
         return PackageSelectionOutcome(
             winner=argmax[1],
@@ -2185,11 +2200,6 @@ def select_package(
         )
 
     peak = argmax[2]
-    window = [
-        candidate
-        for candidate in passing
-        if peak - candidate[2] <= package_selection.window_points
-    ]
     window_ids = tuple(template.id for template, _resolution, _priority in window)
     if len(window) == 1:
         return PackageSelectionOutcome(

--- a/nexus/api/orrery_dev_endpoints.py
+++ b/nexus/api/orrery_dev_endpoints.py
@@ -311,6 +311,7 @@ async def post_resolve(request: OrreryResolveRequest) -> dict[str, Any]:
                 overrides=overrides,
                 selection_settings=orrery.get("selection"),
                 habituation_settings=orrery.get("habituation"),
+                package_selection_settings=orrery.get("package_selection"),
                 fanout_settings=orrery.get("fanout"),
             )
         except OverrideValidationError as exc:
@@ -397,6 +398,7 @@ async def post_coverage(request: OrreryCoverageRequest) -> dict[str, Any]:
             epoch_min_world_times=epoch_min,
             selection_settings=orrery.get("selection"),
             habituation_settings=orrery.get("habituation"),
+            package_selection_settings=orrery.get("package_selection"),
             fanout_settings=orrery.get("fanout"),
         )
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -826,6 +826,43 @@ class OrrerySelectionSettings(BaseModel):
     )
 
 
+class OrreryPackageSelectionSettings(BaseModel):
+    """Near-tie stack-winner policy for [orrery.package_selection]."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["stochastic", "argmax"] = Field(
+        default="stochastic",
+        description=(
+            "Package winner rule: strict effective-priority argmax, or a "
+            "seeded softmax within window_points of the maximum."
+        ),
+    )
+    window_points: float = Field(
+        default=6.0,
+        ge=0.0,
+        description=(
+            "Maximum effective-priority distance from the stack maximum for "
+            "entry into stochastic package selection."
+        ),
+    )
+    temperature: float = Field(
+        default=2.0,
+        gt=0.0,
+        description=(
+            "Softmax temperature on the package priority's 0-100 scale; this "
+            "is intentionally separate from branch magnitude temperature."
+        ),
+    )
+    exempt_bands: list[str] = Field(
+        default_factory=lambda: ["crisis_constraint"],
+        description=(
+            "Drive bands that disable package randomization whenever any "
+            "candidate in that band passes."
+        ),
+    )
+
+
 class OrreryReconstructionSettings(BaseModel):
     """Reconstruction-sufficiency knobs (issue #426)."""
 
@@ -1445,6 +1482,9 @@ class OrrerySettings(BaseModel):
     promote: OrreryPromoteSettings = Field(default_factory=OrreryPromoteSettings)
     sunhelm: OrrerySunhelmSettings = Field(default_factory=OrrerySunhelmSettings)
     selection: OrrerySelectionSettings = Field(default_factory=OrrerySelectionSettings)
+    package_selection: OrreryPackageSelectionSettings = Field(
+        default_factory=OrreryPackageSelectionSettings
+    )
     retrograde: OrreryRetrogradeSettings
     dashboard: OrreryDashboardSettings = Field(default_factory=OrreryDashboardSettings)
     reconstruction: OrreryReconstructionSettings = Field(

--- a/scripts/validate_config_commit.py
+++ b/scripts/validate_config_commit.py
@@ -27,6 +27,12 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
+# The commit under validation must be checked with ITS OWN code, not
+# whatever checkout the shared venv's editable install points at — in a git
+# worktree those differ, and a config change paired with its settings-model
+# change would false-fail against the main checkout's older models.
+sys.path.insert(0, str(REPO_ROOT))
+
 
 def main() -> int:
     failures: list[str] = []

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -60,6 +60,10 @@ def test_orrery_settings_resolve_model_reference() -> None:
         "intimacy": 16,
     }
     assert settings.orrery.sunhelm.pressure.min_severity_level == 2
+    assert settings.orrery.package_selection.mode == "stochastic"
+    assert settings.orrery.package_selection.window_points == 6.0
+    assert settings.orrery.package_selection.temperature == 2.0
+    assert settings.orrery.package_selection.exempt_bands == ["crisis_constraint"]
     # The ship-off invariant applies to the COMMITTED config: flipping the
     # dashboard on locally is a documented workflow (nexus.toml comment,
     # issue #415), and asserting the working tree here trains developers to

--- a/tests/test_orrery/test_package_selection.py
+++ b/tests/test_orrery/test_package_selection.py
@@ -1,0 +1,157 @@
+"""Tests for seeded band-window package selection (issue #474)."""
+
+from __future__ import annotations
+
+from nexus.agents.orrery.substrate import (
+    ALWAYS,
+    Branch,
+    DriveBand,
+    HabituationPolicy,
+    PackageSelection,
+    Slot,
+    Template,
+    WorldState,
+    evaluate_stack,
+    select_package,
+)
+
+BINDINGS = {Slot.ACTOR: 7}
+
+
+def _template(template_id: str, priority: int, band: DriveBand) -> Template:
+    return Template(
+        id=template_id,
+        priority=priority,
+        drive_band=band,
+        blurb="Synthetic package-selection surface.",
+        required_slots=(Slot.ACTOR,),
+        package_gate=ALWAYS,
+        branches=(Branch("act", ALWAYS, "{actor} acts."),),
+    )
+
+
+def _stochastic(**overrides: object) -> PackageSelection:
+    settings: dict[str, object] = {
+        "mode": "stochastic",
+        "window_points": 6.0,
+        "temperature": 2.0,
+        "exempt_bands": frozenset({DriveBand.CRISIS_CONSTRAINT.value}),
+    }
+    settings.update(overrides)
+    return PackageSelection(**settings)  # type: ignore[arg-type]
+
+
+def test_window_uses_habituation_adjusted_effective_priorities() -> None:
+    high = _template("high", 50, DriveBand.PROJECT_IDENTITY)
+    near = _template("near", 40, DriveBand.ANCHORED_ROUTINE)
+    outside = _template("outside", 37, DriveBand.AFFILIATION)
+    habituation = HabituationPolicy(
+        enabled=True,
+        penalty_per_win=3.0,
+        max_penalty=10.0,
+        window_ticks=40,
+    )
+    state = WorldState(current_tick=100, win_history={(7, "high"): 2})
+
+    outcome = select_package(
+        (outside, near, high),
+        state,
+        BINDINGS,
+        habituation=habituation,
+        package_selection=_stochastic(),
+    )
+
+    # Effective priorities are high=44, near=40, outside=37. Only the first
+    # two sit inside the shipped six-point window.
+    assert outcome.window_template_ids == ("high", "near")
+    assert outcome.chosen_by_softmax is True
+    assert outcome.reason == "window_softmax"
+
+
+def test_crisis_candidate_forces_strict_argmax() -> None:
+    crisis = _template("crisis", 60, DriveBand.CRISIS_CONSTRAINT)
+    near = _template("near", 58, DriveBand.ANCHORED_ROUTINE)
+
+    for tick in range(100):
+        outcome = select_package(
+            (near, crisis),
+            WorldState(current_tick=tick),
+            BINDINGS,
+            package_selection=_stochastic(),
+        )
+        assert outcome.winner is not None
+        assert outcome.winner.template_id == "crisis"
+        assert outcome.chosen_by_softmax is False
+        assert outcome.reason == "exempt_band_argmax"
+
+
+def test_same_inputs_choose_same_package_across_evaluations() -> None:
+    high = _template("high", 50, DriveBand.PROJECT_IDENTITY)
+    near = _template("near", 46, DriveBand.ANCHORED_ROUTINE)
+    state = WorldState(current_tick=4242)
+    policy = _stochastic()
+
+    first = evaluate_stack((near, high), state, BINDINGS, package_selection=policy)
+    second = evaluate_stack((near, high), state, BINDINGS, package_selection=policy)
+
+    assert first is not None
+    assert second is not None
+    assert second.template_id == first.template_id
+
+
+def test_configured_exempt_band_disables_randomization() -> None:
+    high = _template("high", 50, DriveBand.PROJECT_IDENTITY)
+    near = _template("near", 49, DriveBand.ANCHORED_ROUTINE)
+    policy = _stochastic(exempt_bands=frozenset({DriveBand.ANCHORED_ROUTINE.value}))
+
+    for tick in range(100):
+        outcome = select_package(
+            (near, high),
+            WorldState(current_tick=tick),
+            BINDINGS,
+            package_selection=policy,
+        )
+        assert outcome.winner is not None
+        assert outcome.winner.template_id == "high"
+        assert outcome.reason == "exempt_band_argmax"
+
+
+def test_argmax_mode_reproduces_legacy_stack_winner() -> None:
+    high = _template("high", 50, DriveBand.PROJECT_IDENTITY)
+    near = _template("near", 49, DriveBand.ANCHORED_ROUTINE)
+    policy = PackageSelection(
+        mode="argmax",
+        window_points=6.0,
+        temperature=2.0,
+        exempt_bands=frozenset({DriveBand.CRISIS_CONSTRAINT.value}),
+    )
+
+    for tick in range(100):
+        state = WorldState(current_tick=tick)
+        legacy = evaluate_stack((near, high), state, BINDINGS)
+        explicit = evaluate_stack(
+            (near, high), state, BINDINGS, package_selection=policy
+        )
+        assert legacy is not None
+        assert explicit is not None
+        assert explicit.template_id == legacy.template_id == "high"
+
+
+def test_explain_reports_window_and_softmax_choice() -> None:
+    from nexus.agents.orrery.explain import explain_stack
+
+    high = _template("high", 50, DriveBand.PROJECT_IDENTITY)
+    near = _template("near", 46, DriveBand.ANCHORED_ROUTINE)
+    state = WorldState(current_tick=42)
+
+    explained = explain_stack(
+        (near, high),
+        state,
+        BINDINGS,
+        package_selection=_stochastic(),
+    )
+
+    assert explained.selection_window_ids == ("high", "near")
+    assert explained.chosen_by_softmax is True
+    assert explained.selection_reason == "window_softmax"
+    assert explained.to_dict()["chosen_by_softmax"] is True

--- a/tests/test_orrery/test_package_selection.py
+++ b/tests/test_orrery/test_package_selection.py
@@ -155,3 +155,57 @@ def test_explain_reports_window_and_softmax_choice() -> None:
     assert explained.chosen_by_softmax is True
     assert explained.selection_reason == "window_softmax"
     assert explained.to_dict()["chosen_by_softmax"] is True
+
+
+def test_argmax_short_circuits_shadowed_templates() -> None:
+    """Legacy laziness is preserved: once a winner fires in argmax mode (or
+    with no policy), shadowed templates' gates are never evaluated — and in
+    stochastic mode, evaluation stops at the near-tie window's floor."""
+
+    from nexus.agents.orrery.substrate import Condition, select_package
+
+    evaluated: list[str] = []
+
+    def _tracking_gate(name: str) -> Condition:
+        def probe(state: WorldState, bindings: dict) -> bool:
+            evaluated.append(name)
+            return True
+
+        probe.__name__ = f"tracking_{name}"
+        return probe
+
+    def _tracked(template_id: str, priority: int) -> Template:
+        return Template(
+            id=template_id,
+            priority=priority,
+            drive_band=DriveBand.ANCHORED_ROUTINE,
+            blurb="Short-circuit probe.",
+            required_slots=(Slot.ACTOR,),
+            package_gate=_tracking_gate(template_id),
+            branches=(Branch("act", ALWAYS, "{actor} acts."),),
+        )
+
+    top = _tracked("top", 50)
+    shadowed = _tracked("shadowed", 40)
+    state = WorldState(current_tick=7)
+
+    evaluated.clear()
+    outcome = select_package((shadowed, top), state, BINDINGS)
+    assert outcome.winner is not None and outcome.winner.template_id == "top"
+    assert evaluated == ["top"], "no-policy argmax must not evaluate shadowed gates"
+
+    evaluated.clear()
+    select_package((shadowed, top), state, BINDINGS, package_selection=_stochastic())
+    assert evaluated == [
+        "top"
+    ], "stochastic evaluation must stop at the window floor (50 - 6 > 40)"
+
+    evaluated.clear()
+    near = _tracked("near", 46)
+    select_package(
+        (shadowed, near, top), state, BINDINGS, package_selection=_stochastic()
+    )
+    assert evaluated == [
+        "top",
+        "near",
+    ], "in-window gates evaluate; below-floor gates never run"


### PR DESCRIPTION
## Summary

Issue #474, Option 2 only (owner verdict: band-window softmax approved; disposition priors rejected — no affinity data anywhere in this diff). Codex-first: Codex implemented from the frozen spec; Claude reviewed the diff and independently verified.

Package selection becomes a two-regime rule: **crisis stays law** (any gate-passing candidate in an exempt band forces strict argmax for the whole stack), and **near-ties become texture** — gate-passing candidates within `window_points` of the maximum enter a seeded softmax with its own temperature knob (priority is 0–100; the branch-level 0.25 calibration deliberately does not transfer). The PRNG keys on binding identity + persisted tick + a package-specific salt, so selection is replay-identical.

One shared `select_package` authority is consumed by production (`evaluate_stack`), explain, audit, and the coverage analyzer — dry-run remains production-parity by construction, and explain payloads now expose the near-tie window, softmax flag, and selection reason for the dashboard.

Rider commit: the validate-config pre-commit hook now imports the repo under commit — its own second-ever run false-failed in this worktree by validating the new config section against the main checkout's older settings models through the shared venv's editable install.

## Evidence (Slot 2, 35 Anchors, Chunks 1427–1461)

Anchored-routine band wins, before → after with shipped knobs (stochastic / 6.0 / 2.0):

| package | gates passed | argmax | stochastic |
|---|---:|---:|---:|
| run_errands | 891 | 761 (92.5%) | 336 (40.8%) |
| stroll | 891 | **0** | 237 (28.8%) |
| upkeep | 891 | **0** | 144 (17.5%) |
| recreate | 850 | 58 (7.0%) | 102 (12.4%) |

Crisis-band behavior unchanged (no passing crisis gates in the slice; a focused test drives passing crisis candidates through 100 ticks and asserts strict argmax throughout).

## Verification (Claude, in the worktree)

- `tests/test_orrery/ tests/config/`: 652 passed offline; 685 passed live (`NEXUS_RUN_POSTGRES=1`).
- New test file covers window formation on habituation-adjusted priorities, crisis preemption, determinism, exempt bands, argmax parity with legacy behavior, and explain metadata.
- black clean; flake8 findings all pre-existing in `turn_cycle.py` (verified against HEAD).

Closes #474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY