### PR TITLE
Re-Point Slot-2-Hardcoded Tests to the Native Slot

### DIFF
--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -7,12 +7,10 @@ exactly the winners the production ``resolve_dry_run`` selects, stack by
 stack, including branch, magnitude, event type, binding hash, and the
 rendered narrative stub.
 
-save_02 is the dense retrograde-backfilled audit target; save_05 is the
-small live-runtime slot exhibiting the NULL-world-time bestowal pathology —
-running parity on both catches data-shape assumptions the other slot would
-hide, and a joint non-vacuity test guards against both slots drifting into
-a state where a parity block silently runs zero iterations. All endpoints
-are read-only, so no cleanup is needed.
+save_05 is the Orrery-native live-runtime audit target. A module-wide
+non-vacuity test guards against it drifting into a state where a parity block
+silently runs zero iterations. All endpoints are read-only, so no cleanup is
+needed.
 """
 
 from __future__ import annotations
@@ -38,7 +36,8 @@ from nexus.api.orrery_dev_endpoints import router as orrery_dev_router
 from nexus.api.slot_utils import get_slot_db_url
 from nexus.config import load_settings, load_settings_as_dict
 
-AUDIT_SLOTS = (2, 5)
+LIVE_SLOT = 5
+AUDIT_SLOTS = (LIVE_SLOT,)
 
 TWO_PARTY_TEMPLATE_IDS = {t.id for t in BUILTIN_TEMPLATES if len(t.required_slots) == 2}
 ACTOR_ONLY_TEMPLATE_IDS = {
@@ -224,10 +223,10 @@ def test_resolve_four_template_states_are_distinguishable(
 ) -> None:
     """Winner / shadowed / gate-failed / not-applicable must never blur."""
 
-    response = client.post("/api/dev/orrery/resolve", json={"slot": 2})
+    response = client.post("/api/dev/orrery/resolve", json={"slot": LIVE_SLOT})
     assert response.status_code == 200
     payload = response.json()
-    assert payload["actors"], "save_02 is expected to bind off-screen actors"
+    assert payload["actors"], "save_05 is expected to bind off-screen actors"
 
     for group in payload["actors"]:
         # Stack composition respects arity — the stack-split trap guard.
@@ -270,7 +269,7 @@ def test_resolve_four_template_states_are_distinguishable(
 
 @pytest.mark.requires_postgres
 def test_entity_context_hover_payload(client: TestClient) -> None:
-    resolve = client.post("/api/dev/orrery/resolve", json={"slot": 2})
+    resolve = client.post("/api/dev/orrery/resolve", json={"slot": LIVE_SLOT})
     assert resolve.status_code == 200
     groups = resolve.json()["actors"]
     assert groups
@@ -278,7 +277,11 @@ def test_entity_context_hover_payload(client: TestClient) -> None:
 
     response = client.post(
         "/api/dev/orrery/context/entities",
-        json={"slot": 2, "entity_ids": entity_ids, "recent_events_limit": 3},
+        json={
+            "slot": LIVE_SLOT,
+            "entity_ids": entity_ids,
+            "recent_events_limit": 3,
+        },
     )
     assert response.status_code == 200
     payload = response.json()
@@ -318,7 +321,7 @@ def test_entity_context_hover_payload(client: TestClient) -> None:
 def test_entity_context_recent_events_respect_anchor(client: TestClient) -> None:
     """A historical anchor must not surface events from its own future."""
 
-    resolve = client.post("/api/dev/orrery/resolve", json={"slot": 2})
+    resolve = client.post("/api/dev/orrery/resolve", json={"slot": LIVE_SLOT})
     assert resolve.status_code == 200
     resolved = resolve.json()
     head_anchor = resolved["anchor_chunk_id"]
@@ -326,7 +329,11 @@ def test_entity_context_recent_events_respect_anchor(client: TestClient) -> None
 
     at_head = client.post(
         "/api/dev/orrery/context/entities",
-        json={"slot": 2, "entity_ids": entity_ids, "anchor_chunk_id": head_anchor},
+        json={
+            "slot": LIVE_SLOT,
+            "entity_ids": entity_ids,
+            "anchor_chunk_id": head_anchor,
+        },
     )
     assert at_head.status_code == 200
     for entity in at_head.json()["entities"]:
@@ -336,7 +343,7 @@ def test_entity_context_recent_events_respect_anchor(client: TestClient) -> None
     # Anchor 0 predates every event; the honest answer is "none yet".
     at_genesis = client.post(
         "/api/dev/orrery/context/entities",
-        json={"slot": 2, "entity_ids": entity_ids, "anchor_chunk_id": 0},
+        json={"slot": LIVE_SLOT, "entity_ids": entity_ids, "anchor_chunk_id": 0},
     )
     assert at_genesis.status_code == 200
     for entity in at_genesis.json()["entities"]:
@@ -380,7 +387,7 @@ def _not_hunted_winners(payload: dict) -> Iterator[tuple[int, dict]]:
 
 @pytest.mark.requires_postgres
 def test_current_mode_carries_no_what_if_payload(client: TestClient) -> None:
-    payload = _resolve(client, 2)
+    payload = _resolve(client, LIVE_SLOT)
     assert payload["mode"] == "current"
     assert payload["overrides"] is None
     assert payload["need_pressures_diff"] is None
@@ -388,7 +395,7 @@ def test_current_mode_carries_no_what_if_payload(client: TestClient) -> None:
         assert stack["diff"] is None
 
     # An explicitly empty override set is still current mode.
-    empty = _resolve(client, 2, overrides={})
+    empty = _resolve(client, LIVE_SLOT, overrides={})
     assert empty["mode"] == "current"
     assert empty["overrides"] is None
 
@@ -503,12 +510,13 @@ def test_what_if_need_override_reaches_stacks_and_pressures(
 
 @pytest.mark.requires_postgres
 def test_what_if_validation_rejections(client: TestClient) -> None:
-    payload = _resolve(client, 2)
+    payload = _resolve(client, LIVE_SLOT)
     actor_id = payload["actors"][0]["actor_entity_id"]
 
     def _post(overrides: dict) -> tuple[int, str]:
         response = client.post(
-            "/api/dev/orrery/resolve", json={"slot": 2, "overrides": overrides}
+            "/api/dev/orrery/resolve",
+            json={"slot": LIVE_SLOT, "overrides": overrides},
         )
         return response.status_code, response.json().get("detail", "")
 
@@ -548,7 +556,7 @@ def test_what_if_validation_rejections(client: TestClient) -> None:
     context = client.post(
         "/api/dev/orrery/context/entities",
         json={
-            "slot": 2,
+            "slot": LIVE_SLOT,
             "entity_ids": [g["actor_entity_id"] for g in payload["actors"]],
         },
     ).json()
@@ -561,7 +569,7 @@ def test_what_if_validation_rejections(client: TestClient) -> None:
         None,
     )
     assert carried is not None, (
-        "no audited actor on save_02 carries a durable tag — layer-mismatch "
+        "no audited actor on save_05 carries a durable tag — layer-mismatch "
         "and no-op rejection checks are vacuous; repoint the test"
     )
     tagged_entity, durable_tag = carried
@@ -589,7 +597,7 @@ def test_what_if_validation_rejections(client: TestClient) -> None:
     response = client.post(
         "/api/dev/orrery/resolve",
         json={
-            "slot": 2,
+            "slot": LIVE_SLOT,
             "overrides": {
                 "tags": [{"entity_id": actor_id, "tag": "x", "op": "toggle"}]
             },
@@ -789,19 +797,23 @@ def test_coverage_anchor_cap_and_sampling(client: TestClient) -> None:
     max_anchors = load_settings_as_dict()["orrery"]["dashboard"]["coverage_max_anchors"]
 
     over = client.post(
-        "/api/dev/orrery/coverage", json={"slot": 2, "count": max_anchors + 1}
+        "/api/dev/orrery/coverage",
+        json={"slot": LIVE_SLOT, "count": max_anchors + 1},
     )
     assert over.status_code == 400
     assert "coverage_max_anchors" in over.json()["detail"]
 
     over_explicit = client.post(
         "/api/dev/orrery/coverage",
-        json={"slot": 2, "anchor_chunk_ids": list(range(1, max_anchors + 2))},
+        json={
+            "slot": LIVE_SLOT,
+            "anchor_chunk_ids": list(range(1, max_anchors + 2)),
+        },
     )
     assert over_explicit.status_code == 400
 
     # Stride sampling walks real chunk ids backward from the head.
-    engine = create_engine(get_slot_db_url(slot=2))
+    engine = create_engine(get_slot_db_url(slot=LIVE_SLOT))
     try:
         with Session(engine) as session:
             ids_desc = list(
@@ -818,7 +830,8 @@ def test_coverage_anchor_cap_and_sampling(client: TestClient) -> None:
     expected = sorted(ids_desc[::3][:3])
 
     response = client.post(
-        "/api/dev/orrery/coverage", json={"slot": 2, "count": 3, "stride": 3}
+        "/api/dev/orrery/coverage",
+        json={"slot": LIVE_SLOT, "count": 3, "stride": 3},
     )
     assert response.status_code == 200
     assert response.json()["anchor_chunk_ids"] == expected
@@ -877,7 +890,7 @@ def test_joint_beats_parity_with_production(
 def test_vocab_endpoint_serves_picker_vocabularies(client: TestClient) -> None:
     """The what-if drawer's pickers read slot-scoped vocab from one call."""
 
-    response = client.get("/api/dev/orrery/vocab?slot=2")
+    response = client.get(f"/api/dev/orrery/vocab?slot={LIVE_SLOT}")
     assert response.status_code == 200
     payload = response.json()
     assert set(payload) == {"tags", "pair_tags", "event_types", "places"}

--- a/tests/test_character_tag_manifest.py
+++ b/tests/test_character_tag_manifest.py
@@ -102,25 +102,8 @@ def test_cli_character_manifest_returns_live_slot2_payload() -> None:
     assert result["character_manifest"]["source"]["slot"] == 2
 
 
-@pytest.mark.requires_postgres
-def test_cli_character_apply_dry_run_skips_unreviewed_slot2_manifest() -> None:
-    """CLI character-apply should not write generated review-required rows."""
-
-    try:
-        result = cli.run_character_apply(
-            Namespace(slot=2, execute=False, manifest=None, source_kind="system")
-        )
-    except psycopg2.Error as exc:
-        pytest.skip(f"{TEST_DBNAME} PostgreSQL test database unavailable: {exc}")
-    finally:
-        close_pool(TEST_DBNAME)
-
-    assert result["success"] is True
-    apply_result = result["character_apply"]
-    assert apply_result["dry_run"] is True
-    assert apply_result["entity_kind"] == "character"
-    assert apply_result["counters"]["ready_entity_tag_operations"] == 0
-    assert apply_result["counters"]["review_required_operations_skipped"] > 0
+# Slot-2 retrofit live coverage was retired by owner order on 2026-07-17;
+# the tooling remains available for any future legacy import.
 
 
 def _row(

--- a/tests/test_faction_table_audit.py
+++ b/tests/test_faction_table_audit.py
@@ -954,24 +954,8 @@ def test_cli_faction_apply_rejects_manifest_slot_mismatch(tmp_path) -> None:
     assert "does not match --slot" in result["error"]
 
 
-@pytest.mark.requires_postgres
-def test_cli_faction_manifest_returns_live_slot2_payload() -> None:
-    """The faction manifest CLI should build from the real slot 2 audit."""
-
-    try:
-        result = cli.run_faction_manifest(Namespace(slot=2, output=None))
-    except psycopg2.Error as exc:
-        pytest.skip(f"{TEST_DBNAME} PostgreSQL test database unavailable: {exc}")
-    finally:
-        close_pool(TEST_DBNAME)
-
-    manifest = result["faction_manifest"]
-
-    assert result["success"] is True
-    assert result["slot"] == 2
-    assert manifest["dry_run"] is True
-    assert manifest["counters"]["operation_items"] >= 1
-    assert manifest["counters"]["operation_items"] == len(manifest["operations"])
+# Slot-2 retrofit live coverage was retired by owner order on 2026-07-17;
+# the tooling remains available for any future legacy import.
 
 
 @pytest.mark.requires_postgres
@@ -1077,37 +1061,6 @@ def test_live_faction_apply_execute_inserts_and_rolls_back() -> None:
         if conn is not None:
             conn.rollback()
             conn.close()
-
-
-@pytest.mark.requires_postgres
-def test_cli_faction_apply_dry_run_returns_live_slot2_payload() -> None:
-    """The faction apply CLI should validate ready writes without mutating."""
-
-    try:
-        result = cli.run_faction_apply(
-            Namespace(slot=2, execute=False, source_kind="system")
-        )
-    except psycopg2.Error as exc:
-        pytest.skip(f"{TEST_DBNAME} PostgreSQL test database unavailable: {exc}")
-    except ValueError as exc:
-        message = str(exc)
-        if (
-            "Unknown or deprecated faction tag" in message
-            or "No Orrery tag categories registered" in message
-            or "not registered for factions" in message
-        ):
-            pytest.skip(f"{TEST_DBNAME} faction vocabulary not seeded: {exc}")
-        raise
-    finally:
-        close_pool(TEST_DBNAME)
-
-    apply_result = result["faction_apply"]
-
-    assert result["success"] is True
-    assert result["slot"] == 2
-    assert apply_result["dry_run"] is True
-    assert apply_result["counters"]["operation_items"] >= 1
-    assert apply_result["counters"]["ready_entity_tag_operations"] >= 0
 
 
 def test_cli_prints_faction_manifest_summary(capsys) -> None:

--- a/tests/test_lore/test_retrieval_coverage_live.py
+++ b/tests/test_lore/test_retrieval_coverage_live.py
@@ -1,4 +1,4 @@
-"""Rolled-back save_02 proof for retrieval coverage instrumentation."""
+"""Rolled-back save_05 proof for retrieval coverage instrumentation."""
 
 from __future__ import annotations
 
@@ -14,6 +14,7 @@ from nexus.memory import ContextMemoryManager
 from scripts.report_retrieval_coverage import format_retrieval_coverage_report
 
 pytestmark = pytest.mark.requires_postgres
+LIVE_SLOT = 5
 
 
 class LiveReferenceMemnon:
@@ -37,7 +38,7 @@ class LiveReferenceMemnon:
 
 
 def test_handle_user_input_writes_exact_coverage_and_empty_detection() -> None:
-    engine = create_engine(get_slot_db_url(slot=2))
+    engine = create_engine(get_slot_db_url(slot=LIVE_SLOT))
     migration_path = (
         Path(__file__).resolve().parents[2]
         / "migrations"
@@ -51,31 +52,43 @@ def test_handle_user_input_writes_exact_coverage_and_empty_detection() -> None:
             covered = connection.execute(
                 text(
                     """
-                    SELECT c.id, c.name, ccr.chunk_id
-                    FROM characters c
-                    JOIN chunk_character_references ccr
-                      ON ccr.character_id = c.id
-                    WHERE lower(c.name) = 'alex'
-                    ORDER BY ccr.chunk_id DESC
-                    LIMIT 1
+                    WITH entity_row AS (
+                        INSERT INTO entities (kind, is_active)
+                        VALUES ('character', true)
+                        RETURNING id
+                    ), character_row AS (
+                        INSERT INTO characters (name, entity_id)
+                        SELECT 'Coverage Hit Probe', id FROM entity_row
+                        RETURNING id, name
+                    ), reference_row AS (
+                        INSERT INTO chunk_character_references (
+                            chunk_id, character_id, reference
+                        )
+                        SELECT max(nc.id), cr.id, 'present'
+                        FROM narrative_chunks nc
+                        CROSS JOIN character_row cr
+                        GROUP BY cr.id
+                        RETURNING chunk_id
+                    )
+                    SELECT cr.id, cr.name, rr.chunk_id
+                    FROM character_row cr
+                    CROSS JOIN reference_row rr
                     """
                 )
             ).one()
             gap = connection.execute(
                 text(
                     """
-                    SELECT c.id, c.name
-                    FROM characters c
-                    WHERE lower(c.name) = 'wren'
-                      AND NOT EXISTS (
-                          SELECT 1
-                          FROM chunk_character_references ccr
-                          WHERE ccr.character_id = c.id
-                            AND ccr.chunk_id = :chunk_id
-                      )
+                    WITH entity_row AS (
+                        INSERT INTO entities (kind, is_active)
+                        VALUES ('character', true)
+                        RETURNING id
+                    )
+                    INSERT INTO characters (name, entity_id)
+                    SELECT 'Coverage Gap Probe', id FROM entity_row
+                    RETURNING id, name
                     """
-                ),
-                {"chunk_id": covered.chunk_id},
+                )
             ).one()
 
             manager = ContextMemoryManager(
@@ -101,8 +114,9 @@ def test_handle_user_input_writes_exact_coverage_and_empty_detection() -> None:
                 turn_id="coverage-live-empty",
             )
 
-            rows = (
-                connection.execute(
+            rows = [
+                dict(row)
+                for row in connection.execute(
                     text(
                         """
                     SELECT turn_id, user_input, detected_entities,
@@ -119,7 +133,7 @@ def test_handle_user_input_writes_exact_coverage_and_empty_detection() -> None:
                 )
                 .mappings()
                 .all()
-            )
+            ]
             assert len(rows) == 2
 
             hit_gap_row = rows[0]
@@ -160,7 +174,7 @@ def test_handle_user_input_writes_exact_coverage_and_empty_detection() -> None:
             assert empty_row["gap_entities"] == []
 
             print()
-            print(format_retrieval_coverage_report(2, rows))
+            print(format_retrieval_coverage_report(LIVE_SLOT, rows))
         finally:
             transaction.rollback()
     engine.dispose()

--- a/tests/test_orrery/test_evidence.py
+++ b/tests/test_orrery/test_evidence.py
@@ -19,6 +19,7 @@ every explain, so the whole explain test suite doubles as a drift tripwire.
 from __future__ import annotations
 
 import json
+from datetime import datetime
 
 import pytest
 
@@ -100,7 +101,8 @@ from nexus.agents.orrery.substrate import (
     weather_is,
 )
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
-from datetime import datetime
+
+LIVE_SLOT = 5
 
 ACTOR, TARGET, FACTION_ID = 1, 2, 9
 PLACE_ENTITY = 501
@@ -403,7 +405,7 @@ def test_slot_backed_explain_carries_evidence_end_to_end() -> None:
     from nexus.config import load_settings_as_dict
 
     orrery = load_settings_as_dict()["orrery"]
-    engine = create_engine(get_slot_db_url(slot=2))
+    engine = create_engine(get_slot_db_url(slot=LIVE_SLOT))
     try:
         with Session(engine) as session:
             report = explain_dry_run(
@@ -417,7 +419,7 @@ def test_slot_backed_explain_carries_evidence_end_to_end() -> None:
         engine.dispose()
 
     payload = json.loads(json.dumps(report.to_dict()))
-    assert payload["actors"], "save_02 is expected to bind off-screen actors"
+    assert payload["actors"], "save_05 is expected to bind off-screen actors"
 
     def _leaves(node: dict):
         if "children" in node:

--- a/tests/test_orrery/test_reconstruction.py
+++ b/tests/test_orrery/test_reconstruction.py
@@ -1,6 +1,6 @@
 """Live tests for the reconstruction-sufficiency layer (migration 065).
 
-Real writers and real triggers against save_02 inside always-rolled-back
+Real writers and real triggers against save_05 inside always-rolled-back
 transactions — zero persistent writes. Pins the issue #426 decisions:
 
 - 7b: every Skald-side scalar write lands in ``state_delta_log``, chunk-keyed.
@@ -35,7 +35,7 @@ from nexus.api.commit_handler_sync import apply_state_updates_sync
 
 pytestmark = pytest.mark.requires_postgres
 
-WRITE_SLOT = 2
+WRITE_SLOT = 5
 
 
 def _connect() -> Any:
@@ -73,7 +73,7 @@ def test_checkpoint_captures_every_section_and_is_idempotent() -> None:
             cur.execute("SELECT count(*) FROM entity_tags WHERE cleared_at IS NULL")
             active_tags = cur.fetchone()[0]
             assert len(state["entity_tags"]) == active_tags
-            assert active_tags > 0, "save_02 must carry active tags"
+            assert active_tags > 0, "save_05 must carry active tags"
             assert state["characters"], "character scalars must be captured"
 
             # Idempotent per (chunk, label): re-commit of the same tick

--- a/tests/test_orrery/test_replay.py
+++ b/tests/test_orrery/test_replay.py
@@ -1,6 +1,6 @@
 """Live tests for the replay consumer (nexus/agents/orrery/replay.py).
 
-Real writers, real triggers, real ledgers against save_02 inside
+Real writers, real triggers, real ledgers against save_05 inside
 always-rolled-back transactions — the #428 test pattern. Each test
 fabricates post-checkpoint history through the same code paths production
 uses, then proves the replayer inverts it:
@@ -53,7 +53,7 @@ from nexus.api.commit_handler_sync import apply_state_updates_sync
 
 pytestmark = pytest.mark.requires_postgres
 
-WRITE_SLOT = 2
+WRITE_SLOT = 5
 
 
 def _connect() -> Any:
@@ -166,7 +166,7 @@ PROJECT_POLICY = ProjectPolicy(
 
 
 def _apply_migration_074(cur: Any) -> None:
-    """Create the pilot table only inside this rolled-back save_02 transaction."""
+    """Create the pilot table only inside this rolled-back save_05 transaction."""
 
     cur.execute(Path("migrations/074_plan_relocation_projects.sql").read_text())
 
@@ -364,7 +364,7 @@ def test_relationship_unwind_restores_updates_deletes_and_drops_inserts() -> Non
         with conn.cursor() as cur:
             # Reconstruct at a fabricated pre-chunk, not the historical head:
             # anchoring at head would unwind any unattributed version rows
-            # accumulated on slot 2 since May, making the assertions hostage
+            # accumulated on native slot 5, making the assertions hostage
             # to unrelated history.
             head = _fabricate_chunk(cur, None)
             cur.execute(
@@ -547,7 +547,7 @@ def test_reconstruction_refuses_pre_instrumentation_chunks() -> None:
                 "WHERE chunk_id IS NOT NULL"
             )
             earliest = cur.fetchone()[0]
-            assert earliest is not None, "save_02 must carry a genesis checkpoint"
+            assert earliest is not None, "save_05 must carry a genesis checkpoint"
             cur.execute(
                 "SELECT max(id) FROM narrative_chunks WHERE id < %s", (earliest,)
             )


### PR DESCRIPTION
The owner-ordered slot-2 reset (2026-07-17: slot 2 is now a byte-clone of slot 1) removed the retrofit-era data that nine postgres-suite tests silently depended on — the long-deferred test re-point, finally forced due.

- Living system tests (`test_replay`, `test_reconstruction`, `test_evidence`, `test_orrery_dev_endpoints`, `test_retrieval_coverage_live`) re-point to Orrery-native slot 5, with rollback-only self-created fixtures where they had leaned on retrofit shapes.
- The three retrofit-tooling live tests (`character_tag_manifest`, `faction_table_audit`) retire with the reason documented in-file: their subject state no longer exists on any slot; the tooling itself remains for future legacy imports. Hermetic coverage preserved.
- Test-only; no production code changed.

Suites: 1395 default / 1611 postgres, both exit 0, independently re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UUKcWGZUXg2jF5Nqrhtqv