### PR TITLE
Fix live coverage accounting

### DIFF
--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -143,6 +143,14 @@ def _tally_report(
     tallies: dict[str, _TemplateTally],
     gap_counts: dict[int, dict[str, int]],
 ) -> dict[str, Any]:
+    fanout_trimmed = {
+        (
+            item["actor_entity_id"],
+            item["target_entity_id"],
+            item["template_id"],
+        )
+        for item in report.fanout_trimmed
+    }
     winners_by_band: dict[str, int] = {}
     gap_actor_ids: list[int] = []
     project_gates: list[dict[str, Any]] = []
@@ -160,7 +168,15 @@ def _tally_report(
                     tally.fired += 1
                     if item.chosen_branch is not None:
                         tally.branch_chosen[item.chosen_branch] += 1
-                if item.template_id == stack.winner_id:
+                winner_key = (
+                    stack.bindings.get("actor"),
+                    stack.bindings.get("target"),
+                    item.template_id,
+                )
+                if (
+                    item.template_id == stack.winner_id
+                    and winner_key not in fanout_trimmed
+                ):
                     tally.won += 1
                     winners_by_band[item.drive_band] = (
                         winners_by_band.get(item.drive_band, 0) + 1
@@ -438,7 +454,9 @@ def analyze_coverage(
         "anchors": anchors,
         "templates": template_payloads,
         "never_fired": sorted(
-            template_id for template_id, tally in tallies.items() if tally.fired == 0
+            template_id
+            for template_id, tally in tallies.items()
+            if tally.fired == 0 and tally.pressure_fired == 0
         ),
         "fired_never_won": sorted(
             template_id

--- a/tests/test_faction_table_audit.py
+++ b/tests/test_faction_table_audit.py
@@ -959,7 +959,7 @@ def test_cli_faction_manifest_returns_live_slot2_payload() -> None:
     """The faction manifest CLI should build from the real slot 2 audit."""
 
     try:
-        result = cli.run_faction_manifest(Namespace(slot=2))
+        result = cli.run_faction_manifest(Namespace(slot=2, output=None))
     except psycopg2.Error as exc:
         pytest.skip(f"{TEST_DBNAME} PostgreSQL test database unavailable: {exc}")
     finally:

--- a/tests/test_orrery/test_coverage_accounting.py
+++ b/tests/test_orrery/test_coverage_accounting.py
@@ -1,0 +1,157 @@
+"""Unit regressions for Orrery coverage winner and pressure accounting."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from nexus.agents.orrery import coverage
+from nexus.agents.orrery.substrate import Template
+
+
+TEMPLATE_ID = "coverage_probe"
+
+
+def _template() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=TEMPLATE_ID,
+        drive_band=SimpleNamespace(value="affiliation"),
+        branches=(SimpleNamespace(label="Probe branch", promotable=True),),
+    )
+
+
+def _item() -> SimpleNamespace:
+    return SimpleNamespace(
+        template_id=TEMPLATE_ID,
+        drive_band="affiliation",
+        gate_passed=True,
+        fired=True,
+        chosen_branch="Probe branch",
+        promotable=True,
+    )
+
+
+def _stack(*, actor: int, target: int | None, winner: bool) -> SimpleNamespace:
+    bindings = {"actor": actor}
+    if target is not None:
+        bindings["target"] = target
+    return SimpleNamespace(
+        bindings=bindings,
+        winner_id=TEMPLATE_ID if winner else None,
+        templates=(_item(),) if winner else (),
+    )
+
+
+def _group(
+    actor: int,
+    *,
+    pair_stacks: tuple[SimpleNamespace, ...] = (),
+    pressure_stacks: tuple[SimpleNamespace, ...] = (),
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        actor_entity_id=actor,
+        actor_stack=_stack(actor=actor, target=None, winner=False),
+        two_party_stacks=pair_stacks,
+        scene_pressure_stacks=pressure_stacks,
+    )
+
+
+def _analyze(
+    monkeypatch: Any,
+    *,
+    groups: tuple[SimpleNamespace, ...],
+    fanout_trimmed: tuple[dict[str, Any], ...] = (),
+) -> dict[str, Any]:
+    report = SimpleNamespace(
+        anchor_chunk_id=42,
+        world_time=None,
+        time_of_day="day",
+        actor_count=len(groups),
+        actors=groups,
+        need_pressures=(),
+        entity_names={
+            group.actor_entity_id: f"Actor {group.actor_entity_id}" for group in groups
+        },
+        fanout_trimmed=fanout_trimmed,
+    )
+    monkeypatch.setattr(
+        coverage,
+        "build_catalog",
+        lambda templates: {
+            "drive_bands": [
+                {
+                    "templates": [
+                        {"template_id": template.id, "arity": "actor_target"}
+                        for template in templates
+                    ]
+                }
+            ],
+            "event_map": {},
+        },
+    )
+    monkeypatch.setattr(coverage, "explain_dry_run", lambda *args, **kwargs: report)
+    monkeypatch.setattr(
+        coverage,
+        "_data_quality_findings",
+        lambda *args, **kwargs: {},
+    )
+    return coverage.analyze_coverage(
+        object(),
+        (cast(Template, _template()),),
+        anchor_chunk_ids=(42,),
+        window_chunks=10,
+        epoch_min_world_times=10,
+    )
+
+
+def test_pressure_only_firing_is_not_reported_as_never_fired(
+    monkeypatch: Any,
+) -> None:
+    payload = _analyze(
+        monkeypatch,
+        groups=(
+            _group(
+                1,
+                pressure_stacks=(_stack(actor=1, target=2, winner=True),),
+            ),
+        ),
+    )
+
+    assert payload["templates"][TEMPLATE_ID]["fired"] == 0
+    assert payload["templates"][TEMPLATE_ID]["pressure_fired"] == 1
+    assert TEMPLATE_ID not in payload["never_fired"]
+
+
+def test_fanout_trimmed_pair_stays_fired_but_is_not_counted_as_winner(
+    monkeypatch: Any,
+) -> None:
+    payload = _analyze(
+        monkeypatch,
+        groups=(
+            _group(1, pair_stacks=(_stack(actor=1, target=2, winner=True),)),
+            _group(3, pair_stacks=(_stack(actor=3, target=4, winner=True),)),
+        ),
+        fanout_trimmed=(
+            {
+                "actor_entity_id": 1,
+                "target_entity_id": 2,
+                "template_id": TEMPLATE_ID,
+            },
+        ),
+    )
+
+    stats = payload["templates"][TEMPLATE_ID]
+    assert stats["evaluated"] == 2
+    assert stats["fired"] == 2
+    assert stats["won"] == 1
+    assert stats["branch_chosen"]["Probe branch"] == 2
+    assert payload["anchors"][0]["winners_by_band"] == {"affiliation": 1}
+    assert payload["anchors"][0]["resolution_winners"] == [
+        {
+            "actor_entity_id": 3,
+            "target_entity_id": 4,
+            "template_id": TEMPLATE_ID,
+            "drive_band": "affiliation",
+            "promotable": True,
+        }
+    ]

--- a/tests/test_orrery/test_pair_tag_writer.py
+++ b/tests/test_orrery/test_pair_tag_writer.py
@@ -435,9 +435,16 @@ def test_polymorphic_object_kind_faction_path(
 
     if test_entities.faction is None:
         pytest.skip(
-            f"{TEST_DBNAME} has no faction entities; skipping faction polymorphism case."
+            f"{TEST_DBNAME} has no faction entities; "
+            "skipping faction polymorphism case."
         )
 
+    active_before = _count_active_pair_tags(
+        slot_connection,
+        subject_id=test_entities.char_a,
+        object_id=test_entities.faction,
+        tag="obligation",
+    )
     with slot_connection:
         with slot_connection.cursor() as cur:
             inserted = apply_pair_tag_bestowal(
@@ -448,4 +455,14 @@ def test_polymorphic_object_kind_faction_path(
                 object_kind="faction",
                 tag="obligation",
             )
-            assert inserted is True
+            assert inserted is (active_before == 0)
+
+    assert (
+        _count_active_pair_tags(
+            slot_connection,
+            subject_id=test_entities.char_a,
+            object_id=test_entities.faction,
+            tag="obligation",
+        )
+        == 1
+    )


### PR DESCRIPTION
## Summary

- exclude pair winners removed by the production fanout quota from coverage winner totals while retaining their evaluated/fired branch accounting
- keep pressure-only package firings out of the `never_fired` list
- make the live faction-manifest test mirror the real parser namespace
- make the polymorphic pair-tag test accept legitimate idempotent pre-existing data
- add unit regressions for both coverage-accounting cases

## Why

The corrected production parity oracle in #512 exposed two latent coverage-analyzer omissions. The other two failures were live-data-aware test fixture assumptions; production behavior was already correct.

## Validation

- `PYTHONPATH=. poetry run pytest -q` — 1,360 passed, 234 skipped
- `PYTHONPATH=. NEXUS_RUN_POSTGRES=1 poetry run pytest -q` — 1,553 passed, 41 skipped
- focused live/API/fixture suite — 60 passed
- Black, flake8, mypy, and `git diff --check`

Codex — GPT-5.6-Sol