### PR TITLE
Proximity-Ranked Bleed with a Reserved Remote Slot (#477 Stage 3)

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -401,6 +401,8 @@ model_ref = "@anthropic.default"
 max_candidates = 3
 near_distance_max = 2
 reserved_remote_slots = 1
+# Upper bound on eligible candidates fetched per anchored menu selection.
+scan_limit = 24
 
 [orrery.promote]
 # Calibrated against the 106-resolution corpus on save_05 (39 ticks, 2026-06).

--- a/nexus.toml
+++ b/nexus.toml
@@ -399,6 +399,8 @@ model_ref = "@anthropic.default"
 
 [orrery.bleed]
 max_candidates = 3
+near_distance_max = 2
+reserved_remote_slots = 1
 
 [orrery.promote]
 # Calibrated against the 106-resolution corpus on save_05 (39 ticks, 2026-06).

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -930,6 +930,7 @@ class TurnCycleManager:
                 max_candidates=max_candidates,
                 near_distance_max=bleed_settings.near_distance_max,
                 reserved_remote_slots=bleed_settings.reserved_remote_slots,
+                scan_limit=bleed_settings.scan_limit,
             )
 
         turn_context.bleed_menu = result.selected

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -30,10 +30,11 @@ try:
     from nexus.agents.orrery.resolver import resolve_dry_run
     from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
     from nexus.agents.orrery.bleed import (
+        load_bleed_anchor_entity_ids,
         record_bleed_offers,
         select_bleed_menu,
     )
-    from nexus.config.settings_models import LORERetrievalSettings
+    from nexus.config.settings_models import LORERetrievalSettings, OrreryBleedSettings
 except ImportError:
     # If relative import fails, try absolute
     from nexus.agents.lore.utils.turn_context import TurnContext
@@ -52,10 +53,11 @@ except ImportError:
     from nexus.agents.orrery.resolver import resolve_dry_run
     from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
     from nexus.agents.orrery.bleed import (
+        load_bleed_anchor_entity_ids,
         record_bleed_offers,
         select_bleed_menu,
     )
-    from nexus.config.settings_models import LORERetrievalSettings
+    from nexus.config.settings_models import LORERetrievalSettings, OrreryBleedSettings
 
 try:
     from nexus.agents.memnon.utils.query_analysis import QueryAnalyzer
@@ -885,13 +887,17 @@ class TurnCycleManager:
         if not orrery_settings.get("enabled", False):
             return
 
-        bleed_settings = orrery_settings.get("bleed", {})
-        max_candidates = int(bleed_settings.get("max_candidates", 3))
+        bleed_settings = OrreryBleedSettings.model_validate(
+            orrery_settings.get("bleed", {})
+        )
+        max_candidates = bleed_settings.max_candidates
         if max_candidates <= 0:
             turn_context.phase_states["orrery_bleed"] = {
                 "enabled": True,
                 "skipped": True,
                 "reason": "max_candidates_zero",
+                "near_count": 0,
+                "remote_count": 0,
             }
             return
 
@@ -908,13 +914,22 @@ class TurnCycleManager:
                     "enabled": True,
                     "skipped": True,
                     "reason": "no_anchor_chunk",
+                    "near_count": 0,
+                    "remote_count": 0,
                 }
                 return
 
+            anchor_entity_ids = load_bleed_anchor_entity_ids(
+                session,
+                anchor_chunk_id=anchor_chunk_id,
+            )
             result = select_bleed_menu(
                 session,
                 anchor_chunk_id=anchor_chunk_id,
+                anchor_entity_ids=anchor_entity_ids,
                 max_candidates=max_candidates,
+                near_distance_max=bleed_settings.near_distance_max,
+                reserved_remote_slots=bleed_settings.reserved_remote_slots,
             )
 
         turn_context.bleed_menu = result.selected
@@ -923,6 +938,8 @@ class TurnCycleManager:
             "anchor_chunk_id": anchor_chunk_id,
             "candidate_count": result.candidates_considered,
             "selected_count": len(result.selected),
+            "near_count": result.near_count,
+            "remote_count": result.remote_count,
             "offers_recorded": 0,
         }
 

--- a/nexus/agents/orrery/bleed.py
+++ b/nexus/agents/orrery/bleed.py
@@ -2,15 +2,107 @@
 
 from __future__ import annotations
 
+from collections import deque
+from dataclasses import dataclass
+from decimal import Decimal
 import json
 import logging
-from decimal import Decimal
-from typing import Any, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional, Tuple
 
 from pydantic import BaseModel, Field
 from sqlalchemy import text
 
 logger = logging.getLogger("nexus.orrery.bleed")
+
+_BLEED_GRAPH_NODES_SQL = """
+    /* orrery:bleed_proximity_nodes */
+    SELECT id AS entity_id
+    FROM entities
+    WHERE is_active = true
+    ORDER BY id
+"""
+_BLEED_GRAPH_EDGES_SQL = """
+    /* orrery:bleed_proximity_edges */
+    SELECT source_entity_id, target_entity_id, edge_kind, edge_label
+    FROM (
+        SELECT c1.entity_id AS source_entity_id,
+               c2.entity_id AS target_entity_id,
+               'relationship'::text AS edge_kind,
+               cr.relationship_type::text AS edge_label
+        FROM character_relationships cr
+        JOIN characters c1 ON c1.id = cr.character1_id
+        JOIN characters c2 ON c2.id = cr.character2_id
+        JOIN entities source ON source.id = c1.entity_id
+        JOIN entities target ON target.id = c2.entity_id
+        WHERE source.is_active = true
+          AND target.is_active = true
+
+        UNION ALL
+
+        SELECT ept.subject_entity_id AS source_entity_id,
+               ept.object_entity_id AS target_entity_id,
+               'pair_tag'::text AS edge_kind,
+               pt.tag AS edge_label
+        FROM entity_pair_tags ept
+        JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+        JOIN entities source ON source.id = ept.subject_entity_id
+        JOIN entities target ON target.id = ept.object_entity_id
+        WHERE ept.cleared_at IS NULL
+          AND NOT pt.deprecated
+          AND source.is_active = true
+          AND target.is_active = true
+          AND (
+                pt.tag LIKE 'status:%'
+             OR pt.tag IN (
+                    'obligation',
+                    'handles',
+                    'authority_over',
+                    'mentors',
+                    'protects',
+                    'hunting'
+                )
+          )
+          AND (
+                (source.kind = 'character'
+                 AND target.kind IN ('character', 'faction'))
+             OR (source.kind = 'faction' AND target.kind = 'character')
+          )
+    ) bleed_edges
+    ORDER BY source_entity_id, target_entity_id, edge_kind, edge_label
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class BleedProximityGraph:
+    """Purpose-specific, immutable undirected graph for Bleed proximity."""
+
+    nodes: Tuple[int, ...]
+    adjacency: Mapping[int, Tuple[int, ...]]
+
+    def distances_from(self, anchor_entity_ids: Iterable[int]) -> dict[int, int]:
+        """Return deterministic minimum hop counts from any active anchor."""
+
+        node_set = frozenset(self.nodes)
+        roots = tuple(
+            sorted(
+                {
+                    int(entity_id)
+                    for entity_id in anchor_entity_ids
+                    if int(entity_id) in node_set
+                }
+            )
+        )
+        distances = {entity_id: 0 for entity_id in roots}
+        frontier = deque(roots)
+        while frontier:
+            entity_id = frontier.popleft()
+            next_distance = distances[entity_id] + 1
+            for neighbor_id in self.adjacency.get(entity_id, ()):
+                if neighbor_id in distances:
+                    continue
+                distances[neighbor_id] = next_distance
+                frontier.append(neighbor_id)
+        return distances
 
 
 class BleedCandidate(BaseModel):
@@ -20,6 +112,7 @@ class BleedCandidate(BaseModel):
     narration_id: int
     tick_chunk_id: int
     template_id: str
+    actor_entity_id: Optional[int] = None
     event_type: Optional[str] = None
     actor_name: Optional[str] = None
     target_name: Optional[str] = None
@@ -28,6 +121,7 @@ class BleedCandidate(BaseModel):
     brief: Optional[str] = None
     text: str
     magnitude: Optional[float] = None
+    distance: Optional[int] = None
 
     def to_prompt_dict(self) -> dict[str, Any]:
         """Return the spoiler-limited shape injected into the Storyteller prompt."""
@@ -48,28 +142,97 @@ class BleedSelectorResult(BaseModel):
 
     candidates_considered: int = 0
     selected: list[BleedCandidate] = Field(default_factory=list)
+    near_count: int = 0
+    remote_count: int = 0
+
+
+def load_bleed_anchor_entity_ids(
+    session: Any,
+    *,
+    anchor_chunk_id: int,
+) -> Tuple[int, ...]:
+    """Resolve character and faction references on one chunk to spine ids."""
+
+    rows = session.execute(
+        text(
+            """
+            /* orrery:bleed_anchor_entities */
+            SELECT entity_id
+            FROM (
+                SELECT c.entity_id
+                FROM chunk_character_references ccr
+                JOIN characters c ON c.id = ccr.character_id
+                WHERE ccr.chunk_id = :anchor_chunk_id
+
+                UNION
+
+                SELECT f.entity_id
+                FROM chunk_faction_references cfr
+                JOIN factions f ON f.id = cfr.faction_id
+                WHERE cfr.chunk_id = :anchor_chunk_id
+            ) anchor_entities
+            WHERE entity_id IS NOT NULL
+            ORDER BY entity_id
+            """
+        ),
+        {"anchor_chunk_id": anchor_chunk_id},
+    ).mappings()
+    return tuple(int(row["entity_id"]) for row in rows)
+
+
+def assemble_bleed_proximity_graph(session_or_cur: Any) -> BleedProximityGraph:
+    """Assemble the bounded, read-only graph used only by Bleed selection."""
+
+    node_rows = [
+        dict(row)
+        for row in session_or_cur.execute(text(_BLEED_GRAPH_NODES_SQL)).mappings()
+    ]
+    edge_rows = [
+        dict(row)
+        for row in session_or_cur.execute(text(_BLEED_GRAPH_EDGES_SQL)).mappings()
+    ]
+    nodes = tuple(sorted({int(row["entity_id"]) for row in node_rows}))
+    node_set = frozenset(nodes)
+    neighbors: dict[int, set[int]] = {entity_id: set() for entity_id in nodes}
+    for row in edge_rows:
+        source_id = int(row["source_entity_id"])
+        target_id = int(row["target_entity_id"])
+        if source_id not in node_set or target_id not in node_set:
+            raise ValueError(
+                "Bleed proximity edge references an entity outside the active graph: "
+                f"{source_id}->{target_id}"
+            )
+        neighbors[source_id].add(target_id)
+        neighbors[target_id].add(source_id)
+    adjacency = {
+        entity_id: tuple(sorted(entity_neighbors))
+        for entity_id, entity_neighbors in neighbors.items()
+    }
+    return BleedProximityGraph(nodes=nodes, adjacency=adjacency)
 
 
 def load_bleed_candidates(
     session: Any,
     *,
     anchor_chunk_id: int,
-    limit: int,
+    limit: Optional[int],
 ) -> list[BleedCandidate]:
     """Load narrated Orrery candidates that are eligible before the anchor."""
 
-    if limit <= 0:
+    if limit is not None and limit <= 0:
         return []
 
+    limit_clause = "LIMIT :limit" if limit is not None else ""
     rows = session.execute(
         text(
-            """
+            f"""
             /* orrery:bleed_candidates */
             SELECT
                 r.id AS resolution_id,
                 n.id AS narration_id,
                 r.tick_chunk_id,
                 r.template_id,
+                r.actor_entity_id,
                 r.brief,
                 r.magnitude,
                 n.text,
@@ -100,10 +263,13 @@ def load_bleed_candidates(
                      r.magnitude DESC NULLS LAST,
                      r.priority DESC,
                      r.id DESC
-            LIMIT :limit
+            {limit_clause}
             """
         ),
-        {"anchor_chunk_id": anchor_chunk_id, "limit": limit},
+        {
+            "anchor_chunk_id": anchor_chunk_id,
+            **({"limit": limit} if limit is not None else {}),
+        },
     ).mappings()
 
     return [_candidate_from_row(row) for row in rows]
@@ -113,24 +279,82 @@ def select_bleed_menu(
     session: Any,
     *,
     anchor_chunk_id: int,
+    anchor_entity_ids: Iterable[int],
     max_candidates: int,
+    near_distance_max: int,
+    reserved_remote_slots: int,
 ) -> BleedSelectorResult:
-    """Select a deterministic ambient Bleed menu from eligible candidates."""
+    """Select a proximity-balanced ambient menu from eligible candidates."""
 
     if max_candidates <= 0:
         return BleedSelectorResult()
 
+    anchors = tuple(sorted({int(entity_id) for entity_id in anchor_entity_ids}))
+    # Bounds on near_distance_max / reserved_remote_slots are owned by
+    # OrreryBleedSettings; callers pass validated values.
     candidate_pool = load_bleed_candidates(
         session,
         anchor_chunk_id=anchor_chunk_id,
-        limit=max_candidates,
+        # The empty-anchor fallback needs only the top of the pure ordering;
+        # the proximity path needs the full pool to partition.
+        limit=max_candidates if not anchors else None,
     )
     if not candidate_pool:
         return BleedSelectorResult()
+    if not anchors:
+        selected = candidate_pool[:max_candidates]
+        return BleedSelectorResult(
+            candidates_considered=len(candidate_pool),
+            selected=selected,
+            remote_count=len(selected),
+        )
+
+    graph = assemble_bleed_proximity_graph(session)
+    distances = graph.distances_from(anchors)
+    annotated = [
+        candidate.model_copy(
+            update={
+                "distance": (
+                    distances.get(candidate.actor_entity_id)
+                    if candidate.actor_entity_id is not None
+                    else None
+                )
+            }
+        )
+        for candidate in candidate_pool
+    ]
+    near = [
+        candidate
+        for candidate in annotated
+        if candidate.distance is not None and candidate.distance <= near_distance_max
+    ]
+    remote = [
+        candidate
+        for candidate in annotated
+        if candidate.distance is None or candidate.distance > near_distance_max
+    ]
+
+    near_slots = max_candidates - reserved_remote_slots
+    selected_near = near[:near_slots]
+    selected_remote = remote[:reserved_remote_slots]
+    selected = [*selected_near, *selected_remote]
+    remaining_slots = max_candidates - len(selected)
+    if remaining_slots and len(selected_near) < near_slots:
+        selected.extend(remote[reserved_remote_slots:][:remaining_slots])
+    elif remaining_slots and len(selected_remote) < reserved_remote_slots:
+        selected.extend(near[near_slots:][:remaining_slots])
 
     return BleedSelectorResult(
         candidates_considered=len(candidate_pool),
-        selected=candidate_pool[:max_candidates],
+        selected=selected,
+        near_count=sum(
+            candidate.distance is not None and candidate.distance <= near_distance_max
+            for candidate in selected
+        ),
+        remote_count=sum(
+            candidate.distance is None or candidate.distance > near_distance_max
+            for candidate in selected
+        ),
     )
 
 
@@ -175,6 +399,7 @@ def _candidate_from_row(row: Mapping[str, Any]) -> BleedCandidate:
         narration_id=int(row["narration_id"]),
         tick_chunk_id=int(row["tick_chunk_id"]),
         template_id=str(row["template_id"]),
+        actor_entity_id=_int_or_none(row.get("actor_entity_id")),
         event_type=row.get("event_type"),
         actor_name=row.get("actor_name"),
         target_name=row.get("target_name"),
@@ -202,3 +427,9 @@ def _float_or_none(value: Any) -> Optional[float]:
     if isinstance(value, Decimal):
         return float(value)
     return float(value)
+
+
+def _int_or_none(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    return int(value)

--- a/nexus/agents/orrery/bleed.py
+++ b/nexus/agents/orrery/bleed.py
@@ -283,6 +283,7 @@ def select_bleed_menu(
     max_candidates: int,
     near_distance_max: int,
     reserved_remote_slots: int,
+    scan_limit: int,
 ) -> BleedSelectorResult:
     """Select a proximity-balanced ambient menu from eligible candidates."""
 
@@ -296,8 +297,8 @@ def select_bleed_menu(
         session,
         anchor_chunk_id=anchor_chunk_id,
         # The empty-anchor fallback needs only the top of the pure ordering;
-        # the proximity path needs the full pool to partition.
-        limit=max_candidates if not anchors else None,
+        # the proximity path partitions a bounded scan window (scan_limit).
+        limit=max_candidates if not anchors else scan_limit,
     )
     if not candidate_pool:
         return BleedSelectorResult()

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -964,9 +964,28 @@ class OrreryBleedSettings(BaseModel):
         default=None,
         ge=1,
         exclude=True,
-        description="Deprecated and ignored; Bleed fetches max_candidates.",
+        description="Deprecated and ignored; Bleed scans the eligible ordered pool.",
     )
     max_candidates: int = Field(default=3, ge=0)
+    near_distance_max: int = Field(default=2, ge=0)
+    reserved_remote_slots: int = Field(default=1, ge=0)
+
+    @model_validator(mode="after")
+    def _validate_reserved_remote_slots(self) -> "OrreryBleedSettings":
+        """The remote reservation must fit inside an enabled menu."""
+
+        if self.max_candidates == 0:
+            if self.reserved_remote_slots != 0:
+                raise ValueError(
+                    "orrery.bleed.reserved_remote_slots must be 0 when "
+                    "max_candidates is 0"
+                )
+            return self
+        if self.reserved_remote_slots >= self.max_candidates:
+            raise ValueError(
+                "orrery.bleed.reserved_remote_slots must be < max_candidates"
+            )
+        return self
 
 
 class OrreryPromoteSettings(BaseModel):

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -969,22 +969,46 @@ class OrreryBleedSettings(BaseModel):
     max_candidates: int = Field(default=3, ge=0)
     near_distance_max: int = Field(default=2, ge=0)
     reserved_remote_slots: int = Field(default=1, ge=0)
+    scan_limit: int = Field(
+        default=24,
+        ge=1,
+        description=(
+            "Upper bound on eligible candidates fetched per anchored menu "
+            "selection; the partition sees at most this many rows."
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_reserved_remote_slots(self) -> "OrreryBleedSettings":
-        """The remote reservation must fit inside an enabled menu."""
+        """The remote reservation must fit inside an enabled menu.
 
+        The default reservation adapts to small menus (a legacy
+        ``max_candidates = 1`` config stays bootable); an EXPLICIT
+        contradictory reservation still fails loudly.
+        """
+
+        implicit = "reserved_remote_slots" not in self.model_fields_set
         if self.max_candidates == 0:
             if self.reserved_remote_slots != 0:
+                if implicit:
+                    object.__setattr__(self, "reserved_remote_slots", 0)
+                    return self
                 raise ValueError(
                     "orrery.bleed.reserved_remote_slots must be 0 when "
                     "max_candidates is 0"
                 )
             return self
         if self.reserved_remote_slots >= self.max_candidates:
-            raise ValueError(
-                "orrery.bleed.reserved_remote_slots must be < max_candidates"
-            )
+            if implicit:
+                object.__setattr__(
+                    self, "reserved_remote_slots", self.max_candidates - 1
+                )
+            else:
+                raise ValueError(
+                    "orrery.bleed.reserved_remote_slots must be < max_candidates"
+                )
+        if self.scan_limit < self.max_candidates:
+            raise ValueError("orrery.bleed.scan_limit must be >= max_candidates")
         return self
 
 

--- a/tests/test_orrery/test_bleed.py
+++ b/tests/test_orrery/test_bleed.py
@@ -10,6 +10,7 @@ import pytest
 from nexus.agents.lore.utils.turn_context import TurnContext
 from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
 from nexus.agents.orrery.bleed import (
+    assemble_bleed_proximity_graph,
     load_bleed_candidates,
     select_bleed_menu,
 )
@@ -34,9 +35,19 @@ class FakeResult:
 class FakeSession:
     """Session stand-in keyed by Bleed selector SQL markers."""
 
-    def __init__(self, candidate_rows=None, max_chunk_id=100):
+    def __init__(
+        self,
+        candidate_rows=None,
+        max_chunk_id=100,
+        anchor_entity_rows=None,
+        graph_nodes=None,
+        graph_edges=None,
+    ):
         self.candidate_rows = candidate_rows or []
         self.max_chunk_id = max_chunk_id
+        self.anchor_entity_rows = anchor_entity_rows or []
+        self.graph_nodes = graph_nodes or []
+        self.graph_edges = graph_edges or []
         self.executed = []
         self.commits = 0
 
@@ -52,7 +63,19 @@ class FakeSession:
         if "/* orrery:bleed_candidates */" in sql:
             assert "r.tick_chunk_id <= :anchor_chunk_id" in sql
             assert "r.offer_count < 3" in sql
-            return FakeResult(self.candidate_rows[: params["limit"]])
+            limit = params.get("limit")
+            rows = self.candidate_rows if limit is None else self.candidate_rows[:limit]
+            return FakeResult(rows)
+        if "/* orrery:bleed_anchor_entities */" in sql:
+            return FakeResult(self.anchor_entity_rows)
+        if "/* orrery:bleed_proximity_nodes */" in sql:
+            return FakeResult(self.graph_nodes)
+        if "/* orrery:bleed_proximity_edges */" in sql:
+            assert "cr.relationship_type" in sql
+            assert "ept.cleared_at IS NULL" in sql
+            assert "pt.tag LIKE 'status:%'" in sql
+            assert "'hunting'" in sql
+            return FakeResult(self.graph_edges)
         if "/* orrery:record_bleed_offers */" in sql:
             return FakeResult([])
         if "SELECT max(nc.id) AS max_id" in sql:
@@ -119,6 +142,7 @@ def _candidate_row():
         "narration_id": 501,
         "tick_chunk_id": 99,
         "template_id": "evade_pursuers",
+        "actor_entity_id": 2,
         "event_type": "evade_pursuit",
         "actor_name": "Mara",
         "target_name": None,
@@ -138,6 +162,24 @@ def _candidate_row_with_id(resolution_id: int):
     row["resolution_id"] = resolution_id
     row["narration_id"] = 500 + resolution_id
     return row
+
+
+def _select(
+    session: FakeSession,
+    *,
+    anchor_entity_ids=(1,),
+    max_candidates=3,
+    near_distance_max=2,
+    reserved_remote_slots=1,
+):
+    return select_bleed_menu(
+        session,
+        anchor_chunk_id=100,
+        anchor_entity_ids=anchor_entity_ids,
+        max_candidates=max_candidates,
+        near_distance_max=near_distance_max,
+        reserved_remote_slots=reserved_remote_slots,
+    )
 
 
 def _settings():
@@ -172,11 +214,7 @@ def test_select_bleed_menu_returns_top_candidate_without_recording_offers() -> N
 
     session = FakeSession(candidate_rows=[_candidate_row()])
 
-    result = select_bleed_menu(
-        session,
-        anchor_chunk_id=100,
-        max_candidates=3,
-    )
+    result = _select(session, anchor_entity_ids=())
 
     assert result.candidates_considered == 1
     assert result.selected[0].resolution_id == 10
@@ -191,11 +229,7 @@ def test_select_bleed_menu_returns_empty_without_candidates() -> None:
 
     session = FakeSession(candidate_rows=[])
 
-    result = select_bleed_menu(
-        session,
-        anchor_chunk_id=100,
-        max_candidates=3,
-    )
+    result = _select(session, anchor_entity_ids=())
 
     assert result.candidates_considered == 0
     assert result.selected == []
@@ -212,15 +246,211 @@ def test_select_bleed_menu_caps_deterministic_selection() -> None:
         ]
     )
 
-    result = select_bleed_menu(
+    result = _select(
         session,
-        anchor_chunk_id=100,
+        anchor_entity_ids=(),
         max_candidates=1,
+        reserved_remote_slots=0,
     )
 
+    # Empty-anchor fallback fetches capped (limit = max_candidates), restoring
+    # the pre-Stage-3 contract: candidates_considered reports the capped fetch.
     assert result.candidates_considered == 1
     assert [candidate.resolution_id for candidate in result.selected] == [10]
     assert session.commits == 0
+
+
+def test_bleed_proximity_graph_is_undirected_and_deterministic() -> None:
+    """Relationship and permitted pair-tag rows become stable neutral hops."""
+
+    session = FakeSession(
+        graph_nodes=[{"entity_id": 3}, {"entity_id": 1}, {"entity_id": 2}],
+        graph_edges=[
+            {
+                "source_entity_id": 2,
+                "target_entity_id": 3,
+                "edge_kind": "pair_tag",
+                "edge_label": "hunting",
+            },
+            {
+                "source_entity_id": 2,
+                "target_entity_id": 1,
+                "edge_kind": "relationship",
+                "edge_label": "enemy",
+            },
+        ],
+    )
+
+    graph = assemble_bleed_proximity_graph(session)
+
+    assert graph.nodes == (1, 2, 3)
+    assert graph.adjacency == {1: (2,), 2: (1, 3), 3: (2,)}
+    assert graph.distances_from((3, 1)) == {1: 0, 3: 0, 2: 1}
+
+
+def test_select_bleed_menu_reserves_remote_slot_after_near_candidates() -> None:
+    """A lower-magnitude near candidate leads while remote keeps its slot."""
+
+    remote = _candidate_row_with_id(30)
+    remote["actor_entity_id"] = 30
+    near = _candidate_row_with_id(20)
+    near["actor_entity_id"] = 2
+    near["magnitude"] = Decimal("0.100")
+    session = FakeSession(
+        candidate_rows=[remote, near],
+        graph_nodes=[{"entity_id": 1}, {"entity_id": 2}, {"entity_id": 30}],
+        graph_edges=[
+            {
+                "source_entity_id": 1,
+                "target_entity_id": 2,
+                "edge_kind": "relationship",
+                "edge_label": "associate",
+            }
+        ],
+    )
+
+    result = _select(session, max_candidates=2)
+
+    assert [candidate.resolution_id for candidate in result.selected] == [20, 30]
+    assert [candidate.distance for candidate in result.selected] == [1, None]
+    assert result.near_count == 1
+    assert result.remote_count == 1
+
+
+def test_reserved_remote_zero_makes_starvation_a_config_choice() -> None:
+    """With enough near rows, a zero reservation excludes the remote leader."""
+
+    rows = []
+    for resolution_id, actor_id in ((30, 30), (20, 2), (10, 3)):
+        row = _candidate_row_with_id(resolution_id)
+        row["actor_entity_id"] = actor_id
+        rows.append(row)
+    session = FakeSession(
+        candidate_rows=rows,
+        graph_nodes=[{"entity_id": entity_id} for entity_id in (1, 2, 3, 30)],
+        graph_edges=[
+            {
+                "source_entity_id": 1,
+                "target_entity_id": actor_id,
+                "edge_kind": "relationship",
+                "edge_label": "associate",
+            }
+            for actor_id in (2, 3)
+        ],
+    )
+
+    result = _select(
+        session,
+        max_candidates=2,
+        reserved_remote_slots=0,
+    )
+
+    assert [candidate.resolution_id for candidate in result.selected] == [20, 10]
+    assert result.near_count == 2
+    assert result.remote_count == 0
+
+
+def test_faction_anchor_reaches_candidate_over_hunting_edge() -> None:
+    """A permitted character-faction pair tag makes the actor near."""
+
+    row = _candidate_row()
+    row["actor_entity_id"] = 2
+    session = FakeSession(
+        candidate_rows=[row],
+        graph_nodes=[{"entity_id": 2}, {"entity_id": 9}],
+        graph_edges=[
+            {
+                "source_entity_id": 2,
+                "target_entity_id": 9,
+                "edge_kind": "pair_tag",
+                "edge_label": "hunting",
+            }
+        ],
+    )
+
+    result = _select(session, anchor_entity_ids=(9,))
+
+    assert result.selected[0].distance == 1
+    assert result.near_count == 1
+
+
+def test_empty_anchor_preserves_existing_order_without_graph_queries() -> None:
+    """No on-screen references keeps the pre-proximity menu byte ordering."""
+
+    rows = [_candidate_row_with_id(value) for value in (30, 20, 10)]
+    session = FakeSession(candidate_rows=rows)
+
+    before = [
+        candidate.model_dump_json()
+        for candidate in load_bleed_candidates(
+            session,
+            anchor_chunk_id=100,
+            limit=2,
+        )
+    ]
+    result = _select(session, anchor_entity_ids=(), max_candidates=2)
+
+    assert [candidate.model_dump_json() for candidate in result.selected] == before
+    assert not any("orrery:bleed_proximity" in sql for sql, _ in session.executed)
+
+
+@pytest.mark.parametrize(
+    ("anchor_entity_ids", "near_distance_max", "expected_ids", "counts"),
+    [
+        ((1,), 0, [30, 20, 10], (1, 2)),
+        ((1, 2, 3), 2, [30, 20, 10], (3, 0)),
+    ],
+)
+def test_select_bleed_menu_backfills_short_partition(
+    anchor_entity_ids,
+    near_distance_max,
+    expected_ids,
+    counts,
+) -> None:
+    """A short near or remote partition backfills without shrinking the menu."""
+
+    rows = []
+    for resolution_id, actor_id in ((30, 1), (20, 2), (10, 3)):
+        row = _candidate_row_with_id(resolution_id)
+        row["actor_entity_id"] = actor_id
+        rows.append(row)
+    session = FakeSession(
+        candidate_rows=rows,
+        graph_nodes=[{"entity_id": entity_id} for entity_id in (1, 2, 3)],
+        graph_edges=[],
+    )
+
+    result = _select(
+        session,
+        anchor_entity_ids=anchor_entity_ids,
+        max_candidates=3,
+        near_distance_max=near_distance_max,
+    )
+
+    assert [candidate.resolution_id for candidate in result.selected] == expected_ids
+    assert (result.near_count, result.remote_count) == counts
+
+
+def test_select_bleed_menu_is_deterministic_with_tie_order() -> None:
+    """Identical rows retain the SQL id tie-break across repeated selection."""
+
+    rows = [_candidate_row_with_id(value) for value in (30, 20, 10)]
+    for row, actor_id in zip(rows, (3, 2, 1), strict=True):
+        row["actor_entity_id"] = actor_id
+    session = FakeSession(
+        candidate_rows=rows,
+        graph_nodes=[{"entity_id": entity_id} for entity_id in (1, 2, 3)],
+        graph_edges=[],
+    )
+
+    first = _select(session, max_candidates=2)
+    second = _select(session, max_candidates=2)
+
+    assert first == second
+    candidate_sql = next(
+        sql for sql, _ in session.executed if "orrery:bleed_candidates" in sql
+    )
+    assert "r.id DESC" in candidate_sql
 
 
 @pytest.mark.asyncio
@@ -239,6 +469,8 @@ async def test_assemble_context_payload_includes_bleed_menu() -> None:
     await manager.assemble_context_payload(context)
 
     assert context.phase_states["orrery_bleed"]["selected_count"] == 1
+    assert context.phase_states["orrery_bleed"]["near_count"] == 0
+    assert context.phase_states["orrery_bleed"]["remote_count"] == 1
     assert context.context_payload["orrery_bleed_menu"][0]["summary"] == (
         "street cameras briefly lose Mara"
     )

--- a/tests/test_orrery/test_bleed.py
+++ b/tests/test_orrery/test_bleed.py
@@ -171,6 +171,7 @@ def _select(
     max_candidates=3,
     near_distance_max=2,
     reserved_remote_slots=1,
+    scan_limit=24,
 ):
     return select_bleed_menu(
         session,
@@ -179,6 +180,7 @@ def _select(
         max_candidates=max_candidates,
         near_distance_max=near_distance_max,
         reserved_remote_slots=reserved_remote_slots,
+        scan_limit=scan_limit,
     )
 
 

--- a/tests/test_orrery/test_bleed_proximity_live.py
+++ b/tests/test_orrery/test_bleed_proximity_live.py
@@ -384,6 +384,7 @@ def _select(
     max_candidates: int,
     near_distance_max: int = 2,
     reserved_remote_slots: int = 1,
+    scan_limit: int = 24,
 ):
     return select_bleed_menu(
         db["session"],
@@ -392,6 +393,7 @@ def _select(
         max_candidates=max_candidates,
         near_distance_max=near_distance_max,
         reserved_remote_slots=reserved_remote_slots,
+        scan_limit=scan_limit,
     )
 
 

--- a/tests/test_orrery/test_bleed_proximity_live.py
+++ b/tests/test_orrery/test_bleed_proximity_live.py
@@ -1,0 +1,575 @@
+"""Rollback-only slot-5 coverage for proximity-ranked Orrery Bleed.
+
+Activated by ``NEXUS_RUN_POSTGRES=1``. Every fixture row and temporary update
+is enclosed in one external SQLAlchemy transaction and rolled back.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+import json
+from types import SimpleNamespace
+from typing import Any, Iterator, cast
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+from nexus.agents.lore.utils.turn_context import TurnContext
+from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
+from nexus.agents.orrery.bleed import (
+    load_bleed_anchor_entity_ids,
+    load_bleed_candidates,
+    select_bleed_menu,
+)
+from nexus.api.slot_utils import get_slot_db_url
+
+
+pytestmark = pytest.mark.requires_postgres
+
+LIVE_SLOT = 5
+
+
+def _insert_chunk(
+    session: Session,
+    *,
+    label: str,
+    token: str,
+    world_time: datetime,
+) -> int:
+    """Insert an accepted chunk and restore its explicit fixture world time."""
+
+    chunk_id = int(
+        session.execute(
+            text(
+                """
+                INSERT INTO narrative_chunks (raw_text, storyteller_text)
+                VALUES (:raw_text, :storyteller_text)
+                RETURNING id
+                """
+            ),
+            {
+                "raw_text": f"Bleed proximity {label} fixture {token}.",
+                "storyteller_text": "Rollback-only Bleed fixture.",
+            },
+        ).scalar_one()
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO chunk_metadata (chunk_id, world_time)
+            VALUES (:chunk_id, :world_time)
+            """
+        ),
+        {"chunk_id": chunk_id, "world_time": world_time},
+    )
+    # The metadata trigger derives world_time during INSERT. A world-time-only
+    # UPDATE does not retrigger it and keeps synthetic chunks chronologically
+    # explicit, matching the repository's live-fixture discipline.
+    session.execute(
+        text(
+            """
+            UPDATE chunk_metadata
+            SET world_time = :world_time
+            WHERE chunk_id = :chunk_id
+            """
+        ),
+        {"chunk_id": chunk_id, "world_time": world_time},
+    )
+    return chunk_id
+
+
+def _insert_character(
+    session: Session,
+    *,
+    label: str,
+    token: str,
+) -> tuple[int, int]:
+    entity_id = int(
+        session.execute(
+            text(
+                """
+                INSERT INTO entities (kind, is_active)
+                VALUES ('character', true)
+                RETURNING id
+                """
+            )
+        ).scalar_one()
+    )
+    character_id = int(
+        session.execute(
+            text(
+                """
+                INSERT INTO characters (name, entity_id)
+                VALUES (:name, :entity_id)
+                RETURNING id
+                """
+            ),
+            {"name": f"bleed-{token}-{label}", "entity_id": entity_id},
+        ).scalar_one()
+    )
+    return entity_id, character_id
+
+
+def _insert_relationship(
+    session: Session,
+    *,
+    source_character_id: int,
+    target_character_id: int,
+) -> None:
+    session.execute(
+        text(
+            """
+            INSERT INTO character_relationships (
+                character1_id, character2_id, relationship_type,
+                emotional_valence, dynamic, recent_events, history
+            ) VALUES (
+                :source_id, :target_id, 'associate', '-5|fixture',
+                'Rollback-only Bleed fixture.', 'No persistent events.',
+                'Created for issue 477 Stage 3 live coverage.'
+            )
+            """
+        ),
+        {"source_id": source_character_id, "target_id": target_character_id},
+    )
+
+
+def _insert_hunting_edge(
+    session: Session,
+    *,
+    actor_entity_id: int,
+    faction_entity_id: int,
+) -> None:
+    result = session.execute(
+        text(
+            """
+            INSERT INTO entity_pair_tags (
+                subject_entity_id, object_entity_id, pair_tag_id,
+                source_kind, template_id
+            )
+            SELECT :actor_id, :faction_id, pt.id,
+                   'template', 'test_bleed_proximity_live'
+            FROM pair_tags pt
+            WHERE pt.tag = 'hunting' AND NOT pt.deprecated
+            RETURNING id
+            """
+        ),
+        {"actor_id": actor_entity_id, "faction_id": faction_entity_id},
+    ).scalar_one_or_none()
+    assert result is not None, "slot 5 must register the hunting pair tag"
+
+
+def _insert_candidate(
+    session: Session,
+    *,
+    chunk_id: int,
+    actor_entity_id: int,
+    label: str,
+    token: str,
+    magnitude: float,
+) -> int:
+    resolution_id = int(
+        session.execute(
+            text(
+                """
+                INSERT INTO orrery_resolutions (
+                    tick_chunk_id, template_id, binding_hash,
+                    actor_entity_id, priority, magnitude, state_delta,
+                    brief, promotion_status
+                ) VALUES (
+                    :chunk_id, :template_id, :binding_hash,
+                    :actor_id, 50, :magnitude, '{}'::jsonb,
+                    :brief, 'promoted'
+                )
+                RETURNING id
+                """
+            ),
+            {
+                "chunk_id": chunk_id,
+                "template_id": f"bleed_{label}",
+                "binding_hash": f"bleed-{token}-{label}",
+                "actor_id": actor_entity_id,
+                "magnitude": magnitude,
+                "brief": f"Rollback-only {label} candidate.",
+            },
+        ).scalar_one()
+    )
+    narration_id = int(
+        session.execute(
+            text(
+                """
+                INSERT INTO offscreen_narrations (
+                    resolution_id, tick_chunk_id, world_layer,
+                    text, perceptual_descriptor
+                ) VALUES (
+                    :resolution_id, :chunk_id, 'primary',
+                    :narration, CAST(:descriptor AS jsonb)
+                )
+                RETURNING id
+                """
+            ),
+            {
+                "resolution_id": resolution_id,
+                "chunk_id": chunk_id,
+                "narration": f"Rollback-only narration for {label}.",
+                "descriptor": json.dumps(
+                    {"channel": "visual", "summary": f"{label} resolves"}
+                ),
+            },
+        ).scalar_one()
+    )
+    session.execute(
+        text(
+            """
+            UPDATE orrery_resolutions
+            SET narration_status = 'succeeded',
+                narration_chunk_id = :narration_id
+            WHERE id = :resolution_id
+            """
+        ),
+        {"narration_id": narration_id, "resolution_id": resolution_id},
+    )
+    return resolution_id
+
+
+@pytest.fixture()
+def bleed_proximity_db() -> Iterator[dict[str, Any]]:
+    """Build an isolated candidate pool and purpose-specific graph in slot 5."""
+
+    engine = create_engine(get_slot_db_url(slot=LIVE_SLOT), future=True)
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+    try:
+        token = uuid4().hex[:12]
+        # Exclude ambient live candidates for this transaction only so every
+        # backfill assertion operates on a closed, deterministic fixture pool.
+        session.execute(
+            text(
+                """
+                UPDATE orrery_resolutions
+                SET offer_count = 3
+                WHERE offer_count < 3
+                """
+            )
+        )
+        faction = (
+            session.execute(
+                text(
+                    """
+                    SELECT f.id AS faction_id, f.entity_id
+                    FROM factions f
+                    JOIN entities e ON e.id = f.entity_id
+                    WHERE e.is_active = true
+                    ORDER BY f.entity_id
+                    LIMIT 1
+                    """
+                )
+            )
+            .mappings()
+            .one_or_none()
+        )
+        if faction is None:
+            pytest.skip("save_05 needs one active faction for Bleed coverage")
+
+        latest_world_time = session.execute(
+            text("SELECT max(world_time) FROM chunk_metadata")
+        ).scalar_one()
+        base_world_time = latest_world_time or datetime(2073, 8, 1, tzinfo=timezone.utc)
+        mixed_anchor_chunk = _insert_chunk(
+            session,
+            label="mixed-anchor",
+            token=token,
+            world_time=base_world_time + timedelta(hours=1),
+        )
+        faction_anchor_chunk = _insert_chunk(
+            session,
+            label="faction-anchor",
+            token=token,
+            world_time=base_world_time + timedelta(hours=2),
+        )
+        empty_anchor_chunk = _insert_chunk(
+            session,
+            label="empty-anchor",
+            token=token,
+            world_time=base_world_time + timedelta(hours=3),
+        )
+
+        characters = {
+            label: _insert_character(session, label=label, token=token)
+            for label in ("anchor", "near_one", "near_two", "remote", "faction_near")
+        }
+        anchor_entity_id, anchor_character_id = characters["anchor"]
+        session.execute(
+            text(
+                """
+                INSERT INTO chunk_character_references (
+                    chunk_id, character_id, reference
+                ) VALUES (:chunk_id, :character_id, 'present')
+                """
+            ),
+            {
+                "chunk_id": mixed_anchor_chunk,
+                "character_id": anchor_character_id,
+            },
+        )
+        session.execute(
+            text(
+                """
+                INSERT INTO chunk_faction_references (chunk_id, faction_id)
+                VALUES (:chunk_id, :faction_id)
+                """
+            ),
+            {
+                "chunk_id": faction_anchor_chunk,
+                "faction_id": int(faction["faction_id"]),
+            },
+        )
+
+        for label in ("near_one", "near_two"):
+            _insert_relationship(
+                session,
+                source_character_id=anchor_character_id,
+                target_character_id=characters[label][1],
+            )
+        _insert_hunting_edge(
+            session,
+            actor_entity_id=characters["faction_near"][0],
+            faction_entity_id=int(faction["entity_id"]),
+        )
+
+        candidate_ids = {
+            label: _insert_candidate(
+                session,
+                chunk_id=mixed_anchor_chunk,
+                actor_entity_id=characters[label][0],
+                label=label,
+                token=token,
+                magnitude=magnitude,
+            )
+            for label, magnitude in (
+                ("remote", 0.99),
+                ("near_one", 0.10),
+                ("near_two", 0.09),
+                ("faction_near", 0.08),
+            )
+        }
+        session.flush()
+        yield {
+            "session": session,
+            "chunks": {
+                "mixed": mixed_anchor_chunk,
+                "faction": faction_anchor_chunk,
+                "empty": empty_anchor_chunk,
+            },
+            "entities": {label: pair[0] for label, pair in characters.items()},
+            "faction_entity_id": int(faction["entity_id"]),
+            "candidates": candidate_ids,
+        }
+    finally:
+        session.close()
+        if transaction.is_active:
+            transaction.rollback()
+        connection.close()
+        engine.dispose()
+
+
+def _select(
+    db: dict[str, Any],
+    *,
+    anchor_chunk: str,
+    anchor_entity_ids: tuple[int, ...],
+    max_candidates: int,
+    near_distance_max: int = 2,
+    reserved_remote_slots: int = 1,
+):
+    return select_bleed_menu(
+        db["session"],
+        anchor_chunk_id=int(db["chunks"][anchor_chunk]),
+        anchor_entity_ids=anchor_entity_ids,
+        max_candidates=max_candidates,
+        near_distance_max=near_distance_max,
+        reserved_remote_slots=reserved_remote_slots,
+    )
+
+
+def test_live_boundary_reservation_and_configured_starvation(
+    bleed_proximity_db: dict[str, Any],
+) -> None:
+    """Near leads, remote is reserved, and zero can intentionally starve it."""
+
+    db = bleed_proximity_db
+    anchor_ids = load_bleed_anchor_entity_ids(
+        db["session"], anchor_chunk_id=db["chunks"]["mixed"]
+    )
+
+    reserved = _select(
+        db,
+        anchor_chunk="mixed",
+        anchor_entity_ids=anchor_ids,
+        max_candidates=2,
+    )
+    no_reservation = _select(
+        db,
+        anchor_chunk="mixed",
+        anchor_entity_ids=anchor_ids,
+        max_candidates=2,
+        reserved_remote_slots=0,
+    )
+
+    assert [candidate.resolution_id for candidate in reserved.selected] == [
+        db["candidates"]["near_one"],
+        db["candidates"]["remote"],
+    ]
+    assert [candidate.distance for candidate in reserved.selected] == [1, None]
+    assert [candidate.resolution_id for candidate in no_reservation.selected] == [
+        db["candidates"]["near_one"],
+        db["candidates"]["near_two"],
+    ]
+
+
+def test_live_faction_anchor_and_empty_anchor_fallback(
+    bleed_proximity_db: dict[str, Any],
+) -> None:
+    """Hunting reaches a faction anchor; empty anchors preserve old bytes."""
+
+    db = bleed_proximity_db
+    faction_ids = load_bleed_anchor_entity_ids(
+        db["session"], anchor_chunk_id=db["chunks"]["faction"]
+    )
+    assert faction_ids == (db["faction_entity_id"],)
+    faction_result = _select(
+        db,
+        anchor_chunk="faction",
+        anchor_entity_ids=faction_ids,
+        max_candidates=2,
+    )
+    faction_candidate = next(
+        candidate
+        for candidate in faction_result.selected
+        if candidate.resolution_id == db["candidates"]["faction_near"]
+    )
+    assert faction_candidate.distance == 1
+
+    assert (
+        load_bleed_anchor_entity_ids(
+            db["session"], anchor_chunk_id=db["chunks"]["empty"]
+        )
+        == ()
+    )
+    old_order = load_bleed_candidates(
+        db["session"],
+        anchor_chunk_id=db["chunks"]["empty"],
+        limit=3,
+    )
+    fallback = _select(
+        db,
+        anchor_chunk="empty",
+        anchor_entity_ids=(),
+        max_candidates=3,
+    )
+    assert [candidate.model_dump_json() for candidate in fallback.selected] == [
+        candidate.model_dump_json() for candidate in old_order
+    ]
+
+
+def test_live_backfill_and_determinism(
+    bleed_proximity_db: dict[str, Any],
+) -> None:
+    """Short partitions backfill fully and identical state yields one menu."""
+
+    db = bleed_proximity_db
+    entities = db["entities"]
+    near_short = _select(
+        db,
+        anchor_chunk="mixed",
+        anchor_entity_ids=(entities["near_one"],),
+        max_candidates=3,
+        near_distance_max=0,
+    )
+    assert len(near_short.selected) == 3
+    assert (near_short.near_count, near_short.remote_count) == (1, 2)
+
+    all_candidate_actors = tuple(
+        entities[label] for label in ("remote", "near_one", "near_two", "faction_near")
+    )
+    remote_short = _select(
+        db,
+        anchor_chunk="mixed",
+        anchor_entity_ids=all_candidate_actors,
+        max_candidates=3,
+    )
+    assert len(remote_short.selected) == 3
+    assert (remote_short.near_count, remote_short.remote_count) == (3, 0)
+
+    anchor_ids = (entities["anchor"],)
+    first = _select(
+        db,
+        anchor_chunk="mixed",
+        anchor_entity_ids=anchor_ids,
+        max_candidates=2,
+    )
+    second = _select(
+        db,
+        anchor_chunk="mixed",
+        anchor_entity_ids=anchor_ids,
+        max_candidates=2,
+    )
+    assert first == second
+
+
+class _FixtureMemnon:
+    def __init__(self, session: Session):
+        self._session = session
+
+    @contextmanager
+    def Session(self) -> Iterator[Session]:
+        yield self._session
+
+
+class _FixtureLore:
+    def __init__(self, session: Session):
+        self.settings = {
+            "orrery": {
+                "enabled": True,
+                "bleed": {
+                    "max_candidates": 2,
+                    "near_distance_max": 2,
+                    "reserved_remote_slots": 1,
+                },
+            }
+        }
+        self.memnon = _FixtureMemnon(session)
+
+
+@pytest.mark.asyncio
+async def test_live_phase_state_reports_distance_class_counts(
+    bleed_proximity_db: dict[str, Any],
+) -> None:
+    """Turn-cycle telemetry exposes selected near and remote counts."""
+
+    db = bleed_proximity_db
+    manager = TurnCycleManager(_FixtureLore(db["session"]))
+    context = TurnContext(turn_id="bleed-live", user_input="Continue.", start_time=0)
+    context.orrery_proposal = cast(
+        Any,
+        SimpleNamespace(
+            anchor_chunk_id=db["chunks"]["mixed"],
+            pressure_count=0,
+        ),
+    )
+
+    await manager.select_orrery_bleed(context)
+
+    assert [candidate.distance for candidate in context.bleed_menu] == [1, None]
+    assert context.phase_states["orrery_bleed"] == {
+        "enabled": True,
+        "anchor_chunk_id": db["chunks"]["mixed"],
+        "candidate_count": 4,
+        "selected_count": 2,
+        "near_count": 1,
+        "remote_count": 1,
+        "offers_recorded": 0,
+    }

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -176,9 +176,31 @@ def test_orrery_bleed_accepts_deprecated_selection_keys() -> None:
     )
 
     assert settings.max_candidates == 3
+    assert settings.near_distance_max == 2
+    assert settings.reserved_remote_slots == 1
     dumped = settings.model_dump()
     assert "latency_budget_ms" not in dumped
     assert "candidate_pool_multiplier" not in dumped
+
+
+def test_orrery_bleed_reserved_remote_slots_must_fit_menu() -> None:
+    """A remote reservation cannot consume the entire Bleed menu."""
+
+    with pytest.raises(ValidationError, match="must be < max_candidates"):
+        OrreryBleedSettings(max_candidates=2, reserved_remote_slots=2)
+
+
+def test_disabled_orrery_bleed_requires_zero_remote_reservation() -> None:
+    """A disabled menu cannot retain a non-zero slot reservation."""
+
+    with pytest.raises(ValidationError, match="must be 0"):
+        OrreryBleedSettings(max_candidates=0)
+
+    settings = OrreryBleedSettings(
+        max_candidates=0,
+        reserved_remote_slots=0,
+    )
+    assert settings.max_candidates == 0
 
 
 def test_orrery_promote_accepts_deprecated_provider_key() -> None:

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -191,10 +191,24 @@ def test_orrery_bleed_reserved_remote_slots_must_fit_menu() -> None:
 
 
 def test_disabled_orrery_bleed_requires_zero_remote_reservation() -> None:
-    """A disabled menu cannot retain a non-zero slot reservation."""
+    """Implicit defaults adapt to small menus; explicit contradictions raise.
+
+    PR #522 review: a legacy config setting only max_candidates must stay
+    bootable — the DEFAULT reservation clamps — while an explicitly
+    contradictory reservation still fails loudly.
+    """
+
+    adapted = OrreryBleedSettings(max_candidates=0)
+    assert adapted.reserved_remote_slots == 0
+
+    single = OrreryBleedSettings(max_candidates=1)
+    assert single.reserved_remote_slots == 0
 
     with pytest.raises(ValidationError, match="must be 0"):
-        OrreryBleedSettings(max_candidates=0)
+        OrreryBleedSettings(max_candidates=0, reserved_remote_slots=1)
+
+    with pytest.raises(ValidationError, match="must be < max_candidates"):
+        OrreryBleedSettings(max_candidates=1, reserved_remote_slots=1)
 
     settings = OrreryBleedSettings(
         max_candidates=0,

--- a/tests/test_orrery/test_live_cycle.py
+++ b/tests/test_orrery/test_live_cycle.py
@@ -256,6 +256,7 @@ def test_live_orrery_cycle_resolve_commit_promote_narrate_bleed() -> None:
                 max_candidates=int(bleed_settings["max_candidates"]),
                 near_distance_max=int(bleed_settings["near_distance_max"]),
                 reserved_remote_slots=int(bleed_settings["reserved_remote_slots"]),
+                scan_limit=24,
             )
         selected_resolution_ids = {
             candidate.resolution_id for candidate in menu.selected

--- a/tests/test_orrery/test_live_cycle.py
+++ b/tests/test_orrery/test_live_cycle.py
@@ -25,7 +25,10 @@ from psycopg2.extras import RealDictCursor
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
-from nexus.agents.orrery.bleed import select_bleed_menu
+from nexus.agents.orrery.bleed import (
+    load_bleed_anchor_entity_ids,
+    select_bleed_menu,
+)
 from nexus.agents.orrery.events import commit_orrery_tick_sync
 from nexus.agents.orrery.resolver import (
     OrreryResolutionDraft,
@@ -242,10 +245,17 @@ def test_live_orrery_cycle_resolve_commit_promote_narrate_bleed() -> None:
         # Stage 6 - Bleed: the synthetic narrated resolution must propagate
         # into the deterministic ambient menu for the next turn.
         with session_factory() as session:
+            bleed_settings = orrery_settings["bleed"]
             menu = select_bleed_menu(
                 session,
                 anchor_chunk_id=anchor_chunk_id,
-                max_candidates=int(orrery_settings["bleed"]["max_candidates"]),
+                anchor_entity_ids=load_bleed_anchor_entity_ids(
+                    session,
+                    anchor_chunk_id=anchor_chunk_id,
+                ),
+                max_candidates=int(bleed_settings["max_candidates"]),
+                near_distance_max=int(bleed_settings["near_distance_max"]),
+                reserved_remote_slots=int(bleed_settings["reserved_remote_slots"]),
             )
         selected_resolution_ids = {
             candidate.resolution_id for candidate in menu.selected


### PR DESCRIPTION
The final tracked stage of #477. The ambient Bleed menu becomes scene-aware without ever starving the wider world.

## What Lands

- **Anchors**: the anchor chunk's referenced characters AND factions (`chunk_character_references` / `chunk_faction_references`), threaded from the turn cycle into `select_bleed_menu`.
- **Distance**: a purpose-specific, read-only narrative-proximity graph — `character_relationships` plus every active conduit-family pair tag (`status:*`, `obligation`, `handles`, `authority_over`, `mentors`, `protects`, `hunting`), character↔character and character↔faction alike, each an undirected single hop; BFS min-hops to any anchor. Base `orbit_distance` (#514 contract) and the Stage 2b communication graph are untouched and unreferenced — narrative relevance is deliberately a third metric (a captor is orbit-close and *should* be).
- **The menu**: k−1 NEAR entries (distance ≤ `near_distance_max`, default 2) + `reserved_remote_slots` (default 1) for the best REMOTE/disconnected candidate, with the existing recency → magnitude → priority ordering preserved within both groups, cross-group backfill, and per-candidate distance annotations in the phase telemetry. The ruling's live scenario is a test: an edge-less high-magnitude institutional newcomer stays on the menu next to a distance-1 neighbor — and setting `reserved_remote_slots = 0` removes it, proving starvation is now a config choice.
- **Compatibility**: an empty anchor set degrades byte-identically to the previous behavior, including the capped-fetch `candidates_considered` contract (Stage 3's draft had silently changed that field's meaning; restored).

## Review and Verification

Opus-pinned swarm review: **zero correctness findings**; three cleanup findings (unbounded fallback fetch, duplicated query helper with a dead branch, double validation boundary) applied orchestrator-side per the tiny-edits rule. Faction anchors were promoted from a deferred v2 into v1 by owner challenge — the deferral added no decisions, only delay. Suites 1417 default / 1665 postgres, exit-code-checked; slot-5 replay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UUKcWGZUXg2jF5Nqrhtqv