### PR TITLE
Add the Relationship Drift Engine (#476 Stage 2)

### DIFF
--- a/migrations/089_relationship_drift_milestone.sql
+++ b/migrations/089_relationship_drift_milestone.sql
@@ -1,18 +1,25 @@
 -- 089_relationship_drift_milestone.sql
 --
 -- Register the visibility event emitted when continuous relationship drift
--- crosses a derived Stage-1 valence rung. The runtime drain owns all movement;
--- this migration intentionally makes no schema changes.
+-- crosses a derived Stage-1 valence rung and the per-tick drain ledger marker.
+-- The runtime drain owns all movement; this migration makes no schema changes.
 
 INSERT INTO event_types (type, category, severity, description)
-VALUES (
-    'relationship_drift_milestone',
-    'emotional',
-    'minor',
-    'A continuous directed relationship valence crossed a derived rung.'
-)
+VALUES
+    (
+        'relationship_drift_milestone',
+        'emotional',
+        'minor',
+        'A continuous directed relationship valence crossed a derived rung.'
+    ),
+    (
+        'relationship_drift_drained',
+        'emotional',
+        'minor',
+        'The continuous relationship drift drain completed for a tick.'
+    )
 ON CONFLICT (type) DO NOTHING;
 
 COMMENT ON COLUMN event_types.type IS
-    'Stable event identifier, including system-emitted relationship drift '
-    'milestones registered by migration 089.';
+    'Stable event identifier; system-emitted event types are registered by '
+    'their introducing migrations alongside narrative vocabulary.';

--- a/migrations/089_relationship_drift_milestone.sql
+++ b/migrations/089_relationship_drift_milestone.sql
@@ -1,0 +1,18 @@
+-- 089_relationship_drift_milestone.sql
+--
+-- Register the visibility event emitted when continuous relationship drift
+-- crosses a derived Stage-1 valence rung. The runtime drain owns all movement;
+-- this migration intentionally makes no schema changes.
+
+INSERT INTO event_types (type, category, severity, description)
+VALUES (
+    'relationship_drift_milestone',
+    'emotional',
+    'minor',
+    'A continuous directed relationship valence crossed a derived rung.'
+)
+ON CONFLICT (type) DO NOTHING;
+
+COMMENT ON COLUMN event_types.type IS
+    'Stable event identifier, including system-emitted relationship drift '
+    'milestones registered by migration 089.';

--- a/nexus.toml
+++ b/nexus.toml
@@ -316,11 +316,29 @@ milestone_magnitude = 0.40
 # Acceptance guard for active-vs-inactive maintenance/routine winner shares.
 coverage_distribution_tolerance = 0.05
 
+[orrery.drift]
+enabled = true
+copresence_rate_per_hour = 0.001
+copresence_max_hours_per_tick = 12.0
+project_milestone_delta = 0.03
+
+[orrery.drift.hostile_events]
+threat_issued = -0.02
+retaliation_attempted = -0.04
+retaliation_executed = -0.06
+
+[orrery.drift.cooperative_events]
+protective_intervention = 0.04
+warning_delivered = 0.02
+welfare_check = 0.02
+kin_visit = 0.02
+confrontation_resolved = 0.03
+
 [orrery.epistemics]
 enabled = true
 # Event types that mint a bounded claim at birth. Types absent from this list
 # remain implicitly common knowledge and create no epistemics rows.
-claim_event_types = ["threat_issued"]
+claim_event_types = ["threat_issued", "relationship_drift_milestone"]
 # Roles on world_event_entities that receive awareness at claim birth.
 aware_roles = ["actor", "target", "observer", "witness"]
 

--- a/nexus/agents/orrery/drift.py
+++ b/nexus/agents/orrery/drift.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import Decimal, ROUND_HALF_UP, localcontext
 import json
 from typing import Any, Mapping, Optional, Sequence
 
@@ -31,12 +31,19 @@ from nexus.config.settings_models import OrreryDriftSettings
 
 
 RELATIONSHIP_DRIFT_EVENT_TYPE = "relationship_drift_milestone"
+RELATIONSHIP_DRIFT_DRAINED_EVENT_TYPE = "relationship_drift_drained"
+RELATIONSHIP_DRIFT_EVENT_TYPES = frozenset(
+    {RELATIONSHIP_DRIFT_EVENT_TYPE, RELATIONSHIP_DRIFT_DRAINED_EVENT_TYPE}
+)
 TWO_PARTY_PROJECT_TYPES = frozenset(
     {"recruit_ally", "pursue_romance", "court_patron", "seek_redemption"}
 )
 ZERO = Decimal("0")
 ONE = Decimal("1")
 RUNG_SCALE = Decimal("5.5")
+VALENCE_QUANTUM = Decimal("1E-12")
+MAX_VALENCE = ONE - VALENCE_QUANTUM
+PLANNER_PRECISION = 40
 
 EdgeKey = tuple[int, int]
 
@@ -130,7 +137,20 @@ class RelationshipDriftDrainResult:
 def derived_rung(valence: Decimal) -> int:
     """Mirror PostgreSQL ``round(numeric * 5.5)`` exactly."""
 
-    return int((valence * RUNG_SCALE).quantize(ONE, rounding=ROUND_HALF_UP))
+    with localcontext() as context:
+        context.prec = PLANNER_PRECISION
+        bounded = _quantize_valence(valence)
+        return int((bounded * RUNG_SCALE).quantize(ONE, rounding=ROUND_HALF_UP))
+
+
+def _quantize_valence(valence: Decimal) -> Decimal:
+    """Return the canonical fixed-scale representation for a valence write."""
+
+    value = Decimal(valence)
+    if abs(value) >= ONE:
+        raise AssertionError(f"Relationship valence is outside (-1, +1): {value}")
+    quantized = value.quantize(VALENCE_QUANTUM, rounding=ROUND_HALF_UP)
+    return min(max(quantized, -MAX_VALENCE), MAX_VALENCE)
 
 
 def soft_clamp_step(valence: Decimal, delta: Decimal) -> tuple[Decimal, Decimal]:
@@ -159,63 +179,77 @@ def plan_relationship_drift(
 ) -> RelationshipDriftPlan:
     """Plan all edge-local drift without database access or side effects."""
 
-    values = {edge: Decimal(value) for edge, value in relationships.items()}
-    old_values = dict(values)
-    applied: dict[EdgeKey, list[tuple[str, Decimal]]] = {}
+    with localcontext() as context:
+        context.prec = PLANNER_PRECISION
+        values = {
+            edge: _quantize_valence(Decimal(value))
+            for edge, value in relationships.items()
+        }
+        old_values = dict(values)
+        applied: dict[EdgeKey, list[tuple[str, Decimal]]] = {}
 
-    def apply(edge: EdgeKey, delta: Decimal, label: str) -> None:
-        current = values.get(edge)
-        if current is None:
-            return
-        next_value, effective = soft_clamp_step(current, delta)
-        values[edge] = next_value
-        applied.setdefault(edge, []).append((label, effective))
-
-    for milestone in sorted(project_milestones, key=lambda item: item.resolution_id):
-        endpoints = (milestone.actor_entity_id, milestone.target_entity_id)
-        label = f"project_milestone:{milestone.resolution_id}"
-        for edge in _directed_edges(*endpoints):
-            apply(edge, settings.project_milestone_delta, label)
-
-    hostile = [event for event in events if event.event_type in settings.hostile_events]
-    for event in sorted(hostile, key=lambda item: item.event_id):
-        delta = settings.hostile_events[event.event_type]
-        label = f"hostile:{event.event_id}:{event.event_type}"
-        for edge in _directed_edges(event.actor_entity_id, event.target_entity_id):
-            apply(edge, delta, label)
-
-    cooperative = [
-        event for event in events if event.event_type in settings.cooperative_events
-    ]
-    for event in sorted(cooperative, key=lambda item: item.event_id):
-        delta = settings.cooperative_events[event.event_type]
-        label = f"cooperative:{event.event_id}:{event.event_type}"
-        for edge in _directed_edges(event.actor_entity_id, event.target_entity_id):
-            apply(edge, delta, label)
-
-    capped_hours = min(max(elapsed_hours, ZERO), settings.copresence_max_hours_per_tick)
-    for pair in sorted(copresence_pairs, key=lambda item: item.ordered()):
-        first, second = pair.ordered()
-        for edge in ((first, second), (second, first)):
+        def apply(edge: EdgeKey, delta: Decimal, label: str) -> None:
             current = values.get(edge)
-            if current is None or current == ZERO or capped_hours == ZERO:
-                continue
-            direction = ONE if current > ZERO else -ONE
-            delta = direction * settings.copresence_rate_per_hour * capped_hours
-            apply(edge, delta, "copresence")
+            if current is None:
+                return
+            next_value, effective = soft_clamp_step(current, delta)
+            values[edge] = next_value
+            applied.setdefault(edge, []).append((label, effective))
 
-    plans = tuple(
-        PlannedEdgeDrift(
-            source_entity_id=edge[0],
-            target_entity_id=edge[1],
-            old_valence=old_values[edge],
-            new_valence=values[edge],
-            producer_deltas=tuple(applied[edge]),
+        for milestone in sorted(
+            project_milestones, key=lambda item: item.resolution_id
+        ):
+            endpoints = (milestone.actor_entity_id, milestone.target_entity_id)
+            label = f"project_milestone:{milestone.resolution_id}"
+            for edge in _directed_edges(*endpoints):
+                apply(edge, settings.project_milestone_delta, label)
+
+        hostile = [
+            event for event in events if event.event_type in settings.hostile_events
+        ]
+        for event in sorted(hostile, key=lambda item: item.event_id):
+            delta = settings.hostile_events[event.event_type]
+            label = f"hostile:{event.event_id}:{event.event_type}"
+            for edge in _directed_edges(event.actor_entity_id, event.target_entity_id):
+                apply(edge, delta, label)
+
+        cooperative = [
+            event for event in events if event.event_type in settings.cooperative_events
+        ]
+        for event in sorted(cooperative, key=lambda item: item.event_id):
+            delta = settings.cooperative_events[event.event_type]
+            label = f"cooperative:{event.event_id}:{event.event_type}"
+            for edge in _directed_edges(event.actor_entity_id, event.target_entity_id):
+                apply(edge, delta, label)
+
+        capped_hours = min(
+            max(elapsed_hours, ZERO), settings.copresence_max_hours_per_tick
         )
-        for edge in sorted(applied)
-        if values[edge] != old_values[edge]
-    )
-    return RelationshipDriftPlan(edges=plans)
+        for pair in sorted(copresence_pairs, key=lambda item: item.ordered()):
+            first, second = pair.ordered()
+            for edge in ((first, second), (second, first)):
+                current = values.get(edge)
+                if current is None or current == ZERO or capped_hours == ZERO:
+                    continue
+                direction = ONE if current > ZERO else -ONE
+                delta = direction * settings.copresence_rate_per_hour * capped_hours
+                apply(edge, delta, "copresence")
+
+        write_values = {
+            edge: _quantize_valence(value) for edge, value in values.items()
+        }
+        plans = tuple(
+            PlannedEdgeDrift(
+                source_entity_id=edge[0],
+                target_entity_id=edge[1],
+                old_valence=old_values[edge],
+                new_valence=write_values[edge],
+                producer_deltas=tuple(applied[edge]),
+            )
+            for edge in sorted(applied)
+            if write_values[edge] != old_values[edge]
+        )
+        return RelationshipDriftPlan(edges=plans)
 
 
 def drain_relationship_drift_sync(
@@ -229,6 +263,9 @@ def drain_relationship_drift_sync(
 
     config = _enabled_config(settings)
     if config is None:
+        return RelationshipDriftDrainResult()
+    _require_migration_089_sync(cur)
+    if _drain_recorded_sync(cur, tick_chunk_id):
         return RelationshipDriftDrainResult()
     world_time, world_layer = _commit_clock_sync(cur, tick_chunk_id)
     if world_layer != "primary" or world_time is None:
@@ -244,13 +281,20 @@ def drain_relationship_drift_sync(
         elapsed_hours=_elapsed_hours(previous_world_time, world_time),
         settings=config,
     )
-    return _apply_plan_sync(
+    result = _apply_plan_sync(
         cur,
         plan=plan,
         tick_chunk_id=tick_chunk_id,
         world_time=world_time,
         epistemics_settings=epistemics_settings,
     )
+    _record_drain_sync(
+        cur,
+        tick_chunk_id=tick_chunk_id,
+        world_time=world_time,
+        result=result,
+    )
+    return result
 
 
 async def drain_relationship_drift_async(
@@ -264,6 +308,9 @@ async def drain_relationship_drift_async(
 
     config = _enabled_config(settings)
     if config is None:
+        return RelationshipDriftDrainResult()
+    await _require_migration_089_async(conn)
+    if await _drain_recorded_async(conn, tick_chunk_id):
         return RelationshipDriftDrainResult()
     world_time, world_layer = await _commit_clock_async(conn, tick_chunk_id)
     if world_layer != "primary" or world_time is None:
@@ -279,13 +326,20 @@ async def drain_relationship_drift_async(
         elapsed_hours=_elapsed_hours(previous_world_time, world_time),
         settings=config,
     )
-    return await _apply_plan_async(
+    result = await _apply_plan_async(
         conn,
         plan=plan,
         tick_chunk_id=tick_chunk_id,
         world_time=world_time,
         epistemics_settings=epistemics_settings,
     )
+    await _record_drain_async(
+        conn,
+        tick_chunk_id=tick_chunk_id,
+        world_time=world_time,
+        result=result,
+    )
+    return result
 
 
 def _enabled_config(settings: Any) -> Optional[OrreryDriftSettings]:
@@ -300,6 +354,74 @@ def _enabled_config(settings: Any) -> Optional[OrreryDriftSettings]:
     else:
         raise TypeError("Orrery drift settings must be a mapping or Pydantic model")
     return config if config.enabled else None
+
+
+_MIGRATION_089_ERROR = (
+    "Relationship drift requires migration 089; apply migration 089 before "
+    "enabling [orrery.drift]."
+)
+
+
+def _require_migration_089_sync(cur: Any) -> None:
+    cur.execute(
+        """
+        SELECT count(*) AS registered_count
+        FROM event_types
+        WHERE type = ANY(%s)
+        """,
+        (sorted(RELATIONSHIP_DRIFT_EVENT_TYPES),),
+    )
+    row = cur.fetchone()
+    if row is None or int(_row_get(row, "registered_count", 0)) != len(
+        RELATIONSHIP_DRIFT_EVENT_TYPES
+    ):
+        raise RuntimeError(_MIGRATION_089_ERROR)
+
+
+async def _require_migration_089_async(conn: Any) -> None:
+    registered_count = await conn.fetchval(
+        """
+        SELECT count(*)
+        FROM event_types
+        WHERE type = ANY($1::text[])
+        """,
+        sorted(RELATIONSHIP_DRIFT_EVENT_TYPES),
+    )
+    if int(registered_count or 0) != len(RELATIONSHIP_DRIFT_EVENT_TYPES):
+        raise RuntimeError(_MIGRATION_089_ERROR)
+
+
+def _drain_recorded_sync(cur: Any, tick_chunk_id: int) -> bool:
+    cur.execute(
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM world_events
+            WHERE tick_chunk_id = %s
+              AND event_type = %s
+        ) AS recorded
+        """,
+        (tick_chunk_id, RELATIONSHIP_DRIFT_DRAINED_EVENT_TYPE),
+    )
+    row = cur.fetchone()
+    return row is not None and bool(_row_get(row, "recorded", 0))
+
+
+async def _drain_recorded_async(conn: Any, tick_chunk_id: int) -> bool:
+    return bool(
+        await conn.fetchval(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM world_events
+                WHERE tick_chunk_id = $1
+                  AND event_type = $2
+            )
+            """,
+            tick_chunk_id,
+            RELATIONSHIP_DRIFT_DRAINED_EVENT_TYPE,
+        )
+    )
 
 
 def _commit_clock_sync(cur: Any, tick_chunk_id: int) -> tuple[Any, Any]:
@@ -367,7 +489,9 @@ def _elapsed_hours(previous: Optional[datetime], current: datetime) -> Decimal:
     if previous is None:
         return ZERO
     elapsed = current - previous
-    return _timedelta_seconds(elapsed) / Decimal("3600")
+    with localcontext() as context:
+        context.prec = PLANNER_PRECISION
+        return _timedelta_seconds(elapsed) / Decimal("3600")
 
 
 def _timedelta_seconds(value: timedelta) -> Decimal:
@@ -394,7 +518,7 @@ def _relationships_sync(cur: Any) -> dict[EdgeKey, Decimal]:
         (
             int(_row_get(row, "source_entity_id", 0)),
             int(_row_get(row, "target_entity_id", 1)),
-        ): Decimal(_row_get(row, "valence_current", 2))
+        ): _quantize_valence(Decimal(_row_get(row, "valence_current", 2)))
         for row in cur.fetchall()
     }
 
@@ -412,9 +536,10 @@ async def _relationships_async(conn: Any) -> dict[EdgeKey, Decimal]:
         """
     )
     return {
-        (int(row["source_entity_id"]), int(row["target_entity_id"])): Decimal(
-            row["valence_current"]
-        )
+        (
+            int(row["source_entity_id"]),
+            int(row["target_entity_id"]),
+        ): _quantize_valence(Decimal(row["valence_current"]))
         for row in rows
     }
 
@@ -681,6 +806,66 @@ async def _apply_plan_async(
         updated_edges=tuple(updated_edges),
         milestone_event_ids=tuple(event_ids),
         claim_ids=tuple(claim_ids),
+    )
+
+
+def _record_drain_sync(
+    cur: Any,
+    *,
+    tick_chunk_id: int,
+    world_time: datetime,
+    result: RelationshipDriftDrainResult,
+) -> None:
+    cur.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, world_layer, source,
+            changed_fields, payload, world_time
+        ) VALUES (
+            %s, %s, 'primary', 'resolver', ARRAY[]::text[],
+            jsonb_build_object(
+                'edges_touched', %s::integer,
+                'milestone_count', %s::integer
+            ),
+            %s
+        )
+        """,
+        (
+            RELATIONSHIP_DRIFT_DRAINED_EVENT_TYPE,
+            tick_chunk_id,
+            len(result.updated_edges),
+            len(result.milestone_event_ids),
+            world_time,
+        ),
+    )
+
+
+async def _record_drain_async(
+    conn: Any,
+    *,
+    tick_chunk_id: int,
+    world_time: datetime,
+    result: RelationshipDriftDrainResult,
+) -> None:
+    await conn.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, world_layer, source,
+            changed_fields, payload, world_time
+        ) VALUES (
+            $1, $2, 'primary', 'resolver', ARRAY[]::text[],
+            jsonb_build_object(
+                'edges_touched', $3::integer,
+                'milestone_count', $4::integer
+            ),
+            $5
+        )
+        """,
+        RELATIONSHIP_DRIFT_DRAINED_EVENT_TYPE,
+        tick_chunk_id,
+        len(result.updated_edges),
+        len(result.milestone_event_ids),
+        world_time,
     )
 
 

--- a/nexus/agents/orrery/drift.py
+++ b/nexus/agents/orrery/drift.py
@@ -1,0 +1,900 @@
+"""Deterministic world-clock relationship-valence drift.
+
+The planner applies producers in a fixed order: project milestones, hostile
+events by event id, cooperative events by event id, then co-presence pairs by
+their ordered entity ids.  Every calculation uses :class:`~decimal.Decimal`,
+and the appliers write the final numeric value once per existing directed edge.
+
+Co-presence is intentionally sampled only when this drain runs.  It compares
+the current locations at the accepted tick with the preceding primary-layer
+world time; it does not reconstruct arrivals, departures, or dwell intervals
+inside that span.  The configured cap bounds the resulting sampling error on
+large world-time jumps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from decimal import Decimal, ROUND_HALF_UP
+import json
+from typing import Any, Mapping, Optional, Sequence
+
+from nexus.agents.orrery.db_rows import row_get as _row_get
+from nexus.agents.orrery.epistemics import (
+    ClaimParticipant,
+    mechanical_claim_summary,
+    mint_claim_for_event,
+    mint_claim_for_event_async,
+)
+from nexus.config.settings_models import OrreryDriftSettings
+
+
+RELATIONSHIP_DRIFT_EVENT_TYPE = "relationship_drift_milestone"
+TWO_PARTY_PROJECT_TYPES = frozenset(
+    {"recruit_ally", "pursue_romance", "court_patron", "seek_redemption"}
+)
+ZERO = Decimal("0")
+ONE = Decimal("1")
+RUNG_SCALE = Decimal("5.5")
+
+EdgeKey = tuple[int, int]
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectMilestone:
+    """One applied two-party project transition from the current tick."""
+
+    resolution_id: int
+    actor_entity_id: int
+    target_entity_id: int
+
+
+@dataclass(frozen=True, slots=True)
+class DriftEvent:
+    """One classified current-tick event with two character endpoints."""
+
+    event_id: int
+    event_type: str
+    actor_entity_id: int
+    target_entity_id: int
+
+
+@dataclass(frozen=True, slots=True)
+class CopresencePair:
+    """One unordered pair of distinct, co-located, non-travelling characters."""
+
+    first_entity_id: int
+    second_entity_id: int
+
+    def ordered(self) -> EdgeKey:
+        """Return the canonical entity-id order for deterministic planning."""
+
+        return (
+            min(self.first_entity_id, self.second_entity_id),
+            max(self.first_entity_id, self.second_entity_id),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedEdgeDrift:
+    """The complete one-drain mutation for one existing directed edge."""
+
+    source_entity_id: int
+    target_entity_id: int
+    old_valence: Decimal
+    new_valence: Decimal
+    producer_deltas: tuple[tuple[str, Decimal], ...]
+
+    @property
+    def old_rung(self) -> int:
+        """Return the Stage-1 derived rung at drain entry."""
+
+        return derived_rung(self.old_valence)
+
+    @property
+    def new_rung(self) -> int:
+        """Return the Stage-1 derived rung after all producers."""
+
+        return derived_rung(self.new_valence)
+
+    @property
+    def is_milestone(self) -> bool:
+        """Whether this drift crosses a derived-rung boundary."""
+
+        return self.old_rung != self.new_rung
+
+
+@dataclass(frozen=True, slots=True)
+class RelationshipDriftPlan:
+    """Pure deterministic output for one accepted tick."""
+
+    edges: tuple[PlannedEdgeDrift, ...] = ()
+
+    @property
+    def milestones(self) -> tuple[PlannedEdgeDrift, ...]:
+        """Return only edges whose Stage-1 derived rung changed."""
+
+        return tuple(edge for edge in self.edges if edge.is_milestone)
+
+
+@dataclass(frozen=True, slots=True)
+class RelationshipDriftDrainResult:
+    """Database rows materialized by one relationship-drift drain."""
+
+    updated_edges: tuple[EdgeKey, ...] = ()
+    milestone_event_ids: tuple[int, ...] = ()
+    claim_ids: tuple[int, ...] = ()
+
+
+def derived_rung(valence: Decimal) -> int:
+    """Mirror PostgreSQL ``round(numeric * 5.5)`` exactly."""
+
+    return int((valence * RUNG_SCALE).quantize(ONE, rounding=ROUND_HALF_UP))
+
+
+def soft_clamp_step(valence: Decimal, delta: Decimal) -> tuple[Decimal, Decimal]:
+    """Apply one asymptotic delta and return ``(new_value, effective_delta)``."""
+
+    if abs(valence) >= ONE:
+        raise AssertionError(f"Relationship valence is outside (-1, +1): {valence}")
+    effective = delta * (ONE - abs(valence))
+    new_valence = valence + effective
+    if abs(new_valence) >= ONE:
+        raise AssertionError(
+            "Relationship drift escaped (-1, +1): "
+            f"v={valence}, delta={delta}, effective={effective}, next={new_valence}"
+        )
+    return new_valence, effective
+
+
+def plan_relationship_drift(
+    *,
+    relationships: Mapping[EdgeKey, Decimal],
+    project_milestones: Sequence[ProjectMilestone],
+    events: Sequence[DriftEvent],
+    copresence_pairs: Sequence[CopresencePair],
+    elapsed_hours: Decimal,
+    settings: OrreryDriftSettings,
+) -> RelationshipDriftPlan:
+    """Plan all edge-local drift without database access or side effects."""
+
+    values = {edge: Decimal(value) for edge, value in relationships.items()}
+    old_values = dict(values)
+    applied: dict[EdgeKey, list[tuple[str, Decimal]]] = {}
+
+    def apply(edge: EdgeKey, delta: Decimal, label: str) -> None:
+        current = values.get(edge)
+        if current is None:
+            return
+        next_value, effective = soft_clamp_step(current, delta)
+        values[edge] = next_value
+        applied.setdefault(edge, []).append((label, effective))
+
+    for milestone in sorted(project_milestones, key=lambda item: item.resolution_id):
+        endpoints = (milestone.actor_entity_id, milestone.target_entity_id)
+        label = f"project_milestone:{milestone.resolution_id}"
+        for edge in _directed_edges(*endpoints):
+            apply(edge, settings.project_milestone_delta, label)
+
+    hostile = [event for event in events if event.event_type in settings.hostile_events]
+    for event in sorted(hostile, key=lambda item: item.event_id):
+        delta = settings.hostile_events[event.event_type]
+        label = f"hostile:{event.event_id}:{event.event_type}"
+        for edge in _directed_edges(event.actor_entity_id, event.target_entity_id):
+            apply(edge, delta, label)
+
+    cooperative = [
+        event for event in events if event.event_type in settings.cooperative_events
+    ]
+    for event in sorted(cooperative, key=lambda item: item.event_id):
+        delta = settings.cooperative_events[event.event_type]
+        label = f"cooperative:{event.event_id}:{event.event_type}"
+        for edge in _directed_edges(event.actor_entity_id, event.target_entity_id):
+            apply(edge, delta, label)
+
+    capped_hours = min(max(elapsed_hours, ZERO), settings.copresence_max_hours_per_tick)
+    for pair in sorted(copresence_pairs, key=lambda item: item.ordered()):
+        first, second = pair.ordered()
+        for edge in ((first, second), (second, first)):
+            current = values.get(edge)
+            if current is None or current == ZERO or capped_hours == ZERO:
+                continue
+            direction = ONE if current > ZERO else -ONE
+            delta = direction * settings.copresence_rate_per_hour * capped_hours
+            apply(edge, delta, "copresence")
+
+    plans = tuple(
+        PlannedEdgeDrift(
+            source_entity_id=edge[0],
+            target_entity_id=edge[1],
+            old_valence=old_values[edge],
+            new_valence=values[edge],
+            producer_deltas=tuple(applied[edge]),
+        )
+        for edge in sorted(applied)
+        if values[edge] != old_values[edge]
+    )
+    return RelationshipDriftPlan(edges=plans)
+
+
+def drain_relationship_drift_sync(
+    cur: Any,
+    *,
+    tick_chunk_id: int,
+    settings: Any,
+    epistemics_settings: Any = None,
+) -> RelationshipDriftDrainResult:
+    """Plan and apply current-tick relationship drift through a DB-API cursor."""
+
+    config = _enabled_config(settings)
+    if config is None:
+        return RelationshipDriftDrainResult()
+    world_time, world_layer = _commit_clock_sync(cur, tick_chunk_id)
+    if world_layer != "primary" or world_time is None:
+        return RelationshipDriftDrainResult()
+    previous_world_time = _previous_primary_world_time_sync(
+        cur, tick_chunk_id=tick_chunk_id
+    )
+    plan = plan_relationship_drift(
+        relationships=_relationships_sync(cur),
+        project_milestones=_project_milestones_sync(cur, tick_chunk_id),
+        events=_drift_events_sync(cur, tick_chunk_id, config),
+        copresence_pairs=_copresence_pairs_sync(cur),
+        elapsed_hours=_elapsed_hours(previous_world_time, world_time),
+        settings=config,
+    )
+    return _apply_plan_sync(
+        cur,
+        plan=plan,
+        tick_chunk_id=tick_chunk_id,
+        world_time=world_time,
+        epistemics_settings=epistemics_settings,
+    )
+
+
+async def drain_relationship_drift_async(
+    conn: Any,
+    *,
+    tick_chunk_id: int,
+    settings: Any,
+    epistemics_settings: Any = None,
+) -> RelationshipDriftDrainResult:
+    """Asyncpg twin of :func:`drain_relationship_drift_sync`."""
+
+    config = _enabled_config(settings)
+    if config is None:
+        return RelationshipDriftDrainResult()
+    world_time, world_layer = await _commit_clock_async(conn, tick_chunk_id)
+    if world_layer != "primary" or world_time is None:
+        return RelationshipDriftDrainResult()
+    previous_world_time = await _previous_primary_world_time_async(
+        conn, tick_chunk_id=tick_chunk_id
+    )
+    plan = plan_relationship_drift(
+        relationships=await _relationships_async(conn),
+        project_milestones=await _project_milestones_async(conn, tick_chunk_id),
+        events=await _drift_events_async(conn, tick_chunk_id, config),
+        copresence_pairs=await _copresence_pairs_async(conn),
+        elapsed_hours=_elapsed_hours(previous_world_time, world_time),
+        settings=config,
+    )
+    return await _apply_plan_async(
+        conn,
+        plan=plan,
+        tick_chunk_id=tick_chunk_id,
+        world_time=world_time,
+        epistemics_settings=epistemics_settings,
+    )
+
+
+def _enabled_config(settings: Any) -> Optional[OrreryDriftSettings]:
+    if settings is None:
+        return None
+    if isinstance(settings, OrreryDriftSettings):
+        config = settings
+    elif hasattr(settings, "model_dump"):
+        config = OrreryDriftSettings.model_validate(settings.model_dump())
+    elif isinstance(settings, Mapping):
+        config = OrreryDriftSettings.model_validate(settings)
+    else:
+        raise TypeError("Orrery drift settings must be a mapping or Pydantic model")
+    return config if config.enabled else None
+
+
+def _commit_clock_sync(cur: Any, tick_chunk_id: int) -> tuple[Any, Any]:
+    cur.execute(
+        """
+        SELECT world_time, world_layer::text AS world_layer
+        FROM chunk_metadata
+        WHERE chunk_id = %s
+        """,
+        (tick_chunk_id,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"Relationship-drift chunk {tick_chunk_id} has no metadata")
+    return _row_get(row, "world_time", 0), _row_get(row, "world_layer", 1)
+
+
+async def _commit_clock_async(conn: Any, tick_chunk_id: int) -> tuple[Any, Any]:
+    row = await conn.fetchrow(
+        """
+        SELECT world_time, world_layer::text AS world_layer
+        FROM chunk_metadata
+        WHERE chunk_id = $1
+        """,
+        tick_chunk_id,
+    )
+    if row is None:
+        raise ValueError(f"Relationship-drift chunk {tick_chunk_id} has no metadata")
+    return row["world_time"], row["world_layer"]
+
+
+def _previous_primary_world_time_sync(cur: Any, *, tick_chunk_id: int) -> Any:
+    cur.execute(
+        """
+        SELECT world_time
+        FROM chunk_metadata
+        WHERE chunk_id < %s
+          AND world_layer = 'primary'
+          AND world_time IS NOT NULL
+        ORDER BY chunk_id DESC
+        LIMIT 1
+        """,
+        (tick_chunk_id,),
+    )
+    row = cur.fetchone()
+    return _row_get(row, "world_time", 0) if row is not None else None
+
+
+async def _previous_primary_world_time_async(conn: Any, *, tick_chunk_id: int) -> Any:
+    return await conn.fetchval(
+        """
+        SELECT world_time
+        FROM chunk_metadata
+        WHERE chunk_id < $1
+          AND world_layer = 'primary'
+          AND world_time IS NOT NULL
+        ORDER BY chunk_id DESC
+        LIMIT 1
+        """,
+        tick_chunk_id,
+    )
+
+
+def _elapsed_hours(previous: Optional[datetime], current: datetime) -> Decimal:
+    if previous is None:
+        return ZERO
+    elapsed = current - previous
+    return _timedelta_seconds(elapsed) / Decimal("3600")
+
+
+def _timedelta_seconds(value: timedelta) -> Decimal:
+    return (
+        Decimal(value.days) * Decimal("86400")
+        + Decimal(value.seconds)
+        + Decimal(value.microseconds) / Decimal("1000000")
+    )
+
+
+def _relationships_sync(cur: Any) -> dict[EdgeKey, Decimal]:
+    cur.execute(
+        """
+        SELECT source.entity_id AS source_entity_id,
+               target.entity_id AS target_entity_id,
+               relation.valence_current
+        FROM character_relationships relation
+        JOIN characters source ON source.id = relation.character1_id
+        JOIN characters target ON target.id = relation.character2_id
+        ORDER BY source.entity_id, target.entity_id
+        """
+    )
+    return {
+        (
+            int(_row_get(row, "source_entity_id", 0)),
+            int(_row_get(row, "target_entity_id", 1)),
+        ): Decimal(_row_get(row, "valence_current", 2))
+        for row in cur.fetchall()
+    }
+
+
+async def _relationships_async(conn: Any) -> dict[EdgeKey, Decimal]:
+    rows = await conn.fetch(
+        """
+        SELECT source.entity_id AS source_entity_id,
+               target.entity_id AS target_entity_id,
+               relation.valence_current
+        FROM character_relationships relation
+        JOIN characters source ON source.id = relation.character1_id
+        JOIN characters target ON target.id = relation.character2_id
+        ORDER BY source.entity_id, target.entity_id
+        """
+    )
+    return {
+        (int(row["source_entity_id"]), int(row["target_entity_id"])): Decimal(
+            row["valence_current"]
+        )
+        for row in rows
+    }
+
+
+_PROJECT_MILESTONE_SQL = """
+    SELECT resolution.id AS resolution_id,
+           resolution.actor_entity_id,
+           COALESCE(
+               resolution.state_delta -> 'project.advance' -> 'applied',
+               resolution.state_delta -> 'project.complete' -> 'applied'
+           ) AS applied
+    FROM orrery_resolutions resolution
+    WHERE resolution.tick_chunk_id = {placeholder}
+      AND (
+          resolution.state_delta ? 'project.complete'
+          OR (
+              resolution.state_delta ? 'project.advance'
+              AND COALESCE(
+                  (resolution.state_delta -> 'project.advance'
+                   ->> 'milestone')::boolean,
+                  false
+              )
+          )
+      )
+    ORDER BY resolution.id
+"""
+
+
+def _project_milestones_sync(
+    cur: Any, tick_chunk_id: int
+) -> tuple[ProjectMilestone, ...]:
+    cur.execute(_PROJECT_MILESTONE_SQL.format(placeholder="%s"), (tick_chunk_id,))
+    return _coerce_project_milestones(cur.fetchall())
+
+
+async def _project_milestones_async(
+    conn: Any, tick_chunk_id: int
+) -> tuple[ProjectMilestone, ...]:
+    rows = await conn.fetch(
+        _PROJECT_MILESTONE_SQL.format(placeholder="$1"), tick_chunk_id
+    )
+    return _coerce_project_milestones(rows)
+
+
+def _coerce_project_milestones(rows: Sequence[Any]) -> tuple[ProjectMilestone, ...]:
+    milestones = []
+    for row in rows:
+        applied = _row_get(row, "applied", 2)
+        if isinstance(applied, str):
+            applied = json.loads(applied)
+        if not isinstance(applied, Mapping):
+            raise ValueError(
+                f"Project resolution {_row_get(row, 'resolution_id', 0)} "
+                "has no applied snapshot"
+            )
+        project_type = str(applied.get("project_type") or "")
+        if project_type not in TWO_PARTY_PROJECT_TYPES:
+            continue
+        target = applied.get("target_character_entity_id")
+        actor = _row_get(row, "actor_entity_id", 1)
+        if actor is None or not isinstance(target, int):
+            raise ValueError(
+                f"Two-party project resolution {_row_get(row, 'resolution_id', 0)} "
+                "has no actor/target entity pair"
+            )
+        milestones.append(
+            ProjectMilestone(
+                resolution_id=int(_row_get(row, "resolution_id", 0)),
+                actor_entity_id=int(actor),
+                target_entity_id=target,
+            )
+        )
+    return tuple(milestones)
+
+
+def _drift_events_sync(
+    cur: Any, tick_chunk_id: int, settings: OrreryDriftSettings
+) -> tuple[DriftEvent, ...]:
+    event_types = sorted({*settings.hostile_events, *settings.cooperative_events})
+    cur.execute(
+        """
+        SELECT id, event_type, actor_entity_id, target_entity_id
+        FROM world_events
+        WHERE tick_chunk_id = %s
+          AND event_type = ANY(%s)
+          AND actor_entity_id IS NOT NULL
+          AND target_entity_id IS NOT NULL
+        ORDER BY id
+        """,
+        (tick_chunk_id, event_types),
+    )
+    return _coerce_drift_events(cur.fetchall())
+
+
+async def _drift_events_async(
+    conn: Any, tick_chunk_id: int, settings: OrreryDriftSettings
+) -> tuple[DriftEvent, ...]:
+    event_types = sorted({*settings.hostile_events, *settings.cooperative_events})
+    rows = await conn.fetch(
+        """
+        SELECT id, event_type, actor_entity_id, target_entity_id
+        FROM world_events
+        WHERE tick_chunk_id = $1
+          AND event_type = ANY($2::text[])
+          AND actor_entity_id IS NOT NULL
+          AND target_entity_id IS NOT NULL
+        ORDER BY id
+        """,
+        tick_chunk_id,
+        event_types,
+    )
+    return _coerce_drift_events(rows)
+
+
+def _coerce_drift_events(rows: Sequence[Any]) -> tuple[DriftEvent, ...]:
+    return tuple(
+        DriftEvent(
+            event_id=int(_row_get(row, "id", 0)),
+            event_type=str(_row_get(row, "event_type", 1)),
+            actor_entity_id=int(_row_get(row, "actor_entity_id", 2)),
+            target_entity_id=int(_row_get(row, "target_entity_id", 3)),
+        )
+        for row in rows
+    )
+
+
+_COPRESENCE_SQL = """
+    SELECT first.entity_id AS first_entity_id,
+           second.entity_id AS second_entity_id
+    FROM characters first
+    JOIN characters second
+      ON second.current_location = first.current_location
+     AND second.entity_id > first.entity_id
+    WHERE first.current_location IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1
+          FROM character_travel_states travel
+          WHERE travel.character_entity_id = first.entity_id
+            AND travel.status = 'in_transit'
+      )
+      AND NOT EXISTS (
+          SELECT 1
+          FROM character_travel_states travel
+          WHERE travel.character_entity_id = second.entity_id
+            AND travel.status = 'in_transit'
+      )
+    ORDER BY first.entity_id, second.entity_id
+"""
+
+
+def _copresence_pairs_sync(cur: Any) -> tuple[CopresencePair, ...]:
+    cur.execute(_COPRESENCE_SQL)
+    return tuple(
+        CopresencePair(
+            int(_row_get(row, "first_entity_id", 0)),
+            int(_row_get(row, "second_entity_id", 1)),
+        )
+        for row in cur.fetchall()
+    )
+
+
+async def _copresence_pairs_async(conn: Any) -> tuple[CopresencePair, ...]:
+    rows = await conn.fetch(_COPRESENCE_SQL)
+    return tuple(
+        CopresencePair(int(row["first_entity_id"]), int(row["second_entity_id"]))
+        for row in rows
+    )
+
+
+def _apply_plan_sync(
+    cur: Any,
+    *,
+    plan: RelationshipDriftPlan,
+    tick_chunk_id: int,
+    world_time: datetime,
+    epistemics_settings: Any,
+) -> RelationshipDriftDrainResult:
+    updated_edges = []
+    event_ids = []
+    claim_ids = []
+    for edge in plan.edges:
+        cur.execute(
+            """
+            UPDATE character_relationships relation
+            SET valence_current = %s
+            FROM characters source, characters target
+            WHERE relation.character1_id = source.id
+              AND relation.character2_id = target.id
+              AND source.entity_id = %s
+              AND target.entity_id = %s
+            """,
+            (edge.new_valence, edge.source_entity_id, edge.target_entity_id),
+        )
+        if cur.rowcount != 1:
+            raise RuntimeError(
+                "Relationship edge disappeared during drift application: "
+                f"{edge.source_entity_id}->{edge.target_entity_id}"
+            )
+        updated_edges.append((edge.source_entity_id, edge.target_entity_id))
+        if not edge.is_milestone:
+            continue
+        event_id, claim_id = _emit_milestone_sync(
+            cur,
+            edge=edge,
+            tick_chunk_id=tick_chunk_id,
+            world_time=world_time,
+            epistemics_settings=epistemics_settings,
+        )
+        event_ids.append(event_id)
+        if claim_id is not None:
+            claim_ids.append(claim_id)
+    return RelationshipDriftDrainResult(
+        updated_edges=tuple(updated_edges),
+        milestone_event_ids=tuple(event_ids),
+        claim_ids=tuple(claim_ids),
+    )
+
+
+async def _apply_plan_async(
+    conn: Any,
+    *,
+    plan: RelationshipDriftPlan,
+    tick_chunk_id: int,
+    world_time: datetime,
+    epistemics_settings: Any,
+) -> RelationshipDriftDrainResult:
+    updated_edges = []
+    event_ids = []
+    claim_ids = []
+    for edge in plan.edges:
+        status = await conn.execute(
+            """
+            UPDATE character_relationships relation
+            SET valence_current = $1
+            FROM characters source, characters target
+            WHERE relation.character1_id = source.id
+              AND relation.character2_id = target.id
+              AND source.entity_id = $2
+              AND target.entity_id = $3
+            """,
+            edge.new_valence,
+            edge.source_entity_id,
+            edge.target_entity_id,
+        )
+        if status != "UPDATE 1":
+            raise RuntimeError(
+                "Relationship edge disappeared during drift application: "
+                f"{edge.source_entity_id}->{edge.target_entity_id}"
+            )
+        updated_edges.append((edge.source_entity_id, edge.target_entity_id))
+        if not edge.is_milestone:
+            continue
+        event_id, claim_id = await _emit_milestone_async(
+            conn,
+            edge=edge,
+            tick_chunk_id=tick_chunk_id,
+            world_time=world_time,
+            epistemics_settings=epistemics_settings,
+        )
+        event_ids.append(event_id)
+        if claim_id is not None:
+            claim_ids.append(claim_id)
+    return RelationshipDriftDrainResult(
+        updated_edges=tuple(updated_edges),
+        milestone_event_ids=tuple(event_ids),
+        claim_ids=tuple(claim_ids),
+    )
+
+
+_MILESTONE_PAYLOAD_SYNC = """
+    jsonb_build_object(
+        'old_rung', %s::integer,
+        'new_rung', %s::integer,
+        'old_valence', %s::numeric,
+        'new_valence', %s::numeric,
+        'producer_deltas', (
+            SELECT COALESCE(jsonb_object_agg(label, delta), '{}'::jsonb)
+            FROM unnest(%s::text[], %s::numeric[]) AS item(label, delta)
+        )
+    )
+"""
+
+_MILESTONE_PAYLOAD_ASYNC = """
+    jsonb_build_object(
+        'old_rung', $5::integer,
+        'new_rung', $6::integer,
+        'old_valence', $7::numeric,
+        'new_valence', $8::numeric,
+        'producer_deltas', (
+            SELECT COALESCE(jsonb_object_agg(label, delta), '{}'::jsonb)
+            FROM unnest($9::text[], $10::numeric[]) AS item(label, delta)
+        )
+    )
+"""
+
+
+def _emit_milestone_sync(
+    cur: Any,
+    *,
+    edge: PlannedEdgeDrift,
+    tick_chunk_id: int,
+    world_time: datetime,
+    epistemics_settings: Any,
+) -> tuple[int, Optional[int]]:
+    labels = [label for label, _delta in edge.producer_deltas]
+    deltas = [delta for _label, delta in edge.producer_deltas]
+    cur.execute(
+        f"""
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, target_entity_id,
+            world_layer, source, changed_fields, payload, world_time
+        ) VALUES (
+            %s, %s, %s, %s, 'primary', 'resolver',
+            ARRAY['character_relationships.valence_current']::text[],
+            {_MILESTONE_PAYLOAD_SYNC}, %s
+        )
+        RETURNING id
+        """,
+        (
+            RELATIONSHIP_DRIFT_EVENT_TYPE,
+            tick_chunk_id,
+            edge.source_entity_id,
+            edge.target_entity_id,
+            edge.old_rung,
+            edge.new_rung,
+            edge.old_valence,
+            edge.new_valence,
+            labels,
+            deltas,
+            world_time,
+        ),
+    )
+    event_id = int(_row_get(cur.fetchone(), "id", 0))
+    _insert_event_entities_sync(cur, event_id=event_id, edge=edge)
+    participants = _claim_participants_sync(cur, edge)
+    mint_result = mint_claim_for_event(
+        cur,
+        world_event_id=event_id,
+        event_type=RELATIONSHIP_DRIFT_EVENT_TYPE,
+        summary=mechanical_claim_summary(RELATIONSHIP_DRIFT_EVENT_TYPE, participants),
+        participants=participants,
+        source_chunk_id=tick_chunk_id,
+        source_resolution_id=None,
+        settings=epistemics_settings,
+    )
+    return event_id, mint_result.claim_id if mint_result is not None else None
+
+
+async def _emit_milestone_async(
+    conn: Any,
+    *,
+    edge: PlannedEdgeDrift,
+    tick_chunk_id: int,
+    world_time: datetime,
+    epistemics_settings: Any,
+) -> tuple[int, Optional[int]]:
+    labels = [label for label, _delta in edge.producer_deltas]
+    deltas = [delta for _label, delta in edge.producer_deltas]
+    event_id = await conn.fetchval(
+        f"""
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, target_entity_id,
+            world_layer, source, changed_fields, payload, world_time
+        ) VALUES (
+            $1, $2, $3, $4, 'primary', 'resolver',
+            ARRAY['character_relationships.valence_current']::text[],
+            {_MILESTONE_PAYLOAD_ASYNC}, $11
+        )
+        RETURNING id
+        """,
+        RELATIONSHIP_DRIFT_EVENT_TYPE,
+        tick_chunk_id,
+        edge.source_entity_id,
+        edge.target_entity_id,
+        edge.old_rung,
+        edge.new_rung,
+        edge.old_valence,
+        edge.new_valence,
+        labels,
+        deltas,
+        world_time,
+    )
+    await _insert_event_entities_async(conn, event_id=int(event_id), edge=edge)
+    participants = await _claim_participants_async(conn, edge)
+    mint_result = await mint_claim_for_event_async(
+        conn,
+        world_event_id=int(event_id),
+        event_type=RELATIONSHIP_DRIFT_EVENT_TYPE,
+        summary=mechanical_claim_summary(RELATIONSHIP_DRIFT_EVENT_TYPE, participants),
+        participants=participants,
+        source_chunk_id=tick_chunk_id,
+        source_resolution_id=None,
+        settings=epistemics_settings,
+    )
+    return int(event_id), mint_result.claim_id if mint_result is not None else None
+
+
+def _insert_event_entities_sync(
+    cur: Any, *, event_id: int, edge: PlannedEdgeDrift
+) -> None:
+    cur.execute(
+        """
+        INSERT INTO world_event_entities (event_id, role, entity_id)
+        VALUES (%s, 'actor', %s), (%s, 'target', %s)
+        ON CONFLICT DO NOTHING
+        """,
+        (event_id, edge.source_entity_id, event_id, edge.target_entity_id),
+    )
+
+
+async def _insert_event_entities_async(
+    conn: Any, *, event_id: int, edge: PlannedEdgeDrift
+) -> None:
+    await conn.execute(
+        """
+        INSERT INTO world_event_entities (event_id, role, entity_id)
+        VALUES ($1, 'actor', $2), ($1, 'target', $3)
+        ON CONFLICT DO NOTHING
+        """,
+        event_id,
+        edge.source_entity_id,
+        edge.target_entity_id,
+    )
+
+
+def _claim_participants_sync(
+    cur: Any, edge: PlannedEdgeDrift
+) -> tuple[ClaimParticipant, ...]:
+    cur.execute(
+        """
+        SELECT names.id, names.name, entities.kind::text AS entity_kind
+        FROM entity_names_v names
+        JOIN entities ON entities.id = names.id
+        WHERE names.id = ANY(%s)
+        """,
+        ([edge.source_entity_id, edge.target_entity_id],),
+    )
+    return _claim_participants_from_rows(cur.fetchall(), edge)
+
+
+async def _claim_participants_async(
+    conn: Any, edge: PlannedEdgeDrift
+) -> tuple[ClaimParticipant, ...]:
+    rows = await conn.fetch(
+        """
+        SELECT names.id, names.name, entities.kind::text AS entity_kind
+        FROM entity_names_v names
+        JOIN entities ON entities.id = names.id
+        WHERE names.id = ANY($1::bigint[])
+        """,
+        [edge.source_entity_id, edge.target_entity_id],
+    )
+    return _claim_participants_from_rows(rows, edge)
+
+
+def _claim_participants_from_rows(
+    rows: Sequence[Any], edge: PlannedEdgeDrift
+) -> tuple[ClaimParticipant, ...]:
+    details = {
+        int(_row_get(row, "id", 0)): (
+            str(_row_get(row, "name", 1)),
+            str(_row_get(row, "entity_kind", 2)),
+        )
+        for row in rows
+    }
+    participants = []
+    for entity_id, role in (
+        (edge.source_entity_id, "actor"),
+        (edge.target_entity_id, "target"),
+    ):
+        if entity_id not in details:
+            raise ValueError(
+                f"Drift milestone cannot mint awareness for unnamed entity {entity_id}"
+            )
+        name, kind = details[entity_id]
+        participants.append(ClaimParticipant(entity_id, role, name, kind))
+    return tuple(participants)
+
+
+def _directed_edges(first: int, second: int) -> tuple[EdgeKey, EdgeKey]:
+    forward = (first, second)
+    reverse = (second, first)
+    return (forward, reverse) if forward < reverse else (reverse, forward)

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -14,6 +14,10 @@ import json
 from typing import Any, Mapping, Optional
 
 from nexus.agents.orrery.db_rows import row_get as _row_get
+from nexus.agents.orrery.drift import (
+    drain_relationship_drift_async,
+    drain_relationship_drift_sync,
+)
 from nexus.agents.orrery.epistemics import (
     ClaimParticipant,
     MintResult,
@@ -355,6 +359,7 @@ def commit_orrery_tick_sync(
     project_settings: Optional[Any] = None,
     epistemics_settings: Optional[Any] = None,
     contagion_settings: Optional[Any] = None,
+    drift_settings: Optional[Any] = None,
 ) -> CommitOrreryTickResult:
     """Materialize a preview proposal inside the accepted-chunk transaction."""
 
@@ -404,6 +409,12 @@ def commit_orrery_tick_sync(
         )
         propagation_count = propagation_result.minted_count
         if not has_resolutions:
+            drain_relationship_drift_sync(
+                cur,
+                tick_chunk_id=tick_chunk_id,
+                settings=drift_settings,
+                epistemics_settings=epistemics_policy,
+            )
             return CommitOrreryTickResult(
                 cleared_tag_count=expired_tag_count,
                 scene_pressure_count=scene_pressure_count,
@@ -561,6 +572,17 @@ def commit_orrery_tick_sync(
                         source_chunk_id=tick_chunk_id,
                     )
 
+        # Project milestone snapshots and resolver events are durable only
+        # after the loop above. Draining here preserves the specified producer
+        # order while the resolution-free path drains directly after
+        # propagation.
+        drain_relationship_drift_sync(
+            cur,
+            tick_chunk_id=tick_chunk_id,
+            settings=drift_settings,
+            epistemics_settings=epistemics_policy,
+        )
+
     return CommitOrreryTickResult(
         resolution_count=resolution_count,
         event_count=event_count,
@@ -592,6 +614,7 @@ async def commit_orrery_tick_async(
     project_settings: Optional[Any] = None,
     epistemics_settings: Optional[Any] = None,
     contagion_settings: Optional[Any] = None,
+    drift_settings: Optional[Any] = None,
 ) -> CommitOrreryTickResult:
     """Async parity wrapper for tests and non-production commit callers."""
 
@@ -640,6 +663,12 @@ async def commit_orrery_tick_async(
     )
     propagation_count = propagation_result.minted_count
     if not has_resolutions:
+        await drain_relationship_drift_async(
+            conn,
+            tick_chunk_id=tick_chunk_id,
+            settings=drift_settings,
+            epistemics_settings=epistemics_policy,
+        )
         return CommitOrreryTickResult(
             cleared_tag_count=expired_tag_count,
             scene_pressure_count=scene_pressure_count,
@@ -796,6 +825,15 @@ async def commit_orrery_tick_async(
                     triggering_event_id=event_id,
                     source_chunk_id=tick_chunk_id,
                 )
+
+    # See the sync path: current-tick applied project snapshots and emitted
+    # events must exist before the deterministic drift planner can consume them.
+    await drain_relationship_drift_async(
+        conn,
+        tick_chunk_id=tick_chunk_id,
+        settings=drift_settings,
+        epistemics_settings=epistemics_policy,
+    )
 
     return CommitOrreryTickResult(
         resolution_count=resolution_count,

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -565,6 +565,11 @@ async def commit_incubator_to_database(
                 prompt_settings=_orrery_prompt_settings(),
                 ecology_settings=_orrery_ecology_settings(),
                 project_settings=_orrery_project_settings(),
+                epistemics_settings=(
+                    _orrery_epistemics_settings()
+                    if incubator.get("orrery_proposal") is None
+                    else None
+                ),
                 contagion_settings=_orrery_contagion_settings(),
                 drift_settings=_orrery_drift_settings(),
             )
@@ -667,6 +672,14 @@ def _orrery_contagion_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("contagion")
+
+
+def _orrery_epistemics_settings() -> Any:
+    """[orrery.epistemics] claim-minting and awareness policy."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("epistemics")
 
 
 def _orrery_drift_settings() -> Any:

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -185,7 +185,9 @@ async def insert_place_references(
     for ref in place_refs:
         await conn.execute(
             """
-            INSERT INTO place_chunk_references (place_id, chunk_id, reference_type, evidence)
+            INSERT INTO place_chunk_references (
+                place_id, chunk_id, reference_type, evidence
+            )
             VALUES ($1, $2, $3, $4)
             """,
             ref["place_id"],
@@ -564,6 +566,7 @@ async def commit_incubator_to_database(
                 ecology_settings=_orrery_ecology_settings(),
                 project_settings=_orrery_project_settings(),
                 contagion_settings=_orrery_contagion_settings(),
+                drift_settings=_orrery_drift_settings(),
             )
             if (
                 orrery_result.resolution_count
@@ -664,6 +667,14 @@ def _orrery_contagion_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("contagion")
+
+
+def _orrery_drift_settings() -> Any:
+    """[orrery.drift] continuous relationship-valence policy."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("drift")
 
 
 def _orrery_checkpoint_interval() -> int:

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -9,8 +9,7 @@ with the existing narrative API.
 import json
 import logging
 from datetime import datetime
-from typing import Optional, Dict, Any, List
-import psycopg2
+from typing import Optional, Any, List
 from psycopg2.extras import RealDictCursor
 
 from nexus.agents.logon.apex_schema import (
@@ -269,7 +268,8 @@ def create_new_faction_sync(cur, new_faction):
         )
         if not cur.fetchone():
             raise ValueError(
-                f"Place ID {new_faction.primary_location} not found for faction location"
+                f"Place ID {new_faction.primary_location} not found for "
+                "faction location"
             )
 
     cur.execute("LOCK TABLE factions IN SHARE ROW EXCLUSIVE MODE")
@@ -377,7 +377,8 @@ def commit_incubator_to_database_sync(
 
                     if not parent_meta:
                         raise ValueError(
-                            f"No metadata found for parent chunk {incubator['parent_chunk_id']}"
+                            "No metadata found for parent chunk "
+                            f"{incubator['parent_chunk_id']}"
                         )
 
                     logger.info(
@@ -459,7 +460,10 @@ def commit_incubator_to_database_sync(
             # Step 6: Insert chunk metadata
             with conn.cursor() as cur:
                 # Generate slug (e.g., "S05E06_001")
-                slug = f"S{db_meta['season']:02d}E{db_meta['episode']:02d}_{db_meta['scene']:03d}"
+                slug = (
+                    f"S{db_meta['season']:02d}E{db_meta['episode']:02d}_"
+                    f"{db_meta['scene']:03d}"
+                )
 
                 cur.execute(
                     """
@@ -489,7 +493,9 @@ def commit_incubator_to_database_sync(
                     for ref in place_refs:
                         cur.execute(
                             """
-                            INSERT INTO place_chunk_references (place_id, chunk_id, reference_type, evidence)
+                            INSERT INTO place_chunk_references (
+                                place_id, chunk_id, reference_type, evidence
+                            )
                             VALUES (%s, %s, %s, %s)
                         """,
                             (
@@ -500,7 +506,9 @@ def commit_incubator_to_database_sync(
                             ),
                         )
                     logger.info(
-                        f"Inserted {len(place_refs)} place references for chunk {chunk_id}"
+                        "Inserted %s place references for chunk %s",
+                        len(place_refs),
+                        chunk_id,
                     )
 
             # Insert character references
@@ -509,7 +517,9 @@ def commit_incubator_to_database_sync(
                     for ref in character_refs:
                         cur.execute(
                             """
-                            INSERT INTO chunk_character_references (chunk_id, character_id, reference)
+                            INSERT INTO chunk_character_references (
+                                chunk_id, character_id, reference
+                            )
                             VALUES (%s, %s, %s)
                             ON CONFLICT (chunk_id, character_id) DO UPDATE
                             SET reference = 'present'
@@ -521,7 +531,9 @@ def commit_incubator_to_database_sync(
                             (chunk_id, ref["character_id"], ref["reference"]),
                         )
                     logger.info(
-                        f"Inserted {len(character_refs)} character references for chunk {chunk_id}"
+                        "Inserted %s character references for chunk %s",
+                        len(character_refs),
+                        chunk_id,
                     )
 
             # Insert faction references
@@ -537,7 +549,9 @@ def commit_incubator_to_database_sync(
                             (chunk_id, ref["faction_id"]),
                         )
                     logger.info(
-                        f"Inserted {len(faction_refs)} faction references for chunk {chunk_id}"
+                        "Inserted %s faction references for chunk %s",
+                        len(faction_refs),
+                        chunk_id,
                     )
 
             # Step 8: Update entity states (if provided)
@@ -558,6 +572,7 @@ def commit_incubator_to_database_sync(
                 ecology_settings=_orrery_ecology_settings(),
                 project_settings=_orrery_project_settings(),
                 contagion_settings=_orrery_contagion_settings(),
+                drift_settings=_orrery_drift_settings(),
             )
             if (
                 orrery_result.resolution_count
@@ -843,6 +858,14 @@ def _orrery_contagion_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("contagion")
+
+
+def _orrery_drift_settings() -> Any:
+    """[orrery.drift] continuous relationship-valence policy."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("drift")
 
 
 def _orrery_checkpoint_interval() -> int:

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -571,6 +571,11 @@ def commit_incubator_to_database_sync(
                 prompt_settings=_orrery_prompt_settings(),
                 ecology_settings=_orrery_ecology_settings(),
                 project_settings=_orrery_project_settings(),
+                epistemics_settings=(
+                    _orrery_epistemics_settings()
+                    if incubator.get("orrery_proposal") is None
+                    else None
+                ),
                 contagion_settings=_orrery_contagion_settings(),
                 drift_settings=_orrery_drift_settings(),
             )
@@ -858,6 +863,14 @@ def _orrery_contagion_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("contagion")
+
+
+def _orrery_epistemics_settings() -> Any:
+    """[orrery.epistemics] claim-minting and awareness policy."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("epistemics")
 
 
 def _orrery_drift_settings() -> Any:

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -7,6 +7,7 @@ All models use `extra='forbid'` to catch typos in configuration keys.
 
 from dataclasses import dataclass
 from datetime import timedelta
+from decimal import Decimal
 import re
 from typing import Any, Dict, List, Literal, Optional, Tuple
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -1252,6 +1253,67 @@ class OrreryProjectSettings(BaseModel):
     )
 
 
+class OrreryDriftSettings(BaseModel):
+    """Continuous relationship-valence policy for ``[orrery.drift]``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    copresence_rate_per_hour: Decimal = Field(default=Decimal("0.001"), gt=0)
+    copresence_max_hours_per_tick: Decimal = Field(default=Decimal("12.0"), gt=0)
+    project_milestone_delta: Decimal = Field(default=Decimal("0.03"), gt=0)
+    hostile_events: Dict[str, Decimal] = Field(
+        default_factory=lambda: {
+            "threat_issued": Decimal("-0.02"),
+            "retaliation_attempted": Decimal("-0.04"),
+            "retaliation_executed": Decimal("-0.06"),
+        }
+    )
+    cooperative_events: Dict[str, Decimal] = Field(
+        default_factory=lambda: {
+            "protective_intervention": Decimal("0.04"),
+            "warning_delivered": Decimal("0.02"),
+            "welfare_check": Decimal("0.02"),
+            "kin_visit": Decimal("0.02"),
+            "confrontation_resolved": Decimal("0.03"),
+        }
+    )
+
+    @field_validator("hostile_events")
+    @classmethod
+    def _validate_hostile_events(cls, values: Dict[str, Decimal]) -> Dict[str, Decimal]:
+        """Require named, strictly negative hostile-event deltas."""
+
+        if any(not event_type.strip() for event_type in values):
+            raise ValueError("hostile_events keys must be non-empty")
+        nonnegative = sorted(
+            event_type for event_type, delta in values.items() if delta >= 0
+        )
+        if nonnegative:
+            raise ValueError(
+                f"hostile_events deltas must be strictly negative: {nonnegative}"
+            )
+        return values
+
+    @field_validator("cooperative_events")
+    @classmethod
+    def _validate_cooperative_events(
+        cls, values: Dict[str, Decimal]
+    ) -> Dict[str, Decimal]:
+        """Require named, strictly positive cooperative-event deltas."""
+
+        if any(not event_type.strip() for event_type in values):
+            raise ValueError("cooperative_events keys must be non-empty")
+        nonpositive = sorted(
+            event_type for event_type, delta in values.items() if delta <= 0
+        )
+        if nonpositive:
+            raise ValueError(
+                f"cooperative_events deltas must be strictly positive: {nonpositive}"
+            )
+        return values
+
+
 class OrreryEpistemicsSettings(BaseModel):
     """Claim minting and awareness policy for [orrery.epistemics]."""
 
@@ -1262,7 +1324,10 @@ class OrreryEpistemicsSettings(BaseModel):
         description="Enable claim producers and knower-gated predicates.",
     )
     claim_event_types: List[str] = Field(
-        default_factory=lambda: ["threat_issued"],
+        default_factory=lambda: [
+            "threat_issued",
+            "relationship_drift_milestone",
+        ],
         description="World event types that mint bounded claims at birth.",
     )
     aware_roles: List[str] = Field(
@@ -1934,6 +1999,7 @@ class OrrerySettings(BaseModel):
         default_factory=OrreryPackageSelectionSettings
     )
     projects: OrreryProjectSettings = Field(default_factory=OrreryProjectSettings)
+    drift: OrreryDriftSettings = Field(default_factory=OrreryDriftSettings)
     epistemics: OrreryEpistemicsSettings = Field(
         default_factory=OrreryEpistemicsSettings
     )

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1258,10 +1258,10 @@ class OrreryDriftSettings(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    enabled: bool = True
+    enabled: bool = False
     copresence_rate_per_hour: Decimal = Field(default=Decimal("0.001"), gt=0)
     copresence_max_hours_per_tick: Decimal = Field(default=Decimal("12.0"), gt=0)
-    project_milestone_delta: Decimal = Field(default=Decimal("0.03"), gt=0)
+    project_milestone_delta: Decimal = Field(default=Decimal("0.03"), gt=0, lt=1)
     hostile_events: Dict[str, Decimal] = Field(
         default_factory=lambda: {
             "threat_issued": Decimal("-0.02"),
@@ -1293,6 +1293,13 @@ class OrreryDriftSettings(BaseModel):
             raise ValueError(
                 f"hostile_events deltas must be strictly negative: {nonnegative}"
             )
+        oversized = sorted(
+            event_type for event_type, delta in values.items() if abs(delta) >= 1
+        )
+        if oversized:
+            raise ValueError(
+                "hostile_events delta magnitudes must be < 1: " f"{oversized}"
+            )
         return values
 
     @field_validator("cooperative_events")
@@ -1311,7 +1318,40 @@ class OrreryDriftSettings(BaseModel):
             raise ValueError(
                 f"cooperative_events deltas must be strictly positive: {nonpositive}"
             )
+        oversized = sorted(
+            event_type for event_type, delta in values.items() if abs(delta) >= 1
+        )
+        if oversized:
+            raise ValueError(
+                "cooperative_events delta magnitudes must be < 1: " f"{oversized}"
+            )
         return values
+
+    @model_validator(mode="after")
+    def _validate_copresence_tick_delta(self) -> "OrreryDriftSettings":
+        """Keep the maximum co-presence delta inside the soft-clamp domain."""
+
+        maximum_delta = (
+            self.copresence_rate_per_hour * self.copresence_max_hours_per_tick
+        )
+        if maximum_delta >= 1:
+            raise ValueError(
+                "copresence_rate_per_hour * copresence_max_hours_per_tick "
+                "must be < 1"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_event_maps_disjoint(self) -> "OrreryDriftSettings":
+        """An event type in both maps would double-apply its deltas."""
+
+        overlap = sorted(set(self.hostile_events) & set(self.cooperative_events))
+        if overlap:
+            raise ValueError(
+                "hostile_events and cooperative_events must be disjoint: "
+                f"{overlap}"
+            )
+        return self
 
 
 class OrreryEpistemicsSettings(BaseModel):

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -173,11 +173,53 @@ def test_drift_rejects_nonnegative_hostile_delta() -> None:
         OrreryDriftSettings(hostile_events={"threat_issued": 0})
 
 
+def test_drift_event_maps_must_be_disjoint() -> None:
+    """The same event type in both maps would double-apply its deltas."""
+
+    with pytest.raises(ValidationError, match="must be disjoint"):
+        OrreryDriftSettings(
+            hostile_events={"threat_issued": Decimal("-0.02")},
+            cooperative_events={"threat_issued": Decimal("0.02")},
+        )
+
+
 def test_drift_rejects_nonpositive_cooperative_delta() -> None:
     """Cooperative classification mistakes fail during config validation."""
 
     with pytest.raises(ValidationError, match="strictly positive"):
         OrreryDriftSettings(cooperative_events={"welfare_check": -0.1})
+
+
+def test_drift_defaults_off_when_block_is_absent() -> None:
+    """Legacy configs cannot silently opt into relationship drift."""
+
+    assert OrreryDriftSettings().enabled is False
+    payload = load_settings("nexus.toml").orrery.model_dump()
+    payload.pop("drift")
+    assert OrrerySettings.model_validate(payload).drift.enabled is False
+
+
+def test_drift_rejects_project_delta_at_or_above_one() -> None:
+    with pytest.raises(ValidationError, match="less than 1"):
+        OrreryDriftSettings(project_milestone_delta=1)
+
+
+def test_drift_rejects_hostile_delta_magnitude_at_or_above_one() -> None:
+    with pytest.raises(ValidationError, match="magnitudes must be < 1"):
+        OrreryDriftSettings(hostile_events={"threat_issued": -1})
+
+
+def test_drift_rejects_cooperative_delta_magnitude_at_or_above_one() -> None:
+    with pytest.raises(ValidationError, match="magnitudes must be < 1"):
+        OrreryDriftSettings(cooperative_events={"welfare_check": 1})
+
+
+def test_drift_rejects_copresence_tick_delta_at_or_above_one() -> None:
+    with pytest.raises(ValidationError, match=r"copresence_rate_per_hour \*"):
+        OrreryDriftSettings(
+            copresence_rate_per_hour=Decimal("0.1"),
+            copresence_max_hours_per_tick=Decimal("10"),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -4,6 +4,7 @@ import subprocess
 import tomllib
 from copy import deepcopy
 from datetime import timedelta
+from decimal import Decimal
 
 import pytest
 from pydantic import ValidationError
@@ -14,6 +15,7 @@ from nexus.config.settings_models import (
     OrreryBleedSettings,
     OrreryContagionSettings,
     OrreryDashboardSettings,
+    OrreryDriftSettings,
     OrreryEpistemicsSettings,
     OrreryPromoteSettings,
     OrrerySettings,
@@ -86,6 +88,19 @@ def test_orrery_settings_resolve_model_reference() -> None:
     assert settings.orrery.projects.abandon_after_stalled_world_hours == 168.0
     assert settings.orrery.projects.milestone_magnitude == 0.40
     assert settings.orrery.projects.coverage_distribution_tolerance == 0.05
+    assert settings.orrery.drift.enabled is True
+    assert settings.orrery.drift.copresence_rate_per_hour == Decimal("0.001")
+    assert settings.orrery.drift.copresence_max_hours_per_tick == Decimal("12.0")
+    assert settings.orrery.drift.project_milestone_delta == Decimal("0.03")
+    assert settings.orrery.drift.hostile_events["retaliation_executed"] == Decimal(
+        "-0.06"
+    )
+    assert settings.orrery.drift.cooperative_events[
+        "protective_intervention"
+    ] == Decimal("0.04")
+    assert "relationship_drift_milestone" in (
+        settings.orrery.epistemics.claim_event_types
+    )
     # The ship-off invariant applies to the COMMITTED config: flipping the
     # dashboard on locally is a documented workflow (nexus.toml comment,
     # issue #415), and asserting the working tree here trains developers to
@@ -149,6 +164,35 @@ def test_epistemics_rejects_claim_propagated_as_claim_producer() -> None:
 
     with pytest.raises(ValidationError, match="claim_propagated cannot appear"):
         OrreryEpistemicsSettings(claim_event_types=["claim_propagated"])
+
+
+def test_drift_rejects_nonnegative_hostile_delta() -> None:
+    """Hostile classification mistakes fail during config validation."""
+
+    with pytest.raises(ValidationError, match="strictly negative"):
+        OrreryDriftSettings(hostile_events={"threat_issued": 0})
+
+
+def test_drift_rejects_nonpositive_cooperative_delta() -> None:
+    """Cooperative classification mistakes fail during config validation."""
+
+    with pytest.raises(ValidationError, match="strictly positive"):
+        OrreryDriftSettings(cooperative_events={"welfare_check": -0.1})
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "copresence_rate_per_hour",
+        "copresence_max_hours_per_tick",
+        "project_milestone_delta",
+    ],
+)
+def test_drift_rejects_nonpositive_rates(field: str) -> None:
+    """All relationship-drift rates must remain strictly positive."""
+
+    with pytest.raises(ValidationError, match="greater than 0"):
+        OrreryDriftSettings.model_validate({field: 0})
 
 
 def test_project_milestones_cannot_fall_below_promotion_floor() -> None:

--- a/tests/test_orrery/test_drift_engine.py
+++ b/tests/test_orrery/test_drift_engine.py
@@ -1,0 +1,183 @@
+"""Pure-planner coverage for deterministic relationship drift."""
+
+from decimal import Decimal
+
+from nexus.agents.orrery.drift import (
+    CopresencePair,
+    DriftEvent,
+    ProjectMilestone,
+    plan_relationship_drift,
+    soft_clamp_step,
+)
+from nexus.config.settings_models import OrreryDriftSettings
+
+
+def _settings(**overrides: object) -> OrreryDriftSettings:
+    payload: dict[str, object] = {
+        "copresence_rate_per_hour": "0.01",
+        "copresence_max_hours_per_tick": "12",
+        "project_milestone_delta": "0.03",
+        "hostile_events": {"hostile": "-0.2"},
+        "cooperative_events": {"cooperative": "0.1"},
+    }
+    payload.update(overrides)
+    return OrreryDriftSettings.model_validate(payload)
+
+
+def test_each_discrete_producer_moves_both_existing_directions() -> None:
+    relationships = {(1, 2): Decimal("0.2"), (2, 1): Decimal("-0.2")}
+
+    milestone = plan_relationship_drift(
+        relationships=relationships,
+        project_milestones=[ProjectMilestone(4, 1, 2)],
+        events=[],
+        copresence_pairs=[],
+        elapsed_hours=Decimal("0"),
+        settings=_settings(),
+    )
+    hostile = plan_relationship_drift(
+        relationships=relationships,
+        project_milestones=[],
+        events=[DriftEvent(8, "hostile", 1, 2)],
+        copresence_pairs=[],
+        elapsed_hours=Decimal("0"),
+        settings=_settings(),
+    )
+    cooperative = plan_relationship_drift(
+        relationships=relationships,
+        project_milestones=[],
+        events=[DriftEvent(9, "cooperative", 1, 2)],
+        copresence_pairs=[],
+        elapsed_hours=Decimal("0"),
+        settings=_settings(),
+    )
+
+    assert [edge.new_valence for edge in milestone.edges] == [
+        Decimal("0.224"),
+        Decimal("-0.176"),
+    ]
+    assert [edge.new_valence for edge in hostile.edges] == [
+        Decimal("0.04"),
+        Decimal("-0.36"),
+    ]
+    assert [edge.new_valence for edge in cooperative.edges] == [
+        Decimal("0.28"),
+        Decimal("-0.12"),
+    ]
+
+
+def test_producers_apply_sequentially_in_frozen_order() -> None:
+    settings = _settings()
+    plan = plan_relationship_drift(
+        relationships={(1, 2): Decimal("0.2")},
+        project_milestones=[ProjectMilestone(20, 1, 2)],
+        events=[
+            DriftEvent(40, "cooperative", 1, 2),
+            DriftEvent(30, "hostile", 1, 2),
+        ],
+        copresence_pairs=[CopresencePair(2, 1)],
+        elapsed_hours=Decimal("2"),
+        settings=settings,
+    )
+    value = Decimal("0.2")
+    expected_deltas = []
+    for delta in (
+        Decimal("0.03"),
+        Decimal("-0.2"),
+        Decimal("0.1"),
+        Decimal("0.02"),
+    ):
+        value, effective = soft_clamp_step(value, delta)
+        expected_deltas.append(effective)
+
+    edge = plan.edges[0]
+    assert edge.new_valence == value
+    assert [delta for _label, delta in edge.producer_deltas] == expected_deltas
+    assert [label.split(":", 1)[0] for label, _delta in edge.producer_deltas] == [
+        "project_milestone",
+        "hostile",
+        "cooperative",
+        "copresence",
+    ]
+
+
+def test_repeated_hostility_approaches_negative_one_without_reaching_it() -> None:
+    events = [DriftEvent(event_id, "hostile", 1, 2) for event_id in range(1000)]
+    plan = plan_relationship_drift(
+        relationships={(1, 2): Decimal("0")},
+        project_milestones=[],
+        events=events,
+        copresence_pairs=[],
+        elapsed_hours=Decimal("0"),
+        settings=_settings(),
+    )
+
+    value = plan.edges[0].new_valence
+    assert Decimal("-1") < value < Decimal("-0.999999999999")
+
+
+def test_copresence_deepens_each_nonzero_sign_and_leaves_zero_inert() -> None:
+    plan = plan_relationship_drift(
+        relationships={
+            (1, 2): Decimal("0.5"),
+            (2, 1): Decimal("-0.5"),
+            (1, 3): Decimal("0"),
+        },
+        project_milestones=[],
+        events=[],
+        copresence_pairs=[CopresencePair(1, 2), CopresencePair(1, 3)],
+        elapsed_hours=Decimal("4"),
+        settings=_settings(),
+    )
+
+    by_edge = {
+        (edge.source_entity_id, edge.target_entity_id): edge.new_valence
+        for edge in plan.edges
+    }
+    assert by_edge == {(1, 2): Decimal("0.520"), (2, 1): Decimal("-0.520")}
+    assert (1, 3) not in by_edge
+
+
+def test_missing_reverse_edge_is_not_created() -> None:
+    plan = plan_relationship_drift(
+        relationships={(1, 2): Decimal("0.1")},
+        project_milestones=[],
+        events=[DriftEvent(1, "cooperative", 1, 2)],
+        copresence_pairs=[],
+        elapsed_hours=Decimal("0"),
+        settings=_settings(),
+    )
+
+    assert [(edge.source_entity_id, edge.target_entity_id) for edge in plan.edges] == [
+        (1, 2)
+    ]
+
+
+def test_copresence_elapsed_hours_are_capped() -> None:
+    common = {
+        "relationships": {(1, 2): Decimal("0.5")},
+        "project_milestones": [],
+        "events": [],
+        "copresence_pairs": [CopresencePair(1, 2)],
+        "settings": _settings(),
+    }
+
+    capped = plan_relationship_drift(elapsed_hours=Decimal("12"), **common)
+    skipped = plan_relationship_drift(elapsed_hours=Decimal("500"), **common)
+    assert capped == skipped
+
+
+def test_decimal_plan_is_bit_exact_across_identical_runs() -> None:
+    inputs = {
+        "relationships": {(1, 2): Decimal("0.123456789")},
+        "project_milestones": [ProjectMilestone(2, 1, 2)],
+        "events": [
+            DriftEvent(4, "hostile", 1, 2),
+            DriftEvent(5, "cooperative", 1, 2),
+        ],
+        "copresence_pairs": [CopresencePair(1, 2)],
+        "elapsed_hours": Decimal("7.25"),
+        "settings": _settings(),
+    }
+
+    assert plan_relationship_drift(**inputs) == plan_relationship_drift(**inputs)

--- a/tests/test_orrery/test_drift_engine.py
+++ b/tests/test_orrery/test_drift_engine.py
@@ -2,10 +2,14 @@
 
 from decimal import Decimal
 
+import pytest
+
 from nexus.agents.orrery.drift import (
     CopresencePair,
     DriftEvent,
     ProjectMilestone,
+    _require_migration_089_async,
+    _require_migration_089_sync,
     plan_relationship_drift,
     soft_clamp_step,
 )
@@ -113,7 +117,7 @@ def test_repeated_hostility_approaches_negative_one_without_reaching_it() -> Non
     )
 
     value = plan.edges[0].new_valence
-    assert Decimal("-1") < value < Decimal("-0.999999999999")
+    assert value == Decimal("-0.999999999999")
 
 
 def test_copresence_deepens_each_nonzero_sign_and_leaves_zero_inert() -> None:
@@ -181,3 +185,43 @@ def test_decimal_plan_is_bit_exact_across_identical_runs() -> None:
     }
 
     assert plan_relationship_drift(**inputs) == plan_relationship_drift(**inputs)
+
+
+def test_written_valence_is_quantized_to_twelve_decimal_places() -> None:
+    plan = plan_relationship_drift(
+        relationships={(1, 2): Decimal("0.12345678901234567890")},
+        project_milestones=[],
+        events=[DriftEvent(1, "cooperative", 1, 2)],
+        copresence_pairs=[],
+        elapsed_hours=Decimal("0"),
+        settings=_settings(),
+    )
+
+    edge = plan.edges[0]
+    assert edge.old_valence == Decimal("0.123456789012")
+    assert edge.new_valence == Decimal("0.211111110111")
+    assert edge.new_valence.as_tuple().exponent == -12
+
+
+class _MigrationGateCursor:
+    def execute(self, _sql: str, _params: object) -> None:
+        return None
+
+    def fetchone(self) -> dict[str, int]:
+        return {"registered_count": 1}
+
+
+class _MigrationGateAsyncConnection:
+    async def fetchval(self, _sql: str, _event_types: object) -> int:
+        return 1
+
+
+def test_sync_migration_gate_requires_both_drift_event_types() -> None:
+    with pytest.raises(RuntimeError, match="migration 089"):
+        _require_migration_089_sync(_MigrationGateCursor())
+
+
+@pytest.mark.asyncio
+async def test_async_migration_gate_requires_both_drift_event_types() -> None:
+    with pytest.raises(RuntimeError, match="migration 089"):
+        await _require_migration_089_async(_MigrationGateAsyncConnection())

--- a/tests/test_orrery/test_drift_live.py
+++ b/tests/test_orrery/test_drift_live.py
@@ -1,0 +1,351 @@
+"""Rollback-only commit-path coverage for relationship drift."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+from itertools import count
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2  # type: ignore[import-untyped]
+import pytest
+from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
+
+from nexus.agents.orrery.events import commit_orrery_tick_sync
+from nexus.api.slot_utils import get_slot_db_url
+from nexus.config.settings_models import OrreryDriftSettings
+
+
+pytestmark = pytest.mark.requires_postgres
+
+_SCENES = count(100)
+EPISTEMICS = {
+    "enabled": True,
+    "claim_event_types": ["relationship_drift_milestone"],
+    "aware_roles": ["actor", "target"],
+}
+
+
+@pytest.fixture()
+def live_conn() -> Iterator[Any]:
+    """Open a slot-5 transaction and roll back every fixture mutation."""
+
+    conn = psycopg2.connect(get_slot_db_url(slot=5), cursor_factory=RealDictCursor)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT EXISTS (
+                           SELECT 1
+                           FROM information_schema.columns
+                           WHERE table_schema = ANY(current_schemas(false))
+                             AND table_name = 'character_relationships'
+                             AND column_name = 'valence_current'
+                       ) AS valence_ready,
+                       EXISTS (
+                           SELECT 1
+                           FROM information_schema.columns
+                           WHERE table_schema = ANY(current_schemas(false))
+                             AND table_name = 'world_events'
+                             AND column_name = 'world_time'
+                       ) AS event_clock_ready
+                """
+            )
+            readiness = cur.fetchone()
+            if not readiness["valence_ready"] or not readiness["event_clock_ready"]:
+                pytest.skip("slot 5 requires applied migrations 083 and 088")
+            cur.execute(
+                """
+                INSERT INTO event_types (type, category, severity, description)
+                VALUES (
+                    'relationship_drift_milestone', 'emotional', 'minor',
+                    'Rollback-only migration-089 event seed.'
+                )
+                ON CONFLICT (type) DO NOTHING
+                """
+            )
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def _settings(*, enabled: bool = True) -> OrreryDriftSettings:
+    return OrreryDriftSettings.model_validate(
+        {
+            "enabled": enabled,
+            "copresence_rate_per_hour": "0.001",
+            "copresence_max_hours_per_tick": "12",
+            "project_milestone_delta": "0.03",
+            "hostile_events": {"threat_issued": "-0.2"},
+            "cooperative_events": {"welfare_check": "0.02"},
+        }
+    )
+
+
+def _insert_chunk(
+    cur: Any, *, world_layer: str = "primary", time_delta: timedelta
+) -> int:
+    token = uuid4().hex[:12]
+    cur.execute(
+        """
+        INSERT INTO narrative_chunks (raw_text, storyteller_text)
+        VALUES (%s, 'Rollback-only relationship drift fixture.')
+        RETURNING id
+        """,
+        (f"Relationship drift fixture {token}.",),
+    )
+    chunk_id = int(cur.fetchone()["id"])
+    cur.execute(
+        """
+        INSERT INTO chunk_metadata (
+            chunk_id, season, episode, scene, world_layer, time_delta,
+            generation_date, slug
+        ) VALUES (
+            %s, 98, 98, %s, %s::world_layer_type, %s, now(), %s
+        )
+        """,
+        (chunk_id, next(_SCENES), world_layer, time_delta, token[:10]),
+    )
+    return chunk_id
+
+
+def _insert_character(cur: Any, label: str) -> tuple[int, int]:
+    cur.execute(
+        "INSERT INTO entities (kind, is_active) "
+        "VALUES ('character', true) RETURNING id"
+    )
+    entity_id = int(cur.fetchone()["id"])
+    cur.execute(
+        "INSERT INTO characters (name, entity_id) VALUES (%s, %s) RETURNING id",
+        (f"drift-{label}-{uuid4().hex[:10]}", entity_id),
+    )
+    return entity_id, int(cur.fetchone()["id"])
+
+
+def _insert_edge(
+    cur: Any,
+    *,
+    source_character_id: int,
+    target_character_id: int,
+    valence: Decimal = Decimal("0.1"),
+) -> None:
+    cur.execute(
+        """
+        INSERT INTO character_relationships (
+            character1_id, character2_id, relationship_type,
+            emotional_valence, valence_current, dynamic,
+            recent_events, history
+        ) VALUES (
+            %s, %s, 'associate', '+1|favorable', %s,
+            'Rollback-only drift edge.', 'None.', 'Fixture.'
+        )
+        """,
+        (source_character_id, target_character_id, valence),
+    )
+
+
+def _insert_hostile_event(
+    cur: Any, *, chunk_id: int, actor_entity_id: int, target_entity_id: int
+) -> int:
+    cur.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, target_entity_id,
+            world_layer, source, changed_fields, payload
+        ) VALUES (
+            'threat_issued', %s, %s, %s, 'primary', 'resolver', '{}', '{}'
+        )
+        RETURNING id
+        """,
+        (chunk_id, actor_entity_id, target_entity_id),
+    )
+    return int(cur.fetchone()["id"])
+
+
+def _seed_tick(
+    cur: Any, *, world_layer: str = "primary"
+) -> tuple[int, int, int, int, int]:
+    _insert_chunk(cur, time_delta=timedelta(0))
+    tick_chunk_id = _insert_chunk(
+        cur, world_layer=world_layer, time_delta=timedelta(hours=1)
+    )
+    actor_entity_id, actor_character_id = _insert_character(cur, "actor")
+    target_entity_id, target_character_id = _insert_character(cur, "target")
+    _insert_edge(
+        cur,
+        source_character_id=actor_character_id,
+        target_character_id=target_character_id,
+    )
+    event_id = _insert_hostile_event(
+        cur,
+        chunk_id=tick_chunk_id,
+        actor_entity_id=actor_entity_id,
+        target_entity_id=target_entity_id,
+    )
+    cur.execute(
+        "SELECT set_config('nexus.source_chunk_id', %s, true)",
+        (str(tick_chunk_id),),
+    )
+    return (
+        tick_chunk_id,
+        actor_entity_id,
+        target_entity_id,
+        actor_character_id,
+        event_id,
+    )
+
+
+def test_commit_drift_updates_versions_projects_literal_and_mints_claim(
+    live_conn: Any,
+) -> None:
+    """A rung-crossing event is double-entered and known by both endpoints."""
+
+    with live_conn.cursor() as cur:
+        tick_chunk_id, actor_id, target_id, actor_character_id, _ = _seed_tick(cur)
+        cur.execute(
+            "SELECT world_time FROM chunk_metadata WHERE chunk_id = %s",
+            (tick_chunk_id,),
+        )
+        tick_world_time = cur.fetchone()["world_time"]
+
+    commit_orrery_tick_sync(
+        live_conn,
+        None,
+        tick_chunk_id=tick_chunk_id,
+        drift_settings=_settings(),
+        epistemics_settings=EPISTEMICS,
+    )
+
+    with live_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT emotional_valence::text, valence_current
+            FROM character_relationships
+            WHERE character1_id = %s
+            """,
+            (actor_character_id,),
+        )
+        relationship = cur.fetchone()
+        assert relationship == {
+            "emotional_valence": "0|neutral",
+            "valence_current": Decimal("-0.08"),
+        }
+
+        cur.execute(
+            """
+            SELECT count(*) AS count
+            FROM relationship_versions
+            WHERE relationship_table = 'character_relationships'
+              AND source_chunk_id = %s
+            """,
+            (tick_chunk_id,),
+        )
+        assert cur.fetchone()["count"] == 1
+
+        cur.execute(
+            """
+            SELECT id, actor_entity_id, target_entity_id, changed_fields,
+                   payload, world_time
+            FROM world_events
+            WHERE tick_chunk_id = %s
+              AND event_type = 'relationship_drift_milestone'
+            """,
+            (tick_chunk_id,),
+        )
+        milestone = cur.fetchone()
+        assert milestone is not None
+        assert cur.fetchone() is None
+        assert milestone["actor_entity_id"] == actor_id
+        assert milestone["target_entity_id"] == target_id
+        assert milestone["changed_fields"] == [
+            "character_relationships.valence_current"
+        ]
+        assert milestone["world_time"] == tick_world_time
+        assert milestone["payload"]["old_rung"] == 1
+        assert milestone["payload"]["new_rung"] == 0
+        assert Decimal(str(milestone["payload"]["old_valence"])) == Decimal("0.1")
+        assert Decimal(str(milestone["payload"]["new_valence"])) == Decimal("-0.08")
+        assert len(milestone["payload"]["producer_deltas"]) == 1
+        producer_label = next(iter(milestone["payload"]["producer_deltas"]))
+        assert producer_label.startswith("hostile:")
+        assert Decimal(
+            str(milestone["payload"]["producer_deltas"][producer_label])
+        ) == Decimal("-0.18")
+
+        cur.execute(
+            """
+            SELECT awareness.knower_entity_id
+            FROM claims claim
+            JOIN claim_awareness awareness ON awareness.claim_id = claim.id
+            WHERE claim.world_event_id = %s
+            ORDER BY awareness.knower_entity_id
+            """,
+            (milestone["id"],),
+        )
+        assert [row["knower_entity_id"] for row in cur.fetchall()] == sorted(
+            [actor_id, target_id]
+        )
+
+        cur.execute(
+            """
+            SELECT role::text, entity_id
+            FROM world_event_entities
+            WHERE event_id = %s
+            ORDER BY role
+            """,
+            (milestone["id"],),
+        )
+        assert {(row["role"], row["entity_id"]) for row in cur.fetchall()} == {
+            ("actor", actor_id),
+            ("target", target_id),
+        }
+
+
+def test_retrograde_world_layer_does_not_drift(live_conn: Any) -> None:
+    """The two-clocks gate rejects non-primary chunks silently."""
+
+    with live_conn.cursor() as cur:
+        tick_chunk_id, _actor, _target, actor_character_id, _event = _seed_tick(
+            cur, world_layer="retrograde"
+        )
+
+    commit_orrery_tick_sync(
+        live_conn,
+        None,
+        tick_chunk_id=tick_chunk_id,
+        drift_settings=_settings(),
+        epistemics_settings=EPISTEMICS,
+    )
+
+    with live_conn.cursor() as cur:
+        cur.execute(
+            "SELECT valence_current FROM character_relationships "
+            "WHERE character1_id = %s",
+            (actor_character_id,),
+        )
+        assert cur.fetchone()["valence_current"] == Decimal("0.1")
+
+
+def test_disabled_config_does_not_drift(live_conn: Any) -> None:
+    """The config gate is silent and performs no relationship write."""
+
+    with live_conn.cursor() as cur:
+        tick_chunk_id, _actor, _target, actor_character_id, _event = _seed_tick(cur)
+
+    commit_orrery_tick_sync(
+        live_conn,
+        None,
+        tick_chunk_id=tick_chunk_id,
+        drift_settings=_settings(enabled=False),
+        epistemics_settings=EPISTEMICS,
+    )
+
+    with live_conn.cursor() as cur:
+        cur.execute(
+            "SELECT valence_current FROM character_relationships "
+            "WHERE character1_id = %s",
+            (actor_character_id,),
+        )
+        assert cur.fetchone()["valence_current"] == Decimal("0.1")

--- a/tests/test_orrery/test_drift_live.py
+++ b/tests/test_orrery/test_drift_live.py
@@ -14,6 +14,7 @@ from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
 
 from nexus.agents.orrery.events import commit_orrery_tick_sync
 from nexus.api.slot_utils import get_slot_db_url
+from nexus.config import load_settings
 from nexus.config.settings_models import OrreryDriftSettings
 
 
@@ -58,10 +59,15 @@ def live_conn() -> Iterator[Any]:
             cur.execute(
                 """
                 INSERT INTO event_types (type, category, severity, description)
-                VALUES (
-                    'relationship_drift_milestone', 'emotional', 'minor',
-                    'Rollback-only migration-089 event seed.'
-                )
+                VALUES
+                    (
+                        'relationship_drift_milestone', 'emotional', 'minor',
+                        'Rollback-only migration-089 milestone event seed.'
+                    ),
+                    (
+                        'relationship_drift_drained', 'emotional', 'minor',
+                        'Rollback-only migration-089 drain event seed.'
+                    )
                 ON CONFLICT (type) DO NOTHING
                 """
             )
@@ -71,17 +77,17 @@ def live_conn() -> Iterator[Any]:
         conn.close()
 
 
-def _settings(*, enabled: bool = True) -> OrreryDriftSettings:
-    return OrreryDriftSettings.model_validate(
-        {
-            "enabled": enabled,
-            "copresence_rate_per_hour": "0.001",
-            "copresence_max_hours_per_tick": "12",
-            "project_milestone_delta": "0.03",
-            "hostile_events": {"threat_issued": "-0.2"},
-            "cooperative_events": {"welfare_check": "0.02"},
-        }
-    )
+def _settings(*, enabled: bool = True, **overrides: object) -> OrreryDriftSettings:
+    payload: dict[str, object] = {
+        "enabled": enabled,
+        "copresence_rate_per_hour": "0.001",
+        "copresence_max_hours_per_tick": "12",
+        "project_milestone_delta": "0.03",
+        "hostile_events": {"threat_issued": "-0.2"},
+        "cooperative_events": {"welfare_check": "0.02"},
+    }
+    payload.update(overrides)
+    return OrreryDriftSettings.model_validate(payload)
 
 
 def _insert_chunk(
@@ -165,7 +171,10 @@ def _insert_hostile_event(
 
 
 def _seed_tick(
-    cur: Any, *, world_layer: str = "primary"
+    cur: Any,
+    *,
+    world_layer: str = "primary",
+    valence: Decimal = Decimal("0.1"),
 ) -> tuple[int, int, int, int, int]:
     _insert_chunk(cur, time_delta=timedelta(0))
     tick_chunk_id = _insert_chunk(
@@ -177,6 +186,7 @@ def _seed_tick(
         cur,
         source_character_id=actor_character_id,
         target_character_id=target_character_id,
+        valence=valence,
     )
     event_id = _insert_hostile_event(
         cur,
@@ -215,7 +225,14 @@ def test_commit_drift_updates_versions_projects_literal_and_mints_claim(
         None,
         tick_chunk_id=tick_chunk_id,
         drift_settings=_settings(),
-        epistemics_settings=EPISTEMICS,
+        epistemics_settings=load_settings("nexus.toml").orrery.epistemics,
+    )
+    commit_orrery_tick_sync(
+        live_conn,
+        None,
+        tick_chunk_id=tick_chunk_id,
+        drift_settings=_settings(),
+        epistemics_settings=load_settings("nexus.toml").orrery.epistemics,
     )
 
     with live_conn.cursor() as cur:
@@ -243,6 +260,23 @@ def test_commit_drift_updates_versions_projects_literal_and_mints_claim(
             (tick_chunk_id,),
         )
         assert cur.fetchone()["count"] == 1
+
+        cur.execute(
+            """
+            SELECT payload
+            FROM world_events
+            WHERE tick_chunk_id = %s
+              AND event_type = 'relationship_drift_drained'
+            """,
+            (tick_chunk_id,),
+        )
+        drain_marker = cur.fetchone()
+        assert drain_marker is not None
+        assert cur.fetchone() is None
+        assert drain_marker["payload"] == {
+            "edges_touched": 1,
+            "milestone_count": 1,
+        }
 
         cur.execute(
             """
@@ -349,3 +383,122 @@ def test_disabled_config_does_not_drift(live_conn: Any) -> None:
             (actor_character_id,),
         )
         assert cur.fetchone()["valence_current"] == Decimal("0.1")
+
+
+def test_zero_edge_tick_still_records_drain_marker(live_conn: Any) -> None:
+    """A completed empty drain is durable and idempotent too."""
+
+    with live_conn.cursor() as cur:
+        _insert_chunk(cur, time_delta=timedelta(0))
+        tick_chunk_id = _insert_chunk(cur, time_delta=timedelta(0))
+
+    commit_orrery_tick_sync(
+        live_conn,
+        None,
+        tick_chunk_id=tick_chunk_id,
+        drift_settings=_settings(),
+        epistemics_settings=EPISTEMICS,
+    )
+
+    with live_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT payload
+            FROM world_events
+            WHERE tick_chunk_id = %s
+              AND event_type = 'relationship_drift_drained'
+            """,
+            (tick_chunk_id,),
+        )
+        assert cur.fetchone()["payload"] == {
+            "edges_touched": 0,
+            "milestone_count": 0,
+        }
+
+
+def test_resolution_free_copresence_crossing_mints_canonical_claim(
+    live_conn: Any,
+) -> None:
+    """Canonical epistemics reaches drift when no Orrery proposal exists."""
+
+    with live_conn.cursor() as cur:
+        tick_chunk_id, actor_id, target_id, _character_id, _event = _seed_tick(
+            cur, valence=Decimal("0.08")
+        )
+        cur.execute("SELECT id FROM places ORDER BY id LIMIT 1")
+        place_id = cur.fetchone()["id"]
+        cur.execute(
+            """
+            UPDATE characters
+            SET current_location = %s
+            WHERE entity_id = ANY(%s)
+            """,
+            (place_id, [actor_id, target_id]),
+        )
+
+    commit_orrery_tick_sync(
+        live_conn,
+        None,
+        tick_chunk_id=tick_chunk_id,
+        drift_settings=_settings(
+            copresence_rate_per_hour="0.2",
+            copresence_max_hours_per_tick="1",
+            hostile_events={},
+            cooperative_events={},
+        ),
+        epistemics_settings=load_settings("nexus.toml").orrery.epistemics,
+    )
+
+    with live_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT claim.id
+            FROM world_events event
+            JOIN claims claim ON claim.world_event_id = event.id
+            WHERE event.tick_chunk_id = %s
+              AND event.event_type = 'relationship_drift_milestone'
+              AND event.actor_entity_id = %s
+              AND event.target_entity_id = %s
+            """,
+            (tick_chunk_id, actor_id, target_id),
+        )
+        assert cur.fetchone() is not None
+
+
+def test_long_scale_valence_uses_same_rung_as_postgres(live_conn: Any) -> None:
+    """Defensive read quantization cannot disagree with SQL rung derivation."""
+
+    long_valence = Decimal("-0.4545454545454545454545454545454545454545")
+    with live_conn.cursor() as cur:
+        tick_chunk_id, _actor, _target, actor_character_id, _event = _seed_tick(
+            cur, valence=long_valence
+        )
+        cur.execute(
+            """
+            SELECT round(valence_current * 5.5)::integer AS sql_rung
+            FROM character_relationships
+            WHERE character1_id = %s
+            """,
+            (actor_character_id,),
+        )
+        sql_rung = cur.fetchone()["sql_rung"]
+
+    commit_orrery_tick_sync(
+        live_conn,
+        None,
+        tick_chunk_id=tick_chunk_id,
+        drift_settings=_settings(),
+        epistemics_settings=EPISTEMICS,
+    )
+
+    with live_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT (payload ->> 'old_rung')::integer AS python_rung
+            FROM world_events
+            WHERE tick_chunk_id = %s
+              AND event_type = 'relationship_drift_milestone'
+            """,
+            (tick_chunk_id,),
+        )
+        assert cur.fetchone()["python_rung"] == sql_rung

--- a/tests/test_orrery/test_generation_model_provenance_live.py
+++ b/tests/test_orrery/test_generation_model_provenance_live.py
@@ -55,6 +55,21 @@ def provenance_db() -> Iterator[dict[str, Any]]:
             cur.execute(migration_sql)
             cur.execute(
                 """
+                INSERT INTO event_types (type, category, severity, description)
+                VALUES
+                    (
+                        'relationship_drift_milestone', 'emotional', 'minor',
+                        'Rollback-only migration-089 milestone event seed.'
+                    ),
+                    (
+                        'relationship_drift_drained', 'emotional', 'minor',
+                        'Rollback-only migration-089 drain event seed.'
+                    )
+                ON CONFLICT (type) DO NOTHING
+                """
+            )
+            cur.execute(
+                """
                 SELECT max(nc.id)
                 FROM narrative_chunks nc
                 JOIN chunk_metadata cm ON cm.chunk_id = nc.id

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -257,6 +257,7 @@ def test_relationship_drift_migration_registers_visibility_event_only() -> None:
 
     assert "INSERT INTO event_types" in migration_sql
     assert "'relationship_drift_milestone'" in migration_sql
+    assert "'relationship_drift_drained'" in migration_sql
     assert "'emotional'" in migration_sql
     assert "'minor'" in migration_sql
     assert "ON CONFLICT (type) DO NOTHING" in migration_sql

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -246,6 +246,25 @@ def test_valence_float_migration_installs_one_canonical_boundary() -> None:
         assert literal in migration_sql
 
 
+def test_relationship_drift_migration_registers_visibility_event_only() -> None:
+    """Migration 089 adds the drift event vocabulary without schema changes."""
+
+    migration_sql = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "089_relationship_drift_milestone.sql"
+    ).read_text()
+
+    assert "INSERT INTO event_types" in migration_sql
+    assert "'relationship_drift_milestone'" in migration_sql
+    assert "'emotional'" in migration_sql
+    assert "'minor'" in migration_sql
+    assert "ON CONFLICT (type) DO NOTHING" in migration_sql
+    assert "COMMENT ON" in migration_sql
+    assert "CREATE TABLE" not in migration_sql
+    assert "ALTER TABLE" not in migration_sql
+
+
 def test_retrograde_persistence_migration_adds_distinct_sources() -> None:
     """Retrograde canonical writes need explicit event and tag provenance."""
 

--- a/tests/test_orrery/test_replay.py
+++ b/tests/test_orrery/test_replay.py
@@ -427,7 +427,7 @@ def test_relationship_unwind_restores_updates_deletes_and_drops_inserts() -> Non
                     character1_id, character2_id, relationship_type,
                     emotional_valence, dynamic, recent_events, history,
                     created_at
-                ) VALUES (%s, %s, 'ally', 'neutral', 'probe', 'probe',
+                ) VALUES (%s, %s, 'ally', '0|neutral', 'probe', 'probe',
                           'probe', now() + interval '1 minute')
                 """,
                 (n1, n2),


### PR DESCRIPTION
## Summary

Stage 2 of #476 — the engine that moves the Stage-1 float, completing the relationship-drift tracker's ruled design (producers, 3B world-time-rated accrual, 4C per-edge independence, 5C claim-minted visibility).

- **Drain** (`nexus/agents/orrery/drift.py`): Decimal-exact pure planner + sync/async appliers at accepted-chunk commit; hard-gated on `world_layer='primary'` + non-null `world_time` (two-clocks). Deterministic producer order: project milestones → hostile events → cooperative events → co-presence.
- **Producers**: two-party project milestones warm both directed edges (`project_milestone_delta`); hostile/cooperative events apply explicit `[orrery.drift.*_events]` config maps (sign-validated loudly by the Pydantic model); co-presence accrues `sign(v) × rate × capped_hours` — sign-following amplification that never creates affect from a zero edge, sampled at drain instants (limitation documented).
- **The asymptotic clamp**: `delta × (1 − |v|)` makes the owner-ruled open interval's endpoints unreachable by construction, with loud assertions.
- **Discipline**: drift never inserts rows — existing directed edges only, each independent (4C) — so every write is ledgered by migration-065 versioning with proper chunk attribution, and the Stage-1 boundary trigger re-projects the literal automatically.
- **Milestones (5C)**: a rung crossing emits one `relationship_drift_milestone` world event (migration 089 seeds the type; payload carries old/new rung+valence and the per-producer delta breakdown) and mints a claim through the existing epistemics rails via one `claim_event_types` addition — both endpoints aware.
- **Determinism**: Decimal end-to-end with `ROUND_HALF_UP` matching PostgreSQL's `round(numeric)`; identical inputs replay to identical floats, pinned by an exactness test.
- **Placement deviation, reasoned** (flagged loudly by the implementer): resolution-bearing ticks drain *after* the resolution loop so same-tick applied project milestones are visible to producer 1; resolution-free ticks drain after propagation. Deterministic per tick shape.

## Validation

- `poetry run pytest -q` → **1522 passed, 325 skipped, 0 failed**
- **Full live-PG orrery suite → 1090 passed, 0 failed** (engine unit + live commit-path coverage: producers, ordering, asymptote, sign-following, per-edge no-insert, elapsed cap, milestone event + claim + awareness, world-layer gate, disabled config)
- `replay_state.py --slot 5 --verify` green; `validate_config_commit.py` green; flake8/black/catalog clean
- En-route catch: a stale test fixture wrote bare `neutral` — migration 088's loud trigger rejected it exactly as designed; fixture canonicalized

## Schema/Data Impact

Migration 089 (event-type seed only, no schema changes) pending everywhere; applied at merge closeout — required before a real rung crossing can emit its event.

Implemented by Sol (GPT-5.6 Codex) from a frozen spec; reviewed by Claude. Completes the #476 build alongside Stage 1 (#533).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TJVTXfD7TouQuxmYfVf8w