### PR TITLE
Add the BUILD_VENTURE Aspiration Package (#496 Slice 3)

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1246,6 +1246,99 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 ---
 
+## ADVANCE_BUILD_VENTURE — priority 47
+
+> A due venture lays groundwork, secures backing, opens doors, stalls, or ends.
+
+**Drive band:** project identity — A due venture shares the established project-advance priority; its cadence and embodied floor preserve routine stability.
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor `build_venture` project passes `ready` due-state
+  - **NOT:** actor is in transit
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:**
+    - **OR:**
+      - actor has `sleep` debt ≥ 8
+      - actor has `thirst` debt ≥ 2
+      - actor has `hunger` debt ≥ 4
+
+### Branch 1 — Open the doors  *(mag 0.4)* · **preemptive**
+
+**When:** actor `build_venture` project passes `completion` due-state
+
+**Does:** applies project `complete` transition; adds `proprietor` to actor
+**Event:** `build_venture_completed`
+
+> The preparations stop being preparations. {actor} opens the doors, takes responsibility for what happens beyond them, and becomes the proprietor of something now alive in the world.
+
+### Branch 2 — Let the venture go  *(mag 0.4)* · **preemptive**
+
+**When:** actor `build_venture` project passes `abandon` due-state
+
+**Does:** applies project `abandon` transition
+**Event:** `build_venture_abandoned`
+
+> {actor} admits that the venture has become an obligation to an unopened future. They release it rather than feed another season into delay.
+
+### Branch 3 — Turn groundwork into backing  *(mag 0.4)* · **preemptive**
+
+**When:** actor `build_venture` project passes `laying_groundwork_milestone` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `build_venture_milestone`
+
+> The shape is credible enough to show another person. {actor} stops refining the idea in private and begins securing the money, materials, promises, and labor that can hold it up.
+
+### Branch 4 — Turn backing into an opening  *(mag 0.4)* · **preemptive**
+
+**When:** actor `build_venture` project passes `securing_backing_milestone` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `build_venture_milestone`
+
+> Enough commitments now hold. {actor} turns from winning support to the last concrete work: a place in the world, a way of operating, and doors ready to open.
+
+### Branch 5 — Lose ground through neglect  *(mag 0.1)* · **preemptive** · **not promotable**
+
+**When:** actor `build_venture` project passes `neglected` due-state
+
+**Does:** applies project `stall` transition
+**Event:** `build_venture_stalled`
+
+> Unanswered messages and unfinished arrangements begin undoing what {actor} assembled. The venture stalls, still possible but no longer moving on its own momentum.
+
+### Branch 6 — Make the venture legible  *(mag 0.18)* · **not promotable**
+
+**When:** actor `build_venture` project passes `laying_groundwork` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `build_venture_progressed`
+
+> {actor} turns another vague requirement into a concrete one: a cost counted, a service defined, or a necessary piece of work finished.
+
+### Branch 7 — Secure one more commitment  *(mag 0.18)* · **not promotable**
+
+**When:** actor `build_venture` project passes `securing_backing` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `build_venture_progressed`
+
+> {actor} wins one more commitment the venture can rely on: capital, material, labor, permission, or a promise with weight.
+
+### Branch 8 — Finish the next opening task  *(mag 0.16)* · **not promotable**
+
+**When:** *(always)*
+
+**Does:** applies project `advance` transition
+**Event:** `build_venture_progressed`
+
+> {actor} finishes one of the unglamorous tasks between backing and opening: a roster, a schedule, a key, a supply line, or the first promise to a customer.
+
+---
+
 ## REACH_OUT — priority 40
 
 > A small thread of contact between people who hold each other.
@@ -2131,6 +2224,40 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 ---
 
+## START_BUILD_VENTURE — priority 17
+
+> An off-screen character turns a business, workshop, or crew from an idea into deliberate groundwork.
+
+**Drive band:** project identity — A venture begins from a stable home anchor and shares the proven project-entry priority with relocation and recruitment.
+**Slots:** ACTOR
+
+**Gate:**
+
+- **AND:**
+  - actor `build_venture` project passes `start` due-state
+  - actor has enough hydrated context
+  - actor is at `home` anchor
+  - **NOT:** actor is in transit
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:**
+    - **OR:**
+      - actor has `sleep` debt ≥ 8
+      - actor has `thirst` debt ≥ 2
+      - actor has `hunger` debt ≥ 4
+  - **NOT:** actor has inbound `hostile_to` pair tag
+  - **NOT:** actor has inbound `hunting` pair tag
+
+### Branch 1 — Lay the first groundwork  *(mag 0.4)*
+
+**When:** *(always)*
+
+**Does:** applies project `start` transition
+**Event:** `build_venture_started`
+
+> {actor} stops leaving the venture in the realm of someday. They name what it will do, what it will need, and the first piece of groundwork they can finish now.
+
+---
+
 ## INTIMACY — priority 16
 
 > The body asks for the kind of connection that is not conversation.
@@ -2989,6 +3116,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `at_vigil`
 - `distressed`
 - `forewarned`
+- `proprietor`
 - `recently_drained`
 - `recently_protective`
 - `recently_tended`
@@ -3010,6 +3138,12 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 ### Event types
 
 - `ate`
+- `build_venture_abandoned`
+- `build_venture_completed`
+- `build_venture_milestone`
+- `build_venture_progressed`
+- `build_venture_stalled`
+- `build_venture_started`
 - `compliance_alert`
 - `contact_deferred`
 - `contact_made`

--- a/migrations/084_build_venture_projects.sql
+++ b/migrations/084_build_venture_projects.sql
@@ -1,0 +1,167 @@
+-- 084_build_venture_projects.sql
+--
+-- Extend the Orrery project chassis with BUILD_VENTURE, an actor-only project
+-- whose eventual venture remains narrative until completion. The projection
+-- therefore carries no place, character, or faction target at any stage.
+
+ALTER TABLE character_project_states
+    DROP CONSTRAINT IF EXISTS character_project_states_project_type_check,
+    DROP CONSTRAINT IF EXISTS character_project_states_stage_by_type_check,
+    DROP CONSTRAINT IF EXISTS character_project_states_target_by_type_check,
+    DROP CONSTRAINT IF EXISTS character_project_states_completed_target_check;
+
+ALTER TABLE character_project_states
+    ADD CONSTRAINT character_project_states_project_type_check
+        CHECK (project_type IN (
+            'plan_relocation', 'recruit_ally', 'build_venture'
+        )),
+    ADD CONSTRAINT character_project_states_stage_by_type_check
+        CHECK (
+            (project_type = 'plan_relocation'
+                AND stage IN ('saving', 'scouting', 'committing'))
+            OR
+            (project_type = 'recruit_ally'
+                AND stage IN (
+                    'sounding_out', 'earning_trust', 'sealing_commitment'
+                ))
+            OR
+            (project_type = 'build_venture'
+                AND stage IN (
+                    'laying_groundwork', 'securing_backing', 'opening_doors'
+                ))
+        ),
+    ADD CONSTRAINT character_project_states_target_by_type_check
+        CHECK (
+            (project_type = 'plan_relocation'
+                AND target_character_entity_id IS NULL)
+            OR
+            (project_type = 'recruit_ally'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NOT NULL)
+            OR
+            (project_type = 'build_venture'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NULL
+                AND target_faction_entity_id IS NULL)
+        ),
+    ADD CONSTRAINT character_project_states_completed_target_check
+        CHECK (
+            status <> 'completed'
+            OR (project_type = 'plan_relocation' AND target_place_id IS NOT NULL)
+            OR (
+                project_type = 'recruit_ally'
+                AND target_character_entity_id IS NOT NULL
+            )
+            OR (project_type = 'build_venture')
+        );
+
+-- Migration 081 deliberately permits an immutable, entry-time faction context
+-- for templates that opt into it. The existing project arms retain that
+-- optional context, while BUILD_VENTURE explicitly forbids it because the
+-- venture does not yet exist as a faction entity during this lifecycle.
+COMMENT ON CONSTRAINT character_project_states_project_type_check
+    ON character_project_states IS
+    'Closed project-type vocabulary extended by migration 084 for BUILD_VENTURE.';
+COMMENT ON CONSTRAINT character_project_states_stage_by_type_check
+    ON character_project_states IS
+    'Enforces independent three-stage ladders for PLAN_RELOCATION, RECRUIT_ALLY, and BUILD_VENTURE.';
+COMMENT ON CONSTRAINT character_project_states_target_by_type_check
+    ON character_project_states IS
+    'Enforces typed targets: relocation forbids character targets, recruitment requires only its character target, and venture building forbids place, character, and faction targets.';
+COMMENT ON CONSTRAINT character_project_states_completed_target_check
+    ON character_project_states IS
+    'Completed relocation and recruitment retain their required targets; BUILD_VENTURE legitimately completes without a target.';
+
+COMMENT ON TABLE character_project_states IS
+    'Additive Orrery project lifecycle projection. Supports PLAN_RELOCATION, RECRUIT_ALLY, and actor-only BUILD_VENTURE under one open project per character.';
+COMMENT ON COLUMN character_project_states.project_type IS
+    'Locked project vocabulary: plan_relocation, recruit_ally, or build_venture.';
+COMMENT ON COLUMN character_project_states.stage IS
+    'Type-specific three-stage ladder, including BUILD_VENTURE laying_groundwork, securing_backing, and opening_doors.';
+COMMENT ON COLUMN character_project_states.target_place_id IS
+    'Place target used only by PLAN_RELOCATION; always NULL for RECRUIT_ALLY and BUILD_VENTURE.';
+COMMENT ON COLUMN character_project_states.target_character_entity_id IS
+    'Character target required by RECRUIT_ALLY; always NULL for PLAN_RELOCATION and BUILD_VENTURE.';
+COMMENT ON COLUMN character_project_states.target_faction_entity_id IS
+    'Optional immutable entry-time institutional context for templates that bind one; always NULL for BUILD_VENTURE because the venture is not yet an entity.';
+
+INSERT INTO event_types (type, category, severity, description)
+VALUES
+    (
+        'build_venture_started',
+        'project',
+        'moderate',
+        'The actor began laying the groundwork for a business, workshop, or crew.'
+    ),
+    (
+        'build_venture_progressed',
+        'project',
+        'minor',
+        'The actor made routine progress toward opening a venture.'
+    ),
+    (
+        'build_venture_milestone',
+        'project',
+        'moderate',
+        'The venture crossed a boundary in its groundwork, backing, or opening ladder.'
+    ),
+    (
+        'build_venture_stalled',
+        'project',
+        'minor',
+        'Neglect or a setback cost the actor ground while building the venture.'
+    ),
+    (
+        'build_venture_abandoned',
+        'project',
+        'moderate',
+        'The actor abandoned a venture after repeated stalls or excessive delay.'
+    ),
+    (
+        'build_venture_completed',
+        'project',
+        'moderate',
+        'The doors opened on the actor''s venture, leaving the founder with the proprietor role.'
+    )
+ON CONFLICT (type) DO NOTHING;
+
+-- role.function is the established, non-deprecated category for multi-valued
+-- character roles (migration 055). Reassert its registry row without changing
+-- the established description or ordering, then register the durable role.
+INSERT INTO tag_category_registry (
+    category, entity_kind, prompt_order, description,
+    deprecated, replacement_categories
+) VALUES (
+    'role.function',
+    'character'::entity_kind,
+    40,
+    'Multi-valued social or operational function recognized by others.',
+    FALSE,
+    NULL
+)
+ON CONFLICT (category, entity_kind) DO NOTHING;
+
+INSERT INTO tags (
+    tag, category, is_ephemeral,
+    clearance_kind, reapplication_policy, clear_on,
+    synonym_for, deprecated, description
+) VALUES (
+    'proprietor',
+    'role.function',
+    FALSE,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    FALSE,
+    'Character role: founder or operator of an opened business, workshop, or crew; bestowed when BUILD_VENTURE completes.'
+)
+ON CONFLICT (tag) DO UPDATE SET
+    category = EXCLUDED.category,
+    is_ephemeral = EXCLUDED.is_ephemeral,
+    clearance_kind = EXCLUDED.clearance_kind,
+    reapplication_policy = EXCLUDED.reapplication_policy,
+    clear_on = EXCLUDED.clear_on,
+    synonym_for = NULL,
+    deprecated = FALSE,
+    description = EXCLUDED.description;

--- a/migrations/084_build_venture_projects.sql
+++ b/migrations/084_build_venture_projects.sql
@@ -156,12 +156,4 @@ INSERT INTO tags (
     FALSE,
     'Character role: founder or operator of an opened business, workshop, or crew; bestowed when BUILD_VENTURE completes.'
 )
-ON CONFLICT (tag) DO UPDATE SET
-    category = EXCLUDED.category,
-    is_ephemeral = EXCLUDED.is_ephemeral,
-    clearance_kind = EXCLUDED.clearance_kind,
-    reapplication_policy = EXCLUDED.reapplication_policy,
-    clear_on = EXCLUDED.clear_on,
-    synonym_for = NULL,
-    deprecated = FALSE,
-    description = EXCLUDED.description;
+ON CONFLICT (tag) DO NOTHING;

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -199,6 +199,8 @@ def _tally_report(
                     "advance_relocation_plan",
                     "start_recruit_ally",
                     "advance_recruit_ally",
+                    "start_build_venture",
+                    "advance_build_venture",
                 }:
                     project_gates.append(
                         {

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -1502,6 +1502,15 @@ def _project_payload_with_bound_faction(
     """Carry the adjudicated draft's immutable faction into a transition."""
 
     data = _coerce_project_payload(draft.state_delta[project_key])
+    if data.get("project_type") == "build_venture" and any(
+        data.get(target) is not None
+        for target in (
+            "target_place_id",
+            "target_character_entity_id",
+            "target_faction_entity_id",
+        )
+    ):
+        raise ValueError("build_venture project.start forbids all targets")
     bound_faction = draft.bindings.get("faction")
     has_faction_binding = "faction" in draft.bindings
     if has_faction_binding and not isinstance(bound_faction, int):
@@ -2138,6 +2147,11 @@ PROJECT_OPEN_STATUSES = ("active", "paused", "stalled")
 PROJECT_STAGE_LADDERS = {
     "plan_relocation": ("saving", "scouting", "committing"),
     "recruit_ally": ("sounding_out", "earning_trust", "sealing_commitment"),
+    "build_venture": (
+        "laying_groundwork",
+        "securing_backing",
+        "opening_doors",
+    ),
 }
 
 
@@ -2375,6 +2389,15 @@ def _apply_project_start_sync(
             raise ValueError("recruit_ally project.start forbids a place target")
         if not isinstance(target_character_entity_id, int):
             raise ValueError("recruit_ally project.start requires a character target")
+    if project_type == "build_venture" and any(
+        target is not None
+        for target in (
+            target_place_id,
+            target_character_entity_id,
+            target_faction_entity_id,
+        )
+    ):
+        raise ValueError("build_venture project.start forbids all targets")
     progress = float(data.get("progress", 0.0))
     cur.execute(
         """
@@ -2445,6 +2468,15 @@ async def _apply_project_start_async(
             raise ValueError("recruit_ally project.start forbids a place target")
         if not isinstance(target_character_entity_id, int):
             raise ValueError("recruit_ally project.start requires a character target")
+    if project_type == "build_venture" and any(
+        target is not None
+        for target in (
+            target_place_id,
+            target_character_entity_id,
+            target_faction_entity_id,
+        )
+    ):
+        raise ValueError("build_venture project.start forbids all targets")
     progress = float(data.get("progress", 0.0))
     await conn.execute(
         """
@@ -2824,6 +2856,15 @@ def _validate_project_completion(
             raise ValueError(
                 "recruit_ally completion target binding does not match its recruit"
             )
+    if project_type == "build_venture" and any(
+        project[target] is not None
+        for target in (
+            "target_place_id",
+            "target_character_entity_id",
+            "target_faction_entity_id",
+        )
+    ):
+        raise ValueError("build_venture completion forbids all targets")
 
 
 def _recruit_ally_relationship_metadata(
@@ -3048,6 +3089,8 @@ def _apply_project_complete_sync(
             template_id=template_id,
             source_chunk_id=source_chunk_id,
         )
+    elif project["project_type"] == "build_venture":
+        pass
     else:
         raise ValueError(
             f"Unsupported project completion type: {project['project_type']!r}"
@@ -3113,6 +3156,8 @@ async def _apply_project_complete_async(
             template_id=template_id,
             source_chunk_id=source_chunk_id,
         )
+    elif project["project_type"] == "build_venture":
+        pass
     else:
         raise ValueError(
             f"Unsupported project completion type: {project['project_type']!r}"

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -79,6 +79,11 @@ from nexus.agents.orrery.substrate import ProjectPolicy, coerce_project_policy
 PROJECT_STAGE_LADDERS = {
     "plan_relocation": ("saving", "scouting", "committing"),
     "recruit_ally": ("sounding_out", "earning_trust", "sealing_commitment"),
+    "build_venture": (
+        "laying_groundwork",
+        "securing_backing",
+        "opening_doors",
+    ),
 }
 
 # Composite natural keys, verbatim column order (faction_relationships
@@ -997,13 +1002,22 @@ class _Replayer:
                 raise ValueError(
                     "plan_relocation replay projection forbids character target"
                 )
-        elif (
+        elif project_type == "recruit_ally" and (
             applied_row["target_place_id"] is not None
             or applied_row["target_character_entity_id"] is None
         ):
             raise ValueError(
                 "recruit_ally replay projection requires only a character target"
             )
+        elif project_type == "build_venture" and any(
+            applied_row[target] is not None
+            for target in (
+                "target_place_id",
+                "target_character_entity_id",
+                "target_faction_entity_id",
+            )
+        ):
+            raise ValueError("build_venture replay projection forbids all targets")
         if applied_row["source_chunk_id"] != chunk_id:
             raise ValueError(
                 f"{delta_key} at chunk {chunk_id} applied source_chunk_id is "
@@ -1062,6 +1076,8 @@ class _Replayer:
                     raise ValueError(
                         "recruit_ally completion replay requires character target"
                     )
+                return
+            if project_type == "build_venture":
                 return
             destination = applied_row["target_place_id"]
             if destination is None:

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -1658,6 +1658,49 @@ def _apply_pair_fanout_quota(
     return [draft for draft in drafts if id(draft) in surviving]
 
 
+def _project_start_template_ids(templates_list: list[Template]) -> frozenset[str]:
+    """Ids of templates with any branch that opens a project."""
+
+    return frozenset(
+        template.id
+        for template in templates_list
+        if any(
+            "project.start" in (branch.state_delta or {})
+            for branch in template.branches
+        )
+    )
+
+
+def _arbitrate_project_starts(
+    drafts: list[_FanoutDraftT],
+    templates_list: list[Template],
+) -> list[_FanoutDraftT]:
+    """Keep at most one project-start draft per actor.
+
+    Slot-signature stacks evaluate independently, so a single proposal can
+    hand one actor several ``project.start`` drafts — an actor-only start
+    plus a routed pair start, or one pair start per candidate target. The
+    one-open-project guard makes committing the second a hard abort of the
+    accepted chunk, so the proposal itself must arbitrate. Assembly order
+    is the deterministic precedence: actor-only stacks precede routed pair
+    stacks, and routes keep their composition order.
+    """
+
+    start_templates = _project_start_template_ids(templates_list)
+    if not start_templates:
+        return drafts
+    actors_with_start: set[Any] = set()
+    kept: list[_FanoutDraftT] = []
+    for draft in drafts:
+        if draft.template_id in start_templates:
+            actor = draft.bindings.get("actor")
+            if actor in actors_with_start:
+                continue
+            actors_with_start.add(actor)
+        kept.append(draft)
+    return kept
+
+
 def resolve_dry_run(
     session: Any,
     templates: Iterable[Template],
@@ -1885,6 +1928,7 @@ def resolve_dry_run(
         max_pair_drafts_per_actor=fanout.max_pair_drafts_per_actor,
         exempt_bands=fanout.exempt_bands,
     )
+    drafts = _arbitrate_project_starts(drafts, templates_list)
 
     # Resolve binding entity names so Skald's adjudication payload says WHO
     # each off-screen proposal is about; bare entity ids invite misattribution

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -1176,12 +1176,22 @@ _PROJECT_DUE_MODES = frozenset(
         "sealing_commitment",
         "sounding_out_milestone",
         "earning_trust_milestone",
+        "laying_groundwork",
+        "securing_backing",
+        "opening_doors",
+        "laying_groundwork_milestone",
+        "securing_backing_milestone",
     }
 )
 
 _PROJECT_STAGE_LADDERS = {
     "plan_relocation": ("saving", "scouting", "committing"),
     "recruit_ally": ("sounding_out", "earning_trust", "sealing_commitment"),
+    "build_venture": (
+        "laying_groundwork",
+        "securing_backing",
+        "opening_doors",
+    ),
 }
 
 
@@ -1282,6 +1292,18 @@ def project_due(
             return due and overdue_hours >= policy.advance_interval_hours
         if not due:
             return False
+        if project_type == "build_venture" and any(
+            target is not None
+            for target in (
+                project.target_place_id,
+                project.target_character_entity_id,
+                project.target_faction_entity_id,
+            )
+        ):
+            raise ValueError(
+                f"BUILD_VENTURE project {project.id} has an impossible target "
+                "projection"
+            )
         if normalized_mode in project_stages:
             return project.stage == normalized_mode
         if normalized_mode == f"{project_stages[0]}_milestone":
@@ -1293,23 +1315,33 @@ def project_due(
                 and project.target_place_id is None
             )
         if normalized_mode == f"{project_stages[1]}_milestone":
+            target_ready = (
+                project.target_place_id is not None
+                if project_type == "plan_relocation"
+                else (
+                    project.target_character_entity_id is not None
+                    if project_type == "recruit_ally"
+                    else True
+                )
+            )
             return (
                 project.stage == project_stages[1]
-                and (
-                    project.target_place_id is not None
-                    if project_type == "plan_relocation"
-                    else project.target_character_entity_id is not None
-                )
+                and target_ready
                 and project.progress >= 1.0
             )
         if normalized_mode == "completion":
+            target_ready = (
+                project.target_place_id is not None
+                if project_type == "plan_relocation"
+                else (
+                    project.target_character_entity_id is not None
+                    if project_type == "recruit_ally"
+                    else True
+                )
+            )
             return (
                 project.stage == project_stages[2]
-                and (
-                    project.target_place_id is not None
-                    if project_type == "plan_relocation"
-                    else project.target_character_entity_id is not None
-                )
+                and target_ready
                 and project.progress >= 1.0
             )
         raise AssertionError(f"Unhandled project_due mode {normalized_mode!r}")

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -4967,6 +4967,259 @@ ADVANCE_RECRUIT_ALLY = Template(
 )
 
 
+START_BUILD_VENTURE = Template(
+    id="start_build_venture",
+    priority=17,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "A venture begins from a stable home anchor and shares the proven "
+        "project-entry priority with relocation and recruitment."
+    ),
+    blurb=(
+        "An off-screen character turns a business, workshop, or crew from an "
+        "idea into deliberate groundwork."
+    ),
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        project_due("start", project_type="build_venture"),
+        has_minimal_context(),
+        at_routine_anchor("home"),
+        NOT(is_in_transit()),
+        NOT(is_constrained()),
+        NOT(
+            OR(
+                has_need_debt_at_or_above("sleep", 8),
+                has_need_debt_at_or_above("thirst", 2),
+                has_need_debt_at_or_above("hunger", 4),
+            )
+        ),
+        NOT(has_inbound_pair_tag("hostile_to")),
+        NOT(has_inbound_pair_tag("hunting")),
+    ),
+    branches=(
+        Branch(
+            label="Lay the first groundwork",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} stops leaving the venture in the realm of someday. "
+                "They name what it will do, what it will need, and the first "
+                "piece of groundwork they can finish now."
+            ),
+            state_delta={
+                "project.start": {
+                    "project_type": "build_venture",
+                    "stage": "laying_groundwork",
+                    "milestone": True,
+                }
+            },
+            event_type="build_venture_started",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.stage",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.40,
+        ),
+    ),
+)
+
+
+ADVANCE_BUILD_VENTURE = Template(
+    id="advance_build_venture",
+    priority=47,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "A due venture shares the established project-advance priority; its "
+        "cadence and embodied floor preserve routine stability."
+    ),
+    blurb=(
+        "A due venture lays groundwork, secures backing, opens doors, stalls, "
+        "or ends."
+    ),
+    required_slots=(Slot.ACTOR,),
+    package_gate=AND(
+        project_due("ready", project_type="build_venture"),
+        NOT(is_in_transit()),
+        NOT(is_constrained()),
+        NOT(
+            OR(
+                has_need_debt_at_or_above("sleep", 8),
+                has_need_debt_at_or_above("thirst", 2),
+                has_need_debt_at_or_above("hunger", 4),
+            )
+        ),
+    ),
+    branches=(
+        Branch(
+            label="Open the doors",
+            conditions=project_due("completion", project_type="build_venture"),
+            narrative_stub=(
+                "The preparations stop being preparations. {actor} opens the "
+                "doors, takes responsibility for what happens beyond them, "
+                "and becomes the proprietor of something now alive in the world."
+            ),
+            state_delta={
+                "project.complete": {"milestone": True},
+                "entity_tags.add": ["proprietor"],
+            },
+            event_type="build_venture_completed",
+            changed_fields=(
+                "character_project_states.status",
+                "entity_tags",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Let the venture go",
+            conditions=project_due("abandon", project_type="build_venture"),
+            narrative_stub=(
+                "{actor} admits that the venture has become an obligation to "
+                "an unopened future. They release it rather than feed another "
+                "season into delay."
+            ),
+            state_delta={
+                "project.abandon": {
+                    "reason": "stalled_or_overdue",
+                    "milestone": True,
+                }
+            },
+            event_type="build_venture_abandoned",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.source_chunk_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Turn groundwork into backing",
+            conditions=project_due(
+                "laying_groundwork_milestone", project_type="build_venture"
+            ),
+            narrative_stub=(
+                "The shape is credible enough to show another person. {actor} "
+                "stops refining the idea in private and begins securing the "
+                "money, materials, promises, and labor that can hold it up."
+            ),
+            state_delta={
+                "project.advance": {
+                    "stage": "securing_backing",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            event_type="build_venture_milestone",
+            changed_fields=(
+                "character_project_states.stage",
+                "character_project_states.progress",
+                "character_project_states.stall_count",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Turn backing into an opening",
+            conditions=project_due(
+                "securing_backing_milestone", project_type="build_venture"
+            ),
+            narrative_stub=(
+                "Enough commitments now hold. {actor} turns from winning "
+                "support to the last concrete work: a place in the world, a "
+                "way of operating, and doors ready to open."
+            ),
+            state_delta={
+                "project.advance": {
+                    "stage": "opening_doors",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            event_type="build_venture_milestone",
+            changed_fields=(
+                "character_project_states.stage",
+                "character_project_states.progress",
+                "character_project_states.stall_count",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Lose ground through neglect",
+            conditions=project_due("neglected", project_type="build_venture"),
+            narrative_stub=(
+                "Unanswered messages and unfinished arrangements begin undoing "
+                "what {actor} assembled. The venture stalls, still possible but "
+                "no longer moving on its own momentum."
+            ),
+            state_delta={"project.stall": {"increment": 1}},
+            event_type="build_venture_stalled",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.stall_count",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.10,
+            promotable=False,
+            preemptive=True,
+        ),
+        Branch(
+            label="Make the venture legible",
+            conditions=project_due("laying_groundwork", project_type="build_venture"),
+            narrative_stub=(
+                "{actor} turns another vague requirement into a concrete one: "
+                "a cost counted, a service defined, or a necessary piece of "
+                "work finished."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.35}},
+            event_type="build_venture_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.18,
+            promotable=False,
+        ),
+        Branch(
+            label="Secure one more commitment",
+            conditions=project_due("securing_backing", project_type="build_venture"),
+            narrative_stub=(
+                "{actor} wins one more commitment the venture can rely on: "
+                "capital, material, labor, permission, or a promise with weight."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.35}},
+            event_type="build_venture_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.18,
+            promotable=False,
+        ),
+        Branch(
+            label="Finish the next opening task",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} finishes one of the unglamorous tasks between backing "
+                "and opening: a roster, a schedule, a key, a supply line, or "
+                "the first promise to a customer."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.25}},
+            event_type="build_venture_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.16,
+            promotable=False,
+        ),
+    ),
+)
+
+
 BUILTIN_TEMPLATES = (
     EVADE_PURSUERS,
     PROTECT_KIN,
@@ -4978,6 +5231,7 @@ BUILTIN_TEMPLATES = (
     SURVEIL,
     ADVANCE_RELOCATION_PLAN,
     ADVANCE_RECRUIT_ALLY,
+    ADVANCE_BUILD_VENTURE,
     ACT_ON_INTEL,
     UNCOVER_PAST,
     CHECK_ON_DEPENDENT,
@@ -5002,6 +5256,7 @@ BUILTIN_TEMPLATES = (
     RECREATE,
     START_RELOCATION_PLAN,
     START_RECRUIT_ALLY,
+    START_BUILD_VENTURE,
     MAINTAIN_COVER,
 )
 

--- a/tests/test_orrery/test_build_venture_async.py
+++ b/tests/test_orrery/test_build_venture_async.py
@@ -1,0 +1,238 @@
+"""Live async-writer parity for actor-only BUILD_VENTURE projects."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import asyncpg
+import pytest
+
+from nexus.agents.orrery.events import _apply_state_delta_async
+from nexus.agents.orrery.needs import NeedTuning
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.substrate import ProjectPolicy
+from nexus.api.slot_utils import get_slot_db_url
+
+
+pytestmark = pytest.mark.requires_postgres
+
+POLICY = ProjectPolicy(enabled=True, advance_interval_hours=24.0)
+
+
+async def _create_runtime_schema(conn: asyncpg.Connection, schema: str) -> None:
+    await conn.execute(f'CREATE SCHEMA "{schema}"')
+    await conn.execute(f'SET LOCAL search_path = "{schema}", public')
+    await conn.execute(
+        """
+        CREATE TABLE event_types (
+            type text PRIMARY KEY, category text NOT NULL,
+            severity text NOT NULL, description text
+        );
+        CREATE TABLE tag_category_registry (
+            category text NOT NULL, entity_kind entity_kind NOT NULL,
+            prompt_order integer NOT NULL, description text,
+            deprecated boolean NOT NULL DEFAULT false,
+            replacement_categories text[], PRIMARY KEY (category, entity_kind)
+        );
+        CREATE TABLE tags (
+            id bigserial PRIMARY KEY, tag text UNIQUE NOT NULL,
+            category text NOT NULL, is_ephemeral boolean NOT NULL DEFAULT false,
+            clearance_kind entity_tag_clearance_kind,
+            reapplication_policy entity_tag_reapplication_policy,
+            clear_on jsonb, synonym_for bigint,
+            deprecated boolean NOT NULL DEFAULT false, description text,
+            CHECK (is_ephemeral = (clearance_kind IS NOT NULL))
+        );
+        CREATE TABLE entity_tags (
+            id bigserial PRIMARY KEY, entity_id bigint NOT NULL,
+            tag_id bigint NOT NULL, applied_at timestamptz NOT NULL DEFAULT now(),
+            applied_at_world_time timestamptz, clear_on_override jsonb,
+            cleared_at timestamptz, template_id text,
+            source_kind entity_tag_source_kind NOT NULL, source_chunk_id bigint
+        );
+        CREATE UNIQUE INDEX ix_entity_tags_current
+            ON entity_tags (entity_id, tag_id) WHERE cleared_at IS NULL;
+        CREATE TABLE orrery_resolutions (
+            id bigint PRIMARY KEY, state_delta jsonb NOT NULL
+        );
+        CREATE TABLE character_project_states (
+            id bigserial PRIMARY KEY, character_entity_id bigint NOT NULL,
+            project_type text NOT NULL, status text NOT NULL,
+            stage text NOT NULL, target_place_id bigint,
+            target_character_entity_id bigint, target_faction_entity_id bigint,
+            progress numeric(5,4) NOT NULL DEFAULT 0,
+            stall_count integer NOT NULL DEFAULT 0,
+            next_eligible_at_world_time timestamptz, source_chunk_id bigint,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now(),
+            CONSTRAINT character_project_states_project_type_check
+                CHECK (project_type IN ('plan_relocation', 'recruit_ally')),
+            CONSTRAINT character_project_states_stage_by_type_check CHECK (
+                (project_type = 'plan_relocation'
+                    AND stage IN ('saving', 'scouting', 'committing')) OR
+                (project_type = 'recruit_ally'
+                    AND stage IN (
+                        'sounding_out', 'earning_trust', 'sealing_commitment'
+                    ))
+            ),
+            CONSTRAINT character_project_states_target_by_type_check CHECK (
+                (project_type = 'plan_relocation'
+                    AND target_character_entity_id IS NULL) OR
+                (project_type = 'recruit_ally'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NOT NULL)
+            ),
+            CONSTRAINT character_project_states_completed_target_check CHECK (
+                status <> 'completed' OR
+                (project_type = 'plan_relocation' AND target_place_id IS NOT NULL) OR
+                (project_type = 'recruit_ally'
+                    AND target_character_entity_id IS NOT NULL)
+            )
+        );
+        CREATE UNIQUE INDEX ux_character_project_states_open_budget
+            ON character_project_states (character_entity_id)
+            WHERE status IN ('active', 'paused', 'stalled')
+        """
+    )
+    migration_sql = (
+        Path(__file__).parents[2] / "migrations" / "084_build_venture_projects.sql"
+    ).read_text()
+    await conn.execute(migration_sql)
+
+
+@pytest.mark.asyncio
+async def test_async_build_venture_start_and_completion_match_sync() -> None:
+    conn = await asyncpg.connect(get_slot_db_url(slot=2))
+    transaction = conn.transaction()
+    await transaction.start()
+    try:
+        await _create_runtime_schema(conn, f"build_venture_async_{uuid4().hex[:12]}")
+        actor = int(
+            await conn.fetchval(
+                "SELECT entity_id FROM characters WHERE entity_id IS NOT NULL "
+                "ORDER BY id LIMIT 1"
+            )
+        )
+        chunk = await conn.fetchrow(
+            "SELECT chunk_id, world_time FROM chunk_metadata "
+            "WHERE world_time IS NOT NULL ORDER BY chunk_id DESC LIMIT 1"
+        )
+        assert chunk is not None
+        chunk_id = int(chunk["chunk_id"])
+
+        start = OrreryResolutionDraft(
+            template_id="start_build_venture",
+            priority=17,
+            binding_hash="async-build-start",
+            bindings={"actor": actor},
+            branch_label="Lay the first groundwork",
+            narrative_stub="start",
+            state_delta={
+                "project.start": {
+                    "project_type": "build_venture",
+                    "stage": "laying_groundwork",
+                    "milestone": True,
+                }
+            },
+            magnitude=0.4,
+        )
+        await conn.execute(
+            "INSERT INTO orrery_resolutions (id, state_delta) VALUES (1, $1::jsonb)",
+            "{}",
+        )
+        assert (
+            await _apply_state_delta_async(
+                conn,
+                start,
+                resolution_id=1,
+                actor_entity_id=actor,
+                target_entity_id=None,
+                source_chunk_id=chunk_id,
+                need_tuning=NeedTuning.default(),
+                project_policy=POLICY,
+            )
+            == 0
+        )
+        project = await conn.fetchrow(
+            "SELECT * FROM character_project_states WHERE character_entity_id = $1",
+            actor,
+        )
+        assert project is not None
+        assert project["project_type"] == "build_venture"
+        assert project["stage"] == "laying_groundwork"
+        assert project["target_place_id"] is None
+        assert project["target_character_entity_id"] is None
+        assert project["target_faction_entity_id"] is None
+
+        await conn.execute(
+            "UPDATE character_project_states SET stage = 'opening_doors', "
+            "progress = 1 WHERE character_entity_id = $1",
+            actor,
+        )
+        complete = OrreryResolutionDraft(
+            template_id="advance_build_venture",
+            priority=47,
+            binding_hash="async-build-complete",
+            bindings={"actor": actor},
+            branch_label="Open the doors",
+            narrative_stub="complete",
+            state_delta={
+                "project.complete": {"milestone": True},
+                "entity_tags.add": ["proprietor"],
+            },
+            magnitude=0.4,
+        )
+        await conn.execute(
+            "INSERT INTO orrery_resolutions (id, state_delta) VALUES (2, $1::jsonb)",
+            "{}",
+        )
+        assert (
+            await _apply_state_delta_async(
+                conn,
+                complete,
+                resolution_id=2,
+                actor_entity_id=actor,
+                target_entity_id=None,
+                source_chunk_id=chunk_id,
+                need_tuning=NeedTuning.default(),
+                project_policy=POLICY,
+            )
+            == 1
+        )
+        completed = await conn.fetchrow(
+            "SELECT status, target_place_id, target_character_entity_id, "
+            "target_faction_entity_id FROM character_project_states "
+            "WHERE character_entity_id = $1",
+            actor,
+        )
+        assert completed is not None
+        assert tuple(completed.values()) == ("completed", None, None, None)
+        tag = await conn.fetchrow(
+            "SELECT t.tag, et.template_id FROM entity_tags et "
+            "JOIN tags t ON t.id = et.tag_id WHERE et.entity_id = $1",
+            actor,
+        )
+        assert tag is not None
+        assert tuple(tag.values()) == ("proprietor", "advance_build_venture")
+        applied = json.loads(
+            await conn.fetchval(
+                "SELECT state_delta::text FROM orrery_resolutions WHERE id = 2"
+            )
+        )
+        assert applied["project.complete"]["applied"] == {
+            "project_type": "build_venture",
+            "status": "completed",
+            "stage": "opening_doors",
+            "target_place_id": None,
+            "target_character_entity_id": None,
+            "target_faction_entity_id": None,
+            "progress": 1.0,
+            "stall_count": 0,
+            "next_eligible_at_world_time": None,
+            "source_chunk_id": chunk_id,
+        }
+    finally:
+        await transaction.rollback()
+        await conn.close()

--- a/tests/test_orrery/test_build_venture_migration_pg.py
+++ b/tests/test_orrery/test_build_venture_migration_pg.py
@@ -107,7 +107,12 @@ def migration_083_schema() -> Iterator[Any]:
                 INSERT INTO character_project_states (
                     character_entity_id, project_type, status, stage,
                     target_character_entity_id, progress
-                ) VALUES (2, 'recruit_ally', 'active', 'earning_trust', 3, 0.5)
+                ) VALUES (2, 'recruit_ally', 'active', 'earning_trust', 3, 0.5);
+                INSERT INTO character_project_states (
+                    character_entity_id, project_type, status, stage,
+                    target_character_entity_id, target_faction_entity_id,
+                    progress
+                ) VALUES (6, 'recruit_ally', 'active', 'sounding_out', 7, 11, 0.1)
                 """
             )
         yield conn
@@ -170,12 +175,16 @@ def test_migration_084_widens_projects_and_registers_vocabulary(
         cur.execute("ROLLBACK TO SAVEPOINT build_target")
 
         cur.execute(
-            "SELECT project_type, stage FROM character_project_states "
-            "WHERE character_entity_id IN (1, 2) ORDER BY character_entity_id"
+            "SELECT project_type, stage, target_faction_entity_id "
+            "FROM character_project_states "
+            "WHERE character_entity_id IN (1, 2, 6) ORDER BY character_entity_id"
         )
+        # The faction-bound recruitment row (migration-081 context) must
+        # survive the constraint replacement untouched.
         assert cur.fetchall() == [
-            ("plan_relocation", "saving"),
-            ("recruit_ally", "earning_trust"),
+            ("plan_relocation", "saving", None),
+            ("recruit_ally", "earning_trust", None),
+            ("recruit_ally", "sounding_out", 11),
         ]
         cur.execute(
             "SELECT type FROM event_types WHERE type LIKE 'build_venture_%' "

--- a/tests/test_orrery/test_build_venture_migration_pg.py
+++ b/tests/test_orrery/test_build_venture_migration_pg.py
@@ -1,0 +1,210 @@
+"""Real-PostgreSQL contract coverage for migration 084."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2
+import pytest
+
+from nexus.api.slot_utils import get_slot_db_url
+
+
+pytestmark = pytest.mark.requires_postgres
+
+
+@pytest.fixture()
+def migration_083_schema() -> Iterator[Any]:
+    """Build the exact project/tag surface migration 084 must widen."""
+
+    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    schema = f"migration_084_{uuid4().hex[:12]}"
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f'CREATE SCHEMA "{schema}"')
+            cur.execute(f'SET LOCAL search_path = "{schema}", public')
+            cur.execute(
+                """
+                CREATE TABLE event_types (
+                    type text PRIMARY KEY,
+                    category text NOT NULL,
+                    severity text NOT NULL,
+                    description text
+                );
+                CREATE TABLE tag_category_registry (
+                    category text NOT NULL,
+                    entity_kind entity_kind NOT NULL,
+                    prompt_order integer NOT NULL,
+                    description text,
+                    deprecated boolean NOT NULL DEFAULT false,
+                    replacement_categories text[],
+                    PRIMARY KEY (category, entity_kind)
+                );
+                CREATE TABLE tags (
+                    id bigserial PRIMARY KEY,
+                    tag text UNIQUE NOT NULL,
+                    category text NOT NULL,
+                    is_ephemeral boolean NOT NULL DEFAULT false,
+                    clearance_kind entity_tag_clearance_kind,
+                    reapplication_policy entity_tag_reapplication_policy,
+                    clear_on jsonb,
+                    synonym_for bigint,
+                    deprecated boolean NOT NULL DEFAULT false,
+                    description text,
+                    CHECK (is_ephemeral = (clearance_kind IS NOT NULL))
+                );
+                CREATE TABLE character_project_states (
+                    id bigserial PRIMARY KEY,
+                    character_entity_id bigint NOT NULL,
+                    project_type text NOT NULL,
+                    status text NOT NULL,
+                    stage text NOT NULL,
+                    target_place_id bigint,
+                    target_character_entity_id bigint,
+                    target_faction_entity_id bigint,
+                    progress numeric(5,4) NOT NULL DEFAULT 0,
+                    stall_count integer NOT NULL DEFAULT 0,
+                    next_eligible_at_world_time timestamptz,
+                    source_chunk_id bigint,
+                    CONSTRAINT character_project_states_project_type_check
+                        CHECK (project_type IN ('plan_relocation', 'recruit_ally')),
+                    CONSTRAINT character_project_states_stage_by_type_check CHECK (
+                        (project_type = 'plan_relocation'
+                            AND stage IN ('saving', 'scouting', 'committing'))
+                        OR
+                        (project_type = 'recruit_ally'
+                            AND stage IN (
+                                'sounding_out', 'earning_trust',
+                                'sealing_commitment'
+                            ))
+                    ),
+                    CONSTRAINT character_project_states_target_by_type_check CHECK (
+                        (project_type = 'plan_relocation'
+                            AND target_character_entity_id IS NULL)
+                        OR
+                        (project_type = 'recruit_ally'
+                            AND target_place_id IS NULL
+                            AND target_character_entity_id IS NOT NULL)
+                    ),
+                    CONSTRAINT character_project_states_completed_target_check CHECK (
+                        status <> 'completed'
+                        OR (project_type = 'plan_relocation'
+                            AND target_place_id IS NOT NULL)
+                        OR (project_type = 'recruit_ally'
+                            AND target_character_entity_id IS NOT NULL)
+                    )
+                )
+                """
+            )
+            cur.execute(
+                """
+                INSERT INTO character_project_states (
+                    character_entity_id, project_type, status, stage,
+                    target_place_id, progress
+                ) VALUES (1, 'plan_relocation', 'active', 'saving', NULL, 0.25);
+                INSERT INTO character_project_states (
+                    character_entity_id, project_type, status, stage,
+                    target_character_entity_id, progress
+                ) VALUES (2, 'recruit_ally', 'active', 'earning_trust', 3, 0.5)
+                """
+            )
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_migration_084_widens_projects_and_registers_vocabulary(
+    migration_083_schema: Any,
+) -> None:
+    migration_sql = (
+        Path(__file__).parents[2] / "migrations" / "084_build_venture_projects.sql"
+    ).read_text()
+    conn = migration_083_schema
+    with conn.cursor() as cur:
+        cur.execute(migration_sql)
+        cur.execute(
+            """
+            SELECT conname, pg_get_constraintdef(oid, true), obj_description(oid)
+            FROM pg_constraint
+            WHERE conrelid = 'character_project_states'::regclass
+              AND conname = ANY(%s)
+            ORDER BY conname
+            """,
+            (
+                [
+                    "character_project_states_project_type_check",
+                    "character_project_states_stage_by_type_check",
+                    "character_project_states_target_by_type_check",
+                    "character_project_states_completed_target_check",
+                ],
+            ),
+        )
+        constraints = {name: (definition, comment) for name, definition, comment in cur}
+        assert len(constraints) == 4
+        assert all(comment for _definition, comment in constraints.values())
+        assert all(
+            "build_venture" in definition
+            for definition, _comment in constraints.values()
+        )
+
+        cur.execute(
+            """
+            INSERT INTO character_project_states (
+                character_entity_id, project_type, status, stage, progress
+            ) VALUES (4, 'build_venture', 'completed', 'opening_doors', 1)
+            """
+        )
+        cur.execute("SAVEPOINT build_target")
+        with pytest.raises(psycopg2.errors.CheckViolation):
+            cur.execute(
+                """
+                INSERT INTO character_project_states (
+                    character_entity_id, project_type, status, stage,
+                    target_faction_entity_id
+                ) VALUES (5, 'build_venture', 'active', 'laying_groundwork', 9)
+                """
+            )
+        cur.execute("ROLLBACK TO SAVEPOINT build_target")
+
+        cur.execute(
+            "SELECT project_type, stage FROM character_project_states "
+            "WHERE character_entity_id IN (1, 2) ORDER BY character_entity_id"
+        )
+        assert cur.fetchall() == [
+            ("plan_relocation", "saving"),
+            ("recruit_ally", "earning_trust"),
+        ]
+        cur.execute(
+            "SELECT type FROM event_types WHERE type LIKE 'build_venture_%' "
+            "ORDER BY type"
+        )
+        assert [row[0] for row in cur] == [
+            "build_venture_abandoned",
+            "build_venture_completed",
+            "build_venture_milestone",
+            "build_venture_progressed",
+            "build_venture_stalled",
+            "build_venture_started",
+        ]
+        cur.execute(
+            """
+            SELECT t.category, t.is_ephemeral, t.deprecated, t.description,
+                   r.entity_kind::text, r.deprecated
+            FROM tags t
+            JOIN tag_category_registry r ON r.category = t.category
+            WHERE t.tag = 'proprietor'
+              AND r.entity_kind = 'character'::entity_kind
+            """
+        )
+        category, ephemeral, deprecated, description, kind, registry_deprecated = (
+            cur.fetchone()
+        )
+        assert category == "role.function"
+        assert ephemeral is False
+        assert deprecated is False
+        assert "BUILD_VENTURE" in description
+        assert kind == "character"
+        assert registry_deprecated is False

--- a/tests/test_orrery/test_build_venture_projects.py
+++ b/tests/test_orrery/test_build_venture_projects.py
@@ -1,0 +1,560 @@
+"""BUILD_VENTURE actor-only project acceptance coverage."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from itertools import count
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2
+import psycopg2.extras
+import pytest
+
+from nexus.agents.orrery.events import _apply_state_delta_sync
+from nexus.agents.orrery.needs import load_need_tuning
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.substrate import (
+    BranchSelection,
+    ProjectPolicy,
+    ProjectState,
+    RoutineAnchor,
+    Slot,
+    TravelState,
+    WorldState,
+    evaluate,
+)
+from nexus.agents.orrery.templates import (
+    ADVANCE_BUILD_VENTURE,
+    START_BUILD_VENTURE,
+)
+from nexus.api.slot_utils import get_slot_db_url
+
+
+ACTOR = 10
+HUNTER = 20
+NOW = datetime(2073, 8, 2, 12, tzinfo=timezone.utc)
+POLICY = ProjectPolicy(
+    enabled=True,
+    advance_interval_hours=24.0,
+    max_active_per_character=1,
+    stall_abandon_threshold=3,
+    abandon_after_stalled_world_hours=168.0,
+    milestone_magnitude=0.40,
+    coverage_distribution_tolerance=0.05,
+)
+BINDINGS = {Slot.ACTOR: ACTOR}
+
+
+def _start_state(*, pair_tags: dict[tuple[int, int], frozenset[str]] | None = None):
+    return WorldState(
+        locations={ACTOR: 1},
+        pair_tags=pair_tags or {},
+        travel_states={ACTOR: TravelState(status="at_place")},
+        project_policy=POLICY,
+        routine_anchors={
+            (ACTOR, "home"): RoutineAnchor(
+                anchor_type="home", place_id=1, mobility_policy="fixed_place"
+            )
+        },
+        world_time=NOW,
+    )
+
+
+def _project(
+    *,
+    stage: str = "laying_groundwork",
+    progress: float = 0.0,
+    stall_count: int = 0,
+    due_at: datetime = NOW,
+) -> ProjectState:
+    return ProjectState(
+        id=7,
+        project_type="build_venture",
+        status="active",
+        stage=stage,
+        progress=progress,
+        stall_count=stall_count,
+        next_eligible_at_world_time=due_at,
+        source_chunk_id=100,
+    )
+
+
+def _advance_state(project: ProjectState, *, world_time: datetime = NOW) -> WorldState:
+    return WorldState(
+        project_states={ACTOR: project},
+        project_policy=POLICY,
+        travel_states={ACTOR: TravelState(status="at_place")},
+        world_time=world_time,
+    )
+
+
+def test_entry_gate_is_actor_only_stable_and_target_free() -> None:
+    eligible = evaluate(START_BUILD_VENTURE, _start_state(), BINDINGS)
+    assert eligible.passes is True
+    assert START_BUILD_VENTURE.required_slots == (Slot.ACTOR,)
+    assert START_BUILD_VENTURE.binds_project_target is False
+    assert START_BUILD_VENTURE.binds_project_faction is False
+    assert START_BUILD_VENTURE.starts_from_social_contact is False
+    assert eligible.state_delta == {
+        "project.start": {
+            "project_type": "build_venture",
+            "stage": "laying_groundwork",
+            "milestone": True,
+        }
+    }
+
+    hunted = _start_state(pair_tags={(HUNTER, ACTOR): frozenset({"hunting"})})
+    hostile = _start_state(pair_tags={(HUNTER, ACTOR): frozenset({"hostile_to"})})
+    assert evaluate(START_BUILD_VENTURE, hunted, BINDINGS).passes is False
+    assert evaluate(START_BUILD_VENTURE, hostile, BINDINGS).passes is False
+
+
+@pytest.mark.parametrize(
+    ("project", "expected_label", "delta_key"),
+    (
+        (
+            _project(stage="opening_doors", progress=1.0),
+            "Open the doors",
+            "project.complete",
+        ),
+        (
+            _project(stall_count=POLICY.stall_abandon_threshold),
+            "Let the venture go",
+            "project.abandon",
+        ),
+        (
+            _project(stage="laying_groundwork", progress=1.0),
+            "Turn groundwork into backing",
+            "project.advance",
+        ),
+        (
+            _project(stage="securing_backing", progress=1.0),
+            "Turn backing into an opening",
+            "project.advance",
+        ),
+        (
+            _project(
+                stage="opening_doors",
+                progress=0.5,
+                due_at=NOW - timedelta(hours=POLICY.advance_interval_hours),
+            ),
+            "Lose ground through neglect",
+            "project.stall",
+        ),
+        (
+            _project(stage="laying_groundwork", progress=0.2),
+            "Make the venture legible",
+            "project.advance",
+        ),
+        (
+            _project(stage="securing_backing", progress=0.2),
+            "Secure one more commitment",
+            "project.advance",
+        ),
+        (
+            _project(stage="opening_doors", progress=0.2),
+            "Finish the next opening task",
+            "project.advance",
+        ),
+    ),
+)
+def test_full_branch_ladder_traversal(
+    project: ProjectState, expected_label: str, delta_key: str
+) -> None:
+    resolution = evaluate(
+        ADVANCE_BUILD_VENTURE,
+        _advance_state(project),
+        BINDINGS,
+        BranchSelection(mode="authored_order"),
+    )
+    assert resolution.branch_label == expected_label
+    assert delta_key in resolution.state_delta
+    if expected_label in {
+        "Make the venture legible",
+        "Secure one more commitment",
+        "Finish the next opening task",
+    }:
+        assert resolution.promotable is False
+
+
+def _create_runtime_schema(cur: Any, schema: str) -> None:
+    cur.execute(f'CREATE SCHEMA "{schema}"')
+    cur.execute(f'SET LOCAL search_path = "{schema}", public')
+    cur.execute(
+        """
+        CREATE TABLE event_types (
+            type text PRIMARY KEY, category text NOT NULL,
+            severity text NOT NULL, description text
+        );
+        CREATE TABLE tag_category_registry (
+            category text NOT NULL, entity_kind entity_kind NOT NULL,
+            prompt_order integer NOT NULL, description text,
+            deprecated boolean NOT NULL DEFAULT false,
+            replacement_categories text[], PRIMARY KEY (category, entity_kind)
+        );
+        CREATE TABLE tags (
+            id bigserial PRIMARY KEY, tag text UNIQUE NOT NULL,
+            category text NOT NULL, is_ephemeral boolean NOT NULL DEFAULT false,
+            clearance_kind entity_tag_clearance_kind,
+            reapplication_policy entity_tag_reapplication_policy,
+            clear_on jsonb, synonym_for bigint,
+            deprecated boolean NOT NULL DEFAULT false, description text,
+            CHECK (is_ephemeral = (clearance_kind IS NOT NULL))
+        );
+        CREATE TABLE entity_tags (
+            id bigserial PRIMARY KEY, entity_id bigint NOT NULL,
+            tag_id bigint NOT NULL, applied_at timestamptz NOT NULL DEFAULT now(),
+            applied_at_world_time timestamptz, clear_on_override jsonb,
+            cleared_at timestamptz, template_id text,
+            source_kind entity_tag_source_kind NOT NULL, source_chunk_id bigint
+        );
+        CREATE UNIQUE INDEX ix_entity_tags_current
+            ON entity_tags (entity_id, tag_id) WHERE cleared_at IS NULL;
+        CREATE TABLE orrery_resolutions (
+            id bigint PRIMARY KEY, state_delta jsonb NOT NULL
+        );
+        CREATE TABLE character_project_states (
+            id bigserial PRIMARY KEY, character_entity_id bigint NOT NULL,
+            project_type text NOT NULL, status text NOT NULL,
+            stage text NOT NULL, target_place_id bigint,
+            target_character_entity_id bigint, target_faction_entity_id bigint,
+            progress numeric(5,4) NOT NULL DEFAULT 0,
+            stall_count integer NOT NULL DEFAULT 0,
+            next_eligible_at_world_time timestamptz, source_chunk_id bigint,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now(),
+            CONSTRAINT character_project_states_project_type_check
+                CHECK (project_type IN ('plan_relocation', 'recruit_ally')),
+            CONSTRAINT character_project_states_stage_by_type_check CHECK (
+                (project_type = 'plan_relocation'
+                    AND stage IN ('saving', 'scouting', 'committing')) OR
+                (project_type = 'recruit_ally'
+                    AND stage IN (
+                        'sounding_out', 'earning_trust', 'sealing_commitment'
+                    ))
+            ),
+            CONSTRAINT character_project_states_target_by_type_check CHECK (
+                (project_type = 'plan_relocation'
+                    AND target_character_entity_id IS NULL) OR
+                (project_type = 'recruit_ally'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NOT NULL)
+            ),
+            CONSTRAINT character_project_states_completed_target_check CHECK (
+                status <> 'completed' OR
+                (project_type = 'plan_relocation' AND target_place_id IS NOT NULL) OR
+                (project_type = 'recruit_ally'
+                    AND target_character_entity_id IS NOT NULL)
+            )
+        );
+        CREATE UNIQUE INDEX ux_character_project_states_open_budget
+            ON character_project_states (character_entity_id)
+            WHERE status IN ('active', 'paused', 'stalled')
+        """
+    )
+    migration_sql = (
+        Path(__file__).parents[2] / "migrations" / "084_build_venture_projects.sql"
+    ).read_text()
+    cur.execute(migration_sql)
+
+
+@pytest.fixture()
+def live_venture_db() -> Iterator[dict[str, Any]]:
+    """Use live entities/time with project writes isolated in a throwaway schema."""
+
+    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    schema = f"build_venture_{uuid4().hex[:12]}"
+    try:
+        with conn.cursor() as cur:
+            _create_runtime_schema(cur, schema)
+            cur.execute(
+                "SELECT entity_id FROM characters WHERE entity_id IS NOT NULL "
+                "ORDER BY id LIMIT 2"
+            )
+            actor, other = (int(row[0]) for row in cur.fetchall())
+            cur.execute(
+                "SELECT cm.chunk_id, cm.world_time FROM chunk_metadata cm "
+                "WHERE cm.world_time IS NOT NULL ORDER BY cm.chunk_id DESC LIMIT 1"
+            )
+            chunk_id, world_time = cur.fetchone()
+        yield {
+            "conn": conn,
+            "actor": actor,
+            "other": other,
+            "chunk_id": int(chunk_id),
+            "world_time": world_time,
+            "resolution_ids": count(1),
+        }
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def _apply(db: dict[str, Any], draft: OrreryResolutionDraft) -> int:
+    resolution_id = next(db["resolution_ids"])
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "INSERT INTO orrery_resolutions (id, state_delta) VALUES (%s, %s::jsonb)",
+            (resolution_id, psycopg2.extras.Json(draft.state_delta)),
+        )
+        return _apply_state_delta_sync(
+            cur,
+            draft,
+            resolution_id=resolution_id,
+            actor_entity_id=int(db["actor"]),
+            target_entity_id=None,
+            source_chunk_id=int(db["chunk_id"]),
+            need_tuning=load_need_tuning(),
+            project_policy=POLICY,
+        )
+
+
+def _row(db: dict[str, Any]) -> tuple[Any, ...]:
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            """
+            SELECT project_type, status, stage, target_place_id,
+                   target_character_entity_id, target_faction_entity_id,
+                   progress, stall_count
+            FROM character_project_states
+            WHERE character_entity_id = %s ORDER BY id DESC LIMIT 1
+            """,
+            (db["actor"],),
+        )
+        return cur.fetchone()
+
+
+@pytest.mark.requires_postgres
+def test_live_applier_runs_start_progress_milestones_and_completion(
+    live_venture_db: dict[str, Any],
+) -> None:
+    db = live_venture_db
+    actor = int(db["actor"])
+    start = OrreryResolutionDraft(
+        template_id="start_build_venture",
+        priority=17,
+        binding_hash="build-start",
+        bindings={"actor": actor},
+        branch_label="Lay the first groundwork",
+        narrative_stub="start",
+        state_delta={
+            "project.start": {
+                "project_type": "build_venture",
+                "stage": "laying_groundwork",
+                "milestone": True,
+            }
+        },
+        magnitude=0.4,
+    )
+    assert _apply(db, start) == 0
+    assert _row(db)[:6] == (
+        "build_venture",
+        "active",
+        "laying_groundwork",
+        None,
+        None,
+        None,
+    )
+
+    progress = replace(
+        start,
+        template_id="advance_build_venture",
+        binding_hash="build-progress",
+        state_delta={"project.advance": {"progress_delta": 0.35}},
+        promotable=False,
+    )
+    assert _apply(db, progress) == 0
+    assert float(_row(db)[6]) == 0.35
+
+    for stage, next_stage in (
+        ("laying_groundwork", "securing_backing"),
+        ("securing_backing", "opening_doors"),
+    ):
+        with db["conn"].cursor() as cur:
+            cur.execute(
+                "UPDATE character_project_states SET stage = %s, progress = 1, "
+                "stall_count = 2 WHERE character_entity_id = %s",
+                (stage, actor),
+            )
+        milestone = replace(
+            start,
+            template_id="advance_build_venture",
+            binding_hash=f"build-{next_stage}",
+            state_delta={
+                "project.advance": {
+                    "stage": next_stage,
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+        )
+        assert _apply(db, milestone) == 0
+        row = _row(db)
+        assert row[2] == next_stage
+        assert float(row[6]) == 0.0
+        assert row[7] == 0
+
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "UPDATE character_project_states SET progress = 1 "
+            "WHERE character_entity_id = %s",
+            (actor,),
+        )
+    complete = replace(
+        start,
+        template_id="advance_build_venture",
+        binding_hash="build-complete",
+        state_delta={
+            "project.complete": {"milestone": True},
+            "entity_tags.add": ["proprietor"],
+        },
+    )
+    assert _apply(db, complete) == 1
+    assert _row(db)[1] == "completed"
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            """
+            SELECT t.tag, et.template_id, et.source_chunk_id
+            FROM entity_tags et JOIN tags t ON t.id = et.tag_id
+            WHERE et.entity_id = %s AND et.cleared_at IS NULL
+            """,
+            (actor,),
+        )
+        assert cur.fetchall() == [
+            ("proprietor", "advance_build_venture", db["chunk_id"])
+        ]
+        cur.execute(
+            "SELECT state_delta FROM orrery_resolutions " "WHERE id = %s",
+            (next(db["resolution_ids"]) - 1,),
+        )
+        applied = cur.fetchone()[0]["project.complete"]["applied"]
+    assert applied["status"] == "completed"
+    assert applied["target_place_id"] is None
+    assert applied["target_character_entity_id"] is None
+    assert applied["target_faction_entity_id"] is None
+
+
+@pytest.mark.requires_postgres
+def test_live_stall_abandon_and_budget_interaction(
+    live_venture_db: dict[str, Any],
+) -> None:
+    db = live_venture_db
+    actor = int(db["actor"])
+    other = int(db["other"])
+    start = OrreryResolutionDraft(
+        template_id="start_build_venture",
+        priority=17,
+        binding_hash="build-stall-start",
+        bindings={"actor": actor},
+        branch_label="start",
+        narrative_stub="start",
+        state_delta={
+            "project.start": {
+                "project_type": "build_venture",
+                "stage": "laying_groundwork",
+            }
+        },
+    )
+    _apply(db, start)
+    with db["conn"].cursor() as cur:
+        cur.execute("SAVEPOINT budget")
+        with pytest.raises(psycopg2.errors.UniqueViolation):
+            cur.execute(
+                """
+                INSERT INTO character_project_states (
+                    character_entity_id, project_type, status, stage
+                ) VALUES (%s, 'build_venture', 'active', 'laying_groundwork')
+                """,
+                (actor,),
+            )
+        cur.execute("ROLLBACK TO SAVEPOINT budget")
+
+    stall = replace(
+        start,
+        template_id="advance_build_venture",
+        binding_hash="build-stall",
+        state_delta={"project.stall": {"increment": 1}},
+    )
+    _apply(db, stall)
+    assert _row(db)[1] == "stalled"
+    assert _row(db)[7] == 1
+
+    abandon = replace(
+        start,
+        template_id="advance_build_venture",
+        binding_hash="build-abandon",
+        state_delta={
+            "project.abandon": {
+                "reason": "stalled_or_overdue",
+                "milestone": True,
+            }
+        },
+    )
+    _apply(db, abandon)
+    assert _row(db)[1] == "abandoned"
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO character_project_states (
+                character_entity_id, project_type, status, stage
+            ) VALUES (%s, 'build_venture', 'active', 'laying_groundwork')
+            """,
+            (actor,),
+        )
+        cur.execute(
+            """
+            INSERT INTO character_project_states (
+                character_entity_id, project_type, status, stage
+            ) VALUES (%s, 'build_venture', 'active', 'laying_groundwork')
+            """,
+            (other,),
+        )
+
+
+@pytest.mark.requires_postgres
+def test_live_start_rejects_every_target_column(
+    live_venture_db: dict[str, Any],
+) -> None:
+    db = live_venture_db
+    for key in (
+        "target_place_id",
+        "target_character_entity_id",
+        "target_faction_entity_id",
+    ):
+        draft = OrreryResolutionDraft(
+            template_id="start_build_venture",
+            priority=17,
+            binding_hash=f"reject-{key}",
+            bindings={"actor": db["actor"]},
+            branch_label="reject target",
+            narrative_stub="reject",
+            state_delta={
+                "project.start": {
+                    "project_type": "build_venture",
+                    "stage": "laying_groundwork",
+                    key: 999,
+                }
+            },
+        )
+        with db["conn"].cursor() as cur:
+            cur.execute("SAVEPOINT reject_target")
+            cur.execute(
+                "INSERT INTO orrery_resolutions (id, state_delta) "
+                "VALUES (%s, '{}'::jsonb)",
+                (next(db["resolution_ids"]),),
+            )
+            with pytest.raises(ValueError, match="forbids all targets"):
+                _apply_state_delta_sync(
+                    cur,
+                    draft,
+                    resolution_id=next(db["resolution_ids"]),
+                    actor_entity_id=int(db["actor"]),
+                    target_entity_id=None,
+                    source_chunk_id=int(db["chunk_id"]),
+                    need_tuning=load_need_tuning(),
+                    project_policy=POLICY,
+                )
+            cur.execute("ROLLBACK TO SAVEPOINT reject_target")

--- a/tests/test_orrery/test_build_venture_replay.py
+++ b/tests/test_orrery/test_build_venture_replay.py
@@ -1,0 +1,243 @@
+"""Checkpoint replay coverage for the BUILD_VENTURE lifecycle."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2
+import psycopg2.extras
+import pytest
+
+from nexus.agents.orrery.events import _apply_state_delta_sync
+from nexus.agents.orrery.needs import load_need_tuning
+from nexus.agents.orrery.reconstruction import capture_state_checkpoint_sync
+from nexus.agents.orrery.replay import reconstruct_state_at_sync
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.substrate import ProjectPolicy
+from nexus.api.slot_utils import get_slot_db_url
+
+
+pytestmark = pytest.mark.requires_postgres
+POLICY = ProjectPolicy(enabled=True, advance_interval_hours=24.0)
+
+
+def _create_schema(cur: Any, schema: str) -> None:
+    cur.execute(f'CREATE SCHEMA "{schema}"')
+    cur.execute(f'SET LOCAL search_path = "{schema}", public')
+    cur.execute(
+        """
+        CREATE TABLE event_types (
+            type text PRIMARY KEY, category text NOT NULL,
+            severity text NOT NULL, description text
+        );
+        CREATE TABLE tag_category_registry (
+            category text NOT NULL, entity_kind entity_kind NOT NULL,
+            prompt_order integer NOT NULL, description text,
+            deprecated boolean NOT NULL DEFAULT false,
+            replacement_categories text[], PRIMARY KEY (category, entity_kind)
+        );
+        CREATE TABLE tags (
+            id bigserial PRIMARY KEY, tag text UNIQUE NOT NULL,
+            category text NOT NULL, is_ephemeral boolean NOT NULL DEFAULT false,
+            clearance_kind entity_tag_clearance_kind,
+            reapplication_policy entity_tag_reapplication_policy,
+            clear_on jsonb, synonym_for bigint,
+            deprecated boolean NOT NULL DEFAULT false, description text,
+            CHECK (is_ephemeral = (clearance_kind IS NOT NULL))
+        );
+        CREATE TABLE entity_tags (
+            id bigserial PRIMARY KEY, entity_id bigint NOT NULL,
+            tag_id bigint NOT NULL, applied_at timestamptz NOT NULL DEFAULT now(),
+            applied_at_world_time timestamptz, clear_on_override jsonb,
+            cleared_at timestamptz, template_id text,
+            source_kind entity_tag_source_kind NOT NULL, source_chunk_id bigint
+        );
+        CREATE UNIQUE INDEX ix_entity_tags_current
+            ON entity_tags (entity_id, tag_id) WHERE cleared_at IS NULL;
+        CREATE TABLE orrery_resolutions (
+            id bigserial PRIMARY KEY, tick_chunk_id bigint NOT NULL,
+            actor_entity_id bigint, state_delta jsonb NOT NULL
+        );
+        CREATE TABLE character_project_states (
+            id bigserial PRIMARY KEY, character_entity_id bigint NOT NULL,
+            project_type text NOT NULL, status text NOT NULL,
+            stage text NOT NULL, target_place_id bigint,
+            target_character_entity_id bigint, target_faction_entity_id bigint,
+            progress numeric(5,4) NOT NULL DEFAULT 0,
+            stall_count integer NOT NULL DEFAULT 0,
+            next_eligible_at_world_time timestamptz, source_chunk_id bigint,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now(),
+            CONSTRAINT character_project_states_project_type_check
+                CHECK (project_type IN ('plan_relocation', 'recruit_ally')),
+            CONSTRAINT character_project_states_stage_by_type_check CHECK (
+                (project_type = 'plan_relocation'
+                    AND stage IN ('saving', 'scouting', 'committing')) OR
+                (project_type = 'recruit_ally'
+                    AND stage IN (
+                        'sounding_out', 'earning_trust', 'sealing_commitment'
+                    ))
+            ),
+            CONSTRAINT character_project_states_target_by_type_check CHECK (
+                (project_type = 'plan_relocation'
+                    AND target_character_entity_id IS NULL) OR
+                (project_type = 'recruit_ally'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NOT NULL)
+            ),
+            CONSTRAINT character_project_states_completed_target_check CHECK (
+                status <> 'completed' OR
+                (project_type = 'plan_relocation' AND target_place_id IS NOT NULL) OR
+                (project_type = 'recruit_ally'
+                    AND target_character_entity_id IS NOT NULL)
+            )
+        );
+        CREATE UNIQUE INDEX ux_character_project_states_open_budget
+            ON character_project_states (character_entity_id)
+            WHERE status IN ('active', 'paused', 'stalled')
+        """
+    )
+    cur.execute(
+        (
+            Path(__file__).parents[2] / "migrations" / "084_build_venture_projects.sql"
+        ).read_text()
+    )
+
+
+@pytest.fixture()
+def replay_db() -> Iterator[dict[str, Any]]:
+    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    try:
+        with conn.cursor() as cur:
+            _create_schema(cur, f"build_venture_replay_{uuid4().hex[:12]}")
+            cur.execute(
+                "SELECT entity_id FROM characters WHERE entity_id IS NOT NULL "
+                "ORDER BY id LIMIT 1"
+            )
+            actor = int(cur.fetchone()[0])
+            cur.execute("SELECT max(world_time) FROM chunk_metadata")
+            base_time = cur.fetchone()[0] or datetime(2026, 1, 1, tzinfo=timezone.utc)
+        yield {"conn": conn, "actor": actor, "base_time": base_time}
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def _chunk(cur: Any, world_time: datetime, offset: int) -> int:
+    cur.execute(
+        """
+        INSERT INTO narrative_chunks (id, raw_text, created_at)
+        SELECT max(id) + 1, 'BUILD_VENTURE replay probe',
+               now() + make_interval(mins => %s)
+        FROM narrative_chunks RETURNING id
+        """,
+        (offset,),
+    )
+    chunk_id = int(cur.fetchone()[0])
+    cur.execute(
+        "INSERT INTO chunk_metadata (chunk_id, world_time) VALUES (%s, %s)",
+        (chunk_id, world_time),
+    )
+    return chunk_id
+
+
+def _apply(cur: Any, actor: int, chunk_id: int, delta: dict[str, Any]) -> None:
+    cur.execute(
+        "INSERT INTO orrery_resolutions (tick_chunk_id, actor_entity_id, state_delta) "
+        "VALUES (%s, %s, %s::jsonb) RETURNING id",
+        (chunk_id, actor, psycopg2.extras.Json(delta)),
+    )
+    resolution_id = int(cur.fetchone()[0])
+    draft = OrreryResolutionDraft(
+        template_id="build_venture_replay_probe",
+        priority=47,
+        binding_hash=f"build-replay-{chunk_id}",
+        bindings={"actor": actor},
+        branch_label="BUILD_VENTURE replay probe",
+        narrative_stub="probe",
+        state_delta=delta,
+        magnitude=0.4,
+    )
+    _apply_state_delta_sync(
+        cur,
+        draft,
+        resolution_id=resolution_id,
+        actor_entity_id=actor,
+        target_entity_id=None,
+        source_chunk_id=chunk_id,
+        need_tuning=load_need_tuning(),
+        project_policy=POLICY,
+    )
+
+
+def test_build_venture_replays_applied_snapshots_through_completion(
+    replay_db: dict[str, Any],
+) -> None:
+    conn = replay_db["conn"]
+    actor = int(replay_db["actor"])
+    base_time = replay_db["base_time"] + timedelta(hours=1)
+    with conn.cursor() as cur:
+        base_chunk = _chunk(cur, base_time, -4)
+        base_id = capture_state_checkpoint_sync(
+            cur, chunk_id=base_chunk, label="manual"
+        )
+        assert base_id is not None
+        transitions = (
+            {
+                "project.start": {
+                    "project_type": "build_venture",
+                    "stage": "laying_groundwork",
+                    "milestone": True,
+                }
+            },
+            {
+                "project.advance": {
+                    "stage": "securing_backing",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            {
+                "project.advance": {
+                    "stage": "opening_doors",
+                    "set_progress": 1.0,
+                    "milestone": True,
+                }
+            },
+            {
+                "project.complete": {"milestone": True},
+                "entity_tags.add": ["proprietor"],
+            },
+        )
+        chunks = []
+        for step, delta in enumerate(transitions, start=1):
+            chunk_id = _chunk(cur, base_time + timedelta(hours=24 * step), step)
+            _apply(cur, actor, chunk_id, delta)
+            chunks.append(chunk_id)
+
+        reconstructed = reconstruct_state_at_sync(
+            cur, chunks[-1], base_checkpoint_id=int(base_id)
+        )
+        projects = [
+            row
+            for row in reconstructed.state["character_project_states"]
+            if row["character_entity_id"] == actor
+            and row["project_type"] == "build_venture"
+        ]
+        assert len(projects) == 1
+        assert projects[0]["status"] == "completed"
+        assert projects[0]["stage"] == "opening_doors"
+        assert float(projects[0]["progress"]) == 1.0
+        assert projects[0]["target_place_id"] is None
+        assert projects[0]["target_character_entity_id"] is None
+        assert projects[0]["target_faction_entity_id"] is None
+
+        cur.execute("SELECT id FROM tags WHERE tag = 'proprietor'")
+        proprietor_id = int(cur.fetchone()[0])
+        assert any(
+            row["entity_id"] == actor and row["tag_id"] == proprietor_id
+            for row in reconstructed.state["entity_tags"]
+        )

--- a/tests/test_orrery/test_catalog.py
+++ b/tests/test_orrery/test_catalog.py
@@ -58,6 +58,20 @@ def test_catalog_includes_every_branch() -> None:
             )
 
 
+def test_catalog_renders_build_venture_completion_vocabulary() -> None:
+    """The actor-only venture and its durable founder trace stay discoverable."""
+
+    content = render_catalog(BUILTIN_TEMPLATES)
+
+    assert "## START_BUILD_VENTURE — priority 17" in content
+    assert "## ADVANCE_BUILD_VENTURE — priority 47" in content
+    assert "actor `build_venture` project passes `completion` due-state" in content
+    assert (
+        "applies project `complete` transition; adds `proprietor` to actor" in content
+    )
+    assert "- `proprietor`" in content
+
+
 def test_catalog_renders_compound_structure() -> None:
     """AND / OR / NOT compositions appear as labeled nested bullets."""
 

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -96,6 +96,31 @@ def test_recruit_ally_migration_discovers_legacy_completion_check() -> None:
     )
 
 
+def test_build_venture_migration_replaces_named_three_type_constraints() -> None:
+    """Migration 084 uses the stable post-077 names and preserves all arms."""
+
+    migration_sql = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "084_build_venture_projects.sql"
+    ).read_text()
+
+    for name in (
+        "character_project_states_project_type_check",
+        "character_project_states_stage_by_type_check",
+        "character_project_states_target_by_type_check",
+        "character_project_states_completed_target_check",
+    ):
+        assert f"DROP CONSTRAINT IF EXISTS {name}" in migration_sql
+        assert f"ADD CONSTRAINT {name}" in migration_sql
+        assert f"COMMENT ON CONSTRAINT {name}" in migration_sql
+    for project_type in ("plan_relocation", "recruit_ally", "build_venture"):
+        assert migration_sql.count(f"project_type = '{project_type}'") >= 3
+    assert "pg_get_constraintdef" not in migration_sql
+    assert "'proprietor'" in migration_sql
+    assert "'role.function'" in migration_sql
+
+
 def test_retrograde_persistence_migration_adds_distinct_sources() -> None:
     """Retrograde canonical writes need explicit event and tag provenance."""
 

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -2886,3 +2886,43 @@ def test_pair_fanout_quota_prefers_template_diversity() -> None:
     assert ("surveil", 3) in kept
     assert ("reach_out", 5) in kept
     assert len(kept) == 4
+
+
+def test_project_start_arbitration_keeps_one_start_per_actor() -> None:
+    """Cross-stack assembly keeps at most one project.start draft per actor."""
+
+    from nexus.agents.orrery.resolver import _arbitrate_project_starts
+    from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+
+    def draft(template_id: str, actor: int, target: int | None = None):
+        bindings: dict[str, int] = {"actor": actor}
+        if target is not None:
+            bindings["target"] = target
+        return OrreryResolutionDraft(
+            template_id=template_id,
+            priority=17,
+            binding_hash=f"hash-{template_id}-{actor}-{target}",
+            bindings=bindings,
+            branch_label="x",
+            narrative_stub="{actor} acts.",
+            magnitude=0.4,
+        )
+
+    drafts = [
+        # Assembly order: the actor-only stack precedes routed pair stacks.
+        draft("start_build_venture", actor=1),
+        draft("surveil", actor=1, target=9),
+        draft("start_recruit_ally", actor=1, target=2),
+        draft("start_recruit_ally", actor=1, target=3),
+        draft("start_recruit_ally", actor=5, target=2),
+    ]
+    kept = [
+        (d.template_id, d.bindings.get("actor"), d.bindings.get("target"))
+        for d in _arbitrate_project_starts(drafts, list(BUILTIN_TEMPLATES))
+    ]
+    # Actor 1 keeps its first start (the venture) and loses both recruit
+    # starts; non-start drafts and other actors are untouched.
+    assert ("start_build_venture", 1, None) in kept
+    assert ("surveil", 1, 9) in kept
+    assert ("start_recruit_ally", 5, 2) in kept
+    assert len(kept) == 3


### PR DESCRIPTION
## Summary

Third aspiration-band package per the #496 Arachne ruling (seq 5: build all four remaining packages, order VENTURE → ROMANCE → PATRON → REDEMPTION). `build_venture` is the family's structural minimum — **actor-only, no target columns at any stage** — an off-screen character stands up a business/workshop/crew.

- **Stage ladder**: `laying_groundwork` → `securing_backing` → `opening_doors`
- **Completion**: bestows the newly registered `proprietor` tag (`role.function`) on the founder via the existing idempotent `entity_tags.add` verb, atomically with `project.complete`
- **Entity-birth boundary (deliberate)**: Orrery does NOT mint the venture as a faction. The milestone-magnitude `build_venture_completed` event reaches the Storyteller, who may instantiate the venture via the existing new-entity declaration machinery (`pair_tag_hints` can carry founder standing). Rationale: the migration-081 faction binding is immutable-at-entry/pre-existing-only, entity birth is owned by the narrative-commit layer, and deterministic code should not name a business.
- **Migration 084**: widens the four named evolving constraints, seeds six `build_venture_*` event types, registers `proprietor`
- **Fixed en route**: replay projection validation previously assumed every non-relocation type was `recruit_ally` (untyped `elif`); it now dispatches per project type
- **Out of scope** (recorded): Retrograde spawn-sourcing (own future slice); project budget stays 1

## Validation

- `poetry run pytest -q` → **1429 passed, 294 skipped, 0 failed** (baseline before branch: 1418/288)
- `NEXUS_RUN_POSTGRES=1 pytest tests/test_orrery/test_build_venture_*.py` → **15 passed** (live PG incl. real-migration contract in a throwaway schema)
- `python -m nexus.agents.orrery.catalog --check` → clean
- `mypy` clean on all changed files (26 pre-existing errors in six untouched Retrograde/tag files are main-branch debt, unrelated)

## Schema/Data Impact

Migration 084 is pending everywhere (template + save_01–05); additive only — no data movement, existing plan_relocation/recruit_ally rows unaffected. Will be applied at merge closeout.

Implemented by Sol (GPT-5.6 Codex) from a frozen spec; reviewed line-by-line by Claude. Part of the #496 campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TJVTXfD7TouQuxmYfVf8w