### PR TITLE
Validate entity declarations during generation

### DIFF
--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -463,10 +463,11 @@ class NewEntityPairTagHint(BaseModel):
     Optional registered pair-tag hint attached to a new-entity declaration.
 
     The declared entity is one endpoint; ``other_entity_name`` names the other.
-    Hints are validated against the live ``pair_tags`` registry at commit time
-    (unregistered or kind-incompatible tags are hard errors) and feed the
-    background maturation pass as prompt material — they are not written
-    directly at declaration time.
+    Hints are validated against the live ``pair_tags`` registry during
+    generation, where unregistered or kind-incompatible tags trigger a retry.
+    The commit path revalidates the complete declaration batch as a backstop.
+    Valid hints feed the background maturation pass as prompt material — they
+    are not written directly at declaration time.
     """
 
     tag: str = Field(
@@ -500,8 +501,9 @@ class NewEntityDeclaration(BaseModel):
 
     Declare SPARINGLY: only entities likely to recur or matter. Background
     crowds and genuinely mundane passersby exist in prose only and must not
-    be declared. Tag hints use registered vocabulary only; unregistered names
-    are hard errors at commit time.
+    be declared. Tag hints use registered vocabulary only; invalid hints
+    trigger generation-time repair, with whole-batch commit-time validation as
+    a mutation-safety backstop.
     """
 
     kind: Literal["character", "place", "faction"] = Field(

--- a/nexus/agents/logon/orrery_tag_validation.py
+++ b/nexus/agents/logon/orrery_tag_validation.py
@@ -133,9 +133,12 @@ def build_storyteller_tag_validator(dbname: Optional[str]) -> Optional[Any]:
             )
             raise ModelRetry(
                 "Your Orrery tags or new-entity declaration hints failed "
-                "closed-registry validation. Use bare registered tag names "
-                "only (e.g. 'comfortable'), never 'category:name' composites; "
-                "drop any tag with no registered equivalent. Fix every listed "
+                "closed-registry validation. For applied_tags and tag_hints, "
+                "use bare registered tag names only (e.g. 'comfortable'), never "
+                "'category:name' composites. For pair_tag_hints, use the exact "
+                "registered pair-tag name; pair tags may contain colons (e.g. "
+                "'contact:social'). Drop any tag with no registered equivalent. "
+                "Fix every listed "
                 f"path and resubmit the complete response:\n{formatted}"
             )
         return output

--- a/nexus/agents/logon/orrery_tag_validation.py
+++ b/nexus/agents/logon/orrery_tag_validation.py
@@ -1,14 +1,15 @@
-"""Generation-time registry validation for storyteller Orrery tag bestowals.
+"""Generation-time registry validation for storyteller Orrery vocabulary.
 
 Skald freely invents tag names (often ``category:name`` composites) when
-introducing entities or updating state. The closed-vocabulary tag writers
-hard-error on unknown names -- but they run inside the chunk COMMIT
-transaction, where the only outcome is a dead player turn (M9 gate finding).
+introducing entities, updating state, or emitting ``new_entities`` declaration
+hints. The closed-vocabulary tag writers hard-error on unknown names -- but
+they run inside the chunk COMMIT transaction, where the only outcome is a dead
+player turn (M9 gate finding).
 
 This module walks a parsed storyteller response and validates every
