### PR TITLE
Add the PURSUE_ROMANCE Aspiration Package (#496 Slice 4)

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -923,6 +923,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - actor has enough hydrated context
   - **NOT:** actor `plan_relocation` project passes `ready` due-state
   - **NOT:** actor `recruit_ally` project passes `ready` due-state
+  - **NOT:** actor `pursue_romance` project passes `ready` due-state
   - **NOT:** actor is constrained or immobilized
   - **NOT:** actor has inbound `hunting` pair tag
   - **NOT:** actor has `grudge_active` ephemeral
@@ -1134,7 +1135,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 - **AND:**
   - actor `recruit_ally` project passes `ready` due-state
-  - advancing recruitment of target
+  - target is the project's bound target
   - **NOT:** actor is in transit
   - **NOT:** actor is constrained or immobilized
   - **NOT:**
@@ -1147,7 +1148,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 **When:**
 
-- **NOT:** target is the project's active-character recruit
+- **NOT:** target is the project's target and still an active character
 
 **Does:** applies project `abandon` transition
 **Event:** `recruit_ally_abandoned`
@@ -1350,7 +1351,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 - **AND:**
   - actor `pursue_romance` project passes `ready` due-state
-  - advancing recruitment of target
+  - target is the project's bound target
   - **NOT:** actor is in transit
   - **NOT:** actor is constrained or immobilized
   - **NOT:**
@@ -1363,7 +1364,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 **When:**
 
-- **NOT:** target is the project's active-character recruit
+- **NOT:** target is the project's target and still an active character
 
 **Does:** applies project `abandon` transition
 **Event:** `pursue_romance_abandoned`
@@ -1377,6 +1378,8 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 - **AND:**
   - actor `pursue_romance` project passes `completion` due-state
   - actor and target have mutual warm trust
+  - **NOT:** actor has any of [`hostile_to`, `hunting`] pair tags to target
+  - **NOT:** target has any of [`hostile_to`, `hunting`] pair tags to actor
 
 **Does:** applies project `complete` transition; adds outbound `contact:intimate` pair tag to target and upserts the actor→target `romantic` relationship
 **Event:** `pursue_romance_completed`

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1339,6 +1339,129 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 ---
 
+## ADVANCE_PURSUE_ROMANCE — priority 47
+
+> A due courtship tests the waters, grows closer, declares intention, stalls, is rebuffed, or becomes mutual.
+
+**Drive band:** project identity — A due courtship shares the established project-continuation slot while cadence and embodied guards preserve routine stability.
+**Slots:** ACTOR, TARGET
+
+**Gate:**
+
+- **AND:**
+  - actor `pursue_romance` project passes `ready` due-state
+  - advancing recruitment of target
+  - **NOT:** actor is in transit
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:**
+    - **OR:**
+      - actor has `sleep` debt ≥ 8
+      - actor has `thirst` debt ≥ 2
+      - actor has `hunger` debt ≥ 4
+
+### Branch 1 — End a courtship whose target is no longer available  *(mag 0.4)* · **preemptive**
+
+**When:**
+
+- **NOT:** target is the project's active-character recruit
+
+**Does:** applies project `abandon` transition
+**Event:** `pursue_romance_abandoned`
+
+> {target} is no longer someone this courtship can reach. {actor} releases the hope rather than preserving an impossible promise.
+
+### Branch 2 — Declare the feeling and be answered  *(mag 0.4)* · **preemptive**
+
+**When:**
+
+- **AND:**
+  - actor `pursue_romance` project passes `completion` due-state
+  - actor and target have mutual warm trust
+
+**Does:** applies project `complete` transition; adds outbound `contact:intimate` pair tag to target and upserts the actor→target `romantic` relationship
+**Event:** `pursue_romance_completed`
+
+> {actor} finally names what has grown between them, and {target} answers with warmth of their own. The courtship becomes a relationship both can recognize.
+
+### Branch 3 — Withdraw after being rebuffed  *(mag 0.4)* · **preemptive**
+
+**When:**
+
+- **OR:**
+  - actor has any of [`hostile_to`, `hunting`] pair tags to target
+  - target has any of [`hostile_to`, `hunting`] pair tags to actor
+  - trust target→actor < -1
+
+**Does:** applies project `abandon` transition
+**Event:** `pursue_romance_abandoned`
+
+> {target}'s answer closes the possibility, whether through plain refusal, disapproval, or danger. {actor} stops pursuing what is not mutual.
+
+### Branch 4 — Let the courtship go rather than force it  *(mag 0.4)* · **preemptive**
+
+**When:** actor `pursue_romance` project passes `abandon` due-state
+
+**Does:** applies project `abandon` transition
+**Event:** `pursue_romance_abandoned`
+
+> Delay has become its own answer. {actor} stops asking the unfinished courtship to become something it has not become.
+
+### Branch 5 — Let tentative interest become closeness  *(mag 0.4)* · **preemptive**
+
+**When:** actor `pursue_romance` project passes `testing_waters_milestone` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `pursue_romance_milestone`
+
+> The first openings have been met rather than ignored. {actor} and {target} begin making room for a closeness neither needs to disguise as accident.
+
+### Branch 6 — Move from closeness toward declared intention  *(mag 0.4)* · **preemptive**
+
+**When:** actor `pursue_romance` project passes `growing_closer_milestone` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `pursue_romance_milestone`
+
+> What has grown between them is too deliberate to leave unnamed. {actor} prepares to say plainly what they want and hear plainly what {target} wants in return.
+
+### Branch 7 — Lose romantic ground through neglect  *(mag 0.1)* · **preemptive** · **not promotable**
+
+**When:** actor `pursue_romance` project passes `neglected` due-state
+
+**Does:** applies project `stall` transition
+**Event:** `pursue_romance_stalled`
+
+> Unanswered openings and postponed honesty do their own work. The courtship stalls, still possible but less certain.
+
+### Branch 8 — Offer another honest opening  *(mag 0.18)* · **not promotable**
+
+**When:** actor `pursue_romance` project passes `testing_waters` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `pursue_romance_progressed`
+
+> {actor} offers {target} another unmistakably personal opening and pays attention to whether it is welcomed.
+
+### Branch 9 — Build closeness through chosen time  *(mag 0.18)* · **not promotable**
+
+**When:** actor `pursue_romance` project passes `growing_closer` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `pursue_romance_progressed`
+
+> {actor} and {target} choose time together that asks for more attention and trust than ordinary company.
+
+### Branch 10 — Make the next intention legible  *(mag 0.16)* · **not promotable**
+
+**When:** *(always)*
+
+**Does:** applies project `advance` transition
+**Event:** `pursue_romance_progressed`
+
+> {actor} makes one more part of their intention legible, leaving {target} room for an answer that is genuinely theirs.
+
+---
+
 ## REACH_OUT — priority 40
 
 > A small thread of contact between people who hold each other.
@@ -2258,6 +2381,62 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 ---
 
+## START_PURSUE_ROMANCE — priority 17
+
+> An off-screen character makes a named person the focus of a courtship.
+
+**Drive band:** project identity — A courtship begins only around existing social plausibility and shares the established project-entry priority.
+**Slots:** ACTOR, TARGET
+
+**Gate:**
+
+- **AND:**
+  - actor `pursue_romance` project passes `start` due-state
+  - actor has enough hydrated context
+  - actor is at `home` anchor
+  - **NOT:** actor is in transit
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:**
+    - **OR:**
+      - actor has `sleep` debt ≥ 8
+      - actor has `thirst` debt ≥ 2
+      - actor has `hunger` debt ≥ 4
+  - **OR:**
+    - **AND:**
+      - actor has outbound `contact:social` pair tag
+      - actor has `contact:social` pair tag to target
+    - actor has `friend` relationship to target
+    - target has `friend` relationship to actor
+    - actor has `companion` relationship to target
+    - target has `companion` relationship to actor
+    - actor has `comrade` relationship to target
+    - target has `comrade` relationship to actor
+    - actor has `chosen_kin` relationship to target
+    - target has `chosen_kin` relationship to actor
+    - trust actor→target ≥ 1
+    - actor has `contact:intimate` pair tag to target
+  - **NOT:** actor has any of [`hostile_to`, `hunting`] pair tags to target
+  - **NOT:** target has any of [`hostile_to`, `hunting`] pair tags to actor
+  - **NOT:** actor and target share `lover` relationship (either direction)
+  - **NOT:** actor and target share `partner` relationship (either direction)
+  - **NOT:** actor and target share `romantic` relationship (either direction)
+  - **NOT:** actor and target share `romantic_partner` relationship (either direction)
+  - **NOT:** actor and target share `spouse` relationship (either direction)
+  - **NOT:** actor has `partnered_exclusively` tag
+  - **NOT:** actor has `married` tag
+  - **NOT:** actor has an intimacy suppressor
+
+### Branch 1 — Begin testing the waters  *(mag 0.4)*
+
+**When:** *(always)*
+
+**Does:** applies project `start` transition
+**Event:** `pursue_romance_started`
+
+> {actor} lets {target} see that their attention is no longer merely friendly, offering one small opening without demanding an answer before either of them is ready.
+
+---
+
 ## INTIMACY — priority 16
 
 > The body asks for the kind of connection that is not conversation.
@@ -3173,6 +3352,12 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `mourning_completed`
 - `protective_intervention`
 - `pursue_identity_lead`
+- `pursue_romance_abandoned`
+- `pursue_romance_completed`
+- `pursue_romance_milestone`
+- `pursue_romance_progressed`
+- `pursue_romance_stalled`
+- `pursue_romance_started`
 - `recreation_taken`
 - `recruit_ally_abandoned`
 - `recruit_ally_completed`
@@ -3248,8 +3433,12 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `friend`
 - `guardian`
 - `handler`
+- `lover`
 - `mentor`
+- `partner`
 - `patron`
 - `rival`
 - `romantic`
+- `romantic_partner`
+- `spouse`
 - `ward`

--- a/migrations/008_populate_mock_database.py
+++ b/migrations/008_populate_mock_database.py
@@ -21,7 +21,9 @@ from psycopg2.extras import Json
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 MOCK_DB = "mock"
-CACHE_FILE = Path(__file__).parent.parent / "tests" / "fixtures" / "test_cache_wizard.json"
+CACHE_FILE = (
+    Path(__file__).parent.parent / "tests" / "fixtures" / "test_cache_wizard.json"
+)
 
 
 def _require_fixture_base_timestamp(cache: dict) -> str:
@@ -76,9 +78,7 @@ def populate_wizard_cache(conn, cache: dict):
 
         # Traits moved from new_story_creator columns to assets.traits in
         # migration 010. Reset and repopulate the normalized rows.
-        cur.execute(
-            "UPDATE assets.traits SET is_selected = FALSE, rationale = NULL"
-        )
+        cur.execute("UPDATE assets.traits SET is_selected = FALSE, rationale = NULL")
         for trait_name in selected_traits:
             cur.execute(
                 """
@@ -106,7 +106,8 @@ def populate_wizard_cache(conn, cache: dict):
 
         # Insert wizard cache row
         # Note: Array columns need explicit casting to enum types
-        cur.execute("""
+        cur.execute(
+            """
             INSERT INTO assets.new_story_creator (
                 id, thread_id, target_slot,
                 -- Setting phase
@@ -148,58 +149,60 @@ def populate_wizard_cache(conn, cache: dict):
                 -- Temporal
                 %s
             )
-        """, (
-            cache.get("thread_id", "test_thread_mock"),
-            cache.get("target_slot", 5),
-            # Setting
-            setting.get("genre"),
-            setting.get("secondary_genres"),
-            setting.get("world_name"),
-            setting.get("time_period"),
-            setting.get("tech_level"),
-            setting.get("magic_exists", False),
-            setting.get("magic_description"),
-            setting.get("political_structure"),
-            setting.get("major_conflict"),
-            setting.get("tone"),
-            setting.get("themes"),
-            setting.get("cultural_notes"),
-            setting.get("language_notes"),
-            setting.get("geographic_scope"),
-            setting.get("diegetic_artifact"),
-            # Character
-            concept.get("name"),
-            concept.get("archetype"),
-            concept.get("background"),
-            concept.get("appearance"),
-            # Seed
-            seed.get("seed_type"),
-            seed.get("title"),
-            seed.get("situation"),
-            seed.get("hook"),
-            seed.get("immediate_goal"),
-            seed.get("stakes"),
-            seed.get("tension_source"),
-            seed.get("starting_location"),
-            seed.get("weather"),
-            seed.get("key_npcs"),
-            seed.get("initial_mystery"),
-            seed.get("potential_allies"),
-            seed.get("potential_obstacles"),
-            seed.get("secrets"),
-            # Layer/Zone (cache uses "type" not "layer_type")
-            layer.get("name"),
-            layer.get("type") or layer.get("layer_type", "planet"),
-            layer.get("description"),
-            zone.get("name"),
-            zone.get("summary"),
-            zone.get("boundary_description"),
-            zone.get("approximate_area"),
-            # Location
-            Json(location) if location else None,
-            # Temporal
-            base_timestamp,
-        ))
+        """,
+            (
+                cache.get("thread_id", "test_thread_mock"),
+                cache.get("target_slot", 5),
+                # Setting
+                setting.get("genre"),
+                setting.get("secondary_genres"),
+                setting.get("world_name"),
+                setting.get("time_period"),
+                setting.get("tech_level"),
+                setting.get("magic_exists", False),
+                setting.get("magic_description"),
+                setting.get("political_structure"),
+                setting.get("major_conflict"),
+                setting.get("tone"),
+                setting.get("themes"),
+                setting.get("cultural_notes"),
+                setting.get("language_notes"),
+                setting.get("geographic_scope"),
+                setting.get("diegetic_artifact"),
+                # Character
+                concept.get("name"),
+                concept.get("archetype"),
+                concept.get("background"),
+                concept.get("appearance"),
+                # Seed
+                seed.get("seed_type"),
+                seed.get("title"),
+                seed.get("situation"),
+                seed.get("hook"),
+                seed.get("immediate_goal"),
+                seed.get("stakes"),
+                seed.get("tension_source"),
+                seed.get("starting_location"),
+                seed.get("weather"),
+                seed.get("key_npcs"),
+                seed.get("initial_mystery"),
+                seed.get("potential_allies"),
+                seed.get("potential_obstacles"),
+                seed.get("secrets"),
+                # Layer/Zone (cache uses "type" not "layer_type")
+                layer.get("name"),
+                layer.get("type") or layer.get("layer_type", "planet"),
+                layer.get("description"),
+                zone.get("name"),
+                zone.get("summary"),
+                zone.get("boundary_description"),
+                zone.get("approximate_area"),
+                # Location
+                Json(location) if location else None,
+                # Temporal
+                base_timestamp,
+            ),
+        )
 
     print("✓ Populated assets.new_story_creator")
 
@@ -222,75 +225,100 @@ def populate_post_transition_data(conn, cache: dict):
         cur.execute("TRUNCATE characters CASCADE")
 
         # Insert layer (column is 'type' not 'layer_type')
-        cur.execute("""
+        cur.execute(
+            """
             INSERT INTO layers (id, name, type, description)
             VALUES (1, %s, %s::layer_type, %s)
-        """, (
-            layer.get("name", "Neon Palimpsest Earth"),
-            layer.get("type") or layer.get("layer_type", "planet"),
-            layer.get("description"),
-        ))
+        """,
+            (
+                layer.get("name", "Neon Palimpsest Earth"),
+                layer.get("type") or layer.get("layer_type", "planet"),
+                layer.get("description"),
+            ),
+        )
 
         # Insert zone (FK column is 'layer' not 'layer_id')
         # Note: boundary_description and approximate_area not in base schema
-        cur.execute("""
+        cur.execute(
+            """
             INSERT INTO zones (id, name, summary, layer)
             VALUES (1, %s, %s, 1)
-        """, (
-            zone.get("name", "Rhine-Ruhr Arcology Belt"),
-            zone.get("summary"),
-        ))
+        """,
+            (
+                zone.get("name", "Rhine-Ruhr Arcology Belt"),
+                zone.get("summary"),
+            ),
+        )
 
         # Insert place (type is required, FK column is 'zone' not 'zone_id')
         # Tram car is a 'vehicle' type
-        cur.execute("""
+        cur.execute(
+            """
             INSERT INTO places (id, name, type, summary, zone, extra_data)
             VALUES (1, %s, 'vehicle'::place_type, %s, 1, %s)
-        """, (
-            location.get("name", "Spine-9 Rootline Tram 3B"),
-            location.get("summary"),
-            Json({
-                "atmosphere": location.get("atmosphere"),
-                "notable_features": location.get("notable_features", []),
-                "boundary_description": zone.get("boundary_description"),
-                "approximate_area": zone.get("approximate_area"),
-            }),
-        ))
+        """,
+            (
+                location.get("name", "Spine-9 Rootline Tram 3B"),
+                location.get("summary"),
+                Json(
+                    {
+                        "atmosphere": location.get("atmosphere"),
+                        "notable_features": location.get("notable_features", []),
+                        "boundary_description": zone.get("boundary_description"),
+                        "approximate_area": zone.get("approximate_area"),
+                    }
+                ),
+            ),
+        )
 
         # Insert character
-        cur.execute("""
+        cur.execute(
+            """
             INSERT INTO characters (id, name, appearance, background, current_location, extra_data)
             VALUES (1, %s, %s, %s, 1, %s)
-        """, (
-            concept.get("name", "Kade Imani"),
-            concept.get("appearance"),
-            concept.get("background"),
-            Json({
-                "archetype": concept.get("archetype"),
-                "wildcard_name": character.get("wildcard", {}).get("wildcard_name"),
-                "wildcard_description": character.get("wildcard", {}).get("wildcard_description"),
-            }),
-        ))
+        """,
+            (
+                concept.get("name", "Kade Imani"),
+                concept.get("appearance"),
+                concept.get("background"),
+                Json(
+                    {
+                        "archetype": concept.get("archetype"),
+                        "wildcard_name": character.get("wildcard", {}).get(
+                            "wildcard_name"
+                        ),
+                        "wildcard_description": character.get("wildcard", {}).get(
+                            "wildcard_description"
+                        ),
+                    }
+                ),
+            ),
+        )
 
         # Update global_variables
         cur.execute("DELETE FROM global_variables WHERE id = TRUE")
-        cur.execute("""
+        cur.execute(
+            """
             INSERT INTO global_variables (id, setting, user_character, base_timestamp)
             VALUES (TRUE, %s, 1, %s)
-        """, (
-            Json({
-                "world_name": setting.get("world_name"),
-                "genre": setting.get("genre"),
-                "tone": setting.get("tone"),
-                "themes": setting.get("themes"),
-                "magic_exists": setting.get("magic_exists", False),
-                "magic_description": setting.get("magic_description"),
-                "story_seed": seed,
-                "content": setting.get("diegetic_artifact"),
-                "title": f"Welcome to {setting.get('world_name', 'the World')}",
-            }),
-            base_timestamp,
-        ))
+        """,
+            (
+                Json(
+                    {
+                        "world_name": setting.get("world_name"),
+                        "genre": setting.get("genre"),
+                        "tone": setting.get("tone"),
+                        "themes": setting.get("themes"),
+                        "magic_exists": setting.get("magic_exists", False),
+                        "magic_description": setting.get("magic_description"),
+                        "story_seed": seed,
+                        "content": setting.get("diegetic_artifact"),
+                        "title": f"Welcome to {setting.get('world_name', 'the World')}",
+                    }
+                ),
+                base_timestamp,
+            ),
+        )
 
     print("✓ Populated layers, zones, places, characters, global_variables")
 
@@ -315,7 +343,7 @@ Rain hammers against the hull above. Somewhere in the distance, the city's heart
     choices = [
         "Examine the satchel more closely, testing the seals for signs of tampering",
         "Study the auditor two cars back—their posture, their equipment, their probable threat level",
-        "Make contact with the sleeping medic, a calculated risk to gauge their intentions"
+        "Make contact with the sleeping medic, a calculated risk to gauge their intentions",
     ]
 
     import uuid
@@ -326,7 +354,8 @@ Rain hammers against the hull above. Somewhere in the distance, the city's heart
 
         # Insert bootstrap narrative
         # Note: incubator uses singleton pattern (id=true)
-        cur.execute("""
+        cur.execute(
+            """
             INSERT INTO incubator (
                 id, chunk_id, parent_chunk_id,
                 user_text, storyteller_text, choice_object,
@@ -338,30 +367,40 @@ Rain hammers against the hull above. Somewhere in the distance, the city's heart
                 %s, %s, %s,
                 %s, %s, 'provisional'
             )
-        """, (
-            "Begin the story.",
-            narrative_text,
-            Json({
-                "presented": choices,
-                "selected": None,
-            }),
-            Json({
-                "chronology": {
-                    "episode_transition": "new_episode",  # Valid: continue, new_episode, new_season
-                    "time_delta_minutes": 0,
-                    "time_delta_description": "Story begins",
-                },
-                "world_layer": "primary",
-            }),
-            Json([]),  # entity_updates is an array
-            Json({
-                "characters": [{"character_id": 1, "reference_type": "present"}],
-                "places": [{"place_id": 1, "reference_type": "setting"}],
-                "factions": [],
-            }),
-            str(uuid.uuid4()),  # Generate real UUID
-            "mock_bootstrap_response",
-        ))
+        """,
+            (
+                "Begin the story.",
+                narrative_text,
+                Json(
+                    {
+                        "presented": choices,
+                        "selected": None,
+                    }
+                ),
+                Json(
+                    {
+                        "chronology": {
+                            "episode_transition": "new_episode",  # Valid: continue, new_episode, new_season
+                            "time_delta_minutes": 0,
+                            "time_delta_description": "Story begins",
+                        },
+                        "world_layer": "primary",
+                    }
+                ),
+                Json([]),  # entity_updates is an array
+                Json(
+                    {
+                        "characters": [
+                            {"character_id": 1, "reference_type": "present"}
+                        ],
+                        "places": [{"place_id": 1, "reference_type": "setting"}],
+                        "factions": [],
+                    }
+                ),
+                str(uuid.uuid4()),  # Generate real UUID
+                "mock_bootstrap_response",
+            ),
+        )
 
     print("✓ Populated incubator with bootstrap narrative")
 

--- a/migrations/085_pursue_romance_projects.sql
+++ b/migrations/085_pursue_romance_projects.sql
@@ -1,0 +1,115 @@
+-- 085_pursue_romance_projects.sql
+--
+-- Extend the Orrery project chassis with PURSUE_ROMANCE, a character-targeted
+-- courtship whose named target is bound from entry through completion.
+
+ALTER TABLE character_project_states
+    DROP CONSTRAINT IF EXISTS character_project_states_project_type_check,
+    DROP CONSTRAINT IF EXISTS character_project_states_stage_by_type_check,
+    DROP CONSTRAINT IF EXISTS character_project_states_target_by_type_check,
+    DROP CONSTRAINT IF EXISTS character_project_states_completed_target_check;
+
+ALTER TABLE character_project_states
+    ADD CONSTRAINT character_project_states_project_type_check
+        CHECK (project_type IN (
+            'plan_relocation', 'recruit_ally', 'build_venture',
+            'pursue_romance'
+        )),
+    ADD CONSTRAINT character_project_states_stage_by_type_check
+        CHECK (
+            (project_type = 'plan_relocation'
+                AND stage IN ('saving', 'scouting', 'committing'))
+            OR
+            (project_type = 'recruit_ally'
+                AND stage IN (
+                    'sounding_out', 'earning_trust', 'sealing_commitment'
+                ))
+            OR
+            (project_type = 'build_venture'
+                AND stage IN (
+                    'laying_groundwork', 'securing_backing', 'opening_doors'
+                ))
+            OR
+            (project_type = 'pursue_romance'
+                AND stage IN (
+                    'testing_waters', 'growing_closer', 'declaring_intentions'
+                ))
+        ),
+    ADD CONSTRAINT character_project_states_target_by_type_check
+        CHECK (
+            (project_type = 'plan_relocation'
+                AND target_character_entity_id IS NULL)
+            OR
+            (project_type = 'recruit_ally'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NOT NULL)
+            OR
+            (project_type = 'build_venture'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NULL
+                AND target_faction_entity_id IS NULL)
+            OR
+            (project_type = 'pursue_romance'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NOT NULL
+                AND target_faction_entity_id IS NULL)
+        ),
+    ADD CONSTRAINT character_project_states_completed_target_check
+        CHECK (
+            status <> 'completed'
+            OR (project_type = 'plan_relocation' AND target_place_id IS NOT NULL)
+            OR (
+                project_type = 'recruit_ally'
+                AND target_character_entity_id IS NOT NULL
+            )
+            OR (project_type = 'build_venture')
+            OR (
+                project_type = 'pursue_romance'
+                AND target_character_entity_id IS NOT NULL
+            )
+        );
+
+-- Migration 081 permits optional immutable faction context for older project
+-- arms. PURSUE_ROMANCE follows RECRUIT_ALLY's character-target discipline but
+-- explicitly forbids faction context so its two parties remain unambiguous.
+COMMENT ON CONSTRAINT character_project_states_project_type_check
+    ON character_project_states IS
+    'Closed project-type vocabulary extended by migration 085 for PURSUE_ROMANCE.';
+COMMENT ON CONSTRAINT character_project_states_stage_by_type_check
+    ON character_project_states IS
+    'Enforces independent three-stage ladders for PLAN_RELOCATION, RECRUIT_ALLY, BUILD_VENTURE, and PURSUE_ROMANCE.';
+COMMENT ON CONSTRAINT character_project_states_target_by_type_check
+    ON character_project_states IS
+    'Enforces typed targets: romance requires only its character target and forbids place and faction targets.';
+COMMENT ON CONSTRAINT character_project_states_completed_target_check
+    ON character_project_states IS
+    'Completed targeted projects retain their required target; PURSUE_ROMANCE retains its named character.';
+
+COMMENT ON TABLE character_project_states IS
+    'Additive Orrery project lifecycle projection. Supports relocation, recruitment, venture-building, and named-character courtship under one open project per character.';
+COMMENT ON COLUMN character_project_states.project_type IS
+    'Locked project vocabulary: plan_relocation, recruit_ally, build_venture, or pursue_romance.';
+COMMENT ON COLUMN character_project_states.stage IS
+    'Type-specific three-stage ladder, including PURSUE_ROMANCE testing_waters, growing_closer, and declaring_intentions.';
+COMMENT ON COLUMN character_project_states.target_place_id IS
+    'Place target used only by PLAN_RELOCATION; always NULL for RECRUIT_ALLY, BUILD_VENTURE, and PURSUE_ROMANCE.';
+COMMENT ON COLUMN character_project_states.target_character_entity_id IS
+    'Character target required by RECRUIT_ALLY and PURSUE_ROMANCE; always NULL for PLAN_RELOCATION and BUILD_VENTURE.';
+COMMENT ON COLUMN character_project_states.target_faction_entity_id IS
+    'Optional immutable entry-time institutional context for templates that bind one; always NULL for BUILD_VENTURE and PURSUE_ROMANCE.';
+
+INSERT INTO event_types (type, category, severity, description)
+VALUES
+    ('pursue_romance_started', 'project', 'moderate',
+     'The actor began testing the waters of a courtship with a named character.'),
+    ('pursue_romance_progressed', 'project', 'minor',
+     'The actor made routine progress in an ongoing courtship.'),
+    ('pursue_romance_milestone', 'project', 'moderate',
+     'The courtship crossed a boundary in closeness or declared intention.'),
+    ('pursue_romance_stalled', 'project', 'minor',
+     'Neglect or uncertainty cost the actor ground in an ongoing courtship.'),
+    ('pursue_romance_abandoned', 'project', 'moderate',
+     'The actor abandoned a courtship after rebuff, repeated stalls, or delay.'),
+    ('pursue_romance_completed', 'project', 'moderate',
+     'Mutual warmth answered the declaration and established a romantic relationship.')
+ON CONFLICT (type) DO NOTHING;

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -448,11 +448,14 @@ _register(
 )
 _register(
     r"project_target_is\((?P<slot>\w+)\)",
-    lambda m: f"advancing recruitment of {_slot(m.group('slot'))}",
+    lambda m: f"{_slot(m.group('slot'))} is the project's bound target",
 )
 _register(
     r"project_target_is_active\((?P<slot>\w+)\)",
-    lambda m: f"{_slot(m.group('slot'))} is the project's active-character recruit",
+    lambda m: (
+        f"{_slot(m.group('slot'))} is the project's target and still an "
+        "active character"
+    ),
 )
 _register(
     r"project_faction_is\((?P<slot>\w+)\)",

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -568,6 +568,11 @@ def _render_state_delta(delta: Mapping[str, Any]) -> str:
                     f"adds outbound {tags} pair tag to target and upserts the "
                     "actor→target `ally` relationship"
                 )
+            elif "project.complete" in delta and "contact:intimate" in value:
+                parts.append(
+                    f"adds outbound {tags} pair tag to target and upserts the "
+                    "actor→target `romantic` relationship"
+                )
             else:
                 parts.append(f"adds outbound {tags} pair tag to target")
             continue

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -201,6 +201,8 @@ def _tally_report(
                     "advance_recruit_ally",
                     "start_build_venture",
                     "advance_build_venture",
+                    "start_pursue_romance",
+                    "advance_pursue_romance",
                 }:
                     project_gates.append(
                         {

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -2152,6 +2152,11 @@ PROJECT_STAGE_LADDERS = {
         "securing_backing",
         "opening_doors",
     ),
+    "pursue_romance": (
+        "testing_waters",
+        "growing_closer",
+        "declaring_intentions",
+    ),
 }
 
 
@@ -2384,11 +2389,15 @@ def _apply_project_start_sync(
         raise ValueError("project.start faction target must be an entity id")
     if project_type == "plan_relocation" and target_character_entity_id is not None:
         raise ValueError("plan_relocation project.start forbids a character target")
-    if project_type == "recruit_ally":
+    if project_type in {"recruit_ally", "pursue_romance"}:
         if target_place_id is not None:
-            raise ValueError("recruit_ally project.start forbids a place target")
+            raise ValueError(f"{project_type} project.start forbids a place target")
         if not isinstance(target_character_entity_id, int):
-            raise ValueError("recruit_ally project.start requires a character target")
+            raise ValueError(
+                f"{project_type} project.start requires a character target"
+            )
+        if project_type == "pursue_romance" and target_faction_entity_id is not None:
+            raise ValueError("pursue_romance project.start forbids a faction target")
     if project_type == "build_venture" and any(
         target is not None
         for target in (
@@ -2463,11 +2472,15 @@ async def _apply_project_start_async(
         raise ValueError("project.start faction target must be an entity id")
     if project_type == "plan_relocation" and target_character_entity_id is not None:
         raise ValueError("plan_relocation project.start forbids a character target")
-    if project_type == "recruit_ally":
+    if project_type in {"recruit_ally", "pursue_romance"}:
         if target_place_id is not None:
-            raise ValueError("recruit_ally project.start forbids a place target")
+            raise ValueError(f"{project_type} project.start forbids a place target")
         if not isinstance(target_character_entity_id, int):
-            raise ValueError("recruit_ally project.start requires a character target")
+            raise ValueError(
+                f"{project_type} project.start requires a character target"
+            )
+        if project_type == "pursue_romance" and target_faction_entity_id is not None:
+            raise ValueError("pursue_romance project.start forbids a faction target")
     if project_type == "build_venture" and any(
         target is not None
         for target in (
@@ -2856,6 +2869,18 @@ def _validate_project_completion(
             raise ValueError(
                 "recruit_ally completion target binding does not match its recruit"
             )
+    if project_type == "pursue_romance":
+        romance_id = project["target_character_entity_id"]
+        if romance_id is None:
+            raise ValueError("pursue_romance completion requires its character target")
+        if target_entity_id != romance_id:
+            raise ValueError(
+                "pursue_romance completion target binding does not match its target"
+            )
+        if project["target_place_id"] is not None:
+            raise ValueError("pursue_romance completion forbids a place target")
+        if project["target_faction_entity_id"] is not None:
+            raise ValueError("pursue_romance completion forbids a faction target")
     if project_type == "build_venture" and any(
         project[target] is not None
         for target in (
@@ -3046,6 +3071,185 @@ async def _upsert_recruited_ally_relationship_async(
     }
 
 
+def _pursue_romance_relationship_metadata(
+    *,
+    template_id: str,
+    source_chunk_id: int,
+    previous_relationship_type: Optional[str],
+    existing_extra_data: Any,
+) -> dict[str, Any]:
+    """Return durable provenance for the canonical romance relation."""
+
+    original_type = previous_relationship_type
+    if isinstance(existing_extra_data, Mapping):
+        prior = existing_extra_data.get("orrery_pursue_romance")
+        if isinstance(prior, Mapping):
+            original_type = prior.get("previous_relationship_type", original_type)
+    return {
+        "orrery_pursue_romance": {
+            "template_id": template_id,
+            "source_chunk_id": source_chunk_id,
+            "previous_relationship_type": original_type,
+        }
+    }
+
+
+def _upsert_pursue_romance_relationship_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    target_entity_id: int,
+    template_id: str,
+    source_chunk_id: int,
+) -> dict[str, Any]:
+    """Persist actor->target as the canonical romantic relationship."""
+
+    cur.execute(
+        """
+        SELECT actor.id AS character1_id,
+               target.id AS character2_id,
+               existing.relationship_type AS previous_relationship_type,
+               existing.extra_data
+        FROM characters actor
+        JOIN characters target ON target.entity_id = %s
+        LEFT JOIN character_relationships existing
+          ON existing.character1_id = actor.id
+         AND existing.character2_id = target.id
+        WHERE actor.entity_id = %s
+        """,
+        (target_entity_id, actor_entity_id),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(
+            "pursue_romance completion requires actor and target character rows"
+        )
+    character1_id = int(_row_get(row, "character1_id", 0))
+    character2_id = int(_row_get(row, "character2_id", 1))
+    if character1_id == character2_id:
+        raise ValueError("pursue_romance completion cannot target the actor")
+    previous = _row_get(row, "previous_relationship_type", 2)
+    previous_type = str(previous) if previous is not None else None
+    metadata = _pursue_romance_relationship_metadata(
+        template_id=template_id,
+        source_chunk_id=source_chunk_id,
+        previous_relationship_type=previous_type,
+        existing_extra_data=_row_get(row, "extra_data", 3),
+    )
+    cur.execute(
+        """
+        INSERT INTO character_relationships (
+            character1_id, character2_id, relationship_type,
+            emotional_valence, dynamic, recent_events, history, extra_data
+        ) VALUES (
+            %s, %s, 'romantic', '+4|admiring',
+            'Romantic partners by mutual courtship.',
+            'A sustained courtship concluded in mutual declared intention.',
+            'Romance established through the PURSUE_ROMANCE project.',
+            %s::jsonb
+        )
+        ON CONFLICT (character1_id, character2_id) DO UPDATE SET
+            relationship_type = EXCLUDED.relationship_type,
+            extra_data = COALESCE(character_relationships.extra_data, '{}'::jsonb)
+                         || EXCLUDED.extra_data,
+            updated_at = now()
+        RETURNING character1_id, character2_id, relationship_type
+        """,
+        (character1_id, character2_id, json.dumps(metadata)),
+    )
+    if cur.fetchone() is None:
+        raise RuntimeError("pursue_romance relationship upsert returned no row")
+    return {
+        "operation": "insert" if previous_type is None else "update",
+        "subject_entity_id": actor_entity_id,
+        "object_entity_id": target_entity_id,
+        "character1_id": character1_id,
+        "character2_id": character2_id,
+        "previous_relationship_type": previous_type,
+        "relationship_type": "romantic",
+        "relationship_type_changed": previous_type != "romantic",
+    }
+
+
+async def _upsert_pursue_romance_relationship_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    target_entity_id: int,
+    template_id: str,
+    source_chunk_id: int,
+) -> dict[str, Any]:
+    """Async twin of _upsert_pursue_romance_relationship_sync."""
+
+    row = await conn.fetchrow(
+        """
+        SELECT actor.id AS character1_id,
+               target.id AS character2_id,
+               existing.relationship_type AS previous_relationship_type,
+               existing.extra_data
+        FROM characters actor
+        JOIN characters target ON target.entity_id = $2
+        LEFT JOIN character_relationships existing
+          ON existing.character1_id = actor.id
+         AND existing.character2_id = target.id
+        WHERE actor.entity_id = $1
+        """,
+        actor_entity_id,
+        target_entity_id,
+    )
+    if row is None:
+        raise ValueError(
+            "pursue_romance completion requires actor and target character rows"
+        )
+    character1_id = int(_row_get(row, "character1_id", 0))
+    character2_id = int(_row_get(row, "character2_id", 1))
+    if character1_id == character2_id:
+        raise ValueError("pursue_romance completion cannot target the actor")
+    previous = _row_get(row, "previous_relationship_type", 2)
+    previous_type = str(previous) if previous is not None else None
+    metadata = _pursue_romance_relationship_metadata(
+        template_id=template_id,
+        source_chunk_id=source_chunk_id,
+        previous_relationship_type=previous_type,
+        existing_extra_data=_row_get(row, "extra_data", 3),
+    )
+    written = await conn.fetchrow(
+        """
+        INSERT INTO character_relationships (
+            character1_id, character2_id, relationship_type,
+            emotional_valence, dynamic, recent_events, history, extra_data
+        ) VALUES (
+            $1, $2, 'romantic', '+4|admiring',
+            'Romantic partners by mutual courtship.',
+            'A sustained courtship concluded in mutual declared intention.',
+            'Romance established through the PURSUE_ROMANCE project.',
+            $3::jsonb
+        )
+        ON CONFLICT (character1_id, character2_id) DO UPDATE SET
+            relationship_type = EXCLUDED.relationship_type,
+            extra_data = COALESCE(character_relationships.extra_data, '{}'::jsonb)
+                         || EXCLUDED.extra_data,
+            updated_at = now()
+        RETURNING character1_id, character2_id, relationship_type
+        """,
+        character1_id,
+        character2_id,
+        json.dumps(metadata),
+    )
+    if written is None:
+        raise RuntimeError("pursue_romance relationship upsert returned no row")
+    return {
+        "operation": "insert" if previous_type is None else "update",
+        "subject_entity_id": actor_entity_id,
+        "object_entity_id": target_entity_id,
+        "character1_id": character1_id,
+        "character2_id": character2_id,
+        "previous_relationship_type": previous_type,
+        "relationship_type": "romantic",
+        "relationship_type_changed": previous_type != "romantic",
+    }
+
+
 def _apply_project_complete_sync(
     cur: Any,
     *,
@@ -3083,6 +3287,15 @@ def _apply_project_complete_sync(
     elif project["project_type"] == "recruit_ally":
         assert target_entity_id is not None
         relationship_mutation = _upsert_recruited_ally_relationship_sync(
+            cur,
+            actor_entity_id=actor_entity_id,
+            target_entity_id=target_entity_id,
+            template_id=template_id,
+            source_chunk_id=source_chunk_id,
+        )
+    elif project["project_type"] == "pursue_romance":
+        assert target_entity_id is not None
+        relationship_mutation = _upsert_pursue_romance_relationship_sync(
             cur,
             actor_entity_id=actor_entity_id,
             target_entity_id=target_entity_id,
@@ -3150,6 +3363,15 @@ async def _apply_project_complete_async(
     elif project["project_type"] == "recruit_ally":
         assert target_entity_id is not None
         relationship_mutation = await _upsert_recruited_ally_relationship_async(
+            conn,
+            actor_entity_id=actor_entity_id,
+            target_entity_id=target_entity_id,
+            template_id=template_id,
+            source_chunk_id=source_chunk_id,
+        )
+    elif project["project_type"] == "pursue_romance":
+        assert target_entity_id is not None
+        relationship_mutation = await _upsert_pursue_romance_relationship_async(
             conn,
             actor_entity_id=actor_entity_id,
             target_entity_id=target_entity_id,

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -84,6 +84,11 @@ PROJECT_STAGE_LADDERS = {
         "securing_backing",
         "opening_doors",
     ),
+    "pursue_romance": (
+        "testing_waters",
+        "growing_closer",
+        "declaring_intentions",
+    ),
 }
 
 # Composite natural keys, verbatim column order (faction_relationships
@@ -1002,12 +1007,16 @@ class _Replayer:
                 raise ValueError(
                     "plan_relocation replay projection forbids character target"
                 )
-        elif project_type == "recruit_ally" and (
+        elif project_type in {"recruit_ally", "pursue_romance"} and (
             applied_row["target_place_id"] is not None
             or applied_row["target_character_entity_id"] is None
+            or (
+                project_type == "pursue_romance"
+                and applied_row["target_faction_entity_id"] is not None
+            )
         ):
             raise ValueError(
-                "recruit_ally replay projection requires only a character target"
+                f"{project_type} replay projection requires only a character target"
             )
         elif project_type == "build_venture" and any(
             applied_row[target] is not None
@@ -1071,10 +1080,10 @@ class _Replayer:
             if float(applied_row["progress"] or 0.0) < 1.0:
                 raise ValueError("project.complete replay requires full progress")
             row.update(applied_row)
-            if project_type == "recruit_ally":
+            if project_type in {"recruit_ally", "pursue_romance"}:
                 if applied_row["target_character_entity_id"] is None:
                     raise ValueError(
-                        "recruit_ally completion replay requires character target"
+                        f"{project_type} completion replay requires character target"
                     )
                 return
             if project_type == "build_venture":

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -2213,10 +2213,13 @@ def _materialize_project_delta(
     raw_start = delta.get("project.start")
     if raw_start is not None:
         start_payload = dict(raw_start) if isinstance(raw_start, Mapping) else {}
-        if start_payload.get("project_type") == "recruit_ally":
+        if start_payload.get("project_type") in {"recruit_ally", "pursue_romance"}:
             target = resolution.bindings.get(Slot.TARGET)
             if not isinstance(target, int):
-                raise ValueError("recruit_ally project.start requires target binding")
+                raise ValueError(
+                    f"{start_payload.get('project_type')} project.start requires "
+                    "target binding"
+                )
             start_payload["target_character_entity_id"] = target
         if resolution.binds_project_faction:
             faction = resolution.bindings.get(Slot.FACTION)

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -1181,6 +1181,11 @@ _PROJECT_DUE_MODES = frozenset(
         "opening_doors",
         "laying_groundwork_milestone",
         "securing_backing_milestone",
+        "testing_waters",
+        "growing_closer",
+        "declaring_intentions",
+        "testing_waters_milestone",
+        "growing_closer_milestone",
     }
 )
 
@@ -1191,6 +1196,11 @@ _PROJECT_STAGE_LADDERS = {
         "laying_groundwork",
         "securing_backing",
         "opening_doors",
+    ),
+    "pursue_romance": (
+        "testing_waters",
+        "growing_closer",
+        "declaring_intentions",
     ),
 }
 
@@ -1320,7 +1330,7 @@ def project_due(
                 if project_type == "plan_relocation"
                 else (
                     project.target_character_entity_id is not None
-                    if project_type == "recruit_ally"
+                    if project_type in {"recruit_ally", "pursue_romance"}
                     else True
                 )
             )
@@ -1335,7 +1345,7 @@ def project_due(
                 if project_type == "plan_relocation"
                 else (
                     project.target_character_entity_id is not None
-                    if project_type == "recruit_ally"
+                    if project_type in {"recruit_ally", "pursue_romance"}
                     else True
                 )
             )

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -1026,6 +1026,7 @@ SURVEIL = Template(
         has_minimal_context(),
         NOT(project_due("ready")),
         NOT(project_due("ready", project_type="recruit_ally")),
+        NOT(project_due("ready", project_type="pursue_romance")),
         NOT(is_constrained()),
         NOT(has_inbound_pair_tag("hunting")),
         NOT(has_ephemeral("grudge_active")),
@@ -5119,6 +5120,26 @@ ADVANCE_PURSUE_ROMANCE = Template(
             conditions=AND(
                 project_due("completion", project_type="pursue_romance"),
                 relationship_is_mutual_warm(Slot.ACTOR, Slot.TARGET),
+                # Trust is valence-derived while hostility is a pair tag, so
+                # the two can coexist; without this exclusion the completion
+                # arm outruns the rebuffed arm (recruit_ally's seal carries
+                # the same guard).
+                NOT(
+                    has_any_pair_tag(
+                        "hostile_to",
+                        "hunting",
+                        subject_slot=Slot.ACTOR,
+                        object_slot=Slot.TARGET,
+                    )
+                ),
+                NOT(
+                    has_any_pair_tag(
+                        "hostile_to",
+                        "hunting",
+                        subject_slot=Slot.TARGET,
+                        object_slot=Slot.ACTOR,
+                    )
+                ),
             ),
             narrative_stub=(
                 "{actor} finally names what has grown between them, and "

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -10,6 +10,7 @@ from nexus.agents.orrery.substrate import (
     Branch,
     Condition,
     DriveBand,
+    ESTABLISHED_PARTNER_RELATIONSHIP_TYPES,
     PresentTargetPolicy,
     Slot,
     Template,
@@ -4967,6 +4968,358 @@ ADVANCE_RECRUIT_ALLY = Template(
 )
 
 
+START_PURSUE_ROMANCE = Template(
+    id="start_pursue_romance",
+    priority=17,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "A courtship begins only around existing social plausibility and shares "
+        "the established project-entry priority."
+    ),
+    blurb="An off-screen character makes a named person the focus of a courtship.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    starts_from_social_contact=True,
+    package_gate=AND(
+        project_due("start", project_type="pursue_romance"),
+        has_minimal_context(),
+        at_routine_anchor("home"),
+        NOT(is_in_transit()),
+        NOT(is_constrained()),
+        NOT(
+            OR(
+                has_need_debt_at_or_above("sleep", 8),
+                has_need_debt_at_or_above("thirst", 2),
+                has_need_debt_at_or_above("hunger", 4),
+            )
+        ),
+        OR(
+            AND(
+                has_contact_of_kind("social"),
+                has_pair_tag("contact:social"),
+            ),
+            has_relationship_of_type("friend", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("friend", Slot.TARGET, Slot.ACTOR),
+            has_relationship_of_type("companion", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("companion", Slot.TARGET, Slot.ACTOR),
+            has_relationship_of_type("comrade", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("comrade", Slot.TARGET, Slot.ACTOR),
+            has_relationship_of_type("chosen_kin", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("chosen_kin", Slot.TARGET, Slot.ACTOR),
+            trust_at_least(1),
+            has_pair_tag("contact:intimate", Slot.ACTOR, Slot.TARGET),
+        ),
+        NOT(
+            has_any_pair_tag(
+                "hostile_to",
+                "hunting",
+                subject_slot=Slot.ACTOR,
+                object_slot=Slot.TARGET,
+            )
+        ),
+        NOT(
+            has_any_pair_tag(
+                "hostile_to",
+                "hunting",
+                subject_slot=Slot.TARGET,
+                object_slot=Slot.ACTOR,
+            )
+        ),
+        *(
+            NOT(has_symmetric_relationship_of_type(relationship_type))
+            for relationship_type in sorted(ESTABLISHED_PARTNER_RELATIONSHIP_TYPES)
+        ),
+        NOT(has_tag("partnered_exclusively")),
+        NOT(has_tag("married")),
+        # The canonical suppressor set (shared with the intimacy band) also
+        # blocks grieving and libido_absent — courtship defers to the same
+        # availability concept intimacy behavior does.
+        NOT(has_any_intimacy_suppressor()),
+    ),
+    branches=(
+        Branch(
+            label="Begin testing the waters",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} lets {target} see that their attention is no longer "
+                "merely friendly, offering one small opening without demanding "
+                "an answer before either of them is ready."
+            ),
+            state_delta={
+                "project.start": {
+                    "project_type": "pursue_romance",
+                    "stage": "testing_waters",
+                    "milestone": True,
+                }
+            },
+            event_type="pursue_romance_started",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.stage",
+                "character_project_states.target_character_entity_id",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.40,
+        ),
+    ),
+)
+
+
+ADVANCE_PURSUE_ROMANCE = Template(
+    id="advance_pursue_romance",
+    priority=47,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "A due courtship shares the established project-continuation slot while "
+        "cadence and embodied guards preserve routine stability."
+    ),
+    blurb=(
+        "A due courtship tests the waters, grows closer, declares intention, "
+        "stalls, is rebuffed, or becomes mutual."
+    ),
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    binds_project_target=True,
+    package_gate=AND(
+        project_due("ready", project_type="pursue_romance"),
+        project_target_is(Slot.TARGET),
+        NOT(is_in_transit()),
+        NOT(is_constrained()),
+        NOT(
+            OR(
+                has_need_debt_at_or_above("sleep", 8),
+                has_need_debt_at_or_above("thirst", 2),
+                has_need_debt_at_or_above("hunger", 4),
+            )
+        ),
+    ),
+    branches=(
+        Branch(
+            label="End a courtship whose target is no longer available",
+            conditions=NOT(project_target_is_active(Slot.TARGET)),
+            narrative_stub=(
+                "{target} is no longer someone this courtship can reach. "
+                "{actor} releases the hope rather than preserving an impossible "
+                "promise."
+            ),
+            state_delta={
+                "project.abandon": {
+                    "reason": "target_inactive_or_non_character",
+                    "milestone": True,
+                }
+            },
+            event_type="pursue_romance_abandoned",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.source_chunk_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Declare the feeling and be answered",
+            conditions=AND(
+                project_due("completion", project_type="pursue_romance"),
+                relationship_is_mutual_warm(Slot.ACTOR, Slot.TARGET),
+            ),
+            narrative_stub=(
+                "{actor} finally names what has grown between them, and "
+                "{target} answers with warmth of their own. The courtship "
+                "becomes a relationship both can recognize."
+            ),
+            state_delta={
+                "project.complete": {"milestone": True},
+                "entity_pair_tags.add_outbound": ["contact:intimate"],
+            },
+            event_type="pursue_romance_completed",
+            changed_fields=(
+                "character_project_states.status",
+                "entity_pair_tags",
+                "character_relationships.relationship_type",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Withdraw after being rebuffed",
+            conditions=OR(
+                has_any_pair_tag(
+                    "hostile_to",
+                    "hunting",
+                    subject_slot=Slot.ACTOR,
+                    object_slot=Slot.TARGET,
+                ),
+                has_any_pair_tag(
+                    "hostile_to",
+                    "hunting",
+                    subject_slot=Slot.TARGET,
+                    object_slot=Slot.ACTOR,
+                ),
+                trust_below(-1, Slot.TARGET, Slot.ACTOR),
+            ),
+            narrative_stub=(
+                "{target}'s answer closes the possibility, whether through "
+                "plain refusal, disapproval, or danger. {actor} stops pursuing "
+                "what is not mutual."
+            ),
+            state_delta={
+                "project.abandon": {
+                    "reason": "target_rebuffed_or_hostile",
+                    "milestone": True,
+                }
+            },
+            event_type="pursue_romance_abandoned",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.source_chunk_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Let the courtship go rather than force it",
+            conditions=project_due("abandon", project_type="pursue_romance"),
+            narrative_stub=(
+                "Delay has become its own answer. {actor} stops asking the "
+                "unfinished courtship to become something it has not become."
+            ),
+            state_delta={
+                "project.abandon": {
+                    "reason": "stalled_or_overdue",
+                    "milestone": True,
+                }
+            },
+            event_type="pursue_romance_abandoned",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.source_chunk_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Let tentative interest become closeness",
+            conditions=project_due(
+                "testing_waters_milestone", project_type="pursue_romance"
+            ),
+            narrative_stub=(
+                "The first openings have been met rather than ignored. {actor} "
+                "and {target} begin making room for a closeness neither needs "
+                "to disguise as accident."
+            ),
+            state_delta={
+                "project.advance": {
+                    "stage": "growing_closer",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            event_type="pursue_romance_milestone",
+            changed_fields=(
+                "character_project_states.stage",
+                "character_project_states.progress",
+                "character_project_states.stall_count",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Move from closeness toward declared intention",
+            conditions=project_due(
+                "growing_closer_milestone", project_type="pursue_romance"
+            ),
+            narrative_stub=(
+                "What has grown between them is too deliberate to leave "
+                "unnamed. {actor} prepares to say plainly what they want and "
+                "hear plainly what {target} wants in return."
+            ),
+            state_delta={
+                "project.advance": {
+                    "stage": "declaring_intentions",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            event_type="pursue_romance_milestone",
+            changed_fields=(
+                "character_project_states.stage",
+                "character_project_states.progress",
+                "character_project_states.stall_count",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Lose romantic ground through neglect",
+            conditions=project_due("neglected", project_type="pursue_romance"),
+            narrative_stub=(
+                "Unanswered openings and postponed honesty do their own work. "
+                "The courtship stalls, still possible but less certain."
+            ),
+            state_delta={"project.stall": {"increment": 1}},
+            event_type="pursue_romance_stalled",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.stall_count",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.10,
+            promotable=False,
+            preemptive=True,
+        ),
+        Branch(
+            label="Offer another honest opening",
+            conditions=project_due("testing_waters", project_type="pursue_romance"),
+            narrative_stub=(
+                "{actor} offers {target} another unmistakably personal opening "
+                "and pays attention to whether it is welcomed."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.35}},
+            event_type="pursue_romance_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.18,
+            promotable=False,
+        ),
+        Branch(
+            label="Build closeness through chosen time",
+            conditions=project_due("growing_closer", project_type="pursue_romance"),
+            narrative_stub=(
+                "{actor} and {target} choose time together that asks for more "
+                "attention and trust than ordinary company."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.35}},
+            event_type="pursue_romance_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.18,
+            promotable=False,
+        ),
+        Branch(
+            label="Make the next intention legible",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} makes one more part of their intention legible, "
+                "leaving {target} room for an answer that is genuinely theirs."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.25}},
+            event_type="pursue_romance_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.16,
+            promotable=False,
+        ),
+    ),
+)
+
+
 START_BUILD_VENTURE = Template(
     id="start_build_venture",
     priority=17,
@@ -5232,6 +5585,7 @@ BUILTIN_TEMPLATES = (
     ADVANCE_RELOCATION_PLAN,
     ADVANCE_RECRUIT_ALLY,
     ADVANCE_BUILD_VENTURE,
+    ADVANCE_PURSUE_ROMANCE,
     ACT_ON_INTEL,
     UNCOVER_PAST,
     CHECK_ON_DEPENDENT,
@@ -5257,6 +5611,7 @@ BUILTIN_TEMPLATES = (
     START_RELOCATION_PLAN,
     START_RECRUIT_ALLY,
     START_BUILD_VENTURE,
+    START_PURSUE_ROMANCE,
     MAINTAIN_COVER,
 )
 

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -628,6 +628,14 @@ def test_catalog_endpoint_over_http(client: TestClient) -> None:
     response = client.get("/api/dev/orrery/catalog")
     assert response.status_code == 200
     payload = response.json()
+    assert set(payload["event_map"]) >= {
+        "pursue_romance_started",
+        "pursue_romance_progressed",
+        "pursue_romance_milestone",
+        "pursue_romance_stalled",
+        "pursue_romance_abandoned",
+        "pursue_romance_completed",
+    }
     assert {band["band"] for band in payload["drive_bands"]} == {
         "crisis_constraint",
         "embodied_maintenance",

--- a/tests/test_orrery/test_catalog.py
+++ b/tests/test_orrery/test_catalog.py
@@ -72,6 +72,17 @@ def test_catalog_renders_build_venture_completion_vocabulary() -> None:
     assert "- `proprietor`" in content
 
 
+def test_catalog_renders_pursue_romance_completion_vocabulary() -> None:
+    """Courtship gates and its relationship seal stay discoverable."""
+
+    content = render_catalog(BUILTIN_TEMPLATES)
+    assert "## START_PURSUE_ROMANCE — priority 17" in content
+    assert "## ADVANCE_PURSUE_ROMANCE — priority 47" in content
+    assert "actor `pursue_romance` project passes `completion` due-state" in content
+    assert "actor→target `romantic` relationship" in content
+    assert "- `contact:intimate`" in content
+
+
 def test_catalog_renders_compound_structure() -> None:
     """AND / OR / NOT compositions appear as labeled nested bullets."""
 

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -121,6 +121,34 @@ def test_build_venture_migration_replaces_named_three_type_constraints() -> None
     assert "'role.function'" in migration_sql
 
 
+def test_pursue_romance_migration_replaces_named_four_type_constraints() -> None:
+    """Migration 085 preserves the 084 arms and adds strict romance targeting."""
+
+    migration_sql = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "085_pursue_romance_projects.sql"
+    ).read_text()
+    for name in (
+        "character_project_states_project_type_check",
+        "character_project_states_stage_by_type_check",
+        "character_project_states_target_by_type_check",
+        "character_project_states_completed_target_check",
+    ):
+        assert f"DROP CONSTRAINT IF EXISTS {name}" in migration_sql
+        assert f"ADD CONSTRAINT {name}" in migration_sql
+        assert f"COMMENT ON CONSTRAINT {name}" in migration_sql
+    for project_type in (
+        "plan_relocation",
+        "recruit_ally",
+        "build_venture",
+        "pursue_romance",
+    ):
+        assert migration_sql.count(f"project_type = '{project_type}'") >= 3
+    assert "target_faction_entity_id IS NULL" in migration_sql
+    assert migration_sql.count("pursue_romance_") >= 6
+
+
 def test_retrograde_persistence_migration_adds_distinct_sources() -> None:
     """Retrograde canonical writes need explicit event and tag provenance."""
 

--- a/tests/test_orrery/test_pursue_romance_async.py
+++ b/tests/test_orrery/test_pursue_romance_async.py
@@ -1,0 +1,189 @@
+"""Live async-writer parity for PURSUE_ROMANCE projects."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import asyncpg
+import pytest
+
+from nexus.agents.orrery.events import _apply_state_delta_async
+from nexus.agents.orrery.needs import NeedTuning
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.substrate import ProjectPolicy
+from nexus.api.slot_utils import get_slot_db_url
+
+pytestmark = pytest.mark.requires_postgres
+POLICY = ProjectPolicy(enabled=True, advance_interval_hours=24.0)
+
+
+async def _create_schema(conn: asyncpg.Connection) -> None:
+    schema = f"pursue_romance_async_{uuid4().hex[:12]}"
+    await conn.execute(f'CREATE SCHEMA "{schema}"')
+    await conn.execute(f'SET LOCAL search_path = "{schema}", public')
+    await conn.execute(
+        """
+        CREATE TABLE event_types (
+            type text PRIMARY KEY, category text NOT NULL,
+            severity text NOT NULL, description text
+        );
+        CREATE TABLE orrery_resolutions (
+            id bigint PRIMARY KEY, state_delta jsonb NOT NULL
+        );
+        CREATE TABLE character_project_states (
+            id bigserial PRIMARY KEY, character_entity_id bigint NOT NULL,
+            project_type text NOT NULL, status text NOT NULL, stage text NOT NULL,
+            target_place_id bigint, target_character_entity_id bigint,
+            target_faction_entity_id bigint, progress numeric(5,4) NOT NULL DEFAULT 0,
+            stall_count integer NOT NULL DEFAULT 0,
+            next_eligible_at_world_time timestamptz, source_chunk_id bigint,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now(),
+            CONSTRAINT character_project_states_project_type_check CHECK (
+                project_type IN ('plan_relocation','recruit_ally','build_venture')),
+            CONSTRAINT character_project_states_stage_by_type_check CHECK (
+                (project_type='plan_relocation' AND stage IN ('saving','scouting','committing')) OR
+                (project_type='recruit_ally' AND stage IN ('sounding_out','earning_trust','sealing_commitment')) OR
+                (project_type='build_venture' AND stage IN ('laying_groundwork','securing_backing','opening_doors'))),
+            CONSTRAINT character_project_states_target_by_type_check CHECK (
+                (project_type='plan_relocation' AND target_character_entity_id IS NULL) OR
+                (project_type='recruit_ally' AND target_place_id IS NULL AND target_character_entity_id IS NOT NULL) OR
+                (project_type='build_venture' AND target_place_id IS NULL AND target_character_entity_id IS NULL AND target_faction_entity_id IS NULL)),
+            CONSTRAINT character_project_states_completed_target_check CHECK (
+                status <> 'completed' OR
+                (project_type='plan_relocation' AND target_place_id IS NOT NULL) OR
+                (project_type='recruit_ally' AND target_character_entity_id IS NOT NULL) OR
+                project_type='build_venture')
+        );
+        CREATE UNIQUE INDEX ux_character_project_states_open_budget
+            ON character_project_states(character_entity_id)
+            WHERE status IN ('active','paused','stalled');
+        """
+    )
+    await conn.execute(
+        (
+            Path(__file__).parents[2] / "migrations/085_pursue_romance_projects.sql"
+        ).read_text()
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_pursue_romance_start_and_completion() -> None:
+    conn = await asyncpg.connect(get_slot_db_url(slot=2))
+    transaction = conn.transaction()
+    await transaction.start()
+    try:
+        await _create_schema(conn)
+        entities = await conn.fetch(
+            "SELECT entity_id FROM characters WHERE entity_id IS NOT NULL ORDER BY id LIMIT 2"
+        )
+        actor, target = (int(row["entity_id"]) for row in entities)
+        chunk_id = int(
+            await conn.fetchval(
+                "SELECT chunk_id FROM chunk_metadata WHERE world_time IS NOT NULL "
+                "ORDER BY chunk_id DESC LIMIT 1"
+            )
+        )
+        await conn.execute(
+            "DELETE FROM character_relationships USING characters a, characters t "
+            "WHERE character_relationships.character1_id=a.id AND "
+            "character_relationships.character2_id=t.id AND a.entity_id=$1 AND t.entity_id=$2",
+            actor,
+            target,
+        )
+        start = OrreryResolutionDraft(
+            template_id="start_pursue_romance",
+            priority=17,
+            binding_hash="async-romance-start",
+            bindings={"actor": actor, "target": target},
+            branch_label="start",
+            narrative_stub="start",
+            state_delta={
+                "project.start": {
+                    "project_type": "pursue_romance",
+                    "stage": "testing_waters",
+                    "target_character_entity_id": target,
+                    "milestone": True,
+                }
+            },
+            magnitude=0.4,
+        )
+        await conn.execute("INSERT INTO orrery_resolutions VALUES (1,'{}'::jsonb)")
+        assert (
+            await _apply_state_delta_async(
+                conn,
+                start,
+                resolution_id=1,
+                actor_entity_id=actor,
+                target_entity_id=target,
+                source_chunk_id=chunk_id,
+                need_tuning=NeedTuning.default(),
+                project_policy=POLICY,
+            )
+            == 0
+        )
+        await conn.execute(
+            "UPDATE character_project_states SET stage='declaring_intentions',progress=1 "
+            "WHERE character_entity_id=$1",
+            actor,
+        )
+        complete = OrreryResolutionDraft(
+            template_id="advance_pursue_romance",
+            priority=47,
+            binding_hash="async-romance-complete",
+            bindings={"actor": actor, "target": target},
+            branch_label="complete",
+            narrative_stub="complete",
+            state_delta={
+                "project.complete": {"milestone": True},
+                "entity_pair_tags.add_outbound": ["contact:intimate"],
+            },
+            magnitude=0.4,
+        )
+        await conn.execute("INSERT INTO orrery_resolutions VALUES (2,'{}'::jsonb)")
+        assert (
+            await _apply_state_delta_async(
+                conn,
+                complete,
+                resolution_id=2,
+                actor_entity_id=actor,
+                target_entity_id=target,
+                source_chunk_id=chunk_id,
+                need_tuning=NeedTuning.default(),
+                project_policy=POLICY,
+            )
+            == 1
+        )
+        row = await conn.fetchrow(
+            "SELECT cr.relationship_type,cr.emotional_valence,cr.extra_data "
+            "FROM character_relationships cr JOIN characters a ON a.id=cr.character1_id "
+            "JOIN characters t ON t.id=cr.character2_id WHERE a.entity_id=$1 AND t.entity_id=$2",
+            actor,
+            target,
+        )
+        assert row is not None
+        assert (row["relationship_type"], row["emotional_valence"]) == (
+            "romantic",
+            "+4|admiring",
+        )
+        extra_data = json.loads(row["extra_data"])
+        assert (
+            extra_data["orrery_pursue_romance"]["template_id"]
+            == "advance_pursue_romance"
+        )
+        applied = json.loads(
+            await conn.fetchval(
+                "SELECT state_delta::text FROM orrery_resolutions WHERE id=2"
+            )
+        )
+        assert (
+            applied["project.complete"]["applied"]["relationship_mutation"][
+                "relationship_type"
+            ]
+            == "romantic"
+        )
+    finally:
+        await transaction.rollback()
+        await conn.close()

--- a/tests/test_orrery/test_pursue_romance_async.py
+++ b/tests/test_orrery/test_pursue_romance_async.py
@@ -44,17 +44,31 @@ async def _create_schema(conn: asyncpg.Connection) -> None:
             CONSTRAINT character_project_states_project_type_check CHECK (
                 project_type IN ('plan_relocation','recruit_ally','build_venture')),
             CONSTRAINT character_project_states_stage_by_type_check CHECK (
-                (project_type='plan_relocation' AND stage IN ('saving','scouting','committing')) OR
-                (project_type='recruit_ally' AND stage IN ('sounding_out','earning_trust','sealing_commitment')) OR
-                (project_type='build_venture' AND stage IN ('laying_groundwork','securing_backing','opening_doors'))),
+                (project_type = 'plan_relocation'
+                    AND stage IN ('saving', 'scouting', 'committing')) OR
+                (project_type = 'recruit_ally'
+                    AND stage IN (
+                        'sounding_out', 'earning_trust', 'sealing_commitment'
+                    )) OR
+                (project_type = 'build_venture'
+                    AND stage IN (
+                        'laying_groundwork', 'securing_backing', 'opening_doors'
+                    ))),
             CONSTRAINT character_project_states_target_by_type_check CHECK (
-                (project_type='plan_relocation' AND target_character_entity_id IS NULL) OR
-                (project_type='recruit_ally' AND target_place_id IS NULL AND target_character_entity_id IS NOT NULL) OR
-                (project_type='build_venture' AND target_place_id IS NULL AND target_character_entity_id IS NULL AND target_faction_entity_id IS NULL)),
+                (project_type = 'plan_relocation'
+                    AND target_character_entity_id IS NULL) OR
+                (project_type = 'recruit_ally'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NOT NULL) OR
+                (project_type = 'build_venture'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NULL
+                    AND target_faction_entity_id IS NULL)),
             CONSTRAINT character_project_states_completed_target_check CHECK (
                 status <> 'completed' OR
                 (project_type='plan_relocation' AND target_place_id IS NOT NULL) OR
-                (project_type='recruit_ally' AND target_character_entity_id IS NOT NULL) OR
+                (project_type = 'recruit_ally'
+                    AND target_character_entity_id IS NOT NULL) OR
                 project_type='build_venture')
         );
         CREATE UNIQUE INDEX ux_character_project_states_open_budget
