### PR TITLE
Add deterministic claim propagation (#477 Stage 2c)

### DIFF
--- a/migrations/083_claim_propagation_ledger.sql
+++ b/migrations/083_claim_propagation_ledger.sql
@@ -1,0 +1,31 @@
+-- 083_claim_propagation_ledger.sql
+--
+-- Register the Stage 2c system event that double-enters every passively
+-- propagated secondhand-knowledge acquisition.  The event-local world clock
+-- preserves the scheduled acquisition time when a large accepted-chunk time
+-- skip releases several staggered hops in one transaction.
+-- New checkpoint captures add the 'claim_awareness' section in Python. Older
+-- checkpoint documents intentionally remain untouched so replay can identify
+-- the missing section and skip that unreproducible comparison window.
+
+ALTER TABLE world_events
+    ADD COLUMN IF NOT EXISTS world_time timestamptz;
+
+COMMENT ON COLUMN world_events.world_time IS
+    'Exact diegetic occurrence time for system events whose schedule may precede their committing chunk; NULL legacy/resolver rows inherit the tick chunk world time.';
+
+CREATE INDEX IF NOT EXISTS ix_world_events_claim_propagated_claim_id
+    ON world_events (((payload ->> 'claim_id')::bigint))
+    WHERE event_type = 'claim_propagated';
+
+COMMENT ON INDEX ix_world_events_claim_propagated_claim_id IS
+    'Supports Stage 2c frontier depth recovery by claim id without scanning unrelated world-event payloads.';
+
+INSERT INTO event_types (type, category, severity, description)
+VALUES (
+    'claim_propagated',
+    'intelligence',
+    'minor',
+    'System-minted secondhand-knowledge acquisition produced by the deterministic Social Contagion frontier drain.'
+)
+ON CONFLICT (type) DO NOTHING;

--- a/nexus/agents/orrery/communication.py
+++ b/nexus/agents/orrery/communication.py
@@ -20,6 +20,57 @@ from nexus.config.settings_models import OrreryContagionSettings
 CommunicationEdgeKind = Literal["dyad", "channel"]
 _VALENCE_RE = re.compile(r"^(?P<magnitude>[+-]?\d+)\|[^|]+$")
 _CULTURE_CATEGORIES = frozenset({"operational_secrecy", "operational_mode"})
+_DYAD_SQL = """
+    /* orrery:communication_dyads */
+    SELECT c1.entity_id AS teller_entity_id,
+           c2.entity_id AS listener_entity_id,
+           cr.relationship_type::text AS relationship_type,
+           cr.emotional_valence::text AS emotional_valence
+    FROM character_relationships cr
+    JOIN characters c1 ON c1.id = cr.character1_id
+    JOIN characters c2 ON c2.id = cr.character2_id
+    JOIN entities teller ON teller.id = c1.entity_id
+    JOIN entities listener ON listener.id = c2.entity_id
+    WHERE teller.kind = 'character'
+      AND listener.kind = 'character'
+      AND teller.is_active = true
+      AND listener.is_active = true
+    ORDER BY c1.entity_id, c2.entity_id, cr.relationship_type::text
+"""
+_REGISTERED_PAIR_TAGS_SQL = """
+    /* orrery:communication_registered_pair_tags */
+    SELECT tag
+    FROM pair_tags
+    WHERE NOT deprecated
+    ORDER BY tag
+"""
+_CHANNEL_SQL = """
+    /* orrery:communication_channels */
+    SELECT ept.subject_entity_id,
+           subject.kind::text AS subject_kind,
+           ept.object_entity_id,
+           object.kind::text AS object_kind,
+           pt.tag
+    FROM entity_pair_tags ept
+    JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+    JOIN entities subject ON subject.id = ept.subject_entity_id
+    JOIN entities object ON object.id = ept.object_entity_id
+    WHERE ept.cleared_at IS NULL
+      AND NOT pt.deprecated
+      AND subject.is_active = true
+      AND object.is_active = true
+    ORDER BY ept.subject_entity_id, ept.object_entity_id, pt.tag
+"""
+_CULTURE_TAGS_SQL = """
+    /* orrery:communication_culture_tags */
+    SELECT etc.entity_id, etc.category, etc.tag
+    FROM entity_tags_current etc
+    JOIN entities institution ON institution.id = etc.entity_id
+    WHERE institution.kind = 'faction'
+      AND institution.is_active = true
+      AND etc.category IN ('operational_secrecy', 'operational_mode')
+    ORDER BY etc.entity_id, etc.category, etc.tag
+"""
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,10 +146,17 @@ def _fetch_mappings(session_or_cur: Any, sql: str) -> list[dict[str, Any]]:
         raise TypeError(
             "session_or_cur must be a SQLAlchemy session/connection or DB-API cursor"
         )
+    rows = session_or_cur.fetchall()
+    if rows and isinstance(rows[0], Mapping):
+        return [dict(row) for row in rows]
     column_names = [column[0] for column in description]
-    return [
-        dict(zip(column_names, row, strict=True)) for row in session_or_cur.fetchall()
-    ]
+    return [dict(zip(column_names, row, strict=True)) for row in rows]
+
+
+async def _fetch_mappings_async(conn: Any, sql: str) -> list[dict[str, Any]]:
+    """Execute read SQL through the asyncpg commit connection."""
+
+    return [dict(row) for row in await conn.fetch(sql)]
 
 
 def _valence_tier(emotional_valence: Any) -> Literal["trusting", "neutral", "hostile"]:
@@ -136,16 +194,12 @@ def _edge_sort_key(edge: CommunicationEdge) -> tuple[Any, ...]:
 
 
 def _registered_channel_tags(session_or_cur: Any) -> frozenset[str]:
-    rows = _fetch_mappings(
-        session_or_cur,
-        """
-        /* orrery:communication_registered_pair_tags */
-        SELECT tag
-        FROM pair_tags
-        WHERE NOT deprecated
-        ORDER BY tag
-        """,
-    )
+    rows = _fetch_mappings(session_or_cur, _REGISTERED_PAIR_TAGS_SQL)
+    return frozenset(str(row["tag"]) for row in rows)
+
+
+async def _registered_channel_tags_async(conn: Any) -> frozenset[str]:
+    rows = await _fetch_mappings_async(conn, _REGISTERED_PAIR_TAGS_SQL)
     return frozenset(str(row["tag"]) for row in rows)
 
 
@@ -169,26 +223,18 @@ def _validate_channel_registry(
 def _dyad_edges(
     session_or_cur: Any, settings: OrreryContagionSettings
 ) -> list[CommunicationEdge]:
-    rows = _fetch_mappings(
-        session_or_cur,
-        """
-        /* orrery:communication_dyads */
-        SELECT c1.entity_id AS teller_entity_id,
-               c2.entity_id AS listener_entity_id,
-               cr.relationship_type::text AS relationship_type,
-               cr.emotional_valence::text AS emotional_valence
-        FROM character_relationships cr
-        JOIN characters c1 ON c1.id = cr.character1_id
-        JOIN characters c2 ON c2.id = cr.character2_id
-        JOIN entities teller ON teller.id = c1.entity_id
-        JOIN entities listener ON listener.id = c2.entity_id
-        WHERE teller.kind = 'character'
-          AND listener.kind = 'character'
-          AND teller.is_active = true
-          AND listener.is_active = true
-        ORDER BY c1.entity_id, c2.entity_id, cr.relationship_type::text
-        """,
-    )
+    return _dyad_edges_from_rows(_fetch_mappings(session_or_cur, _DYAD_SQL), settings)
+
+
+async def _dyad_edges_async(
+    conn: Any, settings: OrreryContagionSettings
+) -> list[CommunicationEdge]:
+    return _dyad_edges_from_rows(await _fetch_mappings_async(conn, _DYAD_SQL), settings)
+
+
+def _dyad_edges_from_rows(
+    rows: Sequence[Mapping[str, Any]], settings: OrreryContagionSettings
+) -> list[CommunicationEdge]:
     row_keys = {
         (
             int(row["teller_entity_id"]),
@@ -231,42 +277,26 @@ def _dyad_edges(
 
 
 def _channel_rows(session_or_cur: Any) -> list[dict[str, Any]]:
-    return _fetch_mappings(
-        session_or_cur,
-        """
-        /* orrery:communication_channels */
-        SELECT ept.subject_entity_id,
-               subject.kind::text AS subject_kind,
-               ept.object_entity_id,
-               object.kind::text AS object_kind,
-               pt.tag
-        FROM entity_pair_tags ept
-        JOIN pair_tags pt ON pt.id = ept.pair_tag_id
-        JOIN entities subject ON subject.id = ept.subject_entity_id
-        JOIN entities object ON object.id = ept.object_entity_id
-        WHERE ept.cleared_at IS NULL
-          AND NOT pt.deprecated
-          AND subject.is_active = true
-          AND object.is_active = true
-        ORDER BY ept.subject_entity_id, ept.object_entity_id, pt.tag
-        """,
-    )
+    return _fetch_mappings(session_or_cur, _CHANNEL_SQL)
+
+
+async def _channel_rows_async(conn: Any) -> list[dict[str, Any]]:
+    return await _fetch_mappings_async(conn, _CHANNEL_SQL)
 
 
 def _culture_tags_by_institution(session_or_cur: Any) -> dict[int, Tuple[str, ...]]:
-    rows = _fetch_mappings(
-        session_or_cur,
-        """
-        /* orrery:communication_culture_tags */
-        SELECT etc.entity_id, etc.category, etc.tag
-        FROM entity_tags_current etc
-        JOIN entities institution ON institution.id = etc.entity_id
-        WHERE institution.kind = 'faction'
-          AND institution.is_active = true
-          AND etc.category IN ('operational_secrecy', 'operational_mode')
-        ORDER BY etc.entity_id, etc.category, etc.tag
-        """,
-    )
+    return _culture_tags_from_rows(_fetch_mappings(session_or_cur, _CULTURE_TAGS_SQL))
+
+
+async def _culture_tags_by_institution_async(
+    conn: Any,
+) -> dict[int, Tuple[str, ...]]:
+    return _culture_tags_from_rows(await _fetch_mappings_async(conn, _CULTURE_TAGS_SQL))
+
+
+def _culture_tags_from_rows(
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[int, Tuple[str, ...]]:
     tags: dict[int, list[str]] = {}
     for row in rows:
         category = str(row["category"])
@@ -346,10 +376,31 @@ def _channel_edges(
     session_or_cur: Any, settings: OrreryContagionSettings
 ) -> list[CommunicationEdge]:
     registered_tags = _registered_channel_tags(session_or_cur)
-    _validate_channel_registry(settings.channels, registered_tags)
     culture_tags = _culture_tags_by_institution(session_or_cur)
+    return _channel_edges_from_rows(
+        _channel_rows(session_or_cur), registered_tags, culture_tags, settings
+    )
+
+
+async def _channel_edges_async(
+    conn: Any, settings: OrreryContagionSettings
+) -> list[CommunicationEdge]:
+    registered_tags = await _registered_channel_tags_async(conn)
+    culture_tags = await _culture_tags_by_institution_async(conn)
+    return _channel_edges_from_rows(
+        await _channel_rows_async(conn), registered_tags, culture_tags, settings
+    )
+
+
+def _channel_edges_from_rows(
+    rows: Sequence[Mapping[str, Any]],
+    registered_tags: frozenset[str],
+    culture_tags: Mapping[int, Sequence[str]],
+    settings: OrreryContagionSettings,
+) -> list[CommunicationEdge]:
+    _validate_channel_registry(settings.channels, registered_tags)
     edges: list[CommunicationEdge] = []
-    for row in _channel_rows(session_or_cur):
+    for row in rows:
         tag = str(row["tag"])
         channel_key = "status:*" if tag.startswith("status:") else tag
         channel = settings.channels.get(channel_key)
@@ -403,6 +454,24 @@ def assemble_communication_graph(
     return CommunicationGraph(edges=tuple(sorted(edges, key=_edge_sort_key)))
 
 
+async def assemble_communication_graph_async(
+    conn: Any,
+    *,
+    settings: Any,
+    world_time: Optional[datetime],
+) -> CommunicationGraph:
+    """Asyncpg twin of :func:`assemble_communication_graph`."""
+
+    del world_time
+    config = coerce_contagion_settings(settings)
+    if not config.enabled:
+        return CommunicationGraph()
+    await _validate_dyad_overrides_async(conn, config.dyad_overrides)
+    edges = await _dyad_edges_async(conn, config)
+    edges.extend(await _channel_edges_async(conn, config))
+    return CommunicationGraph(edges=tuple(sorted(edges, key=_edge_sort_key)))
+
+
 def communication_graph_for_settings(
     session_or_cur: Any,
     settings: Any,
@@ -434,12 +503,7 @@ def _validate_dyad_overrides(session_or_cur: Any, overrides: Mapping[str, Any]) 
 
     if not overrides:
         return
-    from nexus.agents.logon.apex_enums import RelationshipType
-    from nexus.agents.orrery.catalog import collect_template_vocabulary
-    from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
-
-    valid = {member.value for member in RelationshipType}
-    valid.update(collect_template_vocabulary(BUILTIN_TEMPLATES)["relationship_types"])
+    valid = _known_relationship_types()
     valid.update(
         str(row["relationship_type"])
         for row in _fetch_mappings(
@@ -453,3 +517,33 @@ def _validate_dyad_overrides(session_or_cur: Any, overrides: Mapping[str, Any]) 
             "orrery.contagion dyad_overrides reference unknown relationship "
             f"types {unknown}; known types: {sorted(valid)}"
         )
+
+
+async def _validate_dyad_overrides_async(
+    conn: Any, overrides: Mapping[str, Any]
+) -> None:
+    if not overrides:
+        return
+    valid = _known_relationship_types()
+    valid.update(
+        str(row["relationship_type"])
+        for row in await _fetch_mappings_async(
+            conn, "SELECT DISTINCT relationship_type FROM character_relationships"
+        )
+    )
+    unknown = sorted(set(overrides) - valid)
+    if unknown:
+        raise ValueError(
+            "orrery.contagion dyad_overrides reference unknown relationship "
+            f"types {unknown}; known types: {sorted(valid)}"
+        )
+
+
+def _known_relationship_types() -> set[str]:
+    from nexus.agents.logon.apex_enums import RelationshipType
+    from nexus.agents.orrery.catalog import collect_template_vocabulary
+    from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+
+    valid = {member.value for member in RelationshipType}
+    valid.update(collect_template_vocabulary(BUILTIN_TEMPLATES)["relationship_types"])
+    return valid

--- a/nexus/agents/orrery/db_rows.py
+++ b/nexus/agents/orrery/db_rows.py
@@ -1,0 +1,13 @@
+"""Small row-access helpers shared by Orrery DB-API call sites."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def row_get(row: Any, key: str, index: int) -> Any:
+    """Read one value from either a mapping row or a positional row."""
+
+    if isinstance(row, Mapping) or hasattr(row, "keys"):
+        return row[key]
+    return row[index]

--- a/nexus/agents/orrery/epistemics.py
+++ b/nexus/agents/orrery/epistemics.py
@@ -10,6 +10,7 @@ from sqlalchemy import bindparam, text
 
 
 CLAIM_SCOPES = frozenset({"common", "bounded", "private"})
+CLAIM_PROPAGATED_EVENT_TYPE = "claim_propagated"
 EVENT_ROLES = frozenset({"actor", "target", "observer", "witness", "beneficiary"})
 PARTICIPANT_ROLES = frozenset({"actor", "target", "beneficiary"})
 WITNESS_ROLES = frozenset({"observer", "witness"})
@@ -65,7 +66,12 @@ def coerce_epistemics_policy(raw: Any) -> EpistemicsPolicy:
     if raw is None:
         return EpistemicsPolicy()
     if isinstance(raw, EpistemicsPolicy):
-        return raw
+        policy = raw
+        if CLAIM_PROPAGATED_EVENT_TYPE in policy.claim_event_types:
+            raise ValueError(
+                "claim_propagated cannot appear in Epistemics claim_event_types"
+            )
+        return policy
     if hasattr(raw, "model_dump"):
         raw = raw.model_dump()
     if not isinstance(raw, Mapping):
@@ -74,6 +80,10 @@ def coerce_epistemics_policy(raw: Any) -> EpistemicsPolicy:
     aware_roles = [str(value).strip() for value in raw.get("aware_roles", ())]
     if any(not value for value in event_types):
         raise ValueError("Epistemics claim_event_types entries must be non-empty")
+    if CLAIM_PROPAGATED_EVENT_TYPE in event_types:
+        raise ValueError(
+            "claim_propagated cannot appear in Epistemics claim_event_types"
+        )
     unknown_roles = set(aware_roles) - EVENT_ROLES
     if unknown_roles:
         raise ValueError(f"Unknown Epistemics aware roles: {sorted(unknown_roles)}")
@@ -125,6 +135,8 @@ def mint_claim_for_event(
 ) -> Optional[MintResult]:
     """Mint or recover one event claim and its configured awareness rows."""
 
+    if event_type == CLAIM_PROPAGATED_EVENT_TYPE:
+        return None
     policy = coerce_epistemics_policy(settings)
     if not policy.enabled or event_type not in policy.claim_event_types:
         return None
@@ -176,6 +188,8 @@ async def mint_claim_for_event_async(
 ) -> Optional[MintResult]:
     """Async twin of :func:`mint_claim_for_event` for asyncpg appliers."""
 
+    if event_type == CLAIM_PROPAGATED_EVENT_TYPE:
+        return None
     policy = coerce_epistemics_policy(settings)
     if not policy.enabled or event_type not in policy.claim_event_types:
         return None
@@ -500,7 +514,15 @@ def _acquisition_world_time_sync(
             (source_chunk_id,),
         )
     else:
-        cur.execute("SELECT max(world_time) AS world_time FROM chunk_metadata")
+        return current_world_time_sync(cur)
+    row = cur.fetchone()
+    return _row_value(row, "world_time", 0) if row else None
+
+
+def current_world_time_sync(cur: Any) -> Optional[datetime]:
+    """Return the current diegetic clock, or ``None`` in a clockless world."""
+
+    cur.execute("SELECT max(world_time) AS world_time FROM chunk_metadata")
     row = cur.fetchone()
     return _row_value(row, "world_time", 0) if row else None
 

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 import json
 from typing import Any, Mapping, Optional
 
+from nexus.agents.orrery.db_rows import row_get as _row_get
 from nexus.agents.orrery.epistemics import (
     ClaimParticipant,
     MintResult,
@@ -29,6 +30,10 @@ from nexus.agents.orrery.needs import (
     normalize_need_type,
     severity_tag_for_debt,
     severity_tags_for_need,
+)
+from nexus.agents.orrery.propagation import (
+    drain_claim_propagation_async,
+    drain_claim_propagation_sync,
 )
 from nexus.agents.orrery.resolver import (
     LOCATION_CLASS_TAG_CATEGORIES,
@@ -176,6 +181,7 @@ class CommitOrreryTickResult:
     replaced_count: int = 0
     scene_pressure_count: int = 0
     prompt_exposure_count: int = 0
+    propagation_count: int = 0
 
 
 def _coerce_prompt_limits(prompt_settings: Any) -> tuple[int, int]:
@@ -346,6 +352,7 @@ def commit_orrery_tick_sync(
     ecology_settings: Optional[Any] = None,
     project_settings: Optional[Any] = None,
     epistemics_settings: Optional[Any] = None,
+    contagion_settings: Optional[Any] = None,
 ) -> CommitOrreryTickResult:
     """Materialize a preview proposal inside the accepted-chunk transaction."""
 
@@ -388,11 +395,18 @@ def commit_orrery_tick_sync(
                 max_proposals=max_proposals,
                 max_pressures=max_pressures,
             )
+        propagation_result = drain_claim_propagation_sync(
+            cur,
+            tick_chunk_id=tick_chunk_id,
+            settings=contagion_settings,
+        )
+        propagation_count = propagation_result.minted_count
         if not has_resolutions:
             return CommitOrreryTickResult(
                 cleared_tag_count=expired_tag_count,
                 scene_pressure_count=scene_pressure_count,
                 prompt_exposure_count=prompt_exposure_count,
+                propagation_count=propagation_count,
             )
 
         assert coerced is not None
@@ -557,6 +571,7 @@ def commit_orrery_tick_sync(
         replaced_count=replaced_count,
         scene_pressure_count=scene_pressure_count,
         prompt_exposure_count=prompt_exposure_count,
+        propagation_count=propagation_count,
     )
 
 
@@ -574,6 +589,7 @@ async def commit_orrery_tick_async(
     ecology_settings: Optional[Any] = None,
     project_settings: Optional[Any] = None,
     epistemics_settings: Optional[Any] = None,
+    contagion_settings: Optional[Any] = None,
 ) -> CommitOrreryTickResult:
     """Async parity wrapper for tests and non-production commit callers."""
 
@@ -615,11 +631,18 @@ async def commit_orrery_tick_async(
             max_proposals=max_proposals,
             max_pressures=max_pressures,
         )
+    propagation_result = await drain_claim_propagation_async(
+        conn,
+        tick_chunk_id=tick_chunk_id,
+        settings=contagion_settings,
+    )
+    propagation_count = propagation_result.minted_count
     if not has_resolutions:
         return CommitOrreryTickResult(
             cleared_tag_count=expired_tag_count,
             scene_pressure_count=scene_pressure_count,
             prompt_exposure_count=prompt_exposure_count,
+            propagation_count=propagation_count,
         )
 
     assert coerced is not None
@@ -784,6 +807,7 @@ async def commit_orrery_tick_async(
         replaced_count=replaced_count,
         scene_pressure_count=scene_pressure_count,
         prompt_exposure_count=prompt_exposure_count,
+        propagation_count=propagation_count,
     )
 
 
@@ -6062,12 +6086,6 @@ def _coerce_int(value: Any, *, label: str) -> int:
         return int(value)
     except (TypeError, ValueError) as exc:
         raise ValueError(f"Orrery {label} must be an integer entity id") from exc
-
-
-def _row_get(row: Any, key: str, index: int) -> Any:
-    if isinstance(row, Mapping):
-        return row[key]
-    return row[index]
 
 
 def _row_get_optional(row: Any, key: str, index: int, default: Any = None) -> Any:

--- a/nexus/agents/orrery/propagation.py
+++ b/nexus/agents/orrery/propagation.py
@@ -1,0 +1,695 @@
+"""World-clock frontier draining for bounded Orrery claims.
+
+The append-only ``claim_awareness`` projection is the only durable frontier.
+This module derives every eligible transmission from that table plus the
+current Stage 2b communication graph, then double-enters each new awareness
+row as a ``claim_propagated`` world event.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from hashlib import sha256
+import heapq
+from itertools import count
+import json
+from typing import Any, Mapping, Optional, Sequence
+
+from nexus.agents.orrery.communication import (
+    CommunicationEdge,
+    CommunicationGraph,
+    assemble_communication_graph,
+    assemble_communication_graph_async,
+    coerce_contagion_settings,
+)
+from nexus.agents.orrery.db_rows import row_get as _row_get
+from nexus.config.settings_models import OrreryContagionSettings
+
+
+CLAIM_PROPAGATED_EVENT_TYPE = "claim_propagated"
+
+
+@dataclass(frozen=True, slots=True)
+class AwarenessState:
+    """The frontier fields needed to schedule one knower's outbound hops."""
+
+    claim_id: int
+    knower_entity_id: int
+    acquired_at_world_time: Optional[datetime]
+    root_source_entity_id: Optional[int]
+    depth: int
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedPropagation:
+    """One deterministic acquisition derived during a drain fixpoint."""
+
+    claim_id: int
+    knower_entity_id: int
+    immediate_source_entity_id: int
+    root_source_entity_id: int
+    channel: str
+    acquired_at_world_time: datetime
+    latency_seconds: float
+    depth: int
+
+
+@dataclass(frozen=True, slots=True)
+class PropagationDrainResult:
+    """Rows and ledger events materialized by one accepted-chunk drain."""
+
+    awareness_ids: tuple[int, ...] = ()
+    event_ids: tuple[int, ...] = ()
+    policy_digest: Optional[str] = None
+
+    @property
+    def minted_count(self) -> int:
+        """Return the double-entry acquisition count."""
+
+        if len(self.awareness_ids) != len(self.event_ids):
+            raise RuntimeError("Propagation awareness/event ledger counts diverged")
+        return len(self.awareness_ids)
+
+
+def contagion_policy_digest(settings: Any) -> str:
+    """Hash canonical JSON for the effective ``[orrery.contagion]`` policy."""
+
+    config = coerce_contagion_settings(settings)
+    canonical = json.dumps(
+        config.model_dump(mode="json"),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def drain_claim_propagation_sync(
+    cur: Any,
+    *,
+    tick_chunk_id: int,
+    settings: Any,
+) -> PropagationDrainResult:
+    """Drain every eligible bounded-claim hop through a DB-API cursor."""
+
+    config = _enabled_config(settings)
+    if config is None:
+        return PropagationDrainResult()
+    _require_migration_083_sync(cur)
+    world_time, world_layer = _commit_clock_sync(cur, tick_chunk_id)
+    if world_layer != "primary" or world_time is None:
+        return PropagationDrainResult()
+    claim_births = _candidate_claim_births_sync(cur, config)
+    if not claim_births:
+        return PropagationDrainResult(policy_digest=contagion_policy_digest(config))
+    graph = assemble_communication_graph(
+        cur,
+        settings=config,
+        world_time=world_time,
+    )
+    frontier = _awareness_frontier_sync(cur, tuple(claim_births))
+    planned = _plan_propagations(
+        claim_births=claim_births,
+        frontier=frontier,
+        graph=graph,
+        world_time=world_time,
+        settings=config,
+    )
+    digest = contagion_policy_digest(config)
+    awareness_ids: list[int] = []
+    event_ids: list[int] = []
+    for acquisition in planned:
+        inserted = _insert_propagation_sync(
+            cur,
+            acquisition=acquisition,
+            tick_chunk_id=tick_chunk_id,
+            world_layer=world_layer,
+            policy_digest=digest,
+        )
+        if inserted is None:
+            continue
+        awareness_id, event_id = inserted
+        awareness_ids.append(awareness_id)
+        event_ids.append(event_id)
+    return PropagationDrainResult(
+        awareness_ids=tuple(awareness_ids),
+        event_ids=tuple(event_ids),
+        policy_digest=digest,
+    )
+
+
+async def drain_claim_propagation_async(
+    conn: Any,
+    *,
+    tick_chunk_id: int,
+    settings: Any,
+) -> PropagationDrainResult:
+    """Asyncpg twin of :func:`drain_claim_propagation_sync`."""
+
+    config = _enabled_config(settings)
+    if config is None:
+        return PropagationDrainResult()
+    await _require_migration_083_async(conn)
+    world_time, world_layer = await _commit_clock_async(conn, tick_chunk_id)
+    if world_layer != "primary" or world_time is None:
+        return PropagationDrainResult()
+    claim_births = await _candidate_claim_births_async(conn, config)
+    if not claim_births:
+        return PropagationDrainResult(policy_digest=contagion_policy_digest(config))
+    graph = await assemble_communication_graph_async(
+        conn,
+        settings=config,
+        world_time=world_time,
+    )
+    frontier = await _awareness_frontier_async(conn, tuple(claim_births))
+    planned = _plan_propagations(
+        claim_births=claim_births,
+        frontier=frontier,
+        graph=graph,
+        world_time=world_time,
+        settings=config,
+    )
+    digest = contagion_policy_digest(config)
+    awareness_ids: list[int] = []
+    event_ids: list[int] = []
+    for acquisition in planned:
+        inserted = await _insert_propagation_async(
+            conn,
+            acquisition=acquisition,
+            tick_chunk_id=tick_chunk_id,
+            world_layer=world_layer,
+            policy_digest=digest,
+        )
+        if inserted is None:
+            continue
+        awareness_id, event_id = inserted
+        awareness_ids.append(awareness_id)
+        event_ids.append(event_id)
+    return PropagationDrainResult(
+        awareness_ids=tuple(awareness_ids),
+        event_ids=tuple(event_ids),
+        policy_digest=digest,
+    )
+
+
+def _enabled_config(settings: Any) -> Optional[OrreryContagionSettings]:
+    if settings is None:
+        return None
+    config = coerce_contagion_settings(settings)
+    return config if config.enabled else None
+
+
+_MIGRATION_083_ERROR = (
+    "Claim propagation requires migration 083; apply migration 083 before "
+    "enabling [orrery.contagion]."
+)
+
+
+def _require_migration_083_sync(cur: Any) -> None:
+    cur.execute(
+        """
+        SELECT EXISTS (
+                   SELECT 1 FROM event_types
+                   WHERE type = 'claim_propagated'
+               ) AS event_registered,
+               EXISTS (
+                   SELECT 1
+                   FROM information_schema.columns
+                   WHERE table_schema = ANY(current_schemas(false))
+                     AND table_name = 'world_events'
+                     AND column_name = 'world_time'
+               ) AS world_time_column
+        """
+    )
+    row = cur.fetchone()
+    if row is None or not bool(_row_get(row, "event_registered", 0)):
+        raise RuntimeError(_MIGRATION_083_ERROR)
+    if not bool(_row_get(row, "world_time_column", 1)):
+        raise RuntimeError(_MIGRATION_083_ERROR)
+
+
+async def _require_migration_083_async(conn: Any) -> None:
+    row = await conn.fetchrow(
+        """
+        SELECT EXISTS (
+                   SELECT 1 FROM event_types
+                   WHERE type = 'claim_propagated'
+               ) AS event_registered,
+               EXISTS (
+                   SELECT 1
+                   FROM information_schema.columns
+                   WHERE table_schema = ANY(current_schemas(false))
+                     AND table_name = 'world_events'
+                     AND column_name = 'world_time'
+               ) AS world_time_column
+        """
+    )
+    if row is None or not bool(row["event_registered"]):
+        raise RuntimeError(_MIGRATION_083_ERROR)
+    if not bool(row["world_time_column"]):
+        raise RuntimeError(_MIGRATION_083_ERROR)
+
+
+def _commit_clock_sync(cur: Any, tick_chunk_id: int) -> tuple[Optional[datetime], Any]:
+    cur.execute(
+        """
+        SELECT world_time, world_layer::text AS world_layer
+        FROM chunk_metadata
+        WHERE chunk_id = %s
+        """,
+        (tick_chunk_id,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"Propagation chunk {tick_chunk_id} has no metadata")
+    world_time = _row_get(row, "world_time", 0)
+    return world_time, _row_get(row, "world_layer", 1)
+
+
+async def _commit_clock_async(
+    conn: Any, tick_chunk_id: int
+) -> tuple[Optional[datetime], Any]:
+    row = await conn.fetchrow(
+        """
+        SELECT world_time, world_layer::text AS world_layer
+        FROM chunk_metadata
+        WHERE chunk_id = $1
+        """,
+        tick_chunk_id,
+    )
+    if row is None:
+        raise ValueError(f"Propagation chunk {tick_chunk_id} has no metadata")
+    world_time = row["world_time"]
+    return world_time, row["world_layer"]
+
+
+_CANDIDATE_CLAIMS_SQL = """
+    WITH bounded_claims AS (
+        SELECT c.id AS claim_id,
+               COALESCE(we.world_time, cm.world_time) AS birth_world_time
+        FROM claims c
+        JOIN world_events we ON we.id = c.world_event_id
+        LEFT JOIN chunk_metadata cm ON cm.chunk_id = we.tick_chunk_id
+        WHERE c.scope = 'bounded'
+    )
+    SELECT candidate.claim_id, candidate.birth_world_time
+    FROM bounded_claims candidate
+    WHERE candidate.birth_world_time IS NOT NULL
+      AND EXISTS (
+          SELECT 1
+          FROM claim_awareness awareness
+          WHERE awareness.claim_id = candidate.claim_id
+            AND awareness.acquired_at_world_time IS NOT NULL
+            AND awareness.acquired_at_world_time
+                <= candidate.birth_world_time + {horizon_placeholder}
+      )
+    ORDER BY candidate.claim_id
+"""
+
+
+def _candidate_claim_births_sync(
+    cur: Any, settings: OrreryContagionSettings
+) -> dict[int, datetime]:
+    cur.execute(
+        _CANDIDATE_CLAIMS_SQL.format(horizon_placeholder="%s"),
+        (settings.guards.age_horizon,),
+    )
+    return _claim_births(cur.fetchall())
+
+
+async def _candidate_claim_births_async(
+    conn: Any, settings: OrreryContagionSettings
+) -> dict[int, datetime]:
+    rows = await conn.fetch(
+        _CANDIDATE_CLAIMS_SQL.format(horizon_placeholder="$1"),
+        settings.guards.age_horizon,
+    )
+    return _claim_births(rows)
+
+
+def _claim_births(rows: Sequence[Any]) -> dict[int, datetime]:
+    births = {}
+    for row in rows:
+        claim_id = int(_row_get(row, "claim_id", 0))
+        birth = _row_get(row, "birth_world_time", 1)
+        if birth is None:
+            continue
+        births[claim_id] = birth
+    return births
+
+
+def _awareness_frontier_sync(
+    cur: Any, claim_ids: Sequence[int]
+) -> tuple[AwarenessState, ...]:
+    cur.execute(
+        """
+        SELECT id, claim_id, knower_entity_id, root_source_entity_id,
+               acquired_at_world_time
+        FROM claim_awareness
+        WHERE claim_id = ANY(%s)
+        ORDER BY claim_id, acquired_at_world_time, knower_entity_id, id
+        """,
+        (list(claim_ids),),
+    )
+    awareness_rows = cur.fetchall()
+    cur.execute(
+        """
+        SELECT id, payload
+        FROM world_events
+        WHERE event_type = 'claim_propagated'
+          AND (payload ->> 'claim_id')::bigint = ANY(%s)
+        ORDER BY id
+        """,
+        (list(claim_ids),),
+    )
+    return _build_frontier(awareness_rows, cur.fetchall())
+
+
+async def _awareness_frontier_async(
+    conn: Any, claim_ids: Sequence[int]
+) -> tuple[AwarenessState, ...]:
+    awareness_rows = await conn.fetch(
+        """
+        SELECT id, claim_id, knower_entity_id, root_source_entity_id,
+               acquired_at_world_time
+        FROM claim_awareness
+        WHERE claim_id = ANY($1::bigint[])
+        ORDER BY claim_id, acquired_at_world_time, knower_entity_id, id
+        """,
+        list(claim_ids),
+    )
+    event_rows = await conn.fetch(
+        """
+        SELECT id, payload
+        FROM world_events
+        WHERE event_type = 'claim_propagated'
+          AND (payload ->> 'claim_id')::bigint = ANY($1::bigint[])
+        ORDER BY id
+        """,
+        list(claim_ids),
+    )
+    return _build_frontier(awareness_rows, event_rows)
+
+
+def _build_frontier(
+    awareness_rows: Sequence[Any], event_rows: Sequence[Any]
+) -> tuple[AwarenessState, ...]:
+    depths: dict[tuple[int, int], int] = {}
+    for row in event_rows:
+        event_id = int(_row_get(row, "id", 0))
+        payload = _json_object(_row_get(row, "payload", 1), event_id=event_id)
+        key = (
+            _payload_int(payload, "claim_id", event_id),
+            _payload_int(payload, "knower_entity_id", event_id),
+        )
+        depth = _payload_int(payload, "depth", event_id)
+        if depth < 1:
+            raise ValueError(
+                f"claim_propagated event {event_id} has invalid depth {depth}"
+            )
+        if key in depths:
+            raise ValueError(
+                "Duplicate claim_propagated ledger entries for claim/knower " f"{key}"
+            )
+        depths[key] = depth
+
+    frontier = []
+    awareness_keys: set[tuple[int, int]] = set()
+    for row in awareness_rows:
+        claim_id = int(_row_get(row, "claim_id", 1))
+        knower = int(_row_get(row, "knower_entity_id", 2))
+        acquired = _row_get(row, "acquired_at_world_time", 4)
+        root = _row_get(row, "root_source_entity_id", 3)
+        key = (claim_id, knower)
+        awareness_keys.add(key)
+        frontier.append(
+            AwarenessState(
+                claim_id=claim_id,
+                knower_entity_id=knower,
+                acquired_at_world_time=acquired,
+                root_source_entity_id=int(root) if root is not None else None,
+                depth=depths.get(key, 0),
+            )
+        )
+    orphaned = sorted(set(depths) - awareness_keys)
+    if orphaned:
+        raise ValueError(
+            "claim_propagated ledger entries have no awareness projection: "
+            f"{orphaned}"
+        )
+    return tuple(frontier)
+
+
+def _plan_propagations(
+    *,
+    claim_births: Mapping[int, datetime],
+    frontier: Sequence[AwarenessState],
+    graph: CommunicationGraph,
+    world_time: datetime,
+    settings: OrreryContagionSettings,
+) -> tuple[PlannedPropagation, ...]:
+    by_claim: dict[int, list[AwarenessState]] = {
+        claim_id: [] for claim_id in claim_births
+    }
+    for awareness in frontier:
+        by_claim.setdefault(awareness.claim_id, []).append(awareness)
+
+    outbound = _fan_out_edges(graph, settings.guards.fan_out_cap)
+    planned: list[PlannedPropagation] = []
+    sequence = count()
+    for claim_id, birth_world_time in claim_births.items():
+        possessed = {
+            awareness.knower_entity_id: awareness
+            for awareness in by_claim.get(claim_id, ())
+        }
+        pending: list[tuple[Any, ...]] = []
+
+        def offer(source: AwarenessState) -> None:
+            if (
+                source.acquired_at_world_time is None
+                or source.depth >= settings.guards.depth_cap
+            ):
+                return
+            for edge in outbound.get(source.knower_entity_id, ()):
+                scheduled = source.acquired_at_world_time + edge.latency
+                if (
+                    scheduled > world_time
+                    or scheduled > birth_world_time + settings.guards.age_horizon
+                ):
+                    continue
+                heapq.heappush(
+                    pending,
+                    (
+                        scheduled,
+                        source.depth + 1,
+                        edge.listener_entity_id,
+                        source.knower_entity_id,
+                        edge.kind,
+                        edge.label,
+                        next(sequence),
+                        edge,
+                        source,
+                    ),
+                )
+
+        for awareness in sorted(
+            possessed.values(),
+            key=lambda item: (
+                item.acquired_at_world_time is None,
+                item.acquired_at_world_time or world_time,
+                item.depth,
+                item.knower_entity_id,
+            ),
+        ):
+            offer(awareness)
+
+        while pending:
+            (
+                scheduled,
+                depth,
+                listener,
+                source_id,
+                _kind,
+                _label,
+                _sequence,
+                edge,
+                source,
+            ) = heapq.heappop(pending)
+            if listener in possessed:
+                continue
+            root = source.root_source_entity_id or source_id
+            acquisition = PlannedPropagation(
+                claim_id=claim_id,
+                knower_entity_id=listener,
+                immediate_source_entity_id=source_id,
+                root_source_entity_id=root,
+                channel=f"{edge.kind}:{edge.label}",
+                acquired_at_world_time=scheduled,
+                latency_seconds=edge.latency.total_seconds(),
+                depth=depth,
+            )
+            planned.append(acquisition)
+            minted = AwarenessState(
+                claim_id=claim_id,
+                knower_entity_id=listener,
+                acquired_at_world_time=scheduled,
+                root_source_entity_id=root,
+                depth=depth,
+            )
+            possessed[listener] = minted
+            offer(minted)
+    return tuple(planned)
+
+
+def _fan_out_edges(
+    graph: CommunicationGraph, fan_out_cap: int
+) -> dict[int, tuple[CommunicationEdge, ...]]:
+    by_teller: dict[int, list[CommunicationEdge]] = {}
+    for edge in graph.edges:
+        by_teller.setdefault(edge.teller_entity_id, []).append(edge)
+    return {
+        teller: tuple(
+            sorted(
+                edges,
+                key=lambda edge: (edge.latency, edge.listener_entity_id),
+            )[:fan_out_cap]
+        )
+        for teller, edges in by_teller.items()
+    }
+
+
+def _insert_propagation_sync(
+    cur: Any,
+    *,
+    acquisition: PlannedPropagation,
+    tick_chunk_id: int,
+    world_layer: Any,
+    policy_digest: str,
+) -> Optional[tuple[int, int]]:
+    cur.execute(
+        """
+        INSERT INTO claim_awareness (
+            claim_id, knower_entity_id, source_tier,
+            immediate_source_entity_id, root_source_entity_id, channel,
+            acquired_at_world_time, source_chunk_id
+        ) VALUES (%s, %s, 'told', %s, %s, %s, %s, %s)
+        ON CONFLICT (claim_id, knower_entity_id) DO NOTHING
+        RETURNING id
+        """,
+        (
+            acquisition.claim_id,
+            acquisition.knower_entity_id,
+            acquisition.immediate_source_entity_id,
+            acquisition.root_source_entity_id,
+            acquisition.channel,
+            acquisition.acquired_at_world_time,
+            tick_chunk_id,
+        ),
+    )
+    awareness_row = cur.fetchone()
+    if awareness_row is None:
+        return None
+    awareness_id = int(_row_get(awareness_row, "id", 0))
+    payload = _event_payload(acquisition, awareness_id, policy_digest)
+    cur.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, target_entity_id,
+            world_layer, source, changed_fields, payload, world_time
+        ) VALUES (
+            'claim_propagated', %s, NULL, NULL, %s::world_layer_type,
+            'resolver', ARRAY['claim_awareness']::text[], %s::jsonb, %s
+        )
+        RETURNING id
+        """,
+        (
+            tick_chunk_id,
+            world_layer,
+            json.dumps(payload, separators=(",", ":"), sort_keys=True),
+            acquisition.acquired_at_world_time,
+        ),
+    )
+    event_id = int(_row_get(cur.fetchone(), "id", 0))
+    return awareness_id, event_id
+
+
+async def _insert_propagation_async(
+    conn: Any,
+    *,
+    acquisition: PlannedPropagation,
+    tick_chunk_id: int,
+    world_layer: Any,
+    policy_digest: str,
+) -> Optional[tuple[int, int]]:
+    awareness_id = await conn.fetchval(
+        """
+        INSERT INTO claim_awareness (
+            claim_id, knower_entity_id, source_tier,
+            immediate_source_entity_id, root_source_entity_id, channel,
+            acquired_at_world_time, source_chunk_id
+        ) VALUES ($1, $2, 'told', $3, $4, $5, $6, $7)
+        ON CONFLICT (claim_id, knower_entity_id) DO NOTHING
+        RETURNING id
+        """,
+        acquisition.claim_id,
+        acquisition.knower_entity_id,
+        acquisition.immediate_source_entity_id,
+        acquisition.root_source_entity_id,
+        acquisition.channel,
+        acquisition.acquired_at_world_time,
+        tick_chunk_id,
+    )
+    if awareness_id is None:
+        return None
+    payload = _event_payload(acquisition, int(awareness_id), policy_digest)
+    event_id = await conn.fetchval(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, target_entity_id,
+            world_layer, source, changed_fields, payload, world_time
+        ) VALUES (
+            'claim_propagated', $1, NULL, NULL, $2::world_layer_type,
+            'resolver', ARRAY['claim_awareness']::text[], $3::jsonb, $4
+        )
+        RETURNING id
+        """,
+        tick_chunk_id,
+        world_layer,
+        json.dumps(payload, separators=(",", ":"), sort_keys=True),
+        acquisition.acquired_at_world_time,
+    )
+    return int(awareness_id), int(event_id)
+
+
+def _event_payload(
+    acquisition: PlannedPropagation, awareness_id: int, policy_digest: str
+) -> dict[str, Any]:
+    return {
+        "awareness_id": awareness_id,
+        "claim_id": acquisition.claim_id,
+        "knower_entity_id": acquisition.knower_entity_id,
+        "immediate_source_entity_id": acquisition.immediate_source_entity_id,
+        "root_source_entity_id": acquisition.root_source_entity_id,
+        "channel": acquisition.channel,
+        "latency_seconds": acquisition.latency_seconds,
+        "depth": acquisition.depth,
+        "policy_digest": policy_digest,
+    }
+
+
+def _json_object(raw: Any, *, event_id: int) -> Mapping[str, Any]:
+    if isinstance(raw, str):
+        raw = json.loads(raw)
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"claim_propagated event {event_id} payload is not an object")
+    return raw
+
+
+def _payload_int(payload: Mapping[str, Any], key: str, event_id: int) -> int:
+    try:
+        return int(payload[key])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(
+            f"claim_propagated event {event_id} has invalid {key!r}"
+        ) from exc

--- a/nexus/agents/orrery/reconstruction.py
+++ b/nexus/agents/orrery/reconstruction.py
@@ -18,6 +18,7 @@ import json
 import re
 from typing import Any, Optional
 
+from nexus.agents.orrery.db_rows import row_get
 from nexus.agents.orrery.retrograde_markers import RETROGRADE_PROLOGUE_MARKER
 
 
@@ -135,6 +136,9 @@ CHECKPOINT_SECTIONS: dict[str, str] = {
         "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
         "FROM character_routine_anchors t"
     ),
+    "claim_awareness": (
+        "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) " "FROM claim_awareness t"
+    ),
 }
 
 CHECKPOINT_LABELS = ("genesis", "interval", "manual")
@@ -174,7 +178,7 @@ def capture_state_checkpoint_sync(
         (chunk_id, label, json.dumps(state)),
     )
     row = cur.fetchone()
-    return row[0] if row else None
+    return row_get(row, "id", 0) if row else None
 
 
 async def capture_state_checkpoint_async(

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -38,6 +38,9 @@ produces. Sections and their replay sources:
   project.complete also replays its explicit-destination travel.start handoff.
 - ``character_routine_anchors`` — checkpoint pass-through (no runtime
   writer; offline seed scripts mutate it invisibly between checkpoints).
+- ``claim_awareness`` — append-only participant/witness/granted/deliberate-
+  told rows from their chunk provenance, while passive told rows are rebuilt
+  from ``claim_propagated`` world events rather than trusted from projection.
 
 Known undetectable gaps: (1) reapplication policies ``replace`` and
 ``extend_expiry`` overwrite a live tag row's ``source_chunk_id`` in place
@@ -364,7 +367,7 @@ class _Replayer:
                 f"base for reconstruction at chunk {self.target_chunk_id}"
             )
         missing = set(CHECKPOINT_SECTIONS) - set(state)
-        allowed_missing = {"character_project_states"}
+        allowed_missing = {"character_project_states", "claim_awareness"}
         unexpected_missing = missing - allowed_missing
         if unexpected_missing:
             raise ValueError(
@@ -374,6 +377,9 @@ class _Replayer:
         if "character_project_states" in missing:
             state["character_project_states"] = []
             self.missing_base_sections.add("character_project_states")
+        if "claim_awareness" in missing:
+            state["claim_awareness"] = []
+            self.missing_base_sections.add("claim_awareness")
         return checkpoint_id, chunk_id, created_at, state
 
     # -- forward scalar replay ----------------------------------------------
@@ -394,6 +400,13 @@ class _Replayer:
                 "base checkpoint predates migration 074 and lacks the project "
                 "section; treated as empty because no project table/writer "
                 "existed at that checkpoint",
+                approximate=True,
+            )
+        if "claim_awareness" in self.missing_base_sections:
+            result.add_note(
+                "claim_awareness",
+                "base checkpoint predates the claim-awareness checkpoint section; "
+                "pre-checkpoint possession is unreproducible",
                 approximate=True,
             )
 
@@ -464,10 +477,221 @@ class _Replayer:
             "offline seed/backfill scripts are invisible between checkpoints",
             approximate=False,
         )
+        self._replay_claim_awareness(
+            result,
+            base_state=base_state,
+            base_chunk=base_chunk,
+            base_created_at=base_created_at,
+        )
 
         for table in RELATIONSHIP_KEY_COLUMNS:
             self._unwind_relationships(table, result)
         return result
+
+    def _replay_claim_awareness(
+        self,
+        result: ReplayResult,
+        *,
+        base_state: dict[str, Any],
+        base_chunk: int,
+        base_created_at: datetime,
+    ) -> None:
+        """Rebuild awareness from producer provenance and propagation events."""
+
+        working = {
+            (int(row["claim_id"]), int(row["knower_entity_id"])): dict(row)
+            for row in base_state["claim_awareness"]
+        }
+
+        # Participant/witness rows are admitted only when the claim's minting
+        # event names that knower in the corresponding role. This keeps an
+        # arbitrary projection INSERT from masquerading as a producer mint.
+        self.cur.execute(
+            """
+            SELECT DISTINCT ON (ca.id) to_jsonb(ca)
+            FROM claim_awareness ca
+            JOIN claims c ON c.id = ca.claim_id
+            JOIN world_events mint_event ON mint_event.id = c.world_event_id
+            WHERE (
+                  (ca.source_tier = 'participant' AND (
+                      mint_event.actor_entity_id = ca.knower_entity_id
+                      OR mint_event.target_entity_id = ca.knower_entity_id
+                      OR EXISTS (
+                          SELECT 1 FROM world_event_entities participant
+                          WHERE participant.event_id = mint_event.id
+                            AND participant.entity_id = ca.knower_entity_id
+                            AND participant.role::text IN ('actor', 'target')
+                      )
+                  ))
+                  OR
+                  (ca.source_tier = 'witness' AND EXISTS (
+                      SELECT 1 FROM world_event_entities witness
+                      WHERE witness.event_id = mint_event.id
+                        AND witness.entity_id = ca.knower_entity_id
+                        AND witness.role::text IN ('observer', 'witness')
+                  ))
+              )
+              AND (
+                  (ca.source_chunk_id IS NOT NULL
+                   AND ca.source_chunk_id > %s
+                   AND ca.source_chunk_id <= %s)
+                  OR
+                  (ca.source_chunk_id IS NULL
+                   AND ca.created_at > %s
+                   AND ca.created_at <= %s)
+              )
+            ORDER BY ca.id
+            """,
+            (
+                base_chunk,
+                self.target_chunk_id,
+                base_created_at,
+                self.target_created_at,
+            ),
+        )
+        mint_count = 0
+        for (raw,) in self.cur.fetchall():
+            row = dict(_as_document(raw))
+            working[(int(row["claim_id"]), int(row["knower_entity_id"]))] = row
+            mint_count += 1
+
+        # Explicit record-revelation rows are their own append-only
+        # provenance. Passive told rows are excluded by awareness id and are
+        # rebuilt exclusively from claim_propagated events below.
+        self.cur.execute(
+            """
+            SELECT to_jsonb(ca)
+            FROM claim_awareness ca
+            WHERE ca.source_tier IN ('granted', 'told')
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM world_events propagated
+                  WHERE propagated.event_type = 'claim_propagated'
+                    AND (propagated.payload ->> 'awareness_id')::bigint = ca.id
+              )
+              AND (
+                  (ca.source_chunk_id IS NOT NULL
+                   AND ca.source_chunk_id > %s
+                   AND ca.source_chunk_id <= %s)
+                  OR
+                  (ca.source_chunk_id IS NULL
+                   AND ca.created_at > %s
+                   AND ca.created_at <= %s)
+              )
+            ORDER BY ca.id
+            """,
+            (
+                base_chunk,
+                self.target_chunk_id,
+                base_created_at,
+                self.target_created_at,
+            ),
+        )
+        revelation_count = 0
+        for (raw,) in self.cur.fetchall():
+            row = dict(_as_document(raw))
+            working[(int(row["claim_id"]), int(row["knower_entity_id"]))] = row
+            revelation_count += 1
+
+        self.cur.execute(
+            """
+            SELECT EXISTS (
+                       SELECT 1 FROM event_types
+                       WHERE type = 'claim_propagated'
+                   ),
+                   EXISTS (
+                       SELECT 1
+                       FROM information_schema.columns
+                       WHERE table_schema = ANY(current_schemas(false))
+                         AND table_name = 'world_events'
+                         AND column_name = 'world_time'
+                   )
+            """
+        )
+        event_registered, world_time_column = self.cur.fetchone()
+        if event_registered and not world_time_column:
+            raise RuntimeError(
+                "Claim propagation requires migration 083; apply migration 083 "
+                "before replaying claim_propagated events."
+            )
+        if event_registered:
+            self.cur.execute(
+                """
+                SELECT we.id, we.tick_chunk_id, we.world_time,
+                       we.payload, we.created_at
+                FROM world_events we
+                WHERE we.event_type = 'claim_propagated'
+                  AND we.tick_chunk_id > %s
+                  AND we.tick_chunk_id <= %s
+                ORDER BY we.tick_chunk_id, we.id
+                """,
+                (base_chunk, self.target_chunk_id),
+            )
+            event_rows = self.cur.fetchall()
+        else:
+            event_rows = []
+        event_count = 0
+        for (
+            event_id,
+            tick_chunk_id,
+            world_time,
+            raw_payload,
+            created_at,
+        ) in event_rows:
+            payload = _as_document(raw_payload)
+            if not isinstance(payload, dict):
+                raise ValueError(
+                    f"claim_propagated event {event_id} payload is not an object"
+                )
+            required = {
+                "awareness_id",
+                "claim_id",
+                "knower_entity_id",
+                "immediate_source_entity_id",
+                "root_source_entity_id",
+                "channel",
+                "depth",
+                "latency_seconds",
+                "policy_digest",
+            }
+            missing = sorted(required - set(payload))
+            if missing:
+                raise ValueError(
+                    f"claim_propagated event {event_id} lacks payload fields {missing}"
+                )
+            if world_time is None:
+                raise ValueError(
+                    f"claim_propagated event {event_id} has NULL world_time"
+                )
+            if int(payload["depth"]) < 1:
+                raise ValueError(f"claim_propagated event {event_id} has invalid depth")
+            claim_id = int(payload["claim_id"])
+            knower = int(payload["knower_entity_id"])
+            working[(claim_id, knower)] = {
+                "id": int(payload["awareness_id"]),
+                "claim_id": claim_id,
+                "knower_entity_id": knower,
+                "source_tier": "told",
+                "immediate_source_entity_id": int(
+                    payload["immediate_source_entity_id"]
+                ),
+                "root_source_entity_id": int(payload["root_source_entity_id"]),
+                "channel": str(payload["channel"]),
+                "acquired_at_world_time": world_time,
+                "source_chunk_id": int(tick_chunk_id),
+                "created_at": created_at,
+            }
+            event_count += 1
+        result.state["claim_awareness"] = sorted(
+            working.values(), key=lambda row: row["id"]
+        )
+        result.add_note(
+            "claim_awareness",
+            f"rebuilt {mint_count} mint row(s), {revelation_count} explicit "
+            f"revelation row(s), and {event_count} passive row(s) from "
+            "producer provenance",
+            approximate=False,
+        )
 
     def _window_chunks(self, base_chunk: int) -> list[int]:
         self.cur.execute(
@@ -1580,7 +1804,14 @@ def _load_checkpoint_state(cur: Any, checkpoint_id: int) -> dict[str, Any]:
     cur.execute("SELECT state FROM state_checkpoints WHERE id = %s", (checkpoint_id,))
     state = _as_document(_row_value(cur.fetchone(), 0))
     state.setdefault("character_project_states", [])
+    state.setdefault("claim_awareness", [])
     return state
+
+
+def _missing_checkpoint_sections(cur: Any, checkpoint_id: int) -> set[str]:
+    cur.execute("SELECT state FROM state_checkpoints WHERE id = %s", (checkpoint_id,))
+    state = _as_document(_row_value(cur.fetchone(), 0))
+    return set(CHECKPOINT_SECTIONS) - set(state)
 
 
 def verify_checkpoints_sync(cur: Any) -> list[CheckpointPairVerdict]:
@@ -1615,8 +1846,17 @@ def verify_checkpoints_sync(cur: Any) -> list[CheckpointPairVerdict]:
             # directly, no replay involved.
             base_stored = _load_checkpoint_state(cur, base_id)
             target_stored = _load_checkpoint_state(cur, target_id)
+            missing_sections = _missing_checkpoint_sections(
+                cur, base_id
+            ) | _missing_checkpoint_sections(cur, target_id)
             drifts = []
+            skipped = 0
             for section in CHECKPOINT_SECTIONS:
+                if section in missing_sections:
+                    skipped += max(
+                        len(base_stored[section]), len(target_stored[section]), 1
+                    )
+                    continue
                 section_drifts, _ = _diff_section(
                     section,
                     base_stored[section],
@@ -1633,12 +1873,22 @@ def verify_checkpoints_sync(cur: Any) -> list[CheckpointPairVerdict]:
                     target_checkpoint_id=target_id,
                     target_chunk_id=target_chunk,
                     drifts=drifts,
-                    skipped_unreproducible=0,
+                    skipped_unreproducible=skipped,
                     notes={
                         "_pair": [
                             "same-chunk captures compared directly "
                             "(stored vs stored)"
-                        ]
+                        ],
+                        **(
+                            {
+                                "claim_awareness": [
+                                    "checkpoint predates the claim-awareness "
+                                    "section; comparison skipped"
+                                ]
+                            }
+                            if "claim_awareness" in missing_sections
+                            else {}
+                        ),
                     },
                 )
             )
@@ -1647,9 +1897,21 @@ def verify_checkpoints_sync(cur: Any) -> list[CheckpointPairVerdict]:
             cur, target_chunk, base_checkpoint_id=base_id
         )
         stored = _load_checkpoint_state(cur, target_id)
+        missing_sections = _missing_checkpoint_sections(
+            cur, base_id
+        ) | _missing_checkpoint_sections(cur, target_id)
         drifts = []
         skipped = 0
         for section in CHECKPOINT_SECTIONS:
+            if section in missing_sections:
+                skipped += max(len(stored[section]), len(result.state[section]), 1)
+                result.add_note(
+                    section,
+                    "checkpoint pair predates this section on at least one side; "
+                    "comparison skipped",
+                    approximate=True,
+                )
+                continue
             section_drifts, section_skipped = _diff_section(
                 section,
                 stored[section],

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -64,6 +64,7 @@ from datetime import datetime, timezone
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Optional
 
+from nexus.agents.orrery.epistemics import PARTICIPANT_ROLES, WITNESS_ROLES
 from nexus.agents.orrery.needs import (
     NEED_IMMUNITY_TAGS,
     NEED_TYPES,
@@ -520,7 +521,7 @@ class _Replayer:
                           SELECT 1 FROM world_event_entities participant
                           WHERE participant.event_id = mint_event.id
                             AND participant.entity_id = ca.knower_entity_id
-                            AND participant.role::text IN ('actor', 'target')
+                            AND participant.role::text = ANY(%s)
                       )
                   ))
                   OR
@@ -528,7 +529,7 @@ class _Replayer:
                       SELECT 1 FROM world_event_entities witness
                       WHERE witness.event_id = mint_event.id
                         AND witness.entity_id = ca.knower_entity_id
-                        AND witness.role::text IN ('observer', 'witness')
+                        AND witness.role::text = ANY(%s)
                   ))
               )
               AND (
@@ -543,6 +544,8 @@ class _Replayer:
             ORDER BY ca.id
             """,
             (
+                sorted(PARTICIPANT_ROLES),
+                sorted(WITNESS_ROLES),
                 base_chunk,
                 self.target_chunk_id,
                 base_created_at,

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -1952,6 +1952,7 @@ def _load_recent_events(
                    payload
             FROM world_events
             WHERE tick_chunk_id BETWEEN :lower_bound AND :anchor_chunk_id
+              AND event_type <> 'claim_propagated'
               AND (world_layer IS NULL OR world_layer = 'primary')
               AND superseded_by_event_id IS NULL
             ORDER BY tick_chunk_id DESC, id DESC

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -563,6 +563,7 @@ async def commit_incubator_to_database(
                 prompt_settings=_orrery_prompt_settings(),
                 ecology_settings=_orrery_ecology_settings(),
                 project_settings=_orrery_project_settings(),
+                contagion_settings=_orrery_contagion_settings(),
             )
             if (
                 orrery_result.resolution_count
@@ -571,12 +572,13 @@ async def commit_incubator_to_database(
                 or orrery_result.cleared_tag_count
                 or orrery_result.scene_pressure_count
                 or orrery_result.prompt_exposure_count
+                or orrery_result.propagation_count
             ):
                 logger.info(
                     "Committed Orrery tick for chunk %s: %s resolutions, %s events, "
                     "%s tag mutations, %s cleared tags, %s existing skipped, "
                     "%s adjudications (%s deferred, %s voided, %s replaced), "
-                    "%s scene pressures, %s prompt exposures",
+                    "%s scene pressures, %s prompt exposures, %s propagations",
                     chunk_id,
                     orrery_result.resolution_count,
                     orrery_result.event_count,
@@ -589,6 +591,7 @@ async def commit_incubator_to_database(
                     orrery_result.replaced_count,
                     orrery_result.scene_pressure_count,
                     orrery_result.prompt_exposure_count,
+                    orrery_result.propagation_count,
                 )
 
             # Step 8.55: interval state checkpoint (reconstruction bar 7c)
@@ -653,6 +656,14 @@ def _orrery_project_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("projects")
+
+
+def _orrery_contagion_settings() -> Any:
+    """[orrery.contagion] frontier and communication policy."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("contagion")
 
 
 def _orrery_checkpoint_interval() -> int:

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -557,6 +557,7 @@ def commit_incubator_to_database_sync(
                 prompt_settings=_orrery_prompt_settings(),
                 ecology_settings=_orrery_ecology_settings(),
                 project_settings=_orrery_project_settings(),
+                contagion_settings=_orrery_contagion_settings(),
             )
             if (
                 orrery_result.resolution_count
@@ -565,12 +566,13 @@ def commit_incubator_to_database_sync(
                 or orrery_result.cleared_tag_count
                 or orrery_result.scene_pressure_count
                 or orrery_result.prompt_exposure_count
+                or orrery_result.propagation_count
             ):
                 logger.info(
                     "Committed Orrery tick for chunk %s: %s resolutions, %s events, "
                     "%s tag mutations, %s cleared tags, %s existing skipped, "
                     "%s adjudications (%s deferred, %s voided, %s replaced), "
-                    "%s scene pressures, %s prompt exposures",
+                    "%s scene pressures, %s prompt exposures, %s propagations",
                     chunk_id,
                     orrery_result.resolution_count,
                     orrery_result.event_count,
@@ -583,6 +585,7 @@ def commit_incubator_to_database_sync(
                     orrery_result.replaced_count,
                     orrery_result.scene_pressure_count,
                     orrery_result.prompt_exposure_count,
+                    orrery_result.propagation_count,
                 )
 
             # Step 8.55: interval state checkpoint (reconstruction bar 7c).
@@ -832,6 +835,14 @@ def _orrery_project_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("projects")
+
+
+def _orrery_contagion_settings() -> Any:
+    """[orrery.contagion] frontier and communication policy."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("contagion")
 
 
 def _orrery_checkpoint_interval() -> int:

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -2077,7 +2077,10 @@ def run_record_revelation(
 ) -> Dict[str, Any]:
     """Record an explicit told or manual claim-awareness grant."""
 
-    from nexus.agents.orrery.epistemics import record_revelation
+    from nexus.agents.orrery.epistemics import (
+        current_world_time_sync,
+        record_revelation,
+    )
     from nexus.api.db_pool import get_connection
     from nexus.api.slot_utils import slot_dbname
 
@@ -2090,13 +2093,16 @@ def run_record_revelation(
 
     def apply(conn: Any) -> Any:
         with conn.cursor() as cur:
+            resolved_world_time = world_time
+            if resolved_world_time is None:
+                resolved_world_time = current_world_time_sync(cur)
             return record_revelation(
                 cur,
                 claim_id=args.claim_id,
                 knower_entity_id=args.knower,
                 source_entity_id=args.source_entity_id,
                 channel=args.channel,
-                world_time=world_time,
+                world_time=resolved_world_time,
                 source_chunk_id=args.source_chunk_id,
             )
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1239,6 +1239,11 @@ class OrreryEpistemicsSettings(BaseModel):
             raise ValueError("claim_event_types entries must be non-empty")
         if len(set(normalized)) != len(normalized):
             raise ValueError("claim_event_types entries must be unique")
+        if "claim_propagated" in normalized:
+            raise ValueError(
+                "claim_propagated cannot appear in claim_event_types; "
+                "propagation ledger events never mint claims"
+            )
         return normalized
 
     @field_validator("aware_roles")

--- a/tests/test_orrery/test_claim_awareness_replay_live.py
+++ b/tests/test_orrery/test_claim_awareness_replay_live.py
@@ -1,0 +1,192 @@
+"""Template-backed live coverage for claim-awareness checkpoint verification."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2  # type: ignore[import-untyped]
+import pytest
+from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
+
+from nexus.agents.orrery.epistemics import ClaimParticipant, mint_claim_for_event
+from nexus.agents.orrery.reconstruction import capture_state_checkpoint_sync
+from nexus.agents.orrery.replay import verify_checkpoints_sync
+
+
+pytestmark = pytest.mark.requires_postgres
+
+EPISTEMICS = {
+    "enabled": True,
+    "claim_event_types": ["threat_issued"],
+    "aware_roles": ["actor", "target", "observer", "witness"],
+}
+
+
+@pytest.fixture()
+def template_conn() -> Iterator[Any]:
+    conn = psycopg2.connect(
+        dbname="NEXUS_template",
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+    try:
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def _insert_chunk(cur: Any) -> int:
+    token = uuid4().hex[:12]
+    cur.execute(
+        """
+        INSERT INTO narrative_chunks (raw_text, storyteller_text)
+        VALUES (%s, 'Rollback-only awareness replay fixture.')
+        RETURNING id
+        """,
+        (f"Awareness replay fixture {token}.",),
+    )
+    chunk_id = int(cur.fetchone()["id"])
+    cur.execute(
+        """
+        INSERT INTO chunk_metadata (
+            chunk_id, season, episode, scene, world_layer, time_delta,
+            generation_date, slug
+        ) VALUES (
+            %s, 99, 99, %s, 'primary', interval '0 seconds', now(), %s
+        )
+        """,
+        (chunk_id, chunk_id, token[:10]),
+    )
+    return chunk_id
+
+
+def _insert_character_entity(cur: Any) -> int:
+    cur.execute(
+        "INSERT INTO entities (kind, is_active) "
+        "VALUES ('character', true) RETURNING id"
+    )
+    return int(cur.fetchone()["id"])
+
+
+def _mint_fixture_claim(cur: Any, *, chunk_id: int, source: int) -> int:
+    cur.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, world_layer,
+            source, changed_fields, payload
+        ) VALUES (
+            'threat_issued', %s, %s, 'primary', 'resolver', '{}', '{}'::jsonb
+        )
+        RETURNING id
+        """,
+        (chunk_id, source),
+    )
+    event_id = int(cur.fetchone()["id"])
+    cur.execute(
+        """
+        INSERT INTO world_event_entities (event_id, role, entity_id)
+        VALUES (%s, 'actor', %s)
+        """,
+        (event_id, source),
+    )
+    minted = mint_claim_for_event(
+        cur,
+        world_event_id=event_id,
+        event_type="threat_issued",
+        summary="Awareness replay fixture claim.",
+        participants=(
+            ClaimParticipant(source, "actor", f"Replay source {source}", "character"),
+        ),
+        source_chunk_id=chunk_id,
+        source_resolution_id=None,
+        settings=EPISTEMICS,
+    )
+    assert minted is not None
+    return minted.claim_id
+
+
+def test_verify_reports_projection_only_awareness_drift(template_conn: Any) -> None:
+    """A new checkpoint window catches awareness with no mint-event twin."""
+
+    with template_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        source = _insert_character_entity(cur)
+        rogue = _insert_character_entity(cur)
+        base_chunk = _insert_chunk(cur)
+        claim_id = _mint_fixture_claim(cur, chunk_id=base_chunk, source=source)
+        base_id = capture_state_checkpoint_sync(
+            cur, chunk_id=base_chunk, label="manual"
+        )
+        assert base_id is not None
+
+        target_chunk = _insert_chunk(cur)
+        cur.execute(
+            """
+            INSERT INTO claim_awareness (
+                claim_id, knower_entity_id, source_tier, source_chunk_id
+            ) VALUES (%s, %s, 'participant', %s)
+            RETURNING id
+            """,
+            (claim_id, rogue, target_chunk),
+        )
+        rogue_awareness_id = int(cur.fetchone()["id"])
+        target_id = capture_state_checkpoint_sync(
+            cur, chunk_id=target_chunk, label="manual"
+        )
+        assert target_id is not None
+        with template_conn.cursor() as verify_cur:
+            verdicts = verify_checkpoints_sync(verify_cur)
+
+    verdict = next(
+        item
+        for item in verdicts
+        if item.base_checkpoint_id == base_id and item.target_checkpoint_id == target_id
+    )
+    assert any(
+        drift.section == "claim_awareness"
+        and drift.row_key == str(rogue_awareness_id)
+        and drift.kind == "missing_row"
+        for drift in verdict.drifts
+    )
+
+
+def test_verify_skips_checkpoint_that_predates_awareness_section(
+    template_conn: Any,
+) -> None:
+    """An old base document uses the missing-section skip contract."""
+
+    with template_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        source = _insert_character_entity(cur)
+        base_chunk = _insert_chunk(cur)
+        _mint_fixture_claim(cur, chunk_id=base_chunk, source=source)
+        base_id = capture_state_checkpoint_sync(
+            cur, chunk_id=base_chunk, label="manual"
+        )
+        assert base_id is not None
+        cur.execute(
+            "UPDATE state_checkpoints SET state = state - 'claim_awareness' "
+            "WHERE id = %s",
+            (base_id,),
+        )
+        target_chunk = _insert_chunk(cur)
+        target_id = capture_state_checkpoint_sync(
+            cur, chunk_id=target_chunk, label="manual"
+        )
+        assert target_id is not None
+        with template_conn.cursor() as verify_cur:
+            verdicts = verify_checkpoints_sync(verify_cur)
+
+    verdict = next(
+        item
+        for item in verdicts
+        if item.base_checkpoint_id == base_id and item.target_checkpoint_id == target_id
+    )
+    assert not [drift for drift in verdict.drifts if drift.section == "claim_awareness"]
+    assert verdict.skipped_unreproducible >= 1
+    assert any(
+        "comparison skipped" in note
+        for note in verdict.notes.get("claim_awareness", [])
+    )

--- a/tests/test_orrery/test_claim_propagation.py
+++ b/tests/test_orrery/test_claim_propagation.py
@@ -1,0 +1,37 @@
+"""Fast contract tests for the Stage 2c propagation drain."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from nexus.agents.orrery.propagation import drain_claim_propagation_sync
+from nexus.config.settings_models import OrreryContagionSettings
+
+
+class _Pre083Cursor:
+    def execute(self, _sql: str, _params: Any = None) -> None:
+        pass
+
+    def fetchone(self) -> dict[str, bool]:
+        return {"event_registered": False, "world_time_column": False}
+
+
+def test_enabled_drain_requires_migration_083_before_any_write() -> None:
+    """A pre-083 slot fails with the rollout instruction, not SQL fallout."""
+
+    with pytest.raises(RuntimeError, match="apply migration 083"):
+        drain_claim_propagation_sync(
+            _Pre083Cursor(),
+            tick_chunk_id=1,
+            settings=OrreryContagionSettings(),
+        )
+
+
+def test_migration_083_indexes_depth_recovery_expression() -> None:
+    migration = Path("migrations/083_claim_propagation_ledger.sql").read_text()
+
+    assert "ix_world_events_claim_propagated_claim_id" in migration
+    assert "((payload ->> 'claim_id')::bigint)" in migration
+    assert "WHERE event_type = 'claim_propagated'" in migration
+    assert "COMMENT ON INDEX ix_world_events_claim_propagated_claim_id" in migration

--- a/tests/test_orrery/test_claim_propagation_live.py
+++ b/tests/test_orrery/test_claim_propagation_live.py
@@ -1,0 +1,1214 @@
+"""Rollback-only slot-5 coverage for the Stage 2c propagation frontier."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any, Iterator, Mapping, Sequence
+from uuid import uuid4
+
+import asyncpg  # type: ignore[import-untyped]
+import psycopg2  # type: ignore[import-untyped]
+import pytest
+from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
+from sqlalchemy import create_engine
+
+from nexus.agents.orrery.epistemics import (
+    ClaimParticipant,
+    mint_claim_for_event,
+    mint_claim_for_event_async,
+    record_revelation,
+)
+from nexus.agents.orrery.events import commit_orrery_tick_sync
+from nexus.agents.orrery.propagation import (
+    contagion_policy_digest,
+    drain_claim_propagation_async,
+    drain_claim_propagation_sync,
+)
+from nexus.agents.orrery.reconstruction import capture_state_checkpoint_sync
+from nexus.agents.orrery.replay import (
+    canonicalize,
+    reconstruct_state_at_sync,
+    verify_checkpoints_sync,
+)
+from nexus.agents.orrery.resolver import _load_recent_events, compose_actor_bindings
+from nexus.api.slot_utils import get_slot_db_url
+from nexus.config.settings_models import OrreryContagionSettings
+
+
+pytestmark = pytest.mark.requires_postgres
+
+LIVE_SLOT = 5
+EPISTEMICS = {
+    "enabled": True,
+    "claim_event_types": ["threat_issued"],
+    "aware_roles": ["actor", "target", "observer", "witness"],
+}
+
+
+@pytest.fixture()
+def live_conn() -> Iterator[Any]:
+    """Open one slot-5 transaction and roll back fixture writes."""
+
+    conn = psycopg2.connect(get_slot_db_url(slot=LIVE_SLOT))
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT EXISTS (
+                           SELECT 1 FROM event_types
+                           WHERE type = 'claim_propagated'
+                       ),
+                       EXISTS (
+                           SELECT 1 FROM information_schema.columns
+                           WHERE table_schema = ANY(current_schemas(false))
+                             AND table_name = 'world_events'
+                             AND column_name = 'world_time'
+                       )
+                """
+            )
+            registered, shaped = cur.fetchone()
+            if not registered or not shaped:
+                pytest.skip(
+                    "slot 5 has not applied migration 083: claim_propagated "
+                    "registration and world_events.world_time are required"
+                )
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def _settings(
+    *,
+    trusting: str = "1h",
+    neutral: str = "never",
+    hostile: str = "never",
+    depth_cap: int = 4,
+    age_horizon: str = "14d",
+    fan_out_cap: int = 6,
+    channels: Mapping[str, Any] | None = None,
+    culture_profiles: Mapping[str, float] | None = None,
+    enabled: bool = True,
+) -> OrreryContagionSettings:
+    return OrreryContagionSettings.model_validate(
+        {
+            "enabled": enabled,
+            "dyad_tiers": {
+                "trusting": trusting,
+                "neutral": neutral,
+                "hostile": hostile,
+            },
+            "dyad_overrides": {},
+            "channels": dict(channels or {}),
+            "culture_profiles": dict(culture_profiles or {}),
+            "guards": {
+                "depth_cap": depth_cap,
+                "age_horizon": age_horizon,
+                "fan_out_cap": fan_out_cap,
+            },
+        }
+    )
+
+
+def _insert_chunk(
+    cur: Any,
+    *,
+    time_delta: timedelta = timedelta(0),
+    world_layer: str = "primary",
+) -> tuple[int, datetime]:
+    token = uuid4().hex[:12]
+    cur.execute(
+        """
+        INSERT INTO narrative_chunks (raw_text, storyteller_text)
+        VALUES (%s, 'Rollback-only Stage 2c fixture.')
+        RETURNING id
+        """,
+        (f"Stage 2c propagation fixture {token}.",),
+    )
+    chunk_id = int(cur.fetchone()["id"])
+    cur.execute(
+        """
+        INSERT INTO chunk_metadata (
+            chunk_id, season, episode, scene, world_layer, time_delta,
+            generation_date, slug
+        ) VALUES (
+            %s, 99, 99, %s, %s::world_layer_type, %s, now(), %s
+        )
+        """,
+        (chunk_id, chunk_id, world_layer, time_delta, token[:10]),
+    )
+    cur.execute(
+        "SELECT world_time FROM chunk_metadata WHERE chunk_id = %s", (chunk_id,)
+    )
+    stamped_world_time = cur.fetchone()["world_time"]
+    assert stamped_world_time is not None
+    return chunk_id, stamped_world_time
+
+
+def _insert_character(cur: Any, label: str) -> tuple[int, int]:
+    token = uuid4().hex[:10]
+    cur.execute(
+        "INSERT INTO entities (kind, is_active) "
+        "VALUES ('character', true) RETURNING id"
+    )
+    entity_id = int(cur.fetchone()["id"])
+    cur.execute(
+        "INSERT INTO characters (name, entity_id) VALUES (%s, %s) RETURNING id",
+        (f"propagation-{label}-{token}", entity_id),
+    )
+    return entity_id, int(cur.fetchone()["id"])
+
+
+def _insert_faction(cur: Any, label: str) -> int:
+    cur.execute(
+        "INSERT INTO entities (kind, is_active) "
+        "VALUES ('faction', true) RETURNING id"
+    )
+    entity_id = int(cur.fetchone()["id"])
+    cur.execute("SELECT coalesce(max(id), 0) + 1 AS id FROM factions")
+    faction_id = int(cur.fetchone()["id"])
+    cur.execute(
+        "INSERT INTO factions (id, name, entity_id) VALUES (%s, %s, %s)",
+        (faction_id, f"propagation-{label}-{uuid4().hex[:10]}", entity_id),
+    )
+    return entity_id
+
+
+def _insert_relationship(
+    cur: Any,
+    source_character_id: int,
+    target_character_id: int,
+    *,
+    valence: str = "+3|trusting",
+) -> None:
+    cur.execute(
+        """
+        INSERT INTO character_relationships (
+            character1_id, character2_id, relationship_type,
+            emotional_valence, dynamic, recent_events, history
+        ) VALUES (
+            %s, %s, 'associate', %s,
+            'Rollback-only Stage 2c conduit.', 'None.', 'Fixture.'
+        )
+        """,
+        (source_character_id, target_character_id, valence),
+    )
+
+
+def _insert_pair_tag(
+    cur: Any, subject_entity_id: int, object_entity_id: int, tag: str
+) -> None:
+    cur.execute(
+        """
+        INSERT INTO entity_pair_tags (
+            subject_entity_id, object_entity_id, pair_tag_id,
+            source_kind, template_id
+        )
+        SELECT %s, %s, id, 'template', 'test_claim_propagation_live'
+        FROM pair_tags WHERE tag = %s AND NOT deprecated
+        """,
+        (subject_entity_id, object_entity_id, tag),
+    )
+    assert cur.rowcount == 1
+
+
+def _insert_culture_tag(cur: Any, entity_id: int, tag: str) -> None:
+    cur.execute(
+        """
+        INSERT INTO entity_tags (entity_id, tag_id, source_kind, template_id)
+        SELECT %s, id, 'template', 'test_claim_propagation_live'
+        FROM tags WHERE tag = %s AND NOT deprecated
+        """,
+        (entity_id, tag),
+    )
+    assert cur.rowcount == 1
+
+
+def _insert_claim(
+    cur: Any,
+    *,
+    chunk_id: int,
+    source_entity_id: int,
+    birth_world_time: datetime | None,
+    scope: str = "bounded",
+) -> int:
+    cur.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, world_layer,
+            source, changed_fields, payload
+        ) VALUES (
+            'threat_issued', %s, %s, 'primary', 'resolver', '{}', '{}'::jsonb
+        )
+        RETURNING id
+        """,
+        (chunk_id, source_entity_id),
+    )
+    event_id = int(cur.fetchone()["id"])
+    cur.execute(
+        """
+        INSERT INTO world_event_entities (event_id, role, entity_id)
+        VALUES (%s, 'actor', %s)
+        """,
+        (event_id, source_entity_id),
+    )
+    cur.execute("SELECT kind::text FROM entities WHERE id = %s", (source_entity_id,))
+    source_kind = str(cur.fetchone()["kind"])
+    minted = mint_claim_for_event(
+        cur,
+        world_event_id=event_id,
+        event_type="threat_issued",
+        summary="Rollback-only propagated claim.",
+        participants=(
+            ClaimParticipant(
+                source_entity_id,
+                "actor",
+                f"Propagation source {source_entity_id}",
+                source_kind,
+            ),
+        ),
+        source_chunk_id=chunk_id,
+        source_resolution_id=None,
+        settings=EPISTEMICS,
+    )
+    assert minted is not None
+    claim_id = minted.claim_id
+    if scope != "bounded":
+        cur.execute("UPDATE claims SET scope = %s WHERE id = %s", (scope, claim_id))
+    cur.execute(
+        """
+        SELECT acquired_at_world_time
+        FROM claim_awareness
+        WHERE claim_id = %s AND knower_entity_id = %s
+        """,
+        (claim_id, source_entity_id),
+    )
+    assert cur.fetchone()["acquired_at_world_time"] == birth_world_time
+    return claim_id
+
+
+def _awareness(cur: Any, claim_id: int) -> list[dict[str, Any]]:
+    cur.execute(
+        """
+        SELECT id, claim_id, knower_entity_id, source_tier,
+               immediate_source_entity_id, root_source_entity_id, channel,
+               acquired_at_world_time, source_chunk_id, created_at
+        FROM claim_awareness
+        WHERE claim_id = %s
+        ORDER BY acquired_at_world_time, knower_entity_id
+        """,
+        (claim_id,),
+    )
+    return [dict(row) for row in cur.fetchall()]
+
+
+def _propagation_events(cur: Any, claim_id: int) -> list[dict[str, Any]]:
+    cur.execute(
+        """
+        SELECT id, tick_chunk_id, actor_entity_id, target_entity_id,
+               world_layer::text, source::text, changed_fields, resolution_id,
+               payload, world_time
+        FROM world_events
+        WHERE event_type = 'claim_propagated'
+          AND (payload ->> 'claim_id')::bigint = %s
+        ORDER BY world_time, id
+        """,
+        (claim_id,),
+    )
+    return [dict(row) for row in cur.fetchall()]
+
+
+def _chain(cur: Any, length: int) -> tuple[list[int], list[int]]:
+    entities: list[int] = []
+    characters: list[int] = []
+    for index in range(length):
+        entity, character = _insert_character(cur, f"chain-{index}")
+        entities.append(entity)
+        characters.append(character)
+    for source, target in zip(characters, characters[1:]):
+        _insert_relationship(cur, source, target)
+    return entities, characters
+
+
+def test_single_hop_ledgers_scheduled_time_provenance_and_policy(
+    live_conn: Any,
+) -> None:
+    """One mature edge mints matching projection and payload-only event."""
+
+    settings = _settings()
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        source, source_character = _insert_character(cur, "single-source")
+        listener, listener_character = _insert_character(cur, "single-listener")
+        _insert_relationship(cur, source_character, listener_character)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        claim_id = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=source,
+            birth_world_time=birth_world_time,
+        )
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=8))
+        result = drain_claim_propagation_sync(
+            cur, tick_chunk_id=drain_chunk, settings=settings
+        )
+        rows = _awareness(cur, claim_id)
+        events = _propagation_events(cur, claim_id)
+        cur.execute(
+            """
+            SELECT role::text, entity_id
+            FROM world_event_entities
+            WHERE event_id = %s
+            ORDER BY role
+            """,
+            (events[0]["id"],),
+        )
+        participants = {(row["role"], int(row["entity_id"])) for row in cur}
+
+    assert result.minted_count == 1
+    told = rows[1]
+    assert {
+        key: told[key]
+        for key in (
+            "knower_entity_id",
+            "source_tier",
+            "immediate_source_entity_id",
+            "root_source_entity_id",
+            "channel",
+            "acquired_at_world_time",
+            "source_chunk_id",
+        )
+    } == {
+        "knower_entity_id": listener,
+        "source_tier": "told",
+        "immediate_source_entity_id": source,
+        "root_source_entity_id": source,
+        "channel": "dyad:associate",
+        "acquired_at_world_time": birth_world_time + timedelta(hours=1),
+        "source_chunk_id": drain_chunk,
+    }
+    event = events[0]
+    assert event["world_time"] == birth_world_time + timedelta(hours=1)
+    assert event["tick_chunk_id"] == drain_chunk
+    assert event["actor_entity_id"] is None
+    assert event["target_entity_id"] is None
+    assert event["source"] == "resolver"
+    assert event["changed_fields"] == ["claim_awareness"]
+    assert event["resolution_id"] is None
+    assert event["payload"] == {
+        "awareness_id": told["id"],
+        "claim_id": claim_id,
+        "knower_entity_id": listener,
+        "immediate_source_entity_id": source,
+        "root_source_entity_id": source,
+        "channel": "dyad:associate",
+        "latency_seconds": 3600.0,
+        "depth": 1,
+        "policy_digest": contagion_policy_digest(settings),
+    }
+    assert participants == set()
+
+
+def test_propagation_event_does_not_change_salience_or_hydration_feed() -> None:
+    """Payload-only acquisitions stay out of actor and recent-event readers."""
+
+    engine = create_engine(get_slot_db_url(slot=LIVE_SLOT))
+    connection = engine.connect()
+    transaction = connection.begin()
+    try:
+        raw_connection = connection.connection.driver_connection
+        with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT EXISTS (
+                           SELECT 1 FROM event_types
+                           WHERE type = 'claim_propagated'
+                       ) AS registered,
+                       EXISTS (
+                           SELECT 1 FROM information_schema.columns
+                           WHERE table_schema = ANY(current_schemas(false))
+                             AND table_name = 'world_events'
+                             AND column_name = 'world_time'
+                       ) AS shaped
+                """
+            )
+            migration_state = cur.fetchone()
+            if not migration_state["registered"] or not migration_state["shaped"]:
+                pytest.skip(
+                    "slot 5 has not applied migration 083: salience isolation "
+                    "requires the real propagation ledger"
+                )
+            entities, _ = _chain(cur, 2)
+            birth_chunk, birth_world_time = _insert_chunk(cur)
+            claim_id = _insert_claim(
+                cur,
+                chunk_id=birth_chunk,
+                source_entity_id=entities[0],
+                birth_world_time=birth_world_time,
+            )
+            drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=4))
+            before_bindings = compose_actor_bindings(
+                connection, anchor_chunk_id=drain_chunk, window_chunks=1
+            )
+            before_events = _load_recent_events(
+                connection, anchor_chunk_id=drain_chunk, window_chunks=1
+            )
+            result = drain_claim_propagation_sync(
+                cur, tick_chunk_id=drain_chunk, settings=_settings()
+            )
+            after_bindings = compose_actor_bindings(
+                connection, anchor_chunk_id=drain_chunk, window_chunks=1
+            )
+            after_events = _load_recent_events(
+                connection, anchor_chunk_id=drain_chunk, window_chunks=1
+            )
+            events = _propagation_events(cur, claim_id)
+            cur.execute(
+                "SELECT count(*) AS count FROM world_event_entities "
+                "WHERE event_id = %s",
+                (events[0]["id"],),
+            )
+            participant_count = int(cur.fetchone()["count"])
+
+        assert result.minted_count == 1
+        assert before_bindings == after_bindings
+        assert before_events == after_events
+        assert participant_count == 0
+    finally:
+        transaction.rollback()
+        connection.close()
+        engine.dispose()
+
+
+def test_large_skip_drains_chained_hops_at_staggered_times(live_conn: Any) -> None:
+    """A single fixpoint drain releases every mature hop, never at W."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 4)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        claim_id = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=entities[0],
+            birth_world_time=birth_world_time,
+        )
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=12))
+        result = drain_claim_propagation_sync(
+            cur, tick_chunk_id=drain_chunk, settings=_settings()
+        )
+        rows = _awareness(cur, claim_id)
+        events = _propagation_events(cur, claim_id)
+
+    assert result.minted_count == 3
+    assert [row["knower_entity_id"] for row in rows] == entities
+    assert [row["acquired_at_world_time"] for row in rows] == [
+        birth_world_time + timedelta(hours=offset) for offset in range(4)
+    ]
+    assert [event["payload"]["depth"] for event in events] == [1, 2, 3]
+    assert [event["world_time"] for event in events] == [
+        birth_world_time + timedelta(hours=offset) for offset in range(1, 4)
+    ]
+
+
+def test_not_yet_mature_edge_waits(live_conn: Any) -> None:
+    """An edge whose scheduled acquisition is later than W stays pending."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 2)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        claim_id = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=entities[0],
+            birth_world_time=birth_world_time,
+        )
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(minutes=59))
+        result = drain_claim_propagation_sync(
+            cur, tick_chunk_id=drain_chunk, settings=_settings()
+        )
+        rows = _awareness(cur, claim_id)
+
+    assert result.minted_count == 0
+    assert [row["knower_entity_id"] for row in rows] == [entities[0]]
+
+
+def test_fan_out_cap_uses_latency_then_listener_id(live_conn: Any) -> None:
+    """Only the sorted first cap edges ever transmit for a knower/claim."""
+
+    settings = _settings(neutral="2h", fan_out_cap=2)
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        source, source_character = _insert_character(cur, "fanout-source")
+        low, low_character = _insert_character(cur, "fanout-low")
+        high, high_character = _insert_character(cur, "fanout-high")
+        slow, slow_character = _insert_character(cur, "fanout-slow")
+        _insert_relationship(cur, source_character, high_character)
+        _insert_relationship(cur, source_character, low_character)
+        _insert_relationship(cur, source_character, slow_character, valence="0|neutral")
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        claim_id = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=source,
+            birth_world_time=birth_world_time,
+        )
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=8))
+        result = drain_claim_propagation_sync(
+            cur, tick_chunk_id=drain_chunk, settings=settings
+        )
+        knowers = {row["knower_entity_id"] for row in _awareness(cur, claim_id)}
+
+    assert result.minted_count == 2
+    assert knowers == {source, low, high}
+    assert slow not in knowers
+
+
+def test_depth_cap_is_recovered_across_separate_drains(live_conn: Any) -> None:
+    """Persisted event depth releases hop two later and blocks hop three."""
+
+    settings = _settings(depth_cap=2)
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 4)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        claim_id = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=entities[0],
+            birth_world_time=birth_world_time,
+        )
+        first_chunk, first_world_time = _insert_chunk(
+            cur, time_delta=timedelta(hours=1)
+        )
+        first = drain_claim_propagation_sync(
+            cur, tick_chunk_id=first_chunk, settings=settings
+        )
+        second_chunk, _ = _insert_chunk(
+            cur,
+            time_delta=timedelta(hours=12) - (first_world_time - birth_world_time),
+        )
+        second = drain_claim_propagation_sync(
+            cur, tick_chunk_id=second_chunk, settings=settings
+        )
+        rows = _awareness(cur, claim_id)
+        events = _propagation_events(cur, claim_id)
+
+    assert first.minted_count == 1
+    assert second.minted_count == 1
+    assert [row["knower_entity_id"] for row in rows] == entities[:3]
+    assert [event["payload"]["depth"] for event in events] == [1, 2]
+
+
+def test_age_horizon_and_nonbounded_scopes_do_not_propagate(
+    live_conn: Any,
+) -> None:
+    """Old bounded, private, and common claims retain only seeded awareness."""
+
+    settings = _settings(trusting="3h", age_horizon="2h")
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        source, source_character = _insert_character(cur, "gating-source")
+        _, listener_character = _insert_character(cur, "gating-listener")
+        _insert_relationship(cur, source_character, listener_character)
+        old_chunk, old_world_time = _insert_chunk(cur)
+        old_claim = _insert_claim(
+            cur,
+            chunk_id=old_chunk,
+            source_entity_id=source,
+            birth_world_time=old_world_time,
+        )
+        recent_chunk, recent_world_time = _insert_chunk(
+            cur, time_delta=timedelta(hours=9)
+        )
+        private_claim = _insert_claim(
+            cur,
+            chunk_id=recent_chunk,
+            source_entity_id=source,
+            birth_world_time=recent_world_time,
+            scope="private",
+        )
+        common_claim = _insert_claim(
+            cur,
+            chunk_id=recent_chunk,
+            source_entity_id=source,
+            birth_world_time=recent_world_time,
+            scope="common",
+        )
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=1))
+        result = drain_claim_propagation_sync(
+            cur, tick_chunk_id=drain_chunk, settings=settings
+        )
+        counts = {
+            claim_id: len(_awareness(cur, claim_id))
+            for claim_id in (old_claim, private_claim, common_claim)
+        }
+
+    assert result.minted_count == 0
+    assert counts == {old_claim: 1, private_claim: 1, common_claim: 1}
+
+
+def test_late_drain_lands_hop_scheduled_inside_age_horizon(live_conn: Any) -> None:
+    """Hop eligibility uses its scheduled time, never narration cadence W."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 3)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        claim_id = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=entities[0],
+            birth_world_time=birth_world_time,
+        )
+        first_chunk, first_world_time = _insert_chunk(
+            cur, time_delta=timedelta(hours=1)
+        )
+        first = drain_claim_propagation_sync(
+            cur, tick_chunk_id=first_chunk, settings=_settings(age_horizon="14d")
+        )
+        late_chunk, _ = _insert_chunk(
+            cur,
+            time_delta=timedelta(days=15) - (first_world_time - birth_world_time),
+        )
+        late = drain_claim_propagation_sync(
+            cur, tick_chunk_id=late_chunk, settings=_settings(age_horizon="14d")
+        )
+        rows = _awareness(cur, claim_id)
+
+    assert first.minted_count == 1
+    assert late.minted_count == 1
+    assert [row["knower_entity_id"] for row in rows] == entities
+    assert rows[2]["acquired_at_world_time"] == birth_world_time + timedelta(hours=2)
+
+
+def test_null_awareness_is_possession_terminal(live_conn: Any) -> None:
+    """A clockless knower blocks re-minting but schedules no outbound hop."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        source, _ = _insert_character(cur, "terminal-source")
+        terminal, terminal_character = _insert_character(cur, "terminal-knower")
+        downstream, downstream_character = _insert_character(cur, "terminal-downstream")
+        _insert_relationship(cur, terminal_character, downstream_character)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        claim_id = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=source,
+            birth_world_time=birth_world_time,
+        )
+        revelation = record_revelation(
+            cur,
+            claim_id=claim_id,
+            knower_entity_id=terminal,
+            source_entity_id=source,
+            channel="clockless-message",
+            world_time=None,
+            source_chunk_id=birth_chunk,
+        )
+        assert revelation.inserted is True
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=8))
+        result = drain_claim_propagation_sync(
+            cur, tick_chunk_id=drain_chunk, settings=_settings()
+        )
+        rows = _awareness(cur, claim_id)
+
+    assert result.minted_count == 0
+    by_knower = {row["knower_entity_id"]: row for row in rows}
+    assert by_knower[terminal]["acquired_at_world_time"] is None
+    assert downstream not in by_knower
+
+
+def test_null_birth_world_time_excludes_claim_from_propagation(
+    live_conn: Any,
+) -> None:
+    """A genuinely clockless claim is legal history outside the frontier."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        source, source_character = _insert_character(cur, "clockless-source")
+        listener, listener_character = _insert_character(cur, "clockless-listener")
+        _insert_relationship(cur, source_character, listener_character)
+        cur.execute(
+            """
+            INSERT INTO narrative_chunks (raw_text, storyteller_text)
+            VALUES (%s, 'Rollback-only clockless fixture.')
+            RETURNING id
+            """,
+            (f"Stage 2c clockless birth {uuid4().hex[:12]}.",),
+        )
+        clockless_chunk = int(cur.fetchone()["id"])
+        claim_id = _insert_claim(
+            cur,
+            chunk_id=clockless_chunk,
+            source_entity_id=source,
+            birth_world_time=None,
+        )
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=8))
+        result = drain_claim_propagation_sync(
+            cur, tick_chunk_id=drain_chunk, settings=_settings()
+        )
+        rows = _awareness(cur, claim_id)
+
+    assert result.minted_count == 0
+    assert [row["knower_entity_id"] for row in rows] == [source]
+    assert rows[0]["acquired_at_world_time"] is None
+    assert listener not in {row["knower_entity_id"] for row in rows}
+
+
+def test_non_primary_commit_skips_propagation_drain(live_conn: Any) -> None:
+    """Dream/flashback/atemporal-equivalent chunks never move knowledge."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 2)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        claim_id = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=entities[0],
+            birth_world_time=birth_world_time,
+        )
+        dream_chunk, _ = _insert_chunk(
+            cur, time_delta=timedelta(hours=8), world_layer="atemporal"
+        )
+        result = drain_claim_propagation_sync(
+            cur, tick_chunk_id=dream_chunk, settings=_settings()
+        )
+        rows = _awareness(cur, claim_id)
+
+    assert result.minted_count == 0
+    assert result.policy_digest is None
+    assert [row["knower_entity_id"] for row in rows] == [entities[0]]
+
+
+def test_cellular_clandestine_channel_uses_multiplied_latency(
+    live_conn: Any,
+) -> None:
+    """Institutional culture delays the scheduled channel acquisition."""
+
+    settings = _settings(
+        trusting="never",
+        channels={
+            "authority_over": {
+                "direction": "subject_to_object",
+                "latency": "1h",
+            }
+        },
+        culture_profiles={"cellular_clandestine": 4.0},
+    )
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        faction = _insert_faction(cur, "cellular")
+        listener, _ = _insert_character(cur, "cellular-listener")
+        _insert_pair_tag(cur, faction, listener, "authority_over")
+        _insert_culture_tag(cur, faction, "cellular_clandestine")
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        claim_id = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=faction,
+            birth_world_time=birth_world_time,
+        )
+        early_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=3))
+        early = drain_claim_propagation_sync(
+            cur, tick_chunk_id=early_chunk, settings=settings
+        )
+        mature_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=5))
+        mature = drain_claim_propagation_sync(
+            cur, tick_chunk_id=mature_chunk, settings=settings
+        )
+        rows = _awareness(cur, claim_id)
+
+    assert early.minted_count == 0
+    assert mature.minted_count == 1
+    assert rows[1]["channel"] == "channel:authority_over"
+    assert rows[1]["acquired_at_world_time"] == birth_world_time + timedelta(hours=4)
+
+
+def test_idempotent_redrain_and_disabled_config_are_noops(live_conn: Any) -> None:
+    """The awareness uniqueness key closes a drain; disabled reads nothing."""
+
+    settings = _settings()
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 2)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        claim_id = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=entities[0],
+            birth_world_time=birth_world_time,
+        )
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=4))
+        first = drain_claim_propagation_sync(
+            cur, tick_chunk_id=drain_chunk, settings=settings
+        )
+        second = drain_claim_propagation_sync(
+            cur, tick_chunk_id=drain_chunk, settings=settings
+        )
+        disabled = drain_claim_propagation_sync(
+            cur,
+            tick_chunk_id=-1,
+            settings=_settings(enabled=False),
+        )
+        events = _propagation_events(cur, claim_id)
+
+    assert first.minted_count == 1
+    assert second.minted_count == 0
+    assert disabled.minted_count == 0
+    assert len(events) == 1
+
+
+def test_resolution_free_commit_still_drains(live_conn: Any) -> None:
+    """An accepted tick with no proposal/resolutions still advances knowledge."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 2)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        claim_id = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=entities[0],
+            birth_world_time=birth_world_time,
+        )
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=4))
+
+    result = commit_orrery_tick_sync(
+        live_conn,
+        None,
+        tick_chunk_id=drain_chunk,
+        contagion_settings=_settings(),
+    )
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        rows = _awareness(cur, claim_id)
+
+    assert result.resolution_count == 0
+    assert result.propagation_count == 1
+    assert result.event_count == 0
+    assert len(rows) == 2
+
+
+def test_replay_reconstructs_propagated_awareness_from_event(
+    live_conn: Any,
+) -> None:
+    """The event ledger reproduces the live awareness projection after a drain."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 3)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        claim_id = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=entities[0],
+            birth_world_time=birth_world_time,
+        )
+        with live_conn.cursor() as checkpoint_cur:
+            checkpoint_id = capture_state_checkpoint_sync(
+                checkpoint_cur, chunk_id=birth_chunk, label="manual"
+            )
+        assert checkpoint_id is not None
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=8))
+        drained = drain_claim_propagation_sync(
+            cur, tick_chunk_id=drain_chunk, settings=_settings()
+        )
+        live_rows = _awareness(cur, claim_id)
+        with live_conn.cursor() as replay_cur:
+            replay = reconstruct_state_at_sync(
+                replay_cur, drain_chunk, base_checkpoint_id=checkpoint_id
+            )
+
+    replayed_rows = [
+        row for row in replay.state["claim_awareness"] if row["claim_id"] == claim_id
+    ]
+    assert drained.minted_count == 2
+    assert _canonical_rows(replayed_rows) == _canonical_rows(live_rows)
+
+
+def test_checkpoint_verify_reports_unledgered_awareness_drift(
+    live_conn: Any,
+) -> None:
+    """A projection-only awareness INSERT is visible to the replay oracle."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        source, _ = _insert_character(cur, "drift-source")
+        rogue, _ = _insert_character(cur, "drift-rogue")
+        base_chunk, base_world_time = _insert_chunk(cur)
+        claim_id = _insert_claim(
+            cur,
+            chunk_id=base_chunk,
+            source_entity_id=source,
+            birth_world_time=base_world_time,
+        )
+        with live_conn.cursor() as checkpoint_cur:
+            base_checkpoint_id = capture_state_checkpoint_sync(
+                checkpoint_cur, chunk_id=base_chunk, label="manual"
+            )
+        assert base_checkpoint_id is not None
+
+        target_chunk, target_world_time = _insert_chunk(
+            cur, time_delta=timedelta(hours=1)
+        )
+        cur.execute(
+            """
+            INSERT INTO claim_awareness (
+                claim_id, knower_entity_id, source_tier,
+                acquired_at_world_time, source_chunk_id
+            ) VALUES (%s, %s, 'participant', %s, %s)
+            RETURNING id
+            """,
+            (claim_id, rogue, target_world_time, target_chunk),
+        )
+        rogue_awareness_id = int(cur.fetchone()["id"])
+        with live_conn.cursor() as checkpoint_cur:
+            target_checkpoint_id = capture_state_checkpoint_sync(
+                checkpoint_cur, chunk_id=target_chunk, label="manual"
+            )
+        assert target_checkpoint_id is not None
+        with live_conn.cursor() as verify_cur:
+            verdicts = verify_checkpoints_sync(verify_cur)
+
+    verdict = next(
+        item
+        for item in verdicts
+        if item.base_checkpoint_id == base_checkpoint_id
+        and item.target_checkpoint_id == target_checkpoint_id
+    )
+    assert any(
+        drift.section == "claim_awareness"
+        and drift.row_key == str(rogue_awareness_id)
+        and drift.kind == "missing_row"
+        for drift in verdict.drifts
+    )
+
+
+def test_old_checkpoint_without_awareness_section_is_skipped(
+    live_conn: Any,
+) -> None:
+    """Pre-section checkpoints remain verifiable through explicit skipping."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        source, _ = _insert_character(cur, "old-checkpoint-source")
+        base_chunk, base_world_time = _insert_chunk(cur)
+        _insert_claim(
+            cur,
+            chunk_id=base_chunk,
+            source_entity_id=source,
+            birth_world_time=base_world_time,
+        )
+        with live_conn.cursor() as checkpoint_cur:
+            base_checkpoint_id = capture_state_checkpoint_sync(
+                checkpoint_cur, chunk_id=base_chunk, label="manual"
+            )
+        assert base_checkpoint_id is not None
+        cur.execute(
+            """
+            UPDATE state_checkpoints
+            SET state = state - 'claim_awareness'
+            WHERE id = %s
+            """,
+            (base_checkpoint_id,),
+        )
+        target_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=1))
+        with live_conn.cursor() as checkpoint_cur:
+            target_checkpoint_id = capture_state_checkpoint_sync(
+                checkpoint_cur, chunk_id=target_chunk, label="manual"
+            )
+        assert target_checkpoint_id is not None
+        with live_conn.cursor() as verify_cur:
+            verdicts = verify_checkpoints_sync(verify_cur)
+
+    verdict = next(
+        item
+        for item in verdicts
+        if item.base_checkpoint_id == base_checkpoint_id
+        and item.target_checkpoint_id == target_checkpoint_id
+    )
+    assert not [drift for drift in verdict.drifts if drift.section == "claim_awareness"]
+    assert verdict.skipped_unreproducible >= 1
+    assert any(
+        "comparison skipped" in note
+        for note in verdict.notes.get("claim_awareness", [])
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_drain_matches_sync_single_hop() -> None:
+    """The async accepted-chunk twin mints the same scheduled ledger pair."""
+
+    conn = await asyncpg.connect(get_slot_db_url(slot=LIVE_SLOT))
+    transaction = conn.transaction()
+    await transaction.start()
+    try:
+        migration_state = await conn.fetchrow(
+            """
+            SELECT EXISTS (
+                       SELECT 1 FROM event_types
+                       WHERE type = 'claim_propagated'
+                   ) AS registered,
+                   EXISTS (
+                       SELECT 1 FROM information_schema.columns
+                       WHERE table_schema = ANY(current_schemas(false))
+                         AND table_name = 'world_events'
+                         AND column_name = 'world_time'
+                   ) AS shaped
+            """
+        )
+        if not migration_state["registered"] or not migration_state["shaped"]:
+            pytest.skip(
+                "slot 5 has not applied migration 083: async propagation "
+                "coverage requires the registered event and shaped ledger"
+            )
+        source = int(
+            await conn.fetchval(
+                "INSERT INTO entities (kind, is_active) "
+                "VALUES ('character', true) RETURNING id"
+            )
+        )
+        listener = int(
+            await conn.fetchval(
+                "INSERT INTO entities (kind, is_active) "
+                "VALUES ('character', true) RETURNING id"
+            )
+        )
+        source_character = int(
+            await conn.fetchval(
+                "INSERT INTO characters (name, entity_id) "
+                "VALUES ($1, $2) RETURNING id",
+                f"propagation-async-source-{uuid4().hex[:10]}",
+                source,
+            )
+        )
+        listener_character = int(
+            await conn.fetchval(
+                "INSERT INTO characters (name, entity_id) "
+                "VALUES ($1, $2) RETURNING id",
+                f"propagation-async-listener-{uuid4().hex[:10]}",
+                listener,
+            )
+        )
+        await conn.execute(
+            """
+            INSERT INTO character_relationships (
+                character1_id, character2_id, relationship_type,
+                emotional_valence, dynamic, recent_events, history
+            ) VALUES (
+                $1, $2, 'associate', '+3|trusting',
+                'Rollback-only Stage 2c conduit.', 'None.', 'Fixture.'
+            )
+            """,
+            source_character,
+            listener_character,
+        )
+        birth_chunk, birth_world_time = await _insert_chunk_async(conn)
+        event_id = int(
+            await conn.fetchval(
+                """
+                INSERT INTO world_events (
+                    event_type, tick_chunk_id, actor_entity_id, world_layer,
+                    source, changed_fields, payload
+                ) VALUES (
+                    'threat_issued', $1, $2, 'primary',
+                    'resolver', '{}', '{}'::jsonb
+                ) RETURNING id
+                """,
+                birth_chunk,
+                source,
+            )
+        )
+        await conn.execute(
+            """
+            INSERT INTO world_event_entities (event_id, role, entity_id)
+            VALUES ($1, 'actor', $2)
+            """,
+            event_id,
+            source,
+        )
+        minted = await mint_claim_for_event_async(
+            conn,
+            world_event_id=event_id,
+            event_type="threat_issued",
+            summary="Async propagated claim.",
+            participants=(
+                ClaimParticipant(
+                    source,
+                    "actor",
+                    f"Async propagation source {source}",
+                    "character",
+                ),
+            ),
+            source_chunk_id=birth_chunk,
+            source_resolution_id=None,
+            settings=EPISTEMICS,
+        )
+        assert minted is not None
+        claim_id = minted.claim_id
+        drain_chunk, _ = await _insert_chunk_async(conn, time_delta=timedelta(hours=8))
+        result = await drain_claim_propagation_async(
+            conn,
+            tick_chunk_id=drain_chunk,
+            settings=_settings(),
+        )
+        awareness = await conn.fetchrow(
+            """
+            SELECT immediate_source_entity_id, root_source_entity_id,
+                   acquired_at_world_time, source_chunk_id
+            FROM claim_awareness
+            WHERE claim_id = $1 AND knower_entity_id = $2
+            """,
+            claim_id,
+            listener,
+        )
+        ledger_time = await conn.fetchval(
+            """
+            SELECT world_time FROM world_events
+            WHERE event_type = 'claim_propagated'
+              AND (payload ->> 'claim_id')::bigint = $1
+            """,
+            claim_id,
+        )
+    finally:
+        await transaction.rollback()
+        await conn.close()
+
+    assert result.minted_count == 1
+    assert awareness is not None
+    assert awareness["immediate_source_entity_id"] == source
+    assert awareness["root_source_entity_id"] == source
+    expected_acquisition = birth_world_time + timedelta(hours=1)
+    assert awareness["acquired_at_world_time"] == expected_acquisition
+    assert awareness["source_chunk_id"] == drain_chunk
+    assert ledger_time == expected_acquisition
+
+
+async def _insert_chunk_async(
+    conn: Any,
+    *,
+    time_delta: timedelta = timedelta(0),
+    world_layer: str = "primary",
+) -> tuple[int, datetime]:
+    token = uuid4().hex[:12]
+    chunk_id = int(
+        await conn.fetchval(
+            "INSERT INTO narrative_chunks (raw_text, storyteller_text) "
+            "VALUES ($1, 'Rollback-only async fixture.') RETURNING id",
+            f"Stage 2c async chunk {token}.",
+        )
+    )
+    await conn.execute(
+        """
+        INSERT INTO chunk_metadata (
+            chunk_id, season, episode, scene, world_layer, time_delta,
+            generation_date, slug
+        ) VALUES (
+            $1, 99, 99, $2, $3::world_layer_type, $4, now(), $5
+        )
+        """,
+        chunk_id,
+        chunk_id,
+        world_layer,
+        time_delta,
+        token[:10],
+    )
+    stamped = await conn.fetchval(
+        "SELECT world_time FROM chunk_metadata WHERE chunk_id = $1", chunk_id
+    )
+    assert stamped is not None
+    return chunk_id, stamped
+
+
+def _canonical_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {key: canonicalize(value) for key, value in sorted(row.items())}
+        for row in sorted(rows, key=lambda item: int(item["id"]))
+    ]