-``orrery_tags`` bestowal against the live registry, so LOGON's structured
-output validator can hand the issues back to the model as a retry while the
-model still owns the turn.
+``orrery_tags`` bestowal and declaration hint against the live registry, so
+LOGON's structured output validator can hand the issues back to the model as a
+retry while the model still owns the turn.
 """
 
 from __future__ import annotations
@@ -16,6 +17,9 @@ from __future__ import annotations
 import logging
 from typing import Any, List, Optional, Tuple
 
+from nexus.agents.orrery.declaration_validation import (
+    collect_new_entity_declaration_vocabulary_issues,
+)
 from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
 from nexus.agents.orrery.tag_writer import validate_tag_bestowal
 
@@ -84,7 +88,7 @@ def _bestowal_sites(response: Any) -> List[Tuple[str, str, OrreryTagBestowal]]:
 
 
 def collect_orrery_tag_issues(response: Any, cur: Any) -> List[str]:
-    """Validate every bestowal in the response against the live registry."""
+    """Validate every bestowal and declaration against the live registry."""
 
     issues: List[str] = []
     for path, entity_kind, bestowal in _bestowal_sites(response):
@@ -92,6 +96,11 @@ def collect_orrery_tag_issues(response: Any, cur: Any) -> List[str]:
             cur, entity_kind=entity_kind, bestowal=bestowal
         ):
             issues.append(f"{path}: {issue}")
+    issues.extend(
+        collect_new_entity_declaration_vocabulary_issues(
+            cur, getattr(response, "new_entities", None) or []
+        )
+    )
     return issues
 
 
@@ -118,15 +127,16 @@ def build_storyteller_tag_validator(dbname: Optional[str]) -> Optional[Any]:
         if issues:
             formatted = "\n".join(f"- {issue}" for issue in issues)
             logger.info(
-                "Storyteller orrery_tags failed registry validation (%s issues); "
-                "requesting model retry",
+                "Storyteller Orrery vocabulary failed registry validation "
+                "(%s issues); requesting model retry",
                 len(issues),
             )
             raise ModelRetry(
-                "Your orrery_tags failed closed-registry validation. Use bare "
-                "registered tag names only (e.g. 'comfortable'), never "
-                "'category:name' composites; drop any tag with no registered "
-                f"equivalent. Fix these and resubmit:\n{formatted}"
+                "Your Orrery tags or new-entity declaration hints failed "
+                "closed-registry validation. Use bare registered tag names "
+                "only (e.g. 'comfortable'), never 'category:name' composites; "
+                "drop any tag with no registered equivalent. Fix every listed "
+                f"path and resubmit the complete response:\n{formatted}"
             )
         return output
 

--- a/nexus/agents/orrery/declaration_validation.py
+++ b/nexus/agents/orrery/declaration_validation.py
@@ -1,0 +1,51 @@
+"""Shared closed-vocabulary checks for storyteller entity declarations."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from nexus.agents.logon.apex_schema import NewEntityDeclaration
+from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
+from nexus.agents.orrery.tag_writer import (
+    validate_pair_tag_endpoint,
+    validate_tag_bestowal,
+)
+
+
+def collect_new_entity_declaration_vocabulary_issues(
+    cur: Any,
+    declarations: Sequence[NewEntityDeclaration],
+) -> list[str]:
+    """Return path-qualified vocabulary issues without mutating the database.
+
+    The same collector runs at generation time (where issues become a
+    ``ModelRetry``) and again immediately before commit-time stub processing.
+    This keeps both boundaries on one closed-vocabulary contract.
+    """
+
+    issues: list[str] = []
+    for declaration_index, declaration in enumerate(declarations):
+        path = f"new_entities[{declaration_index}]"
+
+        if declaration.tag_hints:
+            bestowal = OrreryTagBestowal(applied_tags=list(declaration.tag_hints))
+            for issue in validate_tag_bestowal(
+                cur,
+                entity_kind=declaration.kind,
+                bestowal=bestowal,
+            ):
+                detail = issue.removeprefix("applied_tags: ")
+                issues.append(f"{path}.tag_hints: {detail}")
+
+        for hint_index, hint in enumerate(declaration.pair_tag_hints):
+            try:
+                validate_pair_tag_endpoint(
+                    cur,
+                    tag=hint.tag,
+                    entity_kind=declaration.kind,
+                    role=hint.declared_entity_role,
+                )
+            except ValueError as exc:
+                issues.append(f"{path}.pair_tag_hints[{hint_index}].tag: {exc}")
+
+    return issues

--- a/nexus/agents/orrery/retrograde_maturation.py
+++ b/nexus/agents/orrery/retrograde_maturation.py
@@ -40,6 +40,9 @@ from psycopg2.extras import RealDictCursor
 from pydantic import BaseModel
 
 from nexus.agents.logon.apex_schema import NewEntityDeclaration