@@ -77,7 +91,8 @@ async def test_async_pursue_romance_start_and_completion() -> None:
     try:
         await _create_schema(conn)
         entities = await conn.fetch(
-            "SELECT entity_id FROM characters WHERE entity_id IS NOT NULL ORDER BY id LIMIT 2"
+            "SELECT entity_id FROM characters WHERE entity_id IS NOT NULL "
+            "ORDER BY id LIMIT 2"
         )
         actor, target = (int(row["entity_id"]) for row in entities)
         chunk_id = int(
@@ -89,7 +104,8 @@ async def test_async_pursue_romance_start_and_completion() -> None:
         await conn.execute(
             "DELETE FROM character_relationships USING characters a, characters t "
             "WHERE character_relationships.character1_id=a.id AND "
-            "character_relationships.character2_id=t.id AND a.entity_id=$1 AND t.entity_id=$2",
+            "character_relationships.character2_id=t.id "
+            "AND a.entity_id=$1 AND t.entity_id=$2",
             actor,
             target,
         )
@@ -125,7 +141,8 @@ async def test_async_pursue_romance_start_and_completion() -> None:
             == 0
         )
         await conn.execute(
-            "UPDATE character_project_states SET stage='declaring_intentions',progress=1 "
+            "UPDATE character_project_states "
+            "SET stage='declaring_intentions',progress=1 "
             "WHERE character_entity_id=$1",
             actor,
         )
@@ -158,8 +175,10 @@ async def test_async_pursue_romance_start_and_completion() -> None:
         )
         row = await conn.fetchrow(
             "SELECT cr.relationship_type,cr.emotional_valence,cr.extra_data "
-            "FROM character_relationships cr JOIN characters a ON a.id=cr.character1_id "
-            "JOIN characters t ON t.id=cr.character2_id WHERE a.entity_id=$1 AND t.entity_id=$2",
+            "FROM character_relationships cr "
+            "JOIN characters a ON a.id=cr.character1_id "
+            "JOIN characters t ON t.id=cr.character2_id "
+            "WHERE a.entity_id=$1 AND t.entity_id=$2",
             actor,
             target,
         )

--- a/tests/test_orrery/test_pursue_romance_migration_pg.py
+++ b/tests/test_orrery/test_pursue_romance_migration_pg.py
@@ -38,23 +38,43 @@ def migration_084_schema() -> Iterator[Any]:
                     stall_count integer NOT NULL DEFAULT 0,
                     next_eligible_at_world_time timestamptz, source_chunk_id bigint,
                     CONSTRAINT character_project_states_project_type_check CHECK (
-                        project_type IN ('plan_relocation','recruit_ally','build_venture')),
+                        project_type IN (
+                            'plan_relocation', 'recruit_ally', 'build_venture'
+                        )),
                     CONSTRAINT character_project_states_stage_by_type_check CHECK (
-                        (project_type='plan_relocation' AND stage IN ('saving','scouting','committing')) OR
-                        (project_type='recruit_ally' AND stage IN ('sounding_out','earning_trust','sealing_commitment')) OR
-                        (project_type='build_venture' AND stage IN ('laying_groundwork','securing_backing','opening_doors'))),
+                        (project_type = 'plan_relocation'
+                            AND stage IN ('saving', 'scouting', 'committing')) OR
+                        (project_type = 'recruit_ally'
+                            AND stage IN (
+                                'sounding_out', 'earning_trust',
+                                'sealing_commitment'
+                            )) OR
+                        (project_type = 'build_venture'
+                            AND stage IN (
+                                'laying_groundwork', 'securing_backing',
+                                'opening_doors'
+                            ))),
                     CONSTRAINT character_project_states_target_by_type_check CHECK (
-                        (project_type='plan_relocation' AND target_character_entity_id IS NULL) OR
-                        (project_type='recruit_ally' AND target_place_id IS NULL AND target_character_entity_id IS NOT NULL) OR
-                        (project_type='build_venture' AND target_place_id IS NULL AND target_character_entity_id IS NULL AND target_faction_entity_id IS NULL)),
+                        (project_type = 'plan_relocation'
+                            AND target_character_entity_id IS NULL) OR
+                        (project_type = 'recruit_ally'
+                            AND target_place_id IS NULL
+                            AND target_character_entity_id IS NOT NULL) OR
+                        (project_type = 'build_venture'
+                            AND target_place_id IS NULL
+                            AND target_character_entity_id IS NULL
+                            AND target_faction_entity_id IS NULL)),
                     CONSTRAINT character_project_states_completed_target_check CHECK (
                         status <> 'completed' OR
-                        (project_type='plan_relocation' AND target_place_id IS NOT NULL) OR
-                        (project_type='recruit_ally' AND target_character_entity_id IS NOT NULL) OR
+                        (project_type = 'plan_relocation'
+                            AND target_place_id IS NOT NULL) OR
+                        (project_type = 'recruit_ally'
+                            AND target_character_entity_id IS NOT NULL) OR
                         project_type='build_venture')
                 );
                 INSERT INTO character_project_states
