### PR TITLE
Add the COURT_PATRON Aspiration Package (#496 Slice 5)

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -924,6 +924,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **NOT:** actor `plan_relocation` project passes `ready` due-state
   - **NOT:** actor `recruit_ally` project passes `ready` due-state
   - **NOT:** actor `pursue_romance` project passes `ready` due-state
+  - **NOT:** actor `court_patron` project passes `ready` due-state
   - **NOT:** actor is constrained or immobilized
   - **NOT:** actor has inbound `hunting` pair tag
   - **NOT:** actor has `grudge_active` ephemeral
@@ -1462,6 +1463,131 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 **Event:** `pursue_romance_progressed`
 
 > {actor} makes one more part of their intention legible, leaving {target} room for an answer that is genuinely theirs.
+
+---
+
+## ADVANCE_COURT_PATRON — priority 47
+
+> A due patronage effort gains notice, proves worth, secures favor, stalls, is spurned, or ends.
+
+**Drive band:** project identity — A due patronage effort shares the established project-continuation slot while SURVEIL yields to its bound two-party work.
+**Slots:** ACTOR, TARGET
+
+**Gate:**
+
+- **AND:**
+  - actor `court_patron` project passes `ready` due-state
+  - target is the project's bound target
+  - **NOT:** actor is in transit
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:**
+    - **OR:**
+      - actor has `sleep` debt ≥ 8
+      - actor has `thirst` debt ≥ 2
+      - actor has `hunger` debt ≥ 4
+
+### Branch 1 — End a patronage effort whose target is no longer available  *(mag 0.4)* · **preemptive**
+
+**When:**
+
+- **NOT:** target is the project's target and still an active character
+
+**Does:** applies project `abandon` transition
+**Event:** `court_patron_abandoned`
+
+> {target} is no longer someone whose favor can be won. {actor} closes the effort rather than courting a power that cannot answer.
+
+### Branch 2 — Secure the patron's favor  *(mag 0.4)* · **preemptive**
+
+**When:**
+
+- **AND:**
+  - actor `court_patron` project passes `completion` due-state
+  - trust target→actor ≥ 2
+  - **NOT:** actor has any of [`hostile_to`, `hunting`] pair tags to target
+  - **NOT:** target has any of [`hostile_to`, `hunting`] pair tags to actor
+
+**Does:** applies project `complete` transition; adds inbound `sponsors` pair tag from target to actor and upserts the actor→target `patron` relationship; adds outbound `obligation` pair tag to target
+**Event:** `court_patron_completed`
+
+> {target} finally answers {actor}'s service with public favor. The protection is real, and so is the obligation attached to it.
+
+### Branch 3 — Withdraw after being spurned  *(mag 0.4)* · **preemptive**
+
+**When:**
+
+- **OR:**
+  - actor has any of [`hostile_to`, `hunting`] pair tags to target
+  - target has any of [`hostile_to`, `hunting`] pair tags to actor
+  - trust target→actor < -1
+
+**Does:** applies project `abandon` transition
+**Event:** `court_patron_abandoned`
+
+> {target}'s answer is rejection, contempt, or danger. {actor} abandons the bid for favor before deference becomes humiliation.
+
+### Branch 4 — Let the bid for patronage go  *(mag 0.4)* · **preemptive**
+
+**When:** actor `court_patron` project passes `abandon` due-state
+
+**Does:** applies project `abandon` transition
+**Event:** `court_patron_abandoned`
+
+> Delay has become its own refusal. {actor} stops spending effort on favor that never comes within reach.
+
+### Branch 5 — Turn notice into a chance to prove worth  *(mag 0.4)* · **preemptive**
+
+**When:** actor `court_patron` project passes `gaining_notice_milestone` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `court_patron_milestone`
+
+> {target} has noticed {actor}. Attention now becomes a test: whether usefulness survives scrutiny and inconvenience.
+
+### Branch 6 — Ask proven worth to become favor  *(mag 0.4)* · **preemptive**
+
+**When:** actor `court_patron` project passes `proving_worth_milestone` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `court_patron_milestone`
+
+> {actor} has supplied proof instead of promises. The remaining question is whether {target} will convert approval into favor.
+
+### Branch 7 — Lose ground through neglect  *(mag 0.1)* · **preemptive** · **not promotable**
+
+**When:** actor `court_patron` project passes `neglected` due-state
+
+**Does:** applies project `stall` transition
+**Event:** `court_patron_stalled`
+
+> Inattention erodes the impression {actor} worked to create. The bid for patronage stalls and must recover its momentum.
+
+### Branch 8 — Make useful work visible  *(mag 0.18)* · **not promotable**
+
+**When:** actor `court_patron` project passes `gaining_notice` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `court_patron_progressed`
+
+> {actor} places one useful act where {target} can see both its value and the judgment behind it.
+
+### Branch 9 — Prove reliable under scrutiny  *(mag 0.18)* · **not promotable**
+
+**When:** actor `court_patron` project passes `proving_worth` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `court_patron_progressed`
+
+> {actor} accepts a consequential task and performs it cleanly, giving {target} evidence that usefulness is not a pose.
+
+### Branch 10 — Make the next claim on favor legible  *(mag 0.16)* · **not promotable**
+
+**When:** *(always)*
+
+**Does:** applies project `advance` transition
+**Event:** `court_patron_progressed`
+
+> {actor} makes one more service, request, or allegiance explicit, bringing {target}'s answer closer without pretending it is owed.
 
 ---
 
@@ -2440,6 +2566,59 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 ---
 
+## START_COURT_PATRON — priority 17
+
+> An off-screen character begins working to win a named power's favor.
+
+**Drive band:** project identity — Courting a patron requires both a plausible social opening and a specific marker of the target's power.
+**Slots:** ACTOR, TARGET
+
+**Gate:**
+
+- **AND:**
+  - actor `court_patron` project passes `start` due-state
+  - actor has enough hydrated context
+  - actor is at `home` anchor
+  - **NOT:** actor is in transit
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:**
+    - **OR:**
+      - actor has `sleep` debt ≥ 8
+      - actor has `thirst` debt ≥ 2
+      - actor has `hunger` debt ≥ 4
+  - **OR:**
+    - **AND:**
+      - actor has outbound `contact:social` pair tag
+      - actor has `contact:social` pair tag to target
+    - actor has `friend` relationship to target
+    - target has `friend` relationship to actor
+    - actor has `companion` relationship to target
+    - target has `companion` relationship to actor
+    - actor has `comrade` relationship to target
+    - target has `comrade` relationship to actor
+    - actor has `chosen_kin` relationship to target
+    - target has `chosen_kin` relationship to actor
+    - trust actor→target ≥ 1
+  - **OR:**
+    - target holds `status:senior`+ toward any faction
+    - target has `leader` tag
+    - target has `authority_over` pair tag to actor
+  - target lacks `sponsors` pair tag to actor
+  - **NOT:** actor has `patron` relationship to target
+  - **NOT:** actor has any of [`hostile_to`, `hunting`] pair tags to target
+  - **NOT:** target has any of [`hostile_to`, `hunting`] pair tags to actor
+
+### Branch 1 — Begin seeking the patron's notice  *(mag 0.4)*
+
+**When:** *(always)*
+
+**Does:** applies project `start` transition
+**Event:** `court_patron_started`
+
+> {actor} stops hoping that {target} will notice them by accident. They choose a first gesture calculated to be useful, visible, and difficult to mistake for idle flattery.
+
+---
+
 ## INTIMACY — priority 16
 
 > The body asks for the kind of connection that is not conversation.
@@ -3215,6 +3394,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `innkeeper`
 - `investigator`
 - `keeps_shop`
+- `leader`
 - `loremaster`
 - `magical_healing`
 - `married`
@@ -3310,12 +3490,15 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 ### Pair tags queried by directed predicates
 
 - `ally`
+- `authority_over`
 - `contact:intimate`
 - `contact:lodging`
 - `contact:social`
 - `hostile_to`
 - `hunting`
+- `obligation`
 - `resides_at`
+- `sponsors`
 
 ### Event types
 
@@ -3330,6 +3513,12 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `contact_deferred`
 - `contact_made`
 - `counter_surveillance_sweep`
+- `court_patron_abandoned`
+- `court_patron_completed`
+- `court_patron_milestone`
+- `court_patron_progressed`
+- `court_patron_stalled`
+- `court_patron_started`
 - `craft_tended`
 - `drank`
 - `encoded_message`

--- a/migrations/086_court_patron_projects.sql
+++ b/migrations/086_court_patron_projects.sql
@@ -1,0 +1,126 @@
+-- 086_court_patron_projects.sql
+--
+-- Extend the Orrery project chassis with COURT_PATRON, a character-targeted
+-- effort to earn the favor of a named power.
+
+ALTER TABLE character_project_states
+    DROP CONSTRAINT IF EXISTS character_project_states_project_type_check,
+    DROP CONSTRAINT IF EXISTS character_project_states_stage_by_type_check,
+    DROP CONSTRAINT IF EXISTS character_project_states_target_by_type_check,
+    DROP CONSTRAINT IF EXISTS character_project_states_completed_target_check;
+
+ALTER TABLE character_project_states
+    ADD CONSTRAINT character_project_states_project_type_check
+        CHECK (project_type IN (
+            'plan_relocation', 'recruit_ally', 'build_venture',
+            'pursue_romance', 'court_patron'
+        )),
+    ADD CONSTRAINT character_project_states_stage_by_type_check
+        CHECK (
+            (project_type = 'plan_relocation'
+                AND stage IN ('saving', 'scouting', 'committing'))
+            OR
+            (project_type = 'recruit_ally'
+                AND stage IN (
+                    'sounding_out', 'earning_trust', 'sealing_commitment'
+                ))
+            OR
+            (project_type = 'build_venture'
+                AND stage IN (
+                    'laying_groundwork', 'securing_backing', 'opening_doors'
+                ))
+            OR
+            (project_type = 'pursue_romance'
+                AND stage IN (
+                    'testing_waters', 'growing_closer', 'declaring_intentions'
+                ))
+            OR
+            (project_type = 'court_patron'
+                AND stage IN (
+                    'gaining_notice', 'proving_worth', 'securing_favor'
+                ))
+        ),
+    ADD CONSTRAINT character_project_states_target_by_type_check
+        CHECK (
+            (project_type = 'plan_relocation'
+                AND target_character_entity_id IS NULL)
+            OR
+            (project_type = 'recruit_ally'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NOT NULL)
+            OR
+            (project_type = 'build_venture'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NULL
+                AND target_faction_entity_id IS NULL)
+            OR
+            (project_type = 'pursue_romance'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NOT NULL
+                AND target_faction_entity_id IS NULL)
+            OR
+            (project_type = 'court_patron'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NOT NULL
+                AND target_faction_entity_id IS NULL)
+        ),
+    ADD CONSTRAINT character_project_states_completed_target_check
+        CHECK (
+            status <> 'completed'
+            OR (project_type = 'plan_relocation' AND target_place_id IS NOT NULL)
+            OR (
+                project_type = 'recruit_ally'
+                AND target_character_entity_id IS NOT NULL
+            )
+            OR (project_type = 'build_venture')
+            OR (
+                project_type = 'pursue_romance'
+                AND target_character_entity_id IS NOT NULL
+            )
+            OR (
+                project_type = 'court_patron'
+                AND target_character_entity_id IS NOT NULL
+            )
+        );
+
+COMMENT ON CONSTRAINT character_project_states_project_type_check
+    ON character_project_states IS
+    'Closed project-type vocabulary extended by migration 086 for COURT_PATRON.';
+COMMENT ON CONSTRAINT character_project_states_stage_by_type_check
+    ON character_project_states IS
+    'Enforces independent three-stage ladders for PLAN_RELOCATION, RECRUIT_ALLY, BUILD_VENTURE, PURSUE_ROMANCE, and COURT_PATRON.';
+COMMENT ON CONSTRAINT character_project_states_target_by_type_check
+    ON character_project_states IS
+    'Enforces typed targets: COURT_PATRON requires only its character patron and forbids place and faction targets.';
+COMMENT ON CONSTRAINT character_project_states_completed_target_check
+    ON character_project_states IS
+    'Completed targeted projects retain their required target; COURT_PATRON retains its named patron character.';
+
+COMMENT ON TABLE character_project_states IS
+    'Additive Orrery project lifecycle projection. Supports relocation, recruitment, venture-building, named-character courtship, and named-character patronage under one open project per character.';
+COMMENT ON COLUMN character_project_states.project_type IS
+    'Locked project vocabulary: plan_relocation, recruit_ally, build_venture, pursue_romance, or court_patron.';
+COMMENT ON COLUMN character_project_states.stage IS
+    'Type-specific three-stage ladder, including COURT_PATRON gaining_notice, proving_worth, and securing_favor.';
+COMMENT ON COLUMN character_project_states.target_place_id IS
+    'Place target used only by PLAN_RELOCATION; always NULL for COURT_PATRON.';
+COMMENT ON COLUMN character_project_states.target_character_entity_id IS
+    'Character target required by RECRUIT_ALLY, PURSUE_ROMANCE, and COURT_PATRON.';
+COMMENT ON COLUMN character_project_states.target_faction_entity_id IS
+    'Optional immutable institutional context for older project arms; always NULL for BUILD_VENTURE, PURSUE_ROMANCE, and COURT_PATRON.';
+
+INSERT INTO event_types (type, category, severity, description)
+VALUES
+    ('court_patron_started', 'project', 'moderate',
+     'The actor began working to gain the notice of a named patron.'),
+    ('court_patron_progressed', 'project', 'minor',
+     'The actor made routine progress toward earning a patron''s favor.'),
+    ('court_patron_milestone', 'project', 'moderate',
+     'The effort to court a patron crossed a boundary of notice or proven worth.'),
+    ('court_patron_stalled', 'project', 'minor',
+     'Neglect cost the actor ground in the effort to secure a patron''s favor.'),
+    ('court_patron_abandoned', 'project', 'moderate',
+     'The actor abandoned an effort to court a patron after delay or rejection.'),
+    ('court_patron_completed', 'project', 'moderate',
+     'The named patron granted favor and accepted the actor''s obligation.')
+ON CONFLICT (type) DO NOTHING;

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -62,6 +62,7 @@ from nexus.agents.orrery.resolver import (
     _LOCATION_CLASS_CATEGORY_SQL,
     OrreryScenePressureDraft,
     _apply_pair_fanout_quota,
+    _arbitrate_project_starts,
     _coerce_fanout,
     _entity_label,
     _load_entity_names,
@@ -151,6 +152,7 @@ class ExplainedTickReport:
     communication_graph: CommunicationGraph
     joint_beats: Tuple[OrreryJointBeat, ...] = ()
     fanout_trimmed: Tuple[Mapping[str, Any], ...] = ()
+    project_start_arbitration_trimmed: Tuple[Mapping[str, Any], ...] = ()
     mode: str = "current"
     overrides: Optional[Mapping[str, Any]] = None
     need_pressures_diff: Optional[Mapping[str, Any]] = None
@@ -174,6 +176,9 @@ class ExplainedTickReport:
             "actors": [self._group_payload(group) for group in self.actors],
             "joint_beats": [beat.to_dict() for beat in self.joint_beats],
             "fanout_trimmed": [dict(item) for item in self.fanout_trimmed],
+            "project_start_arbitration_trimmed": [
+                dict(item) for item in self.project_start_arbitration_trimmed
+            ],
             "need_pressures": [draft.to_dict() for draft in self.need_pressures],
             "need_pressures_diff": (
                 dict(self.need_pressures_diff)
@@ -803,7 +808,39 @@ def explain_dry_run(
         for shim in joint_beat_inputs
         if id(shim) not in kept_ids
     )
-    joint_beats = detect_joint_beats(kept_inputs, entity_names)
+    # Production arbitrates project starts AFTER the fan-out quota
+    # (resolver.resolve_dry_run: _apply_pair_fanout_quota then
+    # _arbitrate_project_starts, then joint beats over the survivors).
+    # Mirror both steps in that order and report what was dropped instead
+    # of silently hiding it. Per-actor precedence is what matters: the
+    # actor-only stack's winner precedes routed pair stacks, as it does in
+    # production draft assembly.
+    solo_winner_shims = [
+        _WinnerShim(stack, item)
+        for _actor_id, stack in sorted(active.actor_stacks.items())
+        if stack.winner_id is not None
+        for item in stack.templates
+        if item.template_id == stack.winner_id
+    ]
+    arbitration_inputs = solo_winner_shims + kept_inputs
+    arbitration_kept_ids = {
+        id(shim)
+        for shim in _arbitrate_project_starts(arbitration_inputs, templates_list)
+    }
+    project_start_arbitration_trimmed = tuple(
+        {
+            "actor_entity_id": shim.bindings.get("actor"),
+            "target_entity_id": shim.bindings.get("target"),
+            "faction_entity_id": shim.bindings.get("faction"),
+            "template_id": shim.template_id,
+        }
+        for shim in arbitration_inputs
+        if id(shim) not in arbitration_kept_ids
+    )
+    joint_beats = detect_joint_beats(
+        [shim for shim in kept_inputs if id(shim) in arbitration_kept_ids],
+        entity_names,
+    )
 
     not_applicable_markers = tuple(
         {
@@ -874,6 +911,7 @@ def explain_dry_run(
         communication_graph=active_state.communication_graph,
         joint_beats=joint_beats,
         fanout_trimmed=fanout_trimmed,
+        project_start_arbitration_trimmed=project_start_arbitration_trimmed,
         mode="what_if" if what_if else "current",
         overrides=overrides.to_dict() if what_if and overrides is not None else None,
         need_pressures_diff=need_pressures_diff,

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -579,6 +579,16 @@ def _render_state_delta(delta: Mapping[str, Any]) -> str:
             else:
                 parts.append(f"adds outbound {tags} pair tag to target")
             continue
+        if key == "entity_pair_tags.add_inbound":
+            tags = ", ".join(f"`{t}`" for t in value)
+            if "project.complete" in delta and "sponsors" in value:
+                parts.append(
+                    f"adds inbound {tags} pair tag from target to actor and "
+                    "upserts the actor→target `patron` relationship"
+                )
+            else:
+                parts.append(f"adds inbound {tags} pair tag from target to actor")
+            continue
         if key == "entity_pair_tags.clear_outbound":
             tags = ", ".join(f"`{t}`" for t in value)
             parts.append(f"clears own outbound {tags} pair tag to target")
@@ -846,6 +856,7 @@ def _collect_vocabulary(
                 if key in (
                     "entity_pair_tags_target.clear_inbound",
                     "entity_pair_tags.add_outbound",
+                    "entity_pair_tags.add_inbound",
                     "entity_pair_tags.clear_outbound",
                 ):
                     if isinstance(value, list):

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -145,7 +145,10 @@ def _tally_report(
     tallies: dict[str, _TemplateTally],
     gap_counts: dict[int, dict[str, int]],
 ) -> dict[str, Any]:
-    fanout_trimmed = {
+    # Winners production dropped never reach commit, so they must not be
+    # tallied — the fan-out quota and the project-start arbitration are the
+    # two draft-level filters (resolver order: quota, then arbitration).
+    trimmed_winners = {
         (
             item["actor_entity_id"],
             item["target_entity_id"],
@@ -153,6 +156,14 @@ def _tally_report(
             item["template_id"],
         )
         for item in report.fanout_trimmed
+    } | {
+        (
+            item["actor_entity_id"],
+            item.get("target_entity_id"),
+            item.get("faction_entity_id"),
+            item["template_id"],
+        )
+        for item in report.project_start_arbitration_trimmed
     }
     winners_by_band: dict[str, int] = {}
     gap_actor_ids: list[int] = []
@@ -179,7 +190,7 @@ def _tally_report(
                 )
                 if (
                     item.template_id == stack.winner_id
-                    and winner_key not in fanout_trimmed
+                    and winner_key not in trimmed_winners
                 ):
                     tally.won += 1
                     winners_by_band[item.drive_band] = (

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -203,6 +203,8 @@ def _tally_report(
                     "advance_build_venture",
                     "start_pursue_romance",
                     "advance_pursue_romance",
+                    "start_court_patron",
+                    "advance_court_patron",
                 }:
                     project_gates.append(
                         {

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -3408,7 +3408,6 @@ def _upsert_court_patron_relationship_sync(
         )
         ON CONFLICT (character1_id, character2_id) DO UPDATE SET
             relationship_type = EXCLUDED.relationship_type,
-            emotional_valence = EXCLUDED.emotional_valence,
             extra_data = COALESCE(character_relationships.extra_data, '{}'::jsonb)
                          || EXCLUDED.extra_data,
             updated_at = now()
@@ -3486,7 +3485,6 @@ async def _upsert_court_patron_relationship_async(
         )
         ON CONFLICT (character1_id, character2_id) DO UPDATE SET
             relationship_type = EXCLUDED.relationship_type,
-            emotional_valence = EXCLUDED.emotional_valence,
             extra_data = COALESCE(character_relationships.extra_data, '{}'::jsonb)
                          || EXCLUDED.extra_data,
             updated_at = now()

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -62,6 +62,7 @@ SUPPORTED_STATE_DELTA_KEYS = frozenset(
         "entity_tags_target.add",
         "entity_tags_target.remove",
         "entity_pair_tags.add_outbound",
+        "entity_pair_tags.add_inbound",
         "entity_pair_tags.clear_outbound",
         "entity_pair_tags_target.clear_inbound",
         "need.fulfill",
@@ -85,6 +86,7 @@ REPLACEMENT_STATE_DELTA_ALIASES = {
     "entity_tags_target_add": "entity_tags_target.add",
     "entity_tags_target_remove": "entity_tags_target.remove",
     "entity_pair_tags_add_outbound": "entity_pair_tags.add_outbound",
+    "entity_pair_tags_add_inbound": "entity_pair_tags.add_inbound",
     "entity_pair_tags_clear_outbound": "entity_pair_tags.clear_outbound",
     "entity_pair_tags_target_clear_inbound": ("entity_pair_tags_target.clear_inbound"),
 }
@@ -1628,6 +1630,35 @@ def _apply_state_delta_sync(
                 template_id=draft.template_id,
                 source_chunk_id=source_chunk_id,
             )
+    inbound_pair_tag_adds = (
+        draft.state_delta.get("entity_pair_tags.add_inbound", ()) or ()
+    )
+    if inbound_pair_tag_adds:
+        if target_entity_id is None:
+            raise ValueError(
+                f"Orrery draft {draft.template_id} adds an inbound pair tag "
+                "but has no target binding"
+            )
+        for tag in inbound_pair_tag_adds:
+            changed = _add_inbound_pair_tag_sync(
+                cur,
+                target_entity_id=target_entity_id,
+                actor_entity_id=actor_entity_id,
+                tag=str(tag),
+                template_id=draft.template_id,
+                source_chunk_id=source_chunk_id,
+            )
+            applied_pair_tag_mutations.append(
+                {
+                    "operation": "add_inbound",
+                    "tag": str(tag),
+                    "subject_entity_id": target_entity_id,
+                    "object_entity_id": actor_entity_id,
+                    "changed": changed,
+                }
+            )
+            if changed:
+                tag_mutations += 1
     outbound_pair_tag_adds = (
         draft.state_delta.get("entity_pair_tags.add_outbound", ()) or ()
     )
@@ -1863,6 +1894,35 @@ async def _apply_state_delta_async(
                 template_id=draft.template_id,
                 source_chunk_id=source_chunk_id,
             )
+    inbound_pair_tag_adds = (
+        draft.state_delta.get("entity_pair_tags.add_inbound", ()) or ()
+    )
+    if inbound_pair_tag_adds:
+        if target_entity_id is None:
+            raise ValueError(
+                f"Orrery draft {draft.template_id} adds an inbound pair tag "
+                "but has no target binding"
+            )
+        for tag in inbound_pair_tag_adds:
+            changed = await _add_inbound_pair_tag_async(
+                conn,
+                target_entity_id=target_entity_id,
+                actor_entity_id=actor_entity_id,
+                tag=str(tag),
+                template_id=draft.template_id,
+                source_chunk_id=source_chunk_id,
+            )
+            applied_pair_tag_mutations.append(
+                {
+                    "operation": "add_inbound",
+                    "tag": str(tag),
+                    "subject_entity_id": target_entity_id,
+                    "object_entity_id": actor_entity_id,
+                    "changed": changed,
+                }
+            )
+            if changed:
+                tag_mutations += 1
     outbound_pair_tag_adds = (
         draft.state_delta.get("entity_pair_tags.add_outbound", ()) or ()
     )
@@ -2157,6 +2217,7 @@ PROJECT_STAGE_LADDERS = {
         "growing_closer",
         "declaring_intentions",
     ),
+    "court_patron": ("gaining_notice", "proving_worth", "securing_favor"),
 }
 
 
@@ -2389,15 +2450,18 @@ def _apply_project_start_sync(
         raise ValueError("project.start faction target must be an entity id")
     if project_type == "plan_relocation" and target_character_entity_id is not None:
         raise ValueError("plan_relocation project.start forbids a character target")
-    if project_type in {"recruit_ally", "pursue_romance"}:
+    if project_type in {"recruit_ally", "pursue_romance", "court_patron"}:
         if target_place_id is not None:
             raise ValueError(f"{project_type} project.start forbids a place target")
         if not isinstance(target_character_entity_id, int):
             raise ValueError(
                 f"{project_type} project.start requires a character target"
             )
-        if project_type == "pursue_romance" and target_faction_entity_id is not None:
-            raise ValueError("pursue_romance project.start forbids a faction target")
+        if (
+            project_type in {"pursue_romance", "court_patron"}
+            and target_faction_entity_id is not None
+        ):
+            raise ValueError(f"{project_type} project.start forbids a faction target")
     if project_type == "build_venture" and any(
         target is not None
         for target in (
@@ -2472,15 +2536,18 @@ async def _apply_project_start_async(
         raise ValueError("project.start faction target must be an entity id")
     if project_type == "plan_relocation" and target_character_entity_id is not None:
         raise ValueError("plan_relocation project.start forbids a character target")
-    if project_type in {"recruit_ally", "pursue_romance"}:
+    if project_type in {"recruit_ally", "pursue_romance", "court_patron"}:
         if target_place_id is not None:
             raise ValueError(f"{project_type} project.start forbids a place target")
         if not isinstance(target_character_entity_id, int):
             raise ValueError(
                 f"{project_type} project.start requires a character target"
             )
-        if project_type == "pursue_romance" and target_faction_entity_id is not None:
-            raise ValueError("pursue_romance project.start forbids a faction target")
+        if (
+            project_type in {"pursue_romance", "court_patron"}
+            and target_faction_entity_id is not None
+        ):
+            raise ValueError(f"{project_type} project.start forbids a faction target")
     if project_type == "build_venture" and any(
         target is not None
         for target in (
@@ -2881,6 +2948,18 @@ def _validate_project_completion(
             raise ValueError("pursue_romance completion forbids a place target")
         if project["target_faction_entity_id"] is not None:
             raise ValueError("pursue_romance completion forbids a faction target")
+    if project_type == "court_patron":
+        patron_id = project["target_character_entity_id"]
+        if patron_id is None:
+            raise ValueError("court_patron completion requires its character target")
+        if target_entity_id != patron_id:
+            raise ValueError(
+                "court_patron completion target binding does not match its patron"
+            )
+        if project["target_place_id"] is not None:
+            raise ValueError("court_patron completion forbids a place target")
+        if project["target_faction_entity_id"] is not None:
+            raise ValueError("court_patron completion forbids a faction target")
     if project_type == "build_venture" and any(
         project[target] is not None
         for target in (
@@ -3250,6 +3329,187 @@ async def _upsert_pursue_romance_relationship_async(
     }
 
 
+def _court_patron_relationship_metadata(
+    *,
+    template_id: str,
+    source_chunk_id: int,
+    previous_relationship_type: Optional[str],
+    existing_extra_data: Any,
+) -> dict[str, Any]:
+    """Return durable provenance for the canonical patron relationship."""
+
+    original_type = previous_relationship_type
+    if isinstance(existing_extra_data, Mapping):
+        prior = existing_extra_data.get("orrery_court_patron")
+        if isinstance(prior, Mapping):
+            original_type = prior.get("previous_relationship_type", original_type)
+    return {
+        "orrery_court_patron": {
+            "template_id": template_id,
+            "source_chunk_id": source_chunk_id,
+            "previous_relationship_type": original_type,
+        }
+    }
+
+
+def _upsert_court_patron_relationship_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    target_entity_id: int,
+    template_id: str,
+    source_chunk_id: int,
+) -> dict[str, Any]:
+    """Persist actor->target using the trait compiler's patron convention."""
+
+    cur.execute(
+        """
+        SELECT actor.id AS character1_id,
+               target.id AS character2_id,
+               existing.relationship_type AS previous_relationship_type,
+               existing.extra_data
+        FROM characters actor
+        JOIN characters target ON target.entity_id = %s
+        LEFT JOIN character_relationships existing
+          ON existing.character1_id = actor.id
+         AND existing.character2_id = target.id
+        WHERE actor.entity_id = %s
+        """,
+        (target_entity_id, actor_entity_id),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(
+            "court_patron completion requires actor and target character rows"
+        )
+    character1_id = int(_row_get(row, "character1_id", 0))
+    character2_id = int(_row_get(row, "character2_id", 1))
+    if character1_id == character2_id:
+        raise ValueError("court_patron completion cannot target the actor")
+    previous = _row_get(row, "previous_relationship_type", 2)
+    previous_type = str(previous) if previous is not None else None
+    metadata = _court_patron_relationship_metadata(
+        template_id=template_id,
+        source_chunk_id=source_chunk_id,
+        previous_relationship_type=previous_type,
+        existing_extra_data=_row_get(row, "extra_data", 3),
+    )
+    cur.execute(
+        """
+        INSERT INTO character_relationships (
+            character1_id, character2_id, relationship_type,
+            emotional_valence, dynamic, recent_events, history, extra_data
+        ) VALUES (
+            %s, %s, 'patron', '+2|friendly',
+            'Patronage secured through demonstrated worth.',
+            'A sustained effort concluded in granted favor and obligation.',
+            'Patronage established through the COURT_PATRON project.',
+            %s::jsonb
+        )
+        ON CONFLICT (character1_id, character2_id) DO UPDATE SET
+            relationship_type = EXCLUDED.relationship_type,
+            emotional_valence = EXCLUDED.emotional_valence,
+            extra_data = COALESCE(character_relationships.extra_data, '{}'::jsonb)
+                         || EXCLUDED.extra_data,
+            updated_at = now()
+        RETURNING character1_id, character2_id, relationship_type
+        """,
+        (character1_id, character2_id, json.dumps(metadata)),
+    )
+    if cur.fetchone() is None:
+        raise RuntimeError("court_patron relationship upsert returned no row")
+    return {
+        "operation": "insert" if previous_type is None else "update",
+        "subject_entity_id": actor_entity_id,
+        "object_entity_id": target_entity_id,
+        "character1_id": character1_id,
+        "character2_id": character2_id,
+        "previous_relationship_type": previous_type,
+        "relationship_type": "patron",
+        "relationship_type_changed": previous_type != "patron",
+    }
+
+
+async def _upsert_court_patron_relationship_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    target_entity_id: int,
+    template_id: str,
+    source_chunk_id: int,
+) -> dict[str, Any]:
+    """Async twin of _upsert_court_patron_relationship_sync."""
+
+    row = await conn.fetchrow(
+        """
+        SELECT actor.id AS character1_id,
+               target.id AS character2_id,
+               existing.relationship_type AS previous_relationship_type,
+               existing.extra_data
+        FROM characters actor
+        JOIN characters target ON target.entity_id = $2
+        LEFT JOIN character_relationships existing
+          ON existing.character1_id = actor.id
+         AND existing.character2_id = target.id
+        WHERE actor.entity_id = $1
+        """,
+        actor_entity_id,
+        target_entity_id,
+    )
+    if row is None:
+        raise ValueError(
+            "court_patron completion requires actor and target character rows"
+        )
+    character1_id = int(_row_get(row, "character1_id", 0))
+    character2_id = int(_row_get(row, "character2_id", 1))
+    if character1_id == character2_id:
+        raise ValueError("court_patron completion cannot target the actor")
+    previous = _row_get(row, "previous_relationship_type", 2)
+    previous_type = str(previous) if previous is not None else None
+    metadata = _court_patron_relationship_metadata(
+        template_id=template_id,
+        source_chunk_id=source_chunk_id,
+        previous_relationship_type=previous_type,
+        existing_extra_data=_row_get(row, "extra_data", 3),
+    )
+    written = await conn.fetchrow(
+        """
+        INSERT INTO character_relationships (
+            character1_id, character2_id, relationship_type,
+            emotional_valence, dynamic, recent_events, history, extra_data
+        ) VALUES (
+            $1, $2, 'patron', '+2|friendly',
+            'Patronage secured through demonstrated worth.',
+            'A sustained effort concluded in granted favor and obligation.',
+            'Patronage established through the COURT_PATRON project.',
+            $3::jsonb
+        )
+        ON CONFLICT (character1_id, character2_id) DO UPDATE SET
+            relationship_type = EXCLUDED.relationship_type,
+            emotional_valence = EXCLUDED.emotional_valence,
+            extra_data = COALESCE(character_relationships.extra_data, '{}'::jsonb)
+                         || EXCLUDED.extra_data,
+            updated_at = now()
+        RETURNING character1_id, character2_id, relationship_type
+        """,
+        character1_id,
+        character2_id,
+        json.dumps(metadata),
+    )
+    if written is None:
+        raise RuntimeError("court_patron relationship upsert returned no row")
+    return {
+        "operation": "insert" if previous_type is None else "update",
+        "subject_entity_id": actor_entity_id,
+        "object_entity_id": target_entity_id,
+        "character1_id": character1_id,
+        "character2_id": character2_id,
+        "previous_relationship_type": previous_type,
+        "relationship_type": "patron",
+        "relationship_type_changed": previous_type != "patron",
+    }
+
+
 def _apply_project_complete_sync(
     cur: Any,
     *,
@@ -3296,6 +3556,15 @@ def _apply_project_complete_sync(
     elif project["project_type"] == "pursue_romance":
         assert target_entity_id is not None
         relationship_mutation = _upsert_pursue_romance_relationship_sync(
+            cur,
+            actor_entity_id=actor_entity_id,
+            target_entity_id=target_entity_id,
+            template_id=template_id,
+            source_chunk_id=source_chunk_id,
+        )
+    elif project["project_type"] == "court_patron":
+        assert target_entity_id is not None
+        relationship_mutation = _upsert_court_patron_relationship_sync(
             cur,
             actor_entity_id=actor_entity_id,
             target_entity_id=target_entity_id,
@@ -3372,6 +3641,15 @@ async def _apply_project_complete_async(
     elif project["project_type"] == "pursue_romance":
         assert target_entity_id is not None
         relationship_mutation = await _upsert_pursue_romance_relationship_async(
+            conn,
+            actor_entity_id=actor_entity_id,
+            target_entity_id=target_entity_id,
+            template_id=template_id,
+            source_chunk_id=source_chunk_id,
+        )
+    elif project["project_type"] == "court_patron":
+        assert target_entity_id is not None
+        relationship_mutation = await _upsert_court_patron_relationship_async(
             conn,
             actor_entity_id=actor_entity_id,
             target_entity_id=target_entity_id,
@@ -4483,6 +4761,27 @@ def _add_outbound_pair_tag_sync(
     return cur.fetchone() is not None
 
 
+def _add_inbound_pair_tag_sync(
+    cur: Any,
+    *,
+    target_entity_id: int,
+    actor_entity_id: int,
+    tag: str,
+    template_id: str,
+    source_chunk_id: int,
+) -> bool:
+    """Create a directed pair tag from the bound target to the actor."""
+
+    return _add_outbound_pair_tag_sync(
+        cur,
+        subject_entity_id=target_entity_id,
+        object_entity_id=actor_entity_id,
+        tag=tag,
+        template_id=template_id,
+        source_chunk_id=source_chunk_id,
+    )
+
+
 def _clear_outbound_pair_tag_sync(
     cur: Any,
     *,
@@ -4670,6 +4969,27 @@ async def _add_outbound_pair_tag_async(
         source_chunk_id,
     )
     return row is not None
+
+
+async def _add_inbound_pair_tag_async(
+    conn: Any,
+    *,
+    target_entity_id: int,
+    actor_entity_id: int,
+    tag: str,
+    template_id: str,
+    source_chunk_id: int,
+) -> bool:
+    """Async twin of _add_inbound_pair_tag_sync."""
+
+    return await _add_outbound_pair_tag_async(
+        conn,
+        subject_entity_id=target_entity_id,
+        object_entity_id=actor_entity_id,
+        tag=tag,
+        template_id=template_id,
+        source_chunk_id=source_chunk_id,
+    )
 
 
 async def _clear_outbound_pair_tag_async(

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -89,6 +89,7 @@ PROJECT_STAGE_LADDERS = {
         "growing_closer",
         "declaring_intentions",
     ),
+    "court_patron": ("gaining_notice", "proving_worth", "securing_favor"),
 }
 
 # Composite natural keys, verbatim column order (faction_relationships
@@ -126,6 +127,7 @@ TAG_DELTA_KEYS = frozenset(
         "entity_tags_target.add",
         "entity_tags_target.remove",
         "entity_pair_tags.add_outbound",
+        "entity_pair_tags.add_inbound",
         "entity_pair_tags.clear_outbound",
         "entity_pair_tags_target.clear_inbound",
     }
@@ -1007,11 +1009,15 @@ class _Replayer:
                 raise ValueError(
                     "plan_relocation replay projection forbids character target"
                 )
-        elif project_type in {"recruit_ally", "pursue_romance"} and (
+        elif project_type in {
+            "recruit_ally",
+            "pursue_romance",
+            "court_patron",
+        } and (
             applied_row["target_place_id"] is not None
             or applied_row["target_character_entity_id"] is None
             or (
-                project_type == "pursue_romance"
+                project_type in {"pursue_romance", "court_patron"}
                 and applied_row["target_faction_entity_id"] is not None
             )
         ):
@@ -1080,7 +1086,11 @@ class _Replayer:
             if float(applied_row["progress"] or 0.0) < 1.0:
                 raise ValueError("project.complete replay requires full progress")
             row.update(applied_row)
-            if project_type in {"recruit_ally", "pursue_romance"}:
+            if project_type in {
+                "recruit_ally",
+                "pursue_romance",
+                "court_patron",
+            }:
                 if applied_row["target_character_entity_id"] is None:
                     raise ValueError(
                         f"{project_type} completion replay requires character target"

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -2213,7 +2213,11 @@ def _materialize_project_delta(
     raw_start = delta.get("project.start")
     if raw_start is not None:
         start_payload = dict(raw_start) if isinstance(raw_start, Mapping) else {}
-        if start_payload.get("project_type") in {"recruit_ally", "pursue_romance"}:
+        if start_payload.get("project_type") in {
+            "recruit_ally",
+            "pursue_romance",
+            "court_patron",
+        }:
             target = resolution.bindings.get(Slot.TARGET)
             if not isinstance(target, int):
                 raise ValueError(

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -1186,6 +1186,11 @@ _PROJECT_DUE_MODES = frozenset(
         "declaring_intentions",
         "testing_waters_milestone",
         "growing_closer_milestone",
+        "gaining_notice",
+        "proving_worth",
+        "securing_favor",
+        "gaining_notice_milestone",
+        "proving_worth_milestone",
     }
 )
 
@@ -1202,6 +1207,7 @@ _PROJECT_STAGE_LADDERS = {
         "growing_closer",
         "declaring_intentions",
     ),
+    "court_patron": ("gaining_notice", "proving_worth", "securing_favor"),
 }
 
 
@@ -1330,7 +1336,12 @@ def project_due(
                 if project_type == "plan_relocation"
                 else (
                     project.target_character_entity_id is not None
-                    if project_type in {"recruit_ally", "pursue_romance"}
+                    if project_type
+                    in {
+                        "recruit_ally",
+                        "pursue_romance",
+                        "court_patron",
+                    }
                     else True
                 )
             )
@@ -1345,7 +1356,12 @@ def project_due(
                 if project_type == "plan_relocation"
                 else (
                     project.target_character_entity_id is not None
-                    if project_type in {"recruit_ally", "pursue_romance"}
+                    if project_type
+                    in {
+                        "recruit_ally",
+                        "pursue_romance",
+                        "court_patron",
+                    }
                     else True
                 )
             )

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -1027,6 +1027,7 @@ SURVEIL = Template(
         NOT(project_due("ready")),
         NOT(project_due("ready", project_type="recruit_ally")),
         NOT(project_due("ready", project_type="pursue_romance")),
+        NOT(project_due("ready", project_type="court_patron")),
         NOT(is_constrained()),
         NOT(has_inbound_pair_tag("hunting")),
         NOT(has_ephemeral("grudge_active")),
@@ -5341,6 +5342,360 @@ ADVANCE_PURSUE_ROMANCE = Template(
 )
 
 
+START_COURT_PATRON = Template(
+    id="start_court_patron",
+    priority=17,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "Courting a patron requires both a plausible social opening and a "
+        "specific marker of the target's power."
+    ),
+    blurb="An off-screen character begins working to win a named power's favor.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    starts_from_social_contact=True,
+    package_gate=AND(
+        project_due("start", project_type="court_patron"),
+        has_minimal_context(),
+        at_routine_anchor("home"),
+        NOT(is_in_transit()),
+        NOT(is_constrained()),
+        NOT(
+            OR(
+                has_need_debt_at_or_above("sleep", 8),
+                has_need_debt_at_or_above("thirst", 2),
+                has_need_debt_at_or_above("hunger", 4),
+            )
+        ),
+        OR(
+            AND(has_contact_of_kind("social"), has_pair_tag("contact:social")),
+            has_relationship_of_type("friend", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("friend", Slot.TARGET, Slot.ACTOR),
+            has_relationship_of_type("companion", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("companion", Slot.TARGET, Slot.ACTOR),
+            has_relationship_of_type("comrade", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("comrade", Slot.TARGET, Slot.ACTOR),
+            has_relationship_of_type("chosen_kin", Slot.ACTOR, Slot.TARGET),
+            has_relationship_of_type("chosen_kin", Slot.TARGET, Slot.ACTOR),
+            trust_at_least(1),
+        ),
+        OR(
+            has_any_status_at_or_above("senior", Slot.TARGET),
+            has_tag("leader", Slot.TARGET),
+            has_pair_tag("authority_over", Slot.TARGET, Slot.ACTOR),
+        ),
+        lacks_pair_tag("sponsors", Slot.TARGET, Slot.ACTOR),
+        NOT(has_relationship_of_type("patron", Slot.ACTOR, Slot.TARGET)),
+        NOT(
+            has_any_pair_tag(
+                "hostile_to",
+                "hunting",
+                subject_slot=Slot.ACTOR,
+                object_slot=Slot.TARGET,
+            )
+        ),
+        NOT(
+            has_any_pair_tag(
+                "hostile_to",
+                "hunting",
+                subject_slot=Slot.TARGET,
+                object_slot=Slot.ACTOR,
+            )
+        ),
+    ),
+    branches=(
+        Branch(
+            label="Begin seeking the patron's notice",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} stops hoping that {target} will notice them by accident. "
+                "They choose a first gesture calculated to be useful, visible, "
+                "and difficult to mistake for idle flattery."
+            ),
+            state_delta={
+                "project.start": {
+                    "project_type": "court_patron",
+                    "stage": "gaining_notice",
+                    "milestone": True,
+                }
+            },
+            event_type="court_patron_started",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.stage",
+                "character_project_states.target_character_entity_id",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.40,
+        ),
+    ),
+)
+
+
+ADVANCE_COURT_PATRON = Template(
+    id="advance_court_patron",
+    priority=47,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "A due patronage effort shares the established project-continuation "
+        "slot while SURVEIL yields to its bound two-party work."
+    ),
+    blurb=(
+        "A due patronage effort gains notice, proves worth, secures favor, "
+        "stalls, is spurned, or ends."
+    ),
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    binds_project_target=True,
+    package_gate=AND(
+        project_due("ready", project_type="court_patron"),
+        project_target_is(Slot.TARGET),
+        NOT(is_in_transit()),
+        NOT(is_constrained()),
+        NOT(
+            OR(
+                has_need_debt_at_or_above("sleep", 8),
+                has_need_debt_at_or_above("thirst", 2),
+                has_need_debt_at_or_above("hunger", 4),
+            )
+        ),
+    ),
+    branches=(
+        Branch(
+            label="End a patronage effort whose target is no longer available",
+            conditions=NOT(project_target_is_active(Slot.TARGET)),
+            narrative_stub=(
+                "{target} is no longer someone whose favor can be won. {actor} "
+                "closes the effort rather than courting a power that cannot answer."
+            ),
+            state_delta={
+                "project.abandon": {
+                    "reason": "target_inactive_or_non_character",
+                    "milestone": True,
+                }
+            },
+            event_type="court_patron_abandoned",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.source_chunk_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Secure the patron's favor",
+            conditions=AND(
+                project_due("completion", project_type="court_patron"),
+                trust_at_least(2, Slot.TARGET, Slot.ACTOR),
+                NOT(
+                    has_any_pair_tag(
+                        "hostile_to",
+                        "hunting",
+                        subject_slot=Slot.ACTOR,
+                        object_slot=Slot.TARGET,
+                    )
+                ),
+                NOT(
+                    has_any_pair_tag(
+                        "hostile_to",
+                        "hunting",
+                        subject_slot=Slot.TARGET,
+                        object_slot=Slot.ACTOR,
+                    )
+                ),
+            ),
+            narrative_stub=(
+                "{target} finally answers {actor}'s service with public favor. "
+                "The protection is real, and so is the obligation attached to it."
+            ),
+            state_delta={
+                "project.complete": {"milestone": True},
+                "entity_pair_tags.add_inbound": ["sponsors"],
+                "entity_pair_tags.add_outbound": ["obligation"],
+            },
+            event_type="court_patron_completed",
+            changed_fields=(
+                "character_project_states.status",
+                "entity_pair_tags",
+                "character_relationships.relationship_type",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Withdraw after being spurned",
+            conditions=OR(
+                has_any_pair_tag(
+                    "hostile_to",
+                    "hunting",
+                    subject_slot=Slot.ACTOR,
+                    object_slot=Slot.TARGET,
+                ),
+                has_any_pair_tag(
+                    "hostile_to",
+                    "hunting",
+                    subject_slot=Slot.TARGET,
+                    object_slot=Slot.ACTOR,
+                ),
+                trust_below(-1, Slot.TARGET, Slot.ACTOR),
+            ),
+            narrative_stub=(
+                "{target}'s answer is rejection, contempt, or danger. {actor} "
+                "abandons the bid for favor before deference becomes humiliation."
+            ),
+            state_delta={
+                "project.abandon": {
+                    "reason": "target_spurned_or_hostile",
+                    "milestone": True,
+                }
+            },
+            event_type="court_patron_abandoned",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.source_chunk_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Let the bid for patronage go",
+            conditions=project_due("abandon", project_type="court_patron"),
+            narrative_stub=(
+                "Delay has become its own refusal. {actor} stops spending effort "
+                "on favor that never comes within reach."
+            ),
+            state_delta={
+                "project.abandon": {"reason": "stalled_or_overdue", "milestone": True}
+            },
+            event_type="court_patron_abandoned",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.source_chunk_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Turn notice into a chance to prove worth",
+            conditions=project_due(
+                "gaining_notice_milestone", project_type="court_patron"
+            ),
+            narrative_stub=(
+                "{target} has noticed {actor}. Attention now becomes a test: "
+                "whether usefulness survives scrutiny and inconvenience."
+            ),
+            state_delta={
+                "project.advance": {
+                    "stage": "proving_worth",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            event_type="court_patron_milestone",
+            changed_fields=(
+                "character_project_states.stage",
+                "character_project_states.progress",
+                "character_project_states.stall_count",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Ask proven worth to become favor",
+            conditions=project_due(
+                "proving_worth_milestone", project_type="court_patron"
+            ),
+            narrative_stub=(
+                "{actor} has supplied proof instead of promises. The remaining "
+                "question is whether {target} will convert approval into favor."
+            ),
+            state_delta={
+                "project.advance": {
+                    "stage": "securing_favor",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            event_type="court_patron_milestone",
+            changed_fields=(
+                "character_project_states.stage",
+                "character_project_states.progress",
+                "character_project_states.stall_count",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Lose ground through neglect",
+            conditions=project_due("neglected", project_type="court_patron"),
+            narrative_stub=(
+                "Inattention erodes the impression {actor} worked to create. "
+                "The bid for patronage stalls and must recover its momentum."
+            ),
+            state_delta={"project.stall": {"increment": 1}},
+            event_type="court_patron_stalled",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.stall_count",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.10,
+            promotable=False,
+            preemptive=True,
+        ),
+        Branch(
+            label="Make useful work visible",
+            conditions=project_due("gaining_notice", project_type="court_patron"),
+            narrative_stub=(
+                "{actor} places one useful act where {target} can see both its "
+                "value and the judgment behind it."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.35}},
+            event_type="court_patron_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.18,
+            promotable=False,
+        ),
+        Branch(
+            label="Prove reliable under scrutiny",
+            conditions=project_due("proving_worth", project_type="court_patron"),
+            narrative_stub=(
+                "{actor} accepts a consequential task and performs it cleanly, "
+                "giving {target} evidence that usefulness is not a pose."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.35}},
+            event_type="court_patron_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.18,
+            promotable=False,
+        ),
+        Branch(
+            label="Make the next claim on favor legible",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} makes one more service, request, or allegiance explicit, "
+                "bringing {target}'s answer closer without pretending it is owed."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.25}},
+            event_type="court_patron_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.16,
+            promotable=False,
+        ),
+    ),
+)
+
+
 START_BUILD_VENTURE = Template(
     id="start_build_venture",
     priority=17,
@@ -5607,6 +5962,7 @@ BUILTIN_TEMPLATES = (
     ADVANCE_RECRUIT_ALLY,
     ADVANCE_BUILD_VENTURE,
     ADVANCE_PURSUE_ROMANCE,
+    ADVANCE_COURT_PATRON,
     ACT_ON_INTEL,
     UNCOVER_PAST,
     CHECK_ON_DEPENDENT,
@@ -5633,6 +5989,7 @@ BUILTIN_TEMPLATES = (
     START_RECRUIT_ALLY,
     START_BUILD_VENTURE,
     START_PURSUE_ROMANCE,
+    START_COURT_PATRON,
     MAINTAIN_COVER,
 )
 

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -151,13 +151,23 @@ def test_resolve_parity_with_production_resolver(
     assert len(payload["actors"]) == proposal.actor_count
 
     # --- Resolution parity: actor-only + off-screen two-party stacks -------
-    fanout_trimmed = {
+    # Production drops drafts via the fan-out quota AND the project-start
+    # arbitration; the endpoint reports both trim lists, and parity holds
+    # only after excluding both.
+    trimmed = {
         (
             item["actor_entity_id"],
             item["target_entity_id"],
             item["template_id"],
         )
         for item in payload["fanout_trimmed"]
+    } | {
+        (
+            item["actor_entity_id"],
+            item.get("target_entity_id"),
+            item["template_id"],
+        )
+        for item in payload["project_start_arbitration_trimmed"]
     }
     endpoint_winners: dict[tuple[str, str], dict] = {}
     for group in payload["actors"]:
@@ -169,7 +179,7 @@ def test_resolve_parity_with_production_resolver(
                 group["actor_entity_id"],
                 stack["bindings"].get("target"),
                 winner["template_id"],
-            ) in fanout_trimmed:
+            ) in trimmed:
                 continue
             key = (winner["template_id"], winner["binding_hash"])
             assert key not in endpoint_winners, "duplicate winner stack"

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -635,6 +635,12 @@ def test_catalog_endpoint_over_http(client: TestClient) -> None:
         "pursue_romance_stalled",
         "pursue_romance_abandoned",
         "pursue_romance_completed",
+        "court_patron_started",
+        "court_patron_progressed",
+        "court_patron_milestone",
+        "court_patron_stalled",
+        "court_patron_abandoned",
+        "court_patron_completed",
     }
     assert {band["band"] for band in payload["drive_bands"]} == {
         "crisis_constraint",

--- a/tests/test_orrery/test_catalog.py
+++ b/tests/test_orrery/test_catalog.py
@@ -83,6 +83,19 @@ def test_catalog_renders_pursue_romance_completion_vocabulary() -> None:
     assert "- `contact:intimate`" in content
 
 
+def test_catalog_renders_court_patron_completion_vocabulary() -> None:
+    """Patronage gates and its three-write completion stay discoverable."""
+
+    content = render_catalog(BUILTIN_TEMPLATES)
+    assert "## START_COURT_PATRON — priority 17" in content
+    assert "## ADVANCE_COURT_PATRON — priority 47" in content
+    assert "actor `court_patron` project passes `completion` due-state" in content
+    assert "inbound `sponsors` pair tag from target to actor" in content
+    assert "actor→target `patron` relationship" in content
+    assert "- `obligation`" in content
+    assert "- `sponsors`" in content
+
+
 def test_catalog_renders_compound_structure() -> None:
     """AND / OR / NOT compositions appear as labeled nested bullets."""
 

--- a/tests/test_orrery/test_claim_awareness_replay_live.py
+++ b/tests/test_orrery/test_claim_awareness_replay_live.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from itertools import count
 from typing import Any, Iterator
 from uuid import uuid4
 
@@ -16,6 +17,9 @@ from nexus.agents.orrery.replay import verify_checkpoints_sync
 
 
 pytestmark = pytest.mark.requires_postgres
+
+# Bounded scene numbers: the slug trigger's TO_CHAR scene mask is 3 digits.
+_SCENE_NUMBERS = count(1)
 
 EPISTEMICS = {
     "enabled": True,
@@ -59,7 +63,7 @@ def _insert_chunk(cur: Any) -> int:
             %s, 99, 99, %s, 'primary', interval '0 seconds', now(), %s
         )
         """,
-        (chunk_id, chunk_id, token[:10]),
+        (chunk_id, next(_SCENE_NUMBERS), token[:10]),
     )
     return chunk_id
 

--- a/tests/test_orrery/test_claim_propagation_live.py
+++ b/tests/test_orrery/test_claim_propagation_live.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from typing import Any, Iterator, Mapping, Sequence
+from itertools import count
 from uuid import uuid4
 
 import asyncpg  # type: ignore[import-untyped]
@@ -38,6 +39,12 @@ from nexus.config.settings_models import OrreryContagionSettings
 pytestmark = pytest.mark.requires_postgres
 
 LIVE_SLOT = 5
+
+# The chunk_metadata slug trigger renders scene with TO_CHAR(..., 'FM000');
+# scenes >= 1000 overflow the mask to literal '###' and collide. Fixtures
+# must therefore use small bounded scene numbers, never chunk ids (the
+# narrative_chunks sequence never rolls back and grows without bound).
+_SCENE_NUMBERS = count(1)
 EPISTEMICS = {
     "enabled": True,
     "claim_event_types": ["threat_issued"],
@@ -135,7 +142,7 @@ def _insert_chunk(
             %s, 99, 99, %s, %s::world_layer_type, %s, now(), %s
         )
         """,
-        (chunk_id, chunk_id, world_layer, time_delta, token[:10]),
+        (chunk_id, next(_SCENE_NUMBERS), world_layer, time_delta, token[:10]),
     )
     cur.execute(
         "SELECT world_time FROM chunk_metadata WHERE chunk_id = %s", (chunk_id,)
@@ -1269,7 +1276,7 @@ async def _insert_chunk_async(
         )
         """,
         chunk_id,
-        chunk_id,
+        next(_SCENE_NUMBERS),
         world_layer,
         time_delta,
         token[:10],

--- a/tests/test_orrery/test_court_patron_async.py
+++ b/tests/test_orrery/test_court_patron_async.py
@@ -1,0 +1,225 @@
+"""Live async-writer parity for COURT_PATRON projects."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import asyncpg
+import pytest
+
+from nexus.agents.orrery.events import _apply_state_delta_async
+from nexus.agents.orrery.needs import NeedTuning
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.substrate import ProjectPolicy
+from nexus.api.slot_utils import get_slot_db_url
+
+pytestmark = pytest.mark.requires_postgres
+POLICY = ProjectPolicy(enabled=True, advance_interval_hours=24.0)
+
+
+async def _create_schema(conn: asyncpg.Connection) -> None:
+    schema = f"court_patron_async_{uuid4().hex[:12]}"
+    await conn.execute(f'CREATE SCHEMA "{schema}"')
+    await conn.execute(f'SET LOCAL search_path = "{schema}", public')
+    await conn.execute(
+        """
+        CREATE TABLE event_types (
+            type text PRIMARY KEY, category text NOT NULL,
+            severity text NOT NULL, description text
+        );
+        CREATE TABLE orrery_resolutions (
+            id bigint PRIMARY KEY, state_delta jsonb NOT NULL
+        );
+        CREATE TABLE character_project_states (
+            id bigserial PRIMARY KEY, character_entity_id bigint NOT NULL,
+            project_type text NOT NULL, status text NOT NULL, stage text NOT NULL,
+            target_place_id bigint, target_character_entity_id bigint,
+            target_faction_entity_id bigint, progress numeric(5,4) NOT NULL DEFAULT 0,
+            stall_count integer NOT NULL DEFAULT 0,
+            next_eligible_at_world_time timestamptz, source_chunk_id bigint,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now(),
+            CONSTRAINT character_project_states_project_type_check CHECK (
+                project_type IN (
+                    'plan_relocation', 'recruit_ally', 'build_venture',
+                    'pursue_romance'
+                )),
+            CONSTRAINT character_project_states_stage_by_type_check CHECK (
+                (project_type='plan_relocation'
+                    AND stage IN ('saving','scouting','committing')) OR
+                (project_type='recruit_ally'
+                    AND stage IN (
+                        'sounding_out','earning_trust','sealing_commitment'
+                    )) OR
+                (project_type='build_venture'
+                    AND stage IN (
+                        'laying_groundwork','securing_backing','opening_doors'
+                    )) OR
+                (project_type='pursue_romance'
+                    AND stage IN (
+                        'testing_waters','growing_closer','declaring_intentions'
+                    ))),
+            CONSTRAINT character_project_states_target_by_type_check CHECK (
+                (project_type='plan_relocation'
+                    AND target_character_entity_id IS NULL) OR
+                (project_type='recruit_ally'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NOT NULL) OR
+                (project_type='build_venture'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NULL
+                    AND target_faction_entity_id IS NULL) OR
+                (project_type='pursue_romance'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NOT NULL
+                    AND target_faction_entity_id IS NULL)),
+            CONSTRAINT character_project_states_completed_target_check CHECK (
+                status <> 'completed' OR
+                (project_type='plan_relocation' AND target_place_id IS NOT NULL) OR
+                (project_type='recruit_ally'
+                    AND target_character_entity_id IS NOT NULL) OR
+                project_type='build_venture' OR
+                (project_type='pursue_romance'
+                    AND target_character_entity_id IS NOT NULL))
+        );
+        CREATE UNIQUE INDEX ux_character_project_states_open_budget
+            ON character_project_states(character_entity_id)
+            WHERE status IN ('active','paused','stalled');
+        """
+    )
+    await conn.execute(
+        (
+            Path(__file__).parents[2] / "migrations/086_court_patron_projects.sql"
+        ).read_text()
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_court_patron_three_write_completion() -> None:
+    conn = await asyncpg.connect(get_slot_db_url(slot=2))
+    transaction = conn.transaction()
+    await transaction.start()
+    try:
+        await _create_schema(conn)
+        entities = await conn.fetch(
+            "SELECT entity_id FROM characters WHERE entity_id IS NOT NULL "
+            "ORDER BY id LIMIT 2"
+        )
+        actor, target = (int(row["entity_id"]) for row in entities)
+        chunk = int(
+            await conn.fetchval(
+                "SELECT chunk_id FROM chunk_metadata WHERE world_time IS NOT NULL "
+                "ORDER BY chunk_id DESC LIMIT 1"
+            )
+        )
+        await conn.execute(
+            "DELETE FROM character_relationships USING characters a,characters t "
+            "WHERE character_relationships.character1_id=a.id "
+            "AND character_relationships.character2_id=t.id "
+            "AND a.entity_id=$1 AND t.entity_id=$2",
+            actor,
+            target,
+        )
+        start = OrreryResolutionDraft(
+            template_id="start_court_patron",
+            priority=17,
+            binding_hash="async-start",
+            bindings={"actor": actor, "target": target},
+            branch_label="start",
+            narrative_stub="start",
+            magnitude=0.4,
+            state_delta={
+                "project.start": {
+                    "project_type": "court_patron",
+                    "stage": "gaining_notice",
+                    "target_character_entity_id": target,
+                    "milestone": True,
+                }
+            },
+        )
+        await conn.execute("INSERT INTO orrery_resolutions VALUES (1,'{}'::jsonb)")
+        assert (
+            await _apply_state_delta_async(
+                conn,
+                start,
+                resolution_id=1,
+                actor_entity_id=actor,
+                target_entity_id=target,
+                source_chunk_id=chunk,
+                need_tuning=NeedTuning.default(),
+                project_policy=POLICY,
+            )
+            == 0
+        )
+        await conn.execute(
+            "UPDATE character_project_states "
+            "SET stage='securing_favor',progress=1 "
+            "WHERE character_entity_id=$1",
+            actor,
+        )
+        complete = OrreryResolutionDraft(
+            template_id="advance_court_patron",
+            priority=47,
+            binding_hash="async-complete",
+            bindings={"actor": actor, "target": target},
+            branch_label="complete",
+            narrative_stub="complete",
+            magnitude=0.4,
+            state_delta={
+                "project.complete": {"milestone": True},
+                "entity_pair_tags.add_inbound": ["sponsors"],
+                "entity_pair_tags.add_outbound": ["obligation"],
+            },
+        )
+        await conn.execute("INSERT INTO orrery_resolutions VALUES (2,'{}'::jsonb)")
+        assert (
+            await _apply_state_delta_async(
+                conn,
+                complete,
+                resolution_id=2,
+                actor_entity_id=actor,
+                target_entity_id=target,
+                source_chunk_id=chunk,
+                need_tuning=NeedTuning.default(),
+                project_policy=POLICY,
+            )
+            == 2
+        )
+        edges = await conn.fetch(
+            "SELECT ept.subject_entity_id,ept.object_entity_id,pt.tag "
+            "FROM entity_pair_tags ept "
+            "JOIN pair_tags pt ON pt.id=ept.pair_tag_id WHERE ept.cleared_at IS NULL "
+            "AND ((ept.subject_entity_id=$1 AND ept.object_entity_id=$2 "
+            "AND pt.tag='sponsors') OR (ept.subject_entity_id=$2 "
+            "AND ept.object_entity_id=$1 AND pt.tag='obligation')) "
+            "ORDER BY pt.tag",
+            target,
+            actor,
+        )
+        assert [
+            (row["subject_entity_id"], row["object_entity_id"], row["tag"])
+            for row in edges
+        ] == [(actor, target, "obligation"), (target, actor, "sponsors")]
+        relationship = await conn.fetchrow(
+            "SELECT cr.relationship_type,cr.emotional_valence,cr.extra_data "
+            "FROM character_relationships cr "
+            "JOIN characters a ON a.id=cr.character1_id "
+            "JOIN characters t ON t.id=cr.character2_id "
+            "WHERE a.entity_id=$1 AND t.entity_id=$2",
+            actor,
+            target,
+        )
+        assert relationship is not None
+        assert (
+            relationship["relationship_type"],
+            relationship["emotional_valence"],
+        ) == ("patron", "+2|friendly")
+        assert (
+            json.loads(relationship["extra_data"])["orrery_court_patron"]["template_id"]
+            == "advance_court_patron"
+        )
+    finally:
+        await transaction.rollback()
+        await conn.close()

--- a/tests/test_orrery/test_court_patron_migration_pg.py
+++ b/tests/test_orrery/test_court_patron_migration_pg.py
@@ -1,0 +1,152 @@
+"""Real-PostgreSQL contract coverage for migration 086."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2
+import pytest
+
+from nexus.api.slot_utils import get_slot_db_url
+
+pytestmark = pytest.mark.requires_postgres
+
+
+@pytest.fixture()
+def migration_085_schema() -> Iterator[Any]:
+    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    try:
+        with conn.cursor() as cur:
+            schema = f"migration_086_{uuid4().hex[:12]}"
+            cur.execute(f'CREATE SCHEMA "{schema}"')
+            cur.execute(f'SET LOCAL search_path = "{schema}", public')
+            cur.execute(
+                """
+                CREATE TABLE event_types (
+                    type text PRIMARY KEY, category text NOT NULL,
+                    severity text NOT NULL, description text
+                );
+                CREATE TABLE character_project_states (
+                    id bigserial PRIMARY KEY, character_entity_id bigint NOT NULL,
+                    project_type text NOT NULL, status text NOT NULL,
+                    stage text NOT NULL, target_place_id bigint,
+                    target_character_entity_id bigint,
+                    target_faction_entity_id bigint,
+                    progress numeric(5,4) NOT NULL DEFAULT 0,
+                    stall_count integer NOT NULL DEFAULT 0,
+                    next_eligible_at_world_time timestamptz, source_chunk_id bigint,
+                    CONSTRAINT character_project_states_project_type_check CHECK (
+                        project_type IN (
+                            'plan_relocation', 'recruit_ally', 'build_venture',
+                            'pursue_romance'
+                        )),
+                    CONSTRAINT character_project_states_stage_by_type_check CHECK (
+                        (project_type='plan_relocation'
+                            AND stage IN ('saving','scouting','committing')) OR
+                        (project_type='recruit_ally'
+                            AND stage IN (
+                                'sounding_out','earning_trust',
+                                'sealing_commitment'
+                            )) OR
+                        (project_type='build_venture'
+                            AND stage IN (
+                                'laying_groundwork','securing_backing',
+                                'opening_doors'
+                            )) OR
+                        (project_type='pursue_romance'
+                            AND stage IN (
+                                'testing_waters','growing_closer',
+                                'declaring_intentions'
+                            ))),
+                    CONSTRAINT character_project_states_target_by_type_check CHECK (
+                        (project_type='plan_relocation'
+                            AND target_character_entity_id IS NULL) OR
+                        (project_type='recruit_ally'
+                            AND target_place_id IS NULL
+                            AND target_character_entity_id IS NOT NULL) OR
+                        (project_type='build_venture'
+                            AND target_place_id IS NULL
+                            AND target_character_entity_id IS NULL
+                            AND target_faction_entity_id IS NULL) OR
+                        (project_type='pursue_romance'
+                            AND target_place_id IS NULL
+                            AND target_character_entity_id IS NOT NULL
+                            AND target_faction_entity_id IS NULL)),
+                    CONSTRAINT character_project_states_completed_target_check CHECK (
+                        status <> 'completed' OR
+                        (project_type='plan_relocation'
+                            AND target_place_id IS NOT NULL) OR
+                        (project_type='recruit_ally'
+                            AND target_character_entity_id IS NOT NULL) OR
+                        project_type='build_venture' OR
+                        (project_type='pursue_romance'
+                            AND target_character_entity_id IS NOT NULL))
+                );
+                INSERT INTO character_project_states
+                    (character_entity_id,project_type,status,stage,
+                     target_character_entity_id)
+                    VALUES (1,'pursue_romance','active','testing_waters',2);
+                """
+            )
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_migration_086_widens_constraints_and_seeds_events(
+    migration_085_schema: Any,
+) -> None:
+    sql = (
+        Path(__file__).parents[2] / "migrations/086_court_patron_projects.sql"
+    ).read_text()
+    with migration_085_schema.cursor() as cur:
+        cur.execute(sql)
+        cur.execute(
+            "SELECT conname,pg_get_constraintdef(oid,true),obj_description(oid) "
+            "FROM pg_constraint WHERE conrelid='character_project_states'::regclass "
+            "AND conname LIKE 'character_project_states_%_check'"
+        )
+        constraints = {name: (definition, comment) for name, definition, comment in cur}
+        assert len(constraints) == 4
+        assert all(
+            "court_patron" in definition for definition, _ in constraints.values()
+        )
+        assert all(comment for _, comment in constraints.values())
+        cur.execute(
+            "INSERT INTO character_project_states "
+            "(character_entity_id,project_type,status,stage,"
+            "target_character_entity_id) "
+            "VALUES (3,'court_patron','completed','securing_favor',4)"
+        )
+        for columns, values in (
+            ("target_place_id,target_character_entity_id", "7,4"),
+            ("target_character_entity_id,target_faction_entity_id", "4,8"),
+        ):
+            cur.execute("SAVEPOINT invalid_patron")
+            with pytest.raises(psycopg2.errors.CheckViolation):
+                cur.execute(
+                    "INSERT INTO character_project_states "
+                    f"(character_entity_id,project_type,status,stage,{columns}) "
+                    f"VALUES (5,'court_patron','active','gaining_notice',{values})"
+                )
+            cur.execute("ROLLBACK TO SAVEPOINT invalid_patron")
+        cur.execute(
+            "SELECT project_type FROM character_project_states "
+            "WHERE character_entity_id=1"
+        )
+        assert cur.fetchone() == ("pursue_romance",)
+        cur.execute(
+            "SELECT type,severity FROM event_types "
+            "WHERE type LIKE 'court_patron_%' ORDER BY type"
+        )
+        assert cur.fetchall() == [
+            ("court_patron_abandoned", "moderate"),
+            ("court_patron_completed", "moderate"),
+            ("court_patron_milestone", "moderate"),
+            ("court_patron_progressed", "minor"),
+            ("court_patron_stalled", "minor"),
+            ("court_patron_started", "moderate"),
+        ]

--- a/tests/test_orrery/test_court_patron_migration_pg.py
+++ b/tests/test_orrery/test_court_patron_migration_pg.py
@@ -88,6 +88,17 @@ def migration_085_schema() -> Iterator[Any]:
                     (character_entity_id,project_type,status,stage,
                      target_character_entity_id)
                     VALUES (1,'pursue_romance','active','testing_waters',2);
+                INSERT INTO character_project_states
+                    (character_entity_id,project_type,status,stage,
+                     target_place_id)
+                    VALUES (30,'plan_relocation','active','saving',NULL);
+                INSERT INTO character_project_states
+                    (character_entity_id,project_type,status,stage,
+                     target_character_entity_id,target_faction_entity_id)
+                    VALUES (4,'recruit_ally','active','sounding_out',5,11);
+                INSERT INTO character_project_states
+                    (character_entity_id,project_type,status,stage)
+                    VALUES (6,'build_venture','active','laying_groundwork');
                 """
             )
         yield conn
@@ -115,6 +126,20 @@ def test_migration_086_widens_constraints_and_seeds_events(
             "court_patron" in definition for definition, _ in constraints.values()
         )
         assert all(comment for _, comment in constraints.values())
+        # Every prior-type row — including the faction-bound recruitment row
+        # (migration-081 context) — must survive the constraint replacement.
+        cur.execute(
+            "SELECT project_type, target_faction_entity_id "
+            "FROM character_project_states "
+            "WHERE character_entity_id IN (1, 30, 4, 6) "
+            "ORDER BY character_entity_id"
+        )
+        assert cur.fetchall() == [
+            ("pursue_romance", None),
+            ("recruit_ally", 11),
+            ("build_venture", None),
+            ("plan_relocation", None),
+        ]
         cur.execute(
             "INSERT INTO character_project_states "
             "(character_entity_id,project_type,status,stage,"

--- a/tests/test_orrery/test_court_patron_projects.py
+++ b/tests/test_orrery/test_court_patron_projects.py
@@ -181,6 +181,14 @@ def test_entry_gate_requires_social_base_and_power_and_blocks_redundancy() -> No
             "project.abandon",
         ),
         (
+            # Strict boundary: a merely wary patron (-1) does NOT spurn —
+            # trust_below(-1) means strictly worse than wary; the courtship
+            # keeps making routine progress instead.
+            _advance_state(_project(), trust={(TARGET, ACTOR): -1}),
+            "Make useful work visible",
+            "project.advance",
+        ),
+        (
             _advance_state(_project(stall_count=3)),
             "Let the bid for patronage go",
             "project.abandon",

--- a/tests/test_orrery/test_court_patron_projects.py
+++ b/tests/test_orrery/test_court_patron_projects.py
@@ -482,3 +482,77 @@ def test_completion_applies_inbound_outbound_and_patron_relationship(
         "add_inbound",
         "add_outbound",
     }
+
+
+@pytest.mark.requires_postgres
+def test_completion_preserves_existing_relationship_valence(
+    live_patron_db: dict[str, Any],
+) -> None:
+    """The conflict arm updates the type but never the valence — the family
+    convention (recruit_ally, pursue_romance); valence movement on existing
+    rows is seek_redemption's deliberate innovation, not patron's."""
+
+    db = live_patron_db
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "INSERT INTO character_relationships "
+            "(character1_id, character2_id, relationship_type, "
+            " emotional_valence, dynamic, recent_events, history) "
+            "SELECT a.id, t.id, 'mentor', '+4|admiring', 'd', 'r', 'h' "
+            "FROM characters a, characters t "
+            "WHERE a.entity_id=%s AND t.entity_id=%s",
+            (db["actor"], db["target"]),
+        )
+    base = OrreryResolutionDraft(
+        template_id="start_court_patron",
+        priority=17,
+        binding_hash="start-preserve",
+        bindings={"actor": db["actor"], "target": db["target"]},
+        branch_label="start",
+        narrative_stub="start",
+        state_delta={
+            "project.start": {
+                "project_type": "court_patron",
+                "stage": "gaining_notice",
+                "target_character_entity_id": db["target"],
+                "milestone": True,
+            }
+        },
+        magnitude=0.4,
+    )
+    _apply(db, base)
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "UPDATE character_project_states "
+            "SET stage='securing_favor',progress=1 "
+            "WHERE character_entity_id=%s",
+            (db["actor"],),
+        )
+    _apply(
+        db,
+        replace(
+            base,
+            template_id="advance_court_patron",
+            binding_hash="complete-preserve",
+            state_delta={
+                "project.complete": {"milestone": True},
+                "entity_pair_tags.add_inbound": ["sponsors"],
+                "entity_pair_tags.add_outbound": ["obligation"],
+            },
+        ),
+    )
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "SELECT cr.relationship_type,cr.emotional_valence,cr.extra_data "
+            "FROM character_relationships cr "
+            "JOIN characters a ON a.id=cr.character1_id "
+            "JOIN characters t ON t.id=cr.character2_id "
+            "WHERE a.entity_id=%s AND t.entity_id=%s",
+            (db["actor"], db["target"]),
+        )
+        relationship_type, valence, extra = cur.fetchone()
+    assert relationship_type == "patron"
+    assert valence == "+4|admiring"
+    assert (
+        extra["orrery_court_patron"]["previous_relationship_type"] == "mentor"
+    )

--- a/tests/test_orrery/test_court_patron_projects.py
+++ b/tests/test_orrery/test_court_patron_projects.py
@@ -1,0 +1,476 @@
+"""COURT_PATRON character-targeted project acceptance coverage."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from itertools import count
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2
+import psycopg2.extras
+import pytest
+
+from nexus.agents.orrery.events import _apply_state_delta_sync
+from nexus.agents.orrery.needs import load_need_tuning
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.substrate import (
+    BranchSelection,
+    ProjectPolicy,
+    ProjectState,
+    RoutineAnchor,
+    Slot,
+    TravelState,
+    WorldState,
+    evaluate,
+)
+from nexus.agents.orrery.templates import ADVANCE_COURT_PATRON, START_COURT_PATRON
+from nexus.api.slot_utils import get_slot_db_url
+
+ACTOR = 10
+TARGET = 20
+FACTION = 30
+NOW = datetime(2073, 8, 2, 12, tzinfo=timezone.utc)
+POLICY = ProjectPolicy(
+    enabled=True,
+    advance_interval_hours=24.0,
+    stall_abandon_threshold=3,
+    abandon_after_stalled_world_hours=168.0,
+)
+BINDINGS = {Slot.ACTOR: ACTOR, Slot.TARGET: TARGET}
+
+
+def _start_state(**changes: Any) -> WorldState:
+    values: dict[str, Any] = {
+        "locations": {ACTOR: 1},
+        "pair_tags": {
+            (ACTOR, TARGET): frozenset({"contact:social"}),
+            (TARGET, ACTOR): frozenset({"authority_over"}),
+        },
+        "travel_states": {ACTOR: TravelState(status="at_place")},
+        "project_policy": POLICY,
+        "routine_anchors": {
+            (ACTOR, "home"): RoutineAnchor(
+                anchor_type="home", place_id=1, mobility_policy="fixed_place"
+            )
+        },
+        "world_time": NOW,
+    }
+    values.update(changes)
+    return WorldState(**values)
+
+
+def _project(
+    *,
+    stage: str = "gaining_notice",
+    progress: float = 0.0,
+    stall_count: int = 0,
+    due_at: datetime = NOW,
+    target_active: bool = True,
+) -> ProjectState:
+    return ProjectState(
+        id=7,
+        project_type="court_patron",
+        status="active",
+        stage=stage,
+        target_character_entity_id=TARGET,
+        target_character_is_active=target_active,
+        progress=progress,
+        stall_count=stall_count,
+        next_eligible_at_world_time=due_at,
+        source_chunk_id=100,
+    )
+
+
+def _advance_state(project: ProjectState, **changes: Any) -> WorldState:
+    values: dict[str, Any] = {
+        "project_states": {ACTOR: project},
+        "project_policy": POLICY,
+        "travel_states": {ACTOR: TravelState(status="at_place")},
+        "world_time": NOW,
+    }
+    values.update(changes)
+    return WorldState(**values)
+
+
+def test_entry_gate_power_marker_or_clause_and_contract() -> None:
+    arms = (
+        _start_state(
+            pair_tags={
+                (ACTOR, TARGET): frozenset({"contact:social"}),
+                (TARGET, FACTION): frozenset({"status:senior"}),
+            }
+        ),
+        _start_state(
+            pair_tags={(ACTOR, TARGET): frozenset({"contact:social"})},
+            tags={TARGET: frozenset({"leader"})},
+        ),
+        _start_state(),
+    )
+    for state in arms:
+        assert evaluate(START_COURT_PATRON, state, BINDINGS).passes is True
+    result = evaluate(START_COURT_PATRON, arms[0], BINDINGS)
+    assert START_COURT_PATRON.required_slots == (Slot.ACTOR, Slot.TARGET)
+    assert START_COURT_PATRON.starts_from_social_contact is True
+    assert result.state_delta["project.start"] == {
+        "project_type": "court_patron",
+        "stage": "gaining_notice",
+        "milestone": True,
+    }
+
+
+def test_entry_gate_requires_social_base_and_power_and_blocks_redundancy() -> None:
+    assert (
+        evaluate(
+            START_COURT_PATRON,
+            _start_state(pair_tags={(ACTOR, TARGET): frozenset({"contact:social"})}),
+            BINDINGS,
+        ).passes
+        is False
+    )
+    assert (
+        evaluate(
+            START_COURT_PATRON,
+            _start_state(pair_tags={(TARGET, ACTOR): frozenset({"authority_over"})}),
+            BINDINGS,
+        ).passes
+        is False
+    )
+    for changes in (
+        {
+            "pair_tags": {
+                (ACTOR, TARGET): frozenset({"contact:social"}),
+                (TARGET, ACTOR): frozenset({"authority_over", "sponsors"}),
+            }
+        },
+        {"relationship_types": {(ACTOR, TARGET): frozenset({"patron"})}},
+        {
+            "pair_tags": {
+                (ACTOR, TARGET): frozenset({"contact:social", "hostile_to"}),
+                (TARGET, ACTOR): frozenset({"authority_over"}),
+            }
+        },
+    ):
+        assert (
+            evaluate(START_COURT_PATRON, _start_state(**changes), BINDINGS).passes
+            is False
+        )
+
+
+@pytest.mark.parametrize(
+    ("state", "label", "delta_key"),
+    (
+        (
+            _advance_state(_project(target_active=False)),
+            "End a patronage effort whose target is no longer available",
+            "project.abandon",
+        ),
+        (
+            _advance_state(
+                _project(stage="securing_favor", progress=1.0),
+                trust={(TARGET, ACTOR): 2},
+            ),
+            "Secure the patron's favor",
+            "project.complete",
+        ),
+        (
+            _advance_state(_project(), trust={(TARGET, ACTOR): -2}),
+            "Withdraw after being spurned",
+            "project.abandon",
+        ),
+        (
+            _advance_state(_project(stall_count=3)),
+            "Let the bid for patronage go",
+            "project.abandon",
+        ),
+        (
+            _advance_state(_project(progress=1.0)),
+            "Turn notice into a chance to prove worth",
+            "project.advance",
+        ),
+        (
+            _advance_state(_project(stage="proving_worth", progress=1.0)),
+            "Ask proven worth to become favor",
+            "project.advance",
+        ),
+        (
+            _advance_state(
+                _project(
+                    stage="securing_favor",
+                    progress=0.5,
+                    due_at=NOW - timedelta(hours=24),
+                )
+            ),
+            "Lose ground through neglect",
+            "project.stall",
+        ),
+        (
+            _advance_state(_project(progress=0.2)),
+            "Make useful work visible",
+            "project.advance",
+        ),
+        (
+            _advance_state(_project(stage="proving_worth", progress=0.2)),
+            "Prove reliable under scrutiny",
+            "project.advance",
+        ),
+        (
+            _advance_state(_project(stage="securing_favor", progress=0.2)),
+            "Make the next claim on favor legible",
+            "project.advance",
+        ),
+    ),
+)
+def test_full_ladder(state: WorldState, label: str, delta_key: str) -> None:
+    result = evaluate(
+        ADVANCE_COURT_PATRON,
+        state,
+        BINDINGS,
+        BranchSelection(mode="authored_order"),
+    )
+    assert result.branch_label == label
+    assert delta_key in result.state_delta
+    if delta_key == "project.complete":
+        assert result.state_delta == {
+            "project.complete": {"milestone": True},
+            "entity_pair_tags.add_inbound": ["sponsors"],
+            "entity_pair_tags.add_outbound": ["obligation"],
+        }
+
+
+def test_completion_uses_patron_reverse_trust_and_yields_to_hostility() -> None:
+    project = _project(stage="securing_favor", progress=1.0)
+    reverse = evaluate(
+        ADVANCE_COURT_PATRON,
+        _advance_state(project, trust={(TARGET, ACTOR): 2}),
+        BINDINGS,
+    )
+    forward_only = evaluate(
+        ADVANCE_COURT_PATRON,
+        _advance_state(project, trust={(ACTOR, TARGET): 2}),
+        BINDINGS,
+    )
+    hostile = evaluate(
+        ADVANCE_COURT_PATRON,
+        _advance_state(
+            project,
+            trust={(TARGET, ACTOR): 2},
+            pair_tags={(ACTOR, TARGET): frozenset({"hostile_to"})},
+        ),
+        BINDINGS,
+    )
+    assert "project.complete" in reverse.state_delta
+    assert "project.complete" not in forward_only.state_delta
+    assert "project.abandon" in hostile.state_delta
+
+
+def _create_schema(cur: Any, schema: str) -> None:
+    cur.execute(f'CREATE SCHEMA "{schema}"')
+    cur.execute(f'SET LOCAL search_path = "{schema}", public')
+    cur.execute(
+        """
+        CREATE TABLE event_types (
+            type text PRIMARY KEY, category text NOT NULL,
+            severity text NOT NULL, description text
+        );
+        CREATE TABLE orrery_resolutions (
+            id bigint PRIMARY KEY, state_delta jsonb NOT NULL
+        );
+        CREATE TABLE character_project_states (
+            id bigserial PRIMARY KEY, character_entity_id bigint NOT NULL,
+            project_type text NOT NULL, status text NOT NULL, stage text NOT NULL,
+            target_place_id bigint, target_character_entity_id bigint,
+            target_faction_entity_id bigint, progress numeric(5,4) NOT NULL DEFAULT 0,
+            stall_count integer NOT NULL DEFAULT 0,
+            next_eligible_at_world_time timestamptz, source_chunk_id bigint,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now(),
+            CONSTRAINT character_project_states_project_type_check CHECK (
+                project_type IN (
+                    'plan_relocation', 'recruit_ally', 'build_venture',
+                    'pursue_romance'
+                )),
+            CONSTRAINT character_project_states_stage_by_type_check CHECK (
+                (project_type='plan_relocation'
+                    AND stage IN ('saving','scouting','committing')) OR
+                (project_type='recruit_ally'
+                    AND stage IN (
+                        'sounding_out','earning_trust','sealing_commitment'
+                    )) OR
+                (project_type='build_venture'
+                    AND stage IN (
+                        'laying_groundwork','securing_backing','opening_doors'
+                    )) OR
+                (project_type='pursue_romance'
+                    AND stage IN (
+                        'testing_waters','growing_closer','declaring_intentions'
+                    ))),
+            CONSTRAINT character_project_states_target_by_type_check CHECK (
+                (project_type='plan_relocation'
+                    AND target_character_entity_id IS NULL) OR
+                (project_type='recruit_ally'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NOT NULL) OR
+                (project_type='build_venture'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NULL
+                    AND target_faction_entity_id IS NULL) OR
+                (project_type='pursue_romance'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NOT NULL
+                    AND target_faction_entity_id IS NULL)),
+            CONSTRAINT character_project_states_completed_target_check CHECK (
+                status <> 'completed' OR
+                (project_type='plan_relocation' AND target_place_id IS NOT NULL) OR
+                (project_type='recruit_ally'
+                    AND target_character_entity_id IS NOT NULL) OR
+                project_type='build_venture' OR
+                (project_type='pursue_romance'
+                    AND target_character_entity_id IS NOT NULL))
+        );
+        CREATE UNIQUE INDEX ux_character_project_states_open_budget
+            ON character_project_states(character_entity_id)
+            WHERE status IN ('active','paused','stalled');
+        """
+    )
+    cur.execute(
+        (
+            Path(__file__).parents[2] / "migrations/086_court_patron_projects.sql"
+        ).read_text()
+    )
+
+
+@pytest.fixture()
+def live_patron_db() -> Iterator[dict[str, Any]]:
+    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    try:
+        with conn.cursor() as cur:
+            _create_schema(cur, f"court_patron_{uuid4().hex[:12]}")
+            cur.execute(
+                "SELECT entity_id FROM characters WHERE entity_id IS NOT NULL "
+                "ORDER BY id LIMIT 2"
+            )
+            actor, target = (int(row[0]) for row in cur.fetchall())
+            cur.execute(
+                "SELECT chunk_id FROM chunk_metadata WHERE world_time IS NOT NULL "
+                "ORDER BY chunk_id DESC LIMIT 1"
+            )
+            chunk = int(cur.fetchone()[0])
+            cur.execute(
+                "DELETE FROM character_relationships USING characters a, characters t "
+                "WHERE character_relationships.character1_id=a.id "
+                "AND character_relationships.character2_id=t.id "
+                "AND a.entity_id=%s AND t.entity_id=%s",
+                (actor, target),
+            )
+        yield {
+            "conn": conn,
+            "actor": actor,
+            "target": target,
+            "chunk": chunk,
+            "ids": count(1),
+        }
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def _apply(db: dict[str, Any], draft: OrreryResolutionDraft) -> dict[str, Any]:
+    resolution_id = next(db["ids"])
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "INSERT INTO orrery_resolutions VALUES (%s,%s::jsonb)",
+            (resolution_id, psycopg2.extras.Json(draft.state_delta)),
+        )
+        _apply_state_delta_sync(
+            cur,
+            draft,
+            resolution_id=resolution_id,
+            actor_entity_id=db["actor"],
+            target_entity_id=db["target"],
+            source_chunk_id=db["chunk"],
+            need_tuning=load_need_tuning(),
+            project_policy=POLICY,
+        )
+        cur.execute(
+            "SELECT state_delta FROM orrery_resolutions WHERE id=%s", (resolution_id,)
+        )
+        return cur.fetchone()[0]
+
+
+@pytest.mark.requires_postgres
+def test_completion_applies_inbound_outbound_and_patron_relationship(
+    live_patron_db: dict[str, Any],
+) -> None:
+    db = live_patron_db
+    base = OrreryResolutionDraft(
+        template_id="start_court_patron",
+        priority=17,
+        binding_hash="start",
+        bindings={"actor": db["actor"], "target": db["target"]},
+        branch_label="start",
+        narrative_stub="start",
+        state_delta={
+            "project.start": {
+                "project_type": "court_patron",
+                "stage": "gaining_notice",
+                "target_character_entity_id": db["target"],
+                "milestone": True,
+            }
+        },
+        magnitude=0.4,
+    )
+    _apply(db, base)
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "UPDATE character_project_states "
+            "SET stage='securing_favor',progress=1 "
+            "WHERE character_entity_id=%s",
+            (db["actor"],),
+        )
+    ledger = _apply(
+        db,
+        replace(
+            base,
+            template_id="advance_court_patron",
+            binding_hash="complete",
+            state_delta={
+                "project.complete": {"milestone": True},
+                "entity_pair_tags.add_inbound": ["sponsors"],
+                "entity_pair_tags.add_outbound": ["obligation"],
+            },
+        ),
+    )
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            "SELECT ept.subject_entity_id,ept.object_entity_id,pt.tag "
+            "FROM entity_pair_tags ept "
+            "JOIN pair_tags pt ON pt.id=ept.pair_tag_id WHERE ept.cleared_at IS NULL "
+            "AND ((ept.subject_entity_id=%s AND ept.object_entity_id=%s "
+            "AND pt.tag='sponsors') OR (ept.subject_entity_id=%s "
+            "AND ept.object_entity_id=%s AND pt.tag='obligation')) ORDER BY pt.tag",
+            (db["target"], db["actor"], db["actor"], db["target"]),
+        )
+        assert cur.fetchall() == [
+            (db["actor"], db["target"], "obligation"),
+            (db["target"], db["actor"], "sponsors"),
+        ]
+        cur.execute(
+            "SELECT cr.relationship_type,cr.emotional_valence,cr.extra_data "
+            "FROM character_relationships cr "
+            "JOIN characters a ON a.id=cr.character1_id "
+            "JOIN characters t ON t.id=cr.character2_id "
+            "WHERE a.entity_id=%s AND t.entity_id=%s",
+            (db["actor"], db["target"]),
+        )
+        relationship_type, valence, extra = cur.fetchone()
+    assert (relationship_type, valence) == ("patron", "+2|friendly")
+    assert extra["orrery_court_patron"]["template_id"] == "advance_court_patron"
+    applied = ledger["project.complete"]["applied"]
+    assert applied["relationship_mutation"]["relationship_type"] == "patron"
+    assert {mutation["operation"] for mutation in applied["pair_tag_mutations"]} == {
+        "add_inbound",
+        "add_outbound",
+    }

--- a/tests/test_orrery/test_court_patron_replay.py
+++ b/tests/test_orrery/test_court_patron_replay.py
@@ -1,0 +1,172 @@
+"""Checkpoint replay coverage for COURT_PATRON and add_inbound."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+import pytest
+
+from nexus.agents.orrery.events import _apply_state_delta_sync, _insert_resolution_sync
+from nexus.agents.orrery.needs import load_need_tuning
+from nexus.agents.orrery.reconstruction import (
+    capture_state_checkpoint_sync,
+    set_commit_chunk_attribution_sync,
+)
+from nexus.agents.orrery.replay import (
+    TAG_DELTA_KEYS,
+    reconstruct_state_at_sync,
+    verify_checkpoints_sync,
+)
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from tests.test_orrery.test_court_patron_projects import POLICY
+from tests.test_orrery.test_pursue_romance_replay import (
+    _fabricate_chunk,
+    _next_world_time,
+)
+
+pytestmark = pytest.mark.requires_postgres
+pytest_plugins = ("tests.test_orrery.test_court_patron_projects",)
+
+
+def _apply_transition(
+    cur: Any,
+    *,
+    chunk_id: int,
+    actor: int,
+    target: int,
+    state_delta: dict[str, Any],
+) -> None:
+    set_commit_chunk_attribution_sync(cur, chunk_id)
+    draft = OrreryResolutionDraft(
+        template_id="court_patron_replay_probe",
+        priority=47,
+        binding_hash=f"court-patron-replay-{chunk_id}",
+        bindings={"actor": actor, "target": target},
+        branch_label="COURT_PATRON replay probe",
+        narrative_stub="probe",
+        state_delta=state_delta,
+        magnitude=0.4,
+    )
+    resolution_id = _insert_resolution_sync(
+        cur,
+        draft,
+        tick_chunk_id=chunk_id,
+        actor_entity_id=actor,
+        brief="COURT_PATRON checkpoint replay probe",
+    )
+    assert resolution_id is not None
+    _apply_state_delta_sync(
+        cur,
+        draft,
+        resolution_id=int(resolution_id),
+        actor_entity_id=actor,
+        target_entity_id=target,
+        source_chunk_id=chunk_id,
+        need_tuning=load_need_tuning(),
+        project_policy=POLICY,
+    )
+
+
+def test_add_inbound_is_a_replay_accepted_tag_delta() -> None:
+    assert "entity_pair_tags.add_inbound" in TAG_DELTA_KEYS
+
+
+def test_court_patron_completion_replays_without_drift(
+    live_patron_db: dict[str, Any],
+) -> None:
+    db = live_patron_db
+    actor = int(db["actor"])
+    target = int(db["target"])
+    with db["conn"].cursor() as cur:
+        # The shared fixture's minimal writer table is useful for direct-applier
+        # tests; replay needs the full public resolution ledger instead.
+        cur.execute("DROP TABLE orrery_resolutions")
+        base_time = _next_world_time(cur)
+        base_chunk = _fabricate_chunk(cur, base_time, created_offset_minutes=-4)
+        base_id = capture_state_checkpoint_sync(
+            cur, chunk_id=base_chunk, label="manual"
+        )
+        assert base_id is not None
+        transitions = (
+            {
+                "project.start": {
+                    "project_type": "court_patron",
+                    "stage": "gaining_notice",
+                    "target_character_entity_id": target,
+                    "milestone": True,
+                }
+            },
+            {
+                "project.advance": {
+                    "stage": "proving_worth",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            {
+                "project.advance": {
+                    "stage": "securing_favor",
+                    "set_progress": 1.0,
+                    "milestone": True,
+                }
+            },
+            {
+                "project.complete": {"milestone": True},
+                "entity_pair_tags.add_inbound": ["sponsors"],
+                "entity_pair_tags.add_outbound": ["obligation"],
+            },
+        )
+        chunks: list[int] = []
+        for step, delta in enumerate(transitions, start=1):
+            chunk = _fabricate_chunk(
+                cur,
+                base_time + timedelta(hours=24 * step),
+                created_offset_minutes=step - len(transitions),
+            )
+            _apply_transition(
+                cur,
+                chunk_id=chunk,
+                actor=actor,
+                target=target,
+                state_delta=delta,
+            )
+            chunks.append(chunk)
+        target_id = capture_state_checkpoint_sync(
+            cur, chunk_id=chunks[-1], label="manual"
+        )
+        assert target_id is not None
+        reconstructed = reconstruct_state_at_sync(
+            cur, chunks[-1], base_checkpoint_id=int(base_id)
+        )
+        project = next(
+            row
+            for row in reconstructed.state["character_project_states"]
+            if row["character_entity_id"] == actor
+            and row["project_type"] == "court_patron"
+        )
+        assert project["status"] == "completed"
+        assert project["target_character_entity_id"] == target
+        cur.execute(
+            "SELECT id,tag FROM pair_tags WHERE tag IN ('sponsors','obligation')"
+        )
+        tag_ids = {tag: int(tag_id) for tag_id, tag in cur.fetchall()}
+        assert any(
+            row["subject_entity_id"] == target
+            and row["object_entity_id"] == actor
+            and row["pair_tag_id"] == tag_ids["sponsors"]
+            for row in reconstructed.state["entity_pair_tags"]
+        )
+        assert any(
+            row["subject_entity_id"] == actor
+            and row["object_entity_id"] == target
+            and row["pair_tag_id"] == tag_ids["obligation"]
+            for row in reconstructed.state["entity_pair_tags"]
+        )
+        pair = next(
+            verdict
+            for verdict in verify_checkpoints_sync(cur)
+            if verdict.base_checkpoint_id == base_id
+            and verdict.target_checkpoint_id == target_id
+        )
+        assert pair.drifts == []

--- a/tests/test_orrery/test_coverage_accounting.py
+++ b/tests/test_orrery/test_coverage_accounting.py
@@ -61,6 +61,7 @@ def _analyze(
     *,
     groups: tuple[SimpleNamespace, ...],
     fanout_trimmed: tuple[dict[str, Any], ...] = (),
+    project_start_arbitration_trimmed: tuple[dict[str, Any], ...] = (),
 ) -> dict[str, Any]:
     report = SimpleNamespace(
         anchor_chunk_id=42,
@@ -73,6 +74,7 @@ def _analyze(
             group.actor_entity_id: f"Actor {group.actor_entity_id}" for group in groups
         },
         fanout_trimmed=fanout_trimmed,
+        project_start_arbitration_trimmed=project_start_arbitration_trimmed,
     )
     monkeypatch.setattr(
         coverage,
@@ -155,3 +157,35 @@ def test_fanout_trimmed_pair_stays_fired_but_is_not_counted_as_winner(
             "promotable": True,
         }
     ]
+
+
+def test_arbitration_trimmed_start_is_not_counted_as_winner(
+    monkeypatch: Any,
+) -> None:
+    """Project starts dropped by _arbitrate_project_starts never commit, so
+    coverage must exclude them from winner tallies like fanout trims."""
+
+    payload = _analyze(
+        monkeypatch,
+        groups=(
+            _group(1, pair_stacks=(_stack(actor=1, target=2, winner=True),)),
+            _group(3, pair_stacks=(_stack(actor=3, target=4, winner=True),)),
+        ),
+        project_start_arbitration_trimmed=(
+            {
+                "actor_entity_id": 1,
+                "target_entity_id": 2,
+                "faction_entity_id": None,
+                "template_id": TEMPLATE_ID,
+            },
+        ),
+    )
+
+    stats = payload["templates"][TEMPLATE_ID]
+    assert stats["fired"] == 2
+    assert stats["won"] == 1
+    assert payload["anchors"][0]["winners_by_band"] == {"affiliation": 1}
+    assert [
+        winner["actor_entity_id"]
+        for winner in payload["anchors"][0]["resolution_winners"]
+    ] == [3]

--- a/tests/test_orrery/test_faction_project_contexts_live.py
+++ b/tests/test_orrery/test_faction_project_contexts_live.py
@@ -783,4 +783,29 @@ def test_live_production_and_explain_compose_same_faction_bindings(
         tuple(sorted(stack.bindings.items())) for stack in actor_group.two_party_stacks
     }
 
-    assert explained_bindings == production_bindings
+    # Production arbitrates project starts to one per actor
+    # (resolver._arbitrate_project_starts); the audit explains every
+    # evaluated stack and reports the arbitrated drops explicitly. The
+    # parity contract is therefore: explained stacks minus the reported
+    # trims equals the production draft set.
+    trimmed_bindings = {
+        tuple(
+            sorted(
+                (slot, entity_id)
+                for slot, entity_id in (
+                    ("actor", item["actor_entity_id"]),
+                    ("target", item["target_entity_id"]),
+                    ("faction", item["faction_entity_id"]),
+                )
+                if entity_id is not None
+            )
+        )
+        for item in explained.project_start_arbitration_trimmed
+        if item["template_id"] == START_FACTION_PROJECT.id
+        and item["actor_entity_id"] == actor_id
+    }
+    assert explained_bindings - trimmed_bindings == production_bindings
+    # Two composable factions, one open-project budget: exactly one start
+    # survives and exactly one is reported trimmed.
+    assert len(production_bindings) == 1
+    assert len(trimmed_bindings) == 1

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -149,6 +149,34 @@ def test_pursue_romance_migration_replaces_named_four_type_constraints() -> None
     assert migration_sql.count("pursue_romance_") >= 6
 
 
+def test_court_patron_migration_replaces_named_five_type_constraints() -> None:
+    """Migration 086 preserves 085 and adds strict character patron targeting."""
+
+    migration_sql = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "086_court_patron_projects.sql"
+    ).read_text()
+    for name in (
+        "character_project_states_project_type_check",
+        "character_project_states_stage_by_type_check",
+        "character_project_states_target_by_type_check",
+        "character_project_states_completed_target_check",
+    ):
+        assert f"DROP CONSTRAINT IF EXISTS {name}" in migration_sql
+        assert f"ADD CONSTRAINT {name}" in migration_sql
+        assert f"COMMENT ON CONSTRAINT {name}" in migration_sql
+    for project_type in (
+        "plan_relocation",
+        "recruit_ally",
+        "build_venture",
+        "pursue_romance",
+        "court_patron",
+    ):
+        assert migration_sql.count(f"project_type = '{project_type}'") >= 3
+    assert migration_sql.count("court_patron_") >= 6
+
+
 def test_retrograde_persistence_migration_adds_distinct_sources() -> None:
     """Retrograde canonical writes need explicit event and tag provenance."""
 


### PR DESCRIPTION
## Summary

Fifth aspiration-band package per the #496 Arachne ruling. `court_patron`: an off-screen character works to win a named power's favor.

- **Stage ladder**: `gaining_notice` → `proving_worth` → `securing_favor`
- **Patron is a character in v1** — faction patrons stay a recorded future slice: `compose_actor_faction_bindings` only enumerates factions with a pre-existing institutional edge, so courting a new faction patron is structurally blocked today
- **Entry**: recruit_ally's eligibility base AND a power marker on the target (`has_any_status_at_or_above("senior")` OR the `leader` role tag OR existing `authority_over` the actor — status alone would never fire on live saves)
- **Completion** ("Secure the patron's favor"): patron's reverse trust ≥ 2 + the family hostility exclusion; three writes in one delta — **inbound `sponsors` (patron→actor) via the new `entity_pair_tags.add_inbound` applier verb**, outbound `obligation` (patronage has a price), and a `patron` relationship upsert mirroring the trait compiler's convention
- **`add_inbound`** is a thin subject/object-swapped delegation to the outbound applier (inherits idempotency + world-time stamping), loud on missing target binding, ledger-recorded with explicit orientation, replay-covered
- **SURVEIL** yields to due patron continuations (per the #527 lesson); the completion hostility exclusion was in the spec from the start (same lesson)
- **Migration 086**: five-type constraint widening, six event types, `DO NOTHING` idioms; zero new vocabulary

## Also in This PR — Audit Parity Fix (Fallout From #526)

The full live-PG suite (`NEXUS_RUN_POSTGRES=1`, which CI never runs) exposed that #526's `_arbitrate_project_starts` had no mirror in `explain_dry_run`: production kept one faction start while the explanation showed both stacks, failing the faction-binding parity test. Separate commit: the audit now mirrors the arbitration over solo+pair winner shims in production order, feeds only survivors to joint-beat detection, and reports drops as `project_start_arbitration_trimmed` (the `fanout_trimmed` doctrine). The parity contract is now *explained stacks − reported trims = production drafts*, encoded in the updated test.

## Validation

- `poetry run pytest -q` → **1471 passed, 303 skipped, 0 failed**
- **`NEXUS_RUN_POSTGRES=1 pytest tests/test_orrery/ -q` → 1018 passed, 0 failed** — the first fully-green complete live-PG run since #526; includes 18 patron tests and the repaired parity test
- catalog `--check` clean; flake8/black clean on all changed files; mypy baseline unchanged (#528)

## Schema/Data Impact

Migration 086 pending everywhere; additive only. Applied at merge closeout.

Implemented by Sol (GPT-5.6 Codex) from a frozen spec; reviewed line-by-line by Claude. Part of the #496 campaign; follows #526/#527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TJVTXfD7TouQuxmYfVf8w