### PR TITLE
Widen the Composition Boundary: Hostile Edges and Faction Rosters (#532 Stage 1)

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -1831,7 +1831,6 @@ Drive bands are authoring metadata: they explain whether a package is crisis/con
   - **OR:**
     - actor has `rival` relationship to target
     - actor and target share `enemy` relationship (either direction)
-    - actor has `complex` relationship to target
     - trust actor→target < 0
   - **OR:**
     - recent `compliance_alert` event in last 10 ticks
@@ -3793,7 +3792,6 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `captor`
 - `chosen_kin`
 - `companion`
-- `complex`
 - `comrade`
 - `enemy`
 - `family`

--- a/nexus.toml
+++ b/nexus.toml
@@ -253,6 +253,12 @@ enabled = true
 [orrery.binding]
 window_chunks = 30
 
+[orrery.composition]
+# Shared binding sources remain model-default-off for legacy configurations.
+hostile_source_enabled = true
+roster_source_enabled = true
+roster_reach = 2
+
 [orrery.contagion]
 enabled = true
 

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -683,6 +683,7 @@ class TurnCycleManager:
                 contagion_settings=orrery_settings.get("contagion"),
                 weather_settings=orrery_settings.get("weather"),
                 mood_settings=orrery_settings.get("mood"),
+                composition_settings=orrery_settings.get("composition"),
             )
 
         turn_context.orrery_proposal = proposal

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -515,6 +515,7 @@ def explain_dry_run(
     contagion_settings: Optional[Any] = None,
     weather_settings: Optional[Any] = None,
     mood_settings: Optional[Any] = None,
+    composition_settings: Optional[Any] = None,
 ) -> ExplainedTickReport:
     """Hydrate, bind, and explain Orrery packages without database writes.
 
@@ -608,6 +609,7 @@ def explain_dry_run(
             window_chunks=window_chunks,
             actor_ids=actor_ids,
             target_presence="offscreen",
+            composition_settings=composition_settings,
         )
         if pressure_templates:
             present_pair_routes = compose_actor_target_routes(
@@ -618,6 +620,7 @@ def explain_dry_run(
                 window_chunks=window_chunks,
                 actor_ids=actor_ids,
                 target_presence="present",
+                composition_settings=composition_settings,
             )
 
     if actor_faction_templates:
@@ -628,6 +631,7 @@ def explain_dry_run(
             anchor_chunk_id=anchor_chunk_id,
             window_chunks=window_chunks,
             actor_ids=actor_ids,
+            composition_settings=composition_settings,
         )
 
     if actor_target_faction_templates:
@@ -639,6 +643,7 @@ def explain_dry_run(
             window_chunks=window_chunks,
             actor_ids=actor_ids,
             target_presence="offscreen",
+            composition_settings=composition_settings,
         )
         triple_pressure_templates = [
             template
@@ -655,6 +660,7 @@ def explain_dry_run(
                 window_chunks=window_chunks,
                 actor_ids=actor_ids,
                 target_presence="present",
+                composition_settings=composition_settings,
             )
 
     present_actor_ids = _present_actor_ids_at_anchor(

--- a/nexus/agents/orrery/coverage.py
+++ b/nexus/agents/orrery/coverage.py
@@ -383,6 +383,7 @@ def analyze_coverage(
     contagion_settings: Optional[Any] = None,
     weather_settings: Optional[Any] = None,
     mood_settings: Optional[Any] = None,
+    composition_settings: Optional[Any] = None,
 ) -> dict[str, Any]:
     """Aggregate explained resolution coverage across historical anchors.
 
@@ -430,6 +431,7 @@ def analyze_coverage(
             contagion_settings=contagion_settings,
             weather_settings=weather_settings,
             mood_settings=mood_settings,
+            composition_settings=composition_settings,
         )
         anchors.append(_tally_report(report, tallies, gap_counts))
         entity_names.update(report.entity_names)

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -1488,21 +1488,11 @@ def compose_project_faction_bindings(
     )
 
 
-def _composition_setting(settings: Optional[Any], name: str, default: Any) -> Any:
-    """Read one composition setting from mapping or model-shaped config."""
-
-    if settings is None:
-        return default
-    if isinstance(settings, Mapping):
-        return settings.get(name, default)
-    return getattr(settings, name, default)
-
-
 def _roster_composition_settings(settings: Optional[Any]) -> tuple[bool, int]:
     """Return validated roster-source enablement and relationship reach."""
 
-    enabled = bool(_composition_setting(settings, "roster_source_enabled", False))
-    reach = int(_composition_setting(settings, "roster_reach", 2))
+    enabled = bool(_weather_setting(settings, "roster_source_enabled", False))
+    reach = int(_weather_setting(settings, "roster_reach", 2))
     if not 1 <= reach <= 4:
         raise ValueError("roster_reach must be between 1 and 4")
     return enabled, reach
@@ -1615,7 +1605,7 @@ def compose_actor_target_faction_routes(
         if any(template.starts_from_social_contact for template in templates_tuple)
         else ()
     )
