### PR TITLE
Assemble the Communication Graph with Per-Institution Culture (#477 Stage 2b)

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -253,6 +253,38 @@ enabled = true
 [orrery.binding]
 window_chunks = 30
 
+[orrery.contagion]
+enabled = true
+
+[orrery.contagion.dyad_tiers]
+trusting = "24h"
+neutral = "96h"
+hostile = "never"
+
+[orrery.contagion.dyad_overrides]
+handler = { forward = "12h", reverse = "12h" }
+captor = { forward = "never", reverse = "24h" }
+
+[orrery.contagion.channels]
+handles = { direction = "both", latency = "12h" }
+obligation = { direction = "object_to_subject", latency = "48h" }
+authority_over = { direction = "subject_to_object", latency = "24h" }
+mentors = { direction = "both", latency = "24h" }
+"contact:social" = { direction = "both", latency = "72h" }
+"status:*" = { direction = "faction_to_member", latency = "48h", min_level = "junior" }
+
+[orrery.contagion.culture_profiles]
+cellular_clandestine = 4.0
+compartmented = 2.0
+covert = 2.0
+hybrid = 1.0
+overt = 0.5
+
+[orrery.contagion.guards]
+depth_cap = 4
+age_horizon = "14d"
+fan_out_cap = 6
+
 [orrery.selection]
 # Branch selection inside a fired package: "stochastic" softmax-samples all
 # passing branches by magnitude (PRNG seeded on per-resolution persisted

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -664,6 +664,7 @@ class TurnCycleManager:
                 project_settings=orrery_settings.get("projects"),
                 epistemics_settings=orrery_settings.get("epistemics"),
                 fanout_settings=orrery_settings.get("fanout"),
+                contagion_settings=orrery_settings.get("contagion"),
             )
 
         turn_context.orrery_proposal = proposal

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -38,7 +38,7 @@ from sqlalchemy import text
 
 from nexus.agents.orrery.communication import (
     CommunicationGraph,
-    assemble_communication_graph,
+    communication_graph_for_settings,
 )
 from nexus.agents.orrery.epistemics import (
     coerce_epistemics_policy,
@@ -1131,14 +1131,8 @@ def entity_context(
 
     need_tuning = coerce_need_tuning(sunhelm_settings)
     world_time = _load_world_time(session, anchor_chunk_id=anchor_chunk_id)
-    communication_graph = (
-        assemble_communication_graph(
-            session,
-            settings=contagion_settings,
-            world_time=world_time,
-        )
-        if contagion_settings is not None
-        else CommunicationGraph()
+    communication_graph = communication_graph_for_settings(
+        session, contagion_settings, world_time=world_time
     )
 
     kinds = {

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -36,6 +36,10 @@ from typing import Any, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from sqlalchemy import text
 
+from nexus.agents.orrery.communication import (
+    CommunicationGraph,
+    assemble_communication_graph,
+)
 from nexus.agents.orrery.epistemics import (
     coerce_epistemics_policy,
     load_epistemics_policy,
@@ -142,6 +146,7 @@ class ExplainedTickReport:
     locations: Mapping[int, Any]
     location_names: Mapping[int, str]
     activities: Mapping[int, str]
+    communication_graph: CommunicationGraph
     joint_beats: Tuple[OrreryJointBeat, ...] = ()
     fanout_trimmed: Tuple[Mapping[str, Any], ...] = ()
     mode: str = "current"
@@ -199,6 +204,9 @@ class ExplainedTickReport:
             "actor_name": _entity_label(actor_id, self.entity_names),
             "location": location,
             "activity": self.activities.get(actor_id),
+            "communication_edges": [
+                edge.to_dict() for edge in self.communication_graph.outbound(actor_id)
+            ],
             "actor_stack": self._stack_payload(
                 group.actor_stack, group.actor_stack_diff
             ),
@@ -497,6 +505,7 @@ def explain_dry_run(
     project_settings: Optional[Any] = None,
     epistemics_settings: Optional[Any] = None,
     fanout_settings: Optional[Any] = None,
+    contagion_settings: Optional[Any] = None,
 ) -> ExplainedTickReport:
     """Hydrate, bind, and explain Orrery packages without database writes.
 
@@ -530,6 +539,7 @@ def explain_dry_run(
         win_history_window=habituation.window_ticks if habituation.enabled else 0,
         project_settings=project_settings,
         epistemics_settings=epistemics_policy,
+        contagion_settings=contagion_settings,
     )
 
     templates_list = list(configure_project_magnitudes(templates, project_policy))
@@ -859,6 +869,7 @@ def explain_dry_run(
         locations=dict(active_state.locations),
         location_names=location_names,
         activities=dict(active_state.activities),
+        communication_graph=active_state.communication_graph,
         joint_beats=joint_beats,
         fanout_trimmed=fanout_trimmed,
         mode="what_if" if what_if else "current",
@@ -1104,6 +1115,7 @@ def entity_context(
     anchor_chunk_id: Optional[int],
     recent_events_limit: int = 5,
     sunhelm_settings: Optional[Any] = None,
+    contagion_settings: Optional[Any] = None,
 ) -> dict[str, Any]:
     """Return the hover-audit payload for a set of entity ids.
 
@@ -1119,6 +1131,15 @@ def entity_context(
 
     need_tuning = coerce_need_tuning(sunhelm_settings)
     world_time = _load_world_time(session, anchor_chunk_id=anchor_chunk_id)
+    communication_graph = (
+        assemble_communication_graph(
+            session,
+            settings=contagion_settings,
+            world_time=world_time,
+        )
+        if contagion_settings is not None
+        else CommunicationGraph()
+    )
 
     kinds = {
         row["id"]: row["kind"]
@@ -1440,6 +1461,9 @@ def entity_context(
                 },
                 "pair_tags": _named(pair_tags_by_entity.get(entity_id, [])),
                 "relationships": _named(relationships_by_entity.get(entity_id, [])),
+                "communication_edges": [
+                    edge.to_dict() for edge in communication_graph.outbound(entity_id)
+                ],
                 "travel_state": asdict(travel) if travel is not None else None,
                 "routine_anchors": anchors,
                 "recent_events": events_by_entity.get(entity_id, []),

--- a/nexus/agents/orrery/communication.py
+++ b/nexus/agents/orrery/communication.py
@@ -1,0 +1,394 @@
+"""Deterministic read-side communication graph assembly for Orrery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import re
+from typing import Any, Iterable, Literal, Mapping, Optional, Sequence, Tuple
+
+from sqlalchemy import text
+
+from nexus.agents.orrery.status_family import (
+    STATUS_TAGS,
+    level_from_status_tag,
+    status_at_or_above_level,
+)
+from nexus.config.settings_models import OrreryContagionSettings
+
+
+CommunicationEdgeKind = Literal["dyad", "channel"]
+_VALENCE_RE = re.compile(r"^(?P<magnitude>[+-]?\d+)\|[^|]+$")
+_CULTURE_CATEGORIES = frozenset({"operational_secrecy", "operational_mode"})
+
+
+@dataclass(frozen=True, slots=True)
+class CommunicationEdge:
+    """One directed, deterministic communication conduit."""
+
+    teller_entity_id: int
+    listener_entity_id: int
+    latency: timedelta
+    kind: CommunicationEdgeKind
+    label: str
+    institution_entity_id: Optional[int] = None
+    culture_multiplier: Optional[float] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe audit representation of this edge."""
+
+        payload: dict[str, Any] = {
+            "teller_entity_id": self.teller_entity_id,
+            "listener_entity_id": self.listener_entity_id,
+            "latency_seconds": self.latency.total_seconds(),
+            "kind": self.kind,
+            "label": self.label,
+        }
+        if self.kind == "channel":
+            payload["institution_entity_id"] = self.institution_entity_id
+            payload["culture_multiplier"] = self.culture_multiplier
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class CommunicationGraph:
+    """Immutable, stably ordered directed communication edges."""
+
+    edges: Tuple[CommunicationEdge, ...] = ()
+
+    def outbound(self, entity_id: int) -> Tuple[CommunicationEdge, ...]:
+        """Return one entity's outbound edges in graph order."""
+
+        return tuple(edge for edge in self.edges if edge.teller_entity_id == entity_id)
+
+    def to_dict(self, *, entity_id: Optional[int] = None) -> dict[str, Any]:
+        """Return all edges, or one entity's outbound explain view."""
+
+        edges = self.edges if entity_id is None else self.outbound(entity_id)
+        return {"edges": [edge.to_dict() for edge in edges]}
+
+
+def coerce_contagion_settings(settings: Any) -> OrreryContagionSettings:
+    """Normalize a Pydantic model or mapping into contagion settings."""
+
+    if isinstance(settings, OrreryContagionSettings):
+        return settings
+    if hasattr(settings, "model_dump"):
+        settings = settings.model_dump()
+    if isinstance(settings, Mapping):
+        return OrreryContagionSettings.model_validate(dict(settings))
+    raise TypeError("contagion settings must be OrreryContagionSettings or a mapping")
+
+
+def _fetch_mappings(session_or_cur: Any, sql: str) -> list[dict[str, Any]]:
+    """Execute parameterless read SQL through SQLAlchemy or a DB-API cursor."""
+
+    if type(session_or_cur).__module__.startswith("sqlalchemy"):
+        result = session_or_cur.execute(text(sql))
+        return [dict(row) for row in result.mappings()]
+
+    result = session_or_cur.execute(sql)
+    if result is not None and hasattr(result, "mappings"):
+        return [dict(row) for row in result.mappings()]
+    description = getattr(session_or_cur, "description", None)
+    if description is None:
+        raise TypeError(
+            "session_or_cur must be a SQLAlchemy session/connection or DB-API cursor"
+        )
+    column_names = [column[0] for column in description]
+    return [
+        dict(zip(column_names, row, strict=True)) for row in session_or_cur.fetchall()
+    ]
+
+
+def _valence_tier(emotional_valence: Any) -> Literal["trusting", "neutral", "hostile"]:
+    """Parse the canonical signed numeric valence prefix, or fail loudly."""
+
+    if not isinstance(emotional_valence, str):
+        raise ValueError(
+            f"Unparseable emotional_valence {emotional_valence!r}; expected "
+            "'<signed integer>|<label>'"
+        )
+    match = _VALENCE_RE.fullmatch(emotional_valence.strip())
+    if match is None:
+        raise ValueError(
+            f"Unparseable emotional_valence {emotional_valence!r}; expected "
+            "'<signed integer>|<label>'"
+        )
+    magnitude = int(match.group("magnitude"))
+    if magnitude > 0:
+        return "trusting"
+    if magnitude < 0:
+        return "hostile"
+    return "neutral"
+
+
+def _edge_sort_key(edge: CommunicationEdge) -> tuple[Any, ...]:
+    return (
+        edge.teller_entity_id,
+        edge.listener_entity_id,
+        edge.kind,
+        edge.label,
+        edge.institution_entity_id if edge.institution_entity_id is not None else -1,
+        edge.latency,
+        edge.culture_multiplier if edge.culture_multiplier is not None else 0.0,
+    )
+
+
+def _registered_channel_tags(session_or_cur: Any) -> frozenset[str]:
+    rows = _fetch_mappings(
+        session_or_cur,
+        """
+        /* orrery:communication_registered_pair_tags */
+        SELECT tag
+        FROM pair_tags
+        WHERE NOT deprecated
+        ORDER BY tag
+        """,
+    )
+    return frozenset(str(row["tag"]) for row in rows)
+
+
+def _validate_channel_registry(
+    configured_tags: Iterable[str], registered_tags: frozenset[str]
+) -> None:
+    configured = frozenset(configured_tags)
+    exact_tags = configured - {"status:*"}
+    missing = sorted(exact_tags - registered_tags)
+    if "status:*" in configured:
+        missing_status_tags = sorted(STATUS_TAGS - registered_tags)
+        if missing_status_tags:
+            missing.append("status:* (missing " + ", ".join(missing_status_tags) + ")")
+    if missing:
+        raise ValueError(
+            "orrery.contagion config references unregistered channel tags: "
+            f"{missing}"
+        )
+
+
+def _dyad_edges(
+    session_or_cur: Any, settings: OrreryContagionSettings
+) -> list[CommunicationEdge]:
+    rows = _fetch_mappings(
+        session_or_cur,
+        """
+        /* orrery:communication_dyads */
+        SELECT c1.entity_id AS teller_entity_id,
+               c2.entity_id AS listener_entity_id,
+               cr.relationship_type::text AS relationship_type,
+               cr.emotional_valence::text AS emotional_valence
+        FROM character_relationships cr
+        JOIN characters c1 ON c1.id = cr.character1_id
+        JOIN characters c2 ON c2.id = cr.character2_id
+        JOIN entities teller ON teller.id = c1.entity_id
+        JOIN entities listener ON listener.id = c2.entity_id
+        WHERE teller.kind = 'character'
+          AND listener.kind = 'character'
+          AND teller.is_active = true
+          AND listener.is_active = true
+        ORDER BY c1.entity_id, c2.entity_id, cr.relationship_type::text
+        """,
+    )
+    row_keys = {
+        (
+            int(row["teller_entity_id"]),
+            int(row["listener_entity_id"]),
+            str(row["relationship_type"]),
+        )
+        for row in rows
+    }
+    edges: list[CommunicationEdge] = []
+    for row in rows:
+        teller = int(row["teller_entity_id"])
+        listener = int(row["listener_entity_id"])
+        relationship_type = str(row["relationship_type"])
+        tier = _valence_tier(row["emotional_valence"])
+        override = settings.dyad_overrides.get(relationship_type)
+        if override is None:
+            latency = getattr(settings.dyad_tiers, tier)
+        else:
+            matching_reverse = (listener, teller, relationship_type) in row_keys
+            # character_relationships has no row id or role-orientation column.
+            # For a same-type reciprocal pair, entity-id order supplies the
+            # frozen stable orientation: low->high is forward, high->low is
+            # the matching reverse row. A sparse row is always its own forward.
+            is_reverse = matching_reverse and teller > listener
+            latency = override.reverse if is_reverse else override.forward
+        if latency is None:
+            continue
+        if teller == listener:
+            raise ValueError("communication dyad produced a forbidden self-loop")
+        edges.append(
+            CommunicationEdge(
+                teller_entity_id=teller,
+                listener_entity_id=listener,
+                latency=latency,
+                kind="dyad",
+                label=relationship_type,
+            )
+        )
+    return edges
+
+
+def _channel_rows(session_or_cur: Any) -> list[dict[str, Any]]:
+    return _fetch_mappings(
+        session_or_cur,
+        """
+        /* orrery:communication_channels */
+        SELECT ept.subject_entity_id,
+               subject.kind::text AS subject_kind,
+               ept.object_entity_id,
+               object.kind::text AS object_kind,
+               pt.tag
+        FROM entity_pair_tags ept
+        JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+        JOIN entities subject ON subject.id = ept.subject_entity_id
+        JOIN entities object ON object.id = ept.object_entity_id
+        WHERE ept.cleared_at IS NULL
+          AND NOT pt.deprecated
+          AND subject.is_active = true
+          AND object.is_active = true
+        ORDER BY ept.subject_entity_id, ept.object_entity_id, pt.tag
+        """,
+    )
+
+
+def _culture_tags_by_institution(session_or_cur: Any) -> dict[int, Tuple[str, ...]]:
+    rows = _fetch_mappings(
+        session_or_cur,
+        """
+        /* orrery:communication_culture_tags */
+        SELECT etc.entity_id, etc.category, etc.tag
+        FROM entity_tags_current etc
+        JOIN entities institution ON institution.id = etc.entity_id
+        WHERE institution.kind = 'faction'
+          AND institution.is_active = true
+          AND etc.category IN ('operational_secrecy', 'operational_mode')
+        ORDER BY etc.entity_id, etc.category, etc.tag
+        """,
+    )
+    tags: dict[int, list[str]] = {}
+    for row in rows:
+        category = str(row["category"])
+        if category not in _CULTURE_CATEGORIES:
+            continue
+        tags.setdefault(int(row["entity_id"]), []).append(str(row["tag"]))
+    return {entity_id: tuple(values) for entity_id, values in tags.items()}
+
+
+def _institution_for_channel(
+    row: Mapping[str, Any], *, teller_entity_id: int
+) -> Optional[int]:
+    if (
+        row["subject_kind"] == "faction"
+        and int(row["subject_entity_id"]) == teller_entity_id
+    ):
+        return int(row["subject_entity_id"])
+    if (
+        row["object_kind"] == "faction"
+        and int(row["object_entity_id"]) == teller_entity_id
+    ):
+        return int(row["object_entity_id"])
+    if row["subject_kind"] == "faction":
+        return int(row["subject_entity_id"])
+    if row["object_kind"] == "faction":
+        return int(row["object_entity_id"])
+    return None
+
+
+def _culture_multiplier(
+    institution_entity_id: Optional[int],
+    culture_tags: Mapping[int, Sequence[str]],
+    profiles: Mapping[str, float],
+) -> float:
+    multiplier = 1.0
+    if institution_entity_id is None:
+        return multiplier
+    for tag in culture_tags.get(institution_entity_id, ()):
+        configured = profiles.get(tag)
+        if configured is not None:
+            multiplier *= configured
+    return multiplier
+
+
+def _channel_directions(
+    row: Mapping[str, Any], direction: str, min_level: Optional[str]
+) -> Tuple[tuple[int, int], ...]:
+    subject = int(row["subject_entity_id"])
+    object_ = int(row["object_entity_id"])
+    if direction == "both":
+        return ((subject, object_), (object_, subject))
+    if direction == "subject_to_object":
+        return ((subject, object_),)
+    if direction == "object_to_subject":
+        return ((object_, subject),)
+    if direction != "faction_to_member":
+        raise ValueError(f"Unknown channel direction {direction!r}")
+    if row["subject_kind"] != "character" or row["object_kind"] != "faction":
+        return ()
+    if min_level is None:
+        raise ValueError("faction_to_member channel requires min_level")
+    level = level_from_status_tag(str(row["tag"]))
+    if not status_at_or_above_level(level, min_level):
+        return ()
+    return ((object_, subject),)
+
+
+def _channel_edges(
+    session_or_cur: Any, settings: OrreryContagionSettings
+) -> list[CommunicationEdge]:
+    registered_tags = _registered_channel_tags(session_or_cur)
+    _validate_channel_registry(settings.channels, registered_tags)
+    culture_tags = _culture_tags_by_institution(session_or_cur)
+    edges: list[CommunicationEdge] = []
+    for row in _channel_rows(session_or_cur):
+        tag = str(row["tag"])
+        channel_key = "status:*" if tag.startswith("status:") else tag
+        channel = settings.channels.get(channel_key)
+        if channel is None or channel.latency is None:
+            continue
+        for teller, listener in _channel_directions(
+            row, channel.direction, channel.min_level
+        ):
+            if teller == listener:
+                raise ValueError("communication channel produced a forbidden self-loop")
+            institution = _institution_for_channel(row, teller_entity_id=teller)
+            multiplier = _culture_multiplier(
+                institution,
+                culture_tags,
+                settings.culture_profiles,
+            )
+            edges.append(
+                CommunicationEdge(
+                    teller_entity_id=teller,
+                    listener_entity_id=listener,
+                    latency=channel.latency * multiplier,
+                    kind="channel",
+                    label=tag,
+                    institution_entity_id=institution,
+                    culture_multiplier=multiplier,
+                )
+            )
+    return edges
+
+
+def assemble_communication_graph(
+    session_or_cur: Any,
+    *,
+    settings: Any,
+    world_time: Optional[datetime],
+) -> CommunicationGraph:
+    """Assemble the immutable communication graph without database writes.
+
+    ``world_time`` is accepted now so Stage 2c can consume the same assembly
+    boundary for world-clock frontier calculations. Stage 2b performs no age
+    or scope gating, so the value cannot alter the graph yet.
+    """
+
+    del world_time
+    config = coerce_contagion_settings(settings)
+    if not config.enabled:
+        return CommunicationGraph()
+    edges = _dyad_edges(session_or_cur, config)
+    edges.extend(_channel_edges(session_or_cur, config))
+    return CommunicationGraph(edges=tuple(sorted(edges, key=_edge_sort_key)))

--- a/nexus/agents/orrery/communication.py
+++ b/nexus/agents/orrery/communication.py
@@ -324,8 +324,16 @@ def _channel_directions(
         return ((object_, subject),)
     if direction != "faction_to_member":
         raise ValueError(f"Unknown channel direction {direction!r}")
-    if row["subject_kind"] != "character" or row["object_kind"] != "faction":
-        return ()
+    if row["subject_kind"] not in ("character", "faction"):
+        raise ValueError(
+            f"status pair tag {row['tag']!r} has subject kind "
+            f"{row['subject_kind']!r}; the registry allows character or faction"
+        )
+    if row["object_kind"] != "faction":
+        raise ValueError(
+            f"status pair tag {row['tag']!r} has object kind "
+            f"{row['object_kind']!r}; the scope must be a faction"
+        )
     if min_level is None:
         raise ValueError("faction_to_member channel requires min_level")
     level = level_from_status_tag(str(row["tag"]))

--- a/nexus/agents/orrery/communication.py
+++ b/nexus/agents/orrery/communication.py
@@ -397,6 +397,59 @@ def assemble_communication_graph(
     config = coerce_contagion_settings(settings)
     if not config.enabled:
         return CommunicationGraph()
+    _validate_dyad_overrides(session_or_cur, config.dyad_overrides)
     edges = _dyad_edges(session_or_cur, config)
     edges.extend(_channel_edges(session_or_cur, config))
     return CommunicationGraph(edges=tuple(sorted(edges, key=_edge_sort_key)))
+
+
+def communication_graph_for_settings(
+    session_or_cur: Any,
+    settings: Any,
+    *,
+    world_time: Optional[datetime] = None,
+) -> CommunicationGraph:
+    """Assemble the graph, or return an empty one when settings are absent.
+
+    The single home for the "no contagion settings -> empty graph" convention
+    shared by production hydration, audit, and future Stage 2c callers.
+    """
+
+    if settings is None:
+        return CommunicationGraph()
+    return assemble_communication_graph(
+        session_or_cur, settings=settings, world_time=world_time
+    )
+
+
+def _validate_dyad_overrides(session_or_cur: Any, overrides: Mapping[str, Any]) -> None:
+    """Reject override keys outside every known relationship vocabulary.
+
+    Valid keys are the union of the apex RelationshipType enum, relationship
+    types referenced by shipped package templates, and types present in the
+    live data — so shipped defaults (captor, handler) validate on a fresh
+    slot while a typo'd or retired key fails loudly instead of silently
+    falling back to its valence tier.
+    """
+
+    if not overrides:
+        return
+    from nexus.agents.logon.apex_enums import RelationshipType
+    from nexus.agents.orrery.catalog import collect_template_vocabulary
+    from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+
+    valid = {member.value for member in RelationshipType}
+    valid.update(collect_template_vocabulary(BUILTIN_TEMPLATES)["relationship_types"])
+    valid.update(
+        str(row["relationship_type"])
+        for row in _fetch_mappings(
+            session_or_cur,
+            "SELECT DISTINCT relationship_type FROM character_relationships",
+        )
+    )
+    unknown = sorted(set(overrides) - valid)
+    if unknown:
+        raise ValueError(
+            "orrery.contagion dyad_overrides reference unknown relationship "
+            f"types {unknown}; known types: {sorted(valid)}"
+        )

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -357,6 +357,7 @@ def analyze_coverage(
     project_settings: Optional[Any] = None,
     epistemics_settings: Optional[Any] = None,
     fanout_settings: Optional[Any] = None,
+    contagion_settings: Optional[Any] = None,
 ) -> dict[str, Any]:
     """Aggregate explained resolution coverage across historical anchors.
 
@@ -401,6 +402,7 @@ def analyze_coverage(
             project_settings=project_settings,
             epistemics_settings=epistemics_settings,
             fanout_settings=fanout_settings,
+            contagion_settings=contagion_settings,
         )
         anchors.append(_tally_report(report, tallies, gap_counts))
         entity_names.update(report.entity_names)

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -12,7 +12,7 @@ from sqlalchemy import text
 
 from nexus.agents.orrery.communication import (
     CommunicationGraph,
-    assemble_communication_graph,
+    communication_graph_for_settings,
 )
 from nexus.agents.orrery.epistemics import (
     coerce_epistemics_policy,
@@ -556,14 +556,8 @@ def hydrate_world_state(
     world_time = world_time_override or _load_world_time(
         session, anchor_chunk_id=anchor_chunk_id
     )
-    communication_graph = (
-        assemble_communication_graph(
-            session,
-            settings=contagion_settings,
-            world_time=world_time,
-        )
-        if contagion_settings is not None
-        else CommunicationGraph()
+    communication_graph = communication_graph_for_settings(
+        session, contagion_settings, world_time=world_time
     )
     time_of_day = _load_time_of_day(world_time)
     weather = _load_weather(session)

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -10,6 +10,10 @@ from typing import Any, Iterable, Mapping, Optional, Protocol, Sequence, Tuple, 
 
 from sqlalchemy import text
 
+from nexus.agents.orrery.communication import (
+    CommunicationGraph,
+    assemble_communication_graph,
+)
 from nexus.agents.orrery.epistemics import (
     coerce_epistemics_policy,
     load_epistemics_policy,
@@ -204,6 +208,11 @@ class OrreryTickProposal:
     resolutions: Tuple[OrreryResolutionDraft, ...]
     scene_pressures: Tuple[OrreryScenePressureDraft, ...] = ()
     joint_beats: Tuple[OrreryJointBeat, ...] = ()
+    # Transient read-side projection. Intentionally omitted from to_dict():
+    # incubator persistence stores decisions, not a hydration-time graph.
+    communication_graph: CommunicationGraph = field(
+        default_factory=CommunicationGraph, compare=False
+    )
     epistemics_settings: Mapping[str, Any] = field(
         default_factory=lambda: {"enabled": False}
     )
@@ -364,6 +373,7 @@ def hydrate_world_state(
     win_history_window: int = 0,
     project_settings: Optional[Any] = None,
     epistemics_settings: Optional[Any] = None,
+    contagion_settings: Optional[Any] = None,
 ) -> WorldState:
     """Hydrate the read-side Orrery state snapshot from database tables.
 
@@ -546,6 +556,15 @@ def hydrate_world_state(
     world_time = world_time_override or _load_world_time(
         session, anchor_chunk_id=anchor_chunk_id
     )
+    communication_graph = (
+        assemble_communication_graph(
+            session,
+            settings=contagion_settings,
+            world_time=world_time,
+        )
+        if contagion_settings is not None
+        else CommunicationGraph()
+    )
     time_of_day = _load_time_of_day(world_time)
     weather = _load_weather(session)
     need_debt_scores = _load_need_debt_scores(
@@ -575,6 +594,7 @@ def hydrate_world_state(
         activities=activities,
         trust=trust,
         orbit_distance=orbit_distance,
+        communication_graph=communication_graph,
         relationship_types={
             key: frozenset(values) for key, values in relationship_types.items()
         },
@@ -1628,6 +1648,7 @@ def resolve_dry_run(
     project_settings: Optional[Any] = None,
     epistemics_settings: Optional[Any] = None,
     fanout_settings: Optional[Any] = None,
+    contagion_settings: Optional[Any] = None,
 ) -> OrreryTickProposal:
     """Hydrate, bind, and evaluate Orrery packages without database writes."""
 
@@ -1653,6 +1674,7 @@ def resolve_dry_run(
         win_history_window=habituation.window_ticks if habituation.enabled else 0,
         project_settings=project_settings,
         epistemics_settings=epistemics_policy,
+        contagion_settings=contagion_settings,
     )
 
     templates_list = list(configure_project_magnitudes(templates, project_policy))
@@ -1901,6 +1923,7 @@ def resolve_dry_run(
         resolutions=tuple(drafts),
         scene_pressures=scene_pressures,
         joint_beats=detect_joint_beats(drafts, draft_entity_names),
+        communication_graph=state.communication_graph,
         epistemics_settings={
             "enabled": epistemics_policy.enabled,
             "claim_event_types": sorted(epistemics_policy.claim_event_types),

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -11,6 +11,7 @@ import math
 import random
 from typing import Any, Callable, Dict, Iterable, Literal, Mapping, Optional, Tuple
 
+from nexus.agents.orrery.communication import CommunicationGraph
 from nexus.agents.orrery.needs import normalize_need_type
 from nexus.agents.orrery.status_family import (
     STATUS_LEVEL_RANKS,
@@ -351,6 +352,7 @@ class WorldState:
     # current active-character relationship graph, treated as undirected.
     # Quality- or direction-sensitive routing belongs in separate projections.
     orbit_distance: Mapping[Tuple[int, int], int] = field(default_factory=dict)
+    communication_graph: CommunicationGraph = field(default_factory=CommunicationGraph)
     need_debt_scores: Mapping[Tuple[int, str], float] = field(default_factory=dict)
     travel_states: Mapping[int, TravelState] = field(default_factory=dict)
     project_states: Mapping[int, ProjectState] = field(default_factory=dict)

--- a/nexus/api/orrery_dev_endpoints.py
+++ b/nexus/api/orrery_dev_endpoints.py
@@ -321,6 +321,7 @@ async def post_resolve(request: OrreryResolveRequest) -> dict[str, Any]:
                 project_settings=orrery.get("projects"),
                 epistemics_settings=orrery.get("epistemics"),
                 fanout_settings=orrery.get("fanout"),
+                contagion_settings=orrery.get("contagion"),
             )
         except OverrideValidationError as exc:
             # Override validation (unknown vocab, no-op toggles) is caller
@@ -348,6 +349,7 @@ async def post_entity_context(
             anchor_chunk_id=anchor_chunk_id,
             recent_events_limit=request.recent_events_limit,
             sunhelm_settings=orrery.get("sunhelm"),
+            contagion_settings=orrery.get("contagion"),
         )
 
 
@@ -410,6 +412,7 @@ async def post_coverage(request: OrreryCoverageRequest) -> dict[str, Any]:
             project_settings=orrery.get("projects"),
             epistemics_settings=orrery.get("epistemics"),
             fanout_settings=orrery.get("fanout"),
+            contagion_settings=orrery.get("contagion"),
         )
 
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -6,6 +6,8 @@ All models use `extra='forbid'` to catch typos in configuration keys.
 """
 
 from dataclasses import dataclass
+from datetime import timedelta
+import re
 from typing import Any, Dict, List, Literal, Optional, Tuple
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -674,6 +676,239 @@ class OrreryBindingSettings(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     window_chunks: int = Field(default=30, ge=1)
+
+
+_CONTAGION_DURATION_RE = re.compile(r"^(?P<amount>\d+(?:\.\d+)?)(?P<unit>[smhdw])$")
+_CONTAGION_DURATION_SECONDS = {
+    "s": 1,
+    "m": 60,
+    "h": 60 * 60,
+    "d": 24 * 60 * 60,
+    "w": 7 * 24 * 60 * 60,
+}
+
+
+def _parse_contagion_duration(value: Any, *, allow_never: bool) -> Optional[timedelta]:
+    """Parse one strict world-time duration used by Social Contagion."""
+
+    if isinstance(value, timedelta):
+        if value <= timedelta(0):
+            raise ValueError("duration must be greater than zero")
+        return value
+    if allow_never and value is None:
+        return None
+    if allow_never and value == "never":
+        return None
+    if not isinstance(value, str):
+        expected = (
+            "a duration string or 'never'" if allow_never else "a duration string"
+        )
+        raise ValueError(f"expected {expected}")
+    match = _CONTAGION_DURATION_RE.fullmatch(value.strip())
+    if match is None:
+        expected = "<number><s|m|h|d|w>"
+        if allow_never:
+            expected += " or 'never'"
+        raise ValueError(f"malformed duration {value!r}; expected {expected}")
+    seconds = (
+        float(match.group("amount")) * _CONTAGION_DURATION_SECONDS[match.group("unit")]
+    )
+    if seconds <= 0:
+        raise ValueError("duration must be greater than zero")
+    return timedelta(seconds=seconds)
+
+
+class OrreryContagionDyadTierSettings(BaseModel):
+    """Outbound-valence latency defaults for character dyads."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    trusting: Optional[timedelta] = timedelta(hours=24)
+    neutral: Optional[timedelta] = timedelta(hours=96)
+    hostile: Optional[timedelta] = None
+
+    @field_validator("trusting", "neutral", "hostile", mode="before")
+    @classmethod
+    def _parse_latency(cls, value: Any) -> Optional[timedelta]:
+        return _parse_contagion_duration(value, allow_never=True)
+
+
+class OrreryContagionDyadOverrideSettings(BaseModel):
+    """Directional latency override for one relationship type."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    forward: Optional[timedelta]
+    reverse: Optional[timedelta]
+
+    @field_validator("forward", "reverse", mode="before")
+    @classmethod
+    def _parse_latency(cls, value: Any) -> Optional[timedelta]:
+        return _parse_contagion_duration(value, allow_never=True)
+
+
+class OrreryContagionChannelSettings(BaseModel):
+    """Direction and base latency for one institutional conduit."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    direction: Literal[
+        "both",
+        "subject_to_object",
+        "object_to_subject",
+        "faction_to_member",
+    ]
+    latency: Optional[timedelta]
+    min_level: Optional[str] = None
+
+    @field_validator("latency", mode="before")
+    @classmethod
+    def _parse_latency(cls, value: Any) -> Optional[timedelta]:
+        return _parse_contagion_duration(value, allow_never=True)
+
+    @field_validator("min_level")
+    @classmethod
+    def _validate_min_level(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        from nexus.agents.orrery.status_family import normalize_status_level
+
+        return normalize_status_level(value)
+
+
+class OrreryContagionGuardSettings(BaseModel):
+    """Validated Stage 2c traversal guards shipped ahead of propagation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    depth_cap: int = Field(default=4, ge=1)
+    age_horizon: timedelta = timedelta(days=14)
+    fan_out_cap: int = Field(default=6, ge=1)
+
+    @field_validator("age_horizon", mode="before")
+    @classmethod
+    def _parse_age_horizon(cls, value: Any) -> timedelta:
+        parsed = _parse_contagion_duration(value, allow_never=False)
+        assert parsed is not None
+        return parsed
+
+
+def _default_contagion_dyad_overrides() -> (
+    Dict[str, OrreryContagionDyadOverrideSettings]
+):
+    return {
+        "handler": OrreryContagionDyadOverrideSettings(
+            forward=timedelta(hours=12), reverse=timedelta(hours=12)
+        ),
+        "captor": OrreryContagionDyadOverrideSettings(
+            forward=None, reverse=timedelta(hours=24)
+        ),
+    }
+
+
+def _default_contagion_channels() -> Dict[str, OrreryContagionChannelSettings]:
+    return {
+        "handles": OrreryContagionChannelSettings(
+            direction="both", latency=timedelta(hours=12)
+        ),
+        "obligation": OrreryContagionChannelSettings(
+            direction="object_to_subject", latency=timedelta(hours=48)
+        ),
+        "authority_over": OrreryContagionChannelSettings(
+            direction="subject_to_object", latency=timedelta(hours=24)
+        ),
+        "mentors": OrreryContagionChannelSettings(
+            direction="both", latency=timedelta(hours=24)
+        ),
+        "contact:social": OrreryContagionChannelSettings(
+            direction="both", latency=timedelta(hours=72)
+        ),
+        "status:*": OrreryContagionChannelSettings(
+            direction="faction_to_member",
+            latency=timedelta(hours=48),
+            min_level="junior",
+        ),
+    }
+
+
+def _default_contagion_culture_profiles() -> Dict[str, float]:
+    return {
+        "cellular_clandestine": 4.0,
+        "compartmented": 2.0,
+        "covert": 2.0,
+        "hybrid": 1.0,
+        "overt": 0.5,
+    }
+
+
+class OrreryContagionSettings(BaseModel):
+    """Deterministic read-side communication graph configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    dyad_tiers: OrreryContagionDyadTierSettings = Field(
+        default_factory=OrreryContagionDyadTierSettings
+    )
+    dyad_overrides: Dict[str, OrreryContagionDyadOverrideSettings] = Field(
+        default_factory=_default_contagion_dyad_overrides
+    )
+    channels: Dict[str, OrreryContagionChannelSettings] = Field(
+        default_factory=_default_contagion_channels
+    )
+    culture_profiles: Dict[str, float] = Field(
+        default_factory=_default_contagion_culture_profiles
+    )
+    guards: OrreryContagionGuardSettings = Field(
+        default_factory=OrreryContagionGuardSettings
+    )
+
+    @field_validator("dyad_overrides")
+    @classmethod
+    def _validate_override_keys(
+        cls,
+        values: Dict[str, OrreryContagionDyadOverrideSettings],
+    ) -> Dict[str, OrreryContagionDyadOverrideSettings]:
+        if any(not key.strip() for key in values):
+            raise ValueError("dyad_overrides keys must be non-empty")
+        return values
+
+    @field_validator("culture_profiles")
+    @classmethod
+    def _validate_culture_profiles(cls, values: Dict[str, float]) -> Dict[str, float]:
+        blank = [key for key in values if not key.strip()]
+        if blank:
+            raise ValueError("culture_profiles keys must be non-empty")
+        invalid = {key: value for key, value in values.items() if value <= 0}
+        if invalid:
+            raise ValueError(
+                "culture profile multipliers must be greater than zero: " f"{invalid}"
+            )
+        return values
+
+    @model_validator(mode="after")
+    def _validate_channel_shapes(self) -> "OrreryContagionSettings":
+        for key, channel in self.channels.items():
+            if not key.strip():
+                raise ValueError("channel keys must be non-empty")
+            if key == "status:*":
+                if channel.direction != "faction_to_member":
+                    raise ValueError(
+                        "orrery.contagion.channels.'status:*' must use "
+                        "direction='faction_to_member'"
+                    )
+                if channel.min_level is None:
+                    raise ValueError(
+                        "orrery.contagion.channels.'status:*' requires min_level"
+                    )
+            elif channel.direction == "faction_to_member":
+                raise ValueError(
+                    "direction='faction_to_member' is reserved for the "
+                    "'status:*' channel"
+                )
+            elif channel.min_level is not None:
+                raise ValueError("min_level is only valid for the 'status:*' channel")
+        return self
 
 
 class OrreryRouteGraphSettings(BaseModel):
@@ -1638,6 +1873,7 @@ class OrrerySettings(BaseModel):
 
     enabled: bool = True
     binding: OrreryBindingSettings = Field(default_factory=OrreryBindingSettings)
+    contagion: OrreryContagionSettings = Field(default_factory=OrreryContagionSettings)
     route_graph: OrreryRouteGraphSettings = Field(
         default_factory=OrreryRouteGraphSettings
     )

--- a/scripts/replay_state.py
+++ b/scripts/replay_state.py
@@ -18,17 +18,24 @@ from __future__ import annotations
 
 import argparse
 import json
+from pathlib import Path
 import sys
 from dataclasses import asdict
 from typing import Any
 
 import psycopg2
 
-from nexus.agents.orrery.replay import (
+# Resolve imports against this checkout, not the shared Poetry environment's
+# editable-install target. Worktrees can carry a settings model and nexus.toml
+# change together, so importing another checkout makes the replay gate lie.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from nexus.agents.orrery.replay import (  # noqa: E402
     reconstruct_state_at_sync,
     verify_checkpoints_sync,
 )
-from nexus.api.slot_utils import slot_dbname
+from nexus.api.slot_utils import slot_dbname  # noqa: E402
 
 
 def _connect(slot: int) -> Any:

--- a/tests/test_orrery/test_communication_graph_live.py
+++ b/tests/test_orrery/test_communication_graph_live.py
@@ -591,6 +591,30 @@ def test_assembly_is_deterministic_and_unknown_configured_channel_is_loud(
         )
 
 
+def test_unknown_dyad_override_key_is_loud(
+    communication_db: dict[str, Any],
+) -> None:
+    """PR #517 review: a typo'd or retired override key raises, never falls back.
+
+    Valid keys are the union of the apex RelationshipType enum, template-
+    referenced relationship types, and types present in the live data — so
+    the shipped captor/handler defaults validate while drift screams.
+    """
+
+    payload = communication_db["settings"].model_dump()
+    payload["dyad_overrides"]["handeler"] = {
+        "forward": "1h",
+        "reverse": "1h",
+    }
+    drifted = OrreryContagionSettings.model_validate(payload)
+    with pytest.raises(ValueError, match="unknown relationship types.*handeler"):
+        assemble_communication_graph(
+            communication_db["session"],
+            settings=drifted,
+            world_time=WORLD_TIME,
+        )
+
+
 def test_unparseable_relationship_valence_is_loud(
     communication_db: dict[str, Any],
 ) -> None:

--- a/tests/test_orrery/test_communication_graph_live.py
+++ b/tests/test_orrery/test_communication_graph_live.py
@@ -486,6 +486,53 @@ def test_channel_directionality_and_status_minimum(
     assert _between(graph, faction, entities["outcast_member"], kind="channel") == ()
 
 
+def test_faction_subject_status_yields_parent_to_member_faction_edge(
+    communication_db: dict[str, Any],
+) -> None:
+    """PR #517 review: the registry allows faction-subject status standing.
+
+    A member faction holding status toward a parent faction is a legal
+    institutional conduit; faction_to_member must emit parent -> member.
+    """
+
+    session = communication_db["session"]
+    parent_faction = communication_db["faction_entity_id"]
+    member_entity_id = int(
+        session.execute(
+            text(
+                """
+                INSERT INTO entities (kind, is_active)
+                VALUES ('faction', true)
+                RETURNING id
+                """
+            )
+        ).scalar_one()
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO factions (id, name, entity_id)
+            VALUES ((SELECT coalesce(max(id), 0) + 1 FROM factions), :name, :entity_id)
+            """
+        ),
+        {
+            "name": f"comm-graph-member-{uuid4().hex[:12]}",
+            "entity_id": member_entity_id,
+        },
+    )
+    _insert_pair_tag(
+        session,
+        subject_entity_id=member_entity_id,
+        object_entity_id=parent_faction,
+        tag="status:senior",
+    )
+
+    graph = _assemble(communication_db)
+    edges = _between(graph, parent_faction, member_entity_id, kind="channel")
+    assert len(edges) == 1
+    assert edges[0].label == "status:senior"
+
+
 def test_culture_profiles_multiply_and_record_provenance(
     communication_db: dict[str, Any],
 ) -> None:

--- a/tests/test_orrery/test_communication_graph_live.py
+++ b/tests/test_orrery/test_communication_graph_live.py
@@ -1,0 +1,592 @@
+"""Rollback-only PostgreSQL coverage for Stage 2b communication assembly."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+from nexus.agents.orrery.audit import entity_context, explain_dry_run
+from nexus.agents.orrery.communication import (
+    CommunicationEdge,
+    CommunicationGraph,
+    assemble_communication_graph,
+)
+from nexus.agents.orrery.resolver import resolve_dry_run
+from nexus.api.slot_utils import get_slot_db_url
+from nexus.config import load_settings
+from nexus.config.settings_models import OrreryContagionSettings
+
+
+pytestmark = pytest.mark.requires_postgres
+
+LIVE_SLOT = 5
+WORLD_TIME = datetime(2073, 8, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def _insert_character(
+    session: Session, *, token: str, label: str, active: bool = True
+) -> tuple[int, int]:
+    entity_id = int(
+        session.execute(
+            text(
+                """
+                INSERT INTO entities (kind, is_active)
+                VALUES ('character', :active)
+                RETURNING id
+                """
+            ),
+            {"active": active},
+        ).scalar_one()
+    )
+    character_id = int(
+        session.execute(
+            text(
+                """
+                INSERT INTO characters (name, entity_id)
+                VALUES (:name, :entity_id)
+                RETURNING id
+                """
+            ),
+            {"name": f"communication-{token}-{label}", "entity_id": entity_id},
+        ).scalar_one()
+    )
+    return entity_id, character_id
+
+
+def _insert_relationship(
+    session: Session,
+    *,
+    source_character_id: int,
+    target_character_id: int,
+    relationship_type: str,
+    emotional_valence: str,
+) -> None:
+    session.execute(
+        text(
+            """
+            INSERT INTO character_relationships (
+                character1_id, character2_id, relationship_type,
+                emotional_valence, dynamic, recent_events, history
+            ) VALUES (
+                :source_id, :target_id, :relationship_type,
+                :emotional_valence, 'Rollback-only communication fixture.',
+                'No persistent events.', 'Created for issue 477 Stage 2b.'
+            )
+            """
+        ),
+        {
+            "source_id": source_character_id,
+            "target_id": target_character_id,
+            "relationship_type": relationship_type,
+            "emotional_valence": emotional_valence,
+        },
+    )
+
+
+def _insert_pair_tag(
+    session: Session,
+    *,
+    subject_entity_id: int,
+    object_entity_id: int,
+    tag: str,
+) -> None:
+    session.execute(
+        text(
+            """
+            INSERT INTO entity_pair_tags (
+                subject_entity_id, object_entity_id, pair_tag_id,
+                source_kind, template_id
+            )
+            SELECT :subject_id, :object_id, pt.id,
+                   'template', 'test_communication_graph_live'
+            FROM pair_tags pt
+            WHERE pt.tag = :tag AND NOT pt.deprecated
+            """
+        ),
+        {
+            "subject_id": subject_entity_id,
+            "object_id": object_entity_id,
+            "tag": tag,
+        },
+    )
+
+
+def _insert_culture_tag(session: Session, *, entity_id: int, tag: str) -> None:
+    session.execute(
+        text(
+            """
+            INSERT INTO entity_tags (entity_id, tag_id, source_kind, template_id)
+            SELECT :entity_id, t.id, 'template', 'test_communication_graph_live'
+            FROM tags t
+            WHERE t.tag = :tag AND NOT t.deprecated
+            """
+        ),
+        {"entity_id": entity_id, "tag": tag},
+    )
+
+
+@pytest.fixture()
+def communication_db() -> Iterator[dict[str, Any]]:
+    """Build isolated character/channel fixtures in one slot-5 transaction."""
+
+    engine = create_engine(get_slot_db_url(slot=LIVE_SLOT), future=True)
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+    try:
+        token = uuid4().hex[:12]
+        labels = (
+            "lone_teller",
+            "lone_listener",
+            "neutral_teller",
+            "neutral_listener",
+            "debtor",
+            "creditor",
+            "authority",
+            "subordinate",
+            "handler",
+            "asset",
+            "junior_member",
+            "outcast_member",
+            "culture_listener",
+            "reciprocal_low",
+            "reciprocal_high",
+            "plain_neutral_teller",
+            "plain_neutral_listener",
+            "hostile_teller",
+            "hostile_listener",
+        )
+        entities: dict[str, int] = {}
+        characters: dict[str, int] = {}
+        for label in labels:
+            entity_id, character_id = _insert_character(
+                session, token=token, label=label
+            )
+            entities[label] = entity_id
+            characters[label] = character_id
+
+        _insert_relationship(
+            session,
+            source_character_id=characters["lone_teller"],
+            target_character_id=characters["lone_listener"],
+            relationship_type="associate",
+            emotional_valence="+3|trusting",
+        )
+        _insert_relationship(
+            session,
+            source_character_id=characters["neutral_teller"],
+            target_character_id=characters["neutral_listener"],
+            relationship_type="handler",
+            emotional_valence="0|neutral",
+        )
+        _insert_relationship(
+            session,
+            source_character_id=characters["plain_neutral_teller"],
+            target_character_id=characters["plain_neutral_listener"],
+            relationship_type="associate",
+            emotional_valence="0|neutral",
+        )
+        _insert_relationship(
+            session,
+            source_character_id=characters["hostile_teller"],
+            target_character_id=characters["hostile_listener"],
+            relationship_type="associate",
+            emotional_valence="-3|resentful",
+        )
+        _insert_relationship(
+            session,
+            source_character_id=characters["reciprocal_low"],
+            target_character_id=characters["reciprocal_high"],
+            relationship_type="captor",
+            emotional_valence="-3|resentful",
+        )
+        _insert_relationship(
+            session,
+            source_character_id=characters["reciprocal_high"],
+            target_character_id=characters["reciprocal_low"],
+            relationship_type="captor",
+            emotional_valence="-3|resentful",
+        )
+
+        inactive_entity, inactive_character = _insert_character(
+            session, token=token, label="inactive", active=False
+        )
+        entities["inactive"] = inactive_entity
+        characters["inactive"] = inactive_character
+        _insert_relationship(
+            session,
+            source_character_id=inactive_character,
+            target_character_id=characters["lone_listener"],
+            relationship_type="associate",
+            emotional_valence="+3|trusting",
+        )
+
+        _insert_pair_tag(
+            session,
+            subject_entity_id=entities["debtor"],
+            object_entity_id=entities["creditor"],
+            tag="obligation",
+        )
+        _insert_pair_tag(
+            session,
+            subject_entity_id=entities["authority"],
+            object_entity_id=entities["subordinate"],
+            tag="authority_over",
+        )
+        _insert_pair_tag(
+            session,
+            subject_entity_id=entities["handler"],
+            object_entity_id=entities["asset"],
+            tag="handles",
+        )
+        _insert_pair_tag(
+            session,
+            subject_entity_id=inactive_entity,
+            object_entity_id=entities["asset"],
+            tag="handles",
+        )
+
+        faction_entity_id = int(
+            session.execute(
+                text(
+                    """
+                    SELECT f.entity_id
+                    FROM factions f
+                    JOIN entities e ON e.id = f.entity_id
+                    WHERE e.is_active = true
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM entity_tags_current etc
+                          WHERE etc.entity_id = f.entity_id
+                            AND etc.category IN (
+                                'operational_secrecy', 'operational_mode'
+                            )
+                      )
+                    ORDER BY f.entity_id
+                    LIMIT 1
+                    """
+                )
+            ).scalar_one()
+        )
+        _insert_pair_tag(
+            session,
+            subject_entity_id=entities["junior_member"],
+            object_entity_id=faction_entity_id,
+            tag="status:junior",
+        )
+        _insert_pair_tag(
+            session,
+            subject_entity_id=entities["outcast_member"],
+            object_entity_id=faction_entity_id,
+            tag="status:outcast",
+        )
+        _insert_pair_tag(
+            session,
+            subject_entity_id=faction_entity_id,
+            object_entity_id=entities["culture_listener"],
+            tag="authority_over",
+        )
+
+        yield {
+            "session": session,
+            "raw_connection": connection.connection.driver_connection,
+            "entities": entities,
+            "characters": characters,
+            "faction_entity_id": faction_entity_id,
+            "settings": load_settings("nexus.toml").orrery.contagion,
+        }
+    finally:
+        session.close()
+        if transaction.is_active:
+            transaction.rollback()
+        connection.close()
+        engine.dispose()
+
+
+def _assemble(db: dict[str, Any]) -> CommunicationGraph:
+    return assemble_communication_graph(
+        db["session"], settings=db["settings"], world_time=WORLD_TIME
+    )
+
+
+def _between(
+    graph: CommunicationGraph, source: int, target: int, *, kind: str
+) -> tuple[CommunicationEdge, ...]:
+    return tuple(
+        edge
+        for edge in graph.edges
+        if edge.teller_entity_id == source
+        and edge.listener_entity_id == target
+        and edge.kind == kind
+    )
+
+
+def test_conflicted_live_pair_licenses_only_each_tellers_own_direction() -> None:
+    """Tomi trusts Kosi; Kosi's captor stance is configured as never."""
+
+    engine = create_engine(get_slot_db_url(slot=LIVE_SLOT), future=True)
+    try:
+        with Session(engine) as session:
+            ids = {
+                row["name"]: int(row["entity_id"])
+                for row in session.execute(
+                    text(
+                        """
+                        SELECT name, entity_id
+                        FROM characters
+                        WHERE name IN ('Tomi', 'Kosi')
+                        ORDER BY name
+                        """
+                    )
+                ).mappings()
+            }
+            if set(ids) != {"Tomi", "Kosi"}:
+                pytest.skip("save_05 does not contain the frozen Tomi/Kosi pair")
+            graph = assemble_communication_graph(
+                session,
+                settings=load_settings("nexus.toml").orrery.contagion,
+                world_time=WORLD_TIME,
+            )
+    finally:
+        engine.dispose()
+
+    tomi_to_kosi = _between(graph, ids["Tomi"], ids["Kosi"], kind="dyad")
+    assert [(edge.label, edge.latency) for edge in tomi_to_kosi] == [
+        ("ward", timedelta(hours=24))
+    ]
+    assert _between(graph, ids["Kosi"], ids["Tomi"], kind="dyad") == ()
+
+
+def test_lone_row_is_sparse_and_handler_override_beats_neutral(
+    communication_db: dict[str, Any],
+) -> None:
+    """No reverse row is invented; handler's 12h override beats neutral 96h."""
+
+    graph = _assemble(communication_db)
+    entities = communication_db["entities"]
+    lone = _between(
+        graph,
+        entities["lone_teller"],
+        entities["lone_listener"],
+        kind="dyad",
+    )
+    assert [(edge.label, edge.latency) for edge in lone] == [
+        ("associate", timedelta(hours=24))
+    ]
+    assert (
+        _between(
+            graph,
+            entities["lone_listener"],
+            entities["lone_teller"],
+            kind="dyad",
+        )
+        == ()
+    )
+    handler = _between(
+        graph,
+        entities["neutral_teller"],
+        entities["neutral_listener"],
+        kind="dyad",
+    )
+    assert [(edge.label, edge.latency) for edge in handler] == [
+        ("handler", timedelta(hours=12))
+    ]
+    neutral = _between(
+        graph,
+        entities["plain_neutral_teller"],
+        entities["plain_neutral_listener"],
+        kind="dyad",
+    )
+    assert [(edge.label, edge.latency) for edge in neutral] == [
+        ("associate", timedelta(hours=96))
+    ]
+    assert (
+        _between(
+            graph,
+            entities["hostile_teller"],
+            entities["hostile_listener"],
+            kind="dyad",
+        )
+        == ()
+    )
+    reciprocal = _between(
+        graph,
+        entities["reciprocal_high"],
+        entities["reciprocal_low"],
+        kind="dyad",
+    )
+    assert [(edge.label, edge.latency) for edge in reciprocal] == [
+        ("captor", timedelta(hours=24))
+    ]
+    assert (
+        _between(
+            graph,
+            entities["reciprocal_low"],
+            entities["reciprocal_high"],
+            kind="dyad",
+        )
+        == ()
+    )
+    assert all(
+        entities["inactive"] not in (edge.teller_entity_id, edge.listener_entity_id)
+        for edge in graph.edges
+    )
+
+
+def test_channel_directionality_and_status_minimum(
+    communication_db: dict[str, Any],
+) -> None:
+    """Obligation, authority, handles, and status follow their configured arrows."""
+
+    graph = _assemble(communication_db)
+    entities = communication_db["entities"]
+    faction = communication_db["faction_entity_id"]
+
+    assert (
+        len(_between(graph, entities["creditor"], entities["debtor"], kind="channel"))
+        == 1
+    )
+    assert (
+        _between(graph, entities["debtor"], entities["creditor"], kind="channel") == ()
+    )
+    assert (
+        len(
+            _between(
+                graph,
+                entities["authority"],
+                entities["subordinate"],
+                kind="channel",
+            )
+        )
+        == 1
+    )
+    assert (
+        _between(
+            graph,
+            entities["subordinate"],
+            entities["authority"],
+            kind="channel",
+        )
+        == ()
+    )
+    assert (
+        len(_between(graph, entities["handler"], entities["asset"], kind="channel"))
+        == 1
+    )
+    assert (
+        len(_between(graph, entities["asset"], entities["handler"], kind="channel"))
+        == 1
+    )
+    assert len(_between(graph, faction, entities["junior_member"], kind="channel")) == 1
+    assert _between(graph, faction, entities["outcast_member"], kind="channel") == ()
+
+
+def test_culture_profiles_multiply_and_record_provenance(
+    communication_db: dict[str, Any],
+) -> None:
+    """Layered culture tags multiply channel latency and remain auditable."""
+
+    session = communication_db["session"]
+    faction = communication_db["faction_entity_id"]
+    listener = communication_db["entities"]["culture_listener"]
+
+    baseline = _between(_assemble(communication_db), faction, listener, kind="channel")
+    assert [(edge.latency, edge.culture_multiplier) for edge in baseline] == [
+        (timedelta(hours=24), 1.0)
+    ]
+
+    _insert_culture_tag(session, entity_id=faction, tag="cellular_clandestine")
+    quadrupled = _between(
+        _assemble(communication_db), faction, listener, kind="channel"
+    )
+    assert [(edge.latency, edge.culture_multiplier) for edge in quadrupled] == [
+        (timedelta(hours=96), 4.0)
+    ]
+
+    _insert_culture_tag(session, entity_id=faction, tag="covert")
+    composed = _between(_assemble(communication_db), faction, listener, kind="channel")
+    assert [(edge.latency, edge.culture_multiplier) for edge in composed] == [
+        (timedelta(hours=192), 8.0)
+    ]
+    assert composed[0].institution_entity_id == faction
+
+
+def test_assembly_is_deterministic_and_unknown_configured_channel_is_loud(
+    communication_db: dict[str, Any],
+) -> None:
+    """Stable state is equal byte-for-byte; registry drift raises."""
+
+    first = _assemble(communication_db)
+    assert first == _assemble(communication_db)
+    with communication_db["raw_connection"].cursor() as cur:
+        assert first == assemble_communication_graph(
+            cur,
+            settings=communication_db["settings"],
+            world_time=WORLD_TIME,
+        )
+
+    payload = communication_db["settings"].model_dump()
+    payload["channels"]["unregistered_conduit"] = {
+        "direction": "both",
+        "latency": "1h",
+    }
+    drifted = OrreryContagionSettings.model_validate(payload)
+    with pytest.raises(ValueError, match="unregistered channel tags"):
+        assemble_communication_graph(
+            communication_db["session"],
+            settings=drifted,
+            world_time=WORLD_TIME,
+        )
+
+
+def test_unparseable_relationship_valence_is_loud(
+    communication_db: dict[str, Any],
+) -> None:
+    """Legacy or drifted valence strings cannot silently lose an edge."""
+
+    characters = communication_db["characters"]
+    _insert_relationship(
+        communication_db["session"],
+        source_character_id=characters["neutral_listener"],
+        target_character_id=characters["neutral_teller"],
+        relationship_type="associate",
+        emotional_valence="friendly",
+    )
+    with pytest.raises(ValueError, match="Unparseable emotional_valence"):
+        _assemble(communication_db)
+
+
+def test_production_explain_and_entity_audit_share_one_edge_list(
+    communication_db: dict[str, Any],
+) -> None:
+    """Production hydration and both audit views expose identical outbound edges."""
+
+    session = communication_db["session"]
+    settings = communication_db["settings"]
+    entity_id = communication_db["entities"]["lone_teller"]
+    kwargs = {
+        "anchor_chunk_id": None,
+        "window_chunks": 30,
+        "world_time_override": WORLD_TIME,
+        "epistemics_settings": {"enabled": False},
+        "contagion_settings": settings,
+    }
+    production = resolve_dry_run(session, (), **kwargs)
+    explained = explain_dry_run(session, (), **kwargs)
+    assert production.communication_graph == explained.communication_graph
+
+    context = entity_context(
+        session,
+        [entity_id],
+        anchor_chunk_id=None,
+        contagion_settings=settings,
+    )
+    production_edges = [
+        edge.to_dict() for edge in production.communication_graph.outbound(entity_id)
+    ]
+    assert context["entities"][0]["communication_edges"] == production_edges

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -3,6 +3,7 @@
 import subprocess
 import tomllib
 from copy import deepcopy
+from datetime import timedelta
 
 import pytest
 from pydantic import ValidationError
@@ -11,6 +12,7 @@ from nexus.config import load_settings
 from nexus.api.new_story_schemas import Genre
 from nexus.config.settings_models import (
     OrreryBleedSettings,
+    OrreryContagionSettings,
     OrreryDashboardSettings,
     OrreryPromoteSettings,
     OrrerySettings,
@@ -38,6 +40,16 @@ def test_orrery_settings_resolve_model_reference() -> None:
     assert settings.orrery is not None
     assert settings.orrery.enabled is True
     assert settings.orrery.binding.window_chunks == 30
+    assert settings.orrery.contagion.dyad_tiers.trusting == timedelta(hours=24)
+    assert settings.orrery.contagion.dyad_tiers.neutral == timedelta(hours=96)
+    assert settings.orrery.contagion.dyad_tiers.hostile is None
+    assert settings.orrery.contagion.dyad_overrides["captor"].forward is None
+    assert settings.orrery.contagion.dyad_overrides["captor"].reverse == timedelta(
+        hours=24
+    )
+    assert settings.orrery.contagion.channels["status:*"].min_level == "junior"
+    assert settings.orrery.contagion.culture_profiles["cellular_clandestine"] == 4.0
+    assert settings.orrery.contagion.guards.age_horizon == timedelta(days=14)
     expected_model = settings.global_.model.api_models["anthropic"].roles["default"]
     assert settings.orrery.narration.model_ref == expected_model
     assert settings.orrery.promote.provider is None
@@ -109,6 +121,26 @@ def test_sunhelm_rejects_retired_story_time_accrual_floor() -> None:
         OrrerySunhelmSettings(
             min_accrual_hours_per_chunk={"socialize": 0.5}  # type: ignore[call-arg]
         )
+
+
+def test_contagion_rejects_malformed_duration() -> None:
+    """World-time latencies fail at settings validation, never at traversal."""
+
+    with pytest.raises(ValidationError, match="malformed duration"):
+        OrreryContagionSettings(
+            dyad_tiers={
+                "trusting": "tomorrow",
+                "neutral": "96h",
+                "hostile": "never",
+            }
+        )
+
+
+def test_contagion_rejects_nonpositive_culture_multiplier() -> None:
+    """Culture profiles may slow or accelerate channels but never erase them."""
+
+    with pytest.raises(ValidationError, match="greater than zero"):
+        OrreryContagionSettings(culture_profiles={"covert": 0.0})
 
 
 def test_project_milestones_cannot_fall_below_promotion_floor() -> None:


### PR DESCRIPTION
Stage 2b of #477 Social Contagion (Option C): the deterministic READ side — the communication graph and its configuration. No propagation, no awareness writes, no migration; the Stage 2c frontier engine consumes what this builds. Governing rulings (frozen sub-decisions, layered-culture model, delegated baseline) are on #477.

## What Lands

- **`nexus/agents/orrery/communication.py`**: immutable, stably ordered directed edges. Dyads license transmission only along the teller's own stored row (the conflicted captor/ward pair behaves per-direction); valence tiers parse strictly; relationship-type overrides beat tiers. Channels derive from the frozen taxonomy with explicit per-kind directions and `status:*` min-level gating.
- **Per-institution culture**: each channel's latency is multiplied by the product of its owning institution's `operational_secrecy` / `operational_mode` profile multipliers — the layered model the owner ruled: one global baseline, guarded and porous institutions coexisting. The applied multiplier rides the edge for audit ("48h → 192h: the Syndicate is cellular_clandestine").
- **`[orrery.contagion]`** config block with the ruled middle-ground defaults, validated end-to-end (`extra="forbid"`); durations are world-time strings or `"never"` — a deterministic engine has no probabilities, only whether and when.
- Graph hydration integrated into production, explain, coverage, and entity-audit paths with parity; outbound-edge audit views carry latency + culture provenance.
- **Oracle honesty fix**: `scripts/replay_state.py` now imports its own checkout — previously a worktree carrying config + settings-model changes together would silently verify against the main checkout's code via the shared editable venv.

## Verification

- Default suite 1387 passed; postgres suite **1604 passed** (baseline 1385/1595) — independently re-run by the orchestrator.
- Seven new rollback-only slot-5 live tests: teller-direction licensing, lone-row sparsity, tier/override precedence, channel directionality, min-level gating, culture-multiplier composition, determinism, config-drift rejection, explain/production parity.
- `replay_state.py --slot 5 --verify` green.

Implemented by Codex (gpt-5.6-sol) from a frozen work order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UUKcWGZUXg2jF5Nqrhtqv