--- a/tests/test_orrery/test_claim_propagation_live.py
+++ b/tests/test_orrery/test_claim_propagation_live.py
@@ -879,6 +879,80 @@ def test_resolution_free_commit_still_drains(live_conn: Any) -> None:
     assert len(rows) == 2
 
 
+def test_replay_readmits_beneficiary_participant_awareness(
+    live_conn: Any,
+) -> None:
+    """PR #520 review: beneficiary-role mints must survive reconstruction.
+
+    PARTICIPANT_ROLES includes beneficiary; the readmission query must accept
+    every role minting accepts, or valid rows reconstruct as drift.
+    """
+
+    beneficiary_settings = {**EPISTEMICS, "aware_roles": ["actor", "beneficiary"]}
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 2)
+        actor_id, beneficiary_id = entities[0], entities[1]
+        base_chunk, _ = _insert_chunk(cur)
+        with live_conn.cursor() as checkpoint_cur:
+            checkpoint_id = capture_state_checkpoint_sync(
+                checkpoint_cur, chunk_id=base_chunk, label="manual"
+            )
+        assert checkpoint_id is not None
+        mint_chunk, birth_world_time = _insert_chunk(cur, time_delta=timedelta(hours=2))
+        cur.execute(
+            """
+            INSERT INTO world_events (
+                event_type, tick_chunk_id, actor_entity_id, world_layer,
+                source, changed_fields, payload
+            ) VALUES (
+                'threat_issued', %s, %s, 'primary', 'resolver', '{}', '{}'::jsonb
+            )
+            RETURNING id
+            """,
+            (mint_chunk, actor_id),
+        )
+        event_id = int(cur.fetchone()["id"])
+        cur.execute(
+            """
+            INSERT INTO world_event_entities (event_id, role, entity_id)
+            VALUES (%s, 'actor', %s), (%s, 'beneficiary', %s)
+            """,
+            (event_id, actor_id, event_id, beneficiary_id),
+        )
+        minted = mint_claim_for_event(
+            cur,
+            world_event_id=event_id,
+            event_type="threat_issued",
+            summary="Rollback-only beneficiary claim.",
+            participants=(
+                ClaimParticipant(actor_id, "actor", "Actor", "character"),
+                ClaimParticipant(
+                    beneficiary_id, "beneficiary", "Beneficiary", "character"
+                ),
+            ),
+            source_chunk_id=mint_chunk,
+            source_resolution_id=None,
+            settings=beneficiary_settings,
+        )
+        assert minted is not None
+        live_rows = _awareness(cur, minted.claim_id)
+        assert {int(r["knower_entity_id"]) for r in live_rows} == {
+            actor_id,
+            beneficiary_id,
+        }
+        with live_conn.cursor() as replay_cur:
+            replay = reconstruct_state_at_sync(
+                replay_cur, mint_chunk, base_checkpoint_id=checkpoint_id
+            )
+
+    replayed_rows = [
+        row
+        for row in replay.state["claim_awareness"]
+        if row["claim_id"] == minted.claim_id
+    ]
+    assert _canonical_rows(replayed_rows) == _canonical_rows(live_rows)
+
+
 def test_replay_reconstructs_propagated_awareness_from_event(
     live_conn: Any,
 ) -> None:

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -14,6 +14,7 @@ from nexus.config.settings_models import (
     OrreryBleedSettings,
     OrreryContagionSettings,
     OrreryDashboardSettings,
+    OrreryEpistemicsSettings,
     OrreryPromoteSettings,
     OrrerySettings,
     OrreryRetrogradeMaturationSettings,
@@ -141,6 +142,13 @@ def test_contagion_rejects_nonpositive_culture_multiplier() -> None:
 
     with pytest.raises(ValidationError, match="greater than zero"):
         OrreryContagionSettings(culture_profiles={"covert": 0.0})
+
+
+def test_epistemics_rejects_claim_propagated_as_claim_producer() -> None:
+    """The propagation ledger cannot recursively create a new claim."""
+
+    with pytest.raises(ValidationError, match="claim_propagated cannot appear"):
+        OrreryEpistemicsSettings(claim_event_types=["claim_propagated"])
 
 
 def test_project_milestones_cannot_fall_below_promotion_floor() -> None:

--- a/tests/test_orrery/test_epistemics.py
+++ b/tests/test_orrery/test_epistemics.py
@@ -123,6 +123,19 @@ def _leaf_evidence(trace: ConditionTrace, kind: str) -> list[dict[str, Any]]:
     ]
 
 