-    hostile_enabled = _composition_setting(
+    hostile_enabled = _weather_setting(
         composition_settings, "hostile_source_enabled", False
     )
     hostile_targets = (
@@ -1786,7 +1776,7 @@ def compose_actor_target_routes(
     hostile_templates = tuple(
         template for template in templates_tuple if template.composes_from_hostility
     )
-    if hostile_templates and _composition_setting(
+    if hostile_templates and _weather_setting(
         composition_settings, "hostile_source_enabled", False
     ):
         hostile_bindings = compose_actor_target_bindings(

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -1068,6 +1068,7 @@ def compose_actor_target_bindings(
     actor_ids: Optional[Iterable[int]] = None,
     target_presence: str = "offscreen",
     include_social_contacts: bool = False,
+    include_hostile_edges: bool = False,
 ) -> Tuple[Bindings, ...]:
     """Compose ACTOR+TARGET bindings from actors' relational neighborhoods.
 
@@ -1077,8 +1078,9 @@ def compose_actor_target_bindings(
     reverse) so templates with symmetric semantics see both orderings. When
     ``include_social_contacts`` is true, current directed ``contact:social``
     edges are unioned into that base pool for templates that explicitly opt
-    into social-contact starts. Gate predicates with asymmetric semantics
-    (handler/asset) filter via role-explicit OR clauses.
+    into social-contact starts. ``include_hostile_edges`` adds active
+    character-only ``hostile_to`` and ``hunting`` edges in both orderings.
+    Gate predicates with asymmetric semantics filter via role-explicit arms.
 
     When actor_ids is provided (typical: resolve_dry_run threads through
     the actor set it already computed), this skips the redundant
@@ -1188,6 +1190,35 @@ def compose_actor_target_bindings(
                 reverse=False,
             )
 
+    if include_hostile_edges:
+        for row in session.execute(
+            text(
+                """
+                /* orrery:actor_target_bindings_hostile_edges */
+                SELECT ept.subject_entity_id AS source_entity_id,
+                       ept.object_entity_id AS target_entity_id
+                FROM entity_pair_tags ept
+                JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+                JOIN entities es ON es.id = ept.subject_entity_id
+                JOIN entities et ON et.id = ept.object_entity_id
+                WHERE pt.tag IN ('hostile_to', 'hunting')
+                  AND NOT pt.deprecated
+                  AND ept.cleared_at IS NULL
+                  AND es.kind = 'character'
+                  AND et.kind = 'character'
+                  AND es.is_active = true
+                  AND et.is_active = true
+                """
+            )
+        ).mappings():
+            # Faction-endpoint hostility deliberately composes nothing until
+            # an authored desire names that faction.
+            add_candidate(
+                int(row["source_entity_id"]),
+                int(row["target_entity_id"]),
+                reverse=True,
+            )
+
     return tuple(
         {Slot.ACTOR: actor_id, Slot.TARGET: target_id}
         for actor_id, target_id in sorted(pairs)
@@ -1200,6 +1231,8 @@ def compose_actor_faction_bindings(
     anchor_chunk_id: Optional[int],
     window_chunks: int,
     actor_ids: Optional[Iterable[int]] = None,
+    include_rosters: bool = False,
+    roster_reach: int = 2,
 ) -> Tuple[Bindings, ...]:
     """Compose ACTOR+FACTION bindings from active institutional pair tags.
 
@@ -1223,6 +1256,8 @@ def compose_actor_faction_bindings(
     )
     if not actor_id_set:
         return ()
+    if include_rosters and not 1 <= roster_reach <= 4:
+        raise ValueError("roster_reach must be between 1 and 4")
 
     pairs: set[tuple[int, int]] = set()
     for row in session.execute(
@@ -1261,6 +1296,98 @@ def compose_actor_faction_bindings(
         if object_id in actor_id_set and row["subject_kind"] == "faction":
             pairs.add((object_id, subject_id))
 
+    if include_rosters:
+        for row in session.execute(
+            text(
+                """
+                /* orrery:actor_faction_bindings_rosters */
+                WITH RECURSIVE relationship_edges AS (
+                    SELECT er.source_entity_id, er.target_entity_id
+                    FROM entity_relationships_v er
+                    JOIN entities source_entity
+                      ON source_entity.id = er.source_entity_id
+                    JOIN entities target_entity
+                      ON target_entity.id = er.target_entity_id
+                    WHERE er.relationship_scope = 'character'
+                      AND source_entity.kind = 'character'
+                      AND target_entity.kind = 'character'
+                      AND source_entity.is_active = true
+                      AND target_entity.is_active = true
+                ), reachable(actor_id, member_id, depth, path) AS (
+                    SELECT actor.id, actor.id, 0, ARRAY[actor.id]
+                    FROM entities actor
+                    WHERE actor.id = ANY(:actor_ids)
+                      AND actor.kind = 'character'
+                      AND actor.is_active = true
+                    UNION ALL
+                    SELECT reachable.actor_id,
+                           CASE
+                               WHEN edge.source_entity_id = reachable.member_id
+                               THEN edge.target_entity_id
+                               ELSE edge.source_entity_id
+                           END,
+                           reachable.depth + 1,
+                           reachable.path || CASE
+                               WHEN edge.source_entity_id = reachable.member_id
+                               THEN edge.target_entity_id
+                               ELSE edge.source_entity_id
+                           END
+                    FROM reachable
+                    JOIN relationship_edges edge
+                      ON edge.source_entity_id = reachable.member_id
+                      OR edge.target_entity_id = reachable.member_id
+                    WHERE reachable.depth < :roster_reach
+                      AND NOT CASE
+                          WHEN edge.source_entity_id = reachable.member_id
+                          THEN edge.target_entity_id
+                          ELSE edge.source_entity_id
+                      END = ANY(reachable.path)
+                ), live_rosters AS (
+                    SELECT DISTINCT
+                           CASE
+                               WHEN subject_entity.kind = 'character'
+                               THEN subject_entity.id
+                               ELSE object_entity.id
+                           END AS member_id,
+                           CASE
+                               WHEN subject_entity.kind = 'faction'
+                               THEN subject_entity.id
+                               ELSE object_entity.id
+                           END AS faction_id
+                    FROM entity_pair_tags ept
+                    JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+                    JOIN entities subject_entity
+                      ON subject_entity.id = ept.subject_entity_id
+                    JOIN entities object_entity
+                      ON object_entity.id = ept.object_entity_id
+                    WHERE pt.tag LIKE 'status:%'
+                      AND NOT pt.deprecated
+                      AND ept.cleared_at IS NULL
+                      AND subject_entity.is_active = true
+                      AND object_entity.is_active = true
+                      AND (
+                          (subject_entity.kind = 'character'
+                           AND object_entity.kind = 'faction')
+                          OR (subject_entity.kind = 'faction'
+                              AND object_entity.kind = 'character')
+                      )
+                )
+                SELECT DISTINCT reachable.actor_id, live_rosters.faction_id
+                FROM reachable
+                JOIN live_rosters
+                  ON live_rosters.member_id = reachable.member_id
+                WHERE reachable.depth <= :roster_reach
+                """
+            ),
+            {
+                "actor_ids": sorted(actor_id_set),
+                "roster_reach": roster_reach,
+            },
+        ).mappings():
+            # A power becomes court-able through someone the actor knows
+            # belongs to it; reach is neutral relationship-graph distance.
+            pairs.add((int(row["actor_id"]), int(row["faction_id"])))
+
     return tuple(
         {Slot.ACTOR: actor_id, Slot.FACTION: faction_id}
         for actor_id, faction_id in sorted(pairs)
@@ -1275,6 +1402,9 @@ def compose_actor_target_faction_bindings(
     actor_ids: Optional[Iterable[int]] = None,
     target_presence: str = "offscreen",
     include_social_contacts: bool = False,
+    include_hostile_edges: bool = False,
+    include_rosters: bool = False,
+    roster_reach: int = 2,
 ) -> Tuple[Bindings, ...]:
     """Compose the deterministic product of target and faction candidates."""
 
@@ -1296,12 +1426,15 @@ def compose_actor_target_faction_bindings(
         actor_ids=actor_id_set,
         target_presence=target_presence,
         include_social_contacts=include_social_contacts,
+        include_hostile_edges=include_hostile_edges,
     )
     faction_bindings = compose_actor_faction_bindings(
         session,
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
         actor_ids=actor_id_set,
+        include_rosters=include_rosters,
+        roster_reach=roster_reach,
     )
     targets_by_actor: dict[int, set[int]] = {}
     for binding in target_bindings:
@@ -1391,6 +1524,26 @@ def compose_project_faction_bindings(
     )
 
 
+def _composition_setting(settings: Optional[Any], name: str, default: Any) -> Any:
+    """Read one composition setting from mapping or model-shaped config."""
+
+    if settings is None:
+        return default
+    if isinstance(settings, Mapping):
+        return settings.get(name, default)
+    return getattr(settings, name, default)
+
+
+def _roster_composition_settings(settings: Optional[Any]) -> tuple[bool, int]:
+    """Return validated roster-source enablement and relationship reach."""
+
+    enabled = bool(_composition_setting(settings, "roster_source_enabled", False))
+    reach = int(_composition_setting(settings, "roster_reach", 2))
+    if not 1 <= reach <= 4:
+        raise ValueError("roster_reach must be between 1 and 4")
+    return enabled, reach
+
+
 def compose_actor_faction_routes(
     session: Any,
     *,
@@ -1399,6 +1552,7 @@ def compose_actor_faction_routes(
     anchor_chunk_id: Optional[int],
     window_chunks: int,
     actor_ids: Iterable[int],
+    composition_settings: Optional[Any] = None,
 ) -> Tuple[tuple[Bindings, Tuple[Template, ...]], ...]:
     """Route institutional and stored-project faction bindings by template."""
 
@@ -1412,6 +1566,19 @@ def compose_actor_faction_routes(
         window_chunks=window_chunks,
         actor_ids=actor_id_set,
     )
+    roster_enabled, roster_reach = _roster_composition_settings(composition_settings)
+    roster = (
+        compose_actor_faction_bindings(
+            session,
+            anchor_chunk_id=anchor_chunk_id,
+            window_chunks=window_chunks,
+            actor_ids=actor_id_set,
+            include_rosters=True,
+            roster_reach=roster_reach,
+        )
+        if roster_enabled and any(t.courts_factions for t in templates_tuple)
+        else ()
+    )
     project = compose_project_faction_bindings(
         session,
         state=state,
@@ -1424,9 +1591,12 @@ def compose_actor_faction_routes(
     project_pairs = {
         (binding[Slot.ACTOR], binding[Slot.FACTION]) for binding in project
     }
+    roster_pairs = {(binding[Slot.ACTOR], binding[Slot.FACTION]) for binding in roster}
     template_ids_by_pair: dict[tuple[int, int], set[str]] = {}
     for template in templates_tuple:
         allowed = set(institutional_pairs)
+        if template.courts_factions:
+            allowed.update(roster_pairs)
         if template.binds_project_faction:
             allowed.update(project_pairs)
         for pair in allowed:
@@ -1453,6 +1623,7 @@ def compose_actor_target_faction_routes(
     window_chunks: int,
     actor_ids: Iterable[int],
     target_presence: str = "offscreen",
+    composition_settings: Optional[Any] = None,
 ) -> Tuple[tuple[Bindings, Tuple[Template, ...]], ...]:
     """Route target-candidate products with institutional/project factions."""
 
@@ -1479,6 +1650,22 @@ def compose_actor_target_faction_routes(
         if any(template.starts_from_social_contact for template in templates_tuple)
         else ()
     )
+    hostile_enabled = _composition_setting(
+        composition_settings, "hostile_source_enabled", False
+    )
+    hostile_targets = (
+        compose_actor_target_bindings(
+            session,
+            anchor_chunk_id=anchor_chunk_id,
+            window_chunks=window_chunks,
+            actor_ids=actor_id_set,
+            target_presence=target_presence,
+            include_hostile_edges=True,
+        )
+        if hostile_enabled
+        and any(template.composes_from_hostility for template in templates_tuple)
+        else ()
+    )
     project_targets = (
         compose_project_target_bindings(
             session,
@@ -1495,6 +1682,19 @@ def compose_actor_target_faction_routes(
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
         actor_ids=actor_id_set,
+    )
+    roster_enabled, roster_reach = _roster_composition_settings(composition_settings)
+    roster_factions = (
+        compose_actor_faction_bindings(
+            session,
+            anchor_chunk_id=anchor_chunk_id,
+            window_chunks=window_chunks,
+            actor_ids=actor_id_set,
+            include_rosters=True,
+            roster_reach=roster_reach,
+        )
+        if roster_enabled and any(t.courts_factions for t in templates_tuple)
+        else ()
     )
     project_factions = (
         compose_project_faction_bindings(
@@ -1517,8 +1717,10 @@ def compose_actor_target_faction_routes(
 
     relationship_by_actor = candidates_by_actor(relationship_targets, Slot.TARGET)
     social_by_actor = candidates_by_actor(social_targets, Slot.TARGET)
+    hostile_by_actor = candidates_by_actor(hostile_targets, Slot.TARGET)
     project_target_by_actor = candidates_by_actor(project_targets, Slot.TARGET)
     institutional_by_actor = candidates_by_actor(institutional_factions, Slot.FACTION)
+    roster_by_actor = candidates_by_actor(roster_factions, Slot.FACTION)
     project_faction_by_actor = candidates_by_actor(project_factions, Slot.FACTION)
 
     template_ids_by_triple: dict[tuple[int, int, int], set[str]] = {}
@@ -1527,9 +1729,13 @@ def compose_actor_target_faction_routes(
             targets = set(relationship_by_actor.get(actor_id, ()))
             if template.starts_from_social_contact:
                 targets.update(social_by_actor.get(actor_id, ()))
+            if template.composes_from_hostility:
+                targets.update(hostile_by_actor.get(actor_id, ()))
             if template.binds_project_target:
                 targets.update(project_target_by_actor.get(actor_id, ()))
             factions = set(institutional_by_actor.get(actor_id, ()))
+            if template.courts_factions:
+                factions.update(roster_by_actor.get(actor_id, ()))
             if template.binds_project_faction:
                 factions.update(project_faction_by_actor.get(actor_id, ()))
             for target_id in targets:
@@ -1564,14 +1770,15 @@ def compose_actor_target_routes(
     window_chunks: int,
     actor_ids: Iterable[int],
     target_presence: str = "offscreen",
+    composition_settings: Optional[Any] = None,
 ) -> Tuple[tuple[Bindings, Tuple[Template, ...]], ...]:
     """Route each ACTOR/TARGET binding to its authorized template stack.
 
     Relationship-backed pairs retain the complete two-party stack and its
-    normal priority competition. Social-contact-only and project-target-only
-    pairs admit only templates that explicitly opt into those broader binding
-    sources. When sources overlap, their template sets are unioned and
-    evaluated once in original stack order.
+    normal priority competition. Social-contact-only, hostile-only, and
+    project-target-only pairs admit only templates that explicitly opt into
+    those broader binding sources. Overlapping source template sets are
+    unioned and evaluated once in original stack order.
     """
 
     templates_tuple = tuple(templates)
@@ -1609,6 +1816,22 @@ def compose_actor_target_routes(
             include_social_contacts=True,
         )
         add_routes(social_bindings, social_templates)
+
+    hostile_templates = tuple(
+        template for template in templates_tuple if template.composes_from_hostility
+    )
+    if hostile_templates and _composition_setting(
+        composition_settings, "hostile_source_enabled", False
+    ):
+        hostile_bindings = compose_actor_target_bindings(
+            session,
+            anchor_chunk_id=anchor_chunk_id,
+            window_chunks=window_chunks,
+            actor_ids=actor_id_set,
+            target_presence=target_presence,
+            include_hostile_edges=True,
+        )
+        add_routes(hostile_bindings, hostile_templates)
 
     project_templates = tuple(
         template for template in templates_tuple if template.binds_project_target
@@ -1800,6 +2023,7 @@ def resolve_dry_run(
     contagion_settings: Optional[Any] = None,
     weather_settings: Optional[Any] = None,
     mood_settings: Optional[Any] = None,
+    composition_settings: Optional[Any] = None,
 ) -> OrreryTickProposal:
     """Hydrate, bind, and evaluate Orrery packages without database writes."""
 
@@ -1893,6 +2117,7 @@ def resolve_dry_run(
             window_chunks=window_chunks,
             actor_ids=actor_ids,
             target_presence="offscreen",
+            composition_settings=composition_settings,
         )
         for bindings, routed_templates in offscreen_routes:
             resolution = evaluate_stack(
@@ -1921,6 +2146,7 @@ def resolve_dry_run(
                 window_chunks=window_chunks,
                 actor_ids=actor_ids,
                 target_presence="present",
+                composition_settings=composition_settings,
             )
             for bindings, routed_templates in present_routes:
                 resolution = evaluate_stack(
@@ -1942,6 +2168,7 @@ def resolve_dry_run(
             anchor_chunk_id=anchor_chunk_id,
             window_chunks=window_chunks,
             actor_ids=actor_ids,
+            composition_settings=composition_settings,
         )
         offscreen_routes += faction_routes
         for bindings, routed_templates in faction_routes:
@@ -1965,6 +2192,7 @@ def resolve_dry_run(
             window_chunks=window_chunks,
             actor_ids=actor_ids,
             target_presence="offscreen",
+            composition_settings=composition_settings,
         )
         offscreen_routes += triple_routes
         for bindings, routed_templates in triple_routes:
@@ -1994,6 +2222,7 @@ def resolve_dry_run(
                 window_chunks=window_chunks,
                 actor_ids=actor_ids,
                 target_presence="present",
+                composition_settings=composition_settings,
             )
             present_routes += triple_pressure_routes
             for bindings, routed_templates in triple_pressure_routes:

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -1233,6 +1233,7 @@ def compose_actor_faction_bindings(
     actor_ids: Optional[Iterable[int]] = None,
     include_rosters: bool = False,
     roster_reach: int = 2,
+    orbit_distance: Optional[Mapping[tuple[int, int], int]] = None,
 ) -> Tuple[Bindings, ...]:
     """Compose ACTOR+FACTION bindings from active institutional pair tags.
 
@@ -1242,6 +1243,8 @@ def compose_actor_faction_bindings(
     enumeration; template entry predicates own those semantic choices.
     """
 
+    if include_rosters and orbit_distance is None:
+        raise ValueError("orbit_distance is required when include_rosters=True")
     if actor_ids is None:
         actor_only = compose_actor_bindings(
             session,
@@ -1297,96 +1300,55 @@ def compose_actor_faction_bindings(
             pairs.add((object_id, subject_id))
 
     if include_rosters:
-        for row in session.execute(
-            text(
-                """
-                /* orrery:actor_faction_bindings_rosters */
-                WITH RECURSIVE relationship_edges AS (
-                    SELECT er.source_entity_id, er.target_entity_id
-                    FROM entity_relationships_v er
-                    JOIN entities source_entity
-                      ON source_entity.id = er.source_entity_id
-                    JOIN entities target_entity
-                      ON target_entity.id = er.target_entity_id
-                    WHERE er.relationship_scope = 'character'
-                      AND source_entity.kind = 'character'
-                      AND target_entity.kind = 'character'
-                      AND source_entity.is_active = true
-                      AND target_entity.is_active = true
-                ), reachable(actor_id, member_id, depth, path) AS (
-                    SELECT actor.id, actor.id, 0, ARRAY[actor.id]
-                    FROM entities actor
-                    WHERE actor.id = ANY(:actor_ids)
-                      AND actor.kind = 'character'
-                      AND actor.is_active = true
-                    UNION ALL
-                    SELECT reachable.actor_id,
-                           CASE
-                               WHEN edge.source_entity_id = reachable.member_id
-                               THEN edge.target_entity_id
-                               ELSE edge.source_entity_id
-                           END,
-                           reachable.depth + 1,
-                           reachable.path || CASE
-                               WHEN edge.source_entity_id = reachable.member_id
-                               THEN edge.target_entity_id
-                               ELSE edge.source_entity_id
-                           END
-                    FROM reachable
-                    JOIN relationship_edges edge
-                      ON edge.source_entity_id = reachable.member_id
-                      OR edge.target_entity_id = reachable.member_id
-                    WHERE reachable.depth < :roster_reach
-                      AND NOT CASE
-                          WHEN edge.source_entity_id = reachable.member_id
-                          THEN edge.target_entity_id
-                          ELSE edge.source_entity_id
-                      END = ANY(reachable.path)
-                ), live_rosters AS (
-                    SELECT DISTINCT
-                           CASE
-                               WHEN subject_entity.kind = 'character'
-                               THEN subject_entity.id
-                               ELSE object_entity.id
-                           END AS member_id,
-                           CASE
-                               WHEN subject_entity.kind = 'faction'
-                               THEN subject_entity.id
-                               ELSE object_entity.id
-                           END AS faction_id
-                    FROM entity_pair_tags ept
-                    JOIN pair_tags pt ON pt.id = ept.pair_tag_id
-                    JOIN entities subject_entity
-                      ON subject_entity.id = ept.subject_entity_id
-                    JOIN entities object_entity
-                      ON object_entity.id = ept.object_entity_id
-                    WHERE pt.tag LIKE 'status:%'
-                      AND NOT pt.deprecated
-                      AND ept.cleared_at IS NULL
-                      AND subject_entity.is_active = true
-                      AND object_entity.is_active = true
-                      AND (
-                          (subject_entity.kind = 'character'
-                           AND object_entity.kind = 'faction')
-                          OR (subject_entity.kind = 'faction'
-                              AND object_entity.kind = 'character')
-                      )
-                )
-                SELECT DISTINCT reachable.actor_id, live_rosters.faction_id
-                FROM reachable
-                JOIN live_rosters
-                  ON live_rosters.member_id = reachable.member_id
-                WHERE reachable.depth <= :roster_reach
-                """
-            ),
+        live_rosters = sorted(
             {
-                "actor_ids": sorted(actor_id_set),
-                "roster_reach": roster_reach,
-            },
-        ).mappings():
-            # A power becomes court-able through someone the actor knows
-            # belongs to it; reach is neutral relationship-graph distance.
-            pairs.add((int(row["actor_id"]), int(row["faction_id"])))
+                (int(row["member_id"]), int(row["faction_id"]))
+                for row in session.execute(
+                    text(
+                        """
+                        /* orrery:actor_faction_bindings_rosters */
+                        SELECT DISTINCT
+                               CASE
+                                   WHEN subject_entity.kind = 'character'
+                                   THEN subject_entity.id
+                                   ELSE object_entity.id
+                               END AS member_id,
+                               CASE
+                                   WHEN subject_entity.kind = 'faction'
+                                   THEN subject_entity.id
+                                   ELSE object_entity.id
+                               END AS faction_id
+                        FROM entity_pair_tags ept
+                        JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+                        JOIN entities subject_entity
+                          ON subject_entity.id = ept.subject_entity_id
+                        JOIN entities object_entity
+                          ON object_entity.id = ept.object_entity_id
+                        WHERE pt.tag LIKE 'status:%'
+                          AND NOT pt.deprecated
+                          AND ept.cleared_at IS NULL
+                          AND subject_entity.is_active = true
+                          AND object_entity.is_active = true
+                          AND (
+                              (subject_entity.kind = 'character'
+                               AND object_entity.kind = 'faction')
+                              OR (subject_entity.kind = 'faction'
+                                  AND object_entity.kind = 'character')
+                          )
+                        """
+                    )
+                ).mappings()
+            }
+        )
+        for actor_id in sorted(actor_id_set):
+            for member_id, faction_id in live_rosters:
+                # Roster reach is relative_orbit_distance <= reach by
+                # construction: this is the same canonical mapping read by
+                # evidence predicates. Review found SQL path enumeration
+                # explodes on dense graphs, so do not recurse here.
+                distance = orbit_distance.get((actor_id, member_id))
+                if distance is not None and distance <= roster_reach:
+                    pairs.add((actor_id, faction_id))
 
     return tuple(
         {Slot.ACTOR: actor_id, Slot.FACTION: faction_id}
@@ -1405,6 +1367,7 @@ def compose_actor_target_faction_bindings(
     include_hostile_edges: bool = False,
     include_rosters: bool = False,
     roster_reach: int = 2,
+    orbit_distance: Optional[Mapping[tuple[int, int], int]] = None,
 ) -> Tuple[Bindings, ...]:
     """Compose the deterministic product of target and faction candidates."""
 
@@ -1435,6 +1398,7 @@ def compose_actor_target_faction_bindings(
         actor_ids=actor_id_set,
         include_rosters=include_rosters,
         roster_reach=roster_reach,
+        orbit_distance=orbit_distance,
     )
     targets_by_actor: dict[int, set[int]] = {}
     for binding in target_bindings:
@@ -1575,6 +1539,7 @@ def compose_actor_faction_routes(
             actor_ids=actor_id_set,
             include_rosters=True,
             roster_reach=roster_reach,
+            orbit_distance=state.orbit_distance,
         )
         if roster_enabled and any(t.courts_factions for t in templates_tuple)
         else ()
@@ -1692,6 +1657,7 @@ def compose_actor_target_faction_routes(
             actor_ids=actor_id_set,
             include_rosters=True,
             roster_reach=roster_reach,
+            orbit_distance=state.orbit_distance,
         )
         if roster_enabled and any(t.courts_factions for t in templates_tuple)
         else ()

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -2412,6 +2412,13 @@ class Template:
     # this authoring metadata on Template prevents one package's broader
     # starting substrate from changing every other two-party package.
     starts_from_social_contact: bool = False
+    # Hostile-only character pairs are another shared candidate source, but
+    # only authored packages may evaluate them. Faction-endpoint hostility is
+    # deliberately not a composition source until a desire names the faction.
+    composes_from_hostility: bool = False
+    # Roster-derived factions are visible through nearby members only to
+    # packages authored to court institutions across that broader boundary.
+    courts_factions: bool = False
     # Character-targeted project continuations bind TARGET from the durable
     # open-project projection. This remains valid if the contact or
     # relationship edge that originally sourced the project later clears.

--- a/nexus/agents/orrery/templates.py
+++ b/nexus/agents/orrery/templates.py
@@ -2910,14 +2910,13 @@ CONSULT_RIVAL = Template(
     # (rival_consulted from the meaningful branches, contact_made from the
     # ALWAYS fallback). Without the rival_consulted cooldown the high-
     # magnitude branches could refire next tick — caught by Codex on PR #223.
-    # The fraught-tie OR deliberately spans rivalry, open enmity, and
-    # `complex` history — the blurb's contract is "people who do not
-    # trust each other," not the narrow rival label.
+    # #530 review: favorable `complex` now records reconciliation, so it is
+    # not itself a fraught tie. Genuine distrust remains covered by the
+    # adjacent trust_below arm.
     package_gate=AND(
         OR(
             has_relationship_of_type("rival"),
             has_symmetric_relationship_of_type("enemy"),
-            has_relationship_of_type("complex"),
             trust_below(0),
         ),
         OR(
@@ -5725,6 +5724,7 @@ START_SEEK_REDEMPTION = Template(
     blurb="An off-screen character begins making amends to someone they wronged.",
     required_slots=(Slot.ACTOR, Slot.TARGET),
     starts_from_social_contact=True,
+    composes_from_hostility=True,
     package_gate=AND(
         project_due("start", project_type="seek_redemption"),
         has_minimal_context(),
@@ -5742,16 +5742,9 @@ START_SEEK_REDEMPTION = Template(
             trust_below(0, Slot.TARGET, Slot.ACTOR),
             has_symmetric_relationship_of_type("enemy", Slot.ACTOR, Slot.TARGET),
             has_symmetric_relationship_of_type("rival", Slot.ACTOR, Slot.TARGET),
-            # Reachability contour: candidate pairs compose from relationship
-            # rows (any type) and contact:social edges, never from hostile
-            # pair tags alone. This arm therefore fires only when the pair
-            # composed via one of those routes and the hostile edge is the
-            # sole EVIDENCE (e.g. a hunting edge atop a neutral-valence
-            # relationship row). A pair whose only connection is a hostile
-            # edge does not compose — deliberately: a wrong worth redeeming
-            # with no relationship row is data-shape-poor, and widening the
-            # shared composer for that corner would touch every two-party
-            # package.
+            # #530 reachability contour closed by the ruled hostile source:
+            # this directed evidence can now source the pair even when no
+            # relationship row or social-contact edge exists.
             has_any_pair_tag(
                 "hostile_to",
                 "hunting",

--- a/nexus/api/orrery_dev_endpoints.py
+++ b/nexus/api/orrery_dev_endpoints.py
@@ -324,6 +324,7 @@ async def post_resolve(request: OrreryResolveRequest) -> dict[str, Any]:
                 contagion_settings=orrery.get("contagion"),
                 weather_settings=orrery.get("weather"),
                 mood_settings=orrery.get("mood"),
+                composition_settings=orrery.get("composition"),
             )
         except OverrideValidationError as exc:
             # Override validation (unknown vocab, no-op toggles) is caller
@@ -417,6 +418,7 @@ async def post_coverage(request: OrreryCoverageRequest) -> dict[str, Any]:
             contagion_settings=orrery.get("contagion"),
             weather_settings=orrery.get("weather"),
             mood_settings=orrery.get("mood"),
+            composition_settings=orrery.get("composition"),
         )
 
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -679,6 +679,16 @@ class OrreryBindingSettings(BaseModel):
     window_chunks: int = Field(default=30, ge=1)
 
 
+class OrreryCompositionSettings(BaseModel):
+    """Opt-in shared binding sources for Orrery package composition."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    hostile_source_enabled: bool = False
+    roster_source_enabled: bool = False
+    roster_reach: int = Field(default=2, ge=1, le=4)
+
+
 def _default_weather_climates() -> Dict[str, List[str]]:
     return {
         "lagoon_wet": [
@@ -2159,6 +2169,9 @@ class OrrerySettings(BaseModel):
 
     enabled: bool = True
     binding: OrreryBindingSettings = Field(default_factory=OrreryBindingSettings)
+    composition: OrreryCompositionSettings = Field(
+        default_factory=OrreryCompositionSettings
+    )
     weather: OrreryWeatherSettings = Field(default_factory=OrreryWeatherSettings)
     mood: OrreryMoodSettings = Field(default_factory=OrreryMoodSettings)
     contagion: OrreryContagionSettings = Field(default_factory=OrreryContagionSettings)

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -77,6 +77,7 @@ def _production_proposal(slot: int) -> tuple[Optional[int], OrreryTickProposal]:
                 project_settings=orrery.get("projects"),
                 epistemics_settings=orrery.get("epistemics"),
                 fanout_settings=orrery.get("fanout"),
+                composition_settings=orrery.get("composition"),
             )
     finally:
         engine.dispose()

--- a/tests/test_orrery/test_composition_sources_live.py
+++ b/tests/test_orrery/test_composition_sources_live.py
@@ -16,6 +16,7 @@ from nexus.agents.orrery.resolver import (
     compose_actor_faction_routes,
     compose_actor_target_bindings,
     compose_actor_target_routes,
+    hydrate_world_state,
     resolve_dry_run,
 )
 from nexus.agents.orrery.substrate import (
@@ -145,6 +146,7 @@ def composition_db() -> Iterator[dict[str, Any]]:
             "hostile_target",
             "near_member",
             "far_member",
+            "beyond_member",
             "unreachable_member",
         ):
             entity_id = int(
@@ -177,7 +179,7 @@ def composition_db() -> Iterator[dict[str, Any]]:
             characters[label] = character_id
 
         factions: dict[str, int] = {}
-        for label in ("near", "far", "unreachable", "no_roster"):
+        for label in ("near", "far", "beyond", "unreachable", "no_roster"):
             factions[label] = int(
                 session.execute(
                     text(
@@ -208,6 +210,9 @@ def composition_db() -> Iterator[dict[str, Any]]:
         _insert_relationship(
             session, characters["near_member"], characters["far_member"]
         )
+        _insert_relationship(
+            session, characters["far_member"], characters["beyond_member"]
+        )
         _insert_pair_tag(
             session,
             entities["hostile_target"],
@@ -220,6 +225,12 @@ def composition_db() -> Iterator[dict[str, Any]]:
         )
         _insert_pair_tag(
             session, entities["far_member"], factions["far"], "status:senior"
+        )
+        _insert_pair_tag(
+            session,
+            entities["beyond_member"],
+            factions["beyond"],
+            "status:senior",
         )
         _insert_pair_tag(
             session,
@@ -317,6 +328,11 @@ def test_live_roster_source_respects_reach_roster_liveness_and_opt_in(
     session = composition_db["session"]
     actor = composition_db["entities"]["actor"]
     factions = composition_db["factions"]
+    state = hydrate_world_state(
+        session,
+        anchor_chunk_id=None,
+        window_chunks=30,
+    )
     at_one = compose_actor_faction_bindings(
         session,
         anchor_chunk_id=None,
@@ -324,6 +340,7 @@ def test_live_roster_source_respects_reach_roster_liveness_and_opt_in(
         actor_ids={actor},
         include_rosters=True,
         roster_reach=1,
+        orbit_distance=state.orbit_distance,
     )
     at_two = compose_actor_faction_bindings(
         session,
@@ -332,6 +349,7 @@ def test_live_roster_source_respects_reach_roster_liveness_and_opt_in(
         actor_ids={actor},
         include_rosters=True,
         roster_reach=2,
+        orbit_distance=state.orbit_distance,
     )
     assert {binding[Slot.FACTION] for binding in at_one} == {factions["near"]}
     assert {binding[Slot.FACTION] for binding in at_two} == {
@@ -339,11 +357,12 @@ def test_live_roster_source_respects_reach_roster_liveness_and_opt_in(
         factions["far"],
     }
     assert factions["unreachable"] not in {binding[Slot.FACTION] for binding in at_two}
+    assert factions["beyond"] not in {binding[Slot.FACTION] for binding in at_two}
     assert factions["no_roster"] not in {binding[Slot.FACTION] for binding in at_two}
 
     routes = compose_actor_faction_routes(
         session,
-        state=WorldState(),
+        state=state,
         templates=(ROSTER_LEGACY_TEMPLATE, ROSTER_TEMPLATE),
         anchor_chunk_id=None,
         window_chunks=30,

--- a/tests/test_orrery/test_composition_sources_live.py
+++ b/tests/test_orrery/test_composition_sources_live.py
@@ -1,0 +1,404 @@
+"""Rollback-only live coverage for ruled Orrery composition sources."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+from nexus.agents.orrery.audit import explain_dry_run
+from nexus.agents.orrery.resolver import (
+    compose_actor_faction_bindings,
+    compose_actor_faction_routes,
+    compose_actor_target_bindings,
+    compose_actor_target_routes,
+    resolve_dry_run,
+)
+from nexus.agents.orrery.substrate import (
+    ALWAYS,
+    Branch,
+    DriveBand,
+    ProjectPolicy,
+    RoutineAnchor,
+    Slot,
+    Template,
+    TravelState,
+    WorldState,
+    evaluate,
+)
+from nexus.agents.orrery.templates import START_SEEK_REDEMPTION
+from nexus.api.slot_utils import get_slot_db_url
+
+
+pytestmark = pytest.mark.requires_postgres
+
+LIVE_SLOT = 5
+COMPOSITION = {
+    "hostile_source_enabled": True,
+    "roster_source_enabled": True,
+    "roster_reach": 2,
+}
+HOSTILE_TEMPLATE = Template(
+    id="live_hostile_composition",
+    priority=10,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    blurb="Live hostile composition fixture.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    package_gate=ALWAYS,
+    branches=(Branch("act", ALWAYS, "{actor} faces {target}."),),
+    composes_from_hostility=True,
+)
+HOSTILE_LEGACY_TEMPLATE = Template(
+    id="live_hostile_legacy",
+    priority=9,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    blurb="Live relationship-only fixture.",
+    required_slots=(Slot.ACTOR, Slot.TARGET),
+    package_gate=ALWAYS,
+    branches=(Branch("act", ALWAYS, "{actor} ignores {target}."),),
+)
+ROSTER_TEMPLATE = Template(
+    id="live_roster_composition",
+    priority=10,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    blurb="Live roster composition fixture.",
+    required_slots=(Slot.ACTOR, Slot.FACTION),
+    package_gate=ALWAYS,
+    branches=(Branch("act", ALWAYS, "{actor} courts {faction}."),),
+    courts_factions=True,
+)
+ROSTER_LEGACY_TEMPLATE = Template(
+    id="live_roster_legacy",
+    priority=9,
+    drive_band=DriveBand.PROJECT_IDENTITY,
+    blurb="Live direct-institution-only fixture.",
+    required_slots=(Slot.ACTOR, Slot.FACTION),
+    package_gate=ALWAYS,
+    branches=(Branch("act", ALWAYS, "{actor} avoids {faction}."),),
+)
+
+
+def _insert_relationship(
+    session: Session, source_character_id: int, target_character_id: int
+) -> None:
+    session.execute(
+        text(
+            """
+            INSERT INTO character_relationships (
+                character1_id, character2_id, relationship_type,
+                emotional_valence, dynamic, recent_events, history
+            ) VALUES (
+                :source_id, :target_id, 'associate', '+1|favorable',
+                'Rollback-only composition fixture.',
+                'No persistent events.',
+                'Created solely for issue 532 live coverage.'
+            )
+            """
+        ),
+        {"source_id": source_character_id, "target_id": target_character_id},
+    )
+
+
+def _insert_pair_tag(
+    session: Session, subject_id: int, object_id: int, tag: str
+) -> None:
+    session.execute(
+        text(
+            """
+            INSERT INTO entity_pair_tags (
+                subject_entity_id, object_entity_id, pair_tag_id,
+                source_kind, template_id
+            )
+            SELECT :subject_id, :object_id, pt.id,
+                   'template', 'test_composition_sources_live'
+            FROM pair_tags pt
+            WHERE pt.tag = :tag AND NOT pt.deprecated
+            """
+        ),
+        {"subject_id": subject_id, "object_id": object_id, "tag": tag},
+    )
+
+
+@pytest.fixture()
+def composition_db() -> Iterator[dict[str, Any]]:
+    """Create a private hostile edge and roster graph, then roll it back."""
+
+    engine = create_engine(get_slot_db_url(slot=LIVE_SLOT), future=True)
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+    try:
+        token = uuid4().hex[:12]
+        place_id = int(
+            session.execute(
+                text("SELECT id FROM places ORDER BY id LIMIT 1")
+            ).scalar_one()
+        )
+        entities: dict[str, int] = {}
+        characters: dict[str, int] = {}
+        for label in (
+            "actor",
+            "hostile_target",
+            "near_member",
+            "far_member",
+            "unreachable_member",
+        ):
+            entity_id = int(
+                session.execute(
+                    text(
+                        """
+                        INSERT INTO entities (kind, is_active)
+                        VALUES ('character', true)
+                        RETURNING id
+                        """
+                    )
+                ).scalar_one()
+            )
+            character_id = int(
+                session.execute(
+                    text(
+                        """
+                        INSERT INTO characters (name, entity_id)
+                        VALUES (:name, :entity_id)
+                        RETURNING id
+                        """
+                    ),
+                    {
+                        "name": f"composition-{token}-{label}",
+                        "entity_id": entity_id,
+                    },
+                ).scalar_one()
+            )
+            entities[label] = entity_id
+            characters[label] = character_id
+
+        factions: dict[str, int] = {}
+        for label in ("near", "far", "unreachable", "no_roster"):
+            factions[label] = int(
+                session.execute(
+                    text(
+                        """
+                        INSERT INTO entities (kind, is_active)
+                        VALUES ('faction', true)
+                        RETURNING id
+                        """
+                    )
+                ).scalar_one()
+            )
+
+        session.execute(
+            text(
+                """
+                INSERT INTO character_routine_anchors (
+                    character_entity_id, anchor_type, place_id,
+                    mobility_policy, source
+                ) VALUES (
+                    :actor_id, 'home', :place_id, 'fixed_place',
+                    'test_composition_sources_live'
+                )
+                """
+            ),
+            {"actor_id": entities["actor"], "place_id": place_id},
+        )
+        _insert_relationship(session, characters["actor"], characters["near_member"])
+        _insert_relationship(
+            session, characters["near_member"], characters["far_member"]
+        )
+        _insert_pair_tag(
+            session,
+            entities["hostile_target"],
+            entities["actor"],
+            "hostile_to",
+        )
+        _insert_pair_tag(session, factions["near"], entities["actor"], "hostile_to")
+        _insert_pair_tag(
+            session, entities["near_member"], factions["near"], "status:junior"
+        )
+        _insert_pair_tag(
+            session, entities["far_member"], factions["far"], "status:senior"
+        )
+        _insert_pair_tag(
+            session,
+            entities["unreachable_member"],
+            factions["unreachable"],
+            "status:junior",
+        )
+        yield {
+            "session": session,
+            "entities": entities,
+            "factions": factions,
+            "place_id": place_id,
+        }
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()
+        engine.dispose()
+
+
+def test_live_hostile_pair_is_symmetric_isolated_and_fires_redemption(
+    composition_db: dict[str, Any],
+) -> None:
+    """A hostile-only pair composes both ways, but only opted stacks see it."""
+
+    session = composition_db["session"]
+    entities = composition_db["entities"]
+    actor = entities["actor"]
+    target = entities["hostile_target"]
+    bindings = compose_actor_target_bindings(
+        session,
+        anchor_chunk_id=None,
+        window_chunks=30,
+        actor_ids={actor, target},
+        include_hostile_edges=True,
+    )
+    observed_pairs = {
+        (binding[Slot.ACTOR], binding[Slot.TARGET]) for binding in bindings
+    }
+    assert {(actor, target), (target, actor)} <= observed_pairs
+    assert not any(
+        composition_db["factions"]["near"] in pair for pair in observed_pairs
+    )
+
+    routes = compose_actor_target_routes(
+        session,
+        state=WorldState(),
+        templates=(HOSTILE_LEGACY_TEMPLATE, HOSTILE_TEMPLATE),
+        anchor_chunk_id=None,
+        window_chunks=30,
+        actor_ids={actor},
+        composition_settings=COMPOSITION,
+    )
+    routed_bindings, routed_templates = next(
+        route for route in routes if route[0][Slot.TARGET] == target
+    )
+    assert routed_bindings == {Slot.ACTOR: actor, Slot.TARGET: target}
+    assert routed_templates == (HOSTILE_TEMPLATE,)
+
+    redemption_routes = compose_actor_target_routes(
+        session,
+        state=WorldState(),
+        templates=(START_SEEK_REDEMPTION,),
+        anchor_chunk_id=None,
+        window_chunks=30,
+        actor_ids={actor},
+        composition_settings=COMPOSITION,
+    )
+    redemption_bindings, redemption_templates = next(
+        route for route in redemption_routes if route[0][Slot.TARGET] == target
+    )
+    state = WorldState(
+        locations={actor: composition_db["place_id"]},
+        pair_tags={(target, actor): frozenset({"hostile_to"})},
+        travel_states={actor: TravelState(status="at_place")},
+        project_policy=ProjectPolicy(enabled=True),
+        routine_anchors={
+            (actor, "home"): RoutineAnchor(
+                anchor_type="home",
+                place_id=composition_db["place_id"],
+                mobility_policy="fixed_place",
+            )
+        },
+        world_time=datetime(2073, 8, 2, 12, tzinfo=timezone.utc),
+    )
+    assert redemption_templates == (START_SEEK_REDEMPTION,)
+    assert evaluate(START_SEEK_REDEMPTION, state, redemption_bindings).passes
+
+
+def test_live_roster_source_respects_reach_roster_liveness_and_opt_in(
+    composition_db: dict[str, Any],
+) -> None:
+    """Only live rosters reachable within the configured neutral orbit compose."""
+
+    session = composition_db["session"]
+    actor = composition_db["entities"]["actor"]
+    factions = composition_db["factions"]
+    at_one = compose_actor_faction_bindings(
+        session,
+        anchor_chunk_id=None,
+        window_chunks=30,
+        actor_ids={actor},
+        include_rosters=True,
+        roster_reach=1,
+    )
+    at_two = compose_actor_faction_bindings(
+        session,
+        anchor_chunk_id=None,
+        window_chunks=30,
+        actor_ids={actor},
+        include_rosters=True,
+        roster_reach=2,
+    )
+    assert {binding[Slot.FACTION] for binding in at_one} == {factions["near"]}
+    assert {binding[Slot.FACTION] for binding in at_two} == {
+        factions["near"],
+        factions["far"],
+    }
+    assert factions["unreachable"] not in {binding[Slot.FACTION] for binding in at_two}
+    assert factions["no_roster"] not in {binding[Slot.FACTION] for binding in at_two}
+
+    routes = compose_actor_faction_routes(
+        session,
+        state=WorldState(),
+        templates=(ROSTER_LEGACY_TEMPLATE, ROSTER_TEMPLATE),
+        anchor_chunk_id=None,
+        window_chunks=30,
+        actor_ids={actor},
+        composition_settings=COMPOSITION,
+    )
+    assert {
+        (
+            route[0][Slot.FACTION],
+            tuple(template.id for template in route[1]),
+        )
+        for route in routes
+    } == {
+        (factions["near"], (ROSTER_TEMPLATE.id,)),
+        (factions["far"], (ROSTER_TEMPLATE.id,)),
+    }
+
+
+def test_live_widened_sources_keep_resolver_and_audit_in_parity(
+    composition_db: dict[str, Any],
+) -> None:
+    """Both real-schema dry-run dispatch sites see identical widened bindings."""
+
+    session = composition_db["session"]
+    actor = composition_db["entities"]["actor"]
+    target = composition_db["entities"]["hostile_target"]
+    factions = composition_db["factions"]
+    templates = (HOSTILE_TEMPLATE, ROSTER_TEMPLATE)
+    kwargs = {
+        "anchor_chunk_id": None,
+        "window_chunks": 30,
+        "composition_settings": COMPOSITION,
+    }
+    proposal = resolve_dry_run(session, templates, **kwargs)
+    report = explain_dry_run(session, templates, **kwargs)
+
+    production = {
+        (draft.template_id, tuple(sorted(draft.bindings.items())))
+        for draft in proposal.resolutions
+        if draft.bindings.get("actor") == actor
+    }
+    actor_report = next(item for item in report.actors if item.actor_entity_id == actor)
+    audited = {
+        (stack.winner_id, tuple(sorted(stack.bindings.items())))
+        for stack in actor_report.two_party_stacks
+    }
+    widened_expected = {
+        (HOSTILE_TEMPLATE.id, (("actor", actor), ("target", target))),
+        *{
+            (
+                ROSTER_TEMPLATE.id,
+                (("actor", actor), ("faction", faction_id)),
+            )
+            for faction_id in (factions["near"], factions["far"])
+        },
+    }
+    assert widened_expected <= production
+    assert audited == production

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -14,6 +14,7 @@ from nexus.api.new_story_schemas import Genre
 from nexus.config.settings_models import (
     OrreryBleedSettings,
     OrreryContagionSettings,
+    OrreryCompositionSettings,
     OrreryDashboardSettings,
     OrreryDistortionSettings,
     OrreryDriftSettings,
@@ -47,6 +48,9 @@ def test_orrery_settings_resolve_model_reference() -> None:
     assert settings.orrery is not None
     assert settings.orrery.enabled is True
     assert settings.orrery.binding.window_chunks == 30
+    assert settings.orrery.composition.hostile_source_enabled is True
+    assert settings.orrery.composition.roster_source_enabled is True
+    assert settings.orrery.composition.roster_reach == 2
     assert settings.orrery.contagion.dyad_tiers.trusting == timedelta(hours=24)
     assert settings.orrery.contagion.dyad_tiers.neutral == timedelta(hours=96)
     assert settings.orrery.contagion.dyad_tiers.hostile is None
@@ -208,6 +212,23 @@ def test_drift_defaults_off_when_block_is_absent() -> None:
     payload = load_settings("nexus.toml").orrery.model_dump()
     payload.pop("drift")
     assert OrrerySettings.model_validate(payload).drift.enabled is False
+
+
+def test_composition_defaults_off_and_validates_roster_reach() -> None:
+    """Legacy configs stay byte-stable and invalid roster depth fails loud."""
+
+    defaults = OrreryCompositionSettings()
+    assert defaults.hostile_source_enabled is False
+    assert defaults.roster_source_enabled is False
+    assert defaults.roster_reach == 2
+    payload = load_settings("nexus.toml").orrery.model_dump()
+    payload.pop("composition")
+    legacy = OrrerySettings.model_validate(payload).composition
+    assert legacy == defaults
+    with pytest.raises(ValidationError, match="greater than or equal to 1"):
+        OrreryCompositionSettings(roster_reach=0)
+    with pytest.raises(ValidationError, match="less than or equal to 4"):
+        OrreryCompositionSettings(roster_reach=5)
 
 
 def test_mood_defaults_off_and_requires_positive_duration() -> None:

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 
 import pytest
 
+from nexus.agents.orrery.audit import explain_dry_run
 from nexus.agents.lore.utils.turn_context import TurnContext
 from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
 from nexus.agents.orrery.resolver import (
@@ -88,7 +89,9 @@ class FakeSession:
         present_actor_rows=None,
         actor_target_relationship_rows=None,
         actor_target_social_contact_rows=None,
+        actor_target_hostile_edge_rows=None,
         actor_faction_pair_tag_rows=None,
+        actor_faction_roster_rows=None,
         entity_name_rows=None,
         need_debt_rows=None,
         travel_state_rows=None,
@@ -136,7 +139,9 @@ class FakeSession:
         self.present_actor_rows = present_actor_rows or []
         self.actor_target_relationship_rows = actor_target_relationship_rows or []
         self.actor_target_social_contact_rows = actor_target_social_contact_rows or []
+        self.actor_target_hostile_edge_rows = actor_target_hostile_edge_rows or []
         self.actor_faction_pair_tag_rows = actor_faction_pair_tag_rows or []
+        self.actor_faction_roster_rows = actor_faction_roster_rows or []
         self.entity_name_rows = entity_name_rows or [
             {"id": 1, "name": "Mara"},
             {"id": 2, "name": "Vale"},
@@ -170,6 +175,7 @@ class FakeSession:
         self.max_chunk_id = max_chunk_id
         self.max_id_queries = 0
         self.world_time_queries = 0
+        self.executed_sql: list[str] = []
 
     def __enter__(self):
         return self
@@ -179,6 +185,7 @@ class FakeSession:
 
     def execute(self, statement, _params=None):
         sql = str(statement)
+        self.executed_sql.append(sql)
         if "/* orrery:epistemics_hydration:backstory_availability */" in sql:
             return FakeResult([{"available": True}])
         if "/* orrery:entity_activity */" in sql:
@@ -279,12 +286,28 @@ class FakeSession:
             assert "pt.tag = 'contact:social'" in sql
             assert "ept.cleared_at IS NULL" in sql
             return FakeResult(self.actor_target_social_contact_rows)
+        if "/* orrery:actor_target_bindings_hostile_edges */" in sql:
+            assert "pt.tag IN ('hostile_to', 'hunting')" in sql
+            assert "es.kind = 'character'" in sql
+            assert "et.kind = 'character'" in sql
+            return FakeResult(self.actor_target_hostile_edge_rows)
         if "/* orrery:actor_faction_bindings_institutional_pair_tags */" in sql:
             assert "pt.tag LIKE 'status:%'" in sql
             assert "'obligation', 'handles', 'authority_over'" in sql
             assert "ept.cleared_at IS NULL" in sql
             assert "NOT pt.deprecated" in sql
             return FakeResult(self.actor_faction_pair_tag_rows)
+        if "/* orrery:actor_faction_bindings_rosters */" in sql:
+            assert "pt.tag LIKE 'status:%'" in sql
+            assert "relationship_scope = 'character'" in sql
+            reach = _params["roster_reach"]
+            return FakeResult(
+                [
+                    row
+                    for row in self.actor_faction_roster_rows
+                    if row.get("depth", 0) <= reach
+                ]
+            )
         if "/* orrery:entity_names */" in sql:
             return FakeResult(self.entity_name_rows)
         if "/* orrery:need_debt_scores */" in sql:
@@ -2354,6 +2377,242 @@ def test_compose_actor_target_bindings_includes_directed_social_contacts() -> No
 
     pairs = {(b[Slot.ACTOR], b[Slot.TARGET]) for b in bindings}
     assert pairs == {(1, 2)}
+
+
+def test_hostile_edges_compose_both_orderings_and_route_only_opted_templates() -> None:
+    """Hostile character pairs are symmetric candidates with isolated stacks."""
+
+    opted = Template(
+        id="hostility_opted",
+        priority=10,
+        drive_band=DriveBand.PROJECT_IDENTITY,
+        blurb="Hostility source fixture.",
+        required_slots=(Slot.ACTOR, Slot.TARGET),
+        package_gate=ALWAYS,
+        branches=(Branch("act", ALWAYS, "{actor} faces {target}."),),
+        composes_from_hostility=True,
+    )
+    legacy = Template(
+        id="hostility_legacy",
+        priority=9,
+        drive_band=DriveBand.PROJECT_IDENTITY,
+        blurb="Legacy relationship-only fixture.",
+        required_slots=(Slot.ACTOR, Slot.TARGET),
+        package_gate=ALWAYS,
+        branches=(Branch("act", ALWAYS, "{actor} ignores {target}."),),
+    )
+    session = FakeSession(
+        actor_target_hostile_edge_rows=[{"source_entity_id": 1, "target_entity_id": 2}]
+    )
+
+    bindings = compose_actor_target_bindings(
+        session,
+        anchor_chunk_id=100,
+        window_chunks=30,
+        actor_ids={1, 2},
+        include_hostile_edges=True,
+    )
+    assert {(binding[Slot.ACTOR], binding[Slot.TARGET]) for binding in bindings} == {
+        (1, 2),
+        (2, 1),
+    }
+
+    routes = compose_actor_target_routes(
+        session,
+        state=WorldState(),
+        templates=(legacy, opted),
+        anchor_chunk_id=100,
+        window_chunks=30,
+        actor_ids={1, 2},
+        composition_settings={"hostile_source_enabled": True},
+    )
+    assert [
+        (
+            route[0][Slot.ACTOR],
+            route[0][Slot.TARGET],
+            tuple(template.id for template in route[1]),
+        )
+        for route in routes
+    ] == [(1, 2, ("hostility_opted",)), (2, 1, ("hostility_opted",))]
+
+
+def test_roster_routes_respect_reach_and_only_admit_courting_templates() -> None:
+    """Roster factions cross the authored boundary only within configured reach."""
+
+    courting = Template(
+        id="roster_courting",
+        priority=10,
+        drive_band=DriveBand.PROJECT_IDENTITY,
+        blurb="Roster courtship fixture.",
+        required_slots=(Slot.ACTOR, Slot.FACTION),
+        package_gate=ALWAYS,
+        branches=(Branch("act", ALWAYS, "{actor} courts {faction}."),),
+        courts_factions=True,
+    )
+    legacy = Template(
+        id="roster_legacy",
+        priority=9,
+        drive_band=DriveBand.PROJECT_IDENTITY,
+        blurb="Direct-institution-only fixture.",
+        required_slots=(Slot.ACTOR, Slot.FACTION),
+        package_gate=ALWAYS,
+        branches=(Branch("act", ALWAYS, "{actor} avoids {faction}."),),
+    )
+    session = FakeSession(
+        actor_faction_roster_rows=[
+            {"actor_id": 1, "faction_id": 9, "depth": 2},
+            {"actor_id": 1, "faction_id": 10, "depth": 3},
+        ]
+    )
+
+    routes = compose_actor_faction_routes(
+        session,
+        state=WorldState(),
+        templates=(legacy, courting),
+        anchor_chunk_id=100,
+        window_chunks=30,
+        actor_ids={1},
+        composition_settings={
+            "roster_source_enabled": True,
+            "roster_reach": 2,
+        },
+    )
+    assert [
+        (
+            route[0][Slot.ACTOR],
+            route[0][Slot.FACTION],
+            tuple(template.id for template in route[1]),
+        )
+        for route in routes
+    ] == [(1, 9, ("roster_courting",))]
+
+    empty_routes = compose_actor_faction_routes(
+        FakeSession(),
+        state=WorldState(),
+        templates=(courting,),
+        anchor_chunk_id=100,
+        window_chunks=30,
+        actor_ids={1},
+        composition_settings={"roster_source_enabled": True, "roster_reach": 4},
+    )
+    assert empty_routes == ()
+
+
+def test_disabled_composition_sources_are_byte_identical_to_legacy() -> None:
+    """Default-off source settings preserve the exact legacy proposal payload."""
+
+    template = Template(
+        id="disabled_source_fixture",
+        priority=10,
+        drive_band=DriveBand.PROJECT_IDENTITY,
+        blurb="Disabled-source fixture.",
+        required_slots=(Slot.ACTOR, Slot.TARGET),
+        package_gate=ALWAYS,
+        branches=(Branch("act", ALWAYS, "{actor} meets {target}."),),
+        composes_from_hostility=True,
+    )
+    rows = [{"source_entity_id": 1, "target_entity_id": 2}]
+    legacy_session = FakeSession(actor_target_hostile_edge_rows=rows)
+    disabled_session = FakeSession(actor_target_hostile_edge_rows=rows)
+    legacy = resolve_dry_run(
+        legacy_session,
+        (template,),
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+    disabled = resolve_dry_run(
+        disabled_session,
+        (template,),
+        anchor_chunk_id=100,
+        window_chunks=30,
+        composition_settings={
+            "hostile_source_enabled": False,
+            "roster_source_enabled": False,
+            "roster_reach": 2,
+        },
+    )
+
+    disabled_payload = disabled.to_dict()
+    legacy_payload = legacy.to_dict()
+    disabled_payload.pop("generated_at")
+    legacy_payload.pop("generated_at")
+    assert disabled_payload == legacy_payload
+    assert disabled_session.executed_sql == legacy_session.executed_sql
+    assert not any("hostile_edges" in sql for sql in disabled_session.executed_sql)
+
+
+def test_enabled_composition_sources_keep_production_and_audit_in_parity() -> None:
+    """Resolver and explained dry-run dispatch both widened sources identically."""
+
+    hostile = Template(
+        id="hostile_parity",
+        priority=10,
+        drive_band=DriveBand.PROJECT_IDENTITY,
+        blurb="Hostile parity fixture.",
+        required_slots=(Slot.ACTOR, Slot.TARGET),
+        package_gate=ALWAYS,
+        branches=(Branch("act", ALWAYS, "{actor} faces {target}."),),
+        composes_from_hostility=True,
+    )
+    roster = Template(
+        id="roster_parity",
+        priority=10,
+        drive_band=DriveBand.PROJECT_IDENTITY,
+        blurb="Roster parity fixture.",
+        required_slots=(Slot.ACTOR, Slot.FACTION),
+        package_gate=ALWAYS,
+        branches=(Branch("act", ALWAYS, "{actor} courts {faction}."),),
+        courts_factions=True,
+    )
+    settings = {
+        "hostile_source_enabled": True,
+        "roster_source_enabled": True,
+        "roster_reach": 2,
+    }
+
+    def session() -> FakeSession:
+        return FakeSession(
+            actor_target_hostile_edge_rows=[
+                {"source_entity_id": 1, "target_entity_id": 2}
+            ],
+            actor_faction_roster_rows=[{"actor_id": 1, "faction_id": 9, "depth": 2}],
+            entity_name_rows=[
+                {"id": 1, "name": "Mara"},
+                {"id": 2, "name": "Vale"},
+                {"id": 9, "name": "The Court"},
+            ],
+        )
+
+    proposal = resolve_dry_run(
+        session(),
+        (hostile, roster),
+        anchor_chunk_id=100,
+        window_chunks=30,
+        composition_settings=settings,
+    )
+    report = explain_dry_run(
+        session(),
+        (hostile, roster),
+        anchor_chunk_id=100,
+        window_chunks=30,
+        composition_settings=settings,
+    )
+    production = {
+        (draft.template_id, tuple(sorted(draft.bindings.items())))
+        for draft in proposal.resolutions
+    }
+    audited = {
+        (stack.winner_id, tuple(sorted(stack.bindings.items())))
+        for stack in report.actors[0].two_party_stacks
+    }
+    assert (
+        audited
+        == production
+        == {
+            ("hostile_parity", (("actor", 1), ("target", 2))),
+            ("roster_parity", (("actor", 1), ("faction", 9))),
+        }
+    )
 
 
 def test_actor_target_routes_preserve_contact_only_recruitment_continuity() -> None:

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -299,15 +299,13 @@ class FakeSession:
             return FakeResult(self.actor_faction_pair_tag_rows)
         if "/* orrery:actor_faction_bindings_rosters */" in sql:
             assert "pt.tag LIKE 'status:%'" in sql
-            assert "relationship_scope = 'character'" in sql
-            reach = _params["roster_reach"]
-            return FakeResult(
-                [
-                    row
-                    for row in self.actor_faction_roster_rows
-                    if row.get("depth", 0) <= reach
-                ]
-            )
+            assert "NOT pt.deprecated" in sql
+            assert "ept.cleared_at IS NULL" in sql
+            assert "subject_entity.is_active = true" in sql
+            assert "object_entity.is_active = true" in sql
+            assert "WITH RECURSIVE" not in sql
+            assert "entity_relationships_v" not in sql
+            return FakeResult(self.actor_faction_roster_rows)
         if "/* orrery:entity_names */" in sql:
             return FakeResult(self.entity_name_rows)
         if "/* orrery:need_debt_scores */" in sql:
@@ -2228,6 +2226,21 @@ def test_compose_actor_faction_bindings_is_distinct_and_ordered() -> None:
     )
 
 
+def test_roster_bindings_require_canonical_orbit_distance() -> None:
+    """Roster reach is undefined without the hydrated canonical metric."""
+
+    with pytest.raises(
+        ValueError, match="orbit_distance is required when include_rosters=True"
+    ):
+        compose_actor_faction_bindings(
+            FakeSession(),
+            anchor_chunk_id=100,
+            window_chunks=30,
+            actor_ids={1},
+            include_rosters=True,
+        )
+
+
 def test_compose_actor_target_faction_bindings_is_cartesian_product() -> None:
     """Triple composition reuses target candidates and products factions."""
 
@@ -2460,14 +2473,14 @@ def test_roster_routes_respect_reach_and_only_admit_courting_templates() -> None
     )
     session = FakeSession(
         actor_faction_roster_rows=[
-            {"actor_id": 1, "faction_id": 9, "depth": 2},
-            {"actor_id": 1, "faction_id": 10, "depth": 3},
+            {"member_id": 2, "faction_id": 9},
+            {"member_id": 3, "faction_id": 10},
         ]
     )
 
     routes = compose_actor_faction_routes(
         session,
-        state=WorldState(),
+        state=WorldState(orbit_distance={(1, 1): 0, (1, 2): 2, (1, 3): 3}),
         templates=(legacy, courting),
         anchor_chunk_id=100,
         window_chunks=30,
@@ -2575,7 +2588,12 @@ def test_enabled_composition_sources_keep_production_and_audit_in_parity() -> No
             actor_target_hostile_edge_rows=[
                 {"source_entity_id": 1, "target_entity_id": 2}
             ],
-            actor_faction_roster_rows=[{"actor_id": 1, "faction_id": 9, "depth": 2}],
+            orbit_rows=[
+                {"source_entity_id": 1, "target_entity_id": None},
+                {"source_entity_id": 1, "target_entity_id": 3},
+                {"source_entity_id": 3, "target_entity_id": 2},
+            ],
+            actor_faction_roster_rows=[{"member_id": 2, "faction_id": 9}],
             entity_name_rows=[
                 {"id": 1, "name": "Mara"},
                 {"id": 2, "name": "Vale"},

--- a/tests/test_orrery/test_seek_redemption_projects.py
+++ b/tests/test_orrery/test_seek_redemption_projects.py
@@ -21,6 +21,7 @@ from nexus.agents.orrery.needs import load_need_tuning
 from nexus.agents.orrery.resolver import OrreryResolutionDraft
 from nexus.agents.orrery.substrate import (
     BranchSelection,
+    EventRecord,
     ProjectPolicy,
     ProjectState,
     RoutineAnchor,
@@ -29,7 +30,11 @@ from nexus.agents.orrery.substrate import (
     WorldState,
     evaluate,
 )
-from nexus.agents.orrery.templates import ADVANCE_SEEK_REDEMPTION, START_SEEK_REDEMPTION
+from nexus.agents.orrery.templates import (
+    ADVANCE_SEEK_REDEMPTION,
+    CONSULT_RIVAL,
+    START_SEEK_REDEMPTION,
+)
 from nexus.api.slot_utils import get_slot_db_url
 
 ACTOR = 10
@@ -115,11 +120,27 @@ def test_entry_gate_wronged_party_evidence_or_clause_and_contract() -> None:
     result = evaluate(START_SEEK_REDEMPTION, arms[0], BINDINGS)
     assert START_SEEK_REDEMPTION.required_slots == (Slot.ACTOR, Slot.TARGET)
     assert START_SEEK_REDEMPTION.starts_from_social_contact is True
+    assert START_SEEK_REDEMPTION.composes_from_hostility is True
     assert result.state_delta["project.start"] == {
         "project_type": "seek_redemption",
         "stage": "owning_the_wrong",
         "milestone": True,
     }
+
+
+def test_consult_rival_excludes_reconciled_complex_but_keeps_distrust() -> None:
+    """#530: favorable reconciliation is not rivalry; negative trust still is."""
+
+    shared = {
+        "relationship_types": {(ACTOR, TARGET): frozenset({"complex"})},
+        "recent_events": (EventRecord(event_type="threat_issued", tick=100),),
+        "current_tick": 100,
+    }
+    reconciled = WorldState(trust={(ACTOR, TARGET): 1}, **shared)
+    distrusting = WorldState(trust={(ACTOR, TARGET): -1}, **shared)
+
+    assert evaluate(CONSULT_RIVAL, reconciled, BINDINGS).passes is False
+    assert evaluate(CONSULT_RIVAL, distrusting, BINDINGS).passes is True
 
 
 def test_entry_gate_requires_wronged_party_evidence_and_blocks_actor_hostility() -> (


### PR DESCRIPTION
Closes nothing yet — Stage 1 of #532 (Stage 2 lands the patron widening, status-bestowal verb, and introduction mechanisms).

## What This Ships (Arachne Ruling Seq 6)

Composition gains **both ruled shared sources**, each behind a `Template` opt-in flag and an `[orrery.composition]` config gate (model defaults off; shipped config on):

- **Hostile edges** — active character-only `hostile_to`/`hunting` pair tags compose ACTOR/TARGET pairs in **both orderings** (the ruling's directionality choice). Hostile-only pairs admit only templates setting `composes_from_hostility`; `START_SEEK_REDEMPTION` opts in, closing the #530 review's reachability contour (a wrong with no relationship row can now source its own amends project — live end-to-end test included). Faction-endpoint hostility deliberately composes nothing until a desire names the faction.
- **Faction rosters** — a faction with any live `status:*` roster becomes enumerable for actors within `roster_reach` relationship-graph hops of a member. The recursive CTE is membership-equivalent to `relative_orbit_distance <= reach` over the identical edge set (`entity_relationships_v`, character scope, active endpoints, undirected). Only `courts_factions` templates admit roster pairs — **nothing sets that flag until Stage 2's patron widening**, so this source is dormant scaffolding with live coverage.
- **CONSULT_RIVAL** drops its `has_relationship_of_type("complex")` arm: SEEK_REDEMPTION now writes favorable `complex` for reconciled pairs, so complex-alone is no longer a fraught tie; `trust_below(0)` keeps genuine distrust covered (#530 review provenance in the comment; catalog regenerated).

## Settings

`[orrery.composition]`: `hostile_source_enabled`, `roster_source_enabled` (both model-default **false**), `roster_reach = 2` (validated 1..4, loud ValueError at the resolver too). Threaded through resolver, audit (`explain_dry_run`), coverage, turn cycle, and dev endpoints in lockstep — disabled sources are byte-identical to legacy composition (tested).

## Evidence

- `NEXUS_RUN_POSTGRES=1 pytest tests/test_orrery/ tests/test_api/test_orrery_dev_endpoints.py -q` → **1246 passed, 5 skipped, 0 failed** (rerun independently after the build)
- Full suite: 1596 passed, 405 skipped
- `replay_state.py --slot 5 --verify` → all checkpoint intervals ok
- flake8/black/validate-config clean; pre-commit hooks passed on commit

No migrations. No schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)