### PR TITLE
Add RECRUIT_ALLY character-targeted projects

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1163,7 +1163,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **NOT:** target has any of [`hostile_to`, `hunting`] pair tags to actor
   - **NOT:** trust target→actor < -2
 
-**Does:** applies project `complete` transition; adds outbound `ally` pair tag to target
+**Does:** applies project `complete` transition; adds outbound `ally` pair tag to target and upserts the actor→target `ally` relationship
 **Event:** `recruit_ally_completed`
 
 > {actor} and {target} stop speaking in contingencies. The understanding becomes a commitment: when the cost arrives, {actor} may call on {target} as an ally.

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1143,7 +1143,18 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
       - actor has `thirst` debt ≥ 2
       - actor has `hunger` debt ≥ 4
 
-### Branch 1 — Seal the alliance  *(mag 0.4)* · **preemptive**
+### Branch 1 — End a recruitment whose candidate is no longer available  *(mag 0.4)* · **preemptive**
+
+**When:**
+
+- **NOT:** target is the project's active-character recruit
+
+**Does:** applies project `abandon` transition
+**Event:** `recruit_ally_abandoned`
+
+> {actor}'s intended recruit is no longer someone an alliance can be made with. The project ends cleanly rather than holding open a promise that cannot be answered.
+
+### Branch 2 — Seal the alliance  *(mag 0.4)* · **preemptive**
 
 **When:**
 
@@ -1157,7 +1168,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} and {target} stop speaking in contingencies. The understanding becomes a commitment: when the cost arrives, {actor} may call on {target} as an ally.
 
-### Branch 2 — Withdraw after a hostile turn  *(mag 0.4)* · **preemptive**
+### Branch 3 — Withdraw after a hostile turn  *(mag 0.4)* · **preemptive**
 
 **When:**
 
@@ -1170,7 +1181,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > Whatever possibility {actor} saw in {target} has hardened into danger or contempt. {actor} ends the recruitment before hope becomes leverage in hostile hands.
 
-### Branch 3 — Let the recruitment go rather than force it  *(mag 0.4)* · **preemptive**
+### Branch 4 — Let the recruitment go rather than force it  *(mag 0.4)* · **preemptive**
 
 **When:** actor `recruit_ally` project passes `abandon` due-state
 
@@ -1179,7 +1190,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {actor} admits that the invitation has become a ritual of delay. They stop pressing {target} for a promise that is not coming and release the unfinished alliance.
 
-### Branch 4 — Turn interest into earned trust  *(mag 0.4)* · **preemptive**
+### Branch 5 — Turn interest into earned trust  *(mag 0.4)* · **preemptive**
 
 **When:** actor `recruit_ally` project passes `sounding_out_milestone` due-state
 
@@ -1188,7 +1199,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > {target} has heard enough to take the possibility seriously. Now {actor} must prove that the offered alliance is reliable, not merely attractive.
 
-### Branch 5 — Ask for a real commitment  *(mag 0.4)* · **preemptive**
+### Branch 6 — Ask for a real commitment  *(mag 0.4)* · **preemptive**
 
 **When:** actor `recruit_ally` project passes `earning_trust_milestone` due-state
 
@@ -1197,25 +1208,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > The small proofs have accumulated. {actor} can finally ask {target} for the thing underneath them: a commitment that will still hold when cooperation becomes costly.
 
-### Branch 6 — Learn what the candidate actually wants  *(mag 0.18)* · **not promotable**
-
-**When:** actor `recruit_ally` project passes `sounding_out` due-state
-
-**Does:** applies project `advance` transition
-**Event:** `recruit_ally_progressed`
-
-> {actor} listens past {target}'s first answer and learns what would make an alliance matter to them, not merely to its would-be recruiter.
-
-### Branch 7 — Prove reliable in a small consequential way  *(mag 0.18)* · **not promotable**
-
-**When:** actor `recruit_ally` project passes `earning_trust` due-state
-
-**Does:** applies project `advance` transition
-**Event:** `recruit_ally_progressed`
-
-> {actor} gives {target} evidence instead of assurances: one promise kept where breaking it would have been easier.
-
-### Branch 8 — Lose ground through neglect  *(mag 0.1)* · **not promotable**
+### Branch 7 — Lose ground through neglect  *(mag 0.1)* · **preemptive** · **not promotable**
 
 **When:** actor `recruit_ally` project passes `neglected` due-state
 
@@ -1224,7 +1217,25 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 > Silence does work of its own. A missed promise or unanswered opening leaves {target} less certain that {actor}'s proposed alliance deserves the risk.
 
-### Branch 9 — Make the next commitment concrete  *(mag 0.16)* · **not promotable**
+### Branch 8 — Learn what the candidate actually wants  *(mag 0.18)* · **not promotable**
+
+**When:** actor `recruit_ally` project passes `sounding_out` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `recruit_ally_progressed`
+
+> {actor} listens past {target}'s first answer and learns what would make an alliance matter to them, not merely to its would-be recruiter.
+
+### Branch 9 — Prove reliable in a small consequential way  *(mag 0.18)* · **not promotable**
+
+**When:** actor `recruit_ally` project passes `earning_trust` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `recruit_ally_progressed`
+
+> {actor} gives {target} evidence instead of assurances: one promise kept where breaking it would have been easier.
+
+### Branch 10 — Make the next commitment concrete  *(mag 0.16)* · **not promotable**
 
 **When:** *(always)*
 

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -922,6 +922,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 - **AND:**
   - actor has enough hydrated context
   - **NOT:** actor `plan_relocation` project passes `ready` due-state
+  - **NOT:** actor `recruit_ally` project passes `ready` due-state
   - **NOT:** actor is constrained or immobilized
   - **NOT:** actor has inbound `hunting` pair tag
   - **NOT:** actor has `grudge_active` ephemeral
@@ -1119,6 +1120,118 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 **Event:** `relocation_plan_progressed`
 
 > {actor} does the next small thing the move requires — a message, a form, a measured risk — work too ordinary to look like transformation until enough of it accumulates.
+
+---
+
+## ADVANCE_RECRUIT_ALLY — priority 47
+
+> A due recruitment sounds out its chosen candidate, earns trust, seals commitment, stalls, or ends.
+
+**Drive band:** project identity — A due recruitment shares relocation's vigilance-adjacent slot; SURVEIL yields to either due project while cadence and embodied guards preserve routine stability.
+**Slots:** ACTOR, TARGET
+
+**Gate:**
+
+- **AND:**
+  - actor `recruit_ally` project passes `ready` due-state
+  - advancing recruitment of target
+  - **NOT:** actor is in transit
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:**
+    - **OR:**
+      - actor has `sleep` debt ≥ 8
+      - actor has `thirst` debt ≥ 2
+      - actor has `hunger` debt ≥ 4
+
+### Branch 1 — Seal the alliance  *(mag 0.4)* · **preemptive**
+
+**When:**
+
+- **AND:**
+  - actor `recruit_ally` project passes `completion` due-state
+  - **NOT:** target has any of [`hostile_to`, `hunting`] pair tags to actor
+  - **NOT:** trust target→actor < -2
+
+**Does:** applies project `complete` transition; adds outbound `ally` pair tag to target
+**Event:** `recruit_ally_completed`
+
+> {actor} and {target} stop speaking in contingencies. The understanding becomes a commitment: when the cost arrives, {actor} may call on {target} as an ally.
+
+### Branch 2 — Withdraw after a hostile turn  *(mag 0.4)* · **preemptive**
+
+**When:**
+
+- **OR:**
+  - target has any of [`hostile_to`, `hunting`] pair tags to actor
+  - trust target→actor < -2
+
+**Does:** applies project `abandon` transition
+**Event:** `recruit_ally_abandoned`
+
+> Whatever possibility {actor} saw in {target} has hardened into danger or contempt. {actor} ends the recruitment before hope becomes leverage in hostile hands.
+
+### Branch 3 — Let the recruitment go rather than force it  *(mag 0.4)* · **preemptive**
+
+**When:** actor `recruit_ally` project passes `abandon` due-state
+
+**Does:** applies project `abandon` transition
+**Event:** `recruit_ally_abandoned`
+
+> {actor} admits that the invitation has become a ritual of delay. They stop pressing {target} for a promise that is not coming and release the unfinished alliance.
+
+### Branch 4 — Turn interest into earned trust  *(mag 0.4)* · **preemptive**
+
+**When:** actor `recruit_ally` project passes `sounding_out_milestone` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `recruit_ally_milestone`
+
+> {target} has heard enough to take the possibility seriously. Now {actor} must prove that the offered alliance is reliable, not merely attractive.
+
+### Branch 5 — Ask for a real commitment  *(mag 0.4)* · **preemptive**
+
+**When:** actor `recruit_ally` project passes `earning_trust_milestone` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `recruit_ally_milestone`
+
+> The small proofs have accumulated. {actor} can finally ask {target} for the thing underneath them: a commitment that will still hold when cooperation becomes costly.
+
+### Branch 6 — Learn what the candidate actually wants  *(mag 0.18)* · **not promotable**
+
+**When:** actor `recruit_ally` project passes `sounding_out` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `recruit_ally_progressed`
+
+> {actor} listens past {target}'s first answer and learns what would make an alliance matter to them, not merely to its would-be recruiter.
+
+### Branch 7 — Prove reliable in a small consequential way  *(mag 0.18)* · **not promotable**
+
+**When:** actor `recruit_ally` project passes `earning_trust` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `recruit_ally_progressed`
+
+> {actor} gives {target} evidence instead of assurances: one promise kept where breaking it would have been easier.
+
+### Branch 8 — Lose ground through neglect  *(mag 0.1)* · **not promotable**
+
+**When:** actor `recruit_ally` project passes `neglected` due-state
+
+**Does:** applies project `stall` transition
+**Event:** `recruit_ally_stalled`
+
+> Silence does work of its own. A missed promise or unanswered opening leaves {target} less certain that {actor}'s proposed alliance deserves the risk.
+
+### Branch 9 — Make the next commitment concrete  *(mag 0.16)* · **not promotable**
+
+**When:** *(always)*
+
+**Does:** applies project `advance` transition
+**Event:** `recruit_ally_progressed`
+
+> {actor} and {target} make one more expectation explicit — who answers, what each protects, and what neither will ask the other to pretend away.
 
 ---
 
@@ -1961,6 +2074,49 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 **Event:** `relocation_plan_started`
 
 > {actor} stops treating departure as the thought that arrives after a bad day. They make a ledger, name what it would cost, and put the first real thing aside.
+
+---
+
+## START_RECRUIT_ALLY — priority 17
+
+> A plausible contact becomes the named target of a recruitment project.
+
+**Drive band:** project identity — A recruitment begins only for a known, warm, or trusted candidate; the narrow pair gate lets explicit positive intent rise above routine.
+**Slots:** ACTOR, TARGET
+
+**Gate:**
+
+- **AND:**
+  - actor `recruit_ally` project passes `start` due-state
+  - actor has enough hydrated context
+  - actor is at `home` anchor
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:** actor is in transit
+  - **OR:**
+    - **AND:**
+      - actor has outbound `contact:social` pair tag
+      - actor has `contact:social` pair tag to target
+    - actor has `friend` relationship to target
+    - target has `friend` relationship to actor
+    - actor has `companion` relationship to target
+    - target has `companion` relationship to actor
+    - actor has `comrade` relationship to target
+    - target has `comrade` relationship to actor
+    - actor has `chosen_kin` relationship to target
+    - target has `chosen_kin` relationship to actor
+    - trust actor→target ≥ 1
+  - actor lacks `ally` pair tag to target
+  - **NOT:** actor has any of [`hostile_to`, `hunting`] pair tags to target
+  - **NOT:** target has any of [`hostile_to`, `hunting`] pair tags to actor
+
+### Branch 1 — Sound out a possible ally  *(mag 0.4)*
+
+**When:** *(always)*
+
+**Does:** applies project `start` transition
+**Event:** `recruit_ally_started`
+
+> {actor} stops treating {target} as merely useful company. A careful conversation tests whether shared concern might become a commitment both can name.
 
 ---
 
@@ -2832,9 +2988,11 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 
 ### Pair tags queried by directed predicates
 
+- `ally`
 - `contact:intimate`
 - `contact:lodging`
 - `contact:social`
+- `hostile_to`
 - `hunting`
 - `resides_at`
 
@@ -2871,6 +3029,12 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `protective_intervention`
 - `pursue_identity_lead`
 - `recreation_taken`
+- `recruit_ally_abandoned`
+- `recruit_ally_completed`
+- `recruit_ally_milestone`
+- `recruit_ally_progressed`
+- `recruit_ally_stalled`
+- `recruit_ally_started`
 - `relocation_plan_abandoned`
 - `relocation_plan_completed`
 - `relocation_plan_milestone`

--- a/migrations/077_recruit_ally_projects.sql
+++ b/migrations/077_recruit_ally_projects.sql
@@ -8,13 +8,52 @@ ALTER TABLE character_project_states
     ADD COLUMN IF NOT EXISTS target_character_entity_id bigint NULL
         REFERENCES entities(id);
 
--- Migration 074 created these three constraints from inline CHECK clauses.
--- Drop them by their stable generated names before replacing them with named,
--- per-type constraints that can be documented and extended deliberately.
+-- Migration 074 created the vocabulary constraints from inline column CHECKs,
+-- whose generated names are stable. Its table-level completed-target CHECK is
+-- deliberately discovered by definition: generated names for multiple
+-- anonymous table CHECKs can vary with PostgreSQL/schema history, and dropping
+-- a guessed suffix risks removing the independent progress-range guard.
 ALTER TABLE character_project_states
     DROP CONSTRAINT IF EXISTS character_project_states_project_type_check,
-    DROP CONSTRAINT IF EXISTS character_project_states_stage_check,
-    DROP CONSTRAINT IF EXISTS character_project_states_check;
+    DROP CONSTRAINT IF EXISTS character_project_states_stage_check;
+
+DO $$
+DECLARE
+    completed_target_constraints text[];
+BEGIN
+    SELECT array_agg(conname ORDER BY conname)
+    INTO completed_target_constraints
+    FROM pg_constraint
+    WHERE conrelid = 'character_project_states'::regclass
+      AND contype = 'c'
+      AND position(
+          'status' IN pg_get_constraintdef(oid, true)
+      ) > 0
+      AND position(
+          'completed' IN pg_get_constraintdef(oid, true)
+      ) > 0
+      AND position(
+          'target_place_id' IN pg_get_constraintdef(oid, true)
+      ) > 0
+      AND position(
+          'project_type' IN pg_get_constraintdef(oid, true)
+      ) = 0
+      AND position(
+          'target_character_entity_id' IN pg_get_constraintdef(oid, true)
+      ) = 0;
+
+    IF COALESCE(array_length(completed_target_constraints, 1), 0) <> 1 THEN
+        RAISE EXCEPTION
+            'Expected exactly one migration-074 completed-target CHECK; found %',
+            completed_target_constraints;
+    END IF;
+
+    EXECUTE format(
+        'ALTER TABLE character_project_states DROP CONSTRAINT %I',
+        completed_target_constraints[1]
+    );
+END
+$$;
 
 ALTER TABLE character_project_states
     ADD CONSTRAINT character_project_states_project_type_check
@@ -55,7 +94,7 @@ ALTER TABLE character_project_states
 COMMENT ON COLUMN character_project_states.target_character_entity_id IS
     'Character entity chosen when a character-targeted project starts; required for RECRUIT_ALLY and forbidden for PLAN_RELOCATION.';
 COMMENT ON TABLE character_project_states IS
-    'Additive Orrery project lifecycle projection. Supports PLAN_RELOCATION and RECRUIT_ALLY with a one-open-project-per-character budget; completed relocation hands off to character_travel_states while completed recruitment bestows an outbound ally tag.';
+    'Additive Orrery project lifecycle projection. Supports PLAN_RELOCATION and RECRUIT_ALLY with a one-open-project-per-character budget; completed relocation hands off to character_travel_states while completed recruitment bestows an outbound ally tag and canonical actor-to-target ally relationship.';
 COMMENT ON COLUMN character_project_states.project_type IS
     'Locked project vocabulary. Permits plan_relocation and recruit_ally; each type has an explicit stage ladder and target discipline.';
 COMMENT ON COLUMN character_project_states.stage IS

--- a/migrations/077_recruit_ally_projects.sql
+++ b/migrations/077_recruit_ally_projects.sql
@@ -1,0 +1,116 @@
+-- 077_recruit_ally_projects.sql
+--
+-- Extend the Orrery project chassis with RECRUIT_ALLY, the first project
+-- whose target is a character rather than a place. The two nullable target
+-- columns remain type-disciplined by explicit CHECK constraints and FKs.
+
+ALTER TABLE character_project_states
+    ADD COLUMN IF NOT EXISTS target_character_entity_id bigint NULL
+        REFERENCES entities(id);
+
+-- Migration 074 created these three constraints from inline CHECK clauses.
+-- Drop them by their stable generated names before replacing them with named,
+-- per-type constraints that can be documented and extended deliberately.
+ALTER TABLE character_project_states
+    DROP CONSTRAINT IF EXISTS character_project_states_project_type_check,
+    DROP CONSTRAINT IF EXISTS character_project_states_stage_check,
+    DROP CONSTRAINT IF EXISTS character_project_states_check;
+
+ALTER TABLE character_project_states
+    ADD CONSTRAINT character_project_states_project_type_check
+        CHECK (project_type IN ('plan_relocation', 'recruit_ally')),
+    ADD CONSTRAINT character_project_states_stage_by_type_check
+        CHECK (
+            (project_type = 'plan_relocation'
+                AND stage IN ('saving', 'scouting', 'committing'))
+            OR
+            (project_type = 'recruit_ally'
+                AND stage IN (
+                    'sounding_out', 'earning_trust', 'sealing_commitment'
+                ))
+        ),
+    ADD CONSTRAINT character_project_states_target_by_type_check
+        CHECK (
+            (project_type = 'plan_relocation'
+                AND target_character_entity_id IS NULL)
+            OR
+            (project_type = 'recruit_ally'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NOT NULL)
+        ),
+    ADD CONSTRAINT character_project_states_completed_target_check
+        CHECK (
+            status <> 'completed'
+            OR (project_type = 'plan_relocation' AND target_place_id IS NOT NULL)
+            OR (
+                project_type = 'recruit_ally'
+                AND target_character_entity_id IS NOT NULL
+            )
+        );
+
+-- No relocation data rewrite is needed: migration 074 already guarantees its
+-- stages and completion target, and its rows predate the new nullable character
+-- target column. Adding the constraints above validates those rows unchanged.
+
+COMMENT ON COLUMN character_project_states.target_character_entity_id IS
+    'Character entity chosen when a character-targeted project starts; required for RECRUIT_ALLY and forbidden for PLAN_RELOCATION.';
+COMMENT ON TABLE character_project_states IS
+    'Additive Orrery project lifecycle projection. Supports PLAN_RELOCATION and RECRUIT_ALLY with a one-open-project-per-character budget; completed relocation hands off to character_travel_states while completed recruitment bestows an outbound ally tag.';
+COMMENT ON COLUMN character_project_states.project_type IS
+    'Locked project vocabulary. Permits plan_relocation and recruit_ally; each type has an explicit stage ladder and target discipline.';
+COMMENT ON COLUMN character_project_states.stage IS
+    'Type-specific ladder: PLAN_RELOCATION uses saving/scouting/committing; RECRUIT_ALLY uses sounding_out/earning_trust/sealing_commitment.';
+COMMENT ON COLUMN character_project_states.target_place_id IS
+    'Place target used only by PLAN_RELOCATION, chosen during scouting and required before relocation completion.';
+COMMENT ON CONSTRAINT character_project_states_project_type_check
+    ON character_project_states IS
+    'Closed project-type vocabulary extended by migration 077 for RECRUIT_ALLY.';
+COMMENT ON CONSTRAINT character_project_states_stage_by_type_check
+    ON character_project_states IS
+    'Enforces the independent stage ladder declared for each supported project type.';
+COMMENT ON CONSTRAINT character_project_states_target_by_type_check
+    ON character_project_states IS
+    'Enforces typed targets: relocation may use only a place; recruitment must use exactly its character target from project start.';
+COMMENT ON CONSTRAINT character_project_states_completed_target_check
+    ON character_project_states IS
+    'Completed projects must retain the target required by their project type.';
+
+INSERT INTO event_types (type, category, severity, description)
+VALUES
+    (
+        'recruit_ally_started',
+        'project',
+        'moderate',
+        'The actor chose a plausible contact and began sounding them out as a committed ally.'
+    ),
+    (
+        'recruit_ally_progressed',
+        'project',
+        'minor',
+        'The actor made routine progress toward recruiting the chosen character.'
+    ),
+    (
+        'recruit_ally_milestone',
+        'project',
+        'moderate',
+        'The recruitment crossed a boundary in its sounding-out, trust-building, or commitment ladder.'
+    ),
+    (
+        'recruit_ally_stalled',
+        'project',
+        'minor',
+        'Neglect cost the actor ground in an ongoing recruitment.'
+    ),
+    (
+        'recruit_ally_abandoned',
+        'project',
+        'moderate',
+        'The actor abandoned a recruitment after repeated stalls, excessive delay, or a hostile turn.'
+    ),
+    (
+        'recruit_ally_completed',
+        'project',
+        'moderate',
+        'The chosen recruit accepted the commitment and became the actor''s outbound ally.'
+    )
+ON CONFLICT (type) DO NOTHING;

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -4,8 +4,8 @@ This module is the read-only bridge between the explain layer
 (:mod:`nexus.agents.orrery.explain`) and real slot databases. It mirrors
 :func:`nexus.agents.orrery.resolver.resolve_dry_run` **exactly** — the same
 hydration, the same actor-only / two-party stack split, the same binding
-composition (including threading the actor set through
-``compose_actor_target_bindings``), and the same present-target pressure pass —
+composition (including source-aware routing through
+``compose_actor_target_routes``), and the same present-target pressure pass —
 but runs :func:`explain_stack` per binding set so every template's gate and
 branch trace is retained, not just the winner.
 
