### PR TITLE
Hydrate neutral Orrery orbit distances

### DIFF
--- a/docs/orrery_audit_dashboard_notes.md
+++ b/docs/orrery_audit_dashboard_notes.md
@@ -28,6 +28,9 @@ So the next step is not "invent explainability"; it is **connect the existing ex
 - tags from `entity_tags_current` (a `VIEW` of `entity_tags WHERE cleared_at IS NULL`)
 - locations/activities from `characters.current_location` / `current_activity` (scalars)
 - relationships/trust from `entity_relationships_v`
+- relationship `orbit_distance`, recomputed at hydration from the current
+  unversioned `character_relationships` projection after excluding inactive
+  character endpoints
 - pair tags from `entity_pair_tags WHERE cleared_at IS NULL`
 - travel states, routine anchors, faction memberships, weather (a static story-seed value) — all current, no as-of variant
 
@@ -49,7 +52,7 @@ The original caveat — "confirm rows carry a chunk-id bestowal key" — **resol
 | Recent events, world time, time-of-day, roster | Already honest |
 | Single-entity tags | Event reconstruction with gaps (bestowal-side filter works only where world time is populated; cleared/replaced rows partly unrecoverable) |
 | Pair tags | Same, worse (no clearance log exists) |
-| Relationships/trust | Impossible by schema; near-static in practice — label as unversioned |
+| Relationships/trust/orbit distance | Impossible by schema; near-static in practice — label as unversioned. Orbit distance is a derived current projection, not an independently versioned axis. |
 | Position/activity | Impossible for Skald-driven changes (no instrumentation); replayable for Orrery-driven changes via `orrery_resolutions.state_delta` |
 | Need debt | Fully replayable from `orrery_resolutions` deltas |
 | Travel state, routine anchors, faction membership, weather | No history; frozen in every mode |

--- a/docs/orrery_design_plan.md
+++ b/docs/orrery_design_plan.md
@@ -529,6 +529,21 @@ If a template package gate includes `since_last_event_at_least(...)` cooldowns, 
 
 The binding composer filters to recently-relevant entities: `(referenced in chunk_character_references in last N chunks) ∪ (has an active ephemeral tag) ∪ (has un-superseded world_events in last N chunks) ∪ (has an active routine anchor)`. Routine anchors are deliberately outside the recency window so boring off-screen citizens can still tick through work/home/needs cycles when the story camera has not looked at them recently. N is config-tunable via `[orrery.binding] window_chunks`; default is 30.
 
+### Relationship Orbit Contract
+
+`WorldState.orbit_distance` is the quality-neutral narrative relationship
+topology used by Orrery package predicates. Every hydration recomputes shortest
+hop counts from the current unversioned `character_relationships` projection,
+using only active character endpoints. The graph is undirected and unweighted:
+stored edge direction, relationship type, valence, and trust do not change its
+hops. Each active character is distance 0 from itself, direct neighbors are 1,
+transitive distance is the shortest path, and disconnected pairs are absent.
+
+This base metric does not model claim contagion, awareness, or Bleed reach.
+Future trust-, hostility-, intimacy-, or salience-aware routing must use a
+separate purpose-specific topology and predicate rather than silently changing
+the meaning of `orbit_distance`.
+
 ---
 
 ## Configuration

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -10,9 +10,10 @@ findings (NULL bestowal world times, wall-clock backfill epochs).
 Honesty: hydration at a historical anchor rewinds only recent event ids, the
 clock, the actor roster, and the need-debt accrual tail; the claims/awareness
 overlay, tags, pair tags, relationships, positions, travel, and routine anchors
-are **current projections**. Every payload carries :data:`HYDRATION_HONESTY`
-verbatim so the UI can render the per-axis label instead of implying a clean
-rewind.
+are **current projections**. Relationship orbit distance is likewise derived
+from that current relationship projection at hydration time. Every payload
+carries :data:`HYDRATION_HONESTY` verbatim so the UI can render the per-axis
+label instead of implying a clean rewind.
 
 Never-chosen branches here mean "never selected across the analyzed window."
 That is weaker than "dead behind its gate" (which needs exhaustive branch
@@ -51,6 +52,7 @@ HYDRATION_HONESTY: Mapping[str, Tuple[str, ...]] = {
         "pair_tags",
         "relationships",
         "trust",
+        "orbit_distance",
         "positions",
         "activities",
         "travel_states",

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Iterable as IterableABC
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
@@ -270,6 +271,89 @@ def _should_replace_trust_magnitude(current: Optional[int], candidate: int) -> b
     return candidate < current
 
 
+def _compute_orbit_distances(
+    active_character_ids: Iterable[int],
+    relationship_edges: Iterable[Tuple[int, int]],
+) -> dict[Tuple[int, int], int]:
+    """Return deterministic all-pairs hop counts for the active cast graph.
+
+    Relationship rows are a directed storage detail. Narrative orbit is the
+    shortest path through the same edges treated as undirected and unweighted;
+    type, valence, and duplicate reciprocal rows therefore cannot change the
+    result. Every active character has a self distance of zero, while
+    disconnected pairs are omitted.
+    """
+
+    active_ids = frozenset(int(entity_id) for entity_id in active_character_ids)
+    adjacency: dict[int, set[int]] = {entity_id: set() for entity_id in active_ids}
+    for source_id, target_id in relationship_edges:
+        source = int(source_id)
+        target = int(target_id)
+        if source not in active_ids or target not in active_ids or source == target:
+            continue
+        adjacency[source].add(target)
+        adjacency[target].add(source)
+
+    orbit_distances: dict[Tuple[int, int], int] = {}
+    for source in sorted(active_ids):
+        distances = {source: 0}
+        pending = deque([source])
+        while pending:
+            current = pending.popleft()
+            for neighbor in sorted(adjacency[current]):
+                if neighbor in distances:
+                    continue
+                distances[neighbor] = distances[current] + 1
+                pending.append(neighbor)
+        for target in sorted(distances):
+            orbit_distances[(source, target)] = distances[target]
+    return orbit_distances
+
+
+def _load_orbit_distances(session: Any) -> dict[Tuple[int, int], int]:
+    """Hydrate neutral narrative-orbit hops from the current cast graph."""
+
+    active_character_ids: set[int] = set()
+    relationship_edges: list[Tuple[int, int]] = []
+    for row in session.execute(
+        text(
+            """
+            /* orrery:orbit_distance_graph */
+            WITH active_character_entities AS (
+                SELECT id
+                FROM entities
+                WHERE kind = 'character'
+                  AND is_active = true
+            )
+            SELECT active.id AS source_entity_id,
+                   NULL::bigint AS target_entity_id
+            FROM active_character_entities active
+            UNION ALL
+            SELECT relationship.source_entity_id,
+                   relationship.target_entity_id
+            FROM entity_relationships_v relationship
+            JOIN active_character_entities source
+              ON source.id = relationship.source_entity_id
+            JOIN active_character_entities target
+              ON target.id = relationship.target_entity_id
+            WHERE relationship.relationship_scope = 'character'
+              AND relationship.source_entity_id IS NOT NULL
+              AND relationship.target_entity_id IS NOT NULL
+            ORDER BY source_entity_id, target_entity_id NULLS FIRST
+            """
+        )
+    ).mappings():
+        source = int(row["source_entity_id"])
+        active_character_ids.add(source)
+        target = row.get("target_entity_id")
+        if target is not None:
+            target_id = int(target)
+            active_character_ids.add(target_id)
+            relationship_edges.append((source, target_id))
+
+    return _compute_orbit_distances(active_character_ids, relationship_edges)
+
+
 def hydrate_world_state(
     session: Any,
     *,
@@ -480,6 +564,7 @@ def hydrate_world_state(
         anchor_chunk_id=anchor_chunk_id,
         win_history_window=win_history_window,
     )
+    orbit_distance = _load_orbit_distances(session)
 
     return WorldState(
         tags={entity_id: frozenset(values) for entity_id, values in tags.items()},
@@ -489,8 +574,7 @@ def hydrate_world_state(
         locations=locations,
         activities=activities,
         trust=trust,
-        # TODO: Hydrate orbit_distance when the resolver has an authoritative
-        # source. Relationship trust is hydrated from entity_relationships_v.
+        orbit_distance=orbit_distance,
         relationship_types={
             key: frozenset(values) for key, values in relationship_types.items()
         },

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -345,6 +345,9 @@ class WorldState:
     location_classes: Mapping[int, frozenset[str]] = field(default_factory=dict)
     location_entity_ids: Mapping[int, int] = field(default_factory=dict)
     location_zones: Mapping[int, int] = field(default_factory=dict)
+    # Neutral narrative proximity: shortest unweighted hop count through the
+    # current active-character relationship graph, treated as undirected.
+    # Quality- or direction-sensitive routing belongs in separate projections.
     orbit_distance: Mapping[Tuple[int, int], int] = field(default_factory=dict)
     need_debt_scores: Mapping[Tuple[int, str], float] = field(default_factory=dict)
     travel_states: Mapping[int, TravelState] = field(default_factory=dict)
@@ -1769,7 +1772,11 @@ def relative_orbit_distance(
     slot_from: Slot = Slot.ACTOR,
     slot_to: Slot = Slot.TARGET,
 ) -> Condition:
-    """Return whether two entities are within an abstract social orbit distance."""
+    """Return whether two entities are within the neutral narrative orbit.
+
+    The hydrated distance is an undirected, unweighted relationship-graph hop
+    count. Relationship quality and direction do not affect this base metric.
+    """
 
     def _condition(state: WorldState, bindings: Bindings) -> bool:
         source = _slot_entity(bindings, slot_from)

--- a/tests/test_orrery/test_orbit_distance_live.py
+++ b/tests/test_orrery/test_orbit_distance_live.py
@@ -1,0 +1,201 @@
+"""Live PostgreSQL coverage for neutral narrative-orbit hydration.
+
+Activated by ``NEXUS_RUN_POSTGRES=1``. The fixture graph is created inside an
+external SQLAlchemy transaction and always rolled back, so no narrative state
+persists in the target slot.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+from nexus.agents.orrery.resolver import hydrate_world_state
+from nexus.api.slot_utils import get_slot_db_url
+
+
+pytestmark = pytest.mark.requires_postgres
+
+LIVE_SLOT = 5
+
+
+def _insert_entity(session: Session, *, active: bool) -> int:
+    return int(
+        session.execute(
+            text(
+                """
+                INSERT INTO entities (kind, is_active)
+                VALUES ('character', :active)
+                RETURNING id
+                """
+            ),
+            {"active": active},
+        ).scalar_one()
+    )
+
+
+def _insert_character(
+    session: Session,
+    *,
+    entity_id: int,
+    label: str,
+    token: str,
+) -> int:
+    return int(
+        session.execute(
+            text(
+                """
+                INSERT INTO characters (name, entity_id)
+                VALUES (:name, :entity_id)
+                RETURNING id
+                """
+            ),
+            {"name": f"orbit-live-{token}-{label}", "entity_id": entity_id},
+        ).scalar_one()
+    )
+
+
+def _insert_relationship(
+    session: Session,
+    *,
+    source_character_id: int,
+    target_character_id: int,
+    relationship_type: str,
+    emotional_valence: str,
+) -> None:
+    session.execute(
+        text(
+            """
+            INSERT INTO character_relationships (
+                character1_id,
+                character2_id,
+                relationship_type,
+                emotional_valence,
+                dynamic,
+                recent_events,
+                history
+            ) VALUES (
+                :source_character_id,
+                :target_character_id,
+                :relationship_type,
+                :emotional_valence,
+                'Rollback-only orbit-distance fixture.',
+                'No persistent events.',
+                'Created solely for PostgreSQL integration coverage.'
+            )
+            """
+        ),
+        {
+            "source_character_id": source_character_id,
+            "target_character_id": target_character_id,
+            "relationship_type": relationship_type,
+            "emotional_valence": emotional_valence,
+        },
+    )
+
+
+def test_hydrate_orbit_distance_from_active_relationship_graph() -> None:
+    """Hydration treats current active-character relationships as neutral hops."""
+
+    engine = create_engine(get_slot_db_url(slot=LIVE_SLOT), future=True)
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+    try:
+        token = uuid4().hex[:12]
+        entity_ids = {
+            label: _insert_entity(session, active=label != "inactive_bridge")
+            for label in ("a", "b", "c", "d", "bare", "inactive_bridge")
+        }
+        character_ids = {
+            label: _insert_character(
+                session,
+                entity_id=entity_ids[label],
+                label=label,
+                token=token,
+            )
+            for label in ("a", "b", "c", "d", "inactive_bridge")
+        }
+
+        # A -> B is maximally friendly. C -> B deliberately stores the second
+        # edge in the reverse direction and with maximally hostile valence.
+        # Both must still be one neutral, undirected hop.
+        _insert_relationship(
+            session,
+            source_character_id=character_ids["a"],
+            target_character_id=character_ids["b"],
+            relationship_type="friend",
+            emotional_valence="+5|devoted",
+        )
+        _insert_relationship(
+            session,
+            source_character_id=character_ids["c"],
+            target_character_id=character_ids["b"],
+            relationship_type="enemy",
+            emotional_valence="-5|hateful",
+        )
+
+        # This apparent A-to-D route exists only through an inactive entity,
+        # so neither edge may enter the active narrative-orbit graph.
+        _insert_relationship(
+            session,
+            source_character_id=character_ids["a"],
+            target_character_id=character_ids["inactive_bridge"],
+            relationship_type="friend",
+            emotional_valence="+5|devoted",
+        )
+        _insert_relationship(
+            session,
+            source_character_id=character_ids["inactive_bridge"],
+            target_character_id=character_ids["d"],
+            relationship_type="enemy",
+            emotional_valence="-5|hateful",
+        )
+
+        state = hydrate_world_state(
+            session,
+            anchor_chunk_id=None,
+            window_chunks=0,
+            world_time_override=datetime(2073, 8, 1, tzinfo=timezone.utc),
+            epistemics_settings={"enabled": False},
+        )
+
+        a = entity_ids["a"]
+        b = entity_ids["b"]
+        c = entity_ids["c"]
+        d = entity_ids["d"]
+        bare = entity_ids["bare"]
+        inactive_bridge = entity_ids["inactive_bridge"]
+        fixture_entities = frozenset(entity_ids.values())
+        observed = {
+            pair: distance
+            for pair, distance in state.orbit_distance.items()
+            if pair[0] in fixture_entities or pair[1] in fixture_entities
+        }
+
+        assert observed == {
+            (a, a): 0,
+            (a, b): 1,
+            (a, c): 2,
+            (b, a): 1,
+            (b, b): 0,
+            (b, c): 1,
+            (c, a): 2,
+            (c, b): 1,
+            (c, c): 0,
+            (d, d): 0,
+            (bare, bare): 0,
+        }
+        assert (a, d) not in state.orbit_distance
+        assert (d, a) not in state.orbit_distance
+        assert not any(inactive_bridge in pair for pair in state.orbit_distance)
+    finally:
+        session.close()
+        if transaction.is_active:
+            transaction.rollback()
+        connection.close()
+        engine.dispose()

--- a/tests/test_orrery/test_orbit_distance_parity.py
+++ b/tests/test_orrery/test_orbit_distance_parity.py
@@ -1,0 +1,113 @@
+"""Production/audit parity for hydrated Orrery social-orbit distances."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.agents.orrery.audit import explain_dry_run
+from nexus.agents.orrery.resolver import resolve_dry_run
+from nexus.agents.orrery.substrate import (
+    ALWAYS,
+    Branch,
+    DriveBand,
+    Slot,
+    Template,
+    relative_orbit_distance,
+)
+from tests.test_orrery.test_resolver import FakeSession
+
+
+ACTOR = 1
+INTERMEDIARY = 2
+TARGET = 3
+
+
+def _orbit_session() -> FakeSession:
+    """Return A--B--C in the orbit graph with a directed A->C binding."""
+
+    return FakeSession(
+        chunk_ref_actor_rows=[{"entity_id": ACTOR}],
+        actor_target_social_contact_rows=[
+            {"source_entity_id": ACTOR, "target_entity_id": TARGET},
+        ],
+        orbit_rows=[
+            {"source_entity_id": ACTOR, "target_entity_id": None},
+            {"source_entity_id": INTERMEDIARY, "target_entity_id": None},
+            {"source_entity_id": TARGET, "target_entity_id": None},
+            {"source_entity_id": ACTOR, "target_entity_id": INTERMEDIARY},
+            {"source_entity_id": INTERMEDIARY, "target_entity_id": TARGET},
+        ],
+    )
+
+
+def _orbit_template(max_distance: int) -> Template:
+    """Build one two-party package gated solely by social-orbit distance."""
+
+    return Template(
+        id=f"orbit_distance_at_most_{max_distance}",
+        priority=10,
+        drive_band=DriveBand.PROJECT_IDENTITY,
+        blurb="Exercise hydrated social-orbit distance.",
+        required_slots=(Slot.ACTOR, Slot.TARGET),
+        package_gate=relative_orbit_distance(max_distance),
+        branches=(
+            Branch(
+                label="Reach across the social orbit",
+                conditions=ALWAYS,
+                narrative_stub="{actor} reaches across the orbit to {target}.",
+            ),
+        ),
+        starts_from_social_contact=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("max_distance", "expected_to_fire"),
+    [(2, True), (1, False)],
+)
+def test_hydrated_orbit_distance_keeps_production_audit_and_evidence_in_parity(
+    max_distance: int,
+    expected_to_fire: bool,
+) -> None:
+    """A--B--C is distance two in both resolver paths and gate evidence."""
+
+    template = _orbit_template(max_distance)
+    proposal = resolve_dry_run(
+        _orbit_session(),
+        [template],
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+    report = explain_dry_run(
+        _orbit_session(),
+        [template],
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    production_fired = any(
+        resolution.template_id == template.id for resolution in proposal.resolutions
+    )
+    assert production_fired is expected_to_fire
+
+    assert report.actor_count == 1
+    actor = report.actors[0]
+    assert actor.actor_entity_id == ACTOR
+    assert len(actor.two_party_stacks) == 1
+    stack = actor.two_party_stacks[0]
+    assert stack.bindings == {"actor": ACTOR, "target": TARGET}
+
+    audit_fired = stack.winner_id == template.id
+    assert audit_fired is production_fired
+    explanation = stack.templates[0]
+    assert explanation.template_id == template.id
+    assert explanation.fired is expected_to_fire
+    assert explanation.gate_trace.result is expected_to_fire
+
+    evidence = explanation.gate_trace.evidence
+    assert evidence is not None
+    assert evidence["kind"] == "relative_orbit_distance"
+    assert evidence["params"]["max_distance"] == max_distance
+    assert evidence["entities"] == {"actor": ACTOR, "target": TARGET}
+    assert evidence["observed"] == {"orbit_distance": 2}
+    assert evidence["result"] is expected_to_fire

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -9,6 +9,7 @@ from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
 from nexus.agents.orrery.resolver import (
     LOCATION_CLASS_TAG_CATEGORIES,
     OrreryResolutionDraft,
+    _compute_orbit_distances,
     _need_pressure_stub,
     compose_actor_target_bindings,
     compose_actor_target_routes,
@@ -63,6 +64,7 @@ class FakeSession:
         location_class_rows=None,
         activity_rows=None,
         relationship_rows=None,
+        orbit_rows=None,
         pair_tag_rows=None,
         faction_rows=None,
         event_rows=None,
@@ -93,6 +95,7 @@ class FakeSession:
             {"entity_id": 1, "current_activity": "idle"}
         ]
         self.relationship_rows = relationship_rows or []
+        self.orbit_rows = orbit_rows or []
         self.pair_tag_rows = pair_tag_rows or []
         self.faction_rows = faction_rows or []
         self.event_rows = event_rows or []
@@ -150,6 +153,14 @@ class FakeSession:
         if "/* orrery:relationship_types */" in sql:
             assert "valence_magnitude" in sql
             return FakeResult(self.relationship_rows)
+        if "/* orrery:orbit_distance_graph */" in sql:
+            assert "FROM entities" in sql
+            assert "kind = 'character'" in sql
+            assert "is_active = true" in sql
+            assert "relationship.relationship_scope = 'character'" in sql
+            assert "relationship_type" not in sql
+            assert "valence_magnitude" not in sql
+            return FakeResult(self.orbit_rows)
         if "/* orrery:pair_tags */" in sql:
             assert "ept.cleared_at IS NULL" in sql
             assert "NOT pt.deprecated" in sql
@@ -1153,6 +1164,78 @@ def test_hydrate_world_state_uses_stable_trust_magnitude_for_duplicate_pairs() -
     assert state.trust[(2, 1)] == -3
     assert state.relationship_types[(1, 2)] == frozenset({"comrade", "enemy"})
     assert state.relationship_types[(2, 1)] == frozenset({"ally", "rival"})
+
+
+def test_compute_orbit_distances_is_symmetric_deterministic_and_active_only() -> None:
+    """Narrative orbit ignores storage direction, duplicates, and inactive hops."""
+
+    expected = {
+        (1, 1): 0,
+        (1, 2): 1,
+        (1, 3): 2,
+        (2, 1): 1,
+        (2, 2): 0,
+        (2, 3): 1,
+        (3, 1): 2,
+        (3, 2): 1,
+        (3, 3): 0,
+        (4, 4): 0,
+    }
+
+    assert (
+        _compute_orbit_distances(
+            {1, 2, 3, 4},
+            [(1, 2), (3, 2), (2, 1), (1, 99), (99, 4)],
+        )
+        == expected
+    )
+    assert (
+        _compute_orbit_distances(
+            [4, 3, 2, 1],
+            [(99, 4), (1, 99), (2, 1), (3, 2), (1, 2)],
+        )
+        == expected
+    )
+
+
+def test_hydrate_world_state_populates_quality_neutral_orbit_distance() -> None:
+    """Hydration keeps directed trust while deriving neutral relationship hops."""
+
+    state = hydrate_world_state(
+        FakeSession(
+            relationship_rows=[
+                {
+                    "source_entity_id": 1,
+                    "target_entity_id": 2,
+                    "relationship_type": "enemy",
+                    "valence_magnitude": -5,
+                },
+                {
+                    "source_entity_id": 3,
+                    "target_entity_id": 2,
+                    "relationship_type": "friend",
+                    "valence_magnitude": 4,
+                },
+            ],
+            orbit_rows=[
+                {"source_entity_id": 1, "target_entity_id": None},
+                {"source_entity_id": 2, "target_entity_id": None},
+                {"source_entity_id": 3, "target_entity_id": None},
+                {"source_entity_id": 4, "target_entity_id": None},
+                {"source_entity_id": 1, "target_entity_id": 2},
+                {"source_entity_id": 3, "target_entity_id": 2},
+            ],
+        ),
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert state.trust == {(1, 2): -5, (3, 2): 4}
+    assert state.orbit_distance[(1, 3)] == 2
+    assert state.orbit_distance[(3, 1)] == 2
+    assert state.orbit_distance[(4, 4)] == 0
+    assert (1, 4) not in state.orbit_distance
+    assert (4, 1) not in state.orbit_distance
 
 
 def test_hydrate_world_state_loads_pair_tags() -> None:


### PR DESCRIPTION
## Summary

- derive deterministic all-pairs shortest hops from the current active-character relationship graph
- keep base `orbit_distance` undirected, unweighted, and independent of relationship direction, type, valence, or trust
- document current-projection honesty and reserve quality-aware routing for separate future topologies
- cover helper semantics, hydration, production/audit evidence parity, and rollback-only PostgreSQL behavior

Implements Stage 1 of #477. Social Contagion and proximity-ranked Bleed remain open for later stages.

## Validation

- `PYTHONPATH=. poetry run pytest -q` — 1,364 passed, 235 skipped
- `PYTHONPATH=. NEXUS_RUN_POSTGRES=1 poetry run pytest -q` — 1,558 passed, 41 skipped
- `PYTHONPATH=. poetry run black --check ...` — passed
- `PYTHONPATH=. poetry run flake8 ...` — passed
- targeted mypy matches `main`: three existing `PackageSelection | None` errors; no new errors
- two independent Codex reviews — no findings

## Data impact

No schema migration, configuration change, or persistent fixture data. Orbit distances are recomputed during WorldState hydration.

Codex — GPT-5.6-Sol