### PR TITLE
Retrieval-Coverage Instrumentation: Measure Before Building the Supplement

### DIFF
--- a/migrations/075_retrieval_coverage_log.sql
+++ b/migrations/075_retrieval_coverage_log.sql
@@ -1,0 +1,43 @@
+-- 075_retrieval_coverage_log.sql
+--
+-- Instrument Pass 2 retrieval coverage without changing retrieval behavior.
+
+CREATE TABLE IF NOT EXISTS retrieval_coverage_log (
+    id                 bigserial PRIMARY KEY,
+    created_at         timestamptz NOT NULL DEFAULT now(),
+    turn_id            text,
+    user_input         text NOT NULL,
+    detected_entities  jsonb NOT NULL DEFAULT '[]'::jsonb,
+    raw_result_count   integer NOT NULL CHECK (raw_result_count >= 0),
+    kept_chunk_ids     bigint[] NOT NULL DEFAULT ARRAY[]::bigint[],
+    kept_tokens        integer NOT NULL CHECK (kept_tokens >= 0),
+    available_budget   integer NOT NULL CHECK (available_budget >= 0),
+    coverage           jsonb NOT NULL DEFAULT '[]'::jsonb,
+    gap_entities       jsonb NOT NULL DEFAULT '[]'::jsonb
+);
+
+COMMENT ON TABLE retrieval_coverage_log IS
+    'Per-turn Pass 2 retrieval coverage telemetry. Records detector matches, kept-chunk references, and detected entities absent from the kept context; never changes retrieval behavior.';
+COMMENT ON COLUMN retrieval_coverage_log.id IS
+    'Monotonic identifier for the retrieval coverage audit row.';
+COMMENT ON COLUMN retrieval_coverage_log.created_at IS
+    'Wall-clock time when the retrieval coverage audit row was written.';
+COMMENT ON COLUMN retrieval_coverage_log.turn_id IS
+    'LORE TurnContext.turn_id when the caller has a turn context; NULL for direct manager callers.';
+COMMENT ON COLUMN retrieval_coverage_log.user_input IS
+    'Exact user text used for Pass 2 raw-input retrieval and entity detection.';
+COMMENT ON COLUMN retrieval_coverage_log.detected_entities IS
+    'Detector matches as a JSON array of objects with kind, id, and canonical name.';
+COMMENT ON COLUMN retrieval_coverage_log.raw_result_count IS
+    'Number of raw-input retrieval results presented to the final Pass 2 budget truncation step.';
+COMMENT ON COLUMN retrieval_coverage_log.kept_chunk_ids IS
+    'Ordered narrative chunk ids retained by the final Pass 2 budget truncation step.';
+COMMENT ON COLUMN retrieval_coverage_log.kept_tokens IS
+    'Estimated token count consumed by the kept Pass 2 chunks.';
+COMMENT ON COLUMN retrieval_coverage_log.available_budget IS
+    'Pass 2 token budget available before the raw-input retrieval step.';
+COMMENT ON COLUMN retrieval_coverage_log.coverage IS
+    'Per detected entity, whether any kept chunk has a commit-time reference and the covering chunk ids.';
+COMMENT ON COLUMN retrieval_coverage_log.gap_entities IS
+    'Detected entities with no commit-time reference from any kept Pass 2 chunk.';
+

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -177,6 +177,7 @@ class TurnCycleManager:
                 pass2_update = self.lore.memory_manager.handle_user_input(
                     turn_context.user_input,
                     turn_context.token_counts,
+                    turn_id=turn_context.turn_id,
                 )
                 memory_update = pass2_update.to_dict()
             except Exception as exc:  # pragma: no cover - defensive logging

--- a/nexus/memory/manager.py
+++ b/nexus/memory/manager.py
@@ -12,10 +12,10 @@ from sqlalchemy import text
 
 from .context_state import ContextPackage, ContextStateManager, PassTransition
 from .divergence import DivergenceDetector, DivergenceResult
-from .entity_detector import HighSpecificityEntityDetector
+from .entity_detector import EntityMatch, HighSpecificityEntityDetector
 from .incremental import IncrementalRetriever
 from .query_memory import QueryMemory
-from .retrieval_coverage import audit_retrieval_coverage
+from .retrieval_coverage import audit_retrieval_coverage, coerce_chunk_id
 
 try:  # pragma: no cover - optional dependency during unit tests
     from nexus.agents.memnon.utils.alias_search import load_aliases_from_db
@@ -394,10 +394,12 @@ class ContextMemoryManager:
     def _detect_divergence(
         self,
         user_input: str,
+        entity_match: Optional["EntityMatch"] = None,
     ) -> DivergenceResult:
         """Detect divergence using high-specificity entity matching."""
 
-        entity_match = self.entity_detector.detect_entities(user_input)
+        if entity_match is None:
+            entity_match = self.entity_detector.detect_entities(user_input)
         summary = self.entity_detector.to_divergence_format(entity_match)
         return DivergenceResult(
             bool(summary.get("detected")),
@@ -449,7 +451,8 @@ class ContextMemoryManager:
         context = self.context_state.context
         transition = self.context_state.transition
 
-        divergence = self._detect_divergence(user_input)
+        entity_match = self.entity_detector.detect_entities(user_input)
+        divergence = self._detect_divergence(user_input, entity_match=entity_match)
         logger.debug(
             "Divergence detection: %s (confidence=%.2f)",
             divergence.detected,
@@ -465,7 +468,7 @@ class ContextMemoryManager:
             logger.debug("No baseline context available; skipping Phase 2")
             audit_retrieval_coverage(
                 incremental_retriever=self.incremental,
-                detector=self.entity_detector,
+                entity_match=entity_match,
                 turn_id=turn_id,
                 user_input=user_input,
                 raw_result_count=0,
@@ -487,7 +490,7 @@ class ContextMemoryManager:
             logger.info("📌 Phase 2 skipped: Simple choice detected")
             audit_retrieval_coverage(
                 incremental_retriever=self.incremental,
-                detector=self.entity_detector,
+                entity_match=entity_match,
                 turn_id=turn_id,
                 user_input=user_input,
                 raw_result_count=0,
@@ -506,7 +509,7 @@ class ContextMemoryManager:
             logger.info("📉 Phase 2 skipped: No remaining token budget available")
             audit_retrieval_coverage(
                 incremental_retriever=self.incremental,
-                detector=self.entity_detector,
+                entity_match=entity_match,
                 turn_id=turn_id,
                 user_input=user_input,
                 raw_result_count=0,
@@ -533,7 +536,7 @@ class ContextMemoryManager:
             logger.info("No results from raw vector search - Phase 2 complete")
             audit_retrieval_coverage(
                 incremental_retriever=self.incremental,
-                detector=self.entity_detector,
+                entity_match=entity_match,
                 turn_id=turn_id,
                 user_input=user_input,
                 raw_result_count=0,
@@ -575,7 +578,7 @@ class ContextMemoryManager:
 
         audit_retrieval_coverage(
             incremental_retriever=self.incremental,
-            detector=self.entity_detector,
+            entity_match=entity_match,
             turn_id=turn_id,
             user_input=user_input,
             raw_result_count=len(raw_search_results),
@@ -603,13 +606,7 @@ class ContextMemoryManager:
     def _coerce_chunk_id(self, chunk: Dict[str, Any]) -> Optional[int]:
         """Attempt to coerce a chunk identifier without logging noise."""
 
-        raw_id = chunk.get("chunk_id", chunk.get("id"))
-        if raw_id is None:
-            return None
-        try:
-            return int(raw_id)
-        except (TypeError, ValueError):
-            return None
+        return coerce_chunk_id(chunk)
 
     def augment_warm_slice(
         self, warm_slice: List[Dict[str, Any]]

--- a/nexus/memory/manager.py
+++ b/nexus/memory/manager.py
@@ -15,6 +15,7 @@ from .divergence import DivergenceDetector, DivergenceResult
 from .entity_detector import HighSpecificityEntityDetector
 from .incremental import IncrementalRetriever
 from .query_memory import QueryMemory
+from .retrieval_coverage import audit_retrieval_coverage
 
 try:  # pragma: no cover - optional dependency during unit tests
     from nexus.agents.memnon.utils.alias_search import load_aliases_from_db
@@ -436,6 +437,7 @@ class ContextMemoryManager:
         self,
         user_input: str,
         token_counts: Optional[Dict[str, int]] = None,
+        turn_id: Optional[str] = None,
     ) -> Pass2Update:
         """Run deterministic Phase 2 retrieval from raw user input.
 
@@ -461,6 +463,16 @@ class ContextMemoryManager:
 
         if not context or not transition:
             logger.debug("No baseline context available; skipping Phase 2")
+            audit_retrieval_coverage(
+                incremental_retriever=self.incremental,
+                detector=self.entity_detector,
+                turn_id=turn_id,
+                user_input=user_input,
+                raw_result_count=0,
+                kept_chunks=[],
+                kept_tokens=0,
+                available_budget=0,
+            )
             return Pass2Update(
                 divergence,
                 [],
@@ -473,6 +485,16 @@ class ContextMemoryManager:
         # STEP 1: Check if simple choice -> skip Phase 2 if yes
         if self.skip_simple_choices and self._is_simple_choice(user_input):
             logger.info("📌 Phase 2 skipped: Simple choice detected")
+            audit_retrieval_coverage(
+                incremental_retriever=self.incremental,
+                detector=self.entity_detector,
+                turn_id=turn_id,
+                user_input=user_input,
+                raw_result_count=0,
+                kept_chunks=[],
+                kept_tokens=0,
+                available_budget=available_budget,
+            )
             return Pass2Update(
                 divergence,
                 [],
@@ -482,6 +504,16 @@ class ContextMemoryManager:
 
         if available_budget <= 0:
             logger.info("📉 Phase 2 skipped: No remaining token budget available")
+            audit_retrieval_coverage(
+                incremental_retriever=self.incremental,
+                detector=self.entity_detector,
+                turn_id=turn_id,
+                user_input=user_input,
+                raw_result_count=0,
+                kept_chunks=[],
+                kept_tokens=0,
+                available_budget=available_budget,
+            )
             return Pass2Update(
                 divergence,
                 [],
@@ -499,6 +531,16 @@ class ContextMemoryManager:
 
         if not raw_search_results:
             logger.info("No results from raw vector search - Phase 2 complete")
+            audit_retrieval_coverage(
+                incremental_retriever=self.incremental,
+                detector=self.entity_detector,
+                turn_id=turn_id,
+                user_input=user_input,
+                raw_result_count=0,
+                kept_chunks=[],
+                kept_tokens=0,
+                available_budget=available_budget,
+            )
             return Pass2Update(
                 divergence,
                 [],
@@ -530,6 +572,17 @@ class ContextMemoryManager:
             )
         else:
             logger.info("Phase 2 complete: No chunks fit in remaining budget")
+
+        audit_retrieval_coverage(
+            incremental_retriever=self.incremental,
+            detector=self.entity_detector,
+            turn_id=turn_id,
+            user_input=user_input,
+            raw_result_count=len(raw_search_results),
+            kept_chunks=kept_chunks,
+            kept_tokens=total_tokens,
+            available_budget=available_budget,
+        )
 
         return Pass2Update(
             divergence,

--- a/nexus/memory/retrieval_coverage.py
+++ b/nexus/memory/retrieval_coverage.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Iterable, List, Optional
 
 from sqlalchemy import text
 
-from .entity_detector import EntityMatch, HighSpecificityEntityDetector
+from .entity_detector import EntityMatch
 
 logger = logging.getLogger(__name__)
 
@@ -74,25 +74,33 @@ def _detected_entities(entity_match: EntityMatch) -> List[Dict[str, Any]]:
     return sorted(detected, key=lambda entity: (entity["kind"], entity["id"]))
 
 
+def coerce_chunk_id(chunk: Dict[str, Any]) -> Optional[int]:
+    """Shared chunk-id coercion (manager._coerce_chunk_id delegates here)."""
+    raw_id = chunk.get("chunk_id", chunk.get("id"))
+    if raw_id is None:
+        return None
+    try:
+        return int(raw_id)
+    except (TypeError, ValueError):
+        return None
+
+
 def _chunk_ids(chunks: Iterable[Dict[str, Any]]) -> List[int]:
     chunk_ids: List[int] = []
+    seen: set = set()
     for chunk in chunks:
-        raw_id = chunk.get("chunk_id", chunk.get("id"))
-        if raw_id is None:
+        chunk_id = coerce_chunk_id(chunk)
+        if chunk_id is None or chunk_id in seen:
             continue
-        try:
-            chunk_id = int(raw_id)
-        except (TypeError, ValueError):
-            continue
-        if chunk_id not in chunk_ids:
-            chunk_ids.append(chunk_id)
+        seen.add(chunk_id)
+        chunk_ids.append(chunk_id)
     return chunk_ids
 
 
 def _write_retrieval_coverage(
     connection: Any,
     *,
-    detector: HighSpecificityEntityDetector,
+    entity_match: EntityMatch,
     turn_id: Optional[str],
     user_input: str,
     raw_result_count: int,
@@ -101,7 +109,6 @@ def _write_retrieval_coverage(
     available_budget: int,
     error_context: Dict[str, Any],
 ) -> None:
-    entity_match = detector.detect_entities(user_input)
     detected_entities = _detected_entities(entity_match)
     error_context["detected_entities"] = detected_entities
 
@@ -152,7 +159,7 @@ def _write_retrieval_coverage(
 def audit_retrieval_coverage(
     *,
     incremental_retriever: Any,
-    detector: HighSpecificityEntityDetector,
+    entity_match: EntityMatch,
     user_input: str,
     raw_result_count: int,
     kept_chunks: Iterable[Dict[str, Any]],
@@ -188,7 +195,7 @@ def audit_retrieval_coverage(
             with database_access.begin() as connection:
                 _write_retrieval_coverage(
                     connection,
-                    detector=detector,
+                    entity_match=entity_match,
                     turn_id=turn_id,
                     user_input=user_input,
                     raw_result_count=raw_result_count,
@@ -200,7 +207,7 @@ def audit_retrieval_coverage(
         else:
             _write_retrieval_coverage(
                 database_access,
-                detector=detector,
+                entity_match=entity_match,
                 turn_id=turn_id,
                 user_input=user_input,
                 raw_result_count=raw_result_count,

--- a/nexus/memory/retrieval_coverage.py
+++ b/nexus/memory/retrieval_coverage.py
@@ -1,0 +1,216 @@
+"""Pass 2 retrieval coverage telemetry."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Iterable, List, Optional
+
+from sqlalchemy import text
+
+from .entity_detector import EntityMatch, HighSpecificityEntityDetector
+
+logger = logging.getLogger(__name__)
+
+
+_REFERENCE_QUERY = text(
+    """
+    SELECT 'character' AS kind, character_id AS entity_id, chunk_id
+    FROM chunk_character_references
+    WHERE chunk_id = ANY(CAST(:kept_chunk_ids AS bigint[]))
+    UNION ALL
+    SELECT 'place' AS kind, place_id AS entity_id, chunk_id
+    FROM place_chunk_references
+    WHERE chunk_id = ANY(CAST(:kept_chunk_ids AS bigint[]))
+    UNION ALL
+    SELECT 'faction' AS kind, faction_id AS entity_id, chunk_id
+    FROM chunk_faction_references
+    WHERE chunk_id = ANY(CAST(:kept_chunk_ids AS bigint[]))
+    """
+)
+
+_INSERT_QUERY = text(
+    """
+    INSERT INTO retrieval_coverage_log (
+        turn_id,
+        user_input,
+        detected_entities,
+        raw_result_count,
+        kept_chunk_ids,
+        kept_tokens,
+        available_budget,
+        coverage,
+        gap_entities
+    ) VALUES (
+        :turn_id,
+        :user_input,
+        CAST(:detected_entities AS jsonb),
+        :raw_result_count,
+        CAST(:kept_chunk_ids AS bigint[]),
+        :kept_tokens,
+        :available_budget,
+        CAST(:coverage AS jsonb),
+        CAST(:gap_entities AS jsonb)
+    )
+    """
+)
+
+
+def _detected_entities(entity_match: EntityMatch) -> List[Dict[str, Any]]:
+    detected: List[Dict[str, Any]] = []
+    for kind, matches in (
+        ("character", entity_match.characters),
+        ("place", entity_match.places),
+        ("faction", entity_match.factions),
+    ):
+        detected.extend(
+            {
+                "kind": kind,
+                "id": int(match["id"]),
+                "name": str(match["name"]),
+            }
+            for match in matches
+        )
+    return sorted(detected, key=lambda entity: (entity["kind"], entity["id"]))
+
+
+def _chunk_ids(chunks: Iterable[Dict[str, Any]]) -> List[int]:
+    chunk_ids: List[int] = []
+    for chunk in chunks:
+        raw_id = chunk.get("chunk_id", chunk.get("id"))
+        if raw_id is None:
+            continue
+        try:
+            chunk_id = int(raw_id)
+        except (TypeError, ValueError):
+            continue
+        if chunk_id not in chunk_ids:
+            chunk_ids.append(chunk_id)
+    return chunk_ids
+
+
+def _write_retrieval_coverage(
+    connection: Any,
+    *,
+    detector: HighSpecificityEntityDetector,
+    turn_id: Optional[str],
+    user_input: str,
+    raw_result_count: int,
+    kept_chunk_ids: List[int],
+    kept_tokens: int,
+    available_budget: int,
+    error_context: Dict[str, Any],
+) -> None:
+    entity_match = detector.detect_entities(user_input)
+    detected_entities = _detected_entities(entity_match)
+    error_context["detected_entities"] = detected_entities
+
+    references: Dict[tuple[str, int], set[int]] = {}
+    if kept_chunk_ids:
+        rows = connection.execute(
+            _REFERENCE_QUERY,
+            {"kept_chunk_ids": kept_chunk_ids},
+        )
+        for row in rows:
+            key = (str(row.kind), int(row.entity_id))
+            references.setdefault(key, set()).add(int(row.chunk_id))
+
+    coverage: List[Dict[str, Any]] = []
+    gap_entities: List[Dict[str, Any]] = []
+    for entity in detected_entities:
+        covering_chunk_ids = sorted(
+            references.get((entity["kind"], entity["id"]), set())
+        )
+        coverage.append(
+            {
+                **entity,
+                "covered": bool(covering_chunk_ids),
+                "covering_chunk_ids": covering_chunk_ids,
+            }
+        )
+        if not covering_chunk_ids:
+            gap_entities.append(dict(entity))
+
+    error_context["coverage"] = coverage
+    error_context["gap_entities"] = gap_entities
+    connection.execute(
+        _INSERT_QUERY,
+        {
+            "turn_id": turn_id,
+            "user_input": user_input,
+            "detected_entities": json.dumps(detected_entities),
+            "raw_result_count": raw_result_count,
+            "kept_chunk_ids": kept_chunk_ids,
+            "kept_tokens": kept_tokens,
+            "available_budget": available_budget,
+            "coverage": json.dumps(coverage),
+            "gap_entities": json.dumps(gap_entities),
+        },
+    )
+
+
+def audit_retrieval_coverage(
+    *,
+    incremental_retriever: Any,
+    detector: HighSpecificityEntityDetector,
+    user_input: str,
+    raw_result_count: int,
+    kept_chunks: Iterable[Dict[str, Any]],
+    kept_tokens: int,
+    available_budget: int,
+    turn_id: Optional[str] = None,
+) -> None:
+    """Write one best-effort retrieval coverage row for a Pass 2 turn.
+
+    A fake or structurally incomplete MEMNON has no SQLAlchemy engine, so unit
+    callers skip telemetry without attempting a connection. Once a database
+    path exists, every failure is logged with the complete audit context and
+    suppressed so telemetry cannot abort narrative generation.
+    """
+
+    memnon = getattr(incremental_retriever, "memnon", None)
+    database_access = getattr(getattr(memnon, "db_manager", None), "engine", None)
+    if database_access is None:
+        return
+
+    kept_chunk_ids = _chunk_ids(kept_chunks)
+    error_context: Dict[str, Any] = {
+        "turn_id": turn_id,
+        "user_input": user_input,
+        "raw_result_count": raw_result_count,
+        "kept_chunk_ids": kept_chunk_ids,
+        "kept_tokens": kept_tokens,
+        "available_budget": available_budget,
+    }
+
+    try:
+        if hasattr(database_access, "connect"):
+            with database_access.begin() as connection:
+                _write_retrieval_coverage(
+                    connection,
+                    detector=detector,
+                    turn_id=turn_id,
+                    user_input=user_input,
+                    raw_result_count=raw_result_count,
+                    kept_chunk_ids=kept_chunk_ids,
+                    kept_tokens=kept_tokens,
+                    available_budget=available_budget,
+                    error_context=error_context,
+                )
+        else:
+            _write_retrieval_coverage(
+                database_access,
+                detector=detector,
+                turn_id=turn_id,
+                user_input=user_input,
+                raw_result_count=raw_result_count,
+                kept_chunk_ids=kept_chunk_ids,
+                kept_tokens=kept_tokens,
+                available_budget=available_budget,
+                error_context=error_context,
+            )
+    except Exception:
+        logger.exception(
+            "Retrieval coverage audit failed; narrative turn continues (context=%r)",
+            error_context,
+        )

--- a/scripts/report_retrieval_coverage.py
+++ b/scripts/report_retrieval_coverage.py
@@ -7,6 +7,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import os
 from collections import Counter, defaultdict
 from typing import Any, Dict, Iterable, List, Mapping, Sequence
 
@@ -133,7 +134,14 @@ def format_retrieval_coverage_report(
 
 
 def _load_rows(slot: int) -> List[Mapping[str, Any]]:
-    connection = psycopg2.connect(dbname=slot_dbname(slot), host="localhost")
+    # Honor the standard libpq env vars (the pattern the live-test helpers
+    # use); bare defaults match the documented single-machine setup.
+    connection = psycopg2.connect(
+        dbname=slot_dbname(slot),
+        host=os.environ.get("PGHOST", "localhost"),
+        user=os.environ.get("PGUSER", "pythagor"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
     connection.set_session(readonly=True)
     try:
         with connection.cursor(cursor_factory=RealDictCursor) as cursor:

--- a/scripts/report_retrieval_coverage.py
+++ b/scripts/report_retrieval_coverage.py
@@ -1,0 +1,160 @@
+"""Report Pass 2 retrieval coverage telemetry for one save slot.
+
+Usage:
+    python scripts/report_retrieval_coverage.py --slot 2
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
+
+import psycopg2  # type: ignore[import-untyped]
+from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
+
+from nexus.api.slot_utils import slot_dbname
+
+
+_LENGTH_BUCKETS = (
+    ("1-4 words", 1, 4),
+    ("5-9 words", 5, 9),
+    ("10-19 words", 10, 19),
+    ("20+ words", 20, None),
+)
+
+
+def _length_bucket(user_input: str) -> str:
+    word_count = len(user_input.split())
+    for label, minimum, maximum in _LENGTH_BUCKETS:
+        if word_count >= minimum and (maximum is None or word_count <= maximum):
+            return label
+    return "0 words"
+
+
+def _percentage(numerator: int, denominator: int) -> str:
+    if not denominator:
+        return "n/a"
+    return f"{numerator / denominator * 100:.1f}%"
+
+
+def format_retrieval_coverage_report(
+    slot: int,
+    rows: Iterable[Mapping[str, Any]],
+) -> str:
+    """Format decision-facing retrieval coverage measures as plain text."""
+
+    row_list = list(rows)
+    total_turns = len(row_list)
+    detected_turns = 0
+    kind_detections: Counter[str] = Counter()
+    kind_gaps: Counter[str] = Counter()
+    entity_detections: Counter[tuple[str, int, str]] = Counter()
+    entity_gaps: Counter[tuple[str, int, str]] = Counter()
+    bucket_counts: Dict[str, Counter[str]] = defaultdict(Counter)
+
+    for row in row_list:
+        detected_entities = row.get("detected_entities") or []
+        gap_entities = row.get("gap_entities") or []
+        gap_keys = {(str(entity["kind"]), int(entity["id"])) for entity in gap_entities}
+        detected = bool(detected_entities)
+        missed = bool(gap_entities)
+        detected_turns += int(detected)
+
+        bucket = _length_bucket(str(row.get("user_input") or ""))
+        bucket_counts[bucket]["turns"] += 1
+        bucket_counts[bucket]["detected_turns"] += int(detected)
+        bucket_counts[bucket]["missed_turns"] += int(missed)
+
+        for entity in detected_entities:
+            kind = str(entity["kind"])
+            entity_id = int(entity["id"])
+            name = str(entity["name"])
+            key = (kind, entity_id, name)
+            kind_detections[kind] += 1
+            entity_detections[key] += 1
+            if (kind, entity_id) in gap_keys:
+                kind_gaps[kind] += 1
+                entity_gaps[key] += 1
+
+    lines = [
+        f"Retrieval coverage report - slot {slot}",
+        f"Total turns audited: {total_turns}",
+        "Detection rate: "
+        f"{_percentage(detected_turns, total_turns)} "
+        f"({detected_turns}/{total_turns})",
+        "",
+        "Per-kind miss rate",
+    ]
+
+    if kind_detections:
+        for kind in sorted(kind_detections):
+            gaps = kind_gaps[kind]
+            detections = kind_detections[kind]
+            lines.append(
+                f"  {kind:<10} {_percentage(gaps, detections):>6} "
+                f"({gaps}/{detections})"
+            )
+    else:
+        lines.append("  no detected entities")
+
+    lines.extend(("", "Gap frequency by entity"))
+    if entity_gaps:
+        ordered_entities = sorted(
+            entity_gaps,
+            key=lambda key: (-entity_gaps[key], key[0], key[2].lower(), key[1]),
+        )
+        for kind, entity_id, name in ordered_entities:
+            key = (kind, entity_id, name)
+            gaps = entity_gaps[key]
+            detections = entity_detections[key]
+            lines.append(
+                f"  {kind}:{name} [{entity_id}] {gaps} gap(s) / "
+                f"{detections} detection(s) ({_percentage(gaps, detections)})"
+            )
+    else:
+        lines.append("  no gaps")
+
+    lines.extend(("", "Miss rate by user-input length (among detected turns)"))
+    bucket_labels = [label for label, _minimum, _maximum in _LENGTH_BUCKETS]
+    if "0 words" in bucket_counts:
+        bucket_labels.insert(0, "0 words")
+    for label in bucket_labels:
+        counts = bucket_counts[label]
+        missed_turns = counts["missed_turns"]
+        detected_in_bucket = counts["detected_turns"]
+        lines.append(
+            f"  {label:<12} {_percentage(missed_turns, detected_in_bucket):>6} "
+            f"({missed_turns}/{detected_in_bucket}); "
+            f"audited turns={counts['turns']}"
+        )
+
+    return "\n".join(lines)
+
+
+def _load_rows(slot: int) -> List[Mapping[str, Any]]:
+    connection = psycopg2.connect(dbname=slot_dbname(slot), host="localhost")
+    connection.set_session(readonly=True)
+    try:
+        with connection.cursor(cursor_factory=RealDictCursor) as cursor:
+            cursor.execute(
+                """
+                SELECT user_input, detected_entities, gap_entities
+                FROM retrieval_coverage_log
+                ORDER BY id
+                """
+            )
+            return list(cursor.fetchall())
+    finally:
+        connection.close()
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--slot", type=int, choices=range(1, 6), required=True)
+    args = parser.parse_args(argv)
+    print(format_retrieval_coverage_report(args.slot, _load_rows(args.slot)))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_lore/test_retrieval_coverage.py
+++ b/tests/test_lore/test_retrieval_coverage.py
@@ -1,0 +1,109 @@
+"""Unit tests for Pass 2 retrieval coverage instrumentation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Dict
+
+from nexus.memory import ContextMemoryManager
+from nexus.memory.retrieval_coverage import audit_retrieval_coverage
+from scripts.report_retrieval_coverage import format_retrieval_coverage_report
+
+
+class FakeMemnon:
+    """MEMNON test double with retrieval but no live database path."""
+
+    def query_memory(
+        self, query: str, k: int = 5, use_hybrid: bool = True
+    ) -> Dict[str, object]:
+        return {"results": [{"chunk_id": 9001, "text": "A compact retrieval result."}]}
+
+
+def test_handle_user_input_skips_retrieval_coverage_without_database(
+    caplog,
+) -> None:
+    manager = ContextMemoryManager(
+        {"memory": {"skip_simple_choices": False}},
+        memnon=FakeMemnon(),
+    )
+    manager.handle_storyteller_response(
+        narrative="The briefing ends.",
+        warm_slice=[{"chunk_id": 1, "text": "Baseline."}],
+        token_usage={"total_available": 1000, "warm_slice": 10},
+    )
+
+    update = manager.handle_user_input(
+        "Continue the briefing.",
+        turn_id="unit-turn",
+    )
+
+    assert update.retrieved_chunks
+    assert not [
+        record
+        for record in caplog.records
+        if record.levelname == "ERROR"
+        and "Retrieval coverage audit failed" in record.getMessage()
+    ]
+
+
+def test_attempted_retrieval_coverage_failure_logs_and_returns(caplog) -> None:
+    class FailingEngine:
+        def connect(self) -> None:
+            return None
+
+        def begin(self) -> None:
+            raise RuntimeError("audit database unavailable")
+
+    retriever = SimpleNamespace(
+        memnon=SimpleNamespace(
+            db_manager=SimpleNamespace(engine=FailingEngine()),
+        )
+    )
+
+    audit_retrieval_coverage(
+        incremental_retriever=retriever,
+        detector=SimpleNamespace(),
+        turn_id="failed-audit-turn",
+        user_input="Ask Alex.",
+        raw_result_count=1,
+        kept_chunks=[{"chunk_id": 42}],
+        kept_tokens=3,
+        available_budget=100,
+    )
+
+    errors = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelname == "ERROR"
+        and "Retrieval coverage audit failed" in record.getMessage()
+    ]
+    assert len(errors) == 1
+    assert "failed-audit-turn" in errors[0]
+    assert "Ask Alex." in errors[0]
+    assert "kept_chunk_ids': [42]" in errors[0]
+
+
+def test_format_retrieval_coverage_report_shows_decision_measures() -> None:
+    rows = [
+        {
+            "user_input": "Ask Alex about Wren.",
+            "detected_entities": [
+                {"kind": "character", "id": 1, "name": "Alex"},
+                {"kind": "character", "id": 106, "name": "Wren"},
+            ],
+            "gap_entities": [{"kind": "character", "id": 106, "name": "Wren"}],
+        },
+        {
+            "user_input": "Continue without changing the plan or naming anyone.",
+            "detected_entities": [],
+            "gap_entities": [],
+        },
+    ]
+
+    report = format_retrieval_coverage_report(2, rows)
+
+    assert "Total turns audited: 2" in report
+    assert "Detection rate: 50.0% (1/2)" in report
+    assert "character   50.0% (1/2)" in report
+    assert "character:Wren [106] 1 gap(s) / 1 detection(s) (100.0%)" in report
+    assert "1-4 words    100.0% (1/1); audited turns=1" in report

--- a/tests/test_lore/test_retrieval_coverage.py
+++ b/tests/test_lore/test_retrieval_coverage.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import Dict
 
 from nexus.memory import ContextMemoryManager
+from nexus.memory.entity_detector import EntityMatch
 from nexus.memory.retrieval_coverage import audit_retrieval_coverage
 from scripts.report_retrieval_coverage import format_retrieval_coverage_report
 
@@ -62,7 +63,7 @@ def test_attempted_retrieval_coverage_failure_logs_and_returns(caplog) -> None:
 
     audit_retrieval_coverage(
         incremental_retriever=retriever,
-        detector=SimpleNamespace(),
+        entity_match=EntityMatch(characters=[], places=[], factions=[]),
         turn_id="failed-audit-turn",
         user_input="Ask Alex.",
         raw_result_count=1,

--- a/tests/test_lore/test_retrieval_coverage_live.py
+++ b/tests/test_lore/test_retrieval_coverage_live.py
@@ -1,0 +1,166 @@
+"""Rolled-back save_02 proof for retrieval coverage instrumentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from nexus.api.slot_utils import get_slot_db_url
+from nexus.memory import ContextMemoryManager
+from scripts.report_retrieval_coverage import format_retrieval_coverage_report
+
+pytestmark = pytest.mark.requires_postgres
+
+
+class LiveReferenceMemnon:
+    """Return one controlled kept chunk while exposing the live DB connection."""
+
+    def __init__(self, connection: Any, chunk_id: int) -> None:
+        self.db_manager = SimpleNamespace(engine=connection)
+        self.chunk_id = chunk_id
+
+    def query_memory(
+        self, query: str, k: int = 5, use_hybrid: bool = True
+    ) -> Dict[str, object]:
+        return {
+            "results": [
+                {
+                    "chunk_id": self.chunk_id,
+                    "text": "Controlled kept chunk for the rolled-back live audit.",
+                }
+            ]
+        }
+
+
+def test_handle_user_input_writes_exact_coverage_and_empty_detection() -> None:
+    engine = create_engine(get_slot_db_url(slot=2))
+    migration_path = (
+        Path(__file__).resolve().parents[2]
+        / "migrations"
+        / "075_retrieval_coverage_log.sql"
+    )
+
+    with engine.connect() as connection:
+        transaction = connection.begin()
+        try:
+            connection.exec_driver_sql(migration_path.read_text())
+            covered = connection.execute(
+                text(
+                    """
+                    SELECT c.id, c.name, ccr.chunk_id
+                    FROM characters c
+                    JOIN chunk_character_references ccr
+                      ON ccr.character_id = c.id
+                    WHERE lower(c.name) = 'alex'
+                    ORDER BY ccr.chunk_id DESC
+                    LIMIT 1
+                    """
+                )
+            ).one()
+            gap = connection.execute(
+                text(
+                    """
+                    SELECT c.id, c.name
+                    FROM characters c
+                    WHERE lower(c.name) = 'wren'
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM chunk_character_references ccr
+                          WHERE ccr.character_id = c.id
+                            AND ccr.chunk_id = :chunk_id
+                      )
+                    """
+                ),
+                {"chunk_id": covered.chunk_id},
+            ).one()
+
+            manager = ContextMemoryManager(
+                {"memory": {"skip_simple_choices": False}},
+                memnon=LiveReferenceMemnon(connection, int(covered.chunk_id)),
+            )
+            manager.handle_storyteller_response(
+                narrative="The prior scene closes.",
+                warm_slice=[{"chunk_id": 1, "text": "Baseline."}],
+                token_usage={"total_available": 1000, "warm_slice": 10},
+            )
+
+            first_update = manager.handle_user_input(
+                f"Ask {covered.name} and {gap.name}.",
+                turn_id="coverage-live-hit-gap",
+            )
+            assert [chunk["chunk_id"] for chunk in first_update.retrieved_chunks] == [
+                covered.chunk_id
+            ]
+
+            manager.handle_user_input(
+                "Proceed without named references.",
+                turn_id="coverage-live-empty",
+            )
+
+            rows = (
+                connection.execute(
+                    text(
+                        """
+                    SELECT turn_id, user_input, detected_entities,
+                           raw_result_count, kept_chunk_ids, kept_tokens,
+                           available_budget, coverage, gap_entities
+                    FROM retrieval_coverage_log
+                    WHERE turn_id IN (
+                        'coverage-live-hit-gap',
+                        'coverage-live-empty'
+                    )
+                    ORDER BY id
+                    """
+                    )
+                )
+                .mappings()
+                .all()
+            )
+            assert len(rows) == 2
+
+            hit_gap_row = rows[0]
+            expected_detected = sorted(
+                [
+                    {
+                        "kind": "character",
+                        "id": int(covered.id),
+                        "name": str(covered.name),
+                    },
+                    {
+                        "kind": "character",
+                        "id": int(gap.id),
+                        "name": str(gap.name),
+                    },
+                ],
+                key=lambda entity: (entity["kind"], entity["id"]),
+            )
+            assert hit_gap_row["detected_entities"] == expected_detected
+            assert hit_gap_row["kept_chunk_ids"] == [covered.chunk_id]
+            assert hit_gap_row["coverage"] == [
+                {
+                    **entity,
+                    "covered": entity["id"] == covered.id,
+                    "covering_chunk_ids": (
+                        [covered.chunk_id] if entity["id"] == covered.id else []
+                    ),
+                }
+                for entity in expected_detected
+            ]
+            assert hit_gap_row["gap_entities"] == [
+                entity for entity in expected_detected if entity["id"] == gap.id
+            ]
+
+            empty_row = rows[1]
+            assert empty_row["detected_entities"] == []
+            assert empty_row["coverage"] == []
+            assert empty_row["gap_entities"] == []
+
+            print()
+            print(format_retrieval_coverage_report(2, rows))
+        finally:
+            transaction.rollback()
+    engine.dispose()


### PR DESCRIPTION
## Summary

Issue #492's instrumentation slice (Codex-first: Codex implemented from the frozen spec; Claude reviewed and verified). Logging only — Pass 2 behavior is byte-identical; Step 3 (the entity-keyed supplement retrieval) deliberately waits for this data per the verify-before-building doctrine.

Every Pass 2 exit path writes one `retrieval_coverage_log` row (migration 075): the high-specificity detector's hits from the **user's input** joined against the **kept chunks'** commit-time entity references, partitioned into covered/gap. Skipped turns (simple choice, no budget) are recorded too — the denominator matters. `scripts/report_retrieval_coverage.py --slot N` renders the decision numbers: detection rate, per-kind miss rate, gap frequency by entity, and miss rate bucketed by input length — the oblique-input hypothesis this exists to test.

Design notes carried from the issue: user-text-only detection (committed chunks are already reference-resolved; the live input is the only un-annotated text at Pass-2 time), and strict retrieval-coverage naming — never "knowledge," which #477's epistemics design owns.

**Codex's catch worth highlighting**: the unified `chunk_entity_references_v` speaks global `entities.id` while the detector returns kind-local character/place/faction ids — joining through the view would have silently reported 100% misses. The kind-specific tables are joined instead.

## Verification (Claude, in the worktree)

- `tests/test_lore/ tests/config/`: 146 passed offline; 122 passed live (rolled-back save_02 proof covers a covered entity, an uncovered entity, and an empty-detection turn); full default suite 1175 passed.
- Telemetry semantics tested both ways: fake-MEMNON contexts skip without touching the psycopg2 tripwire; an attempted-write failure logs at ERROR with full context and does not abort the turn.
- flake8/mypy clean on all new files.

Part of #492 — the issue stays open for the Step-3 decision once live-play data accumulates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY