### PR TITLE
Consume the Epistemics Substrate: Knower-Gated Predicates and Audit (#477 Stage 2d)

### DIFF
--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -1282,13 +1282,18 @@ def entity_context(
                 {**base, "direction": "inbound", "other_entity_id": source_id}
             )
 
-    common_claims: dict[int, dict[str, Any]] = {}
+    common_claims_by_entity: dict[int, dict[int, dict[str, Any]]] = {}
     explicit_claims_by_entity: dict[int, dict[int, dict[str, Any]]] = {}
     for row in session.execute(
         text(
             """
             /* orrery_audit:entity_claim_knowledge */
-            WITH requested_awareness AS (
+            WITH anchor AS (
+                SELECT created_at
+                FROM narrative_chunks
+                WHERE id = :anchor_chunk_id
+            ),
+            requested_awareness AS (
                 SELECT id,
                        claim_id,
                        knower_entity_id,
@@ -1299,6 +1304,38 @@ def entity_context(
                        acquired_at_world_time
                 FROM claim_awareness
                 WHERE knower_entity_id = ANY(:ids)
+                  -- Mirror replay.py's claim-awareness readmission visibility.
+                  AND (
+                      :anchor_chunk_id IS NULL
+                      OR (source_chunk_id IS NOT NULL
+                          AND source_chunk_id <= :anchor_chunk_id)
+                      OR (source_chunk_id IS NULL
+                          AND created_at <= (SELECT created_at FROM anchor))
+                  )
+            ),
+            requested_common_claims AS (
+                SELECT c.id AS claim_id,
+                       array_agg(
+                           DISTINCT about.entity_id ORDER BY about.entity_id
+                       ) AS about_entity_ids
+                FROM claims c
+                JOIN world_events mint_event
+                  ON mint_event.id = c.world_event_id
+                JOIN LATERAL (
+                    SELECT mint_event.actor_entity_id AS entity_id
+                    WHERE mint_event.actor_entity_id IS NOT NULL
+                    UNION
+                    SELECT mint_event.target_entity_id AS entity_id
+                    WHERE mint_event.target_entity_id IS NOT NULL
+                    UNION
+                    SELECT wee.entity_id
+                    FROM world_event_entities wee
+                    WHERE wee.event_id = mint_event.id
+                ) about ON about.entity_id = ANY(:ids)
+                WHERE c.scope = 'common'
+                  AND (:anchor_chunk_id IS NULL
+                       OR mint_event.tick_chunk_id <= :anchor_chunk_id)
+                GROUP BY c.id
             ),
             propagated AS (
                 SELECT requested.id AS awareness_id,
@@ -1314,6 +1351,7 @@ def entity_context(
             SELECT c.id AS claim_id,
                    c.summary,
                    c.scope,
+                   requested_common.about_entity_ids AS common_about_entity_ids,
                    ca.id AS awareness_id,
                    ca.knower_entity_id,
                    ca.source_tier,
@@ -1323,13 +1361,18 @@ def entity_context(
                    ca.acquired_at_world_time,
                    propagated.depth
             FROM claims c
+            JOIN world_events mint_event ON mint_event.id = c.world_event_id
+            LEFT JOIN requested_common_claims requested_common
+              ON requested_common.claim_id = c.id
             LEFT JOIN requested_awareness ca ON ca.claim_id = c.id
             LEFT JOIN propagated ON propagated.awareness_id = ca.id
-            WHERE c.scope = 'common' OR ca.id IS NOT NULL
+            WHERE (:anchor_chunk_id IS NULL
+                   OR mint_event.tick_chunk_id <= :anchor_chunk_id)
+              AND (requested_common.claim_id IS NOT NULL OR ca.id IS NOT NULL)
             ORDER BY c.id, ca.knower_entity_id NULLS FIRST
             """
         ),
-        {"ids": ids},
+        {"ids": ids, "anchor_chunk_id": anchor_chunk_id},
     ).mappings():
         claim_id = int(row["claim_id"])
         scope = str(row["scope"])
@@ -1341,7 +1384,7 @@ def entity_context(
             "scope": scope,
         }
         if scope == "common":
-            common_claims[claim_id] = {
+            common_claim = {
                 **base_claim,
                 "tier": "common",
                 "channel": None,
@@ -1350,6 +1393,10 @@ def entity_context(
                 "acquired_at_world_time": None,
                 "depth": None,
             }
+            for about_entity_id in row["common_about_entity_ids"] or ():
+                common_claims_by_entity.setdefault(int(about_entity_id), {})[
+                    claim_id
+                ] = common_claim
         knower_entity_id = row["knower_entity_id"]
         if knower_entity_id is None:
             continue
@@ -1531,7 +1578,7 @@ def entity_context(
                 )
 
     def _knowledge(entity_id: int) -> list[dict[str, Any]]:
-        possessed = dict(common_claims)
+        possessed = dict(common_claims_by_entity.get(entity_id, {}))
         possessed.update(explicit_claims_by_entity.get(entity_id, {}))
         rows = []
         for claim_id in sorted(possessed):

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -41,6 +41,8 @@ from nexus.agents.orrery.communication import (
     communication_graph_for_settings,
 )
 from nexus.agents.orrery.epistemics import (
+    CLAIM_SCOPES,
+    SOURCE_TIERS,
     coerce_epistemics_policy,
     load_epistemics_policy,
 )
@@ -1122,7 +1124,8 @@ def entity_context(
     Everything the dashboard's HoverCard renders: name, place (with classes),
     activity, effective need debt, tags with per-row provenance and family
     membership, pair tags, relationships (explicitly labeled unversioned),
-    travel state, routine anchors, and recent events. Read-only.
+    possessed claims with acquisition provenance, travel state, routine
+    anchors, and recent events. Read-only.
     """
 
     ids = sorted(set(entity_ids))
@@ -1279,6 +1282,115 @@ def entity_context(
                 {**base, "direction": "inbound", "other_entity_id": source_id}
             )
 
+    common_claims: dict[int, dict[str, Any]] = {}
+    explicit_claims_by_entity: dict[int, dict[int, dict[str, Any]]] = {}
+    for row in session.execute(
+        text(
+            """
+            /* orrery_audit:entity_claim_knowledge */
+            WITH requested_awareness AS (
+                SELECT id,
+                       claim_id,
+                       knower_entity_id,
+                       source_tier,
+                       channel,
+                       immediate_source_entity_id,
+                       root_source_entity_id,
+                       acquired_at_world_time
+                FROM claim_awareness
+                WHERE knower_entity_id = ANY(:ids)
+            ),
+            propagated AS (
+                SELECT requested.id AS awareness_id,
+                       (event.payload ->> 'depth')::integer AS depth
+                FROM requested_awareness requested
+                JOIN world_events event
+                  ON event.event_type = 'claim_propagated'
+                 AND (event.payload ->> 'claim_id')::bigint = requested.claim_id
+                 AND (event.payload ->> 'awareness_id')::bigint = requested.id
+                WHERE event.payload ? 'claim_id'
+                  AND event.payload ? 'awareness_id'
+            )
+            SELECT c.id AS claim_id,
+                   c.summary,
+                   c.scope,
+                   ca.id AS awareness_id,
+                   ca.knower_entity_id,
+                   ca.source_tier,
+                   ca.channel,
+                   ca.immediate_source_entity_id,
+                   ca.root_source_entity_id,
+                   ca.acquired_at_world_time,
+                   propagated.depth
+            FROM claims c
+            LEFT JOIN requested_awareness ca ON ca.claim_id = c.id
+            LEFT JOIN propagated ON propagated.awareness_id = ca.id
+            WHERE c.scope = 'common' OR ca.id IS NOT NULL
+            ORDER BY c.id, ca.knower_entity_id NULLS FIRST
+            """
+        ),
+        {"ids": ids},
+    ).mappings():
+        claim_id = int(row["claim_id"])
+        scope = str(row["scope"])
+        if scope not in CLAIM_SCOPES:
+            raise ValueError(f"Claim {claim_id} has unknown scope {scope!r}")
+        base_claim = {
+            "claim_id": claim_id,
+            "summary": str(row["summary"]),
+            "scope": scope,
+        }
+        if scope == "common":
+            common_claims[claim_id] = {
+                **base_claim,
+                "tier": "common",
+                "channel": None,
+                "immediate_source_entity_id": None,
+                "root_source_entity_id": None,
+                "acquired_at_world_time": None,
+                "depth": None,
+            }
+        knower_entity_id = row["knower_entity_id"]
+        if knower_entity_id is None:
+            continue
+        knower_id = int(knower_entity_id)
+        immediate_source = row["immediate_source_entity_id"]
+        root_source = row["root_source_entity_id"]
+        if immediate_source is not None:
+            referenced_ids.add(int(immediate_source))
+        if root_source is not None:
+            referenced_ids.add(int(root_source))
+        by_claim = explicit_claims_by_entity.setdefault(knower_id, {})
+        if claim_id in by_claim:
+            raise RuntimeError(
+                "Duplicate claim_propagated audit ledger entries for awareness "
+                f"{row['awareness_id']}"
+            )
+        source_tier = str(row["source_tier"])
+        if source_tier not in SOURCE_TIERS:
+            raise ValueError(
+                f"Claim {claim_id} has unknown awareness tier {source_tier!r}"
+            )
+        depth = int(row["depth"]) if row["depth"] is not None else None
+        if depth is not None and depth < 1:
+            raise ValueError(
+                f"Claim {claim_id} awareness {row['awareness_id']} has invalid "
+                f"propagation depth {depth}"
+            )
+        by_claim[claim_id] = {
+            **base_claim,
+            "tier": source_tier,
+            "channel": row["channel"],
+            "immediate_source_entity_id": (
+                int(immediate_source) if immediate_source is not None else None
+            ),
+            "root_source_entity_id": (
+                int(root_source) if root_source is not None else None
+            ),
+            "acquired_at_world_time": _iso(row["acquired_at_world_time"]),
+            "depth": depth,
+        }
+
     place_rows = {
         row["entity_id"]: row
         for row in session.execute(
@@ -1418,6 +1530,37 @@ def entity_context(
                     else None
                 )
 
+    def _knowledge(entity_id: int) -> list[dict[str, Any]]:
+        possessed = dict(common_claims)
+        possessed.update(explicit_claims_by_entity.get(entity_id, {}))
+        rows = []
+        for claim_id in sorted(possessed):
+            claim = possessed[claim_id]
+
+            def source_payload(key: str) -> Optional[dict[str, Any]]:
+                source_id = claim[key]
+                if source_id is None:
+                    return None
+                return {
+                    "entity_id": source_id,
+                    "name": _entity_label(source_id, entity_names),
+                }
+
+            rows.append(
+                {
+                    "claim_id": claim["claim_id"],
+                    "summary": claim["summary"],
+                    "scope": claim["scope"],
+                    "tier": claim["tier"],
+                    "channel": claim["channel"],
+                    "immediate_source": source_payload("immediate_source_entity_id"),
+                    "root_source": source_payload("root_source_entity_id"),
+                    "acquired_at_world_time": claim["acquired_at_world_time"],
+                    "depth": claim["depth"],
+                }
+            )
+        return rows
+
     entities: list[dict[str, Any]] = []
     for entity_id in ids:
         place_row = place_rows.get(entity_id)
@@ -1458,6 +1601,7 @@ def entity_context(
                 "communication_edges": [
                     edge.to_dict() for edge in communication_graph.outbound(entity_id)
                 ],
+                "knowledge": _knowledge(entity_id),
                 "travel_state": asdict(travel) if travel is not None else None,
                 "routine_anchors": anchors,
                 "recent_events": events_by_entity.get(entity_id, []),

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -360,6 +360,17 @@ _register(
         f" ≤ {m.group('n')}"
     ),
 )
+_register(
+    r"knows_claim_about\((?P<subject>\w+)->(?P<about>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('subject'))} possesses a claim about "
+        f"{_slot(m.group('about'))}"
+    ),
+)
+_register(
+    r"heard_secondhand\((?P<subject>\w+)\)",
+    lambda m: f"{_slot(m.group('subject'))} has heard a claim secondhand",
+)
 
 # Time / weather predicates
 _register(

--- a/nexus/agents/orrery/epistemics.py
+++ b/nexus/agents/orrery/epistemics.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Iterable, Mapping, Optional, Sequence
 
-from sqlalchemy import bindparam, text
+from sqlalchemy import text
 
 
 CLAIM_SCOPES = frozenset({"common", "bounded", "private"})
@@ -14,6 +14,7 @@ CLAIM_PROPAGATED_EVENT_TYPE = "claim_propagated"
 EVENT_ROLES = frozenset({"actor", "target", "observer", "witness", "beneficiary"})
 PARTICIPANT_ROLES = frozenset({"actor", "target", "beneficiary"})
 WITNESS_ROLES = frozenset({"observer", "witness"})
+SOURCE_TIERS = frozenset({"participant", "witness", "told", "granted"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -53,11 +54,27 @@ class RevelationResult:
 
 
 @dataclass(frozen=True, slots=True)
-class AwarenessHydration:
-    """Claim scopes and per-entity awareness for one recent-event window."""
+class ClaimKnowledge:
+    """One hydrated claim-possession record consumed by package predicates."""
+
+    claim_id: int
+    world_event_id: int
+    scope: str
+    source_tier: str
+    about_entity_ids: frozenset[int]
+    channel: Optional[str] = None
+    immediate_source_entity_id: Optional[int] = None
+
+
+@dataclass(frozen=True, slots=True)
+class EpistemicsHydration:
+    """Complete claim projection plus the legacy recent-event lookup shapes."""
 
     claimed_event_scopes: Mapping[int, str]
     awareness_by_entity: Mapping[int, frozenset[int]]
+    claim_knowledge_by_entity: Mapping[int, tuple[ClaimKnowledge, ...]]
+    common_claim_knowledge: tuple[ClaimKnowledge, ...]
+    possessed_claim_knowledge_by_entity: Mapping[int, tuple[ClaimKnowledge, ...]]
 
 
 def coerce_epistemics_policy(raw: Any) -> EpistemicsPolicy:
@@ -333,41 +350,220 @@ def promote_claim_scope(cur: Any, *, claim_id: int, new_scope: str) -> None:
     cur.execute("UPDATE claims SET scope = %s WHERE id = %s", (new_scope, claim_id))
 
 
-def load_awareness_for_events(
-    session: Any, *, world_event_ids: Sequence[int]
-) -> AwarenessHydration:
-    """Hydrate claim scopes and awareness in one query for selected events."""
+def load_epistemics_hydration(
+    session: Any, *, entity_ids: Iterable[int]
+) -> EpistemicsHydration:
+    """Hydrate claim possession relevant to an explicit entity universe.
 
-    event_ids = sorted(set(int(event_id) for event_id in world_event_ids))
-    if not event_ids:
-        return AwarenessHydration({}, {})
-    query = text(
+    ``knows_recent_event`` still reads the event-id maps this returns. Claim
+    predicates additionally need time-unbounded possession and every entity
+    involved in the minting event. A non-common claim is relevant when either
+    an active knower or an about-entity intersects ``entity_ids``; common
+    claims are relevant only through their about-entities. Claim subjects and
+    awareness are loaded on separate axes, so neither can multiply the other.
+    No predicate performs follow-up SQL.
+    """
+
+    universe = tuple(sorted({int(entity_id) for entity_id in entity_ids}))
+    if not universe:
+        return EpistemicsHydration(
+            claimed_event_scopes={},
+            awareness_by_entity={},
+            claim_knowledge_by_entity={},
+            common_claim_knowledge=(),
+            possessed_claim_knowledge_by_entity={},
+        )
+
+    claims_query = text(
         """
-        /* orrery:epistemics_awareness */
-        SELECT c.world_event_id, c.scope, ca.knower_entity_id
-        FROM claims c
-        LEFT JOIN claim_awareness ca ON ca.claim_id = c.id
-        WHERE c.world_event_id IN :world_event_ids
-        ORDER BY c.world_event_id, ca.knower_entity_id
+        /* orrery:epistemics_hydration:claims */
+        WITH relevant_claim_ids AS (
+            SELECT c.id AS claim_id
+            FROM claims c
+            JOIN world_events we ON we.id = c.world_event_id
+            WHERE we.actor_entity_id = ANY(:entity_ids)
+               OR we.target_entity_id = ANY(:entity_ids)
+            UNION
+            SELECT c.id AS claim_id
+            FROM claims c
+            JOIN world_event_entities wee ON wee.event_id = c.world_event_id
+            WHERE wee.entity_id = ANY(:entity_ids)
+            UNION
+            SELECT ca.claim_id
+            FROM claim_awareness ca
+            JOIN claims c ON c.id = ca.claim_id
+            WHERE c.scope <> 'common'
+              AND ca.knower_entity_id = ANY(:entity_ids)
+        ),
+        claim_entities AS (
+            SELECT relevant.claim_id, subjects.entity_id
+            FROM relevant_claim_ids relevant
+            JOIN claims c ON c.id = relevant.claim_id
+            JOIN world_events we ON we.id = c.world_event_id
+            JOIN LATERAL (
+                SELECT we.actor_entity_id AS entity_id
+                WHERE we.actor_entity_id IS NOT NULL
+                UNION
+                SELECT we.target_entity_id AS entity_id
+                WHERE we.target_entity_id IS NOT NULL
+                UNION
+                SELECT wee.entity_id
+                FROM world_event_entities wee
+                WHERE wee.event_id = we.id
+            ) subjects ON true
+        ),
+        about_by_claim AS (
+            SELECT claim_id,
+                   array_agg(entity_id ORDER BY entity_id) AS about_entity_ids
+            FROM claim_entities
+            GROUP BY claim_id
+        )
+        SELECT c.id AS claim_id,
+               c.world_event_id,
+               c.scope,
+               COALESCE(
+                   about.about_entity_ids,
+                   ARRAY[]::bigint[]
+               ) AS about_entity_ids
+        FROM relevant_claim_ids relevant
+        JOIN claims c ON c.id = relevant.claim_id
+        LEFT JOIN about_by_claim about ON about.claim_id = c.id
+        WHERE c.scope <> 'common'
+           OR COALESCE(about.about_entity_ids, ARRAY[]::bigint[])
+              && CAST(:entity_ids AS bigint[])
+        ORDER BY c.id
         """
-    ).bindparams(bindparam("world_event_ids", expanding=True))
+    )
     scopes: dict[int, str] = {}
-    awareness: dict[int, set[int]] = {}
-    for row in session.execute(query, {"world_event_ids": event_ids}).mappings():
+    claims: dict[int, dict[str, Any]] = {}
+    for row in session.execute(claims_query, {"entity_ids": list(universe)}).mappings():
+        claim_id = int(row["claim_id"])
         event_id = int(row["world_event_id"])
         scope = str(row["scope"])
         if scope not in CLAIM_SCOPES:
             raise ValueError(f"Claim on event {event_id} has unknown scope {scope!r}")
         scopes[event_id] = scope
+        claims[claim_id] = {
+            "world_event_id": event_id,
+            "scope": scope,
+            "about_entity_ids": frozenset(
+                int(entity_id) for entity_id in (row["about_entity_ids"] or ())
+            ),
+        }
+
+    awareness: dict[int, set[int]] = {}
+    awareness_rows: dict[tuple[int, int], dict[str, Any]] = {}
+    if claims:
+        awareness_query = text(
+            """
+            /* orrery:epistemics_hydration:awareness */
+            SELECT ca.claim_id,
+                   ca.knower_entity_id,
+                   ca.source_tier,
+                   ca.channel,
+                   ca.immediate_source_entity_id
+            FROM claim_awareness ca
+            WHERE ca.claim_id = ANY(:claim_ids)
+              AND ca.knower_entity_id = ANY(:entity_ids)
+            ORDER BY ca.claim_id, ca.knower_entity_id
+            """
+        )
+        awareness_results = session.execute(
+            awareness_query,
+            {
+                "claim_ids": sorted(claims),
+                "entity_ids": list(universe),
+            },
+        ).mappings()
+    else:
+        awareness_results = ()
+
+    for row in awareness_results:
+        claim_id = int(row["claim_id"])
+        event_id = int(claims[claim_id]["world_event_id"])
         knower_entity_id = row["knower_entity_id"]
-        if knower_entity_id is not None:
-            awareness.setdefault(int(knower_entity_id), set()).add(event_id)
-    return AwarenessHydration(
+        knower_id = int(knower_entity_id)
+        source_tier = str(row["source_tier"])
+        if source_tier not in SOURCE_TIERS:
+            raise ValueError(
+                f"Claim {claim_id} has unknown awareness tier {source_tier!r}"
+            )
+        awareness.setdefault(knower_id, set()).add(event_id)
+        awareness_rows.setdefault(
+            (claim_id, knower_id),
+            {
+                "source_tier": source_tier,
+                "channel": row["channel"],
+                "immediate_source_entity_id": row["immediate_source_entity_id"],
+            },
+        )
+
+    claim_knowledge: dict[int, list[ClaimKnowledge]] = {}
+    for (claim_id, knower_id), row in sorted(awareness_rows.items()):
+        claim = claims[claim_id]
+        immediate_source = row["immediate_source_entity_id"]
+        claim_knowledge.setdefault(knower_id, []).append(
+            ClaimKnowledge(
+                claim_id=claim_id,
+                world_event_id=int(claim["world_event_id"]),
+                scope=str(claim["scope"]),
+                source_tier=str(row["source_tier"]),
+                about_entity_ids=frozenset(claim["about_entity_ids"]),
+                channel=(str(row["channel"]) if row["channel"] is not None else None),
+                immediate_source_entity_id=(
+                    int(immediate_source) if immediate_source is not None else None
+                ),
+            )
+        )
+
+    common_claims = tuple(
+        ClaimKnowledge(
+            claim_id=claim_id,
+            world_event_id=int(claim["world_event_id"]),
+            scope="common",
+            source_tier="common",
+            about_entity_ids=frozenset(claim["about_entity_ids"]),
+        )
+        for claim_id, claim in sorted(claims.items())
+        if claim["scope"] == "common"
+    )
+    explicit_claims = {
+        entity_id: tuple(records) for entity_id, records in claim_knowledge.items()
+    }
+    return EpistemicsHydration(
         claimed_event_scopes=scopes,
         awareness_by_entity={
             entity_id: frozenset(events) for entity_id, events in awareness.items()
         },
+        claim_knowledge_by_entity=explicit_claims,
+        common_claim_knowledge=common_claims,
+        possessed_claim_knowledge_by_entity=_merge_possessed_claim_knowledge(
+            universe,
+            explicit_claims=explicit_claims,
+            common_claims=common_claims,
+        ),
     )
+
+
+def _merge_possessed_claim_knowledge(
+    entity_ids: Iterable[int],
+    *,
+    explicit_claims: Mapping[int, tuple[ClaimKnowledge, ...]],
+    common_claims: tuple[ClaimKnowledge, ...],
+) -> dict[int, tuple[ClaimKnowledge, ...]]:
+    """Precompute deterministic universal-plus-explicit possession by entity."""
+
+    common_by_claim_id = {record.claim_id: record for record in common_claims}
+    possessed: dict[int, tuple[ClaimKnowledge, ...]] = {}
+    for entity_id in sorted({int(value) for value in entity_ids}):
+        by_claim_id = dict(common_by_claim_id)
+        by_claim_id.update(
+            {record.claim_id: record for record in explicit_claims.get(entity_id, ())}
+        )
+        possessed[entity_id] = tuple(
+            by_claim_id[claim_id] for claim_id in sorted(by_claim_id)
+        )
+    return possessed
 
 
 def _normalize_participants(

--- a/nexus/agents/orrery/epistemics.py
+++ b/nexus/agents/orrery/epistemics.py
@@ -351,23 +351,69 @@ def promote_claim_scope(cur: Any, *, claim_id: int, new_scope: str) -> None:
 
 
 def load_epistemics_hydration(
-    session: Any, *, entity_ids: Iterable[int]
+    session: Any,
+    *,
+    entity_ids: Iterable[int],
+    recent_event_ids: Iterable[int],
+    anchor_chunk_id: Optional[int],
 ) -> EpistemicsHydration:
-    """Hydrate claim possession relevant to an explicit entity universe.
+    """Hydrate anchor-visible claim possession for an explicit entity universe.
 
-    ``knows_recent_event`` still reads the event-id maps this returns. Claim
-    predicates additionally need time-unbounded possession and every entity
-    involved in the minting event. A non-common claim is relevant when either
-    an active knower or an about-entity intersects ``entity_ids``; common
-    claims are relevant only through their about-entities. Claim subjects and
-    awareness are loaded on separate axes, so neither can multiply the other.
-    No predicate performs follow-up SQL.
+    ``knows_recent_event`` receives scope existence for every recent event,
+    independent of whether its participants remain active. Claim predicates
+    additionally need time-unbounded possession and every entity involved in
+    the minting event. A non-common claim is relevant when either an active
+    knower or an about-entity intersects ``entity_ids``; common claims are
+    relevant only through their about-entities. Claim subjects and awareness
+    are loaded on separate axes, so neither can multiply the other. No
+    predicate performs follow-up SQL. ``None`` retains the unbounded
+    current-table view for direct callers without a historical anchor.
     """
 
     universe = tuple(sorted({int(entity_id) for entity_id in entity_ids}))
-    if not universe:
+    recent_events = tuple(sorted({int(event_id) for event_id in recent_event_ids}))
+    if not universe and not recent_events:
         return EpistemicsHydration(
             claimed_event_scopes={},
+            awareness_by_entity={},
+            claim_knowledge_by_entity={},
+            common_claim_knowledge=(),
+            possessed_claim_knowledge_by_entity={},
+        )
+
+    scopes: dict[int, str] = {}
+    if recent_events:
+        scope_query = text(
+            """
+            /* orrery:epistemics_hydration:recent_event_scopes */
+            SELECT c.world_event_id,
+                   c.scope
+            FROM claims c
+            JOIN world_events we ON we.id = c.world_event_id
+            WHERE c.world_event_id = ANY(:recent_event_ids)
+              AND (:anchor_chunk_id IS NULL
+                   OR we.tick_chunk_id <= :anchor_chunk_id)
+            ORDER BY c.world_event_id
+            """
+        )
+        for row in session.execute(
+            scope_query,
+            {
+                "recent_event_ids": list(recent_events),
+                "anchor_chunk_id": anchor_chunk_id,
+            },
+        ).mappings():
+            event_id = int(row["world_event_id"])
+            scope = str(row["scope"])
+            if scope not in CLAIM_SCOPES:
+                raise ValueError(
+                    f"Claim on event {event_id} has unknown scope {scope!r}"
+                )
+            scopes[event_id] = scope
+
+    if not universe:
+        return EpistemicsHydration(
+            claimed_event_scopes=scopes,
             awareness_by_entity={},
             claim_knowledge_by_entity={},
             common_claim_knowledge=(),
@@ -377,23 +423,44 @@ def load_epistemics_hydration(
     claims_query = text(
         """
         /* orrery:epistemics_hydration:claims */
-        WITH relevant_claim_ids AS (
+        WITH anchor AS (
+            SELECT created_at
+            FROM narrative_chunks
+            WHERE id = :anchor_chunk_id
+        ),
+        relevant_claim_ids AS (
             SELECT c.id AS claim_id
             FROM claims c
             JOIN world_events we ON we.id = c.world_event_id
-            WHERE we.actor_entity_id = ANY(:entity_ids)
-               OR we.target_entity_id = ANY(:entity_ids)
+            WHERE (:anchor_chunk_id IS NULL
+                   OR we.tick_chunk_id <= :anchor_chunk_id)
+              AND (we.actor_entity_id = ANY(:entity_ids)
+                   OR we.target_entity_id = ANY(:entity_ids))
             UNION
             SELECT c.id AS claim_id
             FROM claims c
             JOIN world_event_entities wee ON wee.event_id = c.world_event_id
-            WHERE wee.entity_id = ANY(:entity_ids)
+            JOIN world_events we ON we.id = c.world_event_id
+            WHERE (:anchor_chunk_id IS NULL
+                   OR we.tick_chunk_id <= :anchor_chunk_id)
+              AND wee.entity_id = ANY(:entity_ids)
             UNION
             SELECT ca.claim_id
             FROM claim_awareness ca
             JOIN claims c ON c.id = ca.claim_id
+            JOIN world_events we ON we.id = c.world_event_id
             WHERE c.scope <> 'common'
               AND ca.knower_entity_id = ANY(:entity_ids)
+              AND (:anchor_chunk_id IS NULL
+                   OR we.tick_chunk_id <= :anchor_chunk_id)
+              -- Mirror replay.py's claim-awareness readmission visibility.
+              AND (
+                  :anchor_chunk_id IS NULL
+                  OR (ca.source_chunk_id IS NOT NULL
+                      AND ca.source_chunk_id <= :anchor_chunk_id)
+                  OR (ca.source_chunk_id IS NULL
+                      AND ca.created_at <= (SELECT created_at FROM anchor))
+              )
         ),
         claim_entities AS (
             SELECT relevant.claim_id, subjects.entity_id
@@ -434,15 +501,19 @@ def load_epistemics_hydration(
         ORDER BY c.id
         """
     )
-    scopes: dict[int, str] = {}
     claims: dict[int, dict[str, Any]] = {}
-    for row in session.execute(claims_query, {"entity_ids": list(universe)}).mappings():
+    for row in session.execute(
+        claims_query,
+        {
+            "entity_ids": list(universe),
+            "anchor_chunk_id": anchor_chunk_id,
+        },
+    ).mappings():
         claim_id = int(row["claim_id"])
         event_id = int(row["world_event_id"])
         scope = str(row["scope"])
         if scope not in CLAIM_SCOPES:
             raise ValueError(f"Claim on event {event_id} has unknown scope {scope!r}")
-        scopes[event_id] = scope
         claims[claim_id] = {
             "world_event_id": event_id,
             "scope": scope,
@@ -457,6 +528,11 @@ def load_epistemics_hydration(
         awareness_query = text(
             """
             /* orrery:epistemics_hydration:awareness */
+            WITH anchor AS (
+                SELECT created_at
+                FROM narrative_chunks
+                WHERE id = :anchor_chunk_id
+            )
             SELECT ca.claim_id,
                    ca.knower_entity_id,
                    ca.source_tier,
@@ -465,6 +541,14 @@ def load_epistemics_hydration(
             FROM claim_awareness ca
             WHERE ca.claim_id = ANY(:claim_ids)
               AND ca.knower_entity_id = ANY(:entity_ids)
+              -- Mirror replay.py's claim-awareness readmission visibility.
+              AND (
+                  :anchor_chunk_id IS NULL
+                  OR (ca.source_chunk_id IS NOT NULL
+                      AND ca.source_chunk_id <= :anchor_chunk_id)
+                  OR (ca.source_chunk_id IS NULL
+                      AND ca.created_at <= (SELECT created_at FROM anchor))
+              )
             ORDER BY ca.claim_id, ca.knower_entity_id
             """
         )
@@ -473,6 +557,7 @@ def load_epistemics_hydration(
             {
                 "claim_ids": sorted(claims),
                 "entity_ids": list(universe),
+                "anchor_chunk_id": anchor_chunk_id,
             },
         ).mappings()
     else:

--- a/nexus/agents/orrery/evidence.py
+++ b/nexus/agents/orrery/evidence.py
@@ -66,6 +66,7 @@ from nexus.agents.orrery.substrate import (
     WorldState,
     _at_routine_anchor,
     _is_in_transit,
+    _possessed_claim_knowledge,
     _routine_anchor,
     _routine_anchor_destination_available,
     _routine_schedule_due,
@@ -1527,6 +1528,66 @@ def _knows_recent_event(match: re.Match, state: WorldState, bindings: Bindings) 
         },
         matched=candidates,
         result=None if fields_filter_active else bool(visible_candidates),
+    )
+
+
+@_resolver("knows_claim_about")
+def _knows_claim_about(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    subject_slot = match["subject"]
+    about_slot = match["about"]
+    subject_id = _entity(bindings, subject_slot)
+    about_id = _entity(bindings, about_slot)
+    possessed = (
+        _possessed_claim_knowledge(state, subject_id) if subject_id is not None else ()
+    )
+    matched = [
+        {
+            "claim_id": record.claim_id,
+            "tier": record.source_tier,
+            "scope": record.scope,
+        }
+        for record in possessed
+        if about_id is not None and about_id in record.about_entity_ids
+    ]
+    return _evidence(
+        "knows_claim_about",
+        params={"subject_slot": subject_slot, "about_slot": about_slot},
+        entities={subject_slot: subject_id, about_slot: about_id},
+        observed={
+            "possessed_claims": [
+                {"claim_id": record.claim_id, "tier": record.source_tier}
+                for record in possessed
+            ]
+        },
+        matched=matched,
+        result=bool(matched),
+    )
+
+
+@_resolver("heard_secondhand")
+def _heard_secondhand(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    subject_slot = match["subject"]
+    subject_id = _entity(bindings, subject_slot)
+    records = (
+        _possessed_claim_knowledge(state, subject_id) if subject_id is not None else ()
+    )
+    matched = [
+        {
+            "claim_id": record.claim_id,
+            "tier": record.source_tier,
+            "channel": record.channel,
+            "immediate_source_entity_id": record.immediate_source_entity_id,
+        }
+        for record in records
+        if record.source_tier == "told"
+    ]
+    return _evidence(
+        "heard_secondhand",
+        params={"subject_slot": subject_slot},
+        entities={subject_slot: subject_id},
+        observed={"awareness_count": len(records)},
+        matched=matched,
+        result=bool(matched),
     )
 
 

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -565,7 +565,12 @@ def hydrate_world_state(
     epistemics = None
     if epistemics_policy.enabled:
         epistemics = load_epistemics_hydration(
-            session, entity_ids=_load_active_entity_ids(session)
+            session,
+            entity_ids=_load_active_entity_ids(session),
+            recent_event_ids=(
+                event.event_id for event in recent_events if event.event_id is not None
+            ),
+            anchor_chunk_id=anchor_chunk_id,
         )
     world_time = world_time_override or _load_world_time(
         session, anchor_chunk_id=anchor_chunk_id

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -16,8 +16,8 @@ from nexus.agents.orrery.communication import (
 )
 from nexus.agents.orrery.epistemics import (
     coerce_epistemics_policy,
+    load_epistemics_hydration,
     load_epistemics_policy,
-    load_awareness_for_events,
 )
 from nexus.agents.orrery.reciprocal import (
     OrreryJointBeat,
@@ -363,6 +363,25 @@ def _load_orbit_distances(session: Any) -> dict[Tuple[int, int], int]:
     return _compute_orbit_distances(active_character_ids, relationship_edges)
 
 
+def _load_active_entity_ids(session: Any) -> tuple[int, ...]:
+    """Return the deterministic active entity universe hydrated this tick."""
+
+    return tuple(
+        int(row["id"])
+        for row in session.execute(
+            text(
+                """
+                /* orrery:active_entity_ids */
+                SELECT id
+                FROM entities
+                WHERE is_active = true
+                ORDER BY id
+                """
+            )
+        ).mappings()
+    )
+
+
 def hydrate_world_state(
     session: Any,
     *,
@@ -543,16 +562,11 @@ def hydrate_world_state(
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
     )
-    awareness = (
-        load_awareness_for_events(
-            session,
-            world_event_ids=[
-                event.event_id for event in recent_events if event.event_id is not None
-            ],
+    epistemics = None
+    if epistemics_policy.enabled:
+        epistemics = load_epistemics_hydration(
+            session, entity_ids=_load_active_entity_ids(session)
         )
-        if epistemics_policy.enabled
-        else None
-    )
     world_time = world_time_override or _load_world_time(
         session, anchor_chunk_id=anchor_chunk_id
     )
@@ -611,10 +625,21 @@ def hydrate_world_state(
         routine_anchors=routine_anchors,
         recent_events=recent_events,
         claimed_event_scopes=(
-            awareness.claimed_event_scopes if awareness is not None else {}
+            epistemics.claimed_event_scopes if epistemics is not None else {}
         ),
         awareness_by_entity=(
-            awareness.awareness_by_entity if awareness is not None else {}
+            epistemics.awareness_by_entity if epistemics is not None else {}
+        ),
+        claim_knowledge_by_entity=(
+            epistemics.claim_knowledge_by_entity if epistemics is not None else {}
+        ),
+        common_claim_knowledge=(
+            epistemics.common_claim_knowledge if epistemics is not None else ()
+        ),
+        possessed_claim_knowledge_by_entity=(
+            epistemics.possessed_claim_knowledge_by_entity
+            if epistemics is not None
+            else {}
         ),
         epistemics_enabled=epistemics_policy.enabled,
         win_history=win_history,

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -12,6 +12,7 @@ import random
 from typing import Any, Callable, Dict, Iterable, Literal, Mapping, Optional, Tuple
 
 from nexus.agents.orrery.communication import CommunicationGraph
+from nexus.agents.orrery.epistemics import ClaimKnowledge
 from nexus.agents.orrery.needs import normalize_need_type
 from nexus.agents.orrery.status_family import (
     STATUS_LEVEL_RANKS,
@@ -363,11 +364,35 @@ class WorldState:
     recent_events: Tuple[EventRecord, ...] = ()
     claimed_event_scopes: Mapping[int, str] = field(default_factory=dict)
     awareness_by_entity: Mapping[int, frozenset[int]] = field(default_factory=dict)
+    claim_knowledge_by_entity: Mapping[int, Tuple[ClaimKnowledge, ...]] = field(
+        default_factory=dict
+    )
+    common_claim_knowledge: Tuple[ClaimKnowledge, ...] = ()
+    possessed_claim_knowledge_by_entity: Mapping[int, Tuple[ClaimKnowledge, ...]] = (
+        field(default_factory=dict)
+    )
     epistemics_enabled: bool = False
     time_of_day: str = "midday"
     world_time: Optional[datetime] = None
     weather: str = "clear"
     current_tick: int = 0
+
+    def __post_init__(self) -> None:
+        """Premerge common possession for directly constructed test states."""
+
+        if self.possessed_claim_knowledge_by_entity:
+            return
+        common_by_claim_id = {
+            record.claim_id: record for record in self.common_claim_knowledge
+        }
+        possessed: dict[int, Tuple[ClaimKnowledge, ...]] = {}
+        for entity_id, explicit_records in self.claim_knowledge_by_entity.items():
+            by_claim_id = dict(common_by_claim_id)
+            by_claim_id.update({record.claim_id: record for record in explicit_records})
+            possessed[entity_id] = tuple(
+                by_claim_id[claim_id] for claim_id in sorted(by_claim_id)
+            )
+        object.__setattr__(self, "possessed_claim_knowledge_by_entity", possessed)
 
 
 def _slot_entity(bindings: Bindings, slot: Slot) -> Optional[int]:
@@ -396,6 +421,21 @@ def _has_inbound_pair_tag(state: WorldState, entity_id: int, pair_tag: str) -> b
     return any(
         object_id == entity_id and pair_tag in tags
         for (_subject_id, object_id), tags in state.pair_tags.items()
+    )
+
+
+def _possessed_claim_knowledge(
+    state: WorldState, entity_id: int
+) -> Tuple[ClaimKnowledge, ...]:
+    """Look up premerged possession for one entity.
+
+    Common-scope claims supply universal possession. When the entity also has
+    an explicit awareness row, its actual acquisition tier and provenance win
+    over the synthetic ``common`` tier used for universal possession.
+    """
+
+    return state.possessed_claim_knowledge_by_entity.get(
+        entity_id, state.common_claim_knowledge
     )
 
 
@@ -1836,6 +1876,48 @@ def relative_orbit_distance(
     )
 
 
+def knows_claim_about(
+    subject_slot: Slot = Slot.ACTOR,
+    about_slot: Slot = Slot.TARGET,
+) -> Condition:
+    """Return whether one slot-bound knower possesses a claim about another.
+
+    A claim is about every entity named by its minting world's actor, target,
+    or ``world_event_entities`` rows. Possession comes from an awareness row
+    at any tier or from the claim's common scope.
+    """
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        subject_id = _slot_entity(bindings, subject_slot)
+        about_id = _slot_entity(bindings, about_slot)
+        if subject_id is None or about_id is None:
+            return False
+        return any(
+            about_id in record.about_entity_ids
+            for record in _possessed_claim_knowledge(state, subject_id)
+        )
+
+    return _named(
+        _condition,
+        f"knows_claim_about({subject_slot.value}->{about_slot.value})",
+    )
+
+
+def heard_secondhand(subject_slot: Slot = Slot.ACTOR) -> Condition:
+    """Return whether a slot-bound knower has any told-tier awareness."""
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        subject_id = _slot_entity(bindings, subject_slot)
+        if subject_id is None:
+            return False
+        return any(
+            record.source_tier == "told"
+            for record in _possessed_claim_knowledge(state, subject_id)
+        )
+
+    return _named(_condition, f"heard_secondhand({subject_slot.value})")
+
+
 def time_of_day_in(*times: str) -> Condition:
     """Return whether current in-world time of day is in the given set."""
 
@@ -2645,17 +2727,16 @@ def select_package(
     stochastic = (
         package_selection is not None and package_selection.mode == "stochastic"
     )
-
     window: list[tuple[Template, Resolution, float]] = []
     peak: Optional[float] = None
     for template in ordered:
         effective_priority = habituation_policy.effective_priority(
             template, state, bindings
         )
-        if peak is not None and (
-            effective_priority < peak - package_selection.window_points
-        ):
-            break  # ordered descending: nothing below the floor can win
+        if peak is not None:
+            assert package_selection is not None
+            if effective_priority < peak - package_selection.window_points:
+                break  # ordered descending: nothing below the floor can win
         resolution = evaluate(template, state, bindings, branch_selection)
         if not resolution.passes:
             continue
@@ -2672,6 +2753,7 @@ def select_package(
     if not window:
         return PackageSelectionOutcome(winner=None)
 
+    assert package_selection is not None  # a non-empty window requires stochastic mode
     argmax = window[0]
     if any(
         template.drive_band.value in package_selection.exempt_bands

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -312,6 +312,22 @@ def test_entity_context_hover_payload(client: TestClient) -> None:
             assert relationship["other_name"]
         for need in entity["needs"]:
             assert need["need_type"] in set(NEED_SEVERITY_PREFIX)
+        assert [claim["claim_id"] for claim in entity["knowledge"]] == sorted(
+            claim["claim_id"] for claim in entity["knowledge"]
+        )
+        for claim in entity["knowledge"]:
+            assert claim["tier"] in {
+                "common",
+                "participant",
+                "witness",
+                "told",
+                "granted",
+            }
+            for source_key in ("immediate_source", "root_source"):
+                source = claim[source_key]
+                if source is not None:
+                    assert source["entity_id"] > 0
+                    assert source["name"]
         assert len(entity["recent_events"]) <= 3
         if entity["place"] is not None:
             assert isinstance(entity["place"]["classes"], list)

--- a/tests/test_orrery/test_claim_consumption.py
+++ b/tests/test_orrery/test_claim_consumption.py
@@ -1,0 +1,169 @@
+"""Fast contracts for knower-gated claim-consumption predicates."""
+
+from nexus.agents.orrery.epistemics import ClaimKnowledge, load_epistemics_hydration
+from nexus.agents.orrery.evidence import resolve_evidence
+from nexus.agents.orrery.resolver import hydrate_world_state
+from nexus.agents.orrery.substrate import (
+    Slot,
+    WorldState,
+    heard_secondhand,
+    knows_claim_about,
+)
+from tests.test_orrery.test_resolver import FakeSession
+
+
+ACTOR = 1
+TARGET = 2
+FACTION = 9
+UNRELATED = 11
+
+
+def _claim(
+    claim_id: int,
+    *,
+    tier: str,
+    about: int,
+    scope: str = "bounded",
+    channel: str | None = None,
+    immediate_source: int | None = None,
+) -> ClaimKnowledge:
+    return ClaimKnowledge(
+        claim_id=claim_id,
+        world_event_id=claim_id + 100,
+        scope=scope,
+        source_tier=tier,
+        about_entity_ids=frozenset({about}),
+        channel=channel,
+        immediate_source_entity_id=immediate_source,
+    )
+
+
+def test_claim_predicates_support_explicit_common_and_faction_knowers() -> None:
+    """Possession semantics do not assume a character-only subject slot."""
+
+    state = WorldState(
+        claim_knowledge_by_entity={
+            ACTOR: (_claim(1, tier="participant", about=TARGET),),
+            FACTION: (
+                _claim(
+                    2,
+                    tier="told",
+                    about=TARGET,
+                    channel="channel:authority_over",
+                    immediate_source=ACTOR,
+                ),
+            ),
+        },
+        common_claim_knowledge=(
+            _claim(3, tier="common", about=UNRELATED, scope="common"),
+        ),
+        epistemics_enabled=True,
+    )
+
+    assert knows_claim_about()(state, {Slot.ACTOR: ACTOR, Slot.TARGET: TARGET})
+    assert knows_claim_about()(state, {Slot.ACTOR: ACTOR, Slot.TARGET: UNRELATED})
+    assert not knows_claim_about()(state, {Slot.ACTOR: ACTOR, Slot.TARGET: FACTION})
+    assert knows_claim_about(Slot.FACTION, Slot.TARGET)(
+        state, {Slot.FACTION: FACTION, Slot.TARGET: TARGET}
+    )
+    assert heard_secondhand(Slot.FACTION)(state, {Slot.FACTION: FACTION})
+    assert not heard_secondhand()(state, {Slot.ACTOR: ACTOR})
+
+
+def test_claim_predicate_evidence_names_tier_channel_and_source() -> None:
+    told = _claim(
+        7,
+        tier="told",
+        about=TARGET,
+        channel="dyad:associate",
+        immediate_source=FACTION,
+    )
+    state = WorldState(claim_knowledge_by_entity={ACTOR: (told,)})
+    bindings = {Slot.ACTOR: ACTOR, Slot.TARGET: TARGET}
+
+    about_evidence = resolve_evidence(knows_claim_about().__name__, state, bindings)
+    assert about_evidence["matched"] == [
+        {"claim_id": 7, "tier": "told", "scope": "bounded"}
+    ]
+
+    secondhand_evidence = resolve_evidence(heard_secondhand().__name__, state, bindings)
+    assert secondhand_evidence["matched"] == [
+        {
+            "claim_id": 7,
+            "tier": "told",
+            "channel": "dyad:associate",
+            "immediate_source_entity_id": FACTION,
+        }
+    ]
+
+
+def test_hydration_projects_event_subjects_and_awareness_without_predicate_sql() -> (
+    None
+):
+    """The resolver's single epistemics query supplies both predicate shapes."""
+
+    session = FakeSession(
+        active_entity_rows=[
+            {"id": ACTOR},
+            {"id": TARGET},
+            {"id": FACTION},
+            {"id": UNRELATED},
+        ],
+        epistemics_rows=[
+            {
+                "claim_id": 40,
+                "world_event_id": 140,
+                "scope": "bounded",
+                "about_entity_ids": [TARGET, UNRELATED],
+            },
+            {
+                "claim_id": 41,
+                "world_event_id": 141,
+                "scope": "common",
+                "about_entity_ids": [FACTION],
+            },
+        ],
+        epistemics_awareness_rows=[
+            {
+                "claim_id": 40,
+                "knower_entity_id": ACTOR,
+                "source_tier": "told",
+                "channel": "dyad:associate",
+                "immediate_source_entity_id": FACTION,
+            },
+        ],
+    )
+    state = hydrate_world_state(
+        session,
+        anchor_chunk_id=100,
+        window_chunks=1,
+        epistemics_settings={"enabled": True},
+    )
+
+    assert knows_claim_about()(state, {Slot.ACTOR: ACTOR, Slot.TARGET: TARGET})
+    assert knows_claim_about()(state, {Slot.ACTOR: ACTOR, Slot.TARGET: UNRELATED})
+    assert knows_claim_about()(state, {Slot.ACTOR: ACTOR, Slot.TARGET: FACTION})
+    assert heard_secondhand()(state, {Slot.ACTOR: ACTOR})
+    assert state.claimed_event_scopes == {140: "bounded", 141: "common"}
+    assert state.awareness_by_entity == {ACTOR: frozenset({140})}
+    assert [
+        record.claim_id for record in state.possessed_claim_knowledge_by_entity[ACTOR]
+    ] == [40, 41]
+
+
+def test_empty_entity_universe_skips_all_claim_queries() -> None:
+    """An empty hydration universe returns before touching the database."""
+
+    class QueryCountingSession:
+        calls = 0
+
+        def execute(self, *_args, **_kwargs):
+            self.calls += 1
+            raise AssertionError("empty Epistemics hydration must not issue SQL")
+
+    session = QueryCountingSession()
+    hydration = load_epistemics_hydration(session, entity_ids=())
+
+    assert session.calls == 0
+    assert hydration.claimed_event_scopes == {}
+    assert hydration.possessed_claim_knowledge_by_entity == {}

--- a/tests/test_orrery/test_claim_consumption.py
+++ b/tests/test_orrery/test_claim_consumption.py
@@ -8,6 +8,7 @@ from nexus.agents.orrery.substrate import (
     WorldState,
     heard_secondhand,
     knows_claim_about,
+    knows_recent_event,
 )
 from tests.test_orrery.test_resolver import FakeSession
 
@@ -109,6 +110,30 @@ def test_hydration_projects_event_subjects_and_awareness_without_predicate_sql()
             {"id": FACTION},
             {"id": UNRELATED},
         ],
+        event_rows=[
+            {
+                "id": 140,
+                "event_type": "threat_issued",
+                "tick_chunk_id": 100,
+                "actor_entity_id": ACTOR,
+                "target_entity_id": TARGET,
+                "location_id": None,
+                "changed_fields": [],
+                "world_layer": "primary",
+                "payload": {},
+            },
+            {
+                "id": 141,
+                "event_type": "threat_issued",
+                "tick_chunk_id": 100,
+                "actor_entity_id": ACTOR,
+                "target_entity_id": FACTION,
+                "location_id": None,
+                "changed_fields": [],
+                "world_layer": "primary",
+                "payload": {},
+            },
+        ],
         epistemics_rows=[
             {
                 "claim_id": 40,
@@ -151,6 +176,40 @@ def test_hydration_projects_event_subjects_and_awareness_without_predicate_sql()
     ] == [40, 41]
 
 
+def test_recent_claim_scope_is_independent_of_entity_claim_universe() -> None:
+    """A recent claim remains gated when its endpoints are outside the universe."""
+
+    event_id = 142
+    state = hydrate_world_state(
+        FakeSession(
+            active_entity_rows=[{"id": ACTOR}],
+            event_rows=[
+                {
+                    "id": event_id,
+                    "event_type": "threat_issued",
+                    "tick_chunk_id": 100,
+                    "actor_entity_id": 50,
+                    "target_entity_id": 51,
+                    "location_id": None,
+                    "changed_fields": [],
+                    "world_layer": "primary",
+                    "payload": {},
+                }
+            ],
+            epistemics_scope_rows=[{"world_event_id": event_id, "scope": "bounded"}],
+        ),
+        anchor_chunk_id=100,
+        window_chunks=1,
+        epistemics_settings={"enabled": True},
+    )
+
+    assert state.claimed_event_scopes == {event_id: "bounded"}
+    assert state.claim_knowledge_by_entity == {}
+    assert not knows_recent_event("threat_issued", within_ticks=1)(
+        state, {Slot.ACTOR: ACTOR}
+    )
+
+
 def test_empty_entity_universe_skips_all_claim_queries() -> None:
     """An empty hydration universe returns before touching the database."""
 
@@ -162,7 +221,12 @@ def test_empty_entity_universe_skips_all_claim_queries() -> None:
             raise AssertionError("empty Epistemics hydration must not issue SQL")
 
     session = QueryCountingSession()
-    hydration = load_epistemics_hydration(session, entity_ids=())
+    hydration = load_epistemics_hydration(
+        session,
+        entity_ids=(),
+        recent_event_ids=(),
+        anchor_chunk_id=100,
+    )
 
     assert session.calls == 0
     assert hydration.claimed_event_scopes == {}

--- a/tests/test_orrery/test_claim_consumption_live.py
+++ b/tests/test_orrery/test_claim_consumption_live.py
@@ -27,6 +27,7 @@ from nexus.agents.orrery.substrate import (
     Template,
     heard_secondhand,
     knows_claim_about,
+    knows_recent_event,
 )
 from nexus.api.slot_utils import get_slot_db_url
 from tests.test_orrery.test_claim_propagation_live import (
@@ -236,12 +237,111 @@ def test_hydration_excludes_irrelevant_history_and_empty_universe_issues_no_sql(
 
     event.listen(live_connection, "before_cursor_execute", count_claim_queries)
     try:
-        hydration = load_epistemics_hydration(live_connection, entity_ids=())
+        hydration = load_epistemics_hydration(
+            live_connection,
+            entity_ids=(),
+            recent_event_ids=(),
+            anchor_chunk_id=chunk_id,
+        )
     finally:
         event.remove(live_connection, "before_cursor_execute", count_claim_queries)
 
     assert hydration.claimed_event_scopes == {}
     assert claim_queries == []
+
+
+def test_entity_audit_common_claims_are_bounded_to_their_about_entities(
+    live_connection: Any,
+) -> None:
+    """The knowledge panel excludes unrelated common-claim history."""
+
+    raw_connection = live_connection.connection.driver_connection
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        audited, _ = _insert_character(cur, "audit-common-subject")
+        relevant_source, _ = _insert_character(cur, "audit-common-source")
+        unrelated_source, _ = _insert_character(cur, "audit-unrelated-source")
+        unrelated_subject, _ = _insert_character(cur, "audit-unrelated-subject")
+        chunk_id, _ = _insert_chunk(cur)
+        relevant_claim_id = _insert_claim_about(
+            cur,
+            chunk_id=chunk_id,
+            source_entity_id=relevant_source,
+            about_entity_id=audited,
+            scope="common",
+        )
+        unrelated_claim_id = _insert_claim_about(
+            cur,
+            chunk_id=chunk_id,
+            source_entity_id=unrelated_source,
+            about_entity_id=unrelated_subject,
+            scope="common",
+        )
+        cur.execute(
+            "DELETE FROM claim_awareness WHERE claim_id IN (%s, %s)",
+            (relevant_claim_id, unrelated_claim_id),
+        )
+
+    context = entity_context(
+        live_connection,
+        [audited, unrelated_subject],
+        anchor_chunk_id=chunk_id,
+    )
+    knowledge_by_entity = {
+        entity["entity_id"]: {row["claim_id"]: row for row in entity["knowledge"]}
+        for entity in context["entities"]
+    }
+    audited_knowledge = knowledge_by_entity[audited]
+    unrelated_knowledge = knowledge_by_entity[unrelated_subject]
+
+    assert relevant_claim_id in audited_knowledge
+    assert audited_knowledge[relevant_claim_id]["tier"] == "common"
+    assert unrelated_claim_id not in audited_knowledge
+    assert unrelated_claim_id in unrelated_knowledge
+    assert relevant_claim_id not in unrelated_knowledge
+
+
+def test_recent_claim_scope_survives_inactive_endpoints(
+    live_connection: Any,
+) -> None:
+    """Recent bounded claims still gate actors when their endpoints go inactive."""
+
+    raw_connection = live_connection.connection.driver_connection
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        source, _ = _insert_character(cur, "scope-inactive-source")
+        target, _ = _insert_character(cur, "scope-inactive-target")
+        non_knower, _ = _insert_character(cur, "scope-active-non-knower")
+        chunk_id, _ = _insert_chunk(cur)
+        claim_id = _insert_claim_about(
+            cur,
+            chunk_id=chunk_id,
+            source_entity_id=source,
+            about_entity_id=target,
+        )
+        cur.execute(
+            "SELECT world_event_id FROM claims WHERE id = %s",
+            (claim_id,),
+        )
+        event_id = int(cur.fetchone()["world_event_id"])
+        cur.execute(
+            "UPDATE entities SET is_active = false WHERE id IN (%s, %s)",
+            (source, target),
+        )
+
+    state = hydrate_world_state(
+        live_connection,
+        anchor_chunk_id=chunk_id,
+        window_chunks=1,
+        epistemics_settings=EPISTEMICS,
+    )
+
+    assert any(event.event_id == event_id for event in state.recent_events)
+    assert state.claimed_event_scopes[event_id] == "bounded"
+    assert event_id not in state.awareness_by_entity.get(non_knower, frozenset())
+    assert not knows_recent_event(
+        "threat_issued",
+        within_ticks=1,
+        target_slot=Slot.TARGET,
+    )(state, {Slot.ACTOR: non_knower, Slot.TARGET: target})
 
 
 def test_live_predicates_cover_participant_told_common_false_and_faction(
@@ -330,6 +430,95 @@ def test_live_predicates_cover_participant_told_common_false_and_faction(
         state, {Slot.FACTION: faction, Slot.TARGET: about}
     )
     assert heard_secondhand(Slot.FACTION)(state, {Slot.FACTION: faction})
+
+
+def test_historical_anchor_excludes_future_claim_and_awareness(
+    live_connection: Any,
+) -> None:
+    """Hydration and audit reads cannot acquire knowledge from their future."""
+
+    settings = _settings()
+    raw_connection = live_connection.connection.driver_connection
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        source, source_character = _insert_character(cur, "anchor-source")
+        listener, listener_character = _insert_character(cur, "anchor-listener")
+        about, _ = _insert_character(cur, "anchor-about")
+        _insert_relationship(cur, source_character, listener_character)
+        historical_anchor, _ = _insert_chunk(cur)
+        mint_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=2))
+        claim_id = _insert_claim_about(
+            cur,
+            chunk_id=mint_chunk,
+            source_entity_id=source,
+            about_entity_id=about,
+        )
+        head_anchor, _ = _insert_chunk(cur, time_delta=timedelta(hours=8))
+        drained = drain_claim_propagation_sync(
+            cur, tick_chunk_id=head_anchor, settings=settings
+        )
+        cur.execute("SELECT max(id) AS id FROM narrative_chunks")
+        assert int(cur.fetchone()["id"]) == head_anchor
+
+    historical = hydrate_world_state(
+        live_connection,
+        anchor_chunk_id=historical_anchor,
+        window_chunks=10,
+        epistemics_settings=EPISTEMICS,
+        contagion_settings=settings,
+    )
+    head = hydrate_world_state(
+        live_connection,
+        anchor_chunk_id=head_anchor,
+        window_chunks=10,
+        epistemics_settings=EPISTEMICS,
+        contagion_settings=settings,
+    )
+    bindings = {Slot.ACTOR: listener, Slot.TARGET: about}
+
+    assert drained.minted_count >= 1
+    assert not knows_claim_about()(historical, bindings)
+    assert not heard_secondhand()(historical, {Slot.ACTOR: listener})
+    assert knows_claim_about()(head, bindings)
+    assert heard_secondhand()(head, {Slot.ACTOR: listener})
+
+    historical_context = entity_context(
+        live_connection,
+        [listener],
+        anchor_chunk_id=historical_anchor,
+        contagion_settings=settings,
+    )
+    head_context = entity_context(
+        live_connection,
+        [listener],
+        anchor_chunk_id=head_anchor,
+        contagion_settings=settings,
+    )
+    historical_claim_ids = {
+        row["claim_id"] for row in historical_context["entities"][0]["knowledge"]
+    }
+    head_claim_ids = {
+        row["claim_id"] for row in head_context["entities"][0]["knowledge"]
+    }
+    assert claim_id not in historical_claim_ids
+    assert claim_id in head_claim_ids
+
+    entity_ids = (source, listener, about)
+    recent_event_ids = tuple(
+        event.event_id for event in head.recent_events if event.event_id is not None
+    )
+    anchored_head = load_epistemics_hydration(
+        live_connection,
+        entity_ids=entity_ids,
+        recent_event_ids=recent_event_ids,
+        anchor_chunk_id=head_anchor,
+    )
+    legacy_unbounded_head = load_epistemics_hydration(
+        live_connection,
+        entity_ids=entity_ids,
+        recent_event_ids=recent_event_ids,
+        anchor_chunk_id=None,
+    )
+    assert anchored_head == legacy_unbounded_head
 
 
 def test_template_gate_flips_on_drain_with_production_explain_parity(

--- a/tests/test_orrery/test_claim_consumption_live.py
+++ b/tests/test_orrery/test_claim_consumption_live.py
@@ -1,0 +1,486 @@
+"""Rollback-only slot-5 coverage for Stage 2d claim consumption."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import json
+from typing import Any, Iterator
+
+from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
+import pytest
+from sqlalchemy import create_engine, event
+
+from nexus.agents.orrery.audit import entity_context, explain_dry_run
+from nexus.agents.orrery.epistemics import (
+    ClaimParticipant,
+    load_epistemics_hydration,
+    mechanical_claim_summary,
+    mint_claim_for_event,
+)
+from nexus.agents.orrery.propagation import drain_claim_propagation_sync
+from nexus.agents.orrery.resolver import hydrate_world_state, resolve_dry_run
+from nexus.agents.orrery.substrate import (
+    ALWAYS,
+    Branch,
+    DriveBand,
+    Slot,
+    Template,
+    heard_secondhand,
+    knows_claim_about,
+)
+from nexus.api.slot_utils import get_slot_db_url
+from tests.test_orrery.test_claim_propagation_live import (
+    EPISTEMICS,
+    LIVE_SLOT,
+    _chain,
+    _insert_character,
+    _insert_chunk,
+    _insert_faction,
+    _insert_pair_tag,
+    _insert_relationship,
+    _settings,
+)
+
+
+pytestmark = pytest.mark.requires_postgres
+
+
+@pytest.fixture()
+def live_connection() -> Iterator[Any]:
+    """Expose SQLAlchemy and raw-cursor reads inside one rolled-back tx."""
+
+    engine = create_engine(get_slot_db_url(slot=LIVE_SLOT))
+    connection = engine.connect()
+    transaction = connection.begin()
+    try:
+        raw_connection = connection.connection.driver_connection
+        with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT EXISTS (
+                           SELECT 1 FROM event_types
+                           WHERE type = 'claim_propagated'
+                       ) AS registered,
+                       EXISTS (
+                           SELECT 1 FROM information_schema.columns
+                           WHERE table_schema = ANY(current_schemas(false))
+                             AND table_name = 'world_events'
+                             AND column_name = 'world_time'
+                       ) AS shaped
+                """
+            )
+            migration_state = cur.fetchone()
+            if not migration_state["registered"] or not migration_state["shaped"]:
+                pytest.skip("slot 5 requires migrations 080-083 for Stage 2d")
+        yield connection
+    finally:
+        transaction.rollback()
+        connection.close()
+        engine.dispose()
+
+
+def _insert_claim_about(
+    cur: Any,
+    *,
+    chunk_id: int,
+    source_entity_id: int,
+    about_entity_id: int,
+    scope: str = "bounded",
+) -> int:
+    cur.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, target_entity_id,
+            world_layer, source, changed_fields, payload
+        ) VALUES (
+            'threat_issued', %s, %s, %s, 'primary',
+            'resolver', '{}', '{}'::jsonb
+        )
+        RETURNING id
+        """,
+        (chunk_id, source_entity_id, about_entity_id),
+    )
+    event_id = int(cur.fetchone()["id"])
+    cur.execute(
+        """
+        INSERT INTO world_event_entities (event_id, role, entity_id)
+        VALUES (%s, 'actor', %s), (%s, 'target', %s)
+        """,
+        (event_id, source_entity_id, event_id, about_entity_id),
+    )
+    participants = (
+        ClaimParticipant(
+            source_entity_id,
+            "actor",
+            f"Stage 2d source {source_entity_id}",
+        ),
+        ClaimParticipant(
+            about_entity_id,
+            "target",
+            f"Stage 2d subject {about_entity_id}",
+        ),
+    )
+    minted = mint_claim_for_event(
+        cur,
+        world_event_id=event_id,
+        event_type="threat_issued",
+        summary=mechanical_claim_summary("threat_issued", participants),
+        participants=participants,
+        source_chunk_id=chunk_id,
+        source_resolution_id=None,
+        settings=EPISTEMICS,
+    )
+    assert minted is not None
+    if scope != "bounded":
+        cur.execute(
+            "UPDATE claims SET scope = %s WHERE id = %s", (scope, minted.claim_id)
+        )
+    return minted.claim_id
+
+
+def _mark_actor_relevant(cur: Any, *, chunk_id: int, actor_entity_id: int) -> None:
+    cur.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, world_layer,
+            source, changed_fields, payload
+        ) VALUES (
+            'surveillance_performed', %s, %s, 'primary',
+            'resolver', '{}', '{}'::jsonb
+        )
+        """,
+        (chunk_id, actor_entity_id),
+    )
+
+
+def _consumption_template() -> Template:
+    return Template(
+        id="stage2d_knows_claim_about_probe",
+        priority=100,
+        drive_band=DriveBand.PROJECT_IDENTITY,
+        blurb="Exercise Stage 2d hydrated package gating.",
+        required_slots=(Slot.ACTOR, Slot.TARGET),
+        package_gate=knows_claim_about(),
+        branches=(
+            Branch(
+                label="Act on secondhand knowledge",
+                conditions=ALWAYS,
+                narrative_stub="{actor} acts on what they know about {target}.",
+            ),
+        ),
+    )
+
+
+def test_hydration_excludes_irrelevant_history_and_empty_universe_issues_no_sql(
+    live_connection: Any,
+) -> None:
+    """Entity-scoped hydration ignores irrelevant claim volume entirely."""
+
+    irrelevant_count = 32
+    raw_connection = live_connection.connection.driver_connection
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        relevant_source, _ = _insert_character(cur, "hydrate-relevant-source")
+        relevant_about, _ = _insert_character(cur, "hydrate-relevant-about")
+        irrelevant_source, _ = _insert_character(cur, "hydrate-irrelevant-source")
+        irrelevant_about, _ = _insert_character(cur, "hydrate-irrelevant-about")
+        chunk_id, _ = _insert_chunk(cur)
+        relevant_claim_id = _insert_claim_about(
+            cur,
+            chunk_id=chunk_id,
+            source_entity_id=relevant_source,
+            about_entity_id=relevant_about,
+        )
+        irrelevant_claim_ids = {
+            _insert_claim_about(
+                cur,
+                chunk_id=chunk_id,
+                source_entity_id=irrelevant_source,
+                about_entity_id=irrelevant_about,
+                scope="common" if index % 2 else "bounded",
+            )
+            for index in range(irrelevant_count)
+        }
+        cur.execute(
+            "UPDATE entities SET is_active = false WHERE id IN (%s, %s)",
+            (irrelevant_source, irrelevant_about),
+        )
+
+    state = hydrate_world_state(
+        live_connection,
+        anchor_chunk_id=chunk_id,
+        window_chunks=1,
+        epistemics_settings=EPISTEMICS,
+    )
+    hydrated_claim_ids = {record.claim_id for record in state.common_claim_knowledge}
+    hydrated_claim_ids.update(
+        record.claim_id
+        for records in state.claim_knowledge_by_entity.values()
+        for record in records
+    )
+
+    assert relevant_claim_id in hydrated_claim_ids
+    assert irrelevant_claim_ids.isdisjoint(hydrated_claim_ids)
+
+    claim_queries: list[str] = []
+
+    def count_claim_queries(
+        _connection: Any,
+        _cursor: Any,
+        statement: str,
+        _parameters: Any,
+        _context: Any,
+        _executemany: bool,
+    ) -> None:
+        if "orrery:epistemics_hydration" in statement:
+            claim_queries.append(statement)
+
+    event.listen(live_connection, "before_cursor_execute", count_claim_queries)
+    try:
+        hydration = load_epistemics_hydration(live_connection, entity_ids=())
+    finally:
+        event.remove(live_connection, "before_cursor_execute", count_claim_queries)
+
+    assert hydration.claimed_event_scopes == {}
+    assert claim_queries == []
+
+
+def test_live_predicates_cover_participant_told_common_false_and_faction(
+    live_connection: Any,
+) -> None:
+    """All possession paths hydrate for character and faction knowers."""
+
+    settings = _settings(
+        channels={
+            "authority_over": {
+                "direction": "subject_to_object",
+                "latency": "1h",
+            }
+        }
+    )
+    raw_connection = live_connection.connection.driver_connection
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        source, source_character = _insert_character(cur, "consume-source")
+        listener, listener_character = _insert_character(cur, "consume-listener")
+        about, _ = _insert_character(cur, "consume-about")
+        common_knower, _ = _insert_character(cur, "consume-common-knower")
+        common_about, _ = _insert_character(cur, "consume-common-about")
+        no_claim_about, _ = _insert_character(cur, "consume-no-claim")
+        faction = _insert_faction(cur, "consume-faction")
+        _insert_relationship(cur, source_character, listener_character)
+        _insert_pair_tag(cur, source, faction, "authority_over")
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        bounded_claim = _insert_claim_about(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=source,
+            about_entity_id=about,
+        )
+        _insert_claim_about(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=source,
+            about_entity_id=common_about,
+            scope="common",
+        )
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=8))
+        drained = drain_claim_propagation_sync(
+            cur, tick_chunk_id=drain_chunk, settings=settings
+        )
+        cur.execute(
+            """
+            SELECT knower_entity_id, source_tier, acquired_at_world_time
+            FROM claim_awareness
+            WHERE claim_id = %s
+              AND knower_entity_id IN (%s, %s)
+            ORDER BY knower_entity_id
+            """,
+            (bounded_claim, listener, faction),
+        )
+        stamps = {int(row["knower_entity_id"]): dict(row) for row in cur.fetchall()}
+
+    assert drained.minted_count >= 2
+    assert stamps[listener]["source_tier"] == "told"
+    assert stamps[faction]["source_tier"] == "told"
+    assert stamps[listener]["acquired_at_world_time"] == birth_world_time + timedelta(
+        hours=1
+    )
+    assert stamps[faction]["acquired_at_world_time"] == birth_world_time + timedelta(
+        hours=1
+    )
+
+    state = hydrate_world_state(
+        live_connection,
+        anchor_chunk_id=drain_chunk,
+        window_chunks=10,
+        epistemics_settings=EPISTEMICS,
+        contagion_settings=settings,
+    )
+    about_binding = {Slot.ACTOR: source, Slot.TARGET: about}
+    assert knows_claim_about()(state, about_binding)
+    assert not heard_secondhand()(state, {Slot.ACTOR: source})
+    assert knows_claim_about()(state, {Slot.ACTOR: listener, Slot.TARGET: about})
+    assert heard_secondhand()(state, {Slot.ACTOR: listener})
+    assert knows_claim_about()(
+        state, {Slot.ACTOR: common_knower, Slot.TARGET: common_about}
+    )
+    assert not knows_claim_about()(
+        state, {Slot.ACTOR: common_knower, Slot.TARGET: no_claim_about}
+    )
+    assert knows_claim_about(Slot.FACTION, Slot.TARGET)(
+        state, {Slot.FACTION: faction, Slot.TARGET: about}
+    )
+    assert heard_secondhand(Slot.FACTION)(state, {Slot.FACTION: faction})
+
+
+def test_template_gate_flips_on_drain_with_production_explain_parity(
+    live_connection: Any,
+) -> None:
+    """One hydrated template becomes proposable exactly at acquisition."""
+
+    settings = _settings()
+    template = _consumption_template()
+    raw_connection = live_connection.connection.driver_connection
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        source, source_character = _insert_character(cur, "gate-source")
+        listener, listener_character = _insert_character(cur, "gate-listener")
+        about, about_character = _insert_character(cur, "gate-about")
+        _insert_relationship(cur, source_character, listener_character)
+        _insert_relationship(cur, listener_character, about_character)
+        birth_chunk, _ = _insert_chunk(cur)
+        _insert_claim_about(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=source,
+            about_entity_id=about,
+        )
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=8))
+        _mark_actor_relevant(cur, chunk_id=drain_chunk, actor_entity_id=listener)
+
+        before = resolve_dry_run(
+            live_connection,
+            [template],
+            anchor_chunk_id=drain_chunk,
+            window_chunks=10,
+            epistemics_settings=EPISTEMICS,
+            contagion_settings=settings,
+        )
+        before_explain = explain_dry_run(
+            live_connection,
+            [template],
+            anchor_chunk_id=drain_chunk,
+            window_chunks=10,
+            epistemics_settings=EPISTEMICS,
+            contagion_settings=settings,
+        )
+        drained = drain_claim_propagation_sync(
+            cur, tick_chunk_id=drain_chunk, settings=settings
+        )
+        after = resolve_dry_run(
+            live_connection,
+            [template],
+            anchor_chunk_id=drain_chunk,
+            window_chunks=10,
+            epistemics_settings=EPISTEMICS,
+            contagion_settings=settings,
+        )
+        after_explain = explain_dry_run(
+            live_connection,
+            [template],
+            anchor_chunk_id=drain_chunk,
+            window_chunks=10,
+            epistemics_settings=EPISTEMICS,
+            contagion_settings=settings,
+        )
+
+    def production_has_pair(report: Any) -> bool:
+        return any(
+            draft.template_id == template.id
+            and draft.bindings == {"actor": listener, "target": about}
+            for draft in report.resolutions
+        )
+
+    def explained_pair(report: Any) -> Any:
+        actor = next(
+            group for group in report.actors if group.actor_entity_id == listener
+        )
+        return next(
+            stack
+            for stack in actor.two_party_stacks
+            if stack.bindings == {"actor": listener, "target": about}
+        )
+
+    assert drained.minted_count >= 1
+    assert not production_has_pair(before)
+    assert production_has_pair(after)
+    before_stack = explained_pair(before_explain)
+    after_stack = explained_pair(after_explain)
+    assert before_stack.winner_id is None
+    assert after_stack.winner_id == template.id
+    evidence = after_stack.templates[0].gate_trace.evidence
+    assert evidence is not None
+    assert evidence["kind"] == "knows_claim_about"
+    assert evidence["result"] is True
+    assert {match["tier"] for match in evidence["matched"]} == {"told"}
+
+
+def test_entity_audit_renders_two_hop_provenance_and_ledger_depth(
+    live_connection: Any,
+) -> None:
+    """The entity knowledge panel resolves a two-hop acquisition end to end."""
+
+    settings = _settings()
+    raw_connection = live_connection.connection.driver_connection
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 3)
+        source, relay, recipient = entities
+        about, _ = _insert_character(cur, "audit-about")
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        claim_id = _insert_claim_about(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=source,
+            about_entity_id=about,
+        )
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=12))
+        drained = drain_claim_propagation_sync(
+            cur, tick_chunk_id=drain_chunk, settings=settings
+        )
+
+    assert drained.minted_count >= 2
+    context = entity_context(
+        live_connection,
+        [recipient],
+        anchor_chunk_id=drain_chunk,
+        contagion_settings=settings,
+    )
+    # This is exactly the dev endpoint's return value, so JSON round-tripping
+    # guards the direct audit/dev serialization parity.
+    assert json.loads(json.dumps(context)) == context
+    entity = context["entities"][0]
+    row = next(item for item in entity["knowledge"] if item["claim_id"] == claim_id)
+    assert row == {
+        "claim_id": claim_id,
+        "summary": (
+            f"Threat issued: actor Stage 2d source {source}, "
+            f"target Stage 2d subject {about}."
+        ),
+        "scope": "bounded",
+        "tier": "told",
+        "channel": "dyad:associate",
+        "immediate_source": {
+            "entity_id": relay,
+            "name": row["immediate_source"]["name"],
+        },
+        "root_source": {
+            "entity_id": source,
+            "name": row["root_source"]["name"],
+        },
+        "acquired_at_world_time": (birth_world_time + timedelta(hours=2)).isoformat(),
+        "depth": 2,
+    }
+    assert row["immediate_source"]["name"]
+    assert row["root_source"]["name"]
+    assert row["immediate_source"]["name"] != row["root_source"]["name"]
+    assert [item["claim_id"] for item in entity["knowledge"]] == sorted(
+        item["claim_id"] for item in entity["knowledge"]
+    )

--- a/tests/test_orrery/test_evidence.py
+++ b/tests/test_orrery/test_evidence.py
@@ -29,6 +29,7 @@ from nexus.agents.orrery.evidence import (
     EvidenceResolutionError,
     resolve_evidence,
 )
+from nexus.agents.orrery.epistemics import ClaimKnowledge
 from nexus.agents.orrery.explain import explain_stack
 from nexus.agents.orrery.substrate import (
     ALWAYS,
@@ -57,6 +58,7 @@ from nexus.agents.orrery.substrate import (
     has_contact_of_kind,
     has_ephemeral,
     has_established_partner_co_located,
+    heard_secondhand,
     has_inbound_pair_tag,
     has_location_class_destination,
     has_minimal_context,
@@ -75,6 +77,7 @@ from nexus.agents.orrery.substrate import (
     is_constrained,
     is_hidden,
     is_in_transit,
+    knows_claim_about,
     knows_recent_event,
     lacks_pair_tag,
     lacks_tag,
@@ -157,6 +160,26 @@ RICH_STATE = WorldState(
         EventRecord(event_type="threat_issued", tick=99, target_entity_id=ACTOR),
         EventRecord(event_type="contact_made", tick=95, actor_entity_id=ACTOR),
     ),
+    claim_knowledge_by_entity={
+        ACTOR: (
+            ClaimKnowledge(
+                claim_id=71,
+                world_event_id=81,
+                scope="bounded",
+                source_tier="participant",
+                about_entity_ids=frozenset({TARGET}),
+            ),
+            ClaimKnowledge(
+                claim_id=72,
+                world_event_id=82,
+                scope="bounded",
+                source_tier="told",
+                about_entity_ids=frozenset({3}),
+                channel="dyad:associate",
+                immediate_source_entity_id=TARGET,
+            ),
+        )
+    },
     time_of_day="night",
     world_time=datetime(2073, 5, 3, 11, 30),
     weather="rain",
@@ -218,6 +241,8 @@ FACTORY_SWEEP = [
     has_symmetric_relationship_of_type("romantic", Slot.TARGET, Slot.ACTOR),
     faction_member(),
     relative_orbit_distance(2),
+    knows_claim_about(),
+    heard_secondhand(),
     time_of_day_in("night", "evening"),
     weather_is("clear"),
     recent_event("threat_issued", within_ticks=5, target_slot=Slot.ACTOR),

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -71,6 +71,9 @@ class FakeSession:
         pair_tag_rows=None,
         faction_rows=None,
         event_rows=None,
+        active_entity_rows=None,
+        epistemics_rows=None,
+        epistemics_awareness_rows=None,
         chunk_ref_actor_rows=None,
         event_actor_rows=None,
         ephemeral_actor_rows=None,
@@ -103,6 +106,11 @@ class FakeSession:
         self.pair_tag_rows = pair_tag_rows or []
         self.faction_rows = faction_rows or []
         self.event_rows = event_rows or []
+        self.active_entity_rows = (
+            [{"id": 1}] if active_entity_rows is None else active_entity_rows
+        )
+        self.epistemics_rows = epistemics_rows or []
+        self.epistemics_awareness_rows = epistemics_awareness_rows or []
         self.chunk_ref_actor_rows = chunk_ref_actor_rows or [{"entity_id": 1}]
         self.event_actor_rows = event_actor_rows or []
         self.ephemeral_actor_rows = ephemeral_actor_rows or []
@@ -175,6 +183,20 @@ class FakeSession:
         if "/* orrery:recent_events */" in sql:
             assert "superseded_by_event_id IS NULL" in sql
             return FakeResult(self.event_rows)
+        if "/* orrery:active_entity_ids */" in sql:
+            assert "is_active = true" in sql
+            assert "ORDER BY id" in sql
+            return FakeResult(self.active_entity_rows)
+        if "/* orrery:epistemics_hydration:claims */" in sql:
+            assert "world_event_entities" in sql
+            assert "ca.knower_entity_id" in sql
+            assert "array_agg(entity_id ORDER BY entity_id)" in sql
+            assert "LEFT JOIN claim_awareness" not in sql
+            return FakeResult(self.epistemics_rows)
+        if "/* orrery:epistemics_hydration:awareness */" in sql:
+            assert "ca.claim_id = ANY(:claim_ids)" in sql
+            assert "ca.knower_entity_id = ANY(:entity_ids)" in sql
+            return FakeResult(self.epistemics_awareness_rows)
         if "/* orrery:actor_bindings_chunk_refs */" in sql:
             assert "reference_type IS DISTINCT FROM 'present'" in sql
             return FakeResult(self.chunk_ref_actor_rows)

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -72,6 +72,7 @@ class FakeSession:
         faction_rows=None,
         event_rows=None,
         active_entity_rows=None,
+        epistemics_scope_rows=None,
         epistemics_rows=None,
         epistemics_awareness_rows=None,
         chunk_ref_actor_rows=None,
@@ -110,6 +111,11 @@ class FakeSession:
             [{"id": 1}] if active_entity_rows is None else active_entity_rows
         )
         self.epistemics_rows = epistemics_rows or []
+        self.epistemics_scope_rows = (
+            self.epistemics_rows
+            if epistemics_scope_rows is None
+            else epistemics_scope_rows
+        )
         self.epistemics_awareness_rows = epistemics_awareness_rows or []
         self.chunk_ref_actor_rows = chunk_ref_actor_rows or [{"entity_id": 1}]
         self.event_actor_rows = event_actor_rows or []
@@ -187,15 +193,28 @@ class FakeSession:
             assert "is_active = true" in sql
             assert "ORDER BY id" in sql
             return FakeResult(self.active_entity_rows)
+        if "/* orrery:epistemics_hydration:recent_event_scopes */" in sql:
+            assert "c.world_event_id = ANY(:recent_event_ids)" in sql
+            assert "we.tick_chunk_id <= :anchor_chunk_id" in sql
+            assert "recent_event_ids" in _params
+            assert "anchor_chunk_id" in _params
+            return FakeResult(self.epistemics_scope_rows)
         if "/* orrery:epistemics_hydration:claims */" in sql:
             assert "world_event_entities" in sql
             assert "ca.knower_entity_id" in sql
             assert "array_agg(entity_id ORDER BY entity_id)" in sql
             assert "LEFT JOIN claim_awareness" not in sql
+            assert "we.tick_chunk_id <= :anchor_chunk_id" in sql
+            assert "ca.source_chunk_id <= :anchor_chunk_id" in sql
+            assert "ca.created_at <= (SELECT created_at FROM anchor)" in sql
+            assert "anchor_chunk_id" in _params
             return FakeResult(self.epistemics_rows)
         if "/* orrery:epistemics_hydration:awareness */" in sql:
             assert "ca.claim_id = ANY(:claim_ids)" in sql
             assert "ca.knower_entity_id = ANY(:entity_ids)" in sql
+            assert "ca.source_chunk_id <= :anchor_chunk_id" in sql
+            assert "ca.created_at <= (SELECT created_at FROM anchor)" in sql
+            assert "anchor_chunk_id" in _params
             return FakeResult(self.epistemics_awareness_rows)
         if "/* orrery:actor_bindings_chunk_refs */" in sql:
             assert "reference_type IS DISTINCT FROM 'present'" in sql

--- a/ui/client/src/pages/dev-orrery/EntityAudit.tsx
+++ b/ui/client/src/pages/dev-orrery/EntityAudit.tsx
@@ -291,6 +291,57 @@ export default function EntityAudit({ ent }: { ent: EntityAuditVM }) {
         </div>
       )}
 
+      {ent.hasKnowledge && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 5,
+            borderTop: "1px solid hsl(var(--border))",
+            paddingTop: 6,
+          }}
+        >
+          <span className="font-mono" style={SECTION_LABEL}>
+            Knowledge
+          </span>
+          {ent.knowledge.map((claim) => (
+            <div
+              key={claim.key}
+              style={{ display: "flex", flexDirection: "column", gap: 1 }}
+            >
+              <span
+                className="font-mono"
+                style={{
+                  fontSize: 8,
+                  color: "hsl(var(--chart-5))",
+                  letterSpacing: "0.03em",
+                }}
+              >
+                {claim.meta}
+              </span>
+              <span
+                style={{
+                  fontSize: 10.5,
+                  lineHeight: 1.3,
+                  color: "hsl(var(--foreground) / 0.9)",
+                }}
+              >
+                {claim.summary}
+              </span>
+              <span
+                className="font-mono"
+                style={{
+                  fontSize: 7.5,
+                  color: "hsl(var(--muted-foreground))",
+                }}
+              >
+                {claim.provenance} · {claim.acquired}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
       {ent.hasEvents && (
         <div
           style={{

--- a/ui/client/src/pages/dev-orrery/types.ts
+++ b/ui/client/src/pages/dev-orrery/types.ts
@@ -266,6 +266,17 @@ export interface ContextEntity {
     other_name?: string;
     versioned: boolean;
   }[];
+  knowledge: {
+    claim_id: number;
+    summary: string;
+    scope: "common" | "bounded" | "private";
+    tier: "common" | "participant" | "witness" | "told" | "granted";
+    channel: string | null;
+    immediate_source: { entity_id: number; name: string } | null;
+    root_source: { entity_id: number; name: string } | null;
+    acquired_at_world_time: string | null;
+    depth: number | null;
+  }[];
   recent_events: {
     event_type: string;
     tick_chunk_id: number;
@@ -401,6 +412,14 @@ export interface EntityAuditVM {
   hasEphemeral: boolean;
   rels: { types: string; other: string; trust: string }[];
   hasRels: boolean;
+  knowledge: {
+    key: string;
+    summary: string;
+    meta: string;
+    provenance: string;
+    acquired: string;
+  }[];
+  hasKnowledge: boolean;
   events: { t: string; type: string }[];
   hasEvents: boolean;
 }

--- a/ui/client/src/pages/dev-orrery/vm.ts
+++ b/ui/client/src/pages/dev-orrery/vm.ts
@@ -831,6 +831,28 @@ export function buildEntityAudit(
         ? "—"
         : `${r.valence_magnitude >= 0 ? "+" : ""}${r.valence_magnitude}`,
   }));
+  const knowledge = ent.knowledge.map((claim) => {
+    const detail = [
+      `#${claim.claim_id}`,
+      claim.scope,
+      claim.tier,
+      claim.channel,
+      claim.depth == null ? null : `depth ${claim.depth}`,
+    ].filter((value): value is string => value != null);
+    const immediate = claim.immediate_source?.name;
+    const root = claim.root_source?.name;
+    const provenance =
+      immediate && root && immediate !== root
+        ? `${immediate} ← root ${root}`
+        : immediate ?? (root ? `root ${root}` : "universal / direct");
+    return {
+      key: String(claim.claim_id),
+      summary: claim.summary,
+      meta: detail.join(" · "),
+      provenance,
+      acquired: claim.acquired_at_world_time ?? "world time unstamped",
+    };
+  });
   const events = ent.recent_events.map((ev) => ({
     t: `t${String(ev.tick_chunk_id).padStart(4, "0")}`,
     type: ev.event_type,
@@ -847,6 +869,8 @@ export function buildEntityAudit(
     hasEphemeral: ent.tags.ephemeral.length > 0,
     rels,
     hasRels: rels.length > 0,
+    knowledge,
+    hasKnowledge: knowledge.length > 0,
     events,
     hasEvents: events.length > 0,
   };


### PR DESCRIPTION
The final slice of #477 Stage 2 (Social Contagion): what the substrate, graph, and engine built, packages can now act on.

## What Lands

- **Predicates**: `knows_claim_about(subject_slot, about_slot)` and `heard_secondhand(subject_slot)` — hydration-backed, deterministic, evidence-carrying, equal for character and faction knowers. Common-scope claims are universally known without awareness rows (the frozen scope semantics). The decisive live test drives `resolve_dry_run` before and after a real drain in one transaction: a gated template becomes proposable exactly when the rumor arrives.
- **Hydration**: a claim-knowledge slice bounded to the hydrated entity universe — threaded explicitly, empty-universe early return, array aggregation instead of a knower×about cross-join — so per-turn cost scales with the active cast, not total playthrough history.
- **Audit**: the entity view gains a provenance knowledge panel (claim, scope, tier, channel, immediate/root sources resolved to names, acquired world time, event-payload depth), with the matching dev-dashboard rendering (ship-off invariant untouched).
- No migration; no storyteller-prompt changes (prompt surfacing of secondhand knowledge is deferred with owner visibility).

## Review and Verification

First flight of the Opus-pinned review workflow (per the delegate-model doctrine): 4 verified findings — the headline being an unbounded full-history hydration query the refactor had introduced — all fixed under frozen semantics; 3 candidates correctly refuted. Suites 1406 default / **1647 postgres**, exit-code-checked, independently re-run; slot-5 replay green.

Implemented by Codex (gpt-5.6-sol) from frozen work orders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UUKcWGZUXg2jF5Nqrhtqv