-                    (character_entity_id,project_type,status,stage,target_character_entity_id,target_faction_entity_id)
+                    (character_entity_id, project_type, status, stage,
+                     target_character_entity_id, target_faction_entity_id)
                     VALUES (1,'recruit_ally','active','sounding_out',2,9);
                 INSERT INTO character_project_states
                     (character_entity_id,project_type,status,stage)
@@ -88,7 +108,8 @@ def test_migration_085_widens_constraints_and_seeds_events(
         assert all(comment for _, comment in constraints.values())
         cur.execute(
             "INSERT INTO character_project_states "
-            "(character_entity_id,project_type,status,stage,target_character_entity_id) "
+            "(character_entity_id,project_type,status,stage,"
+            "target_character_entity_id) "
             "VALUES (4,'pursue_romance','completed','declaring_intentions',5)"
         )
         for columns, values in (
@@ -105,7 +126,8 @@ def test_migration_085_widens_constraints_and_seeds_events(
                 )
             cur.execute("ROLLBACK TO SAVEPOINT invalid_romance")
         cur.execute(
-            "SELECT project_type,target_faction_entity_id FROM character_project_states "
+            "SELECT project_type,target_faction_entity_id "
+            "FROM character_project_states "
             "WHERE character_entity_id IN (1,3) ORDER BY character_entity_id"
         )
         assert cur.fetchall() == [("recruit_ally", 9), ("build_venture", None)]

--- a/tests/test_orrery/test_pursue_romance_migration_pg.py
+++ b/tests/test_orrery/test_pursue_romance_migration_pg.py
@@ -1,0 +1,123 @@
+"""Real-PostgreSQL contract coverage for migration 085."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2
+import pytest
+
+from nexus.api.slot_utils import get_slot_db_url
+
+pytestmark = pytest.mark.requires_postgres
+
+
+@pytest.fixture()
+def migration_084_schema() -> Iterator[Any]:
+    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    try:
+        with conn.cursor() as cur:
+            schema = f"migration_085_{uuid4().hex[:12]}"
+            cur.execute(f'CREATE SCHEMA "{schema}"')
+            cur.execute(f'SET LOCAL search_path = "{schema}", public')
+            cur.execute(
+                """
+                CREATE TABLE event_types (
+                    type text PRIMARY KEY, category text NOT NULL,
+                    severity text NOT NULL, description text
+                );
+                CREATE TABLE character_project_states (
+                    id bigserial PRIMARY KEY, character_entity_id bigint NOT NULL,
+                    project_type text NOT NULL, status text NOT NULL,
+                    stage text NOT NULL, target_place_id bigint,
+                    target_character_entity_id bigint,
+                    target_faction_entity_id bigint,
+                    progress numeric(5,4) NOT NULL DEFAULT 0,
+                    stall_count integer NOT NULL DEFAULT 0,
+                    next_eligible_at_world_time timestamptz, source_chunk_id bigint,
+                    CONSTRAINT character_project_states_project_type_check CHECK (
+                        project_type IN ('plan_relocation','recruit_ally','build_venture')),
+                    CONSTRAINT character_project_states_stage_by_type_check CHECK (
+                        (project_type='plan_relocation' AND stage IN ('saving','scouting','committing')) OR
+                        (project_type='recruit_ally' AND stage IN ('sounding_out','earning_trust','sealing_commitment')) OR
+                        (project_type='build_venture' AND stage IN ('laying_groundwork','securing_backing','opening_doors'))),
+                    CONSTRAINT character_project_states_target_by_type_check CHECK (
+                        (project_type='plan_relocation' AND target_character_entity_id IS NULL) OR
+                        (project_type='recruit_ally' AND target_place_id IS NULL AND target_character_entity_id IS NOT NULL) OR
+                        (project_type='build_venture' AND target_place_id IS NULL AND target_character_entity_id IS NULL AND target_faction_entity_id IS NULL)),
+                    CONSTRAINT character_project_states_completed_target_check CHECK (
+                        status <> 'completed' OR
+                        (project_type='plan_relocation' AND target_place_id IS NOT NULL) OR
+                        (project_type='recruit_ally' AND target_character_entity_id IS NOT NULL) OR
+                        project_type='build_venture')
+                );
+                INSERT INTO character_project_states
+                    (character_entity_id,project_type,status,stage,target_character_entity_id,target_faction_entity_id)
+                    VALUES (1,'recruit_ally','active','sounding_out',2,9);
+                INSERT INTO character_project_states
+                    (character_entity_id,project_type,status,stage)
+                    VALUES (3,'build_venture','active','laying_groundwork');
+                """
+            )
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_migration_085_widens_constraints_and_seeds_events(
+    migration_084_schema: Any,
+) -> None:
+    sql = (
+        Path(__file__).parents[2] / "migrations/085_pursue_romance_projects.sql"
+    ).read_text()
+    with migration_084_schema.cursor() as cur:
+        cur.execute(sql)
+        cur.execute(
+            "SELECT conname,pg_get_constraintdef(oid,true),obj_description(oid) "
+            "FROM pg_constraint WHERE conrelid='character_project_states'::regclass "
+            "AND conname LIKE 'character_project_states_%_check'"
+        )
+        constraints = {name: (definition, comment) for name, definition, comment in cur}
+        assert len(constraints) == 4
+        assert all(
+            "pursue_romance" in definition for definition, _ in constraints.values()
+        )
+        assert all(comment for _, comment in constraints.values())
+        cur.execute(
+            "INSERT INTO character_project_states "
+            "(character_entity_id,project_type,status,stage,target_character_entity_id) "
+            "VALUES (4,'pursue_romance','completed','declaring_intentions',5)"
+        )
+        for columns, values in (
+            ("target_place_id,target_character_entity_id", "7,5"),
+            ("target_character_entity_id,target_faction_entity_id", "5,8"),
+        ):
+            cur.execute("SAVEPOINT invalid_romance")
+            with pytest.raises(psycopg2.errors.CheckViolation):
+                cur.execute(
+                    "INSERT INTO character_project_states "
+                    f"(character_entity_id,project_type,status,stage,{columns}) "
+                    "VALUES (6,'pursue_romance','active','testing_waters',"
+                    f"{values})"
+                )
+            cur.execute("ROLLBACK TO SAVEPOINT invalid_romance")
+        cur.execute(
+            "SELECT project_type,target_faction_entity_id FROM character_project_states "
+            "WHERE character_entity_id IN (1,3) ORDER BY character_entity_id"
+        )
+        assert cur.fetchall() == [("recruit_ally", 9), ("build_venture", None)]
+        cur.execute(
+            "SELECT type,severity FROM event_types WHERE type LIKE 'pursue_romance_%' "
+            "ORDER BY type"
+        )
+        assert cur.fetchall() == [
+            ("pursue_romance_abandoned", "moderate"),
+            ("pursue_romance_completed", "moderate"),
+            ("pursue_romance_milestone", "moderate"),
+            ("pursue_romance_progressed", "minor"),
+            ("pursue_romance_stalled", "minor"),
+            ("pursue_romance_started", "moderate"),
+        ]

--- a/tests/test_orrery/test_pursue_romance_projects.py
+++ b/tests/test_orrery/test_pursue_romance_projects.py
@@ -236,8 +236,40 @@ def test_completion_requires_mutual_warmth() -> None:
         _advance_state(project, trust={(ACTOR, TARGET): 2, (TARGET, ACTOR): 1}),
         BINDINGS,
     )
+    # One-sided warmth must NOT complete: forward-only (the actor is smitten,
+    # the target neutral) and reverse-only (the target warm, the actor cooled).
+    forward_only = evaluate(
+        ADVANCE_PURSUE_ROMANCE,
+        _advance_state(project, trust={(ACTOR, TARGET): 2, (TARGET, ACTOR): 0}),
+        BINDINGS,
+    )
+    reverse_only = evaluate(
+        ADVANCE_PURSUE_ROMANCE,
+        _advance_state(project, trust={(ACTOR, TARGET): 0, (TARGET, ACTOR): 1}),
+        BINDINGS,
+    )
     assert "project.complete" not in cold.state_delta
     assert "project.complete" in warm.state_delta
+    assert "project.complete" not in forward_only.state_delta
+    assert "project.complete" not in reverse_only.state_delta
+
+
+def test_completion_yields_to_hostility_despite_mutual_warmth() -> None:
+    """An active hostile edge routes a warm, due courtship to the rebuffed
+    arm instead of completing it (the completion arm's hostility exclusion)."""
+
+    project = _project(stage="declaring_intentions", progress=1.0)
+    hostile = evaluate(
+        ADVANCE_PURSUE_ROMANCE,
+        _advance_state(
+            project,
+            trust={(ACTOR, TARGET): 2, (TARGET, ACTOR): 1},
+            pair_tags={(TARGET, ACTOR): frozenset({"hunting"})},
+        ),
+        BINDINGS,
+    )
+    assert "project.complete" not in hostile.state_delta
+    assert "project.abandon" in hostile.state_delta
 
 
 def _create_schema(cur: Any, schema: str) -> None:
@@ -262,20 +294,37 @@ def _create_schema(cur: Any, schema: str) -> None:
             created_at timestamptz NOT NULL DEFAULT now(),
             updated_at timestamptz NOT NULL DEFAULT now(),
             CONSTRAINT character_project_states_project_type_check CHECK (
-                project_type IN ('plan_relocation','recruit_ally','build_venture')),
+                project_type IN (
+                    'plan_relocation', 'recruit_ally', 'build_venture'
+                )),
             CONSTRAINT character_project_states_stage_by_type_check CHECK (
-                (project_type='plan_relocation' AND stage IN ('saving','scouting','committing')) OR
-                (project_type='recruit_ally' AND stage IN ('sounding_out','earning_trust','sealing_commitment')) OR
-                (project_type='build_venture' AND stage IN ('laying_groundwork','securing_backing','opening_doors'))),
+                (project_type = 'plan_relocation'
+                    AND stage IN ('saving', 'scouting', 'committing')) OR
+                (project_type = 'recruit_ally'
+                    AND stage IN (
+                        'sounding_out', 'earning_trust', 'sealing_commitment'
+                    )) OR
+                (project_type = 'build_venture'
+                    AND stage IN (
+                        'laying_groundwork', 'securing_backing', 'opening_doors'
+                    ))),
             CONSTRAINT character_project_states_target_by_type_check CHECK (
-                (project_type='plan_relocation' AND target_character_entity_id IS NULL) OR
-                (project_type='recruit_ally' AND target_place_id IS NULL AND target_character_entity_id IS NOT NULL) OR
-                (project_type='build_venture' AND target_place_id IS NULL AND target_character_entity_id IS NULL AND target_faction_entity_id IS NULL)),
+                (project_type = 'plan_relocation'
+                    AND target_character_entity_id IS NULL) OR
+                (project_type = 'recruit_ally'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NOT NULL) OR
+                (project_type = 'build_venture'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NULL
+                    AND target_faction_entity_id IS NULL)),
             CONSTRAINT character_project_states_completed_target_check CHECK (
                 status <> 'completed' OR
-                (project_type='plan_relocation' AND target_place_id IS NOT NULL) OR
-                (project_type='recruit_ally' AND target_character_entity_id IS NOT NULL) OR
-                project_type='build_venture')
+                (project_type = 'plan_relocation'
+                    AND target_place_id IS NOT NULL) OR
+                (project_type = 'recruit_ally'
+                    AND target_character_entity_id IS NOT NULL) OR
+                project_type = 'build_venture')
         );
         CREATE UNIQUE INDEX ux_character_project_states_open_budget
             ON character_project_states(character_entity_id)
