### PR TITLE
Let the World Change How It Feels (#480 Slice 2: Mood Valence)

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -228,7 +228,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **NOT:** 2+ other entities co-located with target
   - actor has any of [`vendetta_holder`, `violent_history`]
 
-**Does:** activity → "executing retaliation"; adds `recently_violent` to actor
+**Does:** activity → "executing retaliation"; adds `recently_violent` to actor; sets actor mood to `restless`
 **Event:** `retaliation_executed`
 
 > {actor} moves on {target} in the moment the corridor clears — no warning, no negotiation, the years of waiting compressed into the time it takes to close a few meters of distance.
@@ -1272,7 +1272,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 **When:** actor `build_venture` project passes `completion` due-state
 
-**Does:** applies project `complete` transition; adds `proprietor` to actor
+**Does:** applies project `complete` transition; adds `proprietor` to actor; sets actor mood to `elated`
 **Event:** `build_venture_completed`
 
 > The preparations stop being preparations. {actor} opens the doors, takes responsibility for what happens beyond them, and becomes the proprietor of something now alive in the world.
@@ -1281,7 +1281,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 
 **When:** actor `build_venture` project passes `abandon` due-state
 
-**Does:** applies project `abandon` transition
+**Does:** applies project `abandon` transition; sets actor mood to `grim`
 **Event:** `build_venture_abandoned`
 
 > {actor} admits that the venture has become an obligation to an unopened future. They release it rather than feed another season into delay.
@@ -1383,7 +1383,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **NOT:** actor has any of [`hostile_to`, `hunting`] pair tags to target
   - **NOT:** target has any of [`hostile_to`, `hunting`] pair tags to actor
 
-**Does:** applies project `complete` transition; adds outbound `contact:intimate` pair tag to target and upserts the actor→target `romantic` relationship
+**Does:** applies project `complete` transition; adds outbound `contact:intimate` pair tag to target and upserts the actor→target `romantic` relationship; sets actor mood to `elated`
 **Event:** `pursue_romance_completed`
 
 > {actor} finally names what has grown between them, and {target} answers with warmth of their own. The courtship becomes a relationship both can recognize.
@@ -1397,7 +1397,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - target has any of [`hostile_to`, `hunting`] pair tags to actor
   - trust target→actor < -1
 
-**Does:** applies project `abandon` transition
+**Does:** applies project `abandon` transition; sets actor mood to `sour`
 **Event:** `pursue_romance_abandoned`
 
 > {target}'s answer closes the possibility, whether through plain refusal, disapproval, or danger. {actor} stops pursuing what is not mutual.
@@ -1522,7 +1522,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - target has any of [`hostile_to`, `hunting`] pair tags to actor
   - trust target→actor < -1
 
-**Does:** applies project `abandon` transition
+**Does:** applies project `abandon` transition; sets actor mood to `sour`
 **Event:** `court_patron_abandoned`
 
 > {target}'s answer is rejection, contempt, or danger. {actor} abandons the bid for favor before deference becomes humiliation.
@@ -1632,7 +1632,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **NOT:** actor has any of [`hostile_to`, `hunting`] pair tags to target
   - **NOT:** target has any of [`hostile_to`, `hunting`] pair tags to actor
 
-**Does:** applies project `complete` transition and upserts the actor→target `complex` relationship with `+1|favorable` valence; removes `grudge_active` from target
+**Does:** applies project `complete` transition and upserts the actor→target `complex` relationship with `+1|favorable` valence; removes `grudge_active` from target; sets actor mood to `elated`
 **Event:** `seek_redemption_completed`
 
 > {target} accepts what {actor} has done to make amends. The history remains complicated, but it no longer dictates only hostility between them.
@@ -1646,7 +1646,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - actor has any of [`hostile_to`, `hunting`] pair tags to target
   - target has any of [`hostile_to`, `hunting`] pair tags to actor
 
-**Does:** applies project `abandon` transition
+**Does:** applies project `abandon` transition; sets actor mood to `grim`
 **Event:** `seek_redemption_abandoned`
 
 > The amends are thrown back in {actor}'s face. Whether the answer is hardened resentment or fresh hostility, {target} will not accept reconciliation on these terms.

--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -229,6 +229,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - actor has any of [`vendetta_holder`, `violent_history`]
 
 **Does:** activity → "executing retaliation"; adds `recently_violent` to actor; sets actor mood to `restless`
+**Mood affinity:** stochastic selection weight only — `grim` × 1.5, `restless` × 2
 **Event:** `retaliation_executed`
 
 > {actor} moves on {target} in the moment the corridor clears — no warning, no negotiation, the years of waiting compressed into the time it takes to close a few meters of distance.
@@ -1336,6 +1337,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 **When:** *(always)*
 
 **Does:** applies project `advance` transition
+**Mood affinity:** stochastic selection weight only — `elated` × 1.5
 **Event:** `build_venture_progressed`
 
 > {actor} finishes one of the unglamorous tasks between backing and opening: a roster, a schedule, a key, a supply line, or the first promise to a customer.
@@ -1461,6 +1463,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 **When:** *(always)*
 
 **Does:** applies project `advance` transition
+**Mood affinity:** stochastic selection weight only — `elated` × 1.5
 **Event:** `pursue_romance_progressed`
 
 > {actor} makes one more part of their intention legible, leaving {target} room for an answer that is genuinely theirs.
@@ -1586,6 +1589,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 **When:** *(always)*
 
 **Does:** applies project `advance` transition
+**Mood affinity:** stochastic selection weight only — `elated` × 1.5
 **Event:** `court_patron_progressed`
 
 > {actor} makes one more service, request, or allegiance explicit, bringing {target}'s answer closer without pretending it is owed.
@@ -1710,6 +1714,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
 **When:** *(always)*
 
 **Does:** applies project `advance` transition
+**Mood affinity:** stochastic selection weight only — `elated` × 1.5
 **Event:** `seek_redemption_progressed`
 
 > {actor} continues the work without treating forgiveness as a debt {target} now owes them.
@@ -3364,6 +3369,7 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **NOT:** actor is hidden or off-grid
 
 **Does:** activity → "at games in company"
+**Mood affinity:** stochastic selection weight only — `elated` × 1.5
 **Event:** `recreation_taken`
 
 > {actor} joins whatever the room is playing at — dice, cards, darts, argument — for stakes small enough to laugh about and company good enough to stay for.

--- a/migrations/095_mood_vocabulary.sql
+++ b/migrations/095_mood_vocabulary.sql
@@ -1,0 +1,47 @@
+-- 095_mood_vocabulary.sql
+--
+-- Mood is the bounded, mechanical affect surface used by Orrery branch gates
+-- and stochastic branch-selection bias. Storyteller prose affect remains in
+-- characters.emotional_state; the two surfaces are intentionally separate.
+
+-- Exclusive single-slot character category. A new mood replaces the current
+-- mood, and time-cleared rows expire on the world clock.
+INSERT INTO tag_category_registry (
+    category, entity_kind, prompt_order, description,
+    deprecated, replacement_categories
+) VALUES (
+    'mood',
+    'character'::entity_kind,
+    35,
+    'Mechanical affect read by branch-selection bias and mood gates; characters.emotional_state remains the separate Storyteller prose-affect surface.',
+    FALSE,
+    NULL
+)
+ON CONFLICT (category, entity_kind) DO NOTHING;
+
+-- Elated: mechanically buoyant disposition.
+-- Sour: mechanically resentful or irritable disposition.
+-- Restless: mechanically agitated or action-seeking disposition.
+-- Grim: mechanically severe or downcast disposition.
+INSERT INTO tags (
+    tag, category, is_ephemeral,
+    clearance_kind, reapplication_policy, clear_on,
+    synonym_for, deprecated, description
+) VALUES
+    (
+        'elated', 'mood', TRUE, 'time', 'replace', NULL,
+        NULL, FALSE, 'A buoyant mechanical disposition after a favorable turn.'
+    ),
+    (
+        'sour', 'mood', TRUE, 'time', 'replace', NULL,
+        NULL, FALSE, 'An irritable mechanical disposition after rejection or insult.'
+    ),
+    (
+        'restless', 'mood', TRUE, 'time', 'replace', NULL,
+        NULL, FALSE, 'An agitated mechanical disposition seeking motion or action.'
+    ),
+    (
+        'grim', 'mood', TRUE, 'time', 'replace', NULL,
+        NULL, FALSE, 'A severe mechanical disposition after loss or abandonment.'
+    )
+ON CONFLICT (tag) DO NOTHING;

--- a/nexus.toml
+++ b/nexus.toml
@@ -306,6 +306,12 @@ snow = "cold"
 fog = "temperate"
 clear = "temperate"
 
+[orrery.mood]
+# Mechanical affect is opt-in in the model but enabled for the shipped slot
+# configuration. Branch outcomes replace the actor's one mood for 12 world-hours.
+enabled = true
+duration_hours = 12
+
 [orrery.selection]
 # Branch selection inside a fired package: "stochastic" softmax-samples all
 # passing branches by magnitude (PRNG seeded on per-resolution persisted

--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -1091,6 +1091,15 @@ def _copy_if_present(
         target[target_key or key] = value
 
 
+class OrreryMoodSet(BaseModel):
+    """Closed mechanical mood write used by Orrery replacement deltas."""
+
+    mood: Literal["elated", "sour", "restless", "grim"]
+    hours: Optional[float] = Field(default=None, gt=0)
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class OrreryReplacementStateDelta(BaseModel):
     """
     Limited Orrery state delta Skald may substitute for a proposed resolution.
@@ -1122,6 +1131,10 @@ class OrreryReplacementStateDelta(BaseModel):
     entity_pair_tags_target_clear_inbound: List[str] = Field(
         default_factory=list,
         description="Replacement inbound target pair-tags to clear",
+    )
+    mood_set: Optional[OrreryMoodSet] = Field(
+        default=None,
+        description="Replacement actor mood with optional world-hour duration",
     )
 
     model_config = ConfigDict(extra="forbid")

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -565,10 +565,10 @@ class LogonUtility:
                 sections.append(f"Weather: {scene_conditions['weather']}")
             if "time_of_day" in scene_conditions:
                 sections.append(f"Time of day: {scene_conditions['time_of_day']}")
-            moods = scene_conditions.get("moods") or {}
+            moods = scene_conditions.get("moods") or []
             if moods:
                 rendered_moods = ", ".join(
-                    f"{name}: {mood}" for name, mood in sorted(moods.items())
+                    f"{entry['name']}: {entry['mood']}" for entry in moods
                 )
                 sections.append(f"Moods: {rendered_moods}")
             sections.append("")

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -561,10 +561,16 @@ class LogonUtility:
         scene_conditions = context.get("scene_conditions") or {}
         if scene_conditions:
             sections.append("=== SCENE CONDITIONS ===")
-            sections.append(f"Weather: {scene_conditions.get('weather', 'unknown')}")
-            sections.append(
-                f"Time of day: {scene_conditions.get('time_of_day', 'unknown')}"
-            )
+            if "weather" in scene_conditions:
+                sections.append(f"Weather: {scene_conditions['weather']}")
+            if "time_of_day" in scene_conditions:
+                sections.append(f"Time of day: {scene_conditions['time_of_day']}")
+            moods = scene_conditions.get("moods") or {}
+            if moods:
+                rendered_moods = ", ".join(
+                    f"{name}: {mood}" for name, mood in sorted(moods.items())
+                )
+                sections.append(f"Moods: {rendered_moods}")
             sections.append("")
 
         # Add warm slice

--- a/nexus/agents/lore/utils/entity_queries.py
+++ b/nexus/agents/lore/utils/entity_queries.py
@@ -230,6 +230,17 @@ def fetch_all_factions_with_references(
                ON etc.entity_id = f.entity_id
               AND etc.entity_kind = 'faction'
               AND etc.category IN ({FACTION_TAG_CONTEXT_CATEGORY_SQL})
+              AND EXISTS (
+                    SELECT 1 FROM entity_tags et
+                    WHERE et.id = etc.entity_tag_id
+                      AND (
+                            (SELECT max(world_time) FROM chunk_metadata) IS NULL
+                            OR et.expires_at_world_time IS NULL
+                            OR et.expires_at_world_time > (
+                                SELECT max(world_time) FROM chunk_metadata
+                            )
+                          )
+                  )
         GROUP BY f.id
         ORDER BY f.name
     """
@@ -275,6 +286,17 @@ def fetch_all_factions_with_references(
                    ON etc.entity_id = f.entity_id
                   AND etc.entity_kind = 'faction'
                   AND etc.category IN ({FACTION_TAG_CONTEXT_CATEGORY_SQL})
+                  AND EXISTS (
+                        SELECT 1 FROM entity_tags et
+                        WHERE et.id = etc.entity_tag_id
+                          AND (
+                                (SELECT max(world_time) FROM chunk_metadata) IS NULL
+                                OR et.expires_at_world_time IS NULL
+                                OR et.expires_at_world_time > (
+                                    SELECT max(world_time) FROM chunk_metadata
+                                )
+                              )
+                      )
             WHERE f.id = ANY(:ids)
             GROUP BY f.id
             ORDER BY f.name

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -682,6 +682,7 @@ class TurnCycleManager:
                 fanout_settings=orrery_settings.get("fanout"),
                 contagion_settings=orrery_settings.get("contagion"),
                 weather_settings=orrery_settings.get("weather"),
+                mood_settings=orrery_settings.get("mood"),
             )
 
         turn_context.orrery_proposal = proposal

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -514,6 +514,7 @@ def explain_dry_run(
     fanout_settings: Optional[Any] = None,
     contagion_settings: Optional[Any] = None,
     weather_settings: Optional[Any] = None,
+    mood_settings: Optional[Any] = None,
 ) -> ExplainedTickReport:
     """Hydrate, bind, and explain Orrery packages without database writes.
 
@@ -549,6 +550,7 @@ def explain_dry_run(
         epistemics_settings=epistemics_policy,
         contagion_settings=contagion_settings,
         weather_settings=weather_settings,
+        mood_settings=mood_settings,
     )
 
     templates_list = list(configure_project_magnitudes(templates, project_policy))

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -1201,15 +1201,22 @@ def entity_context(
         text(
             """
             /* orrery_audit:entity_tags */
-            SELECT entity_id, tag, category, is_ephemeral, source_kind::text
-                   AS source_kind, template_id, applied_at,
-                   applied_at_world_time, source_chunk_id
-            FROM entity_tags_current
-            WHERE entity_id = ANY(:ids)
-            ORDER BY entity_id, tag
+            SELECT etc.entity_id, etc.tag, etc.category, etc.is_ephemeral,
+                   etc.source_kind::text AS source_kind, etc.template_id,
+                   etc.applied_at, etc.applied_at_world_time,
+                   etc.source_chunk_id
+            FROM entity_tags_current etc
+            JOIN entity_tags et ON et.id = etc.entity_tag_id
+            WHERE etc.entity_id = ANY(:ids)
+              AND (
+                  :current_world_time IS NULL
+                  OR et.expires_at_world_time IS NULL
+                  OR et.expires_at_world_time > :current_world_time
+              )
+            ORDER BY etc.entity_id, etc.tag
             """
         ),
-        {"ids": ids},
+        {"ids": ids, "current_world_time": world_time},
     ).mappings():
         tag = row["tag"]
         tags_by_entity.setdefault(row["entity_id"], []).append(
@@ -1518,12 +1525,18 @@ def entity_context(
                 SELECT p.id AS place_id, etc.tag
                 FROM places p
                 JOIN entity_tags_current etc ON etc.entity_id = p.entity_id
+                JOIN entity_tags et ON et.id = etc.entity_tag_id
                 WHERE p.id = ANY(:place_ids)
                   AND etc.entity_kind = 'place'
                   AND etc.category IN ({_LOCATION_CLASS_CATEGORY_SQL})
+                  AND (
+                      :current_world_time IS NULL
+                      OR et.expires_at_world_time IS NULL
+                      OR et.expires_at_world_time > :current_world_time
+                  )
                 """
             ),
-            {"place_ids": place_ids},
+            {"place_ids": place_ids, "current_world_time": world_time},
         ).mappings():
             place_classes.setdefault(row["place_id"], set()).add(row["tag"])
     for row in place_rows.values():

--- a/nexus/agents/orrery/catalog.py
+++ b/nexus/agents/orrery/catalog.py
@@ -193,6 +193,14 @@ _register(
     ),
 )
 _register(
+    r"mood_is\((?P<values>[^@()]+)@(?P<slot>\w+)\)",
+    lambda m: (
+        f"{_slot(m.group('slot'))}'s active mood is one of ["
+        + ", ".join(f"`{value}`" for value in m.group("values").split(","))
+        + "]"
+    ),
+)
+_register(
     r"resources_at_or_above\((?P<tier>[^@()]+)@(?P<slot>\w+)\)",
     lambda m: (
         f"{_slot(m.group('slot'))}'s own resources are `{m.group('tier')}` or better"
@@ -552,6 +560,12 @@ def _render_state_delta(delta: Mapping[str, Any]) -> str:
         if key == "character.current_activity":
             parts.append(f'activity → "{value}"')
             continue
+        if key == "mood.set":
+            mood = value.get("mood") if isinstance(value, Mapping) else value
+            hours = value.get("hours") if isinstance(value, Mapping) else None
+            duration = f" for {hours} world-hours" if hours is not None else ""
+            parts.append(f"sets actor mood to `{mood}`{duration}")
+            continue
         if key in ("entity_tags.add", "entity_tags_target.add"):
             target = "actor" if key == "entity_tags.add" else "target"
             tags = ", ".join(f"`{t}`" for t in value)
@@ -689,6 +703,14 @@ def _render_branch(idx: int, branch: Branch) -> List[str]:
     lines.append("")
     if branch.state_delta:
         lines.append(f"**Does:** {_render_state_delta(branch.state_delta)}")
+    if branch.mood_affinities:
+        rendered = ", ".join(
+            f"`{mood}` × {multiplier:g}"
+            for mood, multiplier in sorted(branch.mood_affinities.items())
+        )
+        lines.append(
+            "**Mood affinity:** stochastic selection weight only — " + rendered
+        )
     if branch.event_type:
         lines.append(f"**Event:** `{branch.event_type}`")
     if branch.narrative_stub:

--- a/nexus/agents/orrery/communication.py
+++ b/nexus/agents/orrery/communication.py
@@ -65,10 +65,16 @@ _CULTURE_TAGS_SQL = """
     /* orrery:communication_culture_tags */
     SELECT etc.entity_id, etc.category, etc.tag
     FROM entity_tags_current etc
+    JOIN entity_tags et ON et.id = etc.entity_tag_id
     JOIN entities institution ON institution.id = etc.entity_id
     WHERE institution.kind = 'faction'
       AND institution.is_active = true
       AND etc.category IN ('operational_secrecy', 'operational_mode')
+      AND (
+          CAST(:current_world_time AS timestamptz) IS NULL
+          OR et.expires_at_world_time IS NULL
+          OR et.expires_at_world_time > CAST(:current_world_time AS timestamptz)
+      )
     ORDER BY etc.entity_id, etc.category, etc.tag
 """
 
@@ -141,12 +147,18 @@ def _fetch_mappings(session_or_cur: Any, sql: str) -> list[dict[str, Any]]:
     result = session_or_cur.execute(sql)
     if result is not None and hasattr(result, "mappings"):
         return [dict(row) for row in result.mappings()]
-    description = getattr(session_or_cur, "description", None)
+    return _rows_from_dbapi_cursor(session_or_cur)
+
+
+def _rows_from_dbapi_cursor(cur: Any) -> list[dict[str, Any]]:
+    """Materialize the current DB-API cursor result as dictionaries."""
+
+    description = getattr(cur, "description", None)
     if description is None:
         raise TypeError(
             "session_or_cur must be a SQLAlchemy session/connection or DB-API cursor"
         )
-    rows = session_or_cur.fetchall()
+    rows = cur.fetchall()
     if rows and isinstance(rows[0], Mapping):
         return [dict(row) for row in rows]
     column_names = [column[0] for column in description]
@@ -296,14 +308,30 @@ async def _channel_rows_async(conn: Any) -> list[dict[str, Any]]:
     return await _fetch_mappings_async(conn, _CHANNEL_SQL)
 
 
-def _culture_tags_by_institution(session_or_cur: Any) -> dict[int, Tuple[str, ...]]:
-    return _culture_tags_from_rows(_fetch_mappings(session_or_cur, _CULTURE_TAGS_SQL))
+def _culture_tags_by_institution(
+    session_or_cur: Any, *, world_time: Optional[datetime]
+) -> dict[int, Tuple[str, ...]]:
+    if type(session_or_cur).__module__.startswith("sqlalchemy"):
+        rows = session_or_cur.execute(
+            text(_CULTURE_TAGS_SQL), {"current_world_time": world_time}
+        )
+        return _culture_tags_from_rows([dict(row) for row in rows.mappings()])
+    session_or_cur.execute(
+        _CULTURE_TAGS_SQL.replace(":current_world_time", "%s"),
+        (world_time, world_time),
+    )
+    return _culture_tags_from_rows(_rows_from_dbapi_cursor(session_or_cur))
 
 
 async def _culture_tags_by_institution_async(
     conn: Any,
+    *,
+    world_time: Optional[datetime],
 ) -> dict[int, Tuple[str, ...]]:
-    return _culture_tags_from_rows(await _fetch_mappings_async(conn, _CULTURE_TAGS_SQL))
+    sql = _CULTURE_TAGS_SQL.replace(":current_world_time", "$1")
+    return _culture_tags_from_rows(
+        [dict(row) for row in await conn.fetch(sql, world_time)]
+    )
 
 
 def _culture_tags_from_rows(
@@ -385,20 +413,26 @@ def _channel_directions(
 
 
 def _channel_edges(
-    session_or_cur: Any, settings: OrreryContagionSettings
+    session_or_cur: Any,
+    settings: OrreryContagionSettings,
+    *,
+    world_time: Optional[datetime],
 ) -> list[CommunicationEdge]:
     registered_tags = _registered_channel_tags(session_or_cur)
-    culture_tags = _culture_tags_by_institution(session_or_cur)
+    culture_tags = _culture_tags_by_institution(session_or_cur, world_time=world_time)
     return _channel_edges_from_rows(
         _channel_rows(session_or_cur), registered_tags, culture_tags, settings
     )
 
 
 async def _channel_edges_async(
-    conn: Any, settings: OrreryContagionSettings
+    conn: Any,
+    settings: OrreryContagionSettings,
+    *,
+    world_time: Optional[datetime],
 ) -> list[CommunicationEdge]:
     registered_tags = await _registered_channel_tags_async(conn)
-    culture_tags = await _culture_tags_by_institution_async(conn)
+    culture_tags = await _culture_tags_by_institution_async(conn, world_time=world_time)
     return _channel_edges_from_rows(
         await _channel_rows_async(conn), registered_tags, culture_tags, settings
     )
@@ -451,18 +485,16 @@ def assemble_communication_graph(
 ) -> CommunicationGraph:
     """Assemble the immutable communication graph without database writes.
 
-    ``world_time`` is accepted now so Stage 2c can consume the same assembly
-    boundary for world-clock frontier calculations. Stage 2b performs no age
-    or scope gating, so the value cannot alter the graph yet.
+    Culture tags use the same world-clock boundary as the graph consumer, so
+    expired-unswept ephemeral rows cannot affect channel latency.
     """
 
-    del world_time
     config = coerce_contagion_settings(settings)
     if not config.enabled:
         return CommunicationGraph()
     _validate_dyad_overrides(session_or_cur, config.dyad_overrides)
     edges = _dyad_edges(session_or_cur, config)
-    edges.extend(_channel_edges(session_or_cur, config))
+    edges.extend(_channel_edges(session_or_cur, config, world_time=world_time))
     return CommunicationGraph(edges=tuple(sorted(edges, key=_edge_sort_key)))
 
 
@@ -474,13 +506,12 @@ async def assemble_communication_graph_async(
 ) -> CommunicationGraph:
     """Asyncpg twin of :func:`assemble_communication_graph`."""
 
-    del world_time
     config = coerce_contagion_settings(settings)
     if not config.enabled:
         return CommunicationGraph()
     await _validate_dyad_overrides_async(conn, config.dyad_overrides)
     edges = await _dyad_edges_async(conn, config)
-    edges.extend(await _channel_edges_async(conn, config))
+    edges.extend(await _channel_edges_async(conn, config, world_time=world_time))
     return CommunicationGraph(edges=tuple(sorted(edges, key=_edge_sort_key)))
 
 

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -382,6 +382,7 @@ def analyze_coverage(
     fanout_settings: Optional[Any] = None,
     contagion_settings: Optional[Any] = None,
     weather_settings: Optional[Any] = None,
+    mood_settings: Optional[Any] = None,
 ) -> dict[str, Any]:
     """Aggregate explained resolution coverage across historical anchors.
 
@@ -428,6 +429,7 @@ def analyze_coverage(
             fanout_settings=fanout_settings,
             contagion_settings=contagion_settings,
             weather_settings=weather_settings,
+            mood_settings=mood_settings,
         )
         anchors.append(_tally_report(report, tallies, gap_counts))
         entity_names.update(report.entity_names)

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass, field, replace
 from hashlib import sha256
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 import json
 from typing import Any, Mapping, Optional
 
@@ -55,10 +55,15 @@ from nexus.agents.orrery.routing import (
     shortest_route,
 )
 from nexus.agents.orrery.substrate import (
+    MOOD_VALUES,
     ProjectPolicy,
     SUPPORTED_TRAVEL_PURPOSES,
     coerce_project_policy,
     WorldState,
+)
+from nexus.agents.orrery.tag_writer import (
+    apply_exclusive_tag_bestowal,
+    apply_exclusive_tag_bestowal_async,
 )
 
 
@@ -75,6 +80,7 @@ SUPPORTED_STATE_DELTA_KEYS = frozenset(
         "entity_pair_tags.clear_outbound",
         "entity_pair_tags_target.clear_inbound",
         "need.fulfill",
+        "mood.set",
         "travel.start",
         "travel.advance",
         "travel.arrive",
@@ -98,7 +104,35 @@ REPLACEMENT_STATE_DELTA_ALIASES = {
     "entity_pair_tags_add_inbound": "entity_pair_tags.add_inbound",
     "entity_pair_tags_clear_outbound": "entity_pair_tags.clear_outbound",
     "entity_pair_tags_target_clear_inbound": ("entity_pair_tags_target.clear_inbound"),
+    "mood_set": "mood.set",
 }
+
+
+@dataclass(frozen=True, slots=True)
+class MoodPolicy:
+    """Commit-time mechanical mood policy."""
+
+    enabled: bool = False
+    duration_hours: float = 12.0
+
+
+def coerce_mood_policy(raw: Any) -> MoodPolicy:
+    """Coerce ``[orrery.mood]`` settings without weakening validation."""
+
+    if raw is None:
+        return MoodPolicy()
+    if isinstance(raw, Mapping):
+        enabled = bool(raw.get("enabled", False))
+        duration = raw.get("duration_hours", 12.0)
+    else:
+        enabled = bool(raw.enabled)
+        duration = raw.duration_hours
+    if isinstance(duration, bool) or not isinstance(duration, (int, float)):
+        raise ValueError("orrery.mood.duration_hours must be a positive number")
+    duration_hours = float(duration)
+    if duration_hours <= 0:
+        raise ValueError("orrery.mood.duration_hours must be greater than zero")
+    return MoodPolicy(enabled=enabled, duration_hours=duration_hours)
 
 
 @dataclass(frozen=True)
@@ -363,6 +397,7 @@ def commit_orrery_tick_sync(
     prompt_settings: Optional[Any] = None,
     ecology_settings: Optional[Any] = None,
     project_settings: Optional[Any] = None,
+    mood_settings: Optional[Any] = None,
     epistemics_settings: Optional[Any] = None,
     contagion_settings: Optional[Any] = None,
     distortion_settings: Optional[Any] = None,
@@ -374,6 +409,7 @@ def commit_orrery_tick_sync(
 
     signal_detection = coerce_signal_detection(ecology_settings)
     project_policy = coerce_project_policy(project_settings)
+    mood_policy = coerce_mood_policy(mood_settings)
     coerced = coerce_proposal(proposal)
     effective_epistemics_settings = epistemics_settings
     if effective_epistemics_settings is None and coerced is not None:
@@ -563,6 +599,7 @@ def commit_orrery_tick_sync(
                 source_chunk_id=tick_chunk_id,
                 need_tuning=need_tuning,
                 project_policy=project_policy,
+                mood_policy=mood_policy,
             )
             event_id = _emit_world_event_sync(
                 cur,
@@ -636,6 +673,7 @@ async def commit_orrery_tick_async(
     prompt_settings: Optional[Any] = None,
     ecology_settings: Optional[Any] = None,
     project_settings: Optional[Any] = None,
+    mood_settings: Optional[Any] = None,
     epistemics_settings: Optional[Any] = None,
     contagion_settings: Optional[Any] = None,
     distortion_settings: Optional[Any] = None,
@@ -647,6 +685,7 @@ async def commit_orrery_tick_async(
 
     signal_detection = coerce_signal_detection(ecology_settings)
     project_policy = coerce_project_policy(project_settings)
+    mood_policy = coerce_mood_policy(mood_settings)
     coerced = coerce_proposal(proposal)
     effective_epistemics_settings = epistemics_settings
     if effective_epistemics_settings is None and coerced is not None:
@@ -835,6 +874,7 @@ async def commit_orrery_tick_async(
             source_chunk_id=tick_chunk_id,
             need_tuning=need_tuning,
             project_policy=project_policy,
+            mood_policy=mood_policy,
         )
         event_id = await _emit_world_event_async(
             conn,
@@ -1625,6 +1665,7 @@ def _apply_state_delta_sync(
     source_chunk_id: int,
     need_tuning: NeedTuning,
     project_policy: ProjectPolicy,
+    mood_policy: MoodPolicy = MoodPolicy(),
 ) -> int:
     if not draft.state_delta:
         return 0
@@ -1638,6 +1679,7 @@ def _apply_state_delta_sync(
 
     tag_mutations = 0
     applied_pair_tag_mutations: list[dict[str, Any]] = []
+    mood_applied: Optional[dict[str, Any]] = None
     project_keys = [key for key in draft.state_delta if key.startswith("project.")]
     if len(project_keys) > 1:
         raise ValueError(
@@ -1795,6 +1837,15 @@ def _apply_state_delta_sync(
             source_chunk_id=source_chunk_id,
             need_tuning=need_tuning,
         )
+    if "mood.set" in draft.state_delta:
+        mood_applied, mood_mutations = _apply_mood_set_sync(
+            cur,
+            actor_entity_id=actor_entity_id,
+            raw_payload=draft.state_delta["mood.set"],
+            source_chunk_id=source_chunk_id,
+            policy=mood_policy,
+        )
+        tag_mutations += mood_mutations
     project_applied: Optional[dict[str, Any]] = None
     if "project.start" in draft.state_delta:
         project_applied = _apply_project_start_sync(
@@ -1878,6 +1929,12 @@ def _apply_state_delta_sync(
             payload=draft.state_delta["travel.arrive"],
             source_chunk_id=source_chunk_id,
         )
+    if mood_applied is not None:
+        _update_resolution_mood_applied_sync(
+            cur,
+            resolution_id=resolution_id,
+            applied=mood_applied,
+        )
     return tag_mutations
 
 
@@ -1891,6 +1948,7 @@ async def _apply_state_delta_async(
     source_chunk_id: int,
     need_tuning: NeedTuning,
     project_policy: ProjectPolicy,
+    mood_policy: MoodPolicy = MoodPolicy(),
 ) -> int:
     if not draft.state_delta:
         return 0
@@ -1904,6 +1962,7 @@ async def _apply_state_delta_async(
 
     tag_mutations = 0
     applied_pair_tag_mutations: list[dict[str, Any]] = []
+    mood_applied: Optional[dict[str, Any]] = None
     project_keys = [key for key in draft.state_delta if key.startswith("project.")]
     if len(project_keys) > 1:
         raise ValueError(
@@ -2059,6 +2118,15 @@ async def _apply_state_delta_async(
             source_chunk_id=source_chunk_id,
             need_tuning=need_tuning,
         )
+    if "mood.set" in draft.state_delta:
+        mood_applied, mood_mutations = await _apply_mood_set_async(
+            conn,
+            actor_entity_id=actor_entity_id,
+            raw_payload=draft.state_delta["mood.set"],
+            source_chunk_id=source_chunk_id,
+            policy=mood_policy,
+        )
+        tag_mutations += mood_mutations
     project_applied: Optional[dict[str, Any]] = None
     if "project.start" in draft.state_delta:
         project_applied = await _apply_project_start_async(
@@ -2142,7 +2210,238 @@ async def _apply_state_delta_async(
             payload=draft.state_delta["travel.arrive"],
             source_chunk_id=source_chunk_id,
         )
+    if mood_applied is not None:
+        await _update_resolution_mood_applied_async(
+            conn,
+            resolution_id=resolution_id,
+            applied=mood_applied,
+        )
     return tag_mutations
+
+
+def _coerce_mood_set(raw: Any, policy: MoodPolicy) -> tuple[str, float]:
+    """Validate one closed-vocabulary ``mood.set`` payload."""
+
+    if not isinstance(raw, Mapping):
+        raise ValueError("mood.set must be a mapping")
+    unknown_keys = set(raw) - {"mood", "hours"}
+    if unknown_keys:
+        raise ValueError(f"mood.set contains unknown keys: {sorted(unknown_keys)}")
+    mood = str(raw.get("mood") or "").strip()
+    if mood not in MOOD_VALUES:
+        raise ValueError(
+            f"Unknown mood {mood!r}; expected one of {sorted(MOOD_VALUES)}"
+        )
+    hours = raw.get("hours", policy.duration_hours)
+    if isinstance(hours, bool) or not isinstance(hours, (int, float)):
+        raise ValueError("mood.set hours must be a positive number")
+    duration_hours = float(hours)
+    if duration_hours <= 0:
+        raise ValueError("mood.set hours must be greater than zero")
+    return mood, duration_hours
+
+
+def _json_snapshot(value: Any) -> Any:
+    """Normalize DB-returned values for a durable JSONB applied projection."""
+
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).isoformat()
+    if isinstance(value, str) and "T" in value:
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError:
+            pass
+        else:
+            if parsed.tzinfo is not None:
+                return parsed.astimezone(timezone.utc).isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): _json_snapshot(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_snapshot(item) for item in value]
+    return value
+
+
+def _apply_mood_set_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    raw_payload: Any,
+    source_chunk_id: int,
+    policy: MoodPolicy,
+) -> tuple[dict[str, Any], int]:
+    """Apply exclusive mood replacement and return its replay snapshot."""
+
+    mood, duration_hours = _coerce_mood_set(raw_payload, policy)
+    if not policy.enabled:
+        return {"skipped": "mood_disabled"}, 0
+
+    cur.execute(
+        "SELECT world_time FROM chunk_metadata WHERE chunk_id = %s",
+        (source_chunk_id,),
+    )
+    world_row = cur.fetchone()
+    world_time = _row_get(world_row, "world_time", 0) if world_row else None
+    if world_time is None:
+        raise ValueError(
+            f"mood.set at chunk {source_chunk_id} requires a known world_time"
+        )
+    cur.execute(
+        """
+        SELECT t.tag
+        FROM entity_tags et
+        JOIN tags t ON t.id = et.tag_id
+        WHERE et.entity_id = %s
+          AND t.category = 'mood'
+          AND t.tag <> %s
+          AND et.cleared_at IS NULL
+        ORDER BY et.id
+        FOR UPDATE OF et
+        """,
+        (actor_entity_id, mood),
+    )
+    displaced = [str(_row_get(row, "tag", 0)) for row in cur.fetchall()]
+    changed = apply_exclusive_tag_bestowal(
+        cur,
+        entity_id=actor_entity_id,
+        entity_kind="character",
+        tag=mood,
+        source_kind="template",
+        world_time=world_time,
+        source_chunk_id=source_chunk_id,
+        duration_override=timedelta(hours=duration_hours),
+    )
+    cur.execute(
+        """
+        SELECT to_jsonb(et) AS entity_tag
+        FROM entity_tags et
+        JOIN tags t ON t.id = et.tag_id
+        WHERE et.entity_id = %s
+          AND t.tag = %s
+          AND et.cleared_at IS NULL
+        """,
+        (actor_entity_id, mood),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise RuntimeError("mood.set writer produced no active entity tag row")
+    raw_entity_tag = _row_get(row, "entity_tag", 0)
+    if isinstance(raw_entity_tag, str):
+        raw_entity_tag = json.loads(raw_entity_tag)
+    entity_tag = _json_snapshot(raw_entity_tag)
+    applied = {
+        "mood": mood,
+        "displaced_mood": displaced[0] if len(displaced) == 1 else None,
+        "displaced_moods": displaced,
+        "expires_at_world_time": entity_tag["expires_at_world_time"],
+        "entity_tag": entity_tag,
+    }
+    return applied, len(displaced) + int(changed)
+
+
+async def _apply_mood_set_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    raw_payload: Any,
+    source_chunk_id: int,
+    policy: MoodPolicy,
+) -> tuple[dict[str, Any], int]:
+    """Async twin of :func:`_apply_mood_set_sync`."""
+
+    mood, duration_hours = _coerce_mood_set(raw_payload, policy)
+    if not policy.enabled:
+        return {"skipped": "mood_disabled"}, 0
+    world_time = await conn.fetchval(
+        "SELECT world_time FROM chunk_metadata WHERE chunk_id = $1",
+        source_chunk_id,
+    )
+    if world_time is None:
+        raise ValueError(
+            f"mood.set at chunk {source_chunk_id} requires a known world_time"
+        )
+    displaced_rows = await conn.fetch(
+        """
+        SELECT t.tag
+        FROM entity_tags et
+        JOIN tags t ON t.id = et.tag_id
+        WHERE et.entity_id = $1
+          AND t.category = 'mood'
+          AND t.tag <> $2
+          AND et.cleared_at IS NULL
+        ORDER BY et.id
+        FOR UPDATE OF et
+        """,
+        actor_entity_id,
+        mood,
+    )
+    displaced = [str(_row_get(row, "tag", 0)) for row in displaced_rows]
+    changed = await apply_exclusive_tag_bestowal_async(
+        conn,
+        entity_id=actor_entity_id,
+        entity_kind="character",
+        tag=mood,
+        source_kind="template",
+        world_time=world_time,
+        source_chunk_id=source_chunk_id,
+        duration_override=timedelta(hours=duration_hours),
+    )
+    row = await conn.fetchrow(
+        """
+        SELECT to_jsonb(et) AS entity_tag
+        FROM entity_tags et
+        JOIN tags t ON t.id = et.tag_id
+        WHERE et.entity_id = $1
+          AND t.tag = $2
+          AND et.cleared_at IS NULL
+        """,
+        actor_entity_id,
+        mood,
+    )
+    if row is None:
+        raise RuntimeError("mood.set writer produced no active entity tag row")
+    raw_entity_tag = _row_get(row, "entity_tag", 0)
+    if isinstance(raw_entity_tag, str):
+        raw_entity_tag = json.loads(raw_entity_tag)
+    entity_tag = _json_snapshot(raw_entity_tag)
+    applied = {
+        "mood": mood,
+        "displaced_mood": displaced[0] if len(displaced) == 1 else None,
+        "displaced_moods": displaced,
+        "expires_at_world_time": entity_tag["expires_at_world_time"],
+        "entity_tag": entity_tag,
+    }
+    return applied, len(displaced) + int(changed)
+
+
+def _update_resolution_mood_applied_sync(
+    cur: Any, *, resolution_id: int, applied: Mapping[str, Any]
+) -> None:
+    cur.execute(
+        """
+        UPDATE orrery_resolutions
+        SET state_delta = jsonb_set(
+            state_delta, '{mood.set,applied}', %s::jsonb, true
+        )
+        WHERE id = %s
+        """,
+        (json.dumps(dict(applied)), resolution_id),
+    )
+
+
+async def _update_resolution_mood_applied_async(
+    conn: Any, *, resolution_id: int, applied: Mapping[str, Any]
+) -> None:
+    await conn.execute(
+        """
+        UPDATE orrery_resolutions
+        SET state_delta = jsonb_set(
+            state_delta, '{mood.set,applied}', $1::jsonb, true
+        )
+        WHERE id = $2
+        """,
+        json.dumps(dict(applied)),
+        resolution_id,
+    )
 
 
 def _coerce_need_fulfillment(raw: Any) -> dict[str, Any]:

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -4433,6 +4433,7 @@ def _apply_travel_start_sync(
                 cur,
                 actor_entity_id=actor_entity_id,
                 anchor_type=str(destination_anchor),
+                current_world_time=world_time,
             )
         else:
             destination_classes = _destination_place_classes(data)
@@ -4441,6 +4442,7 @@ def _apply_travel_start_sync(
                     cur,
                     origin_place_id=int(origin_place_id),
                     location_classes=destination_classes,
+                    current_world_time=world_time,
                 )
             else:
                 destination_place_id = _planned_destination_sync(cur, actor_entity_id)
@@ -4538,6 +4540,7 @@ async def _apply_travel_start_async(
                 conn,
                 actor_entity_id=actor_entity_id,
                 anchor_type=str(destination_anchor),
+                current_world_time=world_time,
             )
         else:
             destination_classes = _destination_place_classes(data)
@@ -4546,6 +4549,7 @@ async def _apply_travel_start_async(
                     conn,
                     origin_place_id=int(origin_place_id),
                     location_classes=destination_classes,
+                    current_world_time=world_time,
                 )
             else:
                 destination_place_id = await _planned_destination_async(
@@ -4905,6 +4909,7 @@ def _load_or_create_need_debt_sync(
         cur,
         actor_entity_id=actor_entity_id,
         need_type=need_type,
+        current_world_time=world_time,
     ):
         raise ValueError(
             f"Orrery need {need_type!r} does not apply to actor {actor_entity_id}"
@@ -4958,6 +4963,7 @@ async def _load_or_create_need_debt_async(
         conn,
         actor_entity_id=actor_entity_id,
         need_type=need_type,
+        current_world_time=world_time,
     ):
         raise ValueError(
             f"Orrery need {need_type!r} does not apply to actor {actor_entity_id}"
@@ -5004,14 +5010,21 @@ def _need_applies_to_entity_sync(
     *,
     actor_entity_id: int,
     need_type: str,
+    current_world_time: Any,
 ) -> bool:
     cur.execute(
         """
         SELECT etc.tag
         FROM entity_tags_current etc
+        JOIN entity_tags et ON et.id = etc.entity_tag_id
         WHERE etc.entity_id = %s
+          AND (
+              %s IS NULL
+              OR et.expires_at_world_time IS NULL
+              OR et.expires_at_world_time > %s
+          )
         """,
-        (actor_entity_id,),
+        (actor_entity_id, current_world_time, current_world_time),
     )
     return need_applies_to_tags(
         need_type,
@@ -5024,14 +5037,22 @@ async def _need_applies_to_entity_async(
     *,
     actor_entity_id: int,
     need_type: str,
+    current_world_time: Any,
 ) -> bool:
     rows = await conn.fetch(
         """
         SELECT etc.tag
         FROM entity_tags_current etc
+        JOIN entity_tags et ON et.id = etc.entity_tag_id
         WHERE etc.entity_id = $1
+          AND (
+              $2 IS NULL
+              OR et.expires_at_world_time IS NULL
+              OR et.expires_at_world_time > $2
+          )
         """,
         actor_entity_id,
+        current_world_time,
     )
     return need_applies_to_tags(
         need_type,
@@ -6189,6 +6210,7 @@ def _routine_anchor_destination_sync(
     *,
     actor_entity_id: int,
     anchor_type: str,
+    current_world_time: Any,
 ) -> Optional[int]:
     cur.execute(
         """
@@ -6214,10 +6236,14 @@ def _routine_anchor_destination_sync(
             cur,
             actor_entity_id=actor_entity_id,
             anchor_type="home",
+            current_world_time=current_world_time,
         )
     if policy == "zone_resolved" and zone_id is not None:
         return _routine_zone_destination_sync(
-            cur, zone_id=int(zone_id), anchor_type=anchor_type
+            cur,
+            zone_id=int(zone_id),
+            anchor_type=anchor_type,
+            current_world_time=current_world_time,
         )
     return None
 
@@ -6227,6 +6253,7 @@ def _routine_zone_destination_sync(
     *,
     zone_id: int,
     anchor_type: str,
+    current_world_time: Any,
 ) -> Optional[int]:
     preferred_tags = (
         ("dwelling", "haven")
@@ -6248,12 +6275,26 @@ def _routine_zone_destination_sync(
           ON etc.entity_id = p.entity_id
          AND etc.category = 'place_function'
          AND etc.tag = ANY(%s)
+         AND EXISTS (
+             SELECT 1 FROM entity_tags et
+             WHERE et.id = etc.entity_tag_id
+               AND (
+                   %s IS NULL
+                   OR et.expires_at_world_time IS NULL
+                   OR et.expires_at_world_time > %s
+               )
+         )
         WHERE p.zone = %s
         GROUP BY p.id
         ORDER BY CASE WHEN count(etc.tag) > 0 THEN 0 ELSE 1 END, p.id
         LIMIT 1
         """,
-        (list(preferred_tags), zone_id),
+        (
+            list(preferred_tags),
+            current_world_time,
+            current_world_time,
+            zone_id,
+        ),
     )
     row = cur.fetchone()
     return _row_get(row, "id", 0) if row else None
@@ -6264,6 +6305,7 @@ def _location_class_destination_sync(
     *,
     origin_place_id: int,
     location_classes: tuple[str, ...],
+    current_world_time: Any,
 ) -> Optional[int]:
     cur.execute(
         """
@@ -6274,6 +6316,15 @@ def _location_class_destination_sync(
           ON etc.entity_id = p.entity_id
          AND etc.category = ANY(%s)
          AND etc.tag = ANY(%s)
+         AND EXISTS (
+             SELECT 1 FROM entity_tags et
+             WHERE et.id = etc.entity_tag_id
+               AND (
+                   %s IS NULL
+                   OR et.expires_at_world_time IS NULL
+                   OR et.expires_at_world_time > %s
+               )
+         )
         WHERE p.id <> %s
           AND (p.type::text = ANY(%s) OR etc.tag IS NOT NULL)
         -- Collapse multiple matching tags per place before preferring same-zone
@@ -6290,6 +6341,8 @@ def _location_class_destination_sync(
             origin_place_id,
             list(LOCATION_CLASS_TAG_CATEGORIES),
             list(location_classes),
+            current_world_time,
+            current_world_time,
             origin_place_id,
             list(location_classes),
         ),
@@ -6315,6 +6368,7 @@ async def _routine_anchor_destination_async(
     *,
     actor_entity_id: int,
     anchor_type: str,
+    current_world_time: Any,
 ) -> Optional[int]:
     row = await conn.fetchrow(
         """
@@ -6340,12 +6394,14 @@ async def _routine_anchor_destination_async(
             conn,
             actor_entity_id=actor_entity_id,
             anchor_type="home",
+            current_world_time=current_world_time,
         )
     if policy == "zone_resolved" and zone_id is not None:
         return await _routine_zone_destination_async(
             conn,
             zone_id=int(zone_id),
             anchor_type=anchor_type,
+            current_world_time=current_world_time,
         )
     return None
 
@@ -6355,6 +6411,7 @@ async def _routine_zone_destination_async(
     *,
     zone_id: int,
     anchor_type: str,
+    current_world_time: Any,
 ) -> Optional[int]:
     preferred_tags = (
         ("dwelling", "haven")
@@ -6376,12 +6433,22 @@ async def _routine_zone_destination_async(
           ON etc.entity_id = p.entity_id
          AND etc.category = 'place_function'
          AND etc.tag = ANY($1::text[])
-        WHERE p.zone = $2
+         AND EXISTS (
+             SELECT 1 FROM entity_tags et
+             WHERE et.id = etc.entity_tag_id
+               AND (
+                   $2 IS NULL
+                   OR et.expires_at_world_time IS NULL
+                   OR et.expires_at_world_time > $2
+               )
+         )
+        WHERE p.zone = $3
         GROUP BY p.id
         ORDER BY CASE WHEN count(etc.tag) > 0 THEN 0 ELSE 1 END, p.id
         LIMIT 1
         """,
         list(preferred_tags),
+        current_world_time,
         zone_id,
     )
 
@@ -6391,6 +6458,7 @@ async def _location_class_destination_async(
     *,
     origin_place_id: int,
     location_classes: tuple[str, ...],
+    current_world_time: Any,
 ) -> Optional[int]:
     return await conn.fetchval(
         """
@@ -6401,6 +6469,15 @@ async def _location_class_destination_async(
           ON etc.entity_id = p.entity_id
          AND etc.category = ANY($2::text[])
          AND etc.tag = ANY($3::text[])
+         AND EXISTS (
+             SELECT 1 FROM entity_tags et
+             WHERE et.id = etc.entity_tag_id
+               AND (
+                   $4 IS NULL
+                   OR et.expires_at_world_time IS NULL
+                   OR et.expires_at_world_time > $4
+               )
+         )
         WHERE p.id <> $1
           AND (p.type::text = ANY($3::text[]) OR etc.tag IS NOT NULL)
         -- Collapse multiple matching tags per place before preferring same-zone
@@ -6416,6 +6493,7 @@ async def _location_class_destination_async(
         origin_place_id,
         list(LOCATION_CLASS_TAG_CATEGORIES),
         list(location_classes),
+        current_world_time,
     )
 
 

--- a/nexus/agents/orrery/evidence.py
+++ b/nexus/agents/orrery/evidence.py
@@ -64,6 +64,7 @@ from nexus.agents.orrery.substrate import (
     Bindings,
     Slot,
     WorldState,
+    active_mood,
     _at_routine_anchor,
     _is_in_transit,
     _possessed_claim_knowledge,
@@ -374,6 +375,26 @@ _tier_resolver(
     "resources_at_or_above", RESOURCES_TIER_RANKS, DEFAULT_RESOURCES_TIER, True
 )
 _tier_resolver("resources_below", RESOURCES_TIER_RANKS, DEFAULT_RESOURCES_TIER, False)
+
+
+@_resolver("mood_is")
+def _mood_is(match: re.Match, state: WorldState, bindings: Bindings) -> dict:
+    slot = match["slot"]
+    candidates = match["values"].split(",")
+    entity_id = _entity(bindings, slot)
+    observed_mood = active_mood(state, bindings, Slot(slot))
+    matched = [observed_mood] if observed_mood in candidates else []
+    return _evidence(
+        "mood_is",
+        params={"moods": candidates, "slot": slot},
+        entities={slot: entity_id},
+        observed={
+            "mood_enabled": state.mood_enabled,
+            "active_mood": observed_mood,
+        },
+        matched=matched,
+        result=entity_id is not None and bool(matched),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/nexus/agents/orrery/explain.py
+++ b/nexus/agents/orrery/explain.py
@@ -286,7 +286,26 @@ def explain_template(
             selection=selection,
         )
         chosen_branch = chosen.label if chosen is not None else None
-        for branch, considered in zip(template.branches, considered_flags):
+        branch_results = [
+            bool(branch.conditions(state, bindings)) if considered else False
+            for branch, considered in zip(template.branches, considered_flags)
+        ]
+        weighting_ran = (
+            selection is not None
+            and selection.mode == "stochastic"
+            and selection.temperature > 0
+            and chosen is not None
+            and not chosen.preemptive
+            and sum(
+                passes
+                for branch, passes in zip(template.branches, branch_results)
+                if not branch.preemptive
+            )
+            > 1
+        )
+        for branch, considered, passes in zip(
+            template.branches, considered_flags, branch_results
+        ):
             if not considered:
                 branch_traces.append(
                     BranchTrace(
@@ -301,14 +320,11 @@ def explain_template(
                 )
                 continue
             branch_trace = trace_condition(branch.conditions, state, bindings)
-            passes = bool(branch.conditions(state, bindings))
             affinity = None
             mood = active_mood(state, bindings)
             if (
                 passes
-                and selection is not None
-                and selection.mode == "stochastic"
-                and selection.temperature > 0
+                and weighting_ran
                 and not branch.preemptive
                 and mood in branch.mood_affinities
             ):

--- a/nexus/agents/orrery/explain.py
+++ b/nexus/agents/orrery/explain.py
@@ -41,6 +41,7 @@ from nexus.agents.orrery.substrate import (
     Template,
     WorldState,
     binding_hash,
+    active_mood,
     evaluate,
     select_branch,
     select_package,
@@ -99,6 +100,7 @@ class BranchTrace:
     result: bool
     selected: bool
     trace: Optional[ConditionTrace] = None
+    applied_mood_affinity: Optional[Mapping[str, Any]] = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -109,6 +111,11 @@ class BranchTrace:
             "result": self.result,
             "selected": self.selected,
             "trace": self.trace.to_dict() if self.trace is not None else None,
+            "applied_mood_affinity": (
+                dict(self.applied_mood_affinity)
+                if self.applied_mood_affinity is not None
+                else None
+            ),
         }
 
 
@@ -295,6 +302,20 @@ def explain_template(
                 continue
             branch_trace = trace_condition(branch.conditions, state, bindings)
             passes = bool(branch.conditions(state, bindings))
+            affinity = None
+            mood = active_mood(state, bindings)
+            if (
+                passes
+                and selection is not None
+                and selection.mode == "stochastic"
+                and selection.temperature > 0
+                and not branch.preemptive
+                and mood in branch.mood_affinities
+            ):
+                affinity = {
+                    "mood": mood,
+                    "multiplier": float(branch.mood_affinities[mood]),
+                }
             branch_traces.append(
                 BranchTrace(
                     label=branch.label,
@@ -304,6 +325,7 @@ def explain_template(
                     result=passes,
                     selected=chosen is not None and branch.label == chosen.label,
                     trace=branch_trace,
+                    applied_mood_affinity=affinity,
                 )
             )
 

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -1568,34 +1568,35 @@ class _Replayer:
             ("entity_pair_tags", "entity_pair_tag_id"),
         ):
             working = {row["id"]: dict(row) for row in base_state[section]}
-            self.cur.execute(
-                f"""
-                SELECT to_jsonb(t) FROM {section} t
-                WHERE t.source_chunk_id > %s AND t.source_chunk_id <= %s
-                """,
-                (base_chunk, self.target_chunk_id),
-            )
-            for (row_json,) in self.cur.fetchall():
-                row = _as_document(row_json)
-                # Active-at-N normalization: a row cleared after N was live
-                # at N; the checkpoint shape stores active rows with NULL
-                # cleared_at.
-                row["cleared_at"] = None
-                working[row["id"]] = row
-                if section == "entity_tags":
-                    touched_entities.add(row["entity_id"])
-            self.cur.execute(
-                f"""
-                SELECT {log_column} FROM tag_clearance_log
-                WHERE {log_column} IS NOT NULL
-                  AND source_chunk_id > %s AND source_chunk_id <= %s
-                """,
-                (base_chunk, self.target_chunk_id),
-            )
-            for (tag_row_id,) in self.cur.fetchall():
-                removed = working.pop(tag_row_id, None)
-                if removed is not None and section == "entity_tags":
-                    touched_entities.add(removed["entity_id"])
+            if section == "entity_tags":
+                touched_entities.update(
+                    self._replay_entity_tag_events(working, base_chunk=base_chunk)
+                )
+            else:
+                self.cur.execute(
+                    f"""
+                    SELECT to_jsonb(t) FROM {section} t
+                    WHERE t.source_chunk_id > %s AND t.source_chunk_id <= %s
+                    """,
+                    (base_chunk, self.target_chunk_id),
+                )
+                for (row_json,) in self.cur.fetchall():
+                    row = _as_document(row_json)
+                    # Active-at-N normalization: a row cleared after N was live
+                    # at N; the checkpoint shape stores active rows with NULL
+                    # cleared_at.
+                    row["cleared_at"] = None
+                    working[row["id"]] = row
+                self.cur.execute(
+                    f"""
+                    SELECT {log_column} FROM tag_clearance_log
+                    WHERE {log_column} IS NOT NULL
+                      AND source_chunk_id > %s AND source_chunk_id <= %s
+                    """,
+                    (base_chunk, self.target_chunk_id),
+                )
+                for (tag_row_id,) in self.cur.fetchall():
+                    working.pop(tag_row_id, None)
 
             # Best-effort inclusion of un-keyed bestowals inside the window
             # (mid-commit new-entity bestowals, Step 8.6 tag hints, offline
@@ -1653,10 +1654,93 @@ class _Replayer:
                     approximate=True,
                 )
             workings[section] = working
-        touched_entities.update(
-            self._replay_mood_snapshots(workings["entity_tags"], base_chunk=base_chunk)
-        )
         return workings, touched_entities
+
+    def _replay_entity_tag_events(
+        self,
+        working: dict[int, dict[str, Any]],
+        *,
+        base_chunk: int,
+    ) -> set[int]:
+        """Replay keyed bestowals, clearances, and mood snapshots in order."""
+
+        self.cur.execute(
+            "SELECT id, tag FROM tags WHERE category = 'mood' AND NOT deprecated"
+        )
+        mood_tag_ids = {int(tag_id): str(tag) for tag_id, tag in self.cur.fetchall()}
+        timeline: list[tuple[int, int, int, str, Any]] = []
+
+        self.cur.execute(
+            """
+            SELECT source_chunk_id, id, to_jsonb(et)
+            FROM entity_tags et
+            WHERE source_chunk_id > %s AND source_chunk_id <= %s
+            """,
+            (base_chunk, self.target_chunk_id),
+        )
+        bestowal_rows = self.cur.fetchall()
+        timeline.extend(
+            (int(chunk_id), 0, int(row_id), "bestowal", row_json)
+            for chunk_id, row_id, row_json in bestowal_rows
+        )
+        self.cur.execute(
+            """
+            SELECT source_chunk_id, id, entity_tag_id
+            FROM tag_clearance_log
+            WHERE entity_tag_id IS NOT NULL
+              AND source_chunk_id > %s AND source_chunk_id <= %s
+            """,
+            (base_chunk, self.target_chunk_id),
+        )
+        clearance_rows = self.cur.fetchall()
+        timeline.extend(
+            (int(chunk_id), 1, int(log_id), "clearance", int(entity_tag_id))
+            for chunk_id, log_id, entity_tag_id in clearance_rows
+        )
+        self.cur.execute(
+            """
+            SELECT tick_chunk_id, id, actor_entity_id, state_delta
+            FROM orrery_resolutions
+            WHERE tick_chunk_id > %s
+              AND tick_chunk_id <= %s
+              AND state_delta ? 'mood.set'
+            """,
+            (base_chunk, self.target_chunk_id),
+        )
+        resolution_rows = self.cur.fetchall()
+        timeline.extend(
+            (
+                int(chunk_id),
+                2,
+                int(resolution_id),
+                "mood_snapshot",
+                (int(actor_entity_id), raw_delta),
+            )
+            for chunk_id, resolution_id, actor_entity_id, raw_delta in resolution_rows
+        )
+
+        touched: set[int] = set()
+        for chunk_id, _phase, _event_id, event_kind, payload in sorted(timeline):
+            if event_kind == "bestowal":
+                row = _as_document(payload)
+                row["cleared_at"] = None
+                working[int(row["id"])] = row
+                touched.add(int(row["entity_id"]))
+            elif event_kind == "clearance":
+                removed = working.pop(payload, None)
+                if removed is not None:
+                    touched.add(int(removed["entity_id"]))
+            else:
+                actor_entity_id, raw_delta = payload
+                if self._apply_mood_snapshot(
+                    working,
+                    chunk_id=chunk_id,
+                    actor_entity_id=actor_entity_id,
+                    raw_delta=raw_delta,
+                    mood_tag_ids=mood_tag_ids,
+                ):
+                    touched.add(actor_entity_id)
+        return touched
 
     def _replay_mood_snapshots(
         self,
@@ -1686,49 +1770,66 @@ class _Replayer:
         mood_tag_ids = {int(tag_id): str(tag) for tag_id, tag in self.cur.fetchall()}
         touched: set[int] = set()
         for chunk_id, actor_entity_id, raw_delta in resolutions:
-            delta = _as_document(raw_delta)
-            payload = delta.get("mood.set")
-            if not isinstance(payload, dict):
-                raise ValueError(
-                    f"mood.set at chunk {chunk_id} is not an applied mapping"
-                )
-            applied = payload.get("applied")
-            if not isinstance(applied, dict):
-                raise ValueError(
-                    f"mood.set at chunk {chunk_id} is missing its applied snapshot"
-                )
-            if applied.get("skipped") == "mood_disabled":
-                continue
-            mood = applied.get("mood")
-            projection = applied.get("entity_tag")
-            if mood not in mood_tag_ids.values() or not isinstance(projection, dict):
-                raise ValueError(
-                    f"mood.set at chunk {chunk_id} has an invalid applied projection"
-                )
-            row = dict(projection)
-            row_id = int(row.get("id") or 0)
-            tag_id = int(row.get("tag_id") or 0)
-            if (
-                row_id <= 0
-                or int(row.get("entity_id") or 0) != actor_entity_id
-                or mood_tag_ids.get(tag_id) != mood
-                or row.get("expires_at_world_time")
-                != applied.get("expires_at_world_time")
+            if self._apply_mood_snapshot(
+                working,
+                chunk_id=int(chunk_id),
+                actor_entity_id=int(actor_entity_id),
+                raw_delta=raw_delta,
+                mood_tag_ids=mood_tag_ids,
             ):
-                raise ValueError(
-                    f"mood.set at chunk {chunk_id} carries an inconsistent "
-                    "applied entity-tag snapshot"
-                )
-            for existing_id, existing in list(working.items()):
-                if (
-                    int(existing.get("entity_id") or 0) == actor_entity_id
-                    and int(existing.get("tag_id") or 0) in mood_tag_ids
-                ):
-                    del working[existing_id]
-            row["cleared_at"] = None
-            working[row_id] = row
-            touched.add(actor_entity_id)
+                touched.add(int(actor_entity_id))
         return touched
+
+    @staticmethod
+    def _apply_mood_snapshot(
+        working: dict[int, dict[str, Any]],
+        *,
+        chunk_id: int,
+        actor_entity_id: int,
+        raw_delta: Any,
+        mood_tag_ids: dict[int, str],
+    ) -> bool:
+        """Validate and apply one exact resolution mood projection."""
+
+        delta = _as_document(raw_delta)
+        payload = delta.get("mood.set")
+        if not isinstance(payload, dict):
+            raise ValueError(f"mood.set at chunk {chunk_id} is not an applied mapping")
+        applied = payload.get("applied")
+        if not isinstance(applied, dict):
+            raise ValueError(
+                f"mood.set at chunk {chunk_id} is missing its applied snapshot"
+            )
+        if applied.get("skipped") == "mood_disabled":
+            return False
+        mood = applied.get("mood")
+        projection = applied.get("entity_tag")
+        if mood not in mood_tag_ids.values() or not isinstance(projection, dict):
+            raise ValueError(
+                f"mood.set at chunk {chunk_id} has an invalid applied projection"
+            )
+        row = dict(projection)
+        row_id = int(row.get("id") or 0)
+        tag_id = int(row.get("tag_id") or 0)
+        if (
+            row_id <= 0
+            or int(row.get("entity_id") or 0) != actor_entity_id
+            or mood_tag_ids.get(tag_id) != mood
+            or row.get("expires_at_world_time") != applied.get("expires_at_world_time")
+        ):
+            raise ValueError(
+                f"mood.set at chunk {chunk_id} carries an inconsistent "
+                "applied entity-tag snapshot"
+            )
+        for existing_id, existing in list(working.items()):
+            if (
+                int(existing.get("entity_id") or 0) == actor_entity_id
+                and int(existing.get("tag_id") or 0) in mood_tag_ids
+            ):
+                del working[existing_id]
+        row["cleared_at"] = None
+        working[row_id] = row
+        return True
 
     # -- need-applicability trigger mirror ------------------------------------
 

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -14,6 +14,9 @@ produces. Sections and their replay sources:
   ``orrery_resolutions.state_delta`` are deliberately ignored: the same
   commit already wrote them to the provenance tables (double-entry), and
   ``need.fulfill``'s derived severity tags exist *only* in provenance.
+  ``mood.set`` additionally reapplies its exact entity-tag snapshot, repairing
+  the known provenance gap where replace-policy reapplication overwrites a
+  live row's source chunk in place.
 - the three relationship tables — backward from the *current* rows,
   unwinding ``relationship_versions`` pre-images (``id DESC``), then
   dropping rows whose ``created_at`` postdates chunk N (INSERTs never fire
@@ -137,6 +140,7 @@ TAG_DELTA_KEYS = frozenset(
         "entity_pair_tags.add_inbound",
         "entity_pair_tags.clear_outbound",
         "entity_pair_tags_target.clear_inbound",
+        "mood.set",
     }
 )
 
@@ -1649,7 +1653,82 @@ class _Replayer:
                     approximate=True,
                 )
             workings[section] = working
+        touched_entities.update(
+            self._replay_mood_snapshots(workings["entity_tags"], base_chunk=base_chunk)
+        )
         return workings, touched_entities
+
+    def _replay_mood_snapshots(
+        self,
+        working: dict[int, dict[str, Any]],
+        *,
+        base_chunk: int,
+    ) -> set[int]:
+        """Replay exact mood projections from resolution applied snapshots."""
+
+        self.cur.execute(
+            """
+            SELECT tick_chunk_id, actor_entity_id, state_delta
+            FROM orrery_resolutions
+            WHERE tick_chunk_id > %s
+              AND tick_chunk_id <= %s
+              AND state_delta ? 'mood.set'
+            ORDER BY tick_chunk_id, id
+            """,
+            (base_chunk, self.target_chunk_id),
+        )
+        resolutions = self.cur.fetchall()
+        if not resolutions:
+            return set()
+        self.cur.execute(
+            "SELECT id, tag FROM tags WHERE category = 'mood' AND NOT deprecated"
+        )
+        mood_tag_ids = {int(tag_id): str(tag) for tag_id, tag in self.cur.fetchall()}
+        touched: set[int] = set()
+        for chunk_id, actor_entity_id, raw_delta in resolutions:
+            delta = _as_document(raw_delta)
+            payload = delta.get("mood.set")
+            if not isinstance(payload, dict):
+                raise ValueError(
+                    f"mood.set at chunk {chunk_id} is not an applied mapping"
+                )
+            applied = payload.get("applied")
+            if not isinstance(applied, dict):
+                raise ValueError(
+                    f"mood.set at chunk {chunk_id} is missing its applied snapshot"
+                )
+            if applied.get("skipped") == "mood_disabled":
+                continue
+            mood = applied.get("mood")
+            projection = applied.get("entity_tag")
+            if mood not in mood_tag_ids.values() or not isinstance(projection, dict):
+                raise ValueError(
+                    f"mood.set at chunk {chunk_id} has an invalid applied projection"
+                )
+            row = dict(projection)
+            row_id = int(row.get("id") or 0)
+            tag_id = int(row.get("tag_id") or 0)
+            if (
+                row_id <= 0
+                or int(row.get("entity_id") or 0) != actor_entity_id
+                or mood_tag_ids.get(tag_id) != mood
+                or row.get("expires_at_world_time")
+                != applied.get("expires_at_world_time")
+            ):
+                raise ValueError(
+                    f"mood.set at chunk {chunk_id} carries an inconsistent "
+                    "applied entity-tag snapshot"
+                )
+            for existing_id, existing in list(working.items()):
+                if (
+                    int(existing.get("entity_id") or 0) == actor_entity_id
+                    and int(existing.get("tag_id") or 0) in mood_tag_ids
+                ):
+                    del working[existing_id]
+            row["cleared_at"] = None
+            working[row_id] = row
+            touched.add(actor_entity_id)
+        return touched
 
     # -- need-applicability trigger mirror ------------------------------------
 

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -917,6 +917,7 @@ def compose_actor_bindings(
     """Compose ACTOR-only bindings for recently relevant off-screen characters."""
 
     actor_ids: set[int] = set()
+    current_world_time = _load_world_time(session, anchor_chunk_id=anchor_chunk_id)
     present_actor_ids = _present_actor_ids_at_anchor(
         session, anchor_chunk_id=anchor_chunk_id
     )
@@ -974,12 +975,19 @@ def compose_actor_bindings(
             /* orrery:actor_bindings_ephemeral */
             SELECT DISTINCT etc.entity_id
             FROM entity_tags_current etc
+            JOIN entity_tags et ON et.id = etc.entity_tag_id
             JOIN entities e ON e.id = etc.entity_id
             WHERE etc.is_ephemeral = true
               AND e.kind = 'character'
               AND e.is_active = true
+              AND (
+                  :current_world_time IS NULL
+                  OR et.expires_at_world_time IS NULL
+                  OR et.expires_at_world_time > :current_world_time
+              )
             """
-        )
+        ),
+        {"current_world_time": current_world_time},
     ).mappings():
         actor_ids.add(row["entity_id"])
 
@@ -2076,13 +2084,17 @@ def resolve_dry_run(
             session, anchor_chunk_id=anchor_chunk_id
         )
         present_names = _load_entity_names(session, present_actor_ids)
-        moods = {
-            present_names[entity_id]: mood
+        moods = [
+            {
+                "entity_id": entity_id,
+                "name": present_names[entity_id],
+                "mood": mood,
+            }
             for entity_id in sorted(present_actor_ids)
             if entity_id in present_names
             if (mood := active_mood(state, {Slot.ACTOR: entity_id}, slot=Slot.ACTOR))
             is not None
-        }
+        ]
         if moods:
             scene_conditions["moods"] = moods
     return OrreryTickProposal(

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -50,6 +50,7 @@ from nexus.agents.orrery.substrate import (
     Template,
     TravelState,
     WorldState,
+    active_mood,
     binding_hash,
     evaluate_stack,
 )
@@ -225,7 +226,7 @@ class OrreryTickProposal:
     epistemics_settings: Mapping[str, Any] = field(
         default_factory=lambda: {"enabled": False}
     )
-    scene_conditions: Mapping[str, str] = field(default_factory=dict)
+    scene_conditions: Mapping[str, Any] = field(default_factory=dict)
     generated_at: str = field(
         default_factory=lambda: datetime.now(timezone.utc).isoformat()
     )
@@ -394,6 +395,37 @@ def _load_active_entity_ids(session: Any) -> tuple[int, ...]:
     )
 
 
+def _load_current_entity_tags(
+    session: Any, *, current_world_time: Optional[datetime]
+) -> tuple[dict[int, set[str]], dict[int, set[str]]]:
+    """Hydrate tags honestly at the anchor's world time.
+
+    The durable sweep remains responsible for clearing expired rows. This
+    read-side filter prevents an unswept time-cleared tag from gating behavior
+    after its diegetic expiry.
+    """
+
+    tags: dict[int, set[str]] = {}
+    ephemeral_tags: dict[int, set[str]] = {}
+    for row in session.execute(
+        text(
+            """
+            /* orrery:current_tags */
+            SELECT etc.entity_id, etc.tag, etc.is_ephemeral
+            FROM entity_tags_current etc
+            JOIN entity_tags et ON et.id = etc.entity_tag_id
+            WHERE :current_world_time IS NULL
+               OR et.expires_at_world_time IS NULL
+               OR et.expires_at_world_time > :current_world_time
+            """
+        ),
+        {"current_world_time": current_world_time},
+    ).mappings():
+        target = ephemeral_tags if row["is_ephemeral"] else tags
+        target.setdefault(row["entity_id"], set()).add(row["tag"])
+    return tags, ephemeral_tags
+
+
 def hydrate_world_state(
     session: Any,
     *,
@@ -406,6 +438,7 @@ def hydrate_world_state(
     epistemics_settings: Optional[Any] = None,
     contagion_settings: Optional[Any] = None,
     weather_settings: Optional[Any] = None,
+    mood_settings: Optional[Any] = None,
 ) -> WorldState:
     """Hydrate the read-side Orrery state snapshot from database tables.
 
@@ -417,6 +450,10 @@ def hydrate_world_state(
     need_tuning = coerce_need_tuning(need_tuning)
     project_policy = coerce_project_policy(project_settings)
     epistemics_policy = coerce_epistemics_policy(epistemics_settings)
+    world_time = world_time_override or _load_world_time(
+        session, anchor_chunk_id=anchor_chunk_id
+    )
+    mood_enabled = bool(_weather_setting(mood_settings, "enabled", False))
 
     is_active = {
         int(row["id"]): bool(row["is_active"])
@@ -432,19 +469,9 @@ def hydrate_world_state(
         ).mappings()
     }
 
-    tags: dict[int, set[str]] = {}
-    ephemeral_tags: dict[int, set[str]] = {}
-    for row in session.execute(
-        text(
-            """
-            /* orrery:current_tags */
-            SELECT entity_id, tag, is_ephemeral
-            FROM entity_tags_current
-            """
-        )
-    ).mappings():
-        target = ephemeral_tags if row["is_ephemeral"] else tags
-        target.setdefault(row["entity_id"], set()).add(row["tag"])
+    tags, ephemeral_tags = _load_current_entity_tags(
+        session, current_world_time=world_time
+    )
 
     locations = {
         row["entity_id"]: row["current_location"]
@@ -484,10 +511,17 @@ def hydrate_world_state(
                    false AS is_primary
             FROM places p
             JOIN entity_tags_current etc ON etc.entity_id = p.entity_id
+            JOIN entity_tags et ON et.id = etc.entity_tag_id
             WHERE etc.entity_kind = 'place'
               AND etc.category IN ({_LOCATION_CLASS_CATEGORY_SQL})
+              AND (
+                  :current_world_time IS NULL
+                  OR et.expires_at_world_time IS NULL
+                  OR et.expires_at_world_time > :current_world_time
+              )
             """
-        )
+        ),
+        {"current_world_time": world_time},
     ).mappings():
         place_id = row["id"]
         class_name = row["location_class"]
@@ -599,9 +633,6 @@ def hydrate_world_state(
             ),
             anchor_chunk_id=anchor_chunk_id,
         )
-    world_time = world_time_override or _load_world_time(
-        session, anchor_chunk_id=anchor_chunk_id
-    )
     communication_graph = communication_graph_for_settings(
         session, contagion_settings, world_time=world_time
     )
@@ -693,6 +724,7 @@ def hydrate_world_state(
         weather=weather,
         place_weather=place_weather,
         localized_weather_enabled=bool(weather_enabled),
+        mood_enabled=mood_enabled,
         current_tick=anchor_chunk_id or 0,
     )
 
@@ -1759,6 +1791,7 @@ def resolve_dry_run(
     fanout_settings: Optional[Any] = None,
     contagion_settings: Optional[Any] = None,
     weather_settings: Optional[Any] = None,
+    mood_settings: Optional[Any] = None,
 ) -> OrreryTickProposal:
     """Hydrate, bind, and evaluate Orrery packages without database writes."""
 
@@ -1786,6 +1819,7 @@ def resolve_dry_run(
         epistemics_settings=epistemics_policy,
         contagion_settings=contagion_settings,
         weather_settings=weather_settings,
+        mood_settings=mood_settings,
     )
 
     templates_list = list(configure_project_magnitudes(templates, project_policy))
@@ -2029,15 +2063,28 @@ def resolve_dry_run(
         | {bindings[Slot.ACTOR] for bindings, _templates in present_routes}
     )
 
-    # Scene conditions are a localized-weather contract. Disabled mode retains
-    # legacy predicate behavior but must not leak new prompt context; likewise,
-    # a clockless/anchorless localized snapshot stays wholly unknown rather
-    # than attaching a fabricated time-only condition.
-    scene_conditions = (
-        {"weather": state.weather, "time_of_day": state.time_of_day}
-        if state.localized_weather_enabled and state.weather is not None
-        else {}
-    )
+    # Weather and mood are independent scene-condition channels. Disabled
+    # mechanics do not leak prompt context; mood names are included only for
+    # explicitly present characters carrying an active mechanical mood.
+    scene_conditions: dict[str, Any] = {}
+    if state.localized_weather_enabled and state.weather is not None:
+        scene_conditions.update(
+            {"weather": state.weather, "time_of_day": state.time_of_day}
+        )
+    if state.mood_enabled:
+        present_actor_ids = _present_actor_ids_at_anchor(
+            session, anchor_chunk_id=anchor_chunk_id
+        )
+        present_names = _load_entity_names(session, present_actor_ids)
+        moods = {
+            present_names[entity_id]: mood
+            for entity_id in sorted(present_actor_ids)
+            if entity_id in present_names
+            if (mood := active_mood(state, {Slot.ACTOR: entity_id}, slot=Slot.ACTOR))
+            is not None
+        }
+        if moods:
+            scene_conditions["moods"] = moods
     return OrreryTickProposal(
         anchor_chunk_id=anchor_chunk_id,
         actor_count=len(unique_actors),

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -181,6 +181,8 @@ _FAME_PREDICATE_NAME_PREFIXES: Tuple[str, ...] = (
     "fame_at_or_above(",
     "fame_below(",
 )
+MOOD_VALUES: frozenset[str] = frozenset({"elated", "sour", "restless", "grim"})
+_MOOD_PREDICATE_NAME_PREFIXES: Tuple[str, ...] = ("mood_is(",)
 
 
 @dataclass(frozen=True, slots=True)
@@ -380,6 +382,7 @@ class WorldState:
     weather: Optional[str] = "clear"
     place_weather: Mapping[int, str] = field(default_factory=dict)
     localized_weather_enabled: bool = False
+    mood_enabled: bool = False
     current_tick: int = 0
 
     def __post_init__(self) -> None:
@@ -691,6 +694,56 @@ def fame_below(tier: str, slot: Slot = Slot.ACTOR) -> Condition:
         )
 
     return _named(_condition, f"fame_below({normalized}@{slot.value})")
+
+
+def active_mood(
+    state: WorldState, bindings: Bindings, slot: Slot = Slot.ACTOR
+) -> Optional[str]:
+    """Return one active mechanical mood for a slot-bound character.
+
+    Mood is an exclusive ephemeral category. Multiple values indicate corrupt
+    hydrated state and are refused rather than resolved by arbitrary order.
+    Disabled mood mechanics always read as absent.
+    """
+
+    if not state.mood_enabled:
+        return None
+    entity_id = _slot_entity(bindings, slot)
+    if entity_id is None:
+        return None
+    present = sorted(MOOD_VALUES & state.ephemeral_tags.get(entity_id, frozenset()))
+    if len(present) > 1:
+        raise ValueError(
+            f"Entity {entity_id} holds multiple active moods {present}; "
+            "mood is an exclusive category"
+        )
+    return present[0] if present else None
+
+
+def mood_is(*moods: str, slot: Slot = Slot.ACTOR) -> Condition:
+    """Test a slot-bound character's active mechanical mood.
+
+    Stage-2/3 vocabulary only: package-entry gates may not read mood. When
+    ``[orrery.mood]`` is disabled the predicate always returns ``False``.
+    """
+
+    if not moods:
+        raise ValueError("mood_is requires at least one mood")
+    normalized = tuple(str(mood).strip() for mood in moods)
+    unknown = sorted(set(normalized) - MOOD_VALUES)
+    if unknown:
+        raise ValueError(
+            f"Unknown mood value(s) {unknown}; expected one of {sorted(MOOD_VALUES)}"
+        )
+    candidates = frozenset(normalized)
+
+    def _condition(state: WorldState, bindings: Bindings) -> bool:
+        return active_mood(state, bindings, slot) in candidates
+
+    return _named(
+        _condition,
+        f"mood_is({','.join(normalized)}@{slot.value})",
+    )
 
 
 def resources_at_or_above(tier: str, slot: Slot = Slot.ACTOR) -> Condition:
@@ -2322,6 +2375,9 @@ class Branch:
     event_type: Optional[str] = None
     changed_fields: Tuple[str, ...] = ()
     magnitude: float = 0.0
+    # Stochastic-only softmax multipliers keyed by the actor's mechanical
+    # mood. They change selection weight, never magnitude/promotion salience.
+    mood_affinities: Mapping[str, float] = field(default_factory=dict)
     scene_pressure_stub: Optional[str] = None
     # A second, additive world-event emission: the signal an act gives off
     # (threat_issued, compliance_alert, ...) alongside the deed's own
@@ -2585,14 +2641,28 @@ def select_branch(
     if selection.temperature == 0:
         return max(passing, key=lambda branch: branch.magnitude), considered
 
-    # Softmax over magnitude, shifted for numerical stability.
+    # Softmax over magnitude, shifted for numerical stability. Mood changes
+    # only the stochastic weight after magnitude/temperature conversion; the
+    # authored magnitude remains untouched for promotion and Bleed salience.
     peak = max(branch.magnitude for branch in passing)
     weights = [
         math.exp((branch.magnitude - peak) / selection.temperature)
+        * mood_affinity_multiplier(branch, state, bindings)
         for branch in passing
     ]
     rng = _selection_rng(digest, state.current_tick, template.id, selection.seed_salt)
     return rng.choices(passing, weights=weights, k=1)[0], considered
+
+
+def mood_affinity_multiplier(
+    branch: Branch, state: WorldState, bindings: Bindings
+) -> float:
+    """Return the actor-mood multiplier applied to stochastic branch weight."""
+
+    mood = active_mood(state, bindings)
+    if mood is None:
+        return 1.0
+    return float(branch.mood_affinities.get(mood, 1.0))
 
 
 def evaluate(
@@ -2954,6 +3024,47 @@ def validate_no_fame_in_entry_gates(templates: Iterable[Template]) -> None:
             "Fame predicates are stage-2/3 only and must not appear in "
             "package gates (issue #282 stage contract): " + ", ".join(sorted(offenders))
         )
+
+
+def validate_no_mood_in_entry_gates(templates: Iterable[Template]) -> None:
+    """Enforce mood as stage-2/3 vocabulary, never a package-entry gate."""
+
+    offenders: list[str] = []
+    for template in templates:
+        for leaf in _condition_tree_leaves(template.package_gate):
+            name = getattr(leaf, "__name__", "")
+            if name.startswith(_MOOD_PREDICATE_NAME_PREFIXES):
+                offenders.append(f"{template.id}: {name}")
+    if offenders:
+        raise ValueError(
+            "Mood predicates are stage-2/3 only and must not appear in "
+            "package gates (issue #480 stage contract): " + ", ".join(sorted(offenders))
+        )
+
+
+def validate_mood_affinities(templates: Iterable[Template]) -> None:
+    """Validate the closed mood vocabulary and bounded stochastic weights."""
+
+    offenders: list[str] = []
+    for template in templates:
+        for branch in template.branches:
+            unknown = sorted(set(branch.mood_affinities) - MOOD_VALUES)
+            if unknown:
+                offenders.append(
+                    f"{template.id}/{branch.label}: unknown moods {unknown}"
+                )
+            for mood, value in branch.mood_affinities.items():
+                if isinstance(value, bool) or not isinstance(value, (int, float)):
+                    offenders.append(
+                        f"{template.id}/{branch.label}: {mood}={value!r} is not numeric"
+                    )
+                elif not 0 < float(value) <= 8:
+                    offenders.append(
+                        f"{template.id}/{branch.label}: {mood}={value!r} "
+                        "must be in (0, 8]"
+                    )
+    if offenders:
+        raise ValueError("Invalid mood affinities: " + "; ".join(offenders))
 
 
 def drive_band_priority_warnings(templates: Iterable[Template]) -> Tuple[str, ...]:

--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -379,6 +379,86 @@ def apply_exclusive_tag_bestowal(
     )
 
 
+async def apply_exclusive_tag_bestowal_async(
+    conn: Any,
+    *,
+    entity_id: int,
+    entity_kind: str,
+    tag: str,
+    source_kind: str = "skald_inline",
+    world_time: Optional[datetime] = None,
+    source_chunk_id: Optional[int] = None,
+    duration_override: Optional[timedelta] = None,
+) -> bool:
+    """Async twin of :func:`apply_exclusive_tag_bestowal`."""
+
+    _validate_source_kind(source_kind)
+    if entity_kind not in VALID_ENTITY_KINDS:
+        raise ValueError(
+            f"Unknown entity_kind={entity_kind!r}; expected one of "
+            f"{sorted(VALID_ENTITY_KINDS)}"
+        )
+
+    allowed = await _lookup_allowed_categories_async(conn, entity_kind)
+    if not allowed:
+        raise ValueError(
+            f"No Orrery tag categories registered for entity_kind={entity_kind!r}"
+        )
+
+    canonical_name, tag_row = await _lookup_canonical_tag_async(conn, tag)
+    category = _row_value(tag_row, "category", 1)
+    _validate_allowed_category(
+        category=category,
+        allowed=allowed,
+        tag_name=canonical_name,
+        entity_kind=entity_kind,
+    )
+    tag_id = _row_value(tag_row, "id", 0)
+    reapplication_policy = _row_value(tag_row, "reapplication_policy", 3)
+
+    if world_time is None:
+        if source_chunk_id is not None:
+            world_time = await _chunk_world_time_async(conn, source_chunk_id)
+        else:
+            world_time = await _load_world_time_async(conn)
+
+    sibling_rows = await conn.fetch(
+        """
+        SELECT et.tag_id
+        FROM entity_tags et
+        JOIN tags t ON t.id = et.tag_id
+        WHERE et.entity_id = $1
+          AND t.category = $2
+          AND t.id <> $3
+          AND et.cleared_at IS NULL
+        ORDER BY et.id
+        FOR UPDATE OF et
+        """,
+        entity_id,
+        category,
+        tag_id,
+    )
+    for row in sibling_rows:
+        await _clear_entity_tag_async(
+            conn,
+            entity_id=entity_id,
+            tag_id=_row_value(row, "tag_id", 0),
+            world_time=world_time,
+            source_chunk_id=source_chunk_id,
+            reason="exclusive_ladder_replace",
+        )
+    return await _insert_entity_tag_async(
+        conn,
+        entity_id=entity_id,
+        tag_id=tag_id,
+        source_kind=source_kind,
+        world_time=world_time,
+        source_chunk_id=source_chunk_id,
+        duration_override=duration_override,
+        reapplication_policy=reapplication_policy,
+    )
+
+
 def _lookup_allowed_categories(cur: Any, entity_kind: str) -> set[str]:
     cur.execute(
         """

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -65,7 +65,9 @@ from nexus.agents.orrery.substrate import (
     travel_risk_is,
     trust_at_least,
     trust_below,
+    validate_mood_affinities,
     validate_no_fame_in_entry_gates,
+    validate_no_mood_in_entry_gates,
     weather_is,
 )
 
@@ -785,6 +787,7 @@ EXTRACT_VENGEANCE = Template(
             state_delta={
                 "character.current_activity": "executing retaliation",
                 "entity_tags.add": ["recently_violent"],
+                "mood.set": {"mood": "restless"},
             },
             event_type="retaliation_executed",
             signal_event_type="threat_issued",
@@ -5151,12 +5154,14 @@ ADVANCE_PURSUE_ROMANCE = Template(
             state_delta={
                 "project.complete": {"milestone": True},
                 "entity_pair_tags.add_outbound": ["contact:intimate"],
+                "mood.set": {"mood": "elated"},
             },
             event_type="pursue_romance_completed",
             changed_fields=(
                 "character_project_states.status",
                 "entity_pair_tags",
                 "character_relationships.relationship_type",
+                "entity_tags",
             ),
             magnitude=0.40,
             preemptive=True,
@@ -5187,12 +5192,14 @@ ADVANCE_PURSUE_ROMANCE = Template(
                 "project.abandon": {
                     "reason": "target_rebuffed_or_hostile",
                     "milestone": True,
-                }
+                },
+                "mood.set": {"mood": "sour"},
             },
             event_type="pursue_romance_abandoned",
             changed_fields=(
                 "character_project_states.status",
                 "character_project_states.source_chunk_id",
+                "entity_tags",
             ),
             magnitude=0.40,
             preemptive=True,
@@ -5546,12 +5553,14 @@ ADVANCE_COURT_PATRON = Template(
                 "project.abandon": {
                     "reason": "target_spurned_or_hostile",
                     "milestone": True,
-                }
+                },
+                "mood.set": {"mood": "sour"},
             },
             event_type="court_patron_abandoned",
             changed_fields=(
                 "character_project_states.status",
                 "character_project_states.source_chunk_id",
+                "entity_tags",
             ),
             magnitude=0.40,
             preemptive=True,
@@ -5859,6 +5868,7 @@ ADVANCE_SEEK_REDEMPTION = Template(
             state_delta={
                 "project.complete": {"milestone": True},
                 "entity_tags_target.remove": ["grudge_active"],
+                "mood.set": {"mood": "elated"},
             },
             event_type="seek_redemption_completed",
             changed_fields=(
@@ -5866,6 +5876,7 @@ ADVANCE_SEEK_REDEMPTION = Template(
                 "entity_tags",
                 "character_relationships.relationship_type",
                 "character_relationships.emotional_valence",
+                "entity_tags",
             ),
             magnitude=0.40,
             preemptive=True,
@@ -5896,12 +5907,14 @@ ADVANCE_SEEK_REDEMPTION = Template(
                 "project.abandon": {
                     "reason": "amends_spurned_or_hostility_hardened",
                     "milestone": True,
-                }
+                },
+                "mood.set": {"mood": "grim"},
             },
             event_type="seek_redemption_abandoned",
             changed_fields=(
                 "character_project_states.status",
                 "character_project_states.source_chunk_id",
+                "entity_tags",
             ),
             magnitude=0.40,
             preemptive=True,
@@ -6144,6 +6157,7 @@ ADVANCE_BUILD_VENTURE = Template(
             state_delta={
                 "project.complete": {"milestone": True},
                 "entity_tags.add": ["proprietor"],
+                "mood.set": {"mood": "elated"},
             },
             event_type="build_venture_completed",
             changed_fields=(
@@ -6165,12 +6179,14 @@ ADVANCE_BUILD_VENTURE = Template(
                 "project.abandon": {
                     "reason": "stalled_or_overdue",
                     "milestone": True,
-                }
+                },
+                "mood.set": {"mood": "grim"},
             },
             event_type="build_venture_abandoned",
             changed_fields=(
                 "character_project_states.status",
                 "character_project_states.source_chunk_id",
+                "entity_tags",
             ),
             magnitude=0.40,
             preemptive=True,
@@ -6354,3 +6370,5 @@ BUILTIN_TEMPLATES = (
 # fame-gated template added to this catalog raises immediately rather than
 # relying on test coverage.
 validate_no_fame_in_entry_gates(BUILTIN_TEMPLATES)
+validate_no_mood_in_entry_gates(BUILTIN_TEMPLATES)
+validate_mood_affinities(BUILTIN_TEMPLATES)

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -797,6 +797,7 @@ EXTRACT_VENGEANCE = Template(
                 "world_events",
             ),
             magnitude=0.85,
+            mood_affinities={"restless": 2.0, "grim": 1.5},
             scene_pressure_stub=(
                 "{actor}'s grudge is close enough to {target}'s current scene "
                 "to become immediate pressure. Treat it as a possible threat, "
@@ -4294,6 +4295,7 @@ RECREATE = Template(
             event_type="recreation_taken",
             changed_fields=("character.current_activity",),
             magnitude=0.15,
+            mood_affinities={"elated": 1.5},
         ),
         Branch(
             label="Lose an hour to the loved thing",
@@ -5202,6 +5204,10 @@ ADVANCE_PURSUE_ROMANCE = Template(
                 "entity_tags",
             ),
             magnitude=0.40,
+            # Deliberately preemptive with NO affinity: a rebuff is a
+            # deterministic guard (the family contract recruit_ally's
+            # withdraw arm shares), never a stochastic lean — affinities
+            # are inert on preemptive arms by design.
             preemptive=True,
         ),
         Branch(
@@ -5345,6 +5351,7 @@ ADVANCE_PURSUE_ROMANCE = Template(
             ),
             magnitude=0.16,
             promotable=False,
+            mood_affinities={"elated": 1.5},
         ),
     ),
 )
@@ -5701,6 +5708,7 @@ ADVANCE_COURT_PATRON = Template(
             ),
             magnitude=0.16,
             promotable=False,
+            mood_affinities={"elated": 1.5},
         ),
     ),
 )
@@ -5876,7 +5884,6 @@ ADVANCE_SEEK_REDEMPTION = Template(
                 "entity_tags",
                 "character_relationships.relationship_type",
                 "character_relationships.emotional_valence",
-                "entity_tags",
             ),
             magnitude=0.40,
             preemptive=True,
@@ -6058,6 +6065,7 @@ ADVANCE_SEEK_REDEMPTION = Template(
             ),
             magnitude=0.16,
             promotable=False,
+            mood_affinities={"elated": 1.5},
         ),
     ),
 )
@@ -6314,6 +6322,7 @@ ADVANCE_BUILD_VENTURE = Template(
             ),
             magnitude=0.16,
             promotable=False,
+            mood_affinities={"elated": 1.5},
         ),
     ),
 )

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -590,6 +590,7 @@ async def commit_incubator_to_database(
                 prompt_settings=_orrery_prompt_settings(),
                 ecology_settings=_orrery_ecology_settings(),
                 project_settings=_orrery_project_settings(),
+                mood_settings=_orrery_mood_settings(),
                 epistemics_settings=(
                     _orrery_epistemics_settings()
                     if incubator.get("orrery_proposal") is None
@@ -694,6 +695,14 @@ def _orrery_project_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("projects")
+
+
+def _orrery_mood_settings() -> Any:
+    """[orrery.mood] mechanical affect write policy."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("mood")
 
 
 def _orrery_contagion_settings() -> Any:

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -641,6 +641,7 @@ def commit_incubator_to_database_sync(
                 prompt_settings=_orrery_prompt_settings(),
                 ecology_settings=_orrery_ecology_settings(),
                 project_settings=_orrery_project_settings(),
+                mood_settings=_orrery_mood_settings(),
                 epistemics_settings=(
                     _orrery_epistemics_settings()
                     if incubator.get("orrery_proposal") is None
@@ -930,6 +931,14 @@ def _orrery_project_settings() -> Any:
     from nexus.config import load_settings_as_dict
 
     return (load_settings_as_dict().get("orrery") or {}).get("projects")
+
+
+def _orrery_mood_settings() -> Any:
+    """[orrery.mood] mechanical affect write policy."""
+
+    from nexus.config import load_settings_as_dict
+
+    return (load_settings_as_dict().get("orrery") or {}).get("mood")
 
 
 def _orrery_contagion_settings() -> Any:

--- a/nexus/api/faction_table_audit.py
+++ b/nexus/api/faction_table_audit.py
@@ -801,9 +801,17 @@ def _fetch_legacy_tag_rows(cur: Any) -> list[LegacyTagRow]:
             etc.category,
             etc.tag
         FROM entity_tags_current etc
+        JOIN entity_tags et ON et.id = etc.entity_tag_id
         JOIN factions f ON f.entity_id = etc.entity_id
         WHERE etc.entity_kind = 'faction'
           AND etc.category = ANY(%s)
+          AND (
+              (SELECT max(world_time) FROM chunk_metadata) IS NULL
+              OR et.expires_at_world_time IS NULL
+              OR et.expires_at_world_time > (
+                  SELECT max(world_time) FROM chunk_metadata
+              )
+          )
         ORDER BY f.id, etc.category, etc.tag
         """,
         (list(LEGACY_TAG_CATEGORIES),),

--- a/nexus/api/orrery_dev_endpoints.py
+++ b/nexus/api/orrery_dev_endpoints.py
@@ -323,6 +323,7 @@ async def post_resolve(request: OrreryResolveRequest) -> dict[str, Any]:
                 fanout_settings=orrery.get("fanout"),
                 contagion_settings=orrery.get("contagion"),
                 weather_settings=orrery.get("weather"),
+                mood_settings=orrery.get("mood"),
             )
         except OverrideValidationError as exc:
             # Override validation (unknown vocab, no-op toggles) is caller
@@ -415,6 +416,7 @@ async def post_coverage(request: OrreryCoverageRequest) -> dict[str, Any]:
             fanout_settings=orrery.get("fanout"),
             contagion_settings=orrery.get("contagion"),
             weather_settings=orrery.get("weather"),
+            mood_settings=orrery.get("mood"),
         )
 
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -778,6 +778,15 @@ class OrreryWeatherSettings(BaseModel):
         return self
 
 
+class OrreryMoodSettings(BaseModel):
+    """Mechanical affect settings for ``[orrery.mood]``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    duration_hours: float = Field(default=12.0, gt=0.0)
+
+
 _CONTAGION_DURATION_RE = re.compile(r"^(?P<amount>\d+(?:\.\d+)?)(?P<unit>[smhdw])$")
 _CONTAGION_DURATION_SECONDS = {
     "s": 1,
@@ -2151,6 +2160,7 @@ class OrrerySettings(BaseModel):
     enabled: bool = True
     binding: OrreryBindingSettings = Field(default_factory=OrreryBindingSettings)
     weather: OrreryWeatherSettings = Field(default_factory=OrreryWeatherSettings)
+    mood: OrreryMoodSettings = Field(default_factory=OrreryMoodSettings)
     contagion: OrreryContagionSettings = Field(default_factory=OrreryContagionSettings)
     distortion: OrreryDistortionSettings = Field(
         default_factory=OrreryDistortionSettings

--- a/prompts/storyteller_core.md
+++ b/prompts/storyteller_core.md
@@ -156,6 +156,8 @@ exposition. If older knowledge was omitted, treat the digest as incomplete.
 Treat the derived weather as physical continuity. Override it only for a
 deliberate dramatic effect by setting `chunk_metadata.scene_weather`; the
 override is local to this scene, while weather elsewhere remains derived.
+Moods are mechanical dispositions: color character behavior, but do not recite
+the mood labels in narration.
 
 ---
 

--- a/scripts/orrery_sample.py
+++ b/scripts/orrery_sample.py
@@ -195,7 +195,16 @@ def fetch_actor_sources(
             """
             SELECT DISTINCT etc.entity_id, etc.tag
             FROM entity_tags_current etc
-            WHERE etc.entity_id = ANY(:ids) AND etc.is_ephemeral = true
+            JOIN entity_tags et ON et.id = etc.entity_tag_id
+            WHERE etc.entity_id = ANY(:ids)
+              AND etc.is_ephemeral = true
+              AND (
+                  (SELECT max(world_time) FROM chunk_metadata) IS NULL
+                  OR et.expires_at_world_time IS NULL
+                  OR et.expires_at_world_time > (
+                      SELECT max(world_time) FROM chunk_metadata
+                  )
+              )
             """
         ),
         {"ids": list(actor_ids)},

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -294,11 +294,16 @@ def test_context_prompt_renders_mechanical_moods_without_unknown_weather() -> No
     prompt = LogonUtility({})._format_context_prompt(
         {
             "user_input": "Continue.",
-            "scene_conditions": {"moods": {"Mara": "grim", "Zed": "elated"}},
+            "scene_conditions": {
+                "moods": [
+                    {"entity_id": 7, "name": "Mara", "mood": "grim"},
+                    {"entity_id": 12, "name": "Mara", "mood": "elated"},
+                ]
+            },
         }
     )
 
-    assert "Moods: Mara: grim, Zed: elated" in prompt
+    assert "Moods: Mara: grim, Mara: elated" in prompt
     assert "Weather: unknown" not in prompt
     assert "Time of day: unknown" not in prompt
 

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -288,6 +288,21 @@ def test_context_prompt_renders_anchor_scene_conditions() -> None:
     assert "Time of day: evening" in prompt
 
 
+def test_context_prompt_renders_mechanical_moods_without_unknown_weather() -> None:
+    """Mood-only scene context renders names without fabricated ambience."""
+
+    prompt = LogonUtility({})._format_context_prompt(
+        {
+            "user_input": "Continue.",
+            "scene_conditions": {"moods": {"Mara": "grim", "Zed": "elated"}},
+        }
+    )
+
+    assert "Moods: Mara: grim, Zed: elated" in prompt
+    assert "Weather: unknown" not in prompt
+    assert "Time of day: unknown" not in prompt
+
+
 @pytest.mark.parametrize("truncated", [False, True])
 def test_context_prompt_renders_world_knowledge_without_answer_keys(
     truncated: bool,

--- a/tests/test_orrery/test_bleed.py
+++ b/tests/test_orrery/test_bleed.py
@@ -561,13 +561,15 @@ async def test_assemble_context_payload_preserves_scene_moods() -> None:
     context.orrery_proposal = SimpleNamespace(
         anchor_chunk_id=77,
         pressure_count=0,
-        scene_conditions={"moods": {"Mara": "restless"}},
+        scene_conditions={
+            "moods": [{"entity_id": 1, "name": "Mara", "mood": "restless"}]
+        },
     )
 
     await manager.assemble_context_payload(context)
 
     assert context.context_payload["scene_conditions"] == {
-        "moods": {"Mara": "restless"}
+        "moods": [{"entity_id": 1, "name": "Mara", "mood": "restless"}]
     }
 
 

--- a/tests/test_orrery/test_bleed.py
+++ b/tests/test_orrery/test_bleed.py
@@ -550,6 +550,28 @@ async def test_assemble_context_payload_attaches_scene_conditions() -> None:
 
 
 @pytest.mark.asyncio
+async def test_assemble_context_payload_preserves_scene_moods() -> None:
+    """Present-character mood context reaches the Storyteller unchanged."""
+
+    session = FakeSession()
+    manager = TurnCycleManager(FakeLore(_settings(), session))
+    context = TurnContext(
+        turn_id="t1", user_input="Continue.", start_time=0, warm_slice=[]
+    )
+    context.orrery_proposal = SimpleNamespace(
+        anchor_chunk_id=77,
+        pressure_count=0,
+        scene_conditions={"moods": {"Mara": "restless"}},
+    )
+
+    await manager.assemble_context_payload(context)
+
+    assert context.context_payload["scene_conditions"] == {
+        "moods": {"Mara": "restless"}
+    }
+
+
+@pytest.mark.asyncio
 async def test_call_apex_ai_records_bleed_offers_after_generation_success() -> None:
     """Surfacing bookkeeping is written only after LOGON returns a response."""
 

--- a/tests/test_orrery/test_build_venture_projects.py
+++ b/tests/test_orrery/test_build_venture_projects.py
@@ -172,6 +172,10 @@ def test_full_branch_ladder_traversal(
     )
     assert resolution.branch_label == expected_label
     assert delta_key in resolution.state_delta
+    if expected_label == "Open the doors":
+        assert resolution.state_delta["mood.set"] == {"mood": "elated"}
+    if expected_label == "Let the venture go":
+        assert resolution.state_delta["mood.set"] == {"mood": "grim"}
     if expected_label in {
         "Make the venture legible",
         "Secure one more commitment",

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -19,6 +19,7 @@ from nexus.config.settings_models import (
     OrreryDriftSettings,
     OrreryEpistemicsSettings,
     OrreryKnowledgeSettings,
+    OrreryMoodSettings,
     OrreryPromoteSettings,
     OrreryRevealSettings,
     OrrerySettings,
@@ -57,6 +58,8 @@ def test_orrery_settings_resolve_model_reference() -> None:
     assert settings.orrery.contagion.culture_profiles["cellular_clandestine"] == 4.0
     assert settings.orrery.contagion.guards.age_horizon == timedelta(days=14)
     assert settings.orrery.distortion.enabled is True
+    assert settings.orrery.mood.enabled is True
+    assert settings.orrery.mood.duration_hours == 12.0
     expected_model = settings.global_.model.api_models["anthropic"].roles["default"]
     assert settings.orrery.narration.model_ref == expected_model
     assert settings.orrery.promote.provider is None
@@ -205,6 +208,17 @@ def test_drift_defaults_off_when_block_is_absent() -> None:
     payload = load_settings("nexus.toml").orrery.model_dump()
     payload.pop("drift")
     assert OrrerySettings.model_validate(payload).drift.enabled is False
+
+
+def test_mood_defaults_off_and_requires_positive_duration() -> None:
+    """Legacy configs cannot silently opt in and invalid expiry is loud."""
+
+    assert OrreryMoodSettings().enabled is False
+    payload = load_settings("nexus.toml").orrery.model_dump()
+    payload.pop("mood")
+    assert OrrerySettings.model_validate(payload).mood.enabled is False
+    with pytest.raises(ValidationError, match="greater than 0"):
+        OrreryMoodSettings(duration_hours=0)
 
 
 def test_reveal_defaults_off_when_block_is_absent() -> None:

--- a/tests/test_orrery/test_court_patron_projects.py
+++ b/tests/test_orrery/test_court_patron_projects.py
@@ -240,6 +240,8 @@ def test_full_ladder(state: WorldState, label: str, delta_key: str) -> None:
     )
     assert result.branch_label == label
     assert delta_key in result.state_delta
+    if label == "Withdraw after being spurned":
+        assert result.state_delta["mood.set"] == {"mood": "sour"}
     if delta_key == "project.complete":
         assert result.state_delta == {
             "project.complete": {"milestone": True},

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -340,6 +340,8 @@ class RecordingCursor:
                 origin_place_id,
                 _categories,
                 location_classes,
+                _world_time_null_check,
+                _world_time_expiry_check,
                 excluded_place_id,
                 _type_classes,
             ) = params
@@ -1703,6 +1705,7 @@ def test_sync_malformed_home_work_from_home_anchor_fails_closed() -> None:
             cursor,
             actor_entity_id=1,
             anchor_type="home",
+            current_world_time=cursor.world_time,
         )
         is None
     )
@@ -1731,6 +1734,7 @@ async def test_async_routine_anchor_destination_resolves_work_from_home() -> Non
         conn,
         actor_entity_id=1,
         anchor_type="work",
+        current_world_time=None,
     )
 
     assert destination == 7
@@ -1755,6 +1759,7 @@ async def test_async_routine_anchor_destination_resolves_zone() -> None:
         conn,
         actor_entity_id=1,
         anchor_type="home",
+        current_world_time=None,
     )
 
     assert destination == 42
@@ -1770,6 +1775,7 @@ async def test_async_location_class_destination_resolves_place() -> None:
         conn,
         origin_place_id=99,
         location_classes=("meeting", "commerce"),
+        current_world_time=None,
     )
 
     assert destination == 42
@@ -1793,6 +1799,7 @@ async def test_async_malformed_home_work_from_home_anchor_fails_closed() -> None
         conn,
         actor_entity_id=1,
         anchor_type="home",
+        current_world_time=None,
     )
 
     assert destination is None

--- a/tests/test_orrery/test_evidence.py
+++ b/tests/test_orrery/test_evidence.py
@@ -81,6 +81,7 @@ from nexus.agents.orrery.substrate import (
     knows_recent_event,
     lacks_pair_tag,
     lacks_tag,
+    mood_is,
     project_due,
     project_faction_is,
     project_faction_is_active,
@@ -116,7 +117,7 @@ RICH_STATE = WorldState(
         TARGET: frozenset({"seeking_identity"}),
         3: frozenset({"public_role"}),
     },
-    ephemeral_tags={ACTOR: frozenset({"grieving", "wound_3_severe"})},
+    ephemeral_tags={ACTOR: frozenset({"grieving", "wound_3_severe", "elated"})},
     locations={ACTOR: 101, TARGET: 101, 3: 101, 4: 102},
     activities={ACTOR: "keeping watch"},
     trust={(ACTOR, TARGET): 2, (TARGET, ACTOR): 1},
@@ -183,6 +184,7 @@ RICH_STATE = WorldState(
     time_of_day="night",
     world_time=datetime(2073, 5, 3, 11, 30),
     weather="rain",
+    mood_enabled=True,
     current_tick=100,
 )
 
@@ -203,6 +205,7 @@ FACTORY_SWEEP = [
     has_severity_tag_at_or_above("wound", 2),
     fame_at_or_above("known"),
     fame_below("renowned"),
+    mood_is("elated", "restless"),
     resources_at_or_above("comfortable"),
     resources_below("magnate"),
     has_pair_tag("contact:social"),

--- a/tests/test_orrery/test_explain.py
+++ b/tests/test_orrery/test_explain.py
@@ -17,8 +17,18 @@ from nexus.agents.orrery.explain import (
     ConditionTrace,
     StackExplanation,
     explain_stack,
+    explain_template,
 )
-from nexus.agents.orrery.substrate import evaluate_stack
+from nexus.agents.orrery.substrate import (
+    ALWAYS,
+    Branch,
+    BranchSelection,
+    DriveBand,
+    Slot,
+    Template,
+    WorldState,
+    evaluate_stack,
+)
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 
 
@@ -153,3 +163,36 @@ def test_non_fired_templates_null_magnitude_and_event_in_payload() -> None:
     assert fired
     for template in fired:
         assert template["magnitude"] is not None
+
+
+def test_single_passing_branch_does_not_claim_mood_affinity_weighting() -> None:
+    """Explain records affinity only when stochastic weighting actually runs."""
+
+    template = Template(
+        id="single_passing_affinity",
+        priority=1,
+        drive_band=DriveBand.ANCHORED_ROUTINE,
+        blurb="One eligible branch.",
+        required_slots=(Slot.ACTOR,),
+        package_gate=ALWAYS,
+        branches=(
+            Branch(
+                "only",
+                ALWAYS,
+                "{actor} acts.",
+                mood_affinities={"elated": 2.0},
+            ),
+        ),
+    )
+    explanation = explain_template(
+        template,
+        WorldState(
+            ephemeral_tags={1: frozenset({"elated"})},
+            mood_enabled=True,
+        ),
+        {Slot.ACTOR: 1},
+        BranchSelection(mode="stochastic", temperature=1.0),
+    )
+
+    assert explanation.chosen_branch == "only"
+    assert explanation.branches[0].applied_mood_affinity is None

--- a/tests/test_orrery/test_mood_live.py
+++ b/tests/test_orrery/test_mood_live.py
@@ -16,6 +16,7 @@ from nexus.agents.orrery.events import (
     MoodPolicy,
     _apply_state_delta_async,
     _apply_state_delta_sync,
+    _sweep_expired_entity_tags_sync,
 )
 from nexus.agents.orrery.explain import explain_template
 from nexus.agents.orrery.needs import coerce_need_tuning
@@ -23,6 +24,7 @@ from nexus.agents.orrery.replay import _Replayer
 from nexus.agents.orrery.resolver import (
     OrreryResolutionDraft,
     _load_current_entity_tags,
+    compose_actor_bindings,
 )
 from nexus.agents.orrery.substrate import (
     ALWAYS,
@@ -83,7 +85,8 @@ def _schema_sql() -> str:
         CREATE TABLE tag_clearance_log (
             id bigserial PRIMARY KEY, entity_tag_id bigint,
             mechanism text NOT NULL, cleared_at_world_time timestamptz,
-            justification jsonb, source_chunk_id bigint
+            triggering_event_id bigint, justification jsonb,
+            source_chunk_id bigint
         );
         CREATE TABLE chunk_metadata (
             chunk_id bigint PRIMARY KEY, world_time timestamptz
@@ -191,11 +194,21 @@ def test_set_displace_expire_snapshot_and_replay() -> None:
             assert next(iter(working.values()))["id"] == applied["entity_tag"]["id"]
             cur.execute(
                 "INSERT INTO chunk_metadata VALUES (3, %s)",
-                (NOW + timedelta(hours=2),),
+                (NOW + timedelta(hours=13),),
+            )
+            assert _sweep_expired_entity_tags_sync(cur, source_chunk_id=3) == 1
+            replayer.target_chunk_id = 3
+            working = {}
+            assert replayer._replay_entity_tag_events(working, base_chunk=0) == {11}
+            assert working == {}
+
+            cur.execute(
+                "INSERT INTO chunk_metadata VALUES (4, %s)",
+                (NOW + timedelta(hours=14),),
             )
             cur.execute("SAVEPOINT before_unknown_mood")
             with pytest.raises(ValueError, match="Unknown mood"):
-                _apply_sync(cur, _draft("wistful"), 3)
+                _apply_sync(cur, _draft("wistful"), 4)
             cur.execute("ROLLBACK TO SAVEPOINT before_unknown_mood")
     finally:
         conn.rollback()
@@ -336,6 +349,72 @@ def test_expired_unswept_mood_does_not_hydrate_or_bias() -> None:
             selection=BranchSelection(mode="stochastic", temperature=1.0),
         )
         assert chosen.label == control.label
+    finally:
+        transaction.rollback()
+        connection.close()
+        engine.dispose()
+
+
+def test_expired_unswept_tag_does_not_source_actor_binding() -> None:
+    """An expired ephemeral tag cannot make an otherwise irrelevant actor run."""
+
+    engine = create_engine(get_slot_db_url(slot=5), future=True)
+    connection = engine.connect()
+    transaction = connection.begin()
+    schema = f"mood_binding_{uuid.uuid4().hex}"
+    try:
+        connection.exec_driver_sql(f'CREATE SCHEMA "{schema}"')
+        connection.exec_driver_sql(f'SET LOCAL search_path = "{schema}", public')
+        connection.exec_driver_sql(
+            """
+            CREATE TABLE entities (
+                id bigint PRIMARY KEY, kind text NOT NULL, is_active boolean NOT NULL
+            );
+            INSERT INTO entities VALUES (11, 'character', true);
+            CREATE TABLE chunk_metadata (
+                chunk_id bigint PRIMARY KEY, world_time timestamptz
+            );
+            INSERT INTO chunk_metadata VALUES (1, '2073-05-03 12:00:00+00');
+            CREATE TABLE chunk_entity_references_v (
+                entity_id bigint, reference_type text, chunk_id bigint
+            );
+            CREATE TABLE world_events (
+                actor_entity_id bigint, target_entity_id bigint,
+                tick_chunk_id bigint, world_layer text,
+                superseded_by_event_id bigint
+            );
+            CREATE TABLE entity_tags (
+                id bigint PRIMARY KEY, entity_id bigint,
+                expires_at_world_time timestamptz, cleared_at timestamptz
+            );
+            INSERT INTO entity_tags VALUES (
+                1, 11, '2073-05-03 11:00:00+00', NULL
+            );
+            CREATE VIEW entity_tags_current AS
+            SELECT id AS entity_tag_id, entity_id, true AS is_ephemeral
+            FROM entity_tags WHERE cleared_at IS NULL;
+            CREATE TABLE pair_tags (
+                id bigint PRIMARY KEY, tag text, is_ephemeral boolean,
+                deprecated boolean
+            );
+            CREATE TABLE entity_pair_tags (
+                object_entity_id bigint, subject_entity_id bigint,
+                pair_tag_id bigint, cleared_at timestamptz
+            );
+            CREATE TABLE character_routine_anchors (
+                character_entity_id bigint, mobility_policy text
+            );
+            CREATE TABLE characters (id bigint PRIMARY KEY, entity_id bigint);
+            CREATE TABLE chunk_character_references (
+                chunk_id bigint, character_id bigint, reference text
+            );
+            """
+        )
+        with Session(connection) as session:
+            bindings = compose_actor_bindings(
+                session, anchor_chunk_id=1, window_chunks=1
+            )
+        assert bindings == ()
     finally:
         transaction.rollback()
         connection.close()

--- a/tests/test_orrery/test_mood_live.py
+++ b/tests/test_orrery/test_mood_live.py
@@ -1,0 +1,449 @@
+"""Live, rollback-only coverage for mechanical mood semantics."""
+
+from datetime import datetime, timedelta, timezone
+from dataclasses import replace
+import json
+from pathlib import Path
+import uuid
+
+import asyncpg
+import psycopg2
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from nexus.agents.orrery.events import (
+    MoodPolicy,
+    _apply_state_delta_async,
+    _apply_state_delta_sync,
+)
+from nexus.agents.orrery.explain import explain_template
+from nexus.agents.orrery.needs import coerce_need_tuning
+from nexus.agents.orrery.replay import _Replayer
+from nexus.agents.orrery.resolver import (
+    OrreryResolutionDraft,
+    _load_current_entity_tags,
+)
+from nexus.agents.orrery.substrate import (
+    ALWAYS,
+    Branch,
+    BranchSelection,
+    ProjectPolicy,
+    Slot,
+    Template,
+    WorldState,
+    evaluate,
+    mood_is,
+    select_branch,
+    validate_mood_affinities,
+    validate_no_mood_in_entry_gates,
+)
+from nexus.api.slot_utils import get_slot_db_url
+
+
+pytestmark = pytest.mark.requires_postgres
+NOW = datetime(2073, 5, 3, 12, tzinfo=timezone.utc)
+
+
+def _migration_sql() -> str:
+    return (
+        Path(__file__).parents[2] / "migrations" / "095_mood_vocabulary.sql"
+    ).read_text()
+
+
+def _schema_sql() -> str:
+    return """
+        CREATE TABLE tag_category_registry (
+            category text NOT NULL, entity_kind entity_kind NOT NULL,
+            prompt_order integer NOT NULL, description text,
+            deprecated boolean NOT NULL DEFAULT false,
+            replacement_categories text[], PRIMARY KEY (category, entity_kind)
+        );
+        CREATE TABLE tags (
+            id bigserial PRIMARY KEY, tag text UNIQUE NOT NULL,
+            category text NOT NULL, is_ephemeral boolean NOT NULL DEFAULT false,
+            clearance_kind entity_tag_clearance_kind,
+            reapplication_policy entity_tag_reapplication_policy,
+            clear_on jsonb, synonym_for bigint,
+            deprecated boolean NOT NULL DEFAULT false, description text,
+            CHECK (is_ephemeral = (clearance_kind IS NOT NULL))
+        );
+        CREATE TABLE entity_tags (
+            id bigserial PRIMARY KEY, entity_id bigint NOT NULL,
+            tag_id bigint NOT NULL REFERENCES tags(id),
+            applied_at timestamptz NOT NULL DEFAULT now(),
+            applied_at_world_time timestamptz,
+            expires_at_world_time timestamptz,
+            clear_on_override jsonb, cleared_at timestamptz,
+            template_id text, source_kind entity_tag_source_kind NOT NULL,
+            source_chunk_id bigint
+        );
+        CREATE UNIQUE INDEX ix_entity_tags_current
+            ON entity_tags (entity_id, tag_id) WHERE cleared_at IS NULL;
+        CREATE TABLE tag_clearance_log (
+            id bigserial PRIMARY KEY, entity_tag_id bigint,
+            mechanism text NOT NULL, cleared_at_world_time timestamptz,
+            justification jsonb, source_chunk_id bigint
+        );
+        CREATE TABLE chunk_metadata (
+            chunk_id bigint PRIMARY KEY, world_time timestamptz
+        );
+        CREATE TABLE orrery_resolutions (
+            id bigserial PRIMARY KEY, tick_chunk_id bigint NOT NULL,
+            actor_entity_id bigint, state_delta jsonb NOT NULL
+        );
+    """
+
+
+def _draft(mood: str, *, hours: float | None = None) -> OrreryResolutionDraft:
+    payload: dict[str, object] = {"mood": mood}
+    if hours is not None:
+        payload["hours"] = hours
+    return OrreryResolutionDraft(
+        template_id="mood_test",
+        priority=1,
+        binding_hash=uuid.uuid4().hex,
+        bindings={"actor": 11},
+        branch_label="set mood",
+        narrative_stub="The actor's disposition changes.",
+        state_delta={"mood.set": payload},
+        event_type=None,
+        changed_fields=("entity_tags",),
+        magnitude=0.4,
+    )
+
+
+def _apply_sync(cur: object, draft: OrreryResolutionDraft, chunk_id: int) -> int:
+    cur.execute(
+        """
+        INSERT INTO orrery_resolutions (
+            tick_chunk_id, actor_entity_id, state_delta
+        ) VALUES (%s, 11, %s::jsonb) RETURNING id
+        """,
+        (chunk_id, json.dumps(dict(draft.state_delta))),
+    )
+    resolution_id = cur.fetchone()[0]
+    return _apply_state_delta_sync(
+        cur,
+        draft,
+        resolution_id=resolution_id,
+        actor_entity_id=11,
+        target_entity_id=None,
+        source_chunk_id=chunk_id,
+        need_tuning=coerce_need_tuning(None),
+        project_policy=ProjectPolicy(),
+        mood_policy=MoodPolicy(enabled=True, duration_hours=12),
+    )
+
+
+def test_set_displace_expire_snapshot_and_replay() -> None:
+    conn = psycopg2.connect(get_slot_db_url(slot=5))
+    schema = f"mood_live_{uuid.uuid4().hex}"
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f'CREATE SCHEMA "{schema}"')
+            cur.execute(f'SET LOCAL search_path = "{schema}", public')
+            cur.execute(_schema_sql())
+            cur.execute(_migration_sql())
+            cur.execute(
+                "INSERT INTO chunk_metadata VALUES (1, %s), (2, %s)",
+                (NOW, NOW + timedelta(hours=1)),
+            )
+            assert _apply_sync(cur, _draft("sour", hours=2), 1) == 1
+            assert _apply_sync(cur, _draft("elated"), 2) == 2
+            cur.execute(
+                """
+                SELECT t.tag, et.applied_at_world_time,
+                       et.expires_at_world_time, et.source_kind::text
+                FROM entity_tags et JOIN tags t ON t.id = et.tag_id
+                WHERE et.entity_id = 11 AND et.cleared_at IS NULL
+                """
+            )
+            assert cur.fetchone() == (
+                "elated",
+                NOW + timedelta(hours=1),
+                NOW + timedelta(hours=13),
+                "template",
+            )
+            cur.execute(
+                """
+                SELECT state_delta -> 'mood.set' -> 'applied'
+                FROM orrery_resolutions WHERE tick_chunk_id = 2
+                """
+            )
+            applied = cur.fetchone()[0]
+            assert applied["mood"] == "elated"
+            assert applied["displaced_mood"] == "sour"
+            assert (
+                applied["expires_at_world_time"]
+                == (NOW + timedelta(hours=13)).isoformat()
+            )
+            assert applied["entity_tag"]["source_chunk_id"] == 2
+            cur.execute("SELECT count(*) FROM tag_clearance_log")
+            assert cur.fetchone()[0] == 1
+
+            replayer = _Replayer.__new__(_Replayer)
+            replayer.cur = cur
+            replayer.target_chunk_id = 2
+            working: dict[int, dict[str, object]] = {}
+            assert replayer._replay_mood_snapshots(working, base_chunk=0) == {11}
+            assert len(working) == 1
+            assert next(iter(working.values()))["id"] == applied["entity_tag"]["id"]
+            cur.execute(
+                "INSERT INTO chunk_metadata VALUES (3, %s)",
+                (NOW + timedelta(hours=2),),
+            )
+            cur.execute("SAVEPOINT before_unknown_mood")
+            with pytest.raises(ValueError, match="Unknown mood"):
+                _apply_sync(cur, _draft("wistful"), 3)
+            cur.execute("ROLLBACK TO SAVEPOINT before_unknown_mood")
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_async_writer_and_disabled_snapshot() -> None:
+    conn = await asyncpg.connect(get_slot_db_url(slot=5))
+    transaction = conn.transaction()
+    await transaction.start()
+    schema = f"mood_async_{uuid.uuid4().hex}"
+    try:
+        await conn.execute(f'CREATE SCHEMA "{schema}"')
+        await conn.execute(f'SET LOCAL search_path = "{schema}", public')
+        await conn.execute(_schema_sql())
+        await conn.execute(_migration_sql())
+        await conn.execute(
+            "INSERT INTO chunk_metadata VALUES (1, $1), (2, $2)",
+            NOW,
+            NOW + timedelta(hours=1),
+        )
+        for chunk_id, enabled in ((1, True), (2, False)):
+            draft = _draft("restless")
+            resolution_id = await conn.fetchval(
+                """
+                INSERT INTO orrery_resolutions (
+                    tick_chunk_id, actor_entity_id, state_delta
+                ) VALUES ($1, 11, $2::jsonb) RETURNING id
+                """,
+                chunk_id,
+                json.dumps(dict(draft.state_delta)),
+            )
+            await _apply_state_delta_async(
+                conn,
+                draft,
+                resolution_id=resolution_id,
+                actor_entity_id=11,
+                target_entity_id=None,
+                source_chunk_id=chunk_id,
+                need_tuning=coerce_need_tuning(None),
+                project_policy=ProjectPolicy(),
+                mood_policy=MoodPolicy(enabled=enabled, duration_hours=12),
+            )
+        snapshot = await conn.fetchval(
+            """
+            SELECT state_delta -> 'mood.set' -> 'applied'
+            FROM orrery_resolutions WHERE tick_chunk_id = 2
+            """
+        )
+        assert json.loads(snapshot) == {"skipped": "mood_disabled"}
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM entity_tags WHERE cleared_at IS NULL"
+            )
+            == 1
+        )
+    finally:
+        await transaction.rollback()
+        await conn.close()
+
+
+def test_expired_unswept_mood_does_not_hydrate_or_bias() -> None:
+    engine = create_engine(get_slot_db_url(slot=5), future=True)
+    connection = engine.connect()
+    transaction = connection.begin()
+    schema = f"mood_hydration_{uuid.uuid4().hex}"
+    try:
+        connection.exec_driver_sql(f'CREATE SCHEMA "{schema}"')
+        connection.exec_driver_sql(f'SET LOCAL search_path = "{schema}", public')
+        connection.exec_driver_sql(
+            """
+            CREATE TABLE entity_tags (
+                id bigint PRIMARY KEY, expires_at_world_time timestamptz
+            );
+            INSERT INTO entity_tags VALUES (
+                1, '2073-05-03 11:00:00+00'::timestamptz
+            );
+            CREATE VIEW entity_tags_current AS
+            SELECT 1::bigint AS entity_tag_id, 11::bigint AS entity_id,
+                   'grim'::text AS tag, true AS is_ephemeral
+            """
+        )
+        with Session(connection) as session:
+            tags, ephemeral = _load_current_entity_tags(session, current_world_time=NOW)
+        assert tags == {}
+        assert ephemeral == {}
+
+        state = WorldState(
+            ephemeral_tags={
+                entity: frozenset(values) for entity, values in ephemeral.items()
+            },
+            mood_enabled=True,
+            current_tick=7,
+        )
+        template = Template(
+            id="mood_bias",
+            priority=1,
+            drive_band="anchored_routine",
+            blurb="Bias test.",
+            required_slots=(Slot.ACTOR,),
+            package_gate=ALWAYS,
+            branches=(
+                Branch("first", ALWAYS, "First.", magnitude=0.4),
+                Branch(
+                    "second",
+                    ALWAYS,
+                    "Second.",
+                    magnitude=0.4,
+                    mood_affinities={"grim": 8.0},
+                ),
+            ),
+        )
+        chosen, _ = select_branch(
+            template,
+            state,
+            {Slot.ACTOR: 11},
+            digest="fixed",
+            selection=BranchSelection(mode="stochastic", temperature=1.0),
+        )
+        unbiased = replace(
+            template,
+            branches=tuple(
+                Branch(
+                    branch.label,
+                    branch.conditions,
+                    branch.narrative_stub,
+                    magnitude=branch.magnitude,
+                )
+                for branch in template.branches
+            ),
+        )
+        control, _ = select_branch(
+            unbiased,
+            state,
+            {Slot.ACTOR: 11},
+            digest="fixed",
+            selection=BranchSelection(mode="stochastic", temperature=1.0),
+        )
+        assert chosen.label == control.label
+    finally:
+        transaction.rollback()
+        connection.close()
+        engine.dispose()
+
+
+def test_mood_gate_bias_purity_validation_and_no_magnitude_mutation() -> None:
+    state = WorldState(
+        ephemeral_tags={11: frozenset({"grim"})},
+        mood_enabled=True,
+        current_tick=3,
+    )
+    bindings = {Slot.ACTOR: 11}
+    assert mood_is("grim")(state, bindings)
+    assert not mood_is("grim")(
+        WorldState(ephemeral_tags=state.ephemeral_tags, mood_enabled=False),
+        bindings,
+    )
+    with pytest.raises(ValueError, match="Unknown mood"):
+        mood_is("wistful")
+
+    template = Template(
+        id="mood_bias",
+        priority=1,
+        drive_band="anchored_routine",
+        blurb="Bias test.",
+        required_slots=(Slot.ACTOR,),
+        package_gate=ALWAYS,
+        branches=(
+            Branch("plain", ALWAYS, "Plain.", magnitude=0.4),
+            Branch(
+                "favored",
+                ALWAYS,
+                "Favored.",
+                magnitude=0.4,
+                mood_affinities={"grim": 8.0},
+            ),
+        ),
+    )
+    before = tuple(branch.magnitude for branch in template.branches)
+    outcomes = [
+        select_branch(
+            template,
+            WorldState(
+                ephemeral_tags=state.ephemeral_tags,
+                mood_enabled=enabled,
+                current_tick=tick,
+            ),
+            bindings,
+            digest="fixed",
+            selection=BranchSelection(mode="stochastic", temperature=1.0),
+        )[0].label
+        for enabled in (False, True)
+        for tick in range(64)
+    ]
+    plain = outcomes[:64].count("favored")
+    biased = outcomes[64:].count("favored")
+    assert biased > plain
+    assert tuple(branch.magnitude for branch in template.branches) == before
+    explanation = explain_template(
+        template,
+        state,
+        bindings,
+        BranchSelection(mode="stochastic", temperature=1.0),
+    )
+    favored_trace = next(
+        trace for trace in explanation.branches if trace.label == "favored"
+    )
+    assert favored_trace.applied_mood_affinity == {
+        "mood": "grim",
+        "multiplier": 8.0,
+    }
+    assert (
+        evaluate(
+            template,
+            state,
+            bindings,
+            BranchSelection(mode="authored_order"),
+        ).branch_label
+        == "plain"
+    )
+
+    gated = Template(
+        id="bad_gate",
+        priority=1,
+        drive_band="anchored_routine",
+        blurb="Invalid gate.",
+        required_slots=(Slot.ACTOR,),
+        package_gate=mood_is("grim"),
+        branches=(Branch("fallback", ALWAYS, "Fallback."),),
+    )
+    with pytest.raises(ValueError, match="stage-2/3"):
+        validate_no_mood_in_entry_gates((gated,))
+    invalid = Template(
+        id="bad_affinity",
+        priority=1,
+        drive_band="anchored_routine",
+        blurb="Invalid affinity.",
+        required_slots=(Slot.ACTOR,),
+        package_gate=ALWAYS,
+        branches=(
+            Branch(
+                "bad",
+                ALWAYS,
+                "Bad.",
+                mood_affinities={"grim": 9.0, "wistful": 1.0},
+            ),
+        ),
+    )
+    with pytest.raises(ValueError, match="Invalid mood affinities"):
+        validate_mood_affinities((invalid,))

--- a/tests/test_orrery/test_mood_migration_pg.py
+++ b/tests/test_orrery/test_mood_migration_pg.py
@@ -1,0 +1,84 @@
+"""Rollback-only PostgreSQL contract for migration 095."""
+
+from pathlib import Path
+import uuid
+
+import psycopg2
+import pytest
+
+from nexus.api.slot_utils import get_slot_db_url
+
+
+pytestmark = pytest.mark.requires_postgres
+
+
+def test_mood_vocabulary_contract() -> None:
+    conn = psycopg2.connect(get_slot_db_url(slot=5))
+    schema = f"mood_migration_{uuid.uuid4().hex}"
+    migration = (
+        Path(__file__).parents[2] / "migrations" / "095_mood_vocabulary.sql"
+    ).read_text()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f'CREATE SCHEMA "{schema}"')
+            cur.execute(f'SET LOCAL search_path = "{schema}", public')
+            cur.execute(
+                """
+                CREATE TABLE tag_category_registry (
+                    category text NOT NULL,
+                    entity_kind entity_kind NOT NULL,
+                    prompt_order integer NOT NULL,
+                    description text,
+                    deprecated boolean NOT NULL DEFAULT false,
+                    replacement_categories text[],
+                    PRIMARY KEY (category, entity_kind)
+                );
+                CREATE TABLE tags (
+                    id bigserial PRIMARY KEY,
+                    tag text UNIQUE NOT NULL,
+                    category text NOT NULL,
+                    is_ephemeral boolean NOT NULL DEFAULT false,
+                    clearance_kind entity_tag_clearance_kind,
+                    reapplication_policy entity_tag_reapplication_policy,
+                    clear_on jsonb,
+                    synonym_for bigint,
+                    deprecated boolean NOT NULL DEFAULT false,
+                    description text,
+                    CHECK (is_ephemeral = (clearance_kind IS NOT NULL))
+                );
+                """
+            )
+            cur.execute(migration)
+            cur.execute(migration)
+            cur.execute(
+                """
+                SELECT entity_kind::text, description
+                FROM tag_category_registry
+                WHERE category = 'mood'
+                """
+            )
+            kind, description = cur.fetchone()
+            assert kind == "character"
+            assert "mechanical" in description.lower()
+            assert "emotional_state" in description
+            cur.execute(
+                """
+                SELECT tag, is_ephemeral, clearance_kind::text,
+                       reapplication_policy::text, description
+                FROM tags
+                WHERE category = 'mood'
+                ORDER BY tag
+                """
+            )
+            rows = cur.fetchall()
+            assert [row[0] for row in rows] == [
+                "elated",
+                "grim",
+                "restless",
+                "sour",
+            ]
+            assert all(row[1:4] == (True, "time", "replace") for row in rows)
+            assert all(row[4] and "\n" not in row[4] for row in rows)
+    finally:
+        conn.rollback()
+        conn.close()

--- a/tests/test_orrery/test_pursue_romance_projects.py
+++ b/tests/test_orrery/test_pursue_romance_projects.py
@@ -220,6 +220,10 @@ def test_full_ladder_and_terminals(
     )
     assert result.branch_label == label
     assert delta_key in result.state_delta
+    if label == "Declare the feeling and be answered":
+        assert result.state_delta["mood.set"] == {"mood": "elated"}
+    if label == "Withdraw after being rebuffed":
+        assert result.state_delta["mood.set"] == {"mood": "sour"}
     if label in {
         "Offer another honest opening",
         "Build closeness through chosen time",

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -251,6 +251,9 @@ class FakeSession:
             assert "superseded_by_event_id IS NULL" in sql
             return FakeResult(self.event_actor_rows)
         if "/* orrery:actor_bindings_ephemeral */" in sql:
+            assert "JOIN entity_tags et" in sql
+            assert "et.expires_at_world_time > :current_world_time" in sql
+            assert _params["current_world_time"] in {None, self.world_time}
             return FakeResult(self.ephemeral_actor_rows)
         if "/* orrery:actor_bindings_inbound_ephemeral_pair_tags */" in sql:
             assert "pt.is_ephemeral = true" in sql
@@ -1270,7 +1273,7 @@ def test_disabled_weather_omits_scene_conditions() -> None:
 
 
 def test_scene_conditions_include_only_present_active_moods() -> None:
-    """Mechanical moods attach by present-character name and honor disable."""
+    """Mechanical moods retain same-named present entities and honor disable."""
 
     session = FakeSession(
         tag_rows=[
@@ -1279,6 +1282,10 @@ def test_scene_conditions_include_only_present_active_moods() -> None:
             {"entity_id": 3, "tag": "restless", "is_ephemeral": True},
         ],
         present_actor_rows=[{"entity_id": 1}, {"entity_id": 2}],
+        entity_name_rows=[
+            {"id": 1, "name": "Mara"},
+            {"id": 2, "name": "Mara"},
+        ],
     )
     enabled = resolve_dry_run(
         session,
@@ -1297,7 +1304,12 @@ def test_scene_conditions_include_only_present_active_moods() -> None:
         mood_settings={"enabled": False},
     )
 
-    assert enabled.scene_conditions == {"moods": {"Mara": "elated", "Vale": "grim"}}
+    assert enabled.scene_conditions == {
+        "moods": [
+            {"entity_id": 1, "name": "Mara", "mood": "elated"},
+            {"entity_id": 2, "name": "Mara", "mood": "grim"},
+        ]
+    }
     assert disabled.scene_conditions == {}
 
 

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -1269,6 +1269,38 @@ def test_disabled_weather_omits_scene_conditions() -> None:
     assert proposal.scene_conditions == {}
 
 
+def test_scene_conditions_include_only_present_active_moods() -> None:
+    """Mechanical moods attach by present-character name and honor disable."""
+
+    session = FakeSession(
+        tag_rows=[
+            {"entity_id": 1, "tag": "elated", "is_ephemeral": True},
+            {"entity_id": 2, "tag": "grim", "is_ephemeral": True},
+            {"entity_id": 3, "tag": "restless", "is_ephemeral": True},
+        ],
+        present_actor_rows=[{"entity_id": 1}, {"entity_id": 2}],
+    )
+    enabled = resolve_dry_run(
+        session,
+        (),
+        anchor_chunk_id=100,
+        window_chunks=30,
+        weather_settings={"enabled": False},
+        mood_settings={"enabled": True},
+    )
+    disabled = resolve_dry_run(
+        session,
+        (),
+        anchor_chunk_id=100,
+        window_chunks=30,
+        weather_settings={"enabled": False},
+        mood_settings={"enabled": False},
+    )
+
+    assert enabled.scene_conditions == {"moods": {"Mara": "elated", "Vale": "grim"}}
+    assert disabled.scene_conditions == {}
+
+
 def test_weather_override_uses_displayed_protagonist_place_for_occupants() -> None:
     """A stale setting reference cannot redirect the displayed scene override."""
 

--- a/tests/test_orrery/test_seek_redemption_projects.py
+++ b/tests/test_orrery/test_seek_redemption_projects.py
@@ -229,6 +229,12 @@ def test_full_ladder(state: WorldState, label: str, delta_key: str) -> None:
             "entity_tags_target.remove": ["grudge_active"],
             "mood.set": {"mood": "elated"},
         }
+        assert result.changed_fields == (
+            "character_project_states.status",
+            "entity_tags",
+            "character_relationships.relationship_type",
+            "character_relationships.emotional_valence",
+        )
 
 
 def test_completion_needs_no_trust_recovery_and_yields_to_hostility() -> None:

--- a/tests/test_orrery/test_seek_redemption_projects.py
+++ b/tests/test_orrery/test_seek_redemption_projects.py
@@ -221,10 +221,13 @@ def test_full_ladder(state: WorldState, label: str, delta_key: str) -> None:
     )
     assert result.branch_label == label
     assert delta_key in result.state_delta
+    if label == "Abandon amends that are thrown back":
+        assert result.state_delta["mood.set"] == {"mood": "grim"}
     if delta_key == "project.complete":
         assert result.state_delta == {
             "project.complete": {"milestone": True},
             "entity_tags_target.remove": ["grudge_active"],
+            "mood.set": {"mood": "elated"},
         }
 
 

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -55,7 +55,15 @@ from nexus.agents.orrery.substrate import (
     travel_purpose_is,
     validate_always_fallbacks,
 )
-from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+from nexus.agents.orrery.templates import (
+    ADVANCE_BUILD_VENTURE,
+    ADVANCE_COURT_PATRON,
+    ADVANCE_PURSUE_ROMANCE,
+    ADVANCE_SEEK_REDEMPTION,
+    BUILTIN_TEMPLATES,
+    EXTRACT_VENGEANCE,
+    RECREATE,
+)
 
 
 _SINCE_LAST_EVENT_RE = re.compile(r"since_last_event_at_least\(([^,()]+),")
@@ -80,6 +88,31 @@ def test_builtin_templates_have_always_fallbacks() -> None:
     """Built-in templates must end in a deterministic fallback branch."""
 
     validate_always_fallbacks(BUILTIN_TEMPLATES)
+
+
+def test_builtin_mood_affinity_consumers_cover_requested_read_channels() -> None:
+    """Mood reads bias vengeance, aspiration progress, romance, and recreation."""
+
+    def branch(template: Template, label: str) -> Branch:
+        return next(item for item in template.branches if item.label == label)
+
+    assert branch(
+        EXTRACT_VENGEANCE, "Strike directly when opportunity opens"
+    ).mood_affinities == {"restless": 2.0, "grim": 1.5}
+    # The rebuffed arm stays preemptive with NO affinity: a rebuff is a
+    # deterministic guard (the recruit_ally withdraw-arm contract), never
+    # a stochastic lean.
+    rebuffed = branch(ADVANCE_PURSUE_ROMANCE, "Withdraw after being rebuffed")
+    assert rebuffed.mood_affinities == {}
+    assert rebuffed.preemptive is True
+    assert branch(RECREATE, "Find games and company").mood_affinities == {"elated": 1.5}
+    for template in (
+        ADVANCE_PURSUE_ROMANCE,
+        ADVANCE_COURT_PATRON,
+        ADVANCE_SEEK_REDEMPTION,
+        ADVANCE_BUILD_VENTURE,
+    ):
+        assert template.branches[-1].mood_affinities == {"elated": 1.5}
 
 
 def test_gate_cooldown_chain_covers_branch_events() -> None:


### PR DESCRIPTION
## Summary

The final slice of #480 — and the final unbuilt axis of every Arachne-ruled tracker. M-B per the seq-4 ruling: mood is a stored tag.

- **Vocabulary** (migration 095): `mood` category, four exclusive time-cleared tags (`elated`/`sour`/`restless`/`grim`); the category comment records the deliberate two-surfaces split (mood = mechanical affect; `characters.emotional_state` = prose affect)
- **`mood.set`**: the new state_delta verb routes through the exclusive-replace primitive (async twin added — it never existed) with world-clock expiry; the applied snapshot records mood, displaced mood, expiry, and the exact row — replay reapplies the projection, closing the replace-policy provenance gap
- **The three ruled consumption channels, exactly**: `mood_is` branch gates with fame-style stage-1 purity (validator-enforced — mood never gates package entry); `Branch.mood_affinities` softmax multipliers that bias selection while **magnitude stays untouched** (promotion/Bleed salience proven invariant by test); present characters' moods in `scene_conditions`
- **The two-clocks fix**: hydration now excludes expired-unswept time-cleared tags — a diegetically-expired mood (or intoxication) can no longer gate behavior just because the sweep hasn't run; live-tested
- **Eight exemplar writers** across the four aspiration packages and EXTRACT_VENGEANCE make the system live sparingly (completions → `elated`, rebuffs/spurns → `sour`/`grim`, the vengeance strike → `restless`)
- `[orrery.mood]` opt-in (model off, shipped on); disabled mode skips with a recorded snapshot marker, replay-stable

## Validation

- `poetry run pytest -q` → **1589 passed, 0 failed**
- **Full live-PG orrery suite → 1215 passed, 0 failed** (lifecycle/displacement/expiry, replay exactness, seeded-RNG bias determinism, purity rejection, magnitude invariance, disabled mode, hydration expiry)
- `replay_state.py --slot 5 --verify` green; flake8/black/catalog/config-hook clean

## Schema/Data Impact

Migration 095: vocabulary seeds only. Applied at merge closeout; #480 closes with it.

Implemented by Sol (GPT-5.6 Codex) from a frozen spec; reviewed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TJVTXfD7TouQuxmYfVf8w