### PR TITLE
Add Cloudflare Access authentication to the remote CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,40 @@ poetry run nexus load --slot 5
 poetry run nexus continue --slot 5
 ```
 
+## Remote Runtimes
+
+Story commands use `[runtime.remote].base_url` when `[runtime].profile` is
+`"remote"`. `NEXUS_API_URL` remains an explicit override. If Cloudflare
+Access protects the origin, configure secret-store account names—not token
+values—in `nexus.toml`:
+
+```toml
+[runtime]
+profile = "remote"
+
+[runtime.remote]
+base_url = "https://nexus.example.com"
+
+[runtime.remote.cloudflare_access]
+client_id_secret = "cloudflare_access_client_id"
+client_secret_secret = "cloudflare_access_client_secret"
+```
+
+Store both values through `nexus.util.secret_manager.set_secret()`. On macOS
+they live in Keychain service `nexus-api`. The CLI adds the two `CF-Access-*`
+headers only for the configured origin and does not follow redirects while
+carrying them.
+
+To select an alternate config for story commands without editing the checkout:
+
+```bash
+NEXUS_RUNTIME_CONFIG=/path/to/remote.toml poetry run nexus load --slot 5
+```
+
+An explicit `NEXUS_API_URL` can select the same configured origin directly;
+the Access headers are omitted if its origin differs from
+`[runtime.remote].base_url`.
+
 ## Commands
 
 ### `load` — View Current State

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -21,7 +21,8 @@ FastAPI gateway (`nexus.api.narrative:app`) is the entire serving surface.
 There is no Express layer, no sidecar API process, and no UNIX socket —
 everything a client needs is loopback or remote TCP against one base URL.
 A client that works against `http://127.0.0.1:8002` works against
-`https://nexus.example.com` by changing its base URL and nothing else.
+`https://nexus.example.com` by changing its base URL and, when the remote
+origin is Access-protected, configuring its edge-auth secret references.
 
 ## The Runtime Endpoint
 
@@ -77,10 +78,43 @@ Semantics, fixed now so clients never need retrofitting:
   the contract — a client built today must already have the plumbing.
 - **Hosted runtimes (future): the header is required.** Requests without a
   valid credential are rejected; `auth.enforced` will be `true`.
+- A non-empty credential is sent only over HTTPS, except for genuine loopback
+  HTTP targets used by local development. Credential-bearing requests never
+  follow redirects.
 - Browsers cannot attach custom headers to native `WebSocket` connects, so
   hosted runtimes will accept the same credential for the websocket via the
   first client message or a query token at connect time; the header remains
   authoritative for all HTTP routes.
+
+### Cloudflare Access edge authentication
+
+Cloudflare Access can protect a hosted origin without adding authentication
+code to NEXUS. It is an outer edge boundary, independent of
+`X-Nexus-Auth`. A service-token client sends both:
+
+```
+CF-Access-Client-Id: <service-token ID>
+CF-Access-Client-Secret: <service-token secret>
+```
+
+The remote configuration stores only secret-store account names:
+
+```toml
+[runtime.remote]
+base_url = "https://nexus.example.com"
+
+[runtime.remote.cloudflare_access]
+client_id_secret = "cloudflare_access_client_id"
+client_secret_secret = "cloudflare_access_client_secret"
+```
+
+The CLI and supervisor resolve those accounts only while making a request to
+the exact configured HTTPS origin. Configuration rejects plaintext or
+ambiguous credential-bearing URLs. Requests carrying any non-empty credential
+do not follow redirects, preventing custom headers from crossing to another
+origin. Both references are required when the block is present; missing
+credentials fail the request rather than falling back to interactive browser
+login.
 
 ## Profiles
 
@@ -91,7 +125,7 @@ The runtime is operated in one of three profiles, configured in
 |------------|------------------------|----------------------|--------------------------|
 | `local`    | The supervisor (`nexus/runtime/`): spawns services detached with pidfiles and captured logs under `[runtime].state_dir` | Spawns enabled services, waits for health, fails loud with log excerpts | Merges supervisor process state (pid, port, uptime) with `/runtime/status` |
 | `external` | You (or an IDE, a debugger, another orchestrator) | Health-checks the configured URLs; **spawns nothing**; nonzero exit if anything is down | Reads `/runtime/status` from `external.gateway_url` |
-| `remote`   | A hosted operator | Confirms `<remote.base_url>/runtime/status` answers | Reads the remote runtime's status |
+| `remote`   | A hosted operator | Confirms `<remote.base_url>/runtime/status` answers, using Access service auth when configured | Reads the remote runtime's status with the same authentication |
 
 `nexus down`, `restart`, and `logs` are local-profile verbs: they manage or
 read state that only exists when this machine's supervisor owns the
@@ -132,7 +166,11 @@ All verbs honor the global `--json` flag for machine-readable output.
 `--config` points at an alternate `nexus.toml` (test harnesses, parallel
 checkouts); spawned services receive its absolute path in the
 `NEXUS_RUNTIME_CONFIG` environment variable so their `/runtime/status`
-describes the config that actually launched them.
+describes the config that actually launched them. Story commands use
+`remote.base_url` when the config selected by `NEXUS_RUNTIME_CONFIG` (or the
+working-directory `nexus.toml`) has `profile = "remote"`; an explicit
+`NEXUS_API_URL` still overrides the base URL. Access credentials are attached
+only when that override has the same origin as `remote.base_url`.
 
 ## Model Backends Are Runtime Services
 
@@ -195,6 +233,11 @@ hosts. Consequences for deployment:
 - Keyless local model servers (mock, Ollama) need no secret; a base_url
   provider that does need one names its secret-store account via
   `api_key_secret`.