@@ -308,7 +357,8 @@ def live_romance_db() -> Iterator[dict[str, Any]]:
             cur.execute(
                 "DELETE FROM character_relationships USING characters a, characters t "
                 "WHERE character_relationships.character1_id=a.id AND "
-                "character_relationships.character2_id=t.id AND a.entity_id=%s AND t.entity_id=%s",
+                "character_relationships.character2_id=t.id "
+                "AND a.entity_id=%s AND t.entity_id=%s",
                 (actor, target),
             )
         yield {
@@ -371,7 +421,8 @@ def test_sync_applier_fresh_romance_and_overwrite_preserve_first_provenance(
     _apply(db, base)
     with db["conn"].cursor() as cur:
         cur.execute(
-            "UPDATE character_project_states SET stage='declaring_intentions', progress=1 "
+            "UPDATE character_project_states "
+            "SET stage='declaring_intentions', progress=1 "
             "WHERE character_entity_id=%s",
             (db["actor"],),
         )
@@ -388,8 +439,10 @@ def test_sync_applier_fresh_romance_and_overwrite_preserve_first_provenance(
     with db["conn"].cursor() as cur:
         cur.execute(
             "SELECT cr.relationship_type, cr.emotional_valence, cr.extra_data "
-            "FROM character_relationships cr JOIN characters a ON a.id=cr.character1_id "
-            "JOIN characters t ON t.id=cr.character2_id WHERE a.entity_id=%s AND t.entity_id=%s",
+            "FROM character_relationships cr "
+            "JOIN characters a ON a.id=cr.character1_id "
+            "JOIN characters t ON t.id=cr.character2_id "
+            "WHERE a.entity_id=%s AND t.entity_id=%s",
             (db["actor"], db["target"]),
         )
         relationship_type, valence, extra = cur.fetchone()
@@ -411,15 +464,18 @@ def test_sync_applier_fresh_romance_and_overwrite_preserve_first_provenance(
             (db["actor"], db["target"]),
         )
         cur.execute(
-            "UPDATE character_project_states SET status='active', stage='declaring_intentions', progress=1 "
+            "UPDATE character_project_states "
+            "SET status='active', stage='declaring_intentions', progress=1 "
             "WHERE character_entity_id=%s",
             (db["actor"],),
         )
     _apply(db, replace(complete, binding_hash="complete-again"))
     with db["conn"].cursor() as cur:
         cur.execute(
-            "SELECT cr.relationship_type, cr.extra_data FROM character_relationships cr "
-            "JOIN characters a ON a.id=cr.character1_id JOIN characters t ON t.id=cr.character2_id "
+            "SELECT cr.relationship_type, cr.extra_data "
+            "FROM character_relationships cr "
+            "JOIN characters a ON a.id=cr.character1_id "
+            "JOIN characters t ON t.id=cr.character2_id "
             "WHERE a.entity_id=%s AND t.entity_id=%s",
             (db["actor"], db["target"]),
         )

--- a/tests/test_orrery/test_pursue_romance_projects.py
+++ b/tests/test_orrery/test_pursue_romance_projects.py
@@ -1,0 +1,453 @@
+"""PURSUE_ROMANCE character-targeted project acceptance coverage."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from itertools import count
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2
+import psycopg2.extras
+import pytest
+
+from nexus.agents.orrery.events import _apply_state_delta_sync
+from nexus.agents.orrery.needs import load_need_tuning
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.substrate import (
+    BranchSelection,
+    ProjectPolicy,
+    ProjectState,
+    RoutineAnchor,
+    Slot,
+    TravelState,
+    WorldState,
+    evaluate,
+)
+from nexus.agents.orrery.templates import (
+    ADVANCE_PURSUE_ROMANCE,
+    START_PURSUE_ROMANCE,
+)
+from nexus.api.slot_utils import get_slot_db_url
+
+ACTOR = 10
+TARGET = 20
+NOW = datetime(2073, 8, 2, 12, tzinfo=timezone.utc)
+POLICY = ProjectPolicy(
+    enabled=True,
+    advance_interval_hours=24.0,
+    max_active_per_character=1,
+    stall_abandon_threshold=3,
+    abandon_after_stalled_world_hours=168.0,
+    milestone_magnitude=0.40,
+    coverage_distribution_tolerance=0.05,
+)
+BINDINGS = {Slot.ACTOR: ACTOR, Slot.TARGET: TARGET}
+
+
+def _start_state(**changes: Any) -> WorldState:
+    values: dict[str, Any] = {
+        "locations": {ACTOR: 1},
+        "pair_tags": {(ACTOR, TARGET): frozenset({"contact:social"})},
+        "travel_states": {ACTOR: TravelState(status="at_place")},
+        "project_policy": POLICY,
+        "routine_anchors": {
+            (ACTOR, "home"): RoutineAnchor(
+                anchor_type="home", place_id=1, mobility_policy="fixed_place"
+            )
+        },
+        "world_time": NOW,
+    }
+    values.update(changes)
+    return WorldState(**values)
+
+
+def _project(
+    *,
+    stage: str = "testing_waters",
+    progress: float = 0.0,
+    stall_count: int = 0,
+    due_at: datetime = NOW,
+    target_active: bool = True,
+) -> ProjectState:
+    return ProjectState(
+        id=7,
+        project_type="pursue_romance",
+        status="active",
+        stage=stage,
+        target_character_entity_id=TARGET,
+        target_character_is_active=target_active,
+        progress=progress,
+        stall_count=stall_count,
+        next_eligible_at_world_time=due_at,
+        source_chunk_id=100,
+    )
+
+
+def _advance_state(project: ProjectState, **changes: Any) -> WorldState:
+    values: dict[str, Any] = {
+        "project_states": {ACTOR: project},
+        "project_policy": POLICY,
+        "travel_states": {ACTOR: TravelState(status="at_place")},
+        "world_time": NOW,
+    }
+    values.update(changes)
+    return WorldState(**values)
+
+
+def test_entry_gate_contract_and_all_eligibility_arms() -> None:
+    result = evaluate(START_PURSUE_ROMANCE, _start_state(), BINDINGS)
+    assert result.passes is True
+    assert START_PURSUE_ROMANCE.required_slots == (Slot.ACTOR, Slot.TARGET)
+    assert START_PURSUE_ROMANCE.starts_from_social_contact is True
+    assert result.state_delta["project.start"] == {
+        "project_type": "pursue_romance",
+        "stage": "testing_waters",
+        "milestone": True,
+    }
+    for state in (
+        _start_state(
+            pair_tags={(ACTOR, TARGET): frozenset({"contact:intimate"})},
+        ),
+        _start_state(pair_tags={}, trust={(ACTOR, TARGET): 1}),
+        _start_state(
+            pair_tags={},
+            relationship_types={(TARGET, ACTOR): frozenset({"friend"})},
+        ),
+    ):
+        assert evaluate(START_PURSUE_ROMANCE, state, BINDINGS).passes is True
+
+
+@pytest.mark.parametrize(
+    "changes",
+    (
+        {"tags": {ACTOR: frozenset({"partnered_exclusively"})}},
+        {"tags": {ACTOR: frozenset({"married"})}},
+        {"tags": {ACTOR: frozenset({"closeted"})}},
+        {"tags": {ACTOR: frozenset({"focus_committed"})}},
+        {"tags": {ACTOR: frozenset({"recently_traumatized_intimate"})}},
+        {"tags": {ACTOR: frozenset({"religiously_abstinent"})}},
+        {"tags": {ACTOR: frozenset({"vow_of_celibacy"})}},
+        {"tags": {ACTOR: frozenset({"libido_absent"})}},
+        {"relationship_types": {(ACTOR, TARGET): frozenset({"romantic"})}},
+        {"pair_tags": {(TARGET, ACTOR): frozenset({"hostile_to"})}},
+        {"pair_tags": {(ACTOR, TARGET): frozenset({"hunting"})}},
+    ),
+)
+def test_entry_gate_blocks_partnered_suppressed_or_hostile_actors(
+    changes: dict[str, Any],
+) -> None:
+    assert (
+        evaluate(START_PURSUE_ROMANCE, _start_state(**changes), BINDINGS).passes
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    ("state", "label", "delta_key"),
+    (
+        (
+            _advance_state(_project(target_active=False)),
+            "End a courtship whose target is no longer available",
+            "project.abandon",
+        ),
+        (
+            _advance_state(
+                _project(stage="declaring_intentions", progress=1.0),
+                trust={(ACTOR, TARGET): 2, (TARGET, ACTOR): 1},
+            ),
+            "Declare the feeling and be answered",
+            "project.complete",
+        ),
+        (
+            _advance_state(_project(), trust={(TARGET, ACTOR): -2}),
+            "Withdraw after being rebuffed",
+            "project.abandon",
+        ),
+        (
+            _advance_state(_project(stall_count=3)),
+            "Let the courtship go rather than force it",
+            "project.abandon",
+        ),
+        (
+            _advance_state(_project(progress=1.0)),
+            "Let tentative interest become closeness",
+            "project.advance",
+        ),
+        (
+            _advance_state(_project(stage="growing_closer", progress=1.0)),
+            "Move from closeness toward declared intention",
+            "project.advance",
+        ),
+        (
+            _advance_state(
+                _project(
+                    stage="declaring_intentions",
+                    progress=0.5,
+                    due_at=NOW - timedelta(hours=24),
+                )
+            ),
+            "Lose romantic ground through neglect",
+            "project.stall",
+        ),
+        (
+            _advance_state(_project(progress=0.2)),
+            "Offer another honest opening",
+            "project.advance",
+        ),
+        (
+            _advance_state(_project(stage="growing_closer", progress=0.2)),
+            "Build closeness through chosen time",
+            "project.advance",
+        ),
+        (
+            _advance_state(_project(stage="declaring_intentions", progress=0.2)),
+            "Make the next intention legible",
+            "project.advance",
+        ),
+    ),
+)
+def test_full_ladder_and_terminals(
+    state: WorldState, label: str, delta_key: str
+) -> None:
+    result = evaluate(
+        ADVANCE_PURSUE_ROMANCE,
+        state,
+        BINDINGS,
+        BranchSelection(mode="authored_order"),
+    )
+    assert result.branch_label == label
+    assert delta_key in result.state_delta
+    if label in {
+        "Offer another honest opening",
+        "Build closeness through chosen time",
+        "Make the next intention legible",
+    }:
+        assert result.promotable is False
+
+
+def test_completion_requires_mutual_warmth() -> None:
+    project = _project(stage="declaring_intentions", progress=1.0)
+    cold = evaluate(ADVANCE_PURSUE_ROMANCE, _advance_state(project), BINDINGS)
+    warm = evaluate(
+        ADVANCE_PURSUE_ROMANCE,
+        _advance_state(project, trust={(ACTOR, TARGET): 2, (TARGET, ACTOR): 1}),
+        BINDINGS,
+    )
+    assert "project.complete" not in cold.state_delta
+    assert "project.complete" in warm.state_delta
+
+
+def _create_schema(cur: Any, schema: str) -> None:
+    cur.execute(f'CREATE SCHEMA "{schema}"')
+    cur.execute(f'SET LOCAL search_path = "{schema}", public')
+    cur.execute(
+        """
+        CREATE TABLE event_types (
+            type text PRIMARY KEY, category text NOT NULL,
+            severity text NOT NULL, description text
+        );
+        CREATE TABLE orrery_resolutions (
+            id bigint PRIMARY KEY, state_delta jsonb NOT NULL
+        );
+        CREATE TABLE character_project_states (
+            id bigserial PRIMARY KEY, character_entity_id bigint NOT NULL,
+            project_type text NOT NULL, status text NOT NULL, stage text NOT NULL,
+            target_place_id bigint, target_character_entity_id bigint,
+            target_faction_entity_id bigint, progress numeric(5,4) NOT NULL DEFAULT 0,
+            stall_count integer NOT NULL DEFAULT 0,
+            next_eligible_at_world_time timestamptz, source_chunk_id bigint,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now(),
+            CONSTRAINT character_project_states_project_type_check CHECK (
+                project_type IN ('plan_relocation','recruit_ally','build_venture')),
+            CONSTRAINT character_project_states_stage_by_type_check CHECK (
+                (project_type='plan_relocation' AND stage IN ('saving','scouting','committing')) OR
+                (project_type='recruit_ally' AND stage IN ('sounding_out','earning_trust','sealing_commitment')) OR
+                (project_type='build_venture' AND stage IN ('laying_groundwork','securing_backing','opening_doors'))),
+            CONSTRAINT character_project_states_target_by_type_check CHECK (
+                (project_type='plan_relocation' AND target_character_entity_id IS NULL) OR
+                (project_type='recruit_ally' AND target_place_id IS NULL AND target_character_entity_id IS NOT NULL) OR
+                (project_type='build_venture' AND target_place_id IS NULL AND target_character_entity_id IS NULL AND target_faction_entity_id IS NULL)),
+            CONSTRAINT character_project_states_completed_target_check CHECK (
+                status <> 'completed' OR
+                (project_type='plan_relocation' AND target_place_id IS NOT NULL) OR
+                (project_type='recruit_ally' AND target_character_entity_id IS NOT NULL) OR
+                project_type='build_venture')
+        );
+        CREATE UNIQUE INDEX ux_character_project_states_open_budget
+            ON character_project_states(character_entity_id)
+            WHERE status IN ('active','paused','stalled');
+        """
+    )
+    cur.execute(
+        (
+            Path(__file__).parents[2] / "migrations/085_pursue_romance_projects.sql"
+        ).read_text()
+    )
+
+
+@pytest.fixture()
+def live_romance_db() -> Iterator[dict[str, Any]]:
+    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    try:
+        with conn.cursor() as cur:
+            _create_schema(cur, f"pursue_romance_{uuid4().hex[:12]}")
+            cur.execute(
+                "SELECT entity_id FROM characters WHERE entity_id IS NOT NULL "
+                "ORDER BY id LIMIT 2"
+            )
+            actor, target = (int(row[0]) for row in cur.fetchall())
+            cur.execute(
+                "SELECT chunk_id FROM chunk_metadata WHERE world_time IS NOT NULL "
+                "ORDER BY chunk_id DESC LIMIT 1"
+            )
+            chunk_id = int(cur.fetchone()[0])
+            cur.execute(
+                "DELETE FROM character_relationships USING characters a, characters t "
+                "WHERE character_relationships.character1_id=a.id AND "
+                "character_relationships.character2_id=t.id AND a.entity_id=%s AND t.entity_id=%s",
+                (actor, target),
+            )
+        yield {
+            "conn": conn,
+            "actor": actor,
+            "target": target,
+            "chunk": chunk_id,
+            "ids": count(1),
+        }
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def _apply(db: dict[str, Any], draft: OrreryResolutionDraft) -> dict[str, Any]:
+    resolution_id = next(db["ids"])
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "INSERT INTO orrery_resolutions VALUES (%s,%s::jsonb)",
+            (resolution_id, psycopg2.extras.Json(draft.state_delta)),
+        )
+        _apply_state_delta_sync(
+            cur,
+            draft,
+            resolution_id=resolution_id,
+            actor_entity_id=db["actor"],
+            target_entity_id=db["target"],
+            source_chunk_id=db["chunk"],
+            need_tuning=load_need_tuning(),
+            project_policy=POLICY,
+        )
+        cur.execute(
+            "SELECT state_delta FROM orrery_resolutions WHERE id=%s", (resolution_id,)
+        )
+        return cur.fetchone()[0]
+
+
+@pytest.mark.requires_postgres
+def test_sync_applier_fresh_romance_and_overwrite_preserve_first_provenance(
+    live_romance_db: dict[str, Any],
+) -> None:
+    db = live_romance_db
+    base = OrreryResolutionDraft(
+        template_id="start_pursue_romance",
+        priority=17,
+        binding_hash="start",
+        bindings={"actor": db["actor"], "target": db["target"]},
+        branch_label="start",
+        narrative_stub="start",
+        state_delta={
+            "project.start": {
+                "project_type": "pursue_romance",
+                "stage": "testing_waters",
+                "target_character_entity_id": db["target"],
+                "milestone": True,
+            }
+        },
+        magnitude=0.4,
+    )
+    _apply(db, base)
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "UPDATE character_project_states SET stage='declaring_intentions', progress=1 "
+            "WHERE character_entity_id=%s",
+            (db["actor"],),
+        )
+    complete = replace(
+        base,
+        template_id="advance_pursue_romance",
+        binding_hash="complete",
+        state_delta={
+            "project.complete": {"milestone": True},
+            "entity_pair_tags.add_outbound": ["contact:intimate"],
+        },
+    )
+    ledger = _apply(db, complete)
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "SELECT cr.relationship_type, cr.emotional_valence, cr.extra_data "
+            "FROM character_relationships cr JOIN characters a ON a.id=cr.character1_id "
+            "JOIN characters t ON t.id=cr.character2_id WHERE a.entity_id=%s AND t.entity_id=%s",
+            (db["actor"], db["target"]),
+        )
+        relationship_type, valence, extra = cur.fetchone()
+    assert (relationship_type, valence) == ("romantic", "+4|admiring")
+    assert extra["orrery_pursue_romance"]["previous_relationship_type"] is None
+    assert (
+        ledger["project.complete"]["applied"]["relationship_mutation"][
+            "relationship_type"
+        ]
+        == "romantic"
+    )
+
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "UPDATE character_relationships SET relationship_type='friend', "
+            "extra_data='{}'::jsonb "
+            "WHERE character1_id=(SELECT id FROM characters WHERE entity_id=%s) "
+            "AND character2_id=(SELECT id FROM characters WHERE entity_id=%s)",
+            (db["actor"], db["target"]),
+        )
+        cur.execute(
+            "UPDATE character_project_states SET status='active', stage='declaring_intentions', progress=1 "
+            "WHERE character_entity_id=%s",
+            (db["actor"],),
+        )
+    _apply(db, replace(complete, binding_hash="complete-again"))
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "SELECT cr.relationship_type, cr.extra_data FROM character_relationships cr "
+            "JOIN characters a ON a.id=cr.character1_id JOIN characters t ON t.id=cr.character2_id "
+            "WHERE a.entity_id=%s AND t.entity_id=%s",
+            (db["actor"], db["target"]),
+        )
+        relationship_type, extra = cur.fetchone()
+    assert relationship_type == "romantic"
+    assert extra["orrery_pursue_romance"]["previous_relationship_type"] == "friend"
+
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "UPDATE character_relationships SET relationship_type='rival' "
+            "WHERE character1_id=(SELECT id FROM characters WHERE entity_id=%s) "
+            "AND character2_id=(SELECT id FROM characters WHERE entity_id=%s)",
+            (db["actor"], db["target"]),
+        )
+        cur.execute(
+            "UPDATE character_project_states SET status='active', "
+            "stage='declaring_intentions', progress=1 "
+            "WHERE character_entity_id=%s",
+            (db["actor"],),
+        )
+    _apply(db, replace(complete, binding_hash="complete-third"))
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "SELECT cr.extra_data FROM character_relationships cr "
+            "JOIN characters a ON a.id=cr.character1_id "
+            "JOIN characters t ON t.id=cr.character2_id "
+            "WHERE a.entity_id=%s AND t.entity_id=%s",
+            (db["actor"], db["target"]),
+        )
+        extra = cur.fetchone()[0]
+    assert extra["orrery_pursue_romance"]["previous_relationship_type"] == "friend"

--- a/tests/test_orrery/test_pursue_romance_replay.py
+++ b/tests/test_orrery/test_pursue_romance_replay.py
@@ -1,0 +1,355 @@
+"""Checkpoint replay coverage for the PURSUE_ROMANCE project lifecycle."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterator, Optional
+from uuid import uuid4
+
+import psycopg2
+import pytest
+
+from nexus.agents.orrery.events import (
+    _apply_state_delta_sync,
+    _insert_resolution_sync,
+)
+from nexus.agents.orrery.needs import load_need_tuning
+from nexus.agents.orrery.reconstruction import (
+    capture_state_checkpoint_sync,
+    set_commit_chunk_attribution_sync,
+)
+from nexus.agents.orrery.replay import (
+    reconstruct_state_at_sync,
+    verify_checkpoints_sync,
+)
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.substrate import ProjectPolicy
+from nexus.api.slot_utils import get_slot_db_url
+
+pytestmark = pytest.mark.requires_postgres
+
+POLICY = ProjectPolicy(
+    enabled=True,
+    advance_interval_hours=24.0,
+    max_active_per_character=1,
+    stall_abandon_threshold=3,
+    abandon_after_stalled_world_hours=168.0,
+    milestone_magnitude=0.40,
+    coverage_distribution_tolerance=0.05,
+)
+
+
+@pytest.fixture
+def replay_project_db() -> Iterator[dict[str, Any]]:
+    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    try:
+        with conn.cursor() as cur:
+            schema = f"pursue_romance_replay_{uuid4().hex[:12]}"
+            cur.execute(f'CREATE SCHEMA "{schema}"')
+            cur.execute(f'SET LOCAL search_path = "{schema}", public')
+            cur.execute(
+                """
+                CREATE TABLE event_types (
+                    type text PRIMARY KEY, category text NOT NULL,
+                    severity text NOT NULL, description text
+                );
+                CREATE TABLE character_project_states (
+                    id bigserial PRIMARY KEY, character_entity_id bigint NOT NULL,
+                    project_type text NOT NULL, status text NOT NULL,
+                    stage text NOT NULL, target_place_id bigint,
+                    target_character_entity_id bigint,
+                    target_faction_entity_id bigint,
+                    progress numeric(5,4) NOT NULL DEFAULT 0,
+                    stall_count integer NOT NULL DEFAULT 0,
+                    next_eligible_at_world_time timestamptz,
+                    source_chunk_id bigint,
+                    created_at timestamptz NOT NULL DEFAULT now(),
+                    updated_at timestamptz NOT NULL DEFAULT now(),
+                    CONSTRAINT character_project_states_project_type_check CHECK (
+                        project_type IN ('plan_relocation','recruit_ally','build_venture')),
+                    CONSTRAINT character_project_states_stage_by_type_check CHECK (
+                        (project_type='plan_relocation' AND stage IN ('saving','scouting','committing')) OR
+                        (project_type='recruit_ally' AND stage IN ('sounding_out','earning_trust','sealing_commitment')) OR
+                        (project_type='build_venture' AND stage IN ('laying_groundwork','securing_backing','opening_doors'))),
+                    CONSTRAINT character_project_states_target_by_type_check CHECK (
+                        (project_type='plan_relocation' AND target_character_entity_id IS NULL) OR
+                        (project_type='recruit_ally' AND target_place_id IS NULL AND target_character_entity_id IS NOT NULL) OR
+                        (project_type='build_venture' AND target_place_id IS NULL AND target_character_entity_id IS NULL AND target_faction_entity_id IS NULL)),
+                    CONSTRAINT character_project_states_completed_target_check CHECK (
+                        status <> 'completed' OR
+                        (project_type='plan_relocation' AND target_place_id IS NOT NULL) OR
+                        (project_type='recruit_ally' AND target_character_entity_id IS NOT NULL) OR
+                        project_type='build_venture')
+                );
+                CREATE UNIQUE INDEX ux_character_project_states_open_budget
+                    ON character_project_states(character_entity_id)
+                    WHERE status IN ('active','paused','stalled');
+                """
+            )
+            cur.execute(
+                (
+                    Path(__file__).parents[2]
+                    / "migrations/085_pursue_romance_projects.sql"
+                ).read_text()
+            )
+            cur.execute(
+                "SELECT entity_id FROM characters "
+                "WHERE entity_id IS NOT NULL ORDER BY id LIMIT 2"
+            )
+            entities = [int(row[0]) for row in cur.fetchall()]
+            if len(entities) < 2:
+                pytest.skip("save_02 needs two character entities")
+            actor, target = entities
+            cur.execute(
+                "DELETE FROM character_project_states "
+                "WHERE character_entity_id = %s",
+                (actor,),
+            )
+            cur.execute(
+                """
+                UPDATE entity_pair_tags ept
+                SET cleared_at = now()
+                FROM pair_tags pt
+                WHERE ept.pair_tag_id = pt.id
+                  AND ept.subject_entity_id = %s
+                  AND ept.object_entity_id = %s
+                  AND pt.tag = 'contact:intimate'
+                  AND ept.cleared_at IS NULL
+                """,
+                (actor, target),
+            )
+        yield {"conn": conn, "actor": actor, "target": target}
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def _next_world_time(cur: Any) -> datetime:
+    cur.execute("SELECT max(world_time) FROM chunk_metadata")
+    latest = cur.fetchone()[0]
+    base = latest or datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return base + timedelta(hours=6)
+
+
+def _fabricate_chunk(
+    cur: Any,
+    world_time: datetime,
+    *,
+    created_offset_minutes: int,
+) -> int:
+    cur.execute(
+        """
+        INSERT INTO narrative_chunks (id, raw_text, created_at)
+        SELECT max(id) + 1, 'PURSUE_ROMANCE replay probe',
+               now() + make_interval(mins => %s)
+        FROM narrative_chunks
+        RETURNING id
+        """,
+        (created_offset_minutes,),
+    )
+    chunk_id = int(cur.fetchone()[0])
+    cur.execute(
+        "INSERT INTO chunk_metadata (chunk_id, world_time) VALUES (%s, %s)",
+        (chunk_id, world_time),
+    )
+    cur.execute(
+        "UPDATE chunk_metadata SET world_time = %s WHERE chunk_id = %s",
+        (world_time, chunk_id),
+    )
+    return chunk_id
+
+
+def _apply_transition(
+    cur: Any,
+    *,
+    chunk_id: int,
+    actor_entity_id: int,
+    target_entity_id: int,
+    state_delta: dict[str, Any],
+) -> None:
+    set_commit_chunk_attribution_sync(cur, chunk_id)
+    draft = OrreryResolutionDraft(
+        template_id="pursue_romance_replay_probe",
+        priority=47,
+        binding_hash=f"recruit-ally-replay-{chunk_id}",
+        bindings={"actor": actor_entity_id, "target": target_entity_id},
+        branch_label="PURSUE_ROMANCE replay probe",
+        narrative_stub="probe",
+        state_delta=state_delta,
+        magnitude=0.4,
+    )
+    resolution_id = _insert_resolution_sync(
+        cur,
+        draft,
+        tick_chunk_id=chunk_id,
+        actor_entity_id=actor_entity_id,
+        brief="PURSUE_ROMANCE checkpoint replay probe",
+    )
+    assert resolution_id is not None
+    _apply_state_delta_sync(
+        cur,
+        draft,
+        resolution_id=int(resolution_id),
+        actor_entity_id=actor_entity_id,
+        target_entity_id=target_entity_id,
+        source_chunk_id=chunk_id,
+        need_tuning=load_need_tuning(),
+        project_policy=POLICY,
+    )
+
+
+def _project_row(
+    rows: list[dict[str, Any]], actor_entity_id: int
+) -> Optional[dict[str, Any]]:
+    matching = [
+        row
+        for row in rows
+        if row["character_entity_id"] == actor_entity_id
+        and row["project_type"] == "pursue_romance"
+    ]
+    assert len(matching) == 1
+    return matching[0]
+
+
+def test_pursue_romance_lifecycle_replays_between_checkpoints_without_drift(
+    replay_project_db: dict[str, Any],
+) -> None:
+    db = replay_project_db
+    actor = int(db["actor"])
+    target = int(db["target"])
+
+    with db["conn"].cursor() as cur:
+        base_time = _next_world_time(cur)
+        cur.execute(
+            """
+            SELECT actor.id, target.id, relationship.relationship_type
+            FROM characters actor
+            JOIN characters target ON target.entity_id = %s
+            LEFT JOIN character_relationships relationship
+              ON relationship.character1_id = actor.id
+             AND relationship.character2_id = target.id
+            WHERE actor.entity_id = %s
+            """,
+            (target, actor),
+        )
+        actor_character_id, target_character_id, prior_relationship_type = (
+            cur.fetchone()
+        )
+        base_chunk = _fabricate_chunk(
+            cur,
+            base_time,
+            created_offset_minutes=-4,
+        )
+        base_id = capture_state_checkpoint_sync(
+            cur,
+            chunk_id=base_chunk,
+            label="manual",
+        )
+        assert base_id is not None
+
+        transitions: tuple[dict[str, Any], ...] = (
+            {
+                "project.start": {
+                    "project_type": "pursue_romance",
+                    "stage": "testing_waters",
+                    "target_character_entity_id": target,
+                    "milestone": True,
+                }
+            },
+            {
+                "project.advance": {
+                    "stage": "growing_closer",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            {
+                "project.advance": {
+                    "stage": "declaring_intentions",
+                    "set_progress": 1.0,
+                    "milestone": True,
+                }
+            },
+            {
+                "project.complete": {"milestone": True},
+                "entity_pair_tags.add_outbound": ["contact:intimate"],
+            },
+        )
+        transition_chunks: list[int] = []
+        for step, state_delta in enumerate(transitions, start=1):
+            chunk_id = _fabricate_chunk(
+                cur,
+                base_time + timedelta(hours=24 * step),
+                created_offset_minutes=step - len(transitions),
+            )
+            _apply_transition(
+                cur,
+                chunk_id=chunk_id,
+                actor_entity_id=actor,
+                target_entity_id=target,
+                state_delta=state_delta,
+            )
+            transition_chunks.append(chunk_id)
+
+        complete_chunk = transition_chunks[-1]
+        target_id = capture_state_checkpoint_sync(
+            cur,
+            chunk_id=complete_chunk,
+            label="manual",
+        )
+        assert target_id is not None
+
+        reconstructed = reconstruct_state_at_sync(
+            cur,
+            complete_chunk,
+            base_checkpoint_id=int(base_id),
+        )
+        project = _project_row(reconstructed.state["character_project_states"], actor)
+        assert project is not None
+        assert project["status"] == "completed"
+        assert project["stage"] == "declaring_intentions"
+        assert project["target_place_id"] is None
+        assert project["target_character_entity_id"] == target
+        assert float(project["progress"]) == 1.0
+        assert project["source_chunk_id"] == complete_chunk
+
+        before_completion = reconstruct_state_at_sync(
+            cur,
+            transition_chunks[-2],
+            base_checkpoint_id=int(base_id),
+        )
+        prior_rows = [
+            row
+            for row in before_completion.state["character_relationships"]
+            if row["character1_id"] == actor_character_id
+            and row["character2_id"] == target_character_id
+        ]
+        if prior_relationship_type is None:
+            assert prior_rows == []
+        else:
+            assert len(prior_rows) == 1
+            assert prior_rows[0]["relationship_type"] == prior_relationship_type
+
+        cur.execute("SELECT id FROM pair_tags WHERE tag = 'contact:intimate'")
+        ally_tag_id = int(cur.fetchone()[0])
+        assert any(
+            row["subject_entity_id"] == actor
+            and row["object_entity_id"] == target
+            and row["pair_tag_id"] == ally_tag_id
+            for row in reconstructed.state["entity_pair_tags"]
+        )
+        assert any(
+            row["character1_id"] == actor_character_id
+            and row["character2_id"] == target_character_id
+            and row["relationship_type"] == "romantic"
+            for row in reconstructed.state["character_relationships"]
+        )
+
+        pair = next(
+            verdict
+            for verdict in verify_checkpoints_sync(cur)
+            if verdict.base_checkpoint_id == base_id
+            and verdict.target_checkpoint_id == target_id
+        )
+        assert pair.drifts == []

--- a/tests/test_orrery/test_pursue_romance_replay.py
+++ b/tests/test_orrery/test_pursue_romance_replay.py
@@ -67,19 +67,38 @@ def replay_project_db() -> Iterator[dict[str, Any]]:
                     created_at timestamptz NOT NULL DEFAULT now(),
                     updated_at timestamptz NOT NULL DEFAULT now(),
                     CONSTRAINT character_project_states_project_type_check CHECK (
-                        project_type IN ('plan_relocation','recruit_ally','build_venture')),
+                        project_type IN (
+                            'plan_relocation', 'recruit_ally', 'build_venture'
+                        )),
                     CONSTRAINT character_project_states_stage_by_type_check CHECK (
-                        (project_type='plan_relocation' AND stage IN ('saving','scouting','committing')) OR
-                        (project_type='recruit_ally' AND stage IN ('sounding_out','earning_trust','sealing_commitment')) OR
-                        (project_type='build_venture' AND stage IN ('laying_groundwork','securing_backing','opening_doors'))),
+                        (project_type = 'plan_relocation'
+                            AND stage IN ('saving', 'scouting', 'committing')) OR
+                        (project_type = 'recruit_ally'
+                            AND stage IN (
+                                'sounding_out', 'earning_trust',
+                                'sealing_commitment'
+                            )) OR
+                        (project_type = 'build_venture'
+                            AND stage IN (
+                                'laying_groundwork', 'securing_backing',
+                                'opening_doors'
+                            ))),
                     CONSTRAINT character_project_states_target_by_type_check CHECK (
-                        (project_type='plan_relocation' AND target_character_entity_id IS NULL) OR
-                        (project_type='recruit_ally' AND target_place_id IS NULL AND target_character_entity_id IS NOT NULL) OR
-                        (project_type='build_venture' AND target_place_id IS NULL AND target_character_entity_id IS NULL AND target_faction_entity_id IS NULL)),
+                        (project_type = 'plan_relocation'
+                            AND target_character_entity_id IS NULL) OR
+                        (project_type = 'recruit_ally'
+                            AND target_place_id IS NULL
+                            AND target_character_entity_id IS NOT NULL) OR
+                        (project_type = 'build_venture'
+                            AND target_place_id IS NULL
+                            AND target_character_entity_id IS NULL
+                            AND target_faction_entity_id IS NULL)),
                     CONSTRAINT character_project_states_completed_target_check CHECK (
                         status <> 'completed' OR
-                        (project_type='plan_relocation' AND target_place_id IS NOT NULL) OR
-                        (project_type='recruit_ally' AND target_character_entity_id IS NOT NULL) OR
+                        (project_type = 'plan_relocation'
+                            AND target_place_id IS NOT NULL) OR
+                        (project_type = 'recruit_ally'
+                            AND target_character_entity_id IS NOT NULL) OR
                         project_type='build_venture')
                 );
                 CREATE UNIQUE INDEX ux_character_project_states_open_budget


### PR DESCRIPTION
## Summary

Fourth aspiration-band package per the #496 Arachne ruling (seq 5). `pursue_romance` is a character-targeted staged courtship, the closest structural sibling to `recruit_ally`.

- **Stage ladder**: `testing_waters` → `growing_closer` → `declaring_intentions`
- **Completion** ("Declare the feeling and be answered"): gated on `project_due(completion)` AND `relationship_is_mutual_warm` (reciprocity is the existing fwd≥2/rev≥1 predicate); upserts the canonical ACTOR→TARGET relationship to `romantic` (`'+4|admiring'` on fresh rows; conflict arm mirrors recruit_ally exactly — type/extra_data/updated_at only) with first-write-preserved provenance, plus an outbound `contact:intimate` edge
- **Entry availability**: defers to the intimacy band's canonical `has_any_intimacy_suppressor()` (deliberately a superset of the spec's five tags — also blocks `grieving` and `libido_absent`), blocks `partnered_exclusively`/`married`, and blocks already-established partners via `ESTABLISHED_PARTNER_RELATIONSHIP_TYPES`; eligibility widens recruit_ally's OR-clause by one `contact:intimate` arm
- **Rebuffed arm**: hostility either direction OR reverse trust hardened to disapproving-or-worse abandons the courtship (preemptive)
- **Migration 085**: widens the four named constraints — romance *forbids* faction context outright (its templates never bind one), stricter than recruitment's optional 081 binding, with the rationale commented; seeds six event types with the `DO NOTHING` idiom
- **Vocabulary**: zero new tags/pair tags/types — `romantic` is the only romance relationship_type ever written in this codebase and `ESTABLISHED_PARTNER_RELATIONSHIP_TYPES` already recognizes it

## Validation

- `poetry run pytest -q` → **1455 passed, 298 skipped, 0 failed** (pre-branch baseline: 1429/294)
- `NEXUS_RUN_POSTGRES=1` romance suites (projects/replay/async/migration-pg) → **27 passed** live-PG
- `python -m nexus.agents.orrery.catalog --check` → clean; mypy baseline unchanged (26 pre-existing errors in six untouched files)

## Schema/Data Impact

Migration 085 pending everywhere; additive constraint widening only. Will be applied at merge closeout.

Implemented by Sol (GPT-5.6 Codex) from a frozen spec; reviewed line-by-line by Claude, with one design correction during review (canonical suppressor helper over literal tag enumeration). Part of the #496 campaign; follows #526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TJVTXfD7TouQuxmYfVf8w