### PR TITLE
Add the SEEK_REDEMPTION Aspiration Package (#496 Slice 6)

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -925,6 +925,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **NOT:** actor `recruit_ally` project passes `ready` due-state
   - **NOT:** actor `pursue_romance` project passes `ready` due-state
   - **NOT:** actor `court_patron` project passes `ready` due-state
+  - **NOT:** actor `seek_redemption` project passes `ready` due-state
   - **NOT:** actor is constrained or immobilized
   - **NOT:** actor has inbound `hunting` pair tag
   - **NOT:** actor has `grudge_active` ephemeral
@@ -1588,6 +1589,130 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 **Event:** `court_patron_progressed`
 
 > {actor} makes one more service, request, or allegiance explicit, bringing {target}'s answer closer without pretending it is owed.
+
+---
+
+## ADVANCE_SEEK_REDEMPTION — priority 47
+
+> A due attempt at redemption owns the wrong, makes amends, seeks forgiveness, stalls, is thrown back, or ends.
+
+**Drive band:** project identity — A due reconciliation effort shares the established continuation slot while SURVEIL yields to its bound two-party work.
+**Slots:** ACTOR, TARGET
+
+**Gate:**
+
+- **AND:**
+  - actor `seek_redemption` project passes `ready` due-state
+  - target is the project's bound target
+  - **NOT:** actor is in transit
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:**
+    - **OR:**
+      - actor has `sleep` debt ≥ 8
+      - actor has `thirst` debt ≥ 2
+      - actor has `hunger` debt ≥ 4
+
+### Branch 1 — End amends whose wronged party is no longer available  *(mag 0.4)* · **preemptive**
+
+**When:**
+
+- **NOT:** target is the project's target and still an active character
+
+**Does:** applies project `abandon` transition
+**Event:** `seek_redemption_abandoned`
+
+> {target} is no longer someone who can receive an attempt at amends. {actor} closes the effort rather than preserving an unanswerable claim to forgiveness.
+
+### Branch 2 — Have the amends accepted  *(mag 0.4)* · **preemptive**
+
+**When:**
+
+- **AND:**
+  - actor `seek_redemption` project passes `completion` due-state
+  - **NOT:** actor has any of [`hostile_to`, `hunting`] pair tags to target
+  - **NOT:** target has any of [`hostile_to`, `hunting`] pair tags to actor
+
+**Does:** applies project `complete` transition and upserts the actor→target `complex` relationship with `+1|favorable` valence; removes `grudge_active` from target
+**Event:** `seek_redemption_completed`
+
+> {target} accepts what {actor} has done to make amends. The history remains complicated, but it no longer dictates only hostility between them.
+
+### Branch 3 — Abandon amends that are thrown back  *(mag 0.4)* · **preemptive**
+
+**When:**
+
+- **OR:**
+  - trust target→actor < -2
+  - actor has any of [`hostile_to`, `hunting`] pair tags to target
+  - target has any of [`hostile_to`, `hunting`] pair tags to actor
+
+**Does:** applies project `abandon` transition
+**Event:** `seek_redemption_abandoned`
+
+> The amends are thrown back in {actor}'s face. Whether the answer is hardened resentment or fresh hostility, {target} will not accept reconciliation on these terms.
+
+### Branch 4 — Let the attempt at redemption go  *(mag 0.4)* · **preemptive**
+
+**When:** actor `seek_redemption` project passes `abandon` due-state
+
+**Does:** applies project `abandon` transition
+**Event:** `seek_redemption_abandoned`
+
+> Delay has made the attempt another promise without repair. {actor} stops claiming that unfinished amends are progress.
+
+### Branch 5 — Turn ownership into amends  *(mag 0.4)* · **preemptive**
+
+**When:** actor `seek_redemption` project passes `owning_the_wrong_milestone` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `seek_redemption_milestone`
+
+> {actor} has named the wrong without qualification. Words now have to become repair shaped by what {target} actually lost.
+
+### Branch 6 — Let amends ask for forgiveness  *(mag 0.4)* · **preemptive**
+
+**When:** actor `seek_redemption` project passes `making_amends_milestone` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `seek_redemption_milestone`
+
+> The repair is no longer hypothetical. {actor} leaves the last judgment with {target}: whether these amends can be accepted.
+
+### Branch 7 — Lose ground through neglected amends  *(mag 0.1)* · **preemptive** · **not promotable**
+
+**When:** actor `seek_redemption` project passes `neglected` due-state
+
+**Does:** applies project `stall` transition
+**Event:** `seek_redemption_stalled`
+
+> Neglect makes the apology look like another demand for easy absolution. The attempt at redemption loses ground.
+
+### Branch 8 — Name the wrong without self-exoneration  *(mag 0.18)* · **not promotable**
+
+**When:** actor `seek_redemption` project passes `owning_the_wrong` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `seek_redemption_progressed`
+
+> {actor} examines one consequence from {target}'s side of the harm and removes another comforting excuse from the account.
+
+### Branch 9 — Make one concrete repair  *(mag 0.18)* · **not promotable**
+
+**When:** actor `seek_redemption` project passes `making_amends` due-state
+
+**Does:** applies project `advance` transition
+**Event:** `seek_redemption_progressed`
+
+> {actor} makes one repair that costs them something and returns something meaningful to {target}.
+
+### Branch 10 — Leave forgiveness in the wronged party's hands  *(mag 0.16)* · **not promotable**
+
+**When:** *(always)*
+
+**Does:** applies project `advance` transition
+**Event:** `seek_redemption_progressed`
+
+> {actor} continues the work without treating forgiveness as a debt {target} now owes them.
 
 ---
 
@@ -2619,6 +2744,44 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 ---
 
+## START_SEEK_REDEMPTION — priority 17
+
+> An off-screen character begins making amends to someone they wronged.
+
+**Drive band:** project identity — Seeking redemption requires durable evidence of a wrong and an actor who is no longer actively hostile toward the wronged party.
+**Slots:** ACTOR, TARGET
+
+**Gate:**
+
+- **AND:**
+  - actor `seek_redemption` project passes `start` due-state
+  - actor has enough hydrated context
+  - actor is at `home` anchor
+  - **NOT:** actor is in transit
+  - **NOT:** actor is constrained or immobilized
+  - **NOT:**
+    - **OR:**
+      - actor has `sleep` debt ≥ 8
+      - actor has `thirst` debt ≥ 2
+      - actor has `hunger` debt ≥ 4
+  - **OR:**
+    - trust target→actor < 0
+    - actor and target share `enemy` relationship (either direction)
+    - actor and target share `rival` relationship (either direction)
+    - target has any of [`hostile_to`, `hunting`] pair tags to actor
+  - **NOT:** actor has any of [`hostile_to`, `hunting`] pair tags to target
+
+### Branch 1 — Own the wrong  *(mag 0.4)*
+
+**When:** *(always)*
+
+**Does:** applies project `start` transition
+**Event:** `seek_redemption_started`
+
+> {actor} stops arranging the past into excuses. What they did to {target} becomes a wrong they can name, and therefore one they can begin trying to repair.
+
+---
+
 ## INTIMACY — priority 16
 
 > The body asks for the kind of connection that is not conversation.
@@ -3566,6 +3729,12 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `retaliation_attempted`
 - `retaliation_executed`
 - `rival_consulted`
+- `seek_redemption_abandoned`
+- `seek_redemption_completed`
+- `seek_redemption_milestone`
+- `seek_redemption_progressed`
+- `seek_redemption_stalled`
+- `seek_redemption_started`
 - `signal_exposure_reduced`
 - `slept`
 - `social_travel_departed`

--- a/migrations/087_seek_redemption_projects.sql
+++ b/migrations/087_seek_redemption_projects.sql
@@ -1,0 +1,140 @@
+-- 087_seek_redemption_projects.sql
+--
+-- Extend the Orrery project chassis with SEEK_REDEMPTION, a character-targeted
+-- effort to make amends to a named wronged party.
+
+ALTER TABLE character_project_states
+    DROP CONSTRAINT IF EXISTS character_project_states_project_type_check,
+    DROP CONSTRAINT IF EXISTS character_project_states_stage_by_type_check,
+    DROP CONSTRAINT IF EXISTS character_project_states_target_by_type_check,
+    DROP CONSTRAINT IF EXISTS character_project_states_completed_target_check;
+
+ALTER TABLE character_project_states
+    ADD CONSTRAINT character_project_states_project_type_check
+        CHECK (project_type IN (
+            'plan_relocation', 'recruit_ally', 'build_venture',
+            'pursue_romance', 'court_patron', 'seek_redemption'
+        )),
+    ADD CONSTRAINT character_project_states_stage_by_type_check
+        CHECK (
+            (project_type = 'plan_relocation'
+                AND stage IN ('saving', 'scouting', 'committing'))
+            OR
+            (project_type = 'recruit_ally'
+                AND stage IN (
+                    'sounding_out', 'earning_trust', 'sealing_commitment'
+                ))
+            OR
+            (project_type = 'build_venture'
+                AND stage IN (
+                    'laying_groundwork', 'securing_backing', 'opening_doors'
+                ))
+            OR
+            (project_type = 'pursue_romance'
+                AND stage IN (
+                    'testing_waters', 'growing_closer', 'declaring_intentions'
+                ))
+            OR
+            (project_type = 'court_patron'
+                AND stage IN (
+                    'gaining_notice', 'proving_worth', 'securing_favor'
+                ))
+            OR
+            (project_type = 'seek_redemption'
+                AND stage IN (
+                    'owning_the_wrong', 'making_amends', 'earning_forgiveness'
+                ))
+        ),
+    ADD CONSTRAINT character_project_states_target_by_type_check
+        CHECK (
+            (project_type = 'plan_relocation'
+                AND target_character_entity_id IS NULL)
+            OR
+            (project_type = 'recruit_ally'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NOT NULL)
+            OR
+            (project_type = 'build_venture'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NULL
+                AND target_faction_entity_id IS NULL)
+            OR
+            (project_type = 'pursue_romance'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NOT NULL
+                AND target_faction_entity_id IS NULL)
+            OR
+            (project_type = 'court_patron'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NOT NULL
+                AND target_faction_entity_id IS NULL)
+            OR
+            (project_type = 'seek_redemption'
+                AND target_place_id IS NULL
+                AND target_character_entity_id IS NOT NULL
+                AND target_faction_entity_id IS NULL)
+        ),
+    ADD CONSTRAINT character_project_states_completed_target_check
+        CHECK (
+            status <> 'completed'
+            OR (project_type = 'plan_relocation' AND target_place_id IS NOT NULL)
+            OR (
+                project_type = 'recruit_ally'
+                AND target_character_entity_id IS NOT NULL
+            )
+            OR (project_type = 'build_venture')
+            OR (
+                project_type = 'pursue_romance'
+                AND target_character_entity_id IS NOT NULL
+            )
+            OR (
+                project_type = 'court_patron'
+                AND target_character_entity_id IS NOT NULL
+            )
+            OR (
+                project_type = 'seek_redemption'
+                AND target_character_entity_id IS NOT NULL
+            )
+        );
+
+COMMENT ON CONSTRAINT character_project_states_project_type_check
+    ON character_project_states IS
+    'Closed project-type vocabulary extended by migration 087 for SEEK_REDEMPTION.';
+COMMENT ON CONSTRAINT character_project_states_stage_by_type_check
+    ON character_project_states IS
+    'Enforces independent three-stage ladders for all six Orrery project types.';
+COMMENT ON CONSTRAINT character_project_states_target_by_type_check
+    ON character_project_states IS
+    'Enforces typed targets: SEEK_REDEMPTION requires only its wronged character and forbids place and faction targets.';
+COMMENT ON CONSTRAINT character_project_states_completed_target_check
+    ON character_project_states IS
+    'Completed targeted projects retain their required target; SEEK_REDEMPTION retains its wronged party.';
+
+COMMENT ON TABLE character_project_states IS
+    'Additive Orrery project lifecycle projection. Supports relocation, recruitment, venture-building, romance, patronage, and reconciliation under one open project per character.';
+COMMENT ON COLUMN character_project_states.project_type IS
+    'Locked project vocabulary including seek_redemption as the sixth project type.';
+COMMENT ON COLUMN character_project_states.stage IS
+    'Type-specific three-stage ladder, including SEEK_REDEMPTION owning_the_wrong, making_amends, and earning_forgiveness.';
+COMMENT ON COLUMN character_project_states.target_place_id IS
+    'Place target used only by PLAN_RELOCATION; always NULL for SEEK_REDEMPTION.';
+COMMENT ON COLUMN character_project_states.target_character_entity_id IS
+    'Character target required by RECRUIT_ALLY, PURSUE_ROMANCE, COURT_PATRON, and SEEK_REDEMPTION.';
+COMMENT ON COLUMN character_project_states.target_faction_entity_id IS
+    'Optional immutable institutional context for older project arms; always NULL for BUILD_VENTURE, PURSUE_ROMANCE, COURT_PATRON, and SEEK_REDEMPTION.';
+
+INSERT INTO event_types (type, category, severity, description)
+VALUES
+    ('seek_redemption_started', 'project', 'moderate',
+     'The actor began making amends to a named party they had wronged.'),
+    ('seek_redemption_progressed', 'project', 'minor',
+     'The actor made routine progress toward repairing a past wrong.'),
+    ('seek_redemption_milestone', 'project', 'moderate',
+     'The attempt at amends crossed a boundary of ownership or repair.'),
+    ('seek_redemption_stalled', 'project', 'minor',
+     'Neglect cost the actor ground in their attempt to make amends.'),
+    ('seek_redemption_abandoned', 'project', 'moderate',
+     'The actor abandoned an attempt at reconciliation after delay or rejection.'),
+    ('seek_redemption_completed', 'project', 'moderate',
+     'The wronged party accepted the actor''s amends without erasing the past.')
+ON CONFLICT (type) DO NOTHING;

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -644,7 +644,16 @@ def _render_state_delta(delta: Mapping[str, Any]) -> str:
             continue
         if key.startswith("project."):
             transition = key.removeprefix("project.")
-            parts.append(f"applies project `{transition}` transition")
+            if key == "project.complete" and "grudge_active" in (
+                delta.get("entity_tags_target.remove") or ()
+            ):
+                parts.append(
+                    "applies project `complete` transition and upserts the "
+                    "actor→target `complex` relationship with "
+                    "`+1|favorable` valence"
+                )
+            else:
+                parts.append(f"applies project `{transition}` transition")
             continue
         parts.append(f"`{key}` = `{value}`")
     return "; ".join(parts)

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -216,6 +216,8 @@ def _tally_report(
                     "advance_pursue_romance",
                     "start_court_patron",
                     "advance_court_patron",
+                    "start_seek_redemption",
+                    "advance_seek_redemption",
                 }:
                     project_gates.append(
                         {

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -2218,6 +2218,11 @@ PROJECT_STAGE_LADDERS = {
         "declaring_intentions",
     ),
     "court_patron": ("gaining_notice", "proving_worth", "securing_favor"),
+    "seek_redemption": (
+        "owning_the_wrong",
+        "making_amends",
+        "earning_forgiveness",
+    ),
 }
 
 
@@ -2450,7 +2455,12 @@ def _apply_project_start_sync(
         raise ValueError("project.start faction target must be an entity id")
     if project_type == "plan_relocation" and target_character_entity_id is not None:
         raise ValueError("plan_relocation project.start forbids a character target")
-    if project_type in {"recruit_ally", "pursue_romance", "court_patron"}:
+    if project_type in {
+        "recruit_ally",
+        "pursue_romance",
+        "court_patron",
+        "seek_redemption",
+    }:
         if target_place_id is not None:
             raise ValueError(f"{project_type} project.start forbids a place target")
         if not isinstance(target_character_entity_id, int):
@@ -2458,7 +2468,7 @@ def _apply_project_start_sync(
                 f"{project_type} project.start requires a character target"
             )
         if (
-            project_type in {"pursue_romance", "court_patron"}
+            project_type in {"pursue_romance", "court_patron", "seek_redemption"}
             and target_faction_entity_id is not None
         ):
             raise ValueError(f"{project_type} project.start forbids a faction target")
@@ -2536,7 +2546,12 @@ async def _apply_project_start_async(
         raise ValueError("project.start faction target must be an entity id")
     if project_type == "plan_relocation" and target_character_entity_id is not None:
         raise ValueError("plan_relocation project.start forbids a character target")
-    if project_type in {"recruit_ally", "pursue_romance", "court_patron"}:
+    if project_type in {
+        "recruit_ally",
+        "pursue_romance",
+        "court_patron",
+        "seek_redemption",
+    }:
         if target_place_id is not None:
             raise ValueError(f"{project_type} project.start forbids a place target")
         if not isinstance(target_character_entity_id, int):
@@ -2544,7 +2559,7 @@ async def _apply_project_start_async(
                 f"{project_type} project.start requires a character target"
             )
         if (
-            project_type in {"pursue_romance", "court_patron"}
+            project_type in {"pursue_romance", "court_patron", "seek_redemption"}
             and target_faction_entity_id is not None
         ):
             raise ValueError(f"{project_type} project.start forbids a faction target")
@@ -2960,6 +2975,19 @@ def _validate_project_completion(
             raise ValueError("court_patron completion forbids a place target")
         if project["target_faction_entity_id"] is not None:
             raise ValueError("court_patron completion forbids a faction target")
+    if project_type == "seek_redemption":
+        wronged_party_id = project["target_character_entity_id"]
+        if wronged_party_id is None:
+            raise ValueError("seek_redemption completion requires its character target")
+        if target_entity_id != wronged_party_id:
+            raise ValueError(
+                "seek_redemption completion target binding does not match its "
+                "wronged party"
+            )
+        if project["target_place_id"] is not None:
+            raise ValueError("seek_redemption completion forbids a place target")
+        if project["target_faction_entity_id"] is not None:
+            raise ValueError("seek_redemption completion forbids a faction target")
     if project_type == "build_venture" and any(
         project[target] is not None
         for target in (
@@ -3147,6 +3175,211 @@ async def _upsert_recruited_ally_relationship_async(
         "previous_relationship_type": previous_type,
         "relationship_type": "ally",
         "relationship_type_changed": previous_type != "ally",
+    }
+
+
+def _seek_redemption_relationship_metadata(
+    *,
+    template_id: str,
+    source_chunk_id: int,
+    previous_relationship_type: Optional[str],
+    previous_emotional_valence: Optional[str],
+    existing_extra_data: Any,
+) -> dict[str, Any]:
+    """Return first-write-preserving provenance for reconciliation."""
+
+    original_type = previous_relationship_type
+    original_valence = previous_emotional_valence
+    if isinstance(existing_extra_data, Mapping):
+        prior = existing_extra_data.get("orrery_seek_redemption")
+        if isinstance(prior, Mapping):
+            original_type = prior.get("previous_relationship_type", original_type)
+            original_valence = prior.get("previous_emotional_valence", original_valence)
+    return {
+        "orrery_seek_redemption": {
+            "template_id": template_id,
+            "source_chunk_id": source_chunk_id,
+            "previous_relationship_type": original_type,
+            "previous_emotional_valence": original_valence,
+        }
+    }
+
+
+def _upsert_reconciled_relationship_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    target_entity_id: int,
+    template_id: str,
+    source_chunk_id: int,
+) -> dict[str, Any]:
+    """Persist actor->target as the canonical reconciled relationship."""
+
+    cur.execute(
+        """
+        SELECT actor.id AS character1_id,
+               target.id AS character2_id,
+               existing.relationship_type AS previous_relationship_type,
+               existing.emotional_valence AS previous_emotional_valence,
+               existing.extra_data
+        FROM characters actor
+        JOIN characters target ON target.entity_id = %s
+        LEFT JOIN character_relationships existing
+          ON existing.character1_id = actor.id
+         AND existing.character2_id = target.id
+        WHERE actor.entity_id = %s
+        """,
+        (target_entity_id, actor_entity_id),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(
+            "seek_redemption completion requires actor and target character rows"
+        )
+    character1_id = int(_row_get(row, "character1_id", 0))
+    character2_id = int(_row_get(row, "character2_id", 1))
+    if character1_id == character2_id:
+        raise ValueError("seek_redemption completion cannot target the actor")
+    previous_type_raw = _row_get(row, "previous_relationship_type", 2)
+    previous_valence_raw = _row_get(row, "previous_emotional_valence", 3)
+    previous_type = str(previous_type_raw) if previous_type_raw is not None else None
+    previous_valence = (
+        str(previous_valence_raw) if previous_valence_raw is not None else None
+    )
+    metadata = _seek_redemption_relationship_metadata(
+        template_id=template_id,
+        source_chunk_id=source_chunk_id,
+        previous_relationship_type=previous_type,
+        previous_emotional_valence=previous_valence,
+        existing_extra_data=_row_get(row, "extra_data", 4),
+    )
+    cur.execute(
+        """
+        INSERT INTO character_relationships (
+            character1_id, character2_id, relationship_type,
+            emotional_valence, dynamic, recent_events, history, extra_data
+        ) VALUES (
+            %s, %s, 'complex', '+1|favorable',
+            'Reconciliation accepted without erasing the past.',
+            'A sustained attempt at amends reached acceptance.',
+            'Reconciliation established through the SEEK_REDEMPTION project.',
+            %s::jsonb
+        )
+        ON CONFLICT (character1_id, character2_id) DO UPDATE SET
+            relationship_type = EXCLUDED.relationship_type,
+            emotional_valence = EXCLUDED.emotional_valence,
+            extra_data = COALESCE(character_relationships.extra_data, '{}'::jsonb)
+                         || EXCLUDED.extra_data,
+            updated_at = now()
+        RETURNING character1_id, character2_id, relationship_type,
+                  emotional_valence
+        """,
+        (character1_id, character2_id, json.dumps(metadata)),
+    )
+    if cur.fetchone() is None:
+        raise RuntimeError("seek_redemption relationship upsert returned no row")
+    return {
+        "operation": "insert" if previous_type is None else "update",
+        "subject_entity_id": actor_entity_id,
+        "object_entity_id": target_entity_id,
+        "character1_id": character1_id,
+        "character2_id": character2_id,
+        "previous_relationship_type": previous_type,
+        "previous_emotional_valence": previous_valence,
+        "relationship_type": "complex",
+        "emotional_valence": "+1|favorable",
+        "relationship_type_changed": previous_type != "complex",
+        "emotional_valence_changed": previous_valence != "+1|favorable",
+    }
+
+
+async def _upsert_reconciled_relationship_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    target_entity_id: int,
+    template_id: str,
+    source_chunk_id: int,
+) -> dict[str, Any]:
+    """Async twin of _upsert_reconciled_relationship_sync."""
+
+    row = await conn.fetchrow(
+        """
+        SELECT actor.id AS character1_id,
+               target.id AS character2_id,
+               existing.relationship_type AS previous_relationship_type,
+               existing.emotional_valence AS previous_emotional_valence,
+               existing.extra_data
+        FROM characters actor
+        JOIN characters target ON target.entity_id = $2
+        LEFT JOIN character_relationships existing
+          ON existing.character1_id = actor.id
+         AND existing.character2_id = target.id
+        WHERE actor.entity_id = $1
+        """,
+        actor_entity_id,
+        target_entity_id,
+    )
+    if row is None:
+        raise ValueError(
+            "seek_redemption completion requires actor and target character rows"
+        )
+    character1_id = int(_row_get(row, "character1_id", 0))
+    character2_id = int(_row_get(row, "character2_id", 1))
+    if character1_id == character2_id:
+        raise ValueError("seek_redemption completion cannot target the actor")
+    previous_type_raw = _row_get(row, "previous_relationship_type", 2)
+    previous_valence_raw = _row_get(row, "previous_emotional_valence", 3)
+    previous_type = str(previous_type_raw) if previous_type_raw is not None else None
+    previous_valence = (
+        str(previous_valence_raw) if previous_valence_raw is not None else None
+    )
+    metadata = _seek_redemption_relationship_metadata(
+        template_id=template_id,
+        source_chunk_id=source_chunk_id,
+        previous_relationship_type=previous_type,
+        previous_emotional_valence=previous_valence,
+        existing_extra_data=_row_get(row, "extra_data", 4),
+    )
+    written = await conn.fetchrow(
+        """
+        INSERT INTO character_relationships (
+            character1_id, character2_id, relationship_type,
+            emotional_valence, dynamic, recent_events, history, extra_data
+        ) VALUES (
+            $1, $2, 'complex', '+1|favorable',
+            'Reconciliation accepted without erasing the past.',
+            'A sustained attempt at amends reached acceptance.',
+            'Reconciliation established through the SEEK_REDEMPTION project.',
+            $3::jsonb
+        )
+        ON CONFLICT (character1_id, character2_id) DO UPDATE SET
+            relationship_type = EXCLUDED.relationship_type,
+            emotional_valence = EXCLUDED.emotional_valence,
+            extra_data = COALESCE(character_relationships.extra_data, '{}'::jsonb)
+                         || EXCLUDED.extra_data,
+            updated_at = now()
+        RETURNING character1_id, character2_id, relationship_type,
+                  emotional_valence
+        """,
+        character1_id,
+        character2_id,
+        json.dumps(metadata),
+    )
+    if written is None:
+        raise RuntimeError("seek_redemption relationship upsert returned no row")
+    return {
+        "operation": "insert" if previous_type is None else "update",
+        "subject_entity_id": actor_entity_id,
+        "object_entity_id": target_entity_id,
+        "character1_id": character1_id,
+        "character2_id": character2_id,
+        "previous_relationship_type": previous_type,
+        "previous_emotional_valence": previous_valence,
+        "relationship_type": "complex",
+        "emotional_valence": "+1|favorable",
+        "relationship_type_changed": previous_type != "complex",
+        "emotional_valence_changed": previous_valence != "+1|favorable",
     }
 
 
@@ -3569,6 +3802,15 @@ def _apply_project_complete_sync(
             template_id=template_id,
             source_chunk_id=source_chunk_id,
         )
+    elif project["project_type"] == "seek_redemption":
+        assert target_entity_id is not None
+        relationship_mutation = _upsert_reconciled_relationship_sync(
+            cur,
+            actor_entity_id=actor_entity_id,
+            target_entity_id=target_entity_id,
+            template_id=template_id,
+            source_chunk_id=source_chunk_id,
+        )
     elif project["project_type"] == "build_venture":
         pass
     else:
@@ -3648,6 +3890,15 @@ async def _apply_project_complete_async(
     elif project["project_type"] == "court_patron":
         assert target_entity_id is not None
         relationship_mutation = await _upsert_court_patron_relationship_async(
+            conn,
+            actor_entity_id=actor_entity_id,
+            target_entity_id=target_entity_id,
+            template_id=template_id,
+            source_chunk_id=source_chunk_id,
+        )
+    elif project["project_type"] == "seek_redemption":
+        assert target_entity_id is not None
+        relationship_mutation = await _upsert_reconciled_relationship_async(
             conn,
             actor_entity_id=actor_entity_id,
             target_entity_id=target_entity_id,

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -3009,6 +3009,9 @@ def _recruit_ally_relationship_metadata(
     """Return durable provenance for the canonical recruited-ally relation."""
 
     original_type = previous_relationship_type
+    # asyncpg returns JSONB as str; without decoding, the Mapping check
+    # silently misses prior provenance and a re-run clobbers the originals.
+    existing_extra_data = _decode_json_value(existing_extra_data)
     if isinstance(existing_extra_data, Mapping):
         prior = existing_extra_data.get("orrery_recruit_ally")
         if isinstance(prior, Mapping):
@@ -3190,6 +3193,9 @@ def _seek_redemption_relationship_metadata(
 
     original_type = previous_relationship_type
     original_valence = previous_emotional_valence
+    # asyncpg returns JSONB as str; without decoding, the Mapping check
+    # silently misses prior provenance and a re-run clobbers the originals.
+    existing_extra_data = _decode_json_value(existing_extra_data)
     if isinstance(existing_extra_data, Mapping):
         prior = existing_extra_data.get("orrery_seek_redemption")
         if isinstance(prior, Mapping):
@@ -3393,6 +3399,9 @@ def _pursue_romance_relationship_metadata(
     """Return durable provenance for the canonical romance relation."""
 
     original_type = previous_relationship_type
+    # asyncpg returns JSONB as str; without decoding, the Mapping check
+    # silently misses prior provenance and a re-run clobbers the originals.
+    existing_extra_data = _decode_json_value(existing_extra_data)
     if isinstance(existing_extra_data, Mapping):
         prior = existing_extra_data.get("orrery_pursue_romance")
         if isinstance(prior, Mapping):
@@ -3572,6 +3581,9 @@ def _court_patron_relationship_metadata(
     """Return durable provenance for the canonical patron relationship."""
 
     original_type = previous_relationship_type
+    # asyncpg returns JSONB as str; without decoding, the Mapping check
+    # silently misses prior provenance and a re-run clobbers the originals.
+    existing_extra_data = _decode_json_value(existing_extra_data)
     if isinstance(existing_extra_data, Mapping):
         prior = existing_extra_data.get("orrery_court_patron")
         if isinstance(prior, Mapping):

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -90,6 +90,11 @@ PROJECT_STAGE_LADDERS = {
         "declaring_intentions",
     ),
     "court_patron": ("gaining_notice", "proving_worth", "securing_favor"),
+    "seek_redemption": (
+        "owning_the_wrong",
+        "making_amends",
+        "earning_forgiveness",
+    ),
 }
 
 # Composite natural keys, verbatim column order (faction_relationships
@@ -1013,11 +1018,12 @@ class _Replayer:
             "recruit_ally",
             "pursue_romance",
             "court_patron",
+            "seek_redemption",
         } and (
             applied_row["target_place_id"] is not None
             or applied_row["target_character_entity_id"] is None
             or (
-                project_type in {"pursue_romance", "court_patron"}
+                project_type in {"pursue_romance", "court_patron", "seek_redemption"}
                 and applied_row["target_faction_entity_id"] is not None
             )
         ):
@@ -1090,6 +1096,7 @@ class _Replayer:
                 "recruit_ally",
                 "pursue_romance",
                 "court_patron",
+                "seek_redemption",
             }:
                 if applied_row["target_character_entity_id"] is None:
                     raise ValueError(

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -2217,6 +2217,7 @@ def _materialize_project_delta(
             "recruit_ally",
             "pursue_romance",
             "court_patron",
+            "seek_redemption",
         }:
             target = resolution.bindings.get(Slot.TARGET)
             if not isinstance(target, int):

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -1191,6 +1191,11 @@ _PROJECT_DUE_MODES = frozenset(
         "securing_favor",
         "gaining_notice_milestone",
         "proving_worth_milestone",
+        "owning_the_wrong",
+        "making_amends",
+        "earning_forgiveness",
+        "owning_the_wrong_milestone",
+        "making_amends_milestone",
     }
 )
 
@@ -1208,6 +1213,11 @@ _PROJECT_STAGE_LADDERS = {
         "declaring_intentions",
     ),
     "court_patron": ("gaining_notice", "proving_worth", "securing_favor"),
+    "seek_redemption": (
+        "owning_the_wrong",
+        "making_amends",
+        "earning_forgiveness",
+    ),
 }
 
 
@@ -1341,6 +1351,7 @@ def project_due(
                         "recruit_ally",
                         "pursue_romance",
                         "court_patron",
+                        "seek_redemption",
                     }
                     else True
                 )
@@ -1361,6 +1372,7 @@ def project_due(
                         "recruit_ally",
                         "pursue_romance",
                         "court_patron",
+                        "seek_redemption",
                     }
                     else True
                 )

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -5725,6 +5725,16 @@ START_SEEK_REDEMPTION = Template(
             trust_below(0, Slot.TARGET, Slot.ACTOR),
             has_symmetric_relationship_of_type("enemy", Slot.ACTOR, Slot.TARGET),
             has_symmetric_relationship_of_type("rival", Slot.ACTOR, Slot.TARGET),
+            # Reachability contour: candidate pairs compose from relationship
+            # rows (any type) and contact:social edges, never from hostile
+            # pair tags alone. This arm therefore fires only when the pair
+            # composed via one of those routes and the hostile edge is the
+            # sole EVIDENCE (e.g. a hunting edge atop a neutral-valence
+            # relationship row). A pair whose only connection is a hostile
+            # edge does not compose — deliberately: a wrong worth redeeming
+            # with no relationship row is data-shape-poor, and widening the
+            # shared composer for that corner would touch every two-party
+            # package.
             has_any_pair_tag(
                 "hostile_to",
                 "hunting",

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -1028,6 +1028,7 @@ SURVEIL = Template(
         NOT(project_due("ready", project_type="recruit_ally")),
         NOT(project_due("ready", project_type="pursue_romance")),
         NOT(project_due("ready", project_type="court_patron")),
+        NOT(project_due("ready", project_type="seek_redemption")),
         NOT(is_constrained()),
         NOT(has_inbound_pair_tag("hunting")),
         NOT(has_ephemeral("grudge_active")),
@@ -5696,6 +5697,349 @@ ADVANCE_COURT_PATRON = Template(
 )
 
 
+START_SEEK_REDEMPTION = Template(
+    id="start_seek_redemption",
+    priority=17,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "Seeking redemption requires durable evidence of a wrong and an actor "
+        "who is no longer actively hostile toward the wronged party."
+    ),
+    blurb="An off-screen character begins making amends to someone they wronged.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    starts_from_social_contact=True,
+    package_gate=AND(
+        project_due("start", project_type="seek_redemption"),
+        has_minimal_context(),
+        at_routine_anchor("home"),
+        NOT(is_in_transit()),
+        NOT(is_constrained()),
+        NOT(
+            OR(
+                has_need_debt_at_or_above("sleep", 8),
+                has_need_debt_at_or_above("thirst", 2),
+                has_need_debt_at_or_above("hunger", 4),
+            )
+        ),
+        OR(
+            trust_below(0, Slot.TARGET, Slot.ACTOR),
+            has_symmetric_relationship_of_type("enemy", Slot.ACTOR, Slot.TARGET),
+            has_symmetric_relationship_of_type("rival", Slot.ACTOR, Slot.TARGET),
+            has_any_pair_tag(
+                "hostile_to",
+                "hunting",
+                subject_slot=Slot.TARGET,
+                object_slot=Slot.ACTOR,
+            ),
+        ),
+        NOT(
+            has_any_pair_tag(
+                "hostile_to",
+                "hunting",
+                subject_slot=Slot.ACTOR,
+                object_slot=Slot.TARGET,
+            )
+        ),
+    ),
+    branches=(
+        Branch(
+            label="Own the wrong",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} stops arranging the past into excuses. What they did "
+                "to {target} becomes a wrong they can name, and therefore one "
+                "they can begin trying to repair."
+            ),
+            state_delta={
+                "project.start": {
+                    "project_type": "seek_redemption",
+                    "stage": "owning_the_wrong",
+                    "milestone": True,
+                }
+            },
+            event_type="seek_redemption_started",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.stage",
+                "character_project_states.target_character_entity_id",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.40,
+        ),
+    ),
+)
+
+
+ADVANCE_SEEK_REDEMPTION = Template(
+    id="advance_seek_redemption",
+    priority=47,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    priority_override_rationale=(
+        "A due reconciliation effort shares the established continuation slot "
+        "while SURVEIL yields to its bound two-party work."
+    ),
+    blurb=(
+        "A due attempt at redemption owns the wrong, makes amends, seeks "
+        "forgiveness, stalls, is thrown back, or ends."
+    ),
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    binds_project_target=True,
+    package_gate=AND(
+        project_due("ready", project_type="seek_redemption"),
+        project_target_is(Slot.TARGET),
+        NOT(is_in_transit()),
+        NOT(is_constrained()),
+        NOT(
+            OR(
+                has_need_debt_at_or_above("sleep", 8),
+                has_need_debt_at_or_above("thirst", 2),
+                has_need_debt_at_or_above("hunger", 4),
+            )
+        ),
+    ),
+    branches=(
+        Branch(
+            label="End amends whose wronged party is no longer available",
+            conditions=NOT(project_target_is_active(Slot.TARGET)),
+            narrative_stub=(
+                "{target} is no longer someone who can receive an attempt at "
+                "amends. {actor} closes the effort rather than preserving an "
+                "unanswerable claim to forgiveness."
+            ),
+            state_delta={
+                "project.abandon": {
+                    "reason": "target_inactive_or_non_character",
+                    "milestone": True,
+                }
+            },
+            event_type="seek_redemption_abandoned",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.source_chunk_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Have the amends accepted",
+            conditions=AND(
+                project_due("completion", project_type="seek_redemption"),
+                NOT(
+                    has_any_pair_tag(
+                        "hostile_to",
+                        "hunting",
+                        subject_slot=Slot.ACTOR,
+                        object_slot=Slot.TARGET,
+                    )
+                ),
+                NOT(
+                    has_any_pair_tag(
+                        "hostile_to",
+                        "hunting",
+                        subject_slot=Slot.TARGET,
+                        object_slot=Slot.ACTOR,
+                    )
+                ),
+            ),
+            narrative_stub=(
+                "{target} accepts what {actor} has done to make amends. The "
+                "history remains complicated, but it no longer dictates only "
+                "hostility between them."
+            ),
+            state_delta={
+                "project.complete": {"milestone": True},
+                "entity_tags_target.remove": ["grudge_active"],
+            },
+            event_type="seek_redemption_completed",
+            changed_fields=(
+                "character_project_states.status",
+                "entity_tags",
+                "character_relationships.relationship_type",
+                "character_relationships.emotional_valence",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Abandon amends that are thrown back",
+            conditions=OR(
+                trust_below(-2, Slot.TARGET, Slot.ACTOR),
+                has_any_pair_tag(
+                    "hostile_to",
+                    "hunting",
+                    subject_slot=Slot.ACTOR,
+                    object_slot=Slot.TARGET,
+                ),
+                has_any_pair_tag(
+                    "hostile_to",
+                    "hunting",
+                    subject_slot=Slot.TARGET,
+                    object_slot=Slot.ACTOR,
+                ),
+            ),
+            narrative_stub=(
+                "The amends are thrown back in {actor}'s face. Whether the "
+                "answer is hardened resentment or fresh hostility, {target} "
+                "will not accept reconciliation on these terms."
+            ),
+            state_delta={
+                "project.abandon": {
+                    "reason": "amends_spurned_or_hostility_hardened",
+                    "milestone": True,
+                }
+            },
+            event_type="seek_redemption_abandoned",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.source_chunk_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Let the attempt at redemption go",
+            conditions=project_due("abandon", project_type="seek_redemption"),
+            narrative_stub=(
+                "Delay has made the attempt another promise without repair. "
+                "{actor} stops claiming that unfinished amends are progress."
+            ),
+            state_delta={
+                "project.abandon": {
+                    "reason": "stalled_or_overdue",
+                    "milestone": True,
+                }
+            },
+            event_type="seek_redemption_abandoned",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.source_chunk_id",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Turn ownership into amends",
+            conditions=project_due(
+                "owning_the_wrong_milestone", project_type="seek_redemption"
+            ),
+            narrative_stub=(
+                "{actor} has named the wrong without qualification. Words now "
+                "have to become repair shaped by what {target} actually lost."
+            ),
+            state_delta={
+                "project.advance": {
+                    "stage": "making_amends",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            event_type="seek_redemption_milestone",
+            changed_fields=(
+                "character_project_states.stage",
+                "character_project_states.progress",
+                "character_project_states.stall_count",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Let amends ask for forgiveness",
+            conditions=project_due(
+                "making_amends_milestone", project_type="seek_redemption"
+            ),
+            narrative_stub=(
+                "The repair is no longer hypothetical. {actor} leaves the last "
+                "judgment with {target}: whether these amends can be accepted."
+            ),
+            state_delta={
+                "project.advance": {
+                    "stage": "earning_forgiveness",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            event_type="seek_redemption_milestone",
+            changed_fields=(
+                "character_project_states.stage",
+                "character_project_states.progress",
+                "character_project_states.stall_count",
+            ),
+            magnitude=0.40,
+            preemptive=True,
+        ),
+        Branch(
+            label="Lose ground through neglected amends",
+            conditions=project_due("neglected", project_type="seek_redemption"),
+            narrative_stub=(
+                "Neglect makes the apology look like another demand for easy "
+                "absolution. The attempt at redemption loses ground."
+            ),
+            state_delta={"project.stall": {"increment": 1}},
+            event_type="seek_redemption_stalled",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.stall_count",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.10,
+            promotable=False,
+            preemptive=True,
+        ),
+        Branch(
+            label="Name the wrong without self-exoneration",
+            conditions=project_due("owning_the_wrong", project_type="seek_redemption"),
+            narrative_stub=(
+                "{actor} examines one consequence from {target}'s side of the "
+                "harm and removes another comforting excuse from the account."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.35}},
+            event_type="seek_redemption_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.18,
+            promotable=False,
+        ),
+        Branch(
+            label="Make one concrete repair",
+            conditions=project_due("making_amends", project_type="seek_redemption"),
+            narrative_stub=(
+                "{actor} makes one repair that costs them something and returns "
+                "something meaningful to {target}."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.35}},
+            event_type="seek_redemption_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.18,
+            promotable=False,
+        ),
+        Branch(
+            label="Leave forgiveness in the wronged party's hands",
+            conditions=ALWAYS,
+            narrative_stub=(
+                "{actor} continues the work without treating forgiveness as a "
+                "debt {target} now owes them."
+            ),
+            state_delta={"project.advance": {"progress_delta": 0.25}},
+            event_type="seek_redemption_progressed",
+            changed_fields=(
+                "character_project_states.status",
+                "character_project_states.progress",
+                "character_project_states.next_eligible_at_world_time",
+            ),
+            magnitude=0.16,
+            promotable=False,
+        ),
+    ),
+)
+
+
 START_BUILD_VENTURE = Template(
     id="start_build_venture",
     priority=17,
@@ -5963,6 +6307,7 @@ BUILTIN_TEMPLATES = (
     ADVANCE_BUILD_VENTURE,
     ADVANCE_PURSUE_ROMANCE,
     ADVANCE_COURT_PATRON,
+    ADVANCE_SEEK_REDEMPTION,
     ACT_ON_INTEL,
     UNCOVER_PAST,
     CHECK_ON_DEPENDENT,
@@ -5990,6 +6335,7 @@ BUILTIN_TEMPLATES = (
     START_BUILD_VENTURE,
     START_PURSUE_ROMANCE,
     START_COURT_PATRON,
+    START_SEEK_REDEMPTION,
     MAINTAIN_COVER,
 )
 

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -651,6 +651,12 @@ def test_catalog_endpoint_over_http(client: TestClient) -> None:
         "court_patron_stalled",
         "court_patron_abandoned",
         "court_patron_completed",
+        "seek_redemption_started",
+        "seek_redemption_progressed",
+        "seek_redemption_milestone",
+        "seek_redemption_stalled",
+        "seek_redemption_abandoned",
+        "seek_redemption_completed",
     }
     assert {band["band"] for band in payload["drive_bands"]} == {
         "crisis_constraint",

--- a/tests/test_orrery/test_catalog.py
+++ b/tests/test_orrery/test_catalog.py
@@ -96,6 +96,18 @@ def test_catalog_renders_court_patron_completion_vocabulary() -> None:
     assert "- `sponsors`" in content
 
 
+def test_catalog_renders_seek_redemption_completion_vocabulary() -> None:
+    """Reconciliation gates and its bespoke completion stay discoverable."""
+
+    content = render_catalog(BUILTIN_TEMPLATES)
+    assert "## START_SEEK_REDEMPTION — priority 17" in content
+    assert "## ADVANCE_SEEK_REDEMPTION — priority 47" in content
+    assert "actor `seek_redemption` project passes `completion` due-state" in content
+    assert "actor→target `complex` relationship" in content
+    assert "`+1|favorable` valence" in content
+    assert "removes `grudge_active` from target" in content
+
+
 def test_catalog_renders_compound_structure() -> None:
     """AND / OR / NOT compositions appear as labeled nested bullets."""
 

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -177,6 +177,35 @@ def test_court_patron_migration_replaces_named_five_type_constraints() -> None:
     assert migration_sql.count("court_patron_") >= 6
 
 
+def test_seek_redemption_migration_replaces_named_six_type_constraints() -> None:
+    """Migration 087 preserves 086 and adds strict wronged-party targeting."""
+
+    migration_sql = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "087_seek_redemption_projects.sql"
+    ).read_text()
+    for name in (
+        "character_project_states_project_type_check",
+        "character_project_states_stage_by_type_check",
+        "character_project_states_target_by_type_check",
+        "character_project_states_completed_target_check",
+    ):
+        assert f"DROP CONSTRAINT IF EXISTS {name}" in migration_sql
+        assert f"ADD CONSTRAINT {name}" in migration_sql
+        assert f"COMMENT ON CONSTRAINT {name}" in migration_sql
+    for project_type in (
+        "plan_relocation",
+        "recruit_ally",
+        "build_venture",
+        "pursue_romance",
+        "court_patron",
+        "seek_redemption",
+    ):
+        assert migration_sql.count(f"project_type = '{project_type}'") >= 3
+    assert migration_sql.count("seek_redemption_") >= 6
+
+
 def test_retrograde_persistence_migration_adds_distinct_sources() -> None:
     """Retrograde canonical writes need explicit event and tag provenance."""
 

--- a/tests/test_orrery/test_seek_redemption_async.py
+++ b/tests/test_orrery/test_seek_redemption_async.py
@@ -1,0 +1,232 @@
+"""Live async-writer parity for SEEK_REDEMPTION projects."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import asyncpg
+import pytest
+
+from nexus.agents.orrery.events import _apply_state_delta_async
+from nexus.agents.orrery.needs import NeedTuning
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.substrate import ProjectPolicy
+from nexus.api.slot_utils import get_slot_db_url
+
+pytestmark = pytest.mark.requires_postgres
+POLICY = ProjectPolicy(enabled=True, advance_interval_hours=24.0)
+
+
+async def _create_schema(conn: asyncpg.Connection) -> None:
+    schema = f"seek_redemption_async_{uuid4().hex[:12]}"
+    await conn.execute(f'CREATE SCHEMA "{schema}"')
+    await conn.execute(f'SET LOCAL search_path = "{schema}", public')
+    await conn.execute(
+        """
+        CREATE TABLE event_types (
+            type text PRIMARY KEY, category text NOT NULL,
+            severity text NOT NULL, description text
+        );
+        CREATE TABLE orrery_resolutions (
+            id bigint PRIMARY KEY, state_delta jsonb NOT NULL
+        );
+        CREATE TABLE character_project_states (
+            id bigserial PRIMARY KEY, character_entity_id bigint NOT NULL,
+            project_type text NOT NULL, status text NOT NULL, stage text NOT NULL,
+            target_place_id bigint, target_character_entity_id bigint,
+            target_faction_entity_id bigint, progress numeric(5,4) NOT NULL DEFAULT 0,
+            stall_count integer NOT NULL DEFAULT 0,
+            next_eligible_at_world_time timestamptz, source_chunk_id bigint,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now(),
+            CONSTRAINT character_project_states_project_type_check CHECK (
+                project_type IN (
+                    'plan_relocation', 'recruit_ally', 'build_venture',
+                    'pursue_romance'
+                )),
+            CONSTRAINT character_project_states_stage_by_type_check CHECK (
+                (project_type='plan_relocation'
+                    AND stage IN ('saving','scouting','committing')) OR
+                (project_type='recruit_ally'
+                    AND stage IN (
+                        'sounding_out','earning_trust','sealing_commitment'
+                    )) OR
+                (project_type='build_venture'
+                    AND stage IN (
+                        'laying_groundwork','securing_backing','opening_doors'
+                    )) OR
+                (project_type='pursue_romance'
+                    AND stage IN (
+                        'testing_waters','growing_closer','declaring_intentions'
+                    ))),
+            CONSTRAINT character_project_states_target_by_type_check CHECK (
+                (project_type='plan_relocation'
+                    AND target_character_entity_id IS NULL) OR
+                (project_type='recruit_ally'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NOT NULL) OR
+                (project_type='build_venture'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NULL
+                    AND target_faction_entity_id IS NULL) OR
+                (project_type='pursue_romance'
+                    AND target_place_id IS NULL
+                    AND target_character_entity_id IS NOT NULL
+                    AND target_faction_entity_id IS NULL)),
+            CONSTRAINT character_project_states_completed_target_check CHECK (
+                status <> 'completed' OR
+                (project_type='plan_relocation' AND target_place_id IS NOT NULL) OR
+                (project_type='recruit_ally'
+                    AND target_character_entity_id IS NOT NULL) OR
+                project_type='build_venture' OR
+                (project_type='pursue_romance'
+                    AND target_character_entity_id IS NOT NULL))
+        );
+        CREATE UNIQUE INDEX ux_character_project_states_open_budget
+            ON character_project_states(character_entity_id)
+            WHERE status IN ('active','paused','stalled');
+        """
+    )
+    await conn.execute(
+        (
+            Path(__file__).parents[2] / "migrations/087_seek_redemption_projects.sql"
+        ).read_text()
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_seek_redemption_three_write_completion() -> None:
+    conn = await asyncpg.connect(get_slot_db_url(slot=2))
+    transaction = conn.transaction()
+    await transaction.start()
+    try:
+        await _create_schema(conn)
+        entities = await conn.fetch(
+            "SELECT entity_id FROM characters WHERE entity_id IS NOT NULL "
+            "ORDER BY id LIMIT 2"
+        )
+        actor, target = (int(row["entity_id"]) for row in entities)
+        chunk = int(
+            await conn.fetchval(
+                "SELECT chunk_id FROM chunk_metadata WHERE world_time IS NOT NULL "
+                "ORDER BY chunk_id DESC LIMIT 1"
+            )
+        )
+        await conn.execute(
+            "DELETE FROM character_relationships USING characters a,characters t "
+            "WHERE character_relationships.character1_id=a.id "
+            "AND character_relationships.character2_id=t.id "
+            "AND a.entity_id=$1 AND t.entity_id=$2",
+            actor,
+            target,
+        )
+        await conn.execute(
+            "UPDATE entity_tags et SET cleared_at=now() FROM tags t "
+            "WHERE et.tag_id=t.id AND et.entity_id=$1 "
+            "AND t.tag='grudge_active' AND et.cleared_at IS NULL",
+            target,
+        )
+        await conn.execute(
+            "INSERT INTO entity_tags (entity_id,tag_id,source_kind,template_id) "
+            "SELECT $1,id,'template','test_seek_redemption_async' FROM tags "
+            "WHERE tag='grudge_active'",
+            target,
+        )
+        start = OrreryResolutionDraft(
+            template_id="start_seek_redemption",
+            priority=17,
+            binding_hash="async-start",
+            bindings={"actor": actor, "target": target},
+            branch_label="start",
+            narrative_stub="start",
+            magnitude=0.4,
+            state_delta={
+                "project.start": {
+                    "project_type": "seek_redemption",
+                    "stage": "owning_the_wrong",
+                    "target_character_entity_id": target,
+                    "milestone": True,
+                }
+            },
+        )
+        await conn.execute("INSERT INTO orrery_resolutions VALUES (1,'{}'::jsonb)")
+        assert (
+            await _apply_state_delta_async(
+                conn,
+                start,
+                resolution_id=1,
+                actor_entity_id=actor,
+                target_entity_id=target,
+                source_chunk_id=chunk,
+                need_tuning=NeedTuning.default(),
+                project_policy=POLICY,
+            )
+            == 0
+        )
+        await conn.execute(
+            "UPDATE character_project_states "
+            "SET stage='earning_forgiveness',progress=1 "
+            "WHERE character_entity_id=$1",
+            actor,
+        )
+        complete = OrreryResolutionDraft(
+            template_id="advance_seek_redemption",
+            priority=47,
+            binding_hash="async-complete",
+            bindings={"actor": actor, "target": target},
+            branch_label="complete",
+            narrative_stub="complete",
+            magnitude=0.4,
+            state_delta={
+                "project.complete": {"milestone": True},
+                "entity_tags_target.remove": ["grudge_active"],
+            },
+        )
+        await conn.execute("INSERT INTO orrery_resolutions VALUES (2,'{}'::jsonb)")
+        assert (
+            await _apply_state_delta_async(
+                conn,
+                complete,
+                resolution_id=2,
+                actor_entity_id=actor,
+                target_entity_id=target,
+                source_chunk_id=chunk,
+                need_tuning=NeedTuning.default(),
+                project_policy=POLICY,
+            )
+            == 1
+        )
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM entity_tags et JOIN tags t ON t.id=et.tag_id "
+                "WHERE et.entity_id=$1 AND t.tag='grudge_active' "
+                "AND et.cleared_at IS NULL",
+                target,
+            )
+            == 0
+        )
+        relationship = await conn.fetchrow(
+            "SELECT cr.relationship_type,cr.emotional_valence,cr.extra_data "
+            "FROM character_relationships cr "
+            "JOIN characters a ON a.id=cr.character1_id "
+            "JOIN characters t ON t.id=cr.character2_id "
+            "WHERE a.entity_id=$1 AND t.entity_id=$2",
+            actor,
+            target,
+        )
+        assert relationship is not None
+        assert (
+            relationship["relationship_type"],
+            relationship["emotional_valence"],
+        ) == ("complex", "+1|favorable")
+        assert (
+            json.loads(relationship["extra_data"])["orrery_seek_redemption"][
+                "template_id"
+            ]
+            == "advance_seek_redemption"
+        )
+    finally:
+        await transaction.rollback()
+        await conn.close()

--- a/tests/test_orrery/test_seek_redemption_async.py
+++ b/tests/test_orrery/test_seek_redemption_async.py
@@ -9,7 +9,10 @@ from uuid import uuid4
 import asyncpg
 import pytest
 
-from nexus.agents.orrery.events import _apply_state_delta_async
+from nexus.agents.orrery.events import (
+    _apply_state_delta_async,
+    _upsert_reconciled_relationship_async,
+)
 from nexus.agents.orrery.needs import NeedTuning
 from nexus.agents.orrery.resolver import OrreryResolutionDraft
 from nexus.agents.orrery.substrate import ProjectPolicy
@@ -123,6 +126,16 @@ async def test_async_seek_redemption_three_write_completion() -> None:
             target,
         )
         await conn.execute(
+            "INSERT INTO character_relationships "
+            "(character1_id,character2_id,relationship_type,emotional_valence,"
+            " dynamic,recent_events,history) "
+            "SELECT a.id,t.id,'enemy','-4|hostile','d','r','h' "
+            "FROM characters a,characters t "
+            "WHERE a.entity_id=$1 AND t.entity_id=$2",
+            actor,
+            target,
+        )
+        await conn.execute(
             "UPDATE entity_tags et SET cleared_at=now() FROM tags t "
             "WHERE et.tag_id=t.id AND et.entity_id=$1 "
             "AND t.tag='grudge_active' AND et.cleared_at IS NULL",
@@ -221,12 +234,33 @@ async def test_async_seek_redemption_three_write_completion() -> None:
             relationship["relationship_type"],
             relationship["emotional_valence"],
         ) == ("complex", "+1|favorable")
-        assert (
-            json.loads(relationship["extra_data"])["orrery_seek_redemption"][
-                "template_id"
-            ]
-            == "advance_seek_redemption"
+        provenance = json.loads(relationship["extra_data"])["orrery_seek_redemption"]
+        assert provenance["template_id"] == "advance_seek_redemption"
+        assert provenance["previous_relationship_type"] == "enemy"
+        assert provenance["previous_emotional_valence"] == "-4|hostile"
+
+        # Re-run the upsert directly: asyncpg hands extra_data back as a
+        # JSONB string, and the first-write provenance must survive the
+        # decode (a regression here rewrites the originals as
+        # complex/+1|favorable).
+        await _upsert_reconciled_relationship_async(
+            conn,
+            actor_entity_id=actor,
+            target_entity_id=target,
+            template_id="advance_seek_redemption",
+            source_chunk_id=chunk,
         )
+        rewritten = await conn.fetchrow(
+            "SELECT cr.extra_data FROM character_relationships cr "
+            "JOIN characters a ON a.id=cr.character1_id "
+            "JOIN characters t ON t.id=cr.character2_id "
+            "WHERE a.entity_id=$1 AND t.entity_id=$2",
+            actor,
+            target,
+        )
+        second = json.loads(rewritten["extra_data"])["orrery_seek_redemption"]
+        assert second["previous_relationship_type"] == "enemy"
+        assert second["previous_emotional_valence"] == "-4|hostile"
     finally:
         await transaction.rollback()
         await conn.close()

--- a/tests/test_orrery/test_seek_redemption_migration_pg.py
+++ b/tests/test_orrery/test_seek_redemption_migration_pg.py
@@ -1,0 +1,189 @@
+"""Real-PostgreSQL contract coverage for migration 087."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2
+import pytest
+
+from nexus.api.slot_utils import get_slot_db_url
+
+pytestmark = pytest.mark.requires_postgres
+
+
+@pytest.fixture()
+def migration_086_schema() -> Iterator[Any]:
+    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    try:
+        with conn.cursor() as cur:
+            schema = f"migration_087_{uuid4().hex[:12]}"
+            cur.execute(f'CREATE SCHEMA "{schema}"')
+            cur.execute(f'SET LOCAL search_path = "{schema}", public')
+            cur.execute(
+                """
+                CREATE TABLE event_types (
+                    type text PRIMARY KEY, category text NOT NULL,
+                    severity text NOT NULL, description text
+                );
+                CREATE TABLE character_project_states (
+                    id bigserial PRIMARY KEY, character_entity_id bigint NOT NULL,
+                    project_type text NOT NULL, status text NOT NULL,
+                    stage text NOT NULL, target_place_id bigint,
+                    target_character_entity_id bigint,
+                    target_faction_entity_id bigint,
+                    progress numeric(5,4) NOT NULL DEFAULT 0,
+                    stall_count integer NOT NULL DEFAULT 0,
+                    next_eligible_at_world_time timestamptz, source_chunk_id bigint,
+                    CONSTRAINT character_project_states_project_type_check CHECK (
+                        project_type IN (
+                            'plan_relocation', 'recruit_ally', 'build_venture',
+                            'pursue_romance'
+                        )),
+                    CONSTRAINT character_project_states_stage_by_type_check CHECK (
+                        (project_type='plan_relocation'
+                            AND stage IN ('saving','scouting','committing')) OR
+                        (project_type='recruit_ally'
+                            AND stage IN (
+                                'sounding_out','earning_trust',
+                                'sealing_commitment'
+                            )) OR
+                        (project_type='build_venture'
+                            AND stage IN (
+                                'laying_groundwork','securing_backing',
+                                'opening_doors'
+                            )) OR
+                        (project_type='pursue_romance'
+                            AND stage IN (
+                                'testing_waters','growing_closer',
+                                'declaring_intentions'
+                            ))),
+                    CONSTRAINT character_project_states_target_by_type_check CHECK (
+                        (project_type='plan_relocation'
+                            AND target_character_entity_id IS NULL) OR
+                        (project_type='recruit_ally'
+                            AND target_place_id IS NULL
+                            AND target_character_entity_id IS NOT NULL) OR
+                        (project_type='build_venture'
+                            AND target_place_id IS NULL
+                            AND target_character_entity_id IS NULL
+                            AND target_faction_entity_id IS NULL) OR
+                        (project_type='pursue_romance'
+                            AND target_place_id IS NULL
+                            AND target_character_entity_id IS NOT NULL
+                            AND target_faction_entity_id IS NULL)),
+                    CONSTRAINT character_project_states_completed_target_check CHECK (
+                        status <> 'completed' OR
+                        (project_type='plan_relocation'
+                            AND target_place_id IS NOT NULL) OR
+                        (project_type='recruit_ally'
+                            AND target_character_entity_id IS NOT NULL) OR
+                        project_type='build_venture' OR
+                        (project_type='pursue_romance'
+                            AND target_character_entity_id IS NOT NULL))
+                );
+                INSERT INTO character_project_states
+                    (character_entity_id,project_type,status,stage,
+                     target_character_entity_id)
+                    VALUES (1,'pursue_romance','active','testing_waters',2);
+                INSERT INTO character_project_states
+                    (character_entity_id,project_type,status,stage,
+                     target_place_id)
+                    VALUES (30,'plan_relocation','active','saving',NULL);
+                INSERT INTO character_project_states
+                    (character_entity_id,project_type,status,stage,
+                     target_character_entity_id,target_faction_entity_id)
+                    VALUES (4,'recruit_ally','active','sounding_out',5,11);
+                INSERT INTO character_project_states
+                    (character_entity_id,project_type,status,stage)
+                    VALUES (6,'build_venture','active','laying_groundwork');
+                """
+            )
+            cur.execute(
+                (
+                    Path(__file__).parents[2]
+                    / "migrations/086_court_patron_projects.sql"
+                ).read_text()
+            )
+            cur.execute(
+                "INSERT INTO character_project_states "
+                "(character_entity_id,project_type,status,stage,"
+                "target_character_entity_id) "
+                "VALUES (8,'court_patron','active','gaining_notice',9)"
+            )
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_migration_087_widens_constraints_and_seeds_events(
+    migration_086_schema: Any,
+) -> None:
+    sql = (
+        Path(__file__).parents[2] / "migrations/087_seek_redemption_projects.sql"
+    ).read_text()
+    with migration_086_schema.cursor() as cur:
+        cur.execute(sql)
+        cur.execute(
+            "SELECT conname,pg_get_constraintdef(oid,true),obj_description(oid) "
+            "FROM pg_constraint WHERE conrelid='character_project_states'::regclass "
+            "AND conname LIKE 'character_project_states_%_check'"
+        )
+        constraints = {name: (definition, comment) for name, definition, comment in cur}
+        assert len(constraints) == 4
+        assert all(
+            "seek_redemption" in definition for definition, _ in constraints.values()
+        )
+        assert all(comment for _, comment in constraints.values())
+        # Every prior-type row, including migration-086 COURT_PATRON, survives.
+        cur.execute(
+            "SELECT project_type, target_faction_entity_id "
+            "FROM character_project_states "
+            "WHERE character_entity_id IN (1, 30, 4, 6, 8) "
+            "ORDER BY character_entity_id"
+        )
+        assert cur.fetchall() == [
+            ("pursue_romance", None),
+            ("recruit_ally", 11),
+            ("build_venture", None),
+            ("court_patron", None),
+            ("plan_relocation", None),
+        ]
+        cur.execute(
+            "INSERT INTO character_project_states "
+            "(character_entity_id,project_type,status,stage,"
+            "target_character_entity_id) "
+            "VALUES (3,'seek_redemption','completed','earning_forgiveness',4)"
+        )
+        for columns, values in (
+            ("target_place_id,target_character_entity_id", "7,4"),
+            ("target_character_entity_id,target_faction_entity_id", "4,8"),
+        ):
+            cur.execute("SAVEPOINT invalid_redemption")
+            with pytest.raises(psycopg2.errors.CheckViolation):
+                cur.execute(
+                    "INSERT INTO character_project_states "
+                    f"(character_entity_id,project_type,status,stage,{columns}) "
+                    f"VALUES (5,'seek_redemption','active','owning_the_wrong',{values})"
+                )
+            cur.execute("ROLLBACK TO SAVEPOINT invalid_redemption")
+        cur.execute(
+            "SELECT project_type FROM character_project_states "
+            "WHERE character_entity_id=1"
+        )
+        assert cur.fetchone() == ("pursue_romance",)
+        cur.execute(
+            "SELECT type,severity FROM event_types "
+            "WHERE type LIKE 'seek_redemption_%' ORDER BY type"
+        )
+        assert cur.fetchall() == [
+            ("seek_redemption_abandoned", "moderate"),
+            ("seek_redemption_completed", "moderate"),
+            ("seek_redemption_milestone", "moderate"),
+            ("seek_redemption_progressed", "minor"),
+            ("seek_redemption_stalled", "minor"),
+            ("seek_redemption_started", "moderate"),
+        ]

--- a/tests/test_orrery/test_seek_redemption_projects.py
+++ b/tests/test_orrery/test_seek_redemption_projects.py
@@ -1,4 +1,4 @@
-"""COURT_PATRON character-targeted project acceptance coverage."""
+"""SEEK_REDEMPTION character-targeted project acceptance coverage."""
 
 from __future__ import annotations
 
@@ -13,7 +13,10 @@ import psycopg2
 import psycopg2.extras
 import pytest
 
-from nexus.agents.orrery.events import _apply_state_delta_sync
+from nexus.agents.orrery.events import (
+    _apply_state_delta_sync,
+    _upsert_reconciled_relationship_sync,
+)
 from nexus.agents.orrery.needs import load_need_tuning
 from nexus.agents.orrery.resolver import OrreryResolutionDraft
 from nexus.agents.orrery.substrate import (
@@ -26,12 +29,11 @@ from nexus.agents.orrery.substrate import (
     WorldState,
     evaluate,
 )
-from nexus.agents.orrery.templates import ADVANCE_COURT_PATRON, START_COURT_PATRON
+from nexus.agents.orrery.templates import ADVANCE_SEEK_REDEMPTION, START_SEEK_REDEMPTION
 from nexus.api.slot_utils import get_slot_db_url
 
 ACTOR = 10
 TARGET = 20
-FACTION = 30
 NOW = datetime(2073, 8, 2, 12, tzinfo=timezone.utc)
 POLICY = ProjectPolicy(
     enabled=True,
@@ -45,10 +47,7 @@ BINDINGS = {Slot.ACTOR: ACTOR, Slot.TARGET: TARGET}
 def _start_state(**changes: Any) -> WorldState:
     values: dict[str, Any] = {
         "locations": {ACTOR: 1},
-        "pair_tags": {
-            (ACTOR, TARGET): frozenset({"contact:social"}),
-            (TARGET, ACTOR): frozenset({"authority_over"}),
-        },
+        "trust": {(TARGET, ACTOR): -1},
         "travel_states": {ACTOR: TravelState(status="at_place")},
         "project_policy": POLICY,
         "routine_anchors": {
@@ -64,7 +63,7 @@ def _start_state(**changes: Any) -> WorldState:
 
 def _project(
     *,
-    stage: str = "gaining_notice",
+    stage: str = "owning_the_wrong",
     progress: float = 0.0,
     stall_count: int = 0,
     due_at: datetime = NOW,
@@ -72,7 +71,7 @@ def _project(
 ) -> ProjectState:
     return ProjectState(
         id=7,
-        project_type="court_patron",
+        project_type="seek_redemption",
         status="active",
         stage=stage,
         target_character_entity_id=TARGET,
@@ -95,68 +94,53 @@ def _advance_state(project: ProjectState, **changes: Any) -> WorldState:
     return WorldState(**values)
 
 
-def test_entry_gate_power_marker_or_clause_and_contract() -> None:
+def test_entry_gate_wronged_party_evidence_or_clause_and_contract() -> None:
     arms = (
-        _start_state(
-            pair_tags={
-                (ACTOR, TARGET): frozenset({"contact:social"}),
-                (TARGET, FACTION): frozenset({"status:senior"}),
-            }
-        ),
-        _start_state(
-            pair_tags={(ACTOR, TARGET): frozenset({"contact:social"})},
-            tags={TARGET: frozenset({"leader"})},
-        ),
         _start_state(),
+        _start_state(
+            trust={},
+            relationship_types={(ACTOR, TARGET): frozenset({"enemy"})},
+        ),
+        _start_state(
+            trust={},
+            relationship_types={(TARGET, ACTOR): frozenset({"rival"})},
+        ),
+        _start_state(
+            trust={},
+            pair_tags={(TARGET, ACTOR): frozenset({"hostile_to"})},
+        ),
     )
     for state in arms:
-        assert evaluate(START_COURT_PATRON, state, BINDINGS).passes is True
-    result = evaluate(START_COURT_PATRON, arms[0], BINDINGS)
-    assert START_COURT_PATRON.required_slots == (Slot.ACTOR, Slot.TARGET)
-    assert START_COURT_PATRON.starts_from_social_contact is True
+        assert evaluate(START_SEEK_REDEMPTION, state, BINDINGS).passes is True
+    result = evaluate(START_SEEK_REDEMPTION, arms[0], BINDINGS)
+    assert START_SEEK_REDEMPTION.required_slots == (Slot.ACTOR, Slot.TARGET)
+    assert START_SEEK_REDEMPTION.starts_from_social_contact is True
     assert result.state_delta["project.start"] == {
-        "project_type": "court_patron",
-        "stage": "gaining_notice",
+        "project_type": "seek_redemption",
+        "stage": "owning_the_wrong",
         "milestone": True,
     }
 
 
-def test_entry_gate_requires_social_base_and_power_and_blocks_redundancy() -> None:
+def test_entry_gate_requires_wronged_party_evidence_and_blocks_actor_hostility() -> (
+    None
+):
     assert (
         evaluate(
-            START_COURT_PATRON,
-            _start_state(pair_tags={(ACTOR, TARGET): frozenset({"contact:social"})}),
+            START_SEEK_REDEMPTION,
+            _start_state(trust={}),
             BINDINGS,
         ).passes
         is False
     )
     assert (
         evaluate(
-            START_COURT_PATRON,
-            _start_state(pair_tags={(TARGET, ACTOR): frozenset({"authority_over"})}),
+            START_SEEK_REDEMPTION,
+            _start_state(pair_tags={(ACTOR, TARGET): frozenset({"hostile_to"})}),
             BINDINGS,
         ).passes
         is False
     )
-    for changes in (
-        {
-            "pair_tags": {
-                (ACTOR, TARGET): frozenset({"contact:social"}),
-                (TARGET, ACTOR): frozenset({"authority_over", "sponsors"}),
-            }
-        },
-        {"relationship_types": {(ACTOR, TARGET): frozenset({"patron"})}},
-        {
-            "pair_tags": {
-                (ACTOR, TARGET): frozenset({"contact:social", "hostile_to"}),
-                (TARGET, ACTOR): frozenset({"authority_over"}),
-            }
-        },
-    ):
-        assert (
-            evaluate(START_COURT_PATRON, _start_state(**changes), BINDINGS).passes
-            is False
-        )
 
 
 @pytest.mark.parametrize(
@@ -164,76 +148,73 @@ def test_entry_gate_requires_social_base_and_power_and_blocks_redundancy() -> No
     (
         (
             _advance_state(_project(target_active=False)),
-            "End a patronage effort whose target is no longer available",
+            "End amends whose wronged party is no longer available",
             "project.abandon",
         ),
         (
             _advance_state(
-                _project(stage="securing_favor", progress=1.0),
-                trust={(TARGET, ACTOR): 2},
+                _project(stage="earning_forgiveness", progress=1.0),
             ),
-            "Secure the patron's favor",
+            "Have the amends accepted",
             "project.complete",
         ),
         (
-            _advance_state(_project(), trust={(TARGET, ACTOR): -2}),
-            "Withdraw after being spurned",
+            _advance_state(_project(), trust={(TARGET, ACTOR): -3}),
+            "Abandon amends that are thrown back",
             "project.abandon",
         ),
         (
-            # Strict boundary: a merely wary patron (-1) does NOT spurn —
-            # trust_below(-1) means strictly worse than wary; the courtship
-            # keeps making routine progress instead.
-            _advance_state(_project(), trust={(TARGET, ACTOR): -1}),
-            "Make useful work visible",
+            # Strict boundary: trust_below(-2) does not spurn at exactly -2.
+            _advance_state(_project(), trust={(TARGET, ACTOR): -2}),
+            "Name the wrong without self-exoneration",
             "project.advance",
         ),
         (
             _advance_state(_project(stall_count=3)),
-            "Let the bid for patronage go",
+            "Let the attempt at redemption go",
             "project.abandon",
         ),
         (
             _advance_state(_project(progress=1.0)),
-            "Turn notice into a chance to prove worth",
+            "Turn ownership into amends",
             "project.advance",
         ),
         (
-            _advance_state(_project(stage="proving_worth", progress=1.0)),
-            "Ask proven worth to become favor",
+            _advance_state(_project(stage="making_amends", progress=1.0)),
+            "Let amends ask for forgiveness",
             "project.advance",
         ),
         (
             _advance_state(
                 _project(
-                    stage="securing_favor",
+                    stage="earning_forgiveness",
                     progress=0.5,
                     due_at=NOW - timedelta(hours=24),
                 )
             ),
-            "Lose ground through neglect",
+            "Lose ground through neglected amends",
             "project.stall",
         ),
         (
             _advance_state(_project(progress=0.2)),
-            "Make useful work visible",
+            "Name the wrong without self-exoneration",
             "project.advance",
         ),
         (
-            _advance_state(_project(stage="proving_worth", progress=0.2)),
-            "Prove reliable under scrutiny",
+            _advance_state(_project(stage="making_amends", progress=0.2)),
+            "Make one concrete repair",
             "project.advance",
         ),
         (
-            _advance_state(_project(stage="securing_favor", progress=0.2)),
-            "Make the next claim on favor legible",
+            _advance_state(_project(stage="earning_forgiveness", progress=0.2)),
+            "Leave forgiveness in the wronged party's hands",
             "project.advance",
         ),
     ),
 )
 def test_full_ladder(state: WorldState, label: str, delta_key: str) -> None:
     result = evaluate(
-        ADVANCE_COURT_PATRON,
+        ADVANCE_SEEK_REDEMPTION,
         state,
         BINDINGS,
         BranchSelection(mode="authored_order"),
@@ -243,35 +224,33 @@ def test_full_ladder(state: WorldState, label: str, delta_key: str) -> None:
     if delta_key == "project.complete":
         assert result.state_delta == {
             "project.complete": {"milestone": True},
-            "entity_pair_tags.add_inbound": ["sponsors"],
-            "entity_pair_tags.add_outbound": ["obligation"],
+            "entity_tags_target.remove": ["grudge_active"],
         }
 
 
-def test_completion_uses_patron_reverse_trust_and_yields_to_hostility() -> None:
-    project = _project(stage="securing_favor", progress=1.0)
-    reverse = evaluate(
-        ADVANCE_COURT_PATRON,
-        _advance_state(project, trust={(TARGET, ACTOR): 2}),
+def test_completion_needs_no_trust_recovery_and_yields_to_hostility() -> None:
+    project = _project(stage="earning_forgiveness", progress=1.0)
+    no_trust = evaluate(
+        ADVANCE_SEEK_REDEMPTION,
+        _advance_state(project),
         BINDINGS,
     )
-    forward_only = evaluate(
-        ADVANCE_COURT_PATRON,
-        _advance_state(project, trust={(ACTOR, TARGET): 2}),
+    actor_hostile = evaluate(
+        ADVANCE_SEEK_REDEMPTION,
+        _advance_state(project, pair_tags={(ACTOR, TARGET): frozenset({"hostile_to"})}),
         BINDINGS,
     )
-    hostile = evaluate(
-        ADVANCE_COURT_PATRON,
+    target_hostile = evaluate(
+        ADVANCE_SEEK_REDEMPTION,
         _advance_state(
             project,
-            trust={(TARGET, ACTOR): 2},
-            pair_tags={(ACTOR, TARGET): frozenset({"hostile_to"})},
+            pair_tags={(TARGET, ACTOR): frozenset({"hunting"})},
         ),
         BINDINGS,
     )
-    assert "project.complete" in reverse.state_delta
-    assert "project.complete" not in forward_only.state_delta
-    assert "project.abandon" in hostile.state_delta
+    assert "project.complete" in no_trust.state_delta
+    assert "project.abandon" in actor_hostile.state_delta
+    assert "project.abandon" in target_hostile.state_delta
 
 
 def _create_schema(cur: Any, schema: str) -> None:
@@ -345,17 +324,17 @@ def _create_schema(cur: Any, schema: str) -> None:
     )
     cur.execute(
         (
-            Path(__file__).parents[2] / "migrations/086_court_patron_projects.sql"
+            Path(__file__).parents[2] / "migrations/087_seek_redemption_projects.sql"
         ).read_text()
     )
 
 
 @pytest.fixture()
-def live_patron_db() -> Iterator[dict[str, Any]]:
+def live_redemption_db() -> Iterator[dict[str, Any]]:
     conn = psycopg2.connect(get_slot_db_url(slot=2))
     try:
         with conn.cursor() as cur:
-            _create_schema(cur, f"court_patron_{uuid4().hex[:12]}")
+            _create_schema(cur, f"seek_redemption_{uuid4().hex[:12]}")
             cur.execute(
                 "SELECT entity_id FROM characters WHERE entity_id IS NOT NULL "
                 "ORDER BY id LIMIT 2"
@@ -372,6 +351,12 @@ def live_patron_db() -> Iterator[dict[str, Any]]:
                 "AND character_relationships.character2_id=t.id "
                 "AND a.entity_id=%s AND t.entity_id=%s",
                 (actor, target),
+            )
+            cur.execute(
+                "UPDATE entity_tags et SET cleared_at=now() FROM tags t "
+                "WHERE et.tag_id=t.id AND et.entity_id=%s "
+                "AND t.tag='grudge_active' AND et.cleared_at IS NULL",
+                (target,),
             )
         yield {
             "conn": conn,
@@ -408,13 +393,9 @@ def _apply(db: dict[str, Any], draft: OrreryResolutionDraft) -> dict[str, Any]:
         return cur.fetchone()[0]
 
 
-@pytest.mark.requires_postgres
-def test_completion_applies_inbound_outbound_and_patron_relationship(
-    live_patron_db: dict[str, Any],
-) -> None:
-    db = live_patron_db
+def _start_and_ready_for_completion(db: dict[str, Any]) -> OrreryResolutionDraft:
     base = OrreryResolutionDraft(
-        template_id="start_court_patron",
+        template_id="start_seek_redemption",
         priority=17,
         binding_hash="start",
         bindings={"actor": db["actor"], "target": db["target"]},
@@ -422,8 +403,8 @@ def test_completion_applies_inbound_outbound_and_patron_relationship(
         narrative_stub="start",
         state_delta={
             "project.start": {
-                "project_type": "court_patron",
-                "stage": "gaining_notice",
+                "project_type": "seek_redemption",
+                "stage": "owning_the_wrong",
                 "target_character_entity_id": db["target"],
                 "milestone": True,
             }
@@ -434,37 +415,43 @@ def test_completion_applies_inbound_outbound_and_patron_relationship(
     with db["conn"].cursor() as cur:
         cur.execute(
             "UPDATE character_project_states "
-            "SET stage='securing_favor',progress=1 "
+            "SET stage='earning_forgiveness',progress=1 "
             "WHERE character_entity_id=%s",
             (db["actor"],),
         )
+    return base
+
+
+def _completion_delta() -> dict[str, Any]:
+    return {
+        "project.complete": {"milestone": True},
+        "entity_tags_target.remove": ["grudge_active"],
+    }
+
+
+@pytest.mark.requires_postgres
+def test_fresh_completion_inserts_reconciliation_and_absent_grudge_is_noop(
+    live_redemption_db: dict[str, Any],
+) -> None:
+    db = live_redemption_db
+    base = _start_and_ready_for_completion(db)
     ledger = _apply(
         db,
         replace(
             base,
-            template_id="advance_court_patron",
+            template_id="advance_seek_redemption",
             binding_hash="complete",
-            state_delta={
-                "project.complete": {"milestone": True},
-                "entity_pair_tags.add_inbound": ["sponsors"],
-                "entity_pair_tags.add_outbound": ["obligation"],
-            },
+            state_delta=_completion_delta(),
         ),
     )
     with db["conn"].cursor() as cur:
         cur.execute(
-            "SELECT ept.subject_entity_id,ept.object_entity_id,pt.tag "
-            "FROM entity_pair_tags ept "
-            "JOIN pair_tags pt ON pt.id=ept.pair_tag_id WHERE ept.cleared_at IS NULL "
-            "AND ((ept.subject_entity_id=%s AND ept.object_entity_id=%s "
-            "AND pt.tag='sponsors') OR (ept.subject_entity_id=%s "
-            "AND ept.object_entity_id=%s AND pt.tag='obligation')) ORDER BY pt.tag",
-            (db["target"], db["actor"], db["actor"], db["target"]),
+            "SELECT count(*) FROM entity_tags et JOIN tags t ON t.id=et.tag_id "
+            "WHERE et.entity_id=%s AND t.tag='grudge_active' "
+            "AND et.cleared_at IS NULL",
+            (db["target"],),
         )
-        assert cur.fetchall() == [
-            (db["actor"], db["target"], "obligation"),
-            (db["target"], db["actor"], "sponsors"),
-        ]
+        assert cur.fetchone()[0] == 0
         cur.execute(
             "SELECT cr.relationship_type,cr.emotional_valence,cr.extra_data "
             "FROM character_relationships cr "
@@ -474,74 +461,54 @@ def test_completion_applies_inbound_outbound_and_patron_relationship(
             (db["actor"], db["target"]),
         )
         relationship_type, valence, extra = cur.fetchone()
-    assert (relationship_type, valence) == ("patron", "+2|friendly")
-    assert extra["orrery_court_patron"]["template_id"] == "advance_court_patron"
+    assert (relationship_type, valence) == ("complex", "+1|favorable")
+    assert extra["orrery_seek_redemption"]["template_id"] == "advance_seek_redemption"
+    assert extra["orrery_seek_redemption"]["previous_relationship_type"] is None
+    assert extra["orrery_seek_redemption"]["previous_emotional_valence"] is None
     applied = ledger["project.complete"]["applied"]
-    assert applied["relationship_mutation"]["relationship_type"] == "patron"
-    assert {mutation["operation"] for mutation in applied["pair_tag_mutations"]} == {
-        "add_inbound",
-        "add_outbound",
-    }
+    assert applied["relationship_mutation"]["relationship_type"] == "complex"
+    assert applied["relationship_mutation"]["emotional_valence"] == "+1|favorable"
 
 
 @pytest.mark.requires_postgres
-def test_completion_preserves_existing_relationship_valence(
-    live_patron_db: dict[str, Any],
+def test_existing_negative_relationship_is_repaired_and_originals_survive_rewrite(
+    live_redemption_db: dict[str, Any],
 ) -> None:
-    """The conflict arm updates the type but never the valence — the family
-    convention (recruit_ally, pursue_romance); valence movement on existing
-    rows is seek_redemption's deliberate innovation, not patron's."""
-
-    db = live_patron_db
+    db = live_redemption_db
     with db["conn"].cursor() as cur:
         cur.execute(
             "INSERT INTO character_relationships "
             "(character1_id, character2_id, relationship_type, "
             " emotional_valence, dynamic, recent_events, history) "
-            "SELECT a.id, t.id, 'mentor', '+4|admiring', 'd', 'r', 'h' "
+            "SELECT a.id, t.id, 'enemy', '-4|hostile', 'd', 'r', 'h' "
             "FROM characters a, characters t "
             "WHERE a.entity_id=%s AND t.entity_id=%s",
             (db["actor"], db["target"]),
         )
-    base = OrreryResolutionDraft(
-        template_id="start_court_patron",
-        priority=17,
-        binding_hash="start-preserve",
-        bindings={"actor": db["actor"], "target": db["target"]},
-        branch_label="start",
-        narrative_stub="start",
-        state_delta={
-            "project.start": {
-                "project_type": "court_patron",
-                "stage": "gaining_notice",
-                "target_character_entity_id": db["target"],
-                "milestone": True,
-            }
-        },
-        magnitude=0.4,
-    )
-    _apply(db, base)
-    with db["conn"].cursor() as cur:
         cur.execute(
-            "UPDATE character_project_states "
-            "SET stage='securing_favor',progress=1 "
-            "WHERE character_entity_id=%s",
-            (db["actor"],),
+            "INSERT INTO entity_tags (entity_id,tag_id,source_kind,template_id) "
+            "SELECT %s,id,'template','test_seek_redemption' FROM tags "
+            "WHERE tag='grudge_active'",
+            (db["target"],),
         )
+    base = _start_and_ready_for_completion(db)
     _apply(
         db,
         replace(
             base,
-            template_id="advance_court_patron",
+            template_id="advance_seek_redemption",
             binding_hash="complete-preserve",
-            state_delta={
-                "project.complete": {"milestone": True},
-                "entity_pair_tags.add_inbound": ["sponsors"],
-                "entity_pair_tags.add_outbound": ["obligation"],
-            },
+            state_delta=_completion_delta(),
         ),
     )
     with db["conn"].cursor() as cur:
+        second = _upsert_reconciled_relationship_sync(
+            cur,
+            actor_entity_id=db["actor"],
+            target_entity_id=db["target"],
+            template_id="advance_seek_redemption",
+            source_chunk_id=db["chunk"],
+        )
         cur.execute(
             "SELECT cr.relationship_type,cr.emotional_valence,cr.extra_data "
             "FROM character_relationships cr "
@@ -551,6 +518,17 @@ def test_completion_preserves_existing_relationship_valence(
             (db["actor"], db["target"]),
         )
         relationship_type, valence, extra = cur.fetchone()
-    assert relationship_type == "patron"
-    assert valence == "+4|admiring"
-    assert extra["orrery_court_patron"]["previous_relationship_type"] == "mentor"
+        cur.execute(
+            "SELECT count(*) FROM entity_tags et JOIN tags t ON t.id=et.tag_id "
+            "WHERE et.entity_id=%s AND t.tag='grudge_active' "
+            "AND et.cleared_at IS NULL",
+            (db["target"],),
+        )
+        assert cur.fetchone()[0] == 0
+    assert relationship_type == "complex"
+    assert valence == "+1|favorable"
+    provenance = extra["orrery_seek_redemption"]
+    assert provenance["previous_relationship_type"] == "enemy"
+    assert provenance["previous_emotional_valence"] == "-4|hostile"
+    assert second["previous_relationship_type"] == "complex"
+    assert second["previous_emotional_valence"] == "+1|favorable"

--- a/tests/test_orrery/test_seek_redemption_replay.py
+++ b/tests/test_orrery/test_seek_redemption_replay.py
@@ -1,0 +1,155 @@
+"""Checkpoint replay coverage for SEEK_REDEMPTION reconciliation."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+import pytest
+
+from nexus.agents.orrery.events import _apply_state_delta_sync, _insert_resolution_sync
+from nexus.agents.orrery.needs import load_need_tuning
+from nexus.agents.orrery.reconstruction import (
+    capture_state_checkpoint_sync,
+    set_commit_chunk_attribution_sync,
+)
+from nexus.agents.orrery.replay import (
+    TAG_DELTA_KEYS,
+    reconstruct_state_at_sync,
+    verify_checkpoints_sync,
+)
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from tests.test_orrery.test_seek_redemption_projects import POLICY
+from tests.test_orrery.test_pursue_romance_replay import (
+    _fabricate_chunk,
+    _next_world_time,
+)
+
+pytestmark = pytest.mark.requires_postgres
+pytest_plugins = ("tests.test_orrery.test_seek_redemption_projects",)
+
+
+def _apply_transition(
+    cur: Any,
+    *,
+    chunk_id: int,
+    actor: int,
+    target: int,
+    state_delta: dict[str, Any],
+) -> None:
+    set_commit_chunk_attribution_sync(cur, chunk_id)
+    draft = OrreryResolutionDraft(
+        template_id="seek_redemption_replay_probe",
+        priority=47,
+        binding_hash=f"seek-redemption-replay-{chunk_id}",
+        bindings={"actor": actor, "target": target},
+        branch_label="SEEK_REDEMPTION replay probe",
+        narrative_stub="probe",
+        state_delta=state_delta,
+        magnitude=0.4,
+    )
+    resolution_id = _insert_resolution_sync(
+        cur,
+        draft,
+        tick_chunk_id=chunk_id,
+        actor_entity_id=actor,
+        brief="SEEK_REDEMPTION checkpoint replay probe",
+    )
+    assert resolution_id is not None
+    _apply_state_delta_sync(
+        cur,
+        draft,
+        resolution_id=int(resolution_id),
+        actor_entity_id=actor,
+        target_entity_id=target,
+        source_chunk_id=chunk_id,
+        need_tuning=load_need_tuning(),
+        project_policy=POLICY,
+    )
+
+
+def test_target_remove_is_a_replay_accepted_tag_delta() -> None:
+    assert "entity_tags_target.remove" in TAG_DELTA_KEYS
+
+
+def test_seek_redemption_completion_replays_without_drift(
+    live_redemption_db: dict[str, Any],
+) -> None:
+    db = live_redemption_db
+    actor = int(db["actor"])
+    target = int(db["target"])
+    with db["conn"].cursor() as cur:
+        # The shared fixture's minimal writer table is useful for direct-applier
+        # tests; replay needs the full public resolution ledger instead.
+        cur.execute("DROP TABLE orrery_resolutions")
+        base_time = _next_world_time(cur)
+        base_chunk = _fabricate_chunk(cur, base_time, created_offset_minutes=-4)
+        base_id = capture_state_checkpoint_sync(
+            cur, chunk_id=base_chunk, label="manual"
+        )
+        assert base_id is not None
+        transitions = (
+            {
+                "project.start": {
+                    "project_type": "seek_redemption",
+                    "stage": "owning_the_wrong",
+                    "target_character_entity_id": target,
+                    "milestone": True,
+                }
+            },
+            {
+                "project.advance": {
+                    "stage": "making_amends",
+                    "set_progress": 0.0,
+                    "milestone": True,
+                }
+            },
+            {
+                "project.advance": {
+                    "stage": "earning_forgiveness",
+                    "set_progress": 1.0,
+                    "milestone": True,
+                }
+            },
+            {
+                "project.complete": {"milestone": True},
+                "entity_tags_target.remove": ["grudge_active"],
+            },
+        )
+        chunks: list[int] = []
+        for step, delta in enumerate(transitions, start=1):
+            chunk = _fabricate_chunk(
+                cur,
+                base_time + timedelta(hours=24 * step),
+                created_offset_minutes=step - len(transitions),
+            )
+            _apply_transition(
+                cur,
+                chunk_id=chunk,
+                actor=actor,
+                target=target,
+                state_delta=delta,
+            )
+            chunks.append(chunk)
+        target_id = capture_state_checkpoint_sync(
+            cur, chunk_id=chunks[-1], label="manual"
+        )
+        assert target_id is not None
+        reconstructed = reconstruct_state_at_sync(
+            cur, chunks[-1], base_checkpoint_id=int(base_id)
+        )
+        project = next(
+            row
+            for row in reconstructed.state["character_project_states"]
+            if row["character_entity_id"] == actor
+            and row["project_type"] == "seek_redemption"
+        )
+        assert project["status"] == "completed"
+        assert project["target_character_entity_id"] == target
+        pair = next(
+            verdict
+            for verdict in verify_checkpoints_sync(cur)
+            if verdict.base_checkpoint_id == base_id
+            and verdict.target_checkpoint_id == target_id
+        )
+        assert pair.drifts == []


### PR DESCRIPTION
## Summary

Sixth and final aspiration-band package per the #496 Arachne ruling — the campaign's last slice. `seek_redemption`: an off-screen character stages amends toward a party they wronged.

- **Stage ladder**: `owning_the_wrong` → `making_amends` → `earning_forgiveness`
- **Entry evidence** keys on what live saves actually carry: the wronged party's directional trust at wary-or-worse, `enemy`/`rival` relationship types, or directed `hostile_to`/`hunting` edges (the semantically-obvious `grudge_active`/`vendetta_holder` tags have zero live rows anywhere); actors still actively hostile toward their target are excluded — but TARGET-side hostility deliberately does NOT block entry (amends toward someone who still hates you is the drama)
- **Completion** ("Have the amends accepted"): `project_due` + the family hostility exclusion, deliberately **no trust-recovery precondition** — nothing in the engine moves trust until the #476 drift tracker ships, so a warmth gate would block every redemption permanently; the staged amends are the repair, and active worsening (the spurned arm: resentful −2 or hostility) is what prevents it
- **The family's first valence-UPDATING upsert**: type → `complex`, valence → `+1|favorable` even on existing negative rows, with BOTH original type and original valence preserved as first-write provenance across re-completions (recruit/romance/patron deliberately never touch valence on conflict; this divergence is redemption's whole point)
- `grudge_active` cleared on the wronged party when present (absent-tag removal verified a no-op); entry −1 / spurned −2 threshold split leaves a deliberate high-risk band
- **Migration 087**: six-type constraint widening, six event types, `DO NOTHING` idioms; zero new vocabulary; SURVEIL yields to due redemption continuations

## Validation

- `poetry run pytest -q` → **1489 passed, 310 skipped, 0 failed**
- **Full live-PG orrery suite → 1043 passed, 0 failed** (includes 20 redemption tests: three-write completion, valence repair with originals surviving rewrite, replay drift, migration contract)
- flake8/black/catalog clean on changed files; mypy baseline exact (#528)

Also carries a one-file black reformat of the patron valence test from #529 (shipped flake8-clean but un-black-checked).

## Schema/Data Impact

Migration 087 pending everywhere; additive only. Applied at merge closeout. This PR completes the four-package build ordered by Arachne ruling seq 5.

Implemented by Sol (GPT-5.6 Codex) from a frozen spec carrying every prior slice's review lessons; reviewed line-by-line by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TJVTXfD7TouQuxmYfVf8w