@@ -68,10 +68,11 @@ from nexus.agents.orrery.resolver import (
     _render_bound_text,
     _scene_pressure_from_need_spec,
     compose_actor_bindings,
-    compose_actor_target_bindings,
+    compose_actor_target_routes,
     hydrate_world_state,
 )
 from nexus.agents.orrery.substrate import (
+    Bindings,
     coerce_branch_selection,
     coerce_habituation,
     coerce_package_selection,
@@ -557,19 +558,23 @@ def explain_dry_run(
         for template in actor_target_templates
         if template.present_target_policy is PresentTargetPolicy.STORYTELLER_PRESSURE
     ]
-    offscreen_pair_bindings: Sequence[dict[Slot, Any]] = ()
-    present_pair_bindings: Sequence[dict[Slot, Any]] = ()
+    offscreen_pair_routes: Tuple[Tuple[Bindings, Tuple[Template, ...]], ...] = ()
+    present_pair_routes: Tuple[Tuple[Bindings, Tuple[Template, ...]], ...] = ()
     if actor_target_templates:
-        offscreen_pair_bindings = compose_actor_target_bindings(
+        offscreen_pair_routes = compose_actor_target_routes(
             session,
+            state=state,
+            templates=actor_target_templates,
             anchor_chunk_id=anchor_chunk_id,
             window_chunks=window_chunks,
             actor_ids=actor_ids,
             target_presence="offscreen",
         )
         if pressure_templates:
-            present_pair_bindings = compose_actor_target_bindings(
+            present_pair_routes = compose_actor_target_routes(
                 session,
+                state=state,
+                templates=pressure_templates,
                 anchor_chunk_id=anchor_chunk_id,
                 window_chunks=window_chunks,
                 actor_ids=actor_ids,
@@ -594,10 +599,10 @@ def explain_dry_run(
                 package_selection,
             )
         two_party_stacks: dict[int, List[StackExplanation]] = {}
-        for pair_bindings in offscreen_pair_bindings:
+        for pair_bindings, routed_templates in offscreen_pair_routes:
             two_party_stacks.setdefault(pair_bindings[Slot.ACTOR], []).append(
                 explain_stack(
-                    actor_target_templates,
+                    routed_templates,
                     tick_state,
                     pair_bindings,
                     selection,
@@ -606,10 +611,10 @@ def explain_dry_run(
                 )
             )
         pressure_stacks: dict[int, List[StackExplanation]] = {}
-        for pair_bindings in present_pair_bindings:
+        for pair_bindings, routed_templates in present_pair_routes:
             pressure_stacks.setdefault(pair_bindings[Slot.ACTOR], []).append(
                 explain_stack(
-                    pressure_templates,
+                    routed_templates,
                     tick_state,
                     pair_bindings,
                     selection,

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -544,7 +544,13 @@ def _render_state_delta(delta: Mapping[str, Any]) -> str:
             continue
         if key == "entity_pair_tags.add_outbound":
             tags = ", ".join(f"`{t}`" for t in value)
-            parts.append(f"adds outbound {tags} pair tag to target")
+            if "project.complete" in delta and "ally" in value:
+                parts.append(
+                    f"adds outbound {tags} pair tag to target and upserts the "
+                    "actor→target `ally` relationship"
+                )
+            else:
+                parts.append(f"adds outbound {tags} pair tag to target")
             continue
         if key == "entity_pair_tags.clear_outbound":
             tags = ", ".join(f"`{t}`" for t in value)

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -435,6 +435,10 @@ _register(
         f"passes `{m.group('mode')}` due-state"
     ),
 )
+_register(
+    r"project_target_is\((?P<slot>\w+)\)",
+    lambda m: f"advancing recruitment of {_slot(m.group('slot'))}",
+)
 
 
 def _render_count_recent_events(m: re.Match) -> str:

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -439,6 +439,10 @@ _register(
     r"project_target_is\((?P<slot>\w+)\)",
     lambda m: f"advancing recruitment of {_slot(m.group('slot'))}",
 )
+_register(
+    r"project_target_is_active\((?P<slot>\w+)\)",
+    lambda m: f"{_slot(m.group('slot'))} is the project's active-character recruit",
+)
 
 
 def _render_count_recent_events(m: re.Match) -> str:

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -177,10 +177,13 @@ def _tally_report(
                 if item.template_id in {
                     "start_relocation_plan",
                     "advance_relocation_plan",
+                    "start_recruit_ally",
+                    "advance_recruit_ally",
                 }:
                     project_gates.append(
                         {
                             "actor_entity_id": group.actor_entity_id,
+                            "target_entity_id": stack.bindings.get("target"),
                             "template_id": item.template_id,
                             "gate_passed": item.gate_passed,
                             "stack_winner_id": stack.winner_id,

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -1661,6 +1661,7 @@ def _apply_state_delta_sync(
             payload=draft.state_delta["project.complete"],
             source_chunk_id=source_chunk_id,
             policy=project_policy,
+            template_id=draft.template_id,
             target_entity_id=target_entity_id,
         )
     if project_keys:
@@ -1895,6 +1896,7 @@ async def _apply_state_delta_async(
             payload=draft.state_delta["project.complete"],
             source_chunk_id=source_chunk_id,
             policy=project_policy,
+            template_id=draft.template_id,
             target_entity_id=target_entity_id,
         )
     if project_keys:
@@ -2716,6 +2718,185 @@ def _validate_project_completion(
             )
 
 
+def _recruit_ally_relationship_metadata(
+    *,
+    template_id: str,
+    source_chunk_id: int,
+    previous_relationship_type: Optional[str],
+    existing_extra_data: Any,
+) -> dict[str, Any]:
+    """Return durable provenance for the canonical recruited-ally relation."""
+
+    original_type = previous_relationship_type
+    if isinstance(existing_extra_data, Mapping):
+        prior = existing_extra_data.get("orrery_recruit_ally")
+        if isinstance(prior, Mapping):
+            original_type = prior.get("previous_relationship_type", original_type)
+    return {
+        "orrery_recruit_ally": {
+            "template_id": template_id,
+            "source_chunk_id": source_chunk_id,
+            "previous_relationship_type": original_type,
+        }
+    }
+
+
+def _upsert_recruited_ally_relationship_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    target_entity_id: int,
+    template_id: str,
+    source_chunk_id: int,
+) -> dict[str, Any]:
+    """Persist actor->target as the canonical ally relationship."""
+
+    cur.execute(
+        """
+        SELECT actor.id AS character1_id,
+               target.id AS character2_id,
+               existing.relationship_type AS previous_relationship_type,
+               existing.extra_data
+        FROM characters actor
+        JOIN characters target ON target.entity_id = %s
+        LEFT JOIN character_relationships existing
+          ON existing.character1_id = actor.id
+         AND existing.character2_id = target.id
+        WHERE actor.entity_id = %s
+        """,
+        (target_entity_id, actor_entity_id),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(
+            "recruit_ally completion requires actor and target character rows"
+        )
+    character1_id = int(_row_get(row, "character1_id", 0))
+    character2_id = int(_row_get(row, "character2_id", 1))
+    if character1_id == character2_id:
+        raise ValueError("recruit_ally completion cannot recruit the actor")
+    previous = _row_get(row, "previous_relationship_type", 2)
+    previous_type = str(previous) if previous is not None else None
+    metadata = _recruit_ally_relationship_metadata(
+        template_id=template_id,
+        source_chunk_id=source_chunk_id,
+        previous_relationship_type=previous_type,
+        existing_extra_data=_row_get(row, "extra_data", 3),
+    )
+    cur.execute(
+        """
+        INSERT INTO character_relationships (
+            character1_id, character2_id, relationship_type,
+            emotional_valence, dynamic, recent_events, history, extra_data
+        ) VALUES (
+            %s, %s, 'ally', '+3|trusting',
+            'Allies by earned commitment.',
+            'A sustained recruitment concluded in a named alliance.',
+            'Alliance established through the RECRUIT_ALLY project.',
+            %s::jsonb
+        )
+        ON CONFLICT (character1_id, character2_id) DO UPDATE SET
+            relationship_type = EXCLUDED.relationship_type,
+            extra_data = COALESCE(character_relationships.extra_data, '{}'::jsonb)
+                         || EXCLUDED.extra_data,
+            updated_at = now()
+        RETURNING character1_id, character2_id, relationship_type
+        """,
+        (character1_id, character2_id, json.dumps(metadata)),
+    )
+    if cur.fetchone() is None:
+        raise RuntimeError("recruit_ally relationship upsert returned no row")
+    return {
+        "operation": "insert" if previous_type is None else "update",
+        "subject_entity_id": actor_entity_id,
+        "object_entity_id": target_entity_id,
+        "character1_id": character1_id,
+        "character2_id": character2_id,
+        "previous_relationship_type": previous_type,
+        "relationship_type": "ally",
+        "relationship_type_changed": previous_type != "ally",
+    }
+
+
+async def _upsert_recruited_ally_relationship_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    target_entity_id: int,
+    template_id: str,
+    source_chunk_id: int,
+) -> dict[str, Any]:
+    """Async twin of _upsert_recruited_ally_relationship_sync."""
+
+    row = await conn.fetchrow(
+        """
+        SELECT actor.id AS character1_id,
+               target.id AS character2_id,
+               existing.relationship_type AS previous_relationship_type,
+               existing.extra_data
+        FROM characters actor
+        JOIN characters target ON target.entity_id = $2
+        LEFT JOIN character_relationships existing
+          ON existing.character1_id = actor.id
+         AND existing.character2_id = target.id
+        WHERE actor.entity_id = $1
+        """,
+        actor_entity_id,
+        target_entity_id,
+    )
+    if row is None:
+        raise ValueError(
+            "recruit_ally completion requires actor and target character rows"
+        )
+    character1_id = int(_row_get(row, "character1_id", 0))
+    character2_id = int(_row_get(row, "character2_id", 1))
+    if character1_id == character2_id:
+        raise ValueError("recruit_ally completion cannot recruit the actor")
+    previous = _row_get(row, "previous_relationship_type", 2)
+    previous_type = str(previous) if previous is not None else None
+    metadata = _recruit_ally_relationship_metadata(
+        template_id=template_id,
+        source_chunk_id=source_chunk_id,
+        previous_relationship_type=previous_type,
+        existing_extra_data=_row_get(row, "extra_data", 3),
+    )
+    written = await conn.fetchrow(
+        """
+        INSERT INTO character_relationships (
+            character1_id, character2_id, relationship_type,
+            emotional_valence, dynamic, recent_events, history, extra_data
+        ) VALUES (
+            $1, $2, 'ally', '+3|trusting',
+            'Allies by earned commitment.',
+            'A sustained recruitment concluded in a named alliance.',
+            'Alliance established through the RECRUIT_ALLY project.',
+            $3::jsonb
+        )
+        ON CONFLICT (character1_id, character2_id) DO UPDATE SET
+            relationship_type = EXCLUDED.relationship_type,
+            extra_data = COALESCE(character_relationships.extra_data, '{}'::jsonb)
+                         || EXCLUDED.extra_data,
+            updated_at = now()
+        RETURNING character1_id, character2_id, relationship_type
+        """,
+        character1_id,
+        character2_id,
+        json.dumps(metadata),
+    )
+    if written is None:
+        raise RuntimeError("recruit_ally relationship upsert returned no row")
+    return {
+        "operation": "insert" if previous_type is None else "update",
+        "subject_entity_id": actor_entity_id,
+        "object_entity_id": target_entity_id,
+        "character1_id": character1_id,
+        "character2_id": character2_id,
+        "previous_relationship_type": previous_type,
+        "relationship_type": "ally",
+        "relationship_type_changed": previous_type != "ally",
+    }
+
+
 def _apply_project_complete_sync(
     cur: Any,
     *,
@@ -2723,6 +2904,7 @@ def _apply_project_complete_sync(
     payload: Any,
     source_chunk_id: int,
     policy: ProjectPolicy,
+    template_id: str,
     target_entity_id: Optional[int] = None,
 ) -> dict[str, Any]:
     _require_project_policy(policy)
@@ -2739,6 +2921,7 @@ def _apply_project_complete_sync(
         """,
         (source_chunk_id, project["id"]),
     )
+    relationship_mutation: Optional[dict[str, Any]] = None
     if project["project_type"] == "plan_relocation":
         _apply_travel_start_sync(
             cur,
@@ -2746,9 +2929,21 @@ def _apply_project_complete_sync(
             payload=_project_completion_travel_payload(project, payload),
             source_chunk_id=source_chunk_id,
         )
-    else:
+    elif project["project_type"] == "recruit_ally":
         _coerce_project_payload(payload)
-    return _project_applied_snapshot(
+        assert target_entity_id is not None
+        relationship_mutation = _upsert_recruited_ally_relationship_sync(
+            cur,
+            actor_entity_id=actor_entity_id,
+            target_entity_id=target_entity_id,
+            template_id=template_id,
+            source_chunk_id=source_chunk_id,
+        )
+    else:
+        raise ValueError(
+            f"Unsupported project completion type: {project['project_type']!r}"
+        )
+    applied = _project_applied_snapshot(
         project_type=str(project["project_type"]),
         status="completed",
         stage=str(project["stage"]),
@@ -2759,6 +2954,9 @@ def _apply_project_complete_sync(
         source_chunk_id=source_chunk_id,
         target_character_entity_id=project["target_character_entity_id"],
     )
+    if relationship_mutation is not None:
+        applied["relationship_mutation"] = relationship_mutation
+    return applied
 
 
 async def _apply_project_complete_async(
@@ -2768,6 +2966,7 @@ async def _apply_project_complete_async(
     payload: Any,
     source_chunk_id: int,
     policy: ProjectPolicy,
+    template_id: str,
     target_entity_id: Optional[int] = None,
 ) -> dict[str, Any]:
     _require_project_policy(policy)
@@ -2785,6 +2984,7 @@ async def _apply_project_complete_async(
         source_chunk_id,
         project["id"],
     )
+    relationship_mutation: Optional[dict[str, Any]] = None
     if project["project_type"] == "plan_relocation":
         await _apply_travel_start_async(
             conn,
@@ -2792,9 +2992,21 @@ async def _apply_project_complete_async(
             payload=_project_completion_travel_payload(project, payload),
             source_chunk_id=source_chunk_id,
         )
-    else:
+    elif project["project_type"] == "recruit_ally":
         _coerce_project_payload(payload)
-    return _project_applied_snapshot(
+        assert target_entity_id is not None
+        relationship_mutation = await _upsert_recruited_ally_relationship_async(
+            conn,
+            actor_entity_id=actor_entity_id,
+            target_entity_id=target_entity_id,
+            template_id=template_id,
+            source_chunk_id=source_chunk_id,
+        )
+    else:
+        raise ValueError(
+            f"Unsupported project completion type: {project['project_type']!r}"
+        )
+    applied = _project_applied_snapshot(
         project_type=str(project["project_type"]),
         status="completed",
         stage=str(project["stage"]),
@@ -2805,6 +3017,9 @@ async def _apply_project_complete_async(
         source_chunk_id=source_chunk_id,
         target_character_entity_id=project["target_character_entity_id"],
     )
+    if relationship_mutation is not None:
+        applied["relationship_mutation"] = relationship_mutation
+    return applied
 
 
 def _coerce_travel_payload(raw: Any) -> dict[str, Any]:

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -1492,6 +1492,7 @@ def _apply_state_delta_sync(
         raise ValueError(f"Orrery draft {draft.template_id} has no actor binding")
 
     tag_mutations = 0
+    applied_pair_tag_mutations: list[dict[str, Any]] = []
     project_keys = [key for key in draft.state_delta if key.startswith("project.")]
     if len(project_keys) > 1:
         raise ValueError(
@@ -1574,14 +1575,24 @@ def _apply_state_delta_sync(
                 "but has no target binding"
             )
         for tag in outbound_pair_tag_adds:
-            if _add_outbound_pair_tag_sync(
+            changed = _add_outbound_pair_tag_sync(
                 cur,
                 subject_entity_id=actor_entity_id,
                 object_entity_id=target_entity_id,
                 tag=str(tag),
                 template_id=draft.template_id,
                 source_chunk_id=source_chunk_id,
-            ):
+            )
+            applied_pair_tag_mutations.append(
+                {
+                    "operation": "add_outbound",
+                    "tag": str(tag),
+                    "subject_entity_id": actor_entity_id,
+                    "object_entity_id": target_entity_id,
+                    "changed": changed,
+                }
+            )
+            if changed:
                 tag_mutations += 1
     outbound_pair_tag_clears = (
         draft.state_delta.get("entity_pair_tags.clear_outbound", ()) or ()
@@ -1650,10 +1661,13 @@ def _apply_state_delta_sync(
             payload=draft.state_delta["project.complete"],
             source_chunk_id=source_chunk_id,
             policy=project_policy,
+            target_entity_id=target_entity_id,
         )
     if project_keys:
         if project_applied is None:
             raise AssertionError("project transition produced no applied ledger values")
+        if applied_pair_tag_mutations:
+            project_applied["pair_tag_mutations"] = applied_pair_tag_mutations
         _update_resolution_project_applied_sync(
             cur,
             resolution_id=resolution_id,
@@ -1714,6 +1728,7 @@ async def _apply_state_delta_async(
         raise ValueError(f"Orrery draft {draft.template_id} has no actor binding")
 
     tag_mutations = 0
+    applied_pair_tag_mutations: list[dict[str, Any]] = []
     project_keys = [key for key in draft.state_delta if key.startswith("project.")]
     if len(project_keys) > 1:
         raise ValueError(
@@ -1794,14 +1809,24 @@ async def _apply_state_delta_async(
                 "but has no target binding"
             )
         for tag in outbound_pair_tag_adds:
-            if await _add_outbound_pair_tag_async(
+            changed = await _add_outbound_pair_tag_async(
                 conn,
                 subject_entity_id=actor_entity_id,
                 object_entity_id=target_entity_id,
                 tag=str(tag),
                 template_id=draft.template_id,
                 source_chunk_id=source_chunk_id,
-            ):
+            )
+            applied_pair_tag_mutations.append(
+                {
+                    "operation": "add_outbound",
+                    "tag": str(tag),
+                    "subject_entity_id": actor_entity_id,
+                    "object_entity_id": target_entity_id,
+                    "changed": changed,
+                }
+            )
+            if changed:
                 tag_mutations += 1
     outbound_pair_tag_clears = (
         draft.state_delta.get("entity_pair_tags.clear_outbound", ()) or ()
@@ -1870,10 +1895,13 @@ async def _apply_state_delta_async(
             payload=draft.state_delta["project.complete"],
             source_chunk_id=source_chunk_id,
             policy=project_policy,
+            target_entity_id=target_entity_id,
         )
     if project_keys:
         if project_applied is None:
             raise AssertionError("project transition produced no applied ledger values")
+        if applied_pair_tag_mutations:
+            project_applied["pair_tag_mutations"] = applied_pair_tag_mutations
         await _update_resolution_project_applied_async(
             conn,
             resolution_id=resolution_id,
@@ -2051,7 +2079,10 @@ async def _apply_need_fulfillment_async(
 
 
 PROJECT_OPEN_STATUSES = ("active", "paused", "stalled")
-PROJECT_STAGES = frozenset({"saving", "scouting", "committing"})
+PROJECT_STAGE_LADDERS = {
+    "plan_relocation": ("saving", "scouting", "committing"),
+    "recruit_ally": ("sounding_out", "earning_trust", "sealing_commitment"),
+}
 
 
 def _coerce_project_payload(raw: Any) -> dict[str, Any]:
@@ -2085,6 +2116,7 @@ def _project_applied_snapshot(
     stall_count: int,
     next_eligible_at_world_time: Any,
     source_chunk_id: int,
+    target_character_entity_id: Optional[int] = None,
 ) -> dict[str, Any]:
     """Return the exact project projection values persisted by one transition."""
 
@@ -2093,6 +2125,7 @@ def _project_applied_snapshot(
         "status": status,
         "stage": stage,
         "target_place_id": target_place_id,
+        "target_character_entity_id": target_character_entity_id,
         "progress": float(progress),
         "stall_count": int(stall_count),
         "next_eligible_at_world_time": (
@@ -2154,6 +2187,7 @@ def _current_project_sync(cur: Any, actor_entity_id: int) -> Optional[dict[str, 
     cur.execute(
         """
         SELECT id, project_type, status, stage, target_place_id,
+               target_character_entity_id,
                progress, stall_count, next_eligible_at_world_time,
                source_chunk_id
         FROM character_project_states
@@ -2178,6 +2212,7 @@ def _current_project_sync(cur: Any, actor_entity_id: int) -> Optional[dict[str, 
         "status",
         "stage",
         "target_place_id",
+        "target_character_entity_id",
         "progress",
         "stall_count",
         "next_eligible_at_world_time",
@@ -2192,6 +2227,7 @@ async def _current_project_async(
     rows = await conn.fetch(
         """
         SELECT id, project_type, status, stage, target_place_id,
+               target_character_entity_id,
                progress, stall_count, next_eligible_at_world_time,
                source_chunk_id
         FROM character_project_states
@@ -2209,14 +2245,14 @@ async def _current_project_async(
     return dict(rows[0]) if rows else None
 
 
-def _require_open_relocation_project(
+def _require_open_project(
     project: Optional[Mapping[str, Any]], actor_entity_id: int
 ) -> Mapping[str, Any]:
     if project is None:
         raise ValueError(
             f"Actor entity {actor_entity_id} has no open project to transition"
         )
-    if project["project_type"] != "plan_relocation":
+    if project["project_type"] not in PROJECT_STAGE_LADDERS:
         raise ValueError(
             f"Actor entity {actor_entity_id} has unsupported project type "
             f"{project['project_type']!r}"
@@ -2235,30 +2271,39 @@ def _apply_project_start_sync(
     _require_project_policy(policy)
     data = _coerce_project_payload(payload)
     project_type = str(data.get("project_type") or "plan_relocation")
-    stage = str(data.get("stage") or "saving")
-    if project_type != "plan_relocation":
+    if project_type not in PROJECT_STAGE_LADDERS:
         raise ValueError(f"Unsupported project.start type {project_type!r}")
-    if stage not in PROJECT_STAGES:
+    stage = str(data.get("stage") or PROJECT_STAGE_LADDERS[project_type][0])
+    if stage not in PROJECT_STAGE_LADDERS[project_type]:
         raise ValueError(f"Unsupported project.start stage {stage!r}")
     if _current_project_sync(cur, actor_entity_id) is not None:
         raise ValueError(f"Actor entity {actor_entity_id} already has an open project")
     world_time = _tick_world_time_sync(cur, source_chunk_id)
     next_eligible = _project_next_eligible(world_time, policy)
     target_place_id = data.get("target_place_id")
+    target_character_entity_id = data.get("target_character_entity_id")
+    if project_type == "plan_relocation" and target_character_entity_id is not None:
+        raise ValueError("plan_relocation project.start forbids a character target")
+    if project_type == "recruit_ally":
+        if target_place_id is not None:
+            raise ValueError("recruit_ally project.start forbids a place target")
+        if not isinstance(target_character_entity_id, int):
+            raise ValueError("recruit_ally project.start requires a character target")
     progress = float(data.get("progress", 0.0))
     cur.execute(
         """
         INSERT INTO character_project_states (
             character_entity_id, project_type, status, stage,
-            target_place_id, progress, stall_count,
+            target_place_id, target_character_entity_id, progress, stall_count,
             next_eligible_at_world_time, source_chunk_id
-        ) VALUES (%s, %s, 'active', %s, %s, %s, 0, %s, %s)
+        ) VALUES (%s, %s, 'active', %s, %s, %s, %s, 0, %s, %s)
         """,
         (
             actor_entity_id,
             project_type,
             stage,
             target_place_id,
+            target_character_entity_id,
             progress,
             next_eligible,
             source_chunk_id,
@@ -2273,6 +2318,7 @@ def _apply_project_start_sync(
         stall_count=0,
         next_eligible_at_world_time=next_eligible,
         source_chunk_id=source_chunk_id,
+        target_character_entity_id=target_character_entity_id,
     )
 
 
@@ -2287,29 +2333,38 @@ async def _apply_project_start_async(
     _require_project_policy(policy)
     data = _coerce_project_payload(payload)
     project_type = str(data.get("project_type") or "plan_relocation")
-    stage = str(data.get("stage") or "saving")
-    if project_type != "plan_relocation":
+    if project_type not in PROJECT_STAGE_LADDERS:
         raise ValueError(f"Unsupported project.start type {project_type!r}")
-    if stage not in PROJECT_STAGES:
+    stage = str(data.get("stage") or PROJECT_STAGE_LADDERS[project_type][0])
+    if stage not in PROJECT_STAGE_LADDERS[project_type]:
         raise ValueError(f"Unsupported project.start stage {stage!r}")
     if await _current_project_async(conn, actor_entity_id) is not None:
         raise ValueError(f"Actor entity {actor_entity_id} already has an open project")
     world_time = await _tick_world_time_async(conn, source_chunk_id)
     next_eligible = _project_next_eligible(world_time, policy)
     target_place_id = data.get("target_place_id")
+    target_character_entity_id = data.get("target_character_entity_id")
+    if project_type == "plan_relocation" and target_character_entity_id is not None:
+        raise ValueError("plan_relocation project.start forbids a character target")
+    if project_type == "recruit_ally":
+        if target_place_id is not None:
+            raise ValueError("recruit_ally project.start forbids a place target")
+        if not isinstance(target_character_entity_id, int):
+            raise ValueError("recruit_ally project.start requires a character target")
     progress = float(data.get("progress", 0.0))
     await conn.execute(
         """
         INSERT INTO character_project_states (
             character_entity_id, project_type, status, stage,
-            target_place_id, progress, stall_count,
+            target_place_id, target_character_entity_id, progress, stall_count,
             next_eligible_at_world_time, source_chunk_id
-        ) VALUES ($1, $2, 'active', $3, $4, $5, 0, $6, $7)
+        ) VALUES ($1, $2, 'active', $3, $4, $5, $6, 0, $7, $8)
         """,
         actor_entity_id,
         project_type,
         stage,
         target_place_id,
+        target_character_entity_id,
         progress,
         next_eligible,
         source_chunk_id,
@@ -2323,6 +2378,7 @@ async def _apply_project_start_async(
         stall_count=0,
         next_eligible_at_world_time=next_eligible,
         source_chunk_id=source_chunk_id,
+        target_character_entity_id=target_character_entity_id,
     )
 
 
@@ -2330,7 +2386,7 @@ def _project_advance_values(
     project: Mapping[str, Any], data: Mapping[str, Any]
 ) -> tuple[str, Optional[int], float]:
     stage = str(data.get("stage") or project["stage"])
-    if stage not in PROJECT_STAGES:
+    if stage not in PROJECT_STAGE_LADDERS[str(project["project_type"])]:
         raise ValueError(f"Unsupported project.advance stage {stage!r}")
     if data.get("select_target") and data.get("target_place_id") is None:
         raise ValueError(
@@ -2356,13 +2412,17 @@ def _apply_project_advance_sync(
 ) -> dict[str, Any]:
     _require_project_policy(policy)
     data = _coerce_project_payload(payload)
-    project = _require_open_relocation_project(
+    project = _require_open_project(
         _current_project_sync(cur, actor_entity_id), actor_entity_id
     )
     stage, target_place_id, progress = _project_advance_values(project, data)
     reached_milestone = bool(data.get("milestone")) and (
         (project["stage"], stage)
-        in {("saving", "scouting"), ("scouting", "committing")}
+        in {
+            transition
+            for stages in PROJECT_STAGE_LADDERS.values()
+            for transition in zip(stages, stages[1:])
+        }
     )
     stall_count = 0 if reached_milestone else int(project["stall_count"] or 0)
     world_time = _tick_world_time_sync(cur, source_chunk_id)
@@ -2395,6 +2455,7 @@ def _apply_project_advance_sync(
         stall_count=stall_count,
         next_eligible_at_world_time=next_eligible,
         source_chunk_id=source_chunk_id,
+        target_character_entity_id=project["target_character_entity_id"],
     )
 
 
@@ -2408,13 +2469,17 @@ async def _apply_project_advance_async(
 ) -> dict[str, Any]:
     _require_project_policy(policy)
     data = _coerce_project_payload(payload)
-    project = _require_open_relocation_project(
+    project = _require_open_project(
         await _current_project_async(conn, actor_entity_id), actor_entity_id
     )
     stage, target_place_id, progress = _project_advance_values(project, data)
     reached_milestone = bool(data.get("milestone")) and (
         (project["stage"], stage)
-        in {("saving", "scouting"), ("scouting", "committing")}
+        in {
+            transition
+            for stages in PROJECT_STAGE_LADDERS.values()
+            for transition in zip(stages, stages[1:])
+        }
     )
     stall_count = 0 if reached_milestone else int(project["stall_count"] or 0)
     world_time = await _tick_world_time_async(conn, source_chunk_id)
@@ -2445,6 +2510,7 @@ async def _apply_project_advance_async(
         stall_count=stall_count,
         next_eligible_at_world_time=next_eligible,
         source_chunk_id=source_chunk_id,
+        target_character_entity_id=project["target_character_entity_id"],
     )
 
 
@@ -2458,7 +2524,7 @@ def _apply_project_stall_sync(
 ) -> dict[str, Any]:
     _require_project_policy(policy)
     data = _coerce_project_payload(payload)
-    project = _require_open_relocation_project(
+    project = _require_open_project(
         _current_project_sync(cur, actor_entity_id), actor_entity_id
     )
     increment = int(data.get("increment", 1))
@@ -2491,6 +2557,7 @@ def _apply_project_stall_sync(
         stall_count=stall_count,
         next_eligible_at_world_time=next_eligible,
         source_chunk_id=source_chunk_id,
+        target_character_entity_id=project["target_character_entity_id"],
     )
 
 
@@ -2504,7 +2571,7 @@ async def _apply_project_stall_async(
 ) -> dict[str, Any]:
     _require_project_policy(policy)
     data = _coerce_project_payload(payload)
-    project = _require_open_relocation_project(
+    project = _require_open_project(
         await _current_project_async(conn, actor_entity_id), actor_entity_id
     )
     increment = int(data.get("increment", 1))
@@ -2535,6 +2602,7 @@ async def _apply_project_stall_async(
         stall_count=stall_count,
         next_eligible_at_world_time=next_eligible,
         source_chunk_id=source_chunk_id,
+        target_character_entity_id=project["target_character_entity_id"],
     )
 
 
@@ -2548,7 +2616,7 @@ def _apply_project_abandon_sync(
 ) -> dict[str, Any]:
     _require_project_policy(policy)
     _coerce_project_payload(payload)
-    project = _require_open_relocation_project(
+    project = _require_open_project(
         _current_project_sync(cur, actor_entity_id), actor_entity_id
     )
     cur.execute(
@@ -2569,6 +2637,7 @@ def _apply_project_abandon_sync(
         stall_count=int(project["stall_count"] or 0),
         next_eligible_at_world_time=None,
         source_chunk_id=source_chunk_id,
+        target_character_entity_id=project["target_character_entity_id"],
     )
 
 
@@ -2582,7 +2651,7 @@ async def _apply_project_abandon_async(
 ) -> dict[str, Any]:
     _require_project_policy(policy)
     _coerce_project_payload(payload)
-    project = _require_open_relocation_project(
+    project = _require_open_project(
         await _current_project_async(conn, actor_entity_id), actor_entity_id
     )
     await conn.execute(
@@ -2604,6 +2673,7 @@ async def _apply_project_abandon_async(
         stall_count=int(project["stall_count"] or 0),
         next_eligible_at_world_time=None,
         source_chunk_id=source_chunk_id,
+        target_character_entity_id=project["target_character_entity_id"],
     )
 
 
@@ -2625,6 +2695,27 @@ def _project_completion_travel_payload(
     return travel
 
 
+def _validate_project_completion(
+    project: Mapping[str, Any], target_entity_id: Optional[int]
+) -> None:
+    project_type = str(project["project_type"])
+    final_stage = PROJECT_STAGE_LADDERS[project_type][2]
+    if project["stage"] != final_stage:
+        raise ValueError(f"project.complete requires the {final_stage} stage")
+    if float(project["progress"] or 0.0) < 1.0:
+        raise ValueError("project.complete requires full stage progress")
+    if project_type == "plan_relocation" and project["target_place_id"] is None:
+        raise ValueError("project.complete requires target_place_id")
+    if project_type == "recruit_ally":
+        recruit_id = project["target_character_entity_id"]
+        if recruit_id is None:
+            raise ValueError("recruit_ally completion requires its character target")
+        if target_entity_id != recruit_id:
+            raise ValueError(
+                "recruit_ally completion target binding does not match its recruit"
+            )
+
+
 def _apply_project_complete_sync(
     cur: Any,
     *,
@@ -2632,12 +2723,13 @@ def _apply_project_complete_sync(
     payload: Any,
     source_chunk_id: int,
     policy: ProjectPolicy,
+    target_entity_id: Optional[int] = None,
 ) -> dict[str, Any]:
     _require_project_policy(policy)
-    project = _require_open_relocation_project(
+    project = _require_open_project(
         _current_project_sync(cur, actor_entity_id), actor_entity_id
     )
-    travel_payload = _project_completion_travel_payload(project, payload)
+    _validate_project_completion(project, target_entity_id)
     cur.execute(
         """
         UPDATE character_project_states
@@ -2647,12 +2739,15 @@ def _apply_project_complete_sync(
         """,
         (source_chunk_id, project["id"]),
     )
-    _apply_travel_start_sync(
-        cur,
-        actor_entity_id=actor_entity_id,
-        payload=travel_payload,
-        source_chunk_id=source_chunk_id,
-    )
+    if project["project_type"] == "plan_relocation":
+        _apply_travel_start_sync(
+            cur,
+            actor_entity_id=actor_entity_id,
+            payload=_project_completion_travel_payload(project, payload),
+            source_chunk_id=source_chunk_id,
+        )
+    else:
+        _coerce_project_payload(payload)
     return _project_applied_snapshot(
         project_type=str(project["project_type"]),
         status="completed",
@@ -2662,6 +2757,7 @@ def _apply_project_complete_sync(
         stall_count=int(project["stall_count"] or 0),
         next_eligible_at_world_time=None,
         source_chunk_id=source_chunk_id,
+        target_character_entity_id=project["target_character_entity_id"],
     )
 
 
@@ -2672,12 +2768,13 @@ async def _apply_project_complete_async(
     payload: Any,
     source_chunk_id: int,
     policy: ProjectPolicy,
+    target_entity_id: Optional[int] = None,
 ) -> dict[str, Any]:
     _require_project_policy(policy)
-    project = _require_open_relocation_project(
+    project = _require_open_project(
         await _current_project_async(conn, actor_entity_id), actor_entity_id
     )
-    travel_payload = _project_completion_travel_payload(project, payload)
+    _validate_project_completion(project, target_entity_id)
     await conn.execute(
         """
         UPDATE character_project_states
@@ -2688,12 +2785,15 @@ async def _apply_project_complete_async(
         source_chunk_id,
         project["id"],
     )
-    await _apply_travel_start_async(
-        conn,
-        actor_entity_id=actor_entity_id,
-        payload=travel_payload,
-        source_chunk_id=source_chunk_id,
-    )
+    if project["project_type"] == "plan_relocation":
+        await _apply_travel_start_async(
+            conn,
+            actor_entity_id=actor_entity_id,
+            payload=_project_completion_travel_payload(project, payload),
+            source_chunk_id=source_chunk_id,
+        )
+    else:
+        _coerce_project_payload(payload)
     return _project_applied_snapshot(
         project_type=str(project["project_type"]),
         status="completed",
@@ -2703,6 +2803,7 @@ async def _apply_project_complete_async(
         stall_count=int(project["stall_count"] or 0),
         next_eligible_at_world_time=None,
         source_chunk_id=source_chunk_id,
+        target_character_entity_id=project["target_character_entity_id"],
     )
 
 

--- a/nexus/agents/orrery/evidence.py
+++ b/nexus/agents/orrery/evidence.py
@@ -72,6 +72,7 @@ from nexus.agents.orrery.substrate import (
     _trust_values_are_asymmetric,
     project_due,
     project_overdue_hours,
+    project_target_is,
 )
 
 
@@ -1601,6 +1602,7 @@ def _project_due(
         project_type=project_type,
         slot=Slot(slot),
     )
+
     return _evidence(
         "project_due",
         params={
@@ -1622,6 +1624,43 @@ def _project_due(
             ),
         },
         result=condition(state, bindings),
+    )
+
+
+@_resolver("project_target_is")
+def _project_target_is(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict[str, Any]:
+    slot = match["slot"]
+    actor_entity_id = _entity(bindings, Slot.ACTOR.value)
+    bound_target_entity_id = _entity(bindings, slot)
+    project = (
+        state.project_states.get(actor_entity_id)
+        if actor_entity_id is not None
+        else None
+    )
+    project_target_entity_id = (
+        project.target_character_entity_id if project is not None else None
+    )
+    condition = project_target_is(Slot(slot))
+    result = condition(state, bindings)
+    return _evidence(
+        "project_target_is",
+        params={"slot": slot},
+        entities={"actor": actor_entity_id, slot: bound_target_entity_id},
+        observed={
+            "project_id": project.id if project is not None else None,
+            "project_type": project.project_type if project is not None else None,
+            "project_target_entity_id": project_target_entity_id,
+            "bound_target_entity_id": bound_target_entity_id,
+            "explanation": (
+                f"advancing recruitment of {slot}"
+                if result
+                else "blocked: bound target is not the project's recruit"
+            ),
+        },
+        result=result,
+        matched=[bound_target_entity_id] if result else [],
     )
 
 

--- a/nexus/agents/orrery/evidence.py
+++ b/nexus/agents/orrery/evidence.py
@@ -73,6 +73,7 @@ from nexus.agents.orrery.substrate import (
     project_due,
     project_overdue_hours,
     project_target_is,
+    project_target_is_active,
 )
 
 
@@ -1642,8 +1643,15 @@ def _project_target_is(
     project_target_entity_id = (
         project.target_character_entity_id if project is not None else None
     )
+    project_target_active = (
+        project.target_character_is_active if project is not None else None
+    )
     condition = project_target_is(Slot(slot))
     result = condition(state, bindings)
+    if result:
+        explanation = f"advancing recruitment of {slot}"
+    else:
+        explanation = "blocked: bound target is not the project's recruit"
     return _evidence(
         "project_target_is",
         params={"slot": slot},
@@ -1652,12 +1660,55 @@ def _project_target_is(
             "project_id": project.id if project is not None else None,
             "project_type": project.project_type if project is not None else None,
             "project_target_entity_id": project_target_entity_id,
+            "project_target_is_active": project_target_active,
             "bound_target_entity_id": bound_target_entity_id,
-            "explanation": (
-                f"advancing recruitment of {slot}"
-                if result
-                else "blocked: bound target is not the project's recruit"
-            ),
+            "explanation": explanation,
+        },
+        result=result,
+        matched=[bound_target_entity_id] if result else [],
+    )
+
+
+@_resolver("project_target_is_active")
+def _project_target_is_active(
+    match: re.Match, state: WorldState, bindings: Bindings
+) -> dict[str, Any]:
+    slot = match["slot"]
+    actor_entity_id = _entity(bindings, Slot.ACTOR.value)
+    bound_target_entity_id = _entity(bindings, slot)
+    project = (
+        state.project_states.get(actor_entity_id)
+        if actor_entity_id is not None
+        else None
+    )
+    project_target_entity_id = (
+        project.target_character_entity_id if project is not None else None
+    )
+    project_target_active = (
+        project.target_character_is_active if project is not None else None
+    )
+    condition = project_target_is_active(Slot(slot))
+    result = condition(state, bindings)
+    if result:
+        explanation = "project's recruit is an active character"
+    elif (
+        project_target_entity_id == bound_target_entity_id
+        and project_target_entity_id is not None
+    ):
+        explanation = "project's recruit is inactive or not a character"
+    else:
+        explanation = "blocked: bound target is not the project's recruit"
+    return _evidence(
+        "project_target_is_active",
+        params={"slot": slot},
+        entities={"actor": actor_entity_id, slot: bound_target_entity_id},
+        observed={
+            "project_id": project.id if project is not None else None,
+            "project_type": project.project_type if project is not None else None,
+            "project_target_entity_id": project_target_entity_id,
+            "project_target_is_active": project_target_active,
+            "bound_target_entity_id": bound_target_entity_id,
+            "explanation": explanation,
         },
         result=result,
         matched=[bound_target_entity_id] if result else [],

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -72,6 +72,11 @@ from nexus.agents.orrery.needs import (
 from nexus.agents.orrery.reconstruction import CHECKPOINT_SECTIONS
 from nexus.agents.orrery.substrate import ProjectPolicy, coerce_project_policy
 
+PROJECT_STAGE_LADDERS = {
+    "plan_relocation": ("saving", "scouting", "committing"),
+    "recruit_ally": ("sounding_out", "earning_trust", "sealing_commitment"),
+}
+
 # Composite natural keys, verbatim column order (faction_relationships
 # enforces faction1_id < faction2_id; character_relationships only c1 <> c2
 # — never re-canonicalize when re-inserting delete pre-images).
@@ -405,6 +410,8 @@ class _Replayer:
         projects: dict[Any, dict[str, Any]] = {
             row["id"]: dict(row) for row in base_state["character_project_states"]
         }
+        for project in projects.values():
+            project.setdefault("target_character_entity_id", None)
 
         born_entities = self._seed_window_births(characters, places, result)
 
@@ -678,7 +685,7 @@ class _Replayer:
                 "in replay working state"
             )
         key, row = matches[0]
-        if row["project_type"] != "plan_relocation":
+        if row["project_type"] not in PROJECT_STAGE_LADDERS:
             raise ValueError(
                 f"Actor {actor_entity_id} has unsupported replay project "
                 f"type {row['project_type']!r}"
@@ -724,9 +731,9 @@ class _Replayer:
             )
         project_type = str(applied["project_type"])
         stage = str(applied["stage"])
-        if project_type != "plan_relocation":
+        if project_type not in PROJECT_STAGE_LADDERS:
             raise ValueError(f"Unsupported replay project type {project_type!r}")
-        if stage not in {"saving", "scouting", "committing"}:
+        if stage not in PROJECT_STAGE_LADDERS[project_type]:
             raise ValueError(f"Unsupported replay project stage {stage!r}")
         expected_status = {
             "project.start": "active",
@@ -746,11 +753,26 @@ class _Replayer:
             "status": expected_status,
             "stage": stage,
             "target_place_id": applied["target_place_id"],
+            # Historical PLAN_RELOCATION ledgers predate migration 077. Their
+            # missing character-target field is truthfully NULL.
+            "target_character_entity_id": applied.get("target_character_entity_id"),
             "progress": _pg_round(float(applied["progress"]), 4),
             "stall_count": int(applied["stall_count"]),
             "next_eligible_at_world_time": applied["next_eligible_at_world_time"],
             "source_chunk_id": int(applied["source_chunk_id"]),
         }
+        if project_type == "plan_relocation":
+            if applied_row["target_character_entity_id"] is not None:
+                raise ValueError(
+                    "plan_relocation replay projection forbids character target"
+                )
+        elif (
+            applied_row["target_place_id"] is not None
+            or applied_row["target_character_entity_id"] is None
+        ):
+            raise ValueError(
+                "recruit_ally replay projection requires only a character target"
+            )
         if applied_row["source_chunk_id"] != chunk_id:
             raise ValueError(
                 f"{delta_key} at chunk {chunk_id} applied source_chunk_id is "
@@ -789,16 +811,25 @@ class _Replayer:
             row.update(applied_row)
             return
         if delta_key == "project.complete":
-            if applied_row["stage"] != "committing":
-                raise ValueError("project.complete replay requires committing stage")
+            final_stage = PROJECT_STAGE_LADDERS[project_type][2]
+            if applied_row["stage"] != final_stage:
+                raise ValueError(
+                    f"project.complete replay requires {final_stage} stage"
+                )
             if float(applied_row["progress"] or 0.0) < 1.0:
                 raise ValueError("project.complete replay requires full progress")
+            row.update(applied_row)
+            if project_type == "recruit_ally":
+                if applied_row["target_character_entity_id"] is None:
+                    raise ValueError(
+                        "recruit_ally completion replay requires character target"
+                    )
+                return
             destination = applied_row["target_place_id"]
             if destination is None:
                 raise ValueError(
                     "project.complete replay requires project target_place_id"
                 )
-            row.update(applied_row)
             travel_payload = {
                 key: value
                 for key, value in payload.items()

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable as IterableABC
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
-from typing import Any, Iterable, Mapping, Optional, Tuple
+from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
 
 from sqlalchemy import text
 
@@ -658,6 +658,8 @@ def _load_project_states(session: Any) -> dict[int, ProjectState]:
                    cps.stage,
                    cps.target_place_id,
                    cps.target_character_entity_id,
+                   COALESCE(target_entity.is_active, false)
+                       AS target_character_is_active,
                    cps.progress,
                    cps.stall_count,
                    cps.next_eligible_at_world_time,
@@ -667,6 +669,9 @@ def _load_project_states(session: Any) -> dict[int, ProjectState]:
               ON e.id = cps.character_entity_id
              AND e.kind = 'character'
              AND e.is_active = true
+            LEFT JOIN entities target_entity
+              ON target_entity.id = cps.target_character_entity_id
+             AND target_entity.kind = 'character'
             WHERE cps.status IN ('active', 'paused', 'stalled')
             ORDER BY cps.id
             """
@@ -682,6 +687,9 @@ def _load_project_states(session: Any) -> dict[int, ProjectState]:
             stage=str(row["stage"]),
             target_place_id=row.get("target_place_id"),
             target_character_entity_id=row.get("target_character_entity_id"),
+            target_character_is_active=bool(
+                row.get("target_character_is_active", False)
+            ),
             progress=float(row["progress"] or 0.0),
             stall_count=int(row["stall_count"] or 0),
             next_eligible_at_world_time=row.get("next_eligible_at_world_time"),
@@ -968,6 +976,126 @@ def compose_actor_target_bindings(
     )
 
 
+def compose_project_target_bindings(
+    session: Any,
+    *,
+    state: WorldState,
+    anchor_chunk_id: Optional[int],
+    actor_ids: Iterable[int],
+    target_presence: str = "offscreen",
+) -> Tuple[Bindings, ...]:
+    """Bind character-project actors to their durable project target.
+
+    Inactive or non-character targets remain bound by identity so the project
+    package can select its deterministic abandonment arm. Availability stays
+    in hydrated state and is never inferred from the binding itself.
+    """
+
+    if target_presence not in {"offscreen", "present"}:
+        raise ValueError("target_presence must be 'offscreen' or 'present'")
+    present_actor_ids = _present_actor_ids_at_anchor(
+        session, anchor_chunk_id=anchor_chunk_id
+    )
+    actor_id_set = set(actor_ids) - present_actor_ids
+    pairs: list[tuple[int, int]] = []
+    for actor_id in sorted(actor_id_set):
+        project = state.project_states.get(actor_id)
+        if project is None:
+            continue
+        target_id = project.target_character_entity_id
+        if target_id is None:
+            continue
+        target_present = target_id in present_actor_ids
+        if (target_presence == "offscreen" and not target_present) or (
+            target_presence == "present" and target_present
+        ):
+            pairs.append((actor_id, target_id))
+    return tuple(
+        {Slot.ACTOR: actor_id, Slot.TARGET: target_id} for actor_id, target_id in pairs
+    )
+
+
+def compose_actor_target_routes(
+    session: Any,
+    *,
+    state: WorldState,
+    templates: Sequence[Template],
+    anchor_chunk_id: Optional[int],
+    window_chunks: int,
+    actor_ids: Iterable[int],
+    target_presence: str = "offscreen",
+) -> Tuple[tuple[Bindings, Tuple[Template, ...]], ...]:
+    """Route each ACTOR/TARGET binding to its authorized template stack.
+
+    Relationship-backed pairs retain the complete two-party stack and its
+    normal priority competition. Social-contact-only and project-target-only
+    pairs admit only templates that explicitly opt into those broader binding
+    sources. When sources overlap, their template sets are unioned and
+    evaluated once in original stack order.
+    """
+
+    templates_tuple = tuple(templates)
+    if not templates_tuple:
+        return ()
+    actor_id_set = set(actor_ids)
+    template_ids_by_pair: dict[tuple[int, int], set[str]] = {}
+
+    def add_routes(bindings: Iterable[Bindings], allowed: Sequence[Template]) -> None:
+        allowed_ids = {template.id for template in allowed}
+        for binding in bindings:
+            key = (binding[Slot.ACTOR], binding[Slot.TARGET])
+            template_ids_by_pair.setdefault(key, set()).update(allowed_ids)
+
+    relationship_bindings = compose_actor_target_bindings(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        window_chunks=window_chunks,
+        actor_ids=actor_id_set,
+        target_presence=target_presence,
+        include_social_contacts=False,
+    )
+    add_routes(relationship_bindings, templates_tuple)
+
+    social_templates = tuple(
+        template for template in templates_tuple if template.starts_from_social_contact
+    )
+    if social_templates:
+        social_bindings = compose_actor_target_bindings(
+            session,
+            anchor_chunk_id=anchor_chunk_id,
+            window_chunks=window_chunks,
+            actor_ids=actor_id_set,
+            target_presence=target_presence,
+            include_social_contacts=True,
+        )
+        add_routes(social_bindings, social_templates)
+
+    project_templates = tuple(
+        template for template in templates_tuple if template.binds_project_target
+    )
+    if project_templates:
+        project_bindings = compose_project_target_bindings(
+            session,
+            state=state,
+            anchor_chunk_id=anchor_chunk_id,
+            actor_ids=actor_id_set,
+            target_presence=target_presence,
+        )
+        add_routes(project_bindings, project_templates)
+
+    return tuple(
+        (
+            {Slot.ACTOR: actor_id, Slot.TARGET: target_id},
+            tuple(
+                template
+                for template in templates_tuple
+                if template.id in template_ids_by_pair[(actor_id, target_id)]
+            ),
+        )
+        for actor_id, target_id in sorted(template_ids_by_pair)
+    )
+
+
 _ACTOR_ONLY_SLOTS: Tuple[Slot, ...] = (Slot.ACTOR,)
 _ACTOR_TARGET_SLOTS: Tuple[Slot, ...] = (Slot.ACTOR, Slot.TARGET)
 
@@ -1129,63 +1257,30 @@ def resolve_dry_run(
         if resolution is not None and resolution.passes:
             drafts.append(_draft_from_resolution(resolution, state=state))
 
-    actor_target_bindings: Tuple[Bindings, ...] = ()
-    social_actor_target_bindings: Tuple[Bindings, ...] = ()
-    present_target_bindings: Tuple[Bindings, ...] = ()
+    offscreen_routes: Tuple[Tuple[Bindings, Tuple[Template, ...]], ...] = ()
+    present_routes: Tuple[Tuple[Bindings, Tuple[Template, ...]], ...] = ()
     if actor_target_templates:
-        base_actor_target_templates = [
-            template
-            for template in actor_target_templates
-            if not template.starts_from_social_contact
-        ]
-        social_start_templates = [
-            template
-            for template in actor_target_templates
-            if template.starts_from_social_contact
-        ]
         actor_ids = {bindings[Slot.ACTOR] for bindings in actor_bindings}
-
-        if base_actor_target_templates:
-            actor_target_bindings = compose_actor_target_bindings(
-                session,
-                anchor_chunk_id=anchor_chunk_id,
-                window_chunks=window_chunks,
-                actor_ids=actor_ids,
-                target_presence="offscreen",
-                include_social_contacts=False,
+        offscreen_routes = compose_actor_target_routes(
+            session,
+            state=state,
+            templates=actor_target_templates,
+            anchor_chunk_id=anchor_chunk_id,
+            window_chunks=window_chunks,
+            actor_ids=actor_ids,
+            target_presence="offscreen",
+        )
+        for bindings, routed_templates in offscreen_routes:
+            resolution = evaluate_stack(
+                routed_templates,
+                state,
+                bindings,
+                selection,
+                habituation,
+                package_selection,
             )
-            for bindings in actor_target_bindings:
-                resolution = evaluate_stack(
-                    base_actor_target_templates,
-                    state,
-                    bindings,
-                    selection,
-                    habituation,
-                    package_selection,
-                )
-                if resolution is not None and resolution.passes:
-                    drafts.append(_draft_from_resolution(resolution, state=state))
-
-        if social_start_templates:
-            social_actor_target_bindings = compose_actor_target_bindings(
-                session,
-                anchor_chunk_id=anchor_chunk_id,
-                window_chunks=window_chunks,
-                actor_ids=actor_ids,
-                target_presence="offscreen",
-                include_social_contacts=True,
-            )
-            for bindings in social_actor_target_bindings:
-                resolution = evaluate_stack(
-                    social_start_templates,
-                    state,
-                    bindings,
-                    selection,
-                    habituation,
-                    package_selection,
-                )
-                if resolution is not None and resolution.passes:
-                    drafts.append(_draft_from_resolution(resolution, state=state))
+            if resolution is not None and resolution.passes:
+                drafts.append(_draft_from_resolution(resolution, state=state))
 
         pressure_templates = [
             template
@@ -1194,23 +1289,18 @@ def resolve_dry_run(
             is PresentTargetPolicy.STORYTELLER_PRESSURE
         ]
         if pressure_templates:
-            # Present-target pressure is a distinct target-presence pass. A
-            # future pressure template that starts from social contact keeps
-            # its opt-in here without broadening the base pressure stack.
-            include_social_pressure = any(
-                template.starts_from_social_contact for template in pressure_templates
-            )
-            present_target_bindings = compose_actor_target_bindings(
+            present_routes = compose_actor_target_routes(
                 session,
+                state=state,
+                templates=pressure_templates,
                 anchor_chunk_id=anchor_chunk_id,
                 window_chunks=window_chunks,
                 actor_ids=actor_ids,
                 target_presence="present",
-                include_social_contacts=include_social_pressure,
             )
-            for bindings in present_target_bindings:
+            for bindings, routed_templates in present_routes:
                 resolution = evaluate_stack(
-                    pressure_templates,
+                    routed_templates,
                     state,
                     bindings,
                     selection,
@@ -1278,8 +1368,8 @@ def resolve_dry_run(
 
     unique_actors = (
         {bindings[Slot.ACTOR] for bindings in actor_bindings}
-        | {bindings[Slot.ACTOR] for bindings in actor_target_bindings}
-        | {bindings[Slot.ACTOR] for bindings in present_target_bindings}
+        | {bindings[Slot.ACTOR] for bindings, _templates in offscreen_routes}
+        | {bindings[Slot.ACTOR] for bindings, _templates in present_routes}
     )
 
     return OrreryTickProposal(

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -657,6 +657,7 @@ def _load_project_states(session: Any) -> dict[int, ProjectState]:
                    cps.status,
                    cps.stage,
                    cps.target_place_id,
+                   cps.target_character_entity_id,
                    cps.progress,
                    cps.stall_count,
                    cps.next_eligible_at_world_time,
@@ -680,6 +681,7 @@ def _load_project_states(session: Any) -> dict[int, ProjectState]:
             status=str(row["status"]),
             stage=str(row["stage"]),
             target_place_id=row.get("target_place_id"),
+            target_character_entity_id=row.get("target_character_entity_id"),
             progress=float(row["progress"] or 0.0),
             stall_count=int(row["stall_count"] or 0),
             next_eligible_at_world_time=row.get("next_eligible_at_world_time"),
@@ -839,15 +841,18 @@ def compose_actor_target_bindings(
     window_chunks: int,
     actor_ids: Optional[Iterable[int]] = None,
     target_presence: str = "offscreen",
+    include_social_contacts: bool = False,
 ) -> Tuple[Bindings, ...]:
     """Compose ACTOR+TARGET bindings from actors' relational neighborhoods.
 
     Yields {Slot.ACTOR: a, Slot.TARGET: t} for each character-to-character
     relationship row where the actor side is in the recently-relevant set.
     Each stored relationship row produces up to two bindings (forward and
-    reverse) so templates with symmetric semantics see both orderings; gate
-    predicates with asymmetric semantics (handler/asset) filter via
-    role-explicit OR clauses.
+    reverse) so templates with symmetric semantics see both orderings. When
+    ``include_social_contacts`` is true, current directed ``contact:social``
+    edges are unioned into that base pool for templates that explicitly opt
+    into social-contact starts. Gate predicates with asymmetric semantics
+    (handler/asset) filter via role-explicit OR clauses.
 
     When actor_ids is provided (typical: resolve_dry_run threads through
     the actor set it already computed), this skips the redundant
@@ -883,6 +888,29 @@ def compose_actor_target_bindings(
         return ()
 
     pairs: set[Tuple[int, int]] = set()
+
+    def add_candidate(source: int, target: int, *, reverse: bool) -> None:
+        source_present = source in present_actor_ids
+        target_present = target in present_actor_ids
+        if (
+            source in actor_id_set
+            and not source_present
+            and (
+                (target_presence == "offscreen" and not target_present)
+                or (target_presence == "present" and target_present)
+            )
+        ):
+            pairs.add((source, target))
+        if reverse and (
+            target in actor_id_set
+            and not target_present
+            and (
+                (target_presence == "offscreen" and not source_present)
+                or (target_presence == "present" and source_present)
+            )
+        ):
+            pairs.add((target, source))
+
     for row in session.execute(
         text(
             """
@@ -901,28 +929,38 @@ def compose_actor_target_bindings(
             """
         )
     ).mappings():
-        source = row["source_entity_id"]
-        target = row["target_entity_id"]
-        source_present = source in present_actor_ids
-        target_present = target in present_actor_ids
-        if (
-            source in actor_id_set
-            and not source_present
-            and (
-                (target_presence == "offscreen" and not target_present)
-                or (target_presence == "present" and target_present)
+        add_candidate(
+            int(row["source_entity_id"]),
+            int(row["target_entity_id"]),
+            reverse=True,
+        )
+
+    if include_social_contacts:
+        for row in session.execute(
+            text(
+                """
+                /* orrery:actor_target_bindings_social_contacts */
+                SELECT ept.subject_entity_id AS source_entity_id,
+                       ept.object_entity_id AS target_entity_id
+                FROM entity_pair_tags ept
+                JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+                JOIN entities es ON es.id = ept.subject_entity_id
+                JOIN entities et ON et.id = ept.object_entity_id
+                WHERE pt.tag = 'contact:social'
+                  AND NOT pt.deprecated
+                  AND ept.cleared_at IS NULL
+                  AND es.kind = 'character'
+                  AND et.kind = 'character'
+                  AND es.is_active = true
+                  AND et.is_active = true
+                """
             )
-        ):
-            pairs.add((source, target))
-        if (
-            target in actor_id_set
-            and not target_present
-            and (
-                (target_presence == "offscreen" and not source_present)
-                or (target_presence == "present" and source_present)
+        ).mappings():
+            add_candidate(
+                int(row["source_entity_id"]),
+                int(row["target_entity_id"]),
+                reverse=False,
             )
-        ):
-            pairs.add((target, source))
 
     return tuple(
         {Slot.ACTOR: actor_id, Slot.TARGET: target_id}
@@ -1092,26 +1130,62 @@ def resolve_dry_run(
             drafts.append(_draft_from_resolution(resolution, state=state))
 
     actor_target_bindings: Tuple[Bindings, ...] = ()
+    social_actor_target_bindings: Tuple[Bindings, ...] = ()
     present_target_bindings: Tuple[Bindings, ...] = ()
     if actor_target_templates:
-        actor_target_bindings = compose_actor_target_bindings(
-            session,
-            anchor_chunk_id=anchor_chunk_id,
-            window_chunks=window_chunks,
-            actor_ids={bindings[Slot.ACTOR] for bindings in actor_bindings},
-            target_presence="offscreen",
-        )
-        for bindings in actor_target_bindings:
-            resolution = evaluate_stack(
-                actor_target_templates,
-                state,
-                bindings,
-                selection,
-                habituation,
-                package_selection,
+        base_actor_target_templates = [
+            template
+            for template in actor_target_templates
+            if not template.starts_from_social_contact
+        ]
+        social_start_templates = [
+            template
+            for template in actor_target_templates
+            if template.starts_from_social_contact
+        ]
+        actor_ids = {bindings[Slot.ACTOR] for bindings in actor_bindings}
+
+        if base_actor_target_templates:
+            actor_target_bindings = compose_actor_target_bindings(
+                session,
+                anchor_chunk_id=anchor_chunk_id,
+                window_chunks=window_chunks,
+                actor_ids=actor_ids,
+                target_presence="offscreen",
+                include_social_contacts=False,
             )
-            if resolution is not None and resolution.passes:
-                drafts.append(_draft_from_resolution(resolution, state=state))
+            for bindings in actor_target_bindings:
+                resolution = evaluate_stack(
+                    base_actor_target_templates,
+                    state,
+                    bindings,
+                    selection,
+                    habituation,
+                    package_selection,
+                )
+                if resolution is not None and resolution.passes:
+                    drafts.append(_draft_from_resolution(resolution, state=state))
+
+        if social_start_templates:
+            social_actor_target_bindings = compose_actor_target_bindings(
+                session,
+                anchor_chunk_id=anchor_chunk_id,
+                window_chunks=window_chunks,
+                actor_ids=actor_ids,
+                target_presence="offscreen",
+                include_social_contacts=True,
+            )
+            for bindings in social_actor_target_bindings:
+                resolution = evaluate_stack(
+                    social_start_templates,
+                    state,
+                    bindings,
+                    selection,
+                    habituation,
+                    package_selection,
+                )
+                if resolution is not None and resolution.passes:
+                    drafts.append(_draft_from_resolution(resolution, state=state))
 
         pressure_templates = [
             template
@@ -1120,12 +1194,19 @@ def resolve_dry_run(
             is PresentTargetPolicy.STORYTELLER_PRESSURE
         ]
         if pressure_templates:
+            # Present-target pressure is a distinct target-presence pass. A
+            # future pressure template that starts from social contact keeps
+            # its opt-in here without broadening the base pressure stack.
+            include_social_pressure = any(
+                template.starts_from_social_contact for template in pressure_templates
+            )
             present_target_bindings = compose_actor_target_bindings(
                 session,
                 anchor_chunk_id=anchor_chunk_id,
                 window_chunks=window_chunks,
-                actor_ids={bindings[Slot.ACTOR] for bindings in actor_bindings},
+                actor_ids=actor_ids,
                 target_presence="present",
+                include_social_contacts=include_social_pressure,
             )
             for bindings in present_target_bindings:
                 resolution = evaluate_stack(
@@ -1421,9 +1502,21 @@ def _project_destination(
 def _materialize_project_delta(
     resolution: Resolution, state: WorldState
 ) -> Mapping[str, Any]:
-    """Persist any scouting choice into the resolution ledger before commit."""
+    """Persist bound or selected project targets in the ledger before commit."""
 
     delta = dict(resolution.state_delta)
+    raw_start = delta.get("project.start")
+    if (
+        isinstance(raw_start, Mapping)
+        and raw_start.get("project_type") == "recruit_ally"
+    ):
+        target = resolution.bindings.get(Slot.TARGET)
+        if not isinstance(target, int):
+            raise ValueError("recruit_ally project.start requires target binding")
+        start_payload = dict(raw_start)
+        start_payload["target_character_entity_id"] = target
+        delta["project.start"] = start_payload
+
     raw_advance = delta.get("project.advance")
     if not isinstance(raw_advance, Mapping) or not raw_advance.get("select_target"):
         return delta

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -213,6 +213,7 @@ class ProjectState:
     status: str
     stage: str
     target_place_id: Optional[int] = None
+    target_character_entity_id: Optional[int] = None
     progress: float = 0.0
     stall_count: int = 0
     next_eligible_at_world_time: Optional[datetime] = None
@@ -235,7 +236,7 @@ class ProjectPolicy:
         if self.advance_interval_hours <= 0:
             raise ValueError("Project advance_interval_hours must be > 0")
         if self.max_active_per_character != 1:
-            raise ValueError("PLAN_RELOCATION v1 requires max_active_per_character = 1")
+            raise ValueError("Orrery projects require max_active_per_character = 1")
         if self.stall_abandon_threshold < 1:
             raise ValueError("Project stall_abandon_threshold must be >= 1")
         if self.abandon_after_stalled_world_hours <= 0:
@@ -1122,8 +1123,18 @@ _PROJECT_DUE_MODES = frozenset(
         "scouting_milestone",
         "completion",
         "neglected",
+        "sounding_out",
+        "earning_trust",
+        "sealing_commitment",
+        "sounding_out_milestone",
+        "earning_trust_milestone",
     }
 )
+
+_PROJECT_STAGE_LADDERS = {
+    "plan_relocation": ("saving", "scouting", "committing"),
+    "recruit_ally": ("sounding_out", "earning_trust", "sealing_commitment"),
+}
 
 
 def project_due(
@@ -1147,10 +1158,10 @@ def project_due(
             f"Unsupported project_due mode {mode!r}; expected one of "
             f"{sorted(_PROJECT_DUE_MODES)}"
         )
-    if project_type != "plan_relocation":
+    if project_type not in _PROJECT_STAGE_LADDERS:
         raise ValueError(
             f"Unsupported project_due project type {project_type!r}; "
-            "expected 'plan_relocation'"
+            f"expected one of {sorted(_PROJECT_STAGE_LADDERS)}"
         )
 
     def _condition(state: WorldState, bindings: Bindings) -> bool:
@@ -1161,13 +1172,15 @@ def project_due(
         if entity_id is None:
             return False
         project = state.project_states.get(entity_id)
-        if project is not None and project.project_type != project_type:
+        if normalized_mode == "start":
+            return project is None
+        if project is not None and project.project_type not in _PROJECT_STAGE_LADDERS:
             raise ValueError(
                 f"Actor {entity_id} has unsupported open project type "
                 f"{project.project_type!r}"
             )
-        if normalized_mode == "start":
-            return project is None
+        if project is not None and project.project_type != project_type:
+            return False
         if normalized_mode == "exists":
             return project is not None
         if project is None:
@@ -1203,22 +1216,35 @@ def project_due(
             return due and overdue_hours >= policy.advance_interval_hours
         if not due:
             return False
-        if normalized_mode in {"saving", "scouting", "committing"}:
+        project_stages = _PROJECT_STAGE_LADDERS[project_type]
+        if normalized_mode in project_stages:
             return project.stage == normalized_mode
-        if normalized_mode == "saving_milestone":
-            return project.stage == "saving" and project.progress >= 1.0
+        if normalized_mode == f"{project_stages[0]}_milestone":
+            return project.stage == project_stages[0] and project.progress >= 1.0
         if normalized_mode == "scouting_without_target":
-            return project.stage == "scouting" and project.target_place_id is None
-        if normalized_mode == "scouting_milestone":
             return (
-                project.stage == "scouting"
-                and project.target_place_id is not None
+                project_type == "plan_relocation"
+                and project.stage == "scouting"
+                and project.target_place_id is None
+            )
+        if normalized_mode == f"{project_stages[1]}_milestone":
+            return (
+                project.stage == project_stages[1]
+                and (
+                    project.target_place_id is not None
+                    if project_type == "plan_relocation"
+                    else project.target_character_entity_id is not None
+                )
                 and project.progress >= 1.0
             )
         if normalized_mode == "completion":
             return (
-                project.stage == "committing"
-                and project.target_place_id is not None
+                project.stage == project_stages[2]
+                and (
+                    project.target_place_id is not None
+                    if project_type == "plan_relocation"
+                    else project.target_character_entity_id is not None
+                )
                 and project.progress >= 1.0
             )
         raise AssertionError(f"Unhandled project_due mode {normalized_mode!r}")
@@ -1227,6 +1253,23 @@ def project_due(
         _condition,
         f"project_due({project_type},{normalized_mode}@{slot.value})",
     )
+
+
+def project_target_is(slot: Slot = Slot.TARGET) -> Condition:
+    """Return whether ``slot`` is the actor's character-project target."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        actor_entity_id = _slot_entity(bindings, Slot.ACTOR)
+        target_entity_id = _slot_entity(bindings, slot)
+        if actor_entity_id is None or target_entity_id is None:
+            return False
+        project = state.project_states.get(actor_entity_id)
+        return bool(
+            project is not None
+            and project.target_character_entity_id == target_entity_id
+        )
+
+    return _named(_condition, f"project_target_is({slot.value})")
 
 
 def has_travel_destination(slot: Slot = Slot.ACTOR) -> Condition:
@@ -2033,6 +2076,11 @@ class Template:
     package_gate: Condition
     branches: Tuple[Branch, ...]
     present_target_policy: PresentTargetPolicy = PresentTargetPolicy.OFFSCREEN_ONLY
+    # Project-start packages may opt into directed contact:social edges in
+    # addition to the shared relationship-derived ACTOR/TARGET pool. Keeping
+    # this authoring metadata on Template prevents one package's broader
+    # starting substrate from changing every other two-party package.
+    starts_from_social_contact: bool = False
     priority_override_rationale: Optional[str] = None
     drive_band_priority_exempt: bool = False
 

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -214,6 +214,7 @@ class ProjectState:
     stage: str
     target_place_id: Optional[int] = None
     target_character_entity_id: Optional[int] = None
+    target_character_is_active: bool = False
     progress: float = 0.0
     stall_count: int = 0
     next_eligible_at_world_time: Optional[datetime] = None
@@ -1163,6 +1164,24 @@ def project_due(
             f"Unsupported project_due project type {project_type!r}; "
             f"expected one of {sorted(_PROJECT_STAGE_LADDERS)}"
         )
+    project_stages = _PROJECT_STAGE_LADDERS[project_type]
+    type_modes = {
+        "start",
+        "exists",
+        "ready",
+        "abandon",
+        "completion",
+        "neglected",
+        *project_stages,
+        *(f"{stage}_milestone" for stage in project_stages[:-1]),
+    }
+    if project_type == "plan_relocation":
+        type_modes.add("scouting_without_target")
+    if normalized_mode not in type_modes:
+        raise ValueError(
+            f"project_due mode {normalized_mode!r} is not valid for project "
+            f"type {project_type!r}; expected one of {sorted(type_modes)}"
+        )
 
     def _condition(state: WorldState, bindings: Bindings) -> bool:
         policy = state.project_policy
@@ -1216,7 +1235,6 @@ def project_due(
             return due and overdue_hours >= policy.advance_interval_hours
         if not due:
             return False
-        project_stages = _PROJECT_STAGE_LADDERS[project_type]
         if normalized_mode in project_stages:
             return project.stage == normalized_mode
         if normalized_mode == f"{project_stages[0]}_milestone":
@@ -1270,6 +1288,30 @@ def project_target_is(slot: Slot = Slot.TARGET) -> Condition:
         )
 
     return _named(_condition, f"project_target_is({slot.value})")
+
+
+def project_target_is_active(slot: Slot = Slot.TARGET) -> Condition:
+    """Return whether the bound project target is an active character.
+
+    Target identity and availability are separate predicates so a durable
+    project can keep binding its original target after that entity retires or
+    changes kind, then deterministically abandon instead of stranding the
+    actor's one-open-project budget.
+    """
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        actor_entity_id = _slot_entity(bindings, Slot.ACTOR)
+        target_entity_id = _slot_entity(bindings, slot)
+        if actor_entity_id is None or target_entity_id is None:
+            return False
+        project = state.project_states.get(actor_entity_id)
+        return bool(
+            project is not None
+            and project.target_character_entity_id == target_entity_id
+            and project.target_character_is_active
+        )
+
+    return _named(_condition, f"project_target_is_active({slot.value})")
 
 
 def has_travel_destination(slot: Slot = Slot.ACTOR) -> Condition:
@@ -2081,6 +2123,10 @@ class Template:
     # this authoring metadata on Template prevents one package's broader
     # starting substrate from changing every other two-party package.
     starts_from_social_contact: bool = False
+    # Character-targeted project continuations bind TARGET from the durable
+    # open-project projection. This remains valid if the contact or
+    # relationship edge that originally sourced the project later clears.
+    binds_project_target: bool = False
     priority_override_rationale: Optional[str] = None
     drive_band_priority_exempt: bool = False
 

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -4782,6 +4782,7 @@ ADVANCE_RECRUIT_ALLY = Template(
             changed_fields=(
                 "character_project_states.status",
                 "entity_pair_tags",
+                "character_relationships.relationship_type",
             ),
             magnitude=0.40,
             preemptive=True,

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -21,6 +21,7 @@ from nexus.agents.orrery.substrate import (
     fame_below,
     has_any_intimacy_suppressor,
     has_any_current_tag,
+    has_any_pair_tag,
     has_any_status_at_or_above,
     has_any_tag,
     has_contact_of_kind,
@@ -43,7 +44,9 @@ from nexus.agents.orrery.substrate import (
     is_hidden,
     is_in_transit,
     knows_recent_event,
+    lacks_pair_tag,
     project_due,
+    project_target_is,
     recent_event,
     relationship_is_asymmetric,
     relationship_is_mutual_warm,
@@ -1020,6 +1023,7 @@ SURVEIL = Template(
     package_gate=AND(
         has_minimal_context(),
         NOT(project_due("ready")),
+        NOT(project_due("ready", project_type="recruit_ally")),
         NOT(is_constrained()),
         NOT(has_inbound_pair_tag("hunting")),
         NOT(has_ephemeral("grudge_active")),
@@ -4620,6 +4624,323 @@ ADVANCE_RELOCATION_PLAN = Template(
 )
 
 
+START_RECRUIT_ALLY = Template(
+    id="start_recruit_ally",
+    priority=17,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "A recruitment begins only for a known, warm, or trusted candidate; "
+        "the narrow pair gate lets explicit positive intent rise above routine."
+    ),
+    blurb="A plausible contact becomes the named target of a recruitment project.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    starts_from_social_contact=True,
+    package_gate=AND(
+        project_due("start", project_type="recruit_ally"),
+        has_minimal_context(),
+        at_routine_anchor("home"),
+        NOT(is_constrained()),
+        NOT(is_in_transit()),
+        OR(
+            AND(
+                has_contact_of_kind("social"),
+                has_pair_tag("contact:social"),
+            ),
+            has_relationship_of_type("friend", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("friend", Slot.TARGET, Slot.ACTOR),
+            has_relationship_of_type("companion", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("companion", Slot.TARGET, Slot.ACTOR),
+            has_relationship_of_type("comrade", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("comrade", Slot.TARGET, Slot.ACTOR),
+            has_relationship_of_type("chosen_kin", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("chosen_kin", Slot.TARGET, Slot.ACTOR),
+            trust_at_least(1),
+        ),
+        lacks_pair_tag("ally", Slot.ACTOR, Slot.TARGET),
+        NOT(
+            has_any_pair_tag(
+                "hostile_to",
+                "hunting",
+                subject_slot=Slot.ACTOR,
+                object_slot=Slot.TARGET,
+            )
+        ),
+        NOT(
+            has_any_pair_tag(
+                "hostile_to",
+                "hunting",
+                subject_slot=Slot.TARGET,
+                object_slot=Slot.ACTOR,
+            )
+        ),
+    ),
+    branches=(
+        Branch(
+            label="Sound out a possible ally",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} stops treating {target} as merely useful company. "
+                "A careful conversation tests whether shared concern might "
+                "become a commitment both can name."
+            ),
+            state_delta={
+                "project.start": {
+                    "project_type": "recruit_ally",
+                    "stage": "sounding_out",
+                    "milestone": True,
+                }
+            },
+            event_type="recruit_ally_started",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.stage",
+                "character_project_states.target_character_entity_id",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.40,
+        ),
+    ),
+)
+
+
+ADVANCE_RECRUIT_ALLY = Template(
+    id="advance_recruit_ally",
+    priority=47,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "A due recruitment shares relocation's vigilance-adjacent slot; "
+        "SURVEIL yields to either due project while cadence and embodied "
+        "guards preserve routine stability."
+    ),
+    blurb=(
+        "A due recruitment sounds out its chosen candidate, earns trust, "
+        "seals commitment, stalls, or ends."
+    ),
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    package_gate=AND(
+        project_due("ready", project_type="recruit_ally"),
+        project_target_is(Slot.TARGET),
+        NOT(is_in_transit()),
+        NOT(is_constrained()),
+        NOT(
+            OR(
+                has_need_debt_at_or_above("sleep", 8),
+                has_need_debt_at_or_above("thirst", 2),
+                has_need_debt_at_or_above("hunger", 4),
+            )
+        ),
+    ),
+    branches=(
+        Branch(
+            label="Seal the alliance",
+            conditions=AND(
+                project_due("completion", project_type="recruit_ally"),
+                NOT(
+                    has_any_pair_tag(
+                        "hostile_to",
+                        "hunting",
+                        subject_slot=Slot.TARGET,
+                        object_slot=Slot.ACTOR,
+                    )
+                ),
+                NOT(trust_below(-2, Slot.TARGET, Slot.ACTOR)),
+            ),
+            narrative_stub=(
+                "{actor} and {target} stop speaking in contingencies. The "
+                "understanding becomes a commitment: when the cost arrives, "
+                "{actor} may call on {target} as an ally."
+            ),
+            state_delta={
+                "project.complete": {"milestone": True},
+                "entity_pair_tags.add_outbound": ["ally"],
+            },
+            event_type="recruit_ally_completed",
+            changed_fields=(
+                "character_project_states.status",
+                "entity_pair_tags",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Withdraw after a hostile turn",
+            conditions=OR(
+                has_any_pair_tag(
+                    "hostile_to",
+                    "hunting",
+                    subject_slot=Slot.TARGET,
+                    object_slot=Slot.ACTOR,
+                ),
+                trust_below(-2, Slot.TARGET, Slot.ACTOR),
+            ),
+            narrative_stub=(
+                "Whatever possibility {actor} saw in {target} has hardened "
+                "into danger or contempt. {actor} ends the recruitment before "
+                "hope becomes leverage in hostile hands."
+            ),
+            state_delta={
+                "project.abandon": {
+                    "reason": "target_hostile_or_trust_collapsed",
+                    "milestone": True,
+                }
+            },
+            event_type="recruit_ally_abandoned",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.source_chunk_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Let the recruitment go rather than force it",
+            conditions=project_due("abandon", project_type="recruit_ally"),
+            narrative_stub=(
+                "{actor} admits that the invitation has become a ritual of "
+                "delay. They stop pressing {target} for a promise that is not "
+                "coming and release the unfinished alliance."
+            ),
+            state_delta={
+                "project.abandon": {
+                    "reason": "stalled_or_overdue",
+                    "milestone": True,
+                }
+            },
+            event_type="recruit_ally_abandoned",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.source_chunk_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Turn interest into earned trust",
+            conditions=project_due(
+                "sounding_out_milestone", project_type="recruit_ally"
+            ),
+            narrative_stub=(
+                "{target} has heard enough to take the possibility seriously. "
+                "Now {actor} must prove that the offered alliance is reliable, "
+                "not merely attractive."
+            ),
+            state_delta={
+                "project.advance": {
+                    "stage": "earning_trust",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            event_type="recruit_ally_milestone",
+            changed_fields=(
+                "character_project_states.stage",
+                "character_project_states.progress",
+                "character_project_states.stall_count",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Ask for a real commitment",
+            conditions=project_due(
+                "earning_trust_milestone", project_type="recruit_ally"
+            ),
+            narrative_stub=(
+                "The small proofs have accumulated. {actor} can finally ask "
+                "{target} for the thing underneath them: a commitment that "
+                "will still hold when cooperation becomes costly."
+            ),
+            state_delta={
+                "project.advance": {
+                    "stage": "sealing_commitment",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            event_type="recruit_ally_milestone",
+            changed_fields=(
+                "character_project_states.stage",
+                "character_project_states.progress",
+                "character_project_states.stall_count",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Learn what the candidate actually wants",
+            conditions=project_due("sounding_out", project_type="recruit_ally"),
+            narrative_stub=(
+                "{actor} listens past {target}'s first answer and learns what "
+                "would make an alliance matter to them, not merely to its "
+                "would-be recruiter."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.35}},
+            event_type="recruit_ally_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.18,
+            promotable=False,
+        ),
+        Branch(
+            label="Prove reliable in a small consequential way",
+            conditions=project_due("earning_trust", project_type="recruit_ally"),
+            narrative_stub=(
+                "{actor} gives {target} evidence instead of assurances: one "
+                "promise kept where breaking it would have been easier."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.35}},
+            event_type="recruit_ally_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.18,
+            promotable=False,
+        ),
+        Branch(
+            label="Lose ground through neglect",
+            conditions=project_due("neglected", project_type="recruit_ally"),
+            narrative_stub=(
+                "Silence does work of its own. A missed promise or unanswered "
+                "opening leaves {target} less certain that {actor}'s proposed "
+                "alliance deserves the risk."
+            ),
+            state_delta={"project.stall": {"increment": 1}},
+            event_type="recruit_ally_stalled",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.stall_count",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.10,
+            promotable=False,
+        ),
+        Branch(
+            label="Make the next commitment concrete",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} and {target} make one more expectation explicit — "
+                "who answers, what each protects, and what neither will ask "
+                "the other to pretend away."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.25}},
+            event_type="recruit_ally_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.16,
+            promotable=False,
+        ),
+    ),
+)
+
+
 BUILTIN_TEMPLATES = (
     EVADE_PURSUERS,
     PROTECT_KIN,
@@ -4630,6 +4951,7 @@ BUILTIN_TEMPLATES = (
     WARN_ALLY,
     SURVEIL,
     ADVANCE_RELOCATION_PLAN,
+    ADVANCE_RECRUIT_ALLY,
     ACT_ON_INTEL,
     UNCOVER_PAST,
     CHECK_ON_DEPENDENT,
@@ -4653,6 +4975,7 @@ BUILTIN_TEMPLATES = (
     UPKEEP,
     RECREATE,
     START_RELOCATION_PLAN,
+    START_RECRUIT_ALLY,
     MAINTAIN_COVER,
 )
 

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -47,6 +47,7 @@ from nexus.agents.orrery.substrate import (
     lacks_pair_tag,
     project_due,
     project_target_is,
+    project_target_is_active,
     recent_event,
     relationship_is_asymmetric,
     relationship_is_mutual_warm,
@@ -4717,6 +4718,7 @@ ADVANCE_RECRUIT_ALLY = Template(
         "seals commitment, stalls, or ends."
     ),
     required_slots=(Slot.ACTOR, Slot.TARGET),
+    binds_project_target=True,
     package_gate=AND(
         project_due("ready", project_type="recruit_ally"),
         project_target_is(Slot.TARGET),
@@ -4731,6 +4733,28 @@ ADVANCE_RECRUIT_ALLY = Template(
         ),
     ),
     branches=(
+        Branch(
+            label="End a recruitment whose candidate is no longer available",
+            conditions=NOT(project_target_is_active(Slot.TARGET)),
+            narrative_stub=(
+                "{actor}'s intended recruit is no longer someone an alliance "
+                "can be made with. The project ends cleanly rather than "
+                "holding open a promise that cannot be answered."
+            ),
+            state_delta={
+                "project.abandon": {
+                    "reason": "target_inactive_or_non_character",
+                    "milestone": True,
+                }
+            },
+            event_type="recruit_ally_abandoned",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.source_chunk_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
         Branch(
             label="Seal the alliance",
             conditions=AND(
@@ -4867,6 +4891,25 @@ ADVANCE_RECRUIT_ALLY = Template(
             preemptive=True,
         ),
         Branch(
+            label="Lose ground through neglect",
+            conditions=project_due("neglected", project_type="recruit_ally"),
+            narrative_stub=(
+                "Silence does work of its own. A missed promise or unanswered "
+                "opening leaves {target} less certain that {actor}'s proposed "
+                "alliance deserves the risk."
+            ),
+            state_delta={"project.stall": {"increment": 1}},
+            event_type="recruit_ally_stalled",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.stall_count",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.10,
+            promotable=False,
+            preemptive=True,
+        ),
+        Branch(
             label="Learn what the candidate actually wants",
             conditions=project_due("sounding_out", project_type="recruit_ally"),
             narrative_stub=(
@@ -4899,24 +4942,6 @@ ADVANCE_RECRUIT_ALLY = Template(
                 "character_project_states.next_eligible_at_world_time",
             ),
             magnitude=0.18,
-            promotable=False,
-        ),
-        Branch(
-            label="Lose ground through neglect",
-            conditions=project_due("neglected", project_type="recruit_ally"),
-            narrative_stub=(
-                "Silence does work of its own. A missed promise or unanswered "
-                "opening leaves {target} less certain that {actor}'s proposed "
-                "alliance deserves the risk."
-            ),
-            state_delta={"project.stall": {"increment": 1}},
-            event_type="recruit_ally_stalled",
-            changed_fields=(
-                "character_project_states.status",
-                "character_project_states.stall_count",
-                "character_project_states.next_eligible_at_world_time",
-            ),
-            magnitude=0.10,
             promotable=False,
         ),
         Branch(

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -73,6 +73,11 @@ def _production_proposal(slot: int) -> tuple[Optional[int], OrreryTickProposal]:
                 window_chunks=int(orrery["binding"]["window_chunks"]),
                 sunhelm_settings=orrery.get("sunhelm"),
                 selection_settings=orrery.get("selection"),
+                habituation_settings=orrery.get("habituation"),
+                package_selection_settings=orrery.get("package_selection"),
+                project_settings=orrery.get("projects"),
+                epistemics_settings=orrery.get("epistemics"),
+                fanout_settings=orrery.get("fanout"),
             )
     finally:
         engine.dispose()
@@ -147,12 +152,26 @@ def test_resolve_parity_with_production_resolver(
     assert len(payload["actors"]) == proposal.actor_count
 
     # --- Resolution parity: actor-only + off-screen two-party stacks -------
+    fanout_trimmed = {
+        (
+            item["actor_entity_id"],
+            item["target_entity_id"],
+            item["template_id"],
+        )
+        for item in payload["fanout_trimmed"]
+    }
     endpoint_winners: dict[tuple[str, str], dict] = {}
     for group in payload["actors"]:
         for stack in [group["actor_stack"], *group["two_party_stacks"]]:
             if stack["winner_id"] is None:
                 continue
             winner = _winner(stack)
+            if (
+                group["actor_entity_id"],
+                stack["bindings"].get("target"),
+                winner["template_id"],
+            ) in fanout_trimmed:
+                continue
             key = (winner["template_id"], winner["binding_hash"])
             assert key not in endpoint_winners, "duplicate winner stack"
             endpoint_winners[key] = winner

--- a/tests/test_orrery/test_evidence.py
+++ b/tests/test_orrery/test_evidence.py
@@ -79,6 +79,7 @@ from nexus.agents.orrery.substrate import (
     lacks_tag,
     project_due,
     project_target_is,
+    project_target_is_active,
     recent_event,
     relationship_is_asymmetric,
     relationship_is_mutual_warm,
@@ -222,6 +223,7 @@ FACTORY_SWEEP = [
     since_last_event_at_least("contact_made", 3, target_slot=Slot.TARGET),
     project_due("start"),
     project_target_is(),
+    project_target_is_active(),
     count_recent_events_at_least("mourning_act", within_ticks=30, min_count=4),
     count_recent_events_at_least(
         "surveillance_performed",

--- a/tests/test_orrery/test_evidence.py
+++ b/tests/test_orrery/test_evidence.py
@@ -78,6 +78,7 @@ from nexus.agents.orrery.substrate import (
     lacks_pair_tag,
     lacks_tag,
     project_due,
+    project_target_is,
     recent_event,
     relationship_is_asymmetric,
     relationship_is_mutual_warm,
@@ -220,6 +221,7 @@ FACTORY_SWEEP = [
     since_last_event_at_least("contact_made", 3),
     since_last_event_at_least("contact_made", 3, target_slot=Slot.TARGET),
     project_due("start"),
+    project_target_is(),
     count_recent_events_at_least("mourning_act", within_ticks=30, min_count=4),
     count_recent_events_at_least(
         "surveillance_performed",

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -80,6 +80,22 @@ def test_need_state_chunk_stamp_comment_describes_provenance() -> None:
     assert "min_accrual_hours_per_chunk" not in migration_sql
 
 
+def test_recruit_ally_migration_discovers_legacy_completion_check() -> None:
+    """Migration 077 must never guess an anonymous CHECK constraint suffix."""
+
+    migration_sql = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "077_recruit_ally_projects.sql"
+    ).read_text()
+
+    assert "pg_get_constraintdef" in migration_sql
+    assert "Expected exactly one migration-074 completed-target CHECK" in migration_sql
+    assert "DROP CONSTRAINT IF EXISTS character_project_states_check" not in (
+        migration_sql
+    )
+
+
 def test_retrograde_persistence_migration_adds_distinct_sources() -> None:
     """Retrograde canonical writes need explicit event and tag provenance."""
 

--- a/tests/test_orrery/test_recruit_ally_async.py
+++ b/tests/test_orrery/test_recruit_ally_async.py
@@ -1,0 +1,205 @@
+"""Async writer parity for character-targeted RECRUIT_ALLY projects."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from nexus.agents.orrery.events import _apply_state_delta_async
+from nexus.agents.orrery.needs import NeedTuning
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.substrate import ProjectPolicy
+
+
+ACTOR = 10
+TARGET = 20
+SOURCE_CHUNK = 100
+WORLD_TIME = datetime(2073, 8, 2, 12, tzinfo=timezone.utc)
+POLICY = ProjectPolicy(enabled=True, advance_interval_hours=24.0)
+
+
+class AsyncProjectConn:
+    """Stateful asyncpg stand-in for the project and pair-tag write paths."""
+
+    def __init__(self) -> None:
+        self.project: dict[str, Any] | None = None
+        self.resolution_ledgers: dict[int, dict[str, Any]] = {}
+        self.project_inserts: list[tuple[Any, ...]] = []
+        self.pair_tag_inserts: list[tuple[Any, ...]] = []
+        self.travel_write_seen = False
+
+    async def fetch(self, sql: str, *params: Any) -> list[dict[str, Any]]:
+        normalized = " ".join(sql.split())
+        if "FROM character_project_states" in normalized:
+            if self.project and self.project["status"] in {
+                "active",
+                "paused",
+                "stalled",
+            }:
+                return [dict(self.project)]
+            return []
+        raise AssertionError(f"Unexpected fetch SQL: {normalized}; params={params!r}")
+
+    async def fetchval(self, sql: str, *params: Any) -> Any:
+        normalized = " ".join(sql.split())
+        if "SELECT world_time FROM chunk_metadata" in normalized:
+            assert params == (SOURCE_CHUNK,)
+            return WORLD_TIME
+        raise AssertionError(
+            f"Unexpected fetchval SQL: {normalized}; params={params!r}"
+        )
+
+    async def fetchrow(self, sql: str, *params: Any) -> dict[str, Any] | None:
+        normalized = " ".join(sql.split())
+        if "SELECT id FROM pair_tags" in normalized:
+            assert params == ("ally",)
+            return {"id": 77}
+        if "INSERT INTO entity_pair_tags" in normalized:
+            self.pair_tag_inserts.append(params)
+            return {"id": 88}
+        raise AssertionError(
+            f"Unexpected fetchrow SQL: {normalized}; params={params!r}"
+        )
+
+    async def execute(self, sql: str, *params: Any) -> str:
+        normalized = " ".join(sql.split())
+        if "INSERT INTO character_project_states" in normalized:
+            self.project_inserts.append(params)
+            (
+                actor_entity_id,
+                project_type,
+                stage,
+                target_place_id,
+                target_character_entity_id,
+                progress,
+                next_eligible_at_world_time,
+                source_chunk_id,
+            ) = params
+            self.project = {
+                "id": 7,
+                "character_entity_id": actor_entity_id,
+                "project_type": project_type,
+                "status": "active",
+                "stage": stage,
+                "target_place_id": target_place_id,
+                "target_character_entity_id": target_character_entity_id,
+                "progress": progress,
+                "stall_count": 0,
+                "next_eligible_at_world_time": next_eligible_at_world_time,
+                "source_chunk_id": source_chunk_id,
+            }
+            return "INSERT 0 1"
+        if "UPDATE character_project_states" in normalized:
+            assert self.project is not None
+            self.project["status"] = "completed"
+            self.project["next_eligible_at_world_time"] = None
+            self.project["source_chunk_id"] = params[0]
+            return "UPDATE 1"
+        if "UPDATE orrery_resolutions SET state_delta" in normalized:
+            self.resolution_ledgers[int(params[1])] = json.loads(params[0])
+            return "UPDATE 1"
+        if "character_travel_states" in normalized:
+            self.travel_write_seen = True
+            return "UPDATE 1"
+        raise AssertionError(f"Unexpected execute SQL: {normalized}; params={params!r}")
+
+
+@pytest.mark.asyncio
+async def test_async_recruit_ally_start_and_completion_match_sync_applier() -> None:
+    """Persist the recruit, complete it, add ally, and ledger exact writes."""
+
+    conn = AsyncProjectConn()
+    start = OrreryResolutionDraft(
+        template_id="start_recruit_ally",
+        priority=17,
+        binding_hash="async-recruit-start",
+        bindings={"actor": ACTOR, "target": TARGET},
+        branch_label="Sound out the candidate",
+        narrative_stub="start",
+        state_delta={
+            "project.start": {
+                "project_type": "recruit_ally",
+                "stage": "sounding_out",
+                "target_character_entity_id": TARGET,
+                "milestone": True,
+            }
+        },
+        magnitude=0.4,
+    )
+
+    start_mutations = await _apply_state_delta_async(
+        conn,
+        start,
+        resolution_id=101,
+        actor_entity_id=ACTOR,
+        target_entity_id=TARGET,
+        source_chunk_id=SOURCE_CHUNK,
+        need_tuning=NeedTuning.default(),
+        project_policy=POLICY,
+    )
+
+    assert start_mutations == 0
+    assert conn.project_inserts == [
+        (
+            ACTOR,
+            "recruit_ally",
+            "sounding_out",
+            None,
+            TARGET,
+            0.0,
+            WORLD_TIME.replace(day=3),
+            SOURCE_CHUNK,
+        )
+    ]
+    start_applied = conn.resolution_ledgers[101]["project.start"]["applied"]
+    assert start_applied["target_place_id"] is None
+    assert start_applied["target_character_entity_id"] == TARGET
+
+    assert conn.project is not None
+    conn.project.update(stage="sealing_commitment", progress=1.0)
+    complete = OrreryResolutionDraft(
+        template_id="advance_recruit_ally",
+        priority=17,
+        binding_hash="async-recruit-complete",
+        bindings={"actor": ACTOR, "target": TARGET},
+        branch_label="Seal the alliance",
+        narrative_stub="complete",
+        state_delta={
+            "entity_pair_tags.add_outbound": ["ally"],
+            "project.complete": {"milestone": True},
+        },
+        magnitude=0.4,
+    )
+
+    completion_mutations = await _apply_state_delta_async(
+        conn,
+        complete,
+        resolution_id=102,
+        actor_entity_id=ACTOR,
+        target_entity_id=TARGET,
+        source_chunk_id=SOURCE_CHUNK,
+        need_tuning=NeedTuning.default(),
+        project_policy=POLICY,
+    )
+
+    assert completion_mutations == 1
+    assert conn.project["status"] == "completed"
+    assert conn.pair_tag_inserts == [
+        (ACTOR, TARGET, 77, WORLD_TIME, "advance_recruit_ally", SOURCE_CHUNK)
+    ]
+    complete_applied = conn.resolution_ledgers[102]["project.complete"]["applied"]
+    assert complete_applied["status"] == "completed"
+    assert complete_applied["target_character_entity_id"] == TARGET
+    assert complete_applied["pair_tag_mutations"] == [
+        {
+            "operation": "add_outbound",
+            "tag": "ally",
+            "subject_entity_id": ACTOR,
+            "object_entity_id": TARGET,
+            "changed": True,
+        }
+    ]
+    assert conn.travel_write_seen is False

--- a/tests/test_orrery/test_recruit_ally_async.py
+++ b/tests/test_orrery/test_recruit_ally_async.py
@@ -16,6 +16,8 @@ from nexus.agents.orrery.substrate import ProjectPolicy
 
 ACTOR = 10
 TARGET = 20
+ACTOR_CHARACTER = 101
+TARGET_CHARACTER = 202
 SOURCE_CHUNK = 100
 WORLD_TIME = datetime(2073, 8, 2, 12, tzinfo=timezone.utc)
 POLICY = ProjectPolicy(enabled=True, advance_interval_hours=24.0)
@@ -29,6 +31,7 @@ class AsyncProjectConn:
         self.resolution_ledgers: dict[int, dict[str, Any]] = {}
         self.project_inserts: list[tuple[Any, ...]] = []
         self.pair_tag_inserts: list[tuple[Any, ...]] = []
+        self.relationship_upserts: list[tuple[Any, ...]] = []
         self.travel_write_seen = False
 
     async def fetch(self, sql: str, *params: Any) -> list[dict[str, Any]]:
@@ -60,6 +63,21 @@ class AsyncProjectConn:
         if "INSERT INTO entity_pair_tags" in normalized:
             self.pair_tag_inserts.append(params)
             return {"id": 88}
+        if "FROM characters actor" in normalized:
+            assert params == (ACTOR, TARGET)
+            return {
+                "character1_id": ACTOR_CHARACTER,
+                "character2_id": TARGET_CHARACTER,
+                "previous_relationship_type": None,
+                "extra_data": None,
+            }
+        if "INSERT INTO character_relationships" in normalized:
+            self.relationship_upserts.append(params)
+            return {
+                "character1_id": ACTOR_CHARACTER,
+                "character2_id": TARGET_CHARACTER,
+                "relationship_type": "ally",
+            }
         raise AssertionError(
             f"Unexpected fetchrow SQL: {normalized}; params={params!r}"
         )
@@ -190,6 +208,16 @@ async def test_async_recruit_ally_start_and_completion_match_sync_applier() -> N
     assert conn.pair_tag_inserts == [
         (ACTOR, TARGET, 77, WORLD_TIME, "advance_recruit_ally", SOURCE_CHUNK)
     ]
+    assert len(conn.relationship_upserts) == 1
+    character1_id, character2_id, raw_metadata = conn.relationship_upserts[0]
+    assert (character1_id, character2_id) == (ACTOR_CHARACTER, TARGET_CHARACTER)
+    assert json.loads(raw_metadata) == {
+        "orrery_recruit_ally": {
+            "template_id": "advance_recruit_ally",
+            "source_chunk_id": SOURCE_CHUNK,
+            "previous_relationship_type": None,
+        }
+    }
     complete_applied = conn.resolution_ledgers[102]["project.complete"]["applied"]
     assert complete_applied["status"] == "completed"
     assert complete_applied["target_character_entity_id"] == TARGET
@@ -202,4 +230,14 @@ async def test_async_recruit_ally_start_and_completion_match_sync_applier() -> N
             "changed": True,
         }
     ]
+    assert complete_applied["relationship_mutation"] == {
+        "operation": "insert",
+        "subject_entity_id": ACTOR,
+        "object_entity_id": TARGET,
+        "character1_id": ACTOR_CHARACTER,
+        "character2_id": TARGET_CHARACTER,
+        "previous_relationship_type": None,
+        "relationship_type": "ally",
+        "relationship_type_changed": True,
+    }
     assert conn.travel_write_seen is False

--- a/tests/test_orrery/test_recruit_ally_migration_pg.py
+++ b/tests/test_orrery/test_recruit_ally_migration_pg.py
@@ -1,0 +1,134 @@
+"""Real-PostgreSQL contract coverage for migration 077."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator
+
+import psycopg2  # type: ignore[import-untyped]
+import pytest
+
+from nexus.api.slot_utils import get_slot_db_url
+
+
+pytestmark = pytest.mark.requires_postgres
+
+
+@pytest.fixture()
+def migration_074_schema() -> Iterator[Any]:
+    """Build the exact pre-077 project surface in a rollback-only schema."""
+
+    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    try:
+        with conn.cursor() as cur:
+            cur.execute("CREATE SCHEMA migration_077_test")
+            cur.execute("SET LOCAL search_path = migration_077_test, public")
+            cur.execute("CREATE TABLE entities (id bigint PRIMARY KEY)")
+            cur.execute("CREATE TABLE places (id bigint PRIMARY KEY)")
+            cur.execute("CREATE TABLE narrative_chunks (id bigint PRIMARY KEY)")
+            cur.execute(
+                """
+                CREATE TABLE event_types (
+                    type text PRIMARY KEY,
+                    category text NOT NULL,
+                    severity text NOT NULL,
+                    description text NOT NULL
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE character_project_states (
+                    id bigserial PRIMARY KEY,
+                    character_entity_id bigint NOT NULL REFERENCES entities(id),
+                    project_type text NOT NULL
+                        CHECK (project_type IN ('plan_relocation')),
+                    status text NOT NULL
+                        CHECK (status IN (
+                            'active', 'paused', 'stalled',
+                            'abandoned', 'completed'
+                        )),
+                    stage text NOT NULL
+                        CHECK (stage IN ('saving', 'scouting', 'committing')),
+                    target_place_id bigint REFERENCES places(id),
+                    progress numeric(5,4) NOT NULL DEFAULT 0,
+                    stall_count integer NOT NULL DEFAULT 0,
+                    next_eligible_at_world_time timestamptz,
+                    source_chunk_id bigint REFERENCES narrative_chunks(id),
+                    created_at timestamptz NOT NULL DEFAULT now(),
+                    updated_at timestamptz NOT NULL DEFAULT now(),
+                    CHECK (progress >= 0 AND progress <= 1),
+                    CHECK (stall_count >= 0),
+                    CHECK (status <> 'completed' OR target_place_id IS NOT NULL)
+                )
+                """
+            )
+            cur.execute("INSERT INTO entities (id) VALUES (1), (2)")
+            cur.execute("INSERT INTO places (id) VALUES (1)")
+            cur.execute("INSERT INTO narrative_chunks (id) VALUES (1)")
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_migration_077_preserves_progress_and_replaces_completed_target_guard(
+    migration_074_schema: Any,
+) -> None:
+    """Apply 077 to a 074-only table and exercise both affected invariants."""
+
+    migration_sql = (
+        Path(__file__).parents[2] / "migrations" / "077_recruit_ally_projects.sql"
+    ).read_text()
+    conn = migration_074_schema
+    with conn.cursor() as cur:
+        cur.execute(migration_sql)
+        cur.execute(
+            """
+            SELECT conname, pg_get_constraintdef(oid, true)
+            FROM pg_constraint
+            WHERE conrelid = 'character_project_states'::regclass
+              AND contype = 'c'
+            ORDER BY conname
+            """
+        )
+        constraints = dict(cur.fetchall())
+
+        assert any(
+            "progress >=" in definition and "progress <=" in definition
+            for definition in constraints.values()
+        )
+        assert "character_project_states_completed_target_check" in constraints
+        assert "character_project_states_target_by_type_check" in constraints
+        assert not any(
+            "status <> 'completed'" in definition and "project_type" not in definition
+            for definition in constraints.values()
+        )
+
+        cur.execute(
+            """
+            INSERT INTO character_project_states (
+                character_entity_id, project_type, status, stage,
+                target_character_entity_id, progress, stall_count,
+                source_chunk_id
+            ) VALUES (
+                1, 'recruit_ally', 'completed', 'sealing_commitment',
+                2, 1, 0, 1
+            )
+            """
+        )
+
+        cur.execute("SAVEPOINT invalid_progress")
+        with pytest.raises(psycopg2.errors.CheckViolation):
+            cur.execute(
+                """
+                INSERT INTO character_project_states (
+                    character_entity_id, project_type, status, stage,
+                    target_place_id, progress, stall_count, source_chunk_id
+                ) VALUES (
+                    2, 'plan_relocation', 'active', 'saving',
+                    NULL, 1.1, 0, 1
+                )
+                """
+            )
+        cur.execute("ROLLBACK TO SAVEPOINT invalid_progress")

--- a/tests/test_orrery/test_recruit_ally_projects.py
+++ b/tests/test_orrery/test_recruit_ally_projects.py
@@ -29,6 +29,7 @@ from nexus.agents.orrery.substrate import (
     TravelState,
     WorldState,
     evaluate,
+    has_symmetric_relationship_of_type,
     project_due,
     project_target_is,
     project_target_is_active,
@@ -37,6 +38,7 @@ from nexus.agents.orrery.templates import (
     ADVANCE_RECRUIT_ALLY,
     START_RECRUIT_ALLY,
 )
+from nexus.api.trait_compiler import reconcile_trait_relationship_pair_tags
 from nexus.api.slot_utils import get_slot_db_url
 
 
@@ -286,6 +288,15 @@ def test_hostile_turn_chooses_abandonment_path() -> None:
     assert "project.abandon" in abandoned.state_delta
 
 
+def test_canonical_ally_relationship_satisfies_existing_ally_gate() -> None:
+    """Recruitment's durable relationship unlocks ally-typed packages."""
+
+    state = WorldState(relationship_types={(ACTOR, TARGET): frozenset({"ally"})})
+    predicate = has_symmetric_relationship_of_type("ally")
+
+    assert predicate(state, BINDINGS) is True
+
+
 @pytest.fixture
 def live_project_db() -> Iterator[dict[str, Any]]:
     conn = psycopg2.connect(get_slot_db_url(slot=2))
@@ -436,6 +447,29 @@ def test_live_stage_ladder_completion_and_applied_ledger(
     db = live_project_db
     actor = int(db["actor"])
     target = int(db["target"])
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO character_relationships (
+                character1_id, character2_id, relationship_type,
+                emotional_valence, dynamic, recent_events, history, extra_data
+            )
+            SELECT actor.id, target.id, 'friend', '+2|friendly',
+                   'Preserved recruitment-test dynamic.',
+                   'Preserved recruitment-test recent events.',
+                   'Preserved recruitment-test history.',
+                   '{"test_fixture": true}'::jsonb
+            FROM characters actor
+            JOIN characters target ON target.entity_id = %s
+            WHERE actor.entity_id = %s
+            ON CONFLICT (character1_id, character2_id) DO UPDATE SET
+                relationship_type = 'friend'
+            RETURNING emotional_valence, dynamic, recent_events, history
+            """,
+            (target, actor),
+        )
+        preserved_relationship_fields = cur.fetchone()
+    assert preserved_relationship_fields is not None
     start = OrreryResolutionDraft(
         template_id="start_recruit_ally",
         priority=17,
@@ -547,6 +581,43 @@ def test_live_stage_ladder_completion_and_applied_ledger(
         )
         assert cur.fetchone()[0] == 1
         cur.execute(
+            """
+            SELECT cr.relationship_type, cr.extra_data
+            FROM character_relationships cr
+            JOIN characters actor ON actor.id = cr.character1_id
+            JOIN characters target ON target.id = cr.character2_id
+            WHERE actor.entity_id = %s
+              AND target.entity_id = %s
+            """,
+            (actor, target),
+        )
+        relationship_type, extra_data = cur.fetchone()
+        assert relationship_type == "ally"
+        assert extra_data["orrery_recruit_ally"]["template_id"] == (
+            "advance_recruit_ally"
+        )
+        assert extra_data["orrery_recruit_ally"]["source_chunk_id"] == db["chunk_id"]
+        cur.execute(
+            """
+            SELECT cr.emotional_valence, cr.dynamic, cr.recent_events, cr.history
+            FROM character_relationships cr
+            JOIN characters actor ON actor.id = cr.character1_id
+            JOIN characters target ON target.id = cr.character2_id
+            WHERE actor.entity_id = %s
+              AND target.entity_id = %s
+            """,
+            (actor, target),
+        )
+        assert cur.fetchone() == preserved_relationship_fields
+        relevant_drift = [
+            item
+            for item in reconcile_trait_relationship_pair_tags(cur)
+            if item.subject_entity_id == actor
+            and item.object_entity_id == target
+            and item.pair_tag == "ally"
+        ]
+        assert relevant_drift == []
+        cur.execute(
             "SELECT state_delta FROM orrery_resolutions WHERE id = %s",
             (resolution_id,),
         )
@@ -563,6 +634,11 @@ def test_live_stage_ladder_completion_and_applied_ledger(
             "changed": True,
         }
     ]
+    assert applied["relationship_mutation"]["subject_entity_id"] == actor
+    assert applied["relationship_mutation"]["object_entity_id"] == target
+    assert applied["relationship_mutation"]["previous_relationship_type"] == "friend"
+    assert applied["relationship_mutation"]["relationship_type"] == "ally"
+    assert applied["relationship_mutation"]["relationship_type_changed"] is True
 
 
 @pytest.mark.requires_postgres

--- a/tests/test_orrery/test_recruit_ally_projects.py
+++ b/tests/test_orrery/test_recruit_ally_projects.py
@@ -1,0 +1,546 @@
+"""RECRUIT_ALLY character-targeted project acceptance coverage."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from itertools import count
+from typing import Any, Iterator
+
+import psycopg2
+import pytest
+
+from nexus.agents.orrery.events import (
+    _apply_state_delta_sync,
+    _insert_resolution_sync,
+)
+from nexus.agents.orrery.explain import explain_stack
+from nexus.agents.orrery.needs import load_need_tuning
+from nexus.agents.orrery.resolver import (
+    OrreryResolutionDraft,
+    _draft_from_resolution,
+)
+from nexus.agents.orrery.substrate import (
+    BranchSelection,
+    ProjectPolicy,
+    ProjectState,
+    RoutineAnchor,
+    Slot,
+    TravelState,
+    WorldState,
+    evaluate,
+    project_target_is,
+)
+from nexus.agents.orrery.templates import (
+    ADVANCE_RECRUIT_ALLY,
+    START_RECRUIT_ALLY,
+)
+from nexus.api.slot_utils import get_slot_db_url
+
+
+ACTOR = 10
+TARGET = 20
+OTHER = 30
+NOW = datetime(2073, 8, 2, 12, tzinfo=timezone.utc)
+POLICY = ProjectPolicy(
+    enabled=True,
+    advance_interval_hours=24.0,
+    max_active_per_character=1,
+    stall_abandon_threshold=3,
+    abandon_after_stalled_world_hours=168.0,
+    milestone_magnitude=0.40,
+    coverage_distribution_tolerance=0.05,
+)
+BINDINGS = {Slot.ACTOR: ACTOR, Slot.TARGET: TARGET}
+
+
+def _start_state(
+    *, pair_tags: frozenset[str] = frozenset({"contact:social"})
+) -> WorldState:
+    return WorldState(
+        locations={ACTOR: 1},
+        relationship_types={(ACTOR, TARGET): frozenset({"friend"})},
+        pair_tags={(ACTOR, TARGET): pair_tags} if pair_tags else {},
+        travel_states={ACTOR: TravelState(status="at_place")},
+        project_policy=POLICY,
+        routine_anchors={
+            (ACTOR, "home"): RoutineAnchor(
+                anchor_type="home",
+                place_id=1,
+                mobility_policy="fixed_place",
+            )
+        },
+        world_time=NOW,
+    )
+
+
+def _project(
+    *,
+    target: int = TARGET,
+    stage: str = "sounding_out",
+    progress: float = 0.0,
+    stall_count: int = 0,
+    due_at: datetime = NOW,
+) -> ProjectState:
+    return ProjectState(
+        id=7,
+        project_type="recruit_ally",
+        status="active",
+        stage=stage,
+        target_character_entity_id=target,
+        progress=progress,
+        stall_count=stall_count,
+        next_eligible_at_world_time=due_at,
+        source_chunk_id=100,
+    )
+
+
+def _advance_state(
+    project: ProjectState, *, actor: int = ACTOR, world_time: datetime = NOW
+) -> WorldState:
+    return WorldState(
+        project_states={actor: project},
+        project_policy=POLICY,
+        travel_states={actor: TravelState(status="at_place")},
+        world_time=world_time,
+    )
+
+
+def _leaves(node: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    if "children" in node:
+        for child in node["children"]:
+            yield from _leaves(child)
+    else:
+        yield node
+
+
+def test_start_gate_explains_allied_and_hostile_rejections() -> None:
+    eligible = evaluate(START_RECRUIT_ALLY, _start_state(), BINDINGS)
+    assert eligible.passes is True
+
+    allied = explain_stack(
+        (START_RECRUIT_ALLY,),
+        _start_state(pair_tags=frozenset({"contact:social", "ally"})),
+        BINDINGS,
+    ).to_dict()["templates"][0]
+    allied_leaf = next(
+        leaf
+        for leaf in _leaves(allied["gate_trace"])
+        if leaf["raw"] == "lacks_pair_tag(ally@actor->target)"
+    )
+    assert allied["gate_passed"] is False
+    assert allied_leaf["result"] is False
+
+    hostile_state = replace(
+        _start_state(),
+        pair_tags={
+            (ACTOR, TARGET): frozenset({"contact:social"}),
+            (TARGET, ACTOR): frozenset({"hostile_to"}),
+        },
+    )
+    hostile = explain_stack((START_RECRUIT_ALLY,), hostile_state, BINDINGS).to_dict()[
+        "templates"
+    ][0]
+    hostile_leaf = next(
+        leaf
+        for leaf in _leaves(hostile["gate_trace"])
+        if leaf["raw"] == "has_any_pair_tag(hostile_to,hunting@target->actor)"
+    )
+    assert hostile["gate_passed"] is False
+    assert hostile_leaf["result"] is True
+
+
+def test_project_target_predicate_and_explain_enforce_continuity() -> None:
+    state = _advance_state(_project())
+    assert project_target_is(Slot.TARGET)(state, BINDINGS) is True
+    assert evaluate(ADVANCE_RECRUIT_ALLY, state, BINDINGS).passes is True
+
+    wrong = {Slot.ACTOR: ACTOR, Slot.TARGET: OTHER}
+    assert project_target_is(Slot.TARGET)(state, wrong) is False
+    trace = explain_stack((ADVANCE_RECRUIT_ALLY,), state, wrong).to_dict()["templates"][
+        0
+    ]
+    evidence = next(
+        leaf["evidence"]
+        for leaf in _leaves(trace["gate_trace"])
+        if leaf["raw"] == "project_target_is(target)"
+    )
+    assert trace["gate_passed"] is False
+    assert evidence["observed"]["explanation"] == (
+        "blocked: bound target is not the project's recruit"
+    )
+
+
+def test_neglect_and_hostile_turn_choose_abandonment_paths() -> None:
+    neglected = _advance_state(
+        _project(
+            stage="sealing_commitment",
+            progress=0.5,
+            due_at=NOW - timedelta(hours=POLICY.advance_interval_hours),
+        )
+    )
+    setback = evaluate(
+        ADVANCE_RECRUIT_ALLY,
+        neglected,
+        BINDINGS,
+        BranchSelection(mode="authored_order"),
+    )
+    assert setback.branch_label == "Lose ground through neglect"
+    assert setback.state_delta == {"project.stall": {"increment": 1}}
+
+    hostile = replace(
+        _advance_state(_project(stage="earning_trust", progress=0.5)),
+        pair_tags={(TARGET, ACTOR): frozenset({"hostile_to"})},
+    )
+    abandoned = evaluate(
+        ADVANCE_RECRUIT_ALLY,
+        hostile,
+        BINDINGS,
+        BranchSelection(mode="authored_order"),
+    )
+    assert abandoned.branch_label == "Withdraw after a hostile turn"
+    assert "project.abandon" in abandoned.state_delta
+
+
+@pytest.fixture
+def live_project_db() -> Iterator[dict[str, Any]]:
+    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT max(id) FROM narrative_chunks")
+            chunk_id = int(cur.fetchone()[0])
+            cur.execute(
+                "SELECT entity_id FROM characters "
+                "WHERE entity_id IS NOT NULL ORDER BY id LIMIT 3"
+            )
+            entities = [int(row[0]) for row in cur.fetchall()]
+            if len(entities) < 3:
+                pytest.skip("save_02 needs three character entities")
+            actor, target, other = entities
+            cur.execute(
+                "DELETE FROM character_project_states "
+                "WHERE character_entity_id = %s",
+                (actor,),
+            )
+            cur.execute(
+                """
+                UPDATE entity_pair_tags ept
+                SET cleared_at = now()
+                FROM pair_tags pt
+                WHERE ept.pair_tag_id = pt.id
+                  AND ept.subject_entity_id = %s
+                  AND ept.object_entity_id = %s
+                  AND pt.tag = 'ally'
+                  AND ept.cleared_at IS NULL
+                """,
+                (actor, target),
+            )
+            cur.execute("SELECT id FROM places ORDER BY id LIMIT 1")
+            place_id = int(cur.fetchone()[0])
+        yield {
+            "conn": conn,
+            "chunk_id": chunk_id,
+            "actor": actor,
+            "target": target,
+            "other": other,
+            "place_id": place_id,
+            "sequence": count(1),
+        }
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def _apply_draft(db: dict[str, Any], draft: OrreryResolutionDraft) -> int:
+    actor = int(db["actor"])
+    target = int(db["target"])
+    sequence = next(db["sequence"])
+    draft = replace(draft, binding_hash=f"recruit-ally-{sequence}")
+    with db["conn"].cursor() as cur:
+        resolution_id = _insert_resolution_sync(
+            cur,
+            draft,
+            tick_chunk_id=int(db["chunk_id"]),
+            actor_entity_id=actor,
+            brief="RECRUIT_ALLY acceptance probe",
+        )
+        assert resolution_id is not None
+        _apply_state_delta_sync(
+            cur,
+            draft,
+            resolution_id=resolution_id,
+            actor_entity_id=actor,
+            target_entity_id=target,
+            source_chunk_id=int(db["chunk_id"]),
+            need_tuning=load_need_tuning(),
+            project_policy=POLICY,
+        )
+    return int(resolution_id)
+
+
+def _live_project_row(db: dict[str, Any]) -> ProjectState:
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, project_type, status, stage, target_place_id,
+                   target_character_entity_id, progress, stall_count,
+                   next_eligible_at_world_time, source_chunk_id
+            FROM character_project_states
+            WHERE character_entity_id = %s
+            ORDER BY id DESC LIMIT 1
+            """,
+            (db["actor"],),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    return ProjectState(
+        id=int(row[0]),
+        project_type=str(row[1]),
+        status=str(row[2]),
+        stage=str(row[3]),
+        target_place_id=row[4],
+        target_character_entity_id=row[5],
+        progress=float(row[6]),
+        stall_count=int(row[7]),
+        next_eligible_at_world_time=row[8],
+        source_chunk_id=row[9],
+    )
+
+
+@pytest.mark.requires_postgres
+def test_live_start_persists_bound_character_target(
+    live_project_db: dict[str, Any],
+) -> None:
+    db = live_project_db
+    actor = int(db["actor"])
+    target = int(db["target"])
+    state = replace(
+        _start_state(),
+        locations={actor: 1},
+        relationship_types={(actor, target): frozenset({"friend"})},
+        pair_tags={(actor, target): frozenset({"contact:social"})},
+        routine_anchors={
+            (actor, "home"): RoutineAnchor(
+                anchor_type="home", place_id=1, mobility_policy="fixed_place"
+            )
+        },
+    )
+    bindings = {Slot.ACTOR: actor, Slot.TARGET: target}
+    resolution = evaluate(START_RECRUIT_ALLY, state, bindings)
+    assert resolution.passes is True
+    draft = _draft_from_resolution(resolution, state=state)
+    assert draft.state_delta["project.start"]["target_character_entity_id"] == target
+    _apply_draft(db, draft)
+
+    project = _live_project_row(db)
+    assert project.project_type == "recruit_ally"
+    assert project.stage == "sounding_out"
+    assert project.target_place_id is None
+    assert project.target_character_entity_id == target
+
+
+@pytest.mark.requires_postgres
+def test_live_stage_ladder_completion_and_applied_ledger(
+    live_project_db: dict[str, Any],
+) -> None:
+    db = live_project_db
+    actor = int(db["actor"])
+    target = int(db["target"])
+    start = OrreryResolutionDraft(
+        template_id="start_recruit_ally",
+        priority=17,
+        binding_hash="start",
+        bindings={"actor": actor, "target": target},
+        branch_label="start",
+        narrative_stub="start",
+        state_delta={
+            "project.start": {
+                "project_type": "recruit_ally",
+                "stage": "sounding_out",
+                "target_character_entity_id": target,
+                "milestone": True,
+            }
+        },
+        magnitude=0.40,
+    )
+    _apply_draft(db, start)
+
+    project = _live_project_row(db)
+    routine_state = _advance_state(
+        replace(project, next_eligible_at_world_time=NOW), actor=actor, world_time=NOW
+    )
+    routine = evaluate(
+        ADVANCE_RECRUIT_ALLY,
+        routine_state,
+        {Slot.ACTOR: actor, Slot.TARGET: target},
+        BranchSelection(mode="authored_order"),
+    )
+    assert routine.branch_label == "Learn what the candidate actually wants"
+    assert routine.promotable is False
+    routine_id = _apply_draft(db, _draft_from_resolution(routine, state=routine_state))
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "SELECT promotion_status::text FROM orrery_resolutions WHERE id = %s",
+            (routine_id,),
+        )
+        assert cur.fetchone()[0] == "skipped"
+
+    for current_stage, next_stage in (
+        ("sounding_out", "earning_trust"),
+        ("earning_trust", "sealing_commitment"),
+    ):
+        with db["conn"].cursor() as cur:
+            cur.execute(
+                """
+                UPDATE character_project_states
+                SET stage = %s, progress = 1, stall_count = 2,
+                    next_eligible_at_world_time = %s
+                WHERE character_entity_id = %s
+                  AND status IN ('active', 'paused', 'stalled')
+                """,
+                (current_stage, NOW, actor),
+            )
+        project = _live_project_row(db)
+        milestone_state = _advance_state(project, actor=actor, world_time=NOW)
+        milestone = evaluate(
+            ADVANCE_RECRUIT_ALLY,
+            milestone_state,
+            {Slot.ACTOR: actor, Slot.TARGET: target},
+            BranchSelection(mode="authored_order"),
+        )
+        assert milestone.promotable is True
+        _apply_draft(db, _draft_from_resolution(milestone, state=milestone_state))
+        advanced = _live_project_row(db)
+        assert advanced.stage == next_stage
+        assert advanced.progress == 0.0
+        assert advanced.stall_count == 0
+
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            """
+            UPDATE character_project_states
+            SET progress = 1, next_eligible_at_world_time = %s
+            WHERE character_entity_id = %s AND status = 'active'
+            """,
+            (NOW, actor),
+        )
+    project = _live_project_row(db)
+    completion_state = _advance_state(project, actor=actor, world_time=NOW)
+    completion = evaluate(
+        ADVANCE_RECRUIT_ALLY,
+        completion_state,
+        {Slot.ACTOR: actor, Slot.TARGET: target},
+        BranchSelection(mode="authored_order"),
+    )
+    assert completion.branch_label == "Seal the alliance"
+    resolution_id = _apply_draft(
+        db, _draft_from_resolution(completion, state=completion_state)
+    )
+
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "SELECT status FROM character_project_states WHERE id = %s",
+            (project.id,),
+        )
+        assert cur.fetchone()[0] == "completed"
+        cur.execute(
+            """
+            SELECT count(*)
+            FROM entity_pair_tags ept
+            JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+            WHERE ept.subject_entity_id = %s
+              AND ept.object_entity_id = %s
+              AND pt.tag = 'ally'
+              AND ept.cleared_at IS NULL
+            """,
+            (actor, target),
+        )
+        assert cur.fetchone()[0] == 1
+        cur.execute(
+            "SELECT state_delta FROM orrery_resolutions WHERE id = %s",
+            (resolution_id,),
+        )
+        delta = cur.fetchone()[0]
+    applied = delta["project.complete"]["applied"]
+    assert applied["status"] == "completed"
+    assert applied["target_character_entity_id"] == target
+    assert applied["pair_tag_mutations"] == [
+        {
+            "operation": "add_outbound",
+            "tag": "ally",
+            "subject_entity_id": actor,
+            "object_entity_id": target,
+            "changed": True,
+        }
+    ]
+
+
+@pytest.mark.requires_postgres
+def test_live_schema_target_discipline_and_one_project_budget(
+    live_project_db: dict[str, Any],
+) -> None:
+    db = live_project_db
+    actor = int(db["actor"])
+    target = int(db["target"])
+    place_id = int(db["place_id"])
+    with db["conn"].cursor() as cur:
+        cur.execute("SAVEPOINT invalid_recruit")
+        with pytest.raises(psycopg2.errors.CheckViolation):
+            cur.execute(
+                """
+                INSERT INTO character_project_states (
+                    character_entity_id, project_type, status, stage,
+                    target_place_id, target_character_entity_id
+                ) VALUES (%s, 'recruit_ally', 'active', 'sounding_out', %s, %s)
+                """,
+                (actor, place_id, target),
+            )
+        cur.execute("ROLLBACK TO SAVEPOINT invalid_recruit")
+
+        cur.execute("SAVEPOINT invalid_relocation")
+        with pytest.raises(psycopg2.errors.CheckViolation):
+            cur.execute(
+                """
+                INSERT INTO character_project_states (
+                    character_entity_id, project_type, status, stage,
+                    target_character_entity_id
+                ) VALUES (%s, 'plan_relocation', 'active', 'saving', %s)
+                """,
+                (actor, target),
+            )
+        cur.execute("ROLLBACK TO SAVEPOINT invalid_relocation")
+
+        cur.execute(
+            """
+            INSERT INTO character_project_states (
+                character_entity_id, project_type, status, stage
+            ) VALUES (%s, 'plan_relocation', 'active', 'saving')
+            """,
+            (actor,),
+        )
+        cur.execute("SAVEPOINT project_budget")
+        with pytest.raises(psycopg2.errors.UniqueViolation):
+            cur.execute(
+                """
+                INSERT INTO character_project_states (
+                    character_entity_id, project_type, status, stage,
+                    target_character_entity_id
+                ) VALUES (%s, 'recruit_ally', 'active', 'sounding_out', %s)
+                """,
+                (actor, target),
+            )
+        cur.execute("ROLLBACK TO SAVEPOINT project_budget")
+
+    blocked = replace(
+        _start_state(),
+        project_states={
+            ACTOR: ProjectState(
+                id=99,
+                project_type="plan_relocation",
+                status="active",
+                stage="saving",
+                next_eligible_at_world_time=NOW,
+            )
+        },
+    )
+    assert evaluate(START_RECRUIT_ALLY, blocked, BINDINGS).passes is False

--- a/tests/test_orrery/test_recruit_ally_projects.py
+++ b/tests/test_orrery/test_recruit_ally_projects.py
@@ -29,7 +29,9 @@ from nexus.agents.orrery.substrate import (
     TravelState,
     WorldState,
     evaluate,
+    project_due,
     project_target_is,
+    project_target_is_active,
 )
 from nexus.agents.orrery.templates import (
     ADVANCE_RECRUIT_ALLY,
@@ -88,6 +90,7 @@ def _project(
         status="active",
         stage=stage,
         target_character_entity_id=target,
+        target_character_is_active=True,
         progress=progress,
         stall_count=stall_count,
         next_eligible_at_world_time=due_at,
@@ -171,10 +174,89 @@ def test_project_target_predicate_and_explain_enforce_continuity() -> None:
     )
 
 
-def test_neglect_and_hostile_turn_choose_abandonment_paths() -> None:
+def test_inactive_project_target_preemptively_abandons_without_mutation() -> None:
+    """A dead or retired recruit releases the budget without other writes."""
+
+    project = replace(_project(), target_character_is_active=False)
+    state = _advance_state(project)
+
+    resolution = evaluate(ADVANCE_RECRUIT_ALLY, state, BINDINGS)
+    trace = explain_stack((ADVANCE_RECRUIT_ALLY,), state, BINDINGS).to_dict()[
+        "templates"
+    ][0]
+    evidence = next(
+        leaf["evidence"]
+        for leaf in _leaves(trace["gate_trace"])
+        if leaf["raw"] == "project_target_is(target)"
+    )
+
+    active_evidence = next(
+        leaf["evidence"]
+        for leaf in _leaves(trace["branches"][0]["trace"])
+        if leaf["raw"] == "project_target_is_active(target)"
+    )
+
+    assert project_target_is(Slot.TARGET)(state, BINDINGS) is True
+    assert project_target_is_active(Slot.TARGET)(state, BINDINGS) is False
+    assert resolution.passes is True
+    assert resolution.branch_label == (
+        "End a recruitment whose candidate is no longer available"
+    )
+    assert resolution.state_delta == {
+        "project.abandon": {
+            "reason": "target_inactive_or_non_character",
+            "milestone": True,
+        }
+    }
+    assert "entity_pair_tags.add_outbound" not in resolution.state_delta
+    assert "project.advance" not in resolution.state_delta
+    assert state.project_states[ACTOR] is project
+    assert project.status == "active"
+    assert evidence["result"] is True
+    assert active_evidence["observed"]["project_target_is_active"] is False
+    assert active_evidence["observed"]["explanation"] == (
+        "project's recruit is inactive or not a character"
+    )
+
+
+@pytest.mark.parametrize(
+    ("mode", "project_type"),
+    [
+        ("saving", "recruit_ally"),
+        ("sounding_out", "plan_relocation"),
+    ],
+)
+def test_project_due_rejects_modes_from_another_project_ladder(
+    mode: str, project_type: str
+) -> None:
+    with pytest.raises(ValueError, match="is not valid for project type"):
+        project_due(mode, project_type=project_type)
+
+
+@pytest.mark.parametrize(
+    "stage", ("sounding_out", "earning_trust", "sealing_commitment")
+)
+@pytest.mark.parametrize(
+    "selection",
+    (
+        BranchSelection(mode="authored_order"),
+        BranchSelection(mode="stochastic", temperature=0.25, seed_salt=""),
+        BranchSelection(mode="stochastic", temperature=0.25, seed_salt="alpha"),
+        BranchSelection(mode="stochastic", temperature=0.25, seed_salt="omega"),
+    ),
+    ids=(
+        "authored-order",
+        "configured-stochastic",
+        "stochastic-alpha",
+        "stochastic-omega",
+    ),
+)
+def test_neglect_preempts_routine_progress_at_every_stage(
+    stage: str, selection: BranchSelection
+) -> None:
     neglected = _advance_state(
         _project(
-            stage="sealing_commitment",
+            stage=stage,
             progress=0.5,
             due_at=NOW - timedelta(hours=POLICY.advance_interval_hours),
         )
@@ -183,11 +265,13 @@ def test_neglect_and_hostile_turn_choose_abandonment_paths() -> None:
         ADVANCE_RECRUIT_ALLY,
         neglected,
         BINDINGS,
-        BranchSelection(mode="authored_order"),
+        selection,
     )
     assert setback.branch_label == "Lose ground through neglect"
     assert setback.state_delta == {"project.stall": {"increment": 1}}
 
+
+def test_hostile_turn_chooses_abandonment_path() -> None:
     hostile = replace(
         _advance_state(_project(stage="earning_trust", progress=0.5)),
         pair_tags={(TARGET, ACTOR): frozenset({"hostile_to"})},
@@ -282,12 +366,17 @@ def _live_project_row(db: dict[str, Any]) -> ProjectState:
     with db["conn"].cursor() as cur:
         cur.execute(
             """
-            SELECT id, project_type, status, stage, target_place_id,
-                   target_character_entity_id, progress, stall_count,
-                   next_eligible_at_world_time, source_chunk_id
-            FROM character_project_states
-            WHERE character_entity_id = %s
-            ORDER BY id DESC LIMIT 1
+            SELECT cps.id, cps.project_type, cps.status, cps.stage,
+                   cps.target_place_id, cps.target_character_entity_id,
+                   COALESCE(target_entity.is_active, false), cps.progress,
+                   cps.stall_count, cps.next_eligible_at_world_time,
+                   cps.source_chunk_id
+            FROM character_project_states cps
+            LEFT JOIN entities target_entity
+              ON target_entity.id = cps.target_character_entity_id
+             AND target_entity.kind = 'character'
+            WHERE cps.character_entity_id = %s
+            ORDER BY cps.id DESC LIMIT 1
             """,
             (db["actor"],),
         )
@@ -300,10 +389,11 @@ def _live_project_row(db: dict[str, Any]) -> ProjectState:
         stage=str(row[3]),
         target_place_id=row[4],
         target_character_entity_id=row[5],
-        progress=float(row[6]),
-        stall_count=int(row[7]),
-        next_eligible_at_world_time=row[8],
-        source_chunk_id=row[9],
+        target_character_is_active=bool(row[6]),
+        progress=float(row[7]),
+        stall_count=int(row[8]),
+        next_eligible_at_world_time=row[9],
+        source_chunk_id=row[10],
     )
 
 
@@ -476,6 +566,59 @@ def test_live_stage_ladder_completion_and_applied_ledger(
 
 
 @pytest.mark.requires_postgres
+def test_live_neglect_applies_recruitment_setback(
+    live_project_db: dict[str, Any],
+) -> None:
+    """A neglected recruitment persists its stalled projection and ledger."""
+
+    db = live_project_db
+    actor = int(db["actor"])
+    target = int(db["target"])
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO character_project_states (
+                character_entity_id, project_type, status, stage,
+                target_character_entity_id, progress, stall_count,
+                next_eligible_at_world_time, source_chunk_id
+            ) VALUES (
+                %s, 'recruit_ally', 'active', 'sealing_commitment',
+                %s, 0.5, 0, %s, %s
+            )
+            """,
+            (
+                actor,
+                target,
+                NOW - timedelta(hours=POLICY.advance_interval_hours),
+                int(db["chunk_id"]),
+            ),
+        )
+    project = _live_project_row(db)
+    state = _advance_state(project, actor=actor, world_time=NOW)
+    setback = evaluate(
+        ADVANCE_RECRUIT_ALLY,
+        state,
+        {Slot.ACTOR: actor, Slot.TARGET: target},
+        BranchSelection(mode="authored_order"),
+    )
+    assert setback.branch_label == "Lose ground through neglect"
+    resolution_id = _apply_draft(db, _draft_from_resolution(setback, state=state))
+
+    stalled = _live_project_row(db)
+    assert stalled.status == "stalled"
+    assert stalled.stall_count == 1
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "SELECT state_delta FROM orrery_resolutions WHERE id = %s",
+            (resolution_id,),
+        )
+        applied = cur.fetchone()[0]["project.stall"]["applied"]
+    assert applied["status"] == "stalled"
+    assert applied["stall_count"] == 1
+    assert applied["target_character_entity_id"] == target
+
+
+@pytest.mark.requires_postgres
 def test_live_schema_target_discipline_and_one_project_budget(
     live_project_db: dict[str, Any],
 ) -> None:
@@ -544,3 +687,261 @@ def test_live_schema_target_discipline_and_one_project_budget(
         },
     )
     assert evaluate(START_RECRUIT_ALLY, blocked, BINDINGS).passes is False
+
+
+@pytest.mark.requires_postgres
+def test_slot2_recruitment_routes_persisted_target_without_routine_drift() -> None:
+    """A 35-anchor run keeps recruitment routable after its contact clears."""
+
+    from sqlalchemy import create_engine, text
+    from sqlalchemy.orm import Session
+
+    from nexus.agents.orrery.coverage import analyze_coverage, sample_anchor_ids
+    from nexus.agents.orrery.resolver import resolve_dry_run
+    from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+    from nexus.config import load_settings_as_dict
+
+    orrery = load_settings_as_dict()["orrery"]
+    engine = create_engine(get_slot_db_url(slot=2))
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+    try:
+        anchors = sample_anchor_ids(session, count=35, stride=1)
+        assert len(anchors) == 35, "save_02 must provide 35 coverage anchors"
+        kwargs = {
+            "anchor_chunk_ids": anchors,
+            "window_chunks": int(orrery["binding"]["window_chunks"]),
+            "sunhelm_settings": orrery.get("sunhelm"),
+            "epoch_min_world_times": int(
+                orrery["dashboard"]["coverage_epoch_min_world_times"]
+            ),
+            "selection_settings": orrery.get("selection"),
+            "habituation_settings": orrery.get("habituation"),
+            "package_selection_settings": orrery.get("package_selection"),
+            "project_settings": orrery.get("projects"),
+            "epistemics_settings": orrery.get("epistemics"),
+            "fanout_settings": orrery.get("fanout"),
+        }
+        baseline = analyze_coverage(session, BUILTIN_TEMPLATES, **kwargs)
+        surveil_rows = [
+            winner
+            for anchor in baseline["anchors"]
+            for winner in anchor["resolution_winners"]
+            if winner["template_id"] == "surveil"
+            and winner["target_entity_id"] is not None
+        ]
+        open_project_actor_ids = set(
+            session.execute(
+                text(
+                    """
+                    SELECT character_entity_id
+                    FROM character_project_states
+                    WHERE status IN ('active', 'paused', 'stalled')
+                    """
+                )
+            ).scalars()
+        )
+        surveil_rows = [
+            winner
+            for winner in surveil_rows
+            if int(winner["actor_entity_id"]) not in open_project_actor_ids
+        ]
+        assert surveil_rows, (
+            "slot 2 anchors must include a surveillance actor without an "
+            "open project"
+        )
+        actor = int(surveil_rows[0]["actor_entity_id"])
+        assert actor not in open_project_actor_ids
+        target = session.execute(
+            text(
+                """
+                SELECT e.id
+                FROM entities e
+                WHERE e.kind = 'character'
+                  AND e.is_active = true
+                  AND e.id <> :actor
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM entity_relationships_v er
+                      WHERE er.relationship_scope = 'character'
+                        AND (
+                            (er.source_entity_id = :actor
+                             AND er.target_entity_id = e.id)
+                            OR
+                            (er.source_entity_id = e.id
+                             AND er.target_entity_id = :actor)
+                        )
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM chunk_character_references ccr
+                      JOIN characters c ON c.id = ccr.character_id
+                      WHERE c.entity_id = e.id
+                        AND ccr.chunk_id = :anchor
+                        AND ccr.reference = 'present'
+                  )
+                ORDER BY e.id
+                LIMIT 1
+                """
+            ),
+            {"actor": actor, "anchor": anchors[0]},
+        ).scalar_one_or_none()
+        if target is None:
+            pytest.skip("slot 2 needs an unrelated off-screen recruit target")
+        target = int(target)
+        earliest_world_time = session.execute(
+            text(
+                """
+                SELECT min(cm.world_time)
+                FROM chunk_metadata cm
+                WHERE cm.chunk_id = ANY(:anchors)
+                """
+            ),
+            {"anchors": anchors},
+        ).scalar_one()
+        assert earliest_world_time is not None
+        session.execute(
+            text(
+                """
+                INSERT INTO character_project_states (
+                    character_entity_id, project_type, status, stage,
+                    target_character_entity_id, progress, stall_count,
+                    next_eligible_at_world_time, source_chunk_id
+                ) VALUES (
+                    :actor, 'recruit_ally', 'active', 'sounding_out',
+                    :target, 0.25, 0, :due_at, :source_chunk_id
+                )
+                """
+            ),
+            {
+                "actor": actor,
+                "target": target,
+                "due_at": earliest_world_time - timedelta(hours=1),
+                "source_chunk_id": anchors[0],
+            },
+        )
+        session.execute(
+            text(
+                """
+                UPDATE entity_pair_tags ept
+                SET cleared_at = now()
+                FROM pair_tags pt
+                WHERE ept.pair_tag_id = pt.id
+                  AND ept.subject_entity_id = :actor
+                  AND ept.object_entity_id = :target
+                  AND pt.tag = 'contact:social'
+                  AND ept.cleared_at IS NULL
+                """
+            ),
+            {"actor": actor, "target": target},
+        )
+        active = analyze_coverage(session, BUILTIN_TEMPLATES, **kwargs)
+
+        advance_gates = [
+            gate
+            for anchor in active["anchors"]
+            for gate in anchor["project_gates"]
+            if gate["actor_entity_id"] == actor
+            and gate["target_entity_id"] == target
+            and gate["template_id"] == "advance_recruit_ally"
+        ]
+        assert advance_gates
+        assert any(gate["gate_passed"] for gate in advance_gates)
+        assert active["templates"]["advance_recruit_ally"]["won"] > 0
+
+        proposal = resolve_dry_run(
+            session,
+            BUILTIN_TEMPLATES,
+            anchor_chunk_id=anchors[0],
+            window_chunks=kwargs["window_chunks"],
+            sunhelm_settings=kwargs["sunhelm_settings"],
+            selection_settings=kwargs["selection_settings"],
+            habituation_settings=kwargs["habituation_settings"],
+            package_selection_settings=kwargs["package_selection_settings"],
+            project_settings=kwargs["project_settings"],
+            epistemics_settings=kwargs["epistemics_settings"],
+            fanout_settings=kwargs["fanout_settings"],
+        )
+        assert any(
+            resolution.template_id == "advance_recruit_ally"
+            and resolution.bindings.get("actor") == actor
+            and resolution.bindings.get("target") == target
+            for resolution in proposal.resolutions
+        )
+
+        routine_ids = {
+            template.id
+            for template in BUILTIN_TEMPLATES
+            if template.drive_band.value in {"embodied_maintenance", "anchored_routine"}
+        }
+
+        def winner_shares(report: dict[str, Any]) -> dict[str, float]:
+            total = sum(payload["won"] for payload in report["templates"].values())
+            assert total > 0
+            return {
+                template_id: report["templates"][template_id]["won"] / total
+                for template_id in routine_ids
+            }
+
+        baseline_shares = winner_shares(baseline)
+        active_shares = winner_shares(active)
+        max_shift = max(
+            abs(active_shares[key] - baseline_shares[key]) for key in routine_ids
+        )
+        tolerance = float(orrery["projects"]["coverage_distribution_tolerance"])
+        assert max_shift < tolerance, (max_shift, tolerance)
+
+        session.execute(
+            text("UPDATE entities SET is_active = false WHERE id = :target"),
+            {"target": target},
+        )
+        inactive_target = resolve_dry_run(
+            session,
+            BUILTIN_TEMPLATES,
+            anchor_chunk_id=anchors[0],
+            window_chunks=kwargs["window_chunks"],
+            sunhelm_settings=kwargs["sunhelm_settings"],
+            selection_settings=kwargs["selection_settings"],
+            habituation_settings=kwargs["habituation_settings"],
+            package_selection_settings=kwargs["package_selection_settings"],
+            project_settings=kwargs["project_settings"],
+            epistemics_settings=kwargs["epistemics_settings"],
+            fanout_settings=kwargs["fanout_settings"],
+        )
+        abandonment = next(
+            resolution
+            for resolution in inactive_target.resolutions
+            if resolution.template_id == "advance_recruit_ally"
+            and resolution.bindings.get("actor") == actor
+            and resolution.bindings.get("target") == target
+        )
+        assert abandonment.branch_label == (
+            "End a recruitment whose candidate is no longer available"
+        )
+        assert abandonment.state_delta == {
+            "project.abandon": {
+                "reason": "target_inactive_or_non_character",
+                "milestone": True,
+            }
+        }
+        assert "entity_pair_tags.add_outbound" not in abandonment.state_delta
+        assert "project.advance" not in abandonment.state_delta
+        project_status = session.execute(
+            text(
+                """
+                SELECT status
+                FROM character_project_states
+                WHERE character_entity_id = :actor
+                  AND project_type = 'recruit_ally'
+                  AND status IN ('active', 'paused', 'stalled')
+                """
+            ),
+            {"actor": actor},
+        ).scalar_one()
+        assert project_status == "active"
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()
+        engine.dispose()

--- a/tests/test_orrery/test_recruit_ally_replay.py
+++ b/tests/test_orrery/test_recruit_ally_replay.py
@@ -1,0 +1,263 @@
+"""Checkpoint replay coverage for the RECRUIT_ALLY project lifecycle."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterator, Optional
+
+import psycopg2
+import pytest
+
+from nexus.agents.orrery.events import (
+    _apply_state_delta_sync,
+    _insert_resolution_sync,
+)
+from nexus.agents.orrery.needs import load_need_tuning
+from nexus.agents.orrery.reconstruction import capture_state_checkpoint_sync
+from nexus.agents.orrery.replay import (
+    reconstruct_state_at_sync,
+    verify_checkpoints_sync,
+)
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.substrate import ProjectPolicy
+from nexus.api.slot_utils import get_slot_db_url
+
+pytestmark = pytest.mark.requires_postgres
+
+POLICY = ProjectPolicy(
+    enabled=True,
+    advance_interval_hours=24.0,
+    max_active_per_character=1,
+    stall_abandon_threshold=3,
+    abandon_after_stalled_world_hours=168.0,
+    milestone_magnitude=0.40,
+    coverage_distribution_tolerance=0.05,
+)
+
+
+@pytest.fixture
+def replay_project_db() -> Iterator[dict[str, Any]]:
+    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT entity_id FROM characters "
+                "WHERE entity_id IS NOT NULL ORDER BY id LIMIT 2"
+            )
+            entities = [int(row[0]) for row in cur.fetchall()]
+            if len(entities) < 2:
+                pytest.skip("save_02 needs two character entities")
+            actor, target = entities
+            cur.execute(
+                "DELETE FROM character_project_states "
+                "WHERE character_entity_id = %s",
+                (actor,),
+            )
+            cur.execute(
+                """
+                UPDATE entity_pair_tags ept
+                SET cleared_at = now()
+                FROM pair_tags pt
+                WHERE ept.pair_tag_id = pt.id
+                  AND ept.subject_entity_id = %s
+                  AND ept.object_entity_id = %s
+                  AND pt.tag = 'ally'
+                  AND ept.cleared_at IS NULL
+                """,
+                (actor, target),
+            )
+        yield {"conn": conn, "actor": actor, "target": target}
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def _next_world_time(cur: Any) -> datetime:
+    cur.execute("SELECT max(world_time) FROM chunk_metadata")
+    latest = cur.fetchone()[0]
+    base = latest or datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return base + timedelta(hours=6)
+
+
+def _fabricate_chunk(
+    cur: Any,
+    world_time: datetime,
+    *,
+    created_offset_minutes: int,
+) -> int:
+    cur.execute(
+        """
+        INSERT INTO narrative_chunks (id, raw_text, created_at)
+        SELECT max(id) + 1, 'RECRUIT_ALLY replay probe',
+               now() + make_interval(mins => %s)
+        FROM narrative_chunks
+        RETURNING id
+        """,
+        (created_offset_minutes,),
+    )
+    chunk_id = int(cur.fetchone()[0])
+    cur.execute(
+        "INSERT INTO chunk_metadata (chunk_id, world_time) VALUES (%s, %s)",
+        (chunk_id, world_time),
+    )
+    cur.execute(
+        "UPDATE chunk_metadata SET world_time = %s WHERE chunk_id = %s",
+        (world_time, chunk_id),
+    )
+    return chunk_id
+
+
+def _apply_transition(
+    cur: Any,
+    *,
+    chunk_id: int,
+    actor_entity_id: int,
+    target_entity_id: int,
+    state_delta: dict[str, Any],
+) -> None:
+    draft = OrreryResolutionDraft(
+        template_id="recruit_ally_replay_probe",
+        priority=47,
+        binding_hash=f"recruit-ally-replay-{chunk_id}",
+        bindings={"actor": actor_entity_id, "target": target_entity_id},
+        branch_label="RECRUIT_ALLY replay probe",
+        narrative_stub="probe",
+        state_delta=state_delta,
+        magnitude=0.4,
+    )
+    resolution_id = _insert_resolution_sync(
+        cur,
+        draft,
+        tick_chunk_id=chunk_id,
+        actor_entity_id=actor_entity_id,
+        brief="RECRUIT_ALLY checkpoint replay probe",
+    )
+    assert resolution_id is not None
+    _apply_state_delta_sync(
+        cur,
+        draft,
+        resolution_id=int(resolution_id),
+        actor_entity_id=actor_entity_id,
+        target_entity_id=target_entity_id,
+        source_chunk_id=chunk_id,
+        need_tuning=load_need_tuning(),
+        project_policy=POLICY,
+    )
+
+
+def _project_row(
+    rows: list[dict[str, Any]], actor_entity_id: int
+) -> Optional[dict[str, Any]]:
+    matching = [
+        row
+        for row in rows
+        if row["character_entity_id"] == actor_entity_id
+        and row["project_type"] == "recruit_ally"
+    ]
+    assert len(matching) == 1
+    return matching[0]
+
+
+def test_recruit_ally_lifecycle_replays_between_checkpoints_without_drift(
+    replay_project_db: dict[str, Any],
+) -> None:
+    db = replay_project_db
+    actor = int(db["actor"])
+    target = int(db["target"])
+
+    with db["conn"].cursor() as cur:
+        base_time = _next_world_time(cur)
+        base_chunk = _fabricate_chunk(
+            cur,
+            base_time,
+            created_offset_minutes=1,
+        )
+        base_id = capture_state_checkpoint_sync(
+            cur,
+            chunk_id=base_chunk,
+            label="manual",
+        )
+        assert base_id is not None
+
+        transitions = (
+            {
+                "project.start": {
+                    "project_type": "recruit_ally",
+                    "stage": "sounding_out",
+                    "target_character_entity_id": target,
+                    "milestone": True,
+                }
+            },
+            {
+                "project.advance": {
+                    "stage": "earning_trust",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            {
+                "project.advance": {
+                    "stage": "sealing_commitment",
+                    "set_progress": 1.0,
+                    "milestone": True,
+                }
+            },
+            {
+                "project.complete": {"milestone": True},
+                "entity_pair_tags.add_outbound": ["ally"],
+            },
+        )
+        transition_chunks: list[int] = []
+        for offset, state_delta in enumerate(transitions, start=2):
+            chunk_id = _fabricate_chunk(
+                cur,
+                base_time + timedelta(hours=24 * (offset - 1)),
+                created_offset_minutes=offset,
+            )
+            _apply_transition(
+                cur,
+                chunk_id=chunk_id,
+                actor_entity_id=actor,
+                target_entity_id=target,
+                state_delta=state_delta,
+            )
+            transition_chunks.append(chunk_id)
+
+        complete_chunk = transition_chunks[-1]
+        target_id = capture_state_checkpoint_sync(
+            cur,
+            chunk_id=complete_chunk,
+            label="manual",
+        )
+        assert target_id is not None
+
+        reconstructed = reconstruct_state_at_sync(
+            cur,
+            complete_chunk,
+            base_checkpoint_id=int(base_id),
+        )
+        project = _project_row(reconstructed.state["character_project_states"], actor)
+        assert project is not None
+        assert project["status"] == "completed"
+        assert project["stage"] == "sealing_commitment"
+        assert project["target_place_id"] is None
+        assert project["target_character_entity_id"] == target
+        assert float(project["progress"]) == 1.0
+        assert project["source_chunk_id"] == complete_chunk
+
+        cur.execute("SELECT id FROM pair_tags WHERE tag = 'ally'")
+        ally_tag_id = int(cur.fetchone()[0])
+        assert any(
+            row["subject_entity_id"] == actor
+            and row["object_entity_id"] == target
+            and row["pair_tag_id"] == ally_tag_id
+            for row in reconstructed.state["entity_pair_tags"]
+        )
+
+        pair = next(
+            verdict
+            for verdict in verify_checkpoints_sync(cur)
+            if verdict.base_checkpoint_id == base_id
+            and verdict.target_checkpoint_id == target_id
+        )
+        assert pair.drifts == []

--- a/tests/test_orrery/test_recruit_ally_replay.py
+++ b/tests/test_orrery/test_recruit_ally_replay.py
@@ -13,7 +13,10 @@ from nexus.agents.orrery.events import (
     _insert_resolution_sync,
 )
 from nexus.agents.orrery.needs import load_need_tuning
-from nexus.agents.orrery.reconstruction import capture_state_checkpoint_sync
+from nexus.agents.orrery.reconstruction import (
+    capture_state_checkpoint_sync,
+    set_commit_chunk_attribution_sync,
+)
 from nexus.agents.orrery.replay import (
     reconstruct_state_at_sync,
     verify_checkpoints_sync,
@@ -115,6 +118,7 @@ def _apply_transition(
     target_entity_id: int,
     state_delta: dict[str, Any],
 ) -> None:
+    set_commit_chunk_attribution_sync(cur, chunk_id)
     draft = OrreryResolutionDraft(
         template_id="recruit_ally_replay_probe",
         priority=47,
@@ -167,10 +171,25 @@ def test_recruit_ally_lifecycle_replays_between_checkpoints_without_drift(
 
     with db["conn"].cursor() as cur:
         base_time = _next_world_time(cur)
+        cur.execute(
+            """
+            SELECT actor.id, target.id, relationship.relationship_type
+            FROM characters actor
+            JOIN characters target ON target.entity_id = %s
+            LEFT JOIN character_relationships relationship
+              ON relationship.character1_id = actor.id
+             AND relationship.character2_id = target.id
+            WHERE actor.entity_id = %s
+            """,
+            (target, actor),
+        )
+        actor_character_id, target_character_id, prior_relationship_type = (
+            cur.fetchone()
+        )
         base_chunk = _fabricate_chunk(
             cur,
             base_time,
-            created_offset_minutes=1,
+            created_offset_minutes=-4,
         )
         base_id = capture_state_checkpoint_sync(
             cur,
@@ -179,7 +198,7 @@ def test_recruit_ally_lifecycle_replays_between_checkpoints_without_drift(
         )
         assert base_id is not None
 
-        transitions = (
+        transitions: tuple[dict[str, Any], ...] = (
             {
                 "project.start": {
                     "project_type": "recruit_ally",
@@ -208,11 +227,11 @@ def test_recruit_ally_lifecycle_replays_between_checkpoints_without_drift(
             },
         )
         transition_chunks: list[int] = []
-        for offset, state_delta in enumerate(transitions, start=2):
+        for step, state_delta in enumerate(transitions, start=1):
             chunk_id = _fabricate_chunk(
                 cur,
-                base_time + timedelta(hours=24 * (offset - 1)),
-                created_offset_minutes=offset,
+                base_time + timedelta(hours=24 * step),
+                created_offset_minutes=step - len(transitions),
             )
             _apply_transition(
                 cur,
@@ -245,6 +264,23 @@ def test_recruit_ally_lifecycle_replays_between_checkpoints_without_drift(
         assert float(project["progress"]) == 1.0
         assert project["source_chunk_id"] == complete_chunk
 
+        before_completion = reconstruct_state_at_sync(
+            cur,
+            transition_chunks[-2],
+            base_checkpoint_id=int(base_id),
+        )
+        prior_rows = [
+            row
+            for row in before_completion.state["character_relationships"]
+            if row["character1_id"] == actor_character_id
+            and row["character2_id"] == target_character_id
+        ]
+        if prior_relationship_type is None:
+            assert prior_rows == []
+        else:
+            assert len(prior_rows) == 1
+            assert prior_rows[0]["relationship_type"] == prior_relationship_type
+
         cur.execute("SELECT id FROM pair_tags WHERE tag = 'ally'")
         ally_tag_id = int(cur.fetchone()[0])
         assert any(
@@ -252,6 +288,12 @@ def test_recruit_ally_lifecycle_replays_between_checkpoints_without_drift(
             and row["object_entity_id"] == target
             and row["pair_tag_id"] == ally_tag_id
             for row in reconstructed.state["entity_pair_tags"]
+        )
+        assert any(
+            row["character1_id"] == actor_character_id
+            and row["character2_id"] == target_character_id
+            and row["relationship_type"] == "ally"
+            for row in reconstructed.state["character_relationships"]
         )
 
         pair = next(

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -11,6 +11,7 @@ from nexus.agents.orrery.resolver import (
     OrreryResolutionDraft,
     _need_pressure_stub,
     compose_actor_target_bindings,
+    compose_actor_target_routes,
     hydrate_world_state,
     resolve_dry_run,
 )
@@ -20,12 +21,19 @@ from nexus.agents.orrery.substrate import (
     Branch,
     DriveBand,
     PresentTargetPolicy,
+    ProjectPolicy,
+    ProjectState,
     Slot,
     Template,
+    WorldState,
     trust_at_least,
     trust_below,
 )
-from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+from nexus.agents.orrery.templates import (
+    ADVANCE_RECRUIT_ALLY,
+    BUILTIN_TEMPLATES,
+    START_RECRUIT_ALLY,
+)
 
 
 class FakeResult:
@@ -197,6 +205,8 @@ class FakeSession:
         if "/* orrery:project_states */" in sql:
             assert "JOIN entities e" in sql
             assert "e.is_active = true" in sql
+            assert "target_entity.kind = 'character'" in sql
+            assert "target_entity.is_active" in sql
             return FakeResult(self.project_state_rows)
         if "/* orrery:win_history */" in sql:
             return FakeResult(self.win_history_rows)
@@ -1208,6 +1218,39 @@ def test_hydrate_world_state_loads_travel_states() -> None:
     assert travel.estimated_duration_minutes == pytest.approx(18.6)
 
 
+def test_hydrate_world_state_retains_project_with_inactive_target() -> None:
+    """Hydration retains an inactive recruit so its project can abandon."""
+
+    state = hydrate_world_state(
+        FakeSession(
+            project_state_rows=[
+                {
+                    "id": 7,
+                    "character_entity_id": 1,
+                    "project_type": "recruit_ally",
+                    "status": "active",
+                    "stage": "earning_trust",
+                    "target_place_id": None,
+                    "target_character_entity_id": 2,
+                    "target_character_is_active": False,
+                    "progress": 0.5,
+                    "stall_count": 0,
+                    "next_eligible_at_world_time": None,
+                    "source_chunk_id": 99,
+                }
+            ]
+        ),
+        anchor_chunk_id=100,
+        window_chunks=30,
+        project_settings=ProjectPolicy(enabled=True),
+    )
+
+    project = state.project_states[1]
+    assert project.target_character_entity_id == 2
+    assert project.target_character_is_active is False
+    assert project.status == "active"
+
+
 def test_hydrate_world_state_loads_semantic_place_classes() -> None:
     """Place tags supplement structural place types for location predicates."""
 
@@ -1826,6 +1869,92 @@ def test_compose_actor_target_bindings_includes_directed_social_contacts() -> No
 
     pairs = {(b[Slot.ACTOR], b[Slot.TARGET]) for b in bindings}
     assert pairs == {(1, 2)}
+
+
+def test_actor_target_routes_preserve_contact_only_recruitment_continuity() -> None:
+    """A cleared contact cannot strand its durable RECRUIT_ALLY project."""
+
+    templates = (START_RECRUIT_ALLY, ADVANCE_RECRUIT_ALLY)
+    social_session = FakeSession(
+        actor_target_social_contact_rows=[
+            {"source_entity_id": 1, "target_entity_id": 2},
+        ],
+    )
+    social_routes = compose_actor_target_routes(
+        social_session,
+        state=WorldState(),
+        templates=templates,
+        anchor_chunk_id=100,
+        window_chunks=30,
+        actor_ids={1},
+    )
+    assert [
+        (
+            route[0][Slot.ACTOR],
+            route[0][Slot.TARGET],
+            tuple(template.id for template in route[1]),
+        )
+        for route in social_routes
+    ] == [(1, 2, ("start_recruit_ally",))]
+
+    project_state = WorldState(
+        project_states={
+            1: ProjectState(
+                id=7,
+                project_type="recruit_ally",
+                status="active",
+                stage="sounding_out",
+                target_character_entity_id=2,
+                target_character_is_active=True,
+            )
+        }
+    )
+    project_routes = compose_actor_target_routes(
+        FakeSession(),
+        state=project_state,
+        templates=templates,
+        anchor_chunk_id=100,
+        window_chunks=30,
+        actor_ids={1},
+    )
+    assert [
+        (
+            route[0][Slot.ACTOR],
+            route[0][Slot.TARGET],
+            tuple(template.id for template in route[1]),
+        )
+        for route in project_routes
+    ] == [(1, 2, ("advance_recruit_ally",))]
+
+    unavailable_state = WorldState(
+        project_states={
+            1: ProjectState(
+                id=7,
+                project_type="recruit_ally",
+                status="active",
+                stage="sounding_out",
+                target_character_entity_id=2,
+                target_character_is_active=False,
+            )
+        }
+    )
+    unavailable_routes = compose_actor_target_routes(
+        FakeSession(),
+        state=unavailable_state,
+        templates=templates,
+        anchor_chunk_id=100,
+        window_chunks=30,
+        actor_ids={1},
+    )
+    assert [
+        (
+            route[0][Slot.ACTOR],
+            route[0][Slot.TARGET],
+            tuple(template.id for template in route[1]),
+        )
+        for route in unavailable_routes
+    ] == [(1, 2, ("advance_recruit_ally",))]
+    assert unavailable_state.project_states[1].status == "active"
 
 
 def test_compose_actor_target_bindings_filters_to_recently_relevant_actors() -> None:

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -64,6 +64,7 @@ class FakeSession:
         inbound_ephemeral_pair_actor_rows=None,
         present_actor_rows=None,
         actor_target_relationship_rows=None,
+        actor_target_social_contact_rows=None,
         entity_name_rows=None,
         need_debt_rows=None,
         travel_state_rows=None,
@@ -93,6 +94,7 @@ class FakeSession:
         self.inbound_ephemeral_pair_actor_rows = inbound_ephemeral_pair_actor_rows or []
         self.present_actor_rows = present_actor_rows or []
         self.actor_target_relationship_rows = actor_target_relationship_rows or []
+        self.actor_target_social_contact_rows = actor_target_social_contact_rows or []
         self.entity_name_rows = entity_name_rows or [
             {"id": 1, "name": "Mara"},
             {"id": 2, "name": "Vale"},
@@ -178,6 +180,10 @@ class FakeSession:
         if "/* orrery:actor_target_bindings_character_relationships */" in sql:
             assert "relationship_scope = 'character'" in sql
             return FakeResult(self.actor_target_relationship_rows)
+        if "/* orrery:actor_target_bindings_social_contacts */" in sql:
+            assert "pt.tag = 'contact:social'" in sql
+            assert "ept.cleared_at IS NULL" in sql
+            return FakeResult(self.actor_target_social_contact_rows)
         if "/* orrery:entity_names */" in sql:
             return FakeResult(self.entity_name_rows)
         if "/* orrery:need_debt_scores */" in sql:
@@ -1799,6 +1805,27 @@ def test_compose_actor_target_bindings_yields_both_directions() -> None:
 
     pairs = {(b[Slot.ACTOR], b[Slot.TARGET]) for b in bindings}
     assert pairs == {(1, 2), (2, 1)}
+
+
+def test_compose_actor_target_bindings_includes_directed_social_contacts() -> None:
+    """A social-contact edge can source RECRUIT_ALLY without a relationship."""
+
+    session = FakeSession(
+        chunk_ref_actor_rows=[{"entity_id": 1}, {"entity_id": 2}],
+        actor_target_social_contact_rows=[
+            {"source_entity_id": 1, "target_entity_id": 2},
+        ],
+    )
+
+    bindings = compose_actor_target_bindings(
+        session,
+        anchor_chunk_id=100,
+        window_chunks=30,
+        include_social_contacts=True,
+    )
+
+    pairs = {(b[Slot.ACTOR], b[Slot.TARGET]) for b in bindings}
+    assert pairs == {(1, 2)}
 
 
 def test_compose_actor_target_bindings_filters_to_recently_relevant_actors() -> None:


### PR DESCRIPTION
## Summary

- add migration 077 and typed character-target project schema
- add the RECRUIT_ALLY start, advance, milestone, setback, abandon, and completion lifecycle
- preserve durable target routing after source contacts clear, with deterministic cleanup for inactive targets
- persist both the frozen outbound `ally` pair tag and the canonical actor→target `ally` relationship on completion
- add sync/async/replay/audit/coverage support and generated catalog documentation

## Scope

This implements the RECRUIT_ALLY slice of #496. BUILD_VENTURE, COURT_PATRON, PURSUE_ROMANCE, and SEEK_REDEMPTION remain outstanding; #496 remains open as their umbrella.

The one-open-project-per-character budget remains unchanged. This slice does not add Retrograde spawn sourcing or epistemics coupling.

## Validation

- `PYTHONPATH=. poetry run pytest -q` — 1,358 passed, 234 skipped
- focused live migration/lifecycle/async/replay suite — 27 passed
- migration-077 PostgreSQL contract probe applies against an exact 074-only schema, accepts completed RECRUIT_ALLY, and retains the progress guard
- `PYTHONPATH=. poetry run python -m nexus.agents.orrery.catalog --check`
- Black, flake8, compileall, and `git diff --check`
- migration 077 dry-run: five databases pending; save_02 already applied
- the live 35-anchor comparison remained within the configured routine-share tolerance

## Data impact

Migration 077 adds `target_character_entity_id`, tightens per-project-type target/completion constraints, and installs the RECRUIT_ALLY event templates. It discovers the legacy completion CHECK by definition so the independent progress guard cannot be removed accidentally. The migration is additive and preserves existing relocation rows.

RECRUIT_ALLY completion upserts the canonical actor→target ally relationship while preserving existing relationship narrative fields and recording Orrery provenance.

Codex — GPT-5.6-Sol