### PR TITLE
Dedicated Summaries Model Ref with Durable Failure Markers

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -874,6 +874,16 @@ max_output_tokens = 25000     # Maximum tokens for generated narrative
 structured_output_retries = 3 # Validation retry budget for structured story turns
 
 # =============================================================================
+# Narrative Summary Settings
+# =============================================================================
+
+[summaries]
+# Summary quality varies materially by model. Keep this on a top-tier registry
+# role; the current pipeline accepts native OpenAI or Responses-compatible
+# OpenAI endpoints only (Anthropic/local routing is deferred under issue #481).
+model = "@openai.default"
+
+# =============================================================================
 # IR Evaluation V2 Settings
 # =============================================================================
 

--- a/nexus/api/summary_triggers.py
+++ b/nexus/api/summary_triggers.py
@@ -1,6 +1,4 @@
-"""
-Helper utilities to trigger narrative summary generation after episode/season transitions.
-"""
+"""Trigger narrative summary generation after episode/season transitions."""
 
 from __future__ import annotations
 
@@ -87,8 +85,8 @@ def schedule_summary_generation(
         tasks: Collection of summaries to generate.
         overwrite: Whether to regenerate existing summaries.
         model_candidates: Preferred models to try (fallback order).
-        run_in_thread: Execute generation on a background thread (default) or inline (for testing).
-        db_manager_factory: Optional factory for injecting a preconfigured DatabaseManager (for tests).
+        run_in_thread: Execute on a background thread (default) or inline.
+        db_manager_factory: Optional preconfigured DatabaseManager factory.
         generator_cls: Optional SummaryGenerator class for dependency injection/mocking.
     """
     if not tasks:
@@ -96,14 +94,15 @@ def schedule_summary_generation(
 
     models = _coalesce_models(model_candidates)
 
-    runner = lambda: _run_summary_generation(
-        list(tasks),
-        models,
-        overwrite,
-        slot=slot,
-        db_manager_factory=db_manager_factory,
-        generator_cls=generator_cls,
-    )
+    def runner() -> None:
+        _run_summary_generation(
+            list(tasks),
+            models,
+            overwrite,
+            slot=slot,
+            db_manager_factory=db_manager_factory,
+            generator_cls=generator_cls,
+        )
 
     if run_in_thread:
         _EXECUTOR.submit(runner)
@@ -148,8 +147,14 @@ def _run_summary_generation(
             _run_single_task(
                 task, db_manager, model_candidates, overwrite, generator_cls
             )
-        except Exception as exc:  # pragma: no cover - defensive logging
-            logger.error("Summary generation failed for %s: %s", task, exc)
+        except Exception as exc:  # pragma: no cover - last-resort durability guard
+            logger.exception("Summary generation failed for %s", task)
+            _persist_summary_failure(
+                db_manager,
+                task,
+                model_candidates,
+                f"Unexpected summary worker failure: {exc}",
+            )
 
 
 def _run_single_task(
@@ -182,9 +187,11 @@ def _run_single_task(
                 task.episode,
             )
             return
-        runner: Callable[[SummaryGenerator], Optional[dict]] = (
-            lambda gen: gen.generate_episode_summary(task.season, task.episode)
-        )
+        episode = task.episode
+
+        def generate(generator: SummaryGenerator) -> Optional[dict]:
+            return generator.generate_episode_summary(task.season, episode)
+
         target_label = f"S{task.season:02d}E{task.episode:02d}"
     else:
         if not overwrite and db_manager.season_summary_exists(task.season):
@@ -193,19 +200,35 @@ def _run_single_task(
                 task.season,
             )
             return
-        runner = lambda gen: gen.generate_season_summary(task.season)
+
+        def generate(generator: SummaryGenerator) -> Optional[dict]:
+            return generator.generate_season_summary(task.season)
+
         target_label = f"Season {task.season}"
 
+    failure_reasons: List[str] = []
     for index, model_name in enumerate(model_candidates):
-        generator = generator_cls(
-            model=model_name,
-            db_manager=db_manager,
-            overwrite=overwrite,
-            verbose=False,
-            save_prompt=False,
-            prompt_on_conflict=False,
-        )
-        summary = runner(generator)
+        generator: Optional[SummaryGenerator] = None
+        raised_error: Optional[str] = None
+        try:
+            generator = generator_cls(
+                model=model_name,
+                db_manager=db_manager,
+                overwrite=overwrite,
+                verbose=False,
+                save_prompt=False,
+                prompt_on_conflict=False,
+            )
+            summary = generate(generator)
+        except Exception as exc:
+            logger.exception(
+                "Model %s raised while generating %s summary",
+                model_name,
+                target_label,
+            )
+            raised_error = str(exc)
+            summary = None
+
         if summary:
             if index > 0:
                 logger.info(
@@ -219,17 +242,42 @@ def _run_single_task(
                 )
             return
 
+        reported_error = raised_error or getattr(generator, "last_error", None)
+        failure_reasons.append(
+            f"{model_name}: {reported_error or 'returned no summary'}"
+        )
         if index < len(model_candidates) - 1:
             logger.warning(
                 "Model %s failed to generate %s summary; trying next candidate",
                 model_name,
                 target_label,
             )
+    error = "; ".join(failure_reasons)
     logger.error(
-        "Failed to generate %s summary after trying %s",
+        "Failed to generate %s summary after trying %s: %s",
         target_label,
         ", ".join(model_candidates),
+        error,
     )
+    _persist_summary_failure(db_manager, task, model_candidates, error)
+
+
+def _persist_summary_failure(
+    db_manager: DatabaseManager,
+    task: SummaryTask,
+    model_candidates: Sequence[str],
+    error: str,
+) -> None:
+    """Write a durable error marker and log if even persistence fails."""
+    persisted = db_manager.record_summary_failure(
+        kind=task.kind,
+        season=task.season,
+        episode=task.episode,
+        error=error,
+        model_candidates=list(model_candidates),
+    )
+    if not persisted:
+        logger.error("Failed to persist durable summary error for %s", task)
 
 
 def _coalesce_models(model_candidates: Optional[Sequence[str]]) -> List[str]:
@@ -237,11 +285,13 @@ def _coalesce_models(model_candidates: Optional[Sequence[str]]) -> List[str]:
     # FALLBACK_MODEL constants at argparse time, so they are None when
     # imported here (M9 gate finding: every API-triggered episode summary
     # failed with zero model candidates). Resolve the default from the live
-    # apex config instead, keeping the legacy constants as extra candidates
+    # summaries config instead, keeping the legacy constants as extra candidates
     # for older callers that still set them.
-    models = (
-        list(model_candidates) if model_candidates else [DEFAULT_MODEL, FALLBACK_MODEL]
-    )
+    models: List[Optional[str]]
+    if model_candidates:
+        models = list(model_candidates)
+    else:
+        models = [DEFAULT_MODEL, FALLBACK_MODEL]
     deduped: List[str] = []
 
     for candidate in models:
@@ -251,6 +301,6 @@ def _coalesce_models(model_candidates: Optional[Sequence[str]]) -> List[str]:
     if not deduped:
         from nexus.config import load_settings
 
-        deduped.append(load_settings().apex.model)
+        deduped.append(load_settings().summaries.model)
 
     return deduped

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1705,6 +1705,25 @@ class APEXSettings(BaseModel):
 
 
 # =============================================================================
+# Narrative Summary Settings Models
+# =============================================================================
+
+
+class SummariesSettings(BaseModel):
+    """Episode/season summary generation configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model: str = Field(
+        ...,
+        description=(
+            "Registry model reference used for episode and season summaries. "
+            "The current summarizer requires the OpenAI Responses transport."
+        ),
+    )
+
+
+# =============================================================================
 # Wizard Settings Models
 # =============================================================================
 
@@ -2044,6 +2063,7 @@ class Settings(BaseModel):
     memnon: MEMNONSettings
     memory: MemorySettings
     apex: APEXSettings
+    summaries: SummariesSettings
     wizard: WizardSettings
     api: Optional[APISettings] = Field(default=None, description="API settings")
     ui: UISettings = Field(
@@ -2074,6 +2094,7 @@ class Settings(BaseModel):
             (self.global_.model, "default_model", False),
             (self.global_.model, "default_slot_model", False),
             (self.apex, "model", False),
+            (self.summaries, "model", False),
             (self.wizard, "default_model", False),
             (self.wizard, "fallback_model", True),
         ]
@@ -2108,6 +2129,33 @@ class Settings(BaseModel):
             #      resolution pass or move that logic into _resolve_model_reference.
             object.__setattr__(container, attr, resolved)
 
+        return self
+
+    @model_validator(mode="after")
+    def _validate_summaries_transport(self) -> "Settings":
+        """Reject summary models the current Responses-only pipeline cannot route.
+
+        Issue #481 deliberately decouples summary model selection without also
+        adding Anthropic-native or local Chat Completions routing. Fail at config
+        load so an unsupported selection cannot become a dropped background job.
+        """
+        model_id = self.summaries.model
+        provider = self.provider_for_model(model_id)
+        provider_config = self.global_.model.api_models[provider]
+        responses_compatible = provider == "openai" or (
+            provider not in NATIVE_API_PROVIDERS
+            and provider_config.structured_transport == "responses"
+        )
+        if not responses_compatible:
+            raise ValueError(
+                "[summaries].model must resolve to the native OpenAI provider "
+                "or to an OpenAI-compatible registry provider with "
+                "structured_transport='responses'; "
+                f"'{model_id}' resolves to provider '{provider}' with "
+                f"structured_transport='{provider_config.structured_transport}'. "
+                "Anthropic-native and chat_completions summary routing are "
+                "deferred routing work tracked by #481."
+            )
         return self
 
     @model_validator(mode="after")

--- a/scripts/summarize_narrative.py
+++ b/scripts/summarize_narrative.py
@@ -37,6 +37,7 @@ import json
 import time
 import argparse
 import logging
+from datetime import datetime, timezone
 from typing import Dict, List, Any, Tuple, Optional, Union, Set
 from pydantic import BaseModel, Field
 
@@ -65,10 +66,10 @@ logger = logging.getLogger("nexus.summarize_narrative")
 
 
 def _resolve_default_summary_model() -> str:
-    """Read the default narrative-summary model from nexus.toml's [apex] section."""
+    """Read the dedicated narrative-summary model from nexus.toml."""
     from nexus.config import load_settings
 
-    return load_settings().apex.model
+    return load_settings().summaries.model
 
 
 # Constants
@@ -82,6 +83,7 @@ MAX_TOKENS_SEASON = 4000
 MAX_TOKENS_EPISODE = 2500
 CONTEXT_CHUNK_BEFORE = 1  # Number of chunks to include before target for context
 CONTEXT_CHUNK_AFTER = 1  # Number of chunks to include after target for context
+SUMMARY_FAILURE_STATUS = "error"
 
 # Database connection using SQLAlchemy
 import sqlalchemy as sa
@@ -714,12 +716,17 @@ class DatabaseManager:
                     """
                 SELECT id, summary 
                 FROM public.seasons 
-                WHERE id < :season AND summary IS NOT NULL
+                WHERE id < :season
+                  AND summary IS NOT NULL
+                  AND COALESCE(summary->>'status', '') <> :failure_status
                 ORDER BY id ASC
                 """
                 )
 
-                result = conn.execute(query, {"season": season})
+                result = conn.execute(
+                    query,
+                    {"season": season, "failure_status": SUMMARY_FAILURE_STATUS},
+                )
 
                 for row in result:
                     summaries.append({"season": row.id, "summary": row.summary})
@@ -750,12 +757,22 @@ class DatabaseManager:
                     """
                 SELECT season, episode, summary 
                 FROM public.episodes 
-                WHERE season = :season AND episode < :episode AND summary IS NOT NULL
+                WHERE season = :season
+                  AND episode < :episode
+                  AND summary IS NOT NULL
+                  AND COALESCE(summary->>'status', '') <> :failure_status
                 ORDER BY episode ASC
                 """
                 )
 
-                result = conn.execute(query, {"season": season, "episode": episode})
+                result = conn.execute(
+                    query,
+                    {
+                        "season": season,
+                        "episode": episode,
+                        "failure_status": SUMMARY_FAILURE_STATUS,
+                    },
+                )
 
                 for row in result:
                     summaries.append(
@@ -790,11 +807,18 @@ class DatabaseManager:
                         """
                         SELECT 1
                         FROM public.episodes
-                        WHERE season = :season AND episode = :episode AND summary IS NOT NULL
+                        WHERE season = :season
+                          AND episode = :episode
+                          AND summary IS NOT NULL
+                          AND COALESCE(summary->>'status', '') <> :failure_status
                         LIMIT 1
                         """
                     ),
-                    {"season": season, "episode": episode},
+                    {
+                        "season": season,
+                        "episode": episode,
+                        "failure_status": SUMMARY_FAILURE_STATUS,
+                    },
                 ).scalar()
                 return result is not None
         except Exception as e:
@@ -819,11 +843,16 @@ class DatabaseManager:
                     """
                 SELECT id, summary 
                 FROM public.seasons 
-                WHERE id = :season AND summary IS NOT NULL
+                WHERE id = :season
+                  AND summary IS NOT NULL
+                  AND COALESCE(summary->>'status', '') <> :failure_status
                 """
                 )
 
-                result = conn.execute(query, {"season": season}).fetchone()
+                result = conn.execute(
+                    query,
+                    {"season": season, "failure_status": SUMMARY_FAILURE_STATUS},
+                ).fetchone()
 
                 if result:
                     return {"season": result.id, "summary": result.summary}
@@ -849,11 +878,13 @@ class DatabaseManager:
                         """
                         SELECT 1
                         FROM public.seasons
-                        WHERE id = :season AND summary IS NOT NULL
+                        WHERE id = :season
+                          AND summary IS NOT NULL
+                          AND COALESCE(summary->>'status', '') <> :failure_status
                         LIMIT 1
                         """
                     ),
-                    {"season": season},
+                    {"season": season, "failure_status": SUMMARY_FAILURE_STATUS},
                 ).scalar()
                 return result is not None
         except Exception as e:
@@ -895,7 +926,12 @@ class DatabaseManager:
                 )
                 existing = conn.execute(check_query, {"season": season}).fetchone()
 
-                if existing and existing.summary and not overwrite:
+                if (
+                    existing
+                    and existing.summary
+                    and not self._is_failure_summary(existing.summary)
+                    and not overwrite
+                ):
                     if not prompt_on_conflict:
                         logger.info(
                             f"Existing summary found for Season {season}; skipping (overwrite disabled)"
@@ -1041,7 +1077,12 @@ class DatabaseManager:
                     check_query, {"season": season, "episode": episode}
                 ).fetchone()
 
