### PR TITLE
Add Durable Secrets and Template-Authored Reveal Gates (#479 Stage B)

### DIFF
--- a/migrations/091_backstory_secrets.sql
+++ b/migrations/091_backstory_secrets.sql
@@ -1,0 +1,73 @@
+-- 091_backstory_secrets.sql
+--
+-- Durable template-authored reveal gates for time-release backstory claims.
+
+CREATE TABLE backstory_secrets (
+    id                      bigserial PRIMARY KEY,
+    claim_id                bigint NOT NULL UNIQUE REFERENCES claims(id),
+    gate_template_id        text NOT NULL,
+    status                  text NOT NULL DEFAULT 'latent'
+                                CHECK (
+                                    status IN ('latent', 'revealed', 'retired')
+                                ),
+    holder_entity_id        bigint NOT NULL REFERENCES entities(id),
+    source_chunk_id         bigint REFERENCES narrative_chunks(id),
+    revealed_at_world_time  timestamptz,
+    revealed_by_chunk_id    bigint REFERENCES narrative_chunks(id),
+    created_at              timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE backstory_secrets IS
+    'Durable time-release backstory claims. Lifecycle: latent -> gate fires at commit -> revealed; retired means withdrawn without reveal as a manual authoring correction and is never automatic.';
+COMMENT ON COLUMN backstory_secrets.id IS
+    'Monotonic identifier for one durable backstory secret.';
+COMMENT ON COLUMN backstory_secrets.claim_id IS
+    'Unique claim containing the secret account; authoring requires private scope while the secret is latent.';
+COMMENT ON COLUMN backstory_secrets.gate_template_id IS
+    'Name of a registered code-authored reveal gate, never a serialized predicate.';
+COMMENT ON COLUMN backstory_secrets.status IS
+    'Lifecycle state: latent, revealed, or manually retired without reveal.';
+COMMENT ON COLUMN backstory_secrets.holder_entity_id IS
+    'Entity whose secret this is and whose circumstances reveal gates normally read.';
+COMMENT ON COLUMN backstory_secrets.source_chunk_id IS
+    'Narrative chunk provenance for the authoring operation, when available.';
+COMMENT ON COLUMN backstory_secrets.revealed_at_world_time IS
+    'Diegetic tick time at which the reveal gate fired.';
+COMMENT ON COLUMN backstory_secrets.revealed_by_chunk_id IS
+    'Accepted chunk whose commit drained the latent secret into revealed state.';
+COMMENT ON COLUMN backstory_secrets.created_at IS
+    'Database wall-clock time when the durable secret row was authored.';
+COMMENT ON CONSTRAINT backstory_secrets_pkey ON backstory_secrets IS
+    'Primary identifier for one durable backstory secret.';
+COMMENT ON CONSTRAINT backstory_secrets_claim_id_key ON backstory_secrets IS
+    'A claim may serve as at most one durable backstory secret.';
+COMMENT ON CONSTRAINT backstory_secrets_claim_id_fkey ON backstory_secrets IS
+    'Every secret is anchored to a durable epistemic claim.';
+COMMENT ON CONSTRAINT backstory_secrets_status_check ON backstory_secrets IS
+    'Restricts the explicit secret lifecycle to latent, revealed, or retired.';
+COMMENT ON CONSTRAINT backstory_secrets_holder_entity_id_fkey
+    ON backstory_secrets IS
+    'The holder must exist on the canonical entity spine.';
+COMMENT ON CONSTRAINT backstory_secrets_source_chunk_id_fkey
+    ON backstory_secrets IS
+    'Optional authoring provenance must name a durable narrative chunk.';
+COMMENT ON CONSTRAINT backstory_secrets_revealed_by_chunk_id_fkey
+    ON backstory_secrets IS
+    'A revealed secret records the accepted chunk that fired its gate.';
+
+INSERT INTO event_types (type, category, severity, description)
+VALUES
+    (
+        'backstory_secret_authored',
+        'revelation',
+        'minor',
+        'Append-only ledger record for a template-gated backstory secret.'
+    ),
+    (
+        'backstory_revealed',
+        'revelation',
+        'moderate',
+        'A latent backstory secret fired its authored reveal gate.'
+    )
+ON CONFLICT (type) DO NOTHING;
+

--- a/migrations/091_backstory_secrets.sql
+++ b/migrations/091_backstory_secrets.sql
@@ -1,6 +1,10 @@
 -- 091_backstory_secrets.sql
 --
 -- Durable template-authored reveal gates for time-release backstory claims.
+-- New checkpoint captures add the 'backstory_secrets' section in Python.
+-- Older checkpoint documents intentionally keep the key absent: replay treats
+-- that pre-091 shape as an empty section and skips cross-era verification,
+-- matching the additive checkpoint compatibility contract.
 
 CREATE TABLE backstory_secrets (
     id                      bigserial PRIMARY KEY,
@@ -70,4 +74,3 @@ VALUES
         'A latent backstory secret fired its authored reveal gate.'
     )
 ON CONFLICT (type) DO NOTHING;
-

--- a/nexus.toml
+++ b/nexus.toml
@@ -334,6 +334,9 @@ welfare_check = 0.02
 kin_visit = 0.02
 confrontation_resolved = 0.03
 
+[orrery.reveal]
+enabled = true
+
 [orrery.epistemics]
 enabled = true
 # Event types that mint a bounded claim at birth. Types absent from this list

--- a/nexus/agents/orrery/epistemics.py
+++ b/nexus/agents/orrery/epistemics.py
@@ -451,6 +451,13 @@ def author_backstory_secret_sync(
         (claim_id, gate_template_id, holder_entity_id, source_chunk_id),
     )
     secret_id = int(_row_value(cur.fetchone(), "id", 0))
+    record_revelation(
+        cur,
+        claim_id=claim_id,
+        knower_entity_id=holder_entity_id,
+        world_time=_row_value(clock, "world_time", 0),
+        source_chunk_id=source_chunk_id,
+    )
     payload = json.dumps(
         {
             "claim_id": claim_id,
@@ -529,6 +536,13 @@ async def author_backstory_secret_async(
         gate_template_id,
         holder_entity_id,
         source_chunk_id,
+    )
+    await record_revelation_async(
+        conn,
+        claim_id=claim_id,
+        knower_entity_id=holder_entity_id,
+        world_time=clock["world_time"],
+        source_chunk_id=source_chunk_id,
     )
     payload = json.dumps(
         {
@@ -726,21 +740,25 @@ async def record_revelation_async(
 
 
 def promote_claim_scope(cur: Any, *, claim_id: int, new_scope: str) -> None:
-    """Move every sibling account into bounded spreadability, idempotently."""
+    """Move promotable sibling accounts into bounded spreadability."""
 
     if new_scope not in CLAIM_SCOPES:
         raise ValueError(f"Unknown claim scope {new_scope!r}")
+    # Keep this latent-secret filter aligned with _merge_sibling_scope below:
+    # hydration permits exactly the temporary divergence created here.
     cur.execute(
         """
         SELECT sibling.id, sibling.scope
-        FROM claims sibling
-        WHERE sibling.world_event_id = (
-            SELECT target.world_event_id
-            FROM claims target
-            WHERE target.id = %s
-        )
+        FROM claims target
+        JOIN claims sibling
+          ON sibling.world_event_id = target.world_event_id
+        LEFT JOIN backstory_secrets latent_secret
+          ON latent_secret.claim_id = sibling.id
+         AND latent_secret.status = 'latent'
+        WHERE target.id = %s
+          AND latent_secret.id IS NULL
         ORDER BY sibling.id
-        FOR UPDATE
+        FOR UPDATE OF sibling
         """,
         (claim_id,),
     )
@@ -760,13 +778,23 @@ def promote_claim_scope(cur: Any, *, claim_id: int, new_scope: str) -> None:
         )
     cur.execute(
         """
-        UPDATE claims
-        SET scope = %s
-        WHERE world_event_id = (
-            SELECT world_event_id FROM claims WHERE id = %s
+        WITH promotable AS (
+            SELECT sibling.id
+            FROM claims target
+            JOIN claims sibling
+              ON sibling.world_event_id = target.world_event_id
+            LEFT JOIN backstory_secrets latent_secret
+              ON latent_secret.claim_id = sibling.id
+             AND latent_secret.status = 'latent'
+            WHERE target.id = %s
+              AND latent_secret.id IS NULL
         )
+        UPDATE claims promoted
+        SET scope = %s
+        FROM promotable
+        WHERE promoted.id = promotable.id
         """,
-        (new_scope, claim_id),
+        (claim_id, new_scope),
     )
 
 
@@ -777,17 +805,20 @@ async def promote_claim_scope_async(
 
     if new_scope not in CLAIM_SCOPES:
         raise ValueError(f"Unknown claim scope {new_scope!r}")
+    # Async parity for the promotion/hydration contract documented above.
     siblings = await conn.fetch(
         """
         SELECT sibling.id, sibling.scope
-        FROM claims sibling
-        WHERE sibling.world_event_id = (
-            SELECT target.world_event_id
-            FROM claims target
-            WHERE target.id = $1
-        )
+        FROM claims target
+        JOIN claims sibling
+          ON sibling.world_event_id = target.world_event_id
+        LEFT JOIN backstory_secrets latent_secret
+          ON latent_secret.claim_id = sibling.id
+         AND latent_secret.status = 'latent'
+        WHERE target.id = $1
+          AND latent_secret.id IS NULL
         ORDER BY sibling.id
-        FOR UPDATE
+        FOR UPDATE OF sibling
         """,
         claim_id,
     )
@@ -803,14 +834,51 @@ async def promote_claim_scope_async(
         )
     await conn.execute(
         """
-        UPDATE claims
-        SET scope = $1
-        WHERE world_event_id = (
-            SELECT world_event_id FROM claims WHERE id = $2
+        WITH promotable AS (
+            SELECT sibling.id
+            FROM claims target
+            JOIN claims sibling
+              ON sibling.world_event_id = target.world_event_id
+            LEFT JOIN backstory_secrets latent_secret
+              ON latent_secret.claim_id = sibling.id
+             AND latent_secret.status = 'latent'
+            WHERE target.id = $1
+              AND latent_secret.id IS NULL
         )
+        UPDATE claims promoted
+        SET scope = $2
+        FROM promotable
+        WHERE promoted.id = promotable.id
         """,
-        new_scope,
         claim_id,
+        new_scope,
+    )
+
+
+def _merge_sibling_scope(
+    *,
+    event_id: int,
+    rows: list[tuple[str, bool]],
+) -> str:
+    """Validate one incident's sibling scopes and return its shared scope."""
+
+    scopes = {scope for scope, _is_latent_secret in rows}
+    if len(scopes) == 1:
+        return next(iter(scopes))
+
+    # Keep this exact exemption aligned with promote_claim_scope above: that
+    # writer skips private claims bound to latent backstory secrets so one
+    # reveal cannot expose a sibling whose own gate has not fired.
+    exempt_private = scopes == {"bounded", "private"} and all(
+        is_latent_secret for scope, is_latent_secret in rows if scope == "private"
+    )
+    if exempt_private:
+        return "bounded"
+    raise ValueError(
+        "Sibling claims on event "
+        f"{event_id} have divergent scopes {sorted(scopes)!r}; only a private "
+        "claim bound to a latent backstory secret may coexist with bounded "
+        "siblings"
     )
 
 
@@ -845,14 +913,43 @@ def load_epistemics_hydration(
             possessed_claim_knowledge_by_entity={},
         )
 
+    availability = (
+        session.execute(
+            text(
+                """
+                /* orrery:epistemics_hydration:backstory_availability */
+                SELECT to_regclass('backstory_secrets') IS NOT NULL AS available
+                """
+            )
+        )
+        .mappings()
+        .first()
+    )
+    backstory_available = bool(availability and availability["available"])
+    # A pre-091 schema cannot contain latent backstory bindings. Rendering a
+    # literal false keeps all divergence shapes loud until the table exists.
+    latent_secret_flag = (
+        """
+        EXISTS (
+            SELECT 1
+            FROM backstory_secrets latent_secret
+            WHERE latent_secret.claim_id = c.id
+              AND latent_secret.status = 'latent'
+        )
+        """
+        if backstory_available
+        else "false"
+    )
+
     scopes: dict[int, str] = {}
     if recent_events:
         scope_query = text(
-            """
+            f"""
             /* orrery:epistemics_hydration:recent_event_scopes */
             SELECT c.id AS claim_id,
                    c.world_event_id,
-                   c.scope
+                   c.scope,
+                   {latent_secret_flag} AS is_latent_backstory_secret
             FROM claims c
             JOIN world_events we ON we.id = c.world_event_id
             WHERE c.world_event_id = ANY(:recent_event_ids)
@@ -861,6 +958,7 @@ def load_epistemics_hydration(
             ORDER BY c.world_event_id, c.id
             """
         )
+        scope_rows_by_event: dict[int, list[tuple[str, bool]]] = {}
         for row in session.execute(
             scope_query,
             {
@@ -874,18 +972,17 @@ def load_epistemics_hydration(
                 raise ValueError(
                     f"Claim on event {event_id} has unknown scope {scope!r}"
                 )
-            previous_scope = scopes.get(event_id)
-            if previous_scope is not None and previous_scope != scope:
-                raise ValueError(
-                    "Sibling claims on event "
-                    f"{event_id} have divergent scopes "
-                    f"{previous_scope!r} and {scope!r}"
-                )
+            scope_rows_by_event.setdefault(event_id, []).append(
+                (scope, bool(row.get("is_latent_backstory_secret", False)))
+            )
+        for event_id, sibling_rows in scope_rows_by_event.items():
             # Legacy recent-event predicates are incident-level: possession
             # of any sibling account admits the shared event. Account-aware
-            # predicates remain claim-id keyed below. Variant minting copies
-            # scope, and divergent later mutations fail loudly above.
-            scopes[event_id] = scope
+            # predicates remain claim-id keyed below.
+            scopes[event_id] = _merge_sibling_scope(
+                event_id=event_id,
+                rows=sibling_rows,
+            )
 
     if not universe:
         return EpistemicsHydration(
@@ -897,7 +994,7 @@ def load_epistemics_hydration(
         )
 
     claims_query = text(
-        """
+        f"""
         /* orrery:epistemics_hydration:claims */
         WITH anchor AS (
             SELECT created_at
@@ -964,6 +1061,7 @@ def load_epistemics_hydration(
         SELECT c.id AS claim_id,
                c.world_event_id,
                c.scope,
+               {latent_secret_flag} AS is_latent_backstory_secret,
                COALESCE(
                    about.about_entity_ids,
                    ARRAY[]::bigint[]
@@ -978,7 +1076,7 @@ def load_epistemics_hydration(
         """
     )
     claims: dict[int, dict[str, Any]] = {}
-    hydrated_scopes: dict[int, str] = {}
+    hydrated_scope_rows: dict[int, list[tuple[str, bool]]] = {}
     for row in session.execute(
         claims_query,
         {
@@ -991,14 +1089,9 @@ def load_epistemics_hydration(
         scope = str(row["scope"])
         if scope not in CLAIM_SCOPES:
             raise ValueError(f"Claim on event {event_id} has unknown scope {scope!r}")
-        previous_scope = hydrated_scopes.get(event_id)
-        if previous_scope is not None and previous_scope != scope:
-            raise ValueError(
-                "Sibling claims on event "
-                f"{event_id} have divergent scopes "
-                f"{previous_scope!r} and {scope!r}"
-            )
-        hydrated_scopes[event_id] = scope
+        hydrated_scope_rows.setdefault(event_id, []).append(
+            (scope, bool(row.get("is_latent_backstory_secret", False)))
+        )
         claims[claim_id] = {
             "world_event_id": event_id,
             "scope": scope,
@@ -1006,6 +1099,8 @@ def load_epistemics_hydration(
                 int(entity_id) for entity_id in (row["about_entity_ids"] or ())
             ),
         }
+    for event_id, sibling_rows in hydrated_scope_rows.items():
+        _merge_sibling_scope(event_id=event_id, rows=sibling_rows)
 
     awareness: dict[int, set[int]] = {}
     awareness_rows: dict[tuple[int, int], dict[str, Any]] = {}

--- a/nexus/agents/orrery/epistemics.py
+++ b/nexus/agents/orrery/epistemics.py
@@ -404,6 +404,161 @@ def _account_payload_json(
     )
 
 
+def author_backstory_secret_sync(
+    cur: Any,
+    *,
+    claim_id: int,
+    gate_template_id: str,
+    holder_entity_id: int,
+    source_chunk_id: int,
+) -> int:
+    """Author one private claim as a durable template-gated secret."""
+
+    from nexus.agents.orrery.reveal_gates import REVEAL_GATES
+
+    cur.execute("SELECT scope FROM claims WHERE id = %s", (claim_id,))
+    claim = cur.fetchone()
+    if claim is None:
+        raise ValueError(f"Claim {claim_id} does not exist")
+    scope = str(_row_value(claim, "scope", 0))
+    if scope != "private":
+        raise ValueError(
+            f"Backstory secret claim {claim_id} must be private, not {scope!r}"
+        )
+    if gate_template_id not in REVEAL_GATES:
+        raise ValueError(f"Unregistered reveal gate {gate_template_id!r}")
+    cur.execute("SELECT 1 FROM entities WHERE id = %s", (holder_entity_id,))
+    if cur.fetchone() is None:
+        raise ValueError(f"Secret holder entity {holder_entity_id} does not exist")
+    cur.execute(
+        """
+        SELECT world_time, world_layer::text AS world_layer
+        FROM chunk_metadata
+        WHERE chunk_id = %s
+        """,
+        (source_chunk_id,),
+    )
+    clock = cur.fetchone()
+    if clock is None:
+        raise ValueError(f"Secret source chunk {source_chunk_id} has no metadata")
+    cur.execute(
+        """
+        INSERT INTO backstory_secrets (
+            claim_id, gate_template_id, holder_entity_id, source_chunk_id
+        ) VALUES (%s, %s, %s, %s)
+        RETURNING id
+        """,
+        (claim_id, gate_template_id, holder_entity_id, source_chunk_id),
+    )
+    secret_id = int(_row_value(cur.fetchone(), "id", 0))
+    payload = json.dumps(
+        {
+            "claim_id": claim_id,
+            "gate_template_id": gate_template_id,
+            "holder_entity_id": holder_entity_id,
+            "secret_id": secret_id,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    cur.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, world_layer, source,
+            changed_fields, payload, world_time
+        ) VALUES (
+            'backstory_secret_authored', %s, %s, %s::world_layer_type,
+            'authored', ARRAY['backstory_secrets']::text[], %s::jsonb, %s
+        )
+        """,
+        (
+            source_chunk_id,
+            holder_entity_id,
+            _row_value(clock, "world_layer", 1),
+            payload,
+            _row_value(clock, "world_time", 0),
+        ),
+    )
+    return secret_id
+
+
+async def author_backstory_secret_async(
+    conn: Any,
+    *,
+    claim_id: int,
+    gate_template_id: str,
+    holder_entity_id: int,
+    source_chunk_id: int,
+) -> int:
+    """Asyncpg twin of :func:`author_backstory_secret_sync`."""
+
+    from nexus.agents.orrery.reveal_gates import REVEAL_GATES
+
+    scope = await conn.fetchval("SELECT scope FROM claims WHERE id = $1", claim_id)
+    if scope is None:
+        raise ValueError(f"Claim {claim_id} does not exist")
+    if str(scope) != "private":
+        raise ValueError(
+            f"Backstory secret claim {claim_id} must be private, not {str(scope)!r}"
+        )
+    if gate_template_id not in REVEAL_GATES:
+        raise ValueError(f"Unregistered reveal gate {gate_template_id!r}")
+    holder_exists = await conn.fetchval(
+        "SELECT EXISTS (SELECT 1 FROM entities WHERE id = $1)", holder_entity_id
+    )
+    if not holder_exists:
+        raise ValueError(f"Secret holder entity {holder_entity_id} does not exist")
+    clock = await conn.fetchrow(
+        """
+        SELECT world_time, world_layer::text AS world_layer
+        FROM chunk_metadata
+        WHERE chunk_id = $1
+        """,
+        source_chunk_id,
+    )
+    if clock is None:
+        raise ValueError(f"Secret source chunk {source_chunk_id} has no metadata")
+    secret_id = await conn.fetchval(
+        """
+        INSERT INTO backstory_secrets (
+            claim_id, gate_template_id, holder_entity_id, source_chunk_id
+        ) VALUES ($1, $2, $3, $4)
+        RETURNING id
+        """,
+        claim_id,
+        gate_template_id,
+        holder_entity_id,
+        source_chunk_id,
+    )
+    payload = json.dumps(
+        {
+            "claim_id": claim_id,
+            "gate_template_id": gate_template_id,
+            "holder_entity_id": holder_entity_id,
+            "secret_id": int(secret_id),
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    await conn.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, world_layer, source,
+            changed_fields, payload, world_time
+        ) VALUES (
+            'backstory_secret_authored', $1, $2, $3::world_layer_type,
+            'authored', ARRAY['backstory_secrets']::text[], $4::jsonb, $5
+        )
+        """,
+        source_chunk_id,
+        holder_entity_id,
+        clock["world_layer"],
+        payload,
+        clock["world_time"],
+    )
+    return int(secret_id)
+
+
 def record_revelation(
     cur: Any,
     *,
@@ -490,8 +645,88 @@ def record_revelation(
     )
 
 
+async def record_revelation_async(
+    conn: Any,
+    *,
+    claim_id: int,
+    knower_entity_id: int,
+    source_entity_id: Optional[int] = None,
+    channel: Optional[str] = None,
+    world_time: Optional[datetime] = None,
+    source_chunk_id: Optional[int] = None,
+) -> RevelationResult:
+    """Asyncpg twin of :func:`record_revelation`."""
+
+    source_tier = "told" if source_entity_id is not None else "granted"
+    root_source_entity_id = None
+    if source_entity_id is not None:
+        scope = await conn.fetchval("SELECT scope FROM claims WHERE id = $1", claim_id)
+        if scope is None:
+            raise ValueError(f"Claim {claim_id} does not exist")
+        if str(scope) == "common":
+            root_source_entity_id = source_entity_id
+        else:
+            source_awareness = await conn.fetchrow(
+                """
+                SELECT root_source_entity_id
+                FROM claim_awareness
+                WHERE claim_id = $1 AND knower_entity_id = $2
+                """,
+                claim_id,
+                source_entity_id,
+            )
+            if source_awareness is None:
+                raise ValueError(
+                    f"Entity {source_entity_id} cannot reveal claim {claim_id}: "
+                    "the teller does not possess it"
+                )
+            inherited_root = source_awareness["root_source_entity_id"]
+            root_source_entity_id = (
+                int(inherited_root) if inherited_root is not None else source_entity_id
+            )
+    row = await conn.fetchrow(
+        """
+        INSERT INTO claim_awareness (
+            claim_id, knower_entity_id, source_tier,
+            immediate_source_entity_id, root_source_entity_id, channel,
+            acquired_at_world_time, source_chunk_id
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        ON CONFLICT (claim_id, knower_entity_id) DO NOTHING
+        RETURNING id, source_tier
+        """,
+        claim_id,
+        knower_entity_id,
+        source_tier,
+        source_entity_id,
+        root_source_entity_id,
+        channel,
+        world_time,
+        source_chunk_id,
+    )
+    inserted = row is not None
+    if row is None:
+        row = await conn.fetchrow(
+            """
+            SELECT id, source_tier FROM claim_awareness
+            WHERE claim_id = $1 AND knower_entity_id = $2
+            """,
+            claim_id,
+            knower_entity_id,
+        )
+        if row is None:
+            raise RuntimeError(
+                "Awareness conflict did not resolve to an existing row for "
+                f"claim {claim_id}, entity {knower_entity_id}"
+            )
+    return RevelationResult(
+        awareness_id=int(row["id"]),
+        source_tier=str(row["source_tier"]),
+        inserted=inserted,
+    )
+
+
 def promote_claim_scope(cur: Any, *, claim_id: int, new_scope: str) -> None:
-    """Promote every sibling account on an incident; reject every narrowing."""
+    """Move every sibling account into bounded spreadability, idempotently."""
 
     if new_scope not in CLAIM_SCOPES:
         raise ValueError(f"Unknown claim scope {new_scope!r}")
@@ -519,9 +754,7 @@ def promote_claim_scope(cur: Any, *, claim_id: int, new_scope: str) -> None:
     if target is None:
         raise RuntimeError(f"Claim {claim_id} disappeared during scope promotion")
     current_scope = str(_row_value(target, "scope", 1))
-    if new_scope != current_scope and (
-        current_scope != "common" or new_scope == "common"
-    ):
+    if new_scope != current_scope and new_scope != "bounded":
         raise ValueError(
             f"Illegal claim scope transition {current_scope!r} -> {new_scope!r}"
         )
@@ -534,6 +767,50 @@ def promote_claim_scope(cur: Any, *, claim_id: int, new_scope: str) -> None:
         )
         """,
         (new_scope, claim_id),
+    )
+
+
+async def promote_claim_scope_async(
+    conn: Any, *, claim_id: int, new_scope: str
+) -> None:
+    """Asyncpg twin of :func:`promote_claim_scope`."""
+
+    if new_scope not in CLAIM_SCOPES:
+        raise ValueError(f"Unknown claim scope {new_scope!r}")
+    siblings = await conn.fetch(
+        """
+        SELECT sibling.id, sibling.scope
+        FROM claims sibling
+        WHERE sibling.world_event_id = (
+            SELECT target.world_event_id
+            FROM claims target
+            WHERE target.id = $1
+        )
+        ORDER BY sibling.id
+        FOR UPDATE
+        """,
+        claim_id,
+    )
+    if not siblings:
+        raise ValueError(f"Claim {claim_id} does not exist")
+    target = next((row for row in siblings if int(row["id"]) == claim_id), None)
+    if target is None:
+        raise RuntimeError(f"Claim {claim_id} disappeared during scope promotion")
+    current_scope = str(target["scope"])
+    if new_scope != current_scope and new_scope != "bounded":
+        raise ValueError(
+            f"Illegal claim scope transition {current_scope!r} -> {new_scope!r}"
+        )
+    await conn.execute(
+        """
+        UPDATE claims
+        SET scope = $1
+        WHERE world_event_id = (
+            SELECT world_event_id FROM claims WHERE id = $2
+        )
+        """,
+        new_scope,
+        claim_id,
     )
 
 

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -39,6 +39,10 @@ from nexus.agents.orrery.propagation import (
     drain_claim_propagation_async,
     drain_claim_propagation_sync,
 )
+from nexus.agents.orrery.reveal import (
+    drain_backstory_reveals_async,
+    drain_backstory_reveals_sync,
+)
 from nexus.agents.orrery.resolver import (
     LOCATION_CLASS_TAG_CATEGORIES,
     OrreryResolutionDraft,
@@ -54,6 +58,7 @@ from nexus.agents.orrery.substrate import (
     ProjectPolicy,
     SUPPORTED_TRAVEL_PURPOSES,
     coerce_project_policy,
+    WorldState,
 )
 
 
@@ -188,6 +193,7 @@ class CommitOrreryTickResult:
     scene_pressure_count: int = 0
     prompt_exposure_count: int = 0
     propagation_count: int = 0
+    reveal_count: int = 0
 
 
 def _coerce_prompt_limits(prompt_settings: Any) -> tuple[int, int]:
@@ -360,6 +366,8 @@ def commit_orrery_tick_sync(
     epistemics_settings: Optional[Any] = None,
     contagion_settings: Optional[Any] = None,
     drift_settings: Optional[Any] = None,
+    reveal_settings: Optional[Any] = None,
+    reveal_state: Optional[WorldState] = None,
 ) -> CommitOrreryTickResult:
     """Materialize a preview proposal inside the accepted-chunk transaction."""
 
@@ -415,11 +423,18 @@ def commit_orrery_tick_sync(
                 settings=drift_settings,
                 epistemics_settings=epistemics_policy,
             )
+            reveal_result = drain_backstory_reveals_sync(
+                cur,
+                tick_chunk_id=tick_chunk_id,
+                settings=reveal_settings,
+                state=reveal_state,
+            )
             return CommitOrreryTickResult(
                 cleared_tag_count=expired_tag_count,
                 scene_pressure_count=scene_pressure_count,
                 prompt_exposure_count=prompt_exposure_count,
                 propagation_count=propagation_count,
+                reveal_count=reveal_result.revealed_count,
             )
 
         assert coerced is not None
@@ -582,6 +597,12 @@ def commit_orrery_tick_sync(
             settings=drift_settings,
             epistemics_settings=epistemics_policy,
         )
+        reveal_result = drain_backstory_reveals_sync(
+            cur,
+            tick_chunk_id=tick_chunk_id,
+            settings=reveal_settings,
+            state=reveal_state,
+        )
 
     return CommitOrreryTickResult(
         resolution_count=resolution_count,
@@ -596,6 +617,7 @@ def commit_orrery_tick_sync(
         scene_pressure_count=scene_pressure_count,
         prompt_exposure_count=prompt_exposure_count,
         propagation_count=propagation_count,
+        reveal_count=reveal_result.revealed_count,
     )
 
 
@@ -615,6 +637,8 @@ async def commit_orrery_tick_async(
     epistemics_settings: Optional[Any] = None,
     contagion_settings: Optional[Any] = None,
     drift_settings: Optional[Any] = None,
+    reveal_settings: Optional[Any] = None,
+    reveal_state: Optional[WorldState] = None,
 ) -> CommitOrreryTickResult:
     """Async parity wrapper for tests and non-production commit callers."""
 
@@ -669,11 +693,18 @@ async def commit_orrery_tick_async(
             settings=drift_settings,
             epistemics_settings=epistemics_policy,
         )
+        reveal_result = await drain_backstory_reveals_async(
+            conn,
+            tick_chunk_id=tick_chunk_id,
+            settings=reveal_settings,
+            state=reveal_state,
+        )
         return CommitOrreryTickResult(
             cleared_tag_count=expired_tag_count,
             scene_pressure_count=scene_pressure_count,
             prompt_exposure_count=prompt_exposure_count,
             propagation_count=propagation_count,
+            reveal_count=reveal_result.revealed_count,
         )
 
     assert coerced is not None
@@ -834,6 +865,12 @@ async def commit_orrery_tick_async(
         settings=drift_settings,
         epistemics_settings=epistemics_policy,
     )
+    reveal_result = await drain_backstory_reveals_async(
+        conn,
+        tick_chunk_id=tick_chunk_id,
+        settings=reveal_settings,
+        state=reveal_state,
+    )
 
     return CommitOrreryTickResult(
         resolution_count=resolution_count,
@@ -848,6 +885,7 @@ async def commit_orrery_tick_async(
         scene_pressure_count=scene_pressure_count,
         prompt_exposure_count=prompt_exposure_count,
         propagation_count=propagation_count,
+        reveal_count=reveal_result.revealed_count,
     )
 
 

--- a/nexus/agents/orrery/reconstruction.py
+++ b/nexus/agents/orrery/reconstruction.py
@@ -139,7 +139,13 @@ CHECKPOINT_SECTIONS: dict[str, str] = {
     "claim_awareness": (
         "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) " "FROM claim_awareness t"
     ),
+    "backstory_secrets": (
+        "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
+        "FROM backstory_secrets t"
+    ),
 }
+
+_ADDITIVE_CHECKPOINT_TABLES = {"backstory_secrets": "backstory_secrets"}
 
 CHECKPOINT_LABELS = ("genesis", "interval", "manual")
 
@@ -165,6 +171,17 @@ def capture_state_checkpoint_sync(
     _validate_label(label)
     state: dict[str, Any] = {}
     for section, sql in CHECKPOINT_SECTIONS.items():
+        additive_table = _ADDITIVE_CHECKPOINT_TABLES.get(section)
+        if additive_table is not None:
+            cur.execute(
+                "SELECT to_regclass(%s) AS checkpoint_table",
+                (additive_table,),
+            )
+            if row_get(cur.fetchone(), "checkpoint_table", 0) is None:
+                # A genuinely pre-migration schema produces a pre-migration
+                # checkpoint document. Replay treats the absent key as the
+                # explicit cross-era compatibility boundary.
+                continue
         cur.execute(sql)
         row = cur.fetchone()
         state[section] = row[0] if not hasattr(row, "keys") else list(row.values())[0]
@@ -190,6 +207,12 @@ async def capture_state_checkpoint_async(
     _validate_label(label)
     state: dict[str, Any] = {}
     for section, sql in CHECKPOINT_SECTIONS.items():
+        additive_table = _ADDITIVE_CHECKPOINT_TABLES.get(section)
+        if (
+            additive_table is not None
+            and await conn.fetchval("SELECT to_regclass($1)", additive_table) is None
+        ):
+            continue
         value = await conn.fetchval(sql)
         state[section] = json.loads(value) if isinstance(value, str) else value
     return await conn.fetchval(

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -41,6 +41,8 @@ produces. Sections and their replay sources:
 - ``claim_awareness`` — append-only participant/witness/granted/deliberate-
   told rows from their chunk provenance, while passive told rows are rebuilt
   from ``claim_propagated`` world events rather than trusted from projection.
+- ``backstory_secrets`` — lifecycle rows rebuilt from
+  ``backstory_secret_authored`` and ``backstory_revealed`` world events.
 
 Known undetectable gaps: (1) reapplication policies ``replace`` and
 ``extend_expiry`` overwrite a live tag row's ``source_chunk_id`` in place
@@ -385,7 +387,11 @@ class _Replayer:
                 f"base for reconstruction at chunk {self.target_chunk_id}"
             )
         missing = set(CHECKPOINT_SECTIONS) - set(state)
-        allowed_missing = {"character_project_states", "claim_awareness"}
+        allowed_missing = {
+            "character_project_states",
+            "claim_awareness",
+            "backstory_secrets",
+        }
         unexpected_missing = missing - allowed_missing
         if unexpected_missing:
             raise ValueError(
@@ -398,6 +404,9 @@ class _Replayer:
         if "claim_awareness" in missing:
             state["claim_awareness"] = []
             self.missing_base_sections.add("claim_awareness")
+        if "backstory_secrets" in missing:
+            state["backstory_secrets"] = []
+            self.missing_base_sections.add("backstory_secrets")
         return checkpoint_id, chunk_id, created_at, state
 
     # -- forward scalar replay ----------------------------------------------
@@ -425,6 +434,14 @@ class _Replayer:
                 "claim_awareness",
                 "base checkpoint predates the claim-awareness checkpoint section; "
                 "pre-checkpoint possession is unreproducible",
+                approximate=True,
+            )
+        if "backstory_secrets" in self.missing_base_sections:
+            result.add_note(
+                "backstory_secrets",
+                "base checkpoint predates migration 091 and lacks the backstory-"
+                "secret section; treated as empty because the table and writers "
+                "did not exist at that checkpoint",
                 approximate=True,
             )
 
@@ -500,6 +517,11 @@ class _Replayer:
             base_state=base_state,
             base_chunk=base_chunk,
             base_created_at=base_created_at,
+        )
+        self._replay_backstory_secrets(
+            result,
+            base_state=base_state,
+            base_chunk=base_chunk,
         )
 
         for table in RELATIONSHIP_KEY_COLUMNS:
@@ -710,6 +732,142 @@ class _Replayer:
             f"rebuilt {mint_count} mint row(s), {revelation_count} explicit "
             f"revelation row(s), and {event_count} passive row(s) from "
             "producer provenance",
+            approximate=False,
+        )
+
+    def _replay_backstory_secrets(
+        self,
+        result: ReplayResult,
+        *,
+        base_state: dict[str, Any],
+        base_chunk: int,
+    ) -> None:
+        """Rebuild the secret lifecycle projection from its two event types."""
+
+        working = {int(row["id"]): dict(row) for row in base_state["backstory_secrets"]}
+        self.cur.execute(
+            """
+            SELECT id, event_type, tick_chunk_id, actor_entity_id, world_time,
+                   payload, created_at
+            FROM world_events
+            WHERE event_type IN (
+                      'backstory_secret_authored', 'backstory_revealed'
+                  )
+              AND tick_chunk_id > %s
+              AND tick_chunk_id <= %s
+            ORDER BY tick_chunk_id, id
+            """,
+            (base_chunk, self.target_chunk_id),
+        )
+        authored_count = 0
+        revealed_count = 0
+        for (
+            event_id,
+            event_type,
+            tick_chunk_id,
+            actor_entity_id,
+            world_time,
+            raw_payload,
+            created_at,
+        ) in self.cur.fetchall():
+            payload = _as_document(raw_payload)
+            if not isinstance(payload, dict):
+                raise ValueError(
+                    f"{event_type} event {event_id} payload is not an object"
+                )
+            required = {
+                "claim_id",
+                "gate_template_id",
+                "secret_id",
+            }
+            if event_type == "backstory_secret_authored":
+                required.add("holder_entity_id")
+            missing = sorted(required - set(payload))
+            if missing:
+                raise ValueError(
+                    f"{event_type} event {event_id} lacks payload fields {missing}"
+                )
+
+            secret_id = int(payload["secret_id"])
+            claim_id = int(payload["claim_id"])
+            gate_template_id = str(payload["gate_template_id"])
+            if event_type == "backstory_secret_authored":
+                if secret_id in working:
+                    raise ValueError(
+                        f"backstory_secret_authored event {event_id} duplicates "
+                        f"secret {secret_id}"
+                    )
+                holder_entity_id = int(payload["holder_entity_id"])
+                if int(actor_entity_id) != holder_entity_id:
+                    raise ValueError(
+                        f"backstory_secret_authored event {event_id} actor does "
+                        f"not match holder {holder_entity_id}"
+                    )
+                working[secret_id] = {
+                    "id": secret_id,
+                    "claim_id": claim_id,
+                    "gate_template_id": gate_template_id,
+                    "status": "latent",
+                    "holder_entity_id": holder_entity_id,
+                    "source_chunk_id": int(tick_chunk_id),
+                    "revealed_at_world_time": None,
+                    "revealed_by_chunk_id": None,
+                    "created_at": created_at,
+                }
+                authored_count += 1
+                continue
+
+            secret = working.get(secret_id)
+            if secret is None:
+                raise ValueError(
+                    f"backstory_revealed event {event_id} names unknown secret "
+                    f"{secret_id}"
+                )
+            if secret["status"] != "latent":
+                raise ValueError(
+                    f"backstory_revealed event {event_id} repeats lifecycle flip "
+                    f"for {secret_id} from {secret['status']!r}"
+                )
+            if secret["claim_id"] != claim_id:
+                raise ValueError(
+                    f"backstory_revealed event {event_id} changes secret "
+                    f"{secret_id} claim provenance"
+                )
+            if secret["gate_template_id"] != gate_template_id:
+                raise ValueError(
+                    f"backstory_revealed event {event_id} changes secret "
+                    f"{secret_id} gate provenance"
+                )
+            if int(actor_entity_id) != int(secret["holder_entity_id"]):
+                raise ValueError(
+                    f"backstory_revealed event {event_id} actor does not match "
+                    f"secret {secret_id} holder"
+                )
+            if world_time is None:
+                raise ValueError(
+                    f"backstory_revealed event {event_id} has NULL world_time"
+                )
+            if "world_time" in payload and not _values_equal(
+                payload["world_time"], world_time
+            ):
+                raise ValueError(
+                    f"backstory_revealed event {event_id} payload world_time "
+                    "disagrees with its ledger column"
+                )
+            secret.update(
+                {
+                    "status": "revealed",
+                    "revealed_at_world_time": world_time,
+                    "revealed_by_chunk_id": int(tick_chunk_id),
+                }
+            )
+            revealed_count += 1
+
+        result.state["backstory_secrets"] = [working[key] for key in sorted(working)]
+        result.add_note(
+            "backstory_secrets",
+            f"rebuilt {authored_count} authored row(s) and {revealed_count} "
+            "lifecycle flip(s) from world-event provenance",
             approximate=False,
         )
 
@@ -1850,6 +2008,7 @@ def _load_checkpoint_state(cur: Any, checkpoint_id: int) -> dict[str, Any]:
     state = _as_document(_row_value(cur.fetchone(), 0))
     state.setdefault("character_project_states", [])
     state.setdefault("claim_awareness", [])
+    state.setdefault("backstory_secrets", [])
     return state
 
 
@@ -1932,6 +2091,16 @@ def verify_checkpoints_sync(cur: Any) -> list[CheckpointPairVerdict]:
                                 ]
                             }
                             if "claim_awareness" in missing_sections
+                            else {}
+                        ),
+                        **(
+                            {
+                                "backstory_secrets": [
+                                    "checkpoint predates migration 091 and the "
+                                    "backstory-secret section; comparison skipped"
+                                ]
+                            }
+                            if "backstory_secrets" in missing_sections
                             else {}
                         ),
                     },

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -405,6 +405,20 @@ def hydrate_world_state(
     project_policy = coerce_project_policy(project_settings)
     epistemics_policy = coerce_epistemics_policy(epistemics_settings)
 
+    is_active = {
+        int(row["id"]): bool(row["is_active"])
+        for row in session.execute(
+            text(
+                """
+                /* orrery:entity_activity */
+                SELECT id, is_active
+                FROM entities
+                ORDER BY id
+                """
+            )
+        ).mappings()
+    }
+
     tags: dict[int, set[str]] = {}
     ephemeral_tags: dict[int, set[str]] = {}
     for row in session.execute(
@@ -603,6 +617,7 @@ def hydrate_world_state(
         ephemeral_tags={
             entity_id: frozenset(values) for entity_id, values in ephemeral_tags.items()
         },
+        is_active=is_active,
         locations=locations,
         activities=activities,
         trust=trust,

--- a/nexus/agents/orrery/reveal.py
+++ b/nexus/agents/orrery/reveal.py
@@ -1,0 +1,555 @@
+"""Commit-time draining for template-gated durable backstory secrets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from typing import Any, Mapping, Optional, Sequence
+
+from nexus.agents.orrery.db_rows import row_get as _row_get
+from nexus.agents.orrery.epistemics import (
+    promote_claim_scope,
+    promote_claim_scope_async,
+    record_revelation,
+    record_revelation_async,
+)
+from nexus.agents.orrery.reveal_gates import REVEAL_GATES, SecretContext
+from nexus.agents.orrery.substrate import TravelState, WorldState
+from nexus.config.settings_models import OrreryRevealSettings
+
+
+BACKSTORY_SECRET_AUTHORED_EVENT_TYPE = "backstory_secret_authored"
+BACKSTORY_REVEALED_EVENT_TYPE = "backstory_revealed"
+BACKSTORY_EVENT_TYPES = frozenset(
+    {BACKSTORY_SECRET_AUTHORED_EVENT_TYPE, BACKSTORY_REVEALED_EVENT_TYPE}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RevealDrainResult:
+    """Secret, awareness, and event rows materialized by one reveal drain."""
+
+    secret_ids: tuple[int, ...] = ()
+    awareness_ids: tuple[int, ...] = ()
+    event_ids: tuple[int, ...] = ()
+
+    @property
+    def revealed_count(self) -> int:
+        """Return the number of latent secrets atomically revealed."""
+
+        if len(self.secret_ids) != len(self.event_ids):
+            raise RuntimeError("Backstory reveal status/event ledger counts diverged")
+        return len(self.secret_ids)
+
+
+@dataclass(frozen=True, slots=True)
+class _LatentSecret:
+    secret_id: int
+    claim_id: int
+    gate_template_id: str
+    holder_entity_id: int
+    world_event_id: int
+    participant_entity_ids: tuple[int, ...]
+    created_at: datetime
+
+    def context(self) -> SecretContext:
+        return SecretContext(
+            secret_id=self.secret_id,
+            claim_id=self.claim_id,
+            holder_entity_id=self.holder_entity_id,
+            world_event_id=self.world_event_id,
+            participant_entity_ids=self.participant_entity_ids,
+            created_at=self.created_at,
+        )
+
+
+def drain_backstory_reveals_sync(
+    cur: Any,
+    *,
+    tick_chunk_id: int,
+    settings: Any,
+    state: Optional[WorldState] = None,
+) -> RevealDrainResult:
+    """Reveal every firing latent secret through a DB-API cursor."""
+
+    config = _enabled_config(settings)
+    if config is None:
+        return RevealDrainResult()
+    _require_migration_091_sync(cur)
+    world_time, world_layer = _commit_clock_sync(cur, tick_chunk_id)
+    if world_layer != "primary" or world_time is None:
+        return RevealDrainResult()
+    secrets = _latent_secrets_sync(cur)
+    if not secrets:
+        return RevealDrainResult()
+    effective_state = state or _hydrate_reveal_state_sync(cur, world_time)
+    secret_ids: list[int] = []
+    awareness_ids: list[int] = []
+    event_ids: list[int] = []
+    for secret in secrets:
+        gate = REVEAL_GATES.get(secret.gate_template_id)
+        if gate is None:
+            raise RuntimeError(
+                f"Unregistered reveal gate {secret.gate_template_id!r} on "
+                f"latent secret {secret.secret_id}"
+            )
+        if not gate(effective_state, secret.context()):
+            continue
+        cur.execute(
+            """
+            UPDATE backstory_secrets
+            SET status = 'revealed',
+                revealed_at_world_time = %s,
+                revealed_by_chunk_id = %s
+            WHERE id = %s AND status = 'latent'
+            RETURNING id
+            """,
+            (world_time, tick_chunk_id, secret.secret_id),
+        )
+        if cur.fetchone() is None:
+            continue
+        promote_claim_scope(cur, claim_id=secret.claim_id, new_scope="bounded")
+        granted_entity_ids: list[int] = []
+        for participant_id in _co_located_participants(effective_state, secret):
+            grant = record_revelation(
+                cur,
+                claim_id=secret.claim_id,
+                knower_entity_id=participant_id,
+                source_entity_id=secret.holder_entity_id,
+                channel="backstory_reveal",
+                world_time=world_time,
+                source_chunk_id=tick_chunk_id,
+            )
+            if grant.inserted:
+                awareness_ids.append(grant.awareness_id)
+                granted_entity_ids.append(participant_id)
+        event_id = _emit_revealed_sync(
+            cur,
+            secret=secret,
+            tick_chunk_id=tick_chunk_id,
+            world_time=world_time,
+            granted_entity_ids=granted_entity_ids,
+        )
+        secret_ids.append(secret.secret_id)
+        event_ids.append(event_id)
+    return RevealDrainResult(
+        secret_ids=tuple(secret_ids),
+        awareness_ids=tuple(awareness_ids),
+        event_ids=tuple(event_ids),
+    )
+
+
+async def drain_backstory_reveals_async(
+    conn: Any,
+    *,
+    tick_chunk_id: int,
+    settings: Any,
+    state: Optional[WorldState] = None,
+) -> RevealDrainResult:
+    """Asyncpg twin of :func:`drain_backstory_reveals_sync`."""
+
+    config = _enabled_config(settings)
+    if config is None:
+        return RevealDrainResult()
+    await _require_migration_091_async(conn)
+    world_time, world_layer = await _commit_clock_async(conn, tick_chunk_id)
+    if world_layer != "primary" or world_time is None:
+        return RevealDrainResult()
+    secrets = await _latent_secrets_async(conn)
+    if not secrets:
+        return RevealDrainResult()
+    effective_state = state or await _hydrate_reveal_state_async(conn, world_time)
+    secret_ids: list[int] = []
+    awareness_ids: list[int] = []
+    event_ids: list[int] = []
+    for secret in secrets:
+        gate = REVEAL_GATES.get(secret.gate_template_id)
+        if gate is None:
+            raise RuntimeError(
+                f"Unregistered reveal gate {secret.gate_template_id!r} on "
+                f"latent secret {secret.secret_id}"
+            )
+        if not gate(effective_state, secret.context()):
+            continue
+        updated_id = await conn.fetchval(
+            """
+            UPDATE backstory_secrets
+            SET status = 'revealed',
+                revealed_at_world_time = $1,
+                revealed_by_chunk_id = $2
+            WHERE id = $3 AND status = 'latent'
+            RETURNING id
+            """,
+            world_time,
+            tick_chunk_id,
+            secret.secret_id,
+        )
+        if updated_id is None:
+            continue
+        await promote_claim_scope_async(
+            conn, claim_id=secret.claim_id, new_scope="bounded"
+        )
+        granted_entity_ids: list[int] = []
+        for participant_id in _co_located_participants(effective_state, secret):
+            grant = await record_revelation_async(
+                conn,
+                claim_id=secret.claim_id,
+                knower_entity_id=participant_id,
+                source_entity_id=secret.holder_entity_id,
+                channel="backstory_reveal",
+                world_time=world_time,
+                source_chunk_id=tick_chunk_id,
+            )
+            if grant.inserted:
+                awareness_ids.append(grant.awareness_id)
+                granted_entity_ids.append(participant_id)
+        event_id = await _emit_revealed_async(
+            conn,
+            secret=secret,
+            tick_chunk_id=tick_chunk_id,
+            world_time=world_time,
+            granted_entity_ids=granted_entity_ids,
+        )
+        secret_ids.append(secret.secret_id)
+        event_ids.append(event_id)
+    return RevealDrainResult(
+        secret_ids=tuple(secret_ids),
+        awareness_ids=tuple(awareness_ids),
+        event_ids=tuple(event_ids),
+    )
+
+
+def _enabled_config(settings: Any) -> Optional[OrreryRevealSettings]:
+    if settings is None:
+        return None
+    if isinstance(settings, OrreryRevealSettings):
+        config = settings
+    elif hasattr(settings, "model_dump"):
+        config = OrreryRevealSettings.model_validate(settings.model_dump())
+    elif isinstance(settings, Mapping):
+        config = OrreryRevealSettings.model_validate(settings)
+    else:
+        raise TypeError("Orrery reveal settings must be a mapping or Pydantic model")
+    return config if config.enabled else None
+
+
+_MIGRATION_091_ERROR = (
+    "Backstory reveals require migration 091; apply migration 091 before "
+    "enabling [orrery.reveal]."
+)
+
+
+def _require_migration_091_sync(cur: Any) -> None:
+    cur.execute(
+        """
+        SELECT count(*) AS registered_count,
+               to_regclass('backstory_secrets') IS NOT NULL AS table_exists
+        FROM event_types
+        WHERE type = ANY(%s)
+        """,
+        (sorted(BACKSTORY_EVENT_TYPES),),
+    )
+    row = cur.fetchone()
+    if (
+        row is None
+        or int(_row_get(row, "registered_count", 0)) != len(BACKSTORY_EVENT_TYPES)
+        or not bool(_row_get(row, "table_exists", 1))
+    ):
+        raise RuntimeError(_MIGRATION_091_ERROR)
+
+
+async def _require_migration_091_async(conn: Any) -> None:
+    row = await conn.fetchrow(
+        """
+        SELECT count(*) AS registered_count,
+               to_regclass('backstory_secrets') IS NOT NULL AS table_exists
+        FROM event_types
+        WHERE type = ANY($1::text[])
+        """,
+        sorted(BACKSTORY_EVENT_TYPES),
+    )
+    if (
+        row is None
+        or int(row["registered_count"]) != len(BACKSTORY_EVENT_TYPES)
+        or not bool(row["table_exists"])
+    ):
+        raise RuntimeError(_MIGRATION_091_ERROR)
+
+
+def _commit_clock_sync(cur: Any, tick_chunk_id: int) -> tuple[Any, Any]:
+    cur.execute(
+        """
+        SELECT world_time, world_layer::text AS world_layer
+        FROM chunk_metadata
+        WHERE chunk_id = %s
+        """,
+        (tick_chunk_id,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"Backstory-reveal chunk {tick_chunk_id} has no metadata")
+    return _row_get(row, "world_time", 0), _row_get(row, "world_layer", 1)
+
+
+async def _commit_clock_async(conn: Any, tick_chunk_id: int) -> tuple[Any, Any]:
+    row = await conn.fetchrow(
+        """
+        SELECT world_time, world_layer::text AS world_layer
+        FROM chunk_metadata
+        WHERE chunk_id = $1
+        """,
+        tick_chunk_id,
+    )
+    if row is None:
+        raise ValueError(f"Backstory-reveal chunk {tick_chunk_id} has no metadata")
+    return row["world_time"], row["world_layer"]
+
+
+_LATENT_SECRETS_SQL = """
+    SELECT secret.id AS secret_id,
+           secret.claim_id,
+           secret.gate_template_id,
+           secret.holder_entity_id,
+           claim.world_event_id,
+           secret.created_at,
+           COALESCE(
+               ARRAY(
+                   SELECT DISTINCT participant.entity_id
+                   FROM world_event_entities participant
+                   WHERE participant.event_id = claim.world_event_id
+                     AND participant.role::text IN (
+                         'actor', 'target', 'beneficiary'
+                     )
+                   ORDER BY participant.entity_id
+               ),
+               ARRAY[]::bigint[]
+           ) AS participant_entity_ids
+    FROM backstory_secrets secret
+    JOIN claims claim ON claim.id = secret.claim_id
+    WHERE secret.status = 'latent'
+    ORDER BY secret.id
+"""
+
+
+def _latent_secrets_sync(cur: Any) -> tuple[_LatentSecret, ...]:
+    cur.execute(_LATENT_SECRETS_SQL)
+    return _coerce_latent_secrets(cur.fetchall())
+
+
+async def _latent_secrets_async(conn: Any) -> tuple[_LatentSecret, ...]:
+    return _coerce_latent_secrets(await conn.fetch(_LATENT_SECRETS_SQL))
+
+
+def _coerce_latent_secrets(rows: Sequence[Any]) -> tuple[_LatentSecret, ...]:
+    return tuple(
+        _LatentSecret(
+            secret_id=int(_row_get(row, "secret_id", 0)),
+            claim_id=int(_row_get(row, "claim_id", 1)),
+            gate_template_id=str(_row_get(row, "gate_template_id", 2)),
+            holder_entity_id=int(_row_get(row, "holder_entity_id", 3)),
+            world_event_id=int(_row_get(row, "world_event_id", 4)),
+            created_at=_row_get(row, "created_at", 5),
+            participant_entity_ids=tuple(
+                int(value)
+                for value in (_row_get(row, "participant_entity_ids", 6) or ())
+            ),
+        )
+        for row in rows
+    )
+
+
+def _hydrate_reveal_state_sync(cur: Any, world_time: datetime) -> WorldState:
+    cur.execute("SELECT id, is_active FROM entities ORDER BY id")
+    activity = {
+        int(_row_get(row, "id", 0)): bool(_row_get(row, "is_active", 1))
+        for row in cur.fetchall()
+    }
+    cur.execute(
+        """
+        SELECT entity_id, current_location
+        FROM characters
+        WHERE entity_id IS NOT NULL AND current_location IS NOT NULL
+        ORDER BY entity_id
+        """
+    )
+    locations = {
+        int(_row_get(row, "entity_id", 0)): int(_row_get(row, "current_location", 1))
+        for row in cur.fetchall()
+    }
+    cur.execute(_TRUST_SQL)
+    trust = _coerce_trust(cur.fetchall())
+    cur.execute(_TRAVEL_SQL)
+    travel_states = _coerce_travel_states(cur.fetchall())
+    return WorldState(
+        is_active=activity,
+        locations=locations,
+        trust=trust,
+        travel_states=travel_states,
+        world_time=world_time,
+    )
+
+
+async def _hydrate_reveal_state_async(conn: Any, world_time: datetime) -> WorldState:
+    activity_rows = await conn.fetch("SELECT id, is_active FROM entities ORDER BY id")
+    location_rows = await conn.fetch(
+        """
+        SELECT entity_id, current_location
+        FROM characters
+        WHERE entity_id IS NOT NULL AND current_location IS NOT NULL
+        ORDER BY entity_id
+        """
+    )
+    trust_rows = await conn.fetch(_TRUST_SQL)
+    travel_rows = await conn.fetch(_TRAVEL_SQL)
+    return WorldState(
+        is_active={int(row["id"]): bool(row["is_active"]) for row in activity_rows},
+        locations={
+            int(row["entity_id"]): int(row["current_location"]) for row in location_rows
+        },
+        trust=_coerce_trust(trust_rows),
+        travel_states=_coerce_travel_states(travel_rows),
+        world_time=world_time,
+    )
+
+
+_TRUST_SQL = """
+    SELECT source_entity_id, target_entity_id, valence_magnitude
+    FROM entity_relationships_v
+    WHERE relationship_scope = 'character'
+      AND source_entity_id IS NOT NULL
+      AND target_entity_id IS NOT NULL
+      AND relationship_type IS NOT NULL
+      AND valence_magnitude IS NOT NULL
+    ORDER BY source_entity_id, target_entity_id
+"""
+
+_TRAVEL_SQL = """
+    SELECT cts.character_entity_id, cts.status::text AS status
+    FROM character_travel_states cts
+    JOIN entities entity ON entity.id = cts.character_entity_id
+    WHERE entity.kind = 'character' AND entity.is_active = true
+    ORDER BY cts.character_entity_id
+"""
+
+
+def _coerce_trust(rows: Sequence[Any]) -> dict[tuple[int, int], int]:
+    trust: dict[tuple[int, int], int] = {}
+    for row in rows:
+        key = (
+            int(_row_get(row, "source_entity_id", 0)),
+            int(_row_get(row, "target_entity_id", 1)),
+        )
+        candidate = int(_row_get(row, "valence_magnitude", 2))
+        current = trust.get(key)
+        if (
+            current is None
+            or abs(candidate) > abs(current)
+            or (abs(candidate) == abs(current) and candidate < current)
+        ):
+            trust[key] = candidate
+    return trust
+
+
+def _coerce_travel_states(rows: Sequence[Any]) -> dict[int, TravelState]:
+    return {
+        int(_row_get(row, "character_entity_id", 0)): TravelState(
+            status=str(_row_get(row, "status", 1))
+        )
+        for row in rows
+    }
+
+
+def _co_located_participants(
+    state: WorldState, secret: _LatentSecret
+) -> tuple[int, ...]:
+    holder_location = state.locations.get(secret.holder_entity_id)
+    if holder_location is None or _in_transit(state, secret.holder_entity_id):
+        return ()
+    return tuple(
+        participant_id
+        for participant_id in secret.participant_entity_ids
+        if state.locations.get(participant_id) == holder_location
+        and not _in_transit(state, participant_id)
+    )
+
+
+def _in_transit(state: WorldState, entity_id: int) -> bool:
+    travel_state = state.travel_states.get(entity_id)
+    return bool(travel_state and travel_state.is_in_transit)
+
+
+def _emit_revealed_sync(
+    cur: Any,
+    *,
+    secret: _LatentSecret,
+    tick_chunk_id: int,
+    world_time: datetime,
+    granted_entity_ids: Sequence[int],
+) -> int:
+    payload = _reveal_payload(secret, world_time, granted_entity_ids)
+    cur.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, world_layer, source,
+            changed_fields, payload, world_time
+        ) VALUES (
+            'backstory_revealed', %s, %s, 'primary', 'resolver',
+            ARRAY[
+                'backstory_secrets.status', 'claims.scope', 'claim_awareness'
+            ]::text[],
+            %s::jsonb, %s
+        )
+        RETURNING id
+        """,
+        (tick_chunk_id, secret.holder_entity_id, payload, world_time),
+    )
+    return int(_row_get(cur.fetchone(), "id", 0))
+
+
+async def _emit_revealed_async(
+    conn: Any,
+    *,
+    secret: _LatentSecret,
+    tick_chunk_id: int,
+    world_time: datetime,
+    granted_entity_ids: Sequence[int],
+) -> int:
+    event_id = await conn.fetchval(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, world_layer, source,
+            changed_fields, payload, world_time
+        ) VALUES (
+            'backstory_revealed', $1, $2, 'primary', 'resolver',
+            ARRAY[
+                'backstory_secrets.status', 'claims.scope', 'claim_awareness'
+            ]::text[],
+            $3::jsonb, $4
+        )
+        RETURNING id
+        """,
+        tick_chunk_id,
+        secret.holder_entity_id,
+        _reveal_payload(secret, world_time, granted_entity_ids),
+        world_time,
+    )
+    return int(event_id)
+
+
+def _reveal_payload(
+    secret: _LatentSecret,
+    world_time: datetime,
+    granted_entity_ids: Sequence[int],
+) -> str:
+    return json.dumps(
+        {
+            "claim_id": secret.claim_id,
+            "gate_template_id": secret.gate_template_id,
+            "revealed_participant_entity_ids": list(granted_entity_ids),
+            "secret_id": secret.secret_id,
+            "world_time": world_time.isoformat(),
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )

--- a/nexus/agents/orrery/reveal.py
+++ b/nexus/agents/orrery/reveal.py
@@ -469,7 +469,11 @@ def _co_located_participants(
     return tuple(
         participant_id
         for participant_id in secret.participant_entity_ids
-        if state.locations.get(participant_id) == holder_location
+        # The holder is trivially co-located with themselves; without this
+        # exclusion the drain would record a self-revelation (both gate
+        # functions apply the same filter before consuming this list).
+        if participant_id != secret.holder_entity_id
+        and state.locations.get(participant_id) == holder_location
         and not _in_transit(state, participant_id)
     )
 

--- a/nexus/agents/orrery/reveal_gates.py
+++ b/nexus/agents/orrery/reveal_gates.py
@@ -28,7 +28,11 @@ RevealGate = Callable[[WorldState, SecretContext], bool]
 def holder_death(state: WorldState, context: SecretContext) -> bool:
     """Reveal a secret when its keeper can no longer keep it in the world."""
 
-    return not state.is_active.get(context.holder_entity_id, False)
+    if context.holder_entity_id not in state.is_active:
+        # Irreversible reveals require positive evidence; missing activity is
+        # unknown, not proof that the holder is dead.
+        return False
+    return not state.is_active[context.holder_entity_id]
 
 
 def participants_reunited(state: WorldState, context: SecretContext) -> bool:

--- a/nexus/agents/orrery/reveal_gates.py
+++ b/nexus/agents/orrery/reveal_gates.py
@@ -1,0 +1,95 @@
+"""Pure template-authored gates for durable backstory secrets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import re
+from typing import Callable, Mapping
+
+from nexus.agents.orrery.substrate import WorldState
+
+
+@dataclass(frozen=True, slots=True)
+class SecretContext:
+    """Immutable claim and holder facts supplied to one reveal gate."""
+
+    secret_id: int
+    claim_id: int
+    holder_entity_id: int
+    world_event_id: int
+    participant_entity_ids: tuple[int, ...]
+    created_at: datetime
+
+
+RevealGate = Callable[[WorldState, SecretContext], bool]
+
+
+def holder_death(state: WorldState, context: SecretContext) -> bool:
+    """Reveal a secret when its keeper can no longer keep it in the world."""
+
+    return not state.is_active.get(context.holder_entity_id, False)
+
+
+def participants_reunited(state: WorldState, context: SecretContext) -> bool:
+    """Reveal when two fellow participants safely reunite with the holder."""
+
+    holder_id = context.holder_entity_id
+    holder_location = state.locations.get(holder_id)
+    if holder_location is None or _in_transit(state, holder_id):
+        return False
+    reunited = {
+        participant_id
+        for participant_id in context.participant_entity_ids
+        if participant_id != holder_id
+        and state.locations.get(participant_id) == holder_location
+        and not _in_transit(state, participant_id)
+    }
+    return len(reunited) >= 2
+
+
+def trust_earned(state: WorldState, context: SecretContext) -> bool:
+    """Reveal after a participant and holder establish deep mutual confidence."""
+
+    holder_id = context.holder_entity_id
+    return any(
+        participant_id != holder_id
+        and state.trust.get((participant_id, holder_id), 0) >= 3
+        and state.trust.get((holder_id, participant_id), 0) >= 2
+        for participant_id in context.participant_entity_ids
+    )
+
+
+def _in_transit(state: WorldState, entity_id: int) -> bool:
+    travel_state = state.travel_states.get(entity_id)
+    return bool(travel_state and travel_state.is_in_transit)
+
+
+REVEAL_GATES: Mapping[str, RevealGate] = {
+    "holder_death": holder_death,
+    "participants_reunited": participants_reunited,
+    "trust_earned": trust_earned,
+}
+
+_SNAKE_CASE = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$")
+
+
+def validate_reveal_gate_registry(
+    registry: Mapping[str, RevealGate] = REVEAL_GATES,
+) -> None:
+    """Reject blank, malformed, or non-callable reveal-gate registrations."""
+
+    invalid_names = sorted(
+        name for name in registry if not name or _SNAKE_CASE.fullmatch(name) is None
+    )
+    if invalid_names:
+        raise ValueError(
+            "Reveal gate registry keys must be non-empty snake_case names: "
+            f"{invalid_names}"
+        )
+    non_callable = sorted(name for name, gate in registry.items() if not callable(gate))
+    if non_callable:
+        raise TypeError(f"Reveal gate registry values must be callable: {non_callable}")
+
+
+validate_reveal_gate_registry()

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -333,6 +333,9 @@ class WorldState:
 
     tags: Mapping[int, frozenset[str]] = field(default_factory=dict)
     ephemeral_tags: Mapping[int, frozenset[str]] = field(default_factory=dict)
+    # Includes inactive entities so lifecycle gates can distinguish inactive
+    # holders from ids missing through an incomplete hydration.
+    is_active: Mapping[int, bool] = field(default_factory=dict)
     # Committed wins per (actor_entity_id, template_id) inside the
     # habituation window — hydrated from orrery_resolutions, so replay
     # reconstructs identical dampening. Empty when habituation is off.

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -572,6 +572,7 @@ async def commit_incubator_to_database(
                 ),
                 contagion_settings=_orrery_contagion_settings(),
                 drift_settings=_orrery_drift_settings(),
+                reveal_settings=_orrery_reveal_settings(),
             )
             if (
                 orrery_result.resolution_count
@@ -581,12 +582,14 @@ async def commit_incubator_to_database(
                 or orrery_result.scene_pressure_count
                 or orrery_result.prompt_exposure_count
                 or orrery_result.propagation_count
+                or orrery_result.reveal_count
             ):
                 logger.info(
                     "Committed Orrery tick for chunk %s: %s resolutions, %s events, "
                     "%s tag mutations, %s cleared tags, %s existing skipped, "
                     "%s adjudications (%s deferred, %s voided, %s replaced), "
-                    "%s scene pressures, %s prompt exposures, %s propagations",
+                    "%s scene pressures, %s prompt exposures, %s propagations, "
+                    "%s reveals",
                     chunk_id,
                     orrery_result.resolution_count,
                     orrery_result.event_count,
@@ -600,6 +603,7 @@ async def commit_incubator_to_database(
                     orrery_result.scene_pressure_count,
                     orrery_result.prompt_exposure_count,
                     orrery_result.propagation_count,
+                    orrery_result.reveal_count,
                 )
 
             # Step 8.55: interval state checkpoint (reconstruction bar 7c)
@@ -688,6 +692,14 @@ def _orrery_drift_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("drift")
+
+
+def _orrery_reveal_settings() -> Any:
+    """[orrery.reveal] template-authored backstory reveal policy."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("reveal")
 
 
 def _orrery_checkpoint_interval() -> int:

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -578,6 +578,7 @@ def commit_incubator_to_database_sync(
                 ),
                 contagion_settings=_orrery_contagion_settings(),
                 drift_settings=_orrery_drift_settings(),
+                reveal_settings=_orrery_reveal_settings(),
             )
             if (
                 orrery_result.resolution_count
@@ -587,12 +588,14 @@ def commit_incubator_to_database_sync(
                 or orrery_result.scene_pressure_count
                 or orrery_result.prompt_exposure_count
                 or orrery_result.propagation_count
+                or orrery_result.reveal_count
             ):
                 logger.info(
                     "Committed Orrery tick for chunk %s: %s resolutions, %s events, "
                     "%s tag mutations, %s cleared tags, %s existing skipped, "
                     "%s adjudications (%s deferred, %s voided, %s replaced), "
-                    "%s scene pressures, %s prompt exposures, %s propagations",
+                    "%s scene pressures, %s prompt exposures, %s propagations, "
+                    "%s reveals",
                     chunk_id,
                     orrery_result.resolution_count,
                     orrery_result.event_count,
@@ -606,6 +609,7 @@ def commit_incubator_to_database_sync(
                     orrery_result.scene_pressure_count,
                     orrery_result.prompt_exposure_count,
                     orrery_result.propagation_count,
+                    orrery_result.reveal_count,
                 )
 
             # Step 8.55: interval state checkpoint (reconstruction bar 7c).
@@ -879,6 +883,14 @@ def _orrery_drift_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("drift")
+
+
+def _orrery_reveal_settings() -> Any:
+    """[orrery.reveal] template-authored backstory reveal policy."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("reveal")
 
 
 def _orrery_checkpoint_interval() -> int:

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1348,8 +1348,7 @@ class OrreryDriftSettings(BaseModel):
         overlap = sorted(set(self.hostile_events) & set(self.cooperative_events))
         if overlap:
             raise ValueError(
-                "hostile_events and cooperative_events must be disjoint: "
-                f"{overlap}"
+                "hostile_events and cooperative_events must be disjoint: " f"{overlap}"
             )
         return self
 
@@ -1406,6 +1405,14 @@ class OrreryEpistemicsSettings(BaseModel):
         if len(set(values)) != len(values):
             raise ValueError("aware_roles entries must be unique")
         return values
+
+
+class OrreryRevealSettings(BaseModel):
+    """Template-authored backstory reveal policy for ``[orrery.reveal]``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
 
 
 class OrreryReconstructionSettings(BaseModel):
@@ -2040,6 +2047,7 @@ class OrrerySettings(BaseModel):
     )
     projects: OrreryProjectSettings = Field(default_factory=OrreryProjectSettings)
     drift: OrreryDriftSettings = Field(default_factory=OrreryDriftSettings)
+    reveal: OrreryRevealSettings = Field(default_factory=OrreryRevealSettings)
     epistemics: OrreryEpistemicsSettings = Field(
         default_factory=OrreryEpistemicsSettings
     )

--- a/tests/test_orrery/claim_accounts_test_support.py
+++ b/tests/test_orrery/claim_accounts_test_support.py
@@ -50,6 +50,13 @@ _CREATE_SHADOW_SQL = """
         ADD CHECK (
             source_tier IN ('participant', 'witness', 'told', 'granted')
         );
+
+    CREATE TEMP TABLE backstory_secrets (
+        id bigserial PRIMARY KEY,
+        claim_id bigint NOT NULL UNIQUE,
+        status text NOT NULL DEFAULT 'latent'
+            CHECK (status IN ('latent', 'revealed', 'retired'))
+    ) ON COMMIT DROP;
 """
 
 

--- a/tests/test_orrery/test_backstory_secrets_migration_pg.py
+++ b/tests/test_orrery/test_backstory_secrets_migration_pg.py
@@ -1,0 +1,167 @@
+"""Real-PostgreSQL contract coverage for migration 091."""
+
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2  # type: ignore[import-untyped]
+import pytest
+from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
+
+from nexus.api.slot_utils import get_slot_db_url
+
+
+pytestmark = pytest.mark.requires_postgres
+MIGRATION_SQL = Path("migrations/091_backstory_secrets.sql").read_text()
+
+
+@pytest.fixture()
+def migration_090_schema() -> Iterator[Any]:
+    """Build the exact migration dependencies in a rolled-back schema."""
+
+    conn = psycopg2.connect(get_slot_db_url(slot=2), cursor_factory=RealDictCursor)
+    try:
+        with conn.cursor() as cur:
+            schema = f"migration_091_{uuid4().hex[:12]}"
+            cur.execute(f'CREATE SCHEMA "{schema}"')
+            cur.execute(f'SET LOCAL search_path = "{schema}", public')
+            cur.execute(
+                """
+                CREATE TABLE entities (id bigserial PRIMARY KEY);
+                CREATE TABLE narrative_chunks (id bigserial PRIMARY KEY);
+                CREATE TABLE claims (
+                    id bigserial PRIMARY KEY,
+                    scope text NOT NULL CHECK (
+                        scope IN ('common', 'bounded', 'private')
+                    )
+                );
+                CREATE TABLE event_types (
+                    type text PRIMARY KEY,
+                    category text NOT NULL,
+                    severity text,
+                    description text
+                );
+                INSERT INTO entities DEFAULT VALUES;
+                INSERT INTO narrative_chunks DEFAULT VALUES;
+                INSERT INTO claims (scope) VALUES ('private'), ('private');
+                """
+            )
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_migration_091_installs_secret_contract_and_comments(
+    migration_090_schema: Any,
+) -> None:
+    with migration_090_schema.cursor() as cur:
+        cur.execute(MIGRATION_SQL)
+        cur.execute(
+            """
+            SELECT column_name, is_nullable, column_default
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = 'backstory_secrets'
+            ORDER BY ordinal_position
+            """
+        )
+        columns = {row["column_name"]: row for row in cur.fetchall()}
+        assert list(columns) == [
+            "id",
+            "claim_id",
+            "gate_template_id",
+            "status",
+            "holder_entity_id",
+            "source_chunk_id",
+            "revealed_at_world_time",
+            "revealed_by_chunk_id",
+            "created_at",
+        ]
+        assert columns["claim_id"]["is_nullable"] == "NO"
+        assert columns["status"]["column_default"] == "'latent'::text"
+        cur.execute(
+            """
+            SELECT obj_description('backstory_secrets'::regclass) AS comment,
+                   col_description(
+                       'backstory_secrets'::regclass,
+                       (
+                           SELECT ordinal_position
+                           FROM information_schema.columns
+                           WHERE table_schema = current_schema()
+                             AND table_name = 'backstory_secrets'
+                             AND column_name = 'gate_template_id'
+                       )
+                   ) AS gate_comment
+            """
+        )
+        comments = cur.fetchone()
+        assert "latent -> gate fires at commit -> revealed" in comments["comment"]
+        assert "never a serialized predicate" in comments["gate_comment"]
+
+
+def test_migration_091_enforces_checks_uniqueness_and_foreign_keys(
+    migration_090_schema: Any,
+) -> None:
+    with migration_090_schema.cursor() as cur:
+        cur.execute(MIGRATION_SQL)
+        cur.execute(
+            """
+            INSERT INTO backstory_secrets (
+                claim_id, gate_template_id, holder_entity_id, source_chunk_id
+            ) VALUES (1, 'holder_death', 1, 1)
+            RETURNING status
+            """
+        )
+        assert cur.fetchone()["status"] == "latent"
+
+        cur.execute("SAVEPOINT invalid_status")
+        with pytest.raises(psycopg2.errors.CheckViolation):
+            cur.execute(
+                """
+                INSERT INTO backstory_secrets (
+                    claim_id, gate_template_id, status, holder_entity_id
+                ) VALUES (2, 'holder_death', 'forgotten', 1)
+                """
+            )
+        cur.execute("ROLLBACK TO SAVEPOINT invalid_status")
+
+        cur.execute("SAVEPOINT duplicate_claim")
+        with pytest.raises(psycopg2.errors.UniqueViolation):
+            cur.execute(
+                """
+                INSERT INTO backstory_secrets (
+                    claim_id, gate_template_id, holder_entity_id
+                ) VALUES (1, 'trust_earned', 1)
+                """
+            )
+        cur.execute("ROLLBACK TO SAVEPOINT duplicate_claim")
+
+
+def test_migration_091_seeds_both_revelation_events(
+    migration_090_schema: Any,
+) -> None:
+    with migration_090_schema.cursor() as cur:
+        cur.execute(MIGRATION_SQL)
+        cur.execute(
+            """
+            SELECT type, category, severity
+            FROM event_types
+            WHERE type IN (
+                'backstory_secret_authored', 'backstory_revealed'
+            )
+            ORDER BY type
+            """
+        )
+        assert cur.fetchall() == [
+            {
+                "type": "backstory_revealed",
+                "category": "revelation",
+                "severity": "moderate",
+            },
+            {
+                "type": "backstory_secret_authored",
+                "category": "revelation",
+                "severity": "minor",
+            },
+        ]

--- a/tests/test_orrery/test_claim_accounts_live.py
+++ b/tests/test_orrery/test_claim_accounts_live.py
@@ -15,6 +15,7 @@ from sqlalchemy import create_engine
 
 from nexus.agents.orrery.epistemics import (
     ClaimParticipant,
+    author_backstory_secret_sync,
     load_epistemics_hydration,
     mint_account_variant_async,
     mint_account_variant_sync,
@@ -22,6 +23,7 @@ from nexus.agents.orrery.epistemics import (
     promote_claim_scope,
 )
 from nexus.agents.orrery.propagation import drain_claim_propagation_sync
+from nexus.agents.orrery.reveal import drain_backstory_reveals_sync
 from nexus.agents.orrery.substrate import (
     EventRecord,
     Slot,
@@ -43,6 +45,7 @@ from tests.test_orrery.test_claim_propagation_live import (
 
 pytestmark = pytest.mark.requires_postgres
 MIGRATION_SQL = Path("migrations/090_claim_accounts.sql").read_text()
+BACKSTORY_MIGRATION_SQL = Path("migrations/091_backstory_secrets.sql").read_text()
 EPISTEMICS = {
     "enabled": True,
     "claim_event_types": ["threat_issued"],
@@ -87,6 +90,7 @@ def _install_account_shadow(cur: Any) -> None:
         """
     )
     cur.execute(MIGRATION_SQL)
+    cur.execute(BACKSTORY_MIGRATION_SQL)
 
 
 @pytest.fixture()
@@ -226,7 +230,7 @@ def test_old_divergent_sibling_scopes_raise_during_hydration(
             _mint_sibling_incident(cur, label="old-divergent")
         )
         cur.execute(
-            "UPDATE claims SET scope = 'common' WHERE id = %s",
+            "UPDATE claims SET scope = 'private' WHERE id = %s",
             (variant_id,),
         )
 
@@ -237,6 +241,107 @@ def test_old_divergent_sibling_scopes_raise_during_hydration(
             recent_event_ids=(),
             anchor_chunk_id=anchor,
         )
+
+
+def test_latent_sibling_secret_stays_private_until_its_own_gate_fires(
+    account_connection: Any,
+) -> None:
+    """One reveal cannot promote or spread a differently gated sibling."""
+
+    raw_connection = account_connection.connection.driver_connection
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        event_id, anchor, actor, target, secret_a_claim, secret_b_claim = (
+            _mint_sibling_incident(
+                cur,
+                label="latent-sibling",
+                scope="private",
+            )
+        )
+        secret_a = author_backstory_secret_sync(
+            cur,
+            claim_id=secret_a_claim,
+            gate_template_id="holder_death",
+            holder_entity_id=actor,
+            source_chunk_id=anchor,
+        )
+        secret_b = author_backstory_secret_sync(
+            cur,
+            claim_id=secret_b_claim,
+            gate_template_id="holder_death",
+            holder_entity_id=target,
+            source_chunk_id=anchor,
+        )
+        first_tick, first_world_time = _insert_chunk(
+            cur,
+            time_delta=timedelta(hours=1),
+        )
+        first = drain_backstory_reveals_sync(
+            cur,
+            tick_chunk_id=first_tick,
+            settings={"enabled": True},
+            state=WorldState(
+                is_active={actor: False, target: True},
+                world_time=first_world_time,
+            ),
+        )
+        assert first.secret_ids == (secret_a,)
+        cur.execute(
+            "SELECT id, scope FROM claims WHERE world_event_id = %s ORDER BY id",
+            (event_id,),
+        )
+        assert {row["id"]: row["scope"] for row in cur.fetchall()} == {
+            secret_a_claim: "bounded",
+            secret_b_claim: "private",
+        }
+        cur.execute(
+            """
+            SELECT knower_entity_id, source_tier
+            FROM claim_awareness
+            WHERE claim_id = %s
+            ORDER BY id
+            """,
+            (secret_b_claim,),
+        )
+        assert cur.fetchall() == [
+            {"knower_entity_id": target, "source_tier": "granted"}
+        ]
+
+    hydration = load_epistemics_hydration(
+        account_connection,
+        entity_ids=(actor, target),
+        recent_event_ids=(event_id,),
+        anchor_chunk_id=first_tick,
+    )
+    assert hydration.claimed_event_scopes == {event_id: "bounded"}
+
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        second_tick, second_world_time = _insert_chunk(
+            cur,
+            time_delta=timedelta(hours=1),
+        )
+        second = drain_backstory_reveals_sync(
+            cur,
+            tick_chunk_id=second_tick,
+            settings={"enabled": True},
+            state=WorldState(
+                is_active={actor: False, target: False},
+                world_time=second_world_time,
+            ),
+        )
+        assert second.secret_ids == (secret_b,)
+        cur.execute(
+            "SELECT scope FROM claims WHERE world_event_id = %s ORDER BY id",
+            (event_id,),
+        )
+        assert [row["scope"] for row in cur.fetchall()] == ["bounded", "bounded"]
+
+    converged = load_epistemics_hydration(
+        account_connection,
+        entity_ids=(actor, target),
+        recent_event_ids=(event_id,),
+        anchor_chunk_id=second_tick,
+    )
+    assert converged.claimed_event_scopes == {event_id: "bounded"}
 
 
 def test_sync_variant_rejects_cross_incident_lineage_parent(

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -18,6 +18,7 @@ from nexus.config.settings_models import (
     OrreryDriftSettings,
     OrreryEpistemicsSettings,
     OrreryPromoteSettings,
+    OrreryRevealSettings,
     OrrerySettings,
     OrreryRetrogradeMaturationSettings,
     OrreryRetrogradeWeirdGenreBands,
@@ -98,6 +99,7 @@ def test_orrery_settings_resolve_model_reference() -> None:
     assert settings.orrery.drift.cooperative_events[
         "protective_intervention"
     ] == Decimal("0.04")
+    assert settings.orrery.reveal.enabled is True
     assert "relationship_drift_milestone" in (
         settings.orrery.epistemics.claim_event_types
     )
@@ -197,6 +199,15 @@ def test_drift_defaults_off_when_block_is_absent() -> None:
     payload = load_settings("nexus.toml").orrery.model_dump()
     payload.pop("drift")
     assert OrrerySettings.model_validate(payload).drift.enabled is False
+
+
+def test_reveal_defaults_off_when_block_is_absent() -> None:
+    """Legacy configs cannot silently opt into backstory reveals."""
+
+    assert OrreryRevealSettings().enabled is False
+    payload = load_settings("nexus.toml").orrery.model_dump()
+    payload.pop("reveal")
+    assert OrrerySettings.model_validate(payload).reveal.enabled is False
 
 
 def test_drift_rejects_project_delta_at_or_above_one() -> None:

--- a/tests/test_orrery/test_generation_model_provenance_live.py
+++ b/tests/test_orrery/test_generation_model_provenance_live.py
@@ -41,7 +41,7 @@ class _NonCommittingConnection:
 
 @pytest.fixture()
 def provenance_db() -> Iterator[dict[str, Any]]:
-    """Apply 082 and isolate all slot-5 writes in one outer transaction."""
+    """Apply 082 plus a 091 shadow and roll back every slot-5 write."""
 
     engine = create_engine(get_slot_db_url(slot=LIVE_SLOT), future=True)
     connection = engine.connect()
@@ -50,9 +50,16 @@ def provenance_db() -> Iterator[dict[str, Any]]:
     migration_sql = (
         Path(__file__).parents[2] / "migrations" / "082_generation_model_provenance.sql"
     ).read_text()
+    reveal_migration_sql = (
+        Path(__file__).parents[2] / "migrations" / "091_backstory_secrets.sql"
+    ).read_text()
     try:
         with raw_connection.cursor() as cur:
             cur.execute(migration_sql)
+            schema = f"provenance_reveal_{uuid4().hex[:12]}"
+            cur.execute(f'CREATE SCHEMA "{schema}"')
+            cur.execute(f'SET LOCAL search_path = "{schema}", public')
+            cur.execute(reveal_migration_sql)
             cur.execute(
                 """
                 INSERT INTO event_types (type, category, severity, description)

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -295,6 +295,39 @@ def test_claim_accounts_migration_installs_shape_c_contract() -> None:
     assert "COMMENT ON INDEX ux_claims_world_event_account_v1" in migration_sql
 
 
+def test_backstory_secrets_migration_installs_reveal_contract() -> None:
+    """Migration 091 stores private claims behind named authored gates."""
+
+    migration_sql = (
+        Path(__file__).parent.parent.parent / "migrations" / "091_backstory_secrets.sql"
+    ).read_text()
+
+    assert "CREATE TABLE backstory_secrets" in migration_sql
+    assert "claim_id" in migration_sql
+    assert "UNIQUE REFERENCES claims(id)" in migration_sql
+    assert "gate_template_id" in migration_sql
+    assert "status IN ('latent', 'revealed', 'retired')" in migration_sql
+    assert "holder_entity_id" in migration_sql
+    assert "revealed_at_world_time" in migration_sql
+    assert "revealed_by_chunk_id" in migration_sql
+    assert "'backstory_secret_authored'" in migration_sql
+    assert "'backstory_revealed'" in migration_sql
+    assert "'revelation'" in migration_sql
+    assert "ON CONFLICT (type) DO NOTHING" in migration_sql
+    for column in (
+        "id",
+        "claim_id",
+        "gate_template_id",
+        "status",
+        "holder_entity_id",
+        "source_chunk_id",
+        "revealed_at_world_time",
+        "revealed_by_chunk_id",
+        "created_at",
+    ):
+        assert f"COMMENT ON COLUMN backstory_secrets.{column}" in migration_sql
+
+
 def test_retrograde_persistence_migration_adds_distinct_sources() -> None:
     """Retrograde canonical writes need explicit event and tag provenance."""
 

--- a/tests/test_orrery/test_reconstruction.py
+++ b/tests/test_orrery/test_reconstruction.py
@@ -47,6 +47,7 @@ def _connect() -> Any:
     )
     with conn.cursor() as cur:
         cur.execute(Path("migrations/074_plan_relocation_projects.sql").read_text())
+        cur.execute("CREATE TEMP TABLE backstory_secrets (id bigint) ON COMMIT DROP")
     return conn
 
 
@@ -248,7 +249,8 @@ def test_migration_genesis_sections_mirror_checkpoint_sections() -> None:
     genesis = migration[migration.index("jsonb_build_object") :]
     additive = Path("migrations/074_plan_relocation_projects.sql").read_text()
     propagation = Path("migrations/083_claim_propagation_ledger.sql").read_text()
-    genesis_sources = genesis + additive + propagation
+    backstory = Path("migrations/091_backstory_secrets.sql").read_text()
+    genesis_sources = genesis + additive + propagation + backstory
     for section in CHECKPOINT_SECTIONS:
         assert (
             f"'{section}'" in genesis_sources
@@ -259,4 +261,6 @@ def test_migration_genesis_sections_mirror_checkpoint_sections() -> None:
     migration_sections.update(re.findall(r"'(character_project_states)', \(", additive))
     if "'claim_awareness'" in propagation:
         migration_sections.add("claim_awareness")
+    if "'backstory_secrets'" in backstory:
+        migration_sections.add("backstory_secrets")
     assert migration_sections == set(CHECKPOINT_SECTIONS)

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -164,6 +164,8 @@ class FakeSession:
 
     def execute(self, statement, _params=None):
         sql = str(statement)
+        if "/* orrery:epistemics_hydration:backstory_availability */" in sql:
+            return FakeResult([{"available": True}])
         if "/* orrery:entity_activity */" in sql:
             assert "SELECT id, is_active" in sql
             assert "ORDER BY id" in sql

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -72,6 +72,7 @@ class FakeSession:
         faction_rows=None,
         event_rows=None,
         active_entity_rows=None,
+        entity_activity_rows=None,
         epistemics_scope_rows=None,
         epistemics_rows=None,
         epistemics_awareness_rows=None,
@@ -109,6 +110,11 @@ class FakeSession:
         self.event_rows = event_rows or []
         self.active_entity_rows = (
             [{"id": 1}] if active_entity_rows is None else active_entity_rows
+        )
+        self.entity_activity_rows = (
+            [dict(row, is_active=True) for row in self.active_entity_rows]
+            if entity_activity_rows is None
+            else entity_activity_rows
         )
         self.epistemics_rows = epistemics_rows or []
         self.epistemics_scope_rows = (
@@ -158,6 +164,10 @@ class FakeSession:
 
     def execute(self, statement, _params=None):
         sql = str(statement)
+        if "/* orrery:entity_activity */" in sql:
+            assert "SELECT id, is_active" in sql
+            assert "ORDER BY id" in sql
+            return FakeResult(self.entity_activity_rows)
         if "/* orrery:current_tags */" in sql:
             return FakeResult(self.tag_rows)
         if "/* orrery:character_locations */" in sql:

--- a/tests/test_orrery/test_reveal_gates.py
+++ b/tests/test_orrery/test_reveal_gates.py
@@ -1,0 +1,67 @@
+"""Pure-unit coverage for template-authored backstory reveal gates."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from nexus.agents.orrery.reveal_gates import (
+    SecretContext,
+    holder_death,
+    participants_reunited,
+    trust_earned,
+    validate_reveal_gate_registry,
+)
+from nexus.agents.orrery.substrate import TravelState, WorldState
+
+
+HOLDER = 1
+FIRST = 2
+SECOND = 3
+
+
+@pytest.fixture()
+def context() -> SecretContext:
+    return SecretContext(
+        secret_id=11,
+        claim_id=12,
+        holder_entity_id=HOLDER,
+        world_event_id=13,
+        participant_entity_ids=(HOLDER, FIRST, SECOND),
+        created_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_holder_death_fires_only_for_inactive_holder(context: SecretContext) -> None:
+    assert holder_death(WorldState(is_active={HOLDER: False}), context) is True
+    assert holder_death(WorldState(is_active={HOLDER: True}), context) is False
+
+
+def test_participants_reunited_requires_two_safe_copresent_peers(
+    context: SecretContext,
+) -> None:
+    reunited = WorldState(locations={HOLDER: 8, FIRST: 8, SECOND: 8})
+    assert participants_reunited(reunited, context) is True
+
+    one_elsewhere = WorldState(locations={HOLDER: 8, FIRST: 8, SECOND: 9})
+    assert participants_reunited(one_elsewhere, context) is False
+
+    travelling = WorldState(
+        locations={HOLDER: 8, FIRST: 8, SECOND: 8},
+        travel_states={SECOND: TravelState(status="in_transit")},
+    )
+    assert participants_reunited(travelling, context) is False
+
+
+def test_trust_earned_requires_directional_deep_mutual_trust(
+    context: SecretContext,
+) -> None:
+    earned = WorldState(trust={(FIRST, HOLDER): 3, (HOLDER, FIRST): 2})
+    assert trust_earned(earned, context) is True
+
+    shallow_reverse = WorldState(trust={(FIRST, HOLDER): 3, (HOLDER, FIRST): 1})
+    assert trust_earned(shallow_reverse, context) is False
+
+
+def test_registry_validation_rejects_non_snake_case_names() -> None:
+    with pytest.raises(ValueError, match="snake_case"):
+        validate_reveal_gate_registry({"Not-Snake": holder_death})

--- a/tests/test_orrery/test_reveal_gates.py
+++ b/tests/test_orrery/test_reveal_gates.py
@@ -32,6 +32,7 @@ def context() -> SecretContext:
 
 
 def test_holder_death_fires_only_for_inactive_holder(context: SecretContext) -> None:
+    assert holder_death(WorldState(is_active={}), context) is False
     assert holder_death(WorldState(is_active={HOLDER: False}), context) is True
     assert holder_death(WorldState(is_active={HOLDER: True}), context) is False
 

--- a/tests/test_orrery/test_reveal_live.py
+++ b/tests/test_orrery/test_reveal_live.py
@@ -1,0 +1,377 @@
+"""Rollback-only live PostgreSQL coverage for durable backstory reveals."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from itertools import count
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2  # type: ignore[import-untyped]
+import pytest
+from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
+
+from nexus.agents.orrery.epistemics import (
+    author_backstory_secret_sync,
+    mint_account_variant_sync,
+)
+from nexus.agents.orrery.events import commit_orrery_tick_sync
+from nexus.agents.orrery.reveal import drain_backstory_reveals_sync
+from nexus.agents.orrery.substrate import WorldState
+from nexus.api.slot_utils import get_slot_db_url
+
+
+pytestmark = pytest.mark.requires_postgres
+MIGRATION_SQL = Path("migrations/091_backstory_secrets.sql").read_text()
+_SCENES = count(400)
+
+
+@pytest.fixture()
+def live_conn() -> Iterator[Any]:
+    """Install migration 091 in a throwaway schema and roll back all writes."""
+
+    conn = psycopg2.connect(get_slot_db_url(slot=5), cursor_factory=RealDictCursor)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT to_regclass('claims') IS NOT NULL AS claims_ready,
+                       EXISTS (
+                           SELECT 1
+                           FROM information_schema.columns
+                           WHERE table_schema = ANY(current_schemas(false))
+                             AND table_name = 'claims'
+                             AND column_name = 'account_label'
+                       ) AS accounts_ready,
+                       EXISTS (
+                           SELECT 1
+                           FROM information_schema.columns
+                           WHERE table_schema = ANY(current_schemas(false))
+                             AND table_name = 'world_events'
+                             AND column_name = 'world_time'
+                       ) AS event_clock_ready
+                """
+            )
+            readiness = cur.fetchone()
+            if not all(readiness.values()):
+                pytest.skip("slot 5 requires applied migrations 083 and 090")
+            schema = f"reveal_live_{uuid4().hex[:12]}"
+            cur.execute(f'CREATE SCHEMA "{schema}"')
+            cur.execute(f'SET LOCAL search_path = "{schema}", public')
+            cur.execute(MIGRATION_SQL)
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def _insert_chunk(
+    cur: Any,
+    *,
+    world_layer: str = "primary",
+    time_delta: timedelta = timedelta(0),
+) -> tuple[int, datetime]:
+    token = uuid4().hex[:12]
+    cur.execute(
+        """
+        INSERT INTO narrative_chunks (raw_text, storyteller_text)
+        VALUES (%s, 'Rollback-only backstory reveal fixture.')
+        RETURNING id
+        """,
+        (f"Backstory reveal fixture {token}.",),
+    )
+    chunk_id = int(cur.fetchone()["id"])
+    cur.execute(
+        """
+        INSERT INTO chunk_metadata (
+            chunk_id, season, episode, scene, world_layer, time_delta,
+            generation_date, slug
+        ) VALUES (
+            %s, 97, 97, %s, %s::world_layer_type, %s, now(), %s
+        )
+        """,
+        (chunk_id, next(_SCENES), world_layer, time_delta, token[:10]),
+    )
+    cur.execute(
+        "SELECT world_time FROM chunk_metadata WHERE chunk_id = %s", (chunk_id,)
+    )
+    world_time = cur.fetchone()["world_time"]
+    assert world_time is not None
+    return chunk_id, world_time
+
+
+def _insert_character(cur: Any, label: str, place_id: int) -> int:
+    cur.execute(
+        "INSERT INTO entities (kind, is_active) "
+        "VALUES ('character', true) RETURNING id"
+    )
+    entity_id = int(cur.fetchone()["id"])
+    cur.execute(
+        """
+        INSERT INTO characters (name, entity_id, current_location)
+        VALUES (%s, %s, %s)
+        """,
+        (f"reveal-{label}-{uuid4().hex[:10]}", entity_id, place_id),
+    )
+    return entity_id
+
+
+def _insert_private_incident(
+    cur: Any,
+    *,
+    source_chunk_id: int,
+    scope: str = "private",
+) -> tuple[int, int, tuple[int, int, int], int]:
+    cur.execute("SELECT id FROM places ORDER BY id LIMIT 1")
+    place_id = int(cur.fetchone()["id"])
+    holder = _insert_character(cur, "holder", place_id)
+    first = _insert_character(cur, "first", place_id)
+    second = _insert_character(cur, "second", place_id)
+    cur.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, target_entity_id,
+            world_layer, source, changed_fields, payload
+        ) VALUES (
+            'threat_issued', %s, %s, %s, 'primary', 'authored', '{}', '{}'
+        )
+        RETURNING id
+        """,
+        (source_chunk_id, holder, first),
+    )
+    event_id = int(cur.fetchone()["id"])
+    cur.execute(
+        """
+        INSERT INTO world_event_entities (event_id, role, entity_id)
+        VALUES (%s, 'actor', %s),
+               (%s, 'target', %s),
+               (%s, 'beneficiary', %s)
+        """,
+        (event_id, holder, event_id, first, event_id, second),
+    )
+    cur.execute(
+        """
+        INSERT INTO claims (
+            world_event_id, account_label, summary, scope, source_chunk_id
+        ) VALUES (%s, %s, 'A rollback-only backstory secret.', %s, %s)
+        RETURNING id
+        """,
+        (event_id, f"canonical-{uuid4().hex[:8]}", scope, source_chunk_id),
+    )
+    claim_id = int(cur.fetchone()["id"])
+    cur.execute(
+        """
+        INSERT INTO claim_awareness (
+            claim_id, knower_entity_id, source_tier, source_chunk_id
+        ) VALUES (%s, %s, 'participant', %s)
+        """,
+        (claim_id, holder, source_chunk_id),
+    )
+    return event_id, claim_id, (holder, first, second), place_id
+
+
+def test_authoring_rejects_non_private_and_unregistered_gate(
+    live_conn: Any,
+) -> None:
+    with live_conn.cursor() as cur:
+        source_chunk_id, _ = _insert_chunk(cur)
+        _, bounded_claim, participants, _ = _insert_private_incident(
+            cur, source_chunk_id=source_chunk_id, scope="bounded"
+        )
+        with pytest.raises(ValueError, match="must be private"):
+            author_backstory_secret_sync(
+                cur,
+                claim_id=bounded_claim,
+                gate_template_id="holder_death",
+                holder_entity_id=participants[0],
+                source_chunk_id=source_chunk_id,
+            )
+
+        _, private_claim, private_participants, _ = _insert_private_incident(
+            cur, source_chunk_id=source_chunk_id
+        )
+        with pytest.raises(ValueError, match="Unregistered reveal gate"):
+            author_backstory_secret_sync(
+                cur,
+                claim_id=private_claim,
+                gate_template_id="plot_convenience",
+                holder_entity_id=private_participants[0],
+                source_chunk_id=source_chunk_id,
+            )
+
+
+def test_commit_reveals_promotes_grants_once_and_redrain_is_noop(
+    live_conn: Any,
+) -> None:
+    with live_conn.cursor() as cur:
+        source_chunk_id, source_world_time = _insert_chunk(cur)
+        _, claim_id, participants, place_id = _insert_private_incident(
+            cur, source_chunk_id=source_chunk_id
+        )
+        holder, first, second = participants
+        sibling_id = mint_account_variant_sync(
+            cur,
+            source_claim_id=claim_id,
+            account_label=f"alternate-{uuid4().hex[:8]}",
+            summary="A sibling account promoted with the incident.",
+            source_chunk_id=source_chunk_id,
+        )
+        secret_id = author_backstory_secret_sync(
+            cur,
+            claim_id=claim_id,
+            gate_template_id="participants_reunited",
+            holder_entity_id=holder,
+            source_chunk_id=source_chunk_id,
+        )
+        tick_chunk_id, tick_world_time = _insert_chunk(
+            cur, time_delta=timedelta(hours=2)
+        )
+
+    state = WorldState(
+        is_active={holder: True, first: True, second: True},
+        locations={holder: place_id, first: place_id, second: place_id},
+        world_time=tick_world_time,
+    )
+    first_result = commit_orrery_tick_sync(
+        live_conn,
+        None,
+        tick_chunk_id=tick_chunk_id,
+        reveal_settings={"enabled": True},
+        reveal_state=state,
+    )
+    second_result = commit_orrery_tick_sync(
+        live_conn,
+        None,
+        tick_chunk_id=tick_chunk_id,
+        reveal_settings={"enabled": True},
+        reveal_state=state,
+    )
+
+    assert first_result.reveal_count == 1
+    assert second_result.reveal_count == 0
+    with live_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT status, revealed_at_world_time, revealed_by_chunk_id
+            FROM backstory_secrets WHERE id = %s
+            """,
+            (secret_id,),
+        )
+        assert cur.fetchone() == {
+            "status": "revealed",
+            "revealed_at_world_time": tick_world_time,
+            "revealed_by_chunk_id": tick_chunk_id,
+        }
+        cur.execute(
+            "SELECT id, scope FROM claims WHERE id IN (%s, %s) ORDER BY id",
+            (claim_id, sibling_id),
+        )
+        assert [row["scope"] for row in cur.fetchall()] == ["bounded", "bounded"]
+        cur.execute(
+            """
+            SELECT knower_entity_id, source_tier, immediate_source_entity_id,
+                   acquired_at_world_time
+            FROM claim_awareness
+            WHERE claim_id = %s
+            ORDER BY knower_entity_id
+            """,
+            (claim_id,),
+        )
+        awareness = cur.fetchall()
+        assert [row["knower_entity_id"] for row in awareness] == sorted(participants)
+        told = [row for row in awareness if row["knower_entity_id"] != holder]
+        assert all(row["source_tier"] == "told" for row in told)
+        assert all(row["immediate_source_entity_id"] == holder for row in told)
+        assert all(row["acquired_at_world_time"] == tick_world_time for row in told)
+        cur.execute(
+            """
+            SELECT actor_entity_id, payload, world_time
+            FROM world_events
+            WHERE event_type = 'backstory_revealed'
+              AND (payload ->> 'secret_id')::bigint = %s
+            """,
+            (secret_id,),
+        )
+        events = cur.fetchall()
+        assert len(events) == 1
+        assert events[0]["actor_entity_id"] == holder
+        assert events[0]["world_time"] == tick_world_time
+        assert events[0]["payload"]["claim_id"] == claim_id
+        assert events[0]["payload"]["gate_template_id"] == ("participants_reunited")
+        assert events[0]["payload"]["revealed_participant_entity_ids"] == sorted(
+            [first, second]
+        )
+        cur.execute(
+            """
+            SELECT world_time, payload
+            FROM world_events
+            WHERE event_type = 'backstory_secret_authored'
+              AND (payload ->> 'secret_id')::bigint = %s
+            """,
+            (secret_id,),
+        )
+        authored = cur.fetchone()
+        assert authored["world_time"] == source_world_time
+        assert authored["payload"]["claim_id"] == claim_id
+
+
+def test_unregistered_gate_in_latent_row_raises_loudly(live_conn: Any) -> None:
+    with live_conn.cursor() as cur:
+        source_chunk_id, _ = _insert_chunk(cur)
+        _, claim_id, participants, _ = _insert_private_incident(
+            cur, source_chunk_id=source_chunk_id
+        )
+        cur.execute(
+            """
+            INSERT INTO backstory_secrets (
+                claim_id, gate_template_id, holder_entity_id, source_chunk_id
+            ) VALUES (%s, 'missing_gate', %s, %s)
+            """,
+            (claim_id, participants[0], source_chunk_id),
+        )
+        tick_chunk_id, _ = _insert_chunk(cur, time_delta=timedelta(hours=1))
+        with pytest.raises(RuntimeError, match="Unregistered reveal gate"):
+            drain_backstory_reveals_sync(
+                cur,
+                tick_chunk_id=tick_chunk_id,
+                settings={"enabled": True},
+                state=WorldState(is_active={participants[0]: False}),
+            )
+
+
+@pytest.mark.parametrize(
+    ("world_layer", "settings"),
+    [("retrograde", {"enabled": True}), ("primary", {"enabled": False})],
+)
+def test_world_layer_and_disabled_config_leave_secret_latent(
+    live_conn: Any,
+    world_layer: str,
+    settings: dict[str, bool],
+) -> None:
+    with live_conn.cursor() as cur:
+        source_chunk_id, _ = _insert_chunk(cur)
+        _, claim_id, participants, _ = _insert_private_incident(
+            cur, source_chunk_id=source_chunk_id
+        )
+        secret_id = author_backstory_secret_sync(
+            cur,
+            claim_id=claim_id,
+            gate_template_id="holder_death",
+            holder_entity_id=participants[0],
+            source_chunk_id=source_chunk_id,
+        )
+        tick_chunk_id, _ = _insert_chunk(
+            cur,
+            world_layer=world_layer,
+            time_delta=timedelta(hours=1),
+        )
+        result = drain_backstory_reveals_sync(
+            cur,
+            tick_chunk_id=tick_chunk_id,
+            settings=settings,
+            state=WorldState(is_active={participants[0]: False}),
+        )
+        assert result.revealed_count == 0
+        cur.execute("SELECT status FROM backstory_secrets WHERE id = %s", (secret_id,))
+        assert cur.fetchone()["status"] == "latent"

--- a/tests/test_orrery/test_reveal_live.py
+++ b/tests/test_orrery/test_reveal_live.py
@@ -13,13 +13,19 @@ import pytest
 from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
 
 from nexus.agents.orrery.epistemics import (
+    author_backstory_secret_async,
     author_backstory_secret_sync,
     mint_account_variant_sync,
 )
 from nexus.agents.orrery.events import commit_orrery_tick_sync
 from nexus.agents.orrery.reveal import drain_backstory_reveals_sync
+from nexus.agents.orrery.reconstruction import capture_state_checkpoint_sync
+from nexus.agents.orrery.replay import verify_checkpoints_sync
 from nexus.agents.orrery.substrate import WorldState
 from nexus.api.slot_utils import get_slot_db_url
+from tests.test_orrery.claim_accounts_test_support import (
+    install_claim_accounts_shadow_async,
+)
 
 
 pytestmark = pytest.mark.requires_postgres
@@ -122,6 +128,7 @@ def _insert_private_incident(
     *,
     source_chunk_id: int,
     scope: str = "private",
+    holder_aware: bool = True,
 ) -> tuple[int, int, tuple[int, int, int], int]:
     cur.execute("SELECT id FROM places ORDER BY id LIMIT 1")
     place_id = int(cur.fetchone()["id"])
@@ -160,14 +167,15 @@ def _insert_private_incident(
         (event_id, f"canonical-{uuid4().hex[:8]}", scope, source_chunk_id),
     )
     claim_id = int(cur.fetchone()["id"])
-    cur.execute(
-        """
-        INSERT INTO claim_awareness (
-            claim_id, knower_entity_id, source_tier, source_chunk_id
-        ) VALUES (%s, %s, 'participant', %s)
-        """,
-        (claim_id, holder, source_chunk_id),
-    )
+    if holder_aware:
+        cur.execute(
+            """
+            INSERT INTO claim_awareness (
+                claim_id, knower_entity_id, source_tier, source_chunk_id
+            ) VALUES (%s, %s, 'participant', %s)
+            """,
+            (claim_id, holder, source_chunk_id),
+        )
     return event_id, claim_id, (holder, first, second), place_id
 
 
@@ -199,6 +207,182 @@ def test_authoring_rejects_non_private_and_unregistered_gate(
                 holder_entity_id=private_participants[0],
                 source_chunk_id=source_chunk_id,
             )
+
+
+def test_authoring_grants_unpossessed_holder_and_reveal_completes(
+    live_conn: Any,
+) -> None:
+    with live_conn.cursor() as cur:
+        source_chunk_id, source_world_time = _insert_chunk(cur)
+        _, claim_id, participants, place_id = _insert_private_incident(
+            cur,
+            source_chunk_id=source_chunk_id,
+            holder_aware=False,
+        )
+        holder, first, second = participants
+        secret_id = author_backstory_secret_sync(
+            cur,
+            claim_id=claim_id,
+            gate_template_id="holder_death",
+            holder_entity_id=holder,
+            source_chunk_id=source_chunk_id,
+        )
+        cur.execute(
+            """
+            SELECT source_tier, immediate_source_entity_id,
+                   acquired_at_world_time, source_chunk_id
+            FROM claim_awareness
+            WHERE claim_id = %s AND knower_entity_id = %s
+            """,
+            (claim_id, holder),
+        )
+        assert cur.fetchone() == {
+            "source_tier": "granted",
+            "immediate_source_entity_id": None,
+            "acquired_at_world_time": source_world_time,
+            "source_chunk_id": source_chunk_id,
+        }
+        tick_chunk_id, tick_world_time = _insert_chunk(
+            cur,
+            time_delta=timedelta(hours=1),
+        )
+        result = drain_backstory_reveals_sync(
+            cur,
+            tick_chunk_id=tick_chunk_id,
+            settings={"enabled": True},
+            state=WorldState(
+                is_active={holder: False, first: True, second: True},
+                locations={holder: place_id, first: place_id, second: place_id},
+                world_time=tick_world_time,
+            ),
+        )
+        assert result.secret_ids == (secret_id,)
+        cur.execute(
+            "SELECT status FROM backstory_secrets WHERE id = %s",
+            (secret_id,),
+        )
+        assert cur.fetchone()["status"] == "revealed"
+        cur.execute(
+            """
+            SELECT knower_entity_id
+            FROM claim_awareness
+            WHERE claim_id = %s
+            ORDER BY knower_entity_id
+            """,
+            (claim_id,),
+        )
+        assert [row["knower_entity_id"] for row in cur.fetchall()] == sorted(
+            participants
+        )
+
+
+def test_async_authoring_grants_unpossessed_holder() -> None:
+    import asyncio
+
+    import asyncpg  # type: ignore[import-untyped]
+
+    async def run() -> None:
+        conn = await asyncpg.connect(get_slot_db_url(slot=5))
+        transaction = conn.transaction()
+        await transaction.start()
+        try:
+            schema = f"reveal_async_{uuid4().hex[:12]}"
+            await conn.execute(f'CREATE SCHEMA "{schema}"')
+            await conn.execute(f'SET LOCAL search_path = "{schema}", public')
+            await install_claim_accounts_shadow_async(conn)
+            await conn.execute(
+                """
+                DROP TABLE backstory_secrets;
+                CREATE TEMP TABLE backstory_secrets (
+                    id bigserial PRIMARY KEY,
+                    claim_id bigint NOT NULL UNIQUE,
+                    gate_template_id text NOT NULL,
+                    status text NOT NULL DEFAULT 'latent'
+                        CHECK (status IN ('latent', 'revealed', 'retired')),
+                    holder_entity_id bigint NOT NULL,
+                    source_chunk_id bigint,
+                    revealed_at_world_time timestamptz,
+                    revealed_by_chunk_id bigint,
+                    created_at timestamptz NOT NULL DEFAULT now()
+                ) ON COMMIT DROP;
+                INSERT INTO event_types (
+                    type, category, severity, description
+                ) VALUES (
+                    'backstory_secret_authored', 'revelation', 'minor',
+                    'Async rollback-only authoring fixture.'
+                ) ON CONFLICT (type) DO NOTHING;
+                """
+            )
+            clock = await conn.fetchrow(
+                """
+                SELECT metadata.chunk_id, metadata.world_time,
+                       entity.id AS holder_entity_id
+                FROM chunk_metadata metadata
+                CROSS JOIN LATERAL (
+                    SELECT id FROM entities WHERE kind = 'character'
+                    ORDER BY id LIMIT 1
+                ) entity
+                WHERE metadata.world_time IS NOT NULL
+                ORDER BY metadata.chunk_id DESC
+                LIMIT 1
+                """
+            )
+            assert clock is not None
+            event_id = await conn.fetchval(
+                """
+                INSERT INTO world_events (
+                    event_type, tick_chunk_id, actor_entity_id, world_layer,
+                    source, changed_fields, payload
+                ) VALUES (
+                    'threat_issued', $1, $2, 'primary',
+                    'authored', '{}', '{}'::jsonb
+                )
+                RETURNING id
+                """,
+                clock["chunk_id"],
+                clock["holder_entity_id"],
+            )
+            claim_id = await conn.fetchval(
+                """
+                INSERT INTO claims (
+                    world_event_id, account_label, summary, scope,
+                    source_chunk_id
+                ) VALUES ($1, $2, 'Async holder grant fixture.', 'private', $3)
+                RETURNING id
+                """,
+                event_id,
+                f"async-secret-{uuid4().hex[:8]}",
+                clock["chunk_id"],
+            )
+            await author_backstory_secret_async(
+                conn,
+                claim_id=int(claim_id),
+                gate_template_id="holder_death",
+                holder_entity_id=int(clock["holder_entity_id"]),
+                source_chunk_id=int(clock["chunk_id"]),
+            )
+            awareness = await conn.fetchrow(
+                """
+                SELECT source_tier, immediate_source_entity_id,
+                       acquired_at_world_time, source_chunk_id
+                FROM claim_awareness
+                WHERE claim_id = $1 AND knower_entity_id = $2
+                """,
+                claim_id,
+                clock["holder_entity_id"],
+            )
+            assert awareness is not None
+            assert dict(awareness) == {
+                "source_tier": "granted",
+                "immediate_source_entity_id": None,
+                "acquired_at_world_time": clock["world_time"],
+                "source_chunk_id": clock["chunk_id"],
+            }
+        finally:
+            await transaction.rollback()
+            await conn.close()
+
+    asyncio.run(run())
 
 
 def test_commit_reveals_promotes_grants_once_and_redrain_is_noop(
@@ -375,3 +559,115 @@ def test_world_layer_and_disabled_config_leave_secret_latent(
         assert result.revealed_count == 0
         cur.execute("SELECT status FROM backstory_secrets WHERE id = %s", (secret_id,))
         assert cur.fetchone()["status"] == "latent"
+
+
+def test_authored_and_revealed_secrets_replay_between_checkpoints(
+    live_conn: Any,
+) -> None:
+    with live_conn.cursor() as cur:
+        base_chunk, _ = _insert_chunk(cur)
+        _, claim_id, participants, _ = _insert_private_incident(
+            cur,
+            source_chunk_id=base_chunk,
+        )
+        holder = participants[0]
+        base_id = capture_state_checkpoint_sync(
+            cur,
+            chunk_id=base_chunk,
+            label="manual",
+        )
+        assert base_id is not None
+
+        authored_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=1))
+        secret_id = author_backstory_secret_sync(
+            cur,
+            claim_id=claim_id,
+            gate_template_id="holder_death",
+            holder_entity_id=holder,
+            source_chunk_id=authored_chunk,
+        )
+        authored_checkpoint_id = capture_state_checkpoint_sync(
+            cur,
+            chunk_id=authored_chunk,
+            label="manual",
+        )
+        assert authored_checkpoint_id is not None
+
+        reveal_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=1))
+        result = drain_backstory_reveals_sync(
+            cur,
+            tick_chunk_id=reveal_chunk,
+            settings={"enabled": True},
+            state=WorldState(is_active={holder: False}),
+        )
+        assert result.secret_ids == (secret_id,)
+        revealed_checkpoint_id = capture_state_checkpoint_sync(
+            cur,
+            chunk_id=reveal_chunk,
+            label="manual",
+        )
+        assert revealed_checkpoint_id is not None
+
+    with live_conn.cursor(cursor_factory=psycopg2.extensions.cursor) as cur:
+        verdicts = verify_checkpoints_sync(cur)
+
+    authored_verdict = next(
+        verdict
+        for verdict in verdicts
+        if verdict.base_checkpoint_id == base_id
+        and verdict.target_checkpoint_id == authored_checkpoint_id
+    )
+    revealed_verdict = next(
+        verdict
+        for verdict in verdicts
+        if verdict.base_checkpoint_id == authored_checkpoint_id
+        and verdict.target_checkpoint_id == revealed_checkpoint_id
+    )
+    assert not [
+        drift
+        for verdict in (authored_verdict, revealed_verdict)
+        for drift in verdict.drifts
+        if drift.section == "backstory_secrets"
+    ]
+
+
+def test_verify_skips_checkpoint_that_predates_backstory_section(
+    live_conn: Any,
+) -> None:
+    with live_conn.cursor() as cur:
+        base_chunk, _ = _insert_chunk(cur)
+        base_id = capture_state_checkpoint_sync(
+            cur,
+            chunk_id=base_chunk,
+            label="manual",
+        )
+        assert base_id is not None
+        cur.execute(
+            "UPDATE state_checkpoints SET state = state - 'backstory_secrets' "
+            "WHERE id = %s",
+            (base_id,),
+        )
+        target_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=1))
+        target_id = capture_state_checkpoint_sync(
+            cur,
+            chunk_id=target_chunk,
+            label="manual",
+        )
+        assert target_id is not None
+
+    with live_conn.cursor(cursor_factory=psycopg2.extensions.cursor) as cur:
+        verdicts = verify_checkpoints_sync(cur)
+
+    verdict = next(
+        item
+        for item in verdicts
+        if item.base_checkpoint_id == base_id and item.target_checkpoint_id == target_id
+    )
+    assert not [
+        drift for drift in verdict.drifts if drift.section == "backstory_secrets"
+    ]
+    assert verdict.skipped_unreproducible >= 1
+    assert any(
+        "comparison skipped" in note
+        for note in verdict.notes.get("backstory_secrets", [])
+    )


### PR DESCRIPTION
## Summary

Stage B of #479: Regime B's durable secrets. A `backstory_secrets` row binds a **private** claim to a named reveal gate and a holder; the commit-time drain evaluates latent secrets and a firing gate composes three shipped subsystems — status flip → **incident-wide scope promotion** (the existing contagion drain takes over spreading) → co-located `told` grants → one `backstory_revealed` event.

- **Gates are template-source closures** (`reveal_gates.py`): `holder_death`, `participants_reunited`, `trust_earned` — reading the same hydrated state as every package predicate; an unregistered gate RAISEs at drain time; registry validated at import (the `validate_no_fame_in_entry_gates` precedent)
- **Idempotency verified, not assumed**: the `latent`-guarded `UPDATE ... RETURNING` row count gates every downstream write; live re-drain test proves 1-then-0 with exactly one event — no marker needed (the drift-marker pattern was the mandated fallback)
- **Drain state**: the resolver's WorldState doesn't survive to commit, so the drain hydrates its own minimal post-drift transactional snapshot (entity activity — now an explicit resolver-hydrated WorldState field — locations, trust with the resolver's tie-break, travel); an explicit `reveal_state` parameter accepts an exact snapshot when a caller has one
- **Authoring primitive** enforces private-while-latent and registered-gate-only, emitting a `backstory_secret_authored` ledger event
- **Migration 091**: the lifecycle table + two `revelation` event types; `[orrery.reveal]` opt-in (model default off, shipped config on — the drift precedent)
- Deliberate boundaries: no Retrograde generation-side authoring yet (recorded), no distortion (Stage C), no storyteller conduit (Stage D), no automatic retirement

## Validation

- `poetry run pytest -q` → **1538 passed, 0 failed**
- **Full live-PG orrery suite → 1125 passed, 0 failed** (gates fire/non-fire units; live authoring validation; end-to-end reveal with promotion, grants, single event; re-drain idempotency; world-layer gate; disabled config)
- `replay_state.py --slot 5 --verify` green; flake8/black/catalog/config-hook clean

## Schema/Data Impact

Migration 091 pending everywhere; new table + event-type seeds only. Applied at merge closeout.

Implemented by Sol (GPT-5.6 Codex) from a frozen spec; reviewed by Claude. Stage C (hop distortion) and Stage D (storyteller conduit) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TJVTXfD7TouQuxmYfVf8w