### PR TITLE
Defer MEMNON's Embedding Stack: Cold Import 1.79s → 0.24s

### DIFF
--- a/nexus/agents/memnon/memnon.py
+++ b/nexus/agents/memnon/memnon.py
@@ -44,22 +44,15 @@ from .utils.continuous_temporal_search import (
     analyze_temporal_intent,
 )
 from .utils.idf_dictionary import IDFDictionary
-from .utils.embedding_manager import EmbeddingManager
-from .utils.search import SearchManager
 from .utils.query_analysis import QueryAnalyzer
 from .utils.db_schema import DatabaseManager
-from .utils.content_processor import ContentProcessor
 from .utils.embedding_tables import list_embedding_tables
-
-# Sentence transformers for embedding
-from sentence_transformers import SentenceTransformer
 
 # Legacy Letta framework references (for historical context)
 # Letta imports removed - using custom memory system instead
 
 # Import alias search utilities
 from .utils.alias_search import load_aliases_from_db, ALIAS_LOOKUP
-from .utils.cross_encoder import rerank_results
 
 # Set up a basic console logger for initial settings loading
 settings_logger = logging.getLogger("nexus.memnon.settings")
@@ -290,6 +283,8 @@ class MEMNON:
 
         # Set up embedding models using EmbeddingManager
         logger.info("Initializing embedding models through EmbeddingManager")
+        from .utils.embedding_manager import EmbeddingManager
+
         self.embedding_manager = EmbeddingManager(settings=MEMNON_SETTINGS)
 
         # Initialize IDF dictionary
@@ -336,6 +331,8 @@ class MEMNON:
 
         # Initialize SearchManager with required dependencies
         logger.info("Initializing SearchManager...")
+        from .utils.search import SearchManager
+
         self.search_manager = SearchManager(
             db_url=self.db_url,
             embedding_manager=self.embedding_manager,
@@ -350,6 +347,8 @@ class MEMNON:
 
         # Initialize ContentProcessor
         logger.info("Initializing ContentProcessor...")
+        from .utils.content_processor import ContentProcessor
+
         self.content_processor = ContentProcessor(
             db_manager=self.db_manager,
             embedding_manager=self.embedding_manager,
@@ -2022,6 +2021,8 @@ class MEMNON:
             cross_encoder_config.get("enabled", False)
             and len(search_results_initial) > 0
         ):
+            from .utils.cross_encoder import rerank_results
+
             try:
                 logger.info("Applying cross-encoder reranking")
                 search_metadata["strategies_used"].append("cross_encoder_reranking")

--- a/tests/test_api/test_import_side_effects.py
+++ b/tests/test_api/test_import_side_effects.py
@@ -42,6 +42,14 @@ _FORBIDDEN_AGENT_UTILITY_IMPORT_MODULES = {
     "nexus.agents.memnon.memnon",
 }
 
+_FORBIDDEN_MEMNON_IMPORT_MODULES = {
+    *_FORBIDDEN_ML_IMPORT_MODULES,
+    "nexus.agents.memnon.utils.content_processor",
+    "nexus.agents.memnon.utils.cross_encoder",
+    "nexus.agents.memnon.utils.embedding_manager",
+    "nexus.agents.memnon.utils.search",
+}
+
 
 def _run_fresh_import(code: str) -> "subprocess.CompletedProcess[str]":
     env = {**os.environ, **_UNREACHABLE_DB_ENV}
@@ -137,6 +145,44 @@ def test_agent_utility_imports_do_not_import_agent_or_ml_stack() -> None:
             "print('OK')\n"
         )
         _assert_clean(_run_fresh_import(code))
+
+
+def test_memnon_module_import_defers_embedding_and_reranking_stack() -> None:
+    """Importing MEMNON must defer model tooling until its first use."""
+    module_list = repr(sorted(_FORBIDDEN_MEMNON_IMPORT_MODULES))
+    code = (
+        "import sys\n"
+        "from nexus.agents.memnon.memnon import MEMNON\n"
+        f"forbidden = {module_list}\n"
+        "loaded = [module for module in forbidden if module in sys.modules]\n"
+        "assert MEMNON.__name__ == 'MEMNON'\n"
+        "assert loaded == [], loaded\n"
+        "print('OK')\n"
+    )
+    _assert_clean(_run_fresh_import(code))
+
+
+def test_memnon_deferred_import_error_surfaces_at_first_use() -> None:
+    """A missing deferred dependency must raise its original import error."""
+    code = (
+        "import importlib\n"
+        "import sys\n"
+        "module = importlib.import_module('nexus.agents.memnon.memnon')\n"
+        "class DatabaseManager:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        self.Session = None\n"
+        "module.DatabaseManager = DatabaseManager\n"
+        "dependency = 'nexus.agents.memnon.utils.embedding_manager'\n"
+        "sys.modules[dependency] = None\n"
+        "try:\n"
+        "    module.MEMNON(interface=None, db_url='postgresql://unused')\n"
+        "except ModuleNotFoundError as exc:\n"
+        "    assert exc.name == dependency, (exc.name, str(exc))\n"
+        "else:\n"
+        "    raise AssertionError('deferred import failure was masked')\n"
+        "print('OK')\n"
+    )
+    _assert_clean(_run_fresh_import(code))
 
 
 def test_agent_package_level_imports_still_work() -> None:


### PR DESCRIPTION
## Summary

Closes #486 (Codex-first: Codex implemented from the frozen spec; Claude reviewed and independently verified). The MEMNON module eagerly imported the full sentence-transformers/PyTorch/CrossEncoder chain at top level — ~1.79s on every cold import, taxing test collection and any CLI path that transitively touches MEMNON. The three heavy managers now import at `MEMNON.__init__`, and `rerank_results` imports only when enabled reranking actually runs. No behavior change; a missing deferred dependency raises its original `ModuleNotFoundError` at first use (loud, tested).

## Numbers

- Before: **1.793s** cold import (`sentence_transformers` 1.536s, `CrossEncoder` 0.938s)
- After: **0.238s** (Codex, neutral cwd) / **0.224s** (Claude, independent measurement) — no ML stack in `sys.modules`

## Verification (Claude, in the worktree)

- Full default suite: 1172 passed. New test file flake8-clean; the 84 findings on `memnon.py` are pre-existing whole-file drift (verified against HEAD — the diff's changed lines are clean). No orphaned `SentenceTransformer` references.
- New subprocess guards in the #369/#406 import-hygiene file: forbidden-module assertion for the MEMNON import surface + a masked-failure tripwire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY