### PR TITLE
Preserve operator-selected models during setup

### DIFF
--- a/nexus/api/new_story_flow.py
+++ b/nexus/api/new_story_flow.py
@@ -11,9 +11,8 @@ from typing import Any, Dict, Optional, TYPE_CHECKING
 import psycopg2
 
 from nexus.api.conversations import ConversationsClient
-from nexus.api.config_utils import get_new_story_model
 from nexus.api.new_story_cache import read_cache, write_cache, clear_cache, init_cache
-from nexus.api.save_slots import upsert_slot, clear_active
+from nexus.api.save_slots import clear_active, get_slot_model, upsert_slot
 from nexus.api.slot_utils import slot_dbname, all_slots
 from scripts.new_story_setup import create_slot_schema_only
 
@@ -27,6 +26,27 @@ logger = logging.getLogger("nexus.api.new_story_flow")
 MOCK_WIZARD_MODEL = "TEST"
 
 
+def resolve_setup_model(
+    requested_model: Optional[str],
+    slot_model: Optional[str],
+    *,
+    default_slot_model: str,
+    wizard_default_model: str,
+) -> str:
+    """Resolve the model locked in when a new-story setup starts.
+
+    An explicit request is authoritative. Otherwise, preserve an operator-set
+    slot model, identified by a value other than the configured fresh-slot
+    placeholder. Only an unset/fresh slot falls back to the wizard roster
+    default.
+    """
+    if requested_model:
+        return requested_model
+    if slot_model and slot_model != default_slot_model:
+        return slot_model
+    return wizard_default_model
+
+
 def start_setup(slot_number: int, model: Optional[str] = None) -> str:
     """
     Start a new setup conversation for a slot.
@@ -37,11 +57,9 @@ def start_setup(slot_number: int, model: Optional[str] = None) -> str:
 
     Args:
         slot_number: Target save slot (1-5)
-        model: Optional model name. The HTTP setup endpoint resolves the
-            model before calling (explicit override or the configured
-            wizard default), so it always passes a concrete ID; direct
-            callers (e.g., scripts/new_story_cli.py) may pass None to get
-            the nexus.toml wizard.default_model fallback here.
+        model: Optional explicit model override. When omitted, an existing
+            operator-set slot model is preserved; only an unset/fresh slot
+            uses the configured wizard default.
 
     Returns:
         Thread ID for the new conversation
@@ -58,9 +76,22 @@ def start_setup(slot_number: int, model: Optional[str] = None) -> str:
         # New slot databases are created by cloning this template's structure.
         create_slot_schema_only(slot_number, source_db="NEXUS_template")
 
+    if model:
+        # Preserve the explicit-override path without requiring config or a
+        # metadata read: it is authoritative by definition.
+        model_to_use = model
+    else:
+        from nexus.config import load_settings
+
+        settings = load_settings()
+        model_to_use = resolve_setup_model(
+            None,
+            get_slot_model(slot_number, dbname=dbname),
+            default_slot_model=settings.global_.model.default_slot_model,
+            wizard_default_model=settings.wizard.default_model,
+        )
+
     clear_cache(dbname)
-    # Use provided model or fall back to settings
-    model_to_use = model or get_new_story_model()
     client = ConversationsClient(model=model_to_use)
     thread_id = client.create_thread()
     init_cache(dbname, thread_id=thread_id, target_slot=slot_number)

--- a/nexus/api/new_story_flow.py
+++ b/nexus/api/new_story_flow.py
@@ -11,7 +11,13 @@ from typing import Any, Dict, Optional, TYPE_CHECKING
 import psycopg2
 
 from nexus.api.conversations import ConversationsClient
-from nexus.api.new_story_cache import read_cache, write_cache, clear_cache, init_cache
+from nexus.api.new_story_cache import (
+    clear_cache,
+    init_cache,
+    read_cache,
+    read_cache_raw,
+    write_cache,
+)
 from nexus.api.save_slots import clear_active, get_slot_model, upsert_slot
 from nexus.api.slot_utils import slot_dbname, all_slots
 from scripts.new_story_setup import create_slot_schema_only
@@ -27,22 +33,19 @@ MOCK_WIZARD_MODEL = "TEST"
 
 
 def resolve_setup_model(
-    requested_model: Optional[str],
     slot_model: Optional[str],
     *,
+    setup_started: bool,
     default_slot_model: str,
     wizard_default_model: str,
 ) -> str:
-    """Resolve the model locked in when a new-story setup starts.
+    """Resolve an omitted model when a new-story setup starts.
 
-    An explicit request is authoritative. Otherwise, preserve an operator-set
-    slot model, identified by a value other than the configured fresh-slot
-    placeholder. Only an unset/fresh slot falls back to the wizard roster
-    default.
+    Preserve a slot model when it differs from the fresh-slot placeholder or
+    when an existing wizard-cache row proves setup already locked that model.
+    Only a genuinely fresh slot falls back to the wizard roster default.
     """
-    if requested_model:
-        return requested_model
-    if slot_model and slot_model != default_slot_model:
+    if slot_model and (setup_started or slot_model != default_slot_model):
         return slot_model
     return wizard_default_model
 
@@ -85,8 +88,8 @@ def start_setup(slot_number: int, model: Optional[str] = None) -> str:
 
         settings = load_settings()
         model_to_use = resolve_setup_model(
-            None,
             get_slot_model(slot_number, dbname=dbname),
+            setup_started=read_cache_raw(dbname) is not None,
             default_slot_model=settings.global_.model.default_slot_model,
             wizard_default_model=settings.wizard.default_model,
         )

--- a/nexus/api/setup_endpoints.py
+++ b/nexus/api/setup_endpoints.py
@@ -30,8 +30,8 @@ from nexus.api.new_story_flow import (
     activate_slot,
 )
 from nexus.api.new_story_cache import write_wizard_choices
+from nexus.api.save_slots import get_slot_model
 from nexus.api.slot_utils import slot_dbname
-from nexus.api.config_utils import get_new_story_model
 
 logger = logging.getLogger("nexus.api.setup_endpoints")
 
@@ -42,14 +42,15 @@ router = APIRouter(prefix="/api/story/new", tags=["setup"])
 async def start_setup_endpoint(request: StartSetupRequest) -> Dict[str, Any]:
     """Start a new setup conversation"""
     try:
-        # Resolve the effective model once: an explicit request override
-        # (backend/CLI test flows may pass TEST here) or the configured
-        # wizard default from nexus.toml. The resolved model is stamped on
-        # the slot by start_setup, overriding any pre-wizard slot stamp such
-        # as the dev reset default; the mock TEST server is never selected
-        # implicitly.
-        model_to_use = request.model or get_new_story_model()
-        thread_id = start_setup(request.slot, model_to_use)
+        # The core resolves and persists the setup model. Passing the raw
+        # request keeps omitted client values distinct from explicit
+        # overrides so an operator-set slot model can be preserved.
+        thread_id = start_setup(request.slot, request.model)
+        model_to_use = get_slot_model(request.slot, dbname=slot_dbname(request.slot))
+        if not model_to_use:
+            raise RuntimeError(
+                f"Setup for slot {request.slot} started without a persisted model"
+            )
 
         # Load welcome message and choices from frontmatter
         prompt_path = (

--- a/nexus/api/storyteller.py
+++ b/nexus/api/storyteller.py
@@ -54,7 +54,6 @@ from nexus.api.retry_handler import (
     openai_rate_limiter,
     FallbackChain,
 )
-from nexus.api.config_utils import get_new_story_model
 
 if TYPE_CHECKING:
     from nexus.agents.lore.lore import LORE
@@ -726,9 +725,7 @@ async def delete_session(
 @app.post("/api/story/new/setup/start", response_model=NewStoryStartResponse)
 def new_story_setup_start(request: NewStoryStartRequest) -> NewStoryStartResponse:
     """Start a new story setup for a slot (creates conversations thread, clears cache)."""
-    # Use provided model or fall back to settings
-    model_to_use = request.model or get_new_story_model()
-    thread_id = start_new_story_setup(request.slot, model=model_to_use)
+    thread_id = start_new_story_setup(request.slot, model=request.model)
     return NewStoryStartResponse(thread_id=thread_id, slot=request.slot)
 
 

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -1066,10 +1066,9 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
 
         if state.get("is_empty"):
             # Initialize via setup/start endpoint. Forward only an explicit
-            # --model override; otherwise the backend resolves the configured
-            # wizard default. The empty slot's pre-wizard model stamp (the
-            # dev reset default) is deliberately NOT forwarded so the mock
-            # TEST server is never selected implicitly.
+            # --model override; otherwise the backend preserves an
+            # operator-set slot model or resolves the configured wizard
+            # default for a fresh slot.
             setup_url = f"{get_api_url()}/api/story/new/setup/start"
             setup_payload = {"slot": args.slot}
             model_to_use = getattr(args, "model", None)
@@ -1126,8 +1125,9 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
             else:
                 # Call wizard chat directly
                 url = f"{get_api_url()}/api/story/new/chat"
-                # Use CLI override or slot's configured model (e.g., TEST mode)
-                model_to_use = args.model or state.get("model")
+                # Omission is meaningful: the backend resolves the slot's
+                # locked model. Only forward an explicit CLI override.
+                model_to_use = getattr(args, "model", None)
 
                 # Check if we're in trait selection mode
                 trait_menu = state.get("trait_menu")
@@ -1331,7 +1331,9 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
         # (Also reached after wizard transition above)
         if not state.get("is_wizard_mode"):
             # Narrative mode - call continue directly
-            model_to_use = args.model or state.get("model")
+            # The API already resolves the persisted slot model. Sending a
+            # model is an explicit override and must remain opt-in.
+            model_to_use = getattr(args, "model", None)
             user_text = args.user_text or ""
 
             url = f"{get_api_url()}/api/narrative/continue"

--- a/scripts/new_story_cli.py
+++ b/scripts/new_story_cli.py
@@ -34,7 +34,8 @@ def main():
 
     p_start = sub.add_parser("start")
     p_start.add_argument("--slot", type=int, required=True)
-    # When --model is omitted, fall back to the wizard.default_model from nexus.toml
+    # Omission lets the core preserve an operator-set slot model or choose the
+    # wizard default for a fresh slot.
     p_start.add_argument("--model", default=None)
 
     p_resume = sub.add_parser("resume")
@@ -54,10 +55,6 @@ def main():
     args = parser.parse_args()
 
     if args.command == "start":
-        if args.model is None:
-            from nexus.config import load_settings
-
-            args.model = load_settings().wizard.default_model
         thread_id = start_setup(args.slot, model=args.model)
         print(f"Started thread {thread_id} for slot {args.slot}")
     elif args.command == "resume":

--- a/tests/test_api/test_wizard_model_resolution.py
+++ b/tests/test_api/test_wizard_model_resolution.py
@@ -48,23 +48,11 @@ def test_start_setup_request_model_defaults_to_none() -> None:
     assert request.model is None
 
 
-def test_setup_model_explicit_request_wins() -> None:
-    assert (
-        resolve_setup_model(
-            "explicit-model",
-            "operator-model",
-            default_slot_model="fresh-placeholder",
-            wizard_default_model="wizard-default",
-        )
-        == "explicit-model"
-    )
-
-
 def test_setup_model_preserves_operator_slot_model() -> None:
     assert (
         resolve_setup_model(
-            None,
             "operator-model",
+            setup_started=False,
             default_slot_model="fresh-placeholder",
             wizard_default_model="wizard-default",
         )
@@ -72,15 +60,16 @@ def test_setup_model_preserves_operator_slot_model() -> None:
     )
 
 
-def test_setup_model_treats_empty_request_as_omitted() -> None:
+def test_setup_model_preserves_default_named_model_after_setup_started() -> None:
+    """A prior wizard row disambiguates an intentional TEST model stamp."""
     assert (
         resolve_setup_model(
-            "",
-            "operator-model",
-            default_slot_model="fresh-placeholder",
+            "TEST",
+            setup_started=True,
+            default_slot_model="TEST",
             wizard_default_model="wizard-default",
         )
-        == "operator-model"
+        == "TEST"
     )
 
 
@@ -90,8 +79,8 @@ def test_setup_model_uses_wizard_default_only_for_fresh_slot(
 ) -> None:
     assert (
         resolve_setup_model(
-            None,
             slot_model,
+            setup_started=False,
             default_slot_model="fresh-placeholder",
             wizard_default_model="wizard-default",
         )
@@ -100,17 +89,19 @@ def test_setup_model_uses_wizard_default_only_for_fresh_slot(
 
 
 @pytest.mark.parametrize(
-    ("requested_model", "slot_model", "expected_model"),
+    ("requested_model", "slot_model", "setup_started", "expected_model"),
     [
-        ("explicit-model", "operator-model", "explicit-model"),
-        (None, "operator-model", "operator-model"),
-        (None, "fresh-placeholder", "wizard-default"),
+        ("explicit-model", "operator-model", False, "explicit-model"),
+        (None, "operator-model", False, "operator-model"),
+        (None, "fresh-placeholder", False, "wizard-default"),
+        (None, "fresh-placeholder", True, "fresh-placeholder"),
     ],
 )
 def test_start_setup_persists_resolved_model(
     monkeypatch: pytest.MonkeyPatch,
     requested_model: str | None,
     slot_model: str,
+    setup_started: bool,
     expected_model: str,
 ) -> None:
     """The core applies precedence once, then persists the selected model."""
@@ -139,6 +130,11 @@ def test_start_setup_persists_resolved_model(
         new_story_flow,
         "get_slot_model",
         lambda _slot, dbname=None: slot_model,
+    )
+    monkeypatch.setattr(
+        new_story_flow,
+        "read_cache_raw",
+        lambda _dbname: SimpleNamespace() if setup_started else None,
     )
     monkeypatch.setattr(new_story_flow, "clear_cache", lambda _dbname: None)
     monkeypatch.setattr(new_story_flow, "init_cache", lambda *_args, **_kwargs: None)
@@ -171,6 +167,66 @@ def test_start_setup_persists_resolved_model(
             "dbname": "save_test",
         }
     ]
+
+
+def test_start_setup_preserves_explicit_test_model_on_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A TEST setup stamp survives a later omitted-model restart."""
+    clients: list[str] = []
+    slot_state: dict[str, Any] = {"model": "TEST", "cache": None}
+
+    class FakeConnection:
+        def close(self) -> None:
+            """Mirror the psycopg connection close surface."""
+
+    class FakeConversationsClient:
+        def __init__(self, model: str) -> None:
+            clients.append(model)
+
+        def create_thread(self) -> str:
+            return f"thread-{len(clients)}"
+
+    monkeypatch.setattr(
+        new_story_flow.psycopg2,
+        "connect",
+        lambda **_kwargs: FakeConnection(),
+    )
+    monkeypatch.setattr(new_story_flow, "slot_dbname", lambda _slot: "save_test")
+    monkeypatch.setattr(
+        new_story_flow,
+        "get_slot_model",
+        lambda _slot, dbname=None: slot_state["model"],
+    )
+    monkeypatch.setattr(
+        new_story_flow,
+        "read_cache_raw",
+        lambda _dbname: slot_state["cache"],
+    )
+    monkeypatch.setattr(new_story_flow, "clear_cache", lambda _dbname: None)
+    monkeypatch.setattr(
+        new_story_flow,
+        "init_cache",
+        lambda *_args, **_kwargs: slot_state.update(cache={"id": True}),
+    )
+    monkeypatch.setattr(new_story_flow, "clear_active", lambda _dbname: None)
+    monkeypatch.setattr(
+        new_story_flow,
+        "upsert_slot",
+        lambda _slot, **kwargs: slot_state.update(model=kwargs["model"]),
+    )
+    monkeypatch.setattr(new_story_flow, "ConversationsClient", FakeConversationsClient)
+    monkeypatch.setattr(
+        "nexus.config.load_settings",
+        lambda: SimpleNamespace(
+            global_=SimpleNamespace(model=SimpleNamespace(default_slot_model="TEST")),
+            wizard=SimpleNamespace(default_model="wizard-default"),
+        ),
+    )
+
+    assert new_story_flow.start_setup(4, model="TEST") == "thread-1"
+    assert new_story_flow.start_setup(4) == "thread-2"
+    assert clients == ["TEST", "TEST"]
 
 
 def test_setup_endpoint_passes_omitted_model_to_core(

--- a/tests/test_api/test_wizard_model_resolution.py
+++ b/tests/test_api/test_wizard_model_resolution.py
@@ -7,11 +7,18 @@ backend resolves it: explicit request override -> slot's stamped model
 mock TEST server must never be selected implicitly.
 """
 
+from types import SimpleNamespace
+from typing import Any
+
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
+from nexus.api import new_story_flow, setup_endpoints, storyteller
 from nexus.api.config_utils import get_new_story_model
 from nexus.api.narrative_schemas import ChatRequest, StartSetupRequest
+from nexus.api.new_story_flow import resolve_setup_model
 from nexus.api.wizard_chat import resolve_wizard_model, wizard_model_lock_candidate
 
 
@@ -39,6 +46,194 @@ def test_chat_request_accepts_explicit_test_model() -> None:
 def test_start_setup_request_model_defaults_to_none() -> None:
     request = StartSetupRequest(slot=5)
     assert request.model is None
+
+
+def test_setup_model_explicit_request_wins() -> None:
+    assert (
+        resolve_setup_model(
+            "explicit-model",
+            "operator-model",
+            default_slot_model="fresh-placeholder",
+            wizard_default_model="wizard-default",
+        )
+        == "explicit-model"
+    )
+
+
+def test_setup_model_preserves_operator_slot_model() -> None:
+    assert (
+        resolve_setup_model(
+            None,
+            "operator-model",
+            default_slot_model="fresh-placeholder",
+            wizard_default_model="wizard-default",
+        )
+        == "operator-model"
+    )
+
+
+def test_setup_model_treats_empty_request_as_omitted() -> None:
+    assert (
+        resolve_setup_model(
+            "",
+            "operator-model",
+            default_slot_model="fresh-placeholder",
+            wizard_default_model="wizard-default",
+        )
+        == "operator-model"
+    )
+
+
+@pytest.mark.parametrize("slot_model", [None, "", "fresh-placeholder"])
+def test_setup_model_uses_wizard_default_only_for_fresh_slot(
+    slot_model: str | None,
+) -> None:
+    assert (
+        resolve_setup_model(
+            None,
+            slot_model,
+            default_slot_model="fresh-placeholder",
+            wizard_default_model="wizard-default",
+        )
+        == "wizard-default"
+    )
+
+
+@pytest.mark.parametrize(
+    ("requested_model", "slot_model", "expected_model"),
+    [
+        ("explicit-model", "operator-model", "explicit-model"),
+        (None, "operator-model", "operator-model"),
+        (None, "fresh-placeholder", "wizard-default"),
+    ],
+)
+def test_start_setup_persists_resolved_model(
+    monkeypatch: pytest.MonkeyPatch,
+    requested_model: str | None,
+    slot_model: str,
+    expected_model: str,
+) -> None:
+    """The core applies precedence once, then persists the selected model."""
+    clients: list[str] = []
+    upserts: list[dict[str, Any]] = []
+
+    class FakeConnection:
+        def close(self) -> None:
+            """Mirror the psycopg connection close surface."""
+
+    class FakeConversationsClient:
+        def __init__(self, model: str) -> None:
+            clients.append(model)
+
+        def create_thread(self) -> str:
+            """Return a deterministic thread without a provider call."""
+            return "thread-explicit"
+
+    monkeypatch.setattr(
+        new_story_flow.psycopg2,
+        "connect",
+        lambda **_kwargs: FakeConnection(),
+    )
+    monkeypatch.setattr(new_story_flow, "slot_dbname", lambda _slot: "save_test")
+    monkeypatch.setattr(
+        new_story_flow,
+        "get_slot_model",
+        lambda _slot, dbname=None: slot_model,
+    )
+    monkeypatch.setattr(new_story_flow, "clear_cache", lambda _dbname: None)
+    monkeypatch.setattr(new_story_flow, "init_cache", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(new_story_flow, "clear_active", lambda _dbname: None)
+    monkeypatch.setattr(
+        new_story_flow,
+        "upsert_slot",
+        lambda slot, **kwargs: upserts.append({"slot": slot, **kwargs}),
+    )
+    monkeypatch.setattr(new_story_flow, "ConversationsClient", FakeConversationsClient)
+    monkeypatch.setattr(
+        "nexus.config.load_settings",
+        lambda: SimpleNamespace(
+            global_=SimpleNamespace(
+                model=SimpleNamespace(default_slot_model="fresh-placeholder")
+            ),
+            wizard=SimpleNamespace(default_model="wizard-default"),
+        ),
+    )
+
+    thread_id = new_story_flow.start_setup(4, model=requested_model)
+
+    assert thread_id == "thread-explicit"
+    assert clients == [expected_model]
+    assert upserts == [
+        {
+            "slot": 4,
+            "is_active": True,
+            "model": expected_model,
+            "dbname": "save_test",
+        }
+    ]
+
+
+def test_setup_endpoint_passes_omitted_model_to_core(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The HTTP layer must not replace omission with the roster default."""
+    starts: list[tuple[int, str | None]] = []
+
+    class FakeConversationsClient:
+        def __init__(self, model: str) -> None:
+            assert model == "operator-model"
+
+        def add_message(self, *_args: Any) -> None:
+            """Accept welcome-message seeding without a provider call."""
+
+    def fake_start_setup(slot: int, model: str | None) -> str:
+        starts.append((slot, model))
+        return "thread-operator"
+
+    monkeypatch.setattr(
+        setup_endpoints,
+        "start_setup",
+        fake_start_setup,
+    )
+    monkeypatch.setattr(
+        setup_endpoints,
+        "get_slot_model",
+        lambda _slot, dbname=None: "operator-model",
+    )
+    monkeypatch.setattr(setup_endpoints, "slot_dbname", lambda _slot: "save_test")
+    monkeypatch.setattr(setup_endpoints, "ConversationsClient", FakeConversationsClient)
+    monkeypatch.setattr(
+        setup_endpoints, "write_wizard_choices", lambda *_args, **_kwargs: None
+    )
+
+    app = FastAPI()
+    app.include_router(setup_endpoints.router)
+    response = TestClient(app).post("/api/story/new/setup/start", json={"slot": 4})
+
+    assert response.status_code == 200
+    assert starts == [(4, None)]
+    assert response.json()["model"] == "operator-model"
+
+
+def test_legacy_storyteller_setup_passes_omitted_model_to_core(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The second setup HTTP surface must preserve omission as well."""
+    starts: list[tuple[int, str | None]] = []
+
+    def fake_start_setup(slot: int, model: str | None = None) -> str:
+        starts.append((slot, model))
+        return "thread-operator"
+
+    monkeypatch.setattr(storyteller, "start_new_story_setup", fake_start_setup)
+
+    response = storyteller.new_story_setup_start(
+        storyteller.NewStoryStartRequest(slot=4)
+    )
+
+    assert starts == [(4, None)]
+    assert response.thread_id == "thread-operator"
+    assert response.slot == 4
 
 
 def test_configured_wizard_default_is_not_the_mock() -> None:

--- a/tests/test_cli_model_selection.py
+++ b/tests/test_cli_model_selection.py
@@ -1,0 +1,158 @@
+"""CLI model-selection regression tests for new-story flows."""
+
+from argparse import Namespace
+from typing import Any
+
+from nexus import cli
+
+
+class DummyResponse:
+    """Minimal successful requests response for CLI boundary tests."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+        self.ok = True
+        self.text = ""
+
+    def json(self) -> dict[str, Any]:
+        """Return response JSON."""
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        """Mirror a successful response."""
+
+
+def test_continue_starts_empty_slot_without_implicit_model(monkeypatch) -> None:
+    """An omitted CLI override must stay omitted at the setup API boundary."""
+    posts: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_get(url: str, **kwargs: Any) -> DummyResponse:
+        assert url.endswith("/api/slot/4/state")
+        return DummyResponse(
+            {
+                "is_empty": True,
+                "is_wizard_mode": False,
+                "model": "operator-model",
+            }
+        )
+
+    def fake_post(url: str, json: dict[str, Any], **kwargs: Any) -> DummyResponse:
+        posts.append((url, json))
+        return DummyResponse(
+            {
+                "thread_id": "thread-operator",
+                "model": "operator-model",
+                "welcome_message": "Welcome.",
+                "welcome_choices": [],
+            }
+        )
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+    monkeypatch.setattr(cli.requests, "post", fake_post)
+
+    result = cli.run_continue(
+        Namespace(
+            slot=4,
+            model=None,
+            user_text=None,
+            choice=None,
+            accept_fate=False,
+            dev=False,
+        )
+    )
+
+    assert result["success"] is True
+    assert posts == [
+        (
+            f"{cli.get_api_url()}/api/story/new/setup/start",
+            {"slot": 4},
+        )
+    ]
+
+
+def test_continue_wizard_turn_forwards_only_explicit_model(monkeypatch) -> None:
+    """The server-side slot lock resolves ordinary wizard turns."""
+    posts: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_get(url: str, **kwargs: Any) -> DummyResponse:
+        assert url.endswith("/api/slot/4/state")
+        return DummyResponse(
+            {
+                "is_empty": False,
+                "is_wizard_mode": True,
+                "phase": "setting",
+                "model": "operator-model",
+                "choices": [],
+            }
+        )
+
+    def fake_post(url: str, json: dict[str, Any], **kwargs: Any) -> DummyResponse:
+        posts.append((url, json))
+        return DummyResponse(
+            {
+                "message": "The city waits.",
+                "choices": [],
+                "phase": "setting",
+                "phase_complete": False,
+            }
+        )
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+    monkeypatch.setattr(cli.requests, "post", fake_post)
+
+    result = cli.run_continue(
+        Namespace(
+            slot=4,
+            model=None,
+            user_text="Begin.",
+            choice=None,
+            accept_fate=False,
+            dev=False,
+        )
+    )
+
+    assert result["success"] is True
+    assert len(posts) == 1
+    assert posts[0][0].endswith("/api/story/new/chat")
+    assert posts[0][1]["message"] == "Begin."
+    assert "model" not in posts[0][1]
+
+
+def test_continue_narrative_turn_forwards_only_explicit_model(monkeypatch) -> None:
+    """A persisted narrative model is resolved server-side too."""
+    posts: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_get(url: str, **kwargs: Any) -> DummyResponse:
+        assert url.endswith("/api/slot/4/state")
+        return DummyResponse(
+            {
+                "is_empty": False,
+                "is_wizard_mode": False,
+                "has_pending": False,
+                "model": "operator-model",
+            }
+        )
+
+    def fake_post(url: str, json: dict[str, Any], **kwargs: Any) -> DummyResponse:
+        posts.append((url, json))
+        return DummyResponse({"message": "The city answers.", "session_id": None})
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+    monkeypatch.setattr(cli.requests, "post", fake_post)
+
+    result = cli.run_continue(
+        Namespace(
+            slot=4,
+            model=None,
+            user_text="Continue.",
+            choice=None,
+            accept_fate=False,
+            dev=False,
+        )
+    )
+
+    assert result["success"] is True
+    assert len(posts) == 1
+    assert posts[0][0].endswith("/api/narrative/continue")
+    assert posts[0][1]["user_text"] == "Continue."
+    assert "model" not in posts[0][1]

--- a/tests/test_new_story_cli.py
+++ b/tests/test_new_story_cli.py
@@ -1,0 +1,51 @@
+"""Unit tests for the standalone new-story CLI."""
+
+import sys
+
+from scripts import new_story_cli
+
+
+def test_start_omits_model_when_cli_flag_is_absent(monkeypatch, capsys) -> None:
+    """The standalone client must leave setup-model resolution to the core."""
+    calls: list[tuple[int, str | None]] = []
+
+    def fake_start_setup(slot: int, model: str | None = None) -> str:
+        calls.append((slot, model))
+        return "thread-4"
+
+    monkeypatch.setattr(
+        new_story_cli,
+        "start_setup",
+        fake_start_setup,
+    )
+    monkeypatch.setattr(sys, "argv", ["new_story_cli.py", "start", "--slot", "4"])
+
+    new_story_cli.main()
+
+    assert calls == [(4, None)]
+    assert "Started thread thread-4 for slot 4" in capsys.readouterr().out
+
+
+def test_start_forwards_explicit_model(monkeypatch, capsys) -> None:
+    """An explicit standalone CLI override remains authoritative."""
+    calls: list[tuple[int, str | None]] = []
+
+    def fake_start_setup(slot: int, model: str | None = None) -> str:
+        calls.append((slot, model))
+        return "thread-4"
+
+    monkeypatch.setattr(
+        new_story_cli,
+        "start_setup",
+        fake_start_setup,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["new_story_cli.py", "start", "--slot", "4", "--model", "operator"],
+    )
+
+    new_story_cli.main()
+
+    assert calls == [(4, "operator")]
+    assert "Started thread thread-4 for slot 4" in capsys.readouterr().out

--- a/ui/client/src/components/NewStoryWizard/InteractiveWizard.tsx
+++ b/ui/client/src/components/NewStoryWizard/InteractiveWizard.tsx
@@ -164,8 +164,9 @@ export function InteractiveWizard({
                     return;
                 }
 
-                // No model in the payload: the backend resolves the
-                // configured wizard default and stamps it on the slot.
+                // No model in the payload: the backend preserves an
+                // operator-set slot model, or chooses the wizard default for
+                // a fresh slot, and stamps that resolution on the setup.
                 const startRes = await fetch("/api/story/new/setup/start", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary

- Resolve setup models using explicit override first, then a non-placeholder slot stamp, and the wizard default only for a fresh slot.
- Preserve omitted model fields across HTTP, CLI, standalone wizard, storyteller, and UI surfaces until the core resolves them.
- Cover fresh-slot, operator-selected, explicit-override, and legacy setup paths.

## Impact

Starting or resuming the wizard no longer silently replaces an operator-selected model with the roster default, preserving fixture provenance and model-comparison integrity.

## Validation

- `PYTHONPATH="$PWD" poetry run pytest -q tests/test_api/test_wizard_model_resolution.py tests/test_cli_model_selection.py tests/test_new_story_cli.py` — 27 passed.
- Black and `git diff --check` passed.
- The broader `tests/test_cli.py` module retains an unrelated main-branch collection failure from its import of absent `GENERATION_POLL_SECONDS`; this branch does not touch that symbol.

Closes #498

Codex — GPT-5.6-Sol