+from nexus.agents.orrery.declaration_validation import (
+    collect_new_entity_declaration_vocabulary_issues,
+)
 from nexus.agents.orrery.retrograde_vocabulary import SeedEligibleVocabulary
 from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
 from nexus.agents.orrery.tag_writer import apply_tag_bestowal
@@ -135,8 +138,16 @@ def enqueue_declared_entity_maturations(
     lowered_text = (raw_text or "").lower()
 
     with conn.cursor() as cur:
+        vocabulary_issues = collect_new_entity_declaration_vocabulary_issues(
+            cur, parsed
+        )
+        if vocabulary_issues:
+            formatted = "\n".join(f"- {issue}" for issue in vocabulary_issues)
+            raise RetrogradeMaturationVocabularyError(
+                f"New-entity declaration vocabulary validation failed:\n{formatted}"
+            )
+
         for declaration in parsed:
-            _validate_pair_tag_hints(cur, declaration)
             record = _resolve_or_create_stub(cur, declaration)
             if record.created:
                 result.stubs_created += 1
@@ -166,41 +177,6 @@ def enqueue_declared_entity_maturations(
                 result.jobs_already_present += 1
 
     return result
-
-
-def _validate_pair_tag_hints(cur: Any, declaration: NewEntityDeclaration) -> None:
-    """Reject unregistered or kind-incompatible pair-tag hints loudly."""
-
-    for hint in declaration.pair_tag_hints:
-        cur.execute(
-            """
-            /* orrery:maturation:pair_tag_hint_lookup */
-            SELECT subject_kinds, object_kinds, deprecated
-            FROM pair_tags
-            WHERE tag = %s
-            """,
-            (hint.tag,),
-        )
-        row = cur.fetchone()
-        if row is None:
-            raise RetrogradeMaturationVocabularyError(
-                f"Declaration {declaration.name!r} uses unregistered pair-tag "
-                f"hint {hint.tag!r}"
-            )
-        if _row_value(row, "deprecated", 2):
-            raise RetrogradeMaturationVocabularyError(
-                f"Declaration {declaration.name!r} uses deprecated pair-tag "
-                f"hint {hint.tag!r}"
-            )
-        if hint.declared_entity_role == "subject":
-            allowed = _row_value(row, "subject_kinds", 0)
-        else:
-            allowed = _row_value(row, "object_kinds", 1)
-        if declaration.kind not in set(allowed or ()):
-            raise RetrogradeMaturationVocabularyError(
-                f"Pair-tag hint {hint.tag!r} does not allow "
-                f"{declaration.kind!r} as {hint.declared_entity_role}"
-            )
 
 
 def _resolve_or_create_stub(

--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -1087,6 +1087,38 @@ def _lookup_pair_tag_row(cur: Any, tag: str) -> Any:
     return row
 
 
+def validate_pair_tag_endpoint(
+    cur: Any,
+    *,
+    tag: str,
+    entity_kind: str,
+    role: Literal["subject", "object"],
+) -> None:
+    """Validate one known endpoint of a registered directed pair tag.
+
+    Declaration hints name the other endpoint but do not resolve it yet, so
+    generation and commit can only validate the declared entity's side of the
+    relation.  The registry lookup and kind rules intentionally share the same
+    primitives as :func:`apply_pair_tag_bestowal`.
+    """
+
+    if entity_kind not in VALID_ENTITY_KINDS:
+        raise ValueError(
+            f"Unknown entity_kind={entity_kind!r}; expected one of "
+            f"{sorted(VALID_ENTITY_KINDS)}"
+        )
+
+    row = _lookup_pair_tag_row(cur, tag)
+    allowed_index = 1 if role == "subject" else 2
+    allowed_key = "subject_kinds" if role == "subject" else "object_kinds"
+    allowed = _row_value(row, allowed_key, allowed_index) or []
+    if entity_kind not in allowed:
+        raise ValueError(
+            f"pair_tag {tag!r} does not allow {role}_kind={entity_kind!r}; "
+            f"allowed: {sorted(allowed)}"
+        )
+
+
 def _validate_pair_tag_kinds(
     *,
     tag: str,

--- a/tests/test_orrery/test_retrograde_maturation.py
+++ b/tests/test_orrery/test_retrograde_maturation.py
@@ -175,7 +175,11 @@ class _RecordingCursor:
         normalized = " ".join(str(sql).split())
         self._fetchall = []
         self._fetchone = None
-        if "FROM characters WHERE name" in normalized:
+        if "FROM tag_category_registry" in normalized:
+            self._fetchall = [("bodyform",), ("disposition",)]
+        elif "FROM tags" in normalized:
+            self._fetchone = None
+        elif "FROM characters WHERE name" in normalized:
             self._fetchall = self.existing_entity_rows
         elif "INSERT INTO orrery_maturation_jobs" in normalized:
             self._fetchone = self.job_insert_returns.pop(0)
@@ -307,6 +311,40 @@ def test_enqueue_rejects_ambiguous_names() -> None:
             slot=2,
             settings=_ENABLED_SETTINGS,
         )
+
+
+def test_enqueue_validates_whole_declaration_batch_before_stub_processing() -> None:
+    """The accept-time backstop rejects the turn before any entity mutation."""
+
+    cursor = _RecordingCursor(existing_entity_rows=[], job_insert_returns=[])
+    conn = _RecordingConnection(cursor)
+    invalid_declaration = {
+        "kind": "character",
+        "name": "The Hallucinated Clerk",
+        "summary": "A clerk carrying an unregistered declaration hint.",
+        "tag_hints": ["invented:tag"],
+    }
+
+    with pytest.raises(
+        RetrogradeMaturationVocabularyError,
+        match=r"new_entities\[1\]\.tag_hints",
+    ):
+        enqueue_declared_entity_maturations(
+            conn,
+            declarations=[_DECLARATION, invalid_declaration],
+            chunk_id=10,
+            raw_text="Sister Anechka meets The Hallucinated Clerk.",
+            slot=2,
+            settings=_ENABLED_SETTINGS,
+        )
+
+    assert not any(
+        "FROM characters WHERE name" in " ".join(sql.split())
+        for sql, _params in cursor.executed
+    )
+    assert not any(
+        "INSERT INTO" in sql or "UPDATE " in sql for sql, _params in cursor.executed
+    )
 
 
 # ============================================================================

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -14,6 +14,7 @@ from nexus.agents.logon.apex_schema import (
     LocationStateUpdate,
     NewCharacter,
     NewEntityDeclaration,
+    NewEntityPairTagHint,
     ReferencedEntities,
     ReferenceType,
     StateUpdates,
@@ -255,6 +256,22 @@ def test_registered_new_entity_hints_produce_no_issues() -> None:
     )
 
     assert collect_orrery_tag_issues(response, FakeRegistryCursor()) == []
+
+
+def test_declaration_schema_describes_generation_and_commit_validation() -> None:
+    """Schema documentation matches the two validation boundaries."""
+
+    declaration_description = " ".join(
+        NewEntityDeclaration.model_json_schema()["description"].split()
+    )
+    pair_hint_description = " ".join(
+        NewEntityPairTagHint.model_json_schema()["description"].split()
+    )
+
+    assert "generation-time repair" in declaration_description
+    assert "commit-time validation" in declaration_description
+    assert "during generation" in pair_hint_description
+    assert "commit path revalidates" in pair_hint_description
 
 
 @pytest.mark.asyncio

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -46,6 +46,7 @@ class FakeRegistryCursor:
         # tag -> (id, subject_kinds, object_kinds)
         self.pair_tags = {
             "protects": (11, ["character", "faction"], ["place"]),
+            "contact:social": (12, ["character"], ["character"]),
         }
         self.categories_by_kind = {
             "character": {"bodyform", "disposition"},
@@ -274,10 +275,22 @@ async def test_storyteller_validator_attributes_declaration_failure_to_model_ret
     with pytest.raises(ModelRetry) as exc_info:
         await validator(
             SimpleNamespace(retry=0),
-            _storyteller_response(tag_hints=["invented:tag"]),
+            _storyteller_response(
+                tag_hints=["invented:tag"],
+                pair_tag_hints=[
+                    {
+                        "tag": "contact:social",
+                        "other_entity_name": "Brena Tideloft",
+                        "declared_entity_role": "subject",
+                    }
+                ],
+            ),
         )
 
     assert "new_entities[0].tag_hints" in exc_info.value.message
+    assert "For applied_tags and tag_hints" in exc_info.value.message
+    assert "pair tags may contain colons" in exc_info.value.message
+    assert "'contact:social'" in exc_info.value.message
     assert "resubmit the complete response" in exc_info.value.message
 
 

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, List, Optional, Tuple
+
+import pytest
+from pydantic_ai import ModelRetry
 
 from nexus.agents.logon.apex_schema import (
     CharacterReference,
     CharacterStateUpdate,
     LocationStateUpdate,
     NewCharacter,
+    NewEntityDeclaration,
     ReferencedEntities,
     ReferenceType,
     StateUpdates,
+    StorytellerResponseExtended,
 )
 from nexus.agents.logon.orrery_tag_schema import (
     storyteller_anthropic_output_config,
@@ -24,6 +30,7 @@ from nexus.agents.logon.orrery_tag_validation import (
 )
 from nexus.agents.orrery.tag_library import TagLibraryEntry
 from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
+from scripts.api_openai import OpenAIProvider
 
 
 class FakeRegistryCursor:
@@ -36,6 +43,10 @@ class FakeRegistryCursor:
             "perceptive": (2, "disposition", False, None),
             "haven": (3, "place_class", False, None),
         }
+        # tag -> (id, subject_kinds, object_kinds)
+        self.pair_tags = {
+            "protects": (11, ["character", "faction"], ["place"]),
+        }
         self.categories_by_kind = {
             "character": {"bodyform", "disposition"},
             "place": {"place_class"},
@@ -43,6 +54,12 @@ class FakeRegistryCursor:
         }
         self._result: List[Tuple[Any, ...]] = []
         self._one: Optional[Tuple[Any, ...]] = None
+
+    def __enter__(self) -> "FakeRegistryCursor":
+        return self
+
+    def __exit__(self, *_args: Any) -> bool:
+        return False
 
     def execute(self, sql: str, params: Tuple[Any, ...] = ()) -> None:
         if "tag_category_registry" in sql:
@@ -53,6 +70,10 @@ class FakeRegistryCursor:
             self._one = None
         elif "FROM tags" in sql:
             row = self.tags.get(params[0])
+            self._one = row
+            self._result = [row] if row else []
+        elif "FROM pair_tags" in sql:
+            row = self.pair_tags.get(params[0])
             self._one = row
             self._result = [row] if row else []
         else:
@@ -69,8 +90,53 @@ def _response(**kwargs: Any) -> Any:
     class _FakeResponse:
         referenced_entities = kwargs.get("referenced_entities")
         state_updates = kwargs.get("state_updates")
+        new_entities = kwargs.get("new_entities", [])
 
     return _FakeResponse()
+
+
+class FakeRegistryConnection:
+    """Context-managed connection exposing a fixed registry cursor."""
+
+    def __init__(self, cursor: FakeRegistryCursor) -> None:
+        self._cursor = cursor
+
+    def __enter__(self) -> "FakeRegistryConnection":
+        return self
+
+    def __exit__(self, *_args: Any) -> bool:
+        return False
+
+    def cursor(self) -> FakeRegistryCursor:
+        return self._cursor
+
+
+def _storyteller_response(
+    *,
+    tag_hints: Optional[List[str]] = None,
+    pair_tag_hints: Optional[List[dict[str, str]]] = None,
+) -> StorytellerResponseExtended:
+    return StorytellerResponseExtended.model_validate(
+        {
+            "narrative": "Marra Kest steps out from behind the sluice gate.",
+            "choices": ["Question Marra.", "Keep walking."],
+            "chunk_metadata": {},
+            "referenced_entities": {},
+            "state_updates": {},
+            "operations": None,
+            "orrery_adjudications": [],
+            "new_entities": [
+                {
+                    "kind": "character",
+                    "name": "Marra Kest",
+                    "summary": "A sluice keeper with divided loyalties.",
+                    "tag_hints": tag_hints or [],
+                    "pair_tag_hints": pair_tag_hints or [],
+                }
+            ],
+            "reasoning": None,
+        }
+    )
 
 
 def test_valid_bestowals_produce_no_issues() -> None:
@@ -138,6 +204,214 @@ def test_kind_incompatible_tags_are_flagged() -> None:
     issues = collect_orrery_tag_issues(response, FakeRegistryCursor())
     assert len(issues) == 1
     assert "haven" in issues[0]
+
+
+def test_new_entity_hint_issues_are_path_qualified_and_aggregated() -> None:
+    response = _response(
+        new_entities=[
+            NewEntityDeclaration.model_validate(
+                {
+                    "kind": "character",
+                    "name": "Marra Kest",
+                    "summary": "A sluice keeper with divided loyalties.",
+                    "tag_hints": ["invented:tag"],
+                    "pair_tag_hints": [
+                        {
+                            "tag": "invented_pair_tag",
+                            "other_entity_name": "The Sluice Guild",
+                            "declared_entity_role": "subject",
+                        },
+                        {
+                            "tag": "protects",
+                            "other_entity_name": "The Sluice Guild",
+                            "declared_entity_role": "object",
+                        },
+                    ],
+                }
+            )
+        ]
+    )
+
+    issues = collect_orrery_tag_issues(response, FakeRegistryCursor())
+
+    assert len(issues) == 3
+    assert issues[0].startswith("new_entities[0].tag_hints:")
+    assert issues[1].startswith("new_entities[0].pair_tag_hints[0].tag:")
+    assert issues[2].startswith("new_entities[0].pair_tag_hints[1].tag:")
+    assert "does not allow object_kind='character'" in issues[2]
+
+
+def test_registered_new_entity_hints_produce_no_issues() -> None:
+    response = _storyteller_response(
+        tag_hints=["human"],
+        pair_tag_hints=[
+            {
+                "tag": "protects",
+                "other_entity_name": "The Lower Sluice",
+                "declared_entity_role": "subject",
+            }
+        ],
+    )
+
+    assert collect_orrery_tag_issues(response, FakeRegistryCursor()) == []
+
+
+@pytest.mark.asyncio
+async def test_storyteller_validator_attributes_declaration_failure_to_model_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nexus.api import db_pool
+
+    cursor = FakeRegistryCursor()
+    monkeypatch.setattr(
+        db_pool,
+        "get_connection",
+        lambda _dbname: FakeRegistryConnection(cursor),
+    )
+    validator = build_storyteller_tag_validator("test_slot")
+    assert validator is not None
+
+    with pytest.raises(ModelRetry) as exc_info:
+        await validator(
+            SimpleNamespace(retry=0),
+            _storyteller_response(tag_hints=["invented:tag"]),
+        )
+
+    assert "new_entities[0].tag_hints" in exc_info.value.message
+    assert "resubmit the complete response" in exc_info.value.message
+
+
+def test_provider_repairs_invalid_declaration_inside_structured_retry_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the repaired response can escape LOGON's provider boundary."""
+
+    from nexus.api import db_pool
+
+    cursor = FakeRegistryCursor()
+    monkeypatch.setattr(
+        db_pool,
+        "get_connection",
+        lambda _dbname: FakeRegistryConnection(cursor),
+    )
+
+    invalid = _storyteller_response(tag_hints=["invented:tag"])
+    repaired = _storyteller_response(tag_hints=["human"])
+    prompts: list[str] = []
+    outputs = [invalid, repaired]
+
+    class FakeResponses:
+        def parse(self, **kwargs: Any) -> Any:
+            prompts.append(kwargs["input"][-1]["content"])
+            output = outputs.pop(0)
+            return SimpleNamespace(
+                output_parsed=output,
+                output_text=output.model_dump_json(),
+                usage=SimpleNamespace(input_tokens=11, output_tokens=22),
+            )
+
+    provider = OpenAIProvider(
+        model="gpt-4.1",
+        api_key="test-key",
+        structured_output_retries=1,
+        output_validator=build_storyteller_tag_validator("test_slot"),
+    )
+    provider.client = SimpleNamespace(responses=FakeResponses())
+
+    parsed, _llm_response = provider.get_structured_completion(
+        "Continue the story.", StorytellerResponseExtended
+    )
+
+    assert parsed == repaired
+    assert outputs == []
+    assert len(prompts) == 2
+    assert "=== STRUCTURED OUTPUT RETRY ===" in prompts[1]
+    assert "new_entities[0].tag_hints" in prompts[1]
+
+
+@pytest.mark.asyncio
+async def test_exhausted_declaration_validation_never_reaches_incubator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A declaration rejected at LOGON's boundary cannot be persisted."""
+
+    from nexus.api import db_pool, narrative_generation
+
+    cursor = FakeRegistryCursor()
+    monkeypatch.setattr(
+        db_pool,
+        "get_connection",
+        lambda _dbname: FakeRegistryConnection(cursor),
+    )
+    validator = build_storyteller_tag_validator("test_slot")
+    assert validator is not None
+
+    class InvalidDeclarationLore:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            self.turn_context = SimpleNamespace(error_log=[])
+
+        async def process_turn(
+            self,
+            _user_text: str,
+            parent_chunk_id: int,
+            note: Optional[str] = None,
+        ) -> Any:
+            del parent_chunk_id, note
+            return await validator(
+                SimpleNamespace(retry=1),
+                _storyteller_response(tag_hints=["invented:tag"]),
+            )
+
+        def close(self) -> None:
+            pass
+
+    class GenerationConnection:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class ProgressManager:
+        def __init__(self) -> None:
+            self.events: list[tuple[str, str, Optional[dict[str, Any]]]] = []
+
+        async def send_progress(
+            self,
+            session_id: str,
+            status: str,
+            data: Optional[dict[str, Any]] = None,
+        ) -> None:
+            self.events.append((session_id, status, data))
+
+    async def get_chunk_info(_conn: Any, _chunk_id: int) -> dict[str, Any]:
+        return {"season": 1, "episode": 1, "place_name": "The Sluice"}
+
+    async def reject_incubator_write(*_args: Any, **_kwargs: Any) -> None:
+        pytest.fail("invalid declaration output must not reach the incubator")
+
+    monkeypatch.setattr(narrative_generation, "LORE", InvalidDeclarationLore)
+    monkeypatch.setattr(narrative_generation, "get_chunk_info", get_chunk_info)
+    monkeypatch.setattr(
+        narrative_generation, "write_to_incubator", reject_incubator_write
+    )
+    conn = GenerationConnection()
+    manager = ProgressManager()
+
+    await narrative_generation.generate_narrative_async(
+        session_id="invalid-declaration",
+        parent_chunk_id=12,
+        user_text="Continue.",
+        slot=5,
+        get_db_connection=lambda _slot: conn,
+        load_settings=lambda: {},
+        manager=manager,
+    )
+
+    errors = [data for _session, status, data in manager.events if status == "error"]
+    assert len(errors) == 1
+    assert errors[0] is not None
+    assert "new_entities[0].tag_hints" in errors[0]["error"]
+    assert conn.closed is True
 
 
 def test_validator_skipped_without_slot_database() -> None:


### PR DESCRIPTION
## Summary

- Share one read-only closed-vocabulary validator for new-entity tag and pair-tag hints.
- Run declaration validation inside LOGON’s structured-output loop so invalid generations become `ModelRetry` responses instead of poisoned incubator state.
- Retain a whole-batch accept-time backstop before any stub or maturation mutation.
- Reuse the pair-tag writer’s endpoint semantics at both boundaries.

## Impact

Invalid declaration vocabulary is attributed to the generation that produced it and retried immediately; it can no longer wedge the slot on the following turn or partially mutate entity state.

## Validation

- `PYTHONPATH="$PWD" poetry run pytest -q tests/test_orrery_tag_validation.py tests/test_orrery/test_retrograde_maturation.py` — 32 passed, 4 skipped.
- Broader declaration and pair-tag audit: 83 passed, 16 skipped.
- Black, scoped flake8, diff checks, and focused mypy passed.

Closes #501

Codex — GPT-5.6-Sol