### PR TITLE
Add Hop-Based Account Distortion at Propagation Time (#479 Stage C)

### DIFF
--- a/migrations/092_claim_distortion_depth.sql
+++ b/migrations/092_claim_distortion_depth.sql
@@ -1,0 +1,17 @@
+-- 092_claim_distortion_depth.sql
+--
+-- Authored account variants may opt into deterministic hop-depth selection.
+-- Propagation never invents or mutates account content.
+
+ALTER TABLE claims
+    ADD COLUMN distortion_min_depth integer,
+    ADD CONSTRAINT claims_distortion_min_depth_check
+        CHECK (distortion_min_depth >= 1);
+
+COMMENT ON COLUMN claims.distortion_min_depth IS
+    'NULL means this account is never auto-selected by propagation distortion (canonical accounts and manually granted variants); an integer d means propagation delivers this account instead of the scheduling account to listeners reached at hop depth >= d. Among qualifying sibling variants the largest distortion_min_depth wins, with ties resolved by lowest claim id.';
+COMMENT ON CONSTRAINT claims_distortion_min_depth_check ON claims IS
+    'Authored propagation-distortion thresholds begin at hop depth 1.';
+
+-- No partial unique index is intentional: multiple authored variants may share
+-- a threshold, and propagation resolves that ambiguity by lowest claim id.

--- a/migrations/092_claim_distortion_depth.sql
+++ b/migrations/092_claim_distortion_depth.sql
@@ -6,12 +6,19 @@
 ALTER TABLE claims
     ADD COLUMN distortion_min_depth integer,
     ADD CONSTRAINT claims_distortion_min_depth_check
-        CHECK (distortion_min_depth >= 1);
+        CHECK (distortion_min_depth >= 1),
+    ADD CONSTRAINT claims_canonical_distortion_depth_check
+        CHECK (
+            account_label <> 'canonical'
+            OR distortion_min_depth IS NULL
+        );
 
 COMMENT ON COLUMN claims.distortion_min_depth IS
     'NULL means this account is never auto-selected by propagation distortion (canonical accounts and manually granted variants); an integer d means propagation delivers this account instead of the scheduling account to listeners reached at hop depth >= d. Among qualifying sibling variants the largest distortion_min_depth wins, with ties resolved by lowest claim id.';
 COMMENT ON CONSTRAINT claims_distortion_min_depth_check ON claims IS
     'Authored propagation-distortion thresholds begin at hop depth 1.';
+COMMENT ON CONSTRAINT claims_canonical_distortion_depth_check ON claims IS
+    'Canonical accounts must keep NULL distortion depth so authored variants always win distortion selection legitimately.';
 
 -- No partial unique index is intentional: multiple authored variants may share
 -- a threshold, and propagation resolves that ambiguity by lowest claim id.

--- a/nexus.toml
+++ b/nexus.toml
@@ -285,6 +285,12 @@ depth_cap = 4
 age_horizon = "14d"
 fan_out_cap = 6
 
+[orrery.distortion]
+# Authored sibling accounts may replace the scheduling account at configured
+# total hop depths. Incident-level scheduling suppression remains active when
+# this feature is disabled because it is a propagation correctness invariant.
+enabled = true
+
 [orrery.selection]
 # Branch selection inside a fired package: "stochastic" softmax-samples all
 # passing branches by magnitude (PRNG seeded on per-resolution persisted

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -1381,7 +1381,10 @@ def entity_context(
                 FROM requested_awareness requested
                 JOIN world_events event
                   ON event.event_type = 'claim_propagated'
-                 AND (event.payload ->> 'claim_id')::bigint = requested.claim_id
+                 AND COALESCE(
+                         (event.payload ->> 'delivered_claim_id')::bigint,
+                         (event.payload ->> 'claim_id')::bigint
+                     ) = requested.claim_id
                  AND (event.payload ->> 'awareness_id')::bigint = requested.id
                 WHERE event.payload ? 'claim_id'
                   AND event.payload ? 'awareness_id'

--- a/nexus/agents/orrery/epistemics.py
+++ b/nexus/agents/orrery/epistemics.py
@@ -263,6 +263,7 @@ def mint_account_variant_sync(
     source_chunk_id: Optional[int],
     account_payload: Optional[Mapping[str, Any]] = None,
     distorted_from_claim_id: Optional[int] = None,
+    distortion_min_depth: Optional[int] = None,
 ) -> int:
     """Mint one non-awareness sibling account from an existing claim."""
 
@@ -272,6 +273,7 @@ def mint_account_variant_sync(
         raise ValueError("Account label must be non-empty")
     if not clean_summary:
         raise ValueError("Account variant summary must be non-empty")
+    _validate_distortion_min_depth(distortion_min_depth)
     cur.execute(
         "SELECT world_event_id, scope FROM claims WHERE id = %s FOR SHARE",
         (source_claim_id,),
@@ -305,8 +307,9 @@ def mint_account_variant_sync(
         """
         INSERT INTO claims (
             world_event_id, account_label, account_payload,
-            distorted_from_claim_id, summary, scope, source_chunk_id
-        ) VALUES (%s, %s, %s::jsonb, %s, %s, %s, %s)
+            distorted_from_claim_id, distortion_min_depth, summary, scope,
+            source_chunk_id
+        ) VALUES (%s, %s, %s::jsonb, %s, %s, %s, %s, %s)
         RETURNING id
         """,
         (
@@ -314,6 +317,7 @@ def mint_account_variant_sync(
             clean_label,
             payload_json,
             parent_claim_id,
+            distortion_min_depth,
             clean_summary,
             _row_value(source, "scope", 1),
             source_chunk_id,
@@ -334,6 +338,7 @@ async def mint_account_variant_async(
     source_chunk_id: Optional[int],
     account_payload: Optional[Mapping[str, Any]] = None,
     distorted_from_claim_id: Optional[int] = None,
+    distortion_min_depth: Optional[int] = None,
 ) -> int:
     """Asyncpg twin of :func:`mint_account_variant_sync`."""
 
@@ -343,6 +348,7 @@ async def mint_account_variant_async(
         raise ValueError("Account label must be non-empty")
     if not clean_summary:
         raise ValueError("Account variant summary must be non-empty")
+    _validate_distortion_min_depth(distortion_min_depth)
     source = await conn.fetchrow(
         "SELECT world_event_id, scope FROM claims WHERE id = $1 FOR SHARE",
         source_claim_id,
@@ -372,14 +378,16 @@ async def mint_account_variant_async(
         """
         INSERT INTO claims (
             world_event_id, account_label, account_payload,
-            distorted_from_claim_id, summary, scope, source_chunk_id
-        ) VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7)
+            distorted_from_claim_id, distortion_min_depth, summary, scope,
+            source_chunk_id
+        ) VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7, $8)
         RETURNING id
         """,
         source_event_id,
         clean_label,
         _account_payload_json(account_payload),
         parent_claim_id,
+        distortion_min_depth,
         clean_summary,
         source["scope"],
         source_chunk_id,
@@ -387,6 +395,15 @@ async def mint_account_variant_async(
     if claim_id is None:
         raise RuntimeError("Account variant INSERT returned no claim id")
     return int(claim_id)
+
+
+def _validate_distortion_min_depth(value: Optional[int]) -> None:
+    """Reject invalid authored propagation thresholds before SQL execution."""
+
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError("distortion_min_depth must be an integer >= 1")
 
 
 def _account_payload_json(

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -365,6 +365,7 @@ def commit_orrery_tick_sync(
     project_settings: Optional[Any] = None,
     epistemics_settings: Optional[Any] = None,
     contagion_settings: Optional[Any] = None,
+    distortion_settings: Optional[Any] = None,
     drift_settings: Optional[Any] = None,
     reveal_settings: Optional[Any] = None,
     reveal_state: Optional[WorldState] = None,
@@ -414,6 +415,7 @@ def commit_orrery_tick_sync(
             cur,
             tick_chunk_id=tick_chunk_id,
             settings=contagion_settings,
+            distortion_settings=distortion_settings,
         )
         propagation_count = propagation_result.minted_count
         if not has_resolutions:
@@ -636,6 +638,7 @@ async def commit_orrery_tick_async(
     project_settings: Optional[Any] = None,
     epistemics_settings: Optional[Any] = None,
     contagion_settings: Optional[Any] = None,
+    distortion_settings: Optional[Any] = None,
     drift_settings: Optional[Any] = None,
     reveal_settings: Optional[Any] = None,
     reveal_state: Optional[WorldState] = None,
@@ -684,6 +687,7 @@ async def commit_orrery_tick_async(
         conn,
         tick_chunk_id=tick_chunk_id,
         settings=contagion_settings,
+        distortion_settings=distortion_settings,
     )
     propagation_count = propagation_result.minted_count
     if not has_resolutions:

--- a/nexus/agents/orrery/propagation.py
+++ b/nexus/agents/orrery/propagation.py
@@ -24,7 +24,10 @@ from nexus.agents.orrery.communication import (
     coerce_contagion_settings,
 )
 from nexus.agents.orrery.db_rows import row_get as _row_get
-from nexus.config.settings_models import OrreryContagionSettings
+from nexus.config.settings_models import (
+    OrreryContagionSettings,
+    OrreryDistortionSettings,
+)
 
 
 CLAIM_PROPAGATED_EVENT_TYPE = "claim_propagated"
@@ -35,6 +38,7 @@ class AwarenessState:
     """The frontier fields needed to schedule one knower's outbound hops."""
 
     claim_id: int
+    incident_world_event_id: int
     knower_entity_id: int
     acquired_at_world_time: Optional[datetime]
     root_source_entity_id: Optional[int]
@@ -46,6 +50,8 @@ class PlannedPropagation:
     """One deterministic acquisition derived during a drain fixpoint."""
 
     claim_id: int
+    delivered_claim_id: int
+    incident_world_event_id: int
     knower_entity_id: int
     immediate_source_entity_id: int
     root_source_entity_id: int
@@ -53,6 +59,24 @@ class PlannedPropagation:
     acquired_at_world_time: datetime
     latency_seconds: float
     depth: int
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimAccount:
+    """One authored sibling in a drain-start incident snapshot."""
+
+    claim_id: int
+    distortion_min_depth: Optional[int]
+    propagation_eligible: bool
+
+
+@dataclass(frozen=True, slots=True)
+class IncidentSnapshot:
+    """Sibling accounts and their shared canonical-event clock."""
+
+    world_event_id: int
+    birth_world_time: datetime
+    accounts: tuple[ClaimAccount, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -90,6 +114,7 @@ def drain_claim_propagation_sync(
     *,
     tick_chunk_id: int,
     settings: Any,
+    distortion_settings: Any = None,
 ) -> PropagationDrainResult:
     """Drain every eligible bounded-claim hop through a DB-API cursor."""
 
@@ -100,21 +125,22 @@ def drain_claim_propagation_sync(
     world_time, world_layer = _commit_clock_sync(cur, tick_chunk_id)
     if world_layer != "primary" or world_time is None:
         return PropagationDrainResult()
-    claim_births = _candidate_claim_births_sync(cur, config)
-    if not claim_births:
+    incidents = _candidate_incidents_sync(cur, config)
+    if not incidents:
         return PropagationDrainResult(policy_digest=contagion_policy_digest(config))
     graph = assemble_communication_graph(
         cur,
         settings=config,
         world_time=world_time,
     )
-    frontier = _awareness_frontier_sync(cur, tuple(claim_births))
+    frontier = _awareness_frontier_sync(cur, incidents)
     planned = _plan_propagations(
-        claim_births=claim_births,
+        incidents=incidents,
         frontier=frontier,
         graph=graph,
         world_time=world_time,
         settings=config,
+        distortion_enabled=_distortion_enabled(distortion_settings),
     )
     digest = contagion_policy_digest(config)
     awareness_ids: list[int] = []
@@ -144,6 +170,7 @@ async def drain_claim_propagation_async(
     *,
     tick_chunk_id: int,
     settings: Any,
+    distortion_settings: Any = None,
 ) -> PropagationDrainResult:
     """Asyncpg twin of :func:`drain_claim_propagation_sync`."""
 
@@ -154,21 +181,22 @@ async def drain_claim_propagation_async(
     world_time, world_layer = await _commit_clock_async(conn, tick_chunk_id)
     if world_layer != "primary" or world_time is None:
         return PropagationDrainResult()
-    claim_births = await _candidate_claim_births_async(conn, config)
-    if not claim_births:
+    incidents = await _candidate_incidents_async(conn, config)
+    if not incidents:
         return PropagationDrainResult(policy_digest=contagion_policy_digest(config))
     graph = await assemble_communication_graph_async(
         conn,
         settings=config,
         world_time=world_time,
     )
-    frontier = await _awareness_frontier_async(conn, tuple(claim_births))
+    frontier = await _awareness_frontier_async(conn, incidents)
     planned = _plan_propagations(
-        claim_births=claim_births,
+        incidents=incidents,
         frontier=frontier,
         graph=graph,
         world_time=world_time,
         settings=config,
+        distortion_enabled=_distortion_enabled(distortion_settings),
     )
     digest = contagion_policy_digest(config)
     awareness_ids: list[int] = []
@@ -200,6 +228,12 @@ def _enabled_config(settings: Any) -> Optional[OrreryContagionSettings]:
     return config if config.enabled else None
 
 
+def _distortion_enabled(settings: Any) -> bool:
+    if isinstance(settings, OrreryDistortionSettings):
+        return settings.enabled
+    return OrreryDistortionSettings.model_validate(settings or {}).enabled
+
+
 _MIGRATION_083_ERROR = (
     "Claim propagation requires migration 083; apply migration 083 before "
     "enabling [orrery.contagion]."
@@ -219,7 +253,17 @@ def _require_migration_083_sync(cur: Any) -> None:
                    WHERE table_schema = ANY(current_schemas(false))
                      AND table_name = 'world_events'
                      AND column_name = 'world_time'
-               ) AS world_time_column
+               ) AS world_time_column,
+               EXISTS (
+                   SELECT 1
+                   FROM information_schema.columns
+                   WHERE (
+                         table_schema = ANY(current_schemas(false))
+                         OR table_schema = pg_my_temp_schema()::regnamespace::text
+                     )
+                     AND table_name = 'claims'
+                     AND column_name = 'distortion_min_depth'
+               ) AS distortion_depth_column
         """
     )
     row = cur.fetchone()
@@ -227,6 +271,11 @@ def _require_migration_083_sync(cur: Any) -> None:
         raise RuntimeError(_MIGRATION_083_ERROR)
     if not bool(_row_get(row, "world_time_column", 1)):
         raise RuntimeError(_MIGRATION_083_ERROR)
+    if not bool(_row_get(row, "distortion_depth_column", 2)):
+        raise RuntimeError(
+            "Claim propagation requires migration 092; apply migration 092 "
+            "before draining incident-aware propagation."
+        )
 
 
 async def _require_migration_083_async(conn: Any) -> None:
@@ -242,13 +291,28 @@ async def _require_migration_083_async(conn: Any) -> None:
                    WHERE table_schema = ANY(current_schemas(false))
                      AND table_name = 'world_events'
                      AND column_name = 'world_time'
-               ) AS world_time_column
+               ) AS world_time_column,
+               EXISTS (
+                   SELECT 1
+                   FROM information_schema.columns
+                   WHERE (
+                         table_schema = ANY(current_schemas(false))
+                         OR table_schema = pg_my_temp_schema()::regnamespace::text
+                     )
+                     AND table_name = 'claims'
+                     AND column_name = 'distortion_min_depth'
+               ) AS distortion_depth_column
         """
     )
     if row is None or not bool(row["event_registered"]):
         raise RuntimeError(_MIGRATION_083_ERROR)
     if not bool(row["world_time_column"]):
         raise RuntimeError(_MIGRATION_083_ERROR)
+    if not bool(row["distortion_depth_column"]):
+        raise RuntimeError(
+            "Claim propagation requires migration 092; apply migration 092 "
+            "before draining incident-aware propagation."
+        )
 
 
 def _commit_clock_sync(cur: Any, tick_chunk_id: int) -> tuple[Optional[datetime], Any]:
@@ -284,64 +348,95 @@ async def _commit_clock_async(
     return world_time, row["world_layer"]
 
 
-_CANDIDATE_CLAIMS_SQL = """
-    WITH bounded_claims AS (
-        SELECT c.id AS claim_id,
-               COALESCE(we.world_time, cm.world_time) AS birth_world_time
-        FROM claims c
-        JOIN world_events we ON we.id = c.world_event_id
-        LEFT JOIN chunk_metadata cm ON cm.chunk_id = we.tick_chunk_id
-        WHERE c.scope = 'bounded'
+_CANDIDATE_INCIDENTS_SQL = """
+    WITH incident_accounts AS (
+        SELECT claim.id AS claim_id,
+               claim.world_event_id AS incident_world_event_id,
+               claim.scope,
+               claim.distortion_min_depth,
+               COALESCE(event.world_time, metadata.world_time)
+                   AS birth_world_time
+        FROM claims claim
+        JOIN world_events event ON event.id = claim.world_event_id
+        LEFT JOIN chunk_metadata metadata
+          ON metadata.chunk_id = event.tick_chunk_id
+    ), eligible_incidents AS (
+        SELECT DISTINCT account.incident_world_event_id
+        FROM incident_accounts account
+        JOIN claim_awareness awareness
+          ON awareness.claim_id = account.claim_id
+        WHERE account.scope = 'bounded'
+          AND account.birth_world_time IS NOT NULL
+          AND awareness.acquired_at_world_time IS NOT NULL
+          AND awareness.acquired_at_world_time
+              <= account.birth_world_time + {horizon_placeholder}
     )
-    SELECT candidate.claim_id, candidate.birth_world_time
-    FROM bounded_claims candidate
-    WHERE candidate.birth_world_time IS NOT NULL
-      AND EXISTS (
-          SELECT 1
-          FROM claim_awareness awareness
-          WHERE awareness.claim_id = candidate.claim_id
-            AND awareness.acquired_at_world_time IS NOT NULL
-            AND awareness.acquired_at_world_time
-                <= candidate.birth_world_time + {horizon_placeholder}
-      )
-    ORDER BY candidate.claim_id
+    SELECT account.claim_id, account.incident_world_event_id,
+           account.birth_world_time, account.distortion_min_depth,
+           account.scope
+    FROM incident_accounts account
+    JOIN eligible_incidents eligible
+      ON eligible.incident_world_event_id = account.incident_world_event_id
+    ORDER BY account.incident_world_event_id, account.claim_id
 """
 
 
-def _candidate_claim_births_sync(
+def _candidate_incidents_sync(
     cur: Any, settings: OrreryContagionSettings
-) -> dict[int, datetime]:
+) -> dict[int, IncidentSnapshot]:
     cur.execute(
-        _CANDIDATE_CLAIMS_SQL.format(horizon_placeholder="%s"),
+        _CANDIDATE_INCIDENTS_SQL.format(horizon_placeholder="%s"),
         (settings.guards.age_horizon,),
     )
-    return _claim_births(cur.fetchall())
+    return _incident_snapshots(cur.fetchall())
 
 
-async def _candidate_claim_births_async(
+async def _candidate_incidents_async(
     conn: Any, settings: OrreryContagionSettings
-) -> dict[int, datetime]:
+) -> dict[int, IncidentSnapshot]:
     rows = await conn.fetch(
-        _CANDIDATE_CLAIMS_SQL.format(horizon_placeholder="$1"),
+        _CANDIDATE_INCIDENTS_SQL.format(horizon_placeholder="$1"),
         settings.guards.age_horizon,
     )
-    return _claim_births(rows)
+    return _incident_snapshots(rows)
 
 
-def _claim_births(rows: Sequence[Any]) -> dict[int, datetime]:
-    births = {}
+def _incident_snapshots(rows: Sequence[Any]) -> dict[int, IncidentSnapshot]:
+    grouped: dict[int, tuple[datetime, list[ClaimAccount]]] = {}
     for row in rows:
         claim_id = int(_row_get(row, "claim_id", 0))
-        birth = _row_get(row, "birth_world_time", 1)
+        incident_id = int(_row_get(row, "incident_world_event_id", 1))
+        birth = _row_get(row, "birth_world_time", 2)
         if birth is None:
             continue
-        births[claim_id] = birth
-    return births
+        raw_depth = _row_get(row, "distortion_min_depth", 3)
+        scope = str(_row_get(row, "scope", 4))
+        account = ClaimAccount(
+            claim_id=claim_id,
+            distortion_min_depth=(int(raw_depth) if raw_depth is not None else None),
+            propagation_eligible=scope == "bounded",
+        )
+        existing = grouped.setdefault(incident_id, (birth, []))
+        if existing[0] != birth:
+            raise ValueError(
+                f"Incident {incident_id} sibling claims disagree on birth time"
+            )
+        existing[1].append(account)
+    return {
+        incident_id: IncidentSnapshot(
+            world_event_id=incident_id,
+            birth_world_time=birth,
+            accounts=tuple(accounts),
+        )
+        for incident_id, (birth, accounts) in grouped.items()
+    }
 
 
 def _awareness_frontier_sync(
-    cur: Any, claim_ids: Sequence[int]
+    cur: Any, incidents: Mapping[int, IncidentSnapshot]
 ) -> tuple[AwarenessState, ...]:
+    claim_incidents = _claim_incident_index(incidents)
+    claim_ids = tuple(claim_incidents)
     cur.execute(
         """
         SELECT id, claim_id, knower_entity_id, root_source_entity_id,
@@ -363,12 +458,18 @@ def _awareness_frontier_sync(
         """,
         (list(claim_ids),),
     )
-    return _build_frontier(awareness_rows, cur.fetchall())
+    return _build_frontier(
+        awareness_rows,
+        cur.fetchall(),
+        claim_incidents=claim_incidents,
+    )
 
 
 async def _awareness_frontier_async(
-    conn: Any, claim_ids: Sequence[int]
+    conn: Any, incidents: Mapping[int, IncidentSnapshot]
 ) -> tuple[AwarenessState, ...]:
+    claim_incidents = _claim_incident_index(incidents)
+    claim_ids = tuple(claim_incidents)
     awareness_rows = await conn.fetch(
         """
         SELECT id, claim_id, knower_entity_id, root_source_entity_id,
@@ -389,18 +490,54 @@ async def _awareness_frontier_async(
         """,
         list(claim_ids),
     )
-    return _build_frontier(awareness_rows, event_rows)
+    return _build_frontier(
+        awareness_rows,
+        event_rows,
+        claim_incidents=claim_incidents,
+    )
+
+
+def _claim_incident_index(
+    incidents: Mapping[int, IncidentSnapshot],
+) -> dict[int, int]:
+    return {
+        account.claim_id: incident.world_event_id
+        for incident in incidents.values()
+        for account in incident.accounts
+    }
 
 
 def _build_frontier(
-    awareness_rows: Sequence[Any], event_rows: Sequence[Any]
+    awareness_rows: Sequence[Any],
+    event_rows: Sequence[Any],
+    *,
+    claim_incidents: Mapping[int, int],
 ) -> tuple[AwarenessState, ...]:
     depths: dict[tuple[int, int], int] = {}
     for row in event_rows:
         event_id = int(_row_get(row, "id", 0))
         payload = _json_object(_row_get(row, "payload", 1), event_id=event_id)
+        scheduling_claim_id, delivered_claim_id, incident_id = (
+            _propagation_claim_identity(payload, event_id=event_id)
+        )
+        scheduling_incident = claim_incidents.get(scheduling_claim_id)
+        delivered_incident = claim_incidents.get(delivered_claim_id)
+        if scheduling_incident is None or delivered_incident is None:
+            raise ValueError(
+                f"claim_propagated event {event_id} names a claim outside its "
+                "incident snapshot"
+            )
+        if scheduling_incident != delivered_incident:
+            raise ValueError(
+                f"claim_propagated event {event_id} crosses incident boundaries"
+            )
+        if incident_id is not None and incident_id != scheduling_incident:
+            raise ValueError(
+                f"claim_propagated event {event_id} has incident "
+                f"{incident_id}, expected {scheduling_incident}"
+            )
         key = (
-            _payload_int(payload, "claim_id", event_id),
+            delivered_claim_id,
             _payload_int(payload, "knower_entity_id", event_id),
         )
         depth = _payload_int(payload, "depth", event_id)
@@ -410,7 +547,8 @@ def _build_frontier(
             )
         if key in depths:
             raise ValueError(
-                "Duplicate claim_propagated ledger entries for claim/knower " f"{key}"
+                "Duplicate claim_propagated ledger entries for delivered "
+                f"claim/knower {key}"
             )
         depths[key] = depth
 
@@ -421,14 +559,15 @@ def _build_frontier(
         knower = int(_row_get(row, "knower_entity_id", 2))
         acquired = _row_get(row, "acquired_at_world_time", 4)
         root = _row_get(row, "root_source_entity_id", 3)
-        # NOTE(#479 Stage C): accounts remain independent claim-id frontiers.
-        # Do not skip this account because the knower possesses a sibling;
-        # cross-account exclusion belongs to the later distortion policy.
         key = (claim_id, knower)
         awareness_keys.add(key)
+        incident_id = claim_incidents.get(claim_id)
+        if incident_id is None:
+            raise ValueError(f"Awareness row names unknown incident claim {claim_id}")
         frontier.append(
             AwarenessState(
                 claim_id=claim_id,
+                incident_world_event_id=incident_id,
                 knower_entity_id=knower,
                 acquired_at_world_time=acquired,
                 root_source_entity_id=int(root) if root is not None else None,
@@ -438,7 +577,8 @@ def _build_frontier(
     orphaned = sorted(set(depths) - awareness_keys)
     if orphaned:
         raise ValueError(
-            "claim_propagated ledger entries have no awareness projection: "
+            "claim_propagated delivered claim/knower entries have no awareness "
+            "projection: "
             f"{orphaned}"
         )
     return tuple(frontier)
@@ -446,31 +586,45 @@ def _build_frontier(
 
 def _plan_propagations(
     *,
-    claim_births: Mapping[int, datetime],
+    incidents: Mapping[int, IncidentSnapshot],
     frontier: Sequence[AwarenessState],
     graph: CommunicationGraph,
     world_time: datetime,
     settings: OrreryContagionSettings,
+    distortion_enabled: bool,
 ) -> tuple[PlannedPropagation, ...]:
-    by_claim: dict[int, list[AwarenessState]] = {
-        claim_id: [] for claim_id in claim_births
+    by_incident: dict[int, list[AwarenessState]] = {
+        incident_id: [] for incident_id in incidents
     }
     for awareness in frontier:
-        by_claim.setdefault(awareness.claim_id, []).append(awareness)
+        by_incident.setdefault(awareness.incident_world_event_id, []).append(awareness)
 
     outbound = _fan_out_edges(graph, settings.guards.fan_out_cap)
     planned: list[PlannedPropagation] = []
     sequence = count()
-    for claim_id, birth_world_time in claim_births.items():
-        possessed = {
-            awareness.knower_entity_id: awareness
-            for awareness in by_claim.get(claim_id, ())
+    for incident_id in sorted(incidents):
+        incident = incidents[incident_id]
+        birth_world_time = incident.birth_world_time
+        eligible_claim_ids = {
+            account.claim_id
+            for account in incident.accounts
+            if account.propagation_eligible
         }
+        # Ledger integrity remains keyed by delivered claim/knower, while this
+        # possession frontier is deliberately incident/knower: hearing any
+        # sibling account suppresses every later propagated account.
+        possessed: dict[int, AwarenessState] = {}
+        for awareness in sorted(
+            by_incident.get(incident_id, ()),
+            key=_awareness_source_sort_key,
+        ):
+            possessed.setdefault(awareness.knower_entity_id, awareness)
         pending: list[tuple[Any, ...]] = []
 
         def offer(source: AwarenessState) -> None:
             if (
-                source.acquired_at_world_time is None
+                source.claim_id not in eligible_claim_ids
+                or source.acquired_at_world_time is None
                 or source.depth >= settings.guards.depth_cap
             ):
                 return
@@ -490,21 +644,14 @@ def _plan_propagations(
                         source.knower_entity_id,
                         edge.kind,
                         edge.label,
+                        source.claim_id,
                         next(sequence),
                         edge,
                         source,
                     ),
                 )
 
-        for awareness in sorted(
-            possessed.values(),
-            key=lambda item: (
-                item.acquired_at_world_time is None,
-                item.acquired_at_world_time or world_time,
-                item.depth,
-                item.knower_entity_id,
-            ),
-        ):
+        for awareness in sorted(possessed.values(), key=_awareness_source_sort_key):
             offer(awareness)
 
         while pending:
@@ -515,6 +662,7 @@ def _plan_propagations(
                 source_id,
                 _kind,
                 _label,
+                _scheduling_claim_id,
                 _sequence,
                 edge,
                 source,
@@ -522,8 +670,16 @@ def _plan_propagations(
             if listener in possessed:
                 continue
             root = source.root_source_entity_id or source_id
+            delivered_claim_id = _select_delivered_claim(
+                incident,
+                scheduling_claim_id=source.claim_id,
+                depth=depth,
+                distortion_enabled=distortion_enabled,
+            )
             acquisition = PlannedPropagation(
-                claim_id=claim_id,
+                claim_id=source.claim_id,
+                delivered_claim_id=delivered_claim_id,
+                incident_world_event_id=incident_id,
                 knower_entity_id=listener,
                 immediate_source_entity_id=source_id,
                 root_source_entity_id=root,
@@ -534,7 +690,8 @@ def _plan_propagations(
             )
             planned.append(acquisition)
             minted = AwarenessState(
-                claim_id=claim_id,
+                claim_id=delivered_claim_id,
+                incident_world_event_id=incident_id,
                 knower_entity_id=listener,
                 acquired_at_world_time=scheduled,
                 root_source_entity_id=root,
@@ -543,6 +700,47 @@ def _plan_propagations(
             possessed[listener] = minted
             offer(minted)
     return tuple(planned)
+
+
+def _awareness_source_sort_key(awareness: AwarenessState) -> tuple[Any, ...]:
+    return (
+        awareness.acquired_at_world_time is None,
+        awareness.acquired_at_world_time or datetime.max,
+        awareness.depth,
+        awareness.knower_entity_id,
+        awareness.claim_id,
+    )
+
+
+def _select_delivered_claim(
+    incident: IncidentSnapshot,
+    *,
+    scheduling_claim_id: int,
+    depth: int,
+    distortion_enabled: bool,
+) -> int:
+    """Select from the fixed authored sibling set by total birth-hop depth.
+
+    Variants do not compound through lineage. Each onward hop consults the
+    original drain-start incident snapshot, and the deepest qualifying authored
+    account wins directly.
+    """
+
+    if not distortion_enabled:
+        return scheduling_claim_id
+    qualifying = [
+        account
+        for account in incident.accounts
+        if account.propagation_eligible
+        and account.distortion_min_depth is not None
+        and account.distortion_min_depth <= depth
+    ]
+    if not qualifying:
+        return scheduling_claim_id
+    return min(
+        qualifying,
+        key=lambda account: (-int(account.distortion_min_depth or 0), account.claim_id),
+    ).claim_id
 
 
 def _fan_out_edges(
@@ -581,7 +779,7 @@ def _insert_propagation_sync(
         RETURNING id
         """,
         (
-            acquisition.claim_id,
+            acquisition.delivered_claim_id,
             acquisition.knower_entity_id,
             acquisition.immediate_source_entity_id,
             acquisition.root_source_entity_id,
@@ -635,7 +833,7 @@ async def _insert_propagation_async(
         ON CONFLICT (claim_id, knower_entity_id) DO NOTHING
         RETURNING id
         """,
-        acquisition.claim_id,
+        acquisition.delivered_claim_id,
         acquisition.knower_entity_id,
         acquisition.immediate_source_entity_id,
         acquisition.root_source_entity_id,
@@ -671,6 +869,9 @@ def _event_payload(
     return {
         "awareness_id": awareness_id,
         "claim_id": acquisition.claim_id,
+        "delivered_claim_id": acquisition.delivered_claim_id,
+        "incident_world_event_id": acquisition.incident_world_event_id,
+        "distortion_applied": (acquisition.delivered_claim_id != acquisition.claim_id),
         "knower_entity_id": acquisition.knower_entity_id,
         "immediate_source_entity_id": acquisition.immediate_source_entity_id,
         "root_source_entity_id": acquisition.root_source_entity_id,
@@ -687,6 +888,42 @@ def _json_object(raw: Any, *, event_id: int) -> Mapping[str, Any]:
     if not isinstance(raw, Mapping):
         raise ValueError(f"claim_propagated event {event_id} payload is not an object")
     return raw
+
+
+def _propagation_claim_identity(
+    payload: Mapping[str, Any], *, event_id: int
+) -> tuple[int, int, Optional[int]]:
+    """Validate Stage C identity keys with a pre-092 absent-key fallback."""
+
+    stage_c_keys = {
+        "delivered_claim_id",
+        "incident_world_event_id",
+        "distortion_applied",
+    }
+    present = stage_c_keys & set(payload)
+    if present and present != stage_c_keys:
+        missing = sorted(stage_c_keys - present)
+        raise ValueError(
+            f"claim_propagated event {event_id} lacks Stage C payload fields "
+            f"{missing}"
+        )
+    scheduling_claim_id = _payload_int(payload, "claim_id", event_id)
+    if not present:
+        return scheduling_claim_id, scheduling_claim_id, None
+    delivered_claim_id = _payload_int(payload, "delivered_claim_id", event_id)
+    incident_id = _payload_int(payload, "incident_world_event_id", event_id)
+    distortion_applied = payload["distortion_applied"]
+    if not isinstance(distortion_applied, bool):
+        raise ValueError(
+            f"claim_propagated event {event_id} has invalid " "'distortion_applied'"
+        )
+    expected = delivered_claim_id != scheduling_claim_id
+    if distortion_applied != expected:
+        raise ValueError(
+            f"claim_propagated event {event_id} distortion_applied disagrees "
+            "with its scheduling and delivered claims"
+        )
+    return scheduling_claim_id, delivered_claim_id, incident_id
 
 
 def _payload_int(payload: Mapping[str, Any], key: str, event_id: int) -> int:

--- a/nexus/agents/orrery/propagation.py
+++ b/nexus/agents/orrery/propagation.py
@@ -4,6 +4,12 @@ The append-only ``claim_awareness`` projection is the only durable frontier.
 This module derives every eligible transmission from that table plus the
 current Stage 2b communication graph, then double-enters each new awareness
 row as a ``claim_propagated`` world event.
+
+The accepted-tick commit drains propagation before
+:mod:`nexus.agents.orrery.reveal`. A reveal that promotes a private incident
+to bounded during that same tick is therefore absent from this drain's
+snapshot and first becomes propagatable on the next accepted tick. This pins
+the scene boundary: the secret comes out now; gossip starts next scene.
 """
 
 from __future__ import annotations

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -225,6 +225,50 @@ def _as_document(value: Any) -> dict[str, Any]:
     return value
 
 
+def _propagated_claim_identity(
+    payload: dict[str, Any], *, event_id: int
+) -> tuple[int, int]:
+    """Validate Stage C keys while accepting historical pre-092 payloads."""
+
+    stage_c_keys = {
+        "delivered_claim_id",
+        "incident_world_event_id",
+        "distortion_applied",
+    }
+    present = stage_c_keys & set(payload)
+    if present and present != stage_c_keys:
+        missing = sorted(stage_c_keys - present)
+        raise ValueError(
+            f"claim_propagated event {event_id} lacks payload fields {missing}"
+        )
+    try:
+        scheduling_claim_id = int(payload["claim_id"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(
+            f"claim_propagated event {event_id} has invalid 'claim_id'"
+        ) from exc
+    if not present:
+        return scheduling_claim_id, scheduling_claim_id
+    try:
+        delivered_claim_id = int(payload["delivered_claim_id"])
+        int(payload["incident_world_event_id"])
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"claim_propagated event {event_id} has invalid Stage C claim identity"
+        ) from exc
+    distortion_applied = payload["distortion_applied"]
+    if not isinstance(distortion_applied, bool):
+        raise ValueError(
+            f"claim_propagated event {event_id} has invalid " "'distortion_applied'"
+        )
+    if distortion_applied != (delivered_claim_id != scheduling_claim_id):
+        raise ValueError(
+            f"claim_propagated event {event_id} distortion_applied disagrees "
+            "with its scheduling and delivered claims"
+        )
+    return scheduling_claim_id, delivered_claim_id
+
+
 def _row_value(row: Any, index: int) -> Any:
     return row[index]
 
@@ -707,7 +751,7 @@ class _Replayer:
                 )
             if int(payload["depth"]) < 1:
                 raise ValueError(f"claim_propagated event {event_id} has invalid depth")
-            claim_id = int(payload["claim_id"])
+            _, claim_id = _propagated_claim_identity(payload, event_id=event_id)
             knower = int(payload["knower_entity_id"])
             working[(claim_id, knower)] = {
                 "id": int(payload["awareness_id"]),

--- a/nexus/agents/orrery/reveal.py
+++ b/nexus/agents/orrery/reveal.py
@@ -1,4 +1,11 @@
-"""Commit-time draining for template-gated durable backstory secrets."""
+"""Commit-time draining for template-gated durable backstory secrets.
+
+The accepted-tick commit invokes :mod:`nexus.agents.orrery.propagation` before
+this reveal drain. Consequently, a private incident promoted to bounded here
+cannot enter the same tick's propagation snapshot; its first eligible gossip
+drain is the next accepted tick. The secret comes out this scene, and gossip
+starts the next scene.
+"""
 
 from __future__ import annotations
 

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -571,6 +571,7 @@ async def commit_incubator_to_database(
                     else None
                 ),
                 contagion_settings=_orrery_contagion_settings(),
+                distortion_settings=_orrery_distortion_settings(),
                 drift_settings=_orrery_drift_settings(),
                 reveal_settings=_orrery_reveal_settings(),
             )
@@ -676,6 +677,14 @@ def _orrery_contagion_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("contagion")
+
+
+def _orrery_distortion_settings() -> Any:
+    """[orrery.distortion] authored hop-depth account selection policy."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("distortion")
 
 
 def _orrery_epistemics_settings() -> Any:

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -577,6 +577,7 @@ def commit_incubator_to_database_sync(
                     else None
                 ),
                 contagion_settings=_orrery_contagion_settings(),
+                distortion_settings=_orrery_distortion_settings(),
                 drift_settings=_orrery_drift_settings(),
                 reveal_settings=_orrery_reveal_settings(),
             )
@@ -867,6 +868,14 @@ def _orrery_contagion_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("contagion")
+
+
+def _orrery_distortion_settings() -> Any:
+    """[orrery.distortion] authored hop-depth account selection policy."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("distortion")
 
 
 def _orrery_epistemics_settings() -> Any:

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -912,6 +912,14 @@ class OrreryContagionSettings(BaseModel):
         return self
 
 
+class OrreryDistortionSettings(BaseModel):
+    """Authored hop-depth account selection for ``[orrery.distortion]``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+
+
 class OrreryRouteGraphSettings(BaseModel):
     """Offline route graph safety settings for Orrery travel."""
 
@@ -2034,6 +2042,9 @@ class OrrerySettings(BaseModel):
     enabled: bool = True
     binding: OrreryBindingSettings = Field(default_factory=OrreryBindingSettings)
     contagion: OrreryContagionSettings = Field(default_factory=OrreryContagionSettings)
+    distortion: OrreryDistortionSettings = Field(
+        default_factory=OrreryDistortionSettings
+    )
     route_graph: OrreryRouteGraphSettings = Field(
         default_factory=OrreryRouteGraphSettings
     )

--- a/tests/test_orrery/claim_accounts_test_support.py
+++ b/tests/test_orrery/claim_accounts_test_support.py
@@ -8,6 +8,7 @@ from typing import Any
 
 
 MIGRATION_SQL = Path("migrations/090_claim_accounts.sql").read_text()
+DISTORTION_MIGRATION_SQL = Path("migrations/092_claim_distortion_depth.sql").read_text()
 
 
 _CREATE_SHADOW_SQL = """
@@ -51,6 +52,10 @@ _CREATE_SHADOW_SQL = """
             source_tier IN ('participant', 'witness', 'told', 'granted')
         );
 
+"""
+
+
+_CREATE_BACKSTORY_SHADOW_SQL = """
     CREATE TEMP TABLE backstory_secrets (
         id bigserial PRIMARY KEY,
         claim_id bigint NOT NULL UNIQUE,
@@ -67,7 +72,9 @@ _POST_090_INDEX_SQL = """
 """
 
 
-def install_claim_accounts_shadow_sync(cur: Any) -> None:
+def install_claim_accounts_shadow_sync(
+    cur: Any, *, include_backstory_shadow: bool = True
+) -> None:
     """Shadow durable projections and install 090 without touching public tables."""
 
     cur.execute(
@@ -84,6 +91,8 @@ def install_claim_accounts_shadow_sync(cur: Any) -> None:
     row = cur.fetchone()
     public_is_post_090 = bool(row["applied"] if isinstance(row, Mapping) else row[0])
     cur.execute(_CREATE_SHADOW_SQL)
+    if include_backstory_shadow:
+        cur.execute(_CREATE_BACKSTORY_SHADOW_SQL)
     if public_is_post_090:
         cur.execute(_POST_090_INDEX_SQL)
     else:
@@ -95,9 +104,26 @@ def install_claim_accounts_shadow_sync(cur: Any) -> None:
             """
         )
         cur.execute(MIGRATION_SQL)
+    cur.execute(
+        "SELECT EXISTS ("
+        "SELECT 1 FROM information_schema.columns "
+        "WHERE table_schema = ANY(current_schemas(false)) "
+        "AND table_name = 'claims' AND column_name = 'distortion_min_depth'"
+        ")"
+    )
+    distortion_row = cur.fetchone()
+    distortion_shaped = bool(
+        next(iter(distortion_row.values()))
+        if isinstance(distortion_row, Mapping)
+        else distortion_row[0]
+    )
+    if not distortion_shaped:
+        cur.execute(DISTORTION_MIGRATION_SQL)
 
 
-async def install_claim_accounts_shadow_async(conn: Any) -> None:
+async def install_claim_accounts_shadow_async(
+    conn: Any, *, include_backstory_shadow: bool = True
+) -> None:
     """Asyncpg twin of :func:`install_claim_accounts_shadow_sync`."""
 
     public_is_post_090 = bool(
@@ -114,6 +140,8 @@ async def install_claim_accounts_shadow_async(conn: Any) -> None:
         )
     )
     await conn.execute(_CREATE_SHADOW_SQL)
+    if include_backstory_shadow:
+        await conn.execute(_CREATE_BACKSTORY_SHADOW_SQL)
     if public_is_post_090:
         await conn.execute(_POST_090_INDEX_SQL)
     else:
@@ -125,3 +153,15 @@ async def install_claim_accounts_shadow_async(conn: Any) -> None:
             """
         )
         await conn.execute(MIGRATION_SQL)
+    distortion_shaped = bool(
+        await conn.fetchval(
+            "SELECT EXISTS ("
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = ANY(current_schemas(false)) "
+            "AND table_name = 'claims' "
+            "AND column_name = 'distortion_min_depth'"
+            ")"
+        )
+    )
+    if not distortion_shaped:
+        await conn.execute(DISTORTION_MIGRATION_SQL)

--- a/tests/test_orrery/test_claim_accounts_live.py
+++ b/tests/test_orrery/test_claim_accounts_live.py
@@ -46,6 +46,7 @@ from tests.test_orrery.test_claim_propagation_live import (
 pytestmark = pytest.mark.requires_postgres
 MIGRATION_SQL = Path("migrations/090_claim_accounts.sql").read_text()
 BACKSTORY_MIGRATION_SQL = Path("migrations/091_backstory_secrets.sql").read_text()
+DISTORTION_MIGRATION_SQL = Path("migrations/092_claim_distortion_depth.sql").read_text()
 EPISTEMICS = {
     "enabled": True,
     "claim_event_types": ["threat_issued"],
@@ -91,6 +92,7 @@ def _install_account_shadow(cur: Any) -> None:
     )
     cur.execute(MIGRATION_SQL)
     cur.execute(BACKSTORY_MIGRATION_SQL)
+    cur.execute(DISTORTION_MIGRATION_SQL)
 
 
 @pytest.fixture()
@@ -599,6 +601,7 @@ async def test_async_variant_primitive_uses_real_postgres() -> None:
             """
         )
         await conn.execute(MIGRATION_SQL)
+        await conn.execute(DISTORTION_MIGRATION_SQL)
         variant_id = await mint_account_variant_async(
             conn,
             source_claim_id=1,

--- a/tests/test_orrery/test_claim_accounts_migration_pg.py
+++ b/tests/test_orrery/test_claim_accounts_migration_pg.py
@@ -19,6 +19,7 @@ from nexus.api.slot_utils import get_slot_db_url
 
 pytestmark = pytest.mark.requires_postgres
 MIGRATION_SQL = Path("migrations/090_claim_accounts.sql").read_text()
+DISTORTION_MIGRATION_SQL = Path("migrations/092_claim_distortion_depth.sql").read_text()
 EPISTEMICS = {
     "enabled": True,
     "claim_event_types": ["threat_issued"],
@@ -123,6 +124,7 @@ def test_migration_090_mints_canonical_idempotently_and_variants_loudly(
 
     with migration_089_schema.cursor() as cur:
         cur.execute(MIGRATION_SQL)
+        cur.execute(DISTORTION_MIGRATION_SQL)
         first = mint_claim_for_event(
             cur,
             world_event_id=1,

--- a/tests/test_orrery/test_claim_consumption_live.py
+++ b/tests/test_orrery/test_claim_consumption_live.py
@@ -15,6 +15,7 @@ from nexus.agents.orrery.epistemics import (
     ClaimParticipant,
     load_epistemics_hydration,
     mechanical_claim_summary,
+    mint_account_variant_sync,
     mint_claim_for_event,
 )
 from nexus.agents.orrery.propagation import drain_claim_propagation_sync
@@ -679,3 +680,51 @@ def test_entity_audit_renders_two_hop_provenance_and_ledger_depth(
     assert [item["claim_id"] for item in entity["knowledge"]] == sorted(
         item["claim_id"] for item in entity["knowledge"]
     )
+
+
+def test_entity_audit_joins_distorted_delivery_to_real_depth(
+    live_connection: Any,
+) -> None:
+    """A distorted recipient retains propagation depth in entity context."""
+
+    settings = _settings()
+    raw_connection = live_connection.connection.driver_connection
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 2)
+        source, recipient = entities
+        about, _ = _insert_character(cur, "audit-distortion-about")
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        canonical_claim_id = _insert_claim_about(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=source,
+            about_entity_id=about,
+        )
+        delivered_claim_id = mint_account_variant_sync(
+            cur,
+            source_claim_id=canonical_claim_id,
+            account_label="audit-distorted-delivery",
+            summary="A distorted account delivered to the audit recipient.",
+            source_chunk_id=birth_chunk,
+            distortion_min_depth=1,
+        )
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=2))
+        drained = drain_claim_propagation_sync(
+            cur,
+            tick_chunk_id=drain_chunk,
+            settings=settings,
+            distortion_settings={"enabled": True},
+        )
+
+    assert drained.minted_count == 1
+    context = entity_context(
+        live_connection,
+        [recipient],
+        anchor_chunk_id=drain_chunk,
+        contagion_settings=settings,
+    )
+    knowledge = {row["claim_id"]: row for row in context["entities"][0]["knowledge"]}
+
+    assert delivered_claim_id in knowledge
+    assert canonical_claim_id not in knowledge
+    assert knowledge[delivered_claim_id]["depth"] == 1

--- a/tests/test_orrery/test_claim_propagation.py
+++ b/tests/test_orrery/test_claim_propagation.py
@@ -1,11 +1,16 @@
 """Fast contract tests for the Stage 2c propagation drain."""
 
+from itertools import combinations
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from nexus.agents.orrery.propagation import drain_claim_propagation_sync
+from nexus.agents.orrery.propagation import (
+    _propagation_claim_identity,
+    drain_claim_propagation_sync,
+)
+from nexus.agents.orrery.replay import _propagated_claim_identity
 from nexus.config.settings_models import OrreryContagionSettings
 
 
@@ -35,3 +40,38 @@ def test_migration_083_indexes_depth_recovery_expression() -> None:
     assert "((payload ->> 'claim_id')::bigint)" in migration
     assert "WHERE event_type = 'claim_propagated'" in migration
     assert "COMMENT ON INDEX ix_world_events_claim_propagated_claim_id" in migration
+
+
+_STAGE_C_FIELDS = {
+    "delivered_claim_id": 1,
+    "incident_world_event_id": 2,
+    "distortion_applied": False,
+}
+_PARTIAL_STAGE_C_FIELD_SETS = [
+    subset
+    for subset_size in (1, 2)
+    for subset in combinations(_STAGE_C_FIELDS, subset_size)
+]
+
+
+@pytest.mark.parametrize(
+    "validator",
+    [_propagation_claim_identity, _propagated_claim_identity],
+    ids=["frontier", "replay"],
+)
+@pytest.mark.parametrize(
+    "present_fields",
+    _PARTIAL_STAGE_C_FIELD_SETS,
+    ids=lambda fields: "+".join(fields),
+)
+def test_partial_stage_c_identity_is_rejected_exhaustively(
+    validator: Any,
+    present_fields: tuple[str, ...],
+) -> None:
+    """Every non-empty proper Stage C subset fails in both read paths."""
+
+    payload = {"claim_id": 1}
+    payload.update({field: _STAGE_C_FIELDS[field] for field in present_fields})
+
+    with pytest.raises(ValueError, match="lacks .*payload fields"):
+        validator(payload, event_id=479)

--- a/tests/test_orrery/test_claim_propagation_live.py
+++ b/tests/test_orrery/test_claim_propagation_live.py
@@ -404,6 +404,8 @@ def test_single_hop_ledgers_scheduled_time_provenance_and_policy(
         )
         rows = _awareness(cur, claim_id)
         events = _propagation_events(cur, claim_id)
+        cur.execute("SELECT world_event_id FROM claims WHERE id = %s", (claim_id,))
+        incident_world_event_id = int(cur.fetchone()["world_event_id"])
         cur.execute(
             """
             SELECT role::text, entity_id
@@ -448,6 +450,9 @@ def test_single_hop_ledgers_scheduled_time_provenance_and_policy(
     assert event["payload"] == {
         "awareness_id": told["id"],
         "claim_id": claim_id,
+        "delivered_claim_id": claim_id,
+        "incident_world_event_id": incident_world_event_id,
+        "distortion_applied": False,
         "knower_entity_id": listener,
         "immediate_source_entity_id": source,
         "root_source_entity_id": source,

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -15,6 +15,7 @@ from nexus.config.settings_models import (
     OrreryBleedSettings,
     OrreryContagionSettings,
     OrreryDashboardSettings,
+    OrreryDistortionSettings,
     OrreryDriftSettings,
     OrreryEpistemicsSettings,
     OrreryPromoteSettings,
@@ -54,6 +55,7 @@ def test_orrery_settings_resolve_model_reference() -> None:
     assert settings.orrery.contagion.channels["status:*"].min_level == "junior"
     assert settings.orrery.contagion.culture_profiles["cellular_clandestine"] == 4.0
     assert settings.orrery.contagion.guards.age_horizon == timedelta(days=14)
+    assert settings.orrery.distortion.enabled is True
     expected_model = settings.global_.model.api_models["anthropic"].roles["default"]
     assert settings.orrery.narration.model_ref == expected_model
     assert settings.orrery.promote.provider is None
@@ -208,6 +210,15 @@ def test_reveal_defaults_off_when_block_is_absent() -> None:
     payload = load_settings("nexus.toml").orrery.model_dump()
     payload.pop("reveal")
     assert OrrerySettings.model_validate(payload).reveal.enabled is False
+
+
+def test_distortion_defaults_off_when_block_is_absent() -> None:
+    """Legacy configs cannot silently opt into authored account distortion."""
+
+    assert OrreryDistortionSettings().enabled is False
+    payload = load_settings("nexus.toml").orrery.model_dump()
+    payload.pop("distortion")
+    assert OrrerySettings.model_validate(payload).distortion.enabled is False
 
 
 def test_drift_rejects_project_delta_at_or_above_one() -> None:

--- a/tests/test_orrery/test_distortion_live.py
+++ b/tests/test_orrery/test_distortion_live.py
@@ -1,0 +1,659 @@
+"""Rollback-only PostgreSQL coverage for Stage C hop distortion."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import json
+from typing import Any, Iterator
+
+import asyncpg  # type: ignore[import-untyped]
+import psycopg2  # type: ignore[import-untyped]
+import pytest
+from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
+
+from nexus.agents.orrery.epistemics import (
+    mint_account_variant_async,
+    mint_account_variant_sync,
+    record_revelation,
+)
+from nexus.agents.orrery.propagation import drain_claim_propagation_sync
+from nexus.agents.orrery.reconstruction import capture_state_checkpoint_sync
+from nexus.agents.orrery.replay import reconstruct_state_at_sync
+from nexus.api.slot_utils import get_slot_db_url
+from tests.test_orrery.claim_accounts_test_support import (
+    install_claim_accounts_shadow_async,
+    install_claim_accounts_shadow_sync,
+)
+from tests.test_orrery.test_claim_propagation_live import (
+    LIVE_SLOT,
+    _canonical_rows,
+    _chain,
+    _insert_character,
+    _insert_chunk,
+    _insert_claim,
+    _insert_relationship,
+    _install_valence_shadow,
+    _settings,
+)
+
+
+pytestmark = pytest.mark.requires_postgres
+DISTORTION_ENABLED = {"enabled": True}
+DISTORTION_DISABLED = {"enabled": False}
+
+
+@pytest.fixture()
+def live_conn() -> Iterator[Any]:
+    """Open one slot-5 transaction with post-092 shadow projections."""
+
+    conn = psycopg2.connect(get_slot_db_url(slot=LIVE_SLOT))
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT EXISTS (
+                           SELECT 1 FROM event_types
+                           WHERE type = 'claim_propagated'
+                       ) AS event_registered,
+                       EXISTS (
+                           SELECT 1
+                           FROM information_schema.columns
+                           WHERE table_schema = ANY(current_schemas(false))
+                             AND table_name = 'world_events'
+                             AND column_name = 'world_time'
+                       ) AS world_time_column
+                """
+            )
+            migration_state = cur.fetchone()
+            if (
+                not migration_state["event_registered"]
+                or not migration_state["world_time_column"]
+            ):
+                pytest.skip("slot 5 must have migration 083 before Stage C tests")
+            install_claim_accounts_shadow_sync(cur)
+            _install_valence_shadow(cur)
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def _mint_variant(
+    cur: Any,
+    *,
+    canonical_claim_id: int,
+    label: str,
+    depth: int | None,
+    source_chunk_id: int,
+) -> int:
+    return mint_account_variant_sync(
+        cur,
+        source_claim_id=canonical_claim_id,
+        account_label=label,
+        summary=f"Authored {label} account.",
+        account_payload={"label": label},
+        source_chunk_id=source_chunk_id,
+        distortion_min_depth=depth,
+    )
+
+
+def _incident_id(cur: Any, claim_id: int) -> int:
+    cur.execute("SELECT world_event_id FROM claims WHERE id = %s", (claim_id,))
+    return int(cur.fetchone()["world_event_id"])
+
+
+def _incident_awareness(cur: Any, incident_id: int) -> list[dict[str, Any]]:
+    cur.execute(
+        """
+        SELECT awareness.id, awareness.claim_id,
+               awareness.knower_entity_id, awareness.source_tier,
+               awareness.immediate_source_entity_id,
+               awareness.root_source_entity_id, awareness.channel,
+               awareness.acquired_at_world_time,
+               awareness.source_chunk_id, awareness.created_at
+        FROM claim_awareness awareness
+        JOIN claims claim ON claim.id = awareness.claim_id
+        WHERE claim.world_event_id = %s
+        ORDER BY awareness.acquired_at_world_time,
+                 awareness.knower_entity_id, awareness.id
+        """,
+        (incident_id,),
+    )
+    return [dict(row) for row in cur.fetchall()]
+
+
+def _incident_events(cur: Any, incident_id: int) -> list[dict[str, Any]]:
+    cur.execute(
+        """
+        SELECT id, payload, world_time
+        FROM world_events
+        WHERE event_type = 'claim_propagated'
+          AND (
+              (payload ->> 'incident_world_event_id')::bigint = %s
+              OR (
+                  NOT (payload ? 'incident_world_event_id')
+                  AND (payload ->> 'claim_id')::bigint IN (
+                      SELECT id FROM claims WHERE world_event_id = %s
+                  )
+              )
+          )
+        ORDER BY world_time, id
+        """,
+        (incident_id, incident_id),
+    )
+    return [dict(row) for row in cur.fetchall()]
+
+
+def _assert_event_projection_pairs(
+    awareness: list[dict[str, Any]],
+    events: list[dict[str, Any]],
+) -> None:
+    awareness_keys = {
+        (int(row["id"]), int(row["claim_id"]), int(row["knower_entity_id"]))
+        for row in awareness
+    }
+    event_keys = {
+        (
+            int(event["payload"]["awareness_id"]),
+            int(
+                event["payload"].get(
+                    "delivered_claim_id",
+                    event["payload"]["claim_id"],
+                )
+            ),
+            int(event["payload"]["knower_entity_id"]),
+        )
+        for event in events
+    }
+    assert event_keys <= awareness_keys
+    assert len(event_keys) == len(events)
+
+
+def test_depth_selection_tie_break_and_transitive_total_depth(
+    live_conn: Any,
+) -> None:
+    """Each onward hop re-selects from one authored incident snapshot."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 6)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        canonical = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=entities[0],
+            birth_world_time=birth_world_time,
+        )
+        shallow = _mint_variant(
+            cur,
+            canonical_claim_id=canonical,
+            label="shallow",
+            depth=2,
+            source_chunk_id=birth_chunk,
+        )
+        deepest_low_id = _mint_variant(
+            cur,
+            canonical_claim_id=canonical,
+            label="deepest-low-id",
+            depth=4,
+            source_chunk_id=birth_chunk,
+        )
+        deepest_high_id = _mint_variant(
+            cur,
+            canonical_claim_id=canonical,
+            label="deepest-high-id",
+            depth=4,
+            source_chunk_id=birth_chunk,
+        )
+        incident_id = _incident_id(cur, canonical)
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=8))
+        drained = drain_claim_propagation_sync(
+            cur,
+            tick_chunk_id=drain_chunk,
+            settings=_settings(depth_cap=5),
+            distortion_settings=DISTORTION_ENABLED,
+        )
+        awareness = _incident_awareness(cur, incident_id)
+        events = _incident_events(cur, incident_id)
+
+    by_knower = {
+        int(row["knower_entity_id"]): int(row["claim_id"]) for row in awareness
+    }
+    assert drained.minted_count == 5
+    assert by_knower == {
+        entities[0]: canonical,
+        entities[1]: canonical,
+        entities[2]: shallow,
+        entities[3]: shallow,
+        entities[4]: deepest_low_id,
+        entities[5]: deepest_low_id,
+    }
+    assert deepest_high_id not in by_knower.values()
+    assert [event["payload"]["depth"] for event in events] == [1, 2, 3, 4, 5]
+    assert [event["payload"]["claim_id"] for event in events] == [
+        canonical,
+        canonical,
+        shallow,
+        shallow,
+        deepest_low_id,
+    ]
+    assert [event["payload"]["delivered_claim_id"] for event in events] == [
+        canonical,
+        shallow,
+        shallow,
+        deepest_low_id,
+        deepest_low_id,
+    ]
+    assert [event["payload"]["distortion_applied"] for event in events] == [
+        False,
+        True,
+        False,
+        True,
+        False,
+    ]
+    assert {int(event["payload"]["incident_world_event_id"]) for event in events} == {
+        incident_id
+    }
+    _assert_event_projection_pairs(awareness, events)
+
+
+def test_incident_possession_suppresses_every_sibling_schedule(
+    live_conn: Any,
+) -> None:
+    """A direct variant grant blocks canonical and variant propagation alike."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        source, source_character = _insert_character(cur, "suppression-source")
+        listener, listener_character = _insert_character(cur, "suppression-listener")
+        _insert_relationship(cur, source_character, listener_character)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        canonical = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=source,
+            birth_world_time=birth_world_time,
+        )
+        granted_variant = _mint_variant(
+            cur,
+            canonical_claim_id=canonical,
+            label="manual-grant",
+            depth=None,
+            source_chunk_id=birth_chunk,
+        )
+        cur.execute(
+            "UPDATE claims SET scope = 'private' WHERE id = %s",
+            (granted_variant,),
+        )
+        _mint_variant(
+            cur,
+            canonical_claim_id=canonical,
+            label="automatic-alternative",
+            depth=1,
+            source_chunk_id=birth_chunk,
+        )
+        record_revelation(
+            cur,
+            claim_id=granted_variant,
+            knower_entity_id=listener,
+            world_time=birth_world_time,
+            source_chunk_id=birth_chunk,
+        )
+        incident_id = _incident_id(cur, canonical)
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=8))
+        first = drain_claim_propagation_sync(
+            cur,
+            tick_chunk_id=drain_chunk,
+            settings=_settings(),
+            distortion_settings=DISTORTION_ENABLED,
+        )
+        second = drain_claim_propagation_sync(
+            cur,
+            tick_chunk_id=drain_chunk,
+            settings=_settings(),
+            distortion_settings=DISTORTION_ENABLED,
+        )
+        awareness = _incident_awareness(cur, incident_id)
+        events = _incident_events(cur, incident_id)
+
+    listener_rows = [
+        row for row in awareness if int(row["knower_entity_id"]) == listener
+    ]
+    assert first.minted_count == second.minted_count == 0
+    assert [int(row["claim_id"]) for row in listener_rows] == [granted_variant]
+    assert listener_rows[0]["source_tier"] == "granted"
+    assert events == []
+
+
+def test_disabled_distortion_preserves_stage_b_delivery_but_not_rescheduling(
+    live_conn: Any,
+) -> None:
+    """Feature-off delivery stays claim-identical; incident suppression remains."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 3)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        canonical = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=entities[0],
+            birth_world_time=birth_world_time,
+        )
+        _mint_variant(
+            cur,
+            canonical_claim_id=canonical,
+            label="disabled-threshold",
+            depth=1,
+            source_chunk_id=birth_chunk,
+        )
+        propagated_incident = _incident_id(cur, canonical)
+
+        suppress_source, suppress_source_character = _insert_character(
+            cur, "disabled-suppress-source"
+        )
+        suppress_listener, suppress_listener_character = _insert_character(
+            cur, "disabled-suppress-listener"
+        )
+        _insert_relationship(
+            cur,
+            suppress_source_character,
+            suppress_listener_character,
+        )
+        suppressed_canonical = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=suppress_source,
+            birth_world_time=birth_world_time,
+        )
+        suppressed_variant = _mint_variant(
+            cur,
+            canonical_claim_id=suppressed_canonical,
+            label="already-heard",
+            depth=1,
+            source_chunk_id=birth_chunk,
+        )
+        record_revelation(
+            cur,
+            claim_id=suppressed_variant,
+            knower_entity_id=suppress_listener,
+            world_time=birth_world_time,
+            source_chunk_id=birth_chunk,
+        )
+        suppressed_incident = _incident_id(cur, suppressed_canonical)
+
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=8))
+        drained = drain_claim_propagation_sync(
+            cur,
+            tick_chunk_id=drain_chunk,
+            settings=_settings(),
+            distortion_settings=DISTORTION_DISABLED,
+        )
+        propagated_rows = _incident_awareness(cur, propagated_incident)
+        propagated_events = _incident_events(cur, propagated_incident)
+        suppressed_rows = _incident_awareness(cur, suppressed_incident)
+        suppressed_events = _incident_events(cur, suppressed_incident)
+
+    assert drained.minted_count == 2
+    assert {int(row["claim_id"]) for row in propagated_rows} == {canonical}
+    assert all(
+        event["payload"]["claim_id"] == event["payload"]["delivered_claim_id"]
+        for event in propagated_events
+    )
+    assert all(
+        event["payload"]["distortion_applied"] is False for event in propagated_events
+    )
+    suppressed_listener_rows = [
+        row
+        for row in suppressed_rows
+        if int(row["knower_entity_id"]) == suppress_listener
+    ]
+    assert [int(row["claim_id"]) for row in suppressed_listener_rows] == [
+        suppressed_variant
+    ]
+    assert suppressed_events == []
+
+
+def test_distorted_drain_replays_identical_delivered_awareness(
+    live_conn: Any,
+) -> None:
+    """Replay treats delivered claim ids as the passive projection authority."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 4)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        canonical = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=entities[0],
+            birth_world_time=birth_world_time,
+        )
+        variant = _mint_variant(
+            cur,
+            canonical_claim_id=canonical,
+            label="replay-depth-two",
+            depth=2,
+            source_chunk_id=birth_chunk,
+        )
+        incident_id = _incident_id(cur, canonical)
+        with live_conn.cursor() as checkpoint_cur:
+            checkpoint_id = capture_state_checkpoint_sync(
+                checkpoint_cur,
+                chunk_id=birth_chunk,
+                label="manual",
+            )
+        assert checkpoint_id is not None
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=8))
+        drained = drain_claim_propagation_sync(
+            cur,
+            tick_chunk_id=drain_chunk,
+            settings=_settings(),
+            distortion_settings=DISTORTION_ENABLED,
+        )
+        live_rows = _incident_awareness(cur, incident_id)
+        with live_conn.cursor() as replay_cur:
+            replay = reconstruct_state_at_sync(
+                replay_cur,
+                drain_chunk,
+                base_checkpoint_id=checkpoint_id,
+            )
+
+    replayed_rows = [
+        row
+        for row in replay.state["claim_awareness"]
+        if int(row["claim_id"]) in {canonical, variant}
+    ]
+    assert drained.minted_count == 3
+    assert _canonical_rows(replayed_rows) == _canonical_rows(live_rows)
+
+
+def test_pre_092_payload_fallback_drives_frontier_and_replay(
+    live_conn: Any,
+) -> None:
+    """Historical claim_id-only events recover depth and replay unchanged."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        entities, _ = _chain(cur, 3)
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        canonical = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=entities[0],
+            birth_world_time=birth_world_time,
+        )
+        incident_id = _incident_id(cur, canonical)
+        with live_conn.cursor() as checkpoint_cur:
+            checkpoint_id = capture_state_checkpoint_sync(
+                checkpoint_cur,
+                chunk_id=birth_chunk,
+                label="manual",
+            )
+        assert checkpoint_id is not None
+        historical_chunk, historical_time = _insert_chunk(
+            cur,
+            time_delta=timedelta(hours=1),
+        )
+        cur.execute(
+            """
+            INSERT INTO claim_awareness (
+                claim_id, knower_entity_id, source_tier,
+                immediate_source_entity_id, root_source_entity_id, channel,
+                acquired_at_world_time, source_chunk_id
+            ) VALUES (%s, %s, 'told', %s, %s, 'dyad:associate', %s, %s)
+            RETURNING id
+            """,
+            (
+                canonical,
+                entities[1],
+                entities[0],
+                entities[0],
+                historical_time,
+                historical_chunk,
+            ),
+        )
+        historical_awareness_id = int(cur.fetchone()["id"])
+        historical_payload = {
+            "awareness_id": historical_awareness_id,
+            "claim_id": canonical,
+            "knower_entity_id": entities[1],
+            "immediate_source_entity_id": entities[0],
+            "root_source_entity_id": entities[0],
+            "channel": "dyad:associate",
+            "latency_seconds": 3600.0,
+            "depth": 1,
+            "policy_digest": "pre-092-fixture",
+        }
+        cur.execute(
+            """
+            INSERT INTO world_events (
+                event_type, tick_chunk_id, world_layer, source,
+                changed_fields, payload, world_time
+            ) VALUES (
+                'claim_propagated', %s, 'primary', 'resolver',
+                ARRAY['claim_awareness']::text[], %s::jsonb, %s
+            )
+            """,
+            (
+                historical_chunk,
+                json.dumps(historical_payload),
+                historical_time,
+            ),
+        )
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=2))
+        drained = drain_claim_propagation_sync(
+            cur,
+            tick_chunk_id=drain_chunk,
+            settings=_settings(),
+            distortion_settings=DISTORTION_ENABLED,
+        )
+        live_rows = _incident_awareness(cur, incident_id)
+        events = _incident_events(cur, incident_id)
+        with live_conn.cursor() as replay_cur:
+            replay = reconstruct_state_at_sync(
+                replay_cur,
+                drain_chunk,
+                base_checkpoint_id=checkpoint_id,
+            )
+
+    replayed_rows = [
+        row
+        for row in replay.state["claim_awareness"]
+        if int(row["claim_id"]) == canonical
+    ]
+    assert drained.minted_count == 1
+    assert [event["payload"]["depth"] for event in events] == [1, 2]
+    assert "delivered_claim_id" not in events[0]["payload"]
+    assert events[1]["payload"]["delivered_claim_id"] == canonical
+    assert _canonical_rows(replayed_rows) == _canonical_rows(live_rows)
+
+
+def test_partial_stage_c_payload_fails_frontier_reconciliation(
+    live_conn: Any,
+) -> None:
+    """Any Stage C identity key makes all three mandatory on new events."""
+
+    with live_conn.cursor(cursor_factory=RealDictCursor) as cur:
+        source, _ = _insert_character(cur, "partial-payload-source")
+        birth_chunk, birth_world_time = _insert_chunk(cur)
+        canonical = _insert_claim(
+            cur,
+            chunk_id=birth_chunk,
+            source_entity_id=source,
+            birth_world_time=birth_world_time,
+        )
+        cur.execute(
+            """
+            INSERT INTO world_events (
+                event_type, tick_chunk_id, world_layer, source,
+                changed_fields, payload, world_time
+            ) VALUES (
+                'claim_propagated', %s, 'primary', 'resolver',
+                ARRAY['claim_awareness']::text[], %s::jsonb, %s
+            )
+            """,
+            (
+                birth_chunk,
+                json.dumps(
+                    {
+                        "claim_id": canonical,
+                        "delivered_claim_id": canonical,
+                        "knower_entity_id": source,
+                        "depth": 1,
+                    }
+                ),
+                birth_world_time,
+            ),
+        )
+        drain_chunk, _ = _insert_chunk(cur, time_delta=timedelta(hours=1))
+        with pytest.raises(ValueError, match="lacks Stage C payload fields"):
+            drain_claim_propagation_sync(
+                cur,
+                tick_chunk_id=drain_chunk,
+                settings=_settings(),
+                distortion_settings=DISTORTION_ENABLED,
+            )
+
+
+@pytest.mark.asyncio
+async def test_async_variant_mint_persists_validated_depth() -> None:
+    """The async authoring twin stores the same nullable-positive contract."""
+
+    conn = await asyncpg.connect(get_slot_db_url(slot=LIVE_SLOT))
+    transaction = conn.transaction()
+    await transaction.start()
+    try:
+        await install_claim_accounts_shadow_async(conn)
+        source_claim_id = int(
+            await conn.fetchval(
+                """
+                INSERT INTO claims (
+                    world_event_id, account_label, summary, scope
+                ) VALUES (-92092, 'canonical', 'Async source.', 'bounded')
+                RETURNING id
+                """
+            )
+        )
+        variant_id = await mint_account_variant_async(
+            conn,
+            source_claim_id=source_claim_id,
+            account_label="async-depth-three",
+            summary="Async authored variant.",
+            source_chunk_id=None,
+            distortion_min_depth=3,
+        )
+        assert (
+            await conn.fetchval(
+                "SELECT distortion_min_depth FROM claims WHERE id = $1",
+                variant_id,
+            )
+            == 3
+        )
+        with pytest.raises(ValueError, match="integer >= 1"):
+            await mint_account_variant_async(
+                conn,
+                source_claim_id=source_claim_id,
+                account_label="async-invalid",
+                summary="Invalid async variant.",
+                source_chunk_id=None,
+                distortion_min_depth=0,
+            )
+    finally:
+        await transaction.rollback()
+        await conn.close()

--- a/tests/test_orrery/test_distortion_migration_pg.py
+++ b/tests/test_orrery/test_distortion_migration_pg.py
@@ -173,6 +173,25 @@ def test_migration_092_adds_nullable_positive_documented_depth(
         cur.execute("ROLLBACK TO SAVEPOINT invalid_depth")
 
 
+def test_migration_092_rejects_canonical_account_with_depth(
+    migration_091_schema: Any,
+) -> None:
+    """A direct update cannot turn the canonical account into a variant."""
+
+    with migration_091_schema.cursor() as cur:
+        cur.execute(MIGRATION_SQL)
+        cur.execute("SAVEPOINT canonical_depth")
+        with pytest.raises(psycopg2.errors.CheckViolation):
+            cur.execute(
+                """
+                UPDATE claims
+                SET distortion_min_depth = 1
+                WHERE id = 1
+                """
+            )
+        cur.execute("ROLLBACK TO SAVEPOINT canonical_depth")
+
+
 @pytest.mark.parametrize("invalid_depth", [0, -1, True, 1.5])
 def test_variant_mint_rejects_invalid_distortion_depth_before_sql(
     migration_091_schema: Any,

--- a/tests/test_orrery/test_distortion_migration_pg.py
+++ b/tests/test_orrery/test_distortion_migration_pg.py
@@ -1,0 +1,196 @@
+"""Real-PostgreSQL contract coverage for migration 092."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2  # type: ignore[import-untyped]
+import pytest
+from psycopg2.extras import RealDictCursor  # type: ignore[import-untyped]
+
+from nexus.agents.orrery.epistemics import mint_account_variant_sync
+from nexus.api.slot_utils import get_slot_db_url
+
+
+pytestmark = pytest.mark.requires_postgres
+MIGRATION_SQL = Path("migrations/092_claim_distortion_depth.sql").read_text()
+
+
+@pytest.fixture()
+def migration_091_schema() -> Iterator[Any]:
+    """Build a rolled-back schema with the exact claims shape before 092."""
+
+    conn = psycopg2.connect(get_slot_db_url(slot=2), cursor_factory=RealDictCursor)
+    try:
+        with conn.cursor() as cur:
+            schema = f"migration_092_{uuid4().hex[:12]}"
+            cur.execute(f'CREATE SCHEMA "{schema}"')
+            cur.execute(f'SET LOCAL search_path = "{schema}", public')
+            cur.execute(
+                """
+                CREATE TABLE world_events (id bigserial PRIMARY KEY);
+                CREATE TABLE narrative_chunks (id bigserial PRIMARY KEY);
+                CREATE TABLE orrery_resolutions (id bigserial PRIMARY KEY);
+                CREATE TABLE claims (
+                    id bigserial PRIMARY KEY,
+                    world_event_id bigint NOT NULL
+                        REFERENCES world_events(id),
+                    summary text NOT NULL,
+                    scope text NOT NULL CHECK (
+                        scope IN ('common', 'bounded', 'private')
+                    ),
+                    source_chunk_id bigint REFERENCES narrative_chunks(id),
+                    source_resolution_id bigint
+                        REFERENCES orrery_resolutions(id),
+                    created_at timestamptz NOT NULL DEFAULT now(),
+                    account_label text NOT NULL DEFAULT 'canonical',
+                    account_payload jsonb,
+                    distorted_from_claim_id bigint REFERENCES claims(id),
+                    CHECK (distorted_from_claim_id <> id)
+                );
+                CREATE UNIQUE INDEX ux_claims_world_event_account_v1
+                    ON claims (world_event_id, account_label)
+                    WHERE world_event_id IS NOT NULL;
+                INSERT INTO world_events DEFAULT VALUES;
+                INSERT INTO claims (world_event_id, summary, scope)
+                VALUES (1, 'Canonical account.', 'bounded');
+                """
+            )
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_migration_092_adds_nullable_positive_documented_depth(
+    migration_091_schema: Any,
+) -> None:
+    """Existing accounts stay manual-only and invalid thresholds fail loudly."""
+
+    with migration_091_schema.cursor() as cur:
+        cur.execute(MIGRATION_SQL)
+        cur.execute(
+            """
+            SELECT distortion_min_depth
+            FROM claims
+            WHERE id = 1
+            """
+        )
+        assert cur.fetchone() == {"distortion_min_depth": None}
+        cur.execute(
+            """
+            SELECT is_nullable, data_type
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = 'claims'
+              AND column_name = 'distortion_min_depth'
+            """
+        )
+        assert cur.fetchone() == {
+            "is_nullable": "YES",
+            "data_type": "integer",
+        }
+        cur.execute(
+            """
+            SELECT pg_get_constraintdef(oid) AS definition,
+                   obj_description(oid, 'pg_constraint') AS comment
+            FROM pg_constraint
+            WHERE conrelid = 'claims'::regclass
+              AND conname = 'claims_distortion_min_depth_check'
+            """
+        )
+        constraint = cur.fetchone()
+        assert constraint["definition"] == "CHECK ((distortion_min_depth >= 1))"
+        assert "begin at hop depth 1" in constraint["comment"]
+        cur.execute(
+            """
+            SELECT col_description(
+                'claims'::regclass,
+                attnum
+            ) AS comment
+            FROM pg_attribute
+            WHERE attrelid = 'claims'::regclass
+              AND attname = 'distortion_min_depth'
+            """
+        )
+        comment = cur.fetchone()["comment"]
+        assert "never auto-selected" in comment
+        assert "largest distortion_min_depth wins" in comment
+        assert "lowest claim id" in comment
+        cur.execute(
+            """
+            SELECT indexname
+            FROM pg_indexes
+            WHERE schemaname = current_schema()
+              AND tablename = 'claims'
+              AND indexdef ILIKE '%distortion_min_depth%'
+            """
+        )
+        assert cur.fetchall() == []
+
+        first_variant = mint_account_variant_sync(
+            cur,
+            source_claim_id=1,
+            account_label="first-depth-two",
+            summary="First depth-two account.",
+            source_chunk_id=None,
+            distortion_min_depth=2,
+        )
+        second_variant = mint_account_variant_sync(
+            cur,
+            source_claim_id=1,
+            account_label="second-depth-two",
+            summary="Second depth-two account.",
+            source_chunk_id=None,
+            distortion_min_depth=2,
+        )
+        cur.execute(
+            """
+            SELECT id, distortion_min_depth
+            FROM claims
+            WHERE id = ANY(%s)
+            ORDER BY id
+            """,
+            ([first_variant, second_variant],),
+        )
+        assert cur.fetchall() == [
+            {"id": first_variant, "distortion_min_depth": 2},
+            {"id": second_variant, "distortion_min_depth": 2},
+        ]
+
+        cur.execute("SAVEPOINT invalid_depth")
+        with pytest.raises(psycopg2.errors.CheckViolation):
+            cur.execute(
+                """
+                UPDATE claims
+                SET distortion_min_depth = 0
+                WHERE id = %s
+                """,
+                (first_variant,),
+            )
+        cur.execute("ROLLBACK TO SAVEPOINT invalid_depth")
+
+
+@pytest.mark.parametrize("invalid_depth", [0, -1, True, 1.5])
+def test_variant_mint_rejects_invalid_distortion_depth_before_sql(
+    migration_091_schema: Any,
+    invalid_depth: Any,
+) -> None:
+    """Both type and lower-bound validation precede the INSERT."""
+
+    with migration_091_schema.cursor() as cur:
+        cur.execute(MIGRATION_SQL)
+        with pytest.raises(
+            ValueError,
+            match="distortion_min_depth must be an integer >= 1",
+        ):
+            mint_account_variant_sync(
+                cur,
+                source_claim_id=1,
+                account_label=f"invalid-{invalid_depth!r}",
+                summary="This variant must not be inserted.",
+                source_chunk_id=None,
+                distortion_min_depth=invalid_depth,
+            )

--- a/tests/test_orrery/test_generation_model_provenance_live.py
+++ b/tests/test_orrery/test_generation_model_provenance_live.py
@@ -13,6 +13,9 @@ from sqlalchemy import create_engine, text
 from nexus.api.commit_handler_sync import commit_incubator_to_database_sync
 from nexus.api.narrative_generation import write_to_incubator
 from nexus.api.slot_utils import get_slot_db_url
+from tests.test_orrery.claim_accounts_test_support import (
+    install_claim_accounts_shadow_sync,
+)
 
 
 pytestmark = pytest.mark.requires_postgres
@@ -60,6 +63,10 @@ def provenance_db() -> Iterator[dict[str, Any]]:
             cur.execute(f'CREATE SCHEMA "{schema}"')
             cur.execute(f'SET LOCAL search_path = "{schema}", public')
             cur.execute(reveal_migration_sql)
+            install_claim_accounts_shadow_sync(
+                cur,
+                include_backstory_shadow=False,
+            )
             cur.execute(
                 """
                 INSERT INTO event_types (type, category, severity, description)

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -328,6 +328,24 @@ def test_backstory_secrets_migration_installs_reveal_contract() -> None:
         assert f"COMMENT ON COLUMN backstory_secrets.{column}" in migration_sql
 
 
+def test_claim_distortion_migration_installs_depth_contract() -> None:
+    """Migration 092 adds a nullable, positive authored hop threshold."""
+
+    migration_sql = (
+        Path(__file__).parent.parent.parent
+        / "migrations"
+        / "092_claim_distortion_depth.sql"
+    ).read_text()
+
+    assert "ADD COLUMN distortion_min_depth integer" in migration_sql
+    assert "CHECK (distortion_min_depth >= 1)" in migration_sql
+    assert "COMMENT ON COLUMN claims.distortion_min_depth" in migration_sql
+    assert "largest distortion_min_depth wins" in migration_sql
+    assert "lowest claim id" in migration_sql
+    assert "No partial unique index is intentional" in migration_sql
+    assert "CREATE UNIQUE INDEX" not in migration_sql
+
+
 def test_retrograde_persistence_migration_adds_distinct_sources() -> None:
     """Retrograde canonical writes need explicit event and tag provenance."""
 

--- a/tests/test_orrery/test_migrate.py
+++ b/tests/test_orrery/test_migrate.py
@@ -339,6 +339,8 @@ def test_claim_distortion_migration_installs_depth_contract() -> None:
 
     assert "ADD COLUMN distortion_min_depth integer" in migration_sql
     assert "CHECK (distortion_min_depth >= 1)" in migration_sql
+    assert "claims_canonical_distortion_depth_check" in migration_sql
+    assert "account_label <> 'canonical'" in migration_sql
     assert "COMMENT ON COLUMN claims.distortion_min_depth" in migration_sql
     assert "largest distortion_min_depth wins" in migration_sql
     assert "lowest claim id" in migration_sql

--- a/tests/test_orrery/test_reveal_live.py
+++ b/tests/test_orrery/test_reveal_live.py
@@ -26,6 +26,11 @@ from nexus.api.slot_utils import get_slot_db_url
 from tests.test_orrery.claim_accounts_test_support import (
     install_claim_accounts_shadow_async,
 )
+from tests.test_orrery.test_claim_propagation_live import (
+    _install_valence_shadow,
+    _insert_relationship,
+    _settings,
+)
 
 
 pytestmark = pytest.mark.requires_postgres
@@ -109,6 +114,7 @@ def live_conn() -> Iterator[Any]:
             cur.execute(f'SET LOCAL search_path = "{schema}", public')
             _install_claim_schema(cur)
             cur.execute(MIGRATION_SQL)
+            _install_valence_shadow(cur)
         yield conn
     finally:
         conn.rollback()
@@ -226,7 +232,7 @@ def test_authoring_rejects_non_private_and_unregistered_gate(
     live_conn: Any,
 ) -> None:
     with live_conn.cursor() as cur:
-        source_chunk_id, _ = _insert_chunk(cur)
+        source_chunk_id, source_world_time = _insert_chunk(cur)
         _, bounded_claim, participants, _ = _insert_private_incident(
             cur, source_chunk_id=source_chunk_id, scope="bounded"
         )
@@ -541,6 +547,129 @@ def test_commit_reveals_promotes_grants_once_and_redrain_is_noop(
         authored = cur.fetchone()
         assert authored["world_time"] == source_world_time
         assert authored["payload"]["claim_id"] == claim_id
+
+
+def test_same_tick_reveal_waits_until_next_tick_to_propagate(
+    live_conn: Any,
+) -> None:
+    """Reveal promotion misses this tick's snapshot and enters the next."""
+
+    with live_conn.cursor() as cur:
+        source_chunk_id, source_world_time = _insert_chunk(cur)
+        incident_id, claim_id, participants, place_id = _insert_private_incident(
+            cur, source_chunk_id=source_chunk_id
+        )
+        holder, same_tick_recipient, _ = participants
+        cur.execute(
+            """
+            UPDATE claim_awareness
+            SET acquired_at_world_time = %s
+            WHERE claim_id = %s AND knower_entity_id = %s
+            """,
+            (source_world_time, claim_id, holder),
+        )
+        variant_id = mint_account_variant_sync(
+            cur,
+            source_claim_id=claim_id,
+            account_label=f"next-scene-gossip-{uuid4().hex[:8]}",
+            summary="The next-scene distorted account.",
+            source_chunk_id=source_chunk_id,
+            distortion_min_depth=1,
+        )
+        author_backstory_secret_sync(
+            cur,
+            claim_id=claim_id,
+            gate_template_id="participants_reunited",
+            holder_entity_id=holder,
+            source_chunk_id=source_chunk_id,
+        )
+        outsider = _insert_character(cur, "next-tick-recipient", place_id)
+        cur.execute(
+            "SELECT id FROM characters WHERE entity_id = ANY(%s) ORDER BY entity_id",
+            ([holder, outsider],),
+        )
+        character_ids = [int(row["id"]) for row in cur.fetchall()]
+        _insert_relationship(cur, character_ids[0], character_ids[1])
+        reveal_chunk_id, reveal_world_time = _insert_chunk(
+            cur, time_delta=timedelta(hours=2)
+        )
+
+    reveal_state = WorldState(
+        is_active={entity_id: True for entity_id in (*participants, outsider)},
+        locations={entity_id: place_id for entity_id in (*participants, outsider)},
+        world_time=reveal_world_time,
+    )
+    same_tick = commit_orrery_tick_sync(
+        live_conn,
+        None,
+        tick_chunk_id=reveal_chunk_id,
+        contagion_settings=_settings(),
+        distortion_settings={"enabled": True},
+        reveal_settings={"enabled": True},
+        reveal_state=reveal_state,
+    )
+
+    with live_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT claim_id, knower_entity_id
+            FROM claim_awareness
+            WHERE claim_id IN (%s, %s)
+            ORDER BY claim_id, knower_entity_id
+            """,
+            (claim_id, variant_id),
+        )
+        same_tick_awareness = {
+            (int(row["claim_id"]), int(row["knower_entity_id"]))
+            for row in cur.fetchall()
+        }
+        cur.execute(
+            """
+            SELECT count(*) AS count
+            FROM world_events
+            WHERE event_type = 'claim_propagated'
+              AND tick_chunk_id = %s
+              AND (payload ->> 'incident_world_event_id')::bigint = %s
+            """,
+            (reveal_chunk_id, incident_id),
+        )
+        same_tick_event_count = int(cur.fetchone()["count"])
+        next_chunk_id, _ = _insert_chunk(cur, time_delta=timedelta(hours=1))
+
+    assert same_tick.reveal_count == 1
+    assert same_tick.propagation_count == 0
+    assert same_tick_event_count == 0
+    assert (claim_id, same_tick_recipient) in same_tick_awareness
+    assert (claim_id, outsider) not in same_tick_awareness
+    assert (variant_id, outsider) not in same_tick_awareness
+
+    next_tick = commit_orrery_tick_sync(
+        live_conn,
+        None,
+        tick_chunk_id=next_chunk_id,
+        contagion_settings=_settings(),
+        distortion_settings={"enabled": True},
+    )
+    with live_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT claim_id, knower_entity_id
+            FROM claim_awareness
+            WHERE claim_id IN (%s, %s)
+            ORDER BY claim_id, knower_entity_id
+            """,
+            (claim_id, variant_id),
+        )
+        next_tick_awareness = {
+            (int(row["claim_id"]), int(row["knower_entity_id"]))
+            for row in cur.fetchall()
+        }
+
+    assert next_tick.propagation_count == 1
+    assert (variant_id, outsider) in next_tick_awareness
+    # Suppression contract: hearing any incident sibling blocks every later
+    # account, so this same-tick canonical recipient never receives the variant.
+    assert (variant_id, same_tick_recipient) not in next_tick_awareness
 
 
 def test_unregistered_gate_in_latent_row_raises_loudly(live_conn: Any) -> None:

--- a/tests/test_orrery/test_reveal_live.py
+++ b/tests/test_orrery/test_reveal_live.py
@@ -30,7 +30,49 @@ from tests.test_orrery.claim_accounts_test_support import (
 
 pytestmark = pytest.mark.requires_postgres
 MIGRATION_SQL = Path("migrations/091_backstory_secrets.sql").read_text()
+ACCOUNT_MIGRATION_SQL = Path("migrations/090_claim_accounts.sql").read_text()
+DISTORTION_MIGRATION_SQL = Path("migrations/092_claim_distortion_depth.sql").read_text()
 _SCENES = count(400)
+
+
+def _install_claim_schema(cur: Any) -> None:
+    """Install migrations 090 and 092 in the rollback-only reveal schema."""
+
+    cur.execute(
+        """
+        CREATE TABLE claims (
+            id bigserial PRIMARY KEY,
+            world_event_id bigint NOT NULL,
+            summary text NOT NULL,
+            scope text NOT NULL CHECK (
+                scope IN ('common', 'bounded', 'private')
+            ),
+            source_chunk_id bigint,
+            source_resolution_id bigint,
+            created_at timestamptz NOT NULL DEFAULT now()
+        );
+        CREATE UNIQUE INDEX ux_claims_world_event_v1
+            ON claims (world_event_id)
+            WHERE world_event_id IS NOT NULL;
+        CREATE TABLE claim_awareness (
+            id bigserial PRIMARY KEY,
+            claim_id bigint NOT NULL,
+            knower_entity_id bigint NOT NULL,
+            source_tier text NOT NULL CHECK (
+                source_tier IN ('participant', 'witness', 'told', 'granted')
+            ),
+            immediate_source_entity_id bigint,
+            root_source_entity_id bigint,
+            channel text,
+            acquired_at_world_time timestamptz,
+            source_chunk_id bigint,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            UNIQUE (claim_id, knower_entity_id)
+        );
+        """
+    )
+    cur.execute(ACCOUNT_MIGRATION_SQL)
+    cur.execute(DISTORTION_MIGRATION_SQL)
 
 
 @pytest.fixture()
@@ -65,6 +107,7 @@ def live_conn() -> Iterator[Any]:
             schema = f"reveal_live_{uuid4().hex[:12]}"
             cur.execute(f'CREATE SCHEMA "{schema}"')
             cur.execute(f'SET LOCAL search_path = "{schema}", public')
+            _install_claim_schema(cur)
             cur.execute(MIGRATION_SQL)
         yield conn
     finally:


### PR DESCRIPTION
## Summary

Stage C of #479 (Mechanic 2 of the ruling): accounts mutate as they travel — deterministically.

- **Depth IS the mechanism**: each authored variant declares `distortion_min_depth` (migration 092); a hop at depth d delivers the deepest-qualifying sibling (tie → lowest claim id). Close connections hear the truth; distant ones hear the twisted version. No randomness, no hashing — the engine that expresses conduit weights as world-time latencies does not roll dice
- **Selection, never invention**: the drain chooses among *authored* accounts from a drain-start snapshot, by total depth from the birth knower — variants never lineage-compound
- **Incident-keyed scheduling suppression** (Stage A's deferred exclusion, now load-bearing): possessing any sibling — including a secret holder's private possession — suppresses further propagation of that incident to that knower, killing both the endless-rescheduling loop and the "hears every version" artifact; ledger integrity stays per-(delivered claim, knower)
- **Ledger/replay**: `claim_propagated` payloads gain `delivered_claim_id`/`incident_world_event_id`/`distortion_applied` (all-or-none validated); passive awareness rebuilds against the delivered claim; pre-092 events fall back to delivered == scheduled (absent-key precedent)
- **Config**: `[orrery.distortion]` opt-in (model off, shipped on); disabled = Stage B delivery byte-identical, suppression still active (correctness, not feature — documented)

## Validation

- `poetry run pytest -q` → **1540 passed, 0 failed**
- **Full live-PG orrery suite → 1144 passed, 0 failed** (selection bands, ties, suppression, transitivity, disabled mode, replay determinism incl. delivered variants, pre-092 fallback)
- `replay_state.py --slot 5 --verify` green; flake8/black/config-hook clean

## Schema/Data Impact

Migration 092 pending everywhere; one nullable column + CHECK. Applied at merge closeout.

Implemented by Sol (GPT-5.6 Codex) from a frozen spec; reviewed by Claude. Stage D (the storyteller conduit) completes the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TJVTXfD7TouQuxmYfVf8w