+- **Remote Access clients:** the `cloudflare_access_client_id` and
+  `cloudflare_access_client_secret` accounts live in the same `nexus-api`
+  platform store. With `NEXUS_KEYRING_DISABLE=1`, their environment fallbacks
+  are `CLOUDFLARE_ACCESS_CLIENT_ID_API_KEY` and
+  `CLOUDFLARE_ACCESS_CLIENT_SECRET_API_KEY`.
 
 ## Development Workflows (unchanged)
 
@@ -216,7 +259,9 @@ The entire integration surface for a macOS/Windows/Linux shell:
 2. Point a webview at the gateway origin.
 3. Poll `GET /runtime/status`; gate the UI on `ok`.
 4. Send `X-Nexus-Auth` on every request (empty locally is fine today).
-5. Run `nexus down` on quit.
+5. For an Access-protected remote, resolve and send the configured service
+   token headers without following redirects.
+6. Run `nexus down` on quit.
 
 Nothing else about NEXUS internals — slots, databases, model processes,
 embedders — leaks across this boundary.

--- a/nexus.toml
+++ b/nexus.toml
@@ -1014,6 +1014,11 @@ enabled = "never"
 # gateway_url = "http://127.0.0.1:8002"
 # mock_openai_url = "http://127.0.0.1:5102"
 
-# Hosted runtime for profile = "remote" (uncomment to use):
-# [runtime.remote]
-# base_url = "https://nexus.example.com"
+# Hosted runtime for profile = "remote". The Access values are secret-store
+# account names under service `nexus-api`; credential material never lives here.
+[runtime.remote]
+base_url = "https://nexus.pythagora.net"
+
+[runtime.remote.cloudflare_access]
+client_id_secret = "cloudflare_access_client_id"
+client_secret_secret = "cloudflare_access_client_secret"

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -29,6 +29,7 @@ all other state (wizard phase, current chunk, thread ID) automatically.
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import logging
 import os
@@ -69,16 +70,30 @@ def _load_cli_settings() -> Optional[Settings]:
     """Load explicit, working-directory, or checkout settings when available."""
     explicit = os.environ.get(RUNTIME_CONFIG_ENV)
     if explicit:
-        return load_settings(explicit)
+        return _load_cli_settings_file(Path(explicit))
 
     working_config = Path("nexus.toml")
     if working_config.exists():
-        return load_settings(working_config)
+        return _load_cli_settings_file(working_config)
 
     checkout_config = Path(__file__).resolve().parents[1] / "nexus.toml"
     if checkout_config.exists():
-        return load_settings(checkout_config)
+        return _load_cli_settings_file(checkout_config)
     return None
+
+
+def _load_cli_settings_file(path: Path) -> Settings:
+    """Load one config version once, invalidating when its file changes."""
+    resolved = path.resolve()
+    stat = resolved.stat()
+    return _load_cli_settings_version(str(resolved), stat.st_mtime_ns, stat.st_size)
+
+
+@functools.lru_cache(maxsize=8)
+def _load_cli_settings_version(path: str, modified_ns: int, size: int) -> Settings:
+    """Cache a validated settings tree for an exact on-disk file version."""
+    del modified_ns, size
+    return load_settings(path)
 
 
 def get_api_url() -> str:

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -31,12 +31,19 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 from pathlib import Path
 import sys
 import time
 from typing import Any, Dict, List, Mapping, Optional
 
 import requests
+
+from nexus.config import load_settings
+from nexus.config.settings_models import Settings
+from nexus.runtime.contract import RUNTIME_CONFIG_ENV
+from nexus.runtime.remote_auth import build_runtime_request_auth
+from nexus.util.secret_manager import MissingSecretError
 
 logger = logging.getLogger("nexus.cli")
 
@@ -58,11 +65,66 @@ FACTION_APPLY_SOURCE_KIND_CHOICES = (
 )
 
 
-def get_api_url() -> str:
-    """Get the API server URL from environment or default."""
-    import os
+def _load_cli_settings() -> Optional[Settings]:
+    """Load explicit, working-directory, or checkout settings when available."""
+    explicit = os.environ.get(RUNTIME_CONFIG_ENV)
+    if explicit:
+        return load_settings(explicit)
 
-    return os.environ.get("NEXUS_API_URL", DEFAULT_API_URL)
+    working_config = Path("nexus.toml")
+    if working_config.exists():
+        return load_settings(working_config)
+
+    checkout_config = Path(__file__).resolve().parents[1] / "nexus.toml"
+    if checkout_config.exists():
+        return load_settings(checkout_config)
+    return None
+
+
+def get_api_url() -> str:
+    """Get the API URL from an override, remote profile, or local default."""
+
+    override = os.environ.get("NEXUS_API_URL")
+    if override:
+        return override.rstrip("/")
+
+    settings = _load_cli_settings()
+    runtime = settings.runtime if settings is not None else None
+    if runtime is not None and runtime.profile == "remote":
+        remote = runtime.remote
+        if remote is None:  # guarded by RuntimeSettings validation
+            raise ValueError("Remote runtime profile has no remote configuration")
+        return remote.base_url.rstrip("/")
+    return DEFAULT_API_URL
+
+
+def _api_request(method: str, url: str, **kwargs: Any) -> requests.Response:
+    """Send a NEXUS API request with origin-scoped runtime authentication."""
+    settings = _load_cli_settings()
+    remote = (
+        settings.runtime.remote
+        if settings is not None and settings.runtime is not None
+        else None
+    )
+    auth = build_runtime_request_auth(url, remote)
+
+    supplied_headers = kwargs.pop("headers", None) or {}
+    headers = dict(supplied_headers)
+    headers.update(auth.headers)
+    kwargs["headers"] = headers
+    if not auth.allow_redirects:
+        kwargs["allow_redirects"] = False
+    return getattr(requests, method)(url, **kwargs)
+
+
+def _api_get(url: str, **kwargs: Any) -> requests.Response:
+    """Send an authenticated GET to the configured NEXUS API."""
+    return _api_request("get", url, **kwargs)
+
+
+def _api_post(url: str, **kwargs: Any) -> requests.Response:
+    """Send an authenticated POST to the configured NEXUS API."""
+    return _api_request("post", url, **kwargs)
 
 
 def _is_terminal_generation_status(status: Optional[str]) -> bool:
