### PR TITLE
Add Retrograde history junctions

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -454,6 +454,10 @@ max_sample_retries = 12
 edge_kind_weights = { relationship = 0.4, pair_tag = 0.3, event = 0.3 }
 anchor_role_weights = { protagonist = 3.0, starting_location = 2.0, default = 1.0 }
 event_open_endpoint_weights = { character = 0.6, faction = 0.25, place = 0.15 }
+# Cold-start braiding: low-weird histories remain star-shaped, while medium
+# and high require one pair of seed candidates to resolve separate rolled
+# edges to the same unknown entity. Runtime maturation remains unbraided.
+junction_counts_by_weird = { low = 0, medium = 1, high = 1 }
 # Tick-loop bookkeeping makes weak backstory dice — never roll "once did
 # upkeep with an unknown party" into a history menu. Event types in these
 # registry categories are barred from the event edge pool only; expansion

--- a/nexus/agents/orrery/retrograde_expansion.py
+++ b/nexus/agents/orrery/retrograde_expansion.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any, Literal, Mapping, Optional, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from nexus.agents.orrery.retrograde_junctions import resolve_junctions
 from nexus.agents.orrery.retrograde_packet import (
     CORE_ENTITIES_HEADING,
     NAMED_SEED_NPCS_HEADING,
@@ -533,6 +534,19 @@ def render_expansion_prompt(
         for candidate in candidates.candidates
         if candidate.seed_id in set(candidates.selected_seed_ids)
     ]
+    resolved_junctions, junction_issues = resolve_junctions(
+        seed_generation_request=seed_generation_request,
+        candidates_payload=candidates.model_dump(mode="json"),
+    )
+    if junction_issues:
+        formatted = "; ".join(junction_issues)
+        raise ValueError(f"Retrograde junction resolution failed: {formatted}")
+    selected_seed_ids = set(candidates.selected_seed_ids)
+    selected_junctions = [
+        junction
+        for junction in resolved_junctions
+        if set(junction["seed_ids"]) <= selected_seed_ids
+    ]
     prompt_payload = {
         "task": (
             "Weave selected Retrograde seed candidates into a compact, coherent "
@@ -546,6 +560,7 @@ def render_expansion_prompt(
         "budget": seed_generation_request.get("budget", {}),
         "selected_seed_ids": candidates.selected_seed_ids,
         "selected_candidates": selected_candidates,
+        "selected_junctions": selected_junctions,
         "core_prompt_sections": (
             seed_generation_request.get("prompt_sections", [])[:4]
         ),
@@ -563,6 +578,10 @@ def render_expansion_prompt(
         "These summaries surface later as retrieved documents, not story.\n"
         "Every selected seed must be accounted for as woven, deferred, or "
         "rejected. Every woven thread must terminate in a present leaf anchor.\n"
+        "For every selected junction, either weave both member seeds through "
+        "the promised shared entity using structured event participants/location, "
+        "or reject both without planning events for either seed. Junction members "
+        "cannot be deferred or survive independently.\n"
         "If the woven history means an entity is dead, destroyed, or "
         "dissolved before the story opens, declare it as a mechanical_plan "
         "row with plan='death' citing the causing event; a death asserted "
@@ -594,13 +613,27 @@ def validate_expansion_plan(
         seed_generation_request=seed_generation_request,
         vocabulary=vocabulary,
     )
+    resolved_junctions, junction_issues = resolve_junctions(
+        seed_generation_request=seed_generation_request,
+        candidates_payload=candidates.model_dump(mode="json"),
+    )
+    if junction_issues:
+        formatted = "\n".join(f"- {issue}" for issue in junction_issues)
+        raise RetrogradeExpansionValidationError(formatted)
+    selected_seed_ids = set(candidates.selected_seed_ids)
+    selected_junctions = [
+        junction
+        for junction in resolved_junctions
+        if set(junction["seed_ids"]) <= selected_seed_ids
+    ]
     response = coerce_expansion_response_payload(
         payload,
         selected_seed_ids=list(candidates.selected_seed_ids),
     )
     issues = _expansion_contract_issues(
         response=response,
-        selected_seed_ids=set(candidates.selected_seed_ids),
+        selected_seed_ids=selected_seed_ids,
+        selected_junctions=selected_junctions,
         vocabulary=vocabulary,
         known_entity_keys=_packet_known_entity_keys(packet),
         max_new_entity_stubs=_budget_entity_stub_cap(seed_generation_request),
@@ -683,6 +716,7 @@ def _expansion_contract_issues(
     *,
     response: RetrogradeExpansionPlanResponse,
     selected_seed_ids: set[str],
+    selected_junctions: list[dict[str, Any]],
     vocabulary: SeedEligibleVocabulary,
     known_entity_keys: Optional[set[tuple[str, str]]] = None,
     max_new_entity_stubs: Optional[int] = None,
@@ -784,7 +818,13 @@ def _expansion_contract_issues(
         _thread_plan_issues(
             thread_plan=response.thread_plan,
             selected_seed_ids=selected_seed_ids,
-            event_refs=event_refs,
+            events_by_ref=events_by_ref,
+        )
+    )
+    issues.extend(
+        _junction_plan_issues(
+            response=response,
+            selected_junctions=selected_junctions,
         )
     )
     issues.extend(_commit_readiness_issues(response.commit_readiness))
@@ -1086,7 +1126,7 @@ def _thread_plan_issues(
     *,
     thread_plan: list[RetrogradeExpansionThreadPlan],
     selected_seed_ids: set[str],
-    event_refs: set[str],
+    events_by_ref: Mapping[str, RetrogradeExpansionEventPlan],
 ) -> list[str]:
     issues: list[str] = []
     thread_seed_ids = {thread.seed_id for thread in thread_plan}
@@ -1097,15 +1137,118 @@ def _thread_plan_issues(
     if unknown_threads:
         issues.append(f"thread_plan references non-selected seeds {unknown_threads}")
     for thread in thread_plan:
-        unknown_event_refs = sorted(set(thread.event_refs) - event_refs)
+        unknown_event_refs = sorted(set(thread.event_refs) - set(events_by_ref))
         if unknown_event_refs:
             issues.append(
                 f"thread {thread.seed_id!r} references unknown event_refs "
                 f"{unknown_event_refs}"
             )
+        for event_ref in sorted(set(thread.event_refs) & set(events_by_ref)):
+            event = events_by_ref[event_ref]
+            if thread.seed_id not in event.seed_ids:
+                issues.append(
+                    f"thread {thread.seed_id!r} references event {event_ref!r}, "
+                    "but that event does not list the thread's seed_id"
+                )
         if thread.status == "woven" and not thread.event_refs:
             issues.append(f"woven thread {thread.seed_id!r} must include event_refs")
     return issues
+
+
+def _junction_plan_issues(
+    *,
+    response: RetrogradeExpansionPlanResponse,
+    selected_junctions: list[dict[str, Any]],
+) -> list[str]:
+    """Require selected junctions to survive or fail as realized atomic pairs."""
+
+    issues: list[str] = []
+    threads_by_seed = {thread.seed_id: thread for thread in response.thread_plan}
+    events_by_ref = {event.event_ref: event for event in response.event_plan}
+
+    for junction in selected_junctions:
+        junction_id = str(junction["junction_id"])
+        seed_ids = [str(seed_id) for seed_id in junction["seed_ids"]]
+        threads = [threads_by_seed.get(seed_id) for seed_id in seed_ids]
+        # The general thread-plan validator reports missing accounting. Avoid
+        # duplicating that error while still validating complete junctions.
+        if any(thread is None for thread in threads):
+            continue
+
+        complete_threads = [thread for thread in threads if thread is not None]
+        statuses = [thread.status for thread in complete_threads]
+        if all(status == "rejected" for status in statuses):
+            referenced_events = sorted(
+                {
+                    event.event_ref
+                    for event in response.event_plan
+                    if set(event.seed_ids) & set(seed_ids)
+                }
+                | {
+                    event_ref
+                    for thread in complete_threads
+                    for event_ref in thread.event_refs
+                }
+            )
+            if referenced_events:
+                issues.append(
+                    f"junction {junction_id!r} rejects both seeds but still "
+                    f"plans or references events {referenced_events}"
+                )
+            continue
+
+        if not all(status == "woven" for status in statuses):
+            status_by_seed = {
+                seed_id: thread.status
+                for seed_id, thread in zip(seed_ids, complete_threads)
+            }
+            issues.append(
+                f"junction {junction_id!r} members must be both woven or both "
+                f"rejected, not {status_by_seed}"
+            )
+            continue
+
+        entity_kind = str(junction["entity_kind"])
+        normalized_entity_ref = str(junction["normalized_entity_ref"])
+        for seed_id, thread in zip(seed_ids, complete_threads):
+            evidence_refs = [
+                event_ref
+                for event_ref in thread.event_refs
+                if event_ref in events_by_ref
+                and seed_id in events_by_ref[event_ref].seed_ids
+                and _event_contains_junction_entity(
+                    events_by_ref[event_ref],
+                    entity_kind=entity_kind,
+                    normalized_entity_ref=normalized_entity_ref,
+                )
+            ]
+            if not evidence_refs:
+                issues.append(
+                    f"junction {junction_id!r} woven seed {seed_id!r} lacks a "
+                    "thread event containing the promised shared "
+                    f"{entity_kind} {junction['entity_ref']!r}"
+                )
+
+    return issues
+
+
+def _event_contains_junction_entity(
+    event: RetrogradeExpansionEventPlan,
+    *,
+    entity_kind: str,
+    normalized_entity_ref: str,
+) -> bool:
+    participant_keys = {
+        (participant.entity_kind, normalize_entity_ref(participant.entity_ref))
+        for participant in event.participants
+    }
+    if (entity_kind, normalized_entity_ref) in participant_keys:
+        return True
+    return bool(
+        entity_kind == "place"
+        and event.location_ref
+        and normalize_entity_ref(event.location_ref) == normalized_entity_ref
+    )
 
 
 def _commit_readiness_issues(
@@ -1127,7 +1270,15 @@ def _hard_validation_rules() -> list[str]:
     return [
         "Every event_plan item must reference one or more selected seed ids.",
         "Every selected seed must appear once in thread_plan.",
-        "Woven threads must reference planned event_ref values.",
+        (
+            "Woven threads must reference planned event_ref values whose "
+            "event seed_ids include that thread's seed_id."
+        ),
+        (
+            "Each selected junction must have both member seeds woven through "
+            "its promised shared entity in structured event participants/location, "
+            "or both rejected with no events; junction members cannot be deferred."
+        ),
         (
             "mechanical_plan rows use plan='entity_tag', 'pair_tag', "
             "'relationship', or 'death'. Leave fields irrelevant to that "

--- a/nexus/agents/orrery/retrograde_graph.py
+++ b/nexus/agents/orrery/retrograde_graph.py
@@ -28,7 +28,7 @@ from nexus.agents.orrery.retrograde_vocabulary import SeedEligibleVocabulary
 if TYPE_CHECKING:
     from nexus.config.settings_models import OrreryRetrogradeGraphSettings
 
-GRAPH_SCHEMA_VERSION = 1
+GRAPH_SCHEMA_VERSION = 2
 
 
 def _coerce_graph_settings(raw: Any) -> "OrreryRetrogradeGraphSettings":
@@ -54,6 +54,15 @@ class DanglingEdge(TypedDict):
     open_endpoint_kind: str
     orthogonality: str
     guidance: str
+
+
+class SharedEntityJunction(TypedDict):
+    """Two independently rolled edges whose open endpoint must be one entity."""
+
+    junction_id: str
+    edge_ids: list[str]
+    open_endpoint_kind: str
+    resolution: str
 
 
 def _graph_rng(seed_material: str) -> random.Random:
@@ -82,6 +91,7 @@ def build_candidate_graph(
     generate_candidates: int,
     rng_seed_material: str,
     graph_settings: Any = None,
+    junction_count: int = 0,
 ) -> dict[str, Any]:
     """Build the R3 candidate graph: core nodes plus sampled dangling edges.
 
@@ -153,8 +163,17 @@ def build_candidate_graph(
             "edge pools (relationships, pair tags, events) are empty"
         )
 
+    if junction_count < 0:
+        raise ValueError("Retrograde graph junction_count must be non-negative")
+
     edge_count = max(2, ceil(generate_candidates * cfg.edges_per_candidate))
+    if junction_count * 2 > edge_count:
+        raise ValueError(
+            f"Retrograde graph cannot fit {junction_count} junctions into "
+            f"{edge_count} dangling-edge slots"
+        )
     edges: list[DanglingEdge] = []
+    junctions: list[SharedEntityJunction] = []
     used_edge_types: set[tuple[str, str]] = set()
 
     def _pick_anchor(kind_filter: Optional[str] = None) -> Optional[dict[str, Any]]:
@@ -171,7 +190,14 @@ def build_candidate_graph(
         ]
         return rng.choices(pool, weights=weights, k=1)[0]
 
-    for index in range(edge_count):
+    def _sample_edge(
+        *,
+        index: int,
+        blocked_edge_types: set[tuple[str, str]],
+        required_open_endpoint_kind: Optional[str] = None,
+    ) -> Optional[DanglingEdge]:
+        """Roll one legal edge, optionally constraining only its open kind."""
+
         edge: Optional[DanglingEdge] = None
         for _attempt in range(cfg.max_sample_retries):
             kind = _weighted_choice(rng, edge_kind_weights)
@@ -224,7 +250,11 @@ def build_candidate_graph(
                 open_kind = _weighted_choice(rng, event_endpoint_weights)
                 anchor_role = "participant"
 
-            if (kind, edge_type) in used_edge_types:
+            if required_open_endpoint_kind is not None and (
+                open_kind != required_open_endpoint_kind
+            ):
+                continue
+            if (kind, edge_type) in blocked_edge_types:
                 continue
 
             far = rng.random() < weird_roll
@@ -244,14 +274,62 @@ def build_candidate_graph(
                 ),
             }
             break
-        if edge is None:
+        return edge
+
+    next_index = 0
+    for junction_index in range(junction_count):
+        pair: Optional[tuple[DanglingEdge, DanglingEdge]] = None
+        for _attempt in range(cfg.max_sample_retries):
+            first = _sample_edge(
+                index=next_index,
+                blocked_edge_types=used_edge_types,
+            )
+            if first is None:
+                continue
+            first_key = (first["kind"], first["edge_type"])
+            second = _sample_edge(
+                index=next_index + 1,
+                blocked_edge_types=used_edge_types | {first_key},
+                required_open_endpoint_kind=first["open_endpoint_kind"],
+            )
+            if second is not None:
+                pair = (first, second)
+                break
+        if pair is None:
+            raise ValueError(
+                "Retrograde graph could not sample two distinct dangling edges "
+                f"for junction {junction_index + 1} with a shared open endpoint "
+                "kind; expand the eligible vocabulary or lower "
+                "junction_counts_by_weird"
+            )
+
+        first, second = pair
+        edges.extend(pair)
+        for edge in pair:
+            used_edge_types.add((edge["kind"], edge["edge_type"]))
+        junctions.append(
+            {
+                "junction_id": f"junction_{junction_index + 1:02d}",
+                "edge_ids": [first["edge_id"], second["edge_id"]],
+                "open_endpoint_kind": first["open_endpoint_kind"],
+                "resolution": "shared_entity",
+            }
+        )
+        next_index += 2
+
+    for index in range(next_index, edge_count):
+        sampled_edge = _sample_edge(
+            index=index,
+            blocked_edge_types=used_edge_types,
+        )
+        if sampled_edge is None:
             # Vocabulary too small to keep deduping within the retry
             # budget: under-build the menu rather than emit duplicate
             # ingredient types. Edge capacity already exceeds what
             # candidates can claim, so a short menu costs little.
             continue
-        used_edge_types.add((edge["kind"], edge["edge_type"]))
-        edges.append(edge)
+        used_edge_types.add((sampled_edge["kind"], sampled_edge["edge_type"]))
+        edges.append(sampled_edge)
 
     if not edges:
         raise ValueError(
@@ -277,6 +355,7 @@ def build_candidate_graph(
         },
         "nodes": nodes,
         "dangling_edges": list(edges),
+        "junctions": list(junctions),
         "attachment_contract": {
             "rule": (
                 "Every candidate seed must claim one or two edge_ids from "
@@ -285,6 +364,11 @@ def build_candidate_graph(
                 "open_endpoint_kind). Unclaimed edges are discarded free "
                 "of charge. The seed's story must make the claimed "
                 "edge_type true."
+            ),
+            "junction_rule": (
+                "Each junction's two edge_ids must be claimed by two distinct "
+                "candidate seeds that resolve the open endpoint to the same "
+                "named entity of open_endpoint_kind."
             ),
             "claims_per_seed_min": 1,
             "claims_per_seed_max": 2,

--- a/nexus/agents/orrery/retrograde_junctions.py
+++ b/nexus/agents/orrery/retrograde_junctions.py
@@ -1,0 +1,184 @@
+"""Shared resolution for mechanically sampled Retrograde junctions."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Mapping
+
+from nexus.agents.orrery.retrograde_vocabulary import (
+    ENTITY_REF_MAX_LENGTH,
+    normalize_entity_ref,
+)
+
+
+def resolve_junctions(
+    *,
+    seed_generation_request: Mapping[str, Any],
+    candidates_payload: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Resolve R3 junction legs against R4 candidate edge claims.
+
+    A valid shared-entity junction has exactly two distinct dangling-edge
+    legs. Each leg is claimed exactly once, by a different candidate, using
+    the junction's endpoint kind and the same normalized endpoint name.
+    Resolved rows are deliberately plain dictionaries so R5, R6, audit, and
+    persistence code can share this authority without importing one another's
+    Pydantic response models.
+    """
+
+    graph = _mapping(seed_generation_request.get("candidate_graph"))
+    raw_junctions = graph.get("junctions", [])
+    if not isinstance(raw_junctions, list):
+        return [], ["candidate_graph.junctions must be a list"]
+    if not raw_junctions:
+        return [], []
+
+    graph_edges = {
+        str(edge.get("edge_id")): edge
+        for edge in graph.get("dangling_edges") or []
+        if isinstance(edge, Mapping) and edge.get("edge_id")
+    }
+    claims_by_edge: dict[str, list[dict[str, str]]] = defaultdict(list)
+    for candidate in candidates_payload.get("candidates") or []:
+        if not isinstance(candidate, Mapping):
+            continue
+        seed_id = str(candidate.get("seed_id") or "")
+        for claim in candidate.get("claimed_edges") or []:
+            if not isinstance(claim, Mapping) or not claim.get("edge_id"):
+                continue
+            edge_id = str(claim["edge_id"])
+            claims_by_edge[edge_id].append(
+                {
+                    "seed_id": seed_id,
+                    "entity_ref": str(claim.get("open_endpoint_name") or "").strip(),
+                    "entity_kind": str(claim.get("open_endpoint_kind") or ""),
+                }
+            )
+
+    resolved: list[dict[str, Any]] = []
+    issues: list[str] = []
+    seen_junction_ids: set[str] = set()
+    seen_junction_edge_ids: set[str] = set()
+    for raw_junction in raw_junctions:
+        if not isinstance(raw_junction, Mapping):
+            issues.append("candidate_graph.junctions entries must be objects")
+            continue
+
+        junction_id = str(raw_junction.get("junction_id") or "")
+        prefix = f"junction {junction_id!r}"
+        junction_issues: list[str] = []
+        if not junction_id:
+            junction_issues.append("junction_id must be non-empty")
+        elif junction_id in seen_junction_ids:
+            junction_issues.append(f"duplicate junction_id {junction_id!r}")
+        seen_junction_ids.add(junction_id)
+
+        raw_edge_ids = raw_junction.get("edge_ids")
+        edge_ids = (
+            [str(edge_id) for edge_id in raw_edge_ids]
+            if isinstance(raw_edge_ids, list)
+            else []
+        )
+        if len(edge_ids) != 2 or any(not edge_id for edge_id in edge_ids):
+            junction_issues.append(
+                f"{prefix} must define exactly two non-empty edge_ids"
+            )
+        elif len(set(edge_ids)) != 2:
+            junction_issues.append(f"{prefix} edge_ids must be distinct")
+        else:
+            reused_edge_ids = sorted(set(edge_ids) & seen_junction_edge_ids)
+            if reused_edge_ids:
+                junction_issues.append(
+                    f"{prefix} reuses edge_ids already assigned to another "
+                    f"junction: {reused_edge_ids}"
+                )
+            seen_junction_edge_ids.update(edge_ids)
+
+        entity_kind = str(raw_junction.get("open_endpoint_kind") or "")
+        if not entity_kind:
+            junction_issues.append(f"{prefix} open_endpoint_kind must be non-empty")
+        if raw_junction.get("resolution") != "shared_entity":
+            junction_issues.append(f"{prefix} resolution must be 'shared_entity'")
+
+        leg_claims: list[dict[str, str]] = []
+        for edge_id in edge_ids:
+            graph_edge = graph_edges.get(edge_id)
+            if graph_edge is None:
+                junction_issues.append(
+                    f"{prefix} references unknown dangling edge {edge_id!r}"
+                )
+            elif str(graph_edge.get("open_endpoint_kind") or "") != entity_kind:
+                junction_issues.append(
+                    f"{prefix} edge {edge_id!r} requires endpoint kind "
+                    f"{graph_edge.get('open_endpoint_kind')!r}, not {entity_kind!r}"
+                )
+
+            claims = claims_by_edge.get(edge_id, [])
+            if len(claims) != 1:
+                junction_issues.append(
+                    f"{prefix} leg {edge_id!r} must be claimed exactly once; "
+                    f"found {len(claims)} claims"
+                )
+                continue
+            leg_claims.append(claims[0])
+
+        if len(leg_claims) == 2:
+            seed_ids = [claim["seed_id"] for claim in leg_claims]
+            if any(not seed_id for seed_id in seed_ids):
+                junction_issues.append(
+                    f"{prefix} legs must be claimed by candidates with seed_id values"
+                )
+            elif len(set(seed_ids)) != 2:
+                junction_issues.append(
+                    f"{prefix} legs must be claimed by two distinct candidates"
+                )
+
+            for edge_id, claim in zip(edge_ids, leg_claims):
+                if claim["entity_kind"] != entity_kind:
+                    junction_issues.append(
+                        f"{prefix} leg {edge_id!r} resolves kind "
+                        f"{claim['entity_kind']!r}; expected {entity_kind!r}"
+                    )
+                entity_ref = claim["entity_ref"]
+                if not entity_ref:
+                    junction_issues.append(
+                        f"{prefix} leg {edge_id!r} requires an endpoint name"
+                    )
+                elif len(entity_ref) > ENTITY_REF_MAX_LENGTH:
+                    junction_issues.append(
+                        f"{prefix} leg {edge_id!r} endpoint name exceeds "
+                        f"{ENTITY_REF_MAX_LENGTH} characters"
+                    )
+
+            normalized_refs = [
+                normalize_entity_ref(claim["entity_ref"]) for claim in leg_claims
+            ]
+            if all(normalized_refs) and len(set(normalized_refs)) != 1:
+                junction_issues.append(
+                    f"{prefix} legs must resolve to the same normalized entity name"
+                )
+
+        if junction_issues:
+            issues.extend(junction_issues)
+            continue
+
+        resolved.append(
+            {
+                "junction_id": junction_id,
+                "edge_ids": edge_ids,
+                "seed_ids": [claim["seed_id"] for claim in leg_claims],
+                "entity_ref": leg_claims[0]["entity_ref"],
+                "normalized_entity_ref": normalize_entity_ref(
+                    leg_claims[0]["entity_ref"]
+                ),
+                "entity_kind": entity_kind,
+            }
+        )
+
+    return resolved, issues
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    """Return ``value`` as a mapping, or an empty mapping otherwise."""
+
+    return value if isinstance(value, Mapping) else {}

--- a/nexus/agents/orrery/retrograde_packet.py
+++ b/nexus/agents/orrery/retrograde_packet.py
@@ -102,12 +102,17 @@ def build_retrograde_dry_run_packet(
     )
     if settings.orrery is None:
         raise ValueError("settings.orrery is required for Retrograde budgets")
+    junction_count = getattr(
+        settings.orrery.retrograde.graph.junction_counts_by_weird,
+        str(weird["level"]),
+    )
     seed_generation_request = build_seed_generation_request(
         candidate_scaffolds=candidate_scaffolds,
         vocabulary=vocabulary,
         weird=weird,
         max_new_entity_stubs=settings.orrery.retrograde.wizard.max_new_entity_stubs,
         graph_settings=settings.orrery.retrograde.graph,
+        junction_count=junction_count,
     )
 
     return {
@@ -158,13 +163,16 @@ def build_seed_generation_request(
     rng_seed_material: Optional[str] = None,
     budget_override: Optional[Mapping[str, int]] = None,
     graph_settings: Any = None,
+    junction_count: int = 0,
 ) -> dict[str, Any]:
     """Build the non-mutating R4/R5 request contract for Skald-as-weaver.
 
     ``budget_override`` replaces the level-derived generate/select counts —
     the runtime maturation path passes its tighter budget here so the R3
     candidate graph is sized for the budget that will actually run, not
-    the wizard default.
+    the wizard default. ``junction_count`` defaults to zero so shared-entity
+    braiding remains a wizard cold-start feature rather than leaking into
+    runtime maturation.
     """
 
     level = str(weird.get("level") or "medium")
@@ -200,6 +208,7 @@ def build_seed_generation_request(
         generate_candidates=int(budget["generate_candidates"]),
         rng_seed_material=rng_seed_material,
         graph_settings=graph_settings,
+        junction_count=junction_count,
     )
 
     return {

--- a/nexus/agents/orrery/retrograde_seed_candidates.py
+++ b/nexus/agents/orrery/retrograde_seed_candidates.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
-from typing import Annotated, Any, Literal, Mapping, Optional, cast
+from typing import Annotated, Any, Literal, Mapping, Optional, Sequence, cast
 
 from pydantic import BaseModel, ConfigDict, Field, create_model, model_validator
 
+from nexus.agents.orrery.retrograde_junctions import resolve_junctions
 from nexus.agents.orrery.retrograde_vocabulary import (
     ENTITY_REF_MAX_LENGTH,
     SeedEligibleVocabulary,
@@ -195,7 +196,10 @@ class RetrogradeWireClaimedEdge(BaseModel):
     """Provider-facing claimed dangling edge (issue #442)."""
 
     edge_id: str = Field(min_length=1)
-    open_endpoint_name: str = Field(min_length=1, max_length=120)
+    open_endpoint_name: str = Field(
+        min_length=1,
+        max_length=ENTITY_REF_MAX_LENGTH,
+    )
     open_endpoint_kind: str = Field(min_length=1)
 
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
@@ -241,7 +245,7 @@ class RetrogradeClaimedEdge(BaseModel):
     edge_id: str = Field(min_length=1, description="Dangling edge id claimed.")
     open_endpoint_name: str = Field(
         min_length=1,
-        max_length=120,
+        max_length=ENTITY_REF_MAX_LENGTH,
         description="Name for the edge's unknown endpoint (new or existing).",
     )
     open_endpoint_kind: str = Field(
@@ -500,6 +504,10 @@ def render_seed_generation_prompt(
         "choose: every candidate must claim 1-2 edge_ids via claimed_edges, "
         "name each claimed edge's open endpoint, and make the edge_type "
         "true in the seed's story. Reconcile the roll; do not ignore it.\n"
+        "candidate_graph.junctions are mandatory shared-entity constraints: "
+        "each junction's two edge_ids must be claimed exactly once by two "
+        "different candidates, and both claims must use the same endpoint "
+        "name and required kind.\n"
         "Keep summaries, rationales, and rejection conditions compact.\n"
         "If a mechanical hint cannot satisfy the hard validation rules, omit it.\n"
         "Return JSON only. Unknown mechanical primitives are invalid.\n\n"
@@ -794,13 +802,6 @@ def _response_contract_issues(
             f"{len(response.candidates)} candidates, exceeding budget "
             f"{generate_limit}"
         )
-    if select_limit is not None and len(response.selected_seed_ids) > select_limit:
-        issues.append(
-            "response selected "
-            f"{len(response.selected_seed_ids)} seeds, exceeding target "
-            f"{select_limit}"
-        )
-
     coverage_ids = {
         str(function.get("id"))
         for function in seed_generation_request.get("coverage_functions", [])
@@ -856,6 +857,26 @@ def _response_contract_issues(
                     claims_max=claims_max,
                 )
             )
+
+    resolved_junctions, junction_issues = resolve_junctions(
+        seed_generation_request=seed_generation_request,
+        candidates_payload=response.model_dump(mode="json"),
+    )
+    issues.extend(junction_issues)
+
+    selection_started = bool(response.selected_seed_ids or response.rejected_seed_ids)
+    if selection_started:
+        issues.extend(
+            _selection_contract_issues(
+                candidate_ids=[candidate.seed_id for candidate in response.candidates],
+                selected_seed_ids=response.selected_seed_ids,
+                rejected_seed_ids=response.rejected_seed_ids,
+                select_limit=select_limit,
+                resolved_junctions=resolved_junctions,
+                require_selected=True,
+                require_complete=True,
+            )
+        )
 
     return issues
 
@@ -1176,6 +1197,7 @@ def _prompt_response_contract() -> dict[str, Any]:
             "coverage_functions",
             "mechanical_hints",
             "defer_or_reject_if",
+            "claimed_edges",
         ],
         "mechanical_hint_fields": [
             "events",
@@ -1189,6 +1211,7 @@ def _prompt_response_contract() -> dict[str, Any]:
             "relationships.relationship_ref": (
                 "subject_kind|object_kind|relationship_type"
             ),
+            "claimed_edges": ("edge_id, open_endpoint_name, open_endpoint_kind"),
             "absence": "Use empty strings for absent supporting_event_ref/rationale.",
         },
     }
@@ -1226,6 +1249,11 @@ def _hard_validation_rules() -> list[str]:
             "selected_seed_ids and rejected_seed_ids must reference returned "
             "candidate seed_id values, and a seed cannot be both selected and "
             "rejected."
+        ),
+        (
+            "Every candidate_graph.junctions entry has exactly two edge legs. "
+            "Those legs must be claimed exactly once by two different "
+            "candidates using the same endpoint kind and normalized name."
         ),
         (
             "Entity refs (entity_ref, subject_ref, object_ref, "
@@ -1282,6 +1310,65 @@ def _seed_vocabulary(value: Any) -> SeedEligibleVocabulary:
     return cast(SeedEligibleVocabulary, vocabulary)
 
 
+def _selection_contract_issues(
+    *,
+    candidate_ids: list[str],
+    selected_seed_ids: list[str],
+    rejected_seed_ids: list[str],
+    select_limit: Optional[int],
+    resolved_junctions: Sequence[Mapping[str, Any]],
+    require_selected: bool,
+    require_complete: bool,
+) -> list[str]:
+    """Return ordinary R5 accounting and junction-atomicity violations."""
+
+    issues: list[str] = []
+    known = set(candidate_ids)
+    selected = set(selected_seed_ids)
+    rejected = set(rejected_seed_ids)
+    unknown = sorted((selected | rejected) - known)
+    if unknown:
+        issues.append(f"selection references unknown seed ids {unknown}")
+    if require_selected and not selected_seed_ids:
+        issues.append("selection must select at least one seed")
+    if select_limit is not None and len(selected_seed_ids) > select_limit:
+        issues.append(
+            f"response selected {len(selected_seed_ids)} seeds, exceeding "
+            f"target {select_limit}"
+        )
+    overlap = sorted(selected & rejected)
+    if overlap:
+        issues.append(f"seed ids both selected and rejected: {overlap}")
+    if require_complete:
+        unaccounted = sorted(known - selected - rejected)
+        if unaccounted:
+            issues.append(
+                "every candidate must be selected or rejected; missing "
+                f"{unaccounted}"
+            )
+
+    for junction in resolved_junctions:
+        junction_id = str(junction.get("junction_id") or "")
+        seed_ids = [str(seed_id) for seed_id in junction.get("seed_ids") or []]
+        dispositions = []
+        for seed_id in seed_ids:
+            if seed_id in selected and seed_id in rejected:
+                dispositions.append("both")
+            elif seed_id in selected:
+                dispositions.append("selected")
+            elif seed_id in rejected:
+                dispositions.append("rejected")
+            else:
+                dispositions.append("unaccounted")
+        if len(set(dispositions)) > 1:
+            issues.append(
+                f"junction {junction_id!r} seeds {seed_ids} must be selected "
+                "or rejected together"
+            )
+
+    return issues
+
+
 class RetrogradeSeedSelectionResponse(BaseModel):
     """Structured response from the decoupled R5 selection pass."""
 
@@ -1305,6 +1392,10 @@ def render_seed_selection_prompt(
     (issue #442).
     """
 
+    resolved_junctions, junction_issues = resolve_junctions(
+        seed_generation_request=seed_generation_request,
+        candidates_payload=candidates_payload,
+    )
     prompt_payload = {
         "task": (
             "Select the strongest subset of the candidate seeds below. "
@@ -1323,6 +1414,8 @@ def render_seed_selection_prompt(
         "dangling_edges": (
             seed_generation_request.get("candidate_graph", {}) or {}
         ).get("dangling_edges", []),
+        "resolved_junctions": resolved_junctions,
+        "junction_resolution_issues": junction_issues,
         "candidates": candidates_payload.get("candidates", []),
     }
     return (
@@ -1332,6 +1425,8 @@ def render_seed_selection_prompt(
         "conviction rather than lip service, and would take real creative "
         "work to weave into the story — merge-difficulty is value, not "
         "risk. Reject seeds that ignore their claimed edges.\n"
+        "Resolved junction seed pairs are atomic: select both member seeds "
+        "or reject both. A pair consumes two ordinary selection slots.\n"
         "Every non-selected candidate must appear in rejected_seed_ids.\n\n"
         "RETROGRADE_SEED_SELECTION_REQUEST:\n"
         f"{json.dumps(prompt_payload, indent=2, sort_keys=True)}"
@@ -1370,6 +1465,15 @@ def select_seed_candidates_with_skald(
 
     budget = _mapping(seed_generation_request.get("budget"))
     select_limit = _optional_positive_int(budget.get("select_target"))
+    resolved_junctions, junction_issues = resolve_junctions(
+        seed_generation_request=seed_generation_request,
+        candidates_payload=candidates_payload,
+    )
+    if junction_issues:
+        formatted = "\n".join(f"- {issue}" for issue in junction_issues)
+        raise RetrogradeSeedCandidateValidationError(
+            "Seed selection received unresolved R3 junctions:\n" + formatted
+        )
 
     prompt = render_seed_selection_prompt(
         seed_generation_request=seed_generation_request,
@@ -1407,34 +1511,15 @@ def select_seed_candidates_with_skald(
         selection = RetrogradeSeedSelectionResponse.model_validate(
             output.model_dump(mode="json")
         )
-        issues: list[str] = []
-        known = set(candidate_ids)
-        unknown = sorted(
-            (set(selection.selected_seed_ids) | set(selection.rejected_seed_ids))
-            - known
+        issues = _selection_contract_issues(
+            candidate_ids=candidate_ids,
+            selected_seed_ids=selection.selected_seed_ids,
+            rejected_seed_ids=selection.rejected_seed_ids,
+            select_limit=select_limit,
+            resolved_junctions=resolved_junctions,
+            require_selected=True,
+            require_complete=True,
         )
-        if unknown:
-            issues.append(f"selection references unknown seed ids {unknown}")
-        if not selection.selected_seed_ids:
-            issues.append("selection must select at least one seed")
-        if select_limit is not None and len(selection.selected_seed_ids) > select_limit:
-            issues.append(
-                f"selected {len(selection.selected_seed_ids)} seeds, "
-                f"exceeding select_target {select_limit}"
-            )
-        overlap = sorted(
-            set(selection.selected_seed_ids) & set(selection.rejected_seed_ids)
-        )
-        if overlap:
-            issues.append(f"seed ids both selected and rejected: {overlap}")
-        unaccounted = sorted(
-            known - set(selection.selected_seed_ids) - set(selection.rejected_seed_ids)
-        )
-        if unaccounted:
-            issues.append(
-                f"every candidate must be selected or rejected; missing "
-                f"{unaccounted}"
-            )
         if issues:
             raise ModelRetry(
                 "Retrograde seed selection failed validation:\n"

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1219,6 +1219,16 @@ class OrreryRetrogradeWizardSettings(BaseModel):
     )
 
 
+class OrreryRetrogradeJunctionCountSettings(BaseModel):
+    """Shared-entity junction counts by player-facing weirdness level."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    low: int = Field(default=0, ge=0)
+    medium: int = Field(default=1, ge=0)
+    high: int = Field(default=1, ge=0)
+
+
 class OrreryRetrogradeGraphSettings(BaseModel):
     """R3 candidate-graph sampling calibration ([orrery.retrograde.graph])."""
 
@@ -1274,6 +1284,13 @@ class OrreryRetrogradeGraphSettings(BaseModel):
             "pool. Tick-loop bookkeeping (needs, upkeep, package resolution) "
             "makes weak backstory dice; expansion validation still accepts "
             "every registered type."
+        ),
+    )
+    junction_counts_by_weird: OrreryRetrogradeJunctionCountSettings = Field(
+        default_factory=OrreryRetrogradeJunctionCountSettings,
+        description=(
+            "Cold-start shared-entity junctions sampled at each player-facing "
+            "weirdness level. Runtime maturation does not consume this setting."
         ),
     )
 

--- a/tests/test_orrery/test_retrograde_expansion.py
+++ b/tests/test_orrery/test_retrograde_expansion.py
@@ -610,6 +610,125 @@ def test_expansion_prompt_states_death_contract() -> None:
     assert "must list the dying entity as a" in prompt
 
 
+def test_expansion_prompt_surfaces_selected_junction_contract() -> None:
+    vocabulary = _expansion_test_vocabulary()
+    packet, seed_response = _junction_inputs(vocabulary)
+
+    prompt = render_expansion_prompt(
+        packet=packet,
+        seed_candidate_response=seed_response,
+    )
+
+    assert '"selected_junctions"' in prompt
+    assert "junction_01" in prompt
+    assert "Junction members cannot be deferred or survive independently" in prompt
+
+
+def test_expansion_plan_accepts_woven_junction_with_shared_entity_evidence() -> None:
+    vocabulary = _expansion_test_vocabulary()
+    packet, seed_response = _junction_inputs(vocabulary)
+
+    response = validate_expansion_plan(
+        payload=_woven_junction_expansion(vocabulary),
+        packet=packet,
+        seed_candidate_response=seed_response,
+    )
+
+    assert [thread.status for thread in response.thread_plan] == ["woven", "woven"]
+
+
+def test_expansion_plan_accepts_joint_junction_rejection_without_events() -> None:
+    vocabulary = _expansion_test_vocabulary()
+    packet, seed_response = _junction_inputs(vocabulary)
+
+    response = validate_expansion_plan(
+        payload=_rejected_junction_expansion(vocabulary),
+        packet=packet,
+        seed_candidate_response=seed_response,
+    )
+
+    assert [thread.status for thread in response.thread_plan] == [
+        "rejected",
+        "rejected",
+    ]
+    assert response.event_plan == []
+
+
+@pytest.mark.parametrize("second_status", ["rejected", "deferred"])
+def test_expansion_plan_rejects_non_atomic_junction_statuses(
+    second_status: str,
+) -> None:
+    vocabulary = _expansion_test_vocabulary()
+    packet, seed_response = _junction_inputs(vocabulary)
+    payload = _woven_junction_expansion(vocabulary)
+    payload["thread_plan"][1]["status"] = second_status
+    if second_status == "rejected":
+        payload["thread_plan"][1]["event_refs"] = []
+
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="members must be both woven or both rejected",
+    ):
+        validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+
+
+def test_expansion_plan_rejects_junction_with_partial_structured_evidence() -> None:
+    vocabulary = _expansion_test_vocabulary()
+    packet, seed_response = _junction_inputs(vocabulary)
+    payload = _separate_event_junction_expansion(vocabulary)
+    payload["event_plan"][1]["participants"] = []
+
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="woven seed 'seed_002' lacks a thread event",
+    ):
+        validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+
+
+def test_expansion_plan_rejects_events_for_jointly_rejected_junction() -> None:
+    vocabulary = _expansion_test_vocabulary()
+    packet, seed_response = _junction_inputs(vocabulary)
+    payload = _woven_junction_expansion(vocabulary)
+    for thread in payload["thread_plan"]:
+        thread["status"] = "rejected"
+        thread["event_refs"] = []
+
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="rejects both seeds but still plans or references events",
+    ):
+        validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+
+
+def test_expansion_plan_requires_thread_event_seed_ownership() -> None:
+    vocabulary = _expansion_test_vocabulary()
+    packet, seed_response = _junction_inputs(vocabulary)
+    payload = _separate_event_junction_expansion(vocabulary)
+    payload["thread_plan"][0]["event_refs"] = ["retro_event_002"]
+
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="does not list the thread's seed_id",
+    ):
+        validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+
+
 def _expansion_test_vocabulary() -> SeedEligibleVocabulary:
     vocabulary = enumerate_seed_eligible_vocabulary()
     vocabulary["registered_single_entity_tags"] = [
@@ -709,6 +828,102 @@ def _seed_response_base(vocabulary: SeedEligibleVocabulary) -> dict[str, Any]:
         "selected_seed_ids": ["seed_001"],
         "rejected_seed_ids": [],
     }
+
+
+def _junction_inputs(
+    vocabulary: SeedEligibleVocabulary,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    packet = _packet(vocabulary)
+    graph = packet["seed_generation_request"]["candidate_graph"]
+    first_edge = graph["dangling_edges"][0]
+    second_edge = {**first_edge, "edge_id": "edge_junction_02"}
+    graph["schema_version"] = 2
+    graph["dangling_edges"].append(second_edge)
+    graph["junctions"] = [
+        {
+            "junction_id": "junction_01",
+            "edge_ids": [first_edge["edge_id"], second_edge["edge_id"]],
+            "open_endpoint_kind": first_edge["open_endpoint_kind"],
+            "resolution": "shared_entity",
+        }
+    ]
+
+    response = _seed_response_base(vocabulary)
+    first_candidate = response["candidates"][0]
+    first_candidate["claimed_edges"] = [
+        {
+            "edge_id": first_edge["edge_id"],
+            "open_endpoint_name": "Vale",
+            "open_endpoint_kind": first_edge["open_endpoint_kind"],
+        }
+    ]
+    second_candidate = copy.deepcopy(first_candidate)
+    second_candidate["seed_id"] = "seed_002"
+    second_candidate["summary"] = "Vale also betrayed Mara's former mentor."
+    second_candidate["claimed_edges"] = [
+        {
+            "edge_id": second_edge["edge_id"],
+            "open_endpoint_name": "vale",
+            "open_endpoint_kind": second_edge["open_endpoint_kind"],
+        }
+    ]
+    response["candidates"].append(second_candidate)
+    response["selected_seed_ids"] = ["seed_001", "seed_002"]
+    return packet, response
+
+
+def _woven_junction_expansion(
+    vocabulary: SeedEligibleVocabulary,
+) -> dict[str, Any]:
+    payload = _valid_expansion(vocabulary)
+    payload["selected_seed_ids"] = ["seed_001", "seed_002"]
+    event = payload["event_plan"][0]
+    event["seed_ids"] = ["seed_001", "seed_002"]
+    event["participants"].append(
+        {"entity_ref": "Vale", "entity_kind": "character", "role": "actor"}
+    )
+    second_thread = copy.deepcopy(payload["thread_plan"][0])
+    second_thread["seed_id"] = "seed_002"
+    second_thread["present_leaf_anchor"] = "Vale's betrayal pressures the opening."
+    payload["thread_plan"].append(second_thread)
+    return payload
+
+
+def _separate_event_junction_expansion(
+    vocabulary: SeedEligibleVocabulary,
+) -> dict[str, Any]:
+    payload = _woven_junction_expansion(vocabulary)
+    first_event = payload["event_plan"][0]
+    first_event["seed_ids"] = ["seed_001"]
+    second_event = copy.deepcopy(first_event)
+    second_event["event_ref"] = "retro_event_002"
+    second_event["seed_ids"] = ["seed_002"]
+    second_event["summary"] = "Vale betrayed Mara's former mentor."
+    payload["event_plan"].append(second_event)
+    payload["thread_plan"][1]["event_refs"] = ["retro_event_002"]
+    return payload
+
+
+def _rejected_junction_expansion(
+    vocabulary: SeedEligibleVocabulary,
+) -> dict[str, Any]:
+    payload = _valid_expansion(vocabulary)
+    payload["selected_seed_ids"] = ["seed_001", "seed_002"]
+    payload["event_plan"] = []
+    payload["entity_tag_plan"] = []
+    payload["pair_tag_plan"] = []
+    payload["relationship_plan"] = []
+    payload["death_plan"] = []
+    payload["thread_plan"] = [
+        {
+            "seed_id": seed_id,
+            "status": "rejected",
+            "event_refs": [],
+            "present_leaf_anchor": "Rejected as incoherent with present canon.",
+        }
+        for seed_id in ("seed_001", "seed_002")
+    ]
+    return payload
 
 
 def _valid_expansion(vocabulary: SeedEligibleVocabulary) -> dict[str, Any]:

--- a/tests/test_orrery/test_retrograde_graph.py
+++ b/tests/test_orrery/test_retrograde_graph.py
@@ -82,18 +82,45 @@ VOCABULARY = {
 WEIRD = {"level": "medium", "raw_min": 0.28, "raw_max": 0.55}
 
 
-def _build(seed: str = "test:mara", generate: int = 6) -> dict:
+def _build(
+    seed: str = "test:mara",
+    generate: int = 6,
+    junction_count: int = 0,
+) -> dict:
     return build_candidate_graph(
         candidate_scaffolds=SCAFFOLDS,
         vocabulary=VOCABULARY,
         weird=WEIRD,
         generate_candidates=generate,
         rng_seed_material=seed,
+        junction_count=junction_count,
     )
 
 
 def test_graph_is_deterministic_for_identical_inputs() -> None:
     assert _build() == _build()
+
+
+def test_shared_entity_junction_is_deterministic_and_kind_compatible() -> None:
+    """R3 rolls two distinct edge legs around one shared unknown entity."""
+
+    graph = _build(junction_count=1)
+    assert graph == _build(junction_count=1)
+    assert graph["schema_version"] == 2
+    assert len(graph["junctions"]) == 1
+
+    junction = graph["junctions"][0]
+    assert junction["junction_id"] == "junction_01"
+    assert junction["resolution"] == "shared_entity"
+    assert len(junction["edge_ids"]) == 2
+    assert len(set(junction["edge_ids"])) == 2
+
+    edges_by_id = {edge["edge_id"]: edge for edge in graph["dangling_edges"]}
+    legs = [edges_by_id[edge_id] for edge_id in junction["edge_ids"]]
+    assert all(
+        leg["open_endpoint_kind"] == junction["open_endpoint_kind"] for leg in legs
+    )
+    assert len({(leg["kind"], leg["edge_type"]) for leg in legs}) == 2
 
 
 def test_different_seed_material_rolls_a_different_graph() -> None:
@@ -273,6 +300,32 @@ def test_excluded_event_categories_come_from_settings() -> None:
         "physiological",
         "routine",
     ]
+    assert cfg.junction_counts_by_weird.model_dump() == {
+        "low": 0,
+        "medium": 1,
+        "high": 1,
+    }
+
+
+def test_impossible_junction_vocabulary_fails_loudly() -> None:
+    """A required braid cannot silently degrade into a star-shaped graph."""
+
+    vocabulary = {
+        **VOCABULARY,
+        "relationship_types": ["rival"],
+        "multi_entity_tag_definitions": [],
+        "event_types": [],
+    }
+    with pytest.raises(ValueError, match="junction 1"):
+        build_candidate_graph(
+            candidate_scaffolds=SCAFFOLDS,
+            vocabulary=vocabulary,
+            weird=WEIRD,
+            generate_candidates=4,
+            rng_seed_material="test:impossible-junction",
+            graph_settings={"edge_kind_weights": {"relationship": 1.0}},
+            junction_count=1,
+        )
 
 
 def test_runtime_maturation_packet_sizes_graph_from_its_own_budget() -> None:
@@ -310,6 +363,7 @@ def test_runtime_maturation_packet_sizes_graph_from_its_own_budget() -> None:
     edges = request["candidate_graph"]["dangling_edges"]
     expected_max = max(2, ceil(cfg.generate_candidates * 1.5))
     assert len(edges) <= expected_max
+    assert request["candidate_graph"]["junctions"] == []
 
     # entropy(cold_start) > entropy(maturation): the roll happens inside
     # the genre band contracted by weird_band_fraction from its floor.

--- a/tests/test_orrery/test_retrograde_packet.py
+++ b/tests/test_orrery/test_retrograde_packet.py
@@ -173,6 +173,29 @@ def test_retrograde_packet_budget_carries_entity_stub_cap() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("weird_level", "expected_junctions"),
+    (("low", 0), ("medium", 1), ("high", 1)),
+)
+def test_wizard_packet_applies_configured_junction_count(
+    weird_level: str,
+    expected_junctions: int,
+) -> None:
+    """Cold-start R3 braiding follows the configured low/medium/high counts."""
+
+    packet = build_retrograde_dry_run_packet(
+        slot=5,
+        dbname="save_05",
+        cache=FakeRetrogradeCache(),
+        vocabulary=enumerate_seed_eligible_vocabulary(),
+        settings=load_settings(),
+        weird_level=weird_level,
+    )
+
+    graph = packet["seed_generation_request"]["candidate_graph"]
+    assert len(graph["junctions"]) == expected_junctions
+
+
 def test_retrograde_seed_request_respects_vocabulary_policy() -> None:
     """Registered categories are prompt-visible but not equally seed-writeable."""
 

--- a/tests/test_orrery/test_retrograde_seed_candidates.py
+++ b/tests/test_orrery/test_retrograde_seed_candidates.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
+from nexus.agents.orrery.retrograde_junctions import resolve_junctions
 from nexus.agents.orrery.retrograde_packet import build_seed_generation_request
 from nexus.agents.orrery.retrograde_seed_candidates import (
     SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION,
@@ -15,6 +16,7 @@ from nexus.agents.orrery.retrograde_seed_candidates import (
     RetrogradeSeedCandidateValidationError,
     coerce_seed_candidate_response_payload,
     render_seed_generation_prompt,
+    render_seed_selection_prompt,
     seed_candidate_wire_response_model,
     validate_seed_candidate_response,
 )
@@ -317,6 +319,264 @@ def test_seed_candidate_prompt_states_entity_ref_name_contract() -> None:
     )
 
     assert f"at most {ENTITY_REF_MAX_LENGTH} characters" in prompt
+    assert '"claimed_edges"' in prompt
+
+
+def test_resolve_junctions_accepts_two_normalized_shared_entity_legs() -> None:
+    """R3 legs resolve when distinct candidates name one canonical entity."""
+
+    vocabulary = _seed_test_vocabulary()
+    seed_request, payload = _junction_case(vocabulary)
+    payload["candidates"][0]["claimed_edges"][0]["open_endpoint_name"] = "The   Broker"
+    payload["candidates"][1]["claimed_edges"][0]["open_endpoint_name"] = "the broker"
+
+    resolved, issues = resolve_junctions(
+        seed_generation_request=seed_request,
+        candidates_payload=payload,
+    )
+
+    assert issues == []
+    assert resolved == [
+        {
+            "junction_id": "junction_01",
+            "edge_ids": ["edge_01", "edge_02"],
+            "seed_ids": ["seed_001", "seed_002"],
+            "entity_ref": "The   Broker",
+            "normalized_entity_ref": "the broker",
+            "entity_kind": "character",
+        }
+    ]
+
+
+def test_resolve_junctions_rejects_edge_reused_across_junctions() -> None:
+    """One sampled edge cannot serve two independent junction contracts."""
+
+    vocabulary = _seed_test_vocabulary()
+    seed_request, payload = _junction_case(vocabulary)
+    first_junction = seed_request["candidate_graph"]["junctions"][0]
+    seed_request["candidate_graph"]["junctions"].append(
+        {
+            "junction_id": "junction_02",
+            "edge_ids": list(first_junction["edge_ids"]),
+            "open_endpoint_kind": "character",
+            "resolution": "shared_entity",
+        }
+    )
+
+    _resolved, issues = resolve_junctions(
+        seed_generation_request=seed_request,
+        candidates_payload=payload,
+    )
+
+    assert any("reuses edge_ids" in issue for issue in issues)
+
+
+@pytest.mark.parametrize("junctions", [{}, "", 0])
+def test_resolve_junctions_rejects_falsey_non_list_values(junctions: object) -> None:
+    """Malformed falsey junction containers cannot disable enforcement."""
+
+    vocabulary = _seed_test_vocabulary()
+    seed_request, payload = _junction_case(vocabulary)
+    seed_request["candidate_graph"]["junctions"] = junctions
+
+    resolved, issues = resolve_junctions(
+        seed_generation_request=seed_request,
+        candidates_payload=payload,
+    )
+
+    assert resolved == []
+    assert issues == ["candidate_graph.junctions must be a list"]
+
+
+def test_seed_candidate_generation_accepts_resolved_junction_before_selection() -> None:
+    """R4 may return a valid pair while leaving both R5 lists empty."""
+
+    vocabulary = _seed_test_vocabulary()
+    seed_request, payload = _junction_case(vocabulary)
+    payload["selected_seed_ids"] = []
+    payload["rejected_seed_ids"] = []
+
+    response = validate_seed_candidate_response(
+        payload=payload,
+        seed_generation_request=seed_request,
+        vocabulary=vocabulary,
+    )
+
+    assert response.selected_seed_ids == []
+    assert response.rejected_seed_ids == []
+
+
+def test_seed_candidate_response_rejects_unresolved_junction_name() -> None:
+    """R4 cannot satisfy two junction legs with different entity names."""
+
+    vocabulary = _seed_test_vocabulary()
+    seed_request, payload = _junction_case(vocabulary)
+    payload["candidates"][1]["claimed_edges"][0][
+        "open_endpoint_name"
+    ] = "Another Broker"
+
+    with pytest.raises(
+        RetrogradeSeedCandidateValidationError,
+        match="same normalized entity name",
+    ):
+        validate_seed_candidate_response(
+            payload=payload,
+            seed_generation_request=seed_request,
+            vocabulary=vocabulary,
+        )
+
+
+def test_seed_candidate_response_rejects_wrong_junction_endpoint_kind() -> None:
+    """Both R4 claims must use the exact endpoint kind reserved by R3."""
+
+    vocabulary = _seed_test_vocabulary()
+    seed_request, payload = _junction_case(vocabulary)
+    payload["candidates"][1]["claimed_edges"][0]["open_endpoint_kind"] = "place"
+
+    with pytest.raises(
+        RetrogradeSeedCandidateValidationError,
+        match="resolves kind 'place'; expected 'character'",
+    ):
+        validate_seed_candidate_response(
+            payload=payload,
+            seed_generation_request=seed_request,
+            vocabulary=vocabulary,
+        )
+
+
+def test_seed_candidate_response_rejects_same_candidate_on_both_junction_legs() -> None:
+    """A braid needs two seeds; one candidate cannot consume both legs."""
+
+    vocabulary = _seed_test_vocabulary()
+    seed_request, payload = _junction_case(vocabulary)
+    second_claim = payload["candidates"][1]["claimed_edges"][0]
+    payload["candidates"] = [payload["candidates"][0]]
+    payload["candidates"][0]["claimed_edges"].append(second_claim)
+    payload["selected_seed_ids"] = []
+    payload["rejected_seed_ids"] = []
+
+    with pytest.raises(
+        RetrogradeSeedCandidateValidationError,
+        match="two distinct candidates",
+    ):
+        validate_seed_candidate_response(
+            payload=payload,
+            seed_generation_request=seed_request,
+            vocabulary=vocabulary,
+        )
+
+
+def test_seed_candidate_response_rejects_junction_leg_claimed_twice() -> None:
+    """Every mechanically sampled junction leg has exactly one owner."""
+
+    vocabulary = _seed_test_vocabulary()
+    seed_request, payload = _junction_case(vocabulary)
+    duplicate = copy.deepcopy(payload["candidates"][0])
+    duplicate["seed_id"] = "seed_003"
+    payload["candidates"].append(duplicate)
+    payload["selected_seed_ids"] = []
+    payload["rejected_seed_ids"] = []
+
+    with pytest.raises(
+        RetrogradeSeedCandidateValidationError,
+        match="must be claimed exactly once; found 2 claims",
+    ):
+        validate_seed_candidate_response(
+            payload=payload,
+            seed_generation_request=seed_request,
+            vocabulary=vocabulary,
+        )
+
+
+def test_seed_candidate_claimed_endpoint_uses_canonical_name_length() -> None:
+    """Claimed endpoints obey the same varchar(50) boundary as R6 refs."""
+
+    vocabulary = _seed_test_vocabulary()
+    _seed_request_payload, payload = _junction_case(vocabulary)
+    payload["candidates"][0]["claimed_edges"][0]["open_endpoint_name"] = "x" * (
+        ENTITY_REF_MAX_LENGTH + 1
+    )
+
+    with pytest.raises(ValidationError, match="at most 50 characters"):
+        RetrogradeSeedCandidateResponse.model_validate(payload)
+
+
+def test_seed_selection_requires_atomic_junction_pair() -> None:
+    """R5 cannot select one junction leg while rejecting its partner."""
+
+    vocabulary = _seed_test_vocabulary()
+    seed_request, payload = _junction_case(vocabulary)
+    payload["selected_seed_ids"] = ["seed_001"]
+    payload["rejected_seed_ids"] = ["seed_002"]
+
+    with pytest.raises(
+        RetrogradeSeedCandidateValidationError,
+        match="must be selected or rejected together",
+    ):
+        validate_seed_candidate_response(
+            payload=payload,
+            seed_generation_request=seed_request,
+            vocabulary=vocabulary,
+        )
+
+
+def test_seed_selection_accepts_selected_junction_pair() -> None:
+    """Both members may consume ordinary R5 slots as one atomic decision."""
+
+    vocabulary = _seed_test_vocabulary()
+    seed_request, payload = _junction_case(vocabulary)
+
+    response = validate_seed_candidate_response(
+        payload=payload,
+        seed_generation_request=seed_request,
+        vocabulary=vocabulary,
+    )
+
+    assert response.selected_seed_ids == ["seed_001", "seed_002"]
+
+
+def test_seed_selection_accepts_rejected_pair_and_independent_seed() -> None:
+    """A junction pair may be rejected while an ordinary seed survives."""
+
+    vocabulary = _seed_test_vocabulary()
+    seed_request, payload = _junction_case(vocabulary)
+    independent = copy.deepcopy(payload["candidates"][0])
+    independent["seed_id"] = "seed_003"
+    edge = seed_request["candidate_graph"]["dangling_edges"][2]
+    independent["claimed_edges"] = [
+        {
+            "edge_id": edge["edge_id"],
+            "open_endpoint_name": "Lark",
+            "open_endpoint_kind": edge["open_endpoint_kind"],
+        }
+    ]
+    payload["candidates"].append(independent)
+    payload["selected_seed_ids"] = ["seed_003"]
+    payload["rejected_seed_ids"] = ["seed_001", "seed_002"]
+
+    response = validate_seed_candidate_response(
+        payload=payload,
+        seed_generation_request=seed_request,
+        vocabulary=vocabulary,
+    )
+
+    assert response.selected_seed_ids == ["seed_003"]
+
+
+def test_seed_selection_prompt_surfaces_resolved_atomic_junction() -> None:
+    """The R5 judge sees the exact pair and its shared canonical endpoint."""
+
+    vocabulary = _seed_test_vocabulary()
+    seed_request, payload = _junction_case(vocabulary)
+
+    prompt = render_seed_selection_prompt(
+        seed_generation_request=seed_request,
+        candidates_payload=payload,
+    )
+
+    assert '"junction_id": "junction_01"' in prompt
+    assert '"normalized_entity_ref": "the broker"' in prompt
+    assert "select both member seeds or reject both" in prompt
 
 
 def _seed_test_vocabulary() -> SeedEligibleVocabulary:
@@ -410,6 +670,49 @@ def _first_edge_claims(vocabulary: SeedEligibleVocabulary) -> list[dict[str, Any
             "open_endpoint_kind": edge["open_endpoint_kind"],
         }
     ]
+
+
+def _junction_case(
+    vocabulary: SeedEligibleVocabulary,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return a two-candidate response satisfying one synthetic R3 junction."""
+
+    request = _seed_request(vocabulary)
+    edges = request["candidate_graph"]["dangling_edges"][:2]
+    for edge in edges:
+        edge["open_endpoint_kind"] = "character"
+    request["candidate_graph"]["junctions"] = [
+        {
+            "junction_id": "junction_01",
+            "edge_ids": [edge["edge_id"] for edge in edges],
+            "open_endpoint_kind": "character",
+            "resolution": "shared_entity",
+        }
+    ]
+
+    payload = _valid_response_payload(vocabulary)
+    first = payload["candidates"][0]
+    first["claimed_edges"] = [
+        {
+            "edge_id": edges[0]["edge_id"],
+            "open_endpoint_name": "The Broker",
+            "open_endpoint_kind": "character",
+        }
+    ]
+    second = copy.deepcopy(first)
+    second["seed_id"] = "seed_002"
+    second["summary"] = "The mentor betrayed the same broker Mara owes."
+    second["claimed_edges"] = [
+        {
+            "edge_id": edges[1]["edge_id"],
+            "open_endpoint_name": "the broker",
+            "open_endpoint_kind": "character",
+        }
+    ]
+    payload["candidates"].append(second)
+    payload["selected_seed_ids"] = ["seed_001", "seed_002"]
+    payload["rejected_seed_ids"] = []
+    return request, payload
 
 
 def _valid_response_payload(vocabulary: SeedEligibleVocabulary) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- sample deterministic shared-entity junctions in R3 with the approved low/medium/high counts of 0/1/1
- enforce distinct same-kind, same-normalized-entity realization in R4 and atomic ordinary-slot selection in R5
- require R6 to weave both legs through structured canonicalizable participant/location evidence or reject both
- keep runtime maturation junction-free and leave persistence, migration, and narrative-continuity storage unchanged

## Validation

- `PYTHONPATH=. poetry run pytest -q tests/test_orrery/test_retrograde_graph.py tests/test_orrery/test_retrograde_packet.py tests/test_orrery/test_retrograde_seed_candidates.py tests/test_orrery/test_retrograde_expansion.py` — 88 passed
- `PYTHONPATH=. poetry run pytest -q tests/test_orrery` — 700 passed, 97 skipped
- Black check, scoped flake8, compileall, config-load assertion, and `git diff --check` passed
- targeted mypy adds no errors beyond the 18 existing dynamic-`create_model` errors reproduced on `main`
- repository-wide pytest was attempted; its remaining failures are unrelated timing/local-loopback interaction flakes, with both socket tests passing when run individually

Closes #478

Codex — GPT-5.6-Sol