### PR TITLE
Break One-Claim-Per-Event Into Labeled Sibling Accounts (#479 Stage A)

### DIFF
--- a/migrations/090_claim_accounts.sql
+++ b/migrations/090_claim_accounts.sql
@@ -1,0 +1,39 @@
+-- 090_claim_accounts.sql
+--
+-- Shape-C account substrate: contradictory accounts of one incident are
+-- sibling claims anchored to the same world event and distinguished by label.
+
+ALTER TABLE claims
+    ADD COLUMN account_label text NOT NULL DEFAULT 'canonical',
+    ADD COLUMN account_payload jsonb,
+    ADD COLUMN distorted_from_claim_id bigint,
+    ADD CONSTRAINT claims_distorted_from_claim_id_fkey
+        FOREIGN KEY (distorted_from_claim_id) REFERENCES claims(id),
+    ADD CONSTRAINT claims_distorted_from_not_self_check
+        CHECK (distorted_from_claim_id <> id);
+
+COMMENT ON TABLE claims IS
+    'Epistemic accounts anchored to canonical world events. Sibling claims may describe alternative accounts of one incident; scope is mutable audience policy and all other fields are append-only.';
+COMMENT ON COLUMN claims.world_event_id IS
+    'Canonical world event anchoring an incident; sibling account claims may share this event id.';
+COMMENT ON COLUMN claims.summary IS
+    'MEMNON-searchable human-readable account prose; truth markers and secret structured facts must never be stored here.';
+COMMENT ON COLUMN claims.account_label IS
+    'Variant discriminator among sibling claims for one incident; canonical identifies the single true account.';
+COMMENT ON COLUMN claims.account_payload IS
+    'Structured account content, including truth markers and account facts. Secret values live HERE, never in retrievable or embeddable prose: claims.summary and retrograde_summaries.summary_text are MEMNON-searchable and would leak them through retrieval.';
+COMMENT ON COLUMN claims.distorted_from_claim_id IS
+    'Optional lineage hook to the source claim for Stage C hop distortion.';
+COMMENT ON CONSTRAINT claims_distorted_from_claim_id_fkey ON claims IS
+    'Requires every Stage C distortion-lineage parent to be a durable claim.';
+COMMENT ON CONSTRAINT claims_distorted_from_not_self_check ON claims IS
+    'Rejects a claim that names itself as its distortion ancestor.';
+
+DROP INDEX ux_claims_world_event_v1;
+
+CREATE UNIQUE INDEX ux_claims_world_event_account_v1
+    ON claims (world_event_id, account_label)
+    WHERE world_event_id IS NOT NULL;
+
+COMMENT ON INDEX ux_claims_world_event_account_v1 IS
+    'Allows sibling accounts per incident while enforcing one claim per world event and account label.';

--- a/nexus/agents/orrery/epistemics.py
+++ b/nexus/agents/orrery/epistemics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+import json
 from typing import Any, Iterable, Mapping, Optional, Sequence
 
 from sqlalchemy import text
@@ -164,9 +165,11 @@ def mint_claim_for_event(
     cur.execute(
         """
         INSERT INTO claims (
-            world_event_id, summary, scope, source_chunk_id, source_resolution_id
-        ) VALUES (%s, %s, 'bounded', %s, %s)
-        ON CONFLICT (world_event_id) WHERE world_event_id IS NOT NULL DO NOTHING
+            world_event_id, account_label, summary, scope, source_chunk_id,
+            source_resolution_id
+        ) VALUES (%s, 'canonical', %s, 'bounded', %s, %s)
+        ON CONFLICT (world_event_id, account_label)
+            WHERE world_event_id IS NOT NULL DO NOTHING
         RETURNING id
         """,
         (world_event_id, clean_summary, source_chunk_id, source_resolution_id),
@@ -174,7 +177,9 @@ def mint_claim_for_event(
     row = cur.fetchone()
     if row is None:
         cur.execute(
-            "SELECT id FROM claims WHERE world_event_id = %s", (world_event_id,)
+            "SELECT id FROM claims "
+            "WHERE world_event_id = %s AND account_label = 'canonical'",
+            (world_event_id,),
         )
         row = cur.fetchone()
         if row is None:
@@ -217,9 +222,11 @@ async def mint_claim_for_event_async(
     claim_id = await conn.fetchval(
         """
         INSERT INTO claims (
-            world_event_id, summary, scope, source_chunk_id, source_resolution_id
-        ) VALUES ($1, $2, 'bounded', $3, $4)
-        ON CONFLICT (world_event_id) WHERE world_event_id IS NOT NULL DO NOTHING
+            world_event_id, account_label, summary, scope, source_chunk_id,
+            source_resolution_id
+        ) VALUES ($1, 'canonical', $2, 'bounded', $3, $4)
+        ON CONFLICT (world_event_id, account_label)
+            WHERE world_event_id IS NOT NULL DO NOTHING
         RETURNING id
         """,
         world_event_id,
@@ -229,7 +236,9 @@ async def mint_claim_for_event_async(
     )
     if claim_id is None:
         claim_id = await conn.fetchval(
-            "SELECT id FROM claims WHERE world_event_id = $1", world_event_id
+            "SELECT id FROM claims "
+            "WHERE world_event_id = $1 AND account_label = 'canonical'",
+            world_event_id,
         )
         if claim_id is None:
             raise RuntimeError(
@@ -243,6 +252,122 @@ async def mint_claim_for_event_async(
         source_chunk_id=source_chunk_id,
     )
     return MintResult(claim_id=int(claim_id), awareness_ids=awareness_ids)
+
+
+def mint_account_variant_sync(
+    cur: Any,
+    *,
+    source_claim_id: int,
+    account_label: str,
+    summary: str,
+    source_chunk_id: Optional[int],
+    account_payload: Optional[Mapping[str, Any]] = None,
+    distorted_from_claim_id: Optional[int] = None,
+) -> int:
+    """Mint one non-awareness sibling account from an existing claim."""
+
+    clean_label = account_label.strip()
+    clean_summary = summary.strip()
+    if not clean_label:
+        raise ValueError("Account label must be non-empty")
+    if not clean_summary:
+        raise ValueError("Account variant summary must be non-empty")
+    cur.execute(
+        "SELECT world_event_id, scope FROM claims WHERE id = %s",
+        (source_claim_id,),
+    )
+    source = cur.fetchone()
+    if source is None:
+        raise ValueError(f"Source claim {source_claim_id} does not exist")
+    parent_claim_id = (
+        source_claim_id if distorted_from_claim_id is None else distorted_from_claim_id
+    )
+    payload_json = _account_payload_json(account_payload)
+    cur.execute(
+        """
+        INSERT INTO claims (
+            world_event_id, account_label, account_payload,
+            distorted_from_claim_id, summary, scope, source_chunk_id
+        ) VALUES (%s, %s, %s::jsonb, %s, %s, %s, %s)
+        RETURNING id
+        """,
+        (
+            _row_value(source, "world_event_id", 0),
+            clean_label,
+            payload_json,
+            parent_claim_id,
+            clean_summary,
+            _row_value(source, "scope", 1),
+            source_chunk_id,
+        ),
+    )
+    inserted = cur.fetchone()
+    if inserted is None:
+        raise RuntimeError("Account variant INSERT returned no claim id")
+    return int(_row_value(inserted, "id", 0))
+
+
+async def mint_account_variant_async(
+    conn: Any,
+    *,
+    source_claim_id: int,
+    account_label: str,
+    summary: str,
+    source_chunk_id: Optional[int],
+    account_payload: Optional[Mapping[str, Any]] = None,
+    distorted_from_claim_id: Optional[int] = None,
+) -> int:
+    """Asyncpg twin of :func:`mint_account_variant_sync`."""
+
+    clean_label = account_label.strip()
+    clean_summary = summary.strip()
+    if not clean_label:
+        raise ValueError("Account label must be non-empty")
+    if not clean_summary:
+        raise ValueError("Account variant summary must be non-empty")
+    source = await conn.fetchrow(
+        "SELECT world_event_id, scope FROM claims WHERE id = $1",
+        source_claim_id,
+    )
+    if source is None:
+        raise ValueError(f"Source claim {source_claim_id} does not exist")
+    parent_claim_id = (
+        source_claim_id if distorted_from_claim_id is None else distorted_from_claim_id
+    )
+    claim_id = await conn.fetchval(
+        """
+        INSERT INTO claims (
+            world_event_id, account_label, account_payload,
+            distorted_from_claim_id, summary, scope, source_chunk_id
+        ) VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7)
+        RETURNING id
+        """,
+        source["world_event_id"],
+        clean_label,
+        _account_payload_json(account_payload),
+        parent_claim_id,
+        clean_summary,
+        source["scope"],
+        source_chunk_id,
+    )
+    if claim_id is None:
+        raise RuntimeError("Account variant INSERT returned no claim id")
+    return int(claim_id)
+
+
+def _account_payload_json(
+    account_payload: Optional[Mapping[str, Any]],
+) -> Optional[str]:
+    """Serialize structured account content deterministically or fail loudly."""
+
+    if account_payload is None:
+        return None
+    return json.dumps(
+        dict(account_payload),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
 
 
 def record_revelation(
@@ -386,14 +511,15 @@ def load_epistemics_hydration(
         scope_query = text(
             """
             /* orrery:epistemics_hydration:recent_event_scopes */
-            SELECT c.world_event_id,
+            SELECT c.id AS claim_id,
+                   c.world_event_id,
                    c.scope
             FROM claims c
             JOIN world_events we ON we.id = c.world_event_id
             WHERE c.world_event_id = ANY(:recent_event_ids)
               AND (:anchor_chunk_id IS NULL
                    OR we.tick_chunk_id <= :anchor_chunk_id)
-            ORDER BY c.world_event_id
+            ORDER BY c.world_event_id, c.id
             """
         )
         for row in session.execute(
@@ -409,6 +535,17 @@ def load_epistemics_hydration(
                 raise ValueError(
                     f"Claim on event {event_id} has unknown scope {scope!r}"
                 )
+            previous_scope = scopes.get(event_id)
+            if previous_scope is not None and previous_scope != scope:
+                raise ValueError(
+                    "Sibling claims on event "
+                    f"{event_id} have divergent scopes "
+                    f"{previous_scope!r} and {scope!r}"
+                )
+            # Legacy recent-event predicates are incident-level: possession
+            # of any sibling account admits the shared event. Account-aware
+            # predicates remain claim-id keyed below. Variant minting copies
+            # scope, and divergent later mutations fail loudly above.
             scopes[event_id] = scope
 
     if not universe:
@@ -573,6 +710,8 @@ def load_epistemics_hydration(
             raise ValueError(
                 f"Claim {claim_id} has unknown awareness tier {source_tier!r}"
             )
+        # Event-level knowledge intentionally collapses sibling possession;
+        # claim_knowledge below preserves the exact possessed account id.
         awareness.setdefault(knower_id, set()).add(event_id)
         awareness_rows.setdefault(
             (claim_id, knower_id),

--- a/nexus/agents/orrery/epistemics.py
+++ b/nexus/agents/orrery/epistemics.py
@@ -273,15 +273,33 @@ def mint_account_variant_sync(
     if not clean_summary:
         raise ValueError("Account variant summary must be non-empty")
     cur.execute(
-        "SELECT world_event_id, scope FROM claims WHERE id = %s",
+        "SELECT world_event_id, scope FROM claims WHERE id = %s FOR SHARE",
         (source_claim_id,),
     )
     source = cur.fetchone()
     if source is None:
         raise ValueError(f"Source claim {source_claim_id} does not exist")
+    source_event_id = int(_row_value(source, "world_event_id", 0))
     parent_claim_id = (
         source_claim_id if distorted_from_claim_id is None else distorted_from_claim_id
     )
+    if distorted_from_claim_id is not None:
+        cur.execute(
+            "SELECT world_event_id FROM claims WHERE id = %s FOR SHARE",
+            (distorted_from_claim_id,),
+        )
+        parent = cur.fetchone()
+        if parent is None:
+            raise ValueError(
+                f"Lineage parent claim {distorted_from_claim_id} does not exist"
+            )
+        parent_event_id = int(_row_value(parent, "world_event_id", 0))
+        if parent_event_id != source_event_id:
+            raise ValueError(
+                f"Lineage parent claim {distorted_from_claim_id} belongs to world "
+                f"event {parent_event_id}; source claim {source_claim_id} belongs "
+                f"to world event {source_event_id}"
+            )
     payload_json = _account_payload_json(account_payload)
     cur.execute(
         """
@@ -292,7 +310,7 @@ def mint_account_variant_sync(
         RETURNING id
         """,
         (
-            _row_value(source, "world_event_id", 0),
+            source_event_id,
             clean_label,
             payload_json,
             parent_claim_id,
@@ -326,14 +344,30 @@ async def mint_account_variant_async(
     if not clean_summary:
         raise ValueError("Account variant summary must be non-empty")
     source = await conn.fetchrow(
-        "SELECT world_event_id, scope FROM claims WHERE id = $1",
+        "SELECT world_event_id, scope FROM claims WHERE id = $1 FOR SHARE",
         source_claim_id,
     )
     if source is None:
         raise ValueError(f"Source claim {source_claim_id} does not exist")
+    source_event_id = int(source["world_event_id"])
     parent_claim_id = (
         source_claim_id if distorted_from_claim_id is None else distorted_from_claim_id
     )
+    if distorted_from_claim_id is not None:
+        parent_event_id = await conn.fetchval(
+            "SELECT world_event_id FROM claims WHERE id = $1 FOR SHARE",
+            distorted_from_claim_id,
+        )
+        if parent_event_id is None:
+            raise ValueError(
+                f"Lineage parent claim {distorted_from_claim_id} does not exist"
+            )
+        if int(parent_event_id) != source_event_id:
+            raise ValueError(
+                f"Lineage parent claim {distorted_from_claim_id} belongs to world "
+                f"event {int(parent_event_id)}; source claim {source_claim_id} belongs "
+                f"to world event {source_event_id}"
+            )
     claim_id = await conn.fetchval(
         """
         INSERT INTO claims (
@@ -342,7 +376,7 @@ async def mint_account_variant_async(
         ) VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7)
         RETURNING id
         """,
-        source["world_event_id"],
+        source_event_id,
         clean_label,
         _account_payload_json(account_payload),
         parent_claim_id,
@@ -457,22 +491,50 @@ def record_revelation(
 
 
 def promote_claim_scope(cur: Any, *, claim_id: int, new_scope: str) -> None:
-    """Promote a common claim to bounded/private; reject every narrowing."""
+    """Promote every sibling account on an incident; reject every narrowing."""
 
     if new_scope not in CLAIM_SCOPES:
         raise ValueError(f"Unknown claim scope {new_scope!r}")
-    cur.execute("SELECT scope FROM claims WHERE id = %s FOR UPDATE", (claim_id,))
-    row = cur.fetchone()
-    if row is None:
+    cur.execute(
+        """
+        SELECT sibling.id, sibling.scope
+        FROM claims sibling
+        WHERE sibling.world_event_id = (
+            SELECT target.world_event_id
+            FROM claims target
+            WHERE target.id = %s
+        )
+        ORDER BY sibling.id
+        FOR UPDATE
+        """,
+        (claim_id,),
+    )
+    siblings = cur.fetchall()
+    if not siblings:
         raise ValueError(f"Claim {claim_id} does not exist")
-    current_scope = str(_row_value(row, "scope", 0))
-    if new_scope == current_scope:
-        return
-    if current_scope != "common" or new_scope == "common":
+    target = next(
+        (row for row in siblings if int(_row_value(row, "id", 0)) == claim_id),
+        None,
+    )
+    if target is None:
+        raise RuntimeError(f"Claim {claim_id} disappeared during scope promotion")
+    current_scope = str(_row_value(target, "scope", 1))
+    if new_scope != current_scope and (
+        current_scope != "common" or new_scope == "common"
+    ):
         raise ValueError(
             f"Illegal claim scope transition {current_scope!r} -> {new_scope!r}"
         )
-    cur.execute("UPDATE claims SET scope = %s WHERE id = %s", (new_scope, claim_id))
+    cur.execute(
+        """
+        UPDATE claims
+        SET scope = %s
+        WHERE world_event_id = (
+            SELECT world_event_id FROM claims WHERE id = %s
+        )
+        """,
+        (new_scope, claim_id),
+    )
 
 
 def load_epistemics_hydration(
@@ -639,6 +701,7 @@ def load_epistemics_hydration(
         """
     )
     claims: dict[int, dict[str, Any]] = {}
+    hydrated_scopes: dict[int, str] = {}
     for row in session.execute(
         claims_query,
         {
@@ -651,6 +714,14 @@ def load_epistemics_hydration(
         scope = str(row["scope"])
         if scope not in CLAIM_SCOPES:
             raise ValueError(f"Claim on event {event_id} has unknown scope {scope!r}")
+        previous_scope = hydrated_scopes.get(event_id)
+        if previous_scope is not None and previous_scope != scope:
+            raise ValueError(
+                "Sibling claims on event "
+                f"{event_id} have divergent scopes "
+                f"{previous_scope!r} and {scope!r}"
+            )
+        hydrated_scopes[event_id] = scope
         claims[claim_id] = {
             "world_event_id": event_id,
             "scope": scope,

--- a/nexus/agents/orrery/propagation.py
+++ b/nexus/agents/orrery/propagation.py
@@ -421,6 +421,9 @@ def _build_frontier(
         knower = int(_row_get(row, "knower_entity_id", 2))
         acquired = _row_get(row, "acquired_at_world_time", 4)
         root = _row_get(row, "root_source_entity_id", 3)
+        # NOTE(#479 Stage C): accounts remain independent claim-id frontiers.
+        # Do not skip this account because the knower possesses a sibling;
+        # cross-account exclusion belongs to the later distortion policy.
         key = (claim_id, knower)
         awareness_keys.add(key)
         frontier.append(

--- a/nexus/agents/orrery/retrograde_persistence.py
+++ b/nexus/agents/orrery/retrograde_persistence.py
@@ -1412,6 +1412,8 @@ def _mint_retrograde_event_claim(
     source_chunk_id: Optional[int],
     epistemics_settings: Optional[Any],
 ) -> Any:
+    """Mint the canonical account through the shared tuple-conflict writer."""
+
     policy = coerce_epistemics_policy(epistemics_settings)
     if not policy.enabled or event_type not in policy.claim_event_types:
         return None

--- a/tests/test_orrery/claim_accounts_test_support.py
+++ b/tests/test_orrery/claim_accounts_test_support.py
@@ -1,0 +1,120 @@
+"""Post-090 claim shadows for rollback-only tests on pre-090 slot databases."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+
+MIGRATION_SQL = Path("migrations/090_claim_accounts.sql").read_text()
+
+
+_CREATE_SHADOW_SQL = """
+    CREATE TEMP TABLE claims ON COMMIT DROP AS TABLE public.claims;
+    CREATE TEMP SEQUENCE claims_id_seq;
+    SELECT setval(
+        'pg_temp.claims_id_seq',
+        COALESCE((SELECT max(id) FROM claims), 0) + 1,
+        false
+    );
+    ALTER TABLE claims
+        ALTER COLUMN id SET DEFAULT nextval('pg_temp.claims_id_seq'),
+        ALTER COLUMN created_at SET DEFAULT now(),
+        ALTER COLUMN id SET NOT NULL,
+        ALTER COLUMN world_event_id SET NOT NULL,
+        ALTER COLUMN summary SET NOT NULL,
+        ALTER COLUMN scope SET NOT NULL,
+        ALTER COLUMN created_at SET NOT NULL,
+        ADD PRIMARY KEY (id),
+        ADD CHECK (scope IN ('common', 'bounded', 'private'));
+
+    CREATE TEMP TABLE claim_awareness
+        ON COMMIT DROP AS TABLE public.claim_awareness;
+    CREATE TEMP SEQUENCE claim_awareness_id_seq;
+    SELECT setval(
+        'pg_temp.claim_awareness_id_seq',
+        COALESCE((SELECT max(id) FROM claim_awareness), 0) + 1,
+        false
+    );
+    ALTER TABLE claim_awareness
+        ALTER COLUMN id SET DEFAULT nextval('pg_temp.claim_awareness_id_seq'),
+        ALTER COLUMN created_at SET DEFAULT now(),
+        ALTER COLUMN id SET NOT NULL,
+        ALTER COLUMN claim_id SET NOT NULL,
+        ALTER COLUMN knower_entity_id SET NOT NULL,
+        ALTER COLUMN source_tier SET NOT NULL,
+        ALTER COLUMN created_at SET NOT NULL,
+        ADD PRIMARY KEY (id),
+        ADD UNIQUE (claim_id, knower_entity_id),
+        ADD CHECK (
+            source_tier IN ('participant', 'witness', 'told', 'granted')
+        );
+"""
+
+
+_POST_090_INDEX_SQL = """
+    CREATE UNIQUE INDEX ux_claims_world_event_account_v1
+        ON claims (world_event_id, account_label)
+        WHERE world_event_id IS NOT NULL;
+"""
+
+
+def install_claim_accounts_shadow_sync(cur: Any) -> None:
+    """Shadow durable projections and install 090 without touching public tables."""
+
+    cur.execute(
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'claims'
+              AND column_name = 'account_label'
+        ) AS applied
+        """
+    )
+    row = cur.fetchone()
+    public_is_post_090 = bool(row["applied"] if isinstance(row, Mapping) else row[0])
+    cur.execute(_CREATE_SHADOW_SQL)
+    if public_is_post_090:
+        cur.execute(_POST_090_INDEX_SQL)
+    else:
+        cur.execute(
+            """
+            CREATE UNIQUE INDEX ux_claims_world_event_v1
+                ON claims (world_event_id)
+                WHERE world_event_id IS NOT NULL
+            """
+        )
+        cur.execute(MIGRATION_SQL)
+
+
+async def install_claim_accounts_shadow_async(conn: Any) -> None:
+    """Asyncpg twin of :func:`install_claim_accounts_shadow_sync`."""
+
+    public_is_post_090 = bool(
+        await conn.fetchval(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'claims'
+                  AND column_name = 'account_label'
+            )
+            """
+        )
+    )
+    await conn.execute(_CREATE_SHADOW_SQL)
+    if public_is_post_090:
+        await conn.execute(_POST_090_INDEX_SQL)
+    else:
+        await conn.execute(
+            """
+            CREATE UNIQUE INDEX ux_claims_world_event_v1
+                ON claims (world_event_id)
+                WHERE world_event_id IS NOT NULL
+            """
+        )
+        await conn.execute(MIGRATION_SQL)

--- a/tests/test_orrery/test_claim_accounts_live.py
+++ b/tests/test_orrery/test_claim_accounts_live.py
@@ -19,6 +19,7 @@ from nexus.agents.orrery.epistemics import (
     mint_account_variant_async,
     mint_account_variant_sync,
     mint_claim_for_event,
+    promote_claim_scope,
 )
 from nexus.agents.orrery.propagation import drain_claim_propagation_sync
 from nexus.agents.orrery.substrate import (
@@ -126,6 +127,149 @@ def account_connection() -> Iterator[Any]:
         transaction.rollback()
         connection.close()
         engine.dispose()
+
+
+def _mint_sibling_incident(
+    cur: Any,
+    *,
+    label: str,
+    scope: str = "bounded",
+) -> tuple[int, int, int, int, int, int]:
+    """Mint one real event with canonical and variant account rows."""
+
+    actor, _actor_character = _insert_character(cur, f"{label}-actor")
+    target, _target_character = _insert_character(cur, f"{label}-target")
+    anchor, _world_time = _insert_chunk(cur)
+    cur.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, target_entity_id,
+            world_layer, source, changed_fields, payload
+        ) VALUES (
+            'threat_issued', %s, %s, %s, 'primary',
+            'resolver', '{}', '{}'::jsonb
+        ) RETURNING id
+        """,
+        (anchor, actor, target),
+    )
+    event_id = int(cur.fetchone()["id"])
+    cur.execute(
+        """
+        INSERT INTO world_event_entities (event_id, role, entity_id)
+        VALUES (%s, 'actor', %s), (%s, 'target', %s)
+        """,
+        (event_id, actor, event_id, target),
+    )
+    canonical = mint_claim_for_event(
+        cur,
+        world_event_id=event_id,
+        event_type="threat_issued",
+        summary=f"Canonical account for {label}.",
+        participants=(
+            ClaimParticipant(actor, "actor", f"{label} actor"),
+            ClaimParticipant(target, "target", f"{label} target"),
+        ),
+        source_chunk_id=anchor,
+        source_resolution_id=None,
+        settings=EPISTEMICS,
+    )
+    assert canonical is not None
+    if scope != "bounded":
+        cur.execute(
+            "UPDATE claims SET scope = %s WHERE id = %s",
+            (scope, canonical.claim_id),
+        )
+    variant_id = mint_account_variant_sync(
+        cur,
+        source_claim_id=canonical.claim_id,
+        account_label=f"{label}-variant",
+        summary=f"Variant account for {label}.",
+        source_chunk_id=anchor,
+    )
+    return event_id, anchor, actor, target, canonical.claim_id, variant_id
+
+
+def test_scope_promotion_updates_every_sibling_and_hydrates_cleanly(
+    account_connection: Any,
+) -> None:
+    """Scope promotion is one locked incident mutation, not a claim mutation."""
+
+    raw_connection = account_connection.connection.driver_connection
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        event_id, anchor, actor, target, canonical_id, _variant_id = (
+            _mint_sibling_incident(cur, label="scope-promotion", scope="common")
+        )
+        promote_claim_scope(cur, claim_id=canonical_id, new_scope="bounded")
+        cur.execute(
+            "SELECT scope FROM claims WHERE world_event_id = %s ORDER BY id",
+            (event_id,),
+        )
+        assert [row["scope"] for row in cur.fetchall()] == ["bounded", "bounded"]
+
+    hydration = load_epistemics_hydration(
+        account_connection,
+        entity_ids=(actor, target),
+        recent_event_ids=(event_id,),
+        anchor_chunk_id=anchor,
+    )
+    assert hydration.claimed_event_scopes == {event_id: "bounded"}
+
+
+def test_old_divergent_sibling_scopes_raise_during_hydration(
+    account_connection: Any,
+) -> None:
+    """A divergent incident cannot hide after it leaves the recent window."""
+
+    raw_connection = account_connection.connection.driver_connection
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        event_id, anchor, actor, target, _canonical_id, variant_id = (
+            _mint_sibling_incident(cur, label="old-divergent")
+        )
+        cur.execute(
+            "UPDATE claims SET scope = 'common' WHERE id = %s",
+            (variant_id,),
+        )
+
+    with pytest.raises(ValueError, match="Sibling claims.*divergent scopes"):
+        load_epistemics_hydration(
+            account_connection,
+            entity_ids=(actor, target),
+            recent_event_ids=(),
+            anchor_chunk_id=anchor,
+        )
+
+
+def test_sync_variant_rejects_cross_incident_lineage_parent(
+    account_connection: Any,
+) -> None:
+    """The sync writer rejects missing and cross-incident lineage parents."""
+
+    raw_connection = account_connection.connection.driver_connection
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        _event_a, anchor, _actor, _target, source_id, _variant_a = (
+            _mint_sibling_incident(cur, label="lineage-source")
+        )
+        _event_b, _anchor, _actor, _target, foreign_id, _variant_b = (
+            _mint_sibling_incident(cur, label="lineage-foreign")
+        )
+        with pytest.raises(ValueError, match="belongs to world event"):
+            mint_account_variant_sync(
+                cur,
+                source_claim_id=source_id,
+                account_label="cross-incident-parent",
+                summary="This lineage must be rejected.",
+                source_chunk_id=anchor,
+                distorted_from_claim_id=foreign_id,
+            )
+        with pytest.raises(ValueError, match="Lineage parent claim 999999"):
+            mint_account_variant_sync(
+                cur,
+                source_claim_id=source_id,
+                account_label="missing-parent",
+                summary="This lineage must also be rejected.",
+                source_chunk_id=anchor,
+                distorted_from_claim_id=999999,
+            )
 
 
 def test_sibling_accounts_hydrate_predicates_and_propagate_independently(
@@ -345,7 +489,8 @@ async def test_async_variant_primitive_uses_real_postgres() -> None:
                 knower_entity_id bigint NOT NULL
             );
             INSERT INTO claims (world_event_id, summary, scope)
-            VALUES (77, 'Async canonical account.', 'private');
+            VALUES (77, 'Async canonical account.', 'private'),
+                   (78, 'Foreign async canonical account.', 'private');
             """
         )
         await conn.execute(MIGRATION_SQL)
@@ -369,6 +514,24 @@ async def test_async_variant_primitive_uses_real_postgres() -> None:
             "SELECT count(*) FROM claim_awareness WHERE claim_id = $1",
             variant_id,
         )
+        with pytest.raises(ValueError, match="belongs to world event"):
+            await mint_account_variant_async(
+                conn,
+                source_claim_id=1,
+                account_label="async-cross-incident",
+                summary="This async lineage must be rejected.",
+                source_chunk_id=None,
+                distorted_from_claim_id=2,
+            )
+        with pytest.raises(ValueError, match="Lineage parent claim 999999"):
+            await mint_account_variant_async(
+                conn,
+                source_claim_id=1,
+                account_label="async-missing-parent",
+                summary="This async lineage must also be rejected.",
+                source_chunk_id=None,
+                distorted_from_claim_id=999999,
+            )
     finally:
         await transaction.rollback()
         await conn.close()

--- a/tests/test_orrery/test_claim_accounts_live.py
+++ b/tests/test_orrery/test_claim_accounts_live.py
@@ -1,0 +1,382 @@
+"""Rollback-only live coverage for sibling claim accounts."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import json
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+import asyncpg  # type: ignore[import-untyped]
+import pytest
+from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
+from sqlalchemy import create_engine
+
+from nexus.agents.orrery.epistemics import (
+    ClaimParticipant,
+    load_epistemics_hydration,
+    mint_account_variant_async,
+    mint_account_variant_sync,
+    mint_claim_for_event,
+)
+from nexus.agents.orrery.propagation import drain_claim_propagation_sync
+from nexus.agents.orrery.substrate import (
+    EventRecord,
+    Slot,
+    WorldState,
+    heard_secondhand,
+    knows_claim_about,
+    knows_recent_event,
+)
+from nexus.api.slot_utils import get_slot_db_url
+from tests.test_orrery.test_claim_propagation_live import (
+    LIVE_SLOT,
+    _insert_character,
+    _insert_chunk,
+    _insert_relationship,
+    _install_valence_shadow,
+    _settings,
+)
+
+
+pytestmark = pytest.mark.requires_postgres
+MIGRATION_SQL = Path("migrations/090_claim_accounts.sql").read_text()
+EPISTEMICS = {
+    "enabled": True,
+    "claim_event_types": ["threat_issued"],
+    "aware_roles": ["actor"],
+}
+
+
+def _install_account_shadow(cur: Any) -> None:
+    """Install pre-090 projection tables, then migrate only this test schema."""
+
+    cur.execute(
+        """
+        CREATE TABLE claims (
+            id bigserial PRIMARY KEY,
+            world_event_id bigint NOT NULL,
+            summary text NOT NULL,
+            scope text NOT NULL CHECK (
+                scope IN ('common', 'bounded', 'private')
+            ),
+            source_chunk_id bigint,
+            source_resolution_id bigint,
+            created_at timestamptz NOT NULL DEFAULT now()
+        );
+        CREATE UNIQUE INDEX ux_claims_world_event_v1
+            ON claims (world_event_id)
+            WHERE world_event_id IS NOT NULL;
+        CREATE TABLE claim_awareness (
+            id bigserial PRIMARY KEY,
+            claim_id bigint NOT NULL,
+            knower_entity_id bigint NOT NULL,
+            source_tier text NOT NULL CHECK (
+                source_tier IN ('participant', 'witness', 'told', 'granted')
+            ),
+            immediate_source_entity_id bigint,
+            root_source_entity_id bigint,
+            channel text,
+            acquired_at_world_time timestamptz,
+            source_chunk_id bigint,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            UNIQUE (claim_id, knower_entity_id)
+        );
+        """
+    )
+    cur.execute(MIGRATION_SQL)
+
+
+@pytest.fixture()
+def account_connection() -> Iterator[Any]:
+    """Expose one slot-5 transaction with schema-local migrated claim tables."""
+
+    engine = create_engine(get_slot_db_url(slot=LIVE_SLOT))
+    connection = engine.connect()
+    transaction = connection.begin()
+    try:
+        raw_connection = connection.connection.driver_connection
+        with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT EXISTS (
+                           SELECT 1 FROM event_types
+                           WHERE type = 'claim_propagated'
+                       ) AS registered,
+                       EXISTS (
+                           SELECT 1
+                           FROM information_schema.columns
+                           WHERE table_schema = ANY(current_schemas(false))
+                             AND table_name = 'world_events'
+                             AND column_name = 'world_time'
+                       ) AS shaped
+                """
+            )
+            migration_state = cur.fetchone()
+            if not migration_state["registered"] or not migration_state["shaped"]:
+                pytest.skip("slot 5 requires migration 083 for account propagation")
+            schema = f"claim_accounts_{uuid4().hex[:12]}"
+            cur.execute(f'CREATE SCHEMA "{schema}"')
+            cur.execute(f'SET LOCAL search_path = "{schema}", public')
+            _install_account_shadow(cur)
+            _install_valence_shadow(cur)
+        yield connection
+    finally:
+        transaction.rollback()
+        connection.close()
+        engine.dispose()
+
+
+def test_sibling_accounts_hydrate_predicates_and_propagate_independently(
+    account_connection: Any,
+) -> None:
+    """Specific accounts stay disjoint while incident visibility stays shared."""
+
+    raw_connection = account_connection.connection.driver_connection
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        canonical_knower, canonical_character = _insert_character(
+            cur, "account-canonical-knower"
+        )
+        variant_knower, variant_character = _insert_character(
+            cur, "account-variant-knower"
+        )
+        canonical_listener, canonical_listener_character = _insert_character(
+            cur, "account-canonical-listener"
+        )
+        variant_listener, variant_listener_character = _insert_character(
+            cur, "account-variant-listener"
+        )
+        subject, _subject_character = _insert_character(cur, "account-subject")
+        outsider, _outsider_character = _insert_character(cur, "account-outsider")
+        _insert_relationship(cur, canonical_character, canonical_listener_character)
+        _insert_relationship(cur, variant_character, variant_listener_character)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        cur.execute(
+            """
+            INSERT INTO world_events (
+                event_type, tick_chunk_id, actor_entity_id, target_entity_id,
+                world_layer, source, changed_fields, payload
+            ) VALUES (
+                'threat_issued', %s, %s, %s, 'primary',
+                'resolver', '{}', '{}'::jsonb
+            ) RETURNING id
+            """,
+            (birth_chunk, canonical_knower, subject),
+        )
+        event_id = int(cur.fetchone()["id"])
+        cur.execute(
+            """
+            INSERT INTO world_event_entities (event_id, role, entity_id)
+            VALUES (%s, 'actor', %s), (%s, 'target', %s)
+            """,
+            (event_id, canonical_knower, event_id, subject),
+        )
+        canonical = mint_claim_for_event(
+            cur,
+            world_event_id=event_id,
+            event_type="threat_issued",
+            summary="The canonical witness saw the threat.",
+            participants=(
+                ClaimParticipant(canonical_knower, "actor", "Canonical witness"),
+                ClaimParticipant(subject, "target", "Threatened subject"),
+            ),
+            source_chunk_id=birth_chunk,
+            source_resolution_id=None,
+            settings=EPISTEMICS,
+        )
+        assert canonical is not None
+        variant_id = mint_account_variant_sync(
+            cur,
+            source_claim_id=canonical.claim_id,
+            account_label="mistaken-identity",
+            summary="A second witness says someone else made the threat.",
+            account_payload={"truth_marker": False, "speaker": "unknown"},
+            source_chunk_id=birth_chunk,
+        )
+        cur.execute(
+            """
+            INSERT INTO claim_awareness (
+                claim_id, knower_entity_id, source_tier,
+                immediate_source_entity_id, root_source_entity_id, channel,
+                acquired_at_world_time, source_chunk_id
+            ) VALUES (%s, %s, 'told', %s, %s, 'testimony', %s, %s)
+            """,
+            (
+                variant_id,
+                variant_knower,
+                canonical_knower,
+                canonical_knower,
+                birth_world_time,
+                birth_chunk,
+            ),
+        )
+
+    entities = (
+        canonical_knower,
+        variant_knower,
+        canonical_listener,
+        variant_listener,
+        subject,
+        outsider,
+    )
+    hydration = load_epistemics_hydration(
+        account_connection,
+        entity_ids=entities,
+        recent_event_ids=(event_id,),
+        anchor_chunk_id=birth_chunk,
+    )
+    possessed = {
+        entity_id: {record.claim_id for record in records}
+        for entity_id, records in (
+            hydration.possessed_claim_knowledge_by_entity.items()
+        )
+    }
+    assert possessed[canonical_knower] == {canonical.claim_id}
+    assert possessed[variant_knower] == {variant_id}
+    assert variant_id not in possessed[canonical_knower]
+    assert canonical.claim_id not in possessed[variant_knower]
+    assert hydration.claimed_event_scopes == {event_id: "bounded"}
+    assert hydration.awareness_by_entity[canonical_knower] == frozenset({event_id})
+    assert hydration.awareness_by_entity[variant_knower] == frozenset({event_id})
+
+    state = WorldState(
+        recent_events=(
+            EventRecord(
+                "threat_issued",
+                tick=1,
+                event_id=event_id,
+                actor_entity_id=canonical_knower,
+                target_entity_id=subject,
+            ),
+        ),
+        claimed_event_scopes=hydration.claimed_event_scopes,
+        awareness_by_entity=hydration.awareness_by_entity,
+        claim_knowledge_by_entity=hydration.claim_knowledge_by_entity,
+        common_claim_knowledge=hydration.common_claim_knowledge,
+        possessed_claim_knowledge_by_entity=(
+            hydration.possessed_claim_knowledge_by_entity
+        ),
+        epistemics_enabled=True,
+        current_tick=1,
+    )
+    canonical_bindings = {Slot.ACTOR: canonical_knower, Slot.TARGET: subject}
+    variant_bindings = {Slot.ACTOR: variant_knower, Slot.TARGET: subject}
+    outsider_bindings = {Slot.ACTOR: outsider, Slot.TARGET: subject}
+    assert knows_claim_about()(state, canonical_bindings)
+    assert knows_claim_about()(state, variant_bindings)
+    assert not knows_claim_about()(state, outsider_bindings)
+    assert not heard_secondhand()(state, canonical_bindings)
+    assert heard_secondhand()(state, variant_bindings)
+    predicate = knows_recent_event(
+        "threat_issued", within_ticks=1, target_slot=Slot.TARGET
+    )
+    assert predicate(state, canonical_bindings)
+    assert predicate(state, variant_bindings)
+    assert not predicate(state, outsider_bindings)
+
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=4))
+        drained = drain_claim_propagation_sync(
+            cur, tick_chunk_id=drain_chunk, settings=_settings()
+        )
+        cur.execute(
+            """
+            SELECT claim_id, array_agg(knower_entity_id ORDER BY knower_entity_id)
+                       AS knowers
+            FROM claim_awareness
+            WHERE claim_id IN (%s, %s)
+            GROUP BY claim_id
+            ORDER BY claim_id
+            """,
+            (canonical.claim_id, variant_id),
+        )
+        awareness = {int(row["claim_id"]): row["knowers"] for row in cur}
+        cur.execute(
+            """
+            SELECT (payload ->> 'claim_id')::bigint AS claim_id, count(*) AS n
+            FROM world_events
+            WHERE event_type = 'claim_propagated'
+              AND (payload ->> 'claim_id')::bigint IN (%s, %s)
+            GROUP BY (payload ->> 'claim_id')::bigint
+            """,
+            (canonical.claim_id, variant_id),
+        )
+        ledgers = {int(row["claim_id"]): int(row["n"]) for row in cur}
+
+    assert drained.minted_count == 2
+    assert awareness[canonical.claim_id] == sorted(
+        [canonical_knower, canonical_listener]
+    )
+    assert awareness[variant_id] == sorted([variant_knower, variant_listener])
+    assert ledgers == {canonical.claim_id: 1, variant_id: 1}
+
+
+@pytest.mark.asyncio
+async def test_async_variant_primitive_uses_real_postgres() -> None:
+    """The async twin copies anchor/scope and writes no awareness rows."""
+
+    conn = await asyncpg.connect(get_slot_db_url(slot=LIVE_SLOT))
+    transaction = conn.transaction()
+    await transaction.start()
+    try:
+        schema = f"claim_accounts_async_{uuid4().hex[:12]}"
+        await conn.execute(f'CREATE SCHEMA "{schema}"')
+        await conn.execute(f'SET LOCAL search_path = "{schema}", public')
+        await conn.execute(
+            """
+            CREATE TABLE claims (
+                id bigserial PRIMARY KEY,
+                world_event_id bigint NOT NULL,
+                summary text NOT NULL,
+                scope text NOT NULL CHECK (
+                    scope IN ('common', 'bounded', 'private')
+                ),
+                source_chunk_id bigint,
+                source_resolution_id bigint,
+                created_at timestamptz NOT NULL DEFAULT now()
+            );
+            CREATE UNIQUE INDEX ux_claims_world_event_v1
+                ON claims (world_event_id)
+                WHERE world_event_id IS NOT NULL;
+            CREATE TABLE claim_awareness (
+                id bigserial PRIMARY KEY,
+                claim_id bigint NOT NULL,
+                knower_entity_id bigint NOT NULL
+            );
+            INSERT INTO claims (world_event_id, summary, scope)
+            VALUES (77, 'Async canonical account.', 'private');
+            """
+        )
+        await conn.execute(MIGRATION_SQL)
+        variant_id = await mint_account_variant_async(
+            conn,
+            source_claim_id=1,
+            account_label="async-alibi",
+            summary="Async sibling account.",
+            account_payload={"truth_marker": False},
+            source_chunk_id=None,
+        )
+        row = await conn.fetchrow(
+            """
+            SELECT world_event_id, account_label, account_payload::text AS payload,
+                   scope, distorted_from_claim_id
+            FROM claims WHERE id = $1
+            """,
+            variant_id,
+        )
+        awareness_count = await conn.fetchval(
+            "SELECT count(*) FROM claim_awareness WHERE claim_id = $1",
+            variant_id,
+        )
+    finally:
+        await transaction.rollback()
+        await conn.close()
+
+    assert row is not None
+    assert row["world_event_id"] == 77
+    assert row["account_label"] == "async-alibi"
+    assert json.loads(row["payload"]) == {"truth_marker": False}
+    assert row["scope"] == "private"
+    assert row["distorted_from_claim_id"] == 1
+    assert awareness_count == 0

--- a/tests/test_orrery/test_claim_accounts_migration_pg.py
+++ b/tests/test_orrery/test_claim_accounts_migration_pg.py
@@ -1,0 +1,213 @@
+"""Real-PostgreSQL contract coverage for migration 090."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2  # type: ignore[import-untyped]
+import pytest
+from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
+
+from nexus.agents.orrery.epistemics import (
+    mint_account_variant_sync,
+    mint_claim_for_event,
+)
+from nexus.api.slot_utils import get_slot_db_url
+
+
+pytestmark = pytest.mark.requires_postgres
+MIGRATION_SQL = Path("migrations/090_claim_accounts.sql").read_text()
+EPISTEMICS = {
+    "enabled": True,
+    "claim_event_types": ["threat_issued"],
+    "aware_roles": [],
+}
+
+
+@pytest.fixture()
+def migration_089_schema() -> Iterator[Any]:
+    """Build the exact pre-090 claim contract in a rolled-back schema."""
+
+    conn = psycopg2.connect(get_slot_db_url(slot=2), cursor_factory=RealDictCursor)
+    try:
+        with conn.cursor() as cur:
+            schema = f"migration_090_{uuid4().hex[:12]}"
+            cur.execute(f'CREATE SCHEMA "{schema}"')
+            cur.execute(f'SET LOCAL search_path = "{schema}", public')
+            cur.execute(
+                """
+                CREATE TABLE world_events (id bigserial PRIMARY KEY);
+                CREATE TABLE narrative_chunks (id bigserial PRIMARY KEY);
+                CREATE TABLE orrery_resolutions (id bigserial PRIMARY KEY);
+                CREATE TABLE claims (
+                    id bigserial PRIMARY KEY,
+                    world_event_id bigint NOT NULL REFERENCES world_events(id),
+                    summary text NOT NULL,
+                    scope text NOT NULL CHECK (
+                        scope IN ('common', 'bounded', 'private')
+                    ),
+                    source_chunk_id bigint REFERENCES narrative_chunks(id),
+                    source_resolution_id bigint
+                        REFERENCES orrery_resolutions(id),
+                    created_at timestamptz NOT NULL DEFAULT now()
+                );
+                CREATE UNIQUE INDEX ux_claims_world_event_v1
+                    ON claims (world_event_id)
+                    WHERE world_event_id IS NOT NULL;
+                INSERT INTO world_events DEFAULT VALUES;
+                INSERT INTO claims (world_event_id, summary, scope)
+                VALUES (1, 'Legacy canonical account.', 'bounded');
+                """
+            )
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_migration_090_swaps_index_and_preserves_existing_rows(
+    migration_089_schema: Any,
+) -> None:
+    """Existing claims become canonical and the account contract is documented."""
+
+    with migration_089_schema.cursor() as cur:
+        cur.execute(MIGRATION_SQL)
+        cur.execute(
+            """
+            SELECT account_label, account_payload, distorted_from_claim_id
+            FROM claims WHERE id = 1
+            """
+        )
+        assert cur.fetchone() == {
+            "account_label": "canonical",
+            "account_payload": None,
+            "distorted_from_claim_id": None,
+        }
+        cur.execute(
+            """
+            SELECT column_default, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = 'claims'
+              AND column_name = 'account_label'
+            """
+        )
+        assert cur.fetchone() == {
+            "column_default": "'canonical'::text",
+            "is_nullable": "NO",
+        }
+        cur.execute(
+            """
+            SELECT indexname, indexdef
+            FROM pg_indexes
+            WHERE schemaname = current_schema()
+              AND tablename = 'claims'
+              AND indexname LIKE 'ux_claims_world_event%'
+            """
+        )
+        indexes = cur.fetchall()
+        assert [row["indexname"] for row in indexes] == [
+            "ux_claims_world_event_account_v1"
+        ]
+        assert "UNIQUE INDEX" in indexes[0]["indexdef"]
+        assert "(world_event_id, account_label)" in indexes[0]["indexdef"]
+        assert "WHERE (world_event_id IS NOT NULL)" in indexes[0]["indexdef"]
+
+
+def test_migration_090_mints_canonical_idempotently_and_variants_loudly(
+    migration_089_schema: Any,
+) -> None:
+    """Canonical recovery is unchanged while sibling collisions reach PostgreSQL."""
+
+    with migration_089_schema.cursor() as cur:
+        cur.execute(MIGRATION_SQL)
+        first = mint_claim_for_event(
+            cur,
+            world_event_id=1,
+            event_type="threat_issued",
+            summary="A replacement summary must not overwrite legacy prose.",
+            participants=(),
+            source_chunk_id=None,
+            source_resolution_id=None,
+            settings=EPISTEMICS,
+        )
+        second = mint_claim_for_event(
+            cur,
+            world_event_id=1,
+            event_type="threat_issued",
+            summary="Still idempotent.",
+            participants=(),
+            source_chunk_id=None,
+            source_resolution_id=None,
+            settings=EPISTEMICS,
+        )
+        assert first is not None
+        assert second is not None
+        assert first.claim_id == second.claim_id == 1
+
+        variant_id = mint_account_variant_sync(
+            cur,
+            source_claim_id=first.claim_id,
+            account_label="alibi",
+            summary="The witness insists the accused was elsewhere.",
+            account_payload={"truth_marker": False, "place": "harbor"},
+            source_chunk_id=None,
+        )
+        cur.execute(
+            """
+            SELECT world_event_id, account_label, account_payload, scope,
+                   distorted_from_claim_id
+            FROM claims WHERE id = %s
+            """,
+            (variant_id,),
+        )
+        assert cur.fetchone() == {
+            "world_event_id": 1,
+            "account_label": "alibi",
+            "account_payload": {"truth_marker": False, "place": "harbor"},
+            "scope": "bounded",
+            "distorted_from_claim_id": 1,
+        }
+
+        cur.execute("SAVEPOINT duplicate_label")
+        with pytest.raises(psycopg2.errors.UniqueViolation):
+            mint_account_variant_sync(
+                cur,
+                source_claim_id=first.claim_id,
+                account_label="alibi",
+                summary="A caller bug must not be hidden.",
+                source_chunk_id=None,
+            )
+        cur.execute("ROLLBACK TO SAVEPOINT duplicate_label")
+
+        with pytest.raises(ValueError, match="Source claim 999999 does not exist"):
+            mint_account_variant_sync(
+                cur,
+                source_claim_id=999999,
+                account_label="missing-source",
+                summary="This cannot be anchored.",
+                source_chunk_id=None,
+            )
+
+
+def test_migration_090_rejects_self_ancestor(
+    migration_089_schema: Any,
+) -> None:
+    """The lineage hook cannot point at the row being inserted."""
+
+    with migration_089_schema.cursor() as cur:
+        cur.execute(MIGRATION_SQL)
+        cur.execute("SAVEPOINT self_ancestor")
+        with pytest.raises(psycopg2.errors.CheckViolation):
+            cur.execute(
+                """
+                INSERT INTO claims (
+                    id, world_event_id, account_label, summary, scope,
+                    distorted_from_claim_id
+                ) VALUES (90090, 1, 'self-ancestor', 'Impossible.',
+                          'bounded', 90090)
+                """
+            )
+        cur.execute("ROLLBACK TO SAVEPOINT self_ancestor")

--- a/tests/test_orrery/test_claim_awareness_replay_live.py
+++ b/tests/test_orrery/test_claim_awareness_replay_live.py
@@ -14,6 +14,9 @@ from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
 from nexus.agents.orrery.epistemics import ClaimParticipant, mint_claim_for_event
 from nexus.agents.orrery.reconstruction import capture_state_checkpoint_sync
 from nexus.agents.orrery.replay import verify_checkpoints_sync
+from tests.test_orrery.claim_accounts_test_support import (
+    install_claim_accounts_shadow_sync,
+)
 
 
 pytestmark = pytest.mark.requires_postgres
@@ -37,6 +40,8 @@ def template_conn() -> Iterator[Any]:
         port=os.environ.get("PGPORT", "5432"),
     )
     try:
+        with conn.cursor() as cur:
+            install_claim_accounts_shadow_sync(cur)
         yield conn
     finally:
         conn.rollback()

--- a/tests/test_orrery/test_claim_consumption_live.py
+++ b/tests/test_orrery/test_claim_consumption_live.py
@@ -30,6 +30,9 @@ from nexus.agents.orrery.substrate import (
     knows_recent_event,
 )
 from nexus.api.slot_utils import get_slot_db_url
+from tests.test_orrery.claim_accounts_test_support import (
+    install_claim_accounts_shadow_sync,
+)
 from tests.test_orrery.test_claim_propagation_live import (
     EPISTEMICS,
     LIVE_SLOT,
@@ -74,6 +77,7 @@ def live_connection() -> Iterator[Any]:
             migration_state = cur.fetchone()
             if not migration_state["registered"] or not migration_state["shaped"]:
                 pytest.skip("slot 5 requires migrations 080-083 for Stage 2d")
+            install_claim_accounts_shadow_sync(cur)
             _install_valence_shadow(cur)
         yield connection
     finally:

--- a/tests/test_orrery/test_claim_propagation_live.py
+++ b/tests/test_orrery/test_claim_propagation_live.py
@@ -35,6 +35,10 @@ from nexus.agents.orrery.replay import (
 from nexus.agents.orrery.resolver import _load_recent_events, compose_actor_bindings
 from nexus.api.slot_utils import get_slot_db_url
 from nexus.config.settings_models import OrreryContagionSettings
+from tests.test_orrery.claim_accounts_test_support import (
+    install_claim_accounts_shadow_async,
+    install_claim_accounts_shadow_sync,
+)
 
 
 pytestmark = pytest.mark.requires_postgres
@@ -100,6 +104,7 @@ def live_conn() -> Iterator[Any]:
                     "slot 5 has not applied migration 083: claim_propagated "
                     "registration and world_events.world_time are required"
                 )
+            install_claim_accounts_shadow_sync(cur)
             _install_valence_shadow(cur)
         yield conn
     finally:
@@ -483,6 +488,7 @@ def test_propagation_event_does_not_change_salience_or_hydration_feed() -> None:
                     "slot 5 has not applied migration 083: salience isolation "
                     "requires the real propagation ledger"
                 )
+            install_claim_accounts_shadow_sync(cur)
             _install_valence_shadow(cur)
             entities, _ = _chain(cur, 2)
             birth_chunk, birth_world_time = _insert_chunk(cur)
@@ -1170,6 +1176,7 @@ async def test_async_drain_matches_sync_single_hop() -> None:
                 "slot 5 has not applied migration 083: async propagation "
                 "coverage requires the registered event and shaped ledger"
             )
+        await install_claim_accounts_shadow_async(conn)
         await conn.execute(
             r"""
             CREATE TEMP TABLE character_relationships ON COMMIT DROP AS

--- a/tests/test_orrery/test_drift_live.py
+++ b/tests/test_orrery/test_drift_live.py
@@ -16,6 +16,9 @@ from nexus.agents.orrery.events import commit_orrery_tick_sync
 from nexus.api.slot_utils import get_slot_db_url
 from nexus.config import load_settings
 from nexus.config.settings_models import OrreryDriftSettings
+from tests.test_orrery.claim_accounts_test_support import (
+    install_claim_accounts_shadow_sync,
+)
 
 
 pytestmark = pytest.mark.requires_postgres
@@ -56,6 +59,7 @@ def live_conn() -> Iterator[Any]:
             readiness = cur.fetchone()
             if not readiness["valence_ready"] or not readiness["event_clock_ready"]:
                 pytest.skip("slot 5 requires applied migrations 083 and 088")
+            install_claim_accounts_shadow_sync(cur)
             cur.execute(
                 """
                 INSERT INTO event_types (type, category, severity, description)

--- a/tests/test_orrery/test_epistemics.py
+++ b/tests/test_orrery/test_epistemics.py
@@ -50,6 +50,10 @@ from nexus.agents.orrery.substrate import (
 from nexus.agents.orrery.templates import SURVEIL
 from nexus.api.slot_utils import get_slot_db_url
 from nexus.config.settings_models import OrreryEpistemicsSettings
+from tests.test_orrery.claim_accounts_test_support import (
+    install_claim_accounts_shadow_async,
+    install_claim_accounts_shadow_sync,
+)
 
 
 EPISTEMICS = {
@@ -66,6 +70,8 @@ def save_02_conn() -> Iterator[Any]:
 
     conn = psycopg2.connect(get_slot_db_url(slot=2))
     try:
+        with conn.cursor() as cur:
+            install_claim_accounts_shadow_sync(cur)
         yield conn
     finally:
         conn.rollback()
@@ -640,6 +646,7 @@ def test_async_live_applier_has_epistemics_parity() -> None:
         transaction = conn.transaction()
         await transaction.start()
         try:
+            await install_claim_accounts_shadow_async(conn)
             anchor = int(await conn.fetchval("SELECT max(id) FROM narrative_chunks"))
             rows = await conn.fetch(
                 """
@@ -743,6 +750,8 @@ def test_resolver_hydrates_scopes_and_awareness_in_recent_window() -> None:
     engine = create_engine(get_slot_db_url(slot=2))
     connection = engine.connect()
     transaction = connection.begin()
+    with connection.connection.driver_connection.cursor() as cur:
+        install_claim_accounts_shadow_sync(cur)
     session = Session(bind=connection)
     try:
         anchor_value = session.execute(
@@ -826,6 +835,8 @@ def test_unclaimed_event_is_implicitly_common_with_epistemics_enabled() -> None:
     engine = create_engine(get_slot_db_url(slot=2))
     connection = engine.connect()
     transaction = connection.begin()
+    with connection.connection.driver_connection.cursor() as cur:
+        install_claim_accounts_shadow_sync(cur)
     session = Session(bind=connection)
     try:
         anchor_value = session.execute(

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -266,6 +266,35 @@ def test_relationship_drift_migration_registers_visibility_event_only() -> None:
     assert "ALTER TABLE" not in migration_sql
 
 
+def test_claim_accounts_migration_installs_shape_c_contract() -> None:
+    """Migration 090 replaces event uniqueness with labeled sibling accounts."""
+
+    migration_sql = (
+        Path(__file__).parent.parent.parent / "migrations" / "090_claim_accounts.sql"
+    ).read_text()
+
+    assert "ADD COLUMN account_label text NOT NULL DEFAULT 'canonical'" in (
+        migration_sql
+    )
+    assert "ADD COLUMN account_payload jsonb" in migration_sql
+    assert "ADD COLUMN distorted_from_claim_id bigint" in migration_sql
+    assert "REFERENCES claims(id)" in migration_sql
+    assert "CHECK (distorted_from_claim_id <> id)" in migration_sql
+    assert "DROP INDEX ux_claims_world_event_v1" in migration_sql
+    assert "CREATE UNIQUE INDEX ux_claims_world_event_account_v1" in migration_sql
+    assert "ON claims (world_event_id, account_label)" in migration_sql
+    assert "WHERE world_event_id IS NOT NULL" in migration_sql
+    for column in (
+        "account_label",
+        "account_payload",
+        "distorted_from_claim_id",
+    ):
+        assert f"COMMENT ON COLUMN claims.{column}" in migration_sql
+    assert "truth markers and account facts" in migration_sql
+    assert "retrograde_summaries.summary_text" in migration_sql
+    assert "COMMENT ON INDEX ux_claims_world_event_account_v1" in migration_sql
+
+
 def test_retrograde_persistence_migration_adds_distinct_sources() -> None:
     """Retrograde canonical writes need explicit event and tag provenance."""
 

--- a/tests/test_orrery/test_stage2a_epistemics_live.py
+++ b/tests/test_orrery/test_stage2a_epistemics_live.py
@@ -17,6 +17,9 @@ from nexus.agents.orrery.epistemics import (
     mint_claim_for_event,
     record_revelation,
 )
+from tests.test_orrery.claim_accounts_test_support import (
+    install_claim_accounts_shadow_sync,
+)
 
 
 pytestmark = pytest.mark.requires_postgres
@@ -41,6 +44,8 @@ def live_conn() -> Iterator[Any]:
         port=os.environ.get("PGPORT", "5432"),
     )
     try:
+        with conn.cursor() as cur:
+            install_claim_accounts_shadow_sync(cur)
         yield conn
     finally:
         conn.rollback()


### PR DESCRIPTION
## Summary

Stage A of #479 (time-release backstory): the Shape C accounts substrate, with zero behavior change for existing single-account flows.

- **Migration 090**: `claims.account_label` (default `'canonical'`), `account_payload` jsonb (the spoiler constraint documented on the column: truth markers live in structured payload, never in MEMNON-searchable prose), `distorted_from_claim_id` lineage FK with self-ancestor CHECK (Stage C hook); the V1 one-claim-per-event index becomes unique `(world_event_id, account_label)` — one canonical account guaranteed, N labeled variants possible
- **Mint paths** (live events, drift milestones, retrograde) write the canonical label explicitly on the new conflict tuple — byte-identical observable behavior
- **New primitive** `mint_account_variant_sync/_async`: sibling-account minting with loud collision semantics (unique index raises; no `ON CONFLICT` — a collision is a caller bug)
- **Semantics settled and live-tested**: event-level awareness (`knows_recent_event`) admits any sibling; claim-level predicates (`knows_claim_about`, `heard_secondhand`) are exact-account; sibling scopes must agree (hydration raises loudly on divergence); sibling accounts propagate independently (per-claim frontier invariant untouched); cross-account frontier exclusion deliberately deferred to Stage C with a NOTE at the frontier
- **Full 1:1-consumer inventory** reconciled (hydration, audit, replay, propagation, all test surfaces) — listed in the implementation report

## Validation

- `poetry run pytest -q` → **1532 passed, 0 failed**
- **Full live-PG orrery suite → 1108 passed, 0 failed**
- `replay_state.py --slot 5 --verify` green; flake8/black/catalog clean

## Schema/Data Impact

Migration 090 pending everywhere; additive columns + index swap, no data movement. Applied at merge closeout.

Implemented by Sol (GPT-5.6 Codex) from a frozen spec; reviewed by Claude. Stages B–D (durable secrets + reveal gates, hop distortion, storyteller conduit) follow per the build plan on #479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TJVTXfD7TouQuxmYfVf8w