-                if existing and existing.summary and not overwrite:
+                if (
+                    existing
+                    and existing.summary
+                    and not self._is_failure_summary(existing.summary)
+                    and not overwrite
+                ):
                     if not prompt_on_conflict:
                         logger.info(
                             f"Existing summary found for S{season:02d}E{episode:02d}; skipping (overwrite disabled)"
@@ -1138,6 +1179,89 @@ class DatabaseManager:
 
         except Exception as e:
             logger.error(f"Error saving episode summary: {e}")
+            return False
+
+    @staticmethod
+    def _is_failure_summary(summary: Any) -> bool:
+        """Return whether a JSONB summary value is a retryable failure marker."""
+        if isinstance(summary, str):
+            try:
+                summary = json.loads(summary)
+            except json.JSONDecodeError:
+                return False
+        return (
+            isinstance(summary, dict)
+            and summary.get("status") == SUMMARY_FAILURE_STATUS
+        )
+
+    def record_summary_failure(
+        self,
+        *,
+        kind: str,
+        season: int,
+        episode: Optional[int],
+        error: str,
+        model_candidates: List[str],
+    ) -> bool:
+        """Persist a retryable failure marker on the existing summary record.
+
+        The episodes/seasons JSONB summary columns are the established durable
+        operator surface. A marker remains visible there but is excluded by the
+        summary existence/context queries, so a later transition can refire and
+        replace it without requiring ``overwrite=True``.
+        """
+        failure = json.dumps(
+            {
+                "status": SUMMARY_FAILURE_STATUS,
+                "error": error,
+                "model_candidates": model_candidates,
+                "failed_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+        try:
+            with self.engine.connect() as conn:
+                if kind == "episode":
+                    if episode is None:
+                        raise ValueError(
+                            "episode is required when recording an episode failure"
+                        )
+                    query = text(
+                        """
+                        INSERT INTO public.episodes (season, episode, summary)
+                        VALUES (:season, :episode, CAST(:summary AS jsonb))
+                        ON CONFLICT (season, episode) DO UPDATE
+                        SET summary = EXCLUDED.summary
+                        """
+                    )
+                    params = {
+                        "season": season,
+                        "episode": episode,
+                        "summary": failure,
+                    }
+                elif kind == "season":
+                    query = text(
+                        """
+                        INSERT INTO public.seasons (id, summary)
+                        VALUES (:season, CAST(:summary AS jsonb))
+                        ON CONFLICT (id) DO UPDATE
+                        SET summary = EXCLUDED.summary
+                        """
+                    )
+                    params = {"season": season, "summary": failure}
+                else:
+                    raise ValueError(f"Unknown summary failure kind: {kind!r}")
+
+                conn.execute(query, params)
+                conn.commit()
+            return True
+        except Exception as exc:
+            logger.error(
+                "Unable to persist %s summary failure for season=%s episode=%s: %s",
+                kind,
+                season,
+                episode,
+                exc,
+            )
             return False
 
     def get_episode_chunk_span(
@@ -1258,29 +1382,65 @@ class SummaryGenerator:
         self.model = model
         self.temperature = temperature
         self.effort = effort
-        self.is_reasoning_model = model.startswith("o")
+        self.is_reasoning_model = self._model_rejects_temperature(model)
         self.db_manager = db_manager or DatabaseManager()
         self.dry_run = dry_run
         self.overwrite = overwrite
         self.verbose = verbose
         self.save_prompt = save_prompt
         self.prompt_on_conflict = prompt_on_conflict
+        self.last_error: Optional[str] = None
         self.provider = self._initialize_provider()
+
+    @staticmethod
+    def _model_rejects_temperature(model: str) -> bool:
+        """Registry-driven reasoning-model detection.
+
+        Reasoning-class models reject temperature and take reasoning_effort
+        instead; the [global.model.api_models] registry already declares that
+        per model via unsupported_params, so consult it rather than pattern-
+        matching model-id families that change with every roster bump.
+        """
+        from nexus.config import load_settings
+
+        settings = load_settings()
+        provider = settings.provider_for_model(model)
+        entry = next(
+            m
+            for m in settings.global_.model.api_models[provider].models
+            if m.id == model
+        )
+        return "temperature" in entry.unsupported_params
 
     def _initialize_provider(self) -> OpenAIProvider:
         """Initialize the OpenAI provider."""
         try:
+            from nexus.config import get_openai_compatible_endpoint
+
+            endpoint = get_openai_compatible_endpoint(self.model)
+            endpoint_kwargs: Dict[str, Any] = {}
+            if endpoint:
+                endpoint_kwargs = {
+                    "api_key": endpoint["api_key"],
+                    "base_url": endpoint["base_url"],
+                    "structured_transport": endpoint["structured_transport"],
+                    "request_timeout": endpoint["request_timeout_seconds"],
+                }
             # Use the streamlined provider initialization
             if self.is_reasoning_model:
                 provider = OpenAIProvider(
-                    model=self.model, reasoning_effort=self.effort
+                    model=self.model,
+                    reasoning_effort=self.effort,
+                    **endpoint_kwargs,
                 )
                 logger.info(
                     f"Initialized OpenAI provider with reasoning model: {self.model}, effort: {self.effort}"
                 )
             else:
                 provider = OpenAIProvider(
-                    model=self.model, temperature=self.temperature
+                    model=self.model,
+                    temperature=self.temperature,
+                    **endpoint_kwargs,
                 )
                 logger.info(
                     f"Initialized OpenAI provider with standard model: {self.model}, temperature: {self.temperature}"
@@ -1531,11 +1691,8 @@ I need a comprehensive, structured summary of Season {season} of the narrative. 
         self._save_prompt_to_file(prompt, f"season_{season}")
 
         try:
-            # Use the OpenAI responses.parse API with Pydantic model
-            import openai
-
-            # Set up the API client - using the direct OpenAI client
-            client = openai.OpenAI(api_key=self.provider.api_key)
+            # Reuse the provider client so registry base_url/timeout routing is kept.
+            client = self.provider.client
 
             # Prepare messages
             messages = [{"role": "user", "content": prompt}]
@@ -1607,6 +1764,7 @@ I need a comprehensive, structured summary of Season {season} of the narrative. 
                 return None
 
         except Exception as e:
+            self.last_error = str(e)
             logger.error(f"Error generating season summary: {e}")
             return None
 
@@ -1765,11 +1923,8 @@ I need a comprehensive, structured summary of Season {season}, Episode {episode}
         self._save_prompt_to_file(prompt, f"s{season:02d}e{episode:02d}")
 
         try:
-            # Use the OpenAI responses.parse API with Pydantic model
-            import openai
-
-            # Set up the API client - using the direct OpenAI client
-            client = openai.OpenAI(api_key=self.provider.api_key)
+            # Reuse the provider client so registry base_url/timeout routing is kept.
+            client = self.provider.client
 
             # Prepare messages
             messages = [{"role": "user", "content": prompt}]
@@ -1845,6 +2000,7 @@ I need a comprehensive, structured summary of Season {season}, Episode {episode}
                 return None
 
         except Exception as e:
+            self.last_error = str(e)
             logger.error(f"Error generating episode summary: {e}")
             return None
 
@@ -2137,11 +2293,8 @@ I need a comprehensive, structured summary of the provided narrative chunks (IDs
         self._save_prompt_to_file(prompt, f"chunks_{start_id}_{end_id}")
 
         try:
-            # Use the OpenAI responses.parse API with Pydantic model
-            import openai
-
-            # Set up the API client - using the direct OpenAI client
-            client = openai.OpenAI(api_key=self.provider.api_key)
+            # Reuse the provider client so registry base_url/timeout routing is kept.
+            client = self.provider.client
 
             # Prepare messages
             messages = [{"role": "user", "content": prompt}]
@@ -2274,6 +2427,7 @@ I need a comprehensive, structured summary of the provided narrative chunks (IDs
             return summary_dict
 
         except Exception as e:
+            self.last_error = str(e)
             logger.error(f"Error generating chunk range summary: {e}")
             return None
 
@@ -2326,11 +2480,11 @@ def main():
         help="Chunk ID range to summarize (manual fallback)",
     )
 
-    # OpenAI options. --model defaults to apex.model from nexus.toml when omitted.
+    # OpenAI options. --model defaults to summaries.model when omitted.
     parser.add_argument(
         "--model",
         default=None,
-        help="OpenAI model to use (default: resolved from nexus.toml [apex].model)",
+        help="OpenAI model to use (default: resolved from nexus.toml [summaries].model)",
     )
     parser.add_argument(
         "--fallback-model",

--- a/scripts/summarize_narrative.py
+++ b/scripts/summarize_narrative.py
@@ -1263,8 +1263,22 @@ class DatabaseManager:
                 else:
                     raise ValueError(f"Unknown summary failure kind: {kind!r}")
 
-                conn.execute(query, params)
+                result = conn.execute(query, params)
                 conn.commit()
+                if result.rowcount == 0:
+                    # The no-clobber guard blocked the write: a real summary
+                    # already occupies the row (overwrite=True regeneration
+                    # that failed). Report honestly instead of claiming the
+                    # marker landed.
+                    logger.warning(
+                        "Not recording %s summary failure for season=%s "
+                        "episode=%s: a non-error summary already exists and "
+                        "is preserved",
+                        kind,
+                        season,
+                        episode,
+                    )
+                    return False
             return True
         except Exception as exc:
             logger.error(

--- a/scripts/summarize_narrative.py
+++ b/scripts/summarize_narrative.py
@@ -27,7 +27,7 @@ Usage:
     python summarize_narrative.py --chunks 120 150
 
     # Options
-    python summarize_narrative.py --season 3 --model gpt-4.1 --dry-run
+    python summarize_narrative.py --season 3 --model @openai.default --dry-run
 """
 
 import os
@@ -1225,18 +1225,24 @@ class DatabaseManager:
                         raise ValueError(
                             "episode is required when recording an episode failure"
                         )
+                    # Never clobber a real summary: a slower failing job can
+                    # land after a concurrent success. Only fill NULLs or
+                    # replace an earlier error marker.
                     query = text(
                         """
                         INSERT INTO public.episodes (season, episode, summary)
                         VALUES (:season, :episode, CAST(:summary AS jsonb))
                         ON CONFLICT (season, episode) DO UPDATE
                         SET summary = EXCLUDED.summary
+                        WHERE public.episodes.summary IS NULL
+                           OR public.episodes.summary->>'status' = :failure_status
                         """
                     )
                     params = {
                         "season": season,
                         "episode": episode,
                         "summary": failure,
+                        "failure_status": SUMMARY_FAILURE_STATUS,
                     }
                 elif kind == "season":
                     query = text(
@@ -1245,9 +1251,15 @@ class DatabaseManager:
                         VALUES (:season, CAST(:summary AS jsonb))
                         ON CONFLICT (id) DO UPDATE
                         SET summary = EXCLUDED.summary
+                        WHERE public.seasons.summary IS NULL
+                           OR public.seasons.summary->>'status' = :failure_status
                         """
                     )
-                    params = {"season": season, "summary": failure}
+                    params = {
+                        "season": season,
+                        "summary": failure,
+                        "failure_status": SUMMARY_FAILURE_STATUS,
+                    }
                 else:
                     raise ValueError(f"Unknown summary failure kind: {kind!r}")
 
@@ -1400,11 +1412,23 @@ class SummaryGenerator:
         instead; the [global.model.api_models] registry already declares that
         per model via unsupported_params, so consult it rather than pattern-
         matching model-id families that change with every roster bump.
+
+        Registry membership is deliberately required (loud-errors doctrine):
+        an ad-hoc --model id not in nexus.toml would otherwise silently guess
+        the wrong parameter set.
         """
         from nexus.config import load_settings
 
         settings = load_settings()
-        provider = settings.provider_for_model(model)
+        try:
+            provider = settings.provider_for_model(model)
+        except ValueError as exc:
+            raise ValueError(
+                f"--model {model!r} is not declared in nexus.toml's "
+                "[global.model.api_models] registry, so its parameter "
+                "capabilities (temperature vs reasoning_effort) are unknown. "
+                "Add it to the registry or pass a '@provider.role' reference."
+            ) from exc
         entry = next(
             m
             for m in settings.global_.model.api_models[provider].models
@@ -2540,9 +2564,15 @@ def main():
 
     args = parser.parse_args()
 
-    # Resolve --model from nexus.toml when the user didn't specify it explicitly.
+    # Resolve --model from nexus.toml when the user didn't specify it
+    # explicitly; explicit "@provider.role" references resolve through the
+    # same registry authority.
     if args.model is None:
         args.model = _resolve_default_summary_model()
+    elif args.model.startswith("@"):
+        from nexus.config import resolve_model_ref
+
+        args.model = resolve_model_ref(args.model)
 
     # Set up database manager
     db_manager = DatabaseManager(db_url=args.db_url)

--- a/scripts/summarize_narrative.py
+++ b/scripts/summarize_narrative.py
@@ -16,16 +16,16 @@ Features:
 Usage:
     # Summarize an entire season
     python summarize_narrative.py --season 3
-    
+
     # Summarize a single episode
     python summarize_narrative.py --episode s03e01
-    
+
     # Summarize a range of episodes
     python summarize_narrative.py --episode s03e01 s03e13
-    
+
     # Manually specify chunk range (fallback option)
     python summarize_narrative.py --chunks 120 150
-    
+
     # Options
     python summarize_narrative.py --season 3 --model gpt-4.1 --dry-run
 """
@@ -47,20 +47,22 @@ if parent_dir not in sys.path:
 
 # Import API OpenAI utilities
 from scripts.api_openai import (
-    OpenAIProvider, LLMResponse, setup_abort_handler, 
-    is_abort_requested, reset_abort_flag, get_token_count
+    OpenAIProvider,
+    LLMResponse,
+    setup_abort_handler,
+    is_abort_requested,
+    reset_abort_flag,
+    get_token_count,
 )
 
 # Set up logging
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler("summarize_narrative.log"),
-        logging.StreamHandler()
-    ]
+    handlers=[logging.FileHandler("summarize_narrative.log"), logging.StreamHandler()],
 )
 logger = logging.getLogger("nexus.summarize_narrative")
+
 
 def _resolve_default_summary_model() -> str:
     """Read the default narrative-summary model from nexus.toml's [apex] section."""
@@ -79,103 +81,108 @@ DEFAULT_TEMPERATURE = 0.2
 MAX_TOKENS_SEASON = 4000
 MAX_TOKENS_EPISODE = 2500
 CONTEXT_CHUNK_BEFORE = 1  # Number of chunks to include before target for context
-CONTEXT_CHUNK_AFTER = 1   # Number of chunks to include after target for context
+CONTEXT_CHUNK_AFTER = 1  # Number of chunks to include after target for context
 
 # Database connection using SQLAlchemy
 import sqlalchemy as sa
 from sqlalchemy import create_engine, MetaData, Table, Column, text
 from sqlalchemy.dialects.postgresql import TSRANGE, JSONB
 
+
 class EpisodeSlugParser:
     """Parse and validate episode slugs like 's01e05'."""
-    
+
     @staticmethod
     def parse(slug: str) -> Tuple[int, int]:
         """
         Parse an episode slug string into season and episode numbers.
-        
+
         Args:
             slug: Episode slug string like 's01e05'
-            
+
         Returns:
             Tuple of (season_number, episode_number)
-            
+
         Raises:
             ValueError: If the slug format is invalid
         """
-        pattern = r'^s(\d{1,2})e(\d{1,2})$'
+        pattern = r"^s(\d{1,2})e(\d{1,2})$"
         match = re.match(pattern, slug.lower())
-        
+
         if not match:
-            raise ValueError(f"Invalid episode slug format: {slug}. Expected format: s01e05")
-            
+            raise ValueError(
+                f"Invalid episode slug format: {slug}. Expected format: s01e05"
+            )
+
         season = int(match.group(1))
         episode = int(match.group(2))
-        
+
         return season, episode
-    
+
     @staticmethod
     def format(season: int, episode: int) -> str:
         """
         Format season and episode numbers into a slug.
-        
+
         Args:
             season: Season number
             episode: Episode number
-            
+
         Returns:
             Formatted slug like 's01e05'
         """
         return f"s{season:02d}e{episode:02d}"
-    
+
     @staticmethod
     def validate_range(start_slug: str, end_slug: str) -> bool:
         """
         Validate that end_slug comes after start_slug.
-        
+
         Args:
             start_slug: Starting episode slug
             end_slug: Ending episode slug
-            
+
         Returns:
             True if valid range, False otherwise
         """
         start_season, start_episode = EpisodeSlugParser.parse(start_slug)
         end_season, end_episode = EpisodeSlugParser.parse(end_slug)
-        
+
         if start_season > end_season:
             return False
-        
+
         if start_season == end_season and start_episode > end_episode:
             return False
-            
+
         return True
-    
+
     @staticmethod
     def range_spans_season(start_slug: str, end_slug: str) -> Optional[int]:
         """
         Check if the range spans a complete season.
-        
+
         Args:
             start_slug: Starting episode slug
             end_slug: Ending episode slug
-            
+
         Returns:
             Season number if range spans a complete season, None otherwise
         """
         start_season, start_episode = EpisodeSlugParser.parse(start_slug)
         end_season, end_episode = EpisodeSlugParser.parse(end_slug)
-        
+
         # Must be in same season
         if start_season != end_season:
             return None
-            
+
         # Check if it's a full season by querying the database
         # This will be implemented in the DatabaseManager class
         return None
 
+
 class SeasonSummary(BaseModel):
     """Structured output model for season summaries."""
+
     overview: str = Field(
         description="A concise description of the season's overarching narrative and primary conflicts."
     )
@@ -192,8 +199,10 @@ class SeasonSummary(BaseModel):
         description="Key elements that future narrative must maintain consistency with, including established facts, unresolved questions, and promises/setups."
     )
 
+
 class EpisodeSummary(BaseModel):
     """Structured output model for episode summaries."""
+
     overview: str = Field(
         description="A brief factual summary of what happened in this episode, focusing on major developments."
     )
@@ -210,13 +219,14 @@ class EpisodeSummary(BaseModel):
         description="Important objects, locations, or world states that should be tracked."
     )
 
+
 class DatabaseManager:
     """Manages database connections and operations."""
-    
+
     def __init__(self, db_url: Optional[str] = None):
         """
         Initialize the database manager.
-        
+
         Args:
             db_url: Optional database URL. If not provided, will use environment variables.
         """
@@ -224,7 +234,7 @@ class DatabaseManager:
         self.engine = create_engine(self.db_url)
         self.metadata = MetaData()
         self._init_tables()
-        
+
     def _get_db_url(self) -> str:
         """Get database URL from environment variables."""
         DB_USER = os.environ.get("DB_USER", "pythagor")
@@ -232,68 +242,77 @@ class DatabaseManager:
         DB_HOST = os.environ.get("DB_HOST", "localhost")
         DB_PORT = os.environ.get("DB_PORT", "5432")
         DB_NAME = os.environ.get("DB_NAME", "NEXUS")
-        
+
         # Build connection string (with password if provided)
         if DB_PASSWORD:
-            connection_string = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+            connection_string = (
+                f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+            )
         else:
             connection_string = f"postgresql://{DB_USER}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
-            
+
         return connection_string
-    
+
     def _init_tables(self):
         """Initialize table definitions."""
         # Define table mappings
         self.narrative_chunks = Table(
-            'narrative_chunks', self.metadata,
-            Column('id', sa.BigInteger, primary_key=True),
-            Column('raw_text', sa.Text, nullable=False),
-            Column('created_at', sa.DateTime(timezone=True)),
-            schema='public'
+            "narrative_chunks",
+            self.metadata,
+            Column("id", sa.BigInteger, primary_key=True),
+            Column("raw_text", sa.Text, nullable=False),
+            Column("created_at", sa.DateTime(timezone=True)),
+            schema="public",
         )
-        
+
         self.chunk_metadata = Table(
-            'chunk_metadata', self.metadata,
-            Column('id', sa.BigInteger, primary_key=True),
-            Column('chunk_id', sa.BigInteger, sa.ForeignKey('public.narrative_chunks.id')),
-            Column('season', sa.Integer),
-            Column('episode', sa.Integer),
-            Column('scene', sa.Integer),
-            Column('slug', sa.String(10)),
-            schema='public'
+            "chunk_metadata",
+            self.metadata,
+            Column("id", sa.BigInteger, primary_key=True),
+            Column(
+                "chunk_id", sa.BigInteger, sa.ForeignKey("public.narrative_chunks.id")
+            ),
+            Column("season", sa.Integer),
+            Column("episode", sa.Integer),
+            Column("scene", sa.Integer),
+            Column("slug", sa.String(10)),
+            schema="public",
         )
-        
+
         self.seasons = Table(
-            'seasons', self.metadata,
-            Column('id', sa.BigInteger, primary_key=True),
+            "seasons",
+            self.metadata,
+            Column("id", sa.BigInteger, primary_key=True),
             # Change TEXT to JSONB for structured storage
-            Column('summary', JSONB),
-            schema='public'
+            Column("summary", JSONB),
+            schema="public",
         )
-        
+
         self.episodes = Table(
-            'episodes', self.metadata,
-            Column('season', sa.BigInteger, primary_key=True),
-            Column('episode', sa.BigInteger, primary_key=True),
-            Column('chunk_span', TSRANGE),
+            "episodes",
+            self.metadata,
+            Column("season", sa.BigInteger, primary_key=True),
+            Column("episode", sa.BigInteger, primary_key=True),
+            Column("chunk_span", TSRANGE),
             # Change TEXT to JSONB for structured storage
-            Column('summary', JSONB),
-            schema='public'
+            Column("summary", JSONB),
+            schema="public",
         )
-    
+
     def get_season_chunks(self, season: int) -> List[Dict[str, Any]]:
         """
         Get all chunks for a specific season.
-        
+
         Args:
             season: The season number
-            
+
         Returns:
             List of chunk dictionaries with text and metadata
         """
         with self.engine.connect() as conn:
             # Query chunks and metadata for the season
-            query = text("""
+            query = text(
+                """
             SELECT 
                 nc.id, nc.raw_text, cm.season, cm.episode, cm.scene, cm.slug
             FROM 
@@ -304,11 +323,12 @@ class DatabaseManager:
                 cm.season = :season
             ORDER BY 
                 cm.episode ASC, cm.scene ASC
-            """)
-            
+            """
+            )
+
             result = conn.execute(query, {"season": season})
             chunks = []
-            
+
             for row in result:
                 chunk = {
                     "id": row.id,
@@ -316,32 +336,30 @@ class DatabaseManager:
                     "season": row.season,
                     "episode": row.episode,
                     "scene": row.scene,
-                    "slug": row.slug
+                    "slug": row.slug,
                 }
                 chunks.append(chunk)
-            
+
             return chunks
-    
+
     def get_episode_chunks(
-        self, 
-        season: int, 
-        episode: int,
-        include_context: bool = True
+        self, season: int, episode: int, include_context: bool = True
     ) -> List[Dict[str, Any]]:
         """
         Get all chunks for a specific episode.
-        
+
         Args:
             season: The season number
             episode: The episode number
             include_context: Whether to include context chunks before and after
-            
+
         Returns:
             List of chunk dictionaries with text and metadata
         """
         with self.engine.connect() as conn:
             # Base query for the specific episode
-            base_query = text("""
+            base_query = text(
+                """
             SELECT 
                 nc.id, nc.raw_text, cm.season, cm.episode, cm.scene, cm.slug
             FROM 
@@ -352,14 +370,15 @@ class DatabaseManager:
                 cm.season = :season AND cm.episode = :episode
             ORDER BY 
                 cm.scene ASC
-            """)
-            
+            """
+            )
+
             result = conn.execute(base_query, {"season": season, "episode": episode})
             chunks = []
-            
+
             # Track the min/max chunk IDs to debug any potential issues
             actual_chunk_ids = []
-            
+
             for row in result:
                 chunk = {
                     "id": row.id,
@@ -368,24 +387,27 @@ class DatabaseManager:
                     "episode": row.episode,
                     "scene": row.scene,
                     "slug": row.slug,
-                    "is_context": False  # Mark as non-context chunk explicitly
+                    "is_context": False,  # Mark as non-context chunk explicitly
                 }
                 chunks.append(chunk)
                 actual_chunk_ids.append(row.id)
-            
+
             # Log the actual chunk IDs for this episode
             if actual_chunk_ids:
-                logger.info(f"Actual chunk IDs for S{season:02d}E{episode:02d}: {min(actual_chunk_ids)}-{max(actual_chunk_ids)}")
-            
+                logger.info(
+                    f"Actual chunk IDs for S{season:02d}E{episode:02d}: {min(actual_chunk_ids)}-{max(actual_chunk_ids)}"
+                )
+
             # If no chunks found or no context needed, return as is
             if not chunks or not include_context:
                 return chunks
-            
+
             # Add context chunks before
             if CONTEXT_CHUNK_BEFORE > 0:
                 # Get ID of first chunk to find preceding chunks
                 first_chunk_id = chunks[0]["id"]
-                context_before_query = text("""
+                context_before_query = text(
+                    """
                 SELECT 
                     nc.id, nc.raw_text, cm.season, cm.episode, cm.scene, cm.slug
                 FROM 
@@ -397,18 +419,19 @@ class DatabaseManager:
                 ORDER BY 
                     nc.id DESC
                 LIMIT :limit
-                """)
-                
-                before_result = conn.execute(context_before_query, {
-                    "first_chunk_id": first_chunk_id,
-                    "limit": CONTEXT_CHUNK_BEFORE
-                })
-                
+                """
+                )
+
+                before_result = conn.execute(
+                    context_before_query,
+                    {"first_chunk_id": first_chunk_id, "limit": CONTEXT_CHUNK_BEFORE},
+                )
+
                 context_before = []
                 for row in before_result:
                     # Verify this is actually a context chunk (different episode or season)
                     is_context = row.season != season or row.episode != episode
-                    
+
                     chunk = {
                         "id": row.id,
                         "text": row.raw_text,
@@ -416,22 +439,25 @@ class DatabaseManager:
                         "episode": row.episode,
                         "scene": row.scene,
                         "slug": row.slug,
-                        "is_context": True  # Mark as context chunk
+                        "is_context": True,  # Mark as context chunk
                     }
                     context_before.append(chunk)
-                    
+
                     # Log if we found context chunks that actually belong to this episode
                     if not is_context:
-                        logger.warning(f"Context chunk {row.id} belongs to S{season:02d}E{episode:02d} but is being treated as context")
-                
+                        logger.warning(
+                            f"Context chunk {row.id} belongs to S{season:02d}E{episode:02d} but is being treated as context"
+                        )
+
                 # Reverse to get chronological order
                 chunks = context_before[::-1] + chunks
-            
+
             # Add context chunks after
             if CONTEXT_CHUNK_AFTER > 0:
                 # Get ID of last chunk to find following chunks
                 last_chunk_id = chunks[-1]["id"]
-                context_after_query = text("""
+                context_after_query = text(
+                    """
                 SELECT 
                     nc.id, nc.raw_text, cm.season, cm.episode, cm.scene, cm.slug
                 FROM 
@@ -443,18 +469,19 @@ class DatabaseManager:
                 ORDER BY 
                     nc.id ASC
                 LIMIT :limit
-                """)
-                
-                after_result = conn.execute(context_after_query, {
-                    "last_chunk_id": last_chunk_id,
-                    "limit": CONTEXT_CHUNK_AFTER
-                })
-                
+                """
+                )
+
+                after_result = conn.execute(
+                    context_after_query,
+                    {"last_chunk_id": last_chunk_id, "limit": CONTEXT_CHUNK_AFTER},
+                )
+
                 context_after = []
                 for row in after_result:
                     # Verify this is actually a context chunk (different episode or season)
                     is_context = row.season != season or row.episode != episode
-                    
+
                     chunk = {
                         "id": row.id,
                         "text": row.raw_text,
@@ -462,42 +489,45 @@ class DatabaseManager:
                         "episode": row.episode,
                         "scene": row.scene,
                         "slug": row.slug,
-                        "is_context": True  # Mark as context chunk
+                        "is_context": True,  # Mark as context chunk
                     }
                     context_after.append(chunk)
-                    
+
                     # Log if we found context chunks that actually belong to this episode
                     if not is_context:
-                        logger.warning(f"Context chunk {row.id} belongs to S{season:02d}E{episode:02d} but is being treated as context")
-                
+                        logger.warning(
+                            f"Context chunk {row.id} belongs to S{season:02d}E{episode:02d} but is being treated as context"
+                        )
+
                 chunks = chunks + context_after
-            
+
             return chunks
-    
+
     def get_episode_range_chunks(
-        self, 
-        start_season: int, 
+        self,
+        start_season: int,
         start_episode: int,
         end_season: int,
         end_episode: int,
-        include_context: bool = True
+        include_context: bool = True,
     ) -> List[Dict[str, Any]]:
         """
         Get all chunks for a range of episodes.
-        
+
         Args:
             start_season: The starting season number
             start_episode: The starting episode number
             end_season: The ending season number
             end_episode: The ending episode number
             include_context: Whether to include context chunks before and after
-            
+
         Returns:
             List of chunk dictionaries with text and metadata
         """
         with self.engine.connect() as conn:
             # Query for the episode range
-            range_query = text("""
+            range_query = text(
+                """
             SELECT 
                 nc.id, nc.raw_text, cm.season, cm.episode, cm.scene, cm.slug
             FROM 
@@ -510,15 +540,19 @@ class DatabaseManager:
                 (cm.season < :end_season OR (cm.season = :end_season AND cm.episode <= :end_episode))
             ORDER BY 
                 cm.season ASC, cm.episode ASC, cm.scene ASC
-            """)
-            
-            result = conn.execute(range_query, {
-                "start_season": start_season,
-                "start_episode": start_episode,
-                "end_season": end_season,
-                "end_episode": end_episode
-            })
-            
+            """
+            )
+
+            result = conn.execute(
+                range_query,
+                {
+                    "start_season": start_season,
+                    "start_episode": start_episode,
+                    "end_season": end_season,
+                    "end_episode": end_episode,
+                },
+            )
+
             chunks = []
             for row in result:
                 chunk = {
@@ -527,19 +561,20 @@ class DatabaseManager:
                     "season": row.season,
                     "episode": row.episode,
                     "scene": row.scene,
-                    "slug": row.slug
+                    "slug": row.slug,
                 }
                 chunks.append(chunk)
-            
+
             # If no chunks found or no context needed, return as is
             if not chunks or not include_context:
                 return chunks
-            
+
             # Add context chunks before
             if CONTEXT_CHUNK_BEFORE > 0:
                 # Get ID of first chunk to find preceding chunks
                 first_chunk_id = chunks[0]["id"]
-                context_before_query = text("""
+                context_before_query = text(
+                    """
                 SELECT 
                     nc.id, nc.raw_text, cm.season, cm.episode, cm.scene, cm.slug
                 FROM 
@@ -551,13 +586,14 @@ class DatabaseManager:
                 ORDER BY 
                     nc.id DESC
                 LIMIT :limit
-                """)
-                
-                before_result = conn.execute(context_before_query, {
-                    "first_chunk_id": first_chunk_id,
-                    "limit": CONTEXT_CHUNK_BEFORE
-                })
-                
+                """
+                )
+
+                before_result = conn.execute(
+                    context_before_query,
+                    {"first_chunk_id": first_chunk_id, "limit": CONTEXT_CHUNK_BEFORE},
+                )
+
                 context_before = []
                 for row in before_result:
                     chunk = {
@@ -567,18 +603,19 @@ class DatabaseManager:
                         "episode": row.episode,
                         "scene": row.scene,
                         "slug": row.slug,
-                        "is_context": True
+                        "is_context": True,
                     }
                     context_before.append(chunk)
-                
+
                 # Reverse to get chronological order
                 chunks = context_before[::-1] + chunks
-            
+
             # Add context chunks after
             if CONTEXT_CHUNK_AFTER > 0:
                 # Get ID of last chunk to find following chunks
                 last_chunk_id = chunks[-1]["id"]
-                context_after_query = text("""
+                context_after_query = text(
+                    """
                 SELECT 
                     nc.id, nc.raw_text, cm.season, cm.episode, cm.scene, cm.slug
                 FROM 
@@ -590,13 +627,14 @@ class DatabaseManager:
                 ORDER BY 
                     nc.id ASC
                 LIMIT :limit
-                """)
-                
-                after_result = conn.execute(context_after_query, {
-                    "last_chunk_id": last_chunk_id,
-                    "limit": CONTEXT_CHUNK_AFTER
-                })
-                
+                """
+                )
+
+                after_result = conn.execute(
+                    context_after_query,
+                    {"last_chunk_id": last_chunk_id, "limit": CONTEXT_CHUNK_AFTER},
+                )
+
                 context_after = []
                 for row in after_result:
                     chunk = {
@@ -606,27 +644,30 @@ class DatabaseManager:
                         "episode": row.episode,
                         "scene": row.scene,
                         "slug": row.slug,
-                        "is_context": True
+                        "is_context": True,
                     }
                     context_after.append(chunk)
-                
+
                 chunks = chunks + context_after
-            
+
             return chunks
-    
-    def get_chunks_by_id_range(self, start_id: int, end_id: int) -> List[Dict[str, Any]]:
+
+    def get_chunks_by_id_range(
+        self, start_id: int, end_id: int
+    ) -> List[Dict[str, Any]]:
         """
         Get chunks by ID range (manual fallback).
-        
+
         Args:
             start_id: Starting chunk ID
             end_id: Ending chunk ID
-            
+
         Returns:
             List of chunk dictionaries with text and metadata
         """
         with self.engine.connect() as conn:
-            query = text("""
+            query = text(
+                """
             SELECT 
                 nc.id, nc.raw_text, cm.season, cm.episode, cm.scene, cm.slug
             FROM 
@@ -637,10 +678,11 @@ class DatabaseManager:
                 nc.id >= :start_id AND nc.id <= :end_id
             ORDER BY 
                 nc.id ASC
-            """)
-            
+            """
+            )
+
             result = conn.execute(query, {"start_id": start_id, "end_id": end_id})
-            
+
             chunks = []
             for row in result:
                 chunk = {
@@ -649,53 +691,54 @@ class DatabaseManager:
                     "season": row.season if row.season is not None else None,
                     "episode": row.episode if row.episode is not None else None,
                     "scene": row.scene if row.scene is not None else None,
-                    "slug": row.slug if row.slug is not None else None
+                    "slug": row.slug if row.slug is not None else None,
                 }
                 chunks.append(chunk)
-                
+
             return chunks
-            
+
     def get_previous_season_summaries(self, season: int) -> List[Dict[str, Any]]:
         """
         Get all summaries from previous seasons.
-        
+
         Args:
             season: The current season number
-            
+
         Returns:
             List of dictionaries with season number and summary text
         """
         summaries = []
         try:
             with self.engine.connect() as conn:
-                query = text("""
+                query = text(
+                    """
                 SELECT id, summary 
                 FROM public.seasons 
                 WHERE id < :season AND summary IS NOT NULL
                 ORDER BY id ASC
-                """)
-                
+                """
+                )
+
                 result = conn.execute(query, {"season": season})
-                
+
                 for row in result:
-                    summaries.append({
-                        "season": row.id,
-                        "summary": row.summary
-                    })
-                    
+                    summaries.append({"season": row.id, "summary": row.summary})
+
             return summaries
         except Exception as e:
             logger.error(f"Error retrieving previous season summaries: {e}")
             return []
-            
-    def get_previous_episode_summaries(self, season: int, episode: int) -> List[Dict[str, Any]]:
+
+    def get_previous_episode_summaries(
+        self, season: int, episode: int
+    ) -> List[Dict[str, Any]]:
         """
         Get summaries from previous episodes in the same season.
-        
+
         Args:
             season: The season number
             episode: The current episode number
-            
+
         Returns:
             List of dictionaries with episode info and summary text
         """
@@ -703,23 +746,27 @@ class DatabaseManager:
         try:
             with self.engine.connect() as conn:
                 # Get previous episodes from this season
-                query = text("""
+                query = text(
+                    """
                 SELECT season, episode, summary 
                 FROM public.episodes 
                 WHERE season = :season AND episode < :episode AND summary IS NOT NULL
                 ORDER BY episode ASC
-                """)
-                
+                """
+                )
+
                 result = conn.execute(query, {"season": season, "episode": episode})
-                
+
                 for row in result:
-                    summaries.append({
-                        "season": row.season,
-                        "episode": row.episode,
-                        "slug": EpisodeSlugParser.format(row.season, row.episode),
-                        "summary": row.summary
-                    })
-                    
+                    summaries.append(
+                        {
+                            "season": row.season,
+                            "episode": row.episode,
+                            "slug": EpisodeSlugParser.format(row.season, row.episode),
+                            "summary": row.summary,
+                        }
+                    )
+
             return summaries
         except Exception as e:
             logger.error(f"Error retrieving previous episode summaries: {e}")
@@ -747,38 +794,39 @@ class DatabaseManager:
                         LIMIT 1
                         """
                     ),
-                    {"season": season, "episode": episode}
+                    {"season": season, "episode": episode},
                 ).scalar()
                 return result is not None
         except Exception as e:
-            logger.error(f"Error checking for existing summary for S{season:02d}E{episode:02d}: {e}")
+            logger.error(
+                f"Error checking for existing summary for S{season:02d}E{episode:02d}: {e}"
+            )
             return False
-            
+
     def get_season_summary(self, season: int) -> Optional[Dict[str, Any]]:
         """
         Get the summary for a specific season.
-        
+
         Args:
             season: The season number
-            
+
         Returns:
             Dictionary with the season summary, or None if not found
         """
         try:
             with self.engine.connect() as conn:
-                query = text("""
+                query = text(
+                    """
                 SELECT id, summary 
                 FROM public.seasons 
                 WHERE id = :season AND summary IS NOT NULL
-                """)
-                
+                """
+                )
+
                 result = conn.execute(query, {"season": season}).fetchone()
-                
+
                 if result:
-                    return {
-                        "season": result.id,
-                        "summary": result.summary
-                    }
+                    return {"season": result.id, "summary": result.summary}
                 return None
         except Exception as e:
             logger.error(f"Error retrieving season summary: {e}")
@@ -805,47 +853,53 @@ class DatabaseManager:
                         LIMIT 1
                         """
                     ),
-                    {"season": season}
+                    {"season": season},
                 ).scalar()
                 return result is not None
         except Exception as e:
-            logger.error(f"Error checking for existing summary for Season {season}: {e}")
+            logger.error(
+                f"Error checking for existing summary for Season {season}: {e}"
+            )
             return False
-    
+
     def save_season_summary(
         self,
         season: int,
         summary: dict,
         dry_run: bool = False,
         overwrite: bool = False,
-        prompt_on_conflict: bool = True
+        prompt_on_conflict: bool = True,
     ) -> bool:
         """
         Save a season summary to the database.
-        
+
         Args:
             season: The season number
             summary: The summary as a dictionary (from Pydantic model)
             dry_run: If True, don't actually save
             overwrite: If True, overwrite existing summary even if it exists
             prompt_on_conflict: If False, skip interactive overwrite prompts and keep existing data
-            
+
         Returns:
             True if successful, False otherwise
         """
         if dry_run:
             logger.info(f"[DRY RUN] Would save summary for season {season}")
             return True
-            
+
         try:
             with self.engine.connect() as conn:
                 # Check if season record exists
-                check_query = text("SELECT id, summary FROM public.seasons WHERE id = :season")
+                check_query = text(
+                    "SELECT id, summary FROM public.seasons WHERE id = :season"
+                )
                 existing = conn.execute(check_query, {"season": season}).fetchone()
-                
+
                 if existing and existing.summary and not overwrite:
                     if not prompt_on_conflict:
-                        logger.info(f"Existing summary found for Season {season}; skipping (overwrite disabled)")
+                        logger.info(
+                            f"Existing summary found for Season {season}; skipping (overwrite disabled)"
+                        )
                         return False
 
                     # We have an existing summary but no overwrite flag
@@ -858,17 +912,28 @@ class DatabaseManager:
                     else:
                         print(json.dumps(summary, indent=2))
                     print("=" * 80)
-                    
+
                     # Ask user for decision
-                    choice = input(f"\nOverwrite existing summary for Season {season}? (y/n): ").lower().strip()
-                    if choice == 'y':
-                        update_query = text("""
+                    choice = (
+                        input(
+                            f"\nOverwrite existing summary for Season {season}? (y/n): "
+                        )
+                        .lower()
+                        .strip()
+                    )
+                    if choice == "y":
+                        update_query = text(
+                            """
                         UPDATE public.seasons
                         SET summary = :summary
                         WHERE id = :season
-                        """)
-                        
-                        conn.execute(update_query, {"season": season, "summary": json.dumps(summary)})
+                        """
+                        )
+
+                        conn.execute(
+                            update_query,
+                            {"season": season, "summary": json.dumps(summary)},
+                        )
                         conn.commit()
                         logger.info(f"Updated summary for season {season}")
                         return True
@@ -877,45 +942,53 @@ class DatabaseManager:
                         return False
                 elif existing:
                     # Update existing record (either no summary or overwrite flag is True)
-                    update_query = text("""
+                    update_query = text(
+                        """
                     UPDATE public.seasons
                     SET summary = :summary
                     WHERE id = :season
-                    """)
-                    
-                    conn.execute(update_query, {"season": season, "summary": json.dumps(summary)})
+                    """
+                    )
+
+                    conn.execute(
+                        update_query, {"season": season, "summary": json.dumps(summary)}
+                    )
                     conn.commit()
                     logger.info(f"Updated summary for season {season}")
                     return True
                 else:
                     # Insert new record
-                    insert_query = text("""
+                    insert_query = text(
+                        """
                     INSERT INTO public.seasons (id, summary)
                     VALUES (:season, :summary)
-                    """)
-                    
-                    conn.execute(insert_query, {"season": season, "summary": json.dumps(summary)})
+                    """
+                    )
+
+                    conn.execute(
+                        insert_query, {"season": season, "summary": json.dumps(summary)}
+                    )
                     conn.commit()
                     logger.info(f"Inserted new summary for season {season}")
                     return True
-                
+
         except Exception as e:
             logger.error(f"Error saving season summary: {e}")
             return False
-    
+
     def save_episode_summary(
-        self, 
-        season: int, 
-        episode: int, 
-        summary: dict, 
+        self,
+        season: int,
+        episode: int,
+        summary: dict,
         dry_run: bool = False,
         overwrite: bool = False,
         chunk_span: Optional[Tuple[int, int]] = None,
-        prompt_on_conflict: bool = True
+        prompt_on_conflict: bool = True,
     ) -> bool:
         """
         Save an episode summary to the database.
-        
+
         Args:
             season: The season number
             episode: The episode number
@@ -924,43 +997,55 @@ class DatabaseManager:
             overwrite: If True, overwrite existing summary even if it exists
             chunk_span: Optional tuple of (min_id, max_id) for the episode chunks
             prompt_on_conflict: If False, skip interactive overwrite prompts and keep existing data
-            
+
         Returns:
             True if successful, False otherwise
         """
         if dry_run:
             logger.info(f"[DRY RUN] Would save summary for S{season:02d}E{episode:02d}")
             return True
-            
+
         # Log chunk span details
         if chunk_span:
             min_id, max_id = chunk_span
-            logger.info(f"Saving S{season:02d}E{episode:02d} with chunk_span: [{min_id}, {max_id}]")
+            logger.info(
+                f"Saving S{season:02d}E{episode:02d} with chunk_span: [{min_id}, {max_id}]"
+            )
         else:
             logger.warning(f"No chunk_span provided for S{season:02d}E{episode:02d}")
-            
+
         try:
             with self.engine.connect() as conn:
                 # Prepare parameters and chunk_span clause if provided
-                params = {"season": season, "episode": episode, "summary": json.dumps(summary)}
-                
+                params = {
+                    "season": season,
+                    "episode": episode,
+                    "summary": json.dumps(summary),
+                }
+
                 # Add chunk span parameters if available
                 if chunk_span:
                     min_id, max_id = chunk_span
                     params["min_id"] = min_id
                     params["max_id"] = max_id
-                
+
                 # Check if episode record exists
-                check_query = text("""
+                check_query = text(
+                    """
                 SELECT season, episode, summary FROM public.episodes 
                 WHERE season = :season AND episode = :episode
-                """)
-                
-                existing = conn.execute(check_query, {"season": season, "episode": episode}).fetchone()
-                
+                """
+                )
+
+                existing = conn.execute(
+                    check_query, {"season": season, "episode": episode}
+                ).fetchone()
+
                 if existing and existing.summary and not overwrite:
                     if not prompt_on_conflict:
-                        logger.info(f"Existing summary found for S{season:02d}E{episode:02d}; skipping (overwrite disabled)")
+                        logger.info(
+                            f"Existing summary found for S{season:02d}E{episode:02d}; skipping (overwrite disabled)"
+                        )
                         return False
 
                     # We have an existing summary but no overwrite flag
@@ -974,23 +1059,31 @@ class DatabaseManager:
                     else:
                         print(json.dumps(summary, indent=2))
                     print("=" * 80)
-                    
+
                     # Ask user for decision
-                    choice = input(f"\nOverwrite existing summary for {slug}? (y/n): ").lower().strip()
-                    if choice == 'y':
+                    choice = (
+                        input(f"\nOverwrite existing summary for {slug}? (y/n): ")
+                        .lower()
+                        .strip()
+                    )
+                    if choice == "y":
                         if chunk_span:
-                            update_query = text("""
+                            update_query = text(
+                                """
                             UPDATE public.episodes
                             SET summary = :summary, chunk_span = int8range(:min_id, :max_id)
                             WHERE season = :season AND episode = :episode
-                            """)
+                            """
+                            )
                         else:
-                            update_query = text("""
+                            update_query = text(
+                                """
                             UPDATE public.episodes
                             SET summary = :summary
                             WHERE season = :season AND episode = :episode
-                            """)
-                        
+                            """
+                            )
+
                         conn.execute(update_query, params)
                         conn.commit()
                         logger.info(f"Updated summary for {slug}")
@@ -1001,18 +1094,22 @@ class DatabaseManager:
                 elif existing:
                     # Update existing record (either no summary or overwrite flag is True)
                     if chunk_span:
-                        update_query = text("""
+                        update_query = text(
+                            """
                         UPDATE public.episodes
                         SET summary = :summary, chunk_span = int8range(:min_id, :max_id)
                         WHERE season = :season AND episode = :episode
-                        """)
+                        """
+                        )
                     else:
-                        update_query = text("""
+                        update_query = text(
+                            """
                         UPDATE public.episodes
                         SET summary = :summary
                         WHERE season = :season AND episode = :episode
-                        """)
-                    
+                        """
+                        )
+
                     conn.execute(update_query, params)
                     conn.commit()
                     logger.info(f"Updated summary for S{season:02d}E{episode:02d}")
@@ -1020,40 +1117,47 @@ class DatabaseManager:
                 else:
                     # Insert new record
                     if chunk_span:
-                        insert_query = text("""
+                        insert_query = text(
+                            """
                         INSERT INTO public.episodes (season, episode, summary, chunk_span)
                         VALUES (:season, :episode, :summary, int8range(:min_id, :max_id))
-                        """)
+                        """
+                        )
                     else:
-                        insert_query = text("""
+                        insert_query = text(
+                            """
                         INSERT INTO public.episodes (season, episode, summary)
                         VALUES (:season, :episode, :summary)
-                        """)
-                    
+                        """
+                        )
+
                     conn.execute(insert_query, params)
                     conn.commit()
                     logger.info(f"Inserted new summary for S{season:02d}E{episode:02d}")
                     return True
-                
+
         except Exception as e:
             logger.error(f"Error saving episode summary: {e}")
             return False
-    
-    def get_episode_chunk_span(self, season: int, episode: int) -> Optional[Tuple[int, int]]:
+
+    def get_episode_chunk_span(
+        self, season: int, episode: int
+    ) -> Optional[Tuple[int, int]]:
         """
         Get the exact chunk span (min/max IDs) for a specific episode.
-        
+
         Args:
             season: The season number
             episode: The episode number
-            
+
         Returns:
             Tuple of (min_id, max_id) or None if no chunks found
         """
         try:
             with self.engine.connect() as conn:
                 # First, get all chunk IDs for this episode with metadata
-                chunk_details_query = text("""
+                chunk_details_query = text(
+                    """
                 SELECT 
                     nc.id as chunk_id, cm.season, cm.episode, cm.scene
                 FROM 
@@ -1064,52 +1168,68 @@ class DatabaseManager:
                     cm.season = :season AND cm.episode = :episode
                 ORDER BY 
                     nc.id ASC
-                """)
-                
-                chunk_details = list(conn.execute(chunk_details_query, {"season": season, "episode": episode}))
-                
+                """
+                )
+
+                chunk_details = list(
+                    conn.execute(
+                        chunk_details_query, {"season": season, "episode": episode}
+                    )
+                )
+
                 if not chunk_details:
                     logger.warning(f"No chunks found for S{season:02d}E{episode:02d}")
                     return None
-                
+
                 # Get min and max IDs
                 min_id = chunk_details[0].chunk_id
                 max_id = chunk_details[-1].chunk_id
-                
+
                 # Log all chunks for debugging
                 chunks_str = ", ".join([str(row.chunk_id) for row in chunk_details])
                 logger.info(f"Chunks for S{season:02d}E{episode:02d}: [{chunks_str}]")
-                logger.info(f"Chunk span for S{season:02d}E{episode:02d}: {min_id} to {max_id}")
-                
+                logger.info(
+                    f"Chunk span for S{season:02d}E{episode:02d}: {min_id} to {max_id}"
+                )
+
                 # Verify the boundaries to ensure they don't include other episodes
-                verify_query = text("""
+                verify_query = text(
+                    """
                 SELECT 
                     cm.season, cm.episode, cm.scene
                 FROM 
                     public.chunk_metadata cm
                 WHERE 
                     cm.chunk_id = :min_id OR cm.chunk_id = :max_id
-                """)
-                
-                boundaries = list(conn.execute(verify_query, {"min_id": min_id, "max_id": max_id}))
-                
+                """
+                )
+
+                boundaries = list(
+                    conn.execute(verify_query, {"min_id": min_id, "max_id": max_id})
+                )
+
                 for row in boundaries:
                     if row.season != season or row.episode != episode:
-                        logger.error(f"Boundary issue: Chunk ID belonging to S{row.season:02d}E{row.episode:02d} included in S{season:02d}E{episode:02d} span")
+                        logger.error(
+                            f"Boundary issue: Chunk ID belonging to S{row.season:02d}E{row.episode:02d} included in S{season:02d}E{episode:02d} span"
+                        )
                         # Don't return wrong boundaries
                         return None
-                
+
                 return (min_id, max_id)
-                
+
         except Exception as e:
-            logger.error(f"Error getting chunk span for S{season:02d}E{episode:02d}: {e}")
+            logger.error(
+                f"Error getting chunk span for S{season:02d}E{episode:02d}: {e}"
+            )
             return None
+
 
 class SummaryGenerator:
     """
     Main class to generate summaries using OpenAI's API.
     """
-    
+
     def __init__(
         self,
         model: str,
@@ -1120,11 +1240,11 @@ class SummaryGenerator:
         overwrite: bool = False,
         verbose: bool = False,
         save_prompt: bool = False,
-        prompt_on_conflict: bool = True
+        prompt_on_conflict: bool = True,
     ):
         """
         Initialize the summary generator.
-        
+
         Args:
             model: OpenAI model to use
             temperature: Temperature for generation (used for non-reasoning models)
@@ -1146,36 +1266,38 @@ class SummaryGenerator:
         self.save_prompt = save_prompt
         self.prompt_on_conflict = prompt_on_conflict
         self.provider = self._initialize_provider()
-        
+
     def _initialize_provider(self) -> OpenAIProvider:
         """Initialize the OpenAI provider."""
         try:
             # Use the streamlined provider initialization
             if self.is_reasoning_model:
                 provider = OpenAIProvider(
-                    model=self.model,
-                    reasoning_effort=self.effort
+                    model=self.model, reasoning_effort=self.effort
                 )
-                logger.info(f"Initialized OpenAI provider with reasoning model: {self.model}, effort: {self.effort}")
+                logger.info(
+                    f"Initialized OpenAI provider with reasoning model: {self.model}, effort: {self.effort}"
+                )
             else:
                 provider = OpenAIProvider(
-                    model=self.model,
-                    temperature=self.temperature
+                    model=self.model, temperature=self.temperature
                 )
-                logger.info(f"Initialized OpenAI provider with standard model: {self.model}, temperature: {self.temperature}")
-                
+                logger.info(
+                    f"Initialized OpenAI provider with standard model: {self.model}, temperature: {self.temperature}"
+                )
+
             return provider
         except Exception as e:
             logger.error(f"Error initializing OpenAI provider: {e}")
             raise
-    
+
     def _get_system_prompt(self, mode: str) -> str:
         """
         Get the appropriate system prompt based on mode.
-        
+
         Args:
             mode: Either 'season' or 'episode'
-            
+
         Returns:
             System prompt string
         """
@@ -1219,28 +1341,28 @@ Be factual, objective, and chronological. Focus on concrete events and states ra
             # Generic fallback
             return """You are a narrative continuity AI that creates structured, factual summaries for an AI storytelling system.
 Your summaries will be accessed by another AI to maintain narrative consistency. Be factual, objective, and comprehensive."""
-    
+
     def _prepare_chunks_text(self, chunks: List[Dict[str, Any]], mode: str) -> str:
         """
         Prepare chunks for inclusion in the prompt.
-        
+
         Args:
             chunks: List of chunk dictionaries
             mode: Either 'season' or 'episode'
-            
+
         Returns:
             Formatted chunk text for the prompt
         """
         formatted_chunks = []
-        
+
         for chunk in chunks:
             # Skip context chunks in the final text if there are too many chunks
             if len(chunks) > 20 and chunk.get("is_context", False):
                 continue
-                
+
             # Format the chunk header
             header = "=" * 80 + "\n"
-            
+
             if chunk.get("slug"):
                 header += f"SLUG: {chunk['slug']}"
             elif chunk.get("season") is not None and chunk.get("episode") is not None:
@@ -1250,26 +1372,26 @@ Your summaries will be accessed by another AI to maintain narrative consistency.
                 header += f"S{season:02d}E{episode:02d} Scene {scene}"
             else:
                 header += f"CHUNK ID: {chunk['id']}"
-                
+
             if chunk.get("is_context", False):
                 header += " [CONTEXT CHUNK]"
-                
+
             header += "\n" + "=" * 80 + "\n"
-            
+
             # Add the chunk text
             formatted_chunks.append(header + chunk["text"])
-        
+
         # Join all chunks with newlines
         return "\n\n".join(formatted_chunks)
-    
+
     def _token_check(self, text: str, mode: str) -> bool:
         """
         Check if the text is within token limits for the model.
-        
+
         Args:
             text: The text to check
             mode: Either 'season' or 'episode'
-            
+
         Returns:
             True if within limits, False otherwise
         """
@@ -1277,90 +1399,99 @@ Your summaries will be accessed by another AI to maintain narrative consistency.
 
         # Load settings to get the TPM
         from nexus.config import load_settings_as_dict
+
         settings = load_settings_as_dict()
 
         # Get the OpenAI TPM limit
         openai_tpm = settings.get("API Settings", {}).get("TPM", {}).get("openai")
         if not openai_tpm:
             raise ValueError("Could not find OpenAI TPM limit in configuration")
-            
+
         # Set output token limit based on mode
-        expected_output_tokens = MAX_TOKENS_SEASON if mode == "season" else MAX_TOKENS_EPISODE
-        
+        expected_output_tokens = (
+            MAX_TOKENS_SEASON if mode == "season" else MAX_TOKENS_EPISODE
+        )
+
         # Calculate max input tokens (with a small buffer)
         max_input_tokens = openai_tpm - expected_output_tokens
-        
+
         if token_count > max_input_tokens:
             logger.warning(
                 f"Input too long: {token_count} tokens (limit: {max_input_tokens}). "
                 f"Try using fewer chunks or a smaller range."
             )
             return False
-            
-        logger.info(f"Token count: {token_count} (under limit of {max_input_tokens} from settings.json)")
+
+        logger.info(
+            f"Token count: {token_count} (under limit of {max_input_tokens} from settings.json)"
+        )
         return True
-    
+
     def _save_prompt_to_file(self, prompt: str, prefix: str):
         """Save prompt to a file for debugging."""
         if not self.save_prompt:
             return
-            
+
         try:
             timestamp = time.strftime("%Y%m%d_%H%M%S")
             filename = f"{prefix}_{timestamp}_prompt.txt"
-            
+
             with open(filename, "w") as f:
                 f.write(prompt)
-                
+
             logger.info(f"Saved prompt to {filename}")
         except Exception as e:
             logger.error(f"Error saving prompt to file: {e}")
-    
+
     def generate_season_summary(self, season: int) -> Optional[dict]:
         """
         Generate a comprehensive summary for an entire season.
-        
+
         Args:
             season: The season number
-            
+
         Returns:
             Generated summary as a dictionary, or None if failed
         """
         logger.info(f"Generating summary for Season {season}")
-        
+
         # Get all chunks for the season
         chunks = self.db_manager.get_season_chunks(season)
-        
+
         if not chunks:
             logger.error(f"No chunks found for Season {season}")
             return None
-            
+
         logger.info(f"Found {len(chunks)} chunks for Season {season}")
-        
+
         # Get summaries of previous seasons for context
         previous_summaries = self.db_manager.get_previous_season_summaries(season)
         prev_summaries_text = ""
-        
+
         if previous_summaries:
-            logger.info(f"Found {len(previous_summaries)} previous season summaries for context")
+            logger.info(
+                f"Found {len(previous_summaries)} previous season summaries for context"
+            )
             prev_summaries_text = "## Previous Season Summaries:\n\n"
-            
+
             for prev in previous_summaries:
                 prev_season = prev["season"]
                 prev_summary = prev["summary"]
-                
+
                 # Extract just the summary text from the JSONB object
                 if isinstance(prev_summary, dict) and "summary" in prev_summary:
                     summary_content = prev_summary["summary"]
                 else:
                     # Fallback if structure is different
                     summary_content = str(prev_summary)
-                
-                prev_summaries_text += f"### Season {prev_season} Summary:\n\n{summary_content}\n\n"
+
+                prev_summaries_text += (
+                    f"### Season {prev_season} Summary:\n\n{summary_content}\n\n"
+                )
                 prev_summaries_text += "-" * 80 + "\n\n"
-            
+
             logger.info("Added previous season summaries to the prompt")
-            
+
             # Print context in verbose mode
             if self.verbose and prev_summaries_text:
                 print("\n" + "=" * 80)
@@ -1368,11 +1499,11 @@ Your summaries will be accessed by another AI to maintain narrative consistency.
                 print("=" * 80)
                 print(prev_summaries_text)
                 print("=" * 80 + "\n")
-        
+
         # Prepare the prompt
         system_prompt = self._get_system_prompt("season")
         chunks_text = self._prepare_chunks_text(chunks, "season")
-        
+
         # Build the main prompt with previous summaries
         prompt = f"""# Narrative Summary Request
 
@@ -1390,42 +1521,46 @@ I need a comprehensive, structured summary of Season {season} of the narrative. 
 4. For NARRATIVE_ARCS, identify major storylines and track their progression across episodes.
 5. Be objective, factual, and comprehensive - your summary will be used by another AI to maintain narrative continuity.
 6. Maintain continuity with previous seasons - ensure your summary is compatible with the major plot developments and character arcs established in earlier seasons."""
-        
+
         # Token check
         if not self._token_check(prompt, "season"):
             logger.warning("Token check failed - input may be too long")
             # Proceed anyway - the API will truncate if needed
-        
+
         # Save prompt if requested
         self._save_prompt_to_file(prompt, f"season_{season}")
-        
+
         try:
             # Use the OpenAI responses.parse API with Pydantic model
             import openai
-            
+
             # Set up the API client - using the direct OpenAI client
             client = openai.OpenAI(api_key=self.provider.api_key)
-            
+
             # Prepare messages
             messages = [{"role": "user", "content": prompt}]
             if self.provider.system_prompt:
-                messages.insert(0, {"role": "system", "content": self.provider.system_prompt})
-            
+                messages.insert(
+                    0, {"role": "system", "content": self.provider.system_prompt}
+                )
+
             # Create a simple Pydantic model for season summary
             class SeasonSummaryModel(BaseModel):
                 summary: str = Field(
                     description="A comprehensive, detailed narrative summary of the entire season capturing major plot developments, character arcs, key world-building elements, and themes."
                 )
-            
-            logger.info(f"Using OpenAI responses.parse with model {self.provider.model}")
-            
+
+            logger.info(
+                f"Using OpenAI responses.parse with model {self.provider.model}"
+            )
+
             # Call the API with appropriate parameters based on model type
             if self.is_reasoning_model:
                 response = client.responses.parse(
                     model=self.provider.model,
                     input=messages,
                     reasoning={"effort": self.effort},
-                    text_format=SeasonSummaryModel
+                    text_format=SeasonSummaryModel,
                 )
                 logger.info(f"Used reasoning model with effort: {self.effort}")
             else:
@@ -1433,22 +1568,20 @@ I need a comprehensive, structured summary of Season {season} of the narrative. 
                     model=self.provider.model,
                     input=messages,
                     temperature=self.temperature,
-                    text_format=SeasonSummaryModel
+                    text_format=SeasonSummaryModel,
                 )
                 logger.info(f"Used standard model with temperature: {self.temperature}")
-            
+
             # Create a summary dict that matches our expected format
             summary_text = response.output_parsed.summary
-            summary_dict = {
-                "summary": summary_text
-            }
-            
+            summary_dict = {"summary": summary_text}
+
             # Log completion info
             logger.info(
                 f"Generated season summary with {response.usage.input_tokens} input tokens and "
                 f"{response.usage.output_tokens} output tokens"
             )
-            
+
             # Print summary in verbose mode
             if self.verbose:
                 print("\n" + "=" * 80)
@@ -1456,64 +1589,68 @@ I need a comprehensive, structured summary of Season {season} of the narrative. 
                 print("=" * 80)
                 print(json.dumps(summary_dict, indent=2))
                 print("=" * 80 + "\n")
-            
+
             # Save to database
             success = self.db_manager.save_season_summary(
                 season=season,
                 summary=summary_dict,
                 dry_run=self.dry_run,
                 overwrite=self.overwrite,
-                prompt_on_conflict=self.prompt_on_conflict
+                prompt_on_conflict=self.prompt_on_conflict,
             )
-            
+
             if success:
                 logger.info(f"Successfully saved summary for Season {season}")
                 return summary_dict
             else:
                 logger.error(f"Failed to save summary for Season {season}")
                 return None
-                
+
         except Exception as e:
             logger.error(f"Error generating season summary: {e}")
             return None
-    
+
     def generate_episode_summary(self, season: int, episode: int) -> Optional[dict]:
         """
         Generate a comprehensive summary for a single episode.
-        
+
         Args:
             season: The season number
             episode: The episode number
-            
+
         Returns:
             Generated summary as a dictionary, or None if failed
         """
         logger.info(f"Generating summary for S{season:02d}E{episode:02d}")
-        
+
         # Get the exact chunk span directly from the database
         chunk_span = self.db_manager.get_episode_chunk_span(season, episode)
         if chunk_span:
-            logger.info(f"Found chunk span for S{season:02d}E{episode:02d}: {chunk_span}")
+            logger.info(
+                f"Found chunk span for S{season:02d}E{episode:02d}: {chunk_span}"
+            )
         else:
             logger.warning(f"No chunk span found for S{season:02d}E{episode:02d}")
-        
+
         # Get chunks for the episode
-        chunks = self.db_manager.get_episode_chunks(season, episode, include_context=True)
-        
+        chunks = self.db_manager.get_episode_chunks(
+            season, episode, include_context=True
+        )
+
         if not chunks:
             logger.error(f"No chunks found for S{season:02d}E{episode:02d}")
             return None
-            
+
         # Count main chunks (excluding context)
         main_chunks = [c for c in chunks if not c.get("is_context", False)]
         logger.info(
             f"Found {len(main_chunks)} chunks for S{season:02d}E{episode:02d} "
             f"(plus {len(chunks) - len(main_chunks)} context chunks)"
         )
-        
+
         # Get previous context based on episode number
         context_text = ""
-        
+
         # FIRST, get previous season summaries (if any)
         # For episodes in season 2+, always add summaries of previous seasons for context
         if season > 1:
@@ -1522,56 +1659,64 @@ I need a comprehensive, structured summary of Season {season} of the narrative. 
                 context_text += "## Previous Season Summaries:\n\n"
                 # Sort seasons chronologically
                 prev_seasons = sorted(prev_seasons, key=lambda x: x["season"])
-                
+
                 # If we have too many seasons, limit to the most recent ones to manage prompt size
                 if len(prev_seasons) > 2:
-                    logger.info(f"Found {len(prev_seasons)} previous seasons, using the 2 most recent for context")
+                    logger.info(
+                        f"Found {len(prev_seasons)} previous seasons, using the 2 most recent for context"
+                    )
                     prev_seasons = prev_seasons[-2:]
-                
+
                 for prev in prev_seasons:
                     prev_season_num = prev["season"]
                     prev_summary = prev["summary"]
-                    
+
                     # Extract just the summary text from the JSONB object
                     if isinstance(prev_summary, dict) and "summary" in prev_summary:
                         summary_content = prev_summary["summary"]
                     else:
                         # Fallback if structure is different
                         summary_content = str(prev_summary)
-                    
+
                     context_text += f"### Season {prev_season_num} Summary:\n\n{summary_content}\n\n"
                     context_text += "-" * 80 + "\n\n"
-                
-                logger.info(f"Added {len(prev_seasons)} previous season summaries for context")
-        
+
+                logger.info(
+                    f"Added {len(prev_seasons)} previous season summaries for context"
+                )
+
         # SECOND, add any previous episode summaries from the current season
         if episode > 1:
             # For non-first episodes, include previous episode summaries in the same season
-            prev_episodes = self.db_manager.get_previous_episode_summaries(season, episode)
-            
+            prev_episodes = self.db_manager.get_previous_episode_summaries(
+                season, episode
+            )
+
             if prev_episodes:
                 context_text += "## Previous Episode Summaries:\n\n"
-                
+
                 # Include ALL previous episodes from the current season, in chronological order
                 prev_episodes = sorted(prev_episodes, key=lambda x: x["episode"])
-                
+
                 for prev in prev_episodes:
                     prev_episode = prev["episode"]
                     prev_summary = prev["summary"]
                     prev_slug = prev["slug"]
-                    
+
                     # Extract just the summary text from the JSONB object
                     if isinstance(prev_summary, dict) and "summary" in prev_summary:
                         summary_content = prev_summary["summary"]
                     else:
                         # Fallback if structure is different
                         summary_content = str(prev_summary)
-                    
+
                     context_text += f"### {prev_slug} Summary:\n\n{summary_content}\n\n"
                     context_text += "-" * 80 + "\n\n"
-                
-                logger.info(f"Added all {len(prev_episodes)} previous episode summaries for the current season to the prompt")
-        
+
+                logger.info(
+                    f"Added all {len(prev_episodes)} previous episode summaries for the current season to the prompt"
+                )
+
         # Print context in verbose mode
         if self.verbose and context_text:
             print("\n" + "=" * 80)
@@ -1579,11 +1724,11 @@ I need a comprehensive, structured summary of Season {season} of the narrative. 
             print("=" * 80)
             print(context_text)
             print("=" * 80 + "\n")
-        
+
         # Prepare the prompt
         system_prompt = self._get_system_prompt("episode")
         chunks_text = self._prepare_chunks_text(chunks, "episode")
-        
+
         # Build the main prompt with context
         prompt = f"""# Episode Summary Request
 
@@ -1610,42 +1755,46 @@ I need a comprehensive, structured summary of Season {season}, Episode {episode}
 2. Be objective, factual, and focus on concrete details - your summary will be used by another AI to maintain narrative continuity.
 
 3. Format matters! Your response must follow the exact structure required for machine processing."""
-        
+
         # Token check
         if not self._token_check(prompt, "episode"):
             logger.warning("Token check failed - input may be too long")
             # Proceed anyway - the API will truncate if needed
-        
+
         # Save prompt if requested
         self._save_prompt_to_file(prompt, f"s{season:02d}e{episode:02d}")
-        
+
         try:
             # Use the OpenAI responses.parse API with Pydantic model
             import openai
-            
+
             # Set up the API client - using the direct OpenAI client
             client = openai.OpenAI(api_key=self.provider.api_key)
-            
+
             # Prepare messages
             messages = [{"role": "user", "content": prompt}]
             if self.provider.system_prompt:
-                messages.insert(0, {"role": "system", "content": self.provider.system_prompt})
-            
+                messages.insert(
+                    0, {"role": "system", "content": self.provider.system_prompt}
+                )
+
             # Create a simple Pydantic model for episode summary
             class EpisodeSummaryModel(BaseModel):
                 summary: str = Field(
                     description="A comprehensive, detailed narrative summary of the episode capturing key plot developments, character actions, revelations, and connections to larger season arcs."
                 )
-            
-            logger.info(f"Using OpenAI responses.parse with model {self.provider.model}")
-            
+
+            logger.info(
+                f"Using OpenAI responses.parse with model {self.provider.model}"
+            )
+
             # Call the API with appropriate parameters based on model type
             if self.is_reasoning_model:
                 response = client.responses.parse(
                     model=self.provider.model,
                     input=messages,
                     reasoning={"effort": self.effort},
-                    text_format=EpisodeSummaryModel
+                    text_format=EpisodeSummaryModel,
                 )
                 logger.info(f"Used reasoning model with effort: {self.effort}")
             else:
@@ -1653,22 +1802,20 @@ I need a comprehensive, structured summary of Season {season}, Episode {episode}
                     model=self.provider.model,
                     input=messages,
                     temperature=self.temperature,
-                    text_format=EpisodeSummaryModel
+                    text_format=EpisodeSummaryModel,
                 )
                 logger.info(f"Used standard model with temperature: {self.temperature}")
-            
+
             # Create a summary dict that matches our expected format
             summary_text = response.output_parsed.summary
-            summary_dict = {
-                "summary": summary_text
-            }
-            
+            summary_dict = {"summary": summary_text}
+
             # Log completion info
             logger.info(
                 f"Generated episode summary with {response.usage.input_tokens} input tokens and "
                 f"{response.usage.output_tokens} output tokens"
             )
-            
+
             # Print summary in verbose mode
             if self.verbose:
                 print("\n" + "=" * 80)
@@ -1676,7 +1823,7 @@ I need a comprehensive, structured summary of Season {season}, Episode {episode}
                 print("=" * 80)
                 print(json.dumps(summary_dict, indent=2))
                 print("=" * 80 + "\n")
-            
+
             # Save to database
             success = self.db_manager.save_episode_summary(
                 season=season,
@@ -1685,36 +1832,34 @@ I need a comprehensive, structured summary of Season {season}, Episode {episode}
                 dry_run=self.dry_run,
                 overwrite=self.overwrite,
                 chunk_span=chunk_span,
-                prompt_on_conflict=self.prompt_on_conflict
+                prompt_on_conflict=self.prompt_on_conflict,
             )
-            
+
             if success:
-                logger.info(f"Successfully saved summary for S{season:02d}E{episode:02d}")
+                logger.info(
+                    f"Successfully saved summary for S{season:02d}E{episode:02d}"
+                )
                 return summary_dict
             else:
                 logger.error(f"Failed to save summary for S{season:02d}E{episode:02d}")
                 return None
-                
+
         except Exception as e:
             logger.error(f"Error generating episode summary: {e}")
             return None
-    
+
     def generate_episode_range_summaries(
-        self, 
-        start_season: int, 
-        start_episode: int,
-        end_season: int,
-        end_episode: int
+        self, start_season: int, start_episode: int, end_season: int, end_episode: int
     ) -> Dict[str, Optional[dict]]:
         """
         Generate summaries for a range of episodes.
-        
+
         Args:
             start_season: The starting season number
             start_episode: The starting episode number
             end_season: The ending season number
             end_episode: The ending episode number
-            
+
         Returns:
             Dictionary mapping episode slugs to summaries
         """
@@ -1722,46 +1867,54 @@ I need a comprehensive, structured summary of Season {season}, Episode {episode}
             f"Generating summaries for episodes from S{start_season:02d}E{start_episode:02d} "
             f"to S{end_season:02d}E{end_episode:02d}"
         )
-        
+
         # Check if this is a full season
-        if (start_season == end_season and 
-            start_episode == 1 and 
-            self._is_full_season(start_season, end_episode)):
+        if (
+            start_season == end_season
+            and start_episode == 1
+            and self._is_full_season(start_season, end_episode)
+        ):
             logger.info(f"This range covers the entire Season {start_season}")
-            
+
             # Ask user if they want to generate a season summary instead
             if not self.dry_run:
-                choice = input(
-                    f"This range appears to cover the entire Season {start_season}. "
-                    f"Would you like to generate a season summary instead? (y/n): "
-                ).lower().strip()
-                
-                if choice == 'y':
+                choice = (
+                    input(
+                        f"This range appears to cover the entire Season {start_season}. "
+                        f"Would you like to generate a season summary instead? (y/n): "
+                    )
+                    .lower()
+                    .strip()
+                )
+
+                if choice == "y":
                     season_summary = self.generate_season_summary(start_season)
                     return {f"Season {start_season}": season_summary}
-        
+
         # Generate summaries for each episode in the range sequentially
         results = {}
-        
+
         # If same season, simple loop
         if start_season == end_season:
             for episode in range(start_episode, end_episode + 1):
                 slug = EpisodeSlugParser.format(start_season, episode)
-                
+
                 # Check for abort
                 if is_abort_requested():
                     logger.info("Abort requested, stopping generation")
                     break
-                    
+
                 # Generate summary (using previously saved summaries as context)
                 summary = self.generate_episode_summary(start_season, episode)
                 results[slug] = summary
-                
+
                 # Immediately save to the database if successful, so it can be used for future episodes
                 if summary and not self.dry_run:
                     # Get accurate chunk span
-                    chunk_span = self.db_manager.get_episode_chunk_span(start_season, episode)
-                    
+                    chunk_span = self.db_manager.get_episode_chunk_span(
+                        start_season, episode
+                    )
+
                     # Save interactive mode behavior - user can decide for each episode
                     saved = self.db_manager.save_episode_summary(
                         season=start_season,
@@ -1770,32 +1923,38 @@ I need a comprehensive, structured summary of Season {season}, Episode {episode}
                         dry_run=False,
                         overwrite=self.overwrite,
                         chunk_span=chunk_span,
-                        prompt_on_conflict=self.prompt_on_conflict
+                        prompt_on_conflict=self.prompt_on_conflict,
                     )
                     if saved:
-                        logger.info(f"Saved summary for {slug} to database for future episode context")
-                
+                        logger.info(
+                            f"Saved summary for {slug} to database for future episode context"
+                        )
+
         # If multiple seasons, process them in sequence
         else:
             # First season
-            last_episode_of_first_season = self._get_last_episode_of_season(start_season)
+            last_episode_of_first_season = self._get_last_episode_of_season(
+                start_season
+            )
             for episode in range(start_episode, last_episode_of_first_season + 1):
                 slug = EpisodeSlugParser.format(start_season, episode)
-                
+
                 # Check for abort
                 if is_abort_requested():
                     logger.info("Abort requested, stopping generation")
                     break
-                    
+
                 # Generate summary (using previously saved summaries as context)
                 summary = self.generate_episode_summary(start_season, episode)
                 results[slug] = summary
-                
+
                 # Immediately save to the database if successful, so it can be used for future episodes
                 if summary and not self.dry_run:
                     # Get accurate chunk span
-                    chunk_span = self.db_manager.get_episode_chunk_span(start_season, episode)
-                    
+                    chunk_span = self.db_manager.get_episode_chunk_span(
+                        start_season, episode
+                    )
+
                     # Save interactive mode behavior - user can decide for each episode
                     saved = self.db_manager.save_episode_summary(
                         season=start_season,
@@ -1804,31 +1963,35 @@ I need a comprehensive, structured summary of Season {season}, Episode {episode}
                         dry_run=False,
                         overwrite=self.overwrite,
                         chunk_span=chunk_span,
-                        prompt_on_conflict=self.prompt_on_conflict
+                        prompt_on_conflict=self.prompt_on_conflict,
                     )
                     if saved:
-                        logger.info(f"Saved summary for {slug} to database for future episode context")
-            
+                        logger.info(
+                            f"Saved summary for {slug} to database for future episode context"
+                        )
+
             # Middle seasons (if any)
             for season in range(start_season + 1, end_season):
                 last_episode = self._get_last_episode_of_season(season)
                 for episode in range(1, last_episode + 1):
                     slug = EpisodeSlugParser.format(season, episode)
-                    
+
                     # Check for abort
                     if is_abort_requested():
                         logger.info("Abort requested, stopping generation")
                         break
-                        
+
                     # Generate summary (using previously saved summaries as context)
                     summary = self.generate_episode_summary(season, episode)
                     results[slug] = summary
-                    
+
                     # Immediately save to the database if successful, so it can be used for future episodes
                     if summary and not self.dry_run:
                         # Get accurate chunk span
-                        chunk_span = self.db_manager.get_episode_chunk_span(season, episode)
-                        
+                        chunk_span = self.db_manager.get_episode_chunk_span(
+                            season, episode
+                        )
+
                         # Save interactive mode behavior - user can decide for each episode
                         saved = self.db_manager.save_episode_summary(
                             season=season,
@@ -1837,29 +2000,33 @@ I need a comprehensive, structured summary of Season {season}, Episode {episode}
                             dry_run=False,
                             overwrite=self.overwrite,
                             chunk_span=chunk_span,
-                            prompt_on_conflict=self.prompt_on_conflict
+                            prompt_on_conflict=self.prompt_on_conflict,
                         )
                         if saved:
-                            logger.info(f"Saved summary for {slug} to database for future episode context")
-            
+                            logger.info(
+                                f"Saved summary for {slug} to database for future episode context"
+                            )
+
             # Last season
             for episode in range(1, end_episode + 1):
                 slug = EpisodeSlugParser.format(end_season, episode)
-                
+
                 # Check for abort
                 if is_abort_requested():
                     logger.info("Abort requested, stopping generation")
                     break
-                    
+
                 # Generate summary (using previously saved summaries as context)
                 summary = self.generate_episode_summary(end_season, episode)
                 results[slug] = summary
-                
+
                 # Immediately save to the database if successful, so it can be used for future episodes
                 if summary and not self.dry_run:
                     # Get accurate chunk span
-                    chunk_span = self.db_manager.get_episode_chunk_span(end_season, episode)
-                    
+                    chunk_span = self.db_manager.get_episode_chunk_span(
+                        end_season, episode
+                    )
+
                     # Save interactive mode behavior - user can decide for each episode
                     saved = self.db_manager.save_episode_summary(
                         season=end_season,
@@ -1868,51 +2035,57 @@ I need a comprehensive, structured summary of Season {season}, Episode {episode}
                         dry_run=False,
                         overwrite=self.overwrite,
                         chunk_span=chunk_span,
-                        prompt_on_conflict=self.prompt_on_conflict
+                        prompt_on_conflict=self.prompt_on_conflict,
                     )
                     if saved:
-                        logger.info(f"Saved summary for {slug} to database for future episode context")
-        
+                        logger.info(
+                            f"Saved summary for {slug} to database for future episode context"
+                        )
+
         return results
-    
-    def generate_chunk_range_summary(self, start_id: int, end_id: int) -> Optional[dict]:
+
+    def generate_chunk_range_summary(
+        self, start_id: int, end_id: int
+    ) -> Optional[dict]:
         """
         Generate a summary for a specific range of chunk IDs.
         This is a fallback for manual specification.
-        
+
         Args:
             start_id: Starting chunk ID
             end_id: Ending chunk ID
-            
+
         Returns:
             Generated summary as a dictionary, or None if failed
         """
         logger.info(f"Generating summary for chunk range {start_id}-{end_id}")
-        
+
         # Get chunks for the range
         chunks = self.db_manager.get_chunks_by_id_range(start_id, end_id)
-        
+
         if not chunks:
             logger.error(f"No chunks found for range {start_id}-{end_id}")
             return None
-            
+
         logger.info(f"Found {len(chunks)} chunks for range {start_id}-{end_id}")
-        
+
         # Analyze chunks to determine mode
-        seasons = set(chunk["season"] for chunk in chunks if chunk["season"] is not None)
+        seasons = set(
+            chunk["season"] for chunk in chunks if chunk["season"] is not None
+        )
         episodes = set(
-            (chunk["season"], chunk["episode"]) 
-            for chunk in chunks 
+            (chunk["season"], chunk["episode"])
+            for chunk in chunks
             if chunk["season"] is not None and chunk["episode"] is not None
         )
-        
+
         # Determine if this is a single season, episode, or mixed
         mode = "season" if len(seasons) == 1 and len(episodes) > 1 else "episode"
-        
+
         # Prepare the prompt
         system_prompt = self._get_system_prompt(mode)
         chunks_text = self._prepare_chunks_text(chunks, mode)
-        
+
         # Build the main prompt
         if mode == "season":
             prompt = f"""# Narrative Summary Request
@@ -1954,27 +2127,29 @@ I need a comprehensive, structured summary of the provided narrative chunks (IDs
    - CONTINUITY_ELEMENTS: A dictionary of important objects, locations, and knowledge.
 
 2. Be objective, factual, and focus on concrete details - your summary will be used by another AI to maintain narrative continuity."""
-        
+
         # Token check
         if not self._token_check(prompt, mode):
             logger.warning("Token check failed - input may be too long")
             # Proceed anyway - the API will truncate if needed
-        
+
         # Save prompt if requested
         self._save_prompt_to_file(prompt, f"chunks_{start_id}_{end_id}")
-        
+
         try:
             # Use the OpenAI responses.parse API with Pydantic model
             import openai
-            
+
             # Set up the API client - using the direct OpenAI client
             client = openai.OpenAI(api_key=self.provider.api_key)
-            
+
             # Prepare messages
             messages = [{"role": "user", "content": prompt}]
             if self.provider.system_prompt:
-                messages.insert(0, {"role": "system", "content": self.provider.system_prompt})
-            
+                messages.insert(
+                    0, {"role": "system", "content": self.provider.system_prompt}
+                )
+
             # Choose the appropriate response model based on mode
             if mode == "season":
                 # Create a more simple Pydantic model for season summary
@@ -1982,16 +2157,16 @@ I need a comprehensive, structured summary of the provided narrative chunks (IDs
                     summary: str = Field(
                         description="A comprehensive, detailed narrative summary of the entire season capturing major plot developments, character arcs, key world-building elements, and themes."
                     )
-                
+
                 logger.info(f"Using season summary model")
-                
+
                 # Call the API with appropriate parameters based on model type
                 if self.is_reasoning_model:
                     response = client.responses.parse(
                         model=self.provider.model,
                         input=messages,
                         reasoning={"effort": self.effort},
-                        text_format=SeasonSummaryModel
+                        text_format=SeasonSummaryModel,
                     )
                     logger.info(f"Used reasoning model with effort: {self.effort}")
                 else:
@@ -1999,32 +2174,32 @@ I need a comprehensive, structured summary of the provided narrative chunks (IDs
                         model=self.provider.model,
                         input=messages,
                         temperature=self.temperature,
-                        text_format=SeasonSummaryModel
+                        text_format=SeasonSummaryModel,
                     )
-                    logger.info(f"Used standard model with temperature: {self.temperature}")
-                
+                    logger.info(
+                        f"Used standard model with temperature: {self.temperature}"
+                    )
+
                 # Create a summary dict that matches our expected format
                 summary_text = response.output_parsed.summary
-                summary_dict = {
-                    "summary": summary_text
-                }
-                
+                summary_dict = {"summary": summary_text}
+
             else:
                 # Create a more simple Pydantic model for episode summary
                 class EpisodeSummaryModel(BaseModel):
                     summary: str = Field(
                         description="A comprehensive, detailed narrative summary of the episode capturing key plot developments, character actions, revelations, and connections to larger season arcs."
                     )
-                
+
                 logger.info(f"Using episode summary model")
-                
+
                 # Call the API with appropriate parameters based on model type
                 if self.is_reasoning_model:
                     response = client.responses.parse(
                         model=self.provider.model,
                         input=messages,
                         reasoning={"effort": self.effort},
-                        text_format=EpisodeSummaryModel
+                        text_format=EpisodeSummaryModel,
                     )
                     logger.info(f"Used reasoning model with effort: {self.effort}")
                 else:
@@ -2032,22 +2207,22 @@ I need a comprehensive, structured summary of the provided narrative chunks (IDs
                         model=self.provider.model,
                         input=messages,
                         temperature=self.temperature,
-                        text_format=EpisodeSummaryModel
+                        text_format=EpisodeSummaryModel,
                     )
-                    logger.info(f"Used standard model with temperature: {self.temperature}")
-                
+                    logger.info(
+                        f"Used standard model with temperature: {self.temperature}"
+                    )
+
                 # Create a summary dict that matches our expected format
                 summary_text = response.output_parsed.summary
-                summary_dict = {
-                    "summary": summary_text
-                }
-            
+                summary_dict = {"summary": summary_text}
+
             # Log completion info
             logger.info(
                 f"Generated chunk range summary with {response.usage.input_tokens} input tokens and "
                 f"{response.usage.output_tokens} output tokens"
             )
-            
+
             # Print summary in verbose mode
             if self.verbose:
                 print("\n" + "=" * 80)
@@ -2055,7 +2230,7 @@ I need a comprehensive, structured summary of the provided narrative chunks (IDs
                 print("=" * 80)
                 print(json.dumps(summary_dict, indent=2))
                 print("=" * 80 + "\n")
-            
+
             # Determine where to save based on chunks
             if len(seasons) == 1 and mode == "season":
                 season = list(seasons)[0]
@@ -2063,14 +2238,14 @@ I need a comprehensive, structured summary of the provided narrative chunks (IDs
                     season=season,
                     summary=summary_dict,
                     dry_run=self.dry_run,
-                    prompt_on_conflict=self.prompt_on_conflict
+                    prompt_on_conflict=self.prompt_on_conflict,
                 )
-                
+
                 if success:
                     logger.info(f"Successfully saved summary for Season {season}")
                 else:
                     logger.error(f"Failed to save summary for Season {season}")
-                    
+
             elif len(episodes) == 1:
                 season, episode = list(episodes)[0]
                 success = self.db_manager.save_episode_summary(
@@ -2079,62 +2254,78 @@ I need a comprehensive, structured summary of the provided narrative chunks (IDs
                     summary=summary_dict,
                     dry_run=self.dry_run,
                     overwrite=self.overwrite,
-                    prompt_on_conflict=self.prompt_on_conflict
+                    prompt_on_conflict=self.prompt_on_conflict,
                 )
-                
+
                 if success:
-                    logger.info(f"Successfully saved summary for S{season:02d}E{episode:02d}")
+                    logger.info(
+                        f"Successfully saved summary for S{season:02d}E{episode:02d}"
+                    )
                 else:
-                    logger.error(f"Failed to save summary for S{season:02d}E{episode:02d}")
+                    logger.error(
+                        f"Failed to save summary for S{season:02d}E{episode:02d}"
+                    )
             else:
                 logger.info(
                     "Unable to save summary automatically - mixed seasons/episodes. "
                     "Summary will only be displayed."
                 )
-            
+
             return summary_dict
-                
+
         except Exception as e:
             logger.error(f"Error generating chunk range summary: {e}")
             return None
-    
+
     def _is_full_season(self, season: int, end_episode: int) -> bool:
         """Check if the episode range covers a full season."""
         last_episode = self._get_last_episode_of_season(season)
         return end_episode >= last_episode
-    
+
     def _get_last_episode_of_season(self, season: int) -> int:
         """Get the last episode number of a season."""
         try:
             with self.db_manager.engine.connect() as conn:
-                query = text("""
+                query = text(
+                    """
                 SELECT MAX(episode) FROM public.chunk_metadata
                 WHERE season = :season
-                """)
-                
+                """
+                )
+
                 result = conn.execute(query, {"season": season}).fetchone()
                 if result and result[0]:
                     return result[0]
                 return 1  # Default to 1 if no episodes found
-                
+
         except Exception as e:
             logger.error(f"Error getting last episode of season {season}: {e}")
             return 1  # Default to 1 on error
+
 
 def main():
     """Main entry point."""
     # Set up command line argument parser
     parser = argparse.ArgumentParser(
         description="Generate comprehensive narrative summaries",
-        formatter_class=argparse.RawDescriptionHelpFormatter
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    
+
     # Create mutually exclusive group for input modes
     mode_group = parser.add_mutually_exclusive_group(required=True)
     mode_group.add_argument("--season", type=int, help="Season number to summarize")
-    mode_group.add_argument("--episode", nargs='+', help="Episode(s) to summarize (e.g., s03e01 or s03e01 s03e13 for range)")
-    mode_group.add_argument("--chunks", nargs=2, type=int, help="Chunk ID range to summarize (manual fallback)")
-    
+    mode_group.add_argument(
+        "--episode",
+        nargs="+",
+        help="Episode(s) to summarize (e.g., s03e01 or s03e01 s03e13 for range)",
+    )
+    mode_group.add_argument(
+        "--chunks",
+        nargs=2,
+        type=int,
+        help="Chunk ID range to summarize (manual fallback)",
+    )
+
     # OpenAI options. --model defaults to apex.model from nexus.toml when omitted.
     parser.add_argument(
         "--model",
@@ -2149,22 +2340,50 @@ def main():
     parser.add_argument(
         "--disable-fallback",
         action="store_true",
-        help="Do not attempt a fallback model if the primary fails"
+        help="Do not attempt a fallback model if the primary fails",
     )
-    parser.add_argument("--temperature", type=float, default=DEFAULT_TEMPERATURE,
-                      help=f"Model temperature for standard models (default: {DEFAULT_TEMPERATURE})")
-    parser.add_argument("--effort", choices=["low", "medium", "high"], default="medium",
-                      help="Reasoning effort level for reasoning models (default: medium)")
-    
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=DEFAULT_TEMPERATURE,
+        help=f"Model temperature for standard models (default: {DEFAULT_TEMPERATURE})",
+    )
+    parser.add_argument(
+        "--effort",
+        choices=["low", "medium", "high"],
+        default="medium",
+        help="Reasoning effort level for reasoning models (default: medium)",
+    )
+
     # Processing options
-    parser.add_argument("--dry-run", action="store_true", help="Don't save summaries to database")
-    parser.add_argument("--overwrite", action="store_true", help="Overwrite existing summaries in the database")
-    parser.add_argument("--non-interactive", action="store_true", help="Skip overwrite prompts and keep existing summaries")
-    parser.add_argument("--verbose", action="store_true", help="Print detailed output including summaries")
-    parser.add_argument("--save-prompt", action="store_true", help="Save prompts to files for debugging")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Don't save summaries to database"
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing summaries in the database",
+    )
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Skip overwrite prompts and keep existing summaries",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print detailed output including summaries",
+    )
+    parser.add_argument(
+        "--save-prompt", action="store_true", help="Save prompts to files for debugging"
+    )
     parser.add_argument("--db-url", help="Database connection URL (optional)")
-    parser.add_argument("--disable-abort", action="store_true", help="Disable ESC key and Ctrl+C abort capability")
-    
+    parser.add_argument(
+        "--disable-abort",
+        action="store_true",
+        help="Disable ESC key and Ctrl+C abort capability",
+    )
+
     args = parser.parse_args()
 
     # Resolve --model from nexus.toml when the user didn't specify it explicitly.
@@ -2173,14 +2392,18 @@ def main():
 
     # Set up database manager
     db_manager = DatabaseManager(db_url=args.db_url)
-    
+
     # Set up abort handler (unless disabled)
     if not args.disable_abort:
-        setup_abort_handler("Abort requested! Finishing current summary and stopping...")
-        logger.info("Abort functionality enabled - Press ESC or Ctrl+C to stop processing")
+        setup_abort_handler(
+            "Abort requested! Finishing current summary and stopping..."
+        )
+        logger.info(
+            "Abort functionality enabled - Press ESC or Ctrl+C to stop processing"
+        )
     else:
         logger.info("Abort functionality disabled")
-    
+
     # Build model preference list and helpers
     model_candidates: List[str] = []
     if args.model:
@@ -2202,7 +2425,7 @@ def main():
             overwrite=args.overwrite,
             verbose=args.verbose,
             save_prompt=args.save_prompt,
-            prompt_on_conflict=not args.non_interactive
+            prompt_on_conflict=not args.non_interactive,
         )
 
     def run_with_models(run_fn):
@@ -2214,27 +2437,33 @@ def main():
                     logger.info(f"Used fallback model {model_name}")
                 return result, model_name
             if index < len(model_candidates) - 1:
-                logger.warning(f"Model {model_name} did not produce a summary; trying next candidate")
+                logger.warning(
+                    f"Model {model_name} did not produce a summary; trying next candidate"
+                )
             else:
-                logger.error(f"Model {model_name} did not produce a summary; no more fallback models to try")
+                logger.error(
+                    f"Model {model_name} did not produce a summary; no more fallback models to try"
+                )
         return None, None
-    
+
     start_time = time.time()
-    
+
     # Process based on mode
     if args.season:
         # Season mode
         summary, used_model = run_with_models(
             lambda gen: gen.generate_season_summary(args.season)
         )
-        
+
         if summary:
-            logger.info(f"Successfully generated summary for Season {args.season} using {used_model}")
+            logger.info(
+                f"Successfully generated summary for Season {args.season} using {used_model}"
+            )
             if args.dry_run:
                 logger.info("[DRY RUN] Summary not saved to database")
         else:
             logger.error(f"Failed to generate summary for Season {args.season}")
-            
+
     elif args.episode:
         # Episode mode
         if len(args.episode) == 1:
@@ -2244,7 +2473,7 @@ def main():
                 summary, used_model = run_with_models(
                     lambda gen: gen.generate_episode_summary(season, episode)
                 )
-                
+
                 if summary:
                     logger.info(
                         f"Successfully generated summary for S{season:02d}E{episode:02d} using {used_model}"
@@ -2252,77 +2481,90 @@ def main():
                     if args.dry_run:
                         logger.info("[DRY RUN] Summary not saved to database")
                 else:
-                    logger.error(f"Failed to generate summary for S{season:02d}E{episode:02d}")
-                    
+                    logger.error(
+                        f"Failed to generate summary for S{season:02d}E{episode:02d}"
+                    )
+
             except ValueError as e:
                 logger.error(f"Error parsing episode slug: {e}")
                 return 1
-                
+
         elif len(args.episode) == 2:
             # Episode range
             try:
                 start_slug = args.episode[0]
                 end_slug = args.episode[1]
-                
+
                 if not EpisodeSlugParser.validate_range(start_slug, end_slug):
                     logger.error(f"Invalid episode range: {start_slug} to {end_slug}")
                     return 1
-                
+
                 start_season, start_episode = EpisodeSlugParser.parse(start_slug)
                 end_season, end_episode = EpisodeSlugParser.parse(end_slug)
-                
+
                 results, used_model = run_with_models(
                     lambda gen: gen.generate_episode_range_summaries(
                         start_season, start_episode, end_season, end_episode
                     )
                 )
-                
+
                 # Print summary
                 if results:
-                    success_count = sum(1 for summary in results.values() if summary is not None)
+                    success_count = sum(
+                        1 for summary in results.values() if summary is not None
+                    )
                     logger.info(
                         f"Generated {success_count} out of {len(results)} episode summaries "
                         f"for range {start_slug} to {end_slug} using {used_model}"
                     )
-                    
+
                     if args.dry_run:
                         logger.info("[DRY RUN] Summaries not saved to database")
                 else:
-                    logger.error(f"Failed to generate summaries for range {start_slug} to {end_slug}")
-                    
+                    logger.error(
+                        f"Failed to generate summaries for range {start_slug} to {end_slug}"
+                    )
+
             except ValueError as e:
                 logger.error(f"Error parsing episode slugs: {e}")
                 return 1
-                
+
         else:
-            logger.error("Invalid number of episode arguments. Use one slug for a single episode, or two for a range.")
+            logger.error(
+                "Invalid number of episode arguments. Use one slug for a single episode, or two for a range."
+            )
             return 1
-            
+
     elif args.chunks:
         # Chunk range mode
         start_id, end_id = args.chunks
-        
+
         if start_id > end_id:
             logger.error(f"Invalid chunk range: {start_id} to {end_id}")
             return 1
-            
+
         summary, used_model = run_with_models(
             lambda gen: gen.generate_chunk_range_summary(start_id, end_id)
         )
-        
+
         if summary:
-            logger.info(f"Successfully generated summary for chunk range {start_id}-{end_id} using {used_model}")
+            logger.info(
+                f"Successfully generated summary for chunk range {start_id}-{end_id} using {used_model}"
+            )
             if args.dry_run:
                 logger.info("[DRY RUN] Summary not saved to database")
         else:
-            logger.error(f"Failed to generate summary for chunk range {start_id}-{end_id}")
-    
+            logger.error(
+                f"Failed to generate summary for chunk range {start_id}-{end_id}"
+            )
+
     # Print timing info
     end_time = time.time()
     elapsed = end_time - start_time
     logger.info(f"Total processing time: {elapsed:.2f} seconds")
-    
+
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/validate_config_commit.py
+++ b/scripts/validate_config_commit.py
@@ -27,6 +27,12 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
+# The commit under validation must be checked with ITS OWN code, not
+# whatever checkout the shared venv's editable install points at — in a git
+# worktree those differ, and a config change paired with its settings-model
+# change would false-fail against the main checkout's older models.
+sys.path.insert(0, str(REPO_ROOT))
+
 
 def main() -> int:
     failures: list[str] = []

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -72,6 +72,50 @@ def test_global_default_model_resolves_at_load():
     assert settings.global_.model.default_model == openai_default
 
 
+def test_summaries_model_resolves_openai_default_at_load():
+    """The dedicated summary model uses the same registry resolution pass."""
+    raw = _nexus_toml_dict()
+    assert raw["summaries"]["model"] == "@openai.default"
+
+    settings = Settings(**raw)
+    openai_default = settings.global_.model.api_models["openai"].roles["default"]
+
+    assert settings.summaries.model == openai_default
+
+
+def test_summaries_model_accepts_responses_compatible_test_provider():
+    """A base_url provider is routable when it implements Responses."""
+    raw = _nexus_toml_dict()
+    raw["summaries"]["model"] = "@test.default"
+
+    assert Settings(**raw).summaries.model == "TEST"
+
+
+def test_summaries_model_rejects_local_chat_completions_provider():
+    """Local Chat Completions routing remains outside the near-term fix."""
+    raw = _nexus_toml_dict()
+    raw["summaries"]["model"] = "@local.default"
+
+    with pytest.raises(
+        ValidationError,
+        match="structured_transport='responses'.*deferred routing work.*#481",
+    ):
+        Settings(**raw)
+
+
+def test_summaries_model_rejects_anthropic_literal():
+    """A native Anthropic ID cannot silently enter the OpenAI-only pipeline."""
+    raw = _nexus_toml_dict()
+    anthropic_id = raw["global"]["model"]["api_models"]["anthropic"]["models"][0]["id"]
+    raw["summaries"]["model"] = anthropic_id
+
+    with pytest.raises(
+        ValidationError,
+        match="native OpenAI provider.*deferred routing work.*#481",
+    ):
+        Settings(**raw)
+
+
 def test_global_default_model_unknown_role_rejected():
     """An unknown role in the global display default fails Settings validation."""
     raw = _nexus_toml_dict()

--- a/tests/test_summary_triggers.py
+++ b/tests/test_summary_triggers.py
@@ -263,7 +263,8 @@ def test_generation_failure_marker_round_trips_and_can_be_replaced_live():
         assert db.season_summary_exists(season) is True
 
         # The reverse race: a slower FAILING job must never clobber the real
-        # summary a concurrent job already saved.
+        # summary a concurrent job already saved — and the recorder must
+        # report that it did NOT persist the marker.
         assert (
             db.record_summary_failure(
                 kind="season",
@@ -272,7 +273,7 @@ def test_generation_failure_marker_round_trips_and_can_be_replaced_live():
                 error="late failure after concurrent success",
                 model_candidates=["TEST"],
             )
-            is True
+            is False
         )
         with db.engine.connect() as conn:
             survived = conn.execute(

--- a/tests/test_summary_triggers.py
+++ b/tests/test_summary_triggers.py
@@ -261,6 +261,28 @@ def test_generation_failure_marker_round_trips_and_can_be_replaced_live():
             prompt_on_conflict=False,
         )
         assert db.season_summary_exists(season) is True
+
+        # The reverse race: a slower FAILING job must never clobber the real
+        # summary a concurrent job already saved.
+        assert (
+            db.record_summary_failure(
+                kind="season",
+                season=season,
+                episode=None,
+                error="late failure after concurrent success",
+                model_candidates=["TEST"],
+            )
+            is True
+        )
+        with db.engine.connect() as conn:
+            survived = conn.execute(
+                text("SELECT summary FROM public.seasons WHERE id = :id"),
+                {"id": season},
+            ).scalar_one()
+        assert (
+            survived.get("status") != "error"
+        ), "a late failure marker must not overwrite a saved summary"
+        assert db.season_summary_exists(season) is True
     finally:
         with db.engine.connect() as conn:
             conn.execute(

--- a/tests/test_summary_triggers.py
+++ b/tests/test_summary_triggers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+import uuid
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
@@ -27,20 +29,38 @@ def test_plan_summary_tasks():
 
 @dataclass
 class _FakeDB:
-    episode_summaries: Dict[str, bool]
-    season_summaries: Dict[int, bool]
+    episode_summaries: Dict[str, object]
+    season_summaries: Dict[int, object]
     empty_episodes: Optional[List[str]] = None
+    failure_records: Optional[List[dict]] = None
 
     def episode_summary_exists(self, season: int, episode: int) -> bool:
-        return self.episode_summaries.get(f"{season}-{episode}", False)
+        value = self.episode_summaries.get(f"{season}-{episode}", False)
+        return bool(value) and not (
+            isinstance(value, dict) and value.get("status") == "error"
+        )
 
     def season_summary_exists(self, season: int) -> bool:
-        return self.season_summaries.get(season, False)
+        value = self.season_summaries.get(season, False)
+        return bool(value) and not (
+            isinstance(value, dict) and value.get("status") == "error"
+        )
 
     def get_episode_chunk_span(self, season: int, episode: int):
         if self.empty_episodes and f"{season}-{episode}" in self.empty_episodes:
             return None
         return (1, 2)
+
+    def record_summary_failure(self, **record) -> bool:
+        marker = {"status": "error", **record}
+        if self.failure_records is None:
+            self.failure_records = []
+        self.failure_records.append(marker)
+        if record["kind"] == "episode":
+            self.episode_summaries[f"{record['season']}-{record['episode']}"] = marker
+        else:
+            self.season_summaries[record["season"]] = marker
+        return True
 
 
 @dataclass
@@ -60,6 +80,18 @@ class _RecorderGenerator:
     def generate_season_summary(self, season: int) -> Dict[str, str]:
         self.calls.append(f"season-{season}-{self.model}")
         return {"summary": "ok"}
+
+
+class _FailingGenerator:
+    def __init__(self, **kwargs):
+        self.model = kwargs["model"]
+        self.last_error = "mock Responses failure"
+
+    def generate_episode_summary(self, season: int, episode: int):
+        return None
+
+    def generate_season_summary(self, season: int):
+        return None
 
 
 @pytest.mark.parametrize(
@@ -101,19 +133,30 @@ def test_schedule_summary_generation_skips_existing(
     assert recorder_calls == expected_calls
 
 
-def test_coalesce_models_resolves_apex_default_when_constants_are_none():
-    """Empty candidates resolve to the live apex model, never an empty list.
+def test_coalesce_models_prefers_summaries_default_over_apex(monkeypatch):
+    """Empty candidates resolve to summaries.model, not the storyteller model.
 
     M9 gate finding: scripts/summarize_narrative resolves its module
     constants at argparse time (both None on import), so API-triggered
     episode summaries ran with zero model candidates and always failed.
     """
 
+    from types import SimpleNamespace
+
+    import nexus.config
     from nexus.api.summary_triggers import _coalesce_models
 
+    monkeypatch.setattr(
+        nexus.config,
+        "load_settings",
+        lambda: SimpleNamespace(
+            summaries=SimpleNamespace(model="summary-model"),
+            apex=SimpleNamespace(model="storyteller-model"),
+        ),
+    )
+
     models = _coalesce_models(None)
-    assert models, "model candidate list must never be empty"
-    assert all(isinstance(model, str) and model for model in models)
+    assert models == ["summary-model"]
 
 
 def test_schedule_summary_generation_skips_chunkless_episodes():
@@ -138,3 +181,89 @@ def test_schedule_summary_generation_skips_chunkless_episodes():
     )
 
     assert recorder_calls == []
+
+
+def test_generation_failure_is_durable_visible_and_refireable(caplog):
+    """A dropped worker result becomes an error marker, not a log-only loss."""
+    db = _FakeDB({}, {}, failure_records=[])
+
+    with caplog.at_level(logging.ERROR, logger="nexus.api.summary_triggers"):
+        schedule_summary_generation(
+            [SummaryTask(kind="episode", season=5, episode=1)],
+            model_candidates=["TEST"],
+            run_in_thread=False,
+            db_manager_factory=lambda: db,
+            generator_cls=_FailingGenerator,
+        )
+
+    assert db.failure_records == [
+        {
+            "status": "error",
+            "kind": "episode",
+            "season": 5,
+            "episode": 1,
+            "error": "TEST: mock Responses failure",
+            "model_candidates": ["TEST"],
+        }
+    ]
+    assert db.episode_summary_exists(5, 1) is False
+    assert "Failed to generate S05E01 summary" in caplog.text
+
+
+def test_summary_generator_routes_test_model_to_registry_base_url():
+    """The TEST provider's Responses client uses its registered endpoint."""
+    from nexus.config import load_settings
+    from scripts.summarize_narrative import SummaryGenerator
+
+    generator = SummaryGenerator(model="TEST", db_manager=_FakeDB({}, {}))
+    expected = load_settings().global_.model.api_models["test"].base_url
+
+    assert str(generator.provider.client.base_url).rstrip("/") == expected
+
+
+@pytest.mark.requires_postgres
+def test_generation_failure_marker_round_trips_and_can_be_replaced_live():
+    """The real seasons JSONB surface stores errors and accepts a later summary."""
+    from sqlalchemy import text
+
+    from scripts.summarize_narrative import DatabaseManager
+
+    db = DatabaseManager()
+    season = -(uuid.uuid4().int % 1_000_000_000) - 1
+    try:
+        with db.engine.connect() as conn:
+            conn.execute(
+                text("INSERT INTO public.seasons (id, summary) VALUES (:id, NULL)"),
+                {"id": season},
+            )
+            conn.commit()
+
+        schedule_summary_generation(
+            [SummaryTask(kind="season", season=season)],
+            model_candidates=["TEST"],
+            run_in_thread=False,
+            db_manager_factory=lambda: db,
+            generator_cls=_FailingGenerator,
+        )
+
+        with db.engine.connect() as conn:
+            marker = conn.execute(
+                text("SELECT summary FROM public.seasons WHERE id = :id"),
+                {"id": season},
+            ).scalar_one()
+
+        assert marker["status"] == "error"
+        assert marker["model_candidates"] == ["TEST"]
+        assert db.season_summary_exists(season) is False
+        assert db.save_season_summary(
+            season,
+            {"summary": "retry succeeded"},
+            prompt_on_conflict=False,
+        )
+        assert db.season_summary_exists(season) is True
+    finally:
+        with db.engine.connect() as conn:
+            conn.execute(
+                text("DELETE FROM public.seasons WHERE id = :id"), {"id": season}
+            )
+            conn.commit()


### PR DESCRIPTION
## Summary

Near-term fix for #481 (Codex-first: Codex implemented from the frozen spec; Claude reviewed, corrected, and verified). Episode/season summaries were silently lost for any non-OpenAI storyteller: the pipeline inherited `apex.model`, built a bare OpenAI client, and swallowed failures on a background thread.

- **`[summaries] model = "@openai.default"`** — summaries decouple from the storyteller. Per the owner's quality finding (large cross-model variance in summary quality), the default stays top-tier; a config-load validator rejects any ref the Responses-only pipeline can't route (anthropic / chat_completions locals) with an error naming the deferred routing work.
- **Durable failures**: `status: "error"` markers land in the existing episodes/seasons summary JSONB — operator-visible, excluded from summary-context queries, and refireable without `overwrite=True`.
- **Honest endpoint routing**: the generator consults `get_openai_compatible_endpoint` (the bare client also broke the TEST provider) and reuses the provider client for season summaries.
- **Registry-driven reasoning-model detection** (Claude correction on review): `"temperature" in the model's unsupported_params` replaces model-id family pattern-matching. The old `startswith("o")` check would have sent `temperature` to the new default model and failed every call; Codex's `"gpt-5" in model` replacement was itself flagged by the drift checker — the registry already knows which models reject temperature, so ask it.

Riders: the legacy script gets an isolated mechanical Black-format commit (it predated the standard; 589 flake8 hits on HEAD), and the worktree copy of the validate-config hook carries the same import-the-repo-under-commit fix as PR #488.

## Verification (Claude, in the worktree)

- `tests/config/ tests/test_summary_triggers.py`: 43 passed offline; live Postgres subset (9 passed) includes a real round-trip that writes an error marker, proves it refires, replaces it with a successful summary, and cleans up.
- Config tests pin both directions: `@openai.default` and TEST resolve; `@local.default` and anthropic ids fail config load with the instructive message.
- Drift checker and validate-config gate both pass.

Part of #481 — full anthropic/local summary routing remains open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY