### PR TITLE
Orrery Projects Pilot: PLAN_RELOCATION with Full Reconstructability

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -921,6 +921,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 - **AND:**
   - actor has enough hydrated context
+  - **NOT:** actor `plan_relocation` project passes `ready` due-state
   - **NOT:** actor is constrained or immobilized
   - **NOT:** actor has inbound `hunting` pair tag
   - **NOT:** actor has `grudge_active` ephemeral
@@ -1021,6 +1022,103 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 **Scene-pressure prompt** (storyteller-LLM-only; no state mutation):
 
 > {actor} is watching around {target} but has not made contact. The Storyteller may adapt, delay, ignore, or incorporate that pressure without letting Orrery decide what {target} does.
+
+---
+
+## ADVANCE_RELOCATION_PLAN — priority 47
+
+> A due relocation plan saves, scouts, commits, stalls, or reaches its travel handoff.
+
+**Drive band:** project identity — A due relocation plan occupies SURVEIL's adjacent priority slot; SURVEIL yields while the project is due, so project work displaces surveillance idling while its cadence protects maintenance wins.
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor `plan_relocation` project passes `ready` due-state
+  - **NOT:** actor is in transit
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:**
+    - **OR:**
+      - actor has `sleep` debt ≥ 8
+      - actor has `thirst` debt ≥ 2
+      - actor has `hunger` debt ≥ 4
+
+### Branch 1 — Commit to the road  *(mag 0.4)* · **preemptive**
+
+**When:** actor `plan_relocation` project passes `completion` due-state
+
+**Does:** applies project `complete` transition
+**Event:** `relocation_plan_completed`
+
+> {actor} makes the final commitment. The chosen place stops being a possibility and becomes a destination; the project ends where the journey begins.
+
+### Branch 2 — Let the plan go rather than live in limbo  *(mag 0.4)* · **preemptive**
+
+**When:** actor `plan_relocation` project passes `abandon` due-state
+
+**Does:** applies project `abandon` transition
+**Event:** `relocation_plan_abandoned`
+
+> {actor} opens the plan one last time and recognizes that it has become a ritual of not leaving. They close the ledger and release the future it had been holding hostage.
+
+### Branch 3 — Turn the savings into a search  *(mag 0.4)* · **preemptive**
+
+**When:** actor `plan_relocation` project passes `saving_milestone` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `relocation_plan_milestone`
+
+> {actor} has enough margin now to stop counting and start looking. Prices become neighborhoods, routes, and actual doors they might one day close behind them.
+
+### Branch 4 — Choose the place and begin committing  *(mag 0.4)* · **preemptive**
+
+**When:** actor `plan_relocation` project passes `scouting_milestone` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `relocation_plan_milestone`
+
+> {actor} stops comparing exits. One place has survived every practical objection, and choosing it turns research into a promise with consequences.
+
+### Branch 5 — Put another share aside  *(mag 0.18)* · **not promotable**
+
+**When:** actor `plan_relocation` project passes `saving` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `relocation_plan_progressed`
+
+> {actor} makes the unremarkable sacrifice the plan requires: one expense refused, one small reserve protected from the present.
+
+### Branch 6 — Scout a candidate place  *(mag 0.2)* · **not promotable**
+
+**When:**
+
+- **AND:**
+  - actor `plan_relocation` project passes `scouting_without_target` due-state
+  - actor can resolve a destination with place class `dwelling,haven,urban_sparse,urban_dense`
+
+**Does:** applies project `advance` transition
+**Event:** `relocation_plan_progressed`
+
+> {actor} follows one candidate past the fantasy of it: cost, distance, the shape of an ordinary morning there. For the first time, the plan has a place attached.
+
+### Branch 7 — Lose ground to a setback  *(mag 0.1)* · **not promotable**
+
+**When:** actor `plan_relocation` project passes `ready` due-state
+
+**Does:** applies project `stall` transition
+**Event:** `relocation_plan_stalled`
+
+> The present takes its cut from {actor}'s future: an expense, a closed option, a promise that cannot yet be kept. The plan stalls, but it is not silently erased.
+
+### Branch 8 — Press on with the next practical step  *(mag 0.16)* · **not promotable**
+
+**When:** *(always)*
+
+**Does:** applies project `advance` transition
+**Event:** `relocation_plan_progressed`
+
+> {actor} does the next small thing the move requires — a message, a form, a measured risk — work too ordinary to look like transformation until enough of it accumulates.
 
 ---
 
@@ -1826,6 +1924,43 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 **Event:** `socialized_alone`
 
 > {actor} spends an hour with the voice of a stranger — a book, a serial, a recording — which is not the same as company but is enough like company to take the worst edge off.
+
+---
+
+## START_RELOCATION_PLAN — priority 17
+
+> Repeated local maintenance and a fresh setback become an explicit decision to leave.
+
+**Drive band:** project identity — A relocation plan begins only after repeated local routine plus a recent negative signal; the narrow gate lets it interrupt the mundane floor without becoming ambient project noise.
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor `plan_relocation` project passes `start` due-state
+  - actor has enough hydrated context
+  - actor is at `home` anchor
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:** actor is in transit
+  - **OR:**
+    - ≥ 2 `upkeep_done` events within 30 ticks for actor
+    - ≥ 2 `errands_run` events within 30 ticks for actor
+    - ≥ 2 `recreation_taken` events within 30 ticks for actor
+    - ≥ 2 `work_performed` events within 30 ticks for actor
+  - **OR:**
+    - recent `travel_delayed` event with actor=actor in last 12 ticks
+    - recent `contact_deferred` event with actor=actor in last 12 ticks
+    - recent `threat_issued` event targeting actor in last 12 ticks
+    - recent `retaliation_attempted` event targeting actor in last 12 ticks
+
+### Branch 1 — Begin putting something aside  *(mag 0.4)*
+
+**When:** *(always)*
+
+**Does:** applies project `start` transition
+**Event:** `relocation_plan_started`
+
+> {actor} stops treating departure as the thought that arrives after a bad day. They make a ledger, name what it would cost, and put the first real thing aside.
 
 ---
 
@@ -2736,6 +2871,12 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `protective_intervention`
 - `pursue_identity_lead`
 - `recreation_taken`
+- `relocation_plan_abandoned`
+- `relocation_plan_completed`
+- `relocation_plan_milestone`
+- `relocation_plan_progressed`
+- `relocation_plan_stalled`
+- `relocation_plan_started`
 - `retaliation_attempted`
 - `retaliation_executed`
 - `rival_consulted`
@@ -2780,6 +2921,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `tomb`
 - `transit`
 - `urban_dense`
+- `urban_sparse`
 - `water_source`
 - `wilderness`
 

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1104,7 +1104,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 ### Branch 7 — Lose ground to a setback  *(mag 0.1)* · **not promotable**
 
-**When:** actor `plan_relocation` project passes `ready` due-state
+**When:** actor `plan_relocation` project passes `neglected` due-state
 
 **Does:** applies project `stall` transition
 **Event:** `relocation_plan_stalled`

--- a/migrations/074_plan_relocation_projects.sql
+++ b/migrations/074_plan_relocation_projects.sql
@@ -1,0 +1,116 @@
+-- 074_plan_relocation_projects.sql
+--
+-- Additive project-state projection for the PLAN_RELOCATION pilot. Projects
+-- deliberately do not generalize travel: they own the initiation/staging
+-- ladder and hand a completed relocation to the existing travel.start writer.
+
+CREATE TABLE IF NOT EXISTS character_project_states (
+    id                              bigserial PRIMARY KEY,
+    character_entity_id             bigint NOT NULL REFERENCES entities(id),
+    project_type                    text NOT NULL
+        CHECK (project_type IN ('plan_relocation')),
+    status                          text NOT NULL
+        CHECK (status IN (
+            'active', 'paused', 'stalled', 'abandoned', 'completed'
+        )),
+    stage                           text NOT NULL
+        CHECK (stage IN ('saving', 'scouting', 'committing')),
+    target_place_id                 bigint REFERENCES places(id),
+    progress                        numeric(5,4) NOT NULL DEFAULT 0,
+    stall_count                     integer NOT NULL DEFAULT 0,
+    next_eligible_at_world_time     timestamptz,
+    source_chunk_id                 bigint REFERENCES narrative_chunks(id),
+    created_at                      timestamptz NOT NULL DEFAULT now(),
+    updated_at                      timestamptz NOT NULL DEFAULT now(),
+    CHECK (progress >= 0 AND progress <= 1),
+    CHECK (stall_count >= 0),
+    CHECK (status <> 'completed' OR target_place_id IS NOT NULL)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_character_project_states_open_budget
+    ON character_project_states (character_entity_id)
+    WHERE status IN ('active', 'paused', 'stalled');
+
+CREATE INDEX IF NOT EXISTS ix_character_project_states_status_due
+    ON character_project_states (status, next_eligible_at_world_time);
+
+CREATE INDEX IF NOT EXISTS ix_character_project_states_source_chunk_id
+    ON character_project_states (source_chunk_id);
+
+COMMENT ON TABLE character_project_states IS
+    'Additive Orrery project lifecycle projection. V1 supports PLAN_RELOCATION only and budgets at most one open project per character; completed relocation hands off to character_travel_states.';
+COMMENT ON COLUMN character_project_states.id IS
+    'Surrogate identifier for one project lifecycle, retained after completion or abandonment.';
+COMMENT ON COLUMN character_project_states.character_entity_id IS
+    'Entity spine id for the character pursuing this project.';
+COMMENT ON COLUMN character_project_states.project_type IS
+    'Locked project vocabulary. V1 permits plan_relocation; new types require a migration and their own stage ladder.';
+COMMENT ON COLUMN character_project_states.status IS
+    'Lifecycle status: active, paused, stalled, abandoned, or completed.';
+COMMENT ON COLUMN character_project_states.stage IS
+    'Type-specific PLAN_RELOCATION ladder: saving, scouting, then committing.';
+COMMENT ON COLUMN character_project_states.target_place_id IS
+    'Candidate relocation destination chosen during scouting; required before completion can hand off to travel.start.';
+COMMENT ON COLUMN character_project_states.progress IS
+    'Completion ratio for the current stage, clamped from 0.0000 through 1.0000.';
+COMMENT ON COLUMN character_project_states.stall_count IS
+    'Accumulated setbacks used by configured deterministic abandonment policy.';
+COMMENT ON COLUMN character_project_states.next_eligible_at_world_time IS
+    'Project-owned world-clock cadence gate. Open projects are due when this timestamp is at or before the tick world time.';
+COMMENT ON COLUMN character_project_states.source_chunk_id IS
+    'Narrative chunk responsible for the row current projection; project.start records creation provenance and every later transition advances it to that transition tick.';
+COMMENT ON COLUMN character_project_states.created_at IS
+    'Database timestamp when this project lifecycle row was created.';
+COMMENT ON COLUMN character_project_states.updated_at IS
+    'Database timestamp when this project lifecycle row was last transitioned.';
+
+-- Every checkpoint predating this additive table truthfully contains no
+-- project rows. Extend those documents with an empty genesis section rather
+-- than snapshotting present-day rows into historical checkpoints. replay.py
+-- also accepts an imported pre-074 checkpoint missing this section and emits
+-- an explicit fidelity note.
+UPDATE state_checkpoints
+SET state = state || jsonb_build_object(
+    'character_project_states', ('[]'::jsonb)
+)
+WHERE NOT state ? 'character_project_states';
+
+INSERT INTO event_types (type, category, severity, description)
+VALUES
+    (
+        'relocation_plan_started',
+        'project',
+        'moderate',
+        'The actor turned sustained local discontent into an explicit relocation plan at the saving stage.'
+    ),
+    (
+        'relocation_plan_progressed',
+        'project',
+        'minor',
+        'The actor made routine progress within the current relocation stage.'
+    ),
+    (
+        'relocation_plan_milestone',
+        'project',
+        'moderate',
+        'The relocation plan crossed a stage boundary in its saving, scouting, or committing ladder.'
+    ),
+    (
+        'relocation_plan_stalled',
+        'project',
+        'minor',
+        'A setback stalled the relocation plan and incremented its accumulated stall count.'
+    ),
+    (
+        'relocation_plan_abandoned',
+        'project',
+        'moderate',
+        'The actor abandoned a relocation plan after repeated stalls or excessive overdue world time.'
+    ),
+    (
+        'relocation_plan_completed',
+        'project',
+        'moderate',
+        'The actor committed to the selected destination; the project completed and handed the journey to travel.start.'
+    )
+ON CONFLICT (type) DO NOTHING;

--- a/nexus.toml
+++ b/nexus.toml
@@ -269,6 +269,19 @@ window_points = 6.0
 temperature = 2.0
 exempt_bands = ["crisis_constraint"]
 
+[orrery.projects]
+# PLAN_RELOCATION pilot: projects advance on their own world-clock cadence.
+# The database enforces the v1 budget of one open project per character.
+advance_interval_hours = 24.0
+max_active_per_character = 1
+stall_abandon_threshold = 3
+abandon_after_stalled_world_hours = 168.0
+# Must remain at or above [orrery.promote].magnitude_threshold; routine
+# progress arms stay below that floor in templates.py.
+milestone_magnitude = 0.40
+# Acceptance guard for active-vs-inactive maintenance/routine winner shares.
+coverage_distribution_tolerance = 0.05
+
 [orrery.reconstruction]
 # JSONB state checkpoint every N accepted chunks (0 disables); genesis and
 # manual snapshots via scripts/checkpoint_state.py.

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -643,6 +643,7 @@ class TurnCycleManager:
                 selection_settings=orrery_settings.get("selection"),
                 habituation_settings=orrery_settings.get("habituation"),
                 package_selection_settings=orrery_settings.get("package_selection"),
+                project_settings=orrery_settings.get("projects"),
                 fanout_settings=orrery_settings.get("fanout"),
             )
 

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -71,6 +71,8 @@ from nexus.agents.orrery.substrate import (
     coerce_branch_selection,
     coerce_habituation,
     coerce_package_selection,
+    coerce_project_policy,
+    configure_project_magnitudes,
     CONSTRAINED_TAGS,
     DRAMATIC_CONTACT_TAGS,
     DRIVE_BAND_ORDER,
@@ -479,6 +481,7 @@ def explain_dry_run(
     selection_settings: Optional[Any] = None,
     habituation_settings: Optional[Any] = None,
     package_selection_settings: Optional[Any] = None,
+    project_settings: Optional[Any] = None,
     fanout_settings: Optional[Any] = None,
 ) -> ExplainedTickReport:
     """Hydrate, bind, and explain Orrery packages without database writes.
@@ -498,6 +501,7 @@ def explain_dry_run(
     selection = coerce_branch_selection(selection_settings)
     habituation = coerce_habituation(habituation_settings)
     package_selection = coerce_package_selection(package_selection_settings)
+    project_policy = coerce_project_policy(project_settings)
     state = hydrate_world_state(
         session,
         anchor_chunk_id=anchor_chunk_id,
@@ -505,9 +509,10 @@ def explain_dry_run(
         need_tuning=need_tuning,
         world_time_override=world_time_override,
         win_history_window=habituation.window_ticks if habituation.enabled else 0,
+        project_settings=project_settings,
     )
 
-    templates_list = list(templates)
+    templates_list = list(configure_project_magnitudes(templates, project_policy))
     actor_only_templates = [
         t for t in templates_list if t.required_slots == _ACTOR_ONLY_SLOTS
     ]
@@ -880,6 +885,7 @@ def build_catalog(
                 {
                     "label": branch.label,
                     "magnitude": branch.magnitude,
+                    "promotable": branch.promotable,
                     "event_type": branch.event_type,
                     "signal_event_type": branch.signal_event_type,
                     "has_scene_pressure_stub": branch.scene_pressure_stub is not None,

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -410,6 +410,14 @@ _register(
     _render_since_last_event,
 )
 
+_register(
+    r"project_due\((?P<project>[^,()]+),(?P<mode>[^@()]+)" r"@(?P<slot>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('slot'))} `{m.group('project')}` project "
+        f"passes `{m.group('mode')}` due-state"
+    ),
+)
+
 
 def _render_count_recent_events(m: re.Match) -> str:
     event = m.group("event")
@@ -565,6 +573,10 @@ def _render_state_delta(delta: Mapping[str, Any]) -> str:
         if key == "travel.delay":
             parts.append("records travel delay")
             continue
+        if key.startswith("project."):
+            transition = key.removeprefix("project.")
+            parts.append(f"applies project `{transition}` transition")
+            continue
         parts.append(f"`{key}` = `{value}`")
     return "; ".join(parts)
 
@@ -579,7 +591,12 @@ def _render_narrative_stub(stub: str) -> List[str]:
 
 
 def _render_branch(idx: int, branch: Branch) -> List[str]:
-    marker = " · **preemptive**" if branch.preemptive else ""
+    markers = []
+    if branch.preemptive:
+        markers.append("**preemptive**")
+    if not branch.promotable:
+        markers.append("**not promotable**")
+    marker = f" · {' · '.join(markers)}" if markers else ""
     lines = [
         f"### Branch {idx} — {branch.label}  *(mag {branch.magnitude})*{marker}",
         "",

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -52,6 +52,7 @@ HYDRATION_HONESTY: Mapping[str, Tuple[str, ...]] = {
         "positions",
         "activities",
         "travel_states",
+        "project_states",
         "routine_anchors",
         "faction_memberships",
         "weather",
@@ -139,6 +140,8 @@ def _tally_report(
 ) -> dict[str, Any]:
     winners_by_band: dict[str, int] = {}
     gap_actor_ids: list[int] = []
+    project_gates: list[dict[str, Any]] = []
+    resolution_winners: list[dict[str, Any]] = []
     for group in report.actors:
         fired_anywhere = False
         for stack in _resolution_stacks(group):
@@ -156,6 +159,28 @@ def _tally_report(
                     tally.won += 1
                     winners_by_band[item.drive_band] = (
                         winners_by_band.get(item.drive_band, 0) + 1
+                    )
+                    resolution_winners.append(
+                        {
+                            "actor_entity_id": stack.bindings.get("actor"),
+                            "target_entity_id": stack.bindings.get("target"),
+                            "template_id": item.template_id,
+                            "drive_band": item.drive_band,
+                            "promotable": item.promotable,
+                        }
+                    )
+                if item.template_id in {
+                    "start_relocation_plan",
+                    "advance_relocation_plan",
+                }:
+                    project_gates.append(
+                        {
+                            "actor_entity_id": group.actor_entity_id,
+                            "template_id": item.template_id,
+                            "gate_passed": item.gate_passed,
+                            "stack_winner_id": stack.winner_id,
+                            "gate_trace": item.gate_trace.to_dict(),
+                        }
                     )
         for stack in group.scene_pressure_stacks:
             for item in stack.templates:
@@ -184,6 +209,8 @@ def _tally_report(
         "winners_by_band": winners_by_band,
         "gap_actor_ids": gap_actor_ids,
         "need_pressure_count": len(report.need_pressures),
+        "project_gates": project_gates,
+        "resolution_winners": resolution_winners,
     }
 
 
@@ -299,6 +326,7 @@ def analyze_coverage(
     selection_settings: Optional[Any] = None,
     habituation_settings: Optional[Any] = None,
     package_selection_settings: Optional[Any] = None,
+    project_settings: Optional[Any] = None,
     fanout_settings: Optional[Any] = None,
 ) -> dict[str, Any]:
     """Aggregate explained resolution coverage across historical anchors.
@@ -341,6 +369,7 @@ def analyze_coverage(
             selection_settings=selection_settings,
             habituation_settings=habituation_settings,
             package_selection_settings=package_selection_settings,
+            project_settings=project_settings,
             fanout_settings=fanout_settings,
         )
         anchors.append(_tally_report(report, tallies, gap_counts))
@@ -358,6 +387,14 @@ def analyze_coverage(
             "pressure_fired": tally.pressure_fired,
             "pressure_won": tally.pressure_won,
             "branch_chosen": dict(tally.branch_chosen),
+            "branch_promotable": {
+                branch.label: branch.promotable
+                for branch in next(
+                    template
+                    for template in templates_tuple
+                    if template.id == template_id
+                ).branches
+            },
             "branch_labels_never_chosen": [
                 label for label, chosen in tally.branch_chosen.items() if chosen == 0
             ],

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -33,7 +33,11 @@ from nexus.agents.orrery.routing import (
     RouteGraphEdge,
     shortest_route,
 )
-from nexus.agents.orrery.substrate import SUPPORTED_TRAVEL_PURPOSES
+from nexus.agents.orrery.substrate import (
+    ProjectPolicy,
+    SUPPORTED_TRAVEL_PURPOSES,
+    coerce_project_policy,
+)
 
 
 ENTITY_BINDING_SLOTS = frozenset({"actor", "target", "targets", "faction"})
@@ -52,6 +56,11 @@ SUPPORTED_STATE_DELTA_KEYS = frozenset(
         "travel.advance",
         "travel.arrive",
         "travel.delay",
+        "project.start",
+        "project.advance",
+        "project.stall",
+        "project.abandon",
+        "project.complete",
     }
 )
 ADJUDICATION_ACTIONS = frozenset({"defer", "replace", "void"})
@@ -327,10 +336,12 @@ def commit_orrery_tick_sync(
     storyteller_state_updates: Any = None,
     prompt_settings: Optional[Any] = None,
     ecology_settings: Optional[Any] = None,
+    project_settings: Optional[Any] = None,
 ) -> CommitOrreryTickResult:
     """Materialize a preview proposal inside the accepted-chunk transaction."""
 
     signal_detection = coerce_signal_detection(ecology_settings)
+    project_policy = coerce_project_policy(project_settings)
     coerced = coerce_proposal(proposal)
     has_resolutions = coerced is not None and bool(coerced.resolutions)
     if has_resolutions:
@@ -484,10 +495,12 @@ def commit_orrery_tick_sync(
             tag_mutation_count += _apply_state_delta_sync(
                 cur,
                 adjudicated.draft_to_commit,
+                resolution_id=resolution_id,
                 actor_entity_id=actor_entity_id,
                 target_entity_id=target_entity_id,
                 source_chunk_id=tick_chunk_id,
                 need_tuning=need_tuning,
+                project_policy=project_policy,
             )
             event_id = _emit_world_event_sync(
                 cur,
@@ -538,10 +551,12 @@ async def commit_orrery_tick_async(
     storyteller_state_updates: Any = None,
     prompt_settings: Optional[Any] = None,
     ecology_settings: Optional[Any] = None,
+    project_settings: Optional[Any] = None,
 ) -> CommitOrreryTickResult:
     """Async parity wrapper for tests and non-production commit callers."""
 
     signal_detection = coerce_signal_detection(ecology_settings)
+    project_policy = coerce_project_policy(project_settings)
     coerced = coerce_proposal(proposal)
     has_resolutions = coerced is not None and bool(coerced.resolutions)
     if has_resolutions:
@@ -694,10 +709,12 @@ async def commit_orrery_tick_async(
         tag_mutation_count += await _apply_state_delta_async(
             conn,
             adjudicated.draft_to_commit,
+            resolution_id=resolution_id,
             actor_entity_id=actor_entity_id,
             target_entity_id=target_entity_id,
             source_chunk_id=tick_chunk_id,
             need_tuning=need_tuning,
+            project_policy=project_policy,
         )
         event_id = await _emit_world_event_async(
             conn,
@@ -1347,8 +1364,9 @@ def _insert_resolution_sync(
         """
         INSERT INTO orrery_resolutions (
             tick_chunk_id, template_id, binding_hash, actor_entity_id,
-            priority, magnitude, state_delta, brief
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s)
+            priority, magnitude, state_delta, promotion_status, brief
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb,
+                  %s::orrery_promotion_status, %s)
         ON CONFLICT (tick_chunk_id, template_id, binding_hash) DO NOTHING
         RETURNING id
         """,
@@ -1360,6 +1378,7 @@ def _insert_resolution_sync(
             draft.priority,
             draft.magnitude,
             json.dumps(draft.state_delta),
+            "pending" if draft.promotable else "skipped",
             brief,
         ),
     )
@@ -1381,8 +1400,9 @@ async def _insert_resolution_async(
         """
         INSERT INTO orrery_resolutions (
             tick_chunk_id, template_id, binding_hash, actor_entity_id,
-            priority, magnitude, state_delta, brief
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+            priority, magnitude, state_delta, promotion_status, brief
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb,
+                  $8::orrery_promotion_status, $9)
         ON CONFLICT (tick_chunk_id, template_id, binding_hash) DO NOTHING
         RETURNING id
         """,
@@ -1393,6 +1413,7 @@ async def _insert_resolution_async(
         draft.priority,
         draft.magnitude,
         json.dumps(draft.state_delta),
+        "pending" if draft.promotable else "skipped",
         brief,
     )
 
@@ -1401,10 +1422,12 @@ def _apply_state_delta_sync(
     cur: Any,
     draft: OrreryResolutionDraft,
     *,
+    resolution_id: int,
     actor_entity_id: Optional[int],
     target_entity_id: Optional[int],
     source_chunk_id: int,
     need_tuning: NeedTuning,
+    project_policy: ProjectPolicy,
 ) -> int:
     if not draft.state_delta:
         return 0
@@ -1417,6 +1440,12 @@ def _apply_state_delta_sync(
         raise ValueError(f"Orrery draft {draft.template_id} has no actor binding")
 
     tag_mutations = 0
+    project_keys = [key for key in draft.state_delta if key.startswith("project.")]
+    if len(project_keys) > 1:
+        raise ValueError(
+            f"Orrery draft {draft.template_id} carries multiple project "
+            f"transitions: {sorted(project_keys)}"
+        )
     if "character.current_activity" in draft.state_delta:
         cur.execute(
             "UPDATE characters SET current_activity = %s WHERE entity_id = %s",
@@ -1529,6 +1558,57 @@ def _apply_state_delta_sync(
             source_chunk_id=source_chunk_id,
             need_tuning=need_tuning,
         )
+    project_applied: Optional[dict[str, Any]] = None
+    if "project.start" in draft.state_delta:
+        project_applied = _apply_project_start_sync(
+            cur,
+            actor_entity_id=actor_entity_id,
+            payload=draft.state_delta["project.start"],
+            source_chunk_id=source_chunk_id,
+            policy=project_policy,
+        )
+    if "project.advance" in draft.state_delta:
+        project_applied = _apply_project_advance_sync(
+            cur,
+            actor_entity_id=actor_entity_id,
+            payload=draft.state_delta["project.advance"],
+            source_chunk_id=source_chunk_id,
+            policy=project_policy,
+        )
+    if "project.stall" in draft.state_delta:
+        project_applied = _apply_project_stall_sync(
+            cur,
+            actor_entity_id=actor_entity_id,
+            payload=draft.state_delta["project.stall"],
+            source_chunk_id=source_chunk_id,
+            policy=project_policy,
+        )
+    if "project.abandon" in draft.state_delta:
+        project_applied = _apply_project_abandon_sync(
+            cur,
+            actor_entity_id=actor_entity_id,
+            payload=draft.state_delta["project.abandon"],
+            source_chunk_id=source_chunk_id,
+            policy=project_policy,
+        )
+    if "project.complete" in draft.state_delta:
+        project_applied = _apply_project_complete_sync(
+            cur,
+            actor_entity_id=actor_entity_id,
+            payload=draft.state_delta["project.complete"],
+            source_chunk_id=source_chunk_id,
+            policy=project_policy,
+        )
+    if project_keys:
+        if project_applied is None:
+            raise AssertionError("project transition produced no applied ledger values")
+        _update_resolution_project_applied_sync(
+            cur,
+            resolution_id=resolution_id,
+            state_delta=draft.state_delta,
+            project_key=project_keys[0],
+            applied=project_applied,
+        )
     if "travel.start" in draft.state_delta:
         _apply_travel_start_sync(
             cur,
@@ -1564,10 +1644,12 @@ async def _apply_state_delta_async(
     conn: Any,
     draft: OrreryResolutionDraft,
     *,
+    resolution_id: int,
     actor_entity_id: Optional[int],
     target_entity_id: Optional[int],
     source_chunk_id: int,
     need_tuning: NeedTuning,
+    project_policy: ProjectPolicy,
 ) -> int:
     if not draft.state_delta:
         return 0
@@ -1580,6 +1662,12 @@ async def _apply_state_delta_async(
         raise ValueError(f"Orrery draft {draft.template_id} has no actor binding")
 
     tag_mutations = 0
+    project_keys = [key for key in draft.state_delta if key.startswith("project.")]
+    if len(project_keys) > 1:
+        raise ValueError(
+            f"Orrery draft {draft.template_id} carries multiple project "
+            f"transitions: {sorted(project_keys)}"
+        )
     if "character.current_activity" in draft.state_delta:
         status = await conn.execute(
             "UPDATE characters SET current_activity = $1 WHERE entity_id = $2",
@@ -1689,6 +1777,57 @@ async def _apply_state_delta_async(
             template_id=draft.template_id,
             source_chunk_id=source_chunk_id,
             need_tuning=need_tuning,
+        )
+    project_applied: Optional[dict[str, Any]] = None
+    if "project.start" in draft.state_delta:
+        project_applied = await _apply_project_start_async(
+            conn,
+            actor_entity_id=actor_entity_id,
+            payload=draft.state_delta["project.start"],
+            source_chunk_id=source_chunk_id,
+            policy=project_policy,
+        )
+    if "project.advance" in draft.state_delta:
+        project_applied = await _apply_project_advance_async(
+            conn,
+            actor_entity_id=actor_entity_id,
+            payload=draft.state_delta["project.advance"],
+            source_chunk_id=source_chunk_id,
+            policy=project_policy,
+        )
+    if "project.stall" in draft.state_delta:
+        project_applied = await _apply_project_stall_async(
+            conn,
+            actor_entity_id=actor_entity_id,
+            payload=draft.state_delta["project.stall"],
+            source_chunk_id=source_chunk_id,
+            policy=project_policy,
+        )
+    if "project.abandon" in draft.state_delta:
+        project_applied = await _apply_project_abandon_async(
+            conn,
+            actor_entity_id=actor_entity_id,
+            payload=draft.state_delta["project.abandon"],
+            source_chunk_id=source_chunk_id,
+            policy=project_policy,
+        )
+    if "project.complete" in draft.state_delta:
+        project_applied = await _apply_project_complete_async(
+            conn,
+            actor_entity_id=actor_entity_id,
+            payload=draft.state_delta["project.complete"],
+            source_chunk_id=source_chunk_id,
+            policy=project_policy,
+        )
+    if project_keys:
+        if project_applied is None:
+            raise AssertionError("project transition produced no applied ledger values")
+        await _update_resolution_project_applied_async(
+            conn,
+            resolution_id=resolution_id,
+            state_delta=draft.state_delta,
+            project_key=project_keys[0],
+            applied=project_applied,
         )
     if "travel.start" in draft.state_delta:
         await _apply_travel_start_async(
@@ -1858,6 +1997,662 @@ async def _apply_need_fulfillment_async(
         template_id=template_id,
         source_chunk_id=source_chunk_id,
         need_tuning=need_tuning,
+    )
+
+
+PROJECT_OPEN_STATUSES = ("active", "paused", "stalled")
+PROJECT_STAGES = frozenset({"saving", "scouting", "committing"})
+
+
+def _coerce_project_payload(raw: Any) -> dict[str, Any]:
+    """Normalize one typed project transition payload."""
+
+    if raw is True or raw is None:
+        return {}
+    if isinstance(raw, Mapping):
+        return dict(raw)
+    raise ValueError("project state_delta values must be mappings or true")
+
+
+def _require_project_policy(policy: ProjectPolicy) -> None:
+    if not policy.enabled:
+        raise ValueError(
+            "project state_delta requires configured [orrery.projects] settings"
+        )
+
+
+def _project_next_eligible(world_time: Any, policy: ProjectPolicy) -> Any:
+    return world_time + timedelta(hours=policy.advance_interval_hours)
+
+
+def _project_applied_snapshot(
+    *,
+    project_type: str,
+    status: str,
+    stage: str,
+    target_place_id: Optional[int],
+    progress: float,
+    stall_count: int,
+    next_eligible_at_world_time: Any,
+    source_chunk_id: int,
+) -> dict[str, Any]:
+    """Return the exact project projection values persisted by one transition."""
+
+    return {
+        "project_type": project_type,
+        "status": status,
+        "stage": stage,
+        "target_place_id": target_place_id,
+        "progress": float(progress),
+        "stall_count": int(stall_count),
+        "next_eligible_at_world_time": (
+            next_eligible_at_world_time.isoformat()
+            if next_eligible_at_world_time is not None
+            else None
+        ),
+        "source_chunk_id": source_chunk_id,
+    }
+
+
+def _state_delta_with_project_applied(
+    state_delta: Mapping[str, Any], project_key: str, applied: Mapping[str, Any]
+) -> dict[str, Any]:
+    persisted = dict(state_delta)
+    payload = _coerce_project_payload(persisted[project_key])
+    payload["applied"] = dict(applied)
+    persisted[project_key] = payload
+    return persisted
+
+
+def _update_resolution_project_applied_sync(
+    cur: Any,
+    *,
+    resolution_id: int,
+    state_delta: Mapping[str, Any],
+    project_key: str,
+    applied: Mapping[str, Any],
+) -> None:
+    cur.execute(
+        "UPDATE orrery_resolutions SET state_delta = %s::jsonb WHERE id = %s",
+        (
+            json.dumps(
+                _state_delta_with_project_applied(state_delta, project_key, applied)
+            ),
+            resolution_id,
+        ),
+    )
+
+
+async def _update_resolution_project_applied_async(
+    conn: Any,
+    *,
+    resolution_id: int,
+    state_delta: Mapping[str, Any],
+    project_key: str,
+    applied: Mapping[str, Any],
+) -> None:
+    await conn.execute(
+        "UPDATE orrery_resolutions SET state_delta = $1::jsonb WHERE id = $2",
+        json.dumps(
+            _state_delta_with_project_applied(state_delta, project_key, applied)
+        ),
+        resolution_id,
+    )
+
+
+def _current_project_sync(cur: Any, actor_entity_id: int) -> Optional[dict[str, Any]]:
+    cur.execute(
+        """
+        SELECT id, project_type, status, stage, target_place_id,
+               progress, stall_count, next_eligible_at_world_time,
+               source_chunk_id
+        FROM character_project_states
+        WHERE character_entity_id = %s
+          AND status IN ('active', 'paused', 'stalled')
+        ORDER BY id
+        FOR UPDATE
+        """,
+        (actor_entity_id,),
+    )
+    rows = cur.fetchall()
+    if len(rows) > 1:
+        raise ValueError(
+            f"Character entity {actor_entity_id} has multiple open projects"
+        )
+    if not rows:
+        return None
+    row = rows[0]
+    names = (
+        "id",
+        "project_type",
+        "status",
+        "stage",
+        "target_place_id",
+        "progress",
+        "stall_count",
+        "next_eligible_at_world_time",
+        "source_chunk_id",
+    )
+    return {name: _row_get(row, name, index) for index, name in enumerate(names)}
+
+
+async def _current_project_async(
+    conn: Any, actor_entity_id: int
+) -> Optional[dict[str, Any]]:
+    rows = await conn.fetch(
+        """
+        SELECT id, project_type, status, stage, target_place_id,
+               progress, stall_count, next_eligible_at_world_time,
+               source_chunk_id
+        FROM character_project_states
+        WHERE character_entity_id = $1
+          AND status IN ('active', 'paused', 'stalled')
+        ORDER BY id
+        FOR UPDATE
+        """,
+        actor_entity_id,
+    )
+    if len(rows) > 1:
+        raise ValueError(
+            f"Character entity {actor_entity_id} has multiple open projects"
+        )
+    return dict(rows[0]) if rows else None
+
+
+def _require_open_relocation_project(
+    project: Optional[Mapping[str, Any]], actor_entity_id: int
+) -> Mapping[str, Any]:
+    if project is None:
+        raise ValueError(
+            f"Actor entity {actor_entity_id} has no open project to transition"
+        )
+    if project["project_type"] != "plan_relocation":
+        raise ValueError(
+            f"Actor entity {actor_entity_id} has unsupported project type "
+            f"{project['project_type']!r}"
+        )
+    return project
+
+
+def _apply_project_start_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    payload: Any,
+    source_chunk_id: int,
+    policy: ProjectPolicy,
+) -> dict[str, Any]:
+    _require_project_policy(policy)
+    data = _coerce_project_payload(payload)
+    project_type = str(data.get("project_type") or "plan_relocation")
+    stage = str(data.get("stage") or "saving")
+    if project_type != "plan_relocation":
+        raise ValueError(f"Unsupported project.start type {project_type!r}")
+    if stage not in PROJECT_STAGES:
+        raise ValueError(f"Unsupported project.start stage {stage!r}")
+    if _current_project_sync(cur, actor_entity_id) is not None:
+        raise ValueError(f"Actor entity {actor_entity_id} already has an open project")
+    world_time = _tick_world_time_sync(cur, source_chunk_id)
+    next_eligible = _project_next_eligible(world_time, policy)
+    target_place_id = data.get("target_place_id")
+    progress = float(data.get("progress", 0.0))
+    cur.execute(
+        """
+        INSERT INTO character_project_states (
+            character_entity_id, project_type, status, stage,
+            target_place_id, progress, stall_count,
+            next_eligible_at_world_time, source_chunk_id
+        ) VALUES (%s, %s, 'active', %s, %s, %s, 0, %s, %s)
+        """,
+        (
+            actor_entity_id,
+            project_type,
+            stage,
+            target_place_id,
+            progress,
+            next_eligible,
+            source_chunk_id,
+        ),
+    )
+    return _project_applied_snapshot(
+        project_type=project_type,
+        status="active",
+        stage=stage,
+        target_place_id=target_place_id,
+        progress=progress,
+        stall_count=0,
+        next_eligible_at_world_time=next_eligible,
+        source_chunk_id=source_chunk_id,
+    )
+
+
+async def _apply_project_start_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    payload: Any,
+    source_chunk_id: int,
+    policy: ProjectPolicy,
+) -> dict[str, Any]:
+    _require_project_policy(policy)
+    data = _coerce_project_payload(payload)
+    project_type = str(data.get("project_type") or "plan_relocation")
+    stage = str(data.get("stage") or "saving")
+    if project_type != "plan_relocation":
+        raise ValueError(f"Unsupported project.start type {project_type!r}")
+    if stage not in PROJECT_STAGES:
+        raise ValueError(f"Unsupported project.start stage {stage!r}")
+    if await _current_project_async(conn, actor_entity_id) is not None:
+        raise ValueError(f"Actor entity {actor_entity_id} already has an open project")
+    world_time = await _tick_world_time_async(conn, source_chunk_id)
+    next_eligible = _project_next_eligible(world_time, policy)
+    target_place_id = data.get("target_place_id")
+    progress = float(data.get("progress", 0.0))
+    await conn.execute(
+        """
+        INSERT INTO character_project_states (
+            character_entity_id, project_type, status, stage,
+            target_place_id, progress, stall_count,
+            next_eligible_at_world_time, source_chunk_id
+        ) VALUES ($1, $2, 'active', $3, $4, $5, 0, $6, $7)
+        """,
+        actor_entity_id,
+        project_type,
+        stage,
+        target_place_id,
+        progress,
+        next_eligible,
+        source_chunk_id,
+    )
+    return _project_applied_snapshot(
+        project_type=project_type,
+        status="active",
+        stage=stage,
+        target_place_id=target_place_id,
+        progress=progress,
+        stall_count=0,
+        next_eligible_at_world_time=next_eligible,
+        source_chunk_id=source_chunk_id,
+    )
+
+
+def _project_advance_values(
+    project: Mapping[str, Any], data: Mapping[str, Any]
+) -> tuple[str, Optional[int], float]:
+    stage = str(data.get("stage") or project["stage"])
+    if stage not in PROJECT_STAGES:
+        raise ValueError(f"Unsupported project.advance stage {stage!r}")
+    if data.get("select_target") and data.get("target_place_id") is None:
+        raise ValueError(
+            "project.advance select_target must persist target_place_id in state_delta"
+        )
+    target_place_id = data.get("target_place_id", project["target_place_id"])
+    if "set_progress" in data:
+        progress = float(data["set_progress"])
+    else:
+        progress = float(project["progress"] or 0.0) + float(
+            data.get("progress_delta", 0.25)
+        )
+    return stage, target_place_id, min(1.0, max(0.0, progress))
+
+
+def _apply_project_advance_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    payload: Any,
+    source_chunk_id: int,
+    policy: ProjectPolicy,
+) -> dict[str, Any]:
+    _require_project_policy(policy)
+    data = _coerce_project_payload(payload)
+    project = _require_open_relocation_project(
+        _current_project_sync(cur, actor_entity_id), actor_entity_id
+    )
+    stage, target_place_id, progress = _project_advance_values(project, data)
+    reached_milestone = bool(data.get("milestone")) and (
+        (project["stage"], stage)
+        in {("saving", "scouting"), ("scouting", "committing")}
+    )
+    stall_count = 0 if reached_milestone else int(project["stall_count"] or 0)
+    world_time = _tick_world_time_sync(cur, source_chunk_id)
+    next_eligible = _project_next_eligible(world_time, policy)
+    cur.execute(
+        """
+        UPDATE character_project_states
+        SET status = 'active', stage = %s, target_place_id = %s,
+            progress = %s, stall_count = %s,
+            next_eligible_at_world_time = %s, source_chunk_id = %s,
+            updated_at = now()
+        WHERE id = %s
+        """,
+        (
+            stage,
+            target_place_id,
+            progress,
+            stall_count,
+            next_eligible,
+            source_chunk_id,
+            project["id"],
+        ),
+    )
+    return _project_applied_snapshot(
+        project_type=str(project["project_type"]),
+        status="active",
+        stage=stage,
+        target_place_id=target_place_id,
+        progress=progress,
+        stall_count=stall_count,
+        next_eligible_at_world_time=next_eligible,
+        source_chunk_id=source_chunk_id,
+    )
+
+
+async def _apply_project_advance_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    payload: Any,
+    source_chunk_id: int,
+    policy: ProjectPolicy,
+) -> dict[str, Any]:
+    _require_project_policy(policy)
+    data = _coerce_project_payload(payload)
+    project = _require_open_relocation_project(
+        await _current_project_async(conn, actor_entity_id), actor_entity_id
+    )
+    stage, target_place_id, progress = _project_advance_values(project, data)
+    reached_milestone = bool(data.get("milestone")) and (
+        (project["stage"], stage)
+        in {("saving", "scouting"), ("scouting", "committing")}
+    )
+    stall_count = 0 if reached_milestone else int(project["stall_count"] or 0)
+    world_time = await _tick_world_time_async(conn, source_chunk_id)
+    next_eligible = _project_next_eligible(world_time, policy)
+    await conn.execute(
+        """
+        UPDATE character_project_states
+        SET status = 'active', stage = $1, target_place_id = $2,
+            progress = $3, stall_count = $4,
+            next_eligible_at_world_time = $5, source_chunk_id = $6,
+            updated_at = now()
+        WHERE id = $7
+        """,
+        stage,
+        target_place_id,
+        progress,
+        stall_count,
+        next_eligible,
+        source_chunk_id,
+        project["id"],
+    )
+    return _project_applied_snapshot(
+        project_type=str(project["project_type"]),
+        status="active",
+        stage=stage,
+        target_place_id=target_place_id,
+        progress=progress,
+        stall_count=stall_count,
+        next_eligible_at_world_time=next_eligible,
+        source_chunk_id=source_chunk_id,
+    )
+
+
+def _apply_project_stall_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    payload: Any,
+    source_chunk_id: int,
+    policy: ProjectPolicy,
+) -> dict[str, Any]:
+    _require_project_policy(policy)
+    data = _coerce_project_payload(payload)
+    project = _require_open_relocation_project(
+        _current_project_sync(cur, actor_entity_id), actor_entity_id
+    )
+    increment = int(data.get("increment", 1))
+    if increment < 1:
+        raise ValueError("project.stall increment must be >= 1")
+    stall_count = int(project["stall_count"] or 0) + increment
+    world_time = _tick_world_time_sync(cur, source_chunk_id)
+    next_eligible = _project_next_eligible(world_time, policy)
+    cur.execute(
+        """
+        UPDATE character_project_states
+        SET status = 'stalled', stall_count = stall_count + %s,
+            next_eligible_at_world_time = %s, source_chunk_id = %s,
+            updated_at = now()
+        WHERE id = %s
+        """,
+        (
+            increment,
+            next_eligible,
+            source_chunk_id,
+            project["id"],
+        ),
+    )
+    return _project_applied_snapshot(
+        project_type=str(project["project_type"]),
+        status="stalled",
+        stage=str(project["stage"]),
+        target_place_id=project["target_place_id"],
+        progress=float(project["progress"] or 0.0),
+        stall_count=stall_count,
+        next_eligible_at_world_time=next_eligible,
+        source_chunk_id=source_chunk_id,
+    )
+
+
+async def _apply_project_stall_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    payload: Any,
+    source_chunk_id: int,
+    policy: ProjectPolicy,
+) -> dict[str, Any]:
+    _require_project_policy(policy)
+    data = _coerce_project_payload(payload)
+    project = _require_open_relocation_project(
+        await _current_project_async(conn, actor_entity_id), actor_entity_id
+    )
+    increment = int(data.get("increment", 1))
+    if increment < 1:
+        raise ValueError("project.stall increment must be >= 1")
+    stall_count = int(project["stall_count"] or 0) + increment
+    world_time = await _tick_world_time_async(conn, source_chunk_id)
+    next_eligible = _project_next_eligible(world_time, policy)
+    await conn.execute(
+        """
+        UPDATE character_project_states
+        SET status = 'stalled', stall_count = stall_count + $1,
+            next_eligible_at_world_time = $2, source_chunk_id = $3,
+            updated_at = now()
+        WHERE id = $4
+        """,
+        increment,
+        next_eligible,
+        source_chunk_id,
+        project["id"],
+    )
+    return _project_applied_snapshot(
+        project_type=str(project["project_type"]),
+        status="stalled",
+        stage=str(project["stage"]),
+        target_place_id=project["target_place_id"],
+        progress=float(project["progress"] or 0.0),
+        stall_count=stall_count,
+        next_eligible_at_world_time=next_eligible,
+        source_chunk_id=source_chunk_id,
+    )
+
+
+def _apply_project_abandon_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    payload: Any,
+    source_chunk_id: int,
+    policy: ProjectPolicy,
+) -> dict[str, Any]:
+    _require_project_policy(policy)
+    _coerce_project_payload(payload)
+    project = _require_open_relocation_project(
+        _current_project_sync(cur, actor_entity_id), actor_entity_id
+    )
+    cur.execute(
+        """
+        UPDATE character_project_states
+        SET status = 'abandoned', next_eligible_at_world_time = NULL,
+            source_chunk_id = %s, updated_at = now()
+        WHERE id = %s
+        """,
+        (source_chunk_id, project["id"]),
+    )
+    return _project_applied_snapshot(
+        project_type=str(project["project_type"]),
+        status="abandoned",
+        stage=str(project["stage"]),
+        target_place_id=project["target_place_id"],
+        progress=float(project["progress"] or 0.0),
+        stall_count=int(project["stall_count"] or 0),
+        next_eligible_at_world_time=None,
+        source_chunk_id=source_chunk_id,
+    )
+
+
+async def _apply_project_abandon_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    payload: Any,
+    source_chunk_id: int,
+    policy: ProjectPolicy,
+) -> dict[str, Any]:
+    _require_project_policy(policy)
+    _coerce_project_payload(payload)
+    project = _require_open_relocation_project(
+        await _current_project_async(conn, actor_entity_id), actor_entity_id
+    )
+    await conn.execute(
+        """
+        UPDATE character_project_states
+        SET status = 'abandoned', next_eligible_at_world_time = NULL,
+            source_chunk_id = $1, updated_at = now()
+        WHERE id = $2
+        """,
+        source_chunk_id,
+        project["id"],
+    )
+    return _project_applied_snapshot(
+        project_type=str(project["project_type"]),
+        status="abandoned",
+        stage=str(project["stage"]),
+        target_place_id=project["target_place_id"],
+        progress=float(project["progress"] or 0.0),
+        stall_count=int(project["stall_count"] or 0),
+        next_eligible_at_world_time=None,
+        source_chunk_id=source_chunk_id,
+    )
+
+
+def _project_completion_travel_payload(
+    project: Mapping[str, Any], payload: Any
+) -> dict[str, Any]:
+    data = _coerce_project_payload(payload)
+    if project["stage"] != "committing":
+        raise ValueError("project.complete requires the committing stage")
+    if float(project["progress"] or 0.0) < 1.0:
+        raise ValueError("project.complete requires full committing progress")
+    target_place_id = project["target_place_id"]
+    if target_place_id is None:
+        raise ValueError("project.complete requires target_place_id")
+    travel = {
+        key: value for key, value in data.items() if key not in {"milestone", "reason"}
+    }
+    travel["destination_place_id"] = target_place_id
+    return travel
+
+
+def _apply_project_complete_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    payload: Any,
+    source_chunk_id: int,
+    policy: ProjectPolicy,
+) -> dict[str, Any]:
+    _require_project_policy(policy)
+    project = _require_open_relocation_project(
+        _current_project_sync(cur, actor_entity_id), actor_entity_id
+    )
+    travel_payload = _project_completion_travel_payload(project, payload)
+    cur.execute(
+        """
+        UPDATE character_project_states
+        SET status = 'completed', next_eligible_at_world_time = NULL,
+            source_chunk_id = %s, updated_at = now()
+        WHERE id = %s
+        """,
+        (source_chunk_id, project["id"]),
+    )
+    _apply_travel_start_sync(
+        cur,
+        actor_entity_id=actor_entity_id,
+        payload=travel_payload,
+        source_chunk_id=source_chunk_id,
+    )
+    return _project_applied_snapshot(
+        project_type=str(project["project_type"]),
+        status="completed",
+        stage=str(project["stage"]),
+        target_place_id=project["target_place_id"],
+        progress=float(project["progress"] or 0.0),
+        stall_count=int(project["stall_count"] or 0),
+        next_eligible_at_world_time=None,
+        source_chunk_id=source_chunk_id,
+    )
+
+
+async def _apply_project_complete_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    payload: Any,
+    source_chunk_id: int,
+    policy: ProjectPolicy,
+) -> dict[str, Any]:
+    _require_project_policy(policy)
+    project = _require_open_relocation_project(
+        await _current_project_async(conn, actor_entity_id), actor_entity_id
+    )
+    travel_payload = _project_completion_travel_payload(project, payload)
+    await conn.execute(
+        """
+        UPDATE character_project_states
+        SET status = 'completed', next_eligible_at_world_time = NULL,
+            source_chunk_id = $1, updated_at = now()
+        WHERE id = $2
+        """,
+        source_chunk_id,
+        project["id"],
+    )
+    await _apply_travel_start_async(
+        conn,
+        actor_entity_id=actor_entity_id,
+        payload=travel_payload,
+        source_chunk_id=source_chunk_id,
+    )
+    return _project_applied_snapshot(
+        project_type=str(project["project_type"]),
+        status="completed",
+        stage=str(project["stage"]),
+        target_place_id=project["target_place_id"],
+        progress=float(project["progress"] or 0.0),
+        stall_count=int(project["stall_count"] or 0),
+        next_eligible_at_world_time=None,
+        source_chunk_id=source_chunk_id,
     )
 
 

--- a/nexus/agents/orrery/evidence.py
+++ b/nexus/agents/orrery/evidence.py
@@ -71,6 +71,7 @@ from nexus.agents.orrery.substrate import (
     _routine_schedule_due,
     _trust_values_are_asymmetric,
     project_due,
+    project_overdue_hours,
 )
 
 
@@ -1494,10 +1495,8 @@ def _project_due(
         and project.next_eligible_at_world_time is not None
         and state.world_time is not None
     ):
-        overdue_hours = max(
-            0.0,
-            (state.world_time - project.next_eligible_at_world_time).total_seconds()
-            / 3600.0,
+        overdue_hours = project_overdue_hours(
+            state.world_time, project.next_eligible_at_world_time
         )
     condition = project_due(
         mode,

--- a/nexus/agents/orrery/evidence.py
+++ b/nexus/agents/orrery/evidence.py
@@ -70,6 +70,7 @@ from nexus.agents.orrery.substrate import (
     _routine_anchor_destination_available,
     _routine_schedule_due,
     _trust_values_are_asymmetric,
+    project_due,
 )
 
 
@@ -1470,6 +1471,60 @@ def _since_last_event_at_least(
             "elapsed_ticks": elapsed,
         },
         result=result,
+    )
+
+
+@_resolver("project_due")
+def _project_due(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict[str, Any]:
+    project_type = match["project"]
+    mode = match["mode"]
+    slot = match["slot"]
+    entity_id = _entity(bindings, slot)
+    project = state.project_states.get(entity_id) if entity_id is not None else None
+    project_payload = asdict(project) if project is not None else None
+    if project_payload is not None:
+        next_eligible = project_payload.get("next_eligible_at_world_time")
+        if next_eligible is not None:
+            project_payload["next_eligible_at_world_time"] = next_eligible.isoformat()
+    overdue_hours: Optional[float] = None
+    if (
+        project is not None
+        and project.next_eligible_at_world_time is not None
+        and state.world_time is not None
+    ):
+        overdue_hours = max(
+            0.0,
+            (state.world_time - project.next_eligible_at_world_time).total_seconds()
+            / 3600.0,
+        )
+    condition = project_due(
+        mode,
+        project_type=project_type,
+        slot=Slot(slot),
+    )
+    return _evidence(
+        "project_due",
+        params={
+            "project_type": project_type,
+            "mode": mode,
+            "slot": slot,
+        },
+        entities={slot: entity_id},
+        observed={
+            "world_time": (
+                state.world_time.isoformat() if state.world_time is not None else None
+            ),
+            "project": project_payload,
+            "overdue_hours": overdue_hours,
+            "advance_interval_hours": (state.project_policy.advance_interval_hours),
+            "stall_abandon_threshold": (state.project_policy.stall_abandon_threshold),
+            "abandon_after_stalled_world_hours": (
+                state.project_policy.abandon_after_stalled_world_hours
+            ),
+        },
+        result=condition(state, bindings),
     )
 
 

--- a/nexus/agents/orrery/explain.py
+++ b/nexus/agents/orrery/explain.py
@@ -94,6 +94,7 @@ class BranchTrace:
 
     label: str
     magnitude: float
+    promotable: bool
     considered: bool
     result: bool
     selected: bool
@@ -103,6 +104,7 @@ class BranchTrace:
         return {
             "label": self.label,
             "magnitude": self.magnitude,
+            "promotable": self.promotable,
             "considered": self.considered,
             "result": self.result,
             "selected": self.selected,
@@ -126,6 +128,7 @@ class TemplateExplanation:
     chosen_branch: Optional[str]
     branches: Tuple[BranchTrace, ...]
     magnitude: float
+    promotable: bool
     event_type: Optional[str]
     signal_event_type: Optional[str]
     narrative_stub: Optional[str]
@@ -151,6 +154,7 @@ class TemplateExplanation:
             "chosen_branch": self.chosen_branch,
             "branches": [branch.to_dict() for branch in self.branches],
             "magnitude": self.magnitude if self.fired else None,
+            "promotable": self.promotable if self.fired else None,
             "event_type": self.event_type if self.fired else None,
             "signal_event_type": self.signal_event_type if self.fired else None,
             "narrative_stub": self.narrative_stub,
@@ -281,6 +285,7 @@ def explain_template(
                     BranchTrace(
                         label=branch.label,
                         magnitude=branch.magnitude,
+                        promotable=branch.promotable,
                         considered=False,
                         result=False,
                         selected=False,
@@ -294,6 +299,7 @@ def explain_template(
                 BranchTrace(
                     label=branch.label,
                     magnitude=branch.magnitude,
+                    promotable=branch.promotable,
                     considered=True,
                     result=passes,
                     selected=chosen is not None and branch.label == chosen.label,
@@ -327,6 +333,7 @@ def explain_template(
         chosen_branch=chosen_branch,
         branches=tuple(branch_traces),
         magnitude=truth.magnitude,
+        promotable=truth.promotable,
         event_type=truth.event_type,
         signal_event_type=truth.signal_event_type,
         narrative_stub=truth.narrative_stub,

--- a/nexus/agents/orrery/reconstruction.py
+++ b/nexus/agents/orrery/reconstruction.py
@@ -59,6 +59,10 @@ CHECKPOINT_SECTIONS: dict[str, str] = {
         "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
         "FROM character_travel_states t"
     ),
+    "character_project_states": (
+        "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
+        "FROM character_project_states t"
+    ),
     "character_routine_anchors": (
         "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
         "FROM character_routine_anchors t"

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -32,6 +32,10 @@ produces. Sections and their replay sources:
 - ``character_travel_states`` — forward for explicit payloads;
   ``travel.start`` resolves destinations and routes from live state at
   commit time, so windows containing travel deltas are approximate.
+- ``character_project_states`` — forward from the five ``project.*``
+  transitions. Every transition carries the exact applied project projection,
+  so cadence and applier-derived values are independent of current tuning;
+  project.complete also replays its explicit-destination travel.start handoff.
 - ``character_routine_anchors`` — checkpoint pass-through (no runtime
   writer; offline seed scripts mutate it invisibly between checkpoints).
 
@@ -66,6 +70,7 @@ from nexus.agents.orrery.needs import (
     severity_tags_for_need,
 )
 from nexus.agents.orrery.reconstruction import CHECKPOINT_SECTIONS
+from nexus.agents.orrery.substrate import ProjectPolicy, coerce_project_policy
 
 # Composite natural keys, verbatim column order (faction_relationships
 # enforces faction1_id < faction2_id; character_relationships only c1 <> c2
@@ -81,6 +86,7 @@ RELATIONSHIP_KEY_COLUMNS: dict[str, tuple[str, ...]] = {
 VOLATILE_COLUMNS: dict[str, frozenset[str]] = {
     "character_need_states": frozenset({"created_at", "updated_at"}),
     "character_travel_states": frozenset({"created_at", "updated_at"}),
+    "character_project_states": frozenset({"id", "created_at", "updated_at"}),
 }
 
 SKALD_SCALAR_FIELDS = frozenset(
@@ -114,6 +120,11 @@ REPLAYED_DELTA_KEYS = frozenset(
         "travel.advance",
         "travel.delay",
         "travel.arrive",
+        "project.start",
+        "project.advance",
+        "project.stall",
+        "project.abandon",
+        "project.complete",
     }
 )
 
@@ -277,6 +288,23 @@ def _coerce_travel_payload(raw: Any) -> dict[str, Any]:
     raise ValueError(f"travel payload must be a mapping, null, or true, got {raw!r}")
 
 
+def _coerce_project_payload(raw: Any) -> dict[str, Any]:
+    if raw is None or raw is True:
+        return {}
+    if isinstance(raw, dict):
+        return dict(raw)
+    raise ValueError(f"project payload must be a mapping, null, or true, got {raw!r}")
+
+
+def _load_project_policy() -> ProjectPolicy:
+    from nexus.config import load_settings
+
+    settings = load_settings()
+    if settings.orrery is None:
+        raise ValueError("Replay of project deltas requires [orrery.projects]")
+    return coerce_project_policy(settings.orrery.projects)
+
+
 class _Replayer:
     """Single-use forward/backward replay over one (checkpoint, N] window."""
 
@@ -285,6 +313,8 @@ class _Replayer:
         self.target_chunk_id = target_chunk_id
         self.target_created_at = _fetch_chunk_created_at(cur, target_chunk_id)
         self.need_tuning = load_need_tuning()
+        self.project_policy = _load_project_policy()
+        self.missing_base_sections: set[str] = set()
 
     # -- base checkpoint ---------------------------------------------------
 
@@ -326,10 +356,16 @@ class _Replayer:
                 f"base for reconstruction at chunk {self.target_chunk_id}"
             )
         missing = set(CHECKPOINT_SECTIONS) - set(state)
-        if missing:
+        allowed_missing = {"character_project_states"}
+        unexpected_missing = missing - allowed_missing
+        if unexpected_missing:
             raise ValueError(
-                f"Checkpoint {checkpoint_id} lacks sections {sorted(missing)}"
+                f"Checkpoint {checkpoint_id} lacks sections "
+                f"{sorted(unexpected_missing)}"
             )
+        if "character_project_states" in missing:
+            state["character_project_states"] = []
+            self.missing_base_sections.add("character_project_states")
         return checkpoint_id, chunk_id, created_at, state
 
     # -- forward scalar replay ----------------------------------------------
@@ -344,6 +380,14 @@ class _Replayer:
             base_checkpoint_chunk_id=base_chunk,
             state={},
         )
+        if "character_project_states" in self.missing_base_sections:
+            result.add_note(
+                "character_project_states",
+                "base checkpoint predates migration 074 and lacks the project "
+                "section; treated as empty because no project table/writer "
+                "existed at that checkpoint",
+                approximate=True,
+            )
 
         characters = {row["id"]: dict(row) for row in base_state["characters"]}
         places = {row["id"]: dict(row) for row in base_state["places"]}
@@ -355,6 +399,9 @@ class _Replayer:
             row["character_entity_id"]: dict(row)
             for row in base_state["character_travel_states"]
         }
+        projects: dict[Any, dict[str, Any]] = {
+            row["id"]: dict(row) for row in base_state["character_project_states"]
+        }
 
         born_entities = self._seed_window_births(characters, places, result)
 
@@ -362,7 +409,7 @@ class _Replayer:
             for chunk_id in self._window_chunks(base_chunk):
                 self._apply_skald_rows(chunk_id, characters, places, result)
                 self._apply_orrery_resolutions(
-                    chunk_id, characters, needs, travel, result
+                    chunk_id, characters, needs, travel, projects, result
                 )
 
         tag_workings, tag_touched_entities = self._replay_tags(
@@ -388,6 +435,14 @@ class _Replayer:
         result.state["character_travel_states"] = [
             travel[key] for key in sorted(travel)
         ]
+        result.state["character_project_states"] = sorted(
+            projects.values(),
+            key=lambda row: (
+                row["character_entity_id"],
+                row.get("source_chunk_id") or -1,
+                row.get("id") or -1,
+            ),
+        )
         result.state["character_routine_anchors"] = sorted(
             (dict(row) for row in base_state["character_routine_anchors"]),
             key=lambda r: r["id"],
@@ -521,6 +576,7 @@ class _Replayer:
         characters: dict[int, dict[str, Any]],
         needs: dict[tuple[int, str], dict[str, Any]],
         travel: dict[int, dict[str, Any]],
+        projects: dict[Any, dict[str, Any]],
         result: ReplayResult,
     ) -> None:
         self.cur.execute(
@@ -565,6 +621,25 @@ class _Replayer:
                     needs,
                     result,
                 )
+            for project_key in (
+                "project.start",
+                "project.advance",
+                "project.stall",
+                "project.abandon",
+                "project.complete",
+            ):
+                if project_key in delta:
+                    self._replay_project(
+                        project_key,
+                        chunk_id,
+                        actor_entity_id,
+                        delta[project_key],
+                        world_time,
+                        projects,
+                        travel,
+                        by_entity,
+                        result,
+                    )
             for travel_key in (
                 "travel.start",
                 "travel.advance",
@@ -582,6 +657,163 @@ class _Replayer:
                         by_entity,
                         result,
                     )
+
+    def _open_project(
+        self,
+        projects: dict[Any, dict[str, Any]],
+        actor_entity_id: int,
+    ) -> tuple[Any, dict[str, Any]]:
+        matches = [
+            (key, row)
+            for key, row in projects.items()
+            if row["character_entity_id"] == actor_entity_id
+            and row["status"] in {"active", "paused", "stalled"}
+        ]
+        if len(matches) != 1:
+            raise ValueError(
+                f"Actor {actor_entity_id} has {len(matches)} open projects "
+                "in replay working state"
+            )
+        key, row = matches[0]
+        if row["project_type"] != "plan_relocation":
+            raise ValueError(
+                f"Actor {actor_entity_id} has unsupported replay project "
+                f"type {row['project_type']!r}"
+            )
+        return key, row
+
+    def _replay_project(
+        self,
+        delta_key: str,
+        chunk_id: int,
+        actor_entity_id: int,
+        raw_payload: Any,
+        world_time: Optional[datetime],
+        projects: dict[Any, dict[str, Any]],
+        travel: dict[int, dict[str, Any]],
+        characters_by_entity: dict[int, dict[str, Any]],
+        result: ReplayResult,
+    ) -> None:
+        """Forward one project transition and its completion handoff."""
+
+        payload = _coerce_project_payload(raw_payload)
+        applied = payload.get("applied")
+        if not isinstance(applied, dict):
+            raise ValueError(
+                f"{delta_key} at chunk {chunk_id} is missing its required "
+                "applied project projection"
+            )
+        required_applied = {
+            "project_type",
+            "status",
+            "stage",
+            "target_place_id",
+            "progress",
+            "stall_count",
+            "next_eligible_at_world_time",
+            "source_chunk_id",
+        }
+        missing_applied = required_applied - set(applied)
+        if missing_applied:
+            raise ValueError(
+                f"{delta_key} at chunk {chunk_id} has incomplete applied project "
+                f"projection: missing {sorted(missing_applied)}"
+            )
+        project_type = str(applied["project_type"])
+        stage = str(applied["stage"])
+        if project_type != "plan_relocation":
+            raise ValueError(f"Unsupported replay project type {project_type!r}")
+        if stage not in {"saving", "scouting", "committing"}:
+            raise ValueError(f"Unsupported replay project stage {stage!r}")
+        expected_status = {
+            "project.start": "active",
+            "project.advance": "active",
+            "project.stall": "stalled",
+            "project.abandon": "abandoned",
+            "project.complete": "completed",
+        }[delta_key]
+        if applied["status"] != expected_status:
+            raise ValueError(
+                f"{delta_key} at chunk {chunk_id} applied status must be "
+                f"{expected_status!r}, got {applied['status']!r}"
+            )
+
+        applied_row = {
+            "project_type": project_type,
+            "status": expected_status,
+            "stage": stage,
+            "target_place_id": applied["target_place_id"],
+            "progress": _pg_round(float(applied["progress"]), 4),
+            "stall_count": int(applied["stall_count"]),
+            "next_eligible_at_world_time": applied["next_eligible_at_world_time"],
+            "source_chunk_id": int(applied["source_chunk_id"]),
+        }
+        if applied_row["source_chunk_id"] != chunk_id:
+            raise ValueError(
+                f"{delta_key} at chunk {chunk_id} applied source_chunk_id is "
+                f"{applied_row['source_chunk_id']}"
+            )
+        if delta_key == "project.start":
+            if any(
+                row["character_entity_id"] == actor_entity_id
+                and row["status"] in {"active", "paused", "stalled"}
+                for row in projects.values()
+            ):
+                raise ValueError(
+                    f"project.start at chunk {chunk_id} for actor "
+                    f"{actor_entity_id} already holding an open project"
+                )
+            projects[("new", chunk_id, actor_entity_id)] = {
+                "id": None,
+                "character_entity_id": actor_entity_id,
+                **applied_row,
+            }
+            return
+
+        _project_key, row = self._open_project(projects, actor_entity_id)
+        if row["project_type"] != project_type:
+            raise ValueError(
+                f"{delta_key} at chunk {chunk_id} changes project type from "
+                f"{row['project_type']!r} to {project_type!r}"
+            )
+        if delta_key == "project.advance":
+            row.update(applied_row)
+            return
+        if delta_key == "project.stall":
+            row.update(applied_row)
+            return
+        if delta_key == "project.abandon":
+            row.update(applied_row)
+            return
+        if delta_key == "project.complete":
+            if applied_row["stage"] != "committing":
+                raise ValueError("project.complete replay requires committing stage")
+            if float(applied_row["progress"] or 0.0) < 1.0:
+                raise ValueError("project.complete replay requires full progress")
+            destination = applied_row["target_place_id"]
+            if destination is None:
+                raise ValueError(
+                    "project.complete replay requires project target_place_id"
+                )
+            row.update(applied_row)
+            travel_payload = {
+                key: value
+                for key, value in payload.items()
+                if key not in {"applied", "milestone", "reason"}
+            }
+            travel_payload["destination_place_id"] = destination
+            self._replay_travel(
+                "travel.start",
+                chunk_id,
+                actor_entity_id,
+                travel_payload,
+                world_time,
+                travel,
+                characters_by_entity,
+                result,
+            )
+            return
+        raise AssertionError(f"Unhandled project replay key {delta_key!r}")
 
     def _replay_need_fulfill(
         self,
@@ -1293,12 +1525,19 @@ def _section_key_fn(section: str) -> Any:
         return lambda row: f"{row['character_entity_id']}:{row['need_type']}"
     if section == "character_travel_states":
         return lambda row: row["character_entity_id"]
+    if section == "character_project_states":
+        return lambda row: (
+            f"{row['character_entity_id']}:{row['project_type']}:"
+            f"{row.get('source_chunk_id')}"
+        )
     return lambda row: row["id"]
 
 
 def _load_checkpoint_state(cur: Any, checkpoint_id: int) -> dict[str, Any]:
     cur.execute("SELECT state FROM state_checkpoints WHERE id = %s", (checkpoint_id,))
-    return _as_document(_row_value(cur.fetchone(), 0))
+    state = _as_document(_row_value(cur.fetchone(), 0))
+    state.setdefault("character_project_states", [])
+    return state
 
 
 def verify_checkpoints_sync(cur: Any) -> list[CheckpointPairVerdict]:

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -16,9 +16,13 @@ from nexus.agents.orrery.reciprocal import (
 )
 from nexus.agents.orrery.substrate import (
     PackageSelection,
+    ProjectPolicy,
+    ProjectState,
     coerce_branch_selection,
     coerce_habituation,
     coerce_package_selection,
+    coerce_project_policy,
+    configure_project_magnitudes,
     Bindings,
     EventRecord,
     INTIMACY_SUPPRESSOR_TAGS,
@@ -75,6 +79,7 @@ class OrreryResolutionDraft:
     signal_event_type: Optional[str] = None
     changed_fields: Tuple[str, ...] = ()
     magnitude: float = 0.0
+    promotable: bool = True
     # Slot name -> entity display name. Skald adjudicates these proposals;
     # without names it cannot tell WHO an off-screen resolution is about and
     # may misattribute it to an on-screen character (M9 gate finding).
@@ -103,6 +108,7 @@ class OrreryResolutionDraft:
             "signal_event_type": self.signal_event_type,
             "changed_fields": list(self.changed_fields),
             "magnitude": self.magnitude,
+            "promotable": self.promotable,
         }
 
     @classmethod
@@ -134,6 +140,7 @@ class OrreryResolutionDraft:
             signal_event_type=data.get("signal_event_type"),
             changed_fields=tuple(data.get("changed_fields") or ()),
             magnitude=float(data.get("magnitude") or 0.0),
+            promotable=bool(data.get("promotable", True)),
             binding_names=dict(data.get("binding_names") or {}),
         )
 
@@ -259,6 +266,7 @@ def hydrate_world_state(
     need_tuning: Optional[NeedTuning] = None,
     world_time_override: Optional[datetime] = None,
     win_history_window: int = 0,
+    project_settings: Optional[Any] = None,
 ) -> WorldState:
     """Hydrate the read-side Orrery state snapshot from database tables.
 
@@ -268,6 +276,7 @@ def hydrate_world_state(
     """
 
     need_tuning = coerce_need_tuning(need_tuning)
+    project_policy = coerce_project_policy(project_settings)
 
     tags: dict[int, set[str]] = {}
     ephemeral_tags: dict[int, set[str]] = {}
@@ -441,6 +450,7 @@ def hydrate_world_state(
         anchor_chunk_id=anchor_chunk_id,
     )
     travel_states = _load_travel_states(session)
+    project_states = _load_project_states(session) if project_policy.enabled else {}
     routine_anchors = _load_routine_anchors(session)
     win_history = _load_win_history(
         session,
@@ -475,6 +485,8 @@ def hydrate_world_state(
         location_zones=location_zones,
         need_debt_scores=need_debt_scores,
         travel_states=travel_states,
+        project_states=project_states,
+        project_policy=project_policy,
         routine_anchors=routine_anchors,
         recent_events=recent_events,
         win_history=win_history,
@@ -597,6 +609,51 @@ def _load_travel_states(session: Any) -> dict[int, TravelState]:
                 else None
             ),
             route_purpose=row.get("route_purpose"),
+        )
+    return states
+
+
+def _load_project_states(session: Any) -> dict[int, ProjectState]:
+    """Load the one budgeted open project projection per active character."""
+
+    states: dict[int, ProjectState] = {}
+    for row in session.execute(
+        text(
+            """
+            /* orrery:project_states */
+            SELECT cps.id,
+                   cps.character_entity_id,
+                   cps.project_type,
+                   cps.status,
+                   cps.stage,
+                   cps.target_place_id,
+                   cps.progress,
+                   cps.stall_count,
+                   cps.next_eligible_at_world_time,
+                   cps.source_chunk_id
+            FROM character_project_states cps
+            JOIN entities e
+              ON e.id = cps.character_entity_id
+             AND e.kind = 'character'
+             AND e.is_active = true
+            WHERE cps.status IN ('active', 'paused', 'stalled')
+            ORDER BY cps.id
+            """
+        )
+    ).mappings():
+        entity_id = int(row["character_entity_id"])
+        if entity_id in states:
+            raise ValueError(f"Character entity {entity_id} has multiple open projects")
+        states[entity_id] = ProjectState(
+            id=int(row["id"]),
+            project_type=str(row["project_type"]),
+            status=str(row["status"]),
+            stage=str(row["stage"]),
+            target_place_id=row.get("target_place_id"),
+            progress=float(row["progress"] or 0.0),
+            stall_count=int(row["stall_count"] or 0),
+            next_eligible_at_world_time=row.get("next_eligible_at_world_time"),
+            source_chunk_id=row.get("source_chunk_id"),
         )
     return states
 
@@ -933,6 +990,7 @@ def resolve_dry_run(
     selection_settings: Optional[Any] = None,
     habituation_settings: Optional[Any] = None,
     package_selection_settings: Optional[Any] = None,
+    project_settings: Optional[Any] = None,
     fanout_settings: Optional[Any] = None,
 ) -> OrreryTickProposal:
     """Hydrate, bind, and evaluate Orrery packages without database writes."""
@@ -943,6 +1001,7 @@ def resolve_dry_run(
     package_selection: Optional[PackageSelection] = coerce_package_selection(
         package_selection_settings
     )
+    project_policy: ProjectPolicy = coerce_project_policy(project_settings)
     fanout = _coerce_fanout(fanout_settings)
     state = hydrate_world_state(
         session,
@@ -951,9 +1010,10 @@ def resolve_dry_run(
         need_tuning=need_tuning,
         world_time_override=world_time_override,
         win_history_window=habituation.window_ticks if habituation.enabled else 0,
+        project_settings=project_settings,
     )
 
-    templates_list = list(templates)
+    templates_list = list(configure_project_magnitudes(templates, project_policy))
     actor_only_templates = [
         t for t in templates_list if t.required_slots == _ACTOR_ONLY_SLOTS
     ]
@@ -992,7 +1052,7 @@ def resolve_dry_run(
             package_selection,
         )
         if resolution is not None and resolution.passes:
-            drafts.append(_draft_from_resolution(resolution))
+            drafts.append(_draft_from_resolution(resolution, state=state))
 
     actor_target_bindings: Tuple[Bindings, ...] = ()
     present_target_bindings: Tuple[Bindings, ...] = ()
@@ -1014,7 +1074,7 @@ def resolve_dry_run(
                 package_selection,
             )
             if resolution is not None and resolution.passes:
-                drafts.append(_draft_from_resolution(resolution))
+                drafts.append(_draft_from_resolution(resolution, state=state))
 
         pressure_templates = [
             template
@@ -1277,7 +1337,77 @@ def _classify_weather(raw_weather: str) -> str:
     return "clear"
 
 
-def _draft_from_resolution(resolution: Resolution) -> OrreryResolutionDraft:
+def _project_destination(
+    state: WorldState,
+    *,
+    actor_entity_id: int,
+    location_classes: Iterable[str],
+) -> int:
+    """Choose the same-zone-first deterministic project destination."""
+
+    current_place_id = state.locations.get(actor_entity_id)
+    if current_place_id is None:
+        raise ValueError(
+            f"Project actor {actor_entity_id} has no current place for scouting"
+        )
+    candidates: set[int] = set()
+    requested = frozenset(str(value) for value in location_classes)
+    for place_id, classes in state.location_classes.items():
+        if place_id != current_place_id and requested.intersection(classes):
+            candidates.add(place_id)
+    for place_id, location_class in state.location_class.items():
+        if place_id != current_place_id and location_class in requested:
+            candidates.add(place_id)
+    if not candidates:
+        raise ValueError(
+            f"Project actor {actor_entity_id} has no destination in classes "
+            f"{sorted(requested)}"
+        )
+    origin_zone = state.location_zones.get(current_place_id)
+    return min(
+        candidates,
+        key=lambda place_id: (
+            (
+                0
+                if origin_zone is not None
+                and state.location_zones.get(place_id) == origin_zone
+                else 1
+            ),
+            place_id,
+        ),
+    )
+
+
+def _materialize_project_delta(
+    resolution: Resolution, state: WorldState
+) -> Mapping[str, Any]:
+    """Persist any scouting choice into the resolution ledger before commit."""
+
+    delta = dict(resolution.state_delta)
+    raw_advance = delta.get("project.advance")
+    if not isinstance(raw_advance, Mapping) or not raw_advance.get("select_target"):
+        return delta
+    actor = resolution.bindings.get(Slot.ACTOR)
+    if not isinstance(actor, int):
+        raise ValueError("project.advance target selection requires actor binding")
+    classes = raw_advance.get("destination_place_classes")
+    if not isinstance(classes, (list, tuple)) or not classes:
+        raise ValueError(
+            "project.advance select_target requires destination_place_classes"
+        )
+    payload = dict(raw_advance)
+    payload["target_place_id"] = _project_destination(
+        state,
+        actor_entity_id=actor,
+        location_classes=classes,
+    )
+    delta["project.advance"] = payload
+    return delta
+
+
+def _draft_from_resolution(
+    resolution: Resolution, *, state: Optional[WorldState] = None
+) -> OrreryResolutionDraft:
     if resolution.branch_label is None or resolution.narrative_stub is None:
         raise RuntimeError(
             f"Orrery resolution {resolution.template_id!r} passed gate but lacks "
@@ -1293,11 +1423,16 @@ def _draft_from_resolution(resolution: Resolution) -> OrreryResolutionDraft:
         },
         branch_label=resolution.branch_label,
         narrative_stub=resolution.narrative_stub,
-        state_delta=resolution.state_delta,
+        state_delta=(
+            _materialize_project_delta(resolution, state)
+            if state is not None
+            else resolution.state_delta
+        ),
         event_type=resolution.event_type,
         signal_event_type=resolution.signal_event_type,
         changed_fields=resolution.changed_fields,
         magnitude=resolution.magnitude,
+        promotable=resolution.promotable,
     )
 
 

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -1093,6 +1093,17 @@ def is_in_transit(slot: Slot = Slot.ACTOR) -> Condition:
     return _named(_condition, f"is_in_transit(@{slot.value})")
 
 
+def project_overdue_hours(world_time: Any, next_eligible_at_world_time: Any) -> float:
+    """Shared overdue computation for the project_due predicate AND the
+    explain/coverage evidence display — one formula so the dashboard can
+    never silently diverge from the actual abandonment decision."""
+
+    return max(
+        0.0,
+        (world_time - next_eligible_at_world_time).total_seconds() / 3600.0,
+    )
+
+
 _PROJECT_DUE_MODES = frozenset(
     {
         "start",
@@ -1172,10 +1183,8 @@ def project_due(
         due = project.next_eligible_at_world_time <= state.world_time
         if normalized_mode == "ready":
             return due
-        overdue_hours = max(
-            0.0,
-            (state.world_time - project.next_eligible_at_world_time).total_seconds()
-            / 3600.0,
+        overdue_hours = project_overdue_hours(
+            state.world_time, project.next_eligible_at_world_time
         )
         if normalized_mode == "abandon":
             return due and (

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace as dataclass_replace
 from datetime import datetime
 from enum import Enum
 from hashlib import sha256
@@ -205,6 +205,87 @@ class TravelState:
 
 
 @dataclass(frozen=True, slots=True)
+class ProjectState:
+    """Read-side state for one character's open project."""
+
+    id: int
+    project_type: str
+    status: str
+    stage: str
+    target_place_id: Optional[int] = None
+    progress: float = 0.0
+    stall_count: int = 0
+    next_eligible_at_world_time: Optional[datetime] = None
+    source_chunk_id: Optional[int] = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectPolicy:
+    """Runtime policy from [orrery.projects]."""
+
+    enabled: bool = False
+    advance_interval_hours: float = 24.0
+    max_active_per_character: int = 1
+    stall_abandon_threshold: int = 3
+    abandon_after_stalled_world_hours: float = 168.0
+    milestone_magnitude: float = 0.40
+    coverage_distribution_tolerance: float = 0.05
+
+    def __post_init__(self) -> None:
+        if self.advance_interval_hours <= 0:
+            raise ValueError("Project advance_interval_hours must be > 0")
+        if self.max_active_per_character != 1:
+            raise ValueError("PLAN_RELOCATION v1 requires max_active_per_character = 1")
+        if self.stall_abandon_threshold < 1:
+            raise ValueError("Project stall_abandon_threshold must be >= 1")
+        if self.abandon_after_stalled_world_hours <= 0:
+            raise ValueError("Project abandon_after_stalled_world_hours must be > 0")
+        if not 0 <= self.milestone_magnitude <= 1:
+            raise ValueError("Project milestone_magnitude must be between 0 and 1")
+        if not 0 < self.coverage_distribution_tolerance <= 1:
+            raise ValueError(
+                "Project coverage_distribution_tolerance must be in (0, 1]"
+            )
+
+
+def coerce_project_policy(raw: Any) -> ProjectPolicy:
+    """Coerce [orrery.projects] config; None keeps the subsystem disabled."""
+
+    if raw is None:
+        return ProjectPolicy()
+    if isinstance(raw, ProjectPolicy):
+        return raw
+    if isinstance(raw, Mapping):
+        values = raw
+    elif hasattr(raw, "advance_interval_hours"):
+        values = {
+            "advance_interval_hours": raw.advance_interval_hours,
+            "max_active_per_character": raw.max_active_per_character,
+            "stall_abandon_threshold": raw.stall_abandon_threshold,
+            "abandon_after_stalled_world_hours": (
+                raw.abandon_after_stalled_world_hours
+            ),
+            "milestone_magnitude": raw.milestone_magnitude,
+            "coverage_distribution_tolerance": (raw.coverage_distribution_tolerance),
+        }
+    else:
+        raise ValueError(f"Unsupported Orrery project settings: {type(raw)!r}")
+    return ProjectPolicy(
+        enabled=True,
+        advance_interval_hours=float(values["advance_interval_hours"]),
+        max_active_per_character=int(values["max_active_per_character"]),
+        stall_abandon_threshold=int(values["stall_abandon_threshold"]),
+        abandon_after_stalled_world_hours=float(
+            values["abandon_after_stalled_world_hours"]
+        ),
+        milestone_magnitude=float(values["milestone_magnitude"]),
+        coverage_distribution_tolerance=float(
+            values.get("coverage_distribution_tolerance", 0.05)
+        ),
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class RoutineAnchor:
     """Read-side home/work routine anchor for one character."""
 
@@ -264,6 +345,8 @@ class WorldState:
     orbit_distance: Mapping[Tuple[int, int], int] = field(default_factory=dict)
     need_debt_scores: Mapping[Tuple[int, str], float] = field(default_factory=dict)
     travel_states: Mapping[int, TravelState] = field(default_factory=dict)
+    project_states: Mapping[int, ProjectState] = field(default_factory=dict)
+    project_policy: ProjectPolicy = field(default_factory=ProjectPolicy)
     routine_anchors: Mapping[Tuple[int, str], RoutineAnchor] = field(
         default_factory=dict
     )
@@ -1010,6 +1093,122 @@ def is_in_transit(slot: Slot = Slot.ACTOR) -> Condition:
     return _named(_condition, f"is_in_transit(@{slot.value})")
 
 
+_PROJECT_DUE_MODES = frozenset(
+    {
+        "start",
+        "exists",
+        "ready",
+        "abandon",
+        "saving",
+        "scouting",
+        "committing",
+        "saving_milestone",
+        "scouting_without_target",
+        "scouting_milestone",
+        "completion",
+    }
+)
+
+
+def project_due(
+    mode: str = "ready",
+    *,
+    project_type: str = "plan_relocation",
+    slot: Slot = Slot.ACTOR,
+) -> Condition:
+    """Return a configured project lifecycle/due-ness verdict.
+
+    ``project_due`` is deliberately the one project predicate authority used
+    by production, explain, and coverage. Besides the base cadence verdict it
+    exposes the stage/milestone cases templates need, and the deterministic
+    abandonment case (stall threshold OR overdue world hours). ``start`` means
+    the configured subsystem is enabled and no open project exists.
+    """
+
+    normalized_mode = str(mode).strip().lower()
+    if normalized_mode not in _PROJECT_DUE_MODES:
+        raise ValueError(
+            f"Unsupported project_due mode {mode!r}; expected one of "
+            f"{sorted(_PROJECT_DUE_MODES)}"
+        )
+    if project_type != "plan_relocation":
+        raise ValueError(
+            f"Unsupported project_due project type {project_type!r}; "
+            "expected 'plan_relocation'"
+        )
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        policy = state.project_policy
+        if not policy.enabled:
+            return False
+        entity_id = _slot_entity(bindings, slot)
+        if entity_id is None:
+            return False
+        project = state.project_states.get(entity_id)
+        if project is not None and project.project_type != project_type:
+            raise ValueError(
+                f"Actor {entity_id} has unsupported open project type "
+                f"{project.project_type!r}"
+            )
+        if normalized_mode == "start":
+            return project is None
+        if normalized_mode == "exists":
+            return project is not None
+        if project is None:
+            return False
+        if project.status not in {"active", "paused", "stalled"}:
+            raise ValueError(
+                f"Hydrated project {project.id} is not open: {project.status!r}"
+            )
+        if project.next_eligible_at_world_time is None:
+            raise ValueError(
+                f"Open project {project.id} lacks next_eligible_at_world_time"
+            )
+        if state.world_time is None:
+            raise ValueError(
+                f"Cannot evaluate project {project.id} due-ness without world_time"
+            )
+        due = project.next_eligible_at_world_time <= state.world_time
+        if normalized_mode == "ready":
+            return due
+        overdue_hours = max(
+            0.0,
+            (state.world_time - project.next_eligible_at_world_time).total_seconds()
+            / 3600.0,
+        )
+        if normalized_mode == "abandon":
+            return due and (
+                project.stall_count >= policy.stall_abandon_threshold
+                or overdue_hours >= policy.abandon_after_stalled_world_hours
+            )
+        if not due:
+            return False
+        if normalized_mode in {"saving", "scouting", "committing"}:
+            return project.stage == normalized_mode
+        if normalized_mode == "saving_milestone":
+            return project.stage == "saving" and project.progress >= 1.0
+        if normalized_mode == "scouting_without_target":
+            return project.stage == "scouting" and project.target_place_id is None
+        if normalized_mode == "scouting_milestone":
+            return (
+                project.stage == "scouting"
+                and project.target_place_id is not None
+                and project.progress >= 1.0
+            )
+        if normalized_mode == "completion":
+            return (
+                project.stage == "committing"
+                and project.target_place_id is not None
+                and project.progress >= 1.0
+            )
+        raise AssertionError(f"Unhandled project_due mode {normalized_mode!r}")
+
+    return _named(
+        _condition,
+        f"project_due({project_type},{normalized_mode}@{slot.value})",
+    )
+
+
 def has_travel_destination(slot: Slot = Slot.ACTOR) -> Condition:
     """Return whether a slot-bound character has a planned destination."""
 
@@ -1725,6 +1924,9 @@ class Branch:
     # event_type. Signals feed other packages' gates without disturbing the
     # emitting package's cooldowns.
     signal_event_type: Optional[str] = None
+    # Routine project maintenance can opt out of the promotion queue even
+    # when package priority or branch magnitude clears a generic threshold.
+    promotable: bool = True
     # Lifecycle-terminal branches (a state transition like grief completing)
     # must fire the tick they become eligible in EVERY selection mode;
     # stochastic sampling is for flavor variety among peer branches, not
@@ -1767,6 +1969,44 @@ class Template:
                 )
 
 
+def configure_project_magnitudes(
+    templates: Iterable[Template], policy: ProjectPolicy
+) -> Tuple[Template, ...]:
+    """Apply the configured milestone magnitude to project lifecycle arms.
+
+    Routine project.advance/project.stall arms keep their authored sub-floor
+    magnitudes. A branch opts into the configured promotion magnitude through
+    a ``milestone`` marker inside its project payload; the marker is also
+    persisted in state_delta and harmless to the applier/replayer.
+    """
+
+    configured: list[Template] = []
+    for template in templates:
+        changed = False
+        branches: list[Branch] = []
+        for branch in template.branches:
+            milestone = any(
+                isinstance(branch.state_delta.get(key), Mapping)
+                and bool(branch.state_delta[key].get("milestone"))
+                for key in (
+                    "project.start",
+                    "project.advance",
+                    "project.abandon",
+                    "project.complete",
+                )
+            )
+            if milestone and branch.magnitude != policy.milestone_magnitude:
+                branch = dataclass_replace(branch, magnitude=policy.milestone_magnitude)
+                changed = True
+            branches.append(branch)
+        configured.append(
+            dataclass_replace(template, branches=tuple(branches))
+            if changed
+            else template
+        )
+    return tuple(configured)
+
+
 @dataclass(frozen=True, slots=True)
 class Resolution:
     """Result of evaluating one template against one set of bindings."""
@@ -1784,6 +2024,7 @@ class Resolution:
     magnitude: float = 0.0
     scene_pressure_stub: Optional[str] = None
     signal_event_type: Optional[str] = None
+    promotable: bool = True
 
 
 def binding_hash(bindings: Bindings) -> str:
@@ -1967,6 +2208,7 @@ def evaluate(
             magnitude=branch.magnitude,
             scene_pressure_stub=branch.scene_pressure_stub,
             signal_event_type=branch.signal_event_type,
+            promotable=branch.promotable,
         )
 
     return Resolution(

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -1106,6 +1106,7 @@ _PROJECT_DUE_MODES = frozenset(
         "scouting_without_target",
         "scouting_milestone",
         "completion",
+        "neglected",
     }
 )
 
@@ -1181,6 +1182,12 @@ def project_due(
                 project.stall_count >= policy.stall_abandon_threshold
                 or overdue_hours >= policy.abandon_after_stalled_world_hours
             )
+        if normalized_mode == "neglected":
+            # A setback is diegetic, not dice: the plan lost ground because
+            # a full cadence interval passed unattended. Non-tautological by
+            # construction, so authored_order/deterministic selection can
+            # never stall a promptly-advanced project (PR #494 review).
+            return due and overdue_hours >= policy.advance_interval_hours
         if not due:
             return False
         if normalized_mode in {"saving", "scouting", "committing"}:

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -4579,7 +4579,7 @@ ADVANCE_RELOCATION_PLAN = Template(
         ),
         Branch(
             label="Lose ground to a setback",
-            conditions=project_due("ready"),
+            conditions=project_due("neglected"),
             narrative_stub=(
                 "The present takes its cut from {actor}'s future: an expense, "
                 "a closed option, a promise that cannot yet be kept. The plan "

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -42,6 +42,7 @@ from nexus.agents.orrery.substrate import (
     is_constrained,
     is_hidden,
     is_in_transit,
+    project_due,
     recent_event,
     relationship_is_asymmetric,
     relationship_is_mutual_warm,
@@ -1017,6 +1018,7 @@ SURVEIL = Template(
     required_slots=(Slot.ACTOR, Slot.TARGET),
     package_gate=AND(
         has_minimal_context(),
+        NOT(project_due("ready")),
         NOT(is_constrained()),
         NOT(has_inbound_pair_tag("hunting")),
         NOT(has_ephemeral("grudge_active")),
@@ -4335,6 +4337,286 @@ RECREATE = Template(
 )
 
 
+START_RELOCATION_PLAN = Template(
+    id="start_relocation_plan",
+    priority=17,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "A relocation plan begins only after repeated local routine plus a "
+        "recent negative signal; the narrow gate lets it interrupt the mundane "
+        "floor without becoming ambient project noise."
+    ),
+    blurb=(
+        "Repeated local maintenance and a fresh setback become an explicit "
+        "decision to leave."
+    ),
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        project_due("start"),
+        has_minimal_context(),
+        at_routine_anchor("home"),
+        NOT(is_constrained()),
+        NOT(is_in_transit()),
+        OR(
+            count_recent_events_at_least("upkeep_done", within_ticks=30, min_count=2),
+            count_recent_events_at_least("errands_run", within_ticks=30, min_count=2),
+            count_recent_events_at_least(
+                "recreation_taken", within_ticks=30, min_count=2
+            ),
+            count_recent_events_at_least(
+                "work_performed", within_ticks=30, min_count=2
+            ),
+        ),
+        OR(
+            recent_event("travel_delayed", within_ticks=12, actor_slot=Slot.ACTOR),
+            recent_event("contact_deferred", within_ticks=12, actor_slot=Slot.ACTOR),
+            recent_event("threat_issued", within_ticks=12, target_slot=Slot.ACTOR),
+            recent_event(
+                "retaliation_attempted", within_ticks=12, target_slot=Slot.ACTOR
+            ),
+        ),
+    ),
+    branches=(
+        Branch(
+            label="Begin putting something aside",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} stops treating departure as the thought that arrives "
+                "after a bad day. They make a ledger, name what it would cost, "
+                "and put the first real thing aside."
+            ),
+            state_delta={
+                "project.start": {
+                    "project_type": "plan_relocation",
+                    "stage": "saving",
+                    "milestone": True,
+                }
+            },
+            event_type="relocation_plan_started",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.stage",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.40,
+        ),
+    ),
+)
+
+
+ADVANCE_RELOCATION_PLAN = Template(
+    id="advance_relocation_plan",
+    priority=47,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "A due relocation plan occupies SURVEIL's adjacent priority slot; "
+        "SURVEIL yields while the project is due, so project work displaces "
+        "surveillance idling while its cadence protects maintenance wins."
+    ),
+    blurb=(
+        "A due relocation plan saves, scouts, commits, stalls, or reaches its "
+        "travel handoff."
+    ),
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        project_due("ready"),
+        NOT(is_in_transit()),
+        NOT(is_constrained()),
+        # A due project yields to the embodied floor. The need writer clears
+        # debt when those packages fire, so this delays rather than starves the
+        # project while keeping eating, drinking, and sleep intact.
+        NOT(
+            OR(
+                has_need_debt_at_or_above("sleep", 8),
+                has_need_debt_at_or_above("thirst", 2),
+                has_need_debt_at_or_above("hunger", 4),
+            )
+        ),
+    ),
+    branches=(
+        Branch(
+            label="Commit to the road",
+            conditions=project_due("completion"),
+            narrative_stub=(
+                "{actor} makes the final commitment. The chosen place stops "
+                "being a possibility and becomes a destination; the project "
+                "ends where the journey begins."
+            ),
+            state_delta={
+                "project.complete": {
+                    "mode": "mixed",
+                    "initial_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            event_type="relocation_plan_completed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_travel_states.status",
+                "character_travel_states.destination_place_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Let the plan go rather than live in limbo",
+            conditions=project_due("abandon"),
+            narrative_stub=(
+                "{actor} opens the plan one last time and recognizes that it "
+                "has become a ritual of not leaving. They close the ledger and "
+                "release the future it had been holding hostage."
+            ),
+            state_delta={
+                "project.abandon": {
+                    "reason": "stalled_or_overdue",
+                    "milestone": True,
+                }
+            },
+            event_type="relocation_plan_abandoned",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.source_chunk_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Turn the savings into a search",
+            conditions=project_due("saving_milestone"),
+            narrative_stub=(
+                "{actor} has enough margin now to stop counting and start "
+                "looking. Prices become neighborhoods, routes, and actual "
+                "doors they might one day close behind them."
+            ),
+            state_delta={
+                "project.advance": {
+                    "stage": "scouting",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            event_type="relocation_plan_milestone",
+            changed_fields=(
+                "character_project_states.stage",
+                "character_project_states.progress",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Choose the place and begin committing",
+            conditions=project_due("scouting_milestone"),
+            narrative_stub=(
+                "{actor} stops comparing exits. One place has survived every "
+                "practical objection, and choosing it turns research into a "
+                "promise with consequences."
+            ),
+            state_delta={
+                "project.advance": {
+                    "stage": "committing",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            event_type="relocation_plan_milestone",
+            changed_fields=(
+                "character_project_states.stage",
+                "character_project_states.progress",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Put another share aside",
+            conditions=project_due("saving"),
+            narrative_stub=(
+                "{actor} makes the unremarkable sacrifice the plan requires: "
+                "one expense refused, one small reserve protected from the "
+                "present."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.35}},
+            event_type="relocation_plan_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.18,
+            promotable=False,
+        ),
+        Branch(
+            label="Scout a candidate place",
+            conditions=AND(
+                project_due("scouting_without_target"),
+                has_location_class_destination(
+                    "dwelling", "haven", "urban_sparse", "urban_dense"
+                ),
+            ),
+            narrative_stub=(
+                "{actor} follows one candidate past the fantasy of it: cost, "
+                "distance, the shape of an ordinary morning there. For the "
+                "first time, the plan has a place attached."
+            ),
+            state_delta={
+                "project.advance": {
+                    "progress_delta": 0.50,
+                    "select_target": True,
+                    "destination_place_classes": [
+                        "dwelling",
+                        "haven",
+                        "urban_sparse",
+                        "urban_dense",
+                    ],
+                }
+            },
+            event_type="relocation_plan_progressed",
+            changed_fields=(
+                "character_project_states.target_place_id",
+                "character_project_states.progress",
+            ),
+            magnitude=0.20,
+            promotable=False,
+        ),
+        Branch(
+            label="Lose ground to a setback",
+            conditions=project_due("ready"),
+            narrative_stub=(
+                "The present takes its cut from {actor}'s future: an expense, "
+                "a closed option, a promise that cannot yet be kept. The plan "
+                "stalls, but it is not silently erased."
+            ),
+            state_delta={"project.stall": {"increment": 1}},
+            event_type="relocation_plan_stalled",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.stall_count",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.10,
+            promotable=False,
+        ),
+        Branch(
+            label="Press on with the next practical step",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} does the next small thing the move requires — a "
+                "message, a form, a measured risk — work too ordinary to look "
+                "like transformation until enough of it accumulates."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.25}},
+            event_type="relocation_plan_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.16,
+            promotable=False,
+        ),
+    ),
+)
+
+
 BUILTIN_TEMPLATES = (
     EVADE_PURSUERS,
     PROTECT_KIN,
@@ -4344,6 +4626,7 @@ BUILTIN_TEMPLATES = (
     HONOR_DEBT,
     WARN_ALLY,
     SURVEIL,
+    ADVANCE_RELOCATION_PLAN,
     ACT_ON_INTEL,
     UNCOVER_PAST,
     CHECK_ON_DEPENDENT,
@@ -4366,6 +4649,7 @@ BUILTIN_TEMPLATES = (
     STROLL,
     UPKEEP,
     RECREATE,
+    START_RELOCATION_PLAN,
     MAINTAIN_COVER,
 )
 

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -557,6 +557,7 @@ async def commit_incubator_to_database(
                 storyteller_state_updates=incubator.get("entity_updates"),
                 prompt_settings=_orrery_prompt_settings(),
                 ecology_settings=_orrery_ecology_settings(),
+                project_settings=_orrery_project_settings(),
             )
             if (
                 orrery_result.resolution_count
@@ -632,6 +633,14 @@ def _orrery_prompt_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("prompt")
+
+
+def _orrery_project_settings() -> Any:
+    """[orrery.projects] cadence and abandonment policy."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("projects")
 
 
 def _orrery_checkpoint_interval() -> int:

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -553,6 +553,7 @@ def commit_incubator_to_database_sync(
                 storyteller_state_updates=incubator.get("entity_updates"),
                 prompt_settings=_orrery_prompt_settings(),
                 ecology_settings=_orrery_ecology_settings(),
+                project_settings=_orrery_project_settings(),
             )
             if (
                 orrery_result.resolution_count
@@ -813,6 +814,14 @@ def _orrery_prompt_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("prompt")
+
+
+def _orrery_project_settings() -> Any:
+    """[orrery.projects] cadence and abandonment policy."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("projects")
 
 
 def _orrery_checkpoint_interval() -> int:

--- a/nexus/api/orrery_dev_endpoints.py
+++ b/nexus/api/orrery_dev_endpoints.py
@@ -312,6 +312,7 @@ async def post_resolve(request: OrreryResolveRequest) -> dict[str, Any]:
                 selection_settings=orrery.get("selection"),
                 habituation_settings=orrery.get("habituation"),
                 package_selection_settings=orrery.get("package_selection"),
+                project_settings=orrery.get("projects"),
                 fanout_settings=orrery.get("fanout"),
             )
         except OverrideValidationError as exc:
@@ -399,6 +400,7 @@ async def post_coverage(request: OrreryCoverageRequest) -> dict[str, Any]:
             selection_settings=orrery.get("selection"),
             habituation_settings=orrery.get("habituation"),
             package_selection_settings=orrery.get("package_selection"),
+            project_settings=orrery.get("projects"),
             fanout_settings=orrery.get("fanout"),
         )
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -863,6 +863,61 @@ class OrreryPackageSelectionSettings(BaseModel):
     )
 
 
+class OrreryProjectSettings(BaseModel):
+    """Long-arc project policy for [orrery.projects]."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    advance_interval_hours: float = Field(
+        default=24.0,
+        gt=0.0,
+        description=(
+            "World-clock hours between project transitions; prevents an "
+            "open project from firing on every resolver tick."
+        ),
+    )
+    max_active_per_character: int = Field(
+        default=1,
+        ge=1,
+        le=1,
+        description=(
+            "Open-project budget per character. V1 is intentionally fixed at "
+            "one to match migration 074's partial unique index."
+        ),
+    )
+    stall_abandon_threshold: int = Field(
+        default=3,
+        ge=1,
+        description="Accumulated stalls that make abandonment preemptive when due.",
+    )
+    abandon_after_stalled_world_hours: float = Field(
+        default=168.0,
+        gt=0.0,
+        description=(
+            "Hours a project may remain overdue before deterministic "
+            "abandonment at its next evaluation."
+        ),
+    )
+    milestone_magnitude: float = Field(
+        default=0.40,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Magnitude applied to start, stage-transition, abandonment, and "
+            "completion branches so milestones enter the promotion funnel."
+        ),
+    )
+    coverage_distribution_tolerance: float = Field(
+        default=0.05,
+        gt=0.0,
+        le=1.0,
+        description=(
+            "Maximum accepted maintenance/routine winner-distribution shift "
+            "for the active-project coverage acceptance probe."
+        ),
+    )
+
+
 class OrreryReconstructionSettings(BaseModel):
     """Reconstruction-sufficiency knobs (issue #426)."""
 
@@ -1485,6 +1540,7 @@ class OrrerySettings(BaseModel):
     package_selection: OrreryPackageSelectionSettings = Field(
         default_factory=OrreryPackageSelectionSettings
     )
+    projects: OrreryProjectSettings = Field(default_factory=OrreryProjectSettings)
     retrograde: OrreryRetrogradeSettings
     dashboard: OrreryDashboardSettings = Field(default_factory=OrreryDashboardSettings)
     reconstruction: OrreryReconstructionSettings = Field(
@@ -1496,6 +1552,17 @@ class OrrerySettings(BaseModel):
         default_factory=OrreryHabituationSettings
     )
     fanout: OrreryFanoutSettings = Field(default_factory=OrreryFanoutSettings)
+
+    @model_validator(mode="after")
+    def _validate_project_milestone_promotion_floor(self) -> "OrrerySettings":
+        """Project milestones must enter the configured promotion funnel."""
+
+        if self.projects.milestone_magnitude < self.promote.magnitude_threshold:
+            raise ValueError(
+                "orrery.projects.milestone_magnitude must be >= "
+                "orrery.promote.magnitude_threshold"
+            )
+        return self
 
 
 # =============================================================================

--- a/scripts/orrery_sample.py
+++ b/scripts/orrery_sample.py
@@ -28,6 +28,7 @@ from nexus.agents.orrery.resolver import (
 from nexus.agents.orrery.substrate import PresentTargetPolicy, Slot, evaluate
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 from nexus.api.slot_utils import get_slot_db_url
+from nexus.config import load_settings_as_dict
 
 
 ACTOR_ONLY_SLOTS = (Slot.ACTOR,)
@@ -657,6 +658,7 @@ def sample_anchor(
     world_time_override: Optional[datetime] = None,
     location_overrides: Optional[list[tuple[str, str]]] = None,
 ) -> Path:
+    orrery_settings = load_settings_as_dict()["orrery"]
     engine = create_engine(get_slot_db_url(slot=slot))
     with Session(engine) as session:
         actor_only_templates = [
@@ -671,6 +673,7 @@ def sample_anchor(
             anchor_chunk_id=anchor_chunk_id,
             window_chunks=window_chunks,
             need_tuning=None,
+            project_settings=orrery_settings.get("projects"),
             world_time_override=world_time_override,
         )
         override_locations, override_labels = resolve_location_overrides(

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -13,6 +13,7 @@ from nexus.config.settings_models import (
     OrreryBleedSettings,
     OrreryDashboardSettings,
     OrreryPromoteSettings,
+    OrrerySettings,
     OrreryRetrogradeMaturationSettings,
     OrreryRetrogradeWeirdGenreBands,
     OrreryRetrogradeWeirdSettings,
@@ -64,6 +65,12 @@ def test_orrery_settings_resolve_model_reference() -> None:
     assert settings.orrery.package_selection.window_points == 6.0
     assert settings.orrery.package_selection.temperature == 2.0
     assert settings.orrery.package_selection.exempt_bands == ["crisis_constraint"]
+    assert settings.orrery.projects.advance_interval_hours == 24.0
+    assert settings.orrery.projects.max_active_per_character == 1
+    assert settings.orrery.projects.stall_abandon_threshold == 3
+    assert settings.orrery.projects.abandon_after_stalled_world_hours == 168.0
+    assert settings.orrery.projects.milestone_magnitude == 0.40
+    assert settings.orrery.projects.coverage_distribution_tolerance == 0.05
     # The ship-off invariant applies to the COMMITTED config: flipping the
     # dashboard on locally is a documented workflow (nexus.toml comment,
     # issue #415), and asserting the working tree here trains developers to
@@ -91,6 +98,16 @@ def test_orrery_settings_resolve_model_reference() -> None:
     assert set(weird.bands_by_genre) == {genre.value for genre in Genre}
     assert weird.bands_by_genre["cyberpunk"].medium.min == 0.36
     assert weird.bands_by_genre["historical"].medium.min == 0.12
+
+
+def test_project_milestones_cannot_fall_below_promotion_floor() -> None:
+    """Configured stage changes must remain eligible for promotion."""
+
+    payload = load_settings("nexus.toml").orrery.model_dump()
+    payload["projects"]["milestone_magnitude"] = 0.34
+
+    with pytest.raises(ValidationError, match="milestone_magnitude must be >="):
+        OrrerySettings.model_validate(payload)
 
 
 def test_orrery_dashboard_defaults_to_disabled() -> None:

--- a/tests/test_orrery/test_evidence.py
+++ b/tests/test_orrery/test_evidence.py
@@ -32,6 +32,7 @@ from nexus.agents.orrery.explain import explain_stack
 from nexus.agents.orrery.substrate import (
     ALWAYS,
     EventRecord,
+    ProjectPolicy,
     RoutineAnchor,
     Slot,
     TravelState,
@@ -75,6 +76,7 @@ from nexus.agents.orrery.substrate import (
     is_in_transit,
     lacks_pair_tag,
     lacks_tag,
+    project_due,
     recent_event,
     relationship_is_asymmetric,
     relationship_is_mutual_warm,
@@ -135,6 +137,7 @@ RICH_STATE = WorldState(
         ),
         4: TravelState(status="in_transit"),
     },
+    project_policy=ProjectPolicy(enabled=True),
     routine_anchors={
         (ACTOR, "work"): RoutineAnchor(
             anchor_type="work",
@@ -214,6 +217,7 @@ FACTORY_SWEEP = [
     recent_event(within_ticks=3),
     since_last_event_at_least("contact_made", 3),
     since_last_event_at_least("contact_made", 3, target_slot=Slot.TARGET),
+    project_due("start"),
     count_recent_events_at_least("mourning_act", within_ticks=30, min_count=4),
     count_recent_events_at_least(
         "surveillance_performed",

--- a/tests/test_orrery/test_projects.py
+++ b/tests/test_orrery/test_projects.py
@@ -1,0 +1,631 @@
+"""PLAN_RELOCATION project policy, cadence, and explain parity tests."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import math
+from pathlib import Path
+
+import pytest
+
+from nexus.agents.orrery.coverage import analyze_coverage, sample_anchor_ids
+from nexus.agents.orrery.events import _insert_resolution_sync
+from nexus.agents.orrery.explain import explain_stack
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.substrate import (
+    BranchSelection,
+    EventRecord,
+    ProjectPolicy,
+    ProjectState,
+    RoutineAnchor,
+    Slot,
+    TravelState,
+    WorldState,
+    configure_project_magnitudes,
+    evaluate,
+    evaluate_stack,
+)
+from nexus.agents.orrery.templates import (
+    ADVANCE_RELOCATION_PLAN,
+    BUILTIN_TEMPLATES,
+    EVADE_PURSUERS,
+    START_RELOCATION_PLAN,
+)
+
+
+ACTOR = 10
+HUNTER = 20
+NOW = datetime(2073, 8, 2, 12, tzinfo=timezone.utc)
+POLICY = ProjectPolicy(
+    enabled=True,
+    advance_interval_hours=24.0,
+    max_active_per_character=1,
+    stall_abandon_threshold=3,
+    abandon_after_stalled_world_hours=168.0,
+    milestone_magnitude=0.40,
+    coverage_distribution_tolerance=0.05,
+)
+BINDINGS = {Slot.ACTOR: ACTOR}
+
+
+def _project(
+    *,
+    due_at: datetime,
+    stall_count: int = 0,
+    stage: str = "saving",
+    progress: float = 0.25,
+    target_place_id: int | None = None,
+) -> ProjectState:
+    return ProjectState(
+        id=7,
+        project_type="plan_relocation",
+        status="active",
+        stage=stage,
+        target_place_id=target_place_id,
+        progress=progress,
+        stall_count=stall_count,
+        next_eligible_at_world_time=due_at,
+        source_chunk_id=100,
+    )
+
+
+def _state(
+    *,
+    world_time: datetime,
+    due_at: datetime,
+    hunted: bool = False,
+    stall_count: int = 0,
+    travel_status: str = "at_place",
+    constrained: bool = False,
+    stage: str = "saving",
+    progress: float = 0.25,
+    target_place_id: int | None = None,
+    current_tick: int = 101,
+) -> WorldState:
+    return WorldState(
+        tags={
+            ACTOR: frozenset(
+                {"public_role", "captive"} if constrained else {"public_role"}
+            )
+        },
+        locations={ACTOR: 1},
+        location_classes={
+            1: frozenset({"meeting", "urban_dense"}),
+            2: frozenset({"dwelling"}),
+        },
+        pair_tags=({(HUNTER, ACTOR): frozenset({"hunting"})} if hunted else {}),
+        travel_states={ACTOR: TravelState(status=travel_status)},
+        project_states={
+            ACTOR: _project(
+                due_at=due_at,
+                stall_count=stall_count,
+                stage=stage,
+                progress=progress,
+                target_place_id=target_place_id,
+            )
+        },
+        project_policy=POLICY,
+        world_time=world_time,
+        current_tick=current_tick,
+    )
+
+
+def test_project_cadence_blocks_consecutive_ticks() -> None:
+    """A 24-hour cadence cannot fire across adjacent one-hour ticks."""
+
+    first = _state(world_time=NOW, due_at=NOW)
+    assert evaluate(ADVANCE_RELOCATION_PLAN, first, BINDINGS).passes is True
+
+    next_eligible = NOW + timedelta(hours=POLICY.advance_interval_hours)
+    adjacent = _state(world_time=NOW + timedelta(hours=1), due_at=next_eligible)
+    assert evaluate(ADVANCE_RELOCATION_PLAN, adjacent, BINDINGS).passes is False
+
+    next_due = _state(world_time=next_eligible, due_at=next_eligible)
+    assert evaluate(ADVANCE_RELOCATION_PLAN, next_due, BINDINGS).passes is True
+
+
+def test_due_project_waits_for_arrival_and_constraint_release() -> None:
+    """A due project cannot overwrite transit and remains due after arrival."""
+
+    in_transit = _state(
+        world_time=NOW,
+        due_at=NOW,
+        travel_status="in_transit",
+    )
+    assert evaluate(ADVANCE_RELOCATION_PLAN, in_transit, BINDINGS).passes is False
+
+    arrived = _state(
+        world_time=NOW + timedelta(hours=1),
+        due_at=NOW,
+        travel_status="at_place",
+        current_tick=102,
+    )
+    assert evaluate(ADVANCE_RELOCATION_PLAN, arrived, BINDINGS).passes is True
+
+    constrained = _state(world_time=NOW, due_at=NOW, constrained=True)
+    assert evaluate(ADVANCE_RELOCATION_PLAN, constrained, BINDINGS).passes is False
+
+
+def test_relocation_entry_requires_repeated_routine_and_negative_signal() -> None:
+    """The pilot starts only from the authored sustained-discontent signal."""
+
+    state = WorldState(
+        tags={ACTOR: frozenset({"public_role"})},
+        locations={ACTOR: 1},
+        location_classes={1: frozenset({"dwelling"})},
+        routine_anchors={
+            (ACTOR, "home"): RoutineAnchor(anchor_type="home", place_id=1)
+        },
+        recent_events=(
+            EventRecord(
+                event_type="upkeep_done",
+                tick=100,
+                actor_entity_id=ACTOR,
+                location_id=1,
+            ),
+            EventRecord(
+                event_type="upkeep_done",
+                tick=95,
+                actor_entity_id=ACTOR,
+                location_id=1,
+            ),
+            EventRecord(
+                event_type="threat_issued",
+                tick=99,
+                target_entity_id=ACTOR,
+                location_id=1,
+            ),
+        ),
+        project_policy=POLICY,
+        world_time=NOW,
+        current_tick=101,
+    )
+
+    resolution = evaluate(START_RELOCATION_PLAN, state, BINDINGS)
+    assert resolution.passes is True
+    assert "project.start" in resolution.state_delta
+
+
+def test_crisis_interrupt_survives_resumes_or_ages_deterministically() -> None:
+    """Crisis wins leave project state untouched; due policy decides the next beat."""
+
+    hunted = _state(world_time=NOW, due_at=NOW, hunted=True)
+    original_project = hunted.project_states[ACTOR]
+    crisis = evaluate_stack(
+        (EVADE_PURSUERS, ADVANCE_RELOCATION_PLAN),
+        hunted,
+        BINDINGS,
+        BranchSelection(mode="authored_order"),
+    )
+    assert crisis is not None
+    assert crisis.template_id == "evade_pursuers"
+    assert hunted.project_states[ACTOR] == original_project
+
+    resumed = _state(world_time=NOW, due_at=NOW)
+    resume = evaluate_stack(
+        (EVADE_PURSUERS, ADVANCE_RELOCATION_PLAN),
+        resumed,
+        BINDINGS,
+        BranchSelection(mode="authored_order"),
+    )
+    assert resume is not None
+    assert resume.template_id == "advance_relocation_plan"
+    assert resume.state_delta.keys() <= {"project.advance", "project.stall"}
+
+    aged = _state(
+        world_time=NOW,
+        due_at=NOW - timedelta(hours=POLICY.abandon_after_stalled_world_hours + 1),
+    )
+    outcomes = [
+        evaluate(
+            ADVANCE_RELOCATION_PLAN,
+            aged,
+            BINDINGS,
+            BranchSelection(mode="stochastic", temperature=0.25),
+        )
+        for _ in range(2)
+    ]
+    assert [outcome.branch_label for outcome in outcomes] == [
+        "Let the plan go rather than live in limbo",
+        "Let the plan go rather than live in limbo",
+    ]
+    assert all("project.abandon" in outcome.state_delta for outcome in outcomes)
+
+
+def test_project_due_evidence_is_visible_in_explain_payload() -> None:
+    state = _state(world_time=NOW, due_at=NOW - timedelta(hours=2))
+    payload = explain_stack(
+        (ADVANCE_RELOCATION_PLAN,),
+        state,
+        BINDINGS,
+        BranchSelection(mode="authored_order"),
+    ).to_dict()
+
+    template = payload["templates"][0]
+
+    def leaves(node: dict):
+        if "children" in node:
+            for child in node["children"]:
+                yield from leaves(child)
+        else:
+            yield node
+
+    evidence = next(
+        leaf["evidence"]
+        for leaf in leaves(template["gate_trace"])
+        if leaf["evidence"]["kind"] == "project_due"
+    )
+    assert evidence["kind"] == "project_due"
+    assert evidence["params"]["mode"] == "ready"
+    assert evidence["observed"]["overdue_hours"] == 2.0
+    assert evidence["observed"]["project"]["stage"] == "saving"
+    assert evidence["result"] is True
+
+
+def test_routine_promotability_is_visible_in_explain_and_coverage_shape() -> None:
+    routine = explain_stack(
+        (ADVANCE_RELOCATION_PLAN,),
+        _state(world_time=NOW, due_at=NOW),
+        BINDINGS,
+        BranchSelection(mode="authored_order"),
+    ).to_dict()["templates"][0]
+    assert routine["chosen_branch"] == "Put another share aside"
+    assert routine["promotable"] is False
+    selected = next(branch for branch in routine["branches"] if branch["selected"])
+    assert selected["promotable"] is False
+
+    milestone = explain_stack(
+        (ADVANCE_RELOCATION_PLAN,),
+        _state(world_time=NOW, due_at=NOW, progress=1.0),
+        BINDINGS,
+        BranchSelection(mode="authored_order"),
+    ).to_dict()["templates"][0]
+    assert milestone["chosen_branch"] == "Turn the savings into a search"
+    assert milestone["promotable"] is True
+
+
+def test_seeded_softmax_can_complete_arc_with_bounded_stall_economics() -> None:
+    """Some deterministic seeds finish, and no stage's doom counter dominates."""
+
+    selection_temperature = 0.25
+    completed_seeds: list[int] = []
+    for seed in range(32):
+        project = _project(due_at=NOW, progress=0.0)
+        for tick in range(1, 61):
+            state = _state(
+                world_time=NOW + timedelta(hours=24 * tick),
+                due_at=NOW + timedelta(hours=24 * tick),
+                stall_count=project.stall_count,
+                stage=project.stage,
+                progress=project.progress,
+                target_place_id=project.target_place_id,
+                current_tick=tick,
+            )
+            outcome = evaluate(
+                ADVANCE_RELOCATION_PLAN,
+                state,
+                BINDINGS,
+                BranchSelection(
+                    mode="stochastic",
+                    temperature=selection_temperature,
+                    seed_salt=str(seed),
+                ),
+            )
+            if "project.complete" in outcome.state_delta:
+                completed_seeds.append(seed)
+                break
+            if "project.abandon" in outcome.state_delta:
+                break
+            if "project.stall" in outcome.state_delta:
+                project = replace(
+                    project,
+                    status="stalled",
+                    stall_count=project.stall_count + 1,
+                )
+                continue
+            advance = outcome.state_delta["project.advance"]
+            next_stage = str(advance.get("stage") or project.stage)
+            next_progress = (
+                float(advance["set_progress"])
+                if "set_progress" in advance
+                else min(
+                    1.0,
+                    project.progress + float(advance.get("progress_delta", 0.25)),
+                )
+            )
+            project = replace(
+                project,
+                status="active",
+                stage=next_stage,
+                progress=next_progress,
+                target_place_id=(
+                    2 if advance.get("select_target") else project.target_place_id
+                ),
+                stall_count=(
+                    0
+                    if advance.get("milestone") and next_stage != project.stage
+                    else project.stall_count
+                ),
+            )
+
+    assert completed_seeds
+
+    # The committing stage is the worst routine pair: four 0.25 press-on wins
+    # race the threshold of three stalls. Compute the exact expected terminal
+    # doom counter for that absorbing race from the authored softmax weights.
+    stall_weight = math.exp(0.10 / selection_temperature)
+    press_weight = math.exp(0.16 / selection_temperature)
+    stall_probability = stall_weight / (stall_weight + press_weight)
+
+    memo: dict[tuple[int, int], float] = {}
+
+    def expected_terminal_stalls(progress_wins: int, stalls: int) -> float:
+        if progress_wins == 4 or stalls == POLICY.stall_abandon_threshold:
+            return float(stalls)
+        key = (progress_wins, stalls)
+        if key not in memo:
+            memo[key] = stall_probability * expected_terminal_stalls(
+                progress_wins, stalls + 1
+            ) + (1.0 - stall_probability) * expected_terminal_stalls(
+                progress_wins + 1, stalls
+            )
+        return memo[key]
+
+    assert expected_terminal_stalls(0, 0) < POLICY.stall_abandon_threshold
+
+
+def test_completion_preempts_abandon_when_both_are_due() -> None:
+    state = _state(
+        world_time=NOW,
+        due_at=NOW,
+        stall_count=POLICY.stall_abandon_threshold,
+        stage="committing",
+        progress=1.0,
+        target_place_id=2,
+    )
+    outcome = evaluate(
+        ADVANCE_RELOCATION_PLAN,
+        state,
+        BINDINGS,
+        BranchSelection(mode="stochastic", temperature=0.25),
+    )
+    assert outcome.branch_label == "Commit to the road"
+    assert "project.complete" in outcome.state_delta
+
+
+def test_configured_milestones_promote_while_routine_progress_stays_below_floor() -> (
+    None
+):
+    policy = ProjectPolicy(enabled=True, milestone_magnitude=0.55)
+    start, advance = configure_project_magnitudes(
+        (START_RELOCATION_PLAN, ADVANCE_RELOCATION_PLAN), policy
+    )
+
+    assert start.branches[0].magnitude == 0.55
+    milestone_branches = [
+        branch
+        for branch in advance.branches
+        if any(
+            isinstance(branch.state_delta.get(key), dict)
+            and branch.state_delta[key].get("milestone")
+            for key in (
+                "project.advance",
+                "project.abandon",
+                "project.complete",
+            )
+        )
+    ]
+    assert milestone_branches
+    assert all(branch.magnitude == 0.55 for branch in milestone_branches)
+    routine = [
+        branch
+        for branch in advance.branches
+        if "project.advance" in branch.state_delta
+        and not branch.state_delta["project.advance"].get("milestone")
+    ]
+    assert routine
+    assert all(branch.magnitude < 0.35 for branch in routine)
+
+
+@pytest.mark.requires_postgres
+def test_resolution_insert_skips_routine_promotion_but_queues_milestone() -> None:
+    """The branch opt-out reaches the persisted promotion status directly."""
+
+    import psycopg2
+
+    from nexus.api.slot_utils import get_slot_db_url
+
+    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT max(id) FROM narrative_chunks")
+            chunk_id = cur.fetchone()[0]
+            cur.execute(
+                "SELECT entity_id FROM characters "
+                "WHERE entity_id IS NOT NULL ORDER BY id LIMIT 1"
+            )
+            actor_entity_id = cur.fetchone()[0]
+            statuses: dict[str, str] = {}
+            for label, promotable in (("routine", False), ("milestone", True)):
+                draft = OrreryResolutionDraft(
+                    template_id=f"project_promotion_{label}",
+                    priority=47,
+                    binding_hash=f"project-promotion-{label}-{chunk_id}",
+                    bindings={"actor": actor_entity_id},
+                    branch_label=label,
+                    narrative_stub="probe",
+                    promotable=promotable,
+                )
+                resolution_id = _insert_resolution_sync(
+                    cur,
+                    draft,
+                    tick_chunk_id=chunk_id,
+                    actor_entity_id=actor_entity_id,
+                    brief="probe",
+                )
+                assert resolution_id is not None
+                cur.execute(
+                    "SELECT promotion_status::text FROM orrery_resolutions "
+                    "WHERE id = %s",
+                    (resolution_id,),
+                )
+                statuses[label] = cur.fetchone()[0]
+
+            assert statuses == {"routine": "skipped", "milestone": "pending"}
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+@pytest.mark.requires_postgres
+def test_slot2_coverage_distribution_and_project_gate_payload() -> None:
+    """One due project displaces surveillance without distorting routine shares."""
+
+    from sqlalchemy import create_engine, text
+    from sqlalchemy.orm import Session
+
+    from nexus.api.slot_utils import get_slot_db_url
+    from nexus.config import load_settings_as_dict
+
+    orrery = load_settings_as_dict()["orrery"]
+    engine = create_engine(get_slot_db_url(slot=2))
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+    try:
+        connection.exec_driver_sql(
+            Path("migrations/074_plan_relocation_projects.sql").read_text()
+        )
+        anchors = sample_anchor_ids(session, count=35, stride=1)
+        assert anchors, "save_02 must provide coverage anchors"
+        kwargs = {
+            "anchor_chunk_ids": anchors,
+            "window_chunks": int(orrery["binding"]["window_chunks"]),
+            "sunhelm_settings": orrery.get("sunhelm"),
+            "epoch_min_world_times": int(
+                orrery["dashboard"]["coverage_epoch_min_world_times"]
+            ),
+            "selection_settings": orrery.get("selection"),
+            "habituation_settings": orrery.get("habituation"),
+            "package_selection_settings": orrery.get("package_selection"),
+            "project_settings": orrery.get("projects"),
+            "fanout_settings": orrery.get("fanout"),
+        }
+        baseline = analyze_coverage(session, BUILTIN_TEMPLATES, **kwargs)
+        surveil_rows = [
+            winner
+            for anchor in baseline["anchors"]
+            for winner in anchor["resolution_winners"]
+            if winner["template_id"] == "surveil"
+        ]
+        assert surveil_rows, "slot_2 pilot anchors must include surveillance idling"
+        actor = surveil_rows[0]["actor_entity_id"]
+        earliest_world_time = session.execute(
+            text(
+                """
+                SELECT min(cm.world_time)
+                FROM chunk_metadata cm
+                WHERE cm.chunk_id = ANY(:anchors)
+                """
+            ),
+            {"anchors": anchors},
+        ).scalar_one()
+        assert earliest_world_time is not None
+        session.execute(
+            text(
+                """
+                INSERT INTO character_project_states (
+                    character_entity_id, project_type, status, stage,
+                    progress, stall_count, next_eligible_at_world_time,
+                    source_chunk_id
+                ) VALUES (
+                    :actor, 'plan_relocation', 'active', 'saving',
+                    0.25, 0, :due_at, :source_chunk_id
+                )
+                """
+            ),
+            {
+                "actor": actor,
+                "due_at": earliest_world_time - timedelta(hours=1),
+                "source_chunk_id": anchors[0],
+            },
+        )
+        active = analyze_coverage(session, BUILTIN_TEMPLATES, **kwargs)
+
+        advance_gates = [
+            gate
+            for anchor in active["anchors"]
+            for gate in anchor["project_gates"]
+            if gate["actor_entity_id"] == actor
+            and gate["template_id"] == "advance_relocation_plan"
+        ]
+        assert advance_gates
+        assert any(gate["gate_passed"] for gate in advance_gates)
+
+        def leaves(node: dict):
+            if "children" in node:
+                for child in node["children"]:
+                    yield from leaves(child)
+            else:
+                yield node
+
+        due_evidence = [
+            leaf["evidence"]
+            for gate in advance_gates
+            for leaf in leaves(gate["gate_trace"])
+            if leaf["evidence"]["kind"] == "project_due"
+        ]
+        assert due_evidence
+        assert all(evidence["result"] is True for evidence in due_evidence)
+
+        assert active["templates"]["advance_relocation_plan"]["won"] > 0
+        promotability = active["templates"]["advance_relocation_plan"][
+            "branch_promotable"
+        ]
+        assert promotability["Put another share aside"] is False
+        assert promotability["Turn the savings into a search"] is True
+        advance_winners = [
+            winner
+            for anchor in active["anchors"]
+            for winner in anchor["resolution_winners"]
+            if winner["template_id"] == "advance_relocation_plan"
+        ]
+        assert advance_winners
+        assert all(winner["promotable"] is False for winner in advance_winners)
+        assert (
+            active["templates"]["surveil"]["won"]
+            < baseline["templates"]["surveil"]["won"]
+        )
+        for need_template in ("sleep", "drink", "eat"):
+            assert (
+                active["templates"][need_template]["won"]
+                == baseline["templates"][need_template]["won"]
+            )
+
+        routine_ids = {
+            template.id
+            for template in BUILTIN_TEMPLATES
+            if template.drive_band.value in {"embodied_maintenance", "anchored_routine"}
+        }
+
+        def winner_shares(report: dict) -> dict[str, float]:
+            total = sum(payload["won"] for payload in report["templates"].values())
+            assert total > 0
+            return {
+                template_id: report["templates"][template_id]["won"] / total
+                for template_id in routine_ids
+            }
+
+        baseline_shares = winner_shares(baseline)
+        active_shares = winner_shares(active)
+        max_shift = max(
+            abs(active_shares[key] - baseline_shares[key]) for key in routine_ids
+        )
+        tolerance = float(orrery["projects"]["coverage_distribution_tolerance"])
+        assert max_shift < tolerance, (max_shift, tolerance)
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()
+        engine.dispose()

--- a/tests/test_orrery/test_projects.py
+++ b/tests/test_orrery/test_projects.py
@@ -375,6 +375,97 @@ def test_seeded_softmax_can_complete_arc_with_bounded_stall_economics() -> None:
     assert expected_terminal_stalls(0, 0) < POLICY.stall_abandon_threshold
 
 
+def test_authored_order_completes_arc_without_setbacks() -> None:
+    """Deterministic selection must never stall a promptly-advanced project.
+
+    PR #494 review: the setback arm's old tautological condition made
+    authored_order stall every due tick in scouting-with-target and
+    committing, so relocation could never complete under a supported
+    selection mode. With project_due("neglected") a prompt actor never
+    triggers it, and the full arc completes deterministically.
+    """
+
+    project = _project(due_at=NOW, progress=0.0)
+    stalls = 0
+    completed = False
+    for tick in range(1, 41):
+        state = _state(
+            world_time=NOW + timedelta(hours=24 * tick),
+            due_at=NOW + timedelta(hours=24 * tick),
+            stall_count=project.stall_count,
+            stage=project.stage,
+            progress=project.progress,
+            target_place_id=project.target_place_id,
+            current_tick=tick,
+        )
+        outcome = evaluate(
+            ADVANCE_RELOCATION_PLAN,
+            state,
+            BINDINGS,
+            BranchSelection(mode="authored_order"),
+        )
+        if "project.complete" in outcome.state_delta:
+            completed = True
+            break
+        assert "project.abandon" not in outcome.state_delta
+        if "project.stall" in outcome.state_delta:
+            stalls += 1
+            continue
+        advance = outcome.state_delta["project.advance"]
+        next_stage = str(advance.get("stage") or project.stage)
+        next_progress = (
+            float(advance["set_progress"])
+            if "set_progress" in advance
+            else min(
+                1.0,
+                project.progress + float(advance.get("progress_delta", 0.25)),
+            )
+        )
+        project = replace(
+            project,
+            status="active",
+            stage=next_stage,
+            progress=next_progress,
+            target_place_id=(
+                2 if advance.get("select_target") else project.target_place_id
+            ),
+            stall_count=0 if advance.get("milestone") else project.stall_count,
+        )
+
+    assert completed, "authored_order must complete the arc"
+    assert stalls == 0, "a promptly-advanced project never triggers a setback"
+
+
+def test_neglected_setback_requires_a_full_missed_interval() -> None:
+    """Setbacks are diegetic: due-but-prompt is not neglected; a project
+    overdue by a full cadence interval is."""
+
+    from nexus.agents.orrery.substrate import project_due
+
+    prompt = _state(
+        world_time=NOW,
+        due_at=NOW,
+        stall_count=0,
+        stage="committing",
+        progress=0.5,
+        target_place_id=2,
+        current_tick=5,
+    )
+    assert project_due("ready")(prompt, BINDINGS) is True
+    assert project_due("neglected")(prompt, BINDINGS) is False
+
+    neglected = _state(
+        world_time=NOW + timedelta(hours=POLICY.advance_interval_hours),
+        due_at=NOW,
+        stall_count=0,
+        stage="committing",
+        progress=0.5,
+        target_place_id=2,
+        current_tick=6,
+    )
+    assert project_due("neglected")(neglected, BINDINGS) is True
+
+
 def test_completion_preempts_abandon_when_both_are_due() -> None:
     state = _state(
         world_time=NOW,

--- a/tests/test_orrery/test_reconstruction.py
+++ b/tests/test_orrery/test_reconstruction.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 from typing import Any
 
 import psycopg2
@@ -38,12 +39,15 @@ WRITE_SLOT = 2
 
 
 def _connect() -> Any:
-    return psycopg2.connect(
+    conn = psycopg2.connect(
         host=os.environ.get("PGHOST", "localhost"),
         database=f"save_{WRITE_SLOT:02d}",
         user=os.environ.get("PGUSER", "pythagor"),
         port=os.environ.get("PGPORT", "5432"),
     )
+    with conn.cursor() as cur:
+        cur.execute(Path("migrations/074_plan_relocation_projects.sql").read_text())
+    return conn
 
 
 def test_checkpoint_captures_every_section_and_is_idempotent() -> None:
@@ -236,18 +240,20 @@ def test_unattributed_relationship_write_versions_with_null_chunk() -> None:
 
 
 def test_migration_genesis_sections_mirror_checkpoint_sections() -> None:
-    """The 065 genesis backfill duplicates CHECKPOINT_SECTIONS in SQL; this
-    tripwire fails if either side gains a section the other lacks."""
+    """Genesis SQL across 065 plus additive 074 mirrors checkpoint sections."""
 
     from pathlib import Path
 
     migration = Path("migrations/065_reconstructability.sql").read_text()
     genesis = migration[migration.index("jsonb_build_object") :]
+    additive = Path("migrations/074_plan_relocation_projects.sql").read_text()
+    genesis_sources = genesis + additive
     for section in CHECKPOINT_SECTIONS:
         assert (
-            f"'{section}', (" in genesis
-        ), f"migration genesis backfill lacks section {section!r}"
+            f"'{section}', (" in genesis_sources
+        ), f"migration genesis/extension SQL lacks section {section!r}"
     import re
 
     migration_sections = set(re.findall(r"'(\w+)', \(SELECT", genesis))
+    migration_sections.update(re.findall(r"'(character_project_states)', \(", additive))
     assert migration_sections == set(CHECKPOINT_SECTIONS)

--- a/tests/test_orrery/test_replay.py
+++ b/tests/test_orrery/test_replay.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 import os
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Optional
 
 import psycopg2
@@ -33,7 +34,10 @@ from nexus.agents.logon.apex_schema import (
     LocationStateUpdate,
     StateUpdates,
 )
-from nexus.agents.orrery.events import _apply_need_fulfillment_sync
+from nexus.agents.orrery.events import (
+    _apply_need_fulfillment_sync,
+    _apply_state_delta_sync,
+)
 from nexus.agents.orrery.needs import load_need_tuning
 from nexus.agents.orrery.reconstruction import (
     capture_state_checkpoint_sync,
@@ -43,6 +47,8 @@ from nexus.agents.orrery.replay import (
     reconstruct_state_at_sync,
     verify_checkpoints_sync,
 )
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.substrate import ProjectPolicy
 from nexus.api.commit_handler_sync import apply_state_updates_sync
 
 pytestmark = pytest.mark.requires_postgres
@@ -51,12 +57,15 @@ WRITE_SLOT = 2
 
 
 def _connect() -> Any:
-    return psycopg2.connect(
+    conn = psycopg2.connect(
         host=os.environ.get("PGHOST", "localhost"),
         database=f"save_{WRITE_SLOT:02d}",
         user=os.environ.get("PGUSER", "pythagor"),
         port=os.environ.get("PGPORT", "5432"),
     )
+    with conn.cursor() as cur:
+        _apply_migration_074(cur)
+    return conn
 
 
 def _head_chunk(cur: Any) -> int:
@@ -90,6 +99,13 @@ def _fabricate_chunk(
             "INSERT INTO chunk_metadata (chunk_id, world_time) VALUES (%s, %s)",
             (chunk_id, world_time),
         )
+        # The statement-level metadata trigger recomputes world_time after
+        # INSERT from cumulative time_delta. Restore the requested test clock
+        # with a world_time-only UPDATE, which does not retrigger that function.
+        cur.execute(
+            "UPDATE chunk_metadata SET world_time = %s WHERE chunk_id = %s",
+            (world_time, chunk_id),
+        )
     # No metadata row when world_time is None: trg_chunk_metadata_refresh_
     # world_time backfills world_time on insert, so a NULL-world-time chunk
     # is only fabricable by omitting the row entirely.
@@ -98,16 +114,18 @@ def _fabricate_chunk(
 
 def _insert_resolution(
     cur: Any, chunk_id: int, actor_entity_id: int, state_delta: dict[str, Any]
-) -> None:
+) -> int:
     cur.execute(
         """
         INSERT INTO orrery_resolutions (
             tick_chunk_id, template_id, binding_hash, actor_entity_id,
             priority, magnitude, state_delta
         ) VALUES (%s, 'replay_probe', %s, %s, 50, 0.5, %s)
+        RETURNING id
         """,
         (chunk_id, f"probe-{chunk_id}", actor_entity_id, json.dumps(state_delta)),
     )
+    return cur.fetchone()[0]
 
 
 def _probe_character(cur: Any) -> tuple[int, int, str, Optional[int]]:
@@ -134,6 +152,55 @@ def _next_world_time(cur: Any) -> datetime:
     latest = cur.fetchone()[0]
     base = latest or datetime(2026, 1, 1, tzinfo=timezone.utc)
     return base + timedelta(hours=6)
+
+
+PROJECT_POLICY = ProjectPolicy(
+    enabled=True,
+    advance_interval_hours=24.0,
+    max_active_per_character=1,
+    stall_abandon_threshold=3,
+    abandon_after_stalled_world_hours=168.0,
+    milestone_magnitude=0.40,
+    coverage_distribution_tolerance=0.05,
+)
+
+
+def _apply_migration_074(cur: Any) -> None:
+    """Create the pilot table only inside this rolled-back save_02 transaction."""
+
+    cur.execute(Path("migrations/074_plan_relocation_projects.sql").read_text())
+
+
+def _apply_transition(
+    cur: Any,
+    *,
+    chunk_id: int,
+    actor_entity_id: int,
+    state_delta: dict[str, Any],
+) -> None:
+    """Write a real projection transition plus its replay ledger row."""
+
+    resolution_id = _insert_resolution(cur, chunk_id, actor_entity_id, state_delta)
+    draft = OrreryResolutionDraft(
+        template_id="replay_probe",
+        priority=47,
+        binding_hash=f"project-{chunk_id}",
+        bindings={"actor": actor_entity_id},
+        branch_label="project replay probe",
+        narrative_stub="probe",
+        state_delta=state_delta,
+        magnitude=0.4,
+    )
+    _apply_state_delta_sync(
+        cur,
+        draft,
+        resolution_id=resolution_id,
+        actor_entity_id=actor_entity_id,
+        target_entity_id=None,
+        source_chunk_id=chunk_id,
+        need_tuning=load_need_tuning(),
+        project_policy=PROJECT_POLICY,
+    )
 
 
 def test_scalar_replay_round_trip_and_within_chunk_ordering() -> None:
@@ -948,6 +1015,441 @@ def test_verify_catches_unlogged_tag_clear() -> None:
                 and d.row_key == str(cleared_row_id)
                 for d in probe_pair[0].drifts
             ), "verify must catch the un-logged clear as extra_row drift"
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_project_transition_window_replays_with_zero_checkpoint_drift() -> None:
+    """Every project transition plus a crisis no-op survives checkpoint replay."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            _apply_migration_074(cur)
+            cur.execute(
+                """
+                SELECT c.entity_id, c.current_location
+                FROM characters c
+                WHERE c.entity_id IS NOT NULL
+                  AND c.current_location IS NOT NULL
+                ORDER BY c.id LIMIT 1
+                """
+            )
+            actor_entity, origin = cur.fetchone()
+            cur.execute(
+                "SELECT id FROM places WHERE id <> %s ORDER BY id LIMIT 1", (origin,)
+            )
+            target = cur.fetchone()[0]
+
+            base_time = _next_world_time(cur)
+            base_chunk = _fabricate_chunk(cur, base_time)
+            base_id = capture_state_checkpoint_sync(
+                cur, chunk_id=base_chunk, label="manual"
+            )
+            # Imported pre-074 checkpoints may lack the additive section.
+            # Replay treats that one omission as an empty genesis with an
+            # explicit fidelity note, then applies project ledger entries.
+            cur.execute(
+                """
+                UPDATE state_checkpoints
+                SET state = state - 'character_project_states'
+                WHERE id = %s
+                """,
+                (base_id,),
+            )
+
+            start_one = _fabricate_chunk(cur, base_time + timedelta(hours=24))
+            _apply_transition(
+                cur,
+                chunk_id=start_one,
+                actor_entity_id=actor_entity,
+                state_delta={
+                    "project.start": {
+                        "project_type": "plan_relocation",
+                        "stage": "saving",
+                        "milestone": True,
+                    }
+                },
+            )
+            advance_one = _fabricate_chunk(cur, base_time + timedelta(hours=48))
+            _apply_transition(
+                cur,
+                chunk_id=advance_one,
+                actor_entity_id=actor_entity,
+                state_delta={"project.advance": {"progress_delta": 0.35}},
+            )
+
+            # A crisis-band win writes only its own activity. The project row
+            # must remain byte-for-byte untouched and replay must preserve that.
+            cur.execute(
+                """
+                SELECT status, stage, progress, stall_count,
+                       next_eligible_at_world_time, source_chunk_id
+                FROM character_project_states
+                WHERE character_entity_id = %s
+                  AND status IN ('active', 'paused', 'stalled')
+                """,
+                (actor_entity,),
+            )
+            before_crisis = cur.fetchone()
+            assert before_crisis[4] == base_time + timedelta(hours=72)
+            crisis_chunk = _fabricate_chunk(cur, base_time + timedelta(hours=72))
+            _apply_transition(
+                cur,
+                chunk_id=crisis_chunk,
+                actor_entity_id=actor_entity,
+                state_delta={
+                    "character.current_activity": "evading replay probe crisis"
+                },
+            )
+            cur.execute(
+                """
+                SELECT status, stage, progress, stall_count,
+                       next_eligible_at_world_time, source_chunk_id
+                FROM character_project_states
+                WHERE character_entity_id = %s
+                  AND status IN ('active', 'paused', 'stalled')
+                """,
+                (actor_entity,),
+            )
+            assert cur.fetchone() == before_crisis
+
+            # The crisis tick left the project due. The next project
+            # evaluation resumes it and advances the cadence normally.
+            resume = _fabricate_chunk(cur, base_time + timedelta(hours=73))
+            _apply_transition(
+                cur,
+                chunk_id=resume,
+                actor_entity_id=actor_entity,
+                state_delta={"project.advance": {"progress_delta": 0.15}},
+            )
+            cur.execute(
+                """
+                SELECT status, next_eligible_at_world_time
+                FROM character_project_states
+                WHERE character_entity_id = %s
+                  AND status IN ('active', 'paused', 'stalled')
+                """,
+                (actor_entity,),
+            )
+            assert cur.fetchone() == (
+                "active",
+                base_time + timedelta(hours=97),
+            )
+            stall = _fabricate_chunk(cur, base_time + timedelta(hours=97))
+            _apply_transition(
+                cur,
+                chunk_id=stall,
+                actor_entity_id=actor_entity,
+                state_delta={"project.stall": {"increment": 1}},
+            )
+            # Stall cadence is due at +121h. By +290h it is 169h overdue,
+            # beyond the configured 168h aging threshold.
+            cur.execute(
+                """
+                SELECT stall_count, next_eligible_at_world_time
+                FROM character_project_states
+                WHERE character_entity_id = %s
+                  AND status IN ('active', 'paused', 'stalled')
+                """,
+                (actor_entity,),
+            )
+            assert cur.fetchone() == (
+                1,
+                base_time + timedelta(hours=121),
+            )
+            abandon = _fabricate_chunk(cur, base_time + timedelta(hours=290))
+            _apply_transition(
+                cur,
+                chunk_id=abandon,
+                actor_entity_id=actor_entity,
+                state_delta={
+                    "project.abandon": {
+                        "reason": "overdue_world_time",
+                        "milestone": True,
+                    }
+                },
+            )
+
+            start_two = _fabricate_chunk(cur, base_time + timedelta(hours=314))
+            _apply_transition(
+                cur,
+                chunk_id=start_two,
+                actor_entity_id=actor_entity,
+                state_delta={
+                    "project.start": {
+                        "project_type": "plan_relocation",
+                        "stage": "saving",
+                        "milestone": True,
+                    }
+                },
+            )
+            ready = _fabricate_chunk(cur, base_time + timedelta(hours=338))
+            _apply_transition(
+                cur,
+                chunk_id=ready,
+                actor_entity_id=actor_entity,
+                state_delta={
+                    "project.advance": {
+                        "stage": "committing",
+                        "target_place_id": target,
+                        "set_progress": 1.0,
+                        "milestone": True,
+                    }
+                },
+            )
+            complete = _fabricate_chunk(cur, base_time + timedelta(hours=362))
+            _apply_transition(
+                cur,
+                chunk_id=complete,
+                actor_entity_id=actor_entity,
+                state_delta={
+                    "project.complete": {
+                        "mode": "mixed",
+                        "initial_progress": 0.0,
+                        "milestone": True,
+                    }
+                },
+            )
+            target_id = capture_state_checkpoint_sync(
+                cur, chunk_id=complete, label="manual"
+            )
+
+            reconstructed = reconstruct_state_at_sync(
+                cur, complete, base_checkpoint_id=base_id
+            )
+            assert "character_project_states" in reconstructed.approximate_sections
+            assert any(
+                "migration 074" in note
+                for note in reconstructed.notes["character_project_states"]
+            )
+            statuses = {
+                row["status"]
+                for row in reconstructed.state["character_project_states"]
+                if row["character_entity_id"] == actor_entity
+            }
+            assert statuses == {"abandoned", "completed"}
+
+            verdicts = verify_checkpoints_sync(cur)
+            pair = [
+                verdict
+                for verdict in verdicts
+                if verdict.base_checkpoint_id == base_id
+                and verdict.target_checkpoint_id == target_id
+            ]
+            assert len(pair) == 1
+            assert pair[0].drifts == []
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_project_complete_hands_off_and_real_travel_applier_relocates() -> None:
+    """Completion starts travel at the project target; arrival moves the actor."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            _apply_migration_074(cur)
+            cur.execute(
+                """
+                SELECT c.entity_id, c.current_location
+                FROM characters c
+                WHERE c.entity_id IS NOT NULL
+                  AND c.current_location IS NOT NULL
+                ORDER BY c.id LIMIT 1
+                """
+            )
+            actor_entity, origin = cur.fetchone()
+            cur.execute(
+                "SELECT id FROM places WHERE id <> %s ORDER BY id LIMIT 1", (origin,)
+            )
+            target = cur.fetchone()[0]
+            base_time = _next_world_time(cur)
+
+            start = _fabricate_chunk(cur, base_time)
+            _apply_transition(
+                cur,
+                chunk_id=start,
+                actor_entity_id=actor_entity,
+                state_delta={
+                    "project.start": {
+                        "project_type": "plan_relocation",
+                        "stage": "saving",
+                    }
+                },
+            )
+            ready = _fabricate_chunk(cur, base_time + timedelta(hours=24))
+            _apply_transition(
+                cur,
+                chunk_id=ready,
+                actor_entity_id=actor_entity,
+                state_delta={
+                    "project.advance": {
+                        "stage": "committing",
+                        "target_place_id": target,
+                        "set_progress": 1.0,
+                    }
+                },
+            )
+            complete = _fabricate_chunk(cur, base_time + timedelta(hours=48))
+            _apply_transition(
+                cur,
+                chunk_id=complete,
+                actor_entity_id=actor_entity,
+                state_delta={"project.complete": {"mode": "mixed"}},
+            )
+            cur.execute(
+                """
+                SELECT cps.status, cts.status, cts.destination_place_id
+                FROM character_project_states cps
+                JOIN character_travel_states cts
+                  ON cts.character_entity_id = cps.character_entity_id
+                WHERE cps.character_entity_id = %s
+                ORDER BY cps.id DESC LIMIT 1
+                """,
+                (actor_entity,),
+            )
+            assert cur.fetchone() == ("completed", "in_transit", target)
+
+            arrive = _fabricate_chunk(cur, base_time + timedelta(hours=49))
+            _apply_transition(
+                cur,
+                chunk_id=arrive,
+                actor_entity_id=actor_entity,
+                state_delta={"travel.arrive": True},
+            )
+            cur.execute(
+                """
+                SELECT c.current_location, cts.status,
+                       cts.destination_place_id
+                FROM characters c
+                JOIN character_travel_states cts
+                  ON cts.character_entity_id = c.entity_id
+                WHERE c.entity_id = %s
+                """,
+                (actor_entity,),
+            )
+            assert cur.fetchone() == (target, "at_place", None)
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_project_applied_ledger_survives_replay_policy_retuning(monkeypatch) -> None:
+    """Replay consumes committed cadence and milestone reset, not live tuning."""
+
+    import nexus.agents.orrery.replay as replay_module
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            _char_id, actor_entity, _activity, _location = _probe_character(cur)
+            base_time = _next_world_time(cur)
+            base_chunk = _fabricate_chunk(cur, base_time)
+            base_id = capture_state_checkpoint_sync(
+                cur, chunk_id=base_chunk, label="manual"
+            )
+
+            start = _fabricate_chunk(cur, base_time + timedelta(hours=24))
+            _apply_transition(
+                cur,
+                chunk_id=start,
+                actor_entity_id=actor_entity,
+                state_delta={
+                    "project.start": {
+                        "project_type": "plan_relocation",
+                        "stage": "saving",
+                        "milestone": True,
+                    }
+                },
+            )
+            stall = _fabricate_chunk(cur, base_time + timedelta(hours=48))
+            _apply_transition(
+                cur,
+                chunk_id=stall,
+                actor_entity_id=actor_entity,
+                state_delta={"project.stall": {"increment": 1}},
+            )
+            milestone = _fabricate_chunk(cur, base_time + timedelta(hours=72))
+            _apply_transition(
+                cur,
+                chunk_id=milestone,
+                actor_entity_id=actor_entity,
+                state_delta={
+                    "project.advance": {
+                        "stage": "scouting",
+                        "set_progress": 0.0,
+                        "milestone": True,
+                    }
+                },
+            )
+            target_id = capture_state_checkpoint_sync(
+                cur, chunk_id=milestone, label="manual"
+            )
+
+            cur.execute(
+                """
+                SELECT state_delta->'project.advance'->'applied'
+                FROM orrery_resolutions
+                WHERE tick_chunk_id = %s AND template_id = 'replay_probe'
+                """,
+                (milestone,),
+            )
+            applied = cur.fetchone()[0]
+            assert applied["stage"] == "scouting"
+            assert applied["stall_count"] == 0
+            assert datetime.fromisoformat(
+                applied["next_eligible_at_world_time"]
+            ) == base_time + timedelta(hours=96)
+
+            monkeypatch.setattr(
+                replay_module,
+                "_load_project_policy",
+                lambda: ProjectPolicy(
+                    enabled=True,
+                    advance_interval_hours=12.0,
+                    stall_abandon_threshold=3,
+                    abandon_after_stalled_world_hours=168.0,
+                    milestone_magnitude=0.40,
+                    coverage_distribution_tolerance=0.05,
+                ),
+            )
+            verdicts = verify_checkpoints_sync(cur)
+            pair = [
+                verdict
+                for verdict in verdicts
+                if verdict.base_checkpoint_id == base_id
+                and verdict.target_checkpoint_id == target_id
+            ]
+            assert len(pair) == 1
+            assert pair[0].drifts == []
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_project_replay_rejects_ledger_without_applied_projection() -> None:
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            _char_id, actor_entity, _activity, _location = _probe_character(cur)
+            base_time = _next_world_time(cur)
+            base_chunk = _fabricate_chunk(cur, base_time)
+            base_id = capture_state_checkpoint_sync(
+                cur, chunk_id=base_chunk, label="manual"
+            )
+            raw_chunk = _fabricate_chunk(cur, base_time + timedelta(hours=24))
+            _insert_resolution(
+                cur,
+                raw_chunk,
+                actor_entity,
+                {"project.start": {"project_type": "plan_relocation"}},
+            )
+
+            with pytest.raises(ValueError, match="missing its required applied"):
+                reconstruct_state_at_sync(cur, raw_chunk, base_checkpoint_id=base_id)
     finally:
         conn.rollback()
         conn.close()

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -67,6 +67,7 @@ class FakeSession:
         entity_name_rows=None,
         need_debt_rows=None,
         travel_state_rows=None,
+        project_state_rows=None,
         routine_anchor_rows=None,
         win_history_rows=None,
         intertitle_row=None,
@@ -99,6 +100,7 @@ class FakeSession:
         ]
         self.need_debt_rows = need_debt_rows or []
         self.travel_state_rows = travel_state_rows or []
+        self.project_state_rows = project_state_rows or []
         self.routine_anchor_rows = routine_anchor_rows or []
         self.win_history_rows = win_history_rows or []
         self.intertitle_row = intertitle_row or {
@@ -186,6 +188,10 @@ class FakeSession:
             assert "JOIN entities e" in sql
             assert "e.is_active = true" in sql
             return FakeResult(self.travel_state_rows)
+        if "/* orrery:project_states */" in sql:
+            assert "JOIN entities e" in sql
+            assert "e.is_active = true" in sql
+            return FakeResult(self.project_state_rows)
         if "/* orrery:win_history */" in sql:
             return FakeResult(self.win_history_rows)
         if "/* orrery:intertitle */" in sql:


### PR DESCRIPTION
## Summary

The #475 flagship (Codex-first at xhigh effort; Claude froze the spec, adversarially reviewed, fix-ordered, and verified). NPCs gain persistent positive intent: a staged relocation project — saving → scouting → committing — advancing on its own world-clock cadence (`next_eligible_at_world_time`), completing into the existing `travel.start` writer. Off-screen characters no longer only react and maintain; one of them can now spend three weeks quietly deciding to leave town, and the Storyteller hears about it exactly at the milestones.

**Substrate**: `character_project_states` (migration 074; one-open-project budget as a partial unique index; every column commented), the `project.*` delta family with appliers mirroring the travel family, the `project_due` predicate shared by production/explain/coverage, checkpoint + replay integration (pre-074 checkpoints read as truthfully empty).

**The reconstructability move worth reading**: every applier backfills its computed outcome into the ledger row's `state_delta.applied` block (the `event_ids` backfill precedent), and replay *requires* that block — it never recomputes from live config. The adversarial review live-demonstrated why: recomputing `next_eligible` from `[orrery.projects].advance_interval_hours` meant retuning the knob permanently poisoned `verify_checkpoints_sync` on all historical windows.

**Behavioral economics** (post-review): milestones ride preemptive branches at promotable 0.40; routine cadence arms carry the new `Branch.promotable=False`, landing as `promotion_status='skipped'` at insert — closing the priority-OR promotion spam (ADVANCE sits at priority 47 ≥ the 30 threshold) without touching the global promote rule. Stage milestones reset `stall_count`; completion preempts abandonment; stall magnitude 0.10 keeps organic completion reachable (it was <1% before the fix round).

## Adversarial Review Provenance

18-agent find/refute workflow: 14 raw → 10 confirmed → 6 distinct defects, all fixed: mid-journey `travel.start` clobber (ADVANCE lacked `NOT(is_in_transit())`/`NOT(is_constrained())`), the config-recompute oracle poisoning above, doomed-arc economics (stall arm dominated softmax at 0.22 with no reset), promotion spam, sampler missing project settings, and a one-directional validator mooted by `promotable`.

## Evidence

- Slot-2 coverage (35 anchors, 1427–1461): `advance_relocation_plan` displaces `surveil` (153→128) while **every embodied-maintenance count is byte-identical**; max routine-share shift 0.20% against the configured 5% tolerance.
- Live acceptance tests on save_02 (rolled back): cadence (due/not-due/due-again), crisis interrupt with deterministic resume-then-age-to-abandon, the full arc's checkpoint-pair verify with zero drift across start/advance/stall/abandon/complete/handoff, and the real `travel.arrive` landing the character at the project's target.
- Independent verification: 670 offline / 740 live (orrery+config), full default suite 1181 passed.

Migration 074 is not applied to any slot by this PR; `scripts/migrate.py --all` after merge (together with 075).

Closes #475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNyLUhnkShmdcGHQrxRxsY