### PR TITLE
Route narrative summaries through model providers

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -902,10 +902,16 @@ generation_timeout_seconds = 1200
 # Summaries follow the storyteller (apex.model) by default — summary quality
 # varies materially by model, so the default is never a cheaper model. Set
 # `model` explicitly (advanced) to decouple the summarizer from the
-# storyteller. The current pipeline accepts native OpenAI or
-# Responses-compatible OpenAI endpoints only; a storyteller outside that set
-# requires an explicit routable model here until #481's routing lands.
+# storyteller. Provider routing follows the model registry: native OpenAI,
+# native Anthropic, Responses-compatible endpoints, and local Chat Completions
+# endpoints all use their declared structured-output transport.
 # model = "@openai.default"
+temperature = 0.2
+reasoning_effort = "medium"
+episode_max_output_tokens = 2500
+season_max_output_tokens = 4000
+request_token_budget = 30000
+structured_output_retries = 0
 
 # =============================================================================
 # IR Evaluation V2 Settings

--- a/nexus/api/native_structured_output.py
+++ b/nexus/api/native_structured_output.py
@@ -180,6 +180,8 @@ def build_native_structured_provider(
         anthropic_kwargs: Dict[str, Any] = {}
         if temperature is not None:
             anthropic_kwargs["temperature"] = temperature
+        if reasoning_effort is not None:
+            anthropic_kwargs["reasoning_effort"] = reasoning_effort
         return AnthropicProvider(
             model=model,
             max_tokens=max_tokens,

--- a/nexus/api/native_structured_output.py
+++ b/nexus/api/native_structured_output.py
@@ -73,7 +73,7 @@ def openai_response_text_format(
             "schema": schema,
         }
 
-    return type_to_text_format_param(schema_model)
+    return cast(Dict[str, Any], type_to_text_format_param(schema_model))
 
 
 def _strip_anthropic_unsupported_schema_keys(value: Any) -> Any:
@@ -159,8 +159,15 @@ def build_native_structured_provider(
     system_prompt: str,
     structured_output_retries: int,
     output_validator: Optional[Callable[..., Any]] = None,
+    temperature: Optional[float] = None,
+    reasoning_effort: Optional[str] = None,
 ) -> Any:
-    """Build the repo's native strict structured-output provider wrapper."""
+    """Build the repo's native strict structured-output provider wrapper.
+
+    ``temperature`` and ``reasoning_effort`` are optional so existing callers
+    retain each provider wrapper's defaults. Consumers that expose sampling
+    controls can pass them without reimplementing provider routing.
+    """
 
     from nexus.config import get_openai_compatible_endpoint
     from nexus.config.loader import get_provider_for_model
@@ -170,14 +177,23 @@ def build_native_structured_provider(
     endpoint = get_openai_compatible_endpoint(model)
     provider_type = get_provider_for_model(model)
     if provider_type == "anthropic" and endpoint is None:
+        anthropic_kwargs: Dict[str, Any] = {}
+        if temperature is not None:
+            anthropic_kwargs["temperature"] = temperature
         return AnthropicProvider(
             model=model,
             max_tokens=max_tokens,
             system_prompt=system_prompt,
             structured_output_retries=structured_output_retries,
             output_validator=output_validator,
+            **anthropic_kwargs,
         )
     if provider_type == "openai" or endpoint is not None:
+        openai_kwargs: Dict[str, Any] = {}
+        if temperature is not None:
+            openai_kwargs["temperature"] = temperature
+        if reasoning_effort is not None:
+            openai_kwargs["reasoning_effort"] = reasoning_effort
         return OpenAIProvider(
             model=model,
             max_output_tokens=max_tokens,
@@ -190,6 +206,7 @@ def build_native_structured_provider(
             request_timeout=(endpoint["request_timeout_seconds"] if endpoint else None),
             structured_output_retries=structured_output_retries,
             output_validator=output_validator,
+            **openai_kwargs,
         )
     raise ValueError(f"Unsupported provider type for model {model!r}: {provider_type}")
 

--- a/nexus/api/summary_triggers.py
+++ b/nexus/api/summary_triggers.py
@@ -157,16 +157,17 @@ def _run_summary_generation(
             )
 
 
-def _summaries_model_is_routable(model_name: str) -> bool:
+def _summary_model_is_registered(model_name: str) -> bool:
+    """Return whether a candidate has an authoritative registry route."""
+
     from nexus.config import load_settings
 
     settings = load_settings()
     try:
-        return settings.summaries_model_is_routable(model_name)
+        settings.provider_for_model(model_name)
     except ValueError:
-        # Not in the registry at all — the pre-#481 pipeline would have sent
-        # this id to api.openai.com and 404'd; unroutable is the honest verdict.
         return False
+    return True
 
 
 def _run_single_task(
@@ -220,17 +221,13 @@ def _run_single_task(
 
     failure_reasons: List[str] = []
     for index, model_name in enumerate(model_candidates):
-        if not _summaries_model_is_routable(model_name):
-            # A followed non-OpenAI storyteller lands here (config load
-            # deliberately allows it — the local-Skald path must stay
-            # selectable). Record the gap durably instead of calling a
-            # provider that would 404.
+        if not _summary_model_is_registered(model_name):
+            # Registry membership is the routing authority. Record a durable
+            # configuration error instead of guessing a provider endpoint.
             reason = (
-                f"{model_name}: the Responses-only summary pipeline cannot "
-                "route this model. Set [summaries].model to a routable model "
-                "(native OpenAI, or a registry provider with "
-                "structured_transport='responses') to decouple summaries "
-                "from the storyteller, or wait for the #481 routing work."
+                f"{model_name}: model is not declared in nexus.toml's "
+                "[global.model.api_models] registry. Add the model to the "
+                "registry or set [summaries].model to a registered model."
             )
             logger.error("Cannot generate %s summary: %s", target_label, reason)
             failure_reasons.append(reason)
@@ -328,6 +325,9 @@ def _coalesce_models(model_candidates: Optional[Sequence[str]]) -> List[str]:
     if not deduped:
         from nexus.config import load_settings
 
-        deduped.append(load_settings().summaries.model)
+        model = load_settings().summaries.model
+        if model is None:  # Defensive: Settings resolves the default from apex.
+            raise ValueError("No narrative summary model is configured")
+        deduped.append(model)
 
     return deduped

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1826,10 +1826,57 @@ class SummariesSettings(BaseModel):
         description=(
             "Registry model reference used for episode and season summaries. "
             "Absent (the default) follows the storyteller (apex.model); set "
-            "explicitly to decouple the summarizer from the storyteller. The "
-            "current summarizer requires the OpenAI Responses transport."
+            "explicitly to decouple the summarizer from the storyteller. All "
+            "registered native and OpenAI-compatible providers are routable."
         ),
     )
+    temperature: float = Field(
+        default=0.2,
+        ge=0.0,
+        le=2.0,
+        description="Sampling temperature for summary models that accept it.",
+    )
+    reasoning_effort: Literal["low", "medium", "high"] = Field(
+        default="medium",
+        description="Reasoning effort for summary models that reject temperature.",
+    )
+    episode_max_output_tokens: int = Field(
+        default=2500,
+        gt=0,
+        description="Maximum output tokens for episode summaries.",
+    )
+    season_max_output_tokens: int = Field(
+        default=4000,
+        gt=0,
+        description="Maximum output tokens for season summaries.",
+    )
+    request_token_budget: int = Field(
+        default=30000,
+        gt=0,
+        description=(
+            "Conservative combined input/output token budget for one summary request."
+        ),
+    )
+    structured_output_retries: int = Field(
+        default=0,
+        ge=0,
+        description="Validation retry budget for structured summary output.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_request_budget(self) -> "SummariesSettings":
+        """Keep each output allowance below the combined request budget."""
+
+        largest_output = max(
+            self.episode_max_output_tokens,
+            self.season_max_output_tokens,
+        )
+        if self.request_token_budget <= largest_output:
+            raise ValueError(
+                "summaries.request_token_budget must exceed both summary "
+                "max-output-token settings"
+            )
+        return self
 
 
 # =============================================================================
@@ -2244,53 +2291,14 @@ class Settings(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def _validate_summaries_transport(self) -> "Settings":
-        """Reject summary models the current Responses-only pipeline cannot route.
+    def _resolve_summaries_model(self) -> "Settings":
+        """Make summaries follow the storyteller unless explicitly decoupled."""
 
-        Issue #481 deliberately decouples summary model selection without also
-        adding Anthropic-native or local Chat Completions routing. Fail at config
-        load so an unsupported selection cannot become a dropped background job.
-        """
-        followed = self.summaries.model is None
-        if followed:
-            # Owner decision (2026-07-14): summaries follow the storyteller
-            # unless explicitly decoupled — never a silently-cheaper model.
+        if self.summaries.model is None:
+            # Owner decision (2026-07-14): never choose a silently-cheaper
+            # summarizer. Provider routing is shared across every registry model.
             self.summaries.model = self.apex.model
-        if not self.summaries_model_is_routable(self.summaries.model):
-            model_id = self.summaries.model
-            provider = self.provider_for_model(model_id)
-            provider_config = self.global_.model.api_models[provider]
-            if followed:
-                # A non-OpenAI storyteller is a fully supported choice (the
-                # local-Skald path); refusing it here would block the apex
-                # picker. The summary pipeline records a durable, refireable
-                # error marker instead of silently losing summaries.
-                return self
-            raise ValueError(
-                "[summaries].model must resolve to the native OpenAI provider "
-                "or to an OpenAI-compatible registry provider with "
-                "structured_transport='responses'; "
-                f"'{model_id}' resolves to provider '{provider}' with "
-                f"structured_transport='{provider_config.structured_transport}'. "
-                "Anthropic-native and chat_completions summary routing are "
-                "deferred routing work tracked by #481."
-            )
         return self
-
-    def summaries_model_is_routable(self, model_id: str) -> bool:
-        """Whether the Responses-only summary pipeline can serve this model.
-
-        Shared by config validation (explicit [summaries].model choices fail
-        loudly) and the summary scheduler (a followed-but-unroutable
-        storyteller records a durable error marker instead of calling a
-        provider that would 404).
-        """
-        provider = self.provider_for_model(model_id)
-        provider_config = self.global_.model.api_models[provider]
-        return provider == "openai" or (
-            provider not in NATIVE_API_PROVIDERS
-            and provider_config.structured_transport == "responses"
-        )
 
     @model_validator(mode="after")
     def _validate_param_capabilities(self) -> "Settings":

--- a/scripts/api_anthropic.py
+++ b/scripts/api_anthropic.py
@@ -274,6 +274,7 @@ class AnthropicProvider(LLMProvider):
         top_p: Optional[float] = None,
         top_k: Optional[int] = None,
         timeout: int = 120,
+        reasoning_effort: Optional[str] = None,
         thinking_enabled: bool = False,
         thinking_budget_tokens: Optional[int] = None,
         structured_output_retries: Optional[int] = None,
@@ -291,6 +292,7 @@ class AnthropicProvider(LLMProvider):
             top_p: Optional top-p sampling parameter (0.0-1.0)
             top_k: Optional top-k sampling parameter
             timeout: Request timeout in seconds
+            reasoning_effort: Anthropic output effort for structured requests
             thinking_enabled: Enable extended thinking (requires Claude 4+ models)
             thinking_budget_tokens: Thinking token budget (typically 32000)
             structured_output_retries: Validation retry budget for structured
@@ -301,6 +303,7 @@ class AnthropicProvider(LLMProvider):
         self.top_p = top_p
         self.top_k = top_k
         self.timeout = timeout
+        self.reasoning_effort = reasoning_effort
         self.thinking_enabled = thinking_enabled
         self.thinking_budget_tokens = thinking_budget_tokens
         self.structured_output_retries = (
@@ -314,6 +317,10 @@ class AnthropicProvider(LLMProvider):
         if thinking_enabled and thinking_budget_tokens is None:
             raise ValueError(
                 "thinking_budget_tokens must be specified when thinking_enabled=True"
+            )
+        if reasoning_effort not in {None, "low", "medium", "high"}:
+            raise ValueError(
+                "reasoning_effort must be one of 'low', 'medium', or 'high'"
             )
 
         # Call parent init
@@ -619,6 +626,9 @@ class AnthropicProvider(LLMProvider):
                 if output_format is not None
                 else anthropic_output_config(schema_model)
             )
+        if self.reasoning_effort is not None:
+            output_config = dict(output_config)
+            output_config.setdefault("effort", self.reasoning_effort)
 
         params: Dict[str, Any] = {
             "model": self.model,

--- a/scripts/summarize_narrative.py
+++ b/scripts/summarize_narrative.py
@@ -3,15 +3,16 @@
 NEXUS Narrative Summary Generator
 
 This script generates comprehensive summaries of entire seasons or specific episodes
-using GPT-5.1 by default (with GPT-4.1 as a long-context fallback), saving the results
-to the appropriate tables in the PostgreSQL database.
+using the configured summary model, saving the results to the appropriate tables in
+the PostgreSQL database.
 
 Features:
 - Multi-mode support: season summaries or episode summaries
 - Episode range support: summarize multiple episodes in one run
-- Database integration: saves summaries as structured JSONB to seasons and episodes tables
+- Database integration: saves structured JSONB to seasons and episodes tables
 - Context-aware: includes padding chunks for better continuity
-- Structured output: Uses OpenAI's structured output mode with Pydantic models for consistent results
+- Structured output: Uses each registry provider's native structured-output transport
+  with Pydantic models for consistent results
 
 Usage:
     # Summarize an entire season
@@ -30,15 +31,16 @@ Usage:
     python summarize_narrative.py --season 3 --model @openai.default --dry-run
 """
 
-import os
-import sys
-import re
-import json
-import time
 import argparse
+import json
 import logging
+import os
+import re
+import sys
+import time
 from datetime import datetime, timezone
-from typing import Dict, List, Any, Tuple, Optional, Union, Set
+from typing import Any, Dict, List, Optional, Tuple, Type
+
 from pydantic import BaseModel, Field
 
 # Add parent directory to system path
@@ -46,14 +48,13 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
-# Import API OpenAI utilities
+# Import shared API utilities
+from nexus.api.native_structured_output import build_native_structured_provider
 from scripts.api_openai import (
-    OpenAIProvider,
     LLMResponse,
-    setup_abort_handler,
-    is_abort_requested,
-    reset_abort_flag,
     get_token_count,
+    is_abort_requested,
+    setup_abort_handler,
 )
 
 # Set up logging
@@ -69,18 +70,19 @@ def _resolve_default_summary_model() -> str:
     """Read the dedicated narrative-summary model from nexus.toml."""
     from nexus.config import load_settings
 
-    return load_settings().summaries.model
+    model = load_settings().summaries.model
+    if model is None:  # Defensive: Settings resolves follow-the-storyteller first.
+        raise ValueError("No narrative summary model is configured")
+    return model
 
 
 # Constants
-# DEFAULT_MODEL is resolved from nexus.toml on demand; see _resolve_default_summary_model.
+# DEFAULT_MODEL is resolved from nexus.toml on demand; see
+# _resolve_default_summary_model.
 # FALLBACK_MODEL is a CLI-only escape hatch for a one-off retry attempt — the user
 # must pass --fallback-model explicitly if they want to use it.
 DEFAULT_MODEL = None  # type: ignore[assignment]  # resolved at argparse time
 FALLBACK_MODEL = None  # type: ignore[assignment]
-DEFAULT_TEMPERATURE = 0.2
-MAX_TOKENS_SEASON = 4000
-MAX_TOKENS_EPISODE = 2500
 CONTEXT_CHUNK_BEFORE = 1  # Number of chunks to include before target for context
 CONTEXT_CHUNK_AFTER = 1  # Number of chunks to include after target for context
 SUMMARY_FAILURE_STATUS = "error"
@@ -1377,14 +1379,14 @@ class DatabaseManager:
 
 class SummaryGenerator:
     """
-    Main class to generate summaries using OpenAI's API.
+    Main class to generate summaries through the configured model provider.
     """
 
     def __init__(
         self,
         model: str,
-        temperature: float = DEFAULT_TEMPERATURE,
-        effort: str = "medium",
+        temperature: Optional[float] = None,
+        effort: Optional[str] = None,
         db_manager: Optional[DatabaseManager] = None,
         dry_run: bool = False,
         overwrite: bool = False,
@@ -1396,18 +1398,30 @@ class SummaryGenerator:
         Initialize the summary generator.
 
         Args:
-            model: OpenAI model to use
+            model: Registry model to use
             temperature: Temperature for generation (used for non-reasoning models)
             effort: Reasoning effort level (used for reasoning models)
             db_manager: Database manager instance
             dry_run: If True, don't save results
             verbose: If True, print detailed output
             save_prompt: If True, save prompts to files
-            prompt_on_conflict: If False, skip interactive overwrite prompts when summaries already exist
+            prompt_on_conflict: If False, skip interactive overwrite prompts
+                when summaries already exist
         """
+        from nexus.config import load_settings
+
+        summary_settings = load_settings().summaries
         self.model = model
-        self.temperature = temperature
-        self.effort = effort
+        self.temperature = (
+            summary_settings.temperature if temperature is None else temperature
+        )
+        self.effort = effort or summary_settings.reasoning_effort
+        self._max_output_tokens = {
+            "episode": summary_settings.episode_max_output_tokens,
+            "season": summary_settings.season_max_output_tokens,
+        }
+        self._request_token_budget = summary_settings.request_token_budget
+        self._structured_output_retries = summary_settings.structured_output_retries
         self.is_reasoning_model = self._model_rejects_temperature(model)
         self.db_manager = db_manager or DatabaseManager()
         self.dry_run = dry_run
@@ -1416,7 +1430,8 @@ class SummaryGenerator:
         self.save_prompt = save_prompt
         self.prompt_on_conflict = prompt_on_conflict
         self.last_error: Optional[str] = None
-        self.provider = self._initialize_provider()
+        self._providers: Dict[str, Any] = {}
+        self.provider: Optional[Any] = None
 
     @staticmethod
     def _model_rejects_temperature(model: str) -> bool:
@@ -1450,44 +1465,49 @@ class SummaryGenerator:
         )
         return "temperature" in entry.unsupported_params
 
-    def _initialize_provider(self) -> OpenAIProvider:
-        """Initialize the OpenAI provider."""
+    def _initialize_provider(self, mode: str) -> Any:
+        """Initialize the registry-routed provider for one summary mode."""
+
+        if mode not in self._max_output_tokens:
+            raise ValueError(f"Unsupported summary mode: {mode!r}")
         try:
-            from nexus.config import get_openai_compatible_endpoint
-
-            endpoint = get_openai_compatible_endpoint(self.model)
-            endpoint_kwargs: Dict[str, Any] = {}
-            if endpoint:
-                endpoint_kwargs = {
-                    "api_key": endpoint["api_key"],
-                    "base_url": endpoint["base_url"],
-                    "structured_transport": endpoint["structured_transport"],
-                    "request_timeout": endpoint["request_timeout_seconds"],
-                }
-            # Use the streamlined provider initialization
-            if self.is_reasoning_model:
-                provider = OpenAIProvider(
-                    model=self.model,
-                    reasoning_effort=self.effort,
-                    **endpoint_kwargs,
-                )
-                logger.info(
-                    f"Initialized OpenAI provider with reasoning model: {self.model}, effort: {self.effort}"
-                )
-            else:
-                provider = OpenAIProvider(
-                    model=self.model,
-                    temperature=self.temperature,
-                    **endpoint_kwargs,
-                )
-                logger.info(
-                    f"Initialized OpenAI provider with standard model: {self.model}, temperature: {self.temperature}"
-                )
-
+            provider = build_native_structured_provider(
+                model=self.model,
+                max_tokens=self._max_output_tokens[mode],
+                system_prompt=self._get_system_prompt(mode),
+                structured_output_retries=self._structured_output_retries,
+                temperature=(None if self.is_reasoning_model else self.temperature),
+                reasoning_effort=(self.effort if self.is_reasoning_model else None),
+            )
+            logger.info(
+                "Initialized %s summary provider for %s using %s",
+                provider.provider_name,
+                mode,
+                self.model,
+            )
             return provider
         except Exception as e:
-            logger.error(f"Error initializing OpenAI provider: {e}")
+            logger.error(f"Error initializing summary provider: {e}")
             raise
+
+    def _provider_for_mode(self, mode: str) -> Any:
+        """Return a cached provider configured for the mode's prompt and budget."""
+
+        if mode not in self._providers:
+            self._providers[mode] = self._initialize_provider(mode)
+        self.provider = self._providers[mode]
+        return self.provider
+
+    def _get_structured_summary(
+        self,
+        prompt: str,
+        mode: str,
+        schema_model: Type[BaseModel],
+    ) -> Tuple[Any, LLMResponse]:
+        """Generate one summary through the provider's native transport."""
+
+        provider = self._provider_for_mode(mode)
+        return provider.get_structured_completion(prompt, schema_model)
 
     def _get_system_prompt(self, mode: str) -> str:
         """
@@ -1595,23 +1615,11 @@ Your summaries will be accessed by another AI to maintain narrative consistency.
         """
         token_count = get_token_count(text, self.model)
 
-        # Load settings to get the TPM
-        from nexus.config import load_settings_as_dict
-
-        settings = load_settings_as_dict()
-
-        # Get the OpenAI TPM limit
-        openai_tpm = settings.get("API Settings", {}).get("TPM", {}).get("openai")
-        if not openai_tpm:
-            raise ValueError("Could not find OpenAI TPM limit in configuration")
-
         # Set output token limit based on mode
-        expected_output_tokens = (
-            MAX_TOKENS_SEASON if mode == "season" else MAX_TOKENS_EPISODE
-        )
+        expected_output_tokens = self._max_output_tokens[mode]
 
         # Calculate max input tokens (with a small buffer)
-        max_input_tokens = openai_tpm - expected_output_tokens
+        max_input_tokens = self._request_token_budget - expected_output_tokens
 
         if token_count > max_input_tokens:
             logger.warning(
@@ -1621,7 +1629,9 @@ Your summaries will be accessed by another AI to maintain narrative consistency.
             return False
 
         logger.info(
-            f"Token count: {token_count} (under limit of {max_input_tokens} from settings.json)"
+            "Token count: %s (under configured input limit of %s)",
+            token_count,
+            max_input_tokens,
         )
         return True
 
@@ -1699,7 +1709,6 @@ Your summaries will be accessed by another AI to maintain narrative consistency.
                 print("=" * 80 + "\n")
 
         # Prepare the prompt
-        system_prompt = self._get_system_prompt("season")
         chunks_text = self._prepare_chunks_text(chunks, "season")
 
         # Build the main prompt with previous summaries
@@ -1729,52 +1738,26 @@ I need a comprehensive, structured summary of Season {season} of the narrative. 
         self._save_prompt_to_file(prompt, f"season_{season}")
 
         try:
-            # Reuse the provider client so registry base_url/timeout routing is kept.
-            client = self.provider.client
-
-            # Prepare messages
-            messages = [{"role": "user", "content": prompt}]
-            if self.provider.system_prompt:
-                messages.insert(
-                    0, {"role": "system", "content": self.provider.system_prompt}
-                )
-
             # Create a simple Pydantic model for season summary
             class SeasonSummaryModel(BaseModel):
                 summary: str = Field(
                     description="A comprehensive, detailed narrative summary of the entire season capturing major plot developments, character arcs, key world-building elements, and themes."
                 )
 
-            logger.info(
-                f"Using OpenAI responses.parse with model {self.provider.model}"
+            parsed_summary, llm_response = self._get_structured_summary(
+                prompt,
+                "season",
+                SeasonSummaryModel,
             )
 
-            # Call the API with appropriate parameters based on model type
-            if self.is_reasoning_model:
-                response = client.responses.parse(
-                    model=self.provider.model,
-                    input=messages,
-                    reasoning={"effort": self.effort},
-                    text_format=SeasonSummaryModel,
-                )
-                logger.info(f"Used reasoning model with effort: {self.effort}")
-            else:
-                response = client.responses.parse(
-                    model=self.provider.model,
-                    input=messages,
-                    temperature=self.temperature,
-                    text_format=SeasonSummaryModel,
-                )
-                logger.info(f"Used standard model with temperature: {self.temperature}")
-
             # Create a summary dict that matches our expected format
-            summary_text = response.output_parsed.summary
+            summary_text = parsed_summary.summary
             summary_dict = {"summary": summary_text}
 
             # Log completion info
             logger.info(
-                f"Generated season summary with {response.usage.input_tokens} input tokens and "
-                f"{response.usage.output_tokens} output tokens"
+                f"Generated season summary with {llm_response.input_tokens} input tokens and "
+                f"{llm_response.output_tokens} output tokens"
             )
 
             # Print summary in verbose mode
@@ -1922,7 +1905,6 @@ I need a comprehensive, structured summary of Season {season} of the narrative. 
             print("=" * 80 + "\n")
 
         # Prepare the prompt
-        system_prompt = self._get_system_prompt("episode")
         chunks_text = self._prepare_chunks_text(chunks, "episode")
 
         # Build the main prompt with context
@@ -1961,52 +1943,26 @@ I need a comprehensive, structured summary of Season {season}, Episode {episode}
         self._save_prompt_to_file(prompt, f"s{season:02d}e{episode:02d}")
 
         try:
-            # Reuse the provider client so registry base_url/timeout routing is kept.
-            client = self.provider.client
-
-            # Prepare messages
-            messages = [{"role": "user", "content": prompt}]
-            if self.provider.system_prompt:
-                messages.insert(
-                    0, {"role": "system", "content": self.provider.system_prompt}
-                )
-
             # Create a simple Pydantic model for episode summary
             class EpisodeSummaryModel(BaseModel):
                 summary: str = Field(
                     description="A comprehensive, detailed narrative summary of the episode capturing key plot developments, character actions, revelations, and connections to larger season arcs."
                 )
 
-            logger.info(
-                f"Using OpenAI responses.parse with model {self.provider.model}"
+            parsed_summary, llm_response = self._get_structured_summary(
+                prompt,
+                "episode",
+                EpisodeSummaryModel,
             )
 
-            # Call the API with appropriate parameters based on model type
-            if self.is_reasoning_model:
-                response = client.responses.parse(
-                    model=self.provider.model,
-                    input=messages,
-                    reasoning={"effort": self.effort},
-                    text_format=EpisodeSummaryModel,
-                )
-                logger.info(f"Used reasoning model with effort: {self.effort}")
-            else:
-                response = client.responses.parse(
-                    model=self.provider.model,
-                    input=messages,
-                    temperature=self.temperature,
-                    text_format=EpisodeSummaryModel,
-                )
-                logger.info(f"Used standard model with temperature: {self.temperature}")
-
             # Create a summary dict that matches our expected format
-            summary_text = response.output_parsed.summary
+            summary_text = parsed_summary.summary
             summary_dict = {"summary": summary_text}
 
             # Log completion info
             logger.info(
-                f"Generated episode summary with {response.usage.input_tokens} input tokens and "
-                f"{response.usage.output_tokens} output tokens"
+                f"Generated episode summary with {llm_response.input_tokens} input tokens and "
+                f"{llm_response.output_tokens} output tokens"
             )
 
             # Print summary in verbose mode
@@ -2277,7 +2233,6 @@ I need a comprehensive, structured summary of Season {season}, Episode {episode}
         mode = "season" if len(seasons) == 1 and len(episodes) > 1 else "episode"
 
         # Prepare the prompt
-        system_prompt = self._get_system_prompt(mode)
         chunks_text = self._prepare_chunks_text(chunks, mode)
 
         # Build the main prompt
@@ -2331,16 +2286,6 @@ I need a comprehensive, structured summary of the provided narrative chunks (IDs
         self._save_prompt_to_file(prompt, f"chunks_{start_id}_{end_id}")
 
         try:
-            # Reuse the provider client so registry base_url/timeout routing is kept.
-            client = self.provider.client
-
-            # Prepare messages
-            messages = [{"role": "user", "content": prompt}]
-            if self.provider.system_prompt:
-                messages.insert(
-                    0, {"role": "system", "content": self.provider.system_prompt}
-                )
-
             # Choose the appropriate response model based on mode
             if mode == "season":
                 # Create a more simple Pydantic model for season summary
@@ -2349,32 +2294,7 @@ I need a comprehensive, structured summary of the provided narrative chunks (IDs
                         description="A comprehensive, detailed narrative summary of the entire season capturing major plot developments, character arcs, key world-building elements, and themes."
                     )
 
-                logger.info(f"Using season summary model")
-
-                # Call the API with appropriate parameters based on model type
-                if self.is_reasoning_model:
-                    response = client.responses.parse(
-                        model=self.provider.model,
-                        input=messages,
-                        reasoning={"effort": self.effort},
-                        text_format=SeasonSummaryModel,
-                    )
-                    logger.info(f"Used reasoning model with effort: {self.effort}")
-                else:
-                    response = client.responses.parse(
-                        model=self.provider.model,
-                        input=messages,
-                        temperature=self.temperature,
-                        text_format=SeasonSummaryModel,
-                    )
-                    logger.info(
-                        f"Used standard model with temperature: {self.temperature}"
-                    )
-
-                # Create a summary dict that matches our expected format
-                summary_text = response.output_parsed.summary
-                summary_dict = {"summary": summary_text}
-
+                schema_model: Type[BaseModel] = SeasonSummaryModel
             else:
                 # Create a more simple Pydantic model for episode summary
                 class EpisodeSummaryModel(BaseModel):
@@ -2382,36 +2302,19 @@ I need a comprehensive, structured summary of the provided narrative chunks (IDs
                         description="A comprehensive, detailed narrative summary of the episode capturing key plot developments, character actions, revelations, and connections to larger season arcs."
                     )
 
-                logger.info(f"Using episode summary model")
+                schema_model = EpisodeSummaryModel
 
-                # Call the API with appropriate parameters based on model type
-                if self.is_reasoning_model:
-                    response = client.responses.parse(
-                        model=self.provider.model,
-                        input=messages,
-                        reasoning={"effort": self.effort},
-                        text_format=EpisodeSummaryModel,
-                    )
-                    logger.info(f"Used reasoning model with effort: {self.effort}")
-                else:
-                    response = client.responses.parse(
-                        model=self.provider.model,
-                        input=messages,
-                        temperature=self.temperature,
-                        text_format=EpisodeSummaryModel,
-                    )
-                    logger.info(
-                        f"Used standard model with temperature: {self.temperature}"
-                    )
-
-                # Create a summary dict that matches our expected format
-                summary_text = response.output_parsed.summary
-                summary_dict = {"summary": summary_text}
+            parsed_summary, llm_response = self._get_structured_summary(
+                prompt,
+                mode,
+                schema_model,
+            )
+            summary_dict = {"summary": parsed_summary.summary}
 
             # Log completion info
             logger.info(
-                f"Generated chunk range summary with {response.usage.input_tokens} input tokens and "
-                f"{response.usage.output_tokens} output tokens"
+                f"Generated chunk range summary with {llm_response.input_tokens} input tokens and "
+                f"{llm_response.output_tokens} output tokens"
             )
 
             # Print summary in verbose mode
@@ -2518,16 +2421,19 @@ def main():
         help="Chunk ID range to summarize (manual fallback)",
     )
 
-    # OpenAI options. --model defaults to summaries.model when omitted.
+    # Provider options. --model defaults to summaries.model when omitted.
     parser.add_argument(
         "--model",
         default=None,
-        help="OpenAI model to use (default: resolved from nexus.toml [summaries].model)",
+        help="Registry model to use (default: nexus.toml [summaries].model)",
     )
     parser.add_argument(
         "--fallback-model",
         default=None,
-        help="Alternate model to try if the primary fails (no default; pass --disable-fallback to skip)",
+        help=(
+            "Alternate model to try if the primary fails "
+            "(no default; pass --disable-fallback to skip)"
+        ),
     )
     parser.add_argument(
         "--disable-fallback",
@@ -2537,14 +2443,20 @@ def main():
     parser.add_argument(
         "--temperature",
         type=float,
-        default=DEFAULT_TEMPERATURE,
-        help=f"Model temperature for standard models (default: {DEFAULT_TEMPERATURE})",
+        default=None,
+        help=(
+            "Model temperature override "
+            "(default: nexus.toml [summaries].temperature)"
+        ),
     )
     parser.add_argument(
         "--effort",
         choices=["low", "medium", "high"],
-        default="medium",
-        help="Reasoning effort level for reasoning models (default: medium)",
+        default=None,
+        help=(
+            "Reasoning effort override "
+            "(default: nexus.toml [summaries].reasoning_effort)"
+        ),
     )
 
     # Processing options

--- a/scripts/summarize_narrative.py
+++ b/scripts/summarize_narrative.py
@@ -1431,7 +1431,6 @@ class SummaryGenerator:
         self.prompt_on_conflict = prompt_on_conflict
         self.last_error: Optional[str] = None
         self._providers: Dict[str, Any] = {}
-        self.provider: Optional[Any] = None
 
     @staticmethod
     def _model_rejects_temperature(model: str) -> bool:
@@ -1495,8 +1494,7 @@ class SummaryGenerator:
 
         if mode not in self._providers:
             self._providers[mode] = self._initialize_provider(mode)
-        self.provider = self._providers[mode]
-        return self.provider
+        return self._providers[mode]
 
     def _get_structured_summary(
         self,

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -83,18 +83,15 @@ def test_summaries_follow_the_storyteller_by_default():
     assert settings.summaries.model == settings.apex.model
 
 
-def test_summaries_follow_unroutable_storyteller_is_legal_but_flagged():
-    """A non-OpenAI storyteller stays selectable (the local-Skald path);
-    summaries follow it and the routability helper reports the gap for the
-    scheduler's durable error marker."""
+def test_summaries_follow_anthropic_storyteller_with_registry_route():
+    """A native Anthropic storyteller remains the default summarizer."""
     raw = _nexus_toml_dict()
     raw["apex"]["model"] = "@anthropic.default"
     raw.get("summaries", {}).pop("model", None)
 
     settings = Settings(**raw)
     assert settings.summaries.model == settings.apex.model
-    assert settings.summaries_model_is_routable(settings.summaries.model) is False
-    assert settings.summaries_model_is_routable("TEST") is True
+    assert settings.provider_for_model(settings.summaries.model) == "anthropic"
 
 
 def test_summaries_model_explicit_override_resolves_at_load():
@@ -118,28 +115,34 @@ def test_summaries_model_accepts_responses_compatible_test_provider():
     assert Settings(**raw).summaries.model == "TEST"
 
 
-def test_summaries_model_rejects_local_chat_completions_provider():
-    """Local Chat Completions routing remains outside the near-term fix."""
+def test_summaries_model_accepts_local_chat_completions_provider():
+    """An explicit local summary model resolves through the registry."""
     raw = _nexus_toml_dict()
     raw["summaries"]["model"] = "@local.default"
 
-    with pytest.raises(
-        ValidationError,
-        match="structured_transport='responses'.*deferred routing work.*#481",
-    ):
-        Settings(**raw)
+    settings = Settings(**raw)
+    assert settings.provider_for_model(settings.summaries.model) == "local"
 
 
-def test_summaries_model_rejects_anthropic_literal():
-    """A native Anthropic ID cannot silently enter the OpenAI-only pipeline."""
+def test_summaries_model_accepts_anthropic_literal():
+    """A native Anthropic summary model remains registry-validated."""
     raw = _nexus_toml_dict()
     anthropic_id = raw["global"]["model"]["api_models"]["anthropic"]["models"][0]["id"]
     raw["summaries"]["model"] = anthropic_id
 
-    with pytest.raises(
-        ValidationError,
-        match="native OpenAI provider.*deferred routing work.*#481",
-    ):
+    settings = Settings(**raw)
+    assert settings.summaries.model == anthropic_id
+    assert settings.provider_for_model(anthropic_id) == "anthropic"
+
+
+def test_summaries_request_budget_must_exceed_output_budgets():
+    """A typo cannot leave the input allowance zero or negative."""
+    raw = _nexus_toml_dict()
+    raw["summaries"]["request_token_budget"] = raw["summaries"][
+        "season_max_output_tokens"
+    ]
+
+    with pytest.raises(ValidationError, match="request_token_budget must exceed"):
         Settings(**raw)
 
 

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -447,6 +447,7 @@ def test_anthropic_provider_uses_native_output_format() -> None:
         api_key="test-key",
         system_prompt="System prompt",
         max_tokens=5678,
+        reasoning_effort="high",
     )
     provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
 
@@ -458,6 +459,7 @@ def test_anthropic_provider_uses_native_output_format() -> None:
     assert llm_response.input_tokens == 33
     assert llm_response.output_tokens == 44
     assert captured["output_config"]["format"]["type"] == "json_schema"
+    assert captured["output_config"]["effort"] == "high"
     assert (
         captured["output_config"]["format"]["schema"]["additionalProperties"] is False
     )

--- a/tests/test_summary_triggers.py
+++ b/tests/test_summary_triggers.py
@@ -322,6 +322,7 @@ def test_summary_generator_uses_registry_native_provider_contract(
         assert isinstance(provider, AnthropicProvider)
         assert expected_transport is None
         assert provider.max_tokens == settings.season_max_output_tokens
+        assert provider.reasoning_effort == settings.reasoning_effort
 
 
 @pytest.mark.requires_postgres

--- a/tests/test_summary_triggers.py
+++ b/tests/test_summary_triggers.py
@@ -183,9 +183,30 @@ def test_schedule_summary_generation_skips_chunkless_episodes():
     assert recorder_calls == []
 
 
-def test_unroutable_storyteller_records_durable_marker_without_api_call(caplog):
-    """A followed non-OpenAI storyteller (the local-Skald path) must not
-    reach any provider: the scheduler records the instructive gap durably."""
+def test_local_storyteller_reaches_registry_routed_generator():
+    """A local Chat Completions model reaches summary generation."""
+    recorder_calls: List[str] = []
+
+    def generator_factory(**kwargs):
+        return _RecorderGenerator(calls=recorder_calls, **kwargs)
+
+    db = _FakeDB({}, {}, failure_records=[])
+    schedule_summary_generation(
+        [SummaryTask(kind="episode", season=7, episode=2)],
+        model_candidates=["nousresearch/hermes-4-70b"],
+        run_in_thread=False,
+        db_manager_factory=lambda: db,
+        generator_cls=generator_factory,
+    )
+
+    assert recorder_calls == [
+        "episode-7-2-nousresearch/hermes-4-70b",
+    ]
+    assert db.failure_records == []
+
+
+def test_unregistered_model_records_durable_marker_without_api_call(caplog):
+    """The scheduler never guesses an endpoint for an unknown model ID."""
     recorder_calls: List[str] = []
 
     def generator_factory(**kwargs):
@@ -195,7 +216,7 @@ def test_unroutable_storyteller_records_durable_marker_without_api_call(caplog):
     with caplog.at_level(logging.ERROR, logger="nexus.api.summary_triggers"):
         schedule_summary_generation(
             [SummaryTask(kind="episode", season=7, episode=2)],
-            model_candidates=["nousresearch/hermes-4-70b"],
+            model_candidates=["not-in-the-model-registry"],
             run_in_thread=False,
             db_manager_factory=lambda: db,
             generator_cls=generator_factory,
@@ -205,8 +226,8 @@ def test_unroutable_storyteller_records_durable_marker_without_api_call(caplog):
     assert len(db.failure_records) == 1
     marker = db.failure_records[0]
     assert marker["status"] == "error"
+    assert "not declared" in marker["error"]
     assert "[summaries].model" in marker["error"]
-    assert "#481" in marker["error"]
 
 
 def test_generation_failure_is_durable_visible_and_refireable(caplog):
@@ -243,8 +264,64 @@ def test_summary_generator_routes_test_model_to_registry_base_url():
 
     generator = SummaryGenerator(model="TEST", db_manager=_FakeDB({}, {}))
     expected = load_settings().global_.model.api_models["test"].base_url
+    provider = generator._provider_for_mode("episode")
 
-    assert str(generator.provider.client.base_url).rstrip("/") == expected
+    assert str(provider.client.base_url).rstrip("/") == expected
+
+
+def test_summary_token_check_uses_configured_request_budget():
+    """The retired legacy TPM dictionary is not a prerequisite for summaries."""
+    from scripts.summarize_narrative import SummaryGenerator
+
+    generator = SummaryGenerator(model="TEST", db_manager=_FakeDB({}, {}))
+
+    assert generator._token_check("A short narrative interval.", "episode") is True
+
+
+@pytest.mark.parametrize(
+    "model_ref,expected_provider,expected_transport",
+    [
+        ("@openai.default", "openai", "responses"),
+        ("@anthropic.default", "anthropic", None),
+        ("@local.default", "openai", "chat_completions"),
+    ],
+)
+def test_summary_generator_uses_registry_native_provider_contract(
+    monkeypatch,
+    model_ref: str,
+    expected_provider: str,
+    expected_transport: Optional[str],
+):
+    """OpenAI, Anthropic, and local summaries use their real provider wrappers."""
+    from nexus.config import load_settings, resolve_model_ref
+    from scripts.api_anthropic import AnthropicProvider
+    from scripts.api_openai import OpenAIProvider
+    from scripts.summarize_narrative import SummaryGenerator
+
+    monkeypatch.setattr(OpenAIProvider, "_get_api_key", lambda self: "test-openai")
+    monkeypatch.setattr(
+        AnthropicProvider,
+        "_get_api_key",
+        lambda self: "test-anthropic",
+    )
+
+    generator = SummaryGenerator(
+        model=resolve_model_ref(model_ref),
+        db_manager=_FakeDB({}, {}),
+    )
+    provider = generator._provider_for_mode("season")
+    settings = load_settings().summaries
+
+    assert provider.provider_name == expected_provider
+    assert provider.system_prompt.startswith("You are a narrative continuity AI")
+    assert generator._provider_for_mode("season") is provider
+    if isinstance(provider, OpenAIProvider):
+        assert provider.structured_transport == expected_transport
+        assert provider.max_output_tokens == settings.season_max_output_tokens
+    else:
+        assert isinstance(provider, AnthropicProvider)
+        assert expected_transport is None
+        assert provider.max_tokens == settings.season_max_output_tokens
 
 
 @pytest.mark.requires_postgres


### PR DESCRIPTION
## Summary

- Route episode, season, and manual-range summaries through the shared native structured-output provider.
- Honor registry endpoints and transports for OpenAI Responses, native Anthropic, and local Chat Completions models.
- Keep summaries following the storyteller by default while preserving an explicit `[summaries].model` override.
- Move summary sampling, reasoning, output-token, request-budget, and retry controls into `[summaries]`.
- Preserve durable error markers for unknown models and provider/runtime failures.

## Root Cause

The summary pipeline constructed an OpenAI client directly and called `responses.parse`, bypassing the provider routing used by the storyteller turn loop. Local and Anthropic model IDs therefore reached the wrong endpoint or failed during initialization.

## Impact

Local and Anthropic storytellers can now generate episode and season summaries through their declared provider routes, preserving future retrieval context without requiring an unrelated OpenAI credential.

## Validation

- `PYTHONPATH="$PWD" poetry run pytest -q tests/test_summary_triggers.py tests/config/test_settings_models.py tests/test_native_structured_output.py` — 64 passed, 1 skipped.
- Broader suite excluding the pre-existing `test_cli.py` collection drift and two environment-only macOS Keychain tests — 1,178 passed, 204 skipped, 2 deselected.
- Black, Python compilation, `git diff --check`, and focused mypy passed; scoped flake8 was clean.
- Confirmed no mock-server implementation changes.

Closes #481

Codex — GPT-5.6-Sol