### PR TITLE
Restore Divergence Detection: the Baseline Filter Was Subtracting Every Entity

### DIFF
--- a/nexus/memory/manager.py
+++ b/nexus/memory/manager.py
@@ -12,7 +12,7 @@ from sqlalchemy import text
 
 from .context_state import ContextPackage, ContextStateManager, PassTransition
 from .divergence import DivergenceDetector, DivergenceResult
-from .entity_detector import EntityMatch, HighSpecificityEntityDetector
+from .entity_detector import HighSpecificityEntityDetector
 from .incremental import IncrementalRetriever
 from .query_memory import QueryMemory
 
@@ -393,12 +393,10 @@ class ContextMemoryManager:
     def _detect_divergence(
         self,
         user_input: str,
-        context: Optional[ContextPackage],
     ) -> DivergenceResult:
         """Detect divergence using high-specificity entity matching."""
 
         entity_match = self.entity_detector.detect_entities(user_input)
-        entity_match = self._filter_baseline_entity_matches(entity_match, context)
         summary = self.entity_detector.to_divergence_format(entity_match)
         return DivergenceResult(
             bool(summary.get("detected")),
@@ -407,117 +405,6 @@ class ContextMemoryManager:
             set(summary.get("unmatched_entities", set())),
             set(summary.get("references_seen", set())),
         )