@@ -980,7 +1042,7 @@ def run_load(args: argparse.Namespace) -> Dict[str, Any]:
     url = f"{get_api_url()}/api/slot/{args.slot}/state"
 
     try:
-        response = requests.get(url, timeout=30)
+        response = _api_get(url, timeout=30)
         response.raise_for_status()
         data = response.json()
 
@@ -1072,7 +1134,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
     try:
         # First, get slot state to determine mode
         state_url = f"{get_api_url()}/api/slot/{args.slot}/state"
-        state_response = requests.get(state_url, timeout=30)
+        state_response = _api_get(state_url, timeout=30)
         state_response.raise_for_status()
         state = state_response.json()
 
@@ -1086,7 +1148,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
             model_to_use = getattr(args, "model", None)
             if model_to_use:
                 setup_payload["model"] = model_to_use
-            setup_response = requests.post(setup_url, json=setup_payload, timeout=30)
+            setup_response = _api_post(setup_url, json=setup_payload, timeout=30)
             if not setup_response.ok:
                 return {
                     "success": False,
@@ -1111,7 +1173,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                 # cold-start generation runs inside the transition, so the
                 # timeout comes from orrery.retrograde.wizard settings.
                 transition_url = f"{get_api_url()}/api/story/new/transition"
-                transition_response = requests.post(
+                transition_response = _api_post(
                     transition_url,
                     json={"slot": args.slot},
                     timeout=_transition_timeout_seconds(),
@@ -1124,7 +1186,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                 retrograde_info = transition_response.json().get("retrograde")
 
                 # Transition complete - refresh state and continue to narrative
-                state_response = requests.get(state_url, timeout=30)
+                state_response = _api_get(state_url, timeout=30)
                 state = state_response.json()
 
                 if state.get("is_wizard_mode"):
@@ -1183,7 +1245,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                     if model_to_use:
                         payload["model"] = model_to_use
 
-                    response = requests.post(url, json=payload, timeout=120)
+                    response = _api_post(url, json=payload, timeout=120)
                     response.raise_for_status()
                     data = response.json()
 
@@ -1204,7 +1266,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                             if model_to_use:
                                 intro_payload["model"] = model_to_use
 
-                            intro_response = requests.post(
+                            intro_response = _api_post(
                                 url, json=intro_payload, timeout=120
                             )
                             if intro_response.ok:
@@ -1260,7 +1322,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                 if model_to_use:
                     payload["model"] = model_to_use
 
-                response = requests.post(url, json=payload, timeout=120)
+                response = _api_post(url, json=payload, timeout=120)
                 response.raise_for_status()
                 data = response.json()
 
@@ -1297,7 +1359,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                         if model_to_use:
                             transition_payload["model"] = model_to_use
 
-                        intro_response = requests.post(
+                        intro_response = _api_post(
                             url, json=transition_payload, timeout=120
                         )
                         if intro_response.ok:
@@ -1310,7 +1372,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                     elif next_phase == "ready":
                         # Seed phase complete → transition to narrative mode
                         transition_url = f"{get_api_url()}/api/story/new/transition"
-                        transition_response = requests.post(
+                        transition_response = _api_post(
                             transition_url,
                             json={"slot": args.slot},
                             timeout=_transition_timeout_seconds(),
@@ -1324,7 +1386,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                             continue_payload = {"slot": args.slot, "user_text": ""}
                             if model_to_use:
                                 continue_payload["model"] = model_to_use
-                            narrative_response = requests.post(
+                            narrative_response = _api_post(
                                 continue_url, json=continue_payload, timeout=120
                             )
                             if narrative_response.ok:
@@ -1359,7 +1421,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
             if model_to_use:
                 payload["model"] = model_to_use
 
-            response = requests.post(url, json=payload, timeout=120)
+            response = _api_post(url, json=payload, timeout=120)
             response.raise_for_status()
             data = response.json()
 
@@ -1372,7 +1434,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                 poll_deadline = time.monotonic() + _generation_timeout_seconds()
                 while time.monotonic() < poll_deadline:
                     status_url = f"{get_api_url()}/api/narrative/status/{session_id}"
-                    status_response = requests.get(
+                    status_response = _api_get(
                         status_url,
                         params={"slot": args.slot},
                         timeout=_generation_timeout_seconds(),
@@ -1428,7 +1490,7 @@ def run_undo(args: argparse.Namespace) -> Dict[str, Any]:
     url = f"{get_api_url()}/api/slot/{args.slot}/undo"
 
     try:
-        response = requests.post(url, timeout=30)
+        response = _api_post(url, timeout=30)
         response.raise_for_status()
         data = response.json()
 
@@ -1464,7 +1526,7 @@ def run_regenerate(args: argparse.Namespace) -> Dict[str, Any]:
         payload["note"] = args.note
 
     try:
-        response = requests.post(url, json=payload, timeout=120)
+        response = _api_post(url, json=payload, timeout=120)
         response.raise_for_status()
         data = response.json()
 
@@ -1477,7 +1539,7 @@ def run_regenerate(args: argparse.Namespace) -> Dict[str, Any]:
         while time.monotonic() < poll_deadline:
             status_url = f"{get_api_url()}/api/narrative/status/{session_id}"
             try:
-                status_response = requests.get(
+                status_response = _api_get(
                     status_url, params={"slot": args.slot}, timeout=30
                 )
             except requests.exceptions.RequestException:
@@ -1538,7 +1600,7 @@ def run_model(args: argparse.Namespace) -> Dict[str, Any]:
 
         if args.set:
             # Set the model
-            response = requests.post(base_url, json={"model": args.set}, timeout=30)
+            response = _api_post(base_url, json={"model": args.set}, timeout=30)
             response.raise_for_status()
             data = response.json()
             return {
@@ -1548,7 +1610,7 @@ def run_model(args: argparse.Namespace) -> Dict[str, Any]:
             }
 
         # Get current model
-        response = requests.get(base_url, timeout=30)
+        response = _api_get(base_url, timeout=30)
         response.raise_for_status()
         data = response.json()
         current = data.get("model") or "(default)"
@@ -1579,7 +1641,7 @@ def run_clear(args: argparse.Namespace) -> Dict[str, Any]:
     """
     try:
         url = f"{get_api_url()}/api/story/new/setup/reset"
-        response = requests.post(url, json={"slot": args.slot}, timeout=30)
+        response = _api_post(url, json={"slot": args.slot}, timeout=30)
         response.raise_for_status()
         return {
             "success": True,
@@ -2547,7 +2609,7 @@ def run_lock(args: argparse.Namespace) -> Dict[str, Any]:
     """
     try:
         url = f"{get_api_url()}/api/slot/{args.slot}/lock"
-        response = requests.post(url, timeout=30)
+        response = _api_post(url, timeout=30)
         response.raise_for_status()
         return {
             "success": True,
@@ -2572,7 +2634,7 @@ def run_unlock(args: argparse.Namespace) -> Dict[str, Any]:
     """
     try:
         url = f"{get_api_url()}/api/slot/{args.slot}/unlock"
-        response = requests.post(url, timeout=30)
+        response = _api_post(url, timeout=30)
         response.raise_for_status()
         return {
             "success": True,
@@ -2611,7 +2673,13 @@ def run_up(args: argparse.Namespace) -> Dict[str, Any]:
             foreground=args.foreground,
             echo=not args.json,
         )
-    except (RuntimeError_, FileNotFoundError, requests.RequestException) as exc:
+    except (
+        RuntimeError_,
+        FileNotFoundError,
+        MissingSecretError,
+        ValueError,
+        requests.RequestException,
+    ) as exc:
         return {"success": False, "error": str(exc)}
 
 
@@ -2732,7 +2800,7 @@ def run_status(args: argparse.Namespace) -> Dict[str, Any]:
         if not args.json:
             _print_runtime_status(result)
         return result
-    except (RuntimeError_, FileNotFoundError) as exc:
+    except (RuntimeError_, FileNotFoundError, MissingSecretError, ValueError) as exc:
         return {"success": False, "error": str(exc)}
 
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -415,14 +415,70 @@ class RuntimeExternalSettings(BaseModel):
     )
 
 
-class RuntimeRemoteSettings(BaseModel):
-    """A hosted NEXUS runtime reached purely over HTTP."""
+class RuntimeCloudflareAccessSettings(BaseModel):
+    """Secret-store references for a Cloudflare Access service token."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(
+        extra="forbid", str_strip_whitespace=True, str_to_lower=True
+    )
+
+    client_id_secret: str = Field(
+        ...,
+        min_length=1,
+        description="Secret-store account containing CF-Access-Client-Id",
+    )
+    client_secret_secret: str = Field(
+        ...,
+        min_length=1,
+        description="Secret-store account containing CF-Access-Client-Secret",
+    )
+
+    @model_validator(mode="after")
+    def _require_distinct_accounts(self) -> "RuntimeCloudflareAccessSettings":
+        """The ID and secret must never resolve from the same store entry."""
+        if self.client_id_secret == self.client_secret_secret:
+            raise ValueError(
+                "Cloudflare Access client ID and client secret must use "
+                "different secret-store accounts"
+            )
+        return self
+
+
+class RuntimeRemoteSettings(BaseModel):
+    """A hosted NEXUS runtime reached purely over HTTP(S)."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
     base_url: str = Field(
         ..., min_length=1, description="Base URL of the remote runtime origin"
     )
+    cloudflare_access: Optional[RuntimeCloudflareAccessSettings] = Field(
+        default=None,
+        description="Optional Cloudflare Access service-token references",
+    )
+
+    @model_validator(mode="after")
+    def _require_secure_access_origin(self) -> "RuntimeRemoteSettings":
+        """Never transmit Cloudflare service-token credentials over plaintext."""
+        if self.cloudflare_access is None:
+            return self
+
+        from urllib.parse import urlsplit
+
+        parsed = urlsplit(self.base_url)
+        if (
+            parsed.scheme.lower() != "https"
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError(
+                "cloudflare_access requires an HTTPS base_url without "
+                "credentials, query, or fragment"
+            )
+        return self
 
 
 class RuntimeGatewaySettings(BaseModel):

--- a/nexus/runtime/__init__.py
+++ b/nexus/runtime/__init__.py
@@ -1,17 +1,24 @@
 """NEXUS managed runtime: supervisor, profiles, and runtime contract."""
 
 from nexus.runtime.contract import (
+    CF_ACCESS_CLIENT_ID_HEADER,
+    CF_ACCESS_CLIENT_SECRET_HEADER,
     NEXUS_AUTH_HEADER,
     RUNTIME_CONFIG_ENV,
     RUNTIME_STATUS_PATH,
 )
+from nexus.runtime.remote_auth import RuntimeRequestAuth, build_runtime_request_auth
 from nexus.runtime.supervisor import RuntimeError_, Supervisor, repo_root
 
 __all__ = [
+    "CF_ACCESS_CLIENT_ID_HEADER",
+    "CF_ACCESS_CLIENT_SECRET_HEADER",
     "NEXUS_AUTH_HEADER",
     "RUNTIME_CONFIG_ENV",
     "RUNTIME_STATUS_PATH",
+    "RuntimeRequestAuth",
     "RuntimeError_",
     "Supervisor",
+    "build_runtime_request_auth",
     "repo_root",
 ]

--- a/nexus/runtime/contract.py
+++ b/nexus/runtime/contract.py
@@ -14,6 +14,12 @@ from __future__ import annotations
 # not a code change. Hosted runtimes reject requests without it.
 NEXUS_AUTH_HEADER = "X-Nexus-Auth"
 
+# Cloudflare Access service-token headers. These are edge credentials, not
+# application authentication: clients add them only for a configured remote
+# origin, and the gateway remains unaware of their values.
+CF_ACCESS_CLIENT_ID_HEADER = "CF-Access-Client-Id"
+CF_ACCESS_CLIENT_SECRET_HEADER = "CF-Access-Client-Secret"
+
 # The runtime status endpoint, served by the gateway beside /health.
 RUNTIME_STATUS_PATH = "/runtime/status"
 

--- a/nexus/runtime/remote_auth.py
+++ b/nexus/runtime/remote_auth.py
@@ -1,0 +1,99 @@
+"""Origin-scoped authentication for outbound runtime HTTP requests.
+
+Cloudflare Access is an edge boundary in front of a hosted NEXUS runtime.
+The application remains auth-less behind it: remote clients resolve a service
+token from the platform secret store and attach its two headers only when the
+request target exactly matches the configured remote origin.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import ipaddress
+import os
+from typing import Dict, Optional, Tuple
+from urllib.parse import urlsplit
+
+from nexus.config.settings_models import RuntimeRemoteSettings
+from nexus.runtime.contract import (
+    CF_ACCESS_CLIENT_ID_HEADER,
+    CF_ACCESS_CLIENT_SECRET_HEADER,
+    NEXUS_AUTH_HEADER,
+)
+from nexus.util.secret_manager import get_secret
+
+
+@dataclass(frozen=True)
+class RuntimeRequestAuth:
+    """Headers and redirect policy for one outbound runtime request."""
+
+    headers: Dict[str, str]
+    allow_redirects: bool
+
+
+def _normalized_origin(url: str) -> Optional[Tuple[str, str, int]]:
+    """Return a comparable HTTP(S) origin with default ports expanded."""
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    hostname = parsed.hostname
+    if scheme not in {"http", "https"} or hostname is None:
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    if port is None:
+        port = 443 if scheme == "https" else 80
+    return scheme, hostname.lower(), port
+
+
+def _same_origin(left: str, right: str) -> bool:
+    """Return whether two URLs have the same scheme, host, and effective port."""
+    left_origin = _normalized_origin(left)
+    return left_origin is not None and left_origin == _normalized_origin(right)
+
+
+def _credential_transport_is_safe(url: str) -> bool:
+    """Allow credentials over HTTPS, or HTTP only to genuine loopback."""
+    parsed = urlsplit(url)
+    if parsed.scheme.lower() == "https":
+        return True
+    if parsed.scheme.lower() != "http" or parsed.hostname is None:
+        return False
+    hostname = parsed.hostname.lower()
+    if hostname == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def build_runtime_request_auth(
+    target_url: str,
+    remote: Optional[RuntimeRemoteSettings] = None,
+) -> RuntimeRequestAuth:
+    """Build safe headers for a runtime request.
+
+    ``X-Nexus-Auth`` remains part of every client request. Cloudflare Access
+    credentials are resolved only for the configured remote origin. Requests
+    carrying any credential never follow redirects because ``requests``
+    otherwise preserves arbitrary custom headers across cross-origin redirects.
+    A non-empty application credential also requires HTTPS except on loopback.
+    """
+    nexus_auth = os.environ.get("NEXUS_AUTH", "")
+    if nexus_auth and not _credential_transport_is_safe(target_url):
+        raise ValueError(
+            "Refusing to send NEXUS_AUTH over plaintext to a non-loopback target"
+        )
+    headers = {NEXUS_AUTH_HEADER: nexus_auth}
+    allow_redirects = not bool(nexus_auth)
+    if remote is None or remote.cloudflare_access is None:
+        return RuntimeRequestAuth(headers=headers, allow_redirects=allow_redirects)
+    if not _same_origin(target_url, remote.base_url):
+        return RuntimeRequestAuth(headers=headers, allow_redirects=allow_redirects)
+
+    access = remote.cloudflare_access
+    headers[CF_ACCESS_CLIENT_ID_HEADER] = get_secret(access.client_id_secret)
+    headers[CF_ACCESS_CLIENT_SECRET_HEADER] = get_secret(access.client_secret_secret)
+    return RuntimeRequestAuth(headers=headers, allow_redirects=False)

--- a/nexus/runtime/supervisor.py
+++ b/nexus/runtime/supervisor.py
@@ -35,10 +35,10 @@ from nexus.config.settings_models import (
     Settings,
 )
 from nexus.runtime.contract import (
-    NEXUS_AUTH_HEADER,
     RUNTIME_CONFIG_ENV,
     RUNTIME_STATUS_PATH,
 )
+from nexus.runtime.remote_auth import build_runtime_request_auth
 
 
 class RuntimeError_(Exception):
@@ -403,10 +403,12 @@ class Supervisor:
     def _check_remote(self) -> Dict[str, Any]:
         remote = self.runtime.remote
         url = remote.base_url.rstrip("/") + RUNTIME_STATUS_PATH
+        auth = build_runtime_request_auth(url, remote)
         response = requests.get(
             url,
             timeout=self.runtime.health.timeout_seconds,
-            headers={NEXUS_AUTH_HEADER: os.environ.get("NEXUS_AUTH", "")},
+            headers=auth.headers,
+            allow_redirects=auth.allow_redirects,
         )
         response.raise_for_status()
         return {"success": True, "profile": "remote", "runtime": response.json()}
@@ -528,10 +530,13 @@ class Supervisor:
     def _fetch_runtime_status(self) -> Dict[str, Any]:
         url = self._gateway_url() + RUNTIME_STATUS_PATH
         try:
+            remote = self.runtime.remote if self.runtime.profile == "remote" else None
+            auth = build_runtime_request_auth(url, remote)
             response = requests.get(
                 url,
                 timeout=self.runtime.health.timeout_seconds,
-                headers={NEXUS_AUTH_HEADER: os.environ.get("NEXUS_AUTH", "")},
+                headers=auth.headers,
+                allow_redirects=auth.allow_redirects,
             )
             response.raise_for_status()
             return response.json()

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -16,6 +16,7 @@ from nexus.config.settings_models import (
     APIModelEntry,
     ModelConfig,
     ProviderModels,
+    RuntimeRemoteSettings,
     RuntimeServiceSettings,
     Settings,
 )
@@ -466,6 +467,75 @@ def test_gateway_cors_origins_parse_and_accessor_returns_default() -> None:
     assert settings.runtime is not None
     assert settings.runtime.gateway.cors_allowed_origins == expected
     assert get_gateway_cors_allowed_origins() == expected
+
+
+def test_remote_cloudflare_access_references_parse_from_shipped_config() -> None:
+    """Remote Access configuration contains account names, never credentials."""
+    remote = load_settings("nexus.toml").runtime.remote
+
+    assert remote is not None
+    assert remote.base_url == "https://nexus.pythagora.net"
+    assert remote.cloudflare_access is not None
+    assert remote.cloudflare_access.client_id_secret == "cloudflare_access_client_id"
+    assert (
+        remote.cloudflare_access.client_secret_secret
+        == "cloudflare_access_client_secret"
+    )
+
+
+@pytest.mark.parametrize("missing", ["client_id_secret", "client_secret_secret"])
+def test_remote_cloudflare_access_requires_both_references(missing: str) -> None:
+    """A half-configured service token fails during config validation."""
+    raw = _nexus_toml_dict()
+    del raw["runtime"]["remote"]["cloudflare_access"][missing]
+
+    with pytest.raises(ValidationError, match=missing):
+        Settings(**raw)
+
+
+@pytest.mark.parametrize("field", ["client_id_secret", "client_secret_secret"])
+def test_remote_cloudflare_access_rejects_blank_references(field: str) -> None:
+    """Whitespace is not a valid secret-store account name."""
+    raw = _nexus_toml_dict()
+    raw["runtime"]["remote"]["cloudflare_access"][field] = "   "
+
+    with pytest.raises(ValidationError, match=field):
+        Settings(**raw)
+
+
+def test_remote_cloudflare_access_requires_distinct_accounts() -> None:
+    """The token ID and secret cannot intentionally resolve to one value."""
+    raw = _nexus_toml_dict()
+    access = raw["runtime"]["remote"]["cloudflare_access"]
+    access["client_secret_secret"] = access["client_id_secret"].upper()
+
+    with pytest.raises(ValidationError, match="different secret-store accounts"):
+        Settings(**raw)
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://nexus.example.com",
+        "https://user@nexus.example.com",
+        "https://nexus.example.com?target=other",
+        "https://nexus.example.com#fragment",
+    ],
+)
+def test_remote_cloudflare_access_requires_secure_origin(base_url: str) -> None:
+    """Access credentials require HTTPS and an unambiguous remote URL."""
+    raw = _nexus_toml_dict()
+    raw["runtime"]["remote"]["base_url"] = base_url
+
+    with pytest.raises(ValidationError, match="requires an HTTPS base_url"):
+        Settings(**raw)
+
+
+def test_remote_cloudflare_access_remains_optional() -> None:
+    """Existing remote configurations with only a base URL remain valid."""
+    remote = RuntimeRemoteSettings(base_url="https://example.com")
+
+    assert remote.cloudflare_access is None
 
 
 def test_gateway_cors_origins_reject_wildcard() -> None:

--- a/tests/test_runtime/test_remote_auth.py
+++ b/tests/test_runtime/test_remote_auth.py
@@ -1,0 +1,318 @@
+"""Live and pure-boundary tests for hosted-runtime authentication."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+from pathlib import Path
+from threading import Thread
+from typing import Iterator, Optional
+
+import pytest
+import tomlkit
+
+from nexus import cli
+from nexus.config import load_settings
+from nexus.config.settings_models import RuntimeRemoteSettings
+from nexus.runtime import remote_auth
+from nexus.runtime.contract import (
+    CF_ACCESS_CLIENT_ID_HEADER,
+    CF_ACCESS_CLIENT_SECRET_HEADER,
+    NEXUS_AUTH_HEADER,
+    RUNTIME_CONFIG_ENV,
+)
+from nexus.runtime.supervisor import Supervisor
+from nexus.util.secret_manager import MissingSecretError
+
+CLIENT_ID_ACCOUNT = "cloudflare_access_client_id"
+CLIENT_SECRET_ACCOUNT = "cloudflare_access_client_secret"
+CLIENT_ID_ENV = "CLOUDFLARE_ACCESS_CLIENT_ID_API_KEY"
+CLIENT_SECRET_ENV = "CLOUDFLARE_ACCESS_CLIENT_SECRET_API_KEY"
+
+
+def _access_remote() -> RuntimeRemoteSettings:
+    return RuntimeRemoteSettings(
+        base_url="https://nexus.example.com",
+        cloudflare_access={
+            "client_id_secret": CLIENT_ID_ACCOUNT,
+            "client_secret_secret": CLIENT_SECRET_ACCOUNT,
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_secret_cache() -> Iterator[None]:
+    """Keep environment-backed secret reads isolated between tests."""
+    remote_auth.get_secret.cache_clear()
+    yield
+    remote_auth.get_secret.cache_clear()
+
+
+@pytest.fixture()
+def runtime_http_server() -> Iterator[tuple[str, list[dict[str, Optional[str]]]]]:
+    """Run a real loopback HTTP runtime and record received auth headers."""
+    records: list[dict[str, Optional[str]]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - stdlib handler contract
+            records.append(
+                {
+                    "path": self.path,
+                    "nexus_auth": self.headers.get(NEXUS_AUTH_HEADER),
+                    "access_id": self.headers.get(CF_ACCESS_CLIENT_ID_HEADER),
+                    "access_secret": self.headers.get(CF_ACCESS_CLIENT_SECRET_HEADER),
+                }
+            )
+            if self.path == "/redirect":
+                self.send_response(302)
+                self.send_header("Location", "/redirect-target")
+                self.end_headers()
+                return
+
+            payload = (
+                {
+                    "is_empty": False,
+                    "is_wizard_mode": False,
+                    "storyteller_text": "Remote story state.",
+                }
+                if self.path == "/api/slot/5/state"
+                else {"ok": True}
+            )
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}", records
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_access_headers_resolve_for_exact_remote_origin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The configured origin receives both environment-store Access values."""
+    monkeypatch.setenv("NEXUS_KEYRING_DISABLE", "1")
+    monkeypatch.setenv(CLIENT_ID_ENV, "client-id-value")
+    monkeypatch.setenv(CLIENT_SECRET_ENV, "client-secret-value")
+    monkeypatch.setenv("NEXUS_AUTH", "runtime-token")
+
+    auth = remote_auth.build_runtime_request_auth(
+        "https://NEXUS.example.com:443/api/slot/5/state",
+        _access_remote(),
+    )
+
+    assert auth.headers == {
+        NEXUS_AUTH_HEADER: "runtime-token",
+        CF_ACCESS_CLIENT_ID_HEADER: "client-id-value",
+        CF_ACCESS_CLIENT_SECRET_HEADER: "client-secret-value",
+    }
+    assert auth.allow_redirects is False
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "http://nexus.example.com/api/slot/5/state",
+        "https://nexus.example.com:444/api/slot/5/state",
+        "https://attacker.example/api/slot/5/state",
+    ],
+)
+def test_access_headers_never_leave_configured_origin(
+    target: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Origin drift suppresses Access secret resolution entirely."""
+    monkeypatch.setenv("NEXUS_KEYRING_DISABLE", "1")
+    monkeypatch.delenv(CLIENT_ID_ENV, raising=False)
+    monkeypatch.delenv(CLIENT_SECRET_ENV, raising=False)
+    monkeypatch.delenv("NEXUS_AUTH", raising=False)
+
+    auth = remote_auth.build_runtime_request_auth(target, _access_remote())
+
+    assert auth.headers == {NEXUS_AUTH_HEADER: ""}
+    assert auth.allow_redirects is True
+
+
+def test_unconfigured_access_preserves_runtime_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ordinary local and remote clients keep the existing header contract."""
+    monkeypatch.delenv("NEXUS_AUTH", raising=False)
+    remote = RuntimeRemoteSettings(base_url="https://nexus.example.com")
+
+    auth = remote_auth.build_runtime_request_auth(
+        "https://nexus.example.com/runtime/status", remote
+    )
+
+    assert auth.headers == {NEXUS_AUTH_HEADER: ""}
+    assert auth.allow_redirects is True
+
+
+def test_nonempty_runtime_token_disables_redirects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The application credential cannot cross an HTTP redirect either."""
+    monkeypatch.setenv("NEXUS_AUTH", "runtime-token")
+
+    auth = remote_auth.build_runtime_request_auth(
+        "https://nexus.example.com/runtime/status"
+    )
+
+    assert auth.headers == {NEXUS_AUTH_HEADER: "runtime-token"}
+    assert auth.allow_redirects is False
+
+
+@pytest.mark.parametrize(
+    "target", ["http://example.com/status", "http://192.168.1.20/status"]
+)
+def test_runtime_token_rejects_plaintext_non_loopback(
+    target: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runtime credential is never sent in cleartext across the network."""
+    monkeypatch.setenv("NEXUS_AUTH", "runtime-token")
+
+    with pytest.raises(ValueError, match="plaintext.*non-loopback"):
+        remote_auth.build_runtime_request_auth(target)
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "http://localhost:8002/status",
+        "http://127.0.0.1:8002/status",
+        "http://[::1]:8002/status",
+    ],
+)
+def test_runtime_token_allows_plaintext_loopback(
+    target: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local development keeps its loopback HTTP credential seam."""
+    monkeypatch.setenv("NEXUS_AUTH", "runtime-token")
+
+    auth = remote_auth.build_runtime_request_auth(target)
+
+    assert auth.headers == {NEXUS_AUTH_HEADER: "runtime-token"}
+    assert auth.allow_redirects is False
+
+
+def test_missing_access_secret_fails_before_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing configured credential is a visible error, never a fallback."""
+    monkeypatch.setenv("NEXUS_KEYRING_DISABLE", "1")
+    monkeypatch.delenv(CLIENT_ID_ENV, raising=False)
+    monkeypatch.delenv(CLIENT_SECRET_ENV, raising=False)
+
+    with pytest.raises(MissingSecretError, match=CLIENT_ID_ENV):
+        remote_auth.build_runtime_request_auth(
+            "https://nexus.example.com/runtime/status", _access_remote()
+        )
+
+
+def test_cli_request_reaches_live_loopback_with_runtime_auth(
+    runtime_http_server: tuple[str, list[dict[str, Optional[str]]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The installed story CLI sends auth through a real HTTP socket."""
+    base_url, records = runtime_http_server
+    monkeypatch.setenv("NEXUS_API_URL", base_url)
+    monkeypatch.setenv("NEXUS_AUTH", "runtime-token")
+
+    result = cli.run_load(Namespace(slot=5))
+
+    assert result["success"] is True
+    assert records == [
+        {
+            "path": "/api/slot/5/state",
+            "nexus_auth": "runtime-token",
+            "access_id": None,
+            "access_secret": None,
+        }
+    ]
+
+
+def test_cli_credential_request_does_not_follow_live_redirect(
+    runtime_http_server: tuple[str, list[dict[str, Optional[str]]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Redirect suppression is verified against a real redirect response."""
+    base_url, records = runtime_http_server
+    monkeypatch.setenv("NEXUS_AUTH", "runtime-token")
+
+    response = cli._api_get(f"{base_url}/redirect", timeout=2)
+
+    assert response.status_code == 302
+    assert [record["path"] for record in records] == ["/redirect"]
+
+
+def test_supervisor_remote_probe_reaches_live_runtime(
+    runtime_http_server: tuple[str, list[dict[str, Optional[str]]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The supervisor probe sends shared auth through a real HTTP socket."""
+    base_url, records = runtime_http_server
+    settings = load_settings("nexus.toml")
+    runtime = settings.runtime.model_copy(
+        update={
+            "profile": "remote",
+            "remote": RuntimeRemoteSettings(base_url=base_url),
+        }
+    )
+    settings = settings.model_copy(update={"runtime": runtime})
+    supervisor = Supervisor(settings, Path("nexus.toml"))
+    monkeypatch.setenv("NEXUS_AUTH", "runtime-token")
+
+    result = supervisor._check_remote()
+
+    assert result["runtime"] == {"ok": True}
+    assert records == [
+        {
+            "path": "/runtime/status",
+            "nexus_auth": "runtime-token",
+            "access_id": None,
+            "access_secret": None,
+        }
+    ]
+
+
+def test_cli_uses_remote_profile_from_explicit_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Story commands inherit base_url from NEXUS_RUNTIME_CONFIG."""
+    document = tomlkit.parse(Path("nexus.toml").read_text(encoding="utf-8"))
+    document["runtime"]["profile"] = "remote"
+    config = tmp_path / "remote.toml"
+    config.write_text(tomlkit.dumps(document), encoding="utf-8")
+    monkeypatch.setenv(RUNTIME_CONFIG_ENV, str(config))
+    monkeypatch.delenv("NEXUS_API_URL", raising=False)
+
+    assert cli.get_api_url() == "https://nexus.pythagora.net"
+
+
+def test_cli_outside_checkout_preserves_local_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An installed CLI outside the checkout does not require a cwd config."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv(RUNTIME_CONFIG_ENV, raising=False)
+    monkeypatch.delenv("NEXUS_API_URL", raising=False)
+
+    assert cli.get_api_url() == cli.DEFAULT_API_URL

--- a/tests/test_runtime/test_remote_auth.py
+++ b/tests/test_runtime/test_remote_auth.py
@@ -306,6 +306,40 @@ def test_cli_uses_remote_profile_from_explicit_config(
     assert cli.get_api_url() == "https://nexus.pythagora.net"
 
 
+def test_cli_reuses_unchanged_validated_settings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Polling requests pay full TOML validation once per file version."""
+    config = tmp_path / "nexus.toml"
+    config.write_text(Path("nexus.toml").read_text(encoding="utf-8"))
+    monkeypatch.setenv(RUNTIME_CONFIG_ENV, str(config))
+
+    first = cli._load_cli_settings()
+    second = cli._load_cli_settings()
+
+    assert first is second
+
+
+def test_cli_settings_cache_invalidates_after_config_edit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A changed config is reparsed instead of returning a stale tree."""
+    document = tomlkit.parse(Path("nexus.toml").read_text(encoding="utf-8"))
+    config = tmp_path / "nexus.toml"
+    config.write_text(tomlkit.dumps(document), encoding="utf-8")
+    monkeypatch.setenv(RUNTIME_CONFIG_ENV, str(config))
+    first = cli._load_cli_settings()
+
+    document["runtime"]["state_dir"] = ".nexus/runtime-cache-invalidation"
+    config.write_text(tomlkit.dumps(document), encoding="utf-8")
+    second = cli._load_cli_settings()
+
+    assert first is not second
+    assert second.runtime.state_dir == ".nexus/runtime-cache-invalidation"
+
+
 def test_cli_outside_checkout_preserves_local_default(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- add first-class Cloudflare Access service-token configuration for hosted runtimes, backed by secret-store account names rather than credential values
- route every installed story CLI HTTP call and both supervisor remote-status probes through one shared authentication boundary
- use `runtime.remote.base_url` for story commands under the remote profile while preserving `NEXUS_API_URL` precedence and outside-checkout local behavior
- scope Access credentials to the exact configured HTTPS origin, reject plaintext application credentials outside loopback, and disable redirects whenever a credential is present
- cache the validated CLI settings tree per on-disk file version so long-running status polling does not repeatedly parse the full config; edits invalidate automatically
- document the Keychain-backed configuration and alternate-config CLI workflow

Cloudflare's `nexus-service-token` Service Auth policy is also configured on the hosted application. This PR does not add or enforce application-side authentication; Cloudflare Access remains the outer security boundary.

## Verification

- `poetry run pytest -q tests/test_runtime/test_remote_auth.py tests/test_cli.py tests/test_cli_model_selection.py tests/config/test_settings_models.py` — 82 passed
- `poetry run flake8 nexus/cli.py nexus/config/settings_models.py nexus/runtime/contract.py nexus/runtime/remote_auth.py nexus/runtime/supervisor.py tests/config/test_settings_models.py tests/test_runtime/test_remote_auth.py` — passed
- full suite — 1,296 passed, 213 skipped; one unrelated existing local-inference polling test failed because the live llama-server port was occupied while its mocked sleep did not advance the deadline (`test_deactivate_uses_runtime_poll_interval`); the same test fails alone and neither it nor its implementation changed here
- live Keychain-backed CLI probe — service token passes Access (no 302 login redirect) and reaches Cloudflare Tunnel; the response is currently Tunnel error 1033 because the connector cannot establish outbound port 7844 on the current network path
- repository pre-commit hooks — passed on both commits

Relates to #460. The issue should remain open for its separate passkey acceptance criterion.

Codex — GPT-5.6-Sol