+def test_runtime_epistemics_guard_rejects_claim_propagated_policy() -> None:
+    """Mapping callers cannot bypass the load-time recursion guard."""
+
+    with pytest.raises(ValueError, match="claim_propagated cannot appear"):
+        coerce_epistemics_policy(
+            {
+                "enabled": True,
+                "claim_event_types": ["claim_propagated"],
+                "aware_roles": ["actor"],
+            }
+        )
+
+
 @pytest.mark.requires_postgres
 def test_two_similar_actors_are_separated_only_by_awareness(save_02_conn: Any) -> None:
     """A bounded threat opens SURVEIL only for the actor who knows it."""
@@ -898,7 +911,6 @@ def test_revelation_scope_and_common_semantics(save_02_conn: Any) -> None:
             (event_id, anchor),
         )
         claim_id = int(cur.fetchone()["id"])
-
         state = WorldState(
             recent_events=(
                 EventRecord(
@@ -1130,6 +1142,9 @@ def test_record_revelation_cli_handler_reports_insert_and_dedupe(
             (event_id, anchor),
         )
         claim_id = int(cur.fetchone()["id"])
+        cur.execute("SELECT max(world_time) AS world_time FROM chunk_metadata")
+        expected_world_time = cur.fetchone()["world_time"]
+        assert expected_world_time is not None
 
     parser = build_parser()
     first_args = parser.parse_args(
@@ -1173,7 +1188,8 @@ def test_record_revelation_cli_handler_reports_insert_and_dedupe(
     with save_02_conn.cursor(cursor_factory=RealDictCursor) as cur:
         cur.execute(
             """
-            SELECT source_tier, immediate_source_entity_id, root_source_entity_id
+            SELECT source_tier, immediate_source_entity_id, root_source_entity_id,
+                   acquired_at_world_time
             FROM claim_awareness WHERE id = %s
             """,
             (first["claim_awareness_id"],),
@@ -1183,6 +1199,7 @@ def test_record_revelation_cli_handler_reports_insert_and_dedupe(
             "source_tier": "granted",
             "immediate_source_entity_id": None,
             "root_source_entity_id": None,
+            "acquired_at_world_time": expected_world_time,
         }
 
 

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -734,6 +734,34 @@ def test_commit_orrery_tick_ignores_scene_pressures() -> None:
     assert "INSERT INTO world_events" not in statements
 
 
+def test_propagation_count_does_not_inflate_resolution_event_count(
+    monkeypatch: Any,
+) -> None:
+    """Passive acquisitions have a dedicated tick-result counter."""
+
+    from nexus.agents.orrery.propagation import PropagationDrainResult
+
+    monkeypatch.setattr(
+        orrery_events,
+        "drain_claim_propagation_sync",
+        lambda *_args, **_kwargs: PropagationDrainResult(
+            awareness_ids=(701,), event_ids=(801,)
+        ),
+    )
+
+    result = commit_orrery_tick_sync(
+        RecordingConn(RecordingCursor()),
+        None,
+        tick_chunk_id=100,
+        slot=5,
+        world_layer="primary",
+        contagion_settings={"enabled": True},
+    )
+
+    assert result.event_count == 0
+    assert result.propagation_count == 1
+
+
 def test_commit_orrery_tick_sweeps_expired_entity_tags_without_resolution() -> None:
     """Accepted ticks clear elapsed-time tags even when no package commits."""
 

--- a/tests/test_orrery/test_reconstruction.py
+++ b/tests/test_orrery/test_reconstruction.py
@@ -240,20 +240,23 @@ def test_unattributed_relationship_write_versions_with_null_chunk() -> None:
 
 
 def test_migration_genesis_sections_mirror_checkpoint_sections() -> None:
-    """Genesis SQL across 065 plus additive 074 mirrors checkpoint sections."""
+    """Checkpoint sections are introduced by their owning migrations."""
 
     from pathlib import Path
 
     migration = Path("migrations/065_reconstructability.sql").read_text()
     genesis = migration[migration.index("jsonb_build_object") :]
     additive = Path("migrations/074_plan_relocation_projects.sql").read_text()
-    genesis_sources = genesis + additive
+    propagation = Path("migrations/083_claim_propagation_ledger.sql").read_text()
+    genesis_sources = genesis + additive + propagation
     for section in CHECKPOINT_SECTIONS:
         assert (
-            f"'{section}', (" in genesis_sources
+            f"'{section}'" in genesis_sources
         ), f"migration genesis/extension SQL lacks section {section!r}"
     import re
 
     migration_sections = set(re.findall(r"'(\w+)', \(SELECT", genesis))
     migration_sections.update(re.findall(r"'(character_project_states)', \(", additive))
+    if "'claim_awareness'" in propagation:
+        migration_sections.add("claim_awareness")
     assert migration_sections == set(CHECKPOINT_SECTIONS)


### PR DESCRIPTION
Stage 2c of #477 Social Contagion (Option C): knowledge moves. Governing rulings, frozen sub-decisions, and the layered-culture model are on the issue; this is the propagation frontier engine consuming the Stage 2b graph.

## What Lands

- **`nexus/agents/orrery/propagation.py`**: the awareness-table-as-frontier drain — no scheduler state; at each accepted **primary-layer** chunk commit, bounded claims propagate along the communication graph to fixpoint, each acquisition stamped at its *scheduled* world time (source + latency, never the drain clock), so one large time skip releases chained hops with correctly staggered stamps. Deterministic fan-out (latency, then listener id), per-hop age-horizon gating (cadence-independent by construction), depth via `claim_propagated` event payloads.
- **Ledger**: migration 083 registers `claim_propagated` (+ a partial index for depth recovery); events are payload-only (no actor/target, no `world_event_entities`) so passive gossip never pollutes resolver salience. Policy digest snapshotted per event. Structurally excluded from `claim_event_types` at settings load — propagation can never mint claims.
- **Replay contract**: `claim_awareness` is now a captured, reconstructed, and *verified* checkpoint section — an un-ledgered epistemics write makes `replay_state.py --verify` report drift. Old checkpoints skip the section gracefully.
- **Hardening from the adversarial round (10 confirmed findings)**: NULL world-times are legal history (frontier terminals / excluded claims) instead of a permanent commit wedge; `record-revelation` stamps the current clock by default; non-primary chunks never drain; pre-083 slots fail loudly with a migration instruction; `propagation_count` reports separately from `event_count`.
- **Live tests (18, rollback-only, real slot 5)**: all twelve frozen scenarios plus the fix-round regressions — written to coexist with the `chunk_metadata` world-time trigger (control gaps via `time_delta`, read back the trigger's stamp, derive expectations arithmetically). The trigger interaction only surfaced once the tests ran against the migrated slot — the native-slot doctrine earning its keep again.

## Verification

Default suite 1400 passed; postgres suite **1636 passed**; slot-5 replay green across all checkpoints — all exit-code-checked and independently re-run by the orchestrator after rebase onto #518/#519.

Implemented by Codex (gpt-5.6-sol) from frozen work orders across three rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UUKcWGZUXg2jF5Nqrhtqv