-
-    def _filter_baseline_entity_matches(
-        self,
-        entity_match: EntityMatch,
-        context: Optional[ContextPackage],
-    ) -> EntityMatch:
-        """Ignore matched entities that are already represented in Pass 1."""
-
-        baseline_refs = self._baseline_entity_refs(context)
-
-        return EntityMatch(
-            characters=[
-                character
-                for character in entity_match.characters
-                if not self._entity_in_baseline("character", character, baseline_refs)
-            ],
-            places=[
-                place
-                for place in entity_match.places
-                if not self._entity_in_baseline("place", place, baseline_refs)
-            ],
-            factions=[
-                faction
-                for faction in entity_match.factions
-                if not self._entity_in_baseline("faction", faction, baseline_refs)
-            ],
-        )
-
-    def _baseline_entity_refs(
-        self,
-        context: Optional[ContextPackage],
-    ) -> Dict[str, Set[str]]:
-        """Collect normalized entity refs from the current Pass 1 baseline."""
-
-        refs: Dict[str, Set[str]] = {
-            "character": set(),
-            "place": set(),
-            "faction": set(),
-        }
-        if not context:
-            return refs
-
-        def add_ref(kind: str, value: Any) -> None:
-            if value is None:
-                return
-            if isinstance(value, str):
-                normalized = self._normalize_entity_ref(value)
-                if normalized:
-                    refs[kind].add(normalized)
-                return
-            if isinstance(value, dict):
-                raw_id = value.get("id") or value.get(f"{kind}_id")
-                if raw_id is not None:
-                    refs[kind].add(f"id:{raw_id}")
-                for key in ("name", "alias", "canonical_name"):
-                    normalized = self._normalize_entity_ref(value.get(key))
-                    if normalized:
-                        refs[kind].add(normalized)
-
-        def walk(kind: str, value: Any) -> None:
-            if isinstance(value, dict):
-                if any(key in value for key in ("id", f"{kind}_id", "name")):
-                    add_ref(kind, value)
-                    return
-                for nested in value.values():
-                    walk(kind, nested)
-                return
-            if isinstance(value, (list, tuple, set)):
-                for item in value:
-                    walk(kind, item)
-                return
-            add_ref(kind, value)
-
-        baseline_entities = context.baseline_entities or {}
-        for key in ("characters", "character"):
-            walk("character", baseline_entities.get(key))
-        for key in ("locations", "places", "place"):
-            walk("place", baseline_entities.get(key))
-        for key in ("factions", "faction"):
-            walk("faction", baseline_entities.get(key))
-
-        return refs
-
-    def _entity_in_baseline(
-        self,
-        kind: str,
-        entity: Dict[str, Any],
-        baseline_refs: Dict[str, Set[str]],
-    ) -> bool:
-        """Return true when a detected entity already appears in Pass 1."""
-
-        refs = baseline_refs.get(kind, set())
-        raw_id = entity.get("id") or entity.get(f"{kind}_id")
-        if raw_id is not None and f"id:{raw_id}" in refs:
-            return True
-
-        for key in ("name", "alias", "canonical_name"):
-            normalized = self._normalize_entity_ref(entity.get(key))
-            if normalized and normalized in refs:
-                return True
-
-        return False
-
-    @staticmethod
-    def _normalize_entity_ref(value: Any) -> Optional[str]:
-        """Normalize entity refs for baseline/detected comparisons."""
-
-        if not isinstance(value, str):
-            return None
-        normalized = re.sub(r"\s+", " ", value.strip().lower())
-        return normalized or None
 
     def _compute_available_phase2_budget(
         self, token_counts: Optional[Dict[str, int]]
@@ -560,7 +447,7 @@ class ContextMemoryManager:
         context = self.context_state.context
         transition = self.context_state.transition
 
-        divergence = self._detect_divergence(user_input, context)
+        divergence = self._detect_divergence(user_input)
         logger.debug(
             "Divergence detection: %s (confidence=%.2f)",
             divergence.detected,

--- a/tests/test_lore/test_memory_manager.py
+++ b/tests/test_lore/test_memory_manager.py
@@ -176,7 +176,7 @@ def test_pass2_divergence_triggers_incremental_retrieval(
     )
 
 
-def test_pass2_ignores_entities_already_in_baseline(
+def test_pass2_preserves_entity_detection_when_character_is_in_baseline(
     minimal_settings, dummy_memnon, baseline_inputs
 ):
     manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
@@ -193,8 +193,9 @@ def test_pass2_ignores_entities_already_in_baseline(
 
     update = manager.handle_user_input("Ask Emilia about the vault.")
 
-    assert update.divergence.detected is False
-    assert update.divergence.gaps == {}
+    assert update.divergence.detected is True
+    assert update.divergence.gaps == {"character_2": "Character 'Emilia' mentioned"}
+    assert update.divergence.references_seen == {"user_input"}
 
 
 def test_pass2_marks_matched_entities_outside_baseline(

--- a/tests/test_lore/test_pass2_chunk1369.py
+++ b/tests/test_lore/test_pass2_chunk1369.py
@@ -111,9 +111,8 @@ def test_pass2_handles_karaoke_divergence(
     authorial_passages.append(structured_stub)
 
     analysis = context.phase_states.get("warm_analysis", {}).get("analysis", {})
-    assert analysis.get(
-        "characters"
-    ), "Warm analysis should capture characters for notes"
+    assert analysis.get("source") == "programmatic_warm_slice"
+    assert KARAOKE_CHUNK_ID in analysis.get("warm_chunk_ids", [])
     assert context.entity_data.get(
         "characters"
     ), "Structured character lookups should be populated"


### PR DESCRIPTION
## Summary

Closes #485 (Codex-first: Codex diagnosed from the issue's two-layer investigation and implemented; Claude reviewed the semantics and verified). Divergence detection has been structurally dead since 2026-05-18: commit `2ff10059` added a filter that discarded detector matches present in Pass 1's `baseline_entities` — but the hierarchical entity structure deliberately includes the **universal baseline (every entity in the game)**, so the filter removed *all* matches, always. `references_seen` was permanently empty; Pass-2 deep-cut retrieval never fired; the `requires_postgres` gate kept the karaoke integration spec out of CI.

The fix removes the filter and its helpers. The semantic judgment, made explicit: "entity present in the baseline" never implied "entity's history adequately covered" — asking about a deep-past incident involving on-screen characters (the karaoke case, chunks 743–770) is the feature's primary use, and the high-specificity detector + the Pass-2 token budget remain the retrieval bounds the retrieval bake-off validated. The manager unit test had asserted the filtered behavior (encoding the regression); it now guards the opposite. Layer 1 of the issue (the stale warm-analysis assertion) is fixed per the prescribed programmatic warm-slice contract.

## Root Cause Narrative

Inventory hydration was healthy (245 character/alias entries; the raw detector matched Emilia and Pete). The ancestry between the last-working commit and the break contains exactly `2ff10059`, so no bisect was needed. `test_memory_manager.py` missed it because it injected synthetic inventories *and* asserted the filtering.

## Verification (Claude, in the worktree)

- Karaoke repro green; `tests/test_lore/`: 106 passed offline, 118 passed live; full default suite 1170 passed.
- flake8 findings on touched files all pre-exist on HEAD (identical count); zero added lines